### PR TITLE
feat: 빈 vault empty-state mode-aware + 세션 housekeeping (CHANGELOG + cleanup status)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,67 @@
 
 ---
 
+## 2026-05-01 (저녁) — Phase 3 (AI agent partner) + mission v2 cleanup
+
+PRODUCT-DIRECTION v2 의 mission "사람과 AI agent 가 같이 저작하는 codebase ontology" 를 코드 + functions + dogfood vault 까지 일관시킨 큰 cleanup. 누적 PR #5 / #6 / #7 머지.
+
+### 사용자 가시 변화
+
+- **AI agent partner 신설** — `mcp/` MCP 서버 (`@modelcontextprotocol/sdk@^1.0.0`). Claude Code 같은 LLM agent 가 stdin/stdout JSON-RPC 로 vault ontology 를 read/write. v0.2.0 7 도구: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`. 등록: `.mcp.json.example` 또는 `mcp/README.md`.
+- **`docs/ontology/` dogfood vault** — 이 프로젝트 자기 자신의 mental model 을 frontmatter md 로 표현. 1 project + 8 domain + 6 capability + 4 element = 20 노드.
+- **`/` ontology hub mode-aware** (Q1=(a)) — vault 활성 시 `/` 가 자동으로 vault frontmatter 의 stub 노드를 트리·ego graph·검색에 표시 (LOOP-TASK Open question #1 답).
+- **빈 vault UX** — local 모드에서 vault 가 활성됐는데 ontology 노드가 없으면 "vault 가 비어있어요" 안내 + 2-step (frontmatter / 빌더) CTA. local 모드면 "vault 열기" step skip.
+- **"분석 시작" cloud LLM 추출 흐름 제거** — mission v2 의 비용 모델이 *user-side AI agent (Claude Code)* 로 옮겨감. 영향 surface:
+  - `/knowledge/documents/[id]` 상세 — 4 단계 stepper → 2 단계 (upload → publish), `ExtractorVersionToggle` / "분석 시작" / "다시 분석" CTA 4곳 제거 → "vault 열기" / "빌더 열기" CTA
+  - `/review/knowledge` 검수 큐 — 페이지 + 라우트 통째 삭제. `OperationsNav` '문서 확인' 탭 제거 (5탭 → 4탭). 6 view 의 review 링크 제거
+  - `/ontology` toolbar 의 "검수 큐" pill 제거, "미해결 참조" Stat 의 review 큐 링크 → 페이지 안 stub 리스트로 변경
+  - `WorkspaceOntologyStrip` 의 stub chip target → `/ontology` 트리 stub 리스트로
+  - landing onboarding ValueChainRail "추출 돌리기" → "frontmatter 자체가 자기 승인"
+
+### 새 entity / feature / module
+
+- `mcp/` 통째 — MCP 서버 패키지 (parser.mjs / vault.mjs / index.js / parser.test.mjs). v0.1.0 (5 도구) → v0.2.0 (7 도구).
+- `src/features/vault-ontology/model/use-ontology-insight.ts` — mode-aware ontology insight. local: vault frontmatter stub 변환, cloud: knowledgePublic projection.
+- `docs/ontology/` 통째 — 자기 ontology vault.
+- `docs/MISSION-CLEANUP-CANDIDATES.md` — 4 stage cleanup staging plan (Stage 1+2+3+4 모두 완료).
+- `.mcp.json.example` — Claude Code 등록 템플릿.
+
+### 제거 / 정리
+
+- **functions/index.js: 2,012 → 543 줄 (-73%)**
+  - `enqueueExtractionJob` / `processExtractionJob` / `reclaimStaleExtractionJobs` (extraction 흐름 3 handler) 제거
+  - `applyReviewAction` (검수 큐 callable) 제거
+  - 의존 cores + helpers 약 20 함수 정리
+  - `extract-gemini.js` (224 줄) + `ontology-extract.js` (1,295 줄) + `ontology-extract.test.mjs` (812 줄) 삭제
+  - secrets `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` 제거. `@google/generative-ai` 의존성 제거
+- **`src/views/knowledge-review-workspace/` 통째 삭제** (1,357 줄 view + barrel)
+- **`app/review/` 통째 삭제** (page + redirect + sub-route)
+- **entity layer**: `enqueueKnowledgeExtractionJob` httpsCallable wrapper, `approveKnowledgeOutput` / `rejectKnowledgeOutput` callable + 6 type, `getKnowledgeReviewWorkspaceHref` helper 제거. 각 barrel export 정리.
+- **6 view caller**: KnowledgeDocumentDetailPage / (지운 KnowledgeReviewWorkspacePage) / KnowledgeDocumentsPage / KnowledgeDashboardPage / ProjectSelectorPage / ProjectEditorPage 의 review 큐 링크 정리
+- **누적 정리**: PR #5 -3,729 줄 + PR #6 -2,096 줄 + PR #7 -8 줄 = **약 -5,833 라인**
+
+### 검증 통과 상태
+
+- **117 test files / 843 tests passing**
+- tsc 0 errors
+- lint 0 errors (warnings 79 pre-existing)
+- `node --check functions/index.js` syntax OK
+- MCP 서버 stdin/stdout JSON-RPC: initialize → tools/list (7 도구) → tools/call (`add_concept` / `patch_concept` / `find_backlinks` / `find_evidence` / `get_concept` / `list_concepts`) end-to-end 정상
+- dev server (port 3210) 핵심 라우트 200, 삭제된 `/review/knowledge/` 404, HTML 에 Error 마커 0
+
+### Open questions
+
+- **Q1** — ✅ 답완료 ((a) 채택, useOntologyInsight 도입)
+- **Q2 (share-doc 제거)** — 여전히 대기
+- **Q3-Q8 (V2 spec)** — 여전히 대기
+
+### 운영 노트
+
+- `firebase deploy --only functions` 는 user 가 실행 안 함 (firebase 배포 안 함 정책). functions/ 변경은 코드만 정리, deploy 안 됨. 기존 cloud functions 가 살아있어도 호출자 0 이라 dead.
+- 기존 `knowledgeExtractionJobs` / `knowledgeExtractionOutputs` / `knowledgeReviews` / `knowledgeApprovalEvents` Firestore 컬렉션 데이터 — cold storage (read-only), 더 이상 callable 없어 archive-only.
+
+---
+
 ## 2026-05-01 — Mode-aware CRUD + Builder rebrand
 
 ### 사용자 가시 변화

--- a/docs/MISSION-CLEANUP-CANDIDATES.md
+++ b/docs/MISSION-CLEANUP-CANDIDATES.md
@@ -1,19 +1,26 @@
 # Mission Cleanup Candidates — mission v2 와 코드 정렬
 
 > 작성: 2026-05-01 (Phase 3 MCP partner 머지 후)
+> ✅ **Stage 1 + 2 + 3 + 4 코드 cleanup 모두 머지 완료** (2026-05-01 저녁, PR #5 / #6 / #7).
 > mission v2: "사람과 AI agent 가 같이 저작하는 codebase ontology" — `docs/PRODUCT-DIRECTION.md`
 > 본 문서는 *어떤 surface 가 mission 모순인지* 1원칙 분석 + *제거/단순화 staging plan*.
 
 ---
 
-## TL;DR — 4 stage
+## TL;DR — 4 stage 현황
 
-| Stage | 위험 | 가치 | 단일 atomic 가능? |
+| Stage | 위험 | 가치 | 상태 |
 |---|---|---|---|
-| **1. UI mention 제거** ("분석 시작" 버튼 + 안내 문구) | 낮음 | 높음 | YES — files 4-5, ~80 lines |
-| **2. client httpsCallable 호출 제거** (`enqueueExtractionJob` etc.) | 중 | 높음 | YES — entities/knowledge-job + entities/knowledge-graph |
-| **3. functions/ extraction code 제거** | 중 | 중 | YES — 1295+224 lines (단, Stage 1+2 soak 후) |
-| **4. Firestore 컬렉션 사후 정리** (`knowledgeJobs`, `knowledgeOutputs` 등) | 높음 | 낮음 | NO — 데이터 마이그레이션. 별도 RFC |
+| **1. UI mention 제거** ("분석 시작" 버튼 + 안내 문구) | 낮음 | 높음 | ✅ PR #5 머지 (commit 6208387) |
+| **2. client httpsCallable 호출 제거** (`enqueueExtractionJob` etc.) | 중 | 높음 | ✅ PR #5 머지 (commit 958cc34) |
+| **3. functions/ extraction code 제거** | 중 | 중 | ✅ PR #5 머지 (commit 7203af2) — code 만, deploy 안 함 |
+| **4. review queue 페이지 + Firestore 컬렉션 정리** | 높음 | 낮음 | 부분 ✅ — 페이지 + entity + functions handler 제거 (PR #6 dd09c59), Firestore 컬렉션 데이터는 cold storage 로 보존 (read-only) |
+
+추가 cleanup (본 문서 작성 후 발견):
+- ✅ Stage 4 light (advertising) — PR #5 commit 5905da7
+- ✅ Stage 5 (Q1=(a) 답) — useOntologyInsight, PR #6 commit b6b4edd
+- ✅ MCP v0.2 (patch_concept + find_backlinks) — PR #7 commit 5b6a371
+- ✅ docs/ontology dogfood vault sync — PR #7 commit 6ae9c06
 
 ---
 

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -389,25 +389,37 @@ export function OntologyViewPage() {
             emptyHint="아직 승인된 ontology 노드가 없어요. 아래 단계로 첫 그래프를 자라게 할 수 있어요."
           />
           {/* 빈 상태 onboarding — tree / orphans 모두 비었을 때만 노출.
-              검수 큐 진입과 함께 "온톨로지란 무엇이고, 어떻게 자라는지" 3 단계
-              가이드. 데이터 있을 때 화면 뺏지 않게 빈 상태 한정. */}
+              "온톨로지란 무엇이고, 어떻게 자라는지" 가이드. 데이터 있을 때
+              화면 뺏지 않게 빈 상태 한정. mode 별로 다른 다음-단계 안내:
+              - local (vault 활성): frontmatter 추가 → 빌더 정리 (vault 열기 단계 skip)
+              - 그 외: vault 열기 → frontmatter → 빌더 (3 step) */}
           {treeResult.roots.length === 0 && treeResult.orphans.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-5 py-5">
               <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 Get started
               </p>
               <h2 className="mt-1.5 break-keep text-base font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-                문서가 자라면 트리도 자라요
+                {dataSourceMode === 'local'
+                  ? 'vault 가 비어있어요 — frontmatter 를 적으면 즉시 자라요'
+                  : '문서가 자라면 트리도 자라요'}
               </h2>
               <p className="mt-2 break-keep text-sm leading-6 text-[color:var(--color-text-secondary)]">
-                온톨로지는 vault frontmatter 의 개념·관계가 모인 그래프예요. 다음 3 단계로 첫 트리를 만들어 봐요.
+                {dataSourceMode === 'local'
+                  ? '활성 vault 에 ontology frontmatter 가 있는 .md 파일이 0 개. 다음 2 단계로 첫 노드를 만들어요.'
+                  : '온톨로지는 vault frontmatter 의 개념·관계가 모인 그래프예요. 다음 3 단계로 첫 트리를 만들어 봐요.'}
               </p>
               <ol className="mt-4 space-y-2 text-sm text-[color:var(--color-text-secondary)]">
-                {[
-                  ["1", "vault 열기", "/docs 에서 마크다운 폴더를 선택해 vault 를 활성화해요."],
-                  ["2", "frontmatter 추가", "문서에 kind / capabilities / elements / relates 를 적으면 자동으로 stub 노드가 만들어져요."],
-                  ["3", "빌더에서 정리", "/ontology/edit 캔버스에서 노드와 관계를 다듬으면 여기 트리에 그대로 자라요."],
-                ].map(([step, title, desc]) => (
+                {(dataSourceMode === 'local'
+                  ? [
+                      ["1", "frontmatter 적기", "vault 안 아무 .md 파일에 `kind: capability` 같은 frontmatter 추가하면 즉시 stub 노드로 등장."],
+                      ["2", "빌더에서 정리", "/ontology/edit 캔버스에서 시각적으로 노드·관계 다듬으면 그대로 vault 에 저장 + 트리 갱신."],
+                    ]
+                  : [
+                      ["1", "vault 열기", "/docs 에서 마크다운 폴더를 선택해 vault 를 활성화해요."],
+                      ["2", "frontmatter 추가", "문서에 kind / capabilities / elements / relates 를 적으면 자동으로 stub 노드가 만들어져요."],
+                      ["3", "빌더에서 정리", "/ontology/edit 캔버스에서 노드와 관계를 다듬으면 여기 트리에 그대로 자라요."],
+                    ]
+                ).map(([step, title, desc]) => (
                   <li key={step} className="flex gap-3">
                     <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] font-mono text-[10px] text-[color:rgba(159,170,235,0.95)]">
                       {step}
@@ -420,18 +432,37 @@ export function OntologyViewPage() {
                 ))}
               </ol>
               <div className="mt-5 flex flex-wrap gap-2">
-                <Link
-                  href={"/docs/"}
-                  className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-4 py-2 text-sm text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
-                >
-                  vault 열기 →
-                </Link>
-                <Link
-                  href={"/ontology/edit/"}
-                  className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
-                >
-                  빌더 열기
-                </Link>
+                {dataSourceMode === 'local' ? (
+                  <>
+                    <Link
+                      href={"/ontology/edit/"}
+                      className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-4 py-2 text-sm text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
+                    >
+                      빌더 열기 →
+                    </Link>
+                    <Link
+                      href={"/docs/"}
+                      className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+                    >
+                      vault 살펴보기
+                    </Link>
+                  </>
+                ) : (
+                  <>
+                    <Link
+                      href={"/docs/"}
+                      className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-4 py-2 text-sm text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
+                    >
+                      vault 열기 →
+                    </Link>
+                    <Link
+                      href={"/ontology/edit/"}
+                      className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+                    >
+                      빌더 열기
+                    </Link>
+                  </>
+                )}
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

Q1=(a) Stage 5 후속 마무리:

- **빈 vault UX** — vault 활성됐는데 ontology 노드 0 인 사용자가 `/` 진입 시 mode 별 다른 안내 (local: 2-step / 그 외: 3-step)
- **CHANGELOG entry** — 2026-05-01 (저녁) 큰 변화 (mission v2 cleanup + AI agent partner) 기록
- **MISSION-CLEANUP-CANDIDATES** — 4 stage 모두 ✅ + commit sha 매핑

## 변경

### `src/views/ontology-view/ui/OntologyViewPage.tsx`
빈 트리 onboarding 의 dataSourceMode 분기:
- **local** → 헤딩 "vault 가 비어있어요 — frontmatter 를 적으면 즉시 자라요" + 2-step (frontmatter / 빌더) + primary CTA "빌더 열기" + secondary "vault 살펴보기"
- **그 외** → 기존 3-step (vault 열기 / frontmatter / 빌더) 유지

이전엔 vault 활성 사용자에게도 "vault 열기" CTA 가 노출돼 redundant.

### `docs/CHANGELOG.md`
2026-05-01 (저녁) entry — PR #5/#6/#7 누적:
- AI agent partner (mcp/) + dogfood vault (docs/ontology/) + Q1=(a) ontology hub mode-aware
- "분석 시작" cloud LLM 추출 흐름 surface 5종 제거
- 누적 -5,833 라인 정리
- 검증 + Open questions + 운영 노트

### `docs/MISSION-CLEANUP-CANDIDATES.md`
4 stage 모두 ✅ 표시 + commit sha 매핑 + 본 문서 작성 후 발견 항목 (Stage 4 light / Stage 5 / MCP v0.2 / dogfood sync) 추가.

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **117 files / 843 tests pass**
- `pnpm lint` 0 errors (warnings pre-existing)
- dev server (port 3210) `/` + `/ontology/` 200

## Test plan

- [ ] vault 활성 + 빈 vault 상태로 `/` 진입 → "vault 가 비어있어요" 헤딩 + 2-step + "빌더 열기" primary 확인
- [ ] vault 미활성 (cloud / static 모드) + 빈 ontology 상태로 `/` 진입 → 기존 "문서가 자라면 트리도 자라요" + 3-step + "vault 열기" 유지 확인