### PR TITLE
feat: Phase 1.5 — demo 슬림 + ontology 노드 풍부화

### DIFF
--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-01T08:44:17.944Z",
+  "generatedAt": "2026-05-01T09:55:33.615Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",
@@ -148,8 +148,13 @@
         },
         {
           "depth": 2,
-          "text": "결정 필요 (P0 — 답 주면 즉시 unblock)",
-          "slug": "결정-필요-p0-답-주면-즉시-unblock"
+          "text": "✅ 완료 (refactor/first-principles-slim-1 PR #1, main 머지 완료, 23 commits)",
+          "slug": "완료-refactorfirst-principles-slim-1-pr-1-main-머지-완료-23-commits"
+        },
+        {
+          "depth": 2,
+          "text": "결정 필요 (P0 — answer 후 즉시 unblock)",
+          "slug": "결정-필요-p0-answer-후-즉시-unblock"
         },
         {
           "depth": 3,
@@ -158,28 +163,13 @@
         },
         {
           "depth": 3,
-          "text": "T2. `/` 자동 vault 전환 구현 (T1 답 = a 일 때만)",
-          "slug": "t2-자동-vault-전환-구현-t1-답-a-일-때만"
+          "text": "T13. OperationsNav 온톨로지 탭 분기 결정",
+          "slug": "t13-operationsnav-온톨로지-탭-분기-결정"
         },
         {
           "depth": 3,
-          "text": "T3. share-doc 시스템 제거 결정",
-          "slug": "t3-share-doc-시스템-제거-결정"
-        },
-        {
-          "depth": 3,
-          "text": "T4. share-doc cascade 정리 (T3 답 = b 일 때만)",
-          "slug": "t4-share-doc-cascade-정리-t3-답-b-일-때만"
-        },
-        {
-          "depth": 3,
-          "text": "T5. AI 추출 cloud path (functions/) 제거 결정",
-          "slug": "t5-ai-추출-cloud-path-functions-제거-결정"
-        },
-        {
-          "depth": 3,
-          "text": "T6. AI 추출 cloud path cascade 제거 (T5 답 = b 일 때만)",
-          "slug": "t6-ai-추출-cloud-path-cascade-제거-t5-답-b-일-때만"
+          "text": "AI 추출 cloud Functions 잔재 (T5+T6 마무리)",
+          "slug": "ai-추출-cloud-functions-잔재-t5t6-마무리"
         },
         {
           "depth": 2,
@@ -187,69 +177,14 @@
           "slug": "mission-inconsistency-마무리"
         },
         {
-          "depth": 3,
-          "text": "T7. read 측 mode-aware (`useProjects` hook)",
-          "slug": "t7-read-측-mode-aware-useprojects-hook"
-        },
-        {
-          "depth": 3,
-          "text": "T8. ProjectDrawer / DependencyPicker / 다른 inline 편집 mode-aware",
-          "slug": "t8-projectdrawer-dependencypicker-다른-inline-편집-mode-aware"
-        },
-        {
-          "depth": 3,
-          "text": "T9. 검수 큐 mode-aware 안내",
-          "slug": "t9-검수-큐-mode-aware-안내"
-        },
-        {
           "depth": 2,
-          "text": "UX 다듬기 (small wins)",
-          "slug": "ux-다듬기-small-wins"
-        },
-        {
-          "depth": 3,
-          "text": "T10. 빌더 fullscreen 토글",
-          "slug": "t10-빌더-fullscreen-토글"
-        },
-        {
-          "depth": 3,
-          "text": "T11. 빌더 \"트리로 보기\" 버튼 시각 위계 정리",
-          "slug": "t11-빌더-트리로-보기-버튼-시각-위계-정리"
+          "text": "UX 다듬기 (small wins, additive)",
+          "slug": "ux-다듬기-small-wins-additive"
         },
         {
           "depth": 3,
           "text": "T12. NodeDetailPanel evidence excerpt modal",
           "slug": "t12-nodedetailpanel-evidence-excerpt-modal"
-        },
-        {
-          "depth": 3,
-          "text": "T13. OperationsNav \"온톨로지\" 탭 분기 결정 + 구현",
-          "slug": "t13-operationsnav-온톨로지-탭-분기-결정-구현"
-        },
-        {
-          "depth": 3,
-          "text": "T14. account-settings 369줄 단순화",
-          "slug": "t14-account-settings-369줄-단순화"
-        },
-        {
-          "depth": 3,
-          "text": "T15. dev-admin-bypass 단순화 / `/settings/api-keys` 통합",
-          "slug": "t15-dev-admin-bypass-단순화-settingsapi-keys-통합"
-        },
-        {
-          "depth": 3,
-          "text": "T16. frontmatter parser 강화",
-          "slug": "t16-frontmatter-parser-강화"
-        },
-        {
-          "depth": 3,
-          "text": "T17. 빌더 onboarding 카피 다듬기",
-          "slug": "t17-빌더-onboarding-카피-다듬기"
-        },
-        {
-          "depth": 2,
-          "text": "V1.x 점진 도입 (V2 spec — V1.4 ActionType 은 AI 의존이라 defer)",
-          "slug": "v1x-점진-도입-v2-spec-v14-actiontype-은-ai-의존이라-defer"
         },
         {
           "depth": 3,
@@ -273,8 +208,8 @@
         },
         {
           "depth": 3,
-          "text": "T22. V2 통합 KnowledgeStatement (5-phase migration)",
-          "slug": "t22-v2-통합-knowledgestatement-5-phase-migration"
+          "text": "T22. V2 통합 KnowledgeStatement (5-phase)",
+          "slug": "t22-v2-통합-knowledgestatement-5-phase"
         },
         {
           "depth": 2,
@@ -288,18 +223,8 @@
         },
         {
           "depth": 3,
-          "text": "T24. B8 — knowledge-version / knowledge-job / knowledge-output 컬렉션 통합 검토",
-          "slug": "t24-b8-knowledge-version-knowledge-job-knowledge-output-컬렉션-통합-검토"
-        },
-        {
-          "depth": 3,
-          "text": "T25. B10 — client-error entity 검토",
-          "slug": "t25-b10-client-error-entity-검토"
-        },
-        {
-          "depth": 3,
-          "text": "T26. OntologyEditCanvas 의 dagre layout 단순화",
-          "slug": "t26-ontologyeditcanvas-의-dagre-layout-단순화"
+          "text": "T24. knowledge-* 컬렉션 통합 검토",
+          "slug": "t24-knowledge--컬렉션-통합-검토"
         },
         {
           "depth": 3,
@@ -307,14 +232,19 @@
           "slug": "t27-knowledgedocumentdetailpage-knowledgereviewworkspacepage-정리"
         },
         {
+          "depth": 3,
+          "text": "Review backlog (이미 처리 일부)",
+          "slug": "review-backlog-이미-처리-일부"
+        },
+        {
           "depth": 2,
           "text": "추천 진행 순서",
           "slug": "추천-진행-순서"
         }
       ],
-      "excerpt": "작업 순번 만. user 가 \"T3 진행해\" 하면 그것만 분해해서 실행. 이미 끝난 것은 docs/CHANGELOG.md 참고. 의존 (needs:) 이 있는 항목은 그게 풀리기 전 시작 X. 선택지: (a) YES (mission ideal — vault active 면 / 가 자동으로 vault 데이터) / (b) NO (현재 동작 유지) / (c) v0.x = b, v1.0 부터 a 답 후 작업: (a) 면 T2 즉시 시작. (b)/(c) 면 T2 skip 표시. useDataSourceMode (이미 있음) + RootEntryPage 분기 변경 + 5step",
-      "wordCount": 921,
-      "updatedAt": "2026-05-01T06:52:02.091Z",
+      "excerpt": "작업 순번 만. user 가 \"T?? 진행해\" 하면 그것만 분해해서 실행. 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제. | | 항목 | 결과 | |||| | T3+T4 | sharedoc 시스템 제거 | ✅ entity + view + Firestore rules cascade 정리 | | T5+T6 (부분) | AI 추출 클라이언트 path 제거 | ✅ apikeys + ontologyextraction client + receivedoc. functions/extractgemini · ontologyextract 는 보존 (user 비용 우려로",
+      "wordCount": 797,
+      "updatedAt": "2026-05-01T09:34:42.966Z",
       "mode": "both",
       "linksOut": []
     },
@@ -378,7 +308,7 @@
       ],
       "excerpt": "주요 변경 이력. 코드 commit 메시지가 왜 를 답하고, 이 파일은 언제 / 어떤 surface 가 바뀌었는지 를 답한다. PR 단위가 아닌 사용자 가시 변화 위주. 최신이 위. semver 도입 전 v0.x 단계라 날짜 기반. / Landing — 정적 미니 토폴로지 SVG (14 노드 / 21 relations) + 3step rail (markdown → 추출 → 토폴로지·트리·ERD) + Obsidian/Notion 비교 카피 + footer (MIT licensed · GitHub · 기술 스택). Marketing 섹션 (Why / Coming soon",
       "wordCount": 798,
-      "updatedAt": "2026-05-01T06:33:16.571Z",
+      "updatedAt": "2026-05-01T09:34:42.966Z",
       "mode": "both",
       "linksOut": []
     },
@@ -568,7 +498,7 @@
       ],
       "excerpt": "이 문서는 현재 공개 제품과 설계 승인된 knowledge subsystem v2의 저장 계약을 함께 다룬다. 컬렉션 스키마 변경 시 반드시 이 문서를 먼저 갱신한다. 변경 프로세스는 rules/firestoreschema.md를 따른다. singleuser 모드 (현재): 1 명의 로그인 사용자가 자기 워크스페이스의 owner. account / membership 개념 없음. 모든 컬렉션은 root path. v2 협업 단계에서 multiaccount 가 필요해지면 별도 ADR 로 도입. 1. 현재 공개 제품의 canonical 데이터는 여전히 projects다.",
       "wordCount": 4742,
-      "updatedAt": "2026-05-01T07:54:50.318Z",
+      "updatedAt": "2026-05-01T08:57:06.831Z",
       "mode": "engineer",
       "linksOut": [
         "rules/firestore-schema"
@@ -1002,6 +932,289 @@
       ]
     },
     {
+      "slug": "FEATURES",
+      "path": "docs/FEATURES.md",
+      "title": "FEATURES — oh-my-ontology",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "FEATURES — oh-my-ontology",
+          "slug": "features-oh-my-ontology"
+        },
+        {
+          "depth": 2,
+          "text": "0. 한눈에",
+          "slug": "0-한눈에"
+        },
+        {
+          "depth": 2,
+          "text": "1. 모드 분기 (data source)",
+          "slug": "1-모드-분기-data-source"
+        },
+        {
+          "depth": 2,
+          "text": "2. 라우트별 기능",
+          "slug": "2-라우트별-기능"
+        },
+        {
+          "depth": 3,
+          "text": "토폴로지 + 검색",
+          "slug": "토폴로지-검색"
+        },
+        {
+          "depth": 4,
+          "text": "`/` — 토폴로지 홈 (Sigma WebGL)",
+          "slug": "토폴로지-홈-sigma-webgl"
+        },
+        {
+          "depth": 4,
+          "text": "`/docs` — Vault Picker / Doc Vault",
+          "slug": "docs-vault-picker-doc-vault"
+        },
+        {
+          "depth": 3,
+          "text": "프로젝트",
+          "slug": "프로젝트"
+        },
+        {
+          "depth": 4,
+          "text": "`/projects` — 프로젝트 목록",
+          "slug": "projects-프로젝트-목록"
+        },
+        {
+          "depth": 4,
+          "text": "`/project/[slug]` — 프로젝트 상세",
+          "slug": "projectslug-프로젝트-상세"
+        },
+        {
+          "depth": 4,
+          "text": "`/project/new` · `/project/[slug]/edit` — 에디터",
+          "slug": "projectnew-projectslugedit-에디터"
+        },
+        {
+          "depth": 4,
+          "text": "`/project/fallback` — 정적 export 폴백",
+          "slug": "projectfallback-정적-export-폴백"
+        },
+        {
+          "depth": 3,
+          "text": "온톨로지 3-view",
+          "slug": "온톨로지-3-view"
+        },
+        {
+          "depth": 4,
+          "text": "`/ontology` — Tree (read-only)",
+          "slug": "ontology-tree-read-only"
+        },
+        {
+          "depth": 4,
+          "text": "`/ontology/edit` — Builder (xyflow ERD)",
+          "slug": "ontologyedit-builder-xyflow-erd"
+        },
+        {
+          "depth": 4,
+          "text": "`/ontology/insights` — 인사이트",
+          "slug": "ontologyinsights-인사이트"
+        },
+        {
+          "depth": 4,
+          "text": "`/ontology/relations` — 관계 분포",
+          "slug": "ontologyrelations-관계-분포"
+        },
+        {
+          "depth": 3,
+          "text": "지식 (Cloud — AI 영역 부분 비활성)",
+          "slug": "지식-cloud-ai-영역-부분-비활성"
+        },
+        {
+          "depth": 4,
+          "text": "`/knowledge` — 대시보드",
+          "slug": "knowledge-대시보드"
+        },
+        {
+          "depth": 4,
+          "text": "`/knowledge/documents`",
+          "slug": "knowledgedocuments"
+        },
+        {
+          "depth": 4,
+          "text": "`/knowledge/documents/new`",
+          "slug": "knowledgedocumentsnew"
+        },
+        {
+          "depth": 4,
+          "text": "`/knowledge/documents/view?id=...`",
+          "slug": "knowledgedocumentsviewid"
+        },
+        {
+          "depth": 4,
+          "text": "`/review/knowledge` — 검수 워크스페이스",
+          "slug": "reviewknowledge-검수-워크스페이스"
+        },
+        {
+          "depth": 3,
+          "text": "인증 / 계정",
+          "slug": "인증-계정"
+        },
+        {
+          "depth": 4,
+          "text": "`/login`",
+          "slug": "login"
+        },
+        {
+          "depth": 4,
+          "text": "`/signup`",
+          "slug": "signup"
+        },
+        {
+          "depth": 4,
+          "text": "`/reset-password`",
+          "slug": "reset-password"
+        },
+        {
+          "depth": 4,
+          "text": "`/account` (게스트는 `/login?next=/account` 로 redirect)",
+          "slug": "account-게스트는-loginnextaccount-로-redirect"
+        },
+        {
+          "depth": 3,
+          "text": "운영 / 설정",
+          "slug": "운영-설정"
+        },
+        {
+          "depth": 4,
+          "text": "`/diagnostics/insights` — 오늘 챙길 곳",
+          "slug": "diagnosticsinsights-오늘-챙길-곳"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings` — 정리 허브",
+          "slug": "settings-정리-허브"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings/categories` — 카테고리",
+          "slug": "settingscategories-카테고리"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings/statuses` — 상태",
+          "slug": "settingsstatuses-상태"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings/import` — 프로젝트 가져오기",
+          "slug": "settingsimport-프로젝트-가져오기"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings/ontology` — TBox 보기",
+          "slug": "settingsontology-tbox-보기"
+        },
+        {
+          "depth": 4,
+          "text": "`/settings/ontology/history` — TBox 버전 이력",
+          "slug": "settingsontologyhistory-tbox-버전-이력"
+        },
+        {
+          "depth": 2,
+          "text": "3. 기능 그룹별 정리",
+          "slug": "3-기능-그룹별-정리"
+        },
+        {
+          "depth": 3,
+          "text": "3.1 Vault Local-First",
+          "slug": "31-vault-local-first"
+        },
+        {
+          "depth": 3,
+          "text": "3.2 Mode-Aware Adapters",
+          "slug": "32-mode-aware-adapters"
+        },
+        {
+          "depth": 3,
+          "text": "3.3 검색",
+          "slug": "33-검색"
+        },
+        {
+          "depth": 3,
+          "text": "3.4 Frontmatter 파서 (T16 으로 강화)",
+          "slug": "34-frontmatter-파서-t16-으로-강화"
+        },
+        {
+          "depth": 3,
+          "text": "3.5 Vault Frontmatter → Ontology Stub",
+          "slug": "35-vault-frontmatter-ontology-stub"
+        },
+        {
+          "depth": 3,
+          "text": "3.6 권한",
+          "slug": "36-권한"
+        },
+        {
+          "depth": 3,
+          "text": "3.7 모바일 / 반응형",
+          "slug": "37-모바일-반응형"
+        },
+        {
+          "depth": 3,
+          "text": "3.8 테마 / 접근성 / 알림",
+          "slug": "38-테마-접근성-알림"
+        },
+        {
+          "depth": 3,
+          "text": "3.9 부가 위젯 (홈 / 빌더 보조)",
+          "slug": "39-부가-위젯-홈-빌더-보조"
+        },
+        {
+          "depth": 3,
+          "text": "3.10 단축키",
+          "slug": "310-단축키"
+        },
+        {
+          "depth": 2,
+          "text": "4. 데이터 흐름 (Single source 원칙)",
+          "slug": "4-데이터-흐름-single-source-원칙"
+        },
+        {
+          "depth": 2,
+          "text": "4-B. 프레임워크 / 빌드타임 surface",
+          "slug": "4-b-프레임워크-빌드타임-surface"
+        },
+        {
+          "depth": 2,
+          "text": "4-A. demo 데이터 구조 (현재)",
+          "slug": "4-a-demo-데이터-구조-현재"
+        },
+        {
+          "depth": 2,
+          "text": "5. 제약 / 의도된 부재",
+          "slug": "5-제약-의도된-부재"
+        },
+        {
+          "depth": 2,
+          "text": "6. 검증 (refactor/first-principles-slim-1 머지 시점)",
+          "slug": "6-검증-refactorfirst-principles-slim-1-머지-시점"
+        },
+        {
+          "depth": 2,
+          "text": "7. 어디서부터 손대야 할지 — 사용자 워크플로",
+          "slug": "7-어디서부터-손대야-할지-사용자-워크플로"
+        }
+      ],
+      "excerpt": "사용자가 지금 실제로 사용 가능한 기능 전수 인벤토리. 작성일: 20260501 (refactor/firstprinciplesslim1 main 머지 직후) 출처: routes audit · vault/modeaware audit · ontology+search audit · auth/project/knowledge/settings audit (4 haiku agents 병렬 점검) mission: \"사용자가 글을 쓰면 시스템이 개념·관계·근거를 자라게 한다. 토폴로지·트리·ERD 세 view 로 본다.\" 운영 모델: 1인 도구. localfirst vault. 로그",
+      "wordCount": 2905,
+      "updatedAt": "2026-05-01T09:34:42.966Z",
+      "mode": "both",
+      "linksOut": [
+        "old",
+        "PRODUCT-DIRECTION",
+        "oldSlug"
+      ]
+    },
+    {
       "slug": "LOCAL-FIRST-SYNC",
       "path": "docs/LOCAL-FIRST-SYNC.md",
       "title": "Local-first / Firebase Sync 정책",
@@ -1091,7 +1304,7 @@
       ],
       "excerpt": "Status: 제안 단계 (DRAFT). 자율 루프 iter22 (20260501) 작성. main merge 전 user 승인 필요. 이 문서는 로컬 디스크의 markdown 폴더 와 Firebase (Firestore + Storage) 사이의 데이터 흐름·sync·충돌 정책을 명시한다. .claude/rules/localfirst.md 의 \"Notion 처럼 폴더만 선택해도 사용\" 헌장을 데이터 레이어에서 어떻게 구현하는지 정의. 관련 문서: .claude/rules/localfirst.md — 헌장 (이 문서가 따른다) docs/DATAMODEL.md — Fi",
       "wordCount": 1154,
-      "updatedAt": "2026-04-30T23:03:19.213Z",
+      "updatedAt": "2026-05-01T09:34:42.967Z",
       "mode": "both",
       "linksOut": []
     },
@@ -1185,7 +1398,7 @@
       ],
       "excerpt": "Status: 도입 완료 (Phase 23, 20260501). Why: 기획자 audit 의 root cause 1 — 모드 인지 hook 부재로 모든 게이트가 auth role 만 봄. local vault 활성 비로그인 사용자가 mutation 불가. Spec 의 위치: .claude/rules/localfirst.md 헌장 + docs/LOCALFIRSTSYNC.md § \"운영 모드\" 의 코드 레이어 implementation. 이 문서는 어떤 entity 가 mutation 을 받는지가 사용자의 진실원 모드에 따라 다른 흐름 을 갖도록 하는 패턴이다. 새 e",
       "wordCount": 903,
-      "updatedAt": "2026-05-01T05:48:10.189Z",
+      "updatedAt": "2026-05-01T09:34:42.967Z",
       "mode": "both",
       "linksOut": []
     },
@@ -1309,7 +1522,7 @@
       ],
       "excerpt": "Status: 제안 단계 (DRAFT). 자율 루프 iter25 (20260501) 작성. main merge 전 user 승인 필요. 특히 Open question 1 (HomePage 자동 vault 전환) 답이 정해진 후 §3 의 진입점 분기 확정. 이 문서는 비로그인 사용자가 첫 화면에서 0 마찰로 사용 시작 하도록 라우트별 진입 동작·권한 게이트·온보딩 단계를 명시한다. .claude/rules/localfirst.md 의 헌장 (\"Notion 처럼 폴더만 선택해도 사용\") 을 UI 레이어에서 어떻게 구현하는지 정의. 관련: .claude/rules/loca",
       "wordCount": 1575,
-      "updatedAt": "2026-04-30T23:48:51.909Z",
+      "updatedAt": "2026-05-01T09:34:42.967Z",
       "mode": "both",
       "linksOut": []
     },
@@ -1618,13 +1831,177 @@
       ],
       "excerpt": "Status: 제안 단계. main 머지 전 user 승인 필요. Author: 자율 루프 iter12 (20260501). Inputs: C0 (현재 모델 캡처) · C1 (Wikidata 학습) · C2 (Palantir 학습). Goal: 현재 4layer class + 7relation TBox + evidencegrounded ABox 위에 qualifiers · rank · literal properties · rich references · cardinality · action type 을 점진 도입해 RDFstar + Foundryclass 표현력에 도",
       "wordCount": 7768,
-      "updatedAt": "2026-05-01T06:48:25.686Z",
+      "updatedAt": "2026-05-01T09:34:42.967Z",
       "mode": "both",
       "linksOut": [
         "other-doc",
         "doc:payment-spec",
         "capability:tax"
       ]
+    },
+    {
+      "slug": "PRODUCT-DIRECTION",
+      "path": "docs/PRODUCT-DIRECTION.md",
+      "title": "PRODUCT DIRECTION — 온톨로지 워크벤치 (사람 + AI agent 공동 저작)",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "PRODUCT DIRECTION — 온톨로지 워크벤치 (사람 + AI agent 공동 저작)",
+          "slug": "product-direction-온톨로지-워크벤치-사람-ai-agent-공동-저작"
+        },
+        {
+          "depth": 2,
+          "text": "TL;DR — 1원리 한 줄 (v2)",
+          "slug": "tldr-1원리-한-줄-v2"
+        },
+        {
+          "depth": 2,
+          "text": "1. user 결정 요약",
+          "slug": "1-user-결정-요약"
+        },
+        {
+          "depth": 3,
+          "text": "결정 1 — Direction A (온톨로지 first)",
+          "slug": "결정-1-direction-a-온톨로지-first"
+        },
+        {
+          "depth": 3,
+          "text": "결정 2 — Self-hosting + AI agent 협업",
+          "slug": "결정-2-self-hosting-ai-agent-협업"
+        },
+        {
+          "depth": 2,
+          "text": "2. 두 청중, 한 ontology",
+          "slug": "2-두-청중-한-ontology"
+        },
+        {
+          "depth": 2,
+          "text": "3. AI agent 협업 — 구체적으로 무엇",
+          "slug": "3-ai-agent-협업-구체적으로-무엇"
+        },
+        {
+          "depth": 3,
+          "text": "3-A. 읽기 path (이미 가능)",
+          "slug": "3-a-읽기-path-이미-가능"
+        },
+        {
+          "depth": 3,
+          "text": "3-B. 쓰기 path (필요)",
+          "slug": "3-b-쓰기-path-필요"
+        },
+        {
+          "depth": 3,
+          "text": "3-C. 양방향 sync",
+          "slug": "3-c-양방향-sync"
+        },
+        {
+          "depth": 2,
+          "text": "4. 로컬 패키지 — 어떻게 distribute",
+          "slug": "4-로컬-패키지-어떻게-distribute"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 A — npm 패키지 + CLI",
+          "slug": "옵션-a-npm-패키지-cli"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 B — Electron 데스크톱 앱",
+          "slug": "옵션-b-electron-데스크톱-앱"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 C — 그대로 Next.js 정적 export + 가이드만",
+          "slug": "옵션-c-그대로-nextjs-정적-export-가이드만"
+        },
+        {
+          "depth": 3,
+          "text": "권장: A 옵션 (CLI + npx)",
+          "slug": "권장-a-옵션-cli-npx"
+        },
+        {
+          "depth": 2,
+          "text": "5. AI agent 가 partner 가 되는 surface",
+          "slug": "5-ai-agent-가-partner-가-되는-surface"
+        },
+        {
+          "depth": 3,
+          "text": "5-A. MCP 서버",
+          "slug": "5-a-mcp-서버"
+        },
+        {
+          "depth": 3,
+          "text": "5-B. AGENTS.md / CLAUDE.md 에 ontology 인덱스 자동 생성",
+          "slug": "5-b-agentsmd-claudemd-에-ontology-인덱스-자동-생성"
+        },
+        {
+          "depth": 2,
+          "text": "6. 단계 — 실행 가능 하게 분해",
+          "slug": "6-단계-실행-가능-하게-분해"
+        },
+        {
+          "depth": 3,
+          "text": "Phase 1 — 정체성 정렬 (UI)",
+          "slug": "phase-1-정체성-정렬-ui"
+        },
+        {
+          "depth": 3,
+          "text": "Phase 2 — Self-hosting",
+          "slug": "phase-2-self-hosting"
+        },
+        {
+          "depth": 3,
+          "text": "Phase 3 — AI agent partner",
+          "slug": "phase-3-ai-agent-partner"
+        },
+        {
+          "depth": 3,
+          "text": "Phase 4 — 비개발자 surface 다듬기",
+          "slug": "phase-4-비개발자-surface-다듬기"
+        },
+        {
+          "depth": 2,
+          "text": "7. 신구 mission 비교",
+          "slug": "7-신구-mission-비교"
+        },
+        {
+          "depth": 3,
+          "text": "구 mission (AGENTS.md, 현재)",
+          "slug": "구-mission-agentsmd-현재"
+        },
+        {
+          "depth": 3,
+          "text": "신 mission (이 문서로 제안)",
+          "slug": "신-mission-이-문서로-제안"
+        },
+        {
+          "depth": 2,
+          "text": "8. 즉시 다음 액션 (user 명령 대기 중)",
+          "slug": "8-즉시-다음-액션-user-명령-대기-중"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 A — Phase 1 즉시 시작 (UI 정체성 정렬)",
+          "slug": "옵션-a-phase-1-즉시-시작-ui-정체성-정렬"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 B — Phase 2 먼저 (self-hosting)",
+          "slug": "옵션-b-phase-2-먼저-self-hosting"
+        },
+        {
+          "depth": 3,
+          "text": "옵션 C — 이 문서 review + 추가 결정",
+          "slug": "옵션-c-이-문서-review-추가-결정"
+        }
+      ],
+      "excerpt": "작성일 (v2): 20260501 결정 반영: user 가 Direction A (온톨로지 first) 확정 + dogfooding + AI agent 협업 방향 추가 본 문서는 PRODUCTDIRECTION.md v1 의 strategic 진단을 그대로 두고, 결정 + 새 방향을 v2 로 덮음. 이 프로젝트는 온톨로지 워크벤치다 — 비개발자와 AI agent 가 같이 한 codebase 의 mental model 을 함께 저작한다. 토폴로지 = 출구 (view) 중 하나 척추 = md 문서 → 자라는 ontology 비개발자 (PM · 디자이너 · 운영) 도 ERD",
+      "wordCount": 1454,
+      "updatedAt": "2026-05-01T09:34:42.967Z",
+      "mode": "both",
+      "linksOut": []
     }
   ],
   "backlinksDetail": {
@@ -1682,6 +2059,27 @@
         "fromSlug": "DESIGN-SYSTEM",
         "context": "# Design System > 이 문서는 설계 문서 섹션 3을 기반으로 유지된다. Linear 원본 사양은 **[`design-references/DESIGN-linear.md`]**를 참고. ## 선택 이유 Linear의 \"어둠에서 떠오르는 별빛\" 미학이 토폴로지의 별자리 메타포와 정확히 일치. 흑백 + 단일 인디고 악센트라는 극단적 제약이 **AI 생성 클리셰를 배제하는 최상의 방어책**",
         "linkText": "`design-references/DESIGN-linear.md`"
+      }
+    ],
+    "old": [
+      {
+        "fromSlug": "FEATURES",
+        "context": "| useProjectMutations | 본문 보존 + frontmatter 패치 | | Backlink rewrite | renameDoc 시 best-effort | 다른 파일의 `[[oldSlug]]`, `**[text]**` 자동 치환 | | Scaffold | 명령 팔레트 | 빈 vault 에 README + projects/ + 샘플 | ### 3.2 Mode-Aware Adapters | Hook | 책임 | |---|---",
+        "linkText": "text"
+      }
+    ],
+    "PRODUCT-DIRECTION": [
+      {
+        "fromSlug": "FEATURES",
+        "context": "orceAtlas2 가 dense 하게 그려서 결과적으로 **고-degree 허브만 시각적으로 도드라져 보임**. `/ontology` 는 비어있어서 사용자에게 \"토폴로지 서비스\" 인상 만드는 원인. → 별도 문서 **[`PRODUCT-DIRECTION.md`]** 참고. --- ## 5. 제약 / 의도된 부재 - **Multi-account**: 없음 — `accountId = null` 고정 (v2 협업 단계로 보류) - **외부 IAM**: 없음 — Firebase",
+        "linkText": "`PRODUCT-DIRECTION.md`"
+      }
+    ],
+    "oldSlug": [
+      {
+        "fromSlug": "FEATURES",
+        "context": "ateFrontmatter` | useProjectMutations | 본문 보존 + frontmatter 패치 | | Backlink rewrite | renameDoc 시 best-effort | 다른 파일의 `**[oldSlug]**`, `[text](old.md)` 자동 치환 | | Scaffold | 명령 팔레트 | 빈 vault 에 README + projects/ + 샘플 | ### 3.2 Mode-Aware Adapters | Ho",
+        "linkText": "oldSlug"
       }
     ],
     "other-doc": [
@@ -1798,6 +2196,13 @@
         "title": "Design System"
       },
       {
+        "name": "FEATURES",
+        "path": "FEATURES",
+        "type": "doc",
+        "slug": "FEATURES",
+        "title": "FEATURES — oh-my-ontology"
+      },
+      {
         "name": "LOCAL-FIRST-SYNC",
         "path": "LOCAL-FIRST-SYNC",
         "type": "doc",
@@ -1824,6 +2229,13 @@
         "type": "doc",
         "slug": "ONTOLOGY-MODEL-V2-DRAFT",
         "title": "Ontology Model V2 — DRAFT (제안)"
+      },
+      {
+        "name": "PRODUCT-DIRECTION",
+        "path": "PRODUCT-DIRECTION",
+        "type": "doc",
+        "slug": "PRODUCT-DIRECTION",
+        "title": "PRODUCT DIRECTION — 온톨로지 워크벤치 (사람 + AI agent 공동 저작)"
       }
     ]
   }

--- a/src/entities/knowledge-graph/model/demo-insight.ts
+++ b/src/entities/knowledge-graph/model/demo-insight.ts
@@ -3,6 +3,7 @@ import {
   getDemoKnowledgeDocumentsByProject,
   getDemoProject,
 } from "@/shared/mocks/demo-data";
+import { CONTAINER_THEMES } from "@/shared/mocks/demo-blueprint";
 import type { KnowledgeGraphEdge, KnowledgeGraphNode, KnowledgeProjectInsight } from "./types";
 
 const DEMO_PUBLISHED_AT = new Date("2026-04-20T09:00:00Z");
@@ -47,6 +48,12 @@ export function getDemoKnowledgeProjectInsight(
   projectId: string,
   _accountId?: string | null,
 ): KnowledgeProjectInsight {
+  // /ontology 페이지의 글로벌 view — 모든 도메인의 capability/element 를
+  // ontology 노드로 합쳐서 트리·ego graph 가 풍부하게 보이게.
+  if (projectId === "__all__") {
+    return getDemoGlobalOntology();
+  }
+
   const project = getDemoProject(projectId);
   const documents = getDemoKnowledgeDocumentsByProject(projectId);
   if (!project || documents.length === 0) {
@@ -131,6 +138,101 @@ export function getDemoKnowledgeProjectInsight(
   return {
     nodes: [projectNode, ...documentNodes, ...conceptNodes],
     edges: [...documentEdges, ...conceptEdges],
+    meta: {
+      id: "current",
+      currentPublishId: "demo-public-projection",
+      projectionVersion: "demo-v1",
+      publishedAt: DEMO_PUBLISHED_AT,
+    },
+  };
+}
+
+/**
+ * 모든 컨테이너 도메인의 capability + element 를 ontology 노드로 펼쳐
+ * `/ontology` 글로벌 트리에서 의미 있는 시각화. AI 추출 cloud path 가 비활성
+ * 이라 demo 의 frontmatter 정의 (CONTAINER_THEMES) 가 곧 ontology 진실원.
+ *
+ * 출력 구조:
+ *   각 컨테이너 = domain 노드 (kind: domain)
+ *   각 capability = capability 노드, domain 의 자식 (contains)
+ *   각 element = element 노드, domain 의 자식 (contains)
+ */
+function getDemoGlobalOntology(): KnowledgeProjectInsight {
+  const nodes: KnowledgeGraphNode[] = [];
+  const edges: KnowledgeGraphEdge[] = [];
+
+  for (const theme of CONTAINER_THEMES) {
+    const domainId = `demo:${theme.id}:domain`;
+    nodes.push(
+      demoNode({
+        id: domainId,
+        title: theme.name,
+        kind: "domain",
+        projectIds: [theme.id],
+        summary: theme.description,
+        evidenceIds: [],
+        evidenceCount: 0,
+      }),
+    );
+
+    for (const capability of theme.capabilities) {
+      const capId = `demo:${theme.id}:cap:${slugPart(capability)}`;
+      nodes.push(
+        demoNode({
+          id: capId,
+          title: capability,
+          kind: "capability",
+          projectIds: [theme.id],
+          summary: `${theme.name} 도메인의 사용자 가치.`,
+          evidenceIds: [],
+          evidenceCount: 0,
+        }),
+      );
+      edges.push(
+        demoEdge({
+          id: `demo:${theme.id}:edge:domain-cap:${slugPart(capability)}`,
+          from: domainId,
+          to: capId,
+          type: "contains",
+          label: "contains",
+          projectIds: [theme.id],
+          evidenceIds: [],
+          evidenceCount: 0,
+        }),
+      );
+    }
+
+    for (const element of theme.elements) {
+      const elemId = `demo:${theme.id}:el:${slugPart(element)}`;
+      nodes.push(
+        demoNode({
+          id: elemId,
+          title: element,
+          kind: "element",
+          projectIds: [theme.id],
+          summary: `${theme.name} 가 사용하는 element.`,
+          evidenceIds: [],
+          evidenceCount: 0,
+        }),
+      );
+      edges.push(
+        demoEdge({
+          id: `demo:${theme.id}:edge:domain-el:${slugPart(element)}`,
+          from: domainId,
+          to: elemId,
+          type: "contains",
+          label: "contains",
+          projectIds: [theme.id],
+          evidenceIds: [],
+          evidenceCount: 0,
+        }),
+      );
+    }
+  }
+
+  return {
+    nodes,
+    edges,
     meta: {
       id: "current",
       currentPublishId: "demo-public-projection",

--- a/src/shared/mocks/demo-blueprint.ts
+++ b/src/shared/mocks/demo-blueprint.ts
@@ -1,9 +1,13 @@
 /**
  * DEMO 데모 blueprint 생성기.
  *
- * 20 개 컨테이너 · 컨테이너당 10~20 허브 · 허브당 4~8 노드.
- * 일관된 deterministic random (seed) 로 매 빌드마다 같은 결과.
- * 각 허브·노드 slug 는 컨테이너 id 를 prefix 로 가져 charge 충돌 회피.
+ * Phase 1.5 슬림 (PRODUCT-DIRECTION v2): 21 → 6 컨테이너, hub/node count 도
+ * 축소. mission "온톨로지 first" 정렬 — 토폴로지가 dense 노드 자랑이 아니라
+ * 비개발자가 인식 가능한 도메인 6 개로.
+ *
+ * 6 컨테이너 × 평균 3 hub × 평균 3 node ≈ ~50 프로젝트 + ~18 hub.
+ * 각 컨테이너에는 ontology metadata (capabilities · elements) 가 명시되어
+ * `/ontology` 페이지에서 의미 있는 트리가 보이도록.
  */
 
 interface BlueprintNode {
@@ -30,34 +34,72 @@ interface BlueprintContainer {
 }
 
 // 각 컨테이너 테마 — 실제 플랫폼 도메인으로 felt-real 유지.
-const CONTAINER_THEMES: ReadonlyArray<{
+// `capabilities` / `elements` 는 `/ontology` 의 ontology 노드로 렌더되어
+// 토폴로지 (의존도 그래프) 와 ontology (개념 트리) 두 시각이 모두 살아 보임.
+export interface ContainerTheme {
   id: string;
   name: string;
   description: string;
   hubCount: number;
-  crossDepFrom?: string; // 이 컨테이너 첫 hub 가 다른 컨테이너 hub 에 의존 (system boundary)
-}> = [
-  { id: 'demo', name: 'Demo', description: '메인 제품 — 토폴로지 지도, 컨테이너/허브/노드 4-layer, 실시간 협업.', hubCount: 14 },
-  { id: 'demo-iam', name: 'Demo IAM', description: '인증·세션·권한 인프라.', hubCount: 12 },
-  { id: 'demo-reactor', name: 'Demo Reactor', description: 'Spring AI 기반 엔터프라이즈 AI Agent 런타임.', hubCount: 20, crossDepFrom: 'demo-iam' },
-  { id: 'demo-knowledge', name: 'Demo Knowledge', description: '문서 파이프라인 + 온톨로지 빌더 + 공개 그래프.', hubCount: 12, crossDepFrom: 'demo' },
-  { id: 'demo-billing', name: 'Demo Billing', description: '구독·사용량·청구서 발행.', hubCount: 10, crossDepFrom: 'demo-iam' },
-  { id: 'demo-analytics', name: 'Demo Analytics', description: '사용 지표·대시보드·리포트 파이프라인.', hubCount: 12 },
-  { id: 'demo-notify', name: 'Demo Notify', description: '이메일·Slack·웹훅 다채널 알림 허브.', hubCount: 10 },
-  { id: 'demo-storage', name: 'Demo Storage', description: 'Blob·메타·권한 통합 스토리지.', hubCount: 11, crossDepFrom: 'demo-iam' },
-  { id: 'demo-search', name: 'Demo Search', description: '벡터·키워드·하이브리드 검색 서비스.', hubCount: 10, crossDepFrom: 'demo-knowledge' },
-  { id: 'demo-workflow', name: 'Demo Workflow', description: '휴먼-인-더-루프 승인 + 스케줄 워크플로.', hubCount: 13 },
-  { id: 'demo-audit', name: 'Demo Audit', description: '조작 로그·보안 이벤트 감사.', hubCount: 10, crossDepFrom: 'demo-iam' },
-  { id: 'demo-ingest', name: 'Demo Ingest', description: '외부 소스 → 내부 지식으로 ETL.', hubCount: 11, crossDepFrom: 'demo-knowledge' },
-  { id: 'demo-sdk', name: 'Demo SDK', description: '외부 클라이언트용 SDK · CLI · MCP 서버.', hubCount: 10 },
-  { id: 'demo-presence', name: 'Demo Presence', description: 'WebSocket 기반 실시간 협업 상태.', hubCount: 10, crossDepFrom: 'demo' },
-  { id: 'demo-billing-gateway', name: 'Payment Gateway', description: '다중 PG 결제 추상화 레이어.', hubCount: 10, crossDepFrom: 'demo-billing' },
-  { id: 'demo-email', name: 'Demo Email', description: '트랜잭션 · 캠페인 이메일 라우팅.', hubCount: 10, crossDepFrom: 'demo-notify' },
-  { id: 'demo-scheduler', name: 'Demo Scheduler', description: 'Cron · 분산 큐 · 리트라이 스케줄러.', hubCount: 10, crossDepFrom: 'demo-workflow' },
-  { id: 'demo-observability', name: 'Demo Observability', description: 'Trace · Metric · Log 수집 + 알람.', hubCount: 11, crossDepFrom: 'demo-analytics' },
-  { id: 'demo-featureflag', name: 'Demo FeatureFlag', description: '롤아웃·AB 테스트·동적 토글.', hubCount: 10 },
-  { id: 'demo-onboarding', name: 'Demo Onboarding', description: '신규 사용자 가입·투어·샘플 데이터.', hubCount: 10, crossDepFrom: 'demo-iam' },
-  { id: 'demo-support', name: 'Demo Support', description: '고객지원·티켓·지식베이스 연동.', hubCount: 10, crossDepFrom: 'demo-knowledge' },
+  /** 이 컨테이너 첫 hub 가 다른 컨테이너 hub 에 의존 (system boundary). */
+  crossDepFrom?: string;
+  /** ontology — 이 도메인이 다루는 capabilities (사용자 가치). */
+  capabilities: ReadonlyArray<string>;
+  /** ontology — 이 도메인이 사용하는 elements (구체 element/component). */
+  elements: ReadonlyArray<string>;
+}
+
+export const CONTAINER_THEMES: ReadonlyArray<ContainerTheme> = [
+  {
+    id: 'demo',
+    name: 'Demo Workbench',
+    description: 'oh-my-ontology 본 제품 — 토폴로지 + 트리 + ERD 빌더.',
+    hubCount: 4,
+    capabilities: ['ontology 시각화', 'vault 동기', '검색', '빌더 캔버스'],
+    elements: ['Sigma.js', 'xyflow', 'IndexedDB', 'Next.js'],
+  },
+  {
+    id: 'demo-iam',
+    name: 'Demo IAM',
+    description: '인증·세션·권한 인프라.',
+    hubCount: 3,
+    capabilities: ['이메일 로그인', 'Google OAuth', '비밀번호 재설정', '세션 추적'],
+    elements: ['Firebase Auth', 'JWT', 'refresh token'],
+  },
+  {
+    id: 'demo-knowledge',
+    name: 'Demo Knowledge',
+    description: '문서 파이프라인 + 온톨로지 빌더 + 공개 그래프.',
+    hubCount: 3,
+    crossDepFrom: 'demo',
+    capabilities: ['문서 등록', 'frontmatter 추출', 'stub 승격', '검수 큐'],
+    elements: ['markdown parser', 'Firestore', 'Cloud Functions'],
+  },
+  {
+    id: 'demo-vault',
+    name: 'Demo Vault',
+    description: 'File System Access API 기반 로컬 폴더 동기.',
+    hubCount: 3,
+    capabilities: ['폴더 선택', 'manifest 빌드', '파일 변경 감지', 'frontmatter 패치'],
+    elements: ['File System Access API', 'IndexedDB', 'Web Worker'],
+  },
+  {
+    id: 'demo-search',
+    name: 'Demo Search',
+    description: '글로벌 검색 + 명령 팔레트.',
+    hubCount: 2,
+    crossDepFrom: 'demo-knowledge',
+    capabilities: ['fuzzy 매칭', 'kind 필터', '명령 팔레트', '단축키'],
+    elements: ['cmdk', 'Radix Dialog', '한·영 fuzzy matcher'],
+  },
+  {
+    id: 'demo-design',
+    name: 'Demo Design',
+    description: '디자인 시스템 — 토큰 · 컴포넌트 · 헌장.',
+    hubCount: 2,
+    capabilities: ['디자인 토큰', '다크/라이트 테마', '접근성', '모션 정책'],
+    elements: ['Tailwind CSS 4', 'CSS 변수', 'Radix UI', 'lucide-react'],
+  },
 ];
 
 // 허브 이름 풀 — container 와 조합해 "{Container Short} · {Hub Role}" 형식.
@@ -114,7 +156,7 @@ export function generateDemoBlueprint(): ReadonlyArray<BlueprintContainer> {
       const role = HUB_ROLE_POOL[(hashSeed(theme.id) + h) % HUB_ROLE_POOL.length];
       const hubSlug = `${theme.id}-${toSlugSuffix(role)}${h === 0 ? '' : `-${h}`}`;
       const hubName = `${theme.name} · ${role}`;
-      const nodeCount = pickInRange(rng, 5, 10);
+      const nodeCount = pickInRange(rng, 2, 4);
       const nodes: BlueprintNode[] = [];
       for (let n = 0; n < nodeCount; n += 1) {
         const nodeRole = NODE_ROLE_POOL[(n + h * 3) % NODE_ROLE_POOL.length];

--- a/src/shared/mocks/demo-data.sanity.test.ts
+++ b/src/shared/mocks/demo-data.sanity.test.ts
@@ -2,24 +2,38 @@ import { describe, expect, it } from "vitest";
 import { getDemoDataset } from "./demo-data";
 
 /**
- * 데모 시드 sanity — 청사진이 의도된 풀-스케일로 펼쳐지는지 점검.
+ * 데모 시드 sanity — 슬림 (Phase 1.5) 후 6 컨테이너 / ~50 프로젝트 기준.
+ * 토폴로지가 dense 자랑이 아니라 비개발자도 읽을 수 있는 도메인 6 개로
+ * 정렬됨. ontology 노드는 demo-insight.ts 가 frontmatter capability/element
+ * 로부터 파생.
  */
 describe("demo dataset sanity", () => {
-  it("flat projects 200+ (데모 풀-스케일 기준)", () => {
+  it("6 컨테이너 도메인 — 슬림 후 명확한 4-6 도메인", () => {
+    // hub/leaf 슬러그 prefix 분포로 컨테이너 수 추정. 첫 token = 도메인 id.
+    const domains = new Set(
+      getDemoDataset().projects.map((p) => p.slug.split("-").slice(0, 2).join("-")),
+    );
+    expect(domains.size).toBeGreaterThanOrEqual(4);
+    expect(domains.size).toBeLessThanOrEqual(20);
+  });
+
+  it("flat projects 30~80 (슬림 demo 적정 범위)", () => {
     const total = getDemoDataset().projects.length;
-    expect(total).toBeGreaterThanOrEqual(200);
+    expect(total).toBeGreaterThanOrEqual(30);
+    expect(total).toBeLessThanOrEqual(120);
   });
 
-  it("hub 비율이 일정 수준 (최소 30 hubs)", () => {
+  it("hub 비율 (최소 10 hubs — 도메인 6 × 평균 2 hub)", () => {
     const hubs = getDemoDataset().projects.filter((p) => p.isHub);
-    expect(hubs.length).toBeGreaterThanOrEqual(30);
+    expect(hubs.length).toBeGreaterThanOrEqual(10);
   });
 
-  it("cross-project 의존이 풍부 (총 dependencies 수 100+)", () => {
+  it("cross-project 의존 — 의존 관계 sparse 하지만 존재", () => {
     const total = getDemoDataset().projects.reduce(
       (sum, p) => sum + p.dependencies.length,
       0,
     );
-    expect(total).toBeGreaterThan(100);
+    // 슬림 demo 는 토폴로지 가독성 위해 dense 안 만듦. 일정 비율만 검증.
+    expect(total / getDemoDataset().projects.length).toBeGreaterThan(0.5);
   });
 });


### PR DESCRIPTION
## Summary

PRODUCT-DIRECTION v2 의 demo 권고 적용. 토폴로지 dense 자랑 (2250 노드) 을 비개발자가 인식 가능한 **6 도메인** 으로 격하 + \`/ontology\` 글로벌 view 에 capability + element 노드 직접 노출.

### 변경
- **demo-blueprint.ts**:
  - CONTAINER_THEMES 21 → **6** (Demo Workbench · IAM · Knowledge · Vault · Search · Design)
  - hubCount 10-20 → 2-4
  - 각 컨테이너에 capability + element ontology metadata 명시
- **demo-blueprint.ts** generateDemoBlueprint: nodeCount 5-10 → 2-4
- **demo-insight.ts**: \`getDemoKnowledgeProjectInsight("__all__")\` 신규 → \`getDemoGlobalOntology()\` 가 6 domain × ~4 capability + ~3 element = **~42 ontology 노드 + ~42 edges** 반환
- 결과: \`/\` (OntologyViewPage) 가 demo 모드에서 6 도메인 트리 + capability/element 자식 노드 노출. \`/topology\` 는 sparse ~50 hub/node.

## Test plan
- [x] tsc 0 errors
- [x] vitest 117 / 843 pass
- [x] /topology 정상 + console 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)