### PR TITLE
feat: P1-1 (UX-4) — Builder vault md write (mode-aware)

### DIFF
--- a/docs/ontology/capabilities/builder-vault-write.md
+++ b/docs/ontology/capabilities/builder-vault-write.md
@@ -1,0 +1,31 @@
+---
+slug: capabilities/builder-vault-write
+kind: capability
+title: Builder ↔ Vault md write (mode-aware)
+domain: views
+elements: [src/views/ontology-edit/ui/OntologyEditPage.tsx, src/features/docs-vault-local/model/use-local-vault.ts]
+---
+
+# Builder ↔ Vault md write (mode-aware)
+
+P1-1 (UX-4) — mission v2 의 *사람 + AI agent 양립* 약속의 코드 구현. 빌더 ephemeral 노드 → mode 별 분기 저장:
+
+- **local**: `vault.createDoc(${kind}s/${slug}, md)` — vault 디스크 직접 작성. AI agent (MCP) 가 같은 vault 에서 즉시 본다.
+- **cloud**: 기존 `addManualKnowledgeNode` Firestore httpsCallable.
+- **static**: 저장 차단 + 안내 toast (vault 또는 로그인 유도).
+
+frontmatter 형식 (mission v2):
+
+```yaml
+---
+slug: capabilities/foo
+kind: capability
+title: Foo
+---
+
+# Foo
+```
+
+folder mapping: capability→capabilities, element→elements, domain→domains, project→projects, 그 외 kind+s.
+
+자세히: docs/UX-FIRST-PRINCIPLES.md §2 P1-1.

--- a/docs/ontology/project.md
+++ b/docs/ontology/project.md
@@ -11,6 +11,7 @@ capabilities:
   - ai-agent-partner
   - tbox-versioning
   - v1-1-qualifiers-rank
+  - builder-vault-write
 elements:
   - vault-local-first
   - ontology-core

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -8,12 +8,45 @@ import { Info, Maximize2, Minimize2 } from "lucide-react";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { useUserAuth } from "@/features/user-auth";
 import { addManualKnowledgeNode } from "@/entities/knowledge-graph";
+import { useDataSourceMode } from "@/features/data-source-mode";
+import { useLocalVault } from "@/features/docs-vault-local";
 import { slugify } from "@/shared/lib/slugify";
 import { OperationsNav } from "@/widgets/operations-nav";
 import { Tooltip, useToast } from "@/shared/ui";
 import { useEphemeralNodes } from "../lib/use-ephemeral-nodes";
 import { useEphemeralEdges } from "../lib/use-ephemeral-edges";
 import { downloadAtlasFrontmatter } from "../lib/export-frontmatter";
+
+/**
+ * P1-1 (UX-4) — local 모드 vault `.md` write path.
+ *
+ * 빌더 ephemeral 노드 → `${kind}/${slug}.md` 로 vault 직접 작성.
+ * frontmatter 는 mission v2 V1.x 호환 — kind / title / domain. 본문은
+ * `# {title}` 한 줄. 사용자가 그 후 vault 에서 직접 편집 가능.
+ *
+ * mission v2 의 *사람 + AI agent 양립* 약속의 코드 구현 — 빌더로 만든
+ * 노드를 AI agent (MCP) 가 같은 vault 에서 즉시 본다.
+ */
+function buildVaultMarkdown(args: {
+  kind: string;
+  title: string;
+  slug: string;
+}): string {
+  const lines = ["---"];
+  lines.push(`slug: ${args.slug}`);
+  lines.push(`kind: ${args.kind}`);
+  // title 에 콜론 / 따옴표 들어갈 수 있으니 안전하게 quote.
+  const safeTitle =
+    /[:#\[\]{}"',&|*!%@`]/.test(args.title)
+      ? `"${args.title.replace(/"/g, '\\"')}"`
+      : args.title;
+  lines.push(`title: ${safeTitle}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(`# ${args.title}`);
+  lines.push("");
+  return lines.join("\n");
+}
 import { OntologyKindPalette } from "./OntologyKindPalette";
 import { OntologyInspector } from "./OntologyInspector";
 import { BuilderOnboarding } from "./BuilderOnboarding";
@@ -49,6 +82,8 @@ export function OntologyEditPage() {
   // 캔버스 자체를 볼 수 있지만 manual node 저장 시 toast 로 막힌다.
   const { user } = useUserAuth();
   const accountId = user?.uid ?? null;
+  const dataSourceMode = useDataSourceMode();
+  const vault = useLocalVault();
 
   const { nodes: ephemeralNodes, addNode, clearAll, updateNode, findById, removeNode } =
     useEphemeralNodes();
@@ -61,10 +96,6 @@ export function OntologyEditPage() {
 
   const saveEphemeral = useCallback(
     async (nodeId: string) => {
-      if (!accountId) {
-        toast.show("계정이 확인되지 않았어요.", "error");
-        return;
-      }
       const node = findById(nodeId);
       if (!node) return;
       const slug = slugify(node.title);
@@ -72,18 +103,55 @@ export function OntologyEditPage() {
         toast.show("이름이 비어 있어 저장할 수 없어요.", "error");
         return;
       }
-      const id = `${node.kind}.${slug}`;
       setSavingId(nodeId);
       try {
-        await addManualKnowledgeNode({
-          accountId,
-          id,
-          title: node.title,
-          kind: node.kind,
-        });
-        toast.show(`"${node.title}" 저장 완료`, "success");
-        removeNode(nodeId);
-        setSelectedId(null);
+        if (dataSourceMode === "local") {
+          // P1-1: vault `.md` 직접 작성. 경로 = `${kind}s/${slug}.md`
+          // (capabilities/auth-platform 같은 형식 — dogfood vault 와 일치).
+          // kind 의 복수형: capability→capabilities, element→elements,
+          // domain→domains, project→projects. 그 외는 kind 그대로 +s.
+          const folder =
+            node.kind === "capability"
+              ? "capabilities"
+              : node.kind === "element"
+                ? "elements"
+                : node.kind === "domain"
+                  ? "domains"
+                  : node.kind === "project"
+                    ? "projects"
+                    : `${node.kind}s`;
+          const vaultSlug = `${folder}/${slug}`;
+          const md = buildVaultMarkdown({
+            kind: node.kind,
+            title: node.title,
+            slug: vaultSlug,
+          });
+          await vault.createDoc(vaultSlug, md);
+          toast.show(`"${node.title}" → vault/${vaultSlug}.md 저장`, "success");
+          removeNode(nodeId);
+          setSelectedId(null);
+        } else if (dataSourceMode === "cloud") {
+          if (!accountId) {
+            toast.show("계정이 확인되지 않았어요. 로그인하세요.", "error");
+            return;
+          }
+          const id = `${node.kind}.${slug}`;
+          await addManualKnowledgeNode({
+            accountId,
+            id,
+            title: node.title,
+            kind: node.kind,
+          });
+          toast.show(`"${node.title}" 저장 완료`, "success");
+          removeNode(nodeId);
+          setSelectedId(null);
+        } else {
+          // static — vault 미선택 + 비로그인. 둘 중 하나 활성화 안내.
+          toast.show(
+            "데모 모드라 저장할 수 없어요. /docs 에서 vault 폴더를 열거나 로그인하세요.",
+            "error",
+          );
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : "저장 실패";
         toast.show(message, "error");
@@ -91,7 +159,7 @@ export function OntologyEditPage() {
         setSavingId(null);
       }
     },
-    [accountId, findById, removeNode, toast],
+    [accountId, dataSourceMode, findById, removeNode, toast, vault],
   );
   const ephemeralSelected = findById(selectedId);
   // approved 노드 detail 은 useApprovedGraphFlow 가 캔버스 내부에 있어 page 에선


### PR DESCRIPTION
## Summary

UX 1원리 분석 (PR #17) 의 **가장 큰 1원리 gap** 해소. 빌더에서 노드 저장 시 mode-aware 분기. mission v2 *사람 + AI agent 양립* 약속의 핵심 missing piece.

## 변경

### `OntologyEditPage.saveEphemeral` mode-aware
- **local**: `vault.createDoc(\${kind}s/\${slug}.md, md)` — vault 디스크 직접 작성. AI agent 가 같은 vault 에서 즉시 본다
- **cloud**: 기존 `addManualKnowledgeNode` Firestore upsert
- **static**: 저장 차단 + vault/로그인 유도 toast

### `buildVaultMarkdown` helper
mission v2 frontmatter 형식 (`slug:` + `kind:` + `title:`) + `# Title` body 한 줄. 사용자가 vault 에서 직접 편집 가능.

### kind → folder 매핑
- `capability` → `capabilities/`
- `element` → `elements/`
- `domain` → `domains/`
- `project` → `projects/`
- 그 외 → `\${kind}s/`

dogfood vault (`docs/ontology/`) 와 동일한 컨벤션.

### Dogfood
`docs/ontology/capabilities/builder-vault-write.md` 신설 — 본 변경 자체를 vault 노드로 등재 (MCP add_concept).

## Mission impact

빌더로 만든 노드가:
- 이전: cloud 모드만 (Firestore) → AI agent 가 못 봄
- 이후: vault 모드도 즉시 .md 로 저장 → AI agent (MCP) 가 즉시 read

이로써 *사람이 시각으로 만든 노드* + *AI agent 가 코드 분석으로 만든 노드* 가 같은 vault 에 공존.

## 검증

- tsc 0 errors
- vitest 117 files / 834 tests pass
- Playwright MCP `/ontology/edit/` — 캔버스 정상 mount, console error 0

## 다음 단계

- approved 노드 in-canvas 편집 (C-5) — 별도 PR
- UX-1 빈 vault inline 첫 노드 만들기
- UX-3 MCP onboarding 강화