### PR TITLE
feat: 빌더 C-5 — vault 노드 in-canvas 편집 (mode-aware)

### DIFF
--- a/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { VaultManifest, VaultDoc } from "@/entities/docs-vault";
+import { buildVaultGraphFlow } from "./use-vault-graph-flow";
+
+function makeDoc(partial: Partial<VaultDoc> & { slug: string }): VaultDoc {
+  return {
+    slug: partial.slug,
+    path: partial.path ?? `${partial.slug}.md`,
+    title: partial.title ?? partial.slug,
+    description: partial.description,
+    tags: partial.tags ?? [],
+    frontmatter: partial.frontmatter ?? {},
+    headings: partial.headings ?? [],
+    excerpt: partial.excerpt ?? "",
+    wordCount: partial.wordCount ?? 0,
+    updatedAt: partial.updatedAt ?? "2026-05-01T00:00:00Z",
+    mode: partial.mode ?? "both",
+    linksOut: partial.linksOut ?? [],
+  };
+}
+
+function makeManifest(docs: VaultDoc[]): VaultManifest {
+  return {
+    version: "v1",
+    generatedAt: "2026-05-01T00:00:00Z",
+    docs,
+    backlinksDetail: {},
+    tags: {},
+    tree: { name: "root", path: "", type: "dir", children: [] },
+  };
+}
+
+describe("buildVaultGraphFlow", () => {
+  it("kind 가 없는 doc 은 노드로 만들지 않는다", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({ slug: "no-kind", frontmatter: { title: "X" } }),
+        makeDoc({
+          slug: "capabilities/foo",
+          frontmatter: { kind: "capability", title: "Foo" },
+        }),
+      ]),
+    );
+    expect(result.nodes.map((n) => n.id)).toEqual(["capabilities/foo"]);
+  });
+
+  it("node id 가 vault slug 와 일치 (인스펙터 lookup 안전)", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "capabilities/mcp-server",
+          title: "MCP Server",
+          frontmatter: { kind: "capability", title: "MCP Server" },
+        }),
+      ]),
+    );
+    expect(result.nodes[0].id).toBe("capabilities/mcp-server");
+    expect(result.nodes[0].data).toMatchObject({
+      kind: "capability",
+      vault: true,
+      ephemeral: false,
+    });
+  });
+
+  it("frontmatter array 키에서 edge 를 만들고 마지막 segment 매칭도 적용", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "project",
+          frontmatter: { kind: "project", capabilities: ["mcp-server"] },
+        }),
+        makeDoc({
+          slug: "capabilities/mcp-server",
+          frontmatter: {
+            kind: "capability",
+            elements: ["mcp/src/index.js"],
+          },
+        }),
+        makeDoc({
+          slug: "elements/mcp-sdk",
+          path: "elements/mcp-sdk.md",
+          title: "mcp/src/index.js",
+          frontmatter: { kind: "element", title: "mcp/src/index.js" },
+        }),
+      ]),
+    );
+    const edgePairs = result.edges.map((e) => ({
+      source: e.source,
+      target: e.target,
+    }));
+    // project --capabilities--> capabilities/mcp-server (tail match)
+    expect(edgePairs).toContainEqual({
+      source: "project",
+      target: "capabilities/mcp-server",
+    });
+  });
+
+  it("vault 외부 ref 는 dangling 으로 무시", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "a",
+          frontmatter: { kind: "capability", relates: ["nonexistent"] },
+        }),
+      ]),
+    );
+    expect(result.edges).toEqual([]);
+  });
+
+  it("self-edge 는 추가 안 함", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "a",
+          frontmatter: { kind: "capability", relates: ["a"] },
+        }),
+      ]),
+    );
+    expect(result.edges).toEqual([]);
+  });
+});

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -1,0 +1,207 @@
+"use client";
+
+import { type CSSProperties, useMemo } from "react";
+import type { Edge, Node } from "@xyflow/react";
+import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
+
+/**
+ * mission v2 빌더 — 로컬 vault 의 .md 노드를 캔버스 background 로 노출.
+ *
+ * cloud `useApprovedGraphFlow` 와 동일한 shape (xyflow Node[]/Edge[]) 를
+ * 반환하되 진실원이 vault manifest 다. node id = vault slug (예:
+ * `capabilities/mcp-server`) — 인스펙터가 이 id 로 manifest.docs 에서
+ * 다시 frontmatter 를 lookup 하고 vault.updateFrontmatter 로 patch.
+ *
+ * 노드 필터: frontmatter.kind 가 string 이고 비어있지 않은 doc 만 ontology
+ * 후보로 본다 (vault-readme 같은 sentinel 도 같이 노출되지만 ERD 캔버스
+ * 에서는 일반 노드로 취급해도 무해).
+ *
+ * Edge: 본 doc 의 frontmatter array 키 (capabilities / elements /
+ * dependencies / relates / contains / describes) 의 항목이 다른 doc 의
+ * slug 또는 마지막 segment 와 매칭되면 edge 추가. unresolved 항목은
+ * 무시 — vault 외부 reference 는 dangling 으로 두고 노출 안 함.
+ */
+export function useVaultGraphFlow(manifest: VaultManifest | null) {
+  return useMemo(() => {
+    if (!manifest) return { nodes: [] as Node[], edges: [] as Edge[] };
+    return buildVaultGraphFlow(manifest);
+  }, [manifest]);
+}
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 56;
+
+const NEIGHBOR_KEYS = [
+  "capabilities",
+  "elements",
+  "dependencies",
+  "relates",
+  "contains",
+  "describes",
+] as const;
+
+/**
+ * 순수 함수 — manifest → xyflow Node[] / Edge[]. 테스트용 export.
+ */
+export function buildVaultGraphFlow(manifest: VaultManifest) {
+  const ontologyDocs = manifest.docs.filter(
+    (doc) => typeof doc.frontmatter.kind === "string" && doc.frontmatter.kind,
+  );
+  const slugSet = new Set(ontologyDocs.map((d) => d.slug));
+  const tailToFull = new Map<string, string>();
+  for (const slug of slugSet) {
+    const tail = slug.split("/").pop();
+    if (tail && tail !== slug && !tailToFull.has(tail)) {
+      tailToFull.set(tail, slug);
+    }
+  }
+  function resolveRef(ref: string): string | null {
+    if (slugSet.has(ref)) return ref;
+    if (tailToFull.has(ref)) return tailToFull.get(ref) ?? null;
+    for (const slug of slugSet) {
+      if (slug.endsWith(`/${ref}`)) return slug;
+    }
+    return null;
+  }
+
+  const positions = computeGridLayout(ontologyDocs);
+  const nodes: Node[] = ontologyDocs.map((doc) => {
+    const pos = positions.get(doc.slug) ?? { x: 0, y: 0 };
+    const kind = String(doc.frontmatter.kind);
+    const title = doc.title || doc.slug;
+    return {
+      id: doc.slug,
+      type: "atlas",
+      position: pos,
+      data: {
+        label: `${kindLabel(kind)} · ${title}`,
+        kind,
+        ephemeral: false,
+        vault: true,
+      },
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      // C-5 — vault 노드도 drag 허용 (좌표 patch 는 후속 — 위치는 frontmatter
+      // canvasPosition 에 보낼 수 있으나 첫 단계는 read+rename 만).
+      draggable: false,
+      // edge 재생성 X (vault 가 진실원). 인스펙터에서 수정.
+      connectable: false,
+      selectable: true,
+    };
+  });
+
+  const seenEdges = new Set<string>();
+  const edges: Edge[] = [];
+  for (const doc of ontologyDocs) {
+    for (const key of NEIGHBOR_KEYS) {
+      const value = doc.frontmatter[key];
+      if (!Array.isArray(value)) continue;
+      for (const ref of value) {
+        if (typeof ref !== "string") continue;
+        const resolved = resolveRef(ref);
+        if (!resolved || resolved === doc.slug) continue;
+        const edgeId = `${doc.slug}--${key}-->${resolved}`;
+        if (seenEdges.has(edgeId)) continue;
+        seenEdges.add(edgeId);
+        edges.push({
+          id: edgeId,
+          source: doc.slug,
+          target: resolved,
+          type: "default",
+          label: edgeLabel(key),
+          labelStyle: edgeLabelStyle,
+          labelBgStyle: edgeLabelBgStyle,
+          labelBgPadding: [6, 4] as [number, number],
+          labelBgBorderRadius: 4,
+          style: edgeStrokeStyleByKey(key),
+          animated: false,
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function computeGridLayout(
+  docs: VaultDoc[],
+): Map<string, { x: number; y: number }> {
+  const COLS = Math.max(1, Math.ceil(Math.sqrt(docs.length)));
+  const COL_GAP = NODE_WIDTH + 40;
+  const ROW_GAP = NODE_HEIGHT + 40;
+  const map = new Map<string, { x: number; y: number }>();
+  docs.forEach((d, idx) => {
+    const col = idx % COLS;
+    const row = Math.floor(idx / COLS);
+    map.set(d.slug, { x: col * COL_GAP, y: row * ROW_GAP });
+  });
+  return map;
+}
+
+function kindLabel(kind: string): string {
+  switch (kind) {
+    case "project":
+      return "프로젝트";
+    case "domain":
+      return "도메인";
+    case "capability":
+      return "역량";
+    case "element":
+      return "요소";
+    case "document":
+      return "문서";
+    default:
+      return kind;
+  }
+}
+
+function edgeLabel(key: string): string {
+  switch (key) {
+    case "capabilities":
+      return "역량";
+    case "elements":
+      return "요소";
+    case "dependencies":
+      return "의존";
+    case "relates":
+      return "관련";
+    case "contains":
+      return "포함";
+    case "describes":
+      return "설명";
+    default:
+      return key;
+  }
+}
+
+const edgeLabelStyle = {
+  fontSize: 10,
+  fill: "rgba(220, 226, 240, 0.96)",
+  fontWeight: 600,
+};
+const edgeLabelBgStyle = {
+  fill: "rgba(14, 16, 22, 0.92)",
+  stroke: "rgba(94, 106, 210, 0.32)",
+  strokeWidth: 1,
+};
+
+function edgeStrokeStyleByKey(key: string): CSSProperties {
+  if (key === "contains" || key === "capabilities" || key === "elements") {
+    return { stroke: "rgba(139, 151, 255, 0.66)", strokeWidth: 1.5 };
+  }
+  if (key === "dependencies") {
+    return { stroke: "rgba(94, 106, 210, 0.46)", strokeWidth: 1.25 };
+  }
+  if (key === "describes") {
+    return {
+      stroke: "rgba(180, 188, 220, 0.4)",
+      strokeWidth: 1,
+      strokeDasharray: "2 3",
+    };
+  }
+  return {
+    stroke: "rgba(180, 188, 220, 0.32)",
+    strokeWidth: 1,
+    strokeDasharray: "4 4",
+  };
+}

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -12,13 +12,15 @@ import {
   type Node,
   type OnSelectionChangeParams,
 } from "@xyflow/react";
+import type { VaultManifest } from "@/entities/docs-vault";
 import { useApprovedGraphFlow } from "../lib/use-approved-graph-flow";
+import { useVaultGraphFlow } from "../lib/use-vault-graph-flow";
 import type { EphemeralNode } from "../lib/use-ephemeral-nodes";
 import type { EphemeralEdge } from "../lib/use-ephemeral-edges";
 import { ATLAS_NODE_TYPES } from "./AtlasNode";
 
 /**
- * ERD canvas — v1 C-1~C-3 누적.
+ * ERD canvas — v1 C-1~C-3 누적, C-5 vault 통합.
  *
  * 디자인 헌장 §11 호환:
  * - scale hover 없음 (xyflow 기본 X)
@@ -27,24 +29,34 @@ import { ATLAS_NODE_TYPES } from "./AtlasNode";
  * - edge animation 비활성
  *
  * 노드 합산:
- * - approved (Firestore read-only) — drag X
- * - ephemeral (palette 클릭으로 추가) — drag O, persist 는 C-4/C-5 에서
+ * - vault (local 모드) — manifest 기반 read-only display + 인스펙터에서 rename
+ * - approved (cloud 모드 — legacy) — Firestore read-only, drag X
+ * - ephemeral (palette 클릭으로 추가) — drag O, save 시 vault 또는 cloud 로
  */
 export function OntologyEditCanvas({
   accountId,
+  vaultManifest,
   ephemeralNodes,
   ephemeralEdges,
   onSelectionChange,
   onConnect,
 }: {
   accountId: string | null;
+  vaultManifest: VaultManifest | null;
   ephemeralNodes: EphemeralNode[];
   ephemeralEdges: EphemeralEdge[];
   onSelectionChange?: (selectedId: string | null) => void;
   onConnect?: (connection: Connection) => void;
 }) {
-  const { nodes: approvedNodes, edges: approvedEdges, error, loaded } =
-    useApprovedGraphFlow(accountId);
+  // mode 분기: vault.manifest 가 있으면 vault flow 우선 (local 모드 진실원).
+  // 둘 다 동시에 띄우지 않는다 — 두 진실원 혼합은 사용자 mental model 깨뜨림.
+  const vaultFlow = useVaultGraphFlow(vaultManifest);
+  const approvedFlow = useApprovedGraphFlow(vaultManifest ? null : accountId);
+  const useVaultMode = vaultManifest !== null;
+  const approvedNodes = useVaultMode ? vaultFlow.nodes : approvedFlow.nodes;
+  const approvedEdges = useVaultMode ? vaultFlow.edges : approvedFlow.edges;
+  const error = useVaultMode ? null : approvedFlow.error;
+  const loaded = useVaultMode ? true : approvedFlow.loaded;
 
   const handleSelectionChange = useCallback(
     (params: OnSelectionChangeParams) => {

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -59,6 +59,7 @@ import { BuilderOnboarding } from "./BuilderOnboarding";
  */
 const OntologyEditCanvas = dynamic<{
   accountId: string | null;
+  vaultManifest: import("@/entities/docs-vault").VaultManifest | null;
   ephemeralNodes: ReturnType<typeof useEphemeralNodes>["nodes"];
   ephemeralEdges: ReturnType<typeof useEphemeralEdges>["edges"];
   onSelectionChange?: (selectedId: string | null) => void;
@@ -162,12 +163,47 @@ export function OntologyEditPage() {
     [accountId, dataSourceMode, findById, removeNode, toast, vault],
   );
   const ephemeralSelected = findById(selectedId);
-  // approved 노드 detail 은 useApprovedGraphFlow 가 캔버스 내부에 있어 page 에선
-  // id 만 알 수 있음. 임시로 ephemeral 외 선택 = approved 가정.
+  // C-5 — vault 모드에서는 selectedId 가 vault slug. manifest 에서 lookup
+  // 해 인스펙터에 frontmatter 와 함께 전달 (in-canvas rename 가능).
+  const vaultSelected = (() => {
+    if (!selectedId || ephemeralSelected) return null;
+    const doc = vault.manifest?.docs.find((d) => d.slug === selectedId);
+    if (!doc || typeof doc.frontmatter.kind !== "string") return null;
+    return {
+      slug: doc.slug,
+      kind: String(doc.frontmatter.kind),
+      title: doc.title || doc.slug,
+    };
+  })();
+  // cloud approved 모드 fallback — vault 매니페스트 없을 때만. 현재 사용자
+  // 흐름에서는 vault 모드가 default 라 사실상 dead 지만 cloud 모드 잔존
+  // 사용자 보호용으로 placeholder 유지.
   const approvedSelected =
-    selectedId && !ephemeralSelected
+    selectedId && !ephemeralSelected && !vaultSelected && !vault.manifest
       ? { id: selectedId, kind: "(승인)", title: selectedId }
       : null;
+
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const renameVaultDoc = useCallback(
+    async (slug: string, nextTitle: string) => {
+      const trimmed = nextTitle.trim();
+      if (!trimmed) {
+        toast.show("제목이 비어 있어 저장할 수 없어요.", "error");
+        return;
+      }
+      setRenamingId(slug);
+      try {
+        await vault.updateFrontmatter(slug, { title: trimmed });
+        toast.show(`"${trimmed}" 제목 저장`, "success");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "제목 저장 실패";
+        toast.show(message, "error");
+      } finally {
+        setRenamingId(null);
+      }
+    },
+    [toast, vault],
+  );
 
   const treeHref = accountId
     ? `/ontology/?${ACCOUNT_QUERY_KEY}=${encodeURIComponent(accountId)}`
@@ -331,6 +367,7 @@ export function OntologyEditPage() {
           <div className="relative flex-1">
             <OntologyEditCanvas
               accountId={accountId ?? null}
+              vaultManifest={vault.manifest ?? null}
               ephemeralNodes={ephemeralNodes}
               ephemeralEdges={ephemeralEdges}
               onSelectionChange={setSelectedId}
@@ -343,9 +380,11 @@ export function OntologyEditPage() {
           <OntologyInspector
             ephemeralSelected={ephemeralSelected}
             approvedSelected={approvedSelected}
+            vaultSelected={vaultSelected}
             onRenameEphemeral={(id, title) => updateNode(id, { title })}
             onSaveEphemeral={saveEphemeral}
-            saving={savingId !== null}
+            onSaveVaultRename={renameVaultDoc}
+            saving={savingId !== null || renamingId !== null}
             onClearSelection={() => setSelectedId(null)}
           />
         </section>

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import type { EphemeralNode } from "../lib/use-ephemeral-nodes";
 
@@ -12,21 +13,22 @@ const FADE_MOTION = {
 };
 
 /**
- * Track C-4 — 우측 inspector 패널.
+ * Track C-4 + C-5 — 우측 inspector 패널.
  *
  * 선택된 노드의 상세를 보여주고 편집 가능한 필드는 inline 편집.
  * v1 범위:
- * - ephemeral 노드: 이름 inline 편집 (local state — persist 는 C-5)
- * - approved 노드: read-only (이름 / kind / 요약 / 검수 시각)
+ * - ephemeral 노드: 이름 inline 편집 (local state, 저장 시 vault.md 작성)
+ * - vault 노드 (C-5 신규): 이름 inline 편집, 저장 시 vault.updateFrontmatter
+ * - approved 노드: read-only (cloud 모드 legacy)
  * - 미선택: 안내 placeholder
- *
- * approved 노드 detail 은 C-6 에서 더 채움 (현재 hook 이 title/kind 만 노출).
  */
 export interface OntologyInspectorProps {
   ephemeralSelected: EphemeralNode | null;
   approvedSelected: { id: string; kind: string; title: string } | null;
+  vaultSelected: { slug: string; kind: string; title: string } | null;
   onRenameEphemeral: (id: string, title: string) => void;
   onSaveEphemeral?: (id: string) => Promise<void> | void;
+  onSaveVaultRename?: (slug: string, nextTitle: string) => Promise<void> | void;
   onClearSelection: () => void;
   saving?: boolean;
 }
@@ -42,12 +44,14 @@ const KIND_LABEL_MAP: Record<string, string> = {
 export function OntologyInspector({
   ephemeralSelected,
   approvedSelected,
+  vaultSelected,
   onRenameEphemeral,
   onSaveEphemeral,
+  onSaveVaultRename,
   onClearSelection,
   saving,
 }: OntologyInspectorProps) {
-  const selected = ephemeralSelected ?? approvedSelected;
+  const selected = ephemeralSelected ?? vaultSelected ?? approvedSelected;
   return (
     <aside
       aria-label="선택한 ontology 노드 상세"
@@ -78,6 +82,15 @@ export function OntologyInspector({
               node={ephemeralSelected}
               onRename={onRenameEphemeral}
               onSave={onSaveEphemeral}
+              saving={Boolean(saving)}
+              onDeselect={onClearSelection}
+            />
+          </motion.div>
+        ) : vaultSelected ? (
+          <motion.div key={`vault-${vaultSelected.slug}`} {...FADE_MOTION}>
+            <VaultDetail
+              node={vaultSelected}
+              onSaveRename={onSaveVaultRename}
               saving={Boolean(saving)}
               onDeselect={onClearSelection}
             />
@@ -182,6 +195,78 @@ function EphemeralDetail({
         {titleEmpty
           ? "이름을 입력하면 manual 노드로 저장할 수 있어요."
           : "저장 시 knowledgeApprovedNodes 의 manual 항목으로 추가됩니다."}
+      </p>
+    </div>
+  );
+}
+
+function VaultDetail({
+  node,
+  onSaveRename,
+  saving,
+  onDeselect,
+}: {
+  node: { slug: string; kind: string; title: string };
+  onSaveRename?: (slug: string, nextTitle: string) => Promise<void> | void;
+  saving: boolean;
+  onDeselect: () => void;
+}) {
+  // local draft — 사용자가 입력 중에 patch 가 일어나지 않게 buffer.
+  const [draft, setDraft] = useState(node.title);
+  useEffect(() => {
+    setDraft(node.title);
+  }, [node.slug, node.title]);
+  const trimmed = draft.trim();
+  const dirty = trimmed !== "" && trimmed !== node.title;
+  const canSave = dirty && Boolean(onSaveRename) && !saving;
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+          vault · {KIND_LABEL_MAP[node.kind] ?? node.kind}
+        </span>
+        <button
+          type="button"
+          onClick={onDeselect}
+          aria-label="선택 해제"
+          className="rounded-md p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+        >
+          ×
+        </button>
+      </div>
+      <label className="flex flex-col gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          제목 (frontmatter title)
+        </span>
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[13px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
+        />
+      </label>
+      <div>
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          slug
+        </p>
+        <p className="mt-1 break-all font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+          {node.slug}
+        </p>
+      </div>
+      {onSaveRename ? (
+        <button
+          type="button"
+          onClick={() => onSaveRename(node.slug, draft)}
+          disabled={!canSave}
+          aria-label="제목을 vault frontmatter 에 반영"
+          className="inline-flex h-9 items-center justify-center rounded-md border border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.18)] px-3 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.66)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "저장 중…" : dirty ? "vault 에 저장" : "변경 없음"}
+        </button>
+      ) : null}
+      <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+        제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로
+        유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

Builder 사이클 완성 — vault 노드를 캔버스에서 클릭 → 인스펙터에서 제목 수정 → vault frontmatter patch.

이전엔 \`OntologyEditPage\` 가 selectedId 가 ephemeral 외면 항상 'approved' 라고 가정해 placeholder \`{ kind: '(승인)', title: id }\` 만 노출 (코드 주석이 직접 gap 인정). vault-first mission v2 에서는 사용자가 캔버스에 vault .md 노드를 보고 그 자리에서 제목을 고치고 싶음.

### 새 코드
- **\`useVaultGraphFlow(manifest)\`** — vault.manifest 의 \`kind:\` 가진 docs 를 xyflow Node[]/Edge[] 로 변환. node id = vault slug. edge 는 frontmatter array 키 (capabilities / elements / dependencies / relates / contains / describes) 의 항목과 vault 내 slug 매칭 (tail segment alias 적용 — MCP findPath 와 같은 정책).
- **\`OntologyEditCanvas\`** mode-aware: vault.manifest 가 있으면 vault flow, 없으면 cloud approved flow (legacy). 두 진실원 동시 X.
- **\`OntologyEditPage\`** \`vaultSelected\` 빌드 + \`renameVaultDoc\` 핸들러 (vault.updateFrontmatter title patch).
- **\`OntologyInspector\`** \`VaultDetail\` 새 분기 — local draft state buffer, dirty 토글 라벨.

\`+479 / -15\`.

## Test plan

- [x] 새 단위 test 5 case (\`use-vault-graph-flow.test.ts\`):
  - kind 없는 doc → 노드 X
  - node id = vault slug
  - edge tail segment alias (\`project capabilities=['mcp-server']\` 가 \`capabilities/mcp-server\` 로 매칭)
  - vault 외부 ref → dangling (무시)
  - self-edge → 추가 안 함
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 844 tests (+1 file / +5 tests)

후속 후보 (별도 PR):
- vault 노드 drag 좌표 → frontmatter \`canvasPosition\` patch
- 인스펙터에서 frontmatter array 키 직접 편집
- delete 버튼 (MCP delete_concept 와 동일한 backlinks 가드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)