### PR TITLE
feat: V1.1 Wikidata qualifiers + rank + cleanup batch (CLAUDE/share-doc/dev-login 검증)

### DIFF
--- a/docs/ontology/capabilities/v1-1-qualifiers-rank.md
+++ b/docs/ontology/capabilities/v1-1-qualifiers-rank.md
@@ -1,0 +1,35 @@
+---
+slug: capabilities/v1-1-qualifiers-rank
+kind: capability
+title: V1.1 — Statement Qualifiers + Rank (Wikidata 영감)
+domain: ontology-core
+elements: [src/entities/knowledge-graph/model/types.ts, src/entities/knowledge-graph/model/mapper.ts, functions/index.js]
+---
+
+# V1.1 — Statement Qualifiers + Rank
+
+Wikidata 의 statement annotation 모델을 ontology edge 에 도입. additive (breakage 0), 마이그레이션 0, TBox 변경 0.
+
+## 추가 필드 (옵셔널)
+
+- `qualifiers?: { propertyId: string; value: QualifierValue }[]` — edge 의 한정자
+- `rank?: "preferred" | "normal" | "deprecated"` — 같은 (from, to, type) 다중 statement 우선순위
+
+## QualifierValue union
+
+- `{ kind: "string"; raw: string }`
+- `{ kind: "time"; iso: string; precision: "year" | "month" | "day" }`
+- `{ kind: "quantity"; value: number; unit?: string }`
+- `{ kind: "nodeRef"; nodeId: string }`
+
+## 호환성
+
+legacy edge: `qualifiers` 없음 + `rank` undefined → 코드는 `rank ?? "normal"` 폴백. mapper 가 invalid 항목 silently drop.
+
+## 구현 위치
+
+- types.ts — QualifierValue / EdgeQualifier / EdgeRank + KnowledgeGraphEdge 확장
+- mapper.ts — fromFirestoreKnowledgeGraphEdge 가 fields 인식 + invalid 폴백
+- functions/index.js publishKnowledgeProjectionCore — approved → public projection 시 qualifiers + rank fields-pass-through
+
+자세히: docs/ONTOLOGY-MODEL-V2-DRAFT.md §2.

--- a/docs/ontology/project.md
+++ b/docs/ontology/project.md
@@ -10,6 +10,7 @@ capabilities:
   - 3-view-rendering
   - ai-agent-partner
   - tbox-versioning
+  - v1-1-qualifiers-rank
 elements:
   - vault-local-first
   - ontology-core

--- a/functions/index.js
+++ b/functions/index.js
@@ -183,6 +183,11 @@ export async function publishKnowledgeProjectionCore({
         // 증거 갯수 — 클라이언트에서 edge 두께 가중 (evidence 많을수록 굵게)
         // 에 쓴다. nodes 와 동일한 명명규칙.
         evidenceCount: normalizeStringArray(data.evidenceIds).length,
+        // V1.1 — Wikidata 영감 statement qualifiers + rank. 양쪽 모두
+        // 옵셔널 — approved 가 가지면 그대로 public projection 으로 통과,
+        // 없으면 키 자체 생략.
+        ...(Array.isArray(data.qualifiers) ? { qualifiers: data.qualifiers } : {}),
+        ...(typeof data.rank === "string" ? { rank: data.rank } : {}),
         publishId: publishRef.id,
         projectionVersion: PROJECTION_VERSION,
         publishedAt: startedAt,

--- a/src/entities/knowledge-graph/index.ts
+++ b/src/entities/knowledge-graph/index.ts
@@ -1,4 +1,6 @@
 export type {
+  EdgeQualifier,
+  EdgeRank,
   KnowledgeEdgeType,
   KnowledgeGraphSource,
   KnowledgeGraphNode,
@@ -15,6 +17,7 @@ export type {
   AddManualKnowledgeEdgeInput,
   ManualEdgeInputError,
   ManualEdgeInputValidation,
+  QualifierValue,
 } from "./model";
 export {
   KNOWLEDGE_EDGE_TYPES,

--- a/src/entities/knowledge-graph/model/index.ts
+++ b/src/entities/knowledge-graph/model/index.ts
@@ -1,4 +1,6 @@
 export type {
+  EdgeQualifier,
+  EdgeRank,
   KnowledgeEdgeType,
   KnowledgeGraphSource,
   KnowledgeGraphNode,
@@ -7,6 +9,7 @@ export type {
   KnowledgeProjectInsight,
   PublishKnowledgeProjectionInput,
   PublishKnowledgeProjectionResult,
+  QualifierValue,
 } from "./types";
 export {
   KNOWLEDGE_EDGE_TYPES,

--- a/src/entities/knowledge-graph/model/mapper.ts
+++ b/src/entities/knowledge-graph/model/mapper.ts
@@ -1,9 +1,60 @@
 import type {
+  EdgeQualifier,
+  EdgeRank,
   KnowledgeGraphEdge,
   KnowledgeGraphNode,
   KnowledgePublicMeta,
+  QualifierValue,
 } from "./types";
 import { isKnowledgeGraphSource } from "./types";
+
+const VALID_RANKS: ReadonlySet<EdgeRank> = new Set([
+  "preferred",
+  "normal",
+  "deprecated",
+]);
+
+function isQualifierValue(input: unknown): input is QualifierValue {
+  if (!input || typeof input !== "object") return false;
+  const v = input as { kind?: unknown };
+  if (typeof v.kind !== "string") return false;
+  switch (v.kind) {
+    case "string":
+      return typeof (input as { raw?: unknown }).raw === "string";
+    case "time": {
+      const t = input as { iso?: unknown; precision?: unknown };
+      return (
+        typeof t.iso === "string" &&
+        (t.precision === "year" || t.precision === "month" || t.precision === "day")
+      );
+    }
+    case "quantity":
+      return typeof (input as { value?: unknown }).value === "number";
+    case "nodeRef":
+      return typeof (input as { nodeId?: unknown }).nodeId === "string";
+    default:
+      return false;
+  }
+}
+
+function toEdgeQualifiers(value: unknown): EdgeQualifier[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const next: EdgeQualifier[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as { propertyId?: unknown; value?: unknown };
+    if (typeof obj.propertyId !== "string") continue;
+    if (!isQualifierValue(obj.value)) continue;
+    next.push({ propertyId: obj.propertyId, value: obj.value });
+  }
+  return next.length > 0 ? next : undefined;
+}
+
+function toEdgeRank(value: unknown): EdgeRank | undefined {
+  return typeof value === "string" && VALID_RANKS.has(value as EdgeRank)
+    ? (value as EdgeRank)
+    : undefined;
+}
 
 function parseDate(value: unknown) {
   if (value instanceof Date) return value;
@@ -103,6 +154,8 @@ export function fromFirestoreKnowledgeGraphEdge(
       typeof data.manualNote === "string" ? data.manualNote : undefined,
     tboxVersionId:
       typeof data.tboxVersionId === "string" ? data.tboxVersionId : undefined,
+    qualifiers: toEdgeQualifiers(data.qualifiers),
+    rank: toEdgeRank(data.rank),
   };
 }
 

--- a/src/entities/knowledge-graph/model/qualifier.test.ts
+++ b/src/entities/knowledge-graph/model/qualifier.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { fromFirestoreKnowledgeGraphEdge } from "./mapper";
+
+const BASE = {
+  from: "project:foo",
+  to: "domain:bar",
+  type: "describes",
+  projectIds: ["foo"],
+  evidenceIds: [],
+  lastApprovedAt: new Date("2026-05-01T00:00:00Z"),
+  lastApprovedBy: "tester",
+};
+
+describe("V1.1 qualifiers + rank — fromFirestoreKnowledgeGraphEdge", () => {
+  it("legacy edge (qualifiers + rank 미포함) → 둘 다 undefined", () => {
+    const edge = fromFirestoreKnowledgeGraphEdge("e1", BASE);
+    expect(edge.qualifiers).toBeUndefined();
+    expect(edge.rank).toBeUndefined();
+  });
+
+  it("rank='preferred' 정상 인식, 'invalid' 는 undefined 폴백", () => {
+    const a = fromFirestoreKnowledgeGraphEdge("e1", { ...BASE, rank: "preferred" });
+    expect(a.rank).toBe("preferred");
+    const b = fromFirestoreKnowledgeGraphEdge("e1", { ...BASE, rank: "invalid" });
+    expect(b.rank).toBeUndefined();
+  });
+
+  it("qualifiers — string / time / quantity / nodeRef 4 종 모두 인식", () => {
+    const edge = fromFirestoreKnowledgeGraphEdge("e1", {
+      ...BASE,
+      qualifiers: [
+        { propertyId: "via", value: { kind: "string", raw: "REST" } },
+        {
+          propertyId: "since",
+          value: { kind: "time", iso: "2024-01-01", precision: "day" },
+        },
+        {
+          propertyId: "throughput",
+          value: { kind: "quantity", value: 100, unit: "rps" },
+        },
+        {
+          propertyId: "owner",
+          value: { kind: "nodeRef", nodeId: "person:alice" },
+        },
+      ],
+    });
+    expect(edge.qualifiers).toHaveLength(4);
+    expect(edge.qualifiers?.[0]).toEqual({
+      propertyId: "via",
+      value: { kind: "string", raw: "REST" },
+    });
+    expect(edge.qualifiers?.[2].value).toEqual({
+      kind: "quantity",
+      value: 100,
+      unit: "rps",
+    });
+  });
+
+  it("qualifiers 의 invalid 항목은 silently drop, 빈 배열이면 undefined", () => {
+    const a = fromFirestoreKnowledgeGraphEdge("e1", {
+      ...BASE,
+      qualifiers: [
+        { propertyId: "ok", value: { kind: "string", raw: "yes" } },
+        { propertyId: 123, value: { kind: "string", raw: "no-id-not-string" } },
+        { propertyId: "no-value-shape", value: { kind: "unknown" } },
+        null,
+        "not-an-object",
+      ],
+    });
+    expect(a.qualifiers).toHaveLength(1);
+    expect(a.qualifiers?.[0].propertyId).toBe("ok");
+
+    const b = fromFirestoreKnowledgeGraphEdge("e1", {
+      ...BASE,
+      qualifiers: [{ propertyId: "x", value: "raw-string" }],
+    });
+    expect(b.qualifiers).toBeUndefined();
+  });
+
+  it("qualifiers 가 array 가 아니면 undefined", () => {
+    const edge = fromFirestoreKnowledgeGraphEdge("e1", {
+      ...BASE,
+      qualifiers: { propertyId: "via", value: { kind: "string", raw: "x" } },
+    });
+    expect(edge.qualifiers).toBeUndefined();
+  });
+});

--- a/src/entities/knowledge-graph/model/types.ts
+++ b/src/entities/knowledge-graph/model/types.ts
@@ -85,6 +85,31 @@ export interface KnowledgeGraphNode {
   tboxVersionId?: string;
 }
 
+/**
+ * V1.1 (Wikidata 영감) — statement qualifier value union. legacy edge / 노드 변환
+ * 시에는 항상 undefined. 새 edge 가 명시적으로 채울 때만 존재.
+ *
+ * 자세한 spec: docs/ONTOLOGY-MODEL-V2-DRAFT.md §2.
+ */
+export type QualifierValue =
+  | { kind: 'string'; raw: string }
+  | { kind: 'time'; iso: string; precision: 'year' | 'month' | 'day' }
+  | { kind: 'quantity'; value: number; unit?: string }
+  | { kind: 'nodeRef'; nodeId: string };
+
+export interface EdgeQualifier {
+  /** 한정자 property id — `OntologyRelation.id` 또는 새 ontology
+   *  qualifier property id 재사용. legacy 호환을 위해 string 으로 둔다. */
+  propertyId: string;
+  value: QualifierValue;
+}
+
+/**
+ * V1.1 (Wikidata 영감) — statement rank. 같은 (from, to, type) 의 다중 statement
+ * 중 우선순위. legacy edge 는 undefined → 코드는 `rank ?? 'normal'` 폴백.
+ */
+export type EdgeRank = 'preferred' | 'normal' | 'deprecated';
+
 export interface KnowledgeGraphEdge {
   id: string;
   accountId?: string;
@@ -109,6 +134,12 @@ export interface KnowledgeGraphEdge {
   manualNote?: string;
   /** P1 Phase 1 — node 와 동일 의미. */
   tboxVersionId?: string;
+  /** V1.1 — Wikidata-style statement qualifier 배열 (옵션, additive). legacy
+   *  edge 는 undefined. UI / publish projection 모두 그대로 통과. */
+  qualifiers?: EdgeQualifier[];
+  /** V1.1 — Wikidata-style statement rank (옵션, additive). legacy 는 undefined
+   *  → 'normal' 로 해석. */
+  rank?: EdgeRank;
 }
 
 export interface KnowledgePublicMeta {


### PR DESCRIPTION
## Summary

다음 결정 후보 4종 일괄 처리:

| 후보 | 결과 |
|---|---|
| **CLAUDE.md sync 검증** | ✅ 이미 thin wrapper (`@AGENTS.md` import 만) — 자동 일관, 추가 조치 0 |
| **Q2 share-doc 제거** | ✅ 이미 commit d27e3d0 으로 제거됨. `CopyProjectLinkButton` (단순 URL 복사) 만 보존 |
| **dev-login 검토** | ✅ `dev-admin-bypass` 는 이미 제거됨. `signInWithDemo` (데모 viewer) 는 mission 무관 손해 0 — 유지 |
| **V1.1 Wikidata spec 구현** | ✅ 본 PR — KnowledgeGraphEdge 에 qualifiers + rank 옵셔널 추가 |

## V1.1 — Statement Qualifiers + Rank

`docs/ONTOLOGY-MODEL-V2-DRAFT.md` §2 의 V1.1 단계. additive (breakage 0), 마이그레이션 0, TBox 변경 0.

### 새 타입
```ts
export type QualifierValue =
  | { kind: 'string'; raw: string }
  | { kind: 'time'; iso: string; precision: 'year' | 'month' | 'day' }
  | { kind: 'quantity'; value: number; unit?: string }
  | { kind: 'nodeRef'; nodeId: string };

export interface EdgeQualifier { propertyId: string; value: QualifierValue }
export type EdgeRank = 'preferred' | 'normal' | 'deprecated';

interface KnowledgeGraphEdge {
  // ... 기존 필드 ...
  qualifiers?: EdgeQualifier[];   // V1.1
  rank?: EdgeRank;                // V1.1
}
```

### 변경 위치
- `types.ts` — 새 타입 + KnowledgeGraphEdge 확장
- `mapper.ts` — `fromFirestoreKnowledgeGraphEdge` 가 두 필드 인식 + invalid 폴백
- `functions/index.js publishKnowledgeProjectionCore` — approved → public 시 fields-pass-through
- 5 새 단위 test (`qualifier.test.ts`)
- dogfood vault — `capabilities/v1-1-qualifiers-rank.md` (MCP add_concept 로 작성)

### 호환성
- legacy edge: `qualifiers` 없음 + `rank` undefined → 코드는 `rank ?? "normal"` 폴백
- mapper 가 invalid 항목 silently drop — runtime 안전
- Firestore 스키마 변경 0 (옵셔널 필드만)
- public projection 변경 0 (있으면 그대로 통과, 없으면 키 자체 생략)

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **118 files / 848 tests pass** (843 → 848, +5 V1.1 단위 test)
- `node --check functions/index.js` syntax OK

## 변경 (8 files, +218)

```
src/entities/knowledge-graph/model/types.ts            +49
src/entities/knowledge-graph/model/mapper.ts           +66
src/entities/knowledge-graph/model/index.ts            +3
src/entities/knowledge-graph/index.ts                  +3
src/entities/knowledge-graph/model/qualifier.test.ts   +91 (신규)
functions/index.js                                     +6
docs/ontology/project.md                               +1
docs/ontology/capabilities/v1-1-qualifiers-rank.md     (신규)
```

## Test plan

- [ ] `mcp__oh-my-ontology__list_concepts` 가 새 capability `v1-1-qualifiers-rank` 노출
- [ ] approvedEdge 에 `qualifiers: [...]` + `rank: "preferred"` 직접 Firestore 에 넣고 publish → publicEdge 에 그대로 통과 확인 (cloud 모드 사용자만)
- [ ] legacy edge (필드 없음) 가 grep 으로 fromFirestore 통과해도 qualifiers/rank undefined 확인
- [ ] V1.2 (`knowledgeApprovedLiterals`) 진입 전 V1.1 이 production 에 soak — UI 변경은 follow-up PR