### PR TITLE
feat: P1 batch — UX-1 frontmatter snippet + UX-3 MCP verify CLI

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -68,22 +68,56 @@
 | `add_relation` | 두 slug 사이 edge. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). frontmatter 배열에 append. |
 | `patch_concept` | 기존 노드 frontmatter (key 단위 patch — null = 삭제) + body 갱신. `add_concept` 가 throw 한 기존 slug 를 *수정* 할 때 사용. |
 
-## 로컬 검증
+## 로컬 검증 (UX-3)
+
+### 1줄 verify CLI
 
 ```bash
-# 의존성 install
 cd mcp && npm install
+OMOT_VAULT=../docs/ontology npm run verify
+```
 
-# parser smoke test
+verify 가 성공하면 다음 출력:
+
+```
+[oh-my-ontology-mcp verify]
+· step 1 — parser smoke test
+✓ result: 7 passed, 0 failed
+· step 2 — server boot + tools/list + list_concepts
+✓ initialize OK — server oh-my-ontology-mcp@0.2.0
+✓ tools/list 7/7 — add_concept · add_relation · find_backlinks · find_evidence · get_concept · list_concepts · patch_concept
+✓ list_concepts — vault total 22 노드
+
+전체 통과 — Claude Code 에 .mcp.json 등록 후 재시작하면 7 도구 사용 가능합니다.
+```
+
+실패 시 어느 step 에서 막혔는지 + 진단 메시지 노출.
+
+### 수동 (참고)
+
+```bash
+# parser smoke
 node src/parser.test.mjs
 
-# 실 서버 boot — list_concepts 호출
+# 실 서버 stdin/stdout JSON-RPC
 printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
   '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_concepts","arguments":{"limit":5}}}' \
   | OMOT_VAULT=../docs/ontology node src/index.js
 ```
+
+## Claude Code 등록 후 첫 호출 (sample prompt)
+
+`.mcp.json` 등록 + Claude Code 재시작 후 LLM 에게 다음을 시도하세요:
+
+> **첫 탐색 — vault 의 ontology 가 보이는지 확인**
+> 1. `mcp__oh-my-ontology__list_concepts` 호출해 vault 의 모든 노드를 list 해줘
+> 2. `get_concept({ slug: "project" })` 로 root 노드의 frontmatter + 이웃을 보여줘
+> 3. `find_backlinks({ slug: "capabilities/mcp-server" })` 로 그 capability 의 의존자를 찾아줘
+> 4. (선택) `add_concept` 로 새 capability 노드 만들어줘 — slug, kind, title 필요
+
+LLM 이 7 도구를 정상 호출하면 vault 데이터가 응답으로 반환됨. agent 가 자기 codebase 분석 결과를 이 도구들로 ontology 에 *commit* 하면 사람·AI agent 양립 저작 흐름 시작.
 
 ## 설계 원칙
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -9,7 +9,8 @@
   "main": "./src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test:smoke": "node src/parser.test.mjs"
+    "test:smoke": "node src/parser.test.mjs",
+    "verify": "node scripts/verify.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * MCP server verify CLI — UX-3.
+ *
+ * 사용자가 .mcp.json 등록 후 *서버가 정상* 인지 1 명령으로 확인.
+ *
+ * 사용법:
+ *   node mcp/scripts/verify.mjs                    # vault = cwd
+ *   OMOT_VAULT=./docs/ontology node mcp/scripts/verify.mjs
+ *
+ * 검증 항목:
+ *   1. parser smoke test (parser.test.mjs) 통과
+ *   2. server boot — initialize JSON-RPC 응답
+ *   3. tools/list — 7 도구 모두 노출
+ *   4. tools/call list_concepts — vault 노드 수 출력
+ *
+ * 모두 PASS → exit 0, 실패 → exit 1 + 진단 메시지.
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MCP_ROOT = resolve(__dirname, '..');
+const PARSER_TEST = join(MCP_ROOT, 'src', 'parser.test.mjs');
+const SERVER_ENTRY = join(MCP_ROOT, 'src', 'index.js');
+const VAULT = process.env.OMOT_VAULT || process.cwd();
+
+const EXPECTED_TOOLS = [
+  'list_concepts',
+  'get_concept',
+  'find_evidence',
+  'find_backlinks',
+  'add_concept',
+  'add_relation',
+  'patch_concept',
+];
+
+function log(level, msg) {
+  const tag =
+    level === 'ok' ? '\x1b[32m✓\x1b[0m' :
+    level === 'fail' ? '\x1b[31m✗\x1b[0m' :
+    level === 'info' ? '·' : '?';
+  console.log(`${tag} ${msg}`);
+}
+
+async function step1ParserSmoke() {
+  log('info', 'step 1 — parser smoke test');
+  return new Promise((res) => {
+    const proc = spawn('node', [PARSER_TEST], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (b) => (stdout += b.toString()));
+    proc.stderr.on('data', (b) => (stderr += b.toString()));
+    proc.on('close', (code) => {
+      if (code === 0 && /passed/.test(stdout)) {
+        log('ok', stdout.trim().split('\n').slice(-1)[0]);
+        res(true);
+      } else {
+        log('fail', `parser test 실패 (exit ${code})`);
+        if (stdout) console.error(stdout);
+        if (stderr) console.error(stderr);
+        res(false);
+      }
+    });
+  });
+}
+
+async function step2BootAndCall() {
+  log('info', `step 2 — server boot + tools/list + list_concepts (vault=${VAULT})`);
+
+  const lines = [
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'verify-cli', version: '0' },
+      },
+    }),
+    JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'list_concepts', arguments: { limit: 5 } },
+    }),
+  ];
+
+  return new Promise((res) => {
+    const proc = spawn('node', [SERVER_ENTRY], {
+      env: { ...process.env, OMOT_VAULT: VAULT },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (b) => (stdout += b.toString()));
+    proc.stderr.on('data', (b) => (stderr += b.toString()));
+
+    proc.stdin.write(lines.join('\n') + '\n');
+    setTimeout(() => proc.kill('SIGTERM'), 2000);
+
+    proc.on('close', () => {
+      const responses = stdout
+        .split('\n')
+        .filter(Boolean)
+        .map((s) => {
+          try {
+            return JSON.parse(s);
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
+
+      const initRes = responses.find((r) => r.id === 1);
+      const listRes = responses.find((r) => r.id === 2);
+      const callRes = responses.find((r) => r.id === 3);
+
+      if (!initRes || !initRes.result) {
+        log('fail', `initialize 응답 없음. stderr: ${stderr.slice(0, 300)}`);
+        return res(false);
+      }
+      log('ok', `initialize OK — server ${initRes.result.serverInfo?.name}@${initRes.result.serverInfo?.version}`);
+
+      if (!listRes || !listRes.result?.tools) {
+        log('fail', 'tools/list 응답 없음');
+        return res(false);
+      }
+      const toolNames = listRes.result.tools.map((t) => t.name).sort();
+      const expectedSorted = [...EXPECTED_TOOLS].sort();
+      const missing = expectedSorted.filter((n) => !toolNames.includes(n));
+      const extra = toolNames.filter((n) => !expectedSorted.includes(n));
+      if (missing.length > 0 || extra.length > 0) {
+        log('fail', `tools 불일치 — missing: ${missing.join(',') || '(없음)'}, extra: ${extra.join(',') || '(없음)'}`);
+        return res(false);
+      }
+      log('ok', `tools/list ${toolNames.length}/7 — ${toolNames.join(' · ')}`);
+
+      if (!callRes || !callRes.result) {
+        log('fail', 'list_concepts 호출 응답 없음');
+        return res(false);
+      }
+      try {
+        const text = callRes.result.content?.[0]?.text || '';
+        const parsed = JSON.parse(text);
+        log('ok', `list_concepts — vault total ${parsed.total} 노드 (vaultRoot ${parsed.vaultRoot})`);
+        if (parsed.total === 0) {
+          log('info', '경고: vault 가 비어있음. OMOT_VAULT 가 올바른 폴더를 가리키는지 확인 (예: ./docs/ontology)');
+        }
+        res(true);
+      } catch (err) {
+        log('fail', `list_concepts 응답 파싱 실패: ${err.message}`);
+        res(false);
+      }
+    });
+
+    proc.on('error', (err) => {
+      log('fail', `서버 spawn 실패: ${err.message}`);
+      res(false);
+    });
+  });
+}
+
+async function main() {
+  console.log('\n[oh-my-ontology-mcp verify]\n');
+  const ok1 = await step1ParserSmoke();
+  if (!ok1) process.exit(1);
+  const ok2 = await step2BootAndCall();
+  if (!ok2) process.exit(1);
+  console.log('\n\x1b[32m전체 통과\x1b[0m — Claude Code 에 .mcp.json 등록 후 재시작하면 7 도구 사용 가능합니다.\n');
+  process.exit(0);
+}
+
+main();

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -464,6 +464,35 @@ export function OntologyViewPage() {
                   </>
                 )}
               </div>
+              {/* UX-1 — local 모드 빈 vault 사용자에게 *복사·붙여넣기*
+                  가능한 frontmatter snippet inline 노출. 사용자가 빌더
+                  진입 없이도 vault 에 직접 `.md` 만들 수 있게. AI agent
+                  (MCP) 도 이 형식 그대로 add_concept 호출. */}
+              {dataSourceMode === 'local' ? (
+                <details className="mt-4 rounded-xl border border-[color:var(--color-divider)] bg-[color:var(--color-canvas)] px-4 py-3">
+                  <summary className="cursor-pointer list-none text-[12px] text-[color:var(--color-text-secondary)]">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">snippet</span>
+                    <span className="ml-2">vault 의 첫 노드 — 이 frontmatter 를 `.md` 파일에 붙여넣으면 즉시 트리에 등장</span>
+                  </summary>
+                  <pre className="mt-3 overflow-x-auto rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-3 font-mono text-[11.5px] leading-5 text-[color:var(--color-text-secondary)]">{`---
+slug: capabilities/auth
+kind: capability
+title: 인증
+domain: auth
+relates:
+  - elements/jwt
+  - elements/refresh-token
+---
+
+# 인증
+
+토큰 발급, 권한 검증, 세션 추적 등 사용자 인증 흐름.
+`}</pre>
+                  <p className="mt-2 text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+                    위 내용을 vault 안 어떤 디렉토리에든 <code className="font-mono">capabilities/auth.md</code> 같은 이름으로 저장하세요. 더 자세한 frontmatter 키: <code className="font-mono">domain</code> · <code className="font-mono">capabilities</code> · <code className="font-mono">elements</code> · <code className="font-mono">relates</code> · <code className="font-mono">dependencies</code>.
+                  </p>
+                </details>
+              ) : null}
             </div>
           ) : null}
         </>


### PR DESCRIPTION
## Summary

UX 1원리 분석 (PR #17) 의 **P1 후속 batch**. 사용자 첫 5분 마찰 2 곳 해소.

## UX-1 — OntologyViewPage 빈 vault inline frontmatter snippet

local 모드 빈 vault 일 때 *복사·붙여넣기 가능한* frontmatter 예시 details panel 추가:

```yaml
---
slug: capabilities/auth
kind: capability
title: 인증
domain: auth
relates:
  - elements/jwt
  - elements/refresh-token
---

# 인증

토큰 발급, 권한 검증, 세션 추적 등 사용자 인증 흐름.
```

빌더 진입 없이도 vault 에 직접 `.md` 만들 수 있게. AI agent (MCP) 의 `add_concept` 호출과 같은 형식 — 사람·agent 일관성.

## UX-3 — MCP verify CLI (신규)

`mcp/scripts/verify.mjs` 신설. 1 명령으로 MCP server 검증:

```bash
cd mcp && npm install
OMOT_VAULT=../docs/ontology npm run verify
```

3-step 검증: parser smoke → server boot + initialize → tools/list 7/7 + list_concepts. 실패 시 어느 step + 진단 메시지.

`mcp/README.md` 갱신:
- 로컬 검증 섹션 — `npm run verify` 강조
- **"Claude Code 등록 후 첫 호출 (sample prompt)"** 신설 — LLM 에게 줄 수 있는 4-step 탐색 prompt

## 검증

- tsc 0 errors
- vitest 117 files / 834 tests pass
- `npm run verify` end-to-end 정상 (22 노드 dogfood vault 인식)

## 변경 통계

4 files (+150 / -16)