### PR TITLE
feat: 빌더 vault delete 버튼 (backlinks 가드 — MCP delete_concept 정책)

### DIFF
--- a/src/views/ontology-edit/lib/find-vault-backlinks.test.ts
+++ b/src/views/ontology-edit/lib/find-vault-backlinks.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
+import { findVaultBacklinks } from "./find-vault-backlinks";
+
+function makeDoc(partial: Partial<VaultDoc> & { slug: string }): VaultDoc {
+  return {
+    slug: partial.slug,
+    path: `${partial.slug}.md`,
+    title: partial.title ?? partial.slug,
+    tags: [],
+    frontmatter: partial.frontmatter ?? {},
+    headings: [],
+    excerpt: "",
+    wordCount: 0,
+    updatedAt: "2026-05-02T00:00:00Z",
+    mode: "both",
+    linksOut: [],
+  };
+}
+
+function manifest(docs: VaultDoc[]): VaultManifest {
+  return {
+    version: "v1",
+    generatedAt: "2026-05-02T00:00:00Z",
+    docs,
+    backlinksDetail: {},
+    tags: {},
+    tree: { name: "root", path: "", type: "dir", children: [] },
+  };
+}
+
+describe("findVaultBacklinks", () => {
+  it("frontmatter array 키에서 정확 slug + tail segment 매칭", () => {
+    const result = findVaultBacklinks(
+      manifest([
+        makeDoc({
+          slug: "project",
+          frontmatter: { capabilities: ["mcp-server"] },
+        }),
+        makeDoc({
+          slug: "domains/foo",
+          frontmatter: { contains: ["capabilities/mcp-server"] },
+        }),
+      ]),
+      "capabilities/mcp-server",
+    );
+    expect(result.map((m) => m.slug).sort()).toEqual([
+      "domains/foo",
+      "project",
+    ]);
+  });
+
+  it("self 참조는 무시", () => {
+    const result = findVaultBacklinks(
+      manifest([
+        makeDoc({
+          slug: "a",
+          frontmatter: { relates: ["a"] },
+        }),
+      ]),
+      "a",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("frontmatter 외 키는 무시", () => {
+    const result = findVaultBacklinks(
+      manifest([
+        makeDoc({
+          slug: "x",
+          frontmatter: { tags: ["mcp-server"] },
+        }),
+      ]),
+      "capabilities/mcp-server",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("matchedKeys 가 어느 키에서 매칭됐는지 알려준다", () => {
+    const result = findVaultBacklinks(
+      manifest([
+        makeDoc({
+          slug: "project",
+          frontmatter: {
+            capabilities: ["mcp-server"],
+            relates: ["mcp-server"],
+          },
+        }),
+      ]),
+      "capabilities/mcp-server",
+    );
+    expect(result[0].matchedKeys.sort()).toEqual(["capabilities", "relates"]);
+  });
+});

--- a/src/views/ontology-edit/lib/find-vault-backlinks.ts
+++ b/src/views/ontology-edit/lib/find-vault-backlinks.ts
@@ -1,0 +1,53 @@
+import type { VaultManifest } from "@/entities/docs-vault";
+
+/**
+ * vault 안에서 `targetSlug` 를 가리키는 다른 doc 를 찾는다. MCP `findBacklinks`
+ * (mcp/src/vault.mjs) 와 같은 정책 — frontmatter array 키와 마지막 segment
+ * 매칭까지 본다.
+ *
+ * 빌더에서 vault 노드 delete 버튼을 누르기 전에 호출 — 참조하는 노드가
+ * 있으면 dangling 위험을 사용자에게 명시하고 confirm 을 한 번 더 받는다.
+ */
+const NEIGHBOR_KEYS = [
+  "capabilities",
+  "elements",
+  "dependencies",
+  "relates",
+  "contains",
+  "describes",
+] as const;
+
+export interface VaultBacklinkMatch {
+  slug: string;
+  title: string;
+  matchedKeys: string[];
+}
+
+export function findVaultBacklinks(
+  manifest: VaultManifest,
+  targetSlug: string,
+): VaultBacklinkMatch[] {
+  const tail = targetSlug.split("/").pop() ?? targetSlug;
+  const matches: VaultBacklinkMatch[] = [];
+  for (const doc of manifest.docs) {
+    if (doc.slug === targetSlug) continue;
+    const matchedKeys: string[] = [];
+    for (const key of NEIGHBOR_KEYS) {
+      const value = doc.frontmatter[key];
+      if (!Array.isArray(value)) continue;
+      const hit = value.some(
+        (v) =>
+          typeof v === "string" &&
+          (v === targetSlug || v === tail || v.endsWith(`/${tail}`)),
+      );
+      if (hit) matchedKeys.push(key);
+    }
+    if (matchedKeys.length === 0) continue;
+    matches.push({
+      slug: doc.slug,
+      title: doc.title || doc.slug,
+      matchedKeys,
+    });
+  }
+  return matches;
+}

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -16,6 +16,7 @@ import { Tooltip, useToast } from "@/shared/ui";
 import { useEphemeralNodes } from "../lib/use-ephemeral-nodes";
 import { useEphemeralEdges } from "../lib/use-ephemeral-edges";
 import { downloadAtlasFrontmatter } from "../lib/export-frontmatter";
+import { findVaultBacklinks } from "../lib/find-vault-backlinks";
 
 /**
  * P1-1 (UX-4) — local 모드 vault `.md` write path.
@@ -205,6 +206,42 @@ export function OntologyEditPage() {
     [toast, vault],
   );
 
+  // C-5 vault delete — MCP delete_concept 와 같은 정책: backlinks 가 있으면
+  // confirm 단계에서 list 보여주고 사용자가 의식적으로 진행하게. force 플래그
+  // 는 별도 UI 없이 confirm 한 번 — UI 자체가 사용자 의도 게이트.
+  const deleteVaultDoc = useCallback(
+    async (slug: string) => {
+      if (!vault.manifest) return;
+      const backlinks = findVaultBacklinks(vault.manifest, slug);
+      const message =
+        backlinks.length > 0
+          ? `"${slug}" 를 삭제하면 ${backlinks.length} 개 노드가 dangling 됩니다 (` +
+            backlinks
+              .slice(0, 3)
+              .map((b) => b.slug)
+              .join(", ") +
+            (backlinks.length > 3 ? ` 외 ${backlinks.length - 3}개` : "") +
+            ").\n\n그래도 삭제할까요?"
+          : `"${slug}" 를 vault 에서 삭제할까요? 되돌릴 수 없습니다.`;
+      // 정적 export + WebGL 캔버스 환경 — 가장 단순한 confirm dialog 가
+      // SSR/hydration 위험 없음. modal UI 는 후속 PR 에서 OntologyEditPage 자체
+      // dialog 컴포넌트로 통합 가능.
+      if (typeof window !== "undefined" && !window.confirm(message)) return;
+      setRenamingId(slug);
+      try {
+        await vault.deleteDoc(slug);
+        toast.show(`"${slug}" 삭제`, "success");
+        setSelectedId(null);
+      } catch (err) {
+        const m = err instanceof Error ? err.message : "삭제 실패";
+        toast.show(m, "error");
+      } finally {
+        setRenamingId(null);
+      }
+    },
+    [toast, vault],
+  );
+
   const treeHref = accountId
     ? `/ontology/?${ACCOUNT_QUERY_KEY}=${encodeURIComponent(accountId)}`
     : "/ontology/";
@@ -384,6 +421,7 @@ export function OntologyEditPage() {
             onRenameEphemeral={(id, title) => updateNode(id, { title })}
             onSaveEphemeral={saveEphemeral}
             onSaveVaultRename={renameVaultDoc}
+            onDeleteVault={deleteVaultDoc}
             saving={savingId !== null || renamingId !== null}
             onClearSelection={() => setSelectedId(null)}
           />

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -29,6 +29,7 @@ export interface OntologyInspectorProps {
   onRenameEphemeral: (id: string, title: string) => void;
   onSaveEphemeral?: (id: string) => Promise<void> | void;
   onSaveVaultRename?: (slug: string, nextTitle: string) => Promise<void> | void;
+  onDeleteVault?: (slug: string) => Promise<void> | void;
   onClearSelection: () => void;
   saving?: boolean;
 }
@@ -48,6 +49,7 @@ export function OntologyInspector({
   onRenameEphemeral,
   onSaveEphemeral,
   onSaveVaultRename,
+  onDeleteVault,
   onClearSelection,
   saving,
 }: OntologyInspectorProps) {
@@ -91,6 +93,7 @@ export function OntologyInspector({
             <VaultDetail
               node={vaultSelected}
               onSaveRename={onSaveVaultRename}
+              onDelete={onDeleteVault}
               saving={Boolean(saving)}
               onDeselect={onClearSelection}
             />
@@ -203,11 +206,13 @@ function EphemeralDetail({
 function VaultDetail({
   node,
   onSaveRename,
+  onDelete,
   saving,
   onDeselect,
 }: {
   node: { slug: string; kind: string; title: string };
   onSaveRename?: (slug: string, nextTitle: string) => Promise<void> | void;
+  onDelete?: (slug: string) => Promise<void> | void;
   saving: boolean;
   onDeselect: () => void;
 }) {
@@ -268,6 +273,17 @@ function VaultDetail({
         제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로
         유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다.
       </p>
+      {onDelete ? (
+        <button
+          type="button"
+          onClick={() => onDelete(node.slug)}
+          disabled={saving}
+          aria-label="이 vault 노드 삭제"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-[color:rgba(229,72,77,0.32)] bg-transparent px-3 text-[11px] text-[color:rgba(236,116,116,0.92)] transition-colors hover:border-[color:rgba(229,72,77,0.5)] hover:bg-[color:rgba(229,72,77,0.08)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          ⚠ vault 에서 삭제
+        </button>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

C-5 follow-up. MCP \`delete_concept\` (PR #26) 의 안전 가드 정책을 빌더 인스펙터에도 노출 — vault 노드 선택 시 "⚠ vault 에서 삭제" 버튼.

흐름:
1. \`findVaultBacklinks(manifest, slug)\` 가 frontmatter array 키 (capabilities/elements/dependencies/relates/contains/describes) 전체 스캔 — 정확 slug + 마지막 segment 매칭. self 참조 무시.
2. backlinks 0 → 단순 confirm.
3. backlinks ≥1 → confirm 메시지에 dangling 될 노드 slug 최대 3개 + "외 N개" 미리보기.
4. confirm 통과 → \`vault.deleteDoc(slug)\` → 선택 해제.

\`+201\`. 신규 4 파일.

## Test plan

- [x] 새 단위 test 4 case (\`find-vault-backlinks.test.ts\`):
  - frontmatter array 키 정확 + tail segment 매칭
  - self 참조 무시
  - tags 같은 비대상 키 무시
  - matchedKeys 가 어느 키에서 매칭됐는지 surface
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 840 tests pass (+1 file / +4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)