### PR TITLE
feat: T34 + T36 — 한국어 매핑 layer + 검색 PM 친화 분류

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -277,8 +277,8 @@ export function OntologyInsightsPage() {
               같은 helper 사용. */}
           {edgeTypeRows.length > 0 ? (
             <Panel
-              title="관계 type 분포"
-              subtitle={`총 ${totalEdges} 관계 — 의미 관계 type 별 비율`}
+              title="관계 종류 분포"
+              subtitle={`총 ${totalEdges} 관계 — 의미 관계 종류별 비율`}
             >
               <ul className="space-y-1.5" data-testid="insights-edge-type-rows">
                 {edgeTypeRows.slice(0, 8).map(({ type, count }) => {

--- a/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
+++ b/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
@@ -105,7 +105,7 @@ export function OntologyRelationsPage() {
           </div>
         </div>
         <p className="break-keep text-sm leading-7 text-[color:var(--color-text-secondary)]">
-          노드는 트리, 통계는 인사이트. 관계는 의미 edge type 의 분포와 evidence 풍부한 관계를 보여줍니다.
+          노드는 트리, 통계는 인사이트. 관계는 *의미 관계 종류* 의 분포와 근거 풍부한 관계를 보여줍니다.
         </p>
       </section>
 
@@ -219,7 +219,7 @@ export function OntologyRelationsPage() {
                 ) : null}
               </p>
               <p className="mt-0.5 text-[11px] text-[color:var(--color-text-tertiary)]">
-                evidence 풍부한 위 12 — 자주 인용되는 의미 연결
+                근거 문서 많은 위 12 — 자주 인용되는 의미 연결
                 {selectedType ? ` · ${filteredEdges.length} 매치` : ""}
               </p>
             </header>

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -306,11 +306,11 @@ export function OntologyViewPage() {
                 인사이트
               </Link>
             </Tooltip>
-            <Tooltip content="ontology 관계 — edge type 분포 + 강한 관계" withProvider={false}>
+            <Tooltip content="관계 — 종류 분포 + 근거 풍부한 강한 관계" withProvider={false}>
               <Link
                 href={"/ontology/relations/"}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
-                aria-label="ontology 관계 — edge type 분포 + 강한 관계"
+                aria-label="관계 — 종류 분포 + 근거 풍부한 강한 관계"
               >
                 관계
               </Link>

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -182,7 +182,7 @@ export function GlobalSearch({
           <VisuallyHidden>
             <Dialog.Title>글로벌 검색</Dialog.Title>
             <Dialog.Description>
-              ontology 노드와 knowledge 문서를 한 번에 검색합니다. 위·아래
+              개념 (ontology 노드) · 글 (문서) · 프로젝트를 한 번에 검색합니다. 위·아래
               화살표로 이동, Enter 로 선택, ESC 로 닫기.
             </Dialog.Description>
           </VisuallyHidden>
@@ -199,8 +199,8 @@ export function GlobalSearch({
             onValueChange={setQuery}
             placeholder={
               documents
-                ? "노드 · 문서 검색 — 한·영 혼합 OK"
-                : "ontology 노드 검색 — 한·영 혼합 OK"
+                ? "개념 · 글 검색 — 한·영 혼합 OK"
+                : "개념 검색 — 한·영 혼합 OK"
             }
             className="flex-1 bg-transparent text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           />
@@ -317,7 +317,7 @@ export function GlobalSearch({
           <Command.Empty className="px-3 py-6 text-center text-sm text-[color:var(--color-text-tertiary)]">
             {isEmptyQuery
               ? totalCorpus === 0
-                ? "아직 색인된 ontology 노드·문서가 없어요. 검수 큐에서 후보를 승인하면 여기로 자라요."
+                ? "아직 색인된 개념·글이 없어요. vault frontmatter 또는 빌더에서 첫 노드를 만들면 여기로 자라요."
                 : `${totalCorpus}개 항목이 색인되어 있어요. 한·영 모두 OK.`
               : `"${query}" 와 일치하는 결과가 없어요.`}
           </Command.Empty>
@@ -326,7 +326,7 @@ export function GlobalSearch({
             <Command.Group
               heading={
                 <span className="px-2 pb-1 pt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  {isEmptyQuery ? "Ontology · 최근" : "Ontology · 매치"} · {ontologyResults.length}
+                  {isEmptyQuery ? "개념 · 최근" : "개념 · 매치"} · {ontologyResults.length}
                   {isEmptyQuery && ontologySize > ontologyResults.length ? ` / ${ontologySize}` : ""}
                 </span>
               }
@@ -373,7 +373,7 @@ export function GlobalSearch({
             <Command.Group
               heading={
                 <span className="px-2 pb-1 pt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  {isEmptyQuery ? "Documents · 최근" : "Documents · 매치"} · {documentResults.length}
+                  {isEmptyQuery ? "글 · 최근" : "글 · 매치"} · {documentResults.length}
                   {isEmptyQuery && documentSize > documentResults.length ? ` / ${documentSize}` : ""}
                 </span>
               }
@@ -411,7 +411,7 @@ export function GlobalSearch({
             <Command.Group
               heading={
                 <span className="px-2 pb-1 pt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  {isEmptyQuery ? "Projects · 최근" : "Projects · 매치"} · {projectResults.length}
+                  {isEmptyQuery ? "프로젝트 · 최근" : "프로젝트 · 매치"} · {projectResults.length}
                   {isEmptyQuery && projectSize > projectResults.length ? ` / ${projectSize}` : ""}
                 </span>
               }


### PR DESCRIPTION
## Summary

UX 1원리 (PR #17) Phase 4 비개발자 친화 **batch 2**. T34 (UI 영문 transliteration → 한국어) + T36 (검색 PM 친화 분류).

## T34 — UI 한국어 정렬

| Before | After | 위치 |
|---|---|---|
| ontology 관계 — edge type 분포 | 관계 — 종류 분포 | OntologyView toolbar pill |
| edge type 의 분포 + evidence 풍부 | 관계 종류 의 분포 + 근거 풍부 | OntologyRelations header |
| 관계 type 분포 | 관계 종류 분포 | OntologyInsights panel |
| evidence 풍부한 위 12 | 근거 문서 많은 위 12 | OntologyRelations top12 |

## T36 — GlobalSearch (⇧⌘K) PM 친화

| Before | After |
|---|---|
| 노드 · 문서 검색 | **개념 · 글 검색** (placeholder) |
| Ontology · 매치 | **개념 · 매치** (그룹 heading) |
| Documents · 매치 | **글 · 매치** |
| Projects · 매치 | **프로젝트 · 매치** |
| ontology 노드와 knowledge 문서 | 개념 · 글 · 프로젝트 (aria desc) |
| 검수 큐에서 후보를 승인하면 (mission v1) | vault frontmatter 또는 빌더에서 첫 노드를 만들면 |

## 원칙

코드 식별자 (`kind` / `node` / `edge`) 는 그대로. UI 라벨만 한국어 매핑. `getOntologyKindLabel` 처럼 i18n 가능한 helper 패턴 따름.

## 검증

- tsc 0 errors
- vitest 117 files / 834 tests pass