### PR TITLE
feat: 빌더 vault drag 좌표 → frontmatter.canvasPosition patch

### DIFF
--- a/src/features/docs-vault-local/model/apply-frontmatter-updates.test.ts
+++ b/src/features/docs-vault-local/model/apply-frontmatter-updates.test.ts
@@ -45,6 +45,24 @@ describe('applyFrontmatterUpdates', () => {
     expect(result).toContain('isHub: true');
   });
 
+  it('inline 1-depth 객체 (canvasPosition 등)', () => {
+    const raw = `---\nname: A\n---\n\n본문`;
+    const result = applyFrontmatterUpdates(raw, {
+      canvasPosition: { x: 100, y: 200 },
+    });
+    expect(result).toContain('canvasPosition: { x: 100, y: 200 }');
+    expect(result).toContain('name: A');
+  });
+
+  it('객체 갱신 — 기존 inline 객체 교체', () => {
+    const raw = `---\nname: A\ncanvasPosition: { x: 1, y: 2 }\n---\n\n본문`;
+    const result = applyFrontmatterUpdates(raw, {
+      canvasPosition: { x: 50, y: 60 },
+    });
+    expect(result).toContain('canvasPosition: { x: 50, y: 60 }');
+    expect(result).not.toContain('x: 1, y: 2');
+  });
+
   it('frontmatter 없던 문서에 새로 추가', () => {
     const raw = `# Title\n\n본문`;
     const result = applyFrontmatterUpdates(raw, {

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -60,14 +60,23 @@ function emptyState(status: Status = 'idle'): State {
  *  - string/number/boolean → `key: value` 로 직렬화 (문자열은 따옴표 없이,
  *    공백 포함이면 따옴표)
  *  - string[] → `key: [a, b, c]` inline 배열
+ *  - { primitive: ... } → `key: { k1: v1, k2: v2 }` inline 1-depth 객체
  *  - null → 해당 key 제거
  *
- * 한계: 기존에 없는 복잡한 nested object 는 무시. value serialization 은
- * 우리 간단 frontmatter 파서와 정확히 round-trip.
+ * 한계: nested 2-depth 이상 객체는 지원 안 함. value serialization 은 우리
+ * 간단 frontmatter 파서와 정확히 round-trip.
  */
+export type FrontmatterUpdateValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | Record<string, string | number | boolean>
+  | null;
+
 export function applyFrontmatterUpdates(
   raw: string,
-  updates: Record<string, string | number | boolean | string[] | null>,
+  updates: Record<string, FrontmatterUpdateValue>,
 ): string {
   let fmLines: string[] = [];
   let body = raw;
@@ -112,13 +121,25 @@ export function applyFrontmatterUpdates(
 }
 
 function serializeFrontmatterValue(
-  v: string | number | boolean | string[],
+  v: Exclude<FrontmatterUpdateValue, null>,
 ): string {
   if (Array.isArray(v)) {
     return `[${v.map((s) => (needsQuote(s) ? `"${s.replace(/"/g, '\\"')}"` : s)).join(', ')}]`;
   }
   if (typeof v === 'boolean') return v ? 'true' : 'false';
   if (typeof v === 'number') return String(v);
+  if (typeof v === 'object') {
+    // inline 1-depth object — `{ x: 100, y: 200 }`. parseFrontmatter 가 같은
+    // 형식 round-trip 인식 (parser.test.mjs 'inline object' case).
+    const entries = Object.entries(v).map(([k, val]) => {
+      let serialized: string;
+      if (typeof val === 'boolean') serialized = val ? 'true' : 'false';
+      else if (typeof val === 'number') serialized = String(val);
+      else serialized = needsQuote(val) ? `"${val.replace(/"/g, '\\"')}"` : val;
+      return `${k}: ${serialized}`;
+    });
+    return `{ ${entries.join(', ')} }`;
+  }
   return needsQuote(v) ? `"${v.replace(/"/g, '\\"')}"` : v;
 }
 
@@ -432,7 +453,7 @@ export function useLocalVault() {
   const updateFrontmatter = useCallback(
     async (
       slug: string,
-      updates: Record<string, string | number | boolean | string[] | null>,
+      updates: Record<string, FrontmatterUpdateValue>,
       opts: { skipRefresh?: boolean } = {},
     ) => {
       const fh = state.fileHandles.get(slug);

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -64,9 +64,24 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
     return null;
   }
 
-  const positions = computeGridLayout(ontologyDocs);
+  const fallbackPositions = computeGridLayout(ontologyDocs);
   const nodes: Node[] = ontologyDocs.map((doc) => {
-    const pos = positions.get(doc.slug) ?? { x: 0, y: 0 };
+    // frontmatter.canvasPosition: { x, y } 가 있으면 우선. 없으면 grid fallback.
+    // 사용자가 빌더에서 drag-stop 시 canvasPosition patch — 다음 mount 부터
+    // 같은 좌표 복원. AI agent (MCP) 도 같은 frontmatter 키 read 가능.
+    const fm = doc.frontmatter as Record<string, unknown>;
+    const cp = fm.canvasPosition;
+    const persistedPos =
+      cp && typeof cp === "object" && cp !== null
+        ? (() => {
+            const x = (cp as Record<string, unknown>).x;
+            const y = (cp as Record<string, unknown>).y;
+            return typeof x === "number" && typeof y === "number"
+              ? { x, y }
+              : null;
+          })()
+        : null;
+    const pos = persistedPos ?? fallbackPositions.get(doc.slug) ?? { x: 0, y: 0 };
     const kind = String(doc.frontmatter.kind);
     const title = doc.title || doc.slug;
     return {
@@ -81,10 +96,9 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
       },
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
-      // C-5 — vault 노드도 drag 허용 (좌표 patch 는 후속 — 위치는 frontmatter
-      // canvasPosition 에 보낼 수 있으나 첫 단계는 read+rename 만).
-      draggable: false,
-      // edge 재생성 X (vault 가 진실원). 인스펙터에서 수정.
+      // C-5 fire — drag 활성. drag-stop 시 page 가 frontmatter.canvasPosition patch.
+      draggable: true,
+      // edge 재생성은 vault 진실원 보호 위해 비활성. 인스펙터/frontmatter 수정.
       connectable: false,
       selectable: true,
     };

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -40,6 +40,7 @@ export function OntologyEditCanvas({
   ephemeralEdges,
   onSelectionChange,
   onConnect,
+  onVaultNodeDragStop,
 }: {
   accountId: string | null;
   vaultManifest: VaultManifest | null;
@@ -47,6 +48,8 @@ export function OntologyEditCanvas({
   ephemeralEdges: EphemeralEdge[];
   onSelectionChange?: (selectedId: string | null) => void;
   onConnect?: (connection: Connection) => void;
+  /** vault 노드 drag-stop 시 호출 — 좌표를 frontmatter.canvasPosition 으로 patch. */
+  onVaultNodeDragStop?: (slug: string, position: { x: number; y: number }) => void;
 }) {
   // mode 분기: vault.manifest 가 있으면 vault flow 우선 (local 모드 진실원).
   // 둘 다 동시에 띄우지 않는다 — 두 진실원 혼합은 사용자 mental model 깨뜨림.
@@ -139,6 +142,19 @@ export function OntologyEditCanvas({
     [onConnect],
   );
 
+  const handleNodeDragStop = useCallback(
+    (_event: unknown, node: Node) => {
+      // vault 노드만 patch — ephemeral 은 in-memory 가 진실원이라 무관.
+      const data = node.data as { vault?: boolean } | undefined;
+      if (!data?.vault || !useVaultMode) return;
+      onVaultNodeDragStop?.(node.id, {
+        x: Math.round(node.position.x),
+        y: Math.round(node.position.y),
+      });
+    },
+    [onVaultNodeDragStop, useVaultMode],
+  );
+
   // kind 추출 — '{kindLabel} · {title}' 형식에서 kindLabel → kind enum 매핑.
   function inferKindFromLabel(
     label: string,
@@ -179,6 +195,7 @@ export function OntologyEditCanvas({
         nodesConnectable
         onConnect={handleConnect}
         onSelectionChange={handleSelectionChange}
+        onNodeDragStop={handleNodeDragStop}
         fitView
         fitViewOptions={{ padding: 0.2 }}
       >

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -65,6 +65,7 @@ const OntologyEditCanvas = dynamic<{
   ephemeralEdges: ReturnType<typeof useEphemeralEdges>["edges"];
   onSelectionChange?: (selectedId: string | null) => void;
   onConnect?: (connection: import("@xyflow/react").Connection) => void;
+  onVaultNodeDragStop?: (slug: string, position: { x: number; y: number }) => void;
 }>(
   () => import("./OntologyEditCanvas").then((m) => m.OntologyEditCanvas),
   { ssr: false, loading: () => <CanvasSkeleton /> },
@@ -201,6 +202,26 @@ export function OntologyEditPage() {
         toast.show(message, "error");
       } finally {
         setRenamingId(null);
+      }
+    },
+    [toast, vault],
+  );
+
+  // C-5 fire — vault 노드 drag 좌표를 frontmatter.canvasPosition 으로 patch.
+  // 같은 사용자가 재방문 시 + AI agent (MCP) 가 같은 vault read 시 동일 좌표.
+  // skipRefresh 로 manifest 재빌드 생략 — drag 직후 사용자 시각엔 캔버스 위치
+  // 그대로라 깜빡임 없게. 다음 cold load 부터 canvasPosition 반영.
+  const persistVaultPosition = useCallback(
+    async (slug: string, position: { x: number; y: number }) => {
+      try {
+        await vault.updateFrontmatter(
+          slug,
+          { canvasPosition: { x: position.x, y: position.y } },
+          { skipRefresh: true },
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "좌표 저장 실패";
+        toast.show(message, "error");
       }
     },
     [toast, vault],
@@ -409,6 +430,7 @@ export function OntologyEditPage() {
               ephemeralEdges={ephemeralEdges}
               onSelectionChange={setSelectedId}
               onConnect={addEphemeralEdge}
+              onVaultNodeDragStop={persistVaultPosition}
             />
             <BuilderOnboarding
               empty={ephemeralNodes.length === 0 && ephemeralEdges.length === 0}


### PR DESCRIPTION
## Summary

C-5 follow-up. vault 노드 drag-stop 시 좌표를 frontmatter.canvasPosition 으로 patch — 다음 mount 부터 복원, AI agent (MCP) 도 같은 frontmatter 키 read.

\`+103 / -11\`.

## 확장

- \`applyFrontmatterUpdates\` serializer 가 inline 1-depth 객체 (\`{ x: 100, y: 200 }\`) round-trip. 새 \`FrontmatterUpdateValue\` type alias export.
- \`useVaultGraphFlow\` 가 \`canvasPosition\` 우선 read (없으면 grid fallback) + \`draggable: true\`.
- \`OntologyEditCanvas\` \`onNodeDragStop\` 에서 vault 플래그 노드만 콜백 (ephemeral 은 무관).
- \`OntologyEditPage\` \`persistVaultPosition\` 핸들러 — \`vault.updateFrontmatter + skipRefresh:true\` (drag 직후 manifest 재빌드 생략, 깜빡임 방지).

## Test plan

- [x] apply-frontmatter-updates.test.ts +2 case (inline 객체 신규/교체)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass (+2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)