### PR TITLE
feat: Phase 1.1-1.4 — Direction A 적용 (/ → ontology hub, /topology 신설)

### DIFF
--- a/app/topology/page.tsx
+++ b/app/topology/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import { HomePage } from "@/views/home";
+import { absoluteUrl } from "@/shared/config";
+
+/**
+ * `/topology` — Sigma WebGL 토폴로지 view.
+ *
+ * Phase 1 (Direction A) 진행 중: 토폴로지는 출구 view 중 하나로 격하되며
+ * `/` 는 ontology hub 가 된다. 이 라우트는 토폴로지 자체로의 명시적 진입점.
+ *
+ * 현재는 `/` 와 동일한 HomePage 렌더 (alias). `/` 가 ontology hub 로 교체된
+ * 다음 sub-step 이후엔 토폴로지 전용 surface 가 됨.
+ */
+export const metadata: Metadata = {
+  title: "토폴로지",
+  description: "프로젝트 의존도 지도. 온톨로지의 한 출구 view.",
+  alternates: {
+    canonical: absoluteUrl("/topology/"),
+  },
+};
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <HomePage />
+    </Suspense>
+  );
+}

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -90,7 +90,7 @@ export function LandingPage({ next }: Props) {
         <div className="grid gap-10 md:grid-cols-[minmax(0,1fr)_22rem] md:items-center md:gap-12">
           <div className="space-y-5">
             <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[color:var(--color-text-quaternary)]">
-              {hasReturnTarget ? "권한이 필요한 화면" : "open-source ontology workbench"}
+              {hasReturnTarget ? "권한이 필요한 화면" : "ontology workbench · 사람 + AI agent 협업"}
             </p>
             <h1 className="text-[clamp(2.4rem,5vw,4rem)] leading-[1.04] font-[var(--font-weight-signature)] tracking-[var(--tracking-display)] text-[color:var(--color-text-primary)]">
               {hasReturnTarget ? (
@@ -99,15 +99,15 @@ export function LandingPage({ next }: Props) {
                 </>
               ) : (
                 <>
-                  마크다운에서 자라는<br />
-                  <span className="text-[color:var(--color-indigo-accent)]">지식 그래프</span>
+                  AI 와 함께 자라는<br />
+                  <span className="text-[color:var(--color-indigo-accent)]">codebase ontology</span>
                 </>
               )}
             </h1>
             <p className="max-w-xl text-base leading-7 text-[color:var(--color-text-secondary)]">
               {hasReturnTarget
                 ? "요청한 화면은 로그인이 필요합니다. 로그인하면 방금 열려던 화면으로 바로 돌아갑니다."
-                : "마크다운 문서에서 개념·관계·근거를 추출해 *토폴로지·트리·ERD* 세 시각으로 자라는 오픈소스 온톨로지 워크벤치. Obsidian/Notion 처럼 폴더만 가리키면 시작."}
+                : "사람과 AI agent 가 같이 자라게 하는 codebase ontology. 마크다운 문서가 곧 개념·관계·근거 — *트리·토폴로지·ERD* 세 시각으로 본다. Obsidian/Notion 처럼 폴더만 가리키면 시작."}
             </p>
           </div>
 
@@ -287,17 +287,17 @@ function ValueChainRail() {
     {
       index: "01",
       title: "마크다운 작성",
-      sub: "내가 이미 쓴 .md 들이 노드와 관계의 재료",
+      sub: "내가 쓰거나 AI agent 가 같이 — .md frontmatter 가 그대로 노드/관계",
     },
     {
       index: "02",
-      title: "개념·관계·근거 추출",
-      sub: "검수 큐에서 한 번 확인 후 승인",
+      title: "ontology 자동 자라남",
+      sub: "frontmatter 자체가 자기 승인 — 검수 단계 없이 바로 그래프",
     },
     {
       index: "03",
-      title: "토폴로지·트리·ERD",
-      sub: "세 시각으로 자라는 ontology",
+      title: "트리·토폴로지·ERD",
+      sub: "같은 ontology 를 세 시각으로",
     },
   ];
 

--- a/src/views/root-entry/ui/RootEntryPage.tsx
+++ b/src/views/root-entry/ui/RootEntryPage.tsx
@@ -5,19 +5,22 @@ import { useScopedAccountAccess } from "@/features/account-scope";
 import { useGlobalAdmin } from "@/features/permissions";
 import { useUserAuth } from "@/features/user-auth";
 import { } from "@/shared/lib/account-scope";
-import { HomePage } from "@/views/home";
+import { OntologyViewPage } from "@/views/ontology-view";
 import { LandingPage } from "@/views/landing";
 
 /**
- * 루트 `/` 진입 분기.
+ * 루트 `/` 진입 분기. (Phase 1 — Direction A 적용)
  *
- * `?account=X` 가 있으면 그 공간의 scope 해석 필요 — membership 조회가
- * 끝날 때까지 "권한 확인 중" 스피너. 없으면 공개 홈이므로 Firebase Auth
- * 초기화만 기다리면 됨 (Firestore membership 조회 불필요). 네트워크가
- * Firestore 쪽에서 10초 이상 지연되더라도 홈·랜딩 은 정상 렌더된다.
+ * 이 서비스는 **온톨로지 워크벤치** — 인증 사용자 의 첫 화면은 ontology hub
+ * (트리 + ego graph + stub 처리). 토폴로지는 출구 view 중 하나로 `/topology`
+ * 에 별도 라우트.
  *
- * dev-bypass (로컬 개발 우회 로그인) 는 useUserAuth 의 firebase/demo/iam
- * 세 provider 어디에도 잡히지 않으므로 useGlobalAdmin 으로 별도 확인한다.
+ * - 비인증: LandingPage
+ * - 인증: OntologyViewPage (트리 + 컨텍스트 패널)
+ * - 토폴로지가 보고 싶으면 nav / 헤더 에서 `/topology`
+ *
+ * `?account=X` (legacy multi-account scope) 가 있으면 membership 조회 후
+ * 같은 분기. dev-bypass 사용자는 useGlobalAdmin 으로 인증 처리.
  */
 export function RootEntryPage() {
   const searchParams = useSearchParams();
@@ -35,21 +38,21 @@ export function RootEntryPage() {
     if (scopedAccess.kind === "guest") {
       return <LandingPage accountId={accountId} next={next} />;
     }
-    return <HomePage />;
+    return <OntologyViewPage />;
   }
 
   // 공개 홈 — Firebase Auth 초기화만 기다리면 충분.
   if (userAuth.status === "loading" || globalAdmin.status === "loading") {
     return <AuthLoadingSpinner />;
   }
-  // dev-bypass 사용자도 인증된 사용자로 간주 → HomePage.
+  // dev-bypass 사용자도 인증된 사용자로 간주 → OntologyViewPage.
   if (
     userAuth.status === "unauthenticated" &&
     globalAdmin.status !== "authenticated"
   ) {
     return <LandingPage accountId={null} next={next} />;
   }
-  return <HomePage />;
+  return <OntologyViewPage />;
 }
 
 function AuthLoadingSpinner() {

--- a/src/widgets/bottom-tab-bar/ui/BottomTabBar.tsx
+++ b/src/widgets/bottom-tab-bar/ui/BottomTabBar.tsx
@@ -2,26 +2,27 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Map as MapIcon, FolderKanban, FileText, ListTodo } from 'lucide-react';
+import { Network, FolderKanban, FileText, ListTodo } from 'lucide-react';
 
 interface TabItem {
   href: string;
   label: string;
-  icon: typeof MapIcon;
+  icon: typeof Network;
   /** pathname 이 이 prefix 들 중 하나로 시작하면 활성 탭. 빈 배열이면 정확히 href 와 일치할 때만. */
   matchPrefixes: ReadonlyArray<string>;
 }
 
 // 모바일 한정 하단 탭바. 메인 4개 destination만 노출 — 미니멀 모바일 결.
-// "지도 · 프로젝트 · 문서 · 정리(설정·진단)" 4분할로 정보 구조를 한 번에 잡아준다.
+// "온톨로지 · 프로젝트 · 문서 · 정리" 4분할.
+// Direction A 적용 후 / 가 ontology hub — 첫 탭 라벨/아이콘이 그 정체성을
+// 노출. 토폴로지는 온톨로지의 출구 view 라 별도 탭이 아닌 OntologyView /
+// OperationsNav 안의 sub-link 로 진입.
 const TABS: ReadonlyArray<TabItem> = [
-  { href: '/', label: '지도', icon: MapIcon, matchPrefixes: [] },
+  { href: '/', label: '온톨로지', icon: Network, matchPrefixes: ['/ontology', '/topology'] },
   { href: '/projects/', label: '프로젝트', icon: FolderKanban, matchPrefixes: ['/projects', '/project'] },
-  // "문서" tab 은 docs / knowledge / review / ontology 모두 active. ontology
-  // 는 별도 5번째 탭을 만들지 않는다 — 4 분할 폭 보존. /knowledge hub 에 진입
-  // 카드로 발견. /docs 는 진안 일상 vault — 같은 "문서" 탭 활성으로 위치
-  // 손실 없게 (Fire 1 — BottomTabBar 회귀).
-  { href: '/knowledge/', label: '문서', icon: FileText, matchPrefixes: ['/knowledge', '/review', '/ontology', '/docs'] },
+  // "문서" tab 은 docs / knowledge / review 모두 active. /docs 는 진안 일상
+  // vault — 같은 "문서" 탭 활성으로 위치 손실 없게 (Fire 1 회귀).
+  { href: '/knowledge/', label: '문서', icon: FileText, matchPrefixes: ['/knowledge', '/review', '/docs'] },
   { href: '/settings/', label: '정리', icon: ListTodo, matchPrefixes: ['/diagnostics', '/settings'] },
 ];
 

--- a/src/widgets/operations-nav/ui/OperationsNav.tsx
+++ b/src/widgets/operations-nav/ui/OperationsNav.tsx
@@ -15,7 +15,7 @@ interface OperationsNavProps {
 }
 
 interface NavItem {
-  id: 'knowledge' | 'review' | 'ontology' | 'settings' | 'diagnostics';
+  id: 'knowledge' | 'review' | 'ontology' | 'topology' | 'settings' | 'diagnostics';
   label: string;
   /** Tooltip 본문 — 라벨이 짧아 첫 사용자에게 의미 약할 때 보조 안내. */
   description: string;
@@ -47,13 +47,22 @@ function buildItems(mode: 'static' | 'local' | 'cloud'): ReadonlyArray<NavItem> 
       basePath: '/review/knowledge/',
       prefixes: ['/review'],
     },
-    // ontology view — 승인된 노드/관계의 트리. "두 번째 척추" 의 첫 진입점.
+    // ontology view — 승인된 노드/관계의 트리. mission 의 척추.
+    // / 도 OntologyViewPage 를 렌더하므로 prefix 에 양쪽 포함.
     {
       id: 'ontology',
       label: '온톨로지',
       description: '승인된 노드·관계의 계층 그래프 (project → domain → capability → element)',
-      basePath: '/ontology/',
+      basePath: '/',
       prefixes: ['/ontology'],
+    },
+    // topology — 출구 view 중 하나 (Sigma WebGL 의존도 지도).
+    {
+      id: 'topology',
+      label: '토폴로지',
+      description: '프로젝트 의존도 지도 — 온톨로지의 한 출구 view',
+      basePath: '/topology/',
+      prefixes: ['/topology'],
     },
     // BottomTabBar 의 '정리' 와 라벨 일치 — 같은 destination 인데 데스크톱 / 모바일
     // 라벨이 달라 사용자 혼란 (audit A1 회귀 차단).


### PR DESCRIPTION
## Summary

PRODUCT-DIRECTION v2 의 Direction A (온톨로지 first) 적용. mission "토폴로지는 출구 view 중 하나, 척추는 ontology" 를 UI 상에서도 정렬.

### 변경
- 1.1 — \`/topology\` 라우트 신설 (HomePage alias)
- 1.2 — \`/\` (RootEntryPage 인증 분기) 가 \`OntologyViewPage\` 렌더 (이전엔 HomePage = Sigma 토폴로지)
- 1.3 — OperationsNav 에 "토폴로지" 항목 추가 + BottomTabBar "지도" → "온톨로지" (Network 아이콘)
- 1.4 — LandingPage 카피: "AI 와 함께 자라는 codebase ontology" + "사람 + AI agent 협업" + ValueChainRail 02 step "frontmatter 자체가 자기 승인"

### 남은 (별도 PR)
- 1.5 demo 슬림 — 21 컨테이너 / 2250 노드 → 4-6 컨테이너 / ~50 노드 + ontology 노드 60+ 채움

## Test plan

- [x] tsc 0 errors
- [x] vitest 117 / 842 pass
- [x] Playwright /, /topology, /ontology, /projects 모두 console 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)