### PR TITLE
feat: T33 + T35 — 빌더 onboarding 카피 + kind 별 lucide 아이콘

### DIFF
--- a/src/entities/ontology-class/index.ts
+++ b/src/entities/ontology-class/index.ts
@@ -7,6 +7,7 @@ export {
   DEFAULT_ONTOLOGY_CLASSES,
   isOntologyClassId,
   getOntologyKindLabel,
+  getOntologyKindIcon,
   fromFirestore,
   toFirestore,
 } from './model';

--- a/src/entities/ontology-class/model/icons.ts
+++ b/src/entities/ontology-class/model/icons.ts
@@ -1,0 +1,41 @@
+import {
+  Box,
+  CheckSquare,
+  Cog,
+  FileText,
+  Folder,
+  HelpCircle,
+  Layers,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * ontology kind → lucide icon (Phase 4 / T35).
+ *
+ * 비개발자 청중을 위해 kind 별로 *직관적 metaphor* 를 시각적으로 노출.
+ * 색은 단일 인디고 + 무채색 헌장 유지 — icon 은 `currentColor` 로 받아
+ * 호출자가 색을 결정. 즉 이 매핑은 *모양* 만 정의, *색* 은 디자인 헌장
+ * 그대로.
+ *
+ * unknown / stub 같은 미해결 kind 는 HelpCircle — "kind 미지정" 의미.
+ *
+ * legacy / 알 수 없는 kind 가 들어와도 fallback (HelpCircle) 으로 안전.
+ */
+const KIND_ICON: Record<string, LucideIcon> = {
+  project: Folder,
+  domain: Layers,
+  capability: Cog,
+  element: Box,
+  document: FileText,
+  decision: CheckSquare,
+  workflow: Workflow,
+  unknown: HelpCircle,
+};
+
+/**
+ * kind 의 대표 lucide 아이콘 컴포넌트. 미지정/legacy kind 는 HelpCircle.
+ */
+export function getOntologyKindIcon(kind: string): LucideIcon {
+  return KIND_ICON[kind] ?? HelpCircle;
+}

--- a/src/entities/ontology-class/model/index.ts
+++ b/src/entities/ontology-class/model/index.ts
@@ -2,3 +2,4 @@ export type { OntologyClass, OntologyClassInput, OntologyElementType } from './t
 export { DEFAULT_ONTOLOGY_CLASSES, isOntologyClassId } from './defaults';
 export { fromFirestore, toFirestore } from './mapper';
 export { getOntologyKindLabel } from './labels';
+export { getOntologyKindIcon } from './icons';

--- a/src/views/ontology-edit/ui/BuilderOnboarding.tsx
+++ b/src/views/ontology-edit/ui/BuilderOnboarding.tsx
@@ -64,13 +64,13 @@ export function BuilderOnboarding({ empty }: BuilderOnboardingProps) {
           <header className="mb-4 flex items-start justify-between gap-3">
             <div>
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-indigo-accent)]">
-                온톨로지 빌더
+                도메인 지도 빌더
               </p>
               <h2 className="mt-1 text-[15px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-                세 번 클릭이면 내 첫 노드가 생겨요
+                ERD 이상 — 우리 도메인의 *지도* 를 만들어요
               </h2>
               <p className="mt-1 text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
-                AI 가 따로 추출해주는 게 아니라 — 내가 직접 그리는 캔버스예요.
+                코드/DB 스키마가 아니라 *기능·관계·역할* 의 시각 지도. 비개발자 (PM·디자이너·운영) 도 직접 그릴 수 있어요. AI agent (Claude Code 등) 도 같은 지도에 노드 추가.
               </p>
             </div>
             <button
@@ -89,9 +89,9 @@ export function BuilderOnboarding({ empty }: BuilderOnboardingProps) {
               </span>
               <p>
                 <strong className="font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-                  왼쪽 종류 한 개를 클릭
+                  왼쪽 종류 클릭
                 </strong>{" "}
-                — 프로젝트 · 도메인 · 역량 · 요소 중 하나. 가운데에 노드가 떠요.
+                — 프로젝트 · 도메인 · 역량 · 요소 4 종류. 가운데에 임시 노드가 떠요. (코드 식별자: project / domain / capability / element)
               </p>
             </li>
             <li className="flex gap-2.5">
@@ -102,7 +102,7 @@ export function BuilderOnboarding({ empty }: BuilderOnboardingProps) {
                 <strong className="font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                   노드 가장자리 점을 끌어
                 </strong>{" "}
-                다른 노드 위에 놓으면 — 둘 사이에 관계가 그려져요.
+                다른 노드 위에 놓으면 — 둘 사이에 *관계 (의존 / 포함 / 묘사)* 가 그려져요.
               </p>
             </li>
             <li className="flex gap-2.5">
@@ -110,11 +110,10 @@ export function BuilderOnboarding({ empty }: BuilderOnboardingProps) {
                 <Save size={12} />
               </span>
               <p>
-                노드를 다시 한 번 클릭하면 오른쪽 패널이 열려요. 이름 적고{" "}
                 <strong className="font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                   저장
                 </strong>{" "}
-                — 영구 그래프에 박혀요.
+                — vault 모드면 `.md` 로 디스크에 직접, cloud 모드면 Firestore 에. 같은 지도를 AI agent 도 MCP 로 read/write.
               </p>
             </li>
           </ol>

--- a/src/views/ontology-edit/ui/OntologyKindPalette.tsx
+++ b/src/views/ontology-edit/ui/OntologyKindPalette.tsx
@@ -1,45 +1,36 @@
 "use client";
 
-import { Atom, Layers, ListTree, Zap } from "lucide-react";
+import { getOntologyKindIcon, getOntologyKindLabel } from "@/entities/ontology-class";
 import type { ManualNodeKind } from "@/entities/knowledge-graph";
 
 /**
  * Track C-3 + C-10 폴리시 — 좌측 palette. kind chip 4개.
  *
  * C-10 추가:
- * - kind 별 미니 아이콘 (lucide)
+ * - kind 별 미니 아이콘 (lucide). T35 (Phase 4) — `getOntologyKindIcon`
+ *   shared helper 사용해 Tree / Stub / Search 와 같은 매핑.
  * - hover 시 인디고 alpha bg 톤 변화 (헌장 §11 — scale 없이 색만)
  * - 더 풍부한 시각 hierarchy (label + hint 분리)
  */
 const PALETTE_KINDS: Array<{
   kind: Exclude<ManualNodeKind, "document">;
-  label: string;
   hint: string;
-  Icon: typeof Layers;
 }> = [
   {
     kind: "project",
-    label: "프로젝트",
     hint: "최상위 단위 — 전체 워크스페이스의 한 prj",
-    Icon: Layers,
   },
   {
     kind: "domain",
-    label: "도메인",
     hint: "프로젝트 안의 큰 영역 — auth / billing / ingest 등",
-    Icon: ListTree,
   },
   {
     kind: "capability",
-    label: "역량",
     hint: "도메인 안의 한 기능 — 'JWT 발급' 같은 동사형",
-    Icon: Zap,
   },
   {
     kind: "element",
-    label: "요소",
     hint: "역량 안의 작은 구성 — 클래스 / 함수 / API endpoint",
-    Icon: Atom,
   },
 ];
 
@@ -63,14 +54,15 @@ export function OntologyKindPalette({ onAddNode }: OntologyKindPaletteProps) {
       </header>
       <ul className="flex flex-col gap-1.5">
         {PALETTE_KINDS.map((entry) => {
-          const Icon = entry.Icon;
+          const Icon = getOntologyKindIcon(entry.kind);
+          const label = getOntologyKindLabel(entry.kind);
           return (
             <li key={entry.kind}>
               <button
                 type="button"
                 onClick={() => onAddNode(entry.kind)}
                 className="group flex w-full items-start gap-2.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-elevated)] px-3 py-2.5 text-left transition-colors hover:border-[color:rgba(94,106,210,0.46)] hover:bg-[color:rgba(94,106,210,0.08)]"
-                aria-label={`${entry.label} 노드 추가 — ${entry.hint}`}
+                aria-label={`${label} 노드 추가 — ${entry.hint}`}
               >
                 <span
                   aria-hidden
@@ -80,7 +72,7 @@ export function OntologyKindPalette({ onAddNode }: OntologyKindPaletteProps) {
                 </span>
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <span className="text-[13px] font-medium text-[color:var(--color-text-primary)]">
-                    {entry.label}
+                    {label}
                   </span>
                   <span className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)] group-hover:text-[color:var(--color-text-tertiary)]">
                     {entry.hint}

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, ChevronsDownUp, ChevronsUpDown, Search, X } from "lucide-react";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { getOntologyKindIcon, getOntologyKindLabel } from "@/entities/ontology-class";
 import { ManualSourceChip } from "@/entities/knowledge-graph";
 import {
   filterTreeByQuery,
@@ -69,11 +69,15 @@ const KIND_TONE: Record<
 
 function KindChip({ kind }: { kind: string }) {
   const tone = KIND_TONE[kind] ?? KIND_TONE.element!;
+  // T35 — kind 별 lucide icon. Phase 4 (비개발자 친화) — 시각 직관 보강.
+  // 색은 chip tone 의 text color 이미 currentColor — 추가 색 도입 0.
+  const Icon = getOntologyKindIcon(kind);
   return (
     <span
-      className="inline-flex items-center break-keep rounded-full border px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em]"
+      className="inline-flex items-center gap-1 break-keep rounded-full border px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em]"
       style={{ backgroundColor: tone.bg, color: tone.text, borderColor: tone.border }}
     >
+      <Icon size={10} aria-hidden />
       {getOntologyKindLabel(kind)}
     </span>
   );


### PR DESCRIPTION
## Summary

UX 1원리 (PR #17) 의 **Phase 4 비개발자 친화 batch 1**. T33 (빌더 onboarding 카피) + T35 (kind 별 lucide 아이콘) 합쳐 1 PR.

## T35 — kind 별 lucide 아이콘

`src/entities/ontology-class/model/icons.ts` 신설 — `getOntologyKindIcon(kind)` shared helper:

| kind | icon |
|---|---|
| project | Folder |
| domain | Layers |
| capability | Cog |
| element | Box |
| document | FileText |
| decision | CheckSquare |
| workflow | Workflow |
| unknown / legacy | HelpCircle |

색은 `currentColor` — 헌장 (단일 인디고 + 무채색) 그대로 유지, 추가 색 도입 0.

적용 surface:
- `OntologyTreeView` KindChip — 라벨 옆 10px icon
- `OntologyKindPalette` (빌더) — 기존 매핑 (Layers/ListTree/Zap/Atom) 을 shared helper 로 통일

## T33 — 빌더 onboarding 카피 "ERD 이상 — 도메인 지도"

`BuilderOnboarding` 비개발자 친화 카피로 변경:

- eyebrow: "온톨로지 빌더" → **"도메인 지도 빌더"**
- 헤드: "세 번 클릭이면 내 첫 노드가 생겨요" → **"ERD 이상 — 우리 도메인의 *지도* 를 만들어요"**
- 서브: "코드/DB 스키마가 아니라 *기능·관계·역할* 의 시각 지도. 비개발자도 직접 그릴 수 있어요. AI agent 도 같은 지도에 노드 추가."
- step 3 저장 안내 — vault 모드 .md / cloud 모드 Firestore + AI agent 양립 명시

## 검증

- tsc 0 errors
- vitest 117 files / 834 tests pass