### PR TITLE
feat: T19 V1.5 — Relation Cardinality (Palantir 영감, additive)

### DIFF
--- a/docs/ONTOLOGY-MODEL-V2-DRAFT.md
+++ b/docs/ONTOLOGY-MODEL-V2-DRAFT.md
@@ -13,7 +13,7 @@
 | V1.2 — Literal Properties | ⏳ Q6+Q7 답 후 진행 |
 | V1.3 — Rich References | ⏳ Q5 답 후 진행 |
 | V1.4 — Action Type | ⏸ DEFERRED (Q4 + 보안 sub-spec 필요) |
-| V1.5 — Relation Cardinality | ⏳ 즉시 가능 (Q 답 무관) |
+| V1.5 — Relation Cardinality | ✅ 머지 완료 (PR #23, additive, breakage 0) |
 | V2 — 통합 KnowledgeStatement | ⏳ V1.x 완료 + 90일 dual-read soak 후 |
 
 Open question 진행: Q1=(a) ✅ · Q2 ✅ (share-doc 이미 제거) · Q3-Q8 + multi-vault 시점 대기.
@@ -469,7 +469,9 @@ interface KnowledgeActionInvocation {
 
 ---
 
-## 6. V1.5 — Relation Cardinality (Palantir 영감)
+## 6. V1.5 — Relation Cardinality (Palantir 영감) — ✅ 머지 완료 (PR #23)
+
+> ✅ 2026-05-01 머지. `OntologyRelation` 에 `sourceCardinality` + `targetCardinality` 옵셔널 추가. 5 단위 test. additive, breakage 0. 자세히: `src/entities/ontology-relation/model/types.ts` + `mapper.test.ts`.
 
 **컬렉션 변경**: `OntologyRelation` 에 옵셔널 필드 2개.
 

--- a/src/entities/ontology-relation/model/index.ts
+++ b/src/entities/ontology-relation/model/index.ts
@@ -2,6 +2,7 @@ export type {
   OntologyRelation,
   OntologyRelationInput,
   OntologyRelationCategory,
+  RelationCardinality,
 } from './types';
 export {
   DEFAULT_ONTOLOGY_RELATIONS,

--- a/src/entities/ontology-relation/model/mapper.test.ts
+++ b/src/entities/ontology-relation/model/mapper.test.ts
@@ -84,4 +84,72 @@ describe('ontology-relation mapper', () => {
     expect(relation.sourceClassIds).toEqual(['project', 'domain']);
     expect(relation.targetClassIds).toEqual([]);
   });
+
+  describe('V1.5 cardinality (additive)', () => {
+    it('fromFirestore reads sourceCardinality + targetCardinality when present', () => {
+      const relation = fromFirestore('belongs_to', {
+        name: '소속',
+        sourceClassIds: ['capability'],
+        targetClassIds: ['domain'],
+        category: 'structure',
+        symmetric: false,
+        transitive: false,
+        version: 1,
+        createdBy: 'system',
+        sourceCardinality: 'one',
+        targetCardinality: 'many',
+      });
+      expect(relation.sourceCardinality).toBe('one');
+      expect(relation.targetCardinality).toBe('many');
+    });
+
+    it('fromFirestore returns undefined for invalid cardinality', () => {
+      const relation = fromFirestore('weird', {
+        name: '???',
+        sourceClassIds: [],
+        targetClassIds: [],
+        category: 'weak',
+        symmetric: false,
+        transitive: false,
+        version: 1,
+        createdBy: 'system',
+        sourceCardinality: 'two', // invalid
+        targetCardinality: null,
+      });
+      expect(relation.sourceCardinality).toBeUndefined();
+      expect(relation.targetCardinality).toBeUndefined();
+    });
+
+    it('legacy data (no cardinality fields) → undefined', () => {
+      const relation = fromFirestore('related_to', {
+        name: '연관',
+        sourceClassIds: [],
+        targetClassIds: [],
+        category: 'weak',
+        symmetric: true,
+        transitive: false,
+        version: 1,
+        createdBy: 'system',
+      });
+      expect(relation.sourceCardinality).toBeUndefined();
+      expect(relation.targetCardinality).toBeUndefined();
+    });
+
+    it('toFirestore round-trip preserves cardinality', () => {
+      const input: OntologyRelationInput = {
+        ...inputContains,
+        sourceCardinality: 'many',
+        targetCardinality: 'one',
+      };
+      const payload = toFirestore(input);
+      expect(payload.sourceCardinality).toBe('many');
+      expect(payload.targetCardinality).toBe('one');
+    });
+
+    it('toFirestore drops undefined cardinality', () => {
+      const payload = toFirestore(inputContains);
+      expect(payload).not.toHaveProperty('sourceCardinality');
+      expect(payload).not.toHaveProperty('targetCardinality');
+    });
+  });
 });

--- a/src/entities/ontology-relation/model/mapper.ts
+++ b/src/entities/ontology-relation/model/mapper.ts
@@ -3,6 +3,7 @@ import type {
   OntologyRelation,
   OntologyRelationCategory,
   OntologyRelationInput,
+  RelationCardinality,
 } from './types';
 
 const CATEGORIES: OntologyRelationCategory[] = ['structure', 'behavior', 'evidence', 'weak'];
@@ -12,6 +13,10 @@ function toCategory(value: unknown): OntologyRelationCategory {
     return value as OntologyRelationCategory;
   }
   return 'weak';
+}
+
+function toCardinality(value: unknown): RelationCardinality | undefined {
+  return value === 'one' || value === 'many' ? value : undefined;
 }
 
 function toStringArray(value: unknown): string[] {
@@ -43,6 +48,8 @@ export function fromFirestore(id: string, data: DocumentData): OntologyRelation 
     category: toCategory(data.category),
     symmetric: Boolean(data.symmetric),
     transitive: Boolean(data.transitive),
+    sourceCardinality: toCardinality(data.sourceCardinality),
+    targetCardinality: toCardinality(data.targetCardinality),
     version: typeof data.version === 'number' ? data.version : 1,
     createdAt: toDate(data.createdAt),
     createdBy: String(data.createdBy ?? 'system'),
@@ -63,5 +70,7 @@ export function toFirestore(input: OntologyRelationInput): Record<string, unknow
   };
   if (input.inverseName !== undefined) payload.inverseName = input.inverseName;
   if (input.description !== undefined) payload.description = input.description;
+  if (input.sourceCardinality !== undefined) payload.sourceCardinality = input.sourceCardinality;
+  if (input.targetCardinality !== undefined) payload.targetCardinality = input.targetCardinality;
   return payload;
 }

--- a/src/entities/ontology-relation/model/types.ts
+++ b/src/entities/ontology-relation/model/types.ts
@@ -17,6 +17,19 @@ export type OntologyRelationCategory =
   /** 약 연관 — related_to. 충분한 근거 누적 시 더 구체적 타입으로 승격 후보. */
   | 'weak';
 
+/**
+ * V1.5 — Relation cardinality (Palantir 영감, additive).
+ *
+ * source / target 쪽의 multiplicity 제약. legacy = undefined → 'many' /
+ * 'many' (= 현재 동작 — 제약 0).
+ *
+ * 예: `belongs_to.sourceCardinality = 'one'` — 한 node 는 한 부모만.
+ *     `implements.targetCardinality = 'one'` — 한 spec 만 구현.
+ *
+ * V1.5 spec: docs/ONTOLOGY-MODEL-V2-DRAFT.md §6.
+ */
+export type RelationCardinality = 'one' | 'many';
+
 export interface OntologyRelation {
   /** kebab-case ID. 예: 'depends_on'. */
   id: string;
@@ -38,6 +51,15 @@ export interface OntologyRelation {
   symmetric: boolean;
   /** A→B + B→C ⇒ A→C 가 성립 (예: contains true, uses false). */
   transitive: boolean;
+  /**
+   * V1.5 (Palantir 영감) — source 쪽 cardinality 제약. 옵셔널 (legacy =
+   * many). edge 생성/approve 단계에서 검증 가능.
+   */
+  sourceCardinality?: RelationCardinality;
+  /**
+   * V1.5 — target 쪽 cardinality 제약. 옵셔널.
+   */
+  targetCardinality?: RelationCardinality;
   /** TBox 버전. */
   version: number;
   createdAt: Date;


### PR DESCRIPTION
## Summary

`docs/ONTOLOGY-MODEL-V2-DRAFT.md` §6 의 V1.5 단계. `OntologyRelation` 에 `sourceCardinality` + `targetCardinality` 옵셔널 추가. legacy 데이터는 undefined → 'many'/'many' (현재 동작 호환). additive, breakage 0.

## 변경

### types
```ts
export type RelationCardinality = 'one' | 'many';

export interface OntologyRelation {
  // ... 기존 ...
  sourceCardinality?: RelationCardinality;  // V1.5
  targetCardinality?: RelationCardinality;  // V1.5
}
```

### mapper
- `toCardinality` runtime 검증 ('one' | 'many' 만)
- `fromFirestore` 가 두 필드 인식 + 폴백
- `toFirestore` 가 undefined 키 drop

### tests (V1.5 describe block 5 케이스)
- 정상 cardinality 인식
- invalid value → undefined
- legacy data → undefined
- round-trip 보존
- undefined drop

## V1.x 진화 현황

| 단계 | 상태 |
|---|---|
| V1.1 qualifiers + rank | ✅ PR #10 |
| V1.2 literals | ⏳ Q6+Q7 답 후 |
| V1.3 rich-refs | ⏳ Q5 답 후 |
| V1.4 ActionType | ⏸ DEFERRED |
| **V1.5 cardinality** | **✅ 본 PR** |
| V2 통합 | ⏳ 마지막 |

## 검증

- tsc 0 errors
- vitest 117 files / **839 tests pass** (834 → 839, +5)