### PR TITLE
feat: MCP v0.2 (patch_concept + find_backlinks) + dogfood vault 동기화

### DIFF
--- a/docs/ontology/capabilities/mcp-server.md
+++ b/docs/ontology/capabilities/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 slug: capabilities/mcp-server
 kind: capability
-title: MCP Server (5 tools)
+title: MCP Server (7 tools)
 domain: ai-agent-partner
 elements:
   - mcp/src/index.js
@@ -12,16 +12,18 @@ relates:
   - domains/ai-agent-partner
 ---
 
-# MCP Server (5 tools)
+# MCP Server (7 tools)
 
-`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 5 도구 노출:
+`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버 (v0.2.0). 7 도구 노출:
 
 | 도구 | 동작 |
 |---|---|
 | `list_concepts` | vault 의 모든 노드 (kind 필터) |
 | `get_concept` | 단일 slug 의 frontmatter + body excerpt + 이웃 |
 | `find_evidence` | title 부분매칭으로 vault 문서 검색 |
+| `find_backlinks` | 특정 slug 를 가리키는 다른 노드들 (frontmatter array 키 + body wikilink/mdlink) |
 | `add_concept` | 새 노드 (.md) 작성 — 기존 slug 면 throw |
 | `add_relation` | depends_on / relates / contains / describes edge 추가 |
+| `patch_concept` | 기존 노드 frontmatter (key 단위 patch) + body 갱신 |
 
 환경변수 `OMOT_VAULT` 로 vault 위치 지정. 등록 가이드: `mcp/README.md`.

--- a/docs/ontology/capabilities/mode-aware-adapter.md
+++ b/docs/ontology/capabilities/mode-aware-adapter.md
@@ -7,15 +7,23 @@ elements:
   - src/shared/hooks/use-data-source-mode
   - src/features/project-data-source
   - src/features/use-project-mutations
+  - src/features/vault-ontology
 relates:
   - domains/vault-local-first
   - domains/mode-aware-adapters
+  - capabilities/ontology-hub-mode-aware
 ---
 
 # Mode-Aware Data Source Adapter
 
 `useDataSourceMode()` 가 vault 활성 / Firebase 로그인 / 둘 다 없음 → local / cloud / static
 3 분기. 같은 hook 호출이 mode 별로 다른 source 를 본다 — 호출자 코드는 단일.
+
+적용 surface:
+- `useProjects` — local: vault manifest, cloud: Firestore subscribe
+- `useProjectMutations` — local: vault file write, cloud: Firestore upsert
+- `useOntologyInsight` (mission v2) — local: vault frontmatter stub, cloud: knowledgePublic projection
+- `TaxonomyProvider` — local/static: defaults, cloud: subscribe
 
 회귀 차단 anti-pattern (`docs/MODE-AWARE-CRUD.md` §5):
 - mode 검증 없이 직접 Firestore subscribe

--- a/docs/ontology/capabilities/ontology-hub-mode-aware.md
+++ b/docs/ontology/capabilities/ontology-hub-mode-aware.md
@@ -1,0 +1,20 @@
+---
+slug: capabilities/ontology-hub-mode-aware
+kind: capability
+title: Ontology Hub — Mode-Aware (Q1=(a))
+domain: mode-aware-adapters
+elements: [src/features/vault-ontology/model/use-ontology-insight.ts, src/views/ontology-view/ui/OntologyViewPage.tsx]
+relates: [capabilities/mode-aware-adapter, capabilities/frontmatter-to-ontology, domains/views]
+---
+
+# Ontology Hub — Mode-Aware (Q1=(a))
+
+LOOP-TASK Open question #1 의 (a) — vault 활성 시 `/` 가 자동으로 그 데이터로 전환. mission v2 ideal "Notion 처럼 폴더만 골라도 사용" 의 ontology hub 표현.
+
+`useOntologyInsight(accountId)`:
+- mode === local → useVaultOntology 결과를 KnowledgeProjectInsight shape 으로 변환
+- mode !== local → useKnowledgePublicInsight 그대로
+
+OntologyStubNode → KnowledgeGraphNode 변환은 sentinel lastApprovedAt = Date(0), lastApprovedBy = "vault-frontmatter", source = "manual".
+
+OntologyViewPage 가 useOntologyInsight 로 바꿔 vault 활성 시 즉시 vault frontmatter 의 stub 노드/엣지가 트리·ego graph·검색에 등장.

--- a/docs/ontology/project.md
+++ b/docs/ontology/project.md
@@ -6,6 +6,7 @@ domain: workbench
 capabilities:
   - frontmatter-to-ontology
   - mode-aware-adapter
+  - ontology-hub-mode-aware
   - 3-view-rendering
   - ai-agent-partner
   - tbox-versioning

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -56,15 +56,17 @@
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## 도구 5종
+## 도구 7종 (v0.2.0)
 
 | 도구 | 동작 |
 |---|---|
 | `list_concepts` | vault 의 모든 노드 (`kind:` frontmatter 가진 .md). 옵션 `kind`, `limit`. |
 | `get_concept` | 단일 `slug` (확장자 제외) 의 frontmatter + body excerpt + 이웃 (dependencies / relates) |
 | `find_evidence` | `title` 부분매칭 — frontmatter title/capabilities/elements + body 본문 검색 |
+| `find_backlinks` | 특정 `slug` 를 가리키는 다른 노드들. frontmatter array 키 (capabilities / elements / dependencies / relates / …) + body wikilink/mdlink 모두 검사. |
 | `add_concept` | 새 `.md` 노드 작성. 필수: `slug` `kind` `title`. 옵션: `domain` `capabilities` `elements` `body`. 기존 slug 면 throw. |
 | `add_relation` | 두 slug 사이 edge. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). frontmatter 배열에 append. |
+| `patch_concept` | 기존 노드 frontmatter (key 단위 patch — null = 삭제) + body 갱신. `add_concept` 가 throw 한 기존 slug 를 *수정* 할 때 사용. |
 
 ## 로컬 검증
 
@@ -92,8 +94,9 @@ printf '%s\n' \
 
 ## 상태
 
-- 0.1.0 — 5 도구 (read 3 + write 2). 단일 파일 노드. 의존: `@modelcontextprotocol/sdk@^1.0.0`.
-- 이후: `patch_concept` (기존 노드 frontmatter 패치), `delete_concept` (위험 — confirmation 필요), `find_path` (graph traversal).
+- 0.2.0 — 7 도구 (read 4 + write 3). 단일 파일 노드. 의존: `@modelcontextprotocol/sdk@^1.0.0`.
+- 0.1.0 — 5 도구 (read 3 + write 2).
+- 이후: `delete_concept` (위험 — confirmation 필요), `find_path` (graph traversal), `list_kinds` (kind 분포 요약).
 
 ## 문제 해결
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server — sample/사람과 AI agent 가 같이 vault ontology 를 read/write",
   "type": "module",
   "bin": {

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -28,10 +28,12 @@ import { resolve } from 'node:path';
 
 import {
   ensureVaultRoot,
+  findBacklinks,
   loadVaultDocs,
   readDoc,
   slugToPath,
   patchFrontmatter,
+  updateDoc,
   writeDoc,
 } from './vault.mjs';
 
@@ -39,7 +41,7 @@ const VAULT_ROOT = resolve(process.env.OMOT_VAULT || process.cwd());
 ensureVaultRoot(VAULT_ROOT);
 
 const server = new Server(
-  { name: 'oh-my-ontology-mcp', version: '0.1.0' },
+  { name: 'oh-my-ontology-mcp', version: '0.2.0' },
   { capabilities: { tools: {} } },
 );
 
@@ -150,6 +152,48 @@ const TOOLS = [
       required: ['from', 'to', 'type'],
     },
   },
+  {
+    name: 'patch_concept',
+    description:
+      '기존 ontology 노드 (.md 파일) 의 frontmatter 와/또는 body 를 갱신. ' +
+      'AI agent 가 기존 노드를 수정·심화·재분류할 때 사용. frontmatter ' +
+      'patch 는 키 단위 — null = 키 삭제, 미지정 = 기존 보존. body 는 전체 ' +
+      '교체 또는 미지정 시 보존.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        slug: { type: 'string', description: 'vault-relative slug (확장자 제외).' },
+        frontmatter: {
+          type: 'object',
+          description:
+            '갱신할 frontmatter 키-값 (예: { kind: "capability", domain: "views" }). null 은 키 삭제.',
+        },
+        body: {
+          type: 'string',
+          description: 'markdown 본문 전체 교체 (옵션). 미지정 시 보존.',
+        },
+      },
+      required: ['slug'],
+    },
+  },
+  {
+    name: 'find_backlinks',
+    description:
+      '특정 노드 (slug) 를 가리키는 다른 노드 목록 반환. frontmatter 배열 ' +
+      '키 (capabilities / elements / dependencies / relates / contains / ' +
+      'describes 등) 와 body 의 wikilink / markdown link 모두 검사. AI ' +
+      'agent 가 "이 노드 의존자가 누구인지" 그래프 탐색 시 사용.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          description: 'backlink 대상 vault-relative slug (확장자 제외).',
+        },
+      },
+      required: ['slug'],
+    },
+  },
 ];
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
@@ -170,6 +214,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok(addConcept(args));
       case 'add_relation':
         return ok(addRelation(args));
+      case 'patch_concept':
+        return ok(patchConcept(args));
+      case 'find_backlinks':
+        return ok(findBacklinksTool(args));
       default:
         throw new Error(`Unknown tool: ${name}`);
     }
@@ -284,6 +332,25 @@ function addRelation({ from, to, type }) {
   const next = [...existing, to];
   patchFrontmatter(VAULT_ROOT, from, { [key]: next });
   return { ok: true, from, to, type, key };
+}
+
+function patchConcept({ slug, frontmatter, body }) {
+  if (!slug) {
+    throw new Error('slug 가 필요합니다.');
+  }
+  if (frontmatter === undefined && body === undefined) {
+    throw new Error('frontmatter 또는 body 중 하나는 지정해야 합니다.');
+  }
+  const filePath = updateDoc(VAULT_ROOT, slug, { frontmatter, body });
+  return { ok: true, slug, filePath };
+}
+
+function findBacklinksTool({ slug }) {
+  if (!slug) {
+    throw new Error('slug 가 필요합니다.');
+  }
+  const matches = findBacklinks(VAULT_ROOT, slug);
+  return { target: slug, total: matches.length, matches };
 }
 
 // ── 부팅 ──────────────────────────────────────────────────────────────────

--- a/mcp/src/vault.mjs
+++ b/mcp/src/vault.mjs
@@ -121,6 +121,85 @@ export function patchFrontmatter(rootPath, slug, patch) {
 }
 
 /**
+ * 기존 doc 의 frontmatter + body 를 동시에 갱신. frontmatter 는 patchFrontmatter
+ * 와 동일한 patch 의미 (null = 삭제, undefined = skip). body 가 string 이면
+ * 교체, undefined 면 보존, null 이면 빈 본문.
+ */
+export function updateDoc(rootPath, slug, { frontmatter: patch, body }) {
+  const filePath = slugToPath(rootPath, slug);
+  if (!existsSync(filePath)) {
+    throw new Error(`Doc not found: ${slug}`);
+  }
+  const raw = readFileSync(filePath, 'utf-8');
+  const { frontmatter, body: oldBody } = parseFrontmatter(raw);
+  const nextFm = { ...frontmatter };
+  if (patch) {
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === null) {
+        delete nextFm[key];
+      } else if (value !== undefined) {
+        nextFm[key] = value;
+      }
+    }
+  }
+  const nextBody =
+    body === undefined ? oldBody : body === null ? '' : body;
+  const md = buildMarkdown({ frontmatter: nextFm, body: nextBody });
+  writeFileSync(filePath, md, 'utf-8');
+  return filePath;
+}
+
+/**
+ * 어느 vault doc 이 `targetSlug` 를 가리키는지 스캔. frontmatter 의 array
+ * 키 (capabilities, elements, dependencies, relates, contains, describes)
+ * 와 body 의 wikilink/markdown link 까지 본다.
+ */
+export function findBacklinks(rootPath, targetSlug) {
+  const docs = loadVaultDocs(rootPath);
+  const matches = [];
+  // frontmatter array 키 안의 항목이 targetSlug 와 일치 또는 끝부분 일치
+  // (예: targetSlug='capabilities/mcp-server' 가 항목 'mcp-server' 와도
+  // 매칭). markdown link 형식 `(./capabilities/mcp-server.md)` 도 잡는다.
+  const slugTail = targetSlug.split('/').pop();
+  for (const doc of docs) {
+    if (doc.slug === targetSlug) continue;
+    const matchedKeys = [];
+    for (const key of Object.keys(doc.frontmatter)) {
+      const value = doc.frontmatter[key];
+      if (Array.isArray(value)) {
+        if (
+          value.some(
+            (v) =>
+              typeof v === 'string' &&
+              (v === targetSlug || v === slugTail || v.endsWith(`/${slugTail}`)),
+          )
+        ) {
+          matchedKeys.push(key);
+        }
+      } else if (typeof value === 'string') {
+        if (value === targetSlug || value === slugTail) {
+          matchedKeys.push(key);
+        }
+      }
+    }
+    const bodyHit =
+      doc.body.includes(`[[${targetSlug}]]`) ||
+      doc.body.includes(`[[${slugTail}]]`) ||
+      doc.body.includes(`(${targetSlug}.md)`) ||
+      doc.body.includes(`/${slugTail}.md`);
+    if (matchedKeys.length === 0 && !bodyHit) continue;
+    matches.push({
+      slug: doc.slug,
+      kind: doc.frontmatter.kind,
+      title: doc.frontmatter.title || doc.frontmatter.name || doc.slug,
+      matchedKeys: matchedKeys.length > 0 ? matchedKeys : undefined,
+      matchedInBody: bodyHit || undefined,
+    });
+  }
+  return matches;
+}
+
+/**
  * vault root 가 markdown vault 같은지 가벼운 검사. 절대 경로 + 디렉토리만
  * OK 로 본다 (frontmatter 가 없는 폴더도 빈 vault 로 허용).
  */


### PR DESCRIPTION
## Summary

AI agent 의 ontology 저작 surface 강화:

- **MCP v0.2.0** — `patch_concept` (기존 노드 수정) + `find_backlinks` (그래프 탐색) 추가. 5 → 7 도구
- **dogfood vault 동기화** — `docs/ontology/` 에 Stage 4+5 (mission v2 cleanup) + MCP v0.2 변경 반영. 19 → 20 노드

## Commits

| sha | 변경 |
|---|---|
| 5b6a371 | feat: MCP v0.2 — patch_concept + find_backlinks |
| 6ae9c06 | docs: dogfood vault 동기화 |

## 새 도구

### `patch_concept(slug, frontmatter?, body?)`
기존 `add_concept` 가 throw 했던 *기존 slug* 를 수정. frontmatter 는 키 단위 patch (null = 삭제, 미지정 = 보존), body 는 전체 교체.

### `find_backlinks(slug)`
특정 slug 를 가리키는 다른 노드 목록. frontmatter array 키 (`capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`) + body 의 wikilink (`[[slug]]`) / markdown link (`slug.md`) 모두 검사.

예: `find_backlinks("capabilities/mcp-server")` →
- `elements/mcp-sdk` (relates 키)
- `domains/ai-agent-partner` (capabilities 키)

## Dogfood 검증

Phase 3 의 vision "사람과 AI agent 가 같이 저작" 을 본 PR 자체로 입증:
- `add_concept` 으로 `capabilities/ontology-hub-mode-aware` 신설
- `patch_concept` 으로 위 노드 body 정정 + relates 추가
- `find_backlinks` 로 `capabilities/mcp-server` backlinks 2개 정상 반환

이게 mission v2 의 *AI agent partner* 약속의 살아있는 증명.

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **117 files / 843 tests pass**
- `mcp/src/parser.test.mjs` 7/7 pass
- 실 MCP 서버 stdin/stdout JSON-RPC: initialize → tools/list (7 도구) → tools/call 모두 정상

## 변경 파일

```
mcp/src/index.js       — 2 도구 정의 + 2 핸들러 + import
mcp/src/vault.mjs      — updateDoc + findBacklinks helper
mcp/package.json       — version 0.1.0 → 0.2.0
mcp/README.md          — 도구 표 + 상태
docs/ontology/project.md
docs/ontology/capabilities/mcp-server.md         — 7 도구
docs/ontology/capabilities/mode-aware-adapter.md — useOntologyInsight 추가
docs/ontology/capabilities/ontology-hub-mode-aware.md  (신규)
```

## Test plan

- [ ] Claude Code 등록 후 `/mcp` 메뉴에 oh-my-ontology 도구 7개 노출
- [ ] `mcp__oh-my-ontology__find_backlinks({ slug: "capabilities/mcp-server" })` → 2 backlinks
- [ ] `mcp__oh-my-ontology__patch_concept({ slug: "capabilities/mcp-server", frontmatter: { foo: "bar" } })` → 파일에 `foo: bar` 추가, body 보존
- [ ] `pnpm dev` 후 `/docs/` vault picker 로 `docs/ontology/` 선택 → `/` 트리에 20 노드 + 새 ontology-hub-mode-aware capability 노드 노출 확인