### PR TITLE
fix: stale Demo title 잔재 정리 (Playwright MCP QA 발견)

### DIFF
--- a/app/project/[slug]/opengraph-image.tsx
+++ b/app/project/[slug]/opengraph-image.tsx
@@ -84,7 +84,7 @@ export default async function ProjectOgImage({
                   '"JetBrains Mono", ui-monospace, monospace',
               }}
             >
-              Demo · oh-my-ontology
+              oh-my-ontology
             </span>
             {category ? (
               <span

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -262,8 +262,9 @@ export function HomePage() {
     Array.from(
       new Set(
         [
-          "Demo",
           selectedProject?.name ?? scopedAccountName,
+          "토폴로지",
+          "oh-my-ontology",
         ].filter((value): value is string => Boolean(value)),
       ),
     ).join(" · ") || null,
@@ -605,7 +606,7 @@ export function HomePage() {
         visible h1 을 두기 어려워 sr-only 로 문서 구조 only 에 보이게 한다.
       */}
       <h1 className="sr-only">
-        {scopedAccountName ?? "Demo"} 프로젝트 토폴로지 지도
+        {scopedAccountName ?? "토폴로지"} 프로젝트 토폴로지 지도
       </h1>
       <GestureHint
         disabled={presentationMode || drawerOpen}
@@ -662,7 +663,7 @@ export function HomePage() {
                     onExpand={
                       drawerOpen ? handleClose : toggleLeftPanel
                     }
-                    title={selectedProject?.name ?? scopedAccountName ?? "Demo"}
+                    title={selectedProject?.name ?? scopedAccountName ?? "토폴로지"}
                     subtitle={
                       selectedProject
                         ? "선택한 프로젝트"
@@ -693,7 +694,7 @@ export function HomePage() {
                     activePathLabel={null}
                     onOpenSearch={() => setSearchOpen(true)}
                     onCollapse={toggleLeftPanel}
-                    title={selectedProject?.name ?? scopedAccountName ?? "Demo"}
+                    title={selectedProject?.name ?? scopedAccountName ?? "토폴로지"}
                     eyebrow={
                       selectedProject
                         ? "선택한 프로젝트"

--- a/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
+++ b/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
@@ -65,7 +65,7 @@ function DetailContent({ documentId, returnTo }: Props) {
   const { user } = useGlobalAdmin();
   const [document, setDocument] = useState<KnowledgeDocument | null>(null);
   useDocumentTitle(
-    document?.title ? `${document.title} · Demo` : "문서 상세 · Demo",
+    document?.title ? `${document.title} · oh-my-ontology` : "문서 상세 · oh-my-ontology",
   );
   const [versions, setVersions] = useState<KnowledgeVersion[]>([]);
   const [jobs, setJobs] = useState<KnowledgeJob[]>([]);

--- a/src/views/project-editor/ui/ProjectEditorPage.tsx
+++ b/src/views/project-editor/ui/ProjectEditorPage.tsx
@@ -68,7 +68,7 @@ function EditorContent({
   const projectMutations = useProjectMutations();
   const targetSlug = mode === "edit" ? slug : duplicateFromSlug;
   useDocumentTitle(
-    (mode === "edit" ? "프로젝트 편집 · Demo" : "새 프로젝트 · Demo"),
+    (mode === "edit" ? "프로젝트 편집 · oh-my-ontology" : "새 프로젝트 · oh-my-ontology"),
   );
   const safeReturnTo = normalizeReturnTo(returnTo);
   const safeReturnLabel = resolveReturnLabel(normalizeReturnTo(returnTo));

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -87,12 +87,12 @@ export function ProjectSelectorPage() {
     searchParams.get(PROJECT_LIST_LIMIT_QUERY_KEY),
   );
   // P1-5 — 탭·검색 컨텍스트. 컨테이너·계정 이름이 겹치면 Set dedup.
-  // 페이지 메타 타이틀("프로젝트 · Demo")과 동일한 첫 어휘를 사용해
+  // 페이지 메타 타이틀("프로젝트 · oh-my-ontology")과 동일한 첫 어휘를 사용해
   // 정적 메타와 동적 갱신 사이에 flicker 가 보이지 않게 한다.
   useDocumentTitle(
     Array.from(
       new Set(
-        ["프로젝트", activeContainerName, accountName, "Demo"].filter(
+        ["프로젝트", activeContainerName, accountName, "oh-my-ontology"].filter(
           (value): value is string => Boolean(value),
         ),
       ),

--- a/src/widgets/hero-header/ui/HeroCollapsed.tsx
+++ b/src/widgets/hero-header/ui/HeroCollapsed.tsx
@@ -26,7 +26,7 @@ interface Props {
 export function HeroCollapsed({
   className,
   onExpand,
-  title = "Demo",
+  title = "토폴로지",
   subtitle = "워크스페이스 지도 펼치기",
   icon,
   ariaLabel = "좌측 패널 펼치기",

--- a/src/widgets/hero-header/ui/HeroHeader.tsx
+++ b/src/widgets/hero-header/ui/HeroHeader.tsx
@@ -34,7 +34,7 @@ export function HeroHeader({
   activePathLabel,
   onOpenSearch,
   onCollapse,
-  title = "Demo",
+  title = "토폴로지",
   eyebrow = "워크스페이스 지도",
   description,
   icon,
@@ -122,7 +122,7 @@ export function HeroHeader({
               className="inline-flex h-9 items-center gap-2 rounded-full border border-[color:rgba(94,106,210,0.38)] bg-[color:rgba(94,106,210,0.14)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:rgba(94,106,210,0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
             >
               <Search size={14} />
-              {title === "Demo" ? "프로젝트 찾기" : "다른 프로젝트 찾기"}
+              {title === "토폴로지" ? "프로젝트 찾기" : "다른 프로젝트 찾기"}
             </button>
             {projectsListHref ? (
               <Link


### PR DESCRIPTION
## Summary

Playwright MCP browser-level QA 결과 mission v2 rebrand (d7412ff "Demo→oh-my-ontology") 가 일부 surface 까지 닿지 않은 잔재 발견:

- `/topology/` → \"Demo\"
- `/projects/` → \"프로젝트 · Demo\"
- `/project/new/` → \"새 프로젝트 · Demo\"

## QA 결과 (Playwright MCP)

| Route | Before | After |
|---|---|---|
| `/` | oh-my-ontology ✓ | (변경 없음) |
| `/topology/` | Demo ✗ | 토폴로지 · oh-my-ontology ✓ |
| `/projects/` | 프로젝트 · Demo ✗ | 프로젝트 · oh-my-ontology ✓ |
| `/project/new/` | 새 프로젝트 · Demo ✗ | 새 프로젝트 · oh-my-ontology ✓ |
| `/docs/` | Docs Vault · oh-my-ontology ✓ | (변경 없음) |
| `/ontology/` (외 5) | … · oh-my-ontology ✓ | (변경 없음) |
| `/review/knowledge/` | 404 (expected) | (변경 없음) |

전체 console error 0 (deleted route 의 404 fetch 제외).

## 변경 파일 (7)

- `src/views/home/ui/HomePage.tsx` — useDocumentTitle dedup + 3 fallback
- `src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx`
- `src/views/project-editor/ui/ProjectEditorPage.tsx`
- `src/views/project-selector/ui/ProjectSelectorPage.tsx`
- `src/widgets/hero-header/ui/HeroHeader.tsx` — default + 비교
- `src/widgets/hero-header/ui/HeroCollapsed.tsx` — default
- `app/project/[slug]/opengraph-image.tsx` — OG eyebrow

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **118 files / 848 tests pass**
- Playwright MCP 재확인 — 4 라우트 모두 mission v2 title 노출, console error 0