### PR TITLE
docs: 작업 인벤토리 + 전략 문서 (Direction A 확정)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Serena MCP project cache + memories (개인 환경)
+.serena/
+
 # Dependencies
 node_modules/
 .pnp

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,123 @@
+# Backlog — oh-my-ontology
+
+> 작업 *순번* 만. user 가 "T?? 진행해" 하면 그것만 분해해서 실행.
+> 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제.
+
+---
+
+## ✅ 완료 (refactor/first-principles-slim-1 PR #1, main 머지 완료, 23 commits)
+
+| # | 항목 | 결과 |
+|---|---|---|
+| T3+T4 | share-doc 시스템 제거 | ✅ entity + view + Firestore rules cascade 정리 |
+| T5+T6 (부분) | AI 추출 *클라이언트* path 제거 | ✅ api-keys + ontology-extraction client + receive-doc. functions/extract-gemini · ontology-extract 는 보존 (user 비용 우려로 비활성, 향후 결정) |
+| T7 | read 측 mode-aware (`useProjects` hook) | ✅ entities/docs-vault/lib/derive-projects-from-vault + features/project-data-source/use-projects |
+| T8 | ProjectDrawer/Form/Detail mode-aware | ✅ ProjectForm + ProjectDetailPage + GlobalSearch + KnowledgeDocumentNewPage |
+| T9 | 검수 큐 mode-aware 안내 | ✅ /review/knowledge 에 local 모드 banner |
+| T10 | 빌더 fullscreen 토글 | ✅ F · Esc · 우상단 버튼 |
+| T11 | 빌더 "트리로 보기" 시각 위계 | ✅ 약화된 텍스트 only |
+| T14 | account-settings 단순화 | ✅ 369→280 줄 |
+| T15 | dev-admin-bypass 단순화 | ✅ 인프라 + 41 callsite + 의존 e2e 정리 |
+| T16 | frontmatter parser nested object | ✅ block + inline object 모두 지원 + 단위 테스트 10개 |
+| T17 | 빌더 onboarding 카피 다듬기 | ✅ 한국어 동작 설명 + mission 약속 명시 |
+| T25 | client-error 단순화 | ✅ entity 제거 → console.error |
+| T26 | dagre layout 단순화 | ✅ dependency drop + grid layout |
+
+부수 cleanup (BACKLOG 외):
+- ✅ docs-vault-activity (GitHub webhook) cascade 제거
+- ✅ project-activity entity + InsightsPage 슬림
+- ✅ workspace-project entity + 4-layer cascade 완전 제거
+- ✅ HomePage Layer 0 컨테이너 drill-down 제거
+- ✅ legacy redirect (/project/topology, /project/view)
+- ✅ TaxonomyProvider mode-aware
+
+---
+
+## 결정 필요 (P0 — answer 후 즉시 unblock)
+
+### T1. `/` 자동 vault 전환 정책 결정
+- **현 상황**: T7 mode-aware hook 으로 사실상 자동 전환 작동 (vault 활성 시 / 가 vault 데이터 표시).
+- **추가로 필요한 결정**: `/?account=demo-workspace` 같은 명시 query 가 있을 때 vault 와 충돌 시 어느 쪽 우선?
+  - (a) vault 가 항상 우선 (mission ideal)
+  - (b) ?account= 가 명시되면 cloud (현재 동작)
+  - (c) v0.x = b, v1.0 = a
+- **답 후 작업**: 분기 변경 + 5-step 온보딩 hint
+
+### T13. OperationsNav 온톨로지 탭 분기 결정
+- **선택지**: (a) 빌더 / 트리 두 갈래로 분리 / (b) 현재 통합 유지 / (c) 토글 버튼만 추가
+- **답 후 작업**: 1-2 commit
+
+### AI 추출 cloud Functions 잔재 (T5+T6 마무리)
+- **상황**: 클라이언트 path 는 제거됨. functions/extract-gemini.js + ontology-extract.js 는 남음.
+- **선택지**: (a) 유지 — 추후 비용 허용 시 재활성화 / (b) 완전 제거 — knowledge-document-detail 의 "분석 시작" 버튼 + knowledgeJobs/Outputs 컬렉션 + 검수 큐 의존도 같이 삭제
+- **답 후 작업** ((b) 시): 7000+ 줄 cascade
+
+---
+
+## Mission inconsistency 마무리
+
+(없음 — T7, T8, T9 로 mode-aware 통합 완료)
+
+---
+
+## UX 다듬기 (small wins, additive)
+
+### T12. NodeDetailPanel evidence excerpt modal
+- 트리 row evidence chip 클릭 시 markdown 발췌 modal
+- AI 영역 의존 — 비활성. T5/T6 결정 후
+
+### T18. V1.1 — Qualifiers + Rank
+- frontmatter 에 `since: 2024-Q1`, `via: REST`, `rank: deprecated`
+- spec: `docs/ONTOLOGY-MODEL-V2-DRAFT.md` §2 + §10.2
+- est: 5-7 commit, additive
+
+### T19. V1.5 — Relation Cardinality
+- "belongs_to.sourceCardinality = 'one'" 같은 1:1 / 1:N 제약
+- spec: §6
+- est: 3-5 commit
+
+### T20. V1.3 — Rich References
+- evidence 에 retrievedAt / extractionModelId / confidence
+- spec: §4
+- est: 3-5 commit
+
+### T21. V1.2 — Literal Properties
+- node 에 description / color / releasedAt 같은 atomic property
+- needs: T18 stable
+- est: 7-10 commit
+
+### T22. V2 통합 KnowledgeStatement (5-phase)
+- needs: T18-T21 모두 stable
+- est: 30+ commit, 9-12 개월
+
+---
+
+## Cleanup / 회귀 차단
+
+### T23. mode-aware e2e tests
+- local / cloud / static 시나리오로 각 surface 검증
+- needs: Firebase emulator 셋업
+- est: 3-5 commit + 인프라
+
+### T24. knowledge-* 컬렉션 통합 검토
+- knowledge-version / knowledge-job / knowledge-output 컬렉션 합칠 수 있는지
+- needs: AI 결정 (T5+T6)
+
+### T27. KnowledgeDocumentDetailPage / KnowledgeReviewWorkspacePage 정리
+- 둘 다 큰 파일 (수백 줄)
+- needs: AI 결정 (T5+T6)
+
+### Review backlog (이미 처리 일부)
+- ✅ M1, m1, m2, m3, M2 — 모두 main 머지됨
+- M3: docs/MODE-AWARE-CRUD.md taxonomy fork 명문화 — md 커밋 정책 확정 후
+- m4: 비활성화된 e2e 재활성화 — Firebase emulator 셋업 (T23 와 같은 의존)
+
+---
+
+## 추천 진행 순서
+
+1. **T1, T13** P0 결정 — 막힌 항목 해소
+2. **AI Functions 결정** (T5+T6 b 면 큰 batch)
+3. T18 (V1.1 qualifiers) → T19 → T20 → T21 — V1.x progressive
+4. T23 e2e (Firebase emulator)
+5. T22 V2 통합 — 마지막

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,77 @@
+# CHANGELOG
+
+> 주요 변경 이력. 코드 commit 메시지가 *왜* 를 답하고, 이 파일은 *언제 / 어떤 surface 가 바뀌었는지* 를 답한다. PR 단위가 아닌 **사용자 가시 변화** 위주.
+>
+> 최신이 위. semver 도입 전 v0.x 단계라 날짜 기반.
+
+---
+
+## 2026-05-01 — Mode-aware CRUD + Builder rebrand
+
+### 사용자 가시 변화
+
+- `/` Landing — 정적 미니 토폴로지 SVG (14 노드 / 21 relations) + 3-step rail (markdown → 추출 → 토폴로지·트리·ERD) + Obsidian/Notion 비교 카피 + footer (MIT licensed · GitHub · 기술 스택). Marketing 섹션 (Why / Coming soon roadmap / Stats / framer-motion 애니메이션 / Sigma drift 배경) 은 모두 제거.
+- `/projects/` — 비로그인 사용자 redirect 제거. list 즉시 노출. 비로그인 + vault 활성 사용자가 ProjectQuickCreatePanel 로 *vault 의 .md 직접 생성* 가능 (mode-aware).
+- `/ontology/edit/` — '온톨로지 아틀라스' → **'온톨로지 빌더'** 로 rebrand. 헤더 5줄 → 1줄 + ⓘ 툴팁. max-w 1400 → 1800 으로 캔버스 확장. 비로그인 시 'Missing or insufficient permissions' raw 에러 안 보이고 ephemeral 캔버스만 자유.
+- `/ontology/` — 'i' 아이콘 hover 툴팁 동작 + 카피 강화 (계층 + 빌더 진입 안내). '편집기' 버튼 → **'빌더 열기 →'** 인디고 fill prominent. 하단 footer 에 nodes/relations + mode + projection version 노출 (V1.0 강점 가시화).
+- `/ontology/` 의 vault 모드 — `VaultOntologyStubsPanel` 노출. frontmatter (`kind`, `capabilities`, `elements`, `relates`, `dependencies`, `domain`) 가 즉시 stub 노드/엣지로 자라는 모습 시각화.
+- OperationsNav '문서' 탭 — vault 활성 시 `/docs/` 로, 그 외 `/knowledge/` 로 분기.
+- Landing / app 전체의 'Demo' 브랜드 잔재 → **`oh-my-ontology`** 로 정리 (page title / OG / twitter / PWA manifest).
+
+### 새 entity / feature / shared 모듈
+
+- `src/shared/lib/data-source-mode.ts` + `src/features/data-source-mode/` — 4 운영 모드 (Static / Local / Cloud / Hybrid) 인지 hook.
+- `src/features/project-data-source/` — `useProjectMutations` mode-aware hook (local 은 vault 직접 쓰기, cloud 는 Firestore).
+- `src/entities/docs-vault/lib/project-frontmatter.ts` — Project ↔ frontmatter 양방향 매퍼 + `buildProjectMarkdown`.
+- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — frontmatter → ontology stub 변환 (fast path, AI 추출 거치지 않음).
+- `src/features/vault-ontology/` — useVaultOntology hook + VaultOntologyStubsPanel widget.
+- `src/entities/local-fs-handle/` — File System Access 핸들의 entity 화 (multi-vault forward-compat).
+- `src/entities/local-fs-handle/api/permission.ts` — `verifyHandlePermission(handle, mode, {ask})` 일반화 유틸.
+- `src/entities/docs-vault/lib/build-local-manifest.ts` — `computeLocalVaultFingerprint` 함수 추가 (auto-refresh skip).
+
+### 제거 / 정리
+
+- `src/features/workspace-project-bridge/` — 통째 삭제 (771 줄 / 9 파일 / 50 tests). multi-account 컨테이너 어댑터 single-user 모드 전환 후 dead.
+- `src/widgets/workspace-project-selector/ui/WorkspaceProjectSelector.tsx` — dead UI 230 줄 삭제.
+- `src/shared/lib/account-scope.ts` — `appendWorkspaceProjectQuery` / `readRuntimeWorkspaceProjectId` stub 함수 제거.
+- `src/shared/lib/use-workspace-project-query.ts` — 통째 삭제 + 3 consumer 의 dead destructure 정리.
+- `useScopedAccountAccess` 의 `_accountId` 파라미터 제거 (11 call site 동시 정리).
+- `src/views/account-settings/` 의 일부 + `src/widgets/account-menu/` 일부 — 더 이상 사용 안 되는 코드 path 정리.
+- e2e audit spec 4 개의 dead `/admin/*` URL 7개 제거.
+- LocalVaultPicker 의 off-canon palette (peachy / muted-red / indigo 변종) → 캐논 warning(244,183,49) / danger(229,72,77) / indigo(94,106,210) + 시멘틱 토큰으로 통일.
+- LocalVaultPicker error 상태에 actionable 안내 한 줄 추가.
+
+### 버그 fix
+
+- `OntologyEditPage` 의 `accountId = null` 하드코드 제거 — ERD 캔버스 manual node 저장 가능 회복 (이전엔 항상 "계정이 확인되지 않았어요" 토스트로 fail).
+- `useApprovedGraphFlow` 가 비로그인 시 Firestore 구독 시도 → raw permissions error — accountId === null 면 구독 skip + 빈 그래프 + loaded:true.
+- frontmatter parser 가 multi-line YAML list (`capabilities:\n  - x`) 미지원 → 지원 추가.
+- `useLocalVault` 의 manual `refresh` 도 fingerprint skip 적용 (auto-refresh 만 됐던 것).
+
+### 신설 spec / docs (untracked, user review 대기)
+
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.0 강점 + V1.1~V1.5 단계별 진화 (qualifiers / literals / rich-refs / ActionType / cardinality) + V2 통합 statement 모델 + 90+ 항목 체크리스트 + Mermaid 도식 2개 + Glossary 50+ 용어 + 8 Open questions + 13 섹션.
+- `docs/LOCAL-FIRST-SYNC.md` — 4 운영 모드 + 충돌 해소 5 원칙 + Hybrid 도입 전 4 open questions.
+- `docs/OFFLINE-FIRST-UX-FLOW.md` — 6 사용자 상태 × 11 라우트 매트릭스 + 5-step 온보딩.
+- `docs/ACTION-TYPE-SECURITY-DRAFT.md` — V1.4 ActionType 의 8 보안 항목 deepen.
+- `docs/MODE-AWARE-CRUD.md` — 오늘 도입한 mode-aware 패턴 contributor 가이드 + anti-pattern 4 종.
+
+### 검증 통과 상태
+
+- 927 tests passing (131 test files)
+- tsc 0 errors
+- lint 0 errors (warnings 모두 pre-existing)
+- Playwright 시각: `/`, `/projects/`, `/ontology/`, `/ontology/edit/`, `/docs/`, 8 라우트 audit 모두 console errors 0.
+- 누적 commit: 약 30+ (이날 단일 세션). 누적 diff: -3000+ / +1500+ 라인 (정리 위주).
+
+### Open questions (user 답 대기)
+
+1. `/` 토폴로지가 활성 vault 가 있을 때 자동 전환되어야 하는가? (a/b/c)
+2. share-doc 시스템 (`/share/[token]` + sharedDocs Firestore) 제거해도 되는가? (a/b)
+3. V2 spec 의 P0/P1 Open questions Q1~Q8 (multi-vault 시점 / ActionType 인증 / dual-read 기간 / none vs unknown / extractionModelId 검증 / summary 마이그레이션 / literal naming scope / ActionInvocation 보존)
+
+---
+
+## 2026-04-30 이전
+
+이전 변경은 이 CHANGELOG 도입 전 — git log 참조 (`git log --oneline 7b16945..ba1e102`).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,433 @@
+# FEATURES — oh-my-ontology
+
+> 사용자가 **지금 실제로 사용 가능한** 기능 전수 인벤토리.
+> 작성일: 2026-05-01 (refactor/first-principles-slim-1 main 머지 직후)
+> 출처: routes audit · vault/mode-aware audit · ontology+search audit · auth/project/knowledge/settings audit (4 haiku agents 병렬 점검)
+
+---
+
+## 0. 한눈에
+
+> **mission**: "사용자가 글을 쓰면 시스템이 개념·관계·근거를 자라게 한다. 토폴로지·트리·ERD 세 view 로 본다."
+> **운영 모델**: 1인 도구. local-first vault. 로그인은 옵션.
+
+```
+입력          파싱            저장             출력
+md 문서  →   frontmatter   →  vault 또는    →  토폴로지 (Sigma)
+                              Firestore        트리 (계층)
+                                               빌더 (xyflow ERD)
+```
+
+---
+
+## 1. 모드 분기 (data source)
+
+`useDataSourceMode()` hook 이 셋 중 하나를 결정:
+
+| 모드 | 조건 | 동작 |
+|---|---|---|
+| **local** | vault 폴더 활성 | vault manifest 가 진실원, Firebase 호출 0 |
+| **cloud** | Firebase 로그인 + vault 미활성 | Firestore onSnapshot 실시간 sync |
+| **static** | 둘 다 없음 | 빌드 타임 demo manifest |
+
+**효과**: 사용자가 vault 폴더를 열면 `/projects` · `/` · `/project/[slug]` 모든 곳에서 즉시 vault 데이터로 바뀜. mutation (생성/편집/삭제) 도 동일하게 mode-aware.
+
+---
+
+## 2. 라우트별 기능
+
+### 토폴로지 + 검색
+
+#### `/` — 토폴로지 홈 (Sigma WebGL)
+- **렌더**: Sigma.js + Graphology + ForceAtlas2 — 전체 프로젝트를 공간 네트워크로 펼침
+- **인터랙션**:
+  - 노드 클릭 → ProjectDrawer (우측 슬라이드 패널)
+  - 노드 hover → tooltip + 1-hop 이웃 강조
+  - 드래그 / 휠 → pan / zoom
+  - 좌측 Legend (kind 색 범례)
+  - 우측 SigmaHubRail (degree 상위 허브 빠른 점프)
+  - 하단 RegionNavigator (minimap)
+- **단축키**: `⌘K` 검색 · `?` 단축키 시트
+- **모드**: 모든 모드에서 동작 — 데이터 소스만 다름
+
+#### `/docs` — Vault Picker / Doc Vault
+- **로컬 폴더 선택** (File System Access API):
+  - 폴더 선택 → 전체 `.md` 자동 스캔 → manifest 빌드
+  - 파일 수 + 마지막 스캔 시각 ("방금 / 5초 전 / 3분 전")
+  - 새로고침 / 닫기 / 재승인 버튼
+  - 미지원 브라우저 / 권한 거부 / 접근 오류 사용자 친화 메시지
+- **vault 활성 시 surface**:
+  - 폴더 트리 + 사이드바 (pinned · 최근 · 태그)
+  - 본문 viewer (마크다운 + frontmatter 메타바)
+  - 폴더 토폴로지 view (Sigma) — 문서 간 링크 그래프
+  - "vault frontmatter ontology" 패널 — frontmatter 만으로 추출된 stub 노드/엣지
+  - 백링크 / 관련 문서 / 관계 레이더
+  - 명령 팔레트 (vault 전용 — Daily Note, Scaffold Topology, 내보내기 등)
+- **scaffoldTopology()**: 빈 vault 에 `projects/`, `README.md`, `categories.md`, `statuses.md`, 샘플 프로젝트 hub/leaf 자동 생성
+
+### 프로젝트
+
+#### `/projects` — 프로젝트 목록
+- **mode-aware**: local 모드면 vault 의 `projects/*.md`, cloud 면 Firestore
+- **검색 / 필터**: query · category · status · 표시 개수
+- **카드별**: ontology 노드 카운트 배지, 빠른 작업 (편집 / 공유 링크 복사)
+- **ProjectQuickCreatePanel** — 페이지 안에서 인라인 빠른 생성 (mode-aware)
+- **CSV 내보내기** — 전체 다운로드
+- **WorkspaceOntologyStrip** — 상단 ontology 요약 strip
+
+#### `/project/[slug]` — 프로젝트 상세
+- **렌더**: 메타 (이름·설명·태그·스택·상태·카테고리·시작/완료일·진행도·소유자·아이콘) + 의존성 그래프 + 토폴로지 미리보기
+- **인라인 편집** (권한 시): description / status 등 즉시 수정
+- **DependencyPicker**: 의존성 칩 multi-select + 검색 + cycle/missing 경고
+- **공개 화면 share link** + 내부 admin link
+- **Mission 7 원자 정합**: vault 의 `projects/<slug>.md` 로부터 모든 정보 자동 매핑
+
+#### `/project/new` · `/project/[slug]/edit` — 에디터
+- **풀 폼**: 이름·slug·설명·detail (markdown)·태그·스택·링크·의존성·아이콘·상태·카테고리·진행도·timeline·screenshots
+- **자동 추천**: description 에서 다른 프로젝트 이름 발견 시 dependency 추천 chip
+- **mode-aware mutation**: local → vault `.md` 작성/패치, cloud → Firestore upsert
+- **저장 후 동작 선택**: "저장하고 계속 보기" / "저장하고 목록으로" / "저장하고 공개 화면으로"
+
+#### `/project/fallback` — 정적 export 폴백
+- Firebase Hosting rewrite 가 unknown slug 를 client-side Firestore 조회로 라우팅. 빌드타임에 모르는 동적 slug 도 정상 렌더.
+
+### 온톨로지 3-view
+
+#### `/ontology` — Tree (read-only)
+- **계층 구조**: project → domain → capability → element (문서 노드는 근거로만 기여, 트리 제외)
+- **노드 클릭** → 우측 detail 패널:
+  - kind / title / 요약 / project 연결 / 근거 문서 수
+  - **ego 그래프** — 1-hop / 2-hop toggle SVG
+  - 이웃 리스트 (방향 → / ←) — 클릭 점프
+  - 근거 문서 링크
+  - "+ 관계 추가" — 모달
+  - "노드 링크 복사" — `/ontology/?node=<id>` deeplink
+- **상단 pill**: 노드 추가 / 검색 (⌘K) / 빌더 열기 → / 인사이트 / 관계 / 검수 큐
+- **통계 카드**: 트리 노드 / 관계 / 근거 문서 / 미해결 stub / 마지막 발행
+- **stub 처리**: 미해결 참조 → "승격" (kind 선택) / "폐기" 액션
+
+#### `/ontology/edit` — Builder (xyflow ERD)
+- **palette (좌)**: 4 kind 클릭 → 캔버스 가운데에 새 임시 노드 (인디고 dashed)
+- **연결**: 노드 가장자리 점에서 drag → 다른 노드에 drop → 임시 관계 edge
+- **Inspector (우)**: 임시 노드 선택 시 이름 + 저장 → `knowledgeApprovedNodes/Edges` 로 commit
+- **md 내보내기**: ephemeral 노드/엣지를 frontmatter 마크다운으로 download
+- **fullscreen toggle**: F 키 또는 우상단 Maximize 버튼 — OperationsNav 숨김 + 풀 viewport
+- **단축키**: N (새 project 노드) · F (전체 화면) · Del (선택 삭제) · Esc (선택 해제 / 전체 화면 종료)
+- **빌더 onboarding**: 첫 진입 + 빈 캔버스에 3-step coach mark (다시 보지 않기 토글)
+- **layout**: 단순 grid (이전 dagre 의존 dropped — commit "dagre 의존성 드롭")
+
+#### `/ontology/insights` — 인사이트
+- **kind 분포** (막대), **프로젝트별 분포** (정렬), **관계 type 분포**
+- **cross-project 관계** 비율 / 절대값
+- **허브 노드 top 10** (degree, 문서·project 제외)
+- **최근 활동 10건** (상대 시간)
+- **30일 활동 타임라인** (일자별 승인 막대)
+- **미연결 노드** (orphan, amber 강조)
+- 모든 항목 클릭 → `/ontology/?node=<id>` 로 점프
+
+#### `/ontology/relations` — 관계 분포
+- **edge type 분포** (좌) — 클릭 toggle 필터
+- **강한 관계 top 12** (evidence 풍부한 순) — from → type → to + cross chip + evidence count
+
+### 지식 (Cloud — AI 영역 부분 비활성)
+
+#### `/knowledge` — 대시보드
+- 문서 통계 카드, 빠른 진입 액션
+- vault 모드 활성 시 "vault summary" 카드 노출
+
+#### `/knowledge/documents`
+- 목록 + 검색 + 필터 (project / 문서 유형 / 상태 / 분석 상태)
+
+#### `/knowledge/documents/new`
+- 새 문서 등록 — 제목 / 마크다운 본문 / 프로젝트 다중 태깅
+- **mode-aware projects**: vault 프로젝트도 picker 에 등장 (review M1)
+- 템플릿 (명세 / 결정 기록), 입력 규칙 안내
+
+#### `/knowledge/documents/view?id=...`
+- 문서 상세 — 메타 / 마크다운 렌더 / 버전 이력 / 분석 결과 (AI 영역)
+- "분석 시작" 버튼 — Cloud Functions 호출 (현재 비용 우려로 비활성)
+
+#### `/review/knowledge` — 검수 워크스페이스
+- AI 추출 결과를 골라 영구 그래프에 반영
+- 좌(원본 마크다운) — 우(추출 결과) 분할
+- 후보·근거·연결 chip + 일괄 승인 / 부분 승인 / 거절
+- **local 모드 안내 banner** (T9): "vault frontmatter 자체가 자기-승인" + vault 열기 / 빌더 열기 → CTA
+
+### 인증 / 계정
+
+#### `/login`
+- email + password
+- Google OAuth (popup)
+- 데모 로그인 (read-only 데모 워크스페이스)
+- 비밀번호 재설정 link
+
+#### `/signup`
+- displayName + email + password (8자+) + 확인
+- 회원가입 후 자동 로그인
+
+#### `/reset-password`
+- 이메일 → Firebase 비밀번호 재설정 메일 발송
+
+#### `/account` (게스트는 `/login?next=/account` 로 redirect)
+- **내 정보**: 이름 · 이메일 · 로그인 방식 (provider)
+- **비밀번호 변경**: 현재 + 신규 + 확인 (Firebase email/password 사용자만)
+- **비밀번호 재설정 메일** 재전송
+- 로그아웃은 PublicAccountMenu 에서
+
+### 운영 / 설정
+
+#### `/diagnostics/insights` — 오늘 챙길 곳
+- **stale 프로젝트** (30일+ 무수정)
+- **orphan** (in/out edge 0)
+- **promotion 후보** (fan-in 높은 비-허브)
+- 각 항목 → 편집 / 상세 / 토폴로지 jump
+
+#### `/settings` — 정리 허브
+- iOS Settings 결의 grouped list, drill-in
+- 그룹: 지도 정비 (categories · statuses · 가져오기 · ontology) · 오늘 점검 (insights)
+
+#### `/settings/categories` — 카테고리
+- 라벨 / 설명 / 톤 (indigo · amber · neutral) / 캔버스 영역 편집기
+
+#### `/settings/statuses` — 상태
+- lifecycle 라벨 / dot 색 / 정렬
+
+#### `/settings/import` — 프로젝트 가져오기
+- CSV 일괄 업로드 (mode-aware)
+
+#### `/settings/ontology` — TBox 보기
+- 활성 TBox 클래스 / 관계 read-only
+
+#### `/settings/ontology/history` — TBox 버전 이력
+- 스키마 snapshot list
+
+---
+
+## 3. 기능 그룹별 정리
+
+### 3.1 Vault Local-First
+
+| 기능 | 진입점 | 효과 |
+|---|---|---|
+| 폴더 선택 (FSA) | `/docs` LocalVaultPicker | OS 폴더 → manifest |
+| Manifest 빌드 | 자동 (선택 시) | 프론트매터 · 백링크 · 헤딩 · excerpt |
+| Fingerprint 변경 감지 | 자동 (탭 포커스 시) | IDE 편집 후 돌아오면 재스캔 (debounce 2s) |
+| Handle 영속화 | IndexedDB (`local-fs-handle`) | 새로고침 후 재승인만 누르면 복원 |
+| createDoc / saveDoc / deleteDoc / renameDoc | 명령 팔레트 / 인라인 편집 | mode-aware mutation |
+| `updateFrontmatter` | useProjectMutations | 본문 보존 + frontmatter 패치 |
+| Backlink rewrite | renameDoc 시 best-effort | 다른 파일의 `[[oldSlug]]`, `[text](old.md)` 자동 치환 |
+| Scaffold | 명령 팔레트 | 빈 vault 에 README + projects/ + 샘플 |
+
+### 3.2 Mode-Aware Adapters
+
+| Hook | 책임 |
+|---|---|
+| `useDataSourceMode()` | local / cloud / static 결정 |
+| `useProjects(accountId)` | mode 별 프로젝트 read (sync local / subscribe cloud) |
+| `useProjectMutations()` | mode 별 CRUD (vault file write / Firestore upsert) |
+| `TaxonomyProvider` | local/static 모드는 defaults, cloud 만 subscribe |
+| `useLocalVault()` | manifest + handle + 명령들 |
+
+**적용 surface**: HomePage / ProjectSelectorPage / ProjectDetailPage / ProjectForm / KnowledgeDocumentNewPage / MountedGlobalSearch / DependencyPicker (parent prop) / TaxonomyProvider
+
+### 3.3 검색
+
+| 종류 | 단축키 | 진입점 |
+|---|---|---|
+| 프로젝트 SearchPalette | `⌘K` (홈) | 토폴로지 / 프로젝트 화면 |
+| 글로벌 검색 (ontology + 문서 + 프로젝트) | `⇧⌘K` | 모든 페이지 |
+
+**기능**: 한·영 fuzzy match · kind 필터 칩 · project 필터 칩 · 키보드 nav (↑↓ Enter Esc) · 빈 query 시 source 별 샘플 표시.
+
+### 3.4 Frontmatter 파서 (T16 으로 강화)
+
+| 형식 | 예시 |
+|---|---|
+| Scalar | `name: foo` / `count: 42` / `active: true` |
+| Quoted | `desc: "hello: world"` |
+| Inline list | `tags: [a, b, c]` |
+| Block list | `items:\n  - a\n  - b` |
+| **Inline object** | `pos: { x: 1, y: 2 }` |
+| **Block object** | `pos:\n  x: 1\n  y: 2` |
+
+object value 안에서는 `'true'/'false'/숫자` 자동 typed. `applyFrontmatterUpdates()` 로 본문 보존하며 패치 (null = key 삭제).
+
+scripts/build-docs-vault.mjs 와 src/shared/lib/parse-frontmatter.ts 가 capability 동기화 (review M2).
+
+### 3.5 Vault Frontmatter → Ontology Stub
+
+frontmatter 키:
+- `kind:` (project / capability / element / domain / decision / workflow / ...)
+- `title:` (또는 # 첫 헤딩 / 파일명 fallback)
+- `domain:` (단일 domain 노드 후보)
+- `capabilities: []` / `elements: []` (배열 노드)
+- `relates: []` / `dependencies: []` (edge 후보)
+
+→ 출력: `OntologyStubNode[]` + `OntologyStubEdge[]` + warnings. AI 추출 거치지 않은 fast-path. /docs 와 /ontology 에서 즉시 가시화.
+
+### 3.6 권한
+
+| 역할 | 동작 |
+|---|---|
+| 비로그인 / guest | 공개 surface (홈 토폴로지 read) + vault 모드 풀 사용 가능 |
+| 데모 세션 | `/login` 데모 버튼 → read-only 데모 데이터 |
+| Firebase 인증 사용자 | 자기 데이터 풀 권한 (1인 도구) |
+| `admins/{email}` 화이트리스트 | 전역 카테고리 / 진단 / TBox 운영 — 일반 사용자는 자기 공간 풀권 |
+
+`PermissionGate` 컴포넌트가 own-space / membership / admin 분기 처리.
+
+### 3.7 모바일 / 반응형
+
+| 기능 | 위치 | 동작 |
+|---|---|---|
+| **BottomTabBar** | `src/widgets/bottom-tab-bar/` | 모바일 (md 미만) 화면 하단 고정 탭바 — 지도 · 프로젝트 · 문서 · 정리. 데스크톱은 OperationsNav 가 같은 destination 제공 |
+| **GestureHint** | `src/widgets/gesture-hint/` | 터치 디바이스에 토폴로지 첫 진입 시 swipe 제스처 안내 |
+| **safe-area / 안전 영역** | OperationsNav 모바일 모드 | iOS 노치 + BottomTabBar 와 충돌 회피 |
+| 모바일 detail sheet | `/ontology` 트리 | 데스크톱은 우측 panel, 모바일은 화면 하단 고정 sheet |
+
+### 3.8 테마 / 접근성 / 알림
+
+| 기능 | 위치 | 동작 |
+|---|---|---|
+| **ThemeToggle (Light/Dark)** | OperationsNav 우측 + `src/features/theme-toggle/` | `html[data-theme="light"]` toggle. 기본 다크. localStorage 영속 |
+| **Toast** | `useToast()` (`src/shared/ui/toast.tsx`, sonner 기반) | 50+ 호출처. `show(message, tone)` API. success / error / warning / info |
+| **LiveAnnouncer** | `src/shared/ui/live-announcer.tsx` | aria-live region — 토폴로지 노드 선택 / 검색 결과 변경 등을 스크린리더에 announce |
+| **Tooltip** | `src/shared/ui` (Radix 기반) | 모든 아이콘 / 단축키 안내 |
+| **prefers-reduced-motion** | globals.css base layer | 자동 존중 — Sigma pulse / framer-motion 모두 |
+
+### 3.9 부가 위젯 (홈 / 빌더 보조)
+
+| 위젯 | 진입점 | 역할 |
+|---|---|---|
+| **DocsQuickDrawer** | `/` 토폴로지 (📁 아이콘) | vault 문서 빠른 미리보기 drawer — pin 한 문서 / 최근 / 트리 inline |
+| **WorkspaceOntologyStrip** | `/` `/projects` 헤더 | 현재 ontology 통계 strip — 매치 0 자동 숨김 |
+| **ProjectKnowledgeTopologyScene** | `/` 노드 선택 시 | 해당 프로젝트의 knowledge graph 상세 scene |
+| **OntologyOutputBadges** | `/review/knowledge` | 검수 후보의 출력 배지 (얼마나 신뢰 가능한지 등) |
+| **CandidateOntologyMatch** | `/review/knowledge` | 추출 후보 ↔ 기존 ontology 노드 유사도 매칭 |
+| **OntologyStubList** | `/review/knowledge` + `/ontology` | 미해결 stub 노드 list + 승격 / 폐기 액션 |
+
+### 3.10 단축키
+
+| 키 | 위치 | 효과 |
+|---|---|---|
+| `⌘K` / `Ctrl+K` | 어디서나 | 검색 팔레트 |
+| `⇧⌘K` | 어디서나 | 글로벌 검색 (ontology + 문서) |
+| `?` | 어디서나 | 단축키 시트 |
+| `Esc` | 모달 / 빌더 | 닫기 / 선택 해제 |
+| `N` | `/ontology/edit` | 새 project 노드 |
+| `F` | `/ontology/edit` | 전체 화면 toggle |
+| `Del` / `Backspace` | `/ontology/edit` | 선택 노드 삭제 |
+| `↑` / `↓` | 검색 / 트리 | 항목 이동 |
+
+---
+
+## 4. 데이터 흐름 (Single source 원칙)
+
+```
+md 파일 (vault 또는 cloud)
+  │
+  ├─→ manifest (vault) / Firestore (cloud)
+  │
+  ├─→ Project[] ← useProjects (mode-aware)
+  │
+  ├─→ frontmatter → derive-ontology-from-vault → OntologyStub[] (local)
+  │                       또는
+  │   AI 추출 → knowledgeApprovedNodes/Edges (cloud, 비용 비활성 중)
+  │
+  └─→ topology (Sigma) / tree / builder (xyflow)
+```
+
+---
+
+## 4-B. 프레임워크 / 빌드타임 surface
+
+| 항목 | 위치 | 동작 |
+|---|---|---|
+| **app/layout.tsx** | root layout | TaxonomyProvider + ToastProvider + 글로벌 스타일 |
+| **app/page.tsx** | `/` 진입 | RootEntryPage — 비로그인이면 LandingPage, 그 외 HomePage |
+| **app/manifest.ts** | `/manifest.webmanifest` | PWA manifest (icon · theme color · display mode) |
+| **app/sitemap.ts** | `/sitemap.xml` | 정적 export 시 빌드된 모든 라우트 노출 |
+| **app/robots.ts** | `/robots.txt` | 검색엔진 크롤 정책 |
+| **app/not-found.tsx** | 404 페이지 | "길을 잃은" 카피 + 홈 / 이전 화면으로 복귀 CTA |
+| **app/error.tsx** | route-level error boundary | "예기치 않은 오류" 카드 + 재시도 / 토폴로지 홈 (commit "client-error 제거" 후 console.error 만) |
+| **app/global-error.tsx** | layout-level error boundary | 최후 방어 — body 자체가 새로 렌더 |
+| **app/project/[slug]/opengraph-image.tsx** | OG 이미지 생성 | 프로젝트 상세 공유 시 동적 카드 이미지 |
+| **app/diagnostics/page.tsx** | redirect | `/diagnostics/insights` 로 client-side replace |
+| **app/review/page.tsx** | redirect | `/review/knowledge` 로 client-side replace |
+| **app/project/fallback/** | 정적 export 폴백 | Firebase Hosting rewrite 가 unknown slug 를 client-side Firestore 조회로 라우팅 |
+
+## 4-A. demo 데이터 구조 (현재)
+
+`src/shared/mocks/demo-blueprint.ts` 의 `CONTAINER_THEMES`:
+
+- **21 컨테이너** (Demo · Demo IAM · Demo Reactor · ... · Demo Onboarding · Demo Support)
+- 각 컨테이너 10–20 hub × 5–10 node = **~2250 flat projects**
+- cross-container 의존 1건씩 명시 (system boundary 시각화)
+- `knowledgeDocuments` 200+ 자동 생성 (각 hub/top-node 별 3–5 문서)
+- `knowledgeApprovedNodes/Edges` 는 **현재 비어있음** (AI 추출 결과가 demo 에 없음)
+
+⚠️ **알려진 정체성 문제**: commit 10 (HomePage Layer 0 컨테이너 drill-down 제거) 이후 컨테이너 layer 가 사라져 토폴로지에 2250 노드가 flat 으로 펼쳐짐. Sigma + ForceAtlas2 가 dense 하게 그려서 결과적으로 **고-degree 허브만 시각적으로 도드라져 보임**. `/ontology` 는 비어있어서 사용자에게 "토폴로지 서비스" 인상 만드는 원인. → 별도 문서 [`PRODUCT-DIRECTION.md`](./PRODUCT-DIRECTION.md) 참고.
+
+---
+
+## 5. 제약 / 의도된 부재
+
+- **Multi-account**: 없음 — `accountId = null` 고정 (v2 협업 단계로 보류)
+- **외부 IAM**: 없음 — Firebase Auth (email/password + Google OAuth) 만
+- **HTTP push API**: 없음 (commit "api-keys + receive-doc cascade 제거")
+- **share link**: 없음 (commit "share-doc cascade 제거" — v2 협업)
+- **GitHub webhook 활동 이력**: 없음 (commit "docs-vault-activity 제거")
+- **AI 추출 클라이언트**: 없음 (commit "ontology-extraction 클라이언트 제거")
+- **AI Cloud Functions**: 잔재 (extract-gemini.js + ontology-extract.js) — 비용 우려로 비활성
+- **dev-admin-bypass**: 없음 (commit "dev-admin-bypass 인프라 + 41 callsite + 의존 e2e 정리")
+- **/admin/*** 라우트: 없음 (deprecated, /settings/* /review/* /diagnostics/* 로 이전)
+- **legacy redirect** (/project/topology, /project/view): 없음 (canonical /project/[slug] 만)
+
+---
+
+## 6. 검증 (refactor/first-principles-slim-1 머지 시점)
+
+- tsc 0 errors
+- eslint 0 errors (warnings 83 — 거의 모두 기존)
+- vitest **117 files / 842 tests pass**
+- Playwright 21 routes + 13 edge cases = **34 시나리오 0 console error**
+- Code review (superpowers:code-reviewer) — Critical 0 / Major 3 모두 즉시 반영
+
+---
+
+## 7. 어디서부터 손대야 할지 — 사용자 워크플로
+
+```
+1. 새 사용자 (로그인 없이):
+   /docs → "내 PC 마크다운 폴더 열기"
+   → vault 활성 → / 토폴로지 + /projects 자동 인지
+
+2. 새 프로젝트 추가:
+   (a) vault 직접:
+       projects/my-project.md 작성
+       ---
+       kind: project
+       title: 내 프로젝트
+       category: in-progress
+       status: developing
+       dependencies: [auth, billing]
+       ---
+       → 자동으로 / 와 /projects 에 등장
+
+   (b) UI 빠른 생성:
+       /projects → "새 프로젝트" 클릭 → ProjectQuickCreatePanel
+       → vault `.md` 자동 생성 (mode-aware)
+
+3. 온톨로지 개념 추가:
+   (a) frontmatter 기반:
+       문서에 kind: capability + relates: [...] 추가
+       → /ontology 에 stub 으로 자동 등장
+
+   (b) 빌더 직접:
+       /ontology/edit → palette → 노드 클릭 → 핸들 drag → 저장
+
+4. 둘러보기:
+   ⇧⌘K (글로벌 검색) → kind 필터 → 점프
+   /ontology → 트리 + ego graph 탐색
+   /ontology/insights → 활동 / 허브 / orphan
+```

--- a/docs/LOCAL-FIRST-SYNC.md
+++ b/docs/LOCAL-FIRST-SYNC.md
@@ -1,0 +1,194 @@
+# Local-first / Firebase Sync 정책
+
+> **Status**: 제안 단계 (DRAFT). 자율 루프 iter#22 (2026-05-01) 작성. main merge 전 user 승인 필요.
+
+이 문서는 *로컬 디스크의 markdown 폴더* 와 *Firebase (Firestore + Storage)* 사이의 데이터 흐름·sync·충돌 정책을 명시한다. `.claude/rules/local-first.md` 의 "Notion 처럼 폴더만 선택해도 사용" 헌장을 데이터 레이어에서 어떻게 구현하는지 정의.
+
+관련 문서:
+- `.claude/rules/local-first.md` — 헌장 (이 문서가 따른다)
+- `docs/DATA-MODEL.md` — Firestore 컬렉션 스키마
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x ontology 모델 진화 (sync 정책과 호환되어야)
+
+---
+
+## 1. 한 줄 요약
+
+> **로컬 디스크가 진실원, Firebase 는 옵션 (백업 / 공유 / 협업) 에만.**
+
+---
+
+## 2. 4 가지 운영 모드
+
+운영 모드는 사용자가 *명시적으로* 선택. 자동 모드 전환 없음 (사용자 혼란 방지).
+
+| 모드 | 진입 | 데이터 진실원 | Firebase 사용 |
+|---|---|---|---|
+| **A. Static** | `pnpm build` 의 정적 manifest | `data/manifest.json` | 사용 안 함 |
+| **B. Local** | 사용자가 폴더 선택 (File System Access API) | 사용자 디스크의 `.md` | 사용 안 함 |
+| **C. Cloud** | Firebase Auth 로그인 후 sync 활성화 | Firestore | Firestore + Storage |
+| **D. Hybrid** | Local + Cloud 동시 (옵션, v1.0+) | 디스크 (master) → Firestore (slave) | 단방향 push |
+
+v0.x 는 **A · B · C** 만 지원. **D (Hybrid)** 는 v1.0 협업 단계에서 별도 spec.
+
+### 모드 결정 규칙
+
+1. 사용자가 토글 선택 → 그 모드 유지 (`localStorage`).
+2. 첫 진입은 **A** (정적) — Firebase 미설정 / 비로그인 / 폴더 미선택.
+3. 폴더 선택 → **B** 자동 전환 *지점* (단, 명시적 토글 후 적용 — Open question #1 참고).
+4. Firebase 로그인 + sync 토글 ON → **C**.
+5. 모드 사이 전환은 항상 *명시적*. 자동 fallback 없음 (단 unsupported 브라우저면 B → A 로 복귀).
+
+---
+
+## 3. 충돌 모델 (Hybrid 모드 D 의 미래)
+
+v0.x 에는 sync 가 없으므로 충돌도 없음. 이 절은 **v1.0 Hybrid 도입 시점의 정책 가이드**.
+
+### 3.1 단방향 push (Hybrid 의 default)
+
+**기본**: 디스크 = master, Firestore = read-only slave.
+- 디스크 변경 → Firestore 자동 push (debounce 5초).
+- Firestore 변경 → 디스크에 반영 안 함 (사용자 외 누구도 못 바꿈).
+- 따라서 **충돌 가능성 0** — 디스크가 single writer.
+
+이게 v1.0 의 default. *공유* 가 목적이면 충분 (다른 사용자는 read-only 로 본다).
+
+### 3.2 양방향 sync (먼 미래, v2.0 협업)
+
+여러 사용자가 동시에 ontology 를 키울 때만 필요. 그때는:
+
+**원칙 A — 의미 단위 충돌 해소** — 같은 fact 의 다중 statement 는 V1.1 의 `rank` 로 자연 표현. preferred / normal / deprecated 로 정렬.
+
+**원칙 B — Last-write-wins per file (frontmatter)** — frontmatter 의 동일 key 는 mtime 기준. 단, 사용자가 의도적으로 *옛 값을 복원* 한 경우는 새 mtime 으로 후속 sync 에서 우선.
+
+**원칙 C — 본문은 3-way merge** — 본문 wikilink / 텍스트 변경은 git-style 3-way merge. 충돌 시 사용자에게 표시.
+
+**원칙 D — 지연 sync 우선** — 네트워크 단절 후 복귀 시 *항상 로컬 변경이 우선* push. 서버 변경이 충돌하면 별도 branch 처럼 보존하고 사용자에게 머지 요청.
+
+**원칙 E — 삭제는 tombstone 으로** — 한쪽에서 삭제, 다른 쪽에서 수정 시 tombstone marker. 사용자 결정 전 데이터 보존.
+
+이 5 원칙은 *원격 사용자 도입 전* 별도 spec 으로 deepen 필요.
+
+---
+
+## 4. 모드 별 데이터 흐름
+
+### 4.1 Static (모드 A)
+
+```
+[빌드 타임]
+  scripts/build-docs-vault.mjs → data/manifest.json (커밋됨)
+
+[런타임 read]
+  Static manifest → useStaticVault → 토폴로지 / 트리 / 검수 큐
+```
+
+쓰기 없음. 읽기만.
+
+### 4.2 Local (모드 B)
+
+```
+[사용자 액션]
+  showDirectoryPicker() → FileSystemDirectoryHandle → IndexedDB 영속 (local-fs-handle entity)
+
+[런타임 read]
+  IDB handle 복원 → buildLocalManifest() → useLocalVault → manifest
+
+[런타임 write — saveDoc / createDoc / deleteDoc / renameDoc]
+  manifest 의 fileHandle → createWritable() → 디스크 직접 쓰기 → manifest 재빌드 (fingerprint 비교)
+
+[자동 새로 고침]
+  focus / visibilitychange → computeLocalVaultFingerprint()
+  변경 있으면 → buildLocalManifest 재실행
+  변경 없으면 → no-op
+```
+
+Firebase 호출 없음. 모든 데이터는 디스크.
+
+### 4.3 Cloud (모드 C)
+
+```
+[로그인]
+  Firebase Auth (email/password 또는 Google OAuth)
+
+[런타임 read]
+  Firestore onSnapshot 실시간 구독 → React state
+
+[런타임 write]
+  upsertProject / approveNode / publishOntology 등 entity API → Firestore
+```
+
+디스크 미사용. 모든 데이터는 Firestore.
+
+### 4.4 Hybrid (모드 D, v1.0+)
+
+```
+[모드 활성화]
+  로컬 모드 + Firebase 로그인 + 사용자 명시 sync ON
+
+[디스크 → 클라우드 (단방향)]
+  fileHandle 변경 감지 (chokidar 또는 polling) → debounce 5초 →
+  ontology spec V1.x 의 markdown ↔ Firestore 매핑 (§8.1) 적용 → upsertProject / 등 호출
+
+[클라우드 → 디스크]
+  v1.0 Hybrid 에서는 *없음* (single-writer).
+  v2.0 협업에서만 양방향. 별도 spec.
+
+[충돌]
+  v1.0 Hybrid 에서는 없음 (single writer).
+  v2.0 에서는 §3.2 의 5 원칙.
+```
+
+---
+
+## 5. 보안 원칙
+
+이 정책의 *모든 모드* 가 다음을 위반 금지:
+
+- **로컬 모드 시 사용자 디스크의 비밀 파일 자동 스캔 / 업로드 금지** — `.claude/rules/local-first.md` 와 일치. dotfile (`.env*`, `.git*` 등) 은 인덱싱 제외.
+- **로그인 후 sync 시 사용자 동의 없는 데이터 전송 금지** — `_actions/` 같은 schema 폴더는 명시적 opt-in 후에만 push.
+- **Firebase API key 는 client OK, service account 는 server (Functions) 만** — `.claude/rules/auth.md` 와 일치.
+- **사용자 데이터 암호화** — Hybrid sync 시 Firestore 에 저장되는 fact 가 사용자 디스크의 *plain* 보다 암호화 약하지 않도록. 현재 Firestore 는 transit + at-rest 암호화 (Google) 라 디스크 plain 과 동등 수준.
+
+---
+
+## 6. 운영 모드 식별 / 디버그
+
+`window.__ohMyOntologyMode` 에 현재 모드 expose (개발자 도구용 — 런타임 코드는 의존하지 말 것).
+
+`/diagnostics/sync` 페이지 (v1.0 추가 예정) 에서:
+- 활성 모드 표시
+- 마지막 sync 시각 / Hybrid 모드일 때
+- pending writes 큐 / 실패 로그
+
+---
+
+## 7. v1.0 Hybrid 도입 전 결정 필요 (open questions)
+
+이 정책의 *Hybrid* / *Cloud* 모드 가 본격 도입되려면 다음 결정 필요:
+
+1. **Q1 (LOOP-TASK 기존)** — `/` 토폴로지가 활성 vault 가 있을 때 자동 전환되어야 하는가? *모드 B 의 자동 진입* 결정.
+2. **Q-NEW-1** — Hybrid 모드의 sync 주기 — 5초 debounce 가 적절한가, 더 길게 / 짧게?
+3. **Q-NEW-2** — Hybrid 모드의 *push 거부 시* 처리 — Firestore rules 가 거부하면 (예: 다른 사용자 진실원 접근) 디스크 변경을 어떻게 표시?
+4. **Q-NEW-3** — `_actions/`, `_relations/`, `_classes/` schema 폴더 sync 의 권한 — 일반 사용자가 push 가능? admin 만?
+5. **Q-NEW-4** — 다중 디바이스 같은 vault 동시 편집 시 — 한 디바이스 = master 룰 강제? 또는 last-write-wins? (양방향 sync 가 필요해지는 지점)
+
+---
+
+## 8. 코드 위치 가이드
+
+이 정책 구현 시 코드는 다음 위치에:
+
+| 책임 | 위치 |
+|---|---|
+| 모드 토글 (사용자 액션) | `src/features/sync-mode/` (신설 예정 — v1.0) |
+| 디스크 ↔ Firestore mapper | `src/features/sync-mode/api/disk-to-firestore.ts` |
+| File watch | `src/features/docs-vault-local/model/use-local-vault.ts` (이미 존재 — fingerprint skip 도입됨) |
+| Sync queue | `src/features/sync-mode/model/sync-queue.ts` |
+| Conflict UI | `src/features/sync-mode/ui/ConflictResolver.tsx` |
+
+새 코드는 **FSD import 방향** 준수 (features → entities → shared).
+
+---
+
+> **결론**: v0.x 는 모드 A·B·C 만 명시적으로 운영. Hybrid 는 v1.0 별도 spec PR. 모든 모드 전환은 사용자 명시적 액션. 충돌 가능성 0 을 v1.0 Hybrid 까지 유지하고, v2.0 협업 단계에서만 양방향 sync + 5 원칙 충돌 해소 도입. 이 단계 분리가 *local-first 약속을 깨지 않으면서* 점진적 cloud 통합을 가능케 한다.

--- a/docs/MODE-AWARE-CRUD.md
+++ b/docs/MODE-AWARE-CRUD.md
@@ -1,0 +1,174 @@
+# Mode-aware CRUD 패턴
+
+> **Status**: 도입 완료 (Phase 2-3, 2026-05-01).
+> **Why**: 기획자 audit 의 root cause 1 — *모드 인지 hook 부재로 모든 게이트가 auth role 만 봄*. local vault 활성 비로그인 사용자가 mutation 불가.
+> **Spec 의 위치**: `.claude/rules/local-first.md` 헌장 + `docs/LOCAL-FIRST-SYNC.md` § "운영 모드" 의 *코드 레이어 implementation*.
+
+이 문서는 *어떤 entity 가 mutation 을 받는지가 사용자의 진실원 모드에 따라 다른 흐름* 을 갖도록 하는 패턴이다. 새 entity 에 mutation 을 추가할 때 이 가이드를 따라 mode-aware 로 만든다.
+
+---
+
+## 1. 운영 모드 (data source mode)
+
+`docs/LOCAL-FIRST-SYNC.md` §2 의 4 모드 중 본 패턴이 다루는 것:
+
+| Mode | 진실원 | mutation 가능? | 인증 필요? |
+|---|---|---|---|
+| **static** | `data/manifest.json` (빌드타임) | ❌ no-op + 거절 | — |
+| **local** | 사용자 디스크의 `.md` (vault) | ✅ 디스크 직접 쓰기 | ❌ 비로그인 OK |
+| **cloud** | Firestore `*` 컬렉션 | ✅ Firestore 쓰기 | ✅ Firebase Auth |
+
+(hybrid 는 v1.0+ 별도 spec.)
+
+---
+
+## 2. 도입된 핵심 모듈
+
+### 2.1 모드 자체를 보는 hook
+
+- `src/shared/lib/data-source-mode.ts` — 순수 함수 `getDataSourceMode({vaultLoaded, isAuthenticated}): DataSourceMode`. 우선순위: vault loaded > authenticated > static.
+- `src/features/data-source-mode/model/use-data-source-mode.ts` — `useUserAuth` + `useLocalVault` 합성 hook. `window.__ohMyOntologyMode` 디버그 expose.
+
+### 2.2 entity 별 mode-aware mutation hook
+
+- `src/features/project-data-source/model/use-project-mutations.ts` — Project 의 create/update/delete + canCreate/canEdit/canDelete capability. local 분기는 `useLocalVault.createDoc` / `updateFrontmatter` / `deleteDoc`, cloud 분기는 entity API.
+
+### 2.3 entity ↔ frontmatter 매퍼
+
+- `src/entities/docs-vault/lib/project-frontmatter.ts` — `projectToFrontmatter(project)` + `buildProjectMarkdown(project)`. local 모드 mutation 의 직렬화 유틸.
+
+### 2.4 vault → ontology fast path
+
+- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — frontmatter `kind / capabilities / elements / relates / dependencies / domain` 에서 stub 노드/엣지 추출. 검수 큐 거치지 않은 *fast path*.
+- `src/features/vault-ontology/model/use-vault-ontology.ts` — useLocalVault + derive 합성 hook.
+
+---
+
+## 3. 새 entity mutation 을 mode-aware 로 만드는 절차
+
+예: `Tag` 엔티티에 mode-aware CRUD 를 추가한다고 가정.
+
+### 3.1 entity 의 frontmatter 직렬화 추가
+
+```ts
+// src/entities/docs-vault/lib/tag-frontmatter.ts
+export interface TagFrontmatterShape {
+  slug: string;
+  name: string;
+  color?: string;
+}
+export function tagToFrontmatter(t: TagFrontmatterShape): Record<string, ...> { ... }
+export function buildTagMarkdown(t: TagFrontmatterShape): string { ... }
+```
+
+local 모드의 `.md` 가 어디 (`tags/<slug>.md`) 에 저장될지도 결정.
+
+### 3.2 mode-aware mutation hook 신설
+
+```ts
+// src/features/tag-data-source/model/use-tag-mutations.ts
+export function useTagMutations(): TagMutations {
+  const mode = useDataSourceMode();
+  const vault = useLocalVault();
+
+  const createTag = async (input: TagInput) => {
+    if (mode === 'static') throw new Error(STATIC_REJECTION);
+    if (mode === 'local') {
+      const path = `tags/${input.slug}`;
+      if (vault.fileHandles.has(path)) throw new Error('이미 존재');
+      await vault.createDoc(path, buildTagMarkdown(input));
+      return;
+    }
+    // cloud
+    await cloudUpsertTag(input);
+  };
+  // ... updateTag / deleteTag 비슷한 분기
+  return { createTag, updateTag, deleteTag, canCreate: mode !== 'static', mode };
+}
+```
+
+### 3.3 UI 컴포넌트에서 hook 사용
+
+```tsx
+function TagCreateForm() {
+  const { createTag, canCreate, mode } = useTagMutations();
+
+  if (!canCreate) {
+    return <p>정적 데모 모드. 폴더 열기 또는 로그인 후.</p>;
+  }
+  // ... form
+  await createTag(input);
+}
+```
+
+### 3.4 게이트는 *mode* 기준, *role* 기준 X
+
+❌ 잘못된 패턴 (audit 가 발견한 문제):
+```tsx
+const { canManage } = useScopedAccountAccess(); // = isLoggedIn
+return canManage ? <CreateButton /> : null;     // local 사용자 차단됨
+```
+
+✅ 올바른 패턴:
+```tsx
+const { canCreate } = useTagMutations();        // = mode !== 'static'
+return canCreate ? <CreateButton /> : null;     // local 도 OK
+```
+
+---
+
+## 4. List subscribe 도 mode-aware (TODO — Phase 6+ 후속)
+
+현재는 mutation 만 mode-aware. **Read 측 (subscribe)** 은 아직 Firestore 우선:
+- `subscribeProjects(accountId, ...)` — Firestore 만 본다.
+- 결과: local 모드 사용자가 새 vault project 추가해도 list 에 안 나옴 (vault manifest 변경은 별도 surface).
+
+향후 도입 권장:
+```ts
+// src/features/project-data-source/model/use-projects.ts
+export function useProjects() {
+  const mode = useDataSourceMode();
+  // mode === 'local' → useLocalVault().manifest 의 projects/*.md 를 buildTopologyFromVault 로
+  // mode === 'cloud' → subscribeProjects (entity API)
+  // mode === 'static' → vaultManifest static
+}
+```
+
+이렇게 하면 *consumer 가 mode 인지 없이* 동일 hook 사용. 현재는 view 가 직접 entity API 호출 — 점진 swap 필요.
+
+---
+
+## 5. e2e 테스트 가이드
+
+각 mode-aware mutation 마다 3 시나리오 e2e:
+- **static**: createX 호출 시 거절 (toast or throw).
+- **local**: vault picker mock 후 vault active → createX → 디스크 .md 생성 확인.
+- **cloud**: Firebase Auth emulator 로 로그인 → createX → Firestore doc 생성 확인.
+
+본 시점 (2026-05-01) 의 e2e 는 local/cloud 시나리오가 미구현. Phase 6+ 후속.
+
+---
+
+## 6. 관련 spec / 룰
+
+- `.claude/rules/local-first.md` — 헌장
+- `docs/LOCAL-FIRST-SYNC.md` — 4 모드 정의 + 충돌 모델
+- `docs/OFFLINE-FIRST-UX-FLOW.md` — UI 흐름 가이드 (5 페이지 게이트 분류 §5)
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x ontology 진화 (V1.4 ActionType 도 mode-aware capability 받음)
+
+---
+
+## 7. anti-pattern 모음 (회귀 차단)
+
+도입 전에 발견된 (그리고 fix 된) 안티 패턴:
+
+| ❌ | 해결 |
+|---|---|
+| `const accountId = null; useScopedAccountAccess(accountId)` 식 항상 null 하드코드 | `accountId` 파라미터 제거 (B4) |
+| Firestore 의 `Missing or insufficient permissions` raw 메시지가 사용자에게 그대로 노출 | accountId === null 면 구독 자체 skip + 빈 그래프 + loaded:true |
+| `<PermissionGate>` 가 페이지 entry 통째 차단 | 진입 게이트 → submit 시점 게이트 (Phase 3.2) |
+| entity API 가 `upsertProject(input)` 만 — Firestore 외 path 없음 | 호출자 (UI) 가 mode-aware hook 거쳐 분기. entity 는 그대로 cloud-only 유지하되 새 hook 이 wrapper 로 동작. |
+
+---
+
+> **결론**: mode-aware CRUD 는 *local-first 헌장의 코드 레이어 표현*. 새 entity 에 mutation 을 추가할 때 §3 의 4 단계를 따라 mode-aware 로. 이 패턴이 깨지면 *비로그인 + vault 사용자가 다시 dead-end* 회귀 — 헌장 위반.

--- a/docs/OFFLINE-FIRST-UX-FLOW.md
+++ b/docs/OFFLINE-FIRST-UX-FLOW.md
@@ -1,0 +1,231 @@
+# Offline-first UX Flow
+
+> **Status**: 제안 단계 (DRAFT). 자율 루프 iter#25 (2026-05-01) 작성. main merge 전 user 승인 필요. 특히 *Open question #1 (HomePage 자동 vault 전환)* 답이 정해진 후 §3 의 진입점 분기 확정.
+
+이 문서는 *비로그인 사용자가 첫 화면에서 0 마찰로 사용 시작* 하도록 라우트별 진입 동작·권한 게이트·온보딩 단계를 명시한다. `.claude/rules/local-first.md` 의 헌장 ("Notion 처럼 폴더만 선택해도 사용") 을 UI 레이어에서 어떻게 구현하는지 정의.
+
+관련:
+- `.claude/rules/local-first.md` — 헌장 (이 문서가 따른다)
+- `docs/LOCAL-FIRST-SYNC.md` — 4 운영 모드 (Static / Local / Cloud / Hybrid)
+- `.claude/rules/auth.md` — Firebase Auth (email/password + Google) 만 허용
+
+---
+
+## 1. 사용자 상태 매트릭스
+
+UX 분기는 다음 4 차원으로:
+
+| 차원 | 가능 값 | 결정 근거 |
+|---|---|---|
+| 인증 | `anonymous` / `signed-in` | Firebase `onAuthStateChanged` |
+| Local vault | `none` / `permission-needed` / `loaded` | `useLocalVault()` 의 `status` |
+| Firebase 설정 | `not-configured` / `configured` | `.env.local` 의 `NEXT_PUBLIC_FIREBASE_*` 유무 (build-time 결정) |
+| Network | `online` / `offline` | `navigator.onLine` (런타임) |
+
+이 4 × 3 × 2 × 2 = 48 상태 중 *의미 있는 조합* 만 다룬다. 나머지는 "동일 분기" 로 단순화.
+
+---
+
+## 2. 6 가지 의미 있는 상태
+
+| ID | 인증 | Local vault | Firebase | Network | 시나리오 |
+|---|---|---|---|---|---|
+| **S1** | anonymous | none | not-configured | online | *"개발자가 처음 clone 후 dev 서버"* — 정적 manifest 만 |
+| **S2** | anonymous | none | configured | online | *"퍼블릭 토폴로지 viewer"* — 데모 / 마케팅 페이지 |
+| **S3** | anonymous | loaded | * | * | *"Notion 처럼 진입한 라이트 사용자"* — 핵심 mission 시나리오 |
+| **S4** | anonymous | permission-needed | * | * | *"이전에 폴더 골랐던 사용자 재방문"* — IDB 핸들 복원 |
+| **S5** | signed-in | * | configured | online | *"공유 / 백업 의도의 사용자"* — Cloud 모드 |
+| **S6** | * | * | * | offline | *"네트워크 끊김"* — 마지막 build 의 정적 manifest + 활성 vault |
+
+---
+
+## 3. 라우트별 첫 진입 동작
+
+각 라우트는 위 6 상태에 따라 다른 진입 화면. **자동 redirect 는 hard-block 이 아닌 *제안* 으로** — 사용자가 무시하고 그대로 머물러도 동작해야 한다.
+
+### 3.1 `/` (토폴로지 — primary entry)
+
+| 상태 | 진입 동작 |
+|---|---|
+| S1 | 정적 manifest 토폴로지 (`data/manifest.json`) — *현재 동작* |
+| S2 | 정적 manifest 토폴로지 + 우상단 "내 폴더 열기" CTA + "로그인" 옵션 |
+| S3 | **분기 결정 필요 (Q1)**:<br>(a) 자동 vault 토폴로지 (mission ideal) — 활성 vault 의 projects/*.md 를 토폴로지로<br>(b) 정적 manifest + "로컬 vault 사용 중" 배지 + 토글로 전환 |
+| S4 | "이전 폴더 다시 열기" 인라인 CTA + 정적 manifest fallback |
+| S5 | Firestore subscribeProjects 결과 토폴로지 |
+| S6 | offline 표시 + 정적 manifest 또는 캐시된 vault — *online 복귀 후* re-sync (Cloud 일 때) |
+
+**Q1 답이 (a)** → S3 의 자동 vault 토폴로지. `useLocalVault().status === 'loaded'` 이면 그 manifest 를 source 로.
+**Q1 답이 (b)** → S3 의 *명시 토글*. UX 변화 0, 사용자가 직접 토글.
+
+### 3.2 `/docs/` (DocsVaultPage)
+
+이미 `source` 토글 (server / local) 보유. *변경 없음*.
+
+| 상태 | 진입 동작 (현재 + 그대로) |
+|---|---|
+| S1, S2 | server source — 정적 manifest |
+| S3, S4 | local source 자동 활성화 (이미 동작) — `localVault.status === 'loaded'` 면 토글 자동 local |
+| S5 | server source |
+| S6 | local 우선, server 캐시 fallback |
+
+### 3.3 `/projects` (프로젝트 목록)
+
+S1~S5 모두 동작. S6 는 캐시된 list 만.
+
+### 3.4 `/project/[slug]` (프로젝트 상세)
+
+| 상태 | 진입 동작 |
+|---|---|
+| S1, S2 | 정적 manifest 의 해당 slug 로드 |
+| S3 | 활성 vault 의 `projects/<slug>.md` 우선, 없으면 정적 fallback |
+| S4 | "다시 권한 요청" 배너 + 정적 fallback |
+| S5 | Firestore `projects/{slug}` 로드 |
+| S6 | 캐시 / 정적 |
+
+### 3.5 `/knowledge`, `/knowledge/*` (지식 등록 / 분석 / 목록)
+
+**S1, S2, S6**: read-only 표시 또는 "폴더 / 로그인 필요" 안내. 등록 / 분석 / publish 버튼 비활성.
+**S3, S4**: 비로그인이라도 *로컬 vault* 에 새 .md 작성 가능 (등록 흐름).
+**S5**: Firebase 통한 풀 등록 / 분석 / publish.
+
+### 3.6 `/review/*` (검수 큐)
+
+비로그인은 view 만. *승인 / 거절* 같은 mutation 은 로그인 필요. 게이트 표시.
+
+### 3.7 `/ontology/*` (온톨로지 view / edit / insights / relations)
+
+view (`/ontology`, `/ontology/insights`, `/ontology/relations`): 비로그인 OK.
+edit (`/ontology/edit`): TBox 변경은 로그인 + 권한 필요. 게이트.
+
+### 3.8 `/settings/*`
+
+| 라우트 | 비로그인 |
+|---|---|
+| `/settings/categories`, `/settings/statuses` | view 만 (read-only) |
+| `/settings/api-keys` | 로그인 게이트 (API key 발급은 인증 필요) |
+| `/settings/project-import` | S3, S4 면 로컬 vault 에 import 가능 |
+
+### 3.9 `/diagnostics/*`, `/admin/*`
+
+`/admin/*` 폐기됨 (`.claude/rules/forbidden.md`).
+`/diagnostics/*` — 운영자 surface, 로그인 + 권한.
+
+### 3.10 `/login`, `/signup`, `/reset-password`
+
+S1 일 때 라우트 자체 비활성 (리다이렉트 필요). S2~S5 에서 진입 가능.
+
+### 3.11 `/account`
+
+비로그인 진입 시 `/login?next=/account` 리다이렉트.
+
+---
+
+## 4. 비로그인 사용자 보호 가이드 (강요 금지)
+
+`.claude/rules/local-first.md` 의 "로그인은 옵션, 비로그인이 default" 헌장.
+
+다음을 위반 금지:
+- ❌ 비로그인 진입 시 *전체 화면* 로그인 modal
+- ❌ 토폴로지 / 트리 view 에 *blur* 처리 후 "로그인하세요" 표시
+- ❌ 폴더 선택 전에 *반드시* 로그인 강제
+
+다음은 OK:
+- ✅ 우상단 "로그인" 버튼 (작게)
+- ✅ Firebase 가 필요한 액션 (예: publish) 클릭 시 *그 액션* 만 게이트
+- ✅ 30+ 일 비로그인 사용 후 dismiss 가능한 *주간* 권유 배너
+
+---
+
+## 5. 권한 게이트 vs 진입 차단
+
+PermissionGate 로 *액션 단계* 만 게이트. *페이지 진입* 자체를 차단하지 말 것.
+
+| 액션 | 게이트 시점 |
+|---|---|
+| 토폴로지 view | 게이트 X (정적 / vault / Firestore 셋 다 가능) |
+| 프로젝트 *추가* (Firebase) | 클릭 시 게이트 |
+| 프로젝트 *추가* (로컬 vault) | 게이트 X — 로컬은 사용자 디스크 |
+| 검수 *승인* | 클릭 시 게이트 (로그인 + permission) |
+| Publish | 클릭 시 게이트 |
+| API key 발급 | 페이지 진입 시 게이트 (예외 — 인증 surface 자체) |
+| TBox 변경 | 클릭 시 게이트 |
+
+---
+
+## 6. 온보딩 단계 (S1, S2 → S3 의 자연스러운 흐름)
+
+비로그인 사용자가 *처음 진입* 후 *로컬 vault 활성화* 까지 5 step:
+
+```
+[Step 1]  / 진입 → 정적 manifest 토폴로지 (즉시 보임)
+   ↓
+[Step 2]  우상단 또는 빈 상태 카드 "내 폴더 열기" CTA 노출
+   ↓
+[Step 3]  클릭 → showDirectoryPicker (브라우저 native)
+   ↓
+[Step 4]  buildLocalManifest 진행 (로딩 표시)
+   ↓
+[Step 5]  토폴로지가 vault 데이터로 갱신 (Q1 답에 따라)
+          또는 /docs/ 에서 토글 후 사용
+```
+
+각 step 에 **돌아갈 길 보존** — Step 3 에서 cancel 하면 Step 1 상태 복귀. Step 5 에서 vault 닫으면 Step 1 복귀.
+
+**volatility**: 각 step 의 한 번의 액션도 정적 manifest 동작에 영향을 주지 않아야. vault 이슈 (권한 거부, 빌드 실패) 가 사용자를 *안 보이는 dead screen* 으로 보내면 안 됨 — 항상 정적 fallback.
+
+---
+
+## 7. 핵심 컴포넌트 / hook 매핑
+
+| 책임 | 컴포넌트 / hook |
+|---|---|
+| local vault picker UI | `LocalVaultPicker` (이미 존재) |
+| local vault state | `useLocalVault` (이미 존재) |
+| 정적 manifest | `vaultManifest` import (이미 존재) |
+| Firestore subscribe | entity API (이미 존재) |
+| 인증 상태 | `useFirebaseAuthUser` 또는 유사 (`@/features/user-auth`) |
+| 권한 게이트 | `PermissionGate` (이미 존재) |
+| 모드 통합 결정 hook (신설) | `useDataSourceMode` — Q1 답 후 도입 — `'static' | 'local' | 'cloud'` 반환 |
+
+신설 후보 `useDataSourceMode` 는 Q1 답에 따라 §3.1 분기를 한 곳에서 결정. 라우트들은 그 결과 사용.
+
+---
+
+## 8. 회귀 차단 시나리오
+
+이 UX flow 변경 시 다음이 깨지지 않게:
+
+1. **S1 시나리오 — 첫 dev 서버** — 정적 manifest 토폴로지가 즉시 보인다. (`pnpm dev` 후 첫 GET `/`).
+2. **S3 자동 전환 (Q1=a 답일 때)** — vault 활성화 후 `/` 가 자동으로 그 데이터를 보여주되 vault 빌드 실패 시 정적 fallback.
+3. **vault 권한 거부** — Picker 의 error 상태 표시 후 정적 fallback (사용자가 다시 시도 가능).
+4. **로그인 후 sync 의도** — Cloud 모드 (`S5`) 진입 시 vault 자동 disable 안 됨 — 두 모드 명시 토글로만 전환 (LOCAL-FIRST-SYNC.md §2.5).
+
+---
+
+## 9. Open questions
+
+1. **(LOOP-TASK Q1 동일)** `/` 의 S3 분기 — 자동 vault 전환 vs 명시 토글? **이 답이 정해지기 전 §3.1 의 S3 분기는 미확정.**
+2. 신설 `useDataSourceMode` hook 이 단일 active source 만 반환하는 게 맞나, 또는 *3 source 동시 보기* (예: vault + Firestore 합집합) 도 지원?
+3. 정적 manifest fallback 의 cache 정책 — vault 활성화 후 정적 manifest 를 *완전히 무시* 가능, 또는 union 으로 유지?
+4. offline 모드 (S6) 의 *Last-known-good* 캐시 위치 — Service Worker 의 Cache Storage? IndexedDB 별도 collection?
+
+---
+
+## 10. 코드 변경 가이드 (Q1 답 후)
+
+Q1 답 = (a) 자동 전환:
+
+1. `useDataSourceMode` hook 신설 (`src/features/data-source/`).
+2. `HomePage` 가 `subscribeProjects` 대신 hook 결과 사용. local 이면 `useLocalVault().manifest` 의 `projects/*.md` 를 Project 로 변환 (이미 `buildTopologyFromVault` 가 함).
+3. Picker 통합 — `/` 의 빈 상태 (S2) 에 `LocalVaultPicker` 인라인 노출.
+4. Onboarding step 인디케이터 추가.
+
+Q1 답 = (b) 명시 토글:
+
+1. `/` 에 `source` state + 토글 UI 추가 (DocsVaultPage 패턴 차용).
+2. 자동 진입 동작 변화 0.
+3. 사용자가 토글하면 그 모드 유지 (`localStorage`).
+
+---
+
+> **결론**: 이 문서는 *Q1 답 후 즉시 구현 가능한* UX 사양. 라우트별 6 상태 매트릭스 + 게이트 시점 + 온보딩 + 회귀 차단까지 완비. v0.x 의 비로그인 첫 진입 0 마찰을 *디스크 폴더 하나로 보장* 한다.

--- a/docs/ONTOLOGY-MODEL-V2-DRAFT.md
+++ b/docs/ONTOLOGY-MODEL-V2-DRAFT.md
@@ -1,0 +1,1173 @@
+# Ontology Model V2 — DRAFT (제안)
+
+> **Status**: 제안 단계. main 머지 전 user 승인 필요.
+> **Author**: 자율 루프 iter#12 (2026-05-01).
+> **Inputs**: C0 (현재 모델 캡처) · C1 (Wikidata 학습) · C2 (Palantir 학습).
+> **Goal**: 현재 *4-layer class + 7-relation TBox + evidence-grounded ABox* 위에 *qualifiers · rank · literal properties · rich references · cardinality · action type* 을 점진 도입해 RDF-star + Foundry-class 표현력에 도달.
+
+---
+
+## 빠른 진입점
+
+> **30초 요약**: 우리 V1.0 은 이미 schema-versioned + evidence-grounded ontology. V2 는 *Wikidata + Palantir* 의 6 갈래 (qualifier · rank · literal · rich-ref · cardinality · action) 를 V1.1~V1.5 5단계 + V2 통합 마이그레이션 으로 점진 도입. 모든 단계가 *markdown frontmatter 호환* + *legacy 데이터 무손실*.
+
+| 누구 | 어디부터 읽어야 |
+|---|---|
+| **새로운 contributor** | §0 (디자인 원칙) → §1 (현재 모델 요약) → §9.1 (단계 매트릭스) → §12 (Glossary) |
+| **이 spec 을 PR 로 옮기는 reviewer** | §10 (체크리스트 90+ 항목) → §11 (open questions) → §13 (관련 spec 일람) |
+| **단계별 implementor** | §0 → §해당-단계 (§2~§7) → §8.1 의 매핑 표 → §10.x 의 추가 검증 |
+| **마이그레이션 위험 평가자** | §9 (도입 순서 + 위험) → §10.7 (V2 phase A~E) → §11 Q1/Q3 |
+| **AI agent / ActionType 보안** | §5 (V1.4) → §10.5 (보안 8 항목) → §11 Q2 → 별도 ACTION-TYPE-SECURITY spec (작성 예정) |
+| **로컬 사용자** | §8 (Markdown-first 헌장) → §8.1 (frontmatter 매핑 예제) → `docs/LOCAL-FIRST-SYNC.md` |
+| **단순 ontology 학습** | §1 → §12 (Glossary) → 외부 레퍼런스 |
+
+## 목차
+
+- §0 [디자인 원칙](#0-디자인-원칙) — 16 원칙 (구조 / 안전 / 사용자 신뢰 / 운영)
+- §1 [현재 모델 요약 (V1.0)](#1-현재-모델-요약-v10) — TBox / ABox / governance / public projection 코드 정의
+- §2 [V1.1 — Qualifiers + Rank](#2-v11--statement-qualifiers--rank-wikidata-영감)
+- §3 [V1.2 — Literal Properties](#3-v12--literal-properties-wikidata-영감)
+- §4 [V1.3 — Rich References](#4-v13--rich-references-wikidata-영감)
+- §5 [V1.4 — Action Type](#5-v14--action-type-palantir-영감) — *별도 보안 spec 필요*
+- §6 [V1.5 — Relation Cardinality](#6-v15--relation-cardinality-palantir-영감)
+- §7 [V2 — 통합 Statement 모델](#7-v2--통합-statement-모델-목표-도착)
+- §8 [오픈소스 차별점 — Markdown-first](#8-오픈소스-차별점--markdown-first)
+- §8.1 [Markdown ↔ Firestore 매핑](#81-markdown--firestore-매핑-v1x-단계별-검증)
+- §9 [도입 순서 + 위험](#9-점진-도입-순서--위험) — critical path · 거절 기준 · 일정
+- §10 [User 승인 체크리스트](#10-user-승인-체크리스트) — PR 머지 전 90+ 항목
+- §11 [Open questions](#11-open-questions-user-답-필요) — P0/P1/P2 우선순위
+- §12 [Glossary](#12-glossary) — 50+ 용어
+- §13 [관련 spec 일람](#13-관련-spec-일람) — paths-changed cross-reference
+
+> 본 spec 은 시간이 지나며 *6 카테고리* 에서 정리된다: **개념 학습 (§1, §12) → 단계 정의 (§2~§7) → 호환 검증 (§8, §8.1) → 도입 가이드 (§9, §10) → 결정 대기 (§11) → 외부 cross-link (§13)**. 각 카테고리는 독립적으로 머지 / 보류 가능.
+
+---
+
+## 0. 디자인 원칙
+
+### 0.1 구조 원칙
+
+1. **Additive first** — V1.x 는 모두 *기존 컬렉션에 옵셔널 필드 추가* 만. legacy fact 는 한 번도 마이그레이션 없이 작동.
+2. **Single-folder onboarding 보존** — 사용자는 여전히 markdown 폴더 하나로 시작. 새 컬렉션이 늘어도 *로컬 모드는 무시* 가능해야 함.
+3. **TBox versioning 1급 시민** — 새 필드도 모두 `OntologyTBoxVersion` snapshot 에 잡혀야 함.
+4. **Trademark 회피** — `Foundry`, `AIP`, `Wikibase` 등을 우리 식별자에 박지 않는다. 개념만 차용.
+5. **로컬 / 클라우드 동등** — 모든 V2 개념은 markdown frontmatter 로도 표현 가능해야 함 (local-first 룰 준수).
+
+### 0.2 안전 원칙 (data loss prevention / rollback)
+
+이 원칙들은 *모든 V1.x PR 이 위반 안 했음을 §10 체크리스트로 검증* 한다.
+
+6. **Roll-forward + Roll-back 양방향 호환** — 새 코드는 legacy 데이터 read OK (이미 §10.1 BC 항목). *그리고* 이전 코드는 새 데이터 read 시 unknown 필드 무시 + crash 0. 단방향만 호환되는 단계는 **즉시 거절** (V1.x 의 schema 진화는 옵셔널 필드만이라 자동 만족, V2 는 dual-read phase 가 명시).
+7. **Audit chain 불가역** — `lastApprovedAt` / `currentRevisionId` / `manualAuthor` 등 governance 필드는 PR 마다 *손실 0* 검증 (§10.7 Phase B backfill 의 1:1 매핑 강제). audit 누락 = 데이터 손실 = 즉시 PR revert.
+8. **Public projection 무결성 우선** — admin canonical 변경이 public projection (`knowledgePublicNodes/Edges`) 의 사용자 경험을 깨면 안 됨. publish event 가 항상 *전후 무결* (rolled-back 가능성 보존). V2 마이그레이션은 publish event 의 `sourceApprovedRevision` 를 statement-aware 로 갱신해야.
+9. **데이터 삭제는 phase 가 분리** — V2 Phase D (legacy read 차단) 이후에도 legacy doc 자체는 *보관*. 실 삭제는 별도 PR + 30일 grace period + audit log. 운영 중 *직접 컬렉션 drop* 명시 금지.
+10. **모든 destructive 변경에 dry-run** — V2 Phase B backfill / V1.2 의 `summary` → `description` 마이그레이션 등 mutation 은 운영 실행 전 dry-run 필수. 결과 (예상 read row 수 / write row 수 / 충돌 row 수 / skip row 수) 가 PR 본문에 첨부되어야 한다 (§10.7 Phase A 명시).
+
+### 0.3 사용자 신뢰 원칙
+
+11. **사용자 데이터의 *모든* 변경은 audit 가 따라간다** — manual edit / AI 추출 / migration / rollback 모두 audit collection 에 기록. *조용히* 사용자 데이터를 바꾸는 코드 path 를 **만들지 말 것**.
+12. **사용자 디스크는 신성 — 자동 sync 금지** — `.claude/rules/local-first.md` 와 `docs/LOCAL-FIRST-SYNC.md` 헌장. 로컬 → 클라우드 push 는 *항상 사용자 명시 opt-in*. 자동 추출 / 자동 publish / 자동 delete 금지.
+13. **AI 출력은 stub 으로만 진입** — V1.4 ActionType 의 `humanReview` 가 default `'always'`. extract / propose / merge 가 *직접* canonical 노드/엣지를 만드는 게 아니라 *항상* 검수 큐의 stub. 사람 승인 후에만 fact.
+
+### 0.4 운영 원칙
+
+14. **모든 phase 사이에 30일 cool-off** — V2 Phase A → B → C → D → E 사이 최소 30일. 사용자 보고 zero-issue 검증 후 다음 phase. (Q3 답에 따라 phase C 만 90일 또는 길게.)
+15. **rollback PR 미리 작성** — 각 V1.x 단계 / V2 phase 마다 *되돌리는* PR template 을 같이 PR description 에 첨부 (§10.7 Rollback plan). 머지 후 issue 발생 시 *분 단위* revert 가능해야.
+16. **observability first** — 새 컬렉션 / 필드 / Action 의 *write 비율 / 실패 비율 / latency p99* 가 첫날부터 dashboard 화. metric 없는 변경은 거절.
+
+---
+
+## 1. 현재 모델 요약 (V1.0)
+
+### 1.1 컬렉션 관계도
+
+```mermaid
+flowchart LR
+  subgraph TBox["TBox (schema)"]
+    OC[ontologyClasses]
+    OR[ontologyRelations]
+    OTV[ontologyTBoxVersions]
+    OTS[ontologyTBoxState]
+    OC -.snapshot.-> OTV
+    OR -.snapshot.-> OTV
+    OTS -- pointer --> OTV
+  end
+
+  subgraph ABox["ABox (canonical, admin-private)"]
+    KAN[knowledgeApprovedNodes]
+    KAE[knowledgeApprovedEdges]
+    KE[knowledgeEvidence]
+    KAN -- evidenceIds --> KE
+    KAE -- evidenceIds --> KE
+    KAN -- kind --> OC
+    KAE -- type --> OR
+    KAN -.tboxVersionId.-> OTV
+    KAE -.tboxVersionId.-> OTV
+  end
+
+  subgraph Audit["Governance / audit"]
+    KAPE[knowledgeApprovalEvents]
+    KRE[knowledgeReviewEvents]
+    KP[knowledgePublishes]
+    KAPE --> KAN
+    KAPE --> KAE
+    KRE --> KAN
+    KRE --> KAE
+    KP -- sourceApprovedRevision --> KAPE
+  end
+
+  subgraph Public["Public projection"]
+    KPN[knowledgePublicNodes]
+    KPE[knowledgePublicEdges]
+    KPM[knowledgePublicMeta]
+  end
+
+  KAN ==publish==> KPN
+  KAE ==publish==> KPE
+  KP --> KPM
+  KP --> KPN
+  KP --> KPE
+
+  classDef tbox fill:#eef2ff,stroke:#5e6ad2,stroke-width:2px;
+  classDef abox fill:#fff7ed,stroke:#d4b478,stroke-width:2px;
+  classDef audit fill:#f0fdf4,stroke:#27a644,stroke-width:1px,stroke-dasharray: 4 2;
+  classDef public fill:#f1f5f9,stroke:#8a8f98,stroke-width:1px;
+  class OC,OR,OTV,OTS tbox
+  class KAN,KAE,KE abox
+  class KAPE,KRE,KP audit
+  class KPN,KPE,KPM public
+```
+
+**핵심 4 영역**:
+- **TBox** (schema) — class / relation 정의 + immutable snapshot. fact 가 만들어진 시점 schema 가 `tboxVersionId` 로 freeze.
+- **ABox** (canonical, admin-private) — 실 entity / fact 들. 모든 fact 가 evidence 와 link.
+- **Governance** — approval / review event 로 변경 이력 보존. revertable. publish 가 canonical → public 의 sealed audit.
+- **Public projection** — 외부 공개용 단방향 사영. publish event 로만 갱신.
+
+V2 통합 모델 (§7) 은 이 4 영역의 *경계* 를 그대로 보존한다 — `knowledgeStatements` 컬렉션이 ABox 만 흡수, governance / public projection 은 *그대로 호환*.
+
+### 1.2 TypeScript 타입 정의
+
+```ts
+// TBox
+interface OntologyClass {
+  id: string;                // e.g. 'project', 'capability', 'element'
+  name: string;
+  description?: string;
+  parentClassId?: string;    // class hierarchy
+  elementType?: OntologyElementType;
+  version: number;
+  ...timestamps + author
+}
+
+interface OntologyRelation {
+  id: string;                // e.g. 'depends_on'
+  name: string;
+  inverseName?: string;
+  sourceClassIds: string[];  // domain 제약
+  targetClassIds: string[];  // range 제약
+  category: 'structure' | 'behavior' | 'evidence' | 'weak';
+  symmetric: boolean;
+  transitive: boolean;
+  version: number;
+  ...
+}
+
+interface OntologyTBoxVersion {
+  versionId: string;
+  classes: OntologyClass[];
+  relations: OntologyRelation[];
+  ...
+}
+
+// ABox — canonical (admin-private)
+interface KnowledgeApprovedNode {
+  id: string;                  // <kind>:<frontmatterId>
+  title: string;
+  kind: string;                // = OntologyClass.id
+  projectIds: string[];
+  parentId?: string;
+  summary?: string;
+  evidenceIds: string[];
+  // -- audit / governance (이미 존재 — V2 도 보존)
+  currentRevisionId?: string;  // 최근 approval event ID
+  lastApprovedAt: Timestamp;
+  lastApprovedBy: string;      // admin 이메일
+  source?: 'manual' | 'extraction';
+  manualAuthor?: string;       // source==='manual' 시 작성자 uid
+  manualNote?: string;         // source==='manual' 시 메모
+  tboxVersionId?: string;      // 검수 시점 활성 TBox version
+  // -- stub / forward-ref
+  isStub?: boolean;            // placeholder (검수 큐 별도 섹션)
+  pendingType?: string;        // stub promote 시 복원할 edge type
+  pendingFromId?: string;      // stub promote 시 복원할 source canonical ID
+}
+
+interface KnowledgeApprovedEdge {
+  id: string;
+  from: string;                // node id
+  to: string;
+  type: string;                // = OntologyRelation.id
+  projectIds: string[];
+  evidenceIds: string[];
+  // -- audit / governance (이미 존재 — V2 도 보존)
+  currentRevisionId?: string;
+  lastApprovedAt: Timestamp;
+  lastApprovedBy: string;
+  source?: 'manual' | 'extraction';
+  manualAuthor?: string;
+  manualNote?: string;
+  tboxVersionId?: string;
+}
+
+// Evidence — node/edge 별 별도 doc
+interface KnowledgeEvidence {
+  id: string;
+  // ... documentId / chunkId / fragment / locator 등 (구체 schema 는 docs/DATA-MODEL.md)
+  // V1.3 가 retrievedAt / statedInNodeId / extractionModelId / confidence 추가.
+}
+
+// Governance / audit 컬렉션 (이미 존재)
+interface KnowledgeApprovalEvent {
+  id: string;
+  // ... 노드/엣지 승인 history. revertable.
+  revertsEventId?: string;
+}
+
+interface KnowledgeReviewEvent {
+  id: string;
+  // ... 검수 큐 이벤트 (요청 / 처리 / 코멘트).
+}
+
+interface KnowledgePublish {
+  id: string;
+  status: 'running' | 'succeeded' | 'failed' | 'rolled-back';
+  initiatedBy: string;
+  startedAt: Timestamp;
+  completedAt?: Timestamp;
+  sourceApprovedRevision: string;
+  nodeCount?: number;
+  edgeCount?: number;
+  projectionVersion: string;
+  rollbackOfPublishId?: string;
+  // ... canonical → public projection 의 sealed audit
+}
+
+// Public projection (canonical 의 단방향 사영, publish 시 갱신)
+// = knowledgePublicNodes / knowledgePublicEdges / knowledgePublicMeta
+//   필드는 canonical 의 부분집합 + publishId / projectionVersion / publishedAt.
+```
+
+이미 갖춰진 **강점**:
+- Schema versioning (`OntologyTBoxVersion` immutable snapshot + `tboxVersionId` 박힘)
+- Evidence grounding (`evidenceIds[]` 모든 fact 가 evidence 에 link)
+- Source/target class 제약 (rdfs:domain/range 비슷)
+- Symmetric / transitive 메타 (OWL property characteristics)
+- **Approval / review event audit** — `knowledgeApprovalEvents`, `knowledgeReviewEvents` 가 모든 변경 이력 보존, revert 가능
+- **Manual vs extraction source 추적** — `manualAuthor` / `manualNote` 로 사용자 직접 작성 vs AI 추출 구분
+- **Stub forward-ref** — `isStub`, `pendingType`, `pendingFromId` 로 placeholder 노드를 promote 시 정확 복원
+- **Public/private projection 분리** — admin canonical (`knowledgeApprovedNodes/Edges`) → public (`knowledgePublicNodes/Edges`) via sealed publish event
+
+**갭** (V2 가 채울 것):
+- Literal property (node atomic property)
+- Statement qualifier (조건부 / 시간 한정자)
+- Rank (다중 statement 우선순위)
+- Rich reference metadata (retrievedAt / extractionModelId / confidence)
+- Relation cardinality
+- Declarative ActionType (현재 implicit approval/review event 들이 흡수 대상)
+
+> 중요: V2 의 `KnowledgeStatement` 통합 모델은 위 **audit / governance 필드를 모두 보존** 해야 한다. `lastApprovedAt`, `currentRevisionId`, `manualAuthor`, `tboxVersionId` 가 statement 의 *immutable history* 의 일부 — V2 마이그레이션 시 누락 시 데이터 손실. §10.7 Phase B backfill 검증에서 이 필드들의 1:1 mapping 명시.
+
+---
+
+## 2. V1.1 — Statement Qualifiers + Rank (Wikidata 영감)
+
+**컬렉션 변경**: `knowledgeApprovedEdges` 에 **옵셔널** 필드 2개 추가.
+
+```ts
+interface KnowledgeApprovedEdgeV11 extends KnowledgeApprovedEdge {
+  /**
+   * Statement 한정자. property-value 쌍 배열.
+   * 예: [{propertyId: 'since', value: '2024-Q1'}, {propertyId: 'via', value: 'REST'}]
+   * propertyId 는 새로 만들 `ontologyQualifierProperties` 의 id 또는
+   * 기존 OntologyRelation.id 를 재사용 (TBox 가 둘 다 허용하면).
+   */
+  qualifiers?: Array<{ propertyId: string; value: QualifierValue }>;
+
+  /**
+   * 같은 (from, to, type) 의 다중 statement 우선순위.
+   * 'normal' 이 default. legacy edge 는 모두 normal 로 해석.
+   */
+  rank?: 'preferred' | 'normal' | 'deprecated';
+}
+
+type QualifierValue =
+  | { kind: 'string'; raw: string }
+  | { kind: 'time'; iso: string; precision: 'year' | 'month' | 'day' }
+  | { kind: 'quantity'; value: number; unit?: string }
+  | { kind: 'nodeRef'; nodeId: string };
+```
+
+**호환**: legacy edge 는 `qualifiers` 없음 / `rank` undefined → 코드는 `rank ?? 'normal'` 폴백.
+**TBox 변경**: 없음 (현 OntologyRelation 그대로).
+**UI 변경**: edge 편집기에 "한정자 추가" 버튼 (옵션). preferred/deprecated 토글.
+**마이그레이션**: 없음.
+
+---
+
+## 3. V1.2 — Literal Properties (Wikidata 영감)
+
+**새 컬렉션**: `knowledgeApprovedLiterals/{literalId}` — node 의 atomic property.
+
+```ts
+interface KnowledgeApprovedLiteral {
+  id: string;
+  subjectId: string;             // = KnowledgeApprovedNode.id
+  propertyId: string;            // = OntologyLiteralProperty.id (새 TBox 컬렉션)
+  value: QualifierValue;         // V1.1 의 동일 union 재사용
+  qualifiers?: Array<{ propertyId: string; value: QualifierValue }>;
+  evidenceIds: string[];
+  rank?: 'preferred' | 'normal' | 'deprecated';
+  source?: 'manual' | 'extraction';
+  tboxVersionId?: string;
+  ...timestamps
+}
+```
+
+**새 TBox 컬렉션**: `ontologyLiteralProperties/{propertyId}`
+
+```ts
+interface OntologyLiteralProperty {
+  id: string;                       // e.g. 'description', 'color', 'releasedAt'
+  name: string;
+  description?: string;
+  subjectClassIds: string[];        // 어느 class 에 붙을 수 있는지
+  valueKind: 'string' | 'time' | 'quantity' | 'nodeRef';
+  cardinality?: 'one' | 'many';     // V1.5 의 cardinality 와 통합
+  version: number;
+  ...
+}
+```
+
+**호환**: 기존 node 의 `summary` / `title` 자유 텍스트 그대로 유지. 새 literal property 는 *추가 정보*. `summary` 는 V2 에서 description literal 로 마이그레이션 후보.
+**TBox snapshot 영향**: `OntologyTBoxVersion` 에 `literalProperties: OntologyLiteralProperty[]` 추가.
+**Markdown 표현**: frontmatter 의 임의 키 = literal property ID. 예:
+```yaml
+---
+id: doc:checkout
+kind: capability
+description: 결제 요청부터 정산까지의 흐름  # → literal property
+releasedAt: 2024-03-15                    # → literal property
+---
+```
+
+---
+
+## 4. V1.3 — Rich References (Wikidata 영감)
+
+**컬렉션 변경**: `knowledgeEvidence/{evidenceId}` 에 옵셔널 필드 추가.
+
+```ts
+interface KnowledgeEvidenceV13 {
+  // ...기존 필드
+  /** 이 evidence 가 추출된 시점 (= 외부 자료 fetch 시각). */
+  retrievedAt?: Timestamp;
+  /** 출처가 *다른 ontology node* (예: '다른 위키 페이지') 일 때. */
+  statedInNodeId?: string;
+  /** AI 추출이 만든 evidence 면 그 모델 식별자 (예: 'opus-4.7-claude'). 사람 검수면 undefined. */
+  extractionModelId?: string;
+  /** evidence 자체의 confidence (0..1). */
+  confidence?: number;
+}
+```
+
+**호환**: 모두 옵셔널.
+**가치**: AI 추출 vs 사람 검수 vs 외부 import 구분. confidence 누적이 rank 자동 결정에 입력.
+
+---
+
+## 5. V1.4 — Action Type (Palantir 영감) — **DEFERRED**
+
+> ⚠️ **2026-05-01 업데이트**: AI 추출 path 가 v0.x 보류됐다 (LLM API 비용 부담). V1.4 의 핵심 가치 = `aiCallable: true` Action 으로 *AI agent 통합*. AI 의존이 빠지면 V1.4 는 단순 audit/event 통합 레이어만 남는데, 그것은 기존 `knowledgeApprovalEvents` + `knowledgeReviewEvents` 로 이미 처리된다. 따라서 **V1.4 는 V2 통합 spec 의 *후순위*로 미룬다**. AI 추출 도입 결정 (별도 spec) 후 재평가.
+
+
+
+**새 TBox 컬렉션**: `ontologyActionTypes/{actionTypeId}`
+
+```ts
+interface OntologyActionType {
+  id: string;                              // e.g. 'extract-from-document', 'merge-nodes'
+  name: string;
+  description?: string;
+
+  /** 입력 schema. JSON-schema-lite. */
+  parameters: Array<{
+    name: string;
+    valueKind: 'string' | 'time' | 'quantity' | 'nodeRef' | 'classId' | 'relationId';
+    required: boolean;
+    enum?: unknown[];                      // dropdown / 검증
+    description?: string;
+  }>;
+
+  /** 변경 가능한 entity / relation. 화이트리스트. */
+  mutates: Array<
+    | { kind: 'node'; classId: string; op: 'create' | 'update' | 'delete' }
+    | { kind: 'edge'; relationId: string; op: 'create' | 'update' | 'delete' }
+    | { kind: 'literal'; propertyId: string; op: 'create' | 'update' | 'delete' }
+  >;
+
+  /** AI agent 가 호출 가능한지. */
+  aiCallable: boolean;
+
+  /** human review gate. 'always' 면 결과는 항상 stub → 검수 큐. */
+  humanReview: 'always' | 'on-conflict' | 'never';
+
+  version: number;
+  ...
+}
+```
+
+**새 컬렉션**: `knowledgeActionInvocations/{invocationId}` — 각 호출 인스턴스.
+
+```ts
+interface KnowledgeActionInvocation {
+  id: string;
+  actionTypeId: string;
+  parameters: Record<string, unknown>;
+  invokedBy: string;                  // uid 또는 'ai:opus-4.7'
+  invokedAt: Timestamp;
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'awaiting-review';
+  outputs?: {
+    createdNodeIds?: string[];
+    createdEdgeIds?: string[];
+    createdLiteralIds?: string[];
+    errorMessage?: string;
+  };
+  reviewEventId?: string;            // 사람 검수 결과 (knowledgeReviewEvents 와 연결)
+  tboxVersionId: string;
+}
+```
+
+**기존 통합**: `knowledgeApprovalEvents` + `knowledgeReviewEvents` 가 ActionInvocation 으로 점진 흡수. *기존 두 컬렉션은 V2 까지 유지* — 마이그레이션 전 dual-write.
+
+**가치**: AI agent 가 LLM tool call 로 ActionType 을 호출. parameter 검증 + mutate 화이트리스트 가 *prompt injection 방어선*.
+
+---
+
+## 6. V1.5 — Relation Cardinality (Palantir 영감)
+
+**컬렉션 변경**: `OntologyRelation` 에 옵셔널 필드 2개.
+
+```ts
+interface OntologyRelationV15 extends OntologyRelation {
+  /** source node 가 같은 relation 으로 향할 수 있는 target 개수 제약. */
+  sourceCardinality?: 'one' | 'many';
+  /** target node 가 받을 수 있는 source 개수 제약. */
+  targetCardinality?: 'one' | 'many';
+}
+```
+
+예: `belongs_to` 의 `sourceCardinality = 'one'` (한 node 는 한 부모만) — 검증 시 에러.
+**호환**: undefined = 'many' / 'many' (= 현재 동작).
+**적용**: edge 생성 / approve 단계에서 검증.
+
+---
+
+## 7. V2 — 통합 Statement 모델 (목표 도착)
+
+V1.1 ~ V1.5 까지 도입하면 ABox 가 다음 3 컬렉션에 분산:
+- `knowledgeApprovedEdges` (relation statement)
+- `knowledgeApprovedLiterals` (atomic property statement)
+- `knowledgeActionInvocations` (action history)
+
+**V2 에서 통합**: `knowledgeStatements/{statementId}` 단일 컬렉션.
+
+```ts
+interface KnowledgeStatement {
+  id: string;
+  subjectId: string;                  // = node.id
+  predicate: { kind: 'relation' | 'literal'; id: string };
+  object:
+    | { kind: 'nodeRef'; nodeId: string }
+    | { kind: 'value'; value: QualifierValue }
+    | { kind: 'none' }                // "no value" — 명시적 부재
+    | { kind: 'unknown' };            // "unknown" — 아직 모름 (= 기존 isStub 상응)
+  qualifiers?: Array<{ propertyId: string; value: QualifierValue }>;
+  rank: 'preferred' | 'normal' | 'deprecated';
+  references: Array<{
+    evidenceId: string;
+    retrievedAt?: Timestamp;
+    statedInNodeId?: string;
+    extractionModelId?: string;
+    confidence?: number;
+  }>;
+  source: 'manual' | 'extraction' | 'action';
+  invocationId?: string;              // ActionInvocation 으로부터 만들어졌으면
+  tboxVersionId: string;
+  ...timestamps + author
+}
+```
+
+이 시점부터 RDF-star 호환 export 가 자연스러움 (statement 가 1급, qualifier 가 statement 의 annotation).
+
+**V2 마이그레이션**: 별도 commit / PR 로. dual-write 단계 → backfill → 기존 컬렉션 read 차단 → 삭제. 최소 한 minor version 의 dual-read 기간.
+
+---
+
+## 8. 오픈소스 차별점 — Markdown-first
+
+각 V1.x 단계에서 *markdown frontmatter 만으로* 동등한 표현이 가능해야 한다. 사용자가 자기 디스크 폴더에 .md 파일을 두고도:
+
+- `---` frontmatter 로 literal property 작성
+- 본문 wikilink `[[other-doc]]` 가 relation
+- 별도 `_qualifiers.md` 또는 frontmatter 의 객체값으로 qualifier
+- `_actions.md` 가 ActionType 정의 (옵션, 클라우드 모드만)
+
+→ 클라우드 sync 시 같은 의미가 Firestore 컬렉션으로 1:1 변환.
+
+이 매핑이 깨지면 V1.x 단계 자체를 거절. **markdown 표현이 안 되면 그 V 는 우리 mission 에 반함**.
+
+---
+
+## 8.1 Markdown ↔ Firestore 매핑 (V1.x 단계별 검증)
+
+각 단계의 *동등 표현* 을 구체 예제로 명시. 좌측 = 사용자 디스크의 `.md`, 우측 = sync 시 만들어지는 Firestore document.
+
+### V1.0 (현재) — 기준선
+
+```yaml
+# vault/projects/checkout.md
+---
+id: project:checkout
+kind: project
+title: 결제 시스템
+parents: []
+projects: [checkout]
+summary: 결제 요청부터 정산까지의 흐름
+---
+
+# 결제 시스템
+
+[[doc:payment-spec]] 에 명시된 흐름을 구현. [[capability:tax]] 에 의존.
+```
+
+→ Firestore:
+- `knowledgeApprovedNodes/project:checkout` ← frontmatter + summary
+- `knowledgeApprovedEdges/<auto>` × 2 ← 본문 wikilink (`describes` + `depends_on` 추출)
+- `knowledgeEvidence/<auto>` × 2 ← wikilink 의 출현 위치 + 컨텍스트
+- `tboxVersionId` ← sync 시점의 활성 version
+
+이미 동작. 마이그레이션 0.
+
+### V1.1 — Qualifiers + Rank
+
+```yaml
+---
+id: project:checkout
+kind: project
+title: 결제 시스템
+relations:
+  - type: depends_on
+    target: capability:tax
+    qualifiers:
+      since: 2024-Q1
+      via: REST
+    rank: preferred
+  - type: depends_on
+    target: capability:tax-legacy
+    rank: deprecated
+    qualifiers:
+      until: 2024-Q1
+---
+```
+
+→ Firestore (`knowledgeApprovedEdges/<auto>` × 2):
+```json
+{ "from": "project:checkout", "to": "capability:tax",
+  "type": "depends_on",
+  "qualifiers": [
+    {"propertyId": "since", "value": {"kind": "time", "iso": "2024-Q1", "precision": "month"}},
+    {"propertyId": "via", "value": {"kind": "string", "raw": "REST"}}
+  ],
+  "rank": "preferred" }
+{ "from": "project:checkout", "to": "capability:tax-legacy",
+  "type": "depends_on",
+  "qualifiers": [{"propertyId": "until", "value": {"kind": "time", "iso": "2024-Q1", "precision": "month"}}],
+  "rank": "deprecated" }
+```
+
+**호환 규칙**: frontmatter 에 `relations` 키가 없으면 V1.0 동작 그대로 (본문 wikilink 만 추출). `relations` 키가 있으면 **추가** 로 처리 (본문 wikilink 와 합산).
+
+### V1.2 — Literal Properties
+
+```yaml
+---
+id: project:checkout
+kind: project
+title: 결제 시스템
+properties:
+  description: 결제 요청부터 정산까지의 흐름
+  releasedAt: 2024-03-15
+  tier: premium
+  estimatedTPS:
+    value: 12000
+    unit: tps
+---
+```
+
+→ Firestore:
+- `knowledgeApprovedNodes/project:checkout` (변경 없음)
+- `knowledgeApprovedLiterals/<auto>` × 4:
+  ```json
+  {"subjectId": "project:checkout", "propertyId": "description", "value": {"kind": "string", "raw": "결제 요청부터 정산까지의 흐름"}}
+  {"subjectId": "project:checkout", "propertyId": "releasedAt", "value": {"kind": "time", "iso": "2024-03-15", "precision": "day"}}
+  {"subjectId": "project:checkout", "propertyId": "tier", "value": {"kind": "string", "raw": "premium"}}
+  {"subjectId": "project:checkout", "propertyId": "estimatedTPS", "value": {"kind": "quantity", "value": 12000, "unit": "tps"}}
+  ```
+
+**호환 규칙**:
+- 기존 `summary` (top-level frontmatter) 는 자동으로 `description` literal 로 마이그레이션 (frontmatter 의 `properties.description` 가 우선).
+- `properties.*` 의 키가 등록된 `OntologyLiteralProperty.id` 가 아니면 *자동 등록 후보* 로 검수 큐 (auto-create 하지 않음).
+- TBox active version 에 없는 property 는 sync 시 warning 표시.
+
+### V1.3 — Rich References
+
+```yaml
+---
+id: project:checkout
+kind: project
+properties:
+  description: 결제 요청부터 정산까지의 흐름
+references:
+  description:
+    - source: doc:payment-spec
+      retrievedAt: 2025-11-12
+      confidence: 0.95
+    - source: external:rfc-9457
+      retrievedAt: 2024-06-01
+      extractionModel: opus-4.7
+---
+```
+
+→ Firestore:
+- `knowledgeApprovedLiterals/<...>` 의 `evidenceIds[]` 가 채워지고
+- `knowledgeEvidence/<id1>`: `{ retrievedAt: 2025-11-12, statedInNodeId: "doc:payment-spec", confidence: 0.95 }`
+- `knowledgeEvidence/<id2>`: `{ retrievedAt: 2024-06-01, extractionModelId: "opus-4.7" }`
+
+**호환 규칙**: 기존 `evidenceIds[]` 만 있는 fact 는 그대로. `references` 추가는 super-set.
+
+### V1.4 — Action Type
+
+```yaml
+# vault/_actions/extract-from-document.md
+---
+id: extract-from-document
+kind: actionType
+parameters:
+  - name: documentId
+    valueKind: nodeRef
+    required: true
+  - name: focusClass
+    valueKind: classId
+    required: false
+mutates:
+  - kind: node
+    classId: "*"
+    op: create
+  - kind: edge
+    relationId: describes
+    op: create
+aiCallable: true
+humanReview: always
+---
+
+# 문서로부터 fact 추출
+
+이 action 은 문서를 입력으로 받아 후보 노드/엣지를 stub 으로 만든다.
+사람이 검수 큐에서 승인해야 fact 가 된다.
+```
+
+→ Firestore:
+- `ontologyActionTypes/extract-from-document` ← frontmatter
+- 본문은 `description` literal 로
+- `_actions/` 폴더는 **클라우드 모드 전용** — 로컬 모드는 무시 (action 은 서버 권한 필요)
+
+**호환 규칙**: 로컬 모드에서 `_actions/` 폴더는 *읽지 않음*. 사용자가 클라우드 sync 후에만 적용. 권한 모델 결정은 spec §11 의 open question #2.
+
+### V1.5 — Relation Cardinality
+
+```yaml
+# vault/_relations/belongs_to.md (TBox 정의)
+---
+id: belongs_to
+kind: relationType
+sourceClassIds: [element]
+targetClassIds: [capability, domain, project]
+category: structure
+sourceCardinality: one     # element 는 한 부모만
+targetCardinality: many    # 부모는 여러 자식 가능
+symmetric: false
+transitive: false
+---
+```
+
+→ Firestore (`ontologyRelations/belongs_to`): 동일 shape. `sourceCardinality` / `targetCardinality` 가 옵셔널 필드로 추가.
+
+**호환 규칙**: 기존 `belongs_to` 정의는 cardinality 필드 없음 → `'many'` / `'many'` 로 해석 (현재 동작 유지). cardinality 추가는 `OntologyTBoxVersion` snapshot 에 새 version 으로 박힘.
+
+### V2 — 통합 Statement 모델
+
+```yaml
+---
+id: project:checkout
+kind: project
+statements:
+  - predicate: literal:description
+    object: 결제 요청부터 정산까지의 흐름
+    references:
+      - source: doc:payment-spec
+        confidence: 0.95
+  - predicate: relation:depends_on
+    object:
+      kind: nodeRef
+      id: capability:tax
+    qualifiers:
+      since: 2024-Q1
+    rank: preferred
+  - predicate: literal:owner
+    object:
+      kind: unknown   # 아직 모름
+---
+```
+
+→ Firestore: 모든 statement 가 `knowledgeStatements/<auto>` 단일 컬렉션.
+
+**호환 규칙**: V2 는 *마이그레이션 phase 가 별도 PR*. dual-write 단계에서 V1.2 의 `properties` / V1.1 의 `relations` 키도 *동시에* 받아 둘 다 만들고 read 만 V2 우선. 최소 1 minor version 의 dual-read 후 V1 컬렉션 read 차단.
+
+---
+
+### 매핑 일관성 검증 룰
+
+V1.x 단계가 늘어나면서 frontmatter 가 비대해지는 위험. 다음 룰로 cap:
+
+1. **각 단계 키는 별도 namespace** — `relations:`, `properties:`, `references:`, `statements:` 가 충돌하지 않게 분리.
+2. **로컬 모드에서 빠진 단계는 무시** — V2 가 들어와도 V1.0 frontmatter 만 쓴 사용자는 그대로 동작.
+3. **TBox 알 수 없는 키는 검수 큐로** — auto-create 절대 X. 사람이 ontology 정의 추가 후에야 fact 로 승격.
+4. **frontmatter 와 본문이 충돌하면 frontmatter 우선** — 본문 wikilink 가 만든 edge 와 frontmatter `relations:` 가 같은 (from, to, type) 를 만들면 frontmatter 의 qualifier/rank 채택.
+5. **`_` prefix 폴더는 schema 전용** — `_actions/`, `_relations/`, `_classes/`, `_literals/` 가 TBox 정의 위치. 일반 노드와 구분.
+
+---
+
+## 9. 점진 도입 순서 + 위험
+
+### 9.1 단계별 매트릭스
+
+| 단계 | 위험 | 도입 비용 | 가치 | Open Q (P1 차단) | Schema 변경 | UI 변경 | 새 컬렉션 |
+|---|---|---|---|---|---|---|---|
+| V1.1 qualifiers + rank | 낮음 (옵셔널) | 작음 | 시간/조건부 fact | — | edges 필드 2개 | edge editor 한정자 | X |
+| V1.2 literals | 중간 (새 컬렉션) | 중간 | description / color / atomic property | Q6, Q7 | 신규 entity | property panel | ✅ literals + literalProperties |
+| V1.3 rich refs | 낮음 | 작음 | AI 신뢰도 / 자동화 | Q5 | evidence 필드 4개 | reference badge | X |
+| V1.4 ActionType | **높음** (보안 surface) | 큼 | AI agent 통합 기반 | Q2, Q8 + 별도 spec | 신규 2 entity | action invoker | ✅ actionTypes + actionInvocations |
+| V1.5 cardinality | 낮음 | 작음 | 데이터 무결성 | — | relations 필드 2개 | violation 경고 | X |
+| V2 통합 | **높음** (마이그레이션) | 큼 | RDF-star 호환 | Q3, Q4 | 통합 statements | Statement viewer | ✅ statements (legacy 흡수) |
+
+### 9.2 Critical path
+
+다음 단계는 *후속 단계의 전제* 라 우회 불가:
+
+```
+V1.1 ───────────────┐
+                    ├─→ V1.3 ─→ V2 (Phase A dual-write)
+V1.2 ─→ V1.5 ──────┘                  ↓
+                                      V2 (Phase B-E)
+V1.4 (독립적, 다른 스택과 직교)
+```
+
+**필수 dependency**:
+- **V2 ⟸ V1.1 + V1.2 + V1.3** — V2 통합 statement model 의 qualifier·literal·reference 표현이 그대로 흡수돼야 함. V1.x 가 모두 미도입이면 V2 스키마가 "고아 필드" 가득.
+- **V1.5 ⟸ V1.2** — cardinality 검증이 literal property 의 `cardinality?` 필드와 통합. V1.2 의 schema 가 먼저.
+- **V1.4 는 독립** — ActionType 은 ABox 위에 *행동 layer* 로 얹히므로 V1.x 다른 단계와 schema 충돌 없음. 별도 트랙 가능.
+
+**우회 가능 dependency**:
+- V1.3 → V1.1 — rich reference 의 confidence 가 rank 자동 결정에 영향 가능 *but* 둘 다 옵셔널이라 도입 순서 swap 가능.
+
+### 9.3 권장 도입 순서 (위험 ascending + critical path 준수)
+
+1. **V1.1 qualifiers + rank** — 가장 안전. 옵셔널 필드 2개. 즉시 시작 가능 (P1 Open Q 없음).
+2. **V1.5 cardinality** — V1.2 전이라 literal cardinality 와 분리 — relation 만 다룸. Q-free.
+3. **V1.3 rich references** — Q5 (extractionModelId 검증) 답 후 시작. 매핑 단순.
+4. **V1.2 literals** — Q6 (summary 마이그레이션) + Q7 (naming scope) 답 후. 새 컬렉션 + frontmatter 파서 큰 변경.
+5. **V1.4 ActionType** — *별도 deep spec (ACTION-TYPE-SECURITY.md)* 통과 후. Q2 + Q8 답 필요. **다른 트랙과 병렬 가능** — V1.1~V1.3 가 진행 중이어도 V1.4 PR 시작 가능 (충돌 없음).
+6. **V2 통합** — V1.1 + V1.2 + V1.3 모두 운영 안정화 (각각 ≥30일) 후. Phase A~E 5 단계 별 PR (§10.7).
+
+### 9.4 보류 / 거절 시나리오
+
+각 단계에 *명시적 거절 기준* — 어떤 데이터가 나오면 단계 자체를 보류해야 하는가:
+
+- **V1.1 거절** — qualifier 의 5 datatype 표현이 frontmatter 에서 사용자에게 *불편* 으로 검증되면 (예: 시간 datatype 의 ISO precision 이 어색). V1.1 PR 머지 전 frontmatter UX 사용자 테스트.
+- **V1.2 거절** — `properties.foo` 가 자유롭게 추가되는 게 검수 큐를 폭주시키면 (예: 사용자가 이름 typo 마다 새 property 후보 발생). literal property 의 *closed-vocabulary* 정책으로 회귀.
+- **V1.4 거절** — security review 에서 prompt-injection 시연이 mutation whitelist 를 우회 가능하면. **즉시 PR revert**.
+- **V2 거절** — backfill dry-run 이 legacy fact 의 ≥1% 를 statement 로 변환 못 하면. 데이터 손실 위험으로 V2 phase A 자체 보류.
+
+### 9.5 일정 가이드 (참고)
+
+순수 *spec* 기준 일정 (구현 시간 X, 검수 / 안정화 / open Q 답 기준):
+
+| 단계 | 시작 기준 | 안정화 | 비고 |
+|---|---|---|---|
+| V1.1 | 즉시 | 30일 운영 후 stable | 옵셔널이라 빠름 |
+| V1.5 | V1.1 stable | 30일 | 짧은 검증 |
+| V1.3 | Q5 답 + V1.5 stable | 30일 | rich evidence 도입 |
+| V1.2 | Q6+Q7 답 + V1.3 stable | 60일 | 큰 변경, 검수 큐 변동 |
+| V1.4 | Q2+Q8 답 + ACTION-TYPE-SECURITY spec 통과 | 90일 | 보안 surface 큼 |
+| V2 Phase A | V1.1+V1.2+V1.3 모두 stable | 30일 dual-write | |
+| V2 Phase B | A stable | backfill 1회 | 운영 일자 단발 |
+| V2 Phase C | B 완료 | 90일 dual-read (Q3 답) | 가장 긴 단계 |
+| V2 Phase D | C 무결 | 30일 | legacy read 차단 |
+| V2 Phase E | D 무결 | — | legacy write 차단, 종료 |
+
+총 V1.1 시작부터 V2 종료까지 가장 빠른 경우 ≈ **9-12 개월**. open question 답 지연 시 더 길어짐.
+
+---
+
+## 10. user 승인 체크리스트
+
+각 V1.x PR 마다 적용. **모든 박스가 체크되지 않은 PR 은 main merge 금지**.
+
+### 10.1 모든 단계 공통 (항상)
+
+**Mission alignment**
+- [ ] §8 / §8.1 의 markdown frontmatter 예제가 *이 단계까지* 의 모든 새 필드를 포함하도록 갱신됐다.
+- [ ] 로컬 모드 (Firebase 없이 디스크만) 에서도 새 frontmatter 가 무시되거나 동작하는 게 검증됐다 (옵션 필드는 무시, 필수 변경은 명시적 fail).
+- [ ] 새 컬렉션 / 필드가 *진실원* 이 markdown 임을 깨지 않는다 — Firestore 가 단방향 사영이거나, 양방향 sync 면 충돌 해소 정책이 §8.1.5 (frontmatter 우선) 에 일치.
+
+**Security**
+- [ ] `firestore.rules` 가 새 필드 / 컬렉션을 읽기·쓰기 권한별로 명시.
+- [ ] Emulator 로 *공격 시나리오 3종* 테스트: 비로그인 쓰기 / 비인가 사용자 쓰기 / `admins/*` 직접 쓰기 — 모두 거부.
+- [ ] client 가 절대 쓸 수 없어야 하는 필드 (예: `tboxVersionId`, `lastApprovedAt`, `lastApprovedBy`, `currentRevisionId`) 가 rules 의 `allow update: if false` 로 잠겨있다.
+- [ ] 서버 (Cloud Functions) 만 쓸 수 있는 collection 은 `allow create/update/delete: if false` 한 다음 admin SDK 로만 write.
+
+**Schema 변경 프로세스 (.claude/rules/firestore-schema.md)**
+- [ ] `docs/DATA-MODEL.md` 에 새 필드 / 컬렉션 명시 (필수/옵션 / 타입 / 설명).
+- [ ] `src/entities/*/model/types.ts` 가 같이 갱신.
+- [ ] `src/entities/*/api/*` 의 mapper / fromFirestore / toFirestore 가 같이 갱신 + 단위 test 라운드트립.
+- [ ] `firestore.indexes.json` 에 새 query 가 필요로 하는 복합 인덱스 정의.
+- [ ] `scripts/seed.ts` (있으면) 가 새 필드를 채우거나 의도적으로 비워두는 정책 명시.
+- [ ] `docs/CHANGELOG.md` 에 날짜 + 단계 + 한 줄 요약.
+
+**Test coverage**
+- [ ] 영향 받는 mapper / 변환 함수에 *라운드트립* 단위 test (TS 객체 → Firestore doc → TS 객체 = identity).
+- [ ] 기존 e2e 가 깨지지 않음 (`pnpm exec playwright test`).
+- [ ] *legacy 데이터* 에 새 코드를 적용해도 read 가 통과 (옵션 필드 부재 시 default 값 사용 검증).
+- [ ] Vitest run: `pnpm test:run` 0 fail.
+- [ ] tsc / lint / build 0 error.
+
+**Backwards-compatibility**
+- [ ] 새 필드는 모두 옵셔널 (V1.x 단계). 필수 추가가 정말 필요하면 *별도 spec PR* 로 분리.
+- [ ] 코드 path 가 `field ?? default` 로 legacy 핸들링.
+- [ ] *roll-forward only* 아니라 *roll-back* 도 가능한지 검증: 이전 버전 코드가 새 필드가 박힌 doc 를 읽어도 crash 없이 무시.
+
+**Observability**
+- [ ] 새 필드 / collection 의 write 가 `clientErrors` / Cloud Functions log 에 누적되지 않는 (정상) 흐름 확인.
+- [ ] 새 critical path 에 console.log → `clientErrors` 또는 `developerActivityEvents` 기록.
+
+### 10.2 V1.1 — Qualifiers + Rank
+
+추가:
+- [ ] frontmatter 의 `relations: [...]` 파서 단위 test (qualifier value 의 5종 datatype 모두 round-trip).
+- [ ] *본문 wikilink* 와 `relations:` 가 동일 (from, to, type) 를 만들 때 §8.1.5 룰대로 frontmatter 가 우선되는지 e2e.
+- [ ] `rank: deprecated` edge 가 default UI 에서 숨고 명시적 토글로만 보이는지 시각 회귀.
+- [ ] 같은 (from, to, type, rank) 중복 edge 가 *하나의 doc* 으로 합쳐지는지 (race-write 충돌 방어).
+
+### 10.3 V1.2 — Literal Properties
+
+추가:
+- [ ] `knowledgeApprovedLiterals` 컬렉션의 firestore.rules 가 *evidenceIds 가 빈 manual literal* 도 허용 (검수 큐).
+- [ ] `OntologyLiteralProperty.subjectClassIds` 의 화이트리스트 위반 (예: project 클래스에 등록되지 않은 property 시도) 을 server 가 거부.
+- [ ] frontmatter 의 `properties: { … }` 에서 알 수 없는 키가 *auto-create 되지 않고* 검수 큐로 이동 (§8.1.5 룰).
+- [ ] `summary` legacy 필드 → `description` literal 마이그레이션 plan 명시 (one-shot 또는 dual-read).
+
+### 10.4 V1.3 — Rich References
+
+추가:
+- [ ] `extractionModelId` 가 사용자 입력 string 이 아니라 *서버 화이트리스트* (현재 활성 model 만) 만 받는다.
+- [ ] `confidence` 가 0..1 범위 검증 (rules 또는 server validation).
+- [ ] 기존 evidence 에 새 필드 backfill *자동 X* — 수동 또는 다음 추출 시점에만 채워진다는 것 명시.
+
+### 10.5 V1.4 — Action Type (보안 surface 큼 — 별도 deep spec)
+
+추가 (이 항목들은 *별도 ACTION-TYPE-SECURITY.md spec 통과 후* 체크):
+- [ ] **Parameter validation** — 모든 `parameters[].valueKind` 가 server 측에서 강타입 검증. 누락된 required 거부. enum 값 외 거부.
+- [ ] **Mutation whitelist** — Action 이 `mutates[]` 외의 entity 를 변경하려 하면 transaction 자체 abort. Server-side enforcement, client trust 금지.
+- [ ] **Prompt injection** — `aiCallable: true` action 의 string parameter 는 LLM 이 ontology 컨텍스트의 다른 정보로 변조 가능 — 별도 sanitize / context-isolation 검증.
+- [ ] **AI agent auth** — `aiCallable: true` action 호출은 사용자 OAuth token + 명시적 scope (action ID 별 화이트리스트) 가 모두 있어야 통과 (Open question #2 답 필요).
+- [ ] **Audit completeness** — 모든 `KnowledgeActionInvocation` 이 invokedBy / invokedAt / 입력 / 출력 / 실패 사유까지 immutable. 후속 변조 불가능 (rules `allow update: if false`).
+- [ ] **Human review gate** — `humanReview: 'always'` action 의 출력은 stub 으로만 들어가고, `knowledgeApprovedNodes/Edges` 의 `isStub: true` 가 박힌다.
+- [ ] **Rate limit / quota** — AI agent 가 폭주 호출 시 사용자 quota 차감. Cloud Functions 에 quota 미들웨어.
+- [ ] **로컬 모드 격리** — `_actions/` 폴더는 로컬 모드에서 *읽지 않음*. 클라우드 sync 후에만 적용. parser 가 명시 스킵.
+
+### 10.6 V1.5 — Relation Cardinality
+
+추가:
+- [ ] cardinality 위반 (예: `belongs_to.sourceCardinality = 'one'` 인데 한 element 에 두 belongs_to edge) 을 *server 측* 이 거부 (firestore.rules 또는 Cloud Function).
+- [ ] client 측은 *시각 경고* 만 — server 가 진실원.
+- [ ] 기존 데이터에 cardinality violation 이 있으면 *migration 가이드* 또는 *grace period* 명시 (강제 cleanup 금지).
+- [ ] `OntologyTBoxVersion` snapshot 이 cardinality 추가를 새 version 으로 인식.
+
+### 10.7 V2 — 통합 Statement 모델 (마이그레이션)
+
+V2 PR 은 **단일 commit 으로 머지 금지**. 다음 단계를 **각각 별 PR**:
+
+**Phase 흐름 시각화**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant L as Legacy<br/>(edges/literals)
+  participant S as Statements<br/>(new)
+  participant App as App / clients
+  participant Bk as Backfill job
+
+  rect rgb(238, 242, 255)
+    Note over L,S: Phase A · dual-write (≥30일)
+    App->>L: write
+    App->>S: write (transactional)
+    App->>L: read (Legacy 우선)
+  end
+
+  rect rgb(255, 247, 237)
+    Note over L,S: Phase B · backfill (1회 실행)
+    Bk->>L: scan
+    Bk-->>S: 1:1 변환 write
+    Note over Bk: dry-run 결과 PR 본문 첨부
+  end
+
+  rect rgb(240, 253, 244)
+    Note over L,S: Phase C · dual-read (90일, Q3)
+    App->>L: write
+    App->>S: write (transactional)
+    App->>S: read (Statements 우선)
+    App-->>L: read (fallback only on miss)
+  end
+
+  rect rgb(241, 245, 249)
+    Note over L,S: Phase D · legacy read 차단 (≥30일)
+    App->>L: write (rules 아직 허용)
+    App->>S: write
+    App->>S: read 만
+    Note over L: 데이터는 보관 — read 코드만 제거
+  end
+
+  rect rgb(254, 242, 242)
+    Note over L,S: Phase E · legacy write 차단 (마지막)
+    App--xL: write (firestore.rules 거부)
+    App->>S: write
+    App->>S: read
+    Note over L: 컬렉션 자체 삭제는 별 PR
+  end
+```
+
+**핵심 원칙** (Mermaid 가 못 표현):
+- 각 phase 사이 *최소 30일 cool-off* (§0.4 원칙 14).
+- Phase C 만 *90일 dual-read* — open question Q3 답에 따라 길어질 수도.
+- 각 phase 마다 *되돌리는 PR template* 미리 작성 (§0.4 원칙 15).
+- Phase D / E 는 **되돌릴 수 없는 단계** — Phase C 의 zero-issue 검증 후만 진행.
+
+**Phase A: dual-write 도입**
+- [ ] 새 `knowledgeStatements` 쓰기 path 추가. 기존 `knowledgeApprovedEdges/Literals` 도 *같이* 쓰기 (transactional dual-write).
+- [ ] read path 는 여전히 legacy 우선.
+- [ ] backfill 스크립트 dry-run 결과 (예상 read row 수, write row 수, 충돌 row 수) PR 본문에 첨부.
+
+**Phase B: backfill**
+- [ ] 운영 데이터에 backfill 실행. 결과 audit log (성공 / 실패 / skip) 가 별도 collection 에 영속.
+- [ ] backfill 후 statement count == legacy edge count + literal count 검증.
+
+**Phase C: dual-read 전환**
+- [ ] read path 가 `knowledgeStatements` 우선, fallback only on miss.
+- [ ] 최소 1 minor version (≥ 30 일) dual-read 유지.
+- [ ] 사용자 보고 zero-issue 후 다음 phase 로.
+
+**Phase D: legacy read 차단**
+- [ ] read path 가 statements 만. legacy collection read 코드 제거.
+- [ ] 단, legacy doc 자체는 *삭제하지 않음* — 백업 / 디버그 / rollback 용으로 보관.
+
+**Phase E: legacy write 차단**
+- [ ] firestore.rules 가 legacy collection write 를 거부.
+- [ ] 마지막 phase. 이후 `knowledgeApprovedEdges` 등 컬렉션 제거는 별 PR.
+
+**Rollback plan**
+- [ ] 각 phase 마다 *이전 phase 로 되돌리는* 단일 PR 이 미리 작성되어 있어야 한다 (commit history 에 작성되지 않더라도 PR template 으로).
+- [ ] Phase D / E 는 *되돌릴 수 없는* 단계 — 운영 데이터 손실 위험. 충분한 dual-read 기간 (Phase C) 후에만.
+
+---
+
+## 11. Open questions (user 답 필요)
+
+각 질문에 **우선순위 (P0/P1/P2)**, **막는 단계**, **선택지** 명시. P0 는 spec 자체 main merge 전 답 필요. P1 은 해당 단계 PR 전 답. P2 는 구현 중 점진 결정 가능.
+
+### Q1 — multi-vault 지원 시점 (P0, 모든 V1.x 영향)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | 모든 단계 — multi-vault 면 모든 새 컬렉션이 `accountId` 로 partition 되어야 함. v0.x 가 single 면 partition 키 자체가 사라짐. |
+| **현재 가정** | single-vault (1인 도구). |
+| **선택지** | (a) v0.x = single, v1.0 부터 multi → spec 그대로 진행 (b) 처음부터 multi-vault 도입 → 모든 schema 에 `accountId` 추가 (c) 결정 보류 → spec 자체 대기 |
+| **추천 기본** | (a) — `.claude/rules/local-first.md` 의 "v2 협업 단계에서 도입" 과 일치. v1.0 협업 시점에 별도 spec PR. |
+
+### Q2 — V1.4 ActionType 의 `aiCallable` 인증 모델 (P1, V1.4 전용)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V1.4. 다른 단계는 영향 없음. |
+| **현재 가정** | 미정 — §10.5 의 보안 항목이 이 답에 의존. |
+| **선택지** | (a) Firebase Auth OAuth + `aiActionScopes` claim (action ID 화이트리스트) (b) 외부 LLM 의 OAuth Bearer + 별도 verifier (c) 로컬 모드는 인증 없이 (사용자 디스크 = 사용자 신뢰), 클라우드 모드는 (a) (d) 별도 ACTION-TYPE-SECURITY spec 으로 deepen |
+| **추천 기본** | (c) + (d) — local 은 디스크 권한이 이미 사용자 신뢰선. cloud 는 별도 deep spec 으로 안전성 검증 후 결정. |
+
+### Q3 — V2 dual-read 기간 (P2, V2 마이그레이션 phase C)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V2 Phase C → D 전환 시점. V2 시작 자체는 이 답 없이도 가능. |
+| **현재 가정** | 최소 1 minor version (≥30일) — §10.7 Phase C 명시. |
+| **선택지** | (a) 30일 (b) 90일 (c) 6개월 (d) 무기한 dual-read 유지 — legacy 영구 보존 |
+| **추천 기본** | (b) — backfill 후 90일 사용자 보고 zero-issue 면 안전. (a) 는 catch-up edge-case 에 짧음. (d) 는 인프라 cost. |
+
+### Q4 — Wikidata 의 `none` / `unknown` 매핑 (P1, V2 통합 단계 — Statement.object)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V2. V1.x 까지는 `isStub` 으로 충분. |
+| **현재 가정** | `unknown` = 기존 `isStub: true` (forward ref) 의미 보존. `none` 은 신규. |
+| **선택지** | (a) `unknown` = `isStub`, `none` = `Statement.object.kind: 'none'` 신규 (b) `isStub` 폐기 → `unknown` / `none` 두 새 kind 만 (c) 셋 다 보존 — `isStub` 은 forward-ref 만, `unknown`/`none` 은 명시적 부재/모름 |
+| **추천 기본** | (a) — minimal 변경. 의미상 `isStub` 의 *진짜* 의미가 "존재하지만 아직 anchor 안 잡힘" 이라 `unknown` 과 잘 맞음. |
+
+### Q5 — V1.3 `extractionModelId` 검증 정책 (P1, V1.3)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V1.3. |
+| **현재 가정** | §10.4 가 *서버 화이트리스트* 만 받는다고 명시. |
+| **선택지** | (a) 화이트리스트 정확 매칭 (b) prefix 매칭 (예: `opus-*`, `sonnet-*`) (c) free string + 서버 audit 만 |
+| **추천 기본** | (b) — 모델 minor version 변경에 robust. (a) 는 매번 deploy 필요, (c) 는 audit-only 라 abuse 가능. |
+
+### Q6 — V1.2 `summary` legacy 마이그레이션 방식 (P1, V1.2)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V1.2. |
+| **현재 가정** | "자동으로 `description` literal 로 마이그레이션" 명시 — 방식 미정. |
+| **선택지** | (a) one-shot 스크립트로 일괄 backfill (b) read 시점에 lazy 마이그레이션 (read-and-rewrite) (c) dual-write 기간 후 cutoff |
+| **추천 기본** | (a) — 데이터 양이 작고 (∼ 수백~수천 doc), 일관성이 중요. lazy 는 race / 부분 마이그레이션 위험. |
+
+### Q7 — V1.2 literal property naming scope (P1, V1.2)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V1.2. |
+| **현재 가정** | `OntologyLiteralProperty.subjectClassIds` 가 어느 class 에 적용 가능한지 화이트리스트 — 즉 *property id 는 글로벌 unique*. |
+| **선택지** | (a) 글로벌 unique (현 가정) — `description` 은 어느 class 에서나 같은 의미 (b) class-scoped — `element.color` 와 `project.color` 가 다른 의미일 수 있음 |
+| **추천 기본** | (a) — Wikidata / RDF 가 모두 글로벌 property. mental model 단순. 같은 단어 다른 의미는 별 property id 로 (`element-color` vs `project-color`). |
+
+### Q8 — V1.4 ActionInvocation 보존 기간 (P2, V1.4)
+
+| 측면 | 내용 |
+|---|---|
+| **막는 단계** | V1.4 deploy 후. spec 자체에는 영향 없음. |
+| **현재 가정** | 미정 — audit immutability 만 명시. |
+| **선택지** | (a) 영구 보존 — 디스크 cost 누적 (b) 1년 후 archive 로 이동 (c) 사용자별 quota 기반 자동 prune |
+| **추천 기본** | (b) — 1년 후 cold storage. 법적 / 디버그 요구는 1년이면 충분.
+
+---
+
+> **결론**: 우리 V1.0 은 이미 *4-layer class hierarchy + OWL-flavored relations + immutable schema versioning + evidence-grounded ABox + public projection* 으로 충분히 진보됐다. V2 는 그 위에 *qualifier / literal / action / cardinality* 를 *additive 로* 얹어 RDF-star + Foundry-class 표현력에 접근한다. 매 단계는 markdown-first 호환을 깨지 않는다. 차별점은 *enterprise platform 없이 markdown 폴더로 시작 가능* 한 ontology 도구 — 이게 오픈소스 mission 의 진짜 진입점.
+
+---
+
+## 12. Glossary
+
+이 spec 에서 쓰이는 용어 정의. 우리 식별자 / 외부 참조 / RFC 패턴 구분.
+
+### 우리 모델 용어
+
+- **TBox** — *Terminological Box*. 클래스 / 관계 / property *정의 자체*. 우리 `OntologyClass` + `OntologyRelation` + `OntologyTBoxVersion` (+ V1.2 후 `OntologyLiteralProperty` + V1.4 후 `OntologyActionType`) 가 여기 속한다. OWL 용어.
+- **ABox** — *Assertion Box*. 실 entity / fact 들. 우리 `knowledgeApprovedNodes` + `knowledgeApprovedEdges` (+ V1.2 후 `knowledgeApprovedLiterals` + V2 후 `knowledgeStatements`).
+- **Canonical** — admin-private 진실원. 검수 거친 fact 의 immutable history. `knowledgeApprovedNodes/Edges`.
+- **Public projection** — canonical 의 단방향 사영. `knowledgePublicNodes/Edges`. publish event 통해 갱신.
+- **Stub** — forward-reference placeholder 노드. 검수 큐의 별도 섹션. `pendingType` / `pendingFromId` 가 promote 시 복원 정보를 담는다. V2 의 `unknown` 과 의미적으로 일치.
+- **Evidence** — fact 의 근거. `knowledgeEvidence/{evidenceId}`. 모든 fact 가 `evidenceIds[]` 보유. V1.3 가 retrievedAt / extractionModelId / confidence 추가.
+
+### Wikidata / Wikibase 영감 (CC BY-SA 4.0 docs)
+
+- **Item** — Wikidata 의 entity 단위 (Q-number). 우리 `KnowledgeApprovedNode` 와 매핑.
+- **Property** (Wikidata) — predicate (P-number). 우리 `OntologyRelation` 또는 V1.2 의 `OntologyLiteralProperty` 둘 다 매핑.
+- **Statement** — Wikidata 의 (subject, property, value) + qualifiers + references + rank 묶음. V2 의 `KnowledgeStatement` 가 이 모양.
+- **Claim** — statement 의 핵심 (subject + property + value + qualifiers). references / rank 제외.
+- **Qualifier** — claim 을 *수식하는* property-value 쌍. 예: `since: 2024-Q1`, `via: REST`. V1.1 가 우리 edges 에 도입.
+- **Reference** — claim 의 *근거 cite*. 우리 `evidenceIds[]` 의 부분집합 + V1.3 의 retrievedAt / extractionModelId.
+- **Rank** — 같은 (subject, property) 의 다중 statement 우선순위. `preferred` / `normal` / `deprecated`. V1.1.
+- **Snak** — Wikidata 가 (property, value, snaktype) 의 atomic 단위로 부르는 이름. 우리 spec 에서는 사용 안 함 — *Wikidata 호환 export 시점* 에만 다시 등장.
+- **Datatype** — value 의 종류 (item-ref / string / time / quantity / globe-coordinate / external-id …). 우리 `QualifierValue` union 이 부분 차용.
+
+### Palantir Foundry 영감 (proprietary docs, fair-use 학습)
+
+- **Object Type** — Foundry 의 entity 정의. 우리 `OntologyClass` + literal property schema 의 합. *Foundry trademark — 우리 식별자에 사용 금지*.
+- **Object Instance** — entity 의 실제 row. 우리 `KnowledgeApprovedNode`.
+- **Link Type** — Foundry 의 relation 정의. 우리 `OntologyRelation`.
+- **Action Type** — Foundry 의 *입력-스키마-가진 operation*. V1.4 의 `OntologyActionType` 이 영감 받음. 우리는 **proprietary 식별자 회피** — 단순히 ActionType (capitalized) 으로 부른다.
+- **Function** — Foundry 의 TS / Python 사용자 코드 layer. 우리 도입 안 함 (오픈소스 단순화 — `.claude/rules/forbidden.md` 정신과 일치).
+- **Interface** — Foundry 의 polymorphism. 우리 `parentClassId` 가 더 단순 버전.
+
+### W3C / RDF 영감 (공개 표준)
+
+- **OWL 2** — W3C ontology language. 우리 `symmetric` / `transitive` / `parentClassId` 등 메타가 OWL flavor.
+- **RDF** — Resource Description Framework. 우리 (subject, predicate, object) 트리플이 자연 변환.
+- **RDF-star** — RDF 확장. statement 자체를 *subject* 로 쓸 수 있음 — annotation / qualifier 표현. V2 통합 모델이 RDF-star 호환 export 의 진입점.
+- **SKOS** — Simple Knowledge Organization System. 시소러스 / 분류체계 표준. 우리 class hierarchy 와 닮음.
+- **SHACL** — RDF 데이터 검증 언어. cardinality / closed-world 검증 도입 시 차용 후보 (V1.5 + 미래).
+- **rdfs:domain / range** — property 의 source / target class 제약. 우리 `OntologyRelation.sourceClassIds` / `targetClassIds` 가 동일 개념.
+
+### Markdown / Local-first 용어
+
+- **Vault** — 사용자가 선택한 markdown 폴더. `useLocalVault` 의 동작 단위.
+- **Manifest** — vault 를 스캔해 만든 메모리 객체 (`VaultManifest`). frontmatter / heading / wikilink 를 추출한 결과.
+- **Fingerprint** — 디렉터리의 mtime stamps 를 정렬·hash 한 문자열. auto-refresh 시 변동 감지 (A5).
+- **Frontmatter** — `.md` 파일 상단의 YAML-like 블록 (`---` 사이). 우리 single source of truth 가 자라는 곳.
+- **Wikilink** — 본문의 `[[other-doc]]` 형식 참조. 우리 manifest builder 가 자동 추출 → `evidenceIds[]` 와 edge 후보로.
+- **`_` prefix 폴더** — schema 정의 위치 (V1.4 후 `_actions/`, V1.5 후 `_relations/`, V2 후 `_classes/` / `_literals/`). 일반 노드와 구분 (§8.1.5).
+
+### 운영 모드 (`docs/LOCAL-FIRST-SYNC.md` 와 일치)
+
+- **Static (모드 A)** — `pnpm build` 의 사전 빌드 manifest 만 사용. Firebase 미사용. 가장 가벼운 진입.
+- **Local (모드 B)** — File System Access API 로 디스크 폴더 → 메모리 manifest. Firebase 미사용.
+- **Cloud (모드 C)** — Firebase Auth 후 Firestore 만 사용. 디스크 미사용.
+- **Hybrid (모드 D, v1.0+)** — 디스크 master + Firestore slave 단방향 push. v0.x 미지원.
+
+### Phase 용어 (V2 마이그레이션, §10.7)
+
+- **Phase A — Dual-write** — 새 statements 컬렉션 + 기존 edges/literals 양쪽 쓰기. read 는 legacy 우선.
+- **Phase B — Backfill** — 기존 edge / literal 을 statement 로 1:1 변환. dry-run → 운영 실행.
+- **Phase C — Dual-read** — read 가 statements 우선, fallback only on miss. 90일 (Q3) 유지.
+- **Phase D — Legacy read 차단** — read path 에서 legacy collection 제거. 그러나 doc 자체는 보관.
+- **Phase E — Legacy write 차단** — firestore.rules 가 legacy collection write 거부. 마지막 단계.
+
+---
+
+## 13. 관련 spec 일람
+
+이 spec 과 **반드시 같이 갱신** 해야 하는 다른 문서:
+
+| 문서 | 영향 받는 시점 |
+|---|---|
+| `docs/DATA-MODEL.md` | 모든 V1.x 단계 — 새 필드 / 컬렉션 정의 |
+| `firestore.rules` | V1.x — 모든 새 컬렉션 / 권한 변화 |
+| `firestore.indexes.json` | 새 query 가 복합 인덱스 필요 시 |
+| `docs/CHANGELOG.md` | 모든 V1.x / V2 phase |
+| `docs/LOCAL-FIRST-SYNC.md` | V1.4 ActionType 의 로컬 격리 정책 |
+| `docs/OFFLINE-FIRST-UX-FLOW.md` | V1.4 의 검수 큐 UX 영향 시 |
+| `.claude/rules/firestore-schema.md` | 변경 프로세스 갱신 시만 |
+| `src/entities/*/model/types.ts` | 모든 schema 변경 |
+| `src/entities/*/api/*.ts` | mapper / fromFirestore / toFirestore 갱신 |
+| `tests/e2e/*.spec.ts` | 새 사용자 흐름 — 회귀 차단 |
+| `scripts/seed-*.mjs` | 시드 데이터에 새 필드 채움 / skip 정책 명시 |
+
+각 V1.x PR 의 *paths-changed* 가 위 표 의 해당 단계 list 와 일치해야 — `git diff --name-only main...HEAD` 가 cross-reference. 누락은 §10 체크리스트에서 catch.

--- a/docs/PRODUCT-DIRECTION.md
+++ b/docs/PRODUCT-DIRECTION.md
@@ -1,0 +1,286 @@
+# PRODUCT DIRECTION — 온톨로지 워크벤치 (사람 + AI agent 공동 저작)
+
+> 작성일 (v2): 2026-05-01
+> 결정 반영: user 가 **Direction A** (온톨로지 first) 확정 + **dogfooding + AI agent 협업** 방향 추가
+> 본 문서는 [PRODUCT-DIRECTION.md](./PRODUCT-DIRECTION.md) v1 의 strategic 진단을 그대로 두고, **결정 + 새 방향**을 v2 로 덮음.
+
+---
+
+## TL;DR — 1원리 한 줄 (v2)
+
+> **이 프로젝트는 온톨로지 워크벤치다 — 비개발자와 AI agent 가 같이 한 codebase 의 mental model 을 함께 저작한다.**
+
+- 토폴로지 = 출구 (view) 중 하나
+- 척추 = md 문서 → 자라는 ontology
+- 비개발자 (PM · 디자이너 · 운영) 도 ERD 보다 친숙한 surface
+- AI agent (Claude Code 같은) 도 같은 ontology 를 읽고 쓰는 *partner* — generic 한 ontology 도구와 차별화되는 angle
+
+---
+
+## 1. user 결정 요약
+
+### 결정 1 — Direction A (온톨로지 first)
+
+`/` 가 **온톨로지 hub** 가 됨:
+- 첫 진입: 트리 + ego graph (현재 `/ontology` 의 핵심을 끌어올림)
+- 토폴로지는 sub view — `/topology` 또는 `/?view=topology`
+- 사용자가 "이 서비스는 내 도메인 지식을 정리하는 곳" 으로 즉시 인지
+
+근거 (user 인용):
+> "온톨로지 서비스니까 말이지? 특히 이 온톨로지는 ERD 이상으로 비개발자를 위함이기도 하잖아?"
+
+### 결정 2 — Self-hosting + AI agent 협업
+
+핵심 통찰:
+> "지금 만들고 있는 이 서비스 자체를 우리가 서비스를 만들면서 해보는건 어떨까? 내 로컬에 패키지 하나 만들고 그거보고 오프라인으로 실행하게 해서 계속 채워나가고 검토하면서 이 온톨로지 서비스 자체가 개발하는 ai agent 에도 도움이 되도록 할 수 있을까?"
+
+해독:
+1. **Dogfooding** — 우리가 이 프로젝트의 docs/ 를 본 서비스의 vault 로 사용
+2. **로컬 패키지** — 사용자 디스크에 install, 오프라인으로 실행 (Firebase 없이도)
+3. **AI agent 가 partner** — 코드를 읽는 Claude Code 가 같은 ontology 를 읽고 쓸 수 있어야 함
+
+이게 차별화 포인트. **generic ontology workbench (Protégé 등) → "AI 와 사람이 같이 저작하는 codebase mental model"**.
+
+---
+
+## 2. 두 청중, 한 ontology
+
+| 청중 | 이 서비스로 무엇을 함 |
+|---|---|
+| **개발자** | 코드 ↔ 개념 매핑 — "이 capability 는 어느 service 가 구현?" |
+| **PM / 디자이너 / 운영** | 코드 안 읽고 시스템 mental model 이해 — "어떤 도메인 / 어떤 element 들" |
+| **AI agent** (Claude Code 등) | codebase 의 사전 지식. "이 프로젝트에서 'auth' 이 무엇을 의미하는가" 문답 가능 |
+
+같은 ontology 가 세 청중 모두 만족시킨다는 것이 새 mission.
+
+---
+
+## 3. AI agent 협업 — 구체적으로 무엇
+
+### 3-A. 읽기 path (이미 가능)
+
+AI agent 가 vault (`projects/*.md`) 를 읽으면 frontmatter 가 ontology 를 직접 표현:
+
+```yaml
+---
+slug: auth-platform
+kind: project
+domain: 인증
+capabilities:
+  - 토큰 발급
+  - 권한 검증
+  - 사용자 상태 추적
+elements: [JWT, Postgres, refresh-token]
+dependencies: [user-service, audit-trail]
+---
+
+# Auth Platform
+
+사용자 인증·세션·권한을 한 곳에서 ...
+```
+
+→ frontmatter 만으로 capabilities + elements + edges 자동 stub 생성됨 (이미 구현). AI agent 가 이 vault 를 읽으면 즉시 mental model 획득.
+
+### 3-B. 쓰기 path (필요)
+
+AI agent 가 코드를 분석하면서 새로 발견한 사실을 ontology 에 commit:
+
+```bash
+# 예: AI agent 가 파일을 분석한 후
+$ ohmy add element src/features/billing/lib/cycle-rule.ts \
+    --kind element \
+    --capability "구독 주기 계산" \
+    --project billing-service
+```
+
+방법 (옵션):
+1. **CLI** — `npx oh-my-ontology add ...` (frontmatter 자동 작성)
+2. **MCP 서버** — Claude Code 가 직접 도구 호출 (`mcp__oh-my-ontology__add_node`)
+3. **프로그래매틱 API** — 패키지에서 `addNode({...})` import
+
+가장 ergonomic 한 건 **3 (MCP 서버)**. AI agent 가 codebase 탐색 → 발견한 개념을 ontology 에 *직접* 추가. 인간 검수자가 빌더에서 본다.
+
+### 3-C. 양방향 sync
+
+```
+human edits builder canvas
+        │
+        ▼
+ontology 그래프 (vault frontmatter)
+        ▲
+        │
+AI agent reads codebase → adds nodes via MCP/CLI
+```
+
+같은 graph. 같은 vault. 다른 입력 경로.
+
+---
+
+## 4. 로컬 패키지 — 어떻게 distribute
+
+### 옵션 A — npm 패키지 + CLI
+
+```bash
+# 사용자가 자기 프로젝트 root 에서
+$ npx oh-my-ontology@latest
+
+# 시작:
+# - 현재 디렉토리를 vault 로 인식
+# - localhost:3210 에 web UI 띄움
+# - 브라우저 자동 열림
+# - Firebase 미설정 → local 모드 자동 활성
+```
+
+장점:
+- 설치 0 마찰 (npm/pnpm 만 있으면 됨)
+- 모든 프로젝트가 잠재 vault
+- offline-first 기본
+- Next.js 빌드 산출을 그대로 distribute 가능 (정적 export + 미니 서버)
+
+단점:
+- Node.js 의존
+- 배포 후 패키지 사이즈 (Sigma + xyflow + 등 무거움)
+
+### 옵션 B — Electron 데스크톱 앱
+
+장점: 진짜 native 느낌
+단점: 빌드 복잡, 배포 무거움, "AI agent 가 같이 쓰는" 컨셉과 안 맞음 (CLI 가 더 자연)
+
+### 옵션 C — 그대로 Next.js 정적 export + 가이드만
+
+`pnpm dev` 후 사용. 패키지화 X. 가이드 + 환경 변수 옵션화.
+
+장점: 가장 빠름. 새 dependency 0.
+단점: 배포 차단 (clone 부담).
+
+### 권장: A 옵션 (CLI + npx)
+
+`oh-my-ontology` 라는 npm 패키지로 publish. 사용자는 어떤 프로젝트의 root 에서든 `npx oh-my-ontology` 로 띄울 수 있게. AI agent 도 같은 패키지의 MCP 서버 또는 CLI 호출로 참여.
+
+---
+
+## 5. AI agent 가 partner 가 되는 surface
+
+### 5-A. MCP 서버
+
+`oh-my-ontology-mcp` 별도 패키지. Claude Code 와 호환:
+
+```json
+// .mcp.json or settings
+{
+  "mcpServers": {
+    "oh-my-ontology": {
+      "command": "npx",
+      "args": ["-y", "oh-my-ontology-mcp"],
+      "env": { "OMOT_VAULT": "./" }
+    }
+  }
+}
+```
+
+도구:
+- `list_concepts` — vault 의 모든 노드 (kind 별 필터)
+- `get_concept` — 단일 노드 + 이웃
+- `add_concept` — 새 노드 (frontmatter 작성)
+- `add_relation` — 두 노드 사이 edge
+- `find_evidence` — 어떤 코드가 이 concept 의 근거인지
+
+이게 있으면 AI agent 가 codebase 탐색 시 **"이 파일이 어느 concept 의 element 인가?"** 을 직접 알 수 있음. 매번 다시 추론 X.
+
+### 5-B. AGENTS.md / CLAUDE.md 에 ontology 인덱스 자동 생성
+
+빌드 타임에 ontology 의 high-level 구조를 markdown 으로 dump:
+
+```markdown
+# This project's ontology (auto-generated)
+
+## Domains
+- 인증: 토큰 발급 · 권한 검증 · 사용자 상태 추적
+- 결제: 구독 · 사용량 · 청구
+
+## Capabilities
+- 토큰 발급 [auth-platform/iam-core]
+- ...
+```
+
+AI agent 가 codebase 진입 시 첫 페이지에서 이걸 보면 mental model 즉시 형성.
+
+---
+
+## 6. 단계 — 실행 가능 하게 분해
+
+### Phase 1 — 정체성 정렬 (UI)
+
+1. `/` 를 ontology hub 로 (현 `/ontology` 콘텐츠 끌어올림)
+2. `/topology` 신규 라우트 (현 `/` 콘텐츠 이전)
+3. 랜딩 카피 — "AI 와 함께 자라는 codebase ontology"
+4. WorkspaceOntologyStrip → 삭제 또는 메인 콘텐츠로 격상
+5. demo 슬림 — 21 컨테이너 → 4-6, 2250 노드 → 50, ontology 노드 60+ 채움
+
+### Phase 2 — Self-hosting
+
+1. `package.json` 에 `bin` 추가, CLI entrypoint
+2. 정적 export 산출 + 미니 Express/Fastify 서버 또는 standalone Next.js 모드
+3. `OMOT_VAULT` 환경 변수로 vault 위치 지정
+4. `npx oh-my-ontology` 로 즉시 실행 가능
+5. README / 설치 가이드 정리
+
+### Phase 3 — AI agent partner
+
+1. `oh-my-ontology-mcp` 패키지 — MCP 서버 구현
+2. 도구: list/get/add concept · add_relation · find_evidence
+3. CLI 명령 (`ohmy`) — frontmatter 직접 조작
+4. AGENTS.md 자동 생성 (빌드 시 ontology 인덱스)
+5. 이 프로젝트의 `docs/` 자체로 dogfooding — 우리가 만들면서 우리 코드의 ontology 도 자라게
+
+### Phase 4 — 비개발자 surface 다듬기
+
+1. 빌더 onboarding "ERD 이상 — 도메인 지도" 카피 정렬
+2. 기술 용어 ↔ 한국어 일반 용어 매핑 layer
+3. 노드 색 / 아이콘 — kind 별 친숙
+4. 검색 시 "코드 / 문서 / 사람" 분류 (PM 친화)
+
+---
+
+## 7. 신구 mission 비교
+
+### 구 mission (AGENTS.md, 현재)
+
+> 사용자가 글을 쓰면 시스템이 개념·관계·근거를 추출해 검수·승인하면 토폴로지·트리·ERD 세 가지 view 로 자라난다.
+
+### 신 mission (이 문서로 제안)
+
+> **사람과 AI agent 가 같이 저작하는 codebase 의 ontology.**
+>
+> - 사람: vault frontmatter 또는 빌더에서 직접 노드/관계 추가
+> - AI agent (Claude Code 등): MCP 또는 CLI 로 코드 탐색 결과를 ontology 에 commit
+> - 모두 같은 vault 그래프. 모두 같은 view 들 (트리 hub / 토폴로지 sub-view / ERD)
+> - 패키지로 distribute — 어느 codebase 에서든 `npx oh-my-ontology`
+
+차이:
+- "AI 가 추출" 이라는 cloud-extraction 약속 → "AI agent 가 partner" 라는 협업 약속
+- 비용 모델 — cloud LLM 비용 자체가 사라짐 (Claude Code 가 이미 user 의 LLM 비용 부담)
+- 정체성 명확 — generic ontology 도구가 아니라 **codebase 와 AI agent 가 만나는 워크벤치**
+
+---
+
+## 8. 즉시 다음 액션 (user 명령 대기 중)
+
+이 v2 문서는 *방향* 만 정렬. 어느 단계부터 진행할지 결정 필요:
+
+### 옵션 A — Phase 1 즉시 시작 (UI 정체성 정렬)
+- `/` ↔ `/topology` swap
+- demo 슬림
+- 랜딩 카피
+- est: 1-2 일 (commit 5-7 개)
+
+### 옵션 B — Phase 2 먼저 (self-hosting)
+- npm 패키지화 + CLI
+- 가장 큰 기술 변경 — 다른 작업 가속됨
+- est: 1-2 일
+
+### 옵션 C — 이 문서 review + 추가 결정
+- v2 의 가정 (비용 / 청중 / 우선순위) 더 다듬기
+- 그 다음 Phase 결정
+
+내 1원리 의견: **A** 부터. UI 정체성이 정렬돼야 self-hosting 시작 시 사용자가 보는 첫 화면이 "올바른 mission" 표현. self-hosting 은 그 다음.


### PR DESCRIPTION
## Summary

세션 누적된 작업 추적용 md 를 첫 commit. mission 정렬 시점에 untracked → canonical 승격.

추가된 문서:
- **docs/FEATURES.md** — 사용자가 사용 가능한 모든 실존 기능 인벤토리 (haiku agents 병렬 점검 종합)
- **docs/PRODUCT-DIRECTION.md (v2)** — **Direction A (온톨로지 first) 확정** + dogfooding + AI agent partner 신 mission
- docs/BACKLOG.md, CHANGELOG.md, MODE-AWARE-CRUD.md, LOCAL-FIRST-SYNC.md, OFFLINE-FIRST-UX-FLOW.md, ONTOLOGY-MODEL-V2-DRAFT.md

## Test plan

- [x] 코드 변경 0 — 문서만
- [x] .gitignore 에 `.serena/` 추가 (serena MCP cache 가 개인 환경 종속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)