### PR TITLE
docs: README + AGENTS mission v2 동기화 (1원칙: 진입점 문서가 가장 high-leverage)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,30 @@
 
 ## Project overview
 
-`oh-my-ontology` 는 markdown 문서에서 지식 그래프를 자동으로 키우는 오픈소스 온톨로지 워크벤치다. 사용자가 글을 쓰면 시스템이 개념·관계·근거를 추출해 검수·승인하면 토폴로지·트리·ERD 세 가지 view 로 자라난다.
+`oh-my-ontology` 는 **사람과 AI agent 가 같이 저작하는 codebase ontology workbench** 다 (mission v2 — 2026-05-01). vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — frontmatter 자체가 자기-승인이라 별도 검수 단계 없음. 사람은 빌더 캔버스 또는 직접 `.md` 편집으로, AI agent (Claude Code 등) 는 `mcp/` MCP 서버로 같은 graph 를 read/write.
 
-자세한 소개와 모티베이션: `README.md`.
+자세한 방향: `docs/PRODUCT-DIRECTION.md`. 사용자 가시 기능 전수: `docs/FEATURES.md`.
 
 핵심 원칙 한 줄:
 
-> **토폴로지는 출구 중 하나, 진짜 척추는 md 문서 → 온톨로지.**
+> **md frontmatter 가 곧 그래프. 사람도 AI agent 도 같은 vault 에 쓴다.**
 
 ## Quick start
 
 ```bash
 pnpm install
-cp .env.example .env.local        # Firebase 사용 시 값 채움 (optional)
-pnpm dev                          # http://localhost:3000
+pnpm dev                          # http://localhost:3000 — 로그인 0, vault 폴더 선택만으로 즉시 동작
 
-pnpm test:run                     # vitest 137 files / 958 tests
+# Firebase 사용 시 (옵션 — cloud sync 필요할 때만)
+cp .env.example .env.local
+
+# 검증
+pnpm test:run                     # vitest 117 files / 843 tests
 pnpm exec tsc --noEmit
 pnpm lint
 pnpm build                        # 정적 export → out/
+
+# AI agent (Claude Code) 등록 — .mcp.json.example 복사 + 가이드: mcp/README.md
 ```
 
 ## Tech stack
@@ -30,9 +35,11 @@ pnpm build                        # 정적 export → out/
 - **Framework** Next.js 16 · App Router · `output: 'export'`
 - **Language** TypeScript 5
 - **Style** Tailwind CSS 4 (`@theme` CSS-based tokens)
-- **Visualization** Sigma.js (WebGL) · Graphology · ForceAtlas2 · d3-force · xyflow · Framer Motion
-- **Backend** Firebase (Firestore · Storage · Auth · Hosting · Functions 2nd gen) — 옵션. 로컬 폴더 모드만 써도 동작
-- **State** Firestore `onSnapshot` 실시간 구독 + React local state · URL state
+- **Visualization** Sigma.js (WebGL) · Graphology · ForceAtlas2 · xyflow
+- **Local-first** File System Access API + IndexedDB (vault handle 영속)
+- **AI agent** `@modelcontextprotocol/sdk` (stdin/stdout JSON-RPC server, `mcp/` 패키지)
+- **Backend** Firebase (Firestore · Storage · Auth · Hosting · Functions) — **옵션**. local-first 가 default
+- **State** Firestore `onSnapshot` (cloud) 또는 in-memory + IndexedDB (local) · React local state · URL state
 - **Architecture** Feature-Sliced Design (ESLint boundaries 로 import 방향 강제)
 - **Test** Vitest + Testing Library + jsdom · Playwright (E2E)
 - **Lint** ESLint 9 flat config
@@ -49,8 +56,10 @@ src/                       FSD 레이어
   ├── features/            인터랙션 단위
   ├── entities/            비즈니스 엔티티
   └── shared/              UI · lib · config · api 재사용 기반
+mcp/                       MCP 서버 (AI agent partner surface)
 docs/                      장기 문서 (architecture / data-model / design / deployment)
-functions/                 Cloud Functions (2nd gen)
+docs/ontology/             이 프로젝트 자기 ontology vault (dogfood, 20 노드)
+functions/                 Cloud Functions — 옵션 (mission v2 후 cold storage)
 tests/                     Vitest 단위 + Playwright E2E
 scripts/                   시드 / 배포 / 검증 보조
 .claude/rules/             세부 작업 규율 (자동 로드)
@@ -61,19 +70,21 @@ scripts/                   시드 / 배포 / 검증 보조
 ## Routes
 
 ```
-/                          토폴로지 view (전체 그래프)
-/projects                  프로젝트 목록
+/                          ontology 트리 hub (vault 활성 시 자동 vault 데이터)
+/topology                  토폴로지 view (Sigma WebGL)
+/projects                  프로젝트 목록 (mode-aware)
 /project/[slug]            프로젝트 상세 (권한 시 인라인 편집)
-/knowledge · /knowledge/*  문서 등록 / 분석 / 목록
-/review/knowledge          검수 큐
-/ontology                  승인된 트리 view
-/ontology/edit             ERD 캔버스 편집기
+/docs                      vault picker / vault 활성 시 문서 surface
+/knowledge · /knowledge/*  cloud 모드 문서 등록 / 목록
+/ontology/edit             ERD 캔버스 빌더 (xyflow + .md 내보내기)
 /ontology/insights         그래프 인사이트
 /ontology/relations        관계 분포
-/settings/*                카테고리 / 상태 / API 키 / 임포트
-/diagnostics/*             운영 인사이트
-/login · /signup · /reset-password · /account   인증 surface (옵션)
+/settings/*                카테고리 / 상태 / 가져오기
+/diagnostics/insights      운영 인사이트
+/login · /signup · /reset-password · /account   Firebase Auth surface (옵션)
 ```
+
+> mission v2 정렬: `/review/knowledge` 검수 큐 라우트 + `/admin/*` 네임스페이스는 폐기됨 (vault frontmatter 가 자기-승인). cloud LLM 추출 흐름 (`enqueueExtractionJob` 등) 도 functions/ 와 entity layer 모두에서 제거됨 — 자세히 `docs/MISSION-CLEANUP-CANDIDATES.md`.
 
 ## Working principles
 
@@ -95,12 +106,16 @@ scripts/                   시드 / 배포 / 검증 보조
 - `next.config.ts`
 - `app/layout.tsx`
 
-장기 문서:
+장기 문서 (mission v2 우선):
 
-- `@docs/ARCHITECTURE.md`
-- `@docs/DATA-MODEL.md`
-- `@docs/DESIGN-SYSTEM.md`
-- `@docs/DEPLOYMENT.md`
+- `@docs/PRODUCT-DIRECTION.md` — mission v2 방향
+- `@docs/FEATURES.md` — 사용자가 *지금* 사용 가능한 기능 전수
+- `@docs/MISSION-CLEANUP-CANDIDATES.md` — mission 정렬 cleanup 진행 (4 stage 완료)
+- `@docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x → V2 ontology 모델 진화 spec
+- `@docs/MODE-AWARE-CRUD.md` — local/cloud/static 분기 contributor 가이드
+- `@docs/ARCHITECTURE.md` · `@docs/DATA-MODEL.md` · `@docs/DESIGN-SYSTEM.md` · `@docs/DEPLOYMENT.md`
+- `@docs/CHANGELOG.md` — 사용자 가시 변화 시간순
+- `@mcp/README.md` — AI agent partner (MCP 7 도구) 등록 + 사용
 
 ## 이 프로젝트의 ontology
 

--- a/README.md
+++ b/README.md
@@ -1,113 +1,140 @@
 # oh-my-ontology
 
-> Markdown 문서에서 지식 그래프를 자동으로 키우는 오픈소스 온톨로지 워크벤치.
-> An open-source ontology workbench that grows a knowledge graph from your markdown.
+> 사람과 AI agent 가 같이 저작하는 codebase ontology workbench.
+> A workbench where humans and AI agents grow a codebase ontology — together.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://www.typescriptlang.org/)
-[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-38B2AC?logo=tailwind-css)](https://tailwindcss.com/)
+[![MCP](https://img.shields.io/badge/MCP-0.2.0-5e6ad2)](mcp/README.md)
 
 ---
 
 ## 무엇인가
 
-`oh-my-ontology` 는 **내가 쓴 글이 곧 그래프가 되는 도구**입니다.
+`oh-my-ontology` 는 **markdown frontmatter 가 곧 그래프** 인 도구입니다.
 
-- 도메인에 대해 markdown 문서를 적는다
-- 시스템이 문서에서 **개념(node)**, **관계(edge)**, **근거(provenance)** 를 추출한다
-- 사람이 검수·승인한다
-- 승인된 그래프는 토폴로지 / 트리 / ERD 세 가지 view 로 읽고, ERD 캔버스에서 직접 편집할 수도 있다
-- 외부 도구가 쓸 수 있게 공개 발행한다
+- vault 폴더 (markdown `.md` 들이 있는 폴더) 를 가리키면 즉시 시작 — 로그인은 옵션
+- `.md` 의 frontmatter 에 `kind: capability` / `capabilities: [...]` / `dependencies: [...]` 같은 키를 적으면 그게 *그대로* 노드와 관계
+- 사람은 빌더 캔버스 또는 직접 `.md` 편집으로, **AI agent (Claude Code 등) 는 MCP 서버로** 같은 그래프를 read/write
+- 같은 ontology 를 **세 시각** 으로 본다 — 트리 (`/`), 토폴로지 (`/topology`), ERD 빌더 (`/ontology/edit`)
 
-> "토폴로지는 출구 중 하나, 진짜 척추는 md 문서 → 온톨로지" — 프로젝트 작업 원칙
+> mission v2 (2026-05-01): "사람과 AI agent 가 같이 저작하는 codebase 의 ontology"
+>
+> 자세히: [`docs/PRODUCT-DIRECTION.md`](docs/PRODUCT-DIRECTION.md)
 
 ## 왜 만드는가
 
-- **노트 도구는 "글"** 만 다루고, **그래프 도구는 "구조"** 만 다룬다.
-- 사이에 비어 있는 자리가 있다 — *글에서 그래프가 자라는 워크벤치*.
-- Palantir Foundry 의 ontology 모델, Notion 의 database, Obsidian 의 graph view 를 한 워크플로 안에 묶는다는 시도.
+- 노트 도구는 **글** 만, 그래프 도구는 **구조** 만 다룬다 — 사이의 빈 자리.
+- LLM 이 codebase 를 분석할 때마다 *처음부터* 추론. agent 가 누적 지식을 *공유* 할 surface 가 필요.
+- *글에서 ontology 가 자라고, AI agent 가 그 ontology 를 같이 키운다* — 우리만의 차별화.
 
 ## 핵심 흐름
 
 ```
-                ┌────────────┐
-                │  markdown  │  사용자가 문서 작성
-                └──────┬─────┘
-                       │
-                       ▼
-                ┌────────────┐
-                │  Extract   │  LLM 또는 규칙 기반 추출
-                └──────┬─────┘
-                       │
-                       ▼
-                ┌────────────┐
-                │   Review   │  사람이 후보 검수
-                └──────┬─────┘
-                       │
-                       ▼
-            ┌──────────┴──────────┐
-            ▼                     ▼
-     ┌────────────┐        ┌────────────┐
-     │  Approved  │ ◄────► │   Public   │  발행 후 외부 도구가 활용
-     │   graph    │        │ projection │
-     └────────────┘        └────────────┘
-            │
-            ├── Topology view (force-directed)
-            ├── Tree view (taxonomy)
-            └── ERD canvas (직접 편집)
+                 ┌──────────────────┐
+                 │   .md vault      │  사용자 또는 AI agent 가 작성
+                 │   (frontmatter)  │
+                 └────────┬─────────┘
+                          │
+              ┌───────────┴────────────┐
+              │                        │
+              ▼                        ▼
+       ┌────────────┐           ┌────────────┐
+       │   사람     │           │  AI agent  │
+       │ 빌더 캔버스│           │   (MCP)    │
+       │ /docs 편집 │           │ Claude Code│
+       └────────────┘           └────────────┘
+              │                        │
+              └───────────┬────────────┘
+                          ▼
+                 ┌──────────────────┐
+                 │  ontology graph  │
+                 │ frontmatter 자체 │
+                 │ 가 자기-승인     │
+                 └────────┬─────────┘
+                          │
+              ┌───────────┼───────────┐
+              ▼           ▼           ▼
+        ┌─────────┐ ┌──────────┐ ┌──────────┐
+        │  Tree   │ │ Topology │ │   ERD    │
+        │   (/)   │ │(/topology│ │ (/edit)  │
+        │ ontology│ │  Sigma)  │ │ (xyflow) │
+        └─────────┘ └──────────┘ └──────────┘
 ```
 
 ## 핵심 기능
 
-- **문서 등록 + 버전 관리** — markdown 을 등록하고 분석 트리거
-- **추출 + 후보 생성** — 노드 / 관계 / 근거 후보를 자동 생성
-- **검수 큐** — 후보를 한 번에 살펴보고 승인 / 반려
-- **승인된 그래프 시각화**
-  - 토폴로지 (Sigma.js + ForceAtlas2 + d3-force) — 전체 그래프 탐색
-  - 트리 (taxonomy) — 계층 구조 빠르게 파악
-  - ERD 캔버스 (xyflow 기반) — 노드 / 관계를 직접 그리며 편집
-- **공개 발행** — private approved graph 와 public projection 을 분리해 외부 도구에 안전하게 노출
-- **검색 팔레트** (`⌘K`) — 노드·문서·명령 통합 검색
-- **다크 / 라이트 테마**
+- **vault frontmatter → ontology stub** — `kind:` 가진 `.md` 가 즉시 노드. `capabilities`, `elements`, `relates`, `dependencies`, `domain` 등 frontmatter 키가 곧 관계
+- **AI agent partner (MCP)** — `mcp/` 패키지가 Claude Code 같은 LLM agent 와 stdin/stdout JSON-RPC 로 7 도구 노출 (`list_concepts` · `get_concept` · `find_evidence` · `find_backlinks` · `add_concept` · `add_relation` · `patch_concept`)
+- **Mode-aware data source** — local (vault 활성) / cloud (Firebase 로그인) / static (둘 다 없음). 사용자에겐 단일 UX, 호출자 코드는 mode 분기 추상화
+- **3 view** — tree (`/` 의 계층), topology (`/topology` Sigma WebGL), builder (`/ontology/edit` xyflow ERD canvas + .md 내보내기)
+- **TBox versioning** — schema 의 git. 모든 fact 가 작성 시점 schema snapshot 을 frozen reference 로 가짐
+- **Search** — `⌘K` 프로젝트 / `⇧⌘K` 글로벌 (ontology + 문서 + 프로젝트)
+- **다크 / 라이트 테마** + 모바일 BottomTabBar + 한국어 UI
 
 ## 빠른 시작
+
+### Local-first (로그인 0)
 
 ```bash
 # 1. 의존성 설치
 pnpm install
 
-# 2. 환경 변수 설정 (Firebase 사용 시)
-cp .env.example .env.local
-# .env.local 을 열어 Firebase 설정값 채움
-
-# 3. 개발 서버
+# 2. 개발 서버
 pnpm dev
 # → http://localhost:3000
 
-# 4. 테스트 / 타입 체크 / 린트
-pnpm test:run
-pnpm exec tsc --noEmit
-pnpm lint
-
-# 5. 정적 export 빌드
-pnpm build
-# → out/
+# 3. /docs 진입 → "내 PC 마크다운 폴더 열기" → 즉시 사용
 ```
 
-### 로컬 Firestore 에뮬레이터
+### AI agent (Claude Code) 등록
+
+프로젝트 root 의 `.mcp.json` (예시: `.mcp.json.example` 복사):
+
+```json
+{
+  "mcpServers": {
+    "oh-my-ontology": {
+      "command": "node",
+      "args": ["./mcp/src/index.js"],
+      "env": { "OMOT_VAULT": "./docs/ontology" }
+    }
+  }
+}
+```
+
+Claude Code 재시작 → tool 메뉴에 `mcp__oh-my-ontology__*` 7 도구 등장. 자세히: [`mcp/README.md`](mcp/README.md).
+
+### 검증 / 빌드
 
 ```bash
-pnpm dev:firestore-emulator      # 별도 터미널 (127.0.0.1:18080)
-pnpm seed:emulator               # 시드 데이터 주입
+pnpm test:run                 # vitest 117 files / 843 tests
+pnpm exec tsc --noEmit
+pnpm lint
+pnpm build                    # 정적 export → out/
 ```
 
-`.env.local` 에 다음 추가:
+### Firebase (옵션)
 
+cloud sync 가 필요할 때만:
+
+```bash
+cp .env.example .env.local    # Firebase 설정 채움
 ```
-NEXT_PUBLIC_FIREBASE_USE_EMULATORS=1
-NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST=127.0.0.1:18080
+
+로컬 emulator:
+
+```bash
+pnpm dev:firestore-emulator   # 별도 터미널 (127.0.0.1:18080)
+pnpm seed:emulator            # 시드 주입
 ```
+
+`.env.local` 에 `NEXT_PUBLIC_FIREBASE_USE_EMULATORS=1` 추가.
+
+## Dogfooding — 이 프로젝트 자기 ontology
+
+이 repo 는 자기 자신의 mental model 을 `docs/ontology/` 에 vault 로 갖고 있습니다 (1 project + 8 domain + 6 capability + 4 element = 20 노드). `pnpm dev` 후 `/docs/` 에서 `docs/ontology/` 폴더 선택 → `/` 트리에서 즉시 노출. AI agent 가 MCP 로 같은 vault 를 query 할 때도 같은 데이터.
 
 ## 기술 스택
 
@@ -116,39 +143,40 @@ NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST=127.0.0.1:18080
 | Framework     | Next.js 16 (App Router · `output: 'export'`)                          |
 | Language      | TypeScript 5                                                          |
 | Style         | Tailwind CSS 4 (CSS-based `@theme`)                                   |
-| Visualization | Sigma.js (WebGL) · Graphology · ForceAtlas2 · d3-force · Framer Motion · xyflow |
-| Backend       | Firebase (Firestore · Storage · Auth · Hosting · Functions 2nd gen)   |
-| State         | Firestore `onSnapshot` 실시간 구독 + React local state / URL state    |
-| Architecture  | Feature-Sliced Design (ESLint boundaries 로 import 방향 강제)         |
+| Visualization | Sigma.js (WebGL) · Graphology · ForceAtlas2 · xyflow                  |
+| Local-first   | File System Access API + IndexedDB                                    |
+| AI agent      | `@modelcontextprotocol/sdk` (stdin/stdout JSON-RPC server)            |
+| Backend       | Firebase (Firestore · Storage · Auth · Hosting · Functions) — 옵션    |
+| Architecture  | Feature-Sliced Design (ESLint boundaries 강제)                        |
 | Test          | Vitest + Testing Library + jsdom · Playwright (E2E)                   |
 | Lint          | ESLint 9 flat config                                                  |
 | Package       | pnpm                                                                  |
 
 ## 디자인 철학
 
-- **Linear 베이스, 무채색 + 단일 인디고 (`#5e6ad2`)** — AI 생성 UI 클리셰 차단을 위한 극단적 제약.
-- **금지 목록**: 보라→핑크 그라디언트, glassmorphism, glow pulse, 움직이는 그라디언트 배경, scale 호버, 둘 이상의 채색 시스템.
-- 신호 톤만 예외 (경고 amber, 에러 red, 인디고 정책과 분리).
+- **Linear 베이스, 무채색 + 단일 인디고 (`#5e6ad2`)** — AI 생성 UI 클리셰 차단을 위한 극단적 제약
+- **금지 목록**: 보라→핑크 그라디언트, glassmorphism, glow pulse, 움직이는 그라디언트 배경, scale 호버, 둘 이상의 채색 시스템
+- 신호 톤만 예외 (경고 amber, 에러 red, 인디고 정책과 분리)
 
-자세한 토큰 / 모션 / 금지 규칙은 [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md).
+자세한 토큰 / 모션 / 금지 규칙: [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md).
 
 ## 주요 라우트
 
 ```
-/                          토폴로지 view (전체 그래프)
-/projects                  프로젝트 목록
+/                          ontology 트리 hub (vault 활성 시 자동 vault 데이터)
+/topology                  토폴로지 view (Sigma WebGL)
+/projects                  프로젝트 목록 (mode-aware)
 /project/[slug]            프로젝트 상세
-/knowledge                 문서 등록 / 분석
-/knowledge/documents       문서 목록
-/review/knowledge          검수 큐
-/ontology                  승인된 트리 view
-/ontology/edit             ERD 캔버스 편집기
+/docs                      vault picker / vault 활성 시 문서 surface
+/knowledge                 cloud 모드 문서 등록
+/knowledge/documents       cloud 모드 문서 목록
+/ontology/edit             ERD 캔버스 (xyflow + frontmatter md 내보내기)
 /ontology/insights         그래프 인사이트
 /ontology/relations        관계 분포
-/settings/*                카테고리 / 상태 / API 키 / 임포트
+/settings/*                카테고리 / 상태 / 가져오기
 /diagnostics/insights      운영 인사이트
-/account                   계정 설정
-/login · /signup           인증
+/account                   계정 설정 (Firebase 로그인 시)
+/login · /signup           Firebase Auth (옵션)
 ```
 
 ## 프로젝트 구조
@@ -162,99 +190,99 @@ src/                       FSD 레이어
   ├── features/            인터랙션 단위
   ├── entities/            비즈니스 엔티티
   └── shared/              재사용 기반 (UI · lib · config · api)
-docs/                      아키텍처 / 데이터 모델 / 디자인 시스템 문서
-functions/                 Cloud Functions (2nd gen)
-packages/                  내부 패키지
-tests/                     Vitest 단위 + Playwright E2E + golden fixtures
+mcp/                       MCP 서버 패키지 (AI agent partner surface)
+docs/                      장기 문서 (architecture / data-model / design / deployment)
+docs/ontology/             이 프로젝트 자기 ontology vault (dogfood)
+functions/                 Cloud Functions — 옵션 (mission v2 후 cold storage)
+tests/                     Vitest 단위 + Playwright E2E
 scripts/                   시드 / 배포 / 검증 스크립트
+.claude/rules/             세부 작업 규율 (Claude Code 자동 로드)
 ```
 
-**Import 방향**: `app → views → widgets → features → entities → shared`
+**Import 방향**: `app → views → widgets → features → entities → shared`. 역방향은 ESLint 가 차단.
 
 ## 로드맵
 
-> 자세한 1원칙 분해와 우선순위는 별도 작업 라운드에서 정리합니다.
+자세한 단계: [`docs/PRODUCT-DIRECTION.md`](docs/PRODUCT-DIRECTION.md).
 
-### v0.1 (현재 상태)
+### v0.x (현재)
 
-- 토폴로지 / 트리 / ERD 세 가지 view
-- 검수 큐 + 승인된 그래프 저장
-- Firebase 기반 multi-account workspace
-- 데모 / 시드 데이터로 즉시 체험 가능
+- ✅ Phase 1 — UI 정체성 정렬 (`/` ontology hub, `/topology` 분리)
+- ✅ Phase 2 — local-first vault (File System Access + IndexedDB 영속)
+- ✅ Phase 3 — AI agent partner (MCP 서버, dogfood vault)
+- ✅ mission v2 cleanup — cloud LLM extraction 흐름 / 검수 큐 surface 제거
+- 다음: V1.1 spec 진행 (statement qualifiers + rank, Wikidata 영감)
 
-### v1.0 (계획) — 1원칙 슬림화
+### v1.x (계획)
 
-- surface 를 핵심 5개로 단순화 (`/`, `/docs`, `/review`, `/edit`, `/tree`)
-- multi-account / demo / portfolio showcase 등 본질 외 기능 정리
-- contributor 가 5분 안에 첫 노드를 볼 수 있는 onboarding
+- V1.1 — `qualifiers?[]` + `rank?` (additive, breakage 0)
+- V1.2 — `knowledgeApprovedLiterals` (atomic property)
+- V1.3 — evidence rich references (retrievedAt / extractionModelId)
+- V1.4 — `OntologyActionType` (Palantir 영감)
+- V1.5 — relation cardinality
 
-### v2.0 (계획) — 협업 / 호스팅
+### v2.0 (계획)
 
-- 협업 워크스페이스 재도입 (server / cloud sync)
-- self-host 가이드
-- public projection API + SDK
-
-### Backlog
-
-- Local-first 모드 (IndexedDB / SQLite WASM 어댑터)
-- Property matrix view (노드 한 개의 모든 속성·관계 표)
-- Faceted / sunburst 시각화
-- Action types (Palantir 스타일 — entity 변경 명세를 ontology 일부로)
+- V1.x 통합 `KnowledgeStatement` 모델 — RDF-star 호환
+- 협업 워크스페이스 (multi-vault sync)
+- self-host 가이드 + npm distribution
 
 ## 키보드 단축키
 
-| Key             | 동작                       |
-| --------------- | -------------------------- |
-| `⌘K` / `Ctrl+K` | 검색 팔레트 열기 / 닫기    |
-| `F`             | 프레젠테이션 모드 토글     |
-| `Shift + 클릭`  | 두 노드 사이 최단 경로     |
-| `Tab`           | 이웃 순회                  |
-| `/`             | 캔버스 검색 포커스         |
-| `?`             | 단축키 전체 보기           |
-| `Esc`           | 드로어 / 팔레트 닫기       |
+| Key             | 동작                                       |
+| --------------- | ------------------------------------------ |
+| `⌘K` / `Ctrl+K` | 검색 팔레트 (프로젝트)                     |
+| `⇧⌘K`           | 글로벌 검색 (ontology + 문서 + 프로젝트)   |
+| `?`             | 단축키 시트                                |
+| `F`             | 빌더 전체 화면 토글                        |
+| `N`             | 빌더에서 새 project 노드                   |
+| `Del` / `⌫`     | 빌더에서 선택 노드 삭제                    |
+| `Esc`           | 모달 / 팔레트 닫기 / 선택 해제             |
 
 ## 문서 지도
 
-| 문서                                                    | 읽는 시점                                        |
-| ------------------------------------------------------- | ------------------------------------------------ |
-| [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md)     | AI 에이전트 / 컨트리뷰터 작업 시작 전            |
-| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)          | 제품 구조 · URL 공간 · 공개/운영 경계            |
-| [`docs/DATA-MODEL.md`](docs/DATA-MODEL.md)              | Firestore 스키마 + Security Rules                |
-| [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md)        | 디자인 토큰 · 모션 · 금지 규칙                   |
-| [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)              | Firebase 배포 절차 · 롤백 · 도메인               |
-| [`docs/OPERATIONS-GUIDE.md`](docs/OPERATIONS-GUIDE.md)  | 운영 흐름                                        |
-| [`docs/SEED-DATA.md`](docs/SEED-DATA.md)                | 시드 주입 절차                                   |
-| [`docs/rules/`](docs/rules/)                            | FSD · git · 네이밍 · 스키마 작업 규율            |
+| 문서                                                          | 읽는 시점                                        |
+| ------------------------------------------------------------- | ------------------------------------------------ |
+| [`AGENTS.md`](AGENTS.md) / [`CLAUDE.md`](CLAUDE.md)           | AI 도구 / contributor 작업 시작 전 (canonical)   |
+| [`docs/PRODUCT-DIRECTION.md`](docs/PRODUCT-DIRECTION.md)      | mission v2 방향 (필수)                           |
+| [`docs/FEATURES.md`](docs/FEATURES.md)                        | 사용자가 *지금* 사용 가능한 기능 전수            |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                | 제품 구조 · URL 공간 · 공개/운영 경계            |
+| [`docs/DATA-MODEL.md`](docs/DATA-MODEL.md)                    | Firestore 스키마 + Security Rules                |
+| [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md)              | 디자인 토큰 · 모션 · 금지 규칙                   |
+| [`docs/MODE-AWARE-CRUD.md`](docs/MODE-AWARE-CRUD.md)          | local/cloud/static 분기 contributor 가이드       |
+| [`docs/ONTOLOGY-MODEL-V2-DRAFT.md`](docs/ONTOLOGY-MODEL-V2-DRAFT.md) | V1.x → V2 ontology 모델 진화 spec          |
+| [`docs/MISSION-CLEANUP-CANDIDATES.md`](docs/MISSION-CLEANUP-CANDIDATES.md) | mission v2 정렬 4-stage 정리 (완료) |
+| [`docs/CHANGELOG.md`](docs/CHANGELOG.md)                      | 사용자 가시 변화 시간순                          |
+| [`mcp/README.md`](mcp/README.md)                              | MCP 서버 7 도구 + Claude Code 등록               |
+| [`.claude/rules/`](.claude/rules/)                            | FSD · git · 디자인 · testing · auth 작업 규율    |
 
 ## Contributing
 
-오픈소스 컨트리뷰션을 환영합니다. 본격적인 가이드 (`CONTRIBUTING.md`) 는 v0.1 안정화 후 정리됩니다. 그전까지의 안내:
+오픈소스 컨트리뷰션을 환영합니다.
 
-1. Issue 로 먼저 의도를 공유해 주세요 — 작업 중복 방지.
-2. 코드 변경은 새 브랜치에서. PR 단위는 작게.
-3. 커밋 메시지는 conventional prefix + 짧은 본문 (`feat: ...`, `fix: ...`, `refactor: ...`, `docs: ...`).
-4. 문서가 구현보다 앞섭니다 — 스키마 / 라우트 / 운영 모델 변경은 `docs/` 도 같이 갱신.
-5. 테스트가 있는 영역은 PR 에서 통과 확인 (`pnpm test:run`, `pnpm exec tsc --noEmit`, `pnpm lint`).
-6. 디자인 변경은 [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md) 의 금지 목록을 지킵니다.
-
-작업 규율 패키지: [`docs/rules/`](docs/rules/).
+1. Issue 로 의도 공유 — 작업 중복 방지
+2. 새 브랜치 + 작은 PR 단위
+3. 커밋 메시지 — 영문 conventional prefix + 한국어 본문 (`feat:` / `fix:` / `refactor:` / `docs:` …)
+4. **Docs-first** — 스키마 / 라우트 / 운영 모델 변경은 `docs/` 도 같이 갱신
+5. 검증 — `pnpm test:run`, `pnpm exec tsc --noEmit`, `pnpm lint` 모두 통과
+6. 디자인 — [`docs/DESIGN-SYSTEM.md`](docs/DESIGN-SYSTEM.md) 의 금지 목록 준수
 
 ## 라이선스
 
-[MIT License](LICENSE) — fork·수정·재배포 자유. 자세한 내용은 [`LICENSE`](LICENSE).
+[MIT License](LICENSE) — fork·수정·재배포 자유.
 
 ## Credits
 
-`oh-my-ontology` 는 다음 오픈소스 프로젝트들 위에 만들어졌습니다:
+오픈소스 의존:
 
 - [Next.js](https://nextjs.org/) · [TypeScript](https://www.typescriptlang.org/) · [Tailwind CSS](https://tailwindcss.com/)
-- [Sigma.js](https://www.sigmajs.org/) · [Graphology](https://graphology.github.io/)
-- [xyflow](https://xyflow.com/) (React Flow)
-- [Firebase](https://firebase.google.com/)
+- [Sigma.js](https://www.sigmajs.org/) · [Graphology](https://graphology.github.io/) · [xyflow](https://xyflow.com/)
+- [Firebase](https://firebase.google.com/) (옵션)
+- [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol) — AI agent partner
 - [Vitest](https://vitest.dev/) · [Playwright](https://playwright.dev/) · [Testing Library](https://testing-library.com/)
 - [Linear](https://linear.app/) — 디자인 영감 (해당 회사와 무관)
 
-영감을 준 제품군: Palantir Foundry · Notion · Obsidian · Neo4j Bloom · TerminusDB.
+영감을 준 모델: Wikidata · Palantir Foundry · OWL/RDF · Property Graph · Notion · Obsidian.
 
 ---
 


### PR DESCRIPTION
## 1원칙 분석

mission v2 (2026-05-01) 가 코드 + functions + dogfood vault 까지 정렬됐는데 진입점 문서 2종 (README / AGENTS) 이 mission v1 시대 — 새 contributor / AI 도구 / 사람 사용자 모두 첫 진입에서 mission 자체를 못 봄.

후보 비교 결과:

| 후보 | 1원칙 게이트 | 결정 |
|---|---|---|
| Q2 share-doc 제거 | mission 무관 (subtraction) — 마찰 marginal | skip |
| MCP `find_path` | ergonomic 보탬 (alternative 있음) | skip |
| MCP `delete_concept` | fs 로 대체 가능 + 위험 | skip |
| functions Firestore archival | operational only | skip |
| V1.1 Wikidata spec PR | 핵심이지만 user 승인 게이트 | 대기 |
| **README + AGENTS mission v2** | clone 한 사람 / AI 도구의 진입점. stale 하면 발견 가능성 망침 | ✅ |

## 변경

### README.md (통째 재작성)
- 무엇인가 — vault frontmatter = 그래프 + AI agent partner 명시
- 핵심 흐름 ASCII — Extract → Review → Approved (v1) → vault frontmatter → 사람 빌더 / AI agent MCP → ontology → 3 view
- 핵심 기능 — vault frontmatter / AI agent partner / mode-aware / 3-view / TBox versioning / search
- 빠른 시작 — Local-first 0 마찰 진입 → AI agent 등록 → 검증 → Firebase 옵션
- Dogfooding 섹션 신설 — `docs/ontology/` 자기 vault 안내 (1 project + 8 domain + 6 capability + 4 element = 20 노드)
- 주요 라우트 — `/review/knowledge` 제거, `/docs` + `/topology` 추가
- 로드맵 — v0.x Phase 1/2/3 완료 + V1.x spec 단계
- 단축키 정정 — F/N/Del 추가, Tab/Shift+클릭 잘못된 항목 제거
- 문서 지도 갱신, Credits 에 MCP SDK 추가

### AGENTS.md
- Project overview — mission v2 정렬
- Quick start — local-first default + AI agent 등록 줄. tests 카운트 갱신
- Tech stack — Local-first / AI agent 신규, Firebase 옵션 명시
- Folder map — mcp/ + docs/ontology/ 추가
- Routes — `/topology` 추가, `/review/knowledge` + `/admin/*` 폐기 명시
- Source-of-truth — 8 신규/갱신 문서 추가

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **117 files / 843 tests pass**
- 문서 변경만이라 코드 영향 0

## 누적 변경

- README.md: -261 → 289 줄 (+28 net, 큰 부분 재작성)
- AGENTS.md: 118 → 133 줄 (+15)
- **2 files changed, +211 / -168**

## Test plan

- [ ] README clone 첫인상 — "AI agent partner" 와 "vault frontmatter = ontology" 가 30초 안에 보임
- [ ] AGENTS.md "Project overview" 가 mission v2 + frontmatter 자기-승인 명시
- [ ] 라우트 표 — `/review/knowledge` 0, `/topology` 추가
- [ ] 문서 지도 — PRODUCT-DIRECTION / FEATURES / mcp/README 등 핵심 8 신규 진입점 모두 link