### PR TITLE
feat: P0 batch — T28 demo + T29 dogfood hint + UX-2 mode badge

### DIFF
--- a/src/shared/mocks/demo-blueprint.ts
+++ b/src/shared/mocks/demo-blueprint.ts
@@ -69,11 +69,11 @@ export const CONTAINER_THEMES: ReadonlyArray<ContainerTheme> = [
   {
     id: 'demo-knowledge',
     name: 'Demo Knowledge',
-    description: '문서 파이프라인 + 온톨로지 빌더 + 공개 그래프.',
+    description: 'vault frontmatter → ontology 척추 + 사람·AI agent 양립 저작.',
     hubCount: 3,
     crossDepFrom: 'demo',
-    capabilities: ['문서 등록', 'frontmatter 추출', 'stub 승격', '검수 큐'],
-    elements: ['markdown parser', 'Firestore', 'Cloud Functions'],
+    capabilities: ['vault frontmatter 진실원', 'AI agent partner (MCP)', '빌더 직접 저작', 'TBox 버전'],
+    elements: ['markdown parser', 'frontmatter 파서', 'MCP SDK', 'IndexedDB'],
   },
   {
     id: 'demo-vault',

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -1600,6 +1600,19 @@ function AdminDocsContent() {
                       onRefresh={localVault.refresh}
                       onRequestPermission={localVault.requestPermission}
                     />
+                    {/* T29 dogfood hint — vault 미활성 사용자에게 *어떤
+                        폴더를 골라야 하는지* 답. 이 repo 자체의 ontology 가
+                        `docs/ontology/` 에 21 노드로 표현돼 있어 첫 시도
+                        path 로 적합. */}
+                    {localVault.status === 'idle' ? (
+                      <p className="text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+                        처음이세요? 이 repo 의{' '}
+                        <code className="rounded bg-[color:var(--color-overlay-1)] px-1 py-0.5 font-mono text-[10.5px] text-[color:var(--color-indigo-accent)]">
+                          docs/ontology/
+                        </code>
+                        를 선택해 보세요 — 이 도구 자체의 ontology (21 노드) 가 즉시 트리에 등장합니다.
+                      </p>
+                    ) : null}
                     {canEditCurrent ? (
                       <button
                         type="button"

--- a/src/widgets/operations-nav/ui/OperationsNav.tsx
+++ b/src/widgets/operations-nav/ui/OperationsNav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { signOut } from '@/features/user-auth';
 import { useDataSourceMode } from '@/features/data-source-mode';
+import { useLocalVault } from '@/features/docs-vault-local';
 import { ThemeToggle } from '@/features/theme-toggle';
 import { Button, Tooltip } from '@/shared/ui';
 
@@ -91,6 +92,59 @@ function buildItems(mode: 'static' | 'local' | 'cloud'): ReadonlyArray<NavItem> 
  *
  * 활성 표시는 pathname prefix 매칭 — 동일 룰 양쪽 적용.
  */
+/**
+ * Mode badge — UX-2. 사용자가 *지금 어떤 source 에 데이터가 가는지* 한눈에
+ * 보게. local 모드면 vault 폴더 이름 + doc count, cloud 면 "cloud sync",
+ * static (비활성/비로그인) 이면 "데모". mode 바뀜 = 데이터 destination 바뀜.
+ */
+function ModeBadge({ mode }: { mode: 'static' | 'local' | 'cloud' }) {
+  // local 모드일 때만 vault 메타 가져오기. cloud/static 은 그냥 chip.
+  // useLocalVault 자체는 SSR-safe (window 가드).
+  const vault = useLocalVault();
+  if (mode === 'local') {
+    const docCount = vault.manifest?.docs.length ?? 0;
+    const handleName = vault.handle?.name ?? 'vault';
+    const tooltip = `vault 모드 — ${handleName} (${docCount} docs). 모든 변경이 로컬 디스크에 저장됨.`;
+    return (
+      <Tooltip content={tooltip}>
+        <span
+          aria-label={tooltip}
+          className="inline-flex h-7 items-center gap-1.5 rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.1)] px-2.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)]"
+        >
+          <span aria-hidden>●</span>
+          <span>vault</span>
+          <span className="text-[color:var(--color-text-tertiary)]">·</span>
+          <span>{docCount} docs</span>
+        </span>
+      </Tooltip>
+    );
+  }
+  if (mode === 'cloud') {
+    return (
+      <Tooltip content="cloud 모드 — Firestore 실시간 동기. 변경이 cloud 저장.">
+        <span
+          aria-label="cloud 모드"
+          className="inline-flex h-7 items-center gap-1.5 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+        >
+          <span aria-hidden>●</span>
+          <span>cloud sync</span>
+        </span>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip content="데모 모드 — vault 미선택 + 비로그인. 빌드 타임 demo manifest 만 노출, 변경 저장 안 됨.">
+      <span
+        aria-label="데모 모드"
+        className="inline-flex h-7 items-center gap-1.5 rounded-full border border-[color:rgba(244,183,49,0.32)] bg-[color:rgba(244,183,49,0.08)] px-2.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:rgba(238,198,128,0.95)]"
+      >
+        <span aria-hidden>●</span>
+        <span>데모</span>
+      </span>
+    </Tooltip>
+  );
+}
+
 export function OperationsNav({ accountId, rightSlot }: OperationsNavProps) {
   const pathname = usePathname() ?? '';
   const searchParams = useSearchParams();
@@ -167,6 +221,7 @@ export function OperationsNav({ accountId, rightSlot }: OperationsNavProps) {
         </div>
         <div className="flex items-center gap-2">
           {rightSlot}
+          <ModeBadge mode={dataSourceMode} />
           <ThemeToggle />
           <Link href={'/projects/'} className="inline-flex">
             {/* '↗' 는 외부 링크 의미로 오해 가능 — 내부 라우트라
@@ -199,6 +254,9 @@ export function OperationsNav({ accountId, rightSlot }: OperationsNavProps) {
         >
           {items.map((item) => renderTab(item, 'mobile'))}
         </ul>
+        <div className="ml-auto shrink-0">
+          <ModeBadge mode={dataSourceMode} />
+        </div>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary

UX 1원리 분석 (PR #17) 의 **P0 3 atomic** 한 PR. 사용자 첫 5분 마찰 3 곳 직접 해소.

## 변경

### T28 — demo blueprint mission v2 정렬
`src/shared/mocks/demo-blueprint.ts` 의 `Demo Knowledge` 컨테이너:
- capabilities: "문서 등록 / frontmatter 추출 / stub 승격 / 검수 큐" (mission v1) → "vault frontmatter 진실원 / AI agent partner (MCP) / 빌더 직접 저작 / TBox 버전" (mission v2)
- elements: "Cloud Functions" 제거, "frontmatter 파서 / MCP SDK" 추가

### T29 — `/docs/` dogfood vault hint
`DocsVaultPage` 의 LocalVaultPicker idle 상태에 inline 안내:
> 처음이세요? 이 repo 의 `docs/ontology/` 를 선택해 보세요 — 이 도구 자체의 ontology (21 노드) 가 즉시 트리에 등장합니다.

사용자 첫 사용 시 *어떤 폴더를 골라야 하나* 의 답을 즉시 제공.

### UX-2 — OperationsNav mode badge
신설 `ModeBadge` 컴포넌트 — 현재 `dataSourceMode` chip 으로 항상 표시:
- **local**: indigo chip `vault · NN docs` + tooltip (vault 폴더 이름 + 변경 로컬 저장)
- **cloud**: 무채 chip `cloud sync` + tooltip (Firestore 실시간 동기)
- **static**: amber chip `데모` + tooltip (변경 저장 안 됨)

데스크톱 nav 의 ThemeToggle 옆 + 모바일 nav 의 ml-auto. 사용자가 *데이터가 어디로 가는지* 한눈에.

## 검증

- `pnpm exec tsc --noEmit` 0 errors
- `pnpm test:run` **117 files / 834 tests pass**
- Playwright MCP `/ontology/` — mode badge "데모" HTML 노출, console error 0
- demo-data sanity test 4/4 pass

## 변경 통계

3 files, +74 / -3