### PR TITLE
feat: 빌더 인스펙터 — frontmatter array 키 직접 편집 (chip × · input + Enter)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -166,15 +166,25 @@ export function OntologyEditPage() {
   );
   const ephemeralSelected = findById(selectedId);
   // C-5 — vault 모드에서는 selectedId 가 vault slug. manifest 에서 lookup
-  // 해 인스펙터에 frontmatter 와 함께 전달 (in-canvas rename 가능).
+  // 해 인스펙터에 frontmatter + array 키 (capabilities/elements/...) 까지
+  // 함께 전달 (in-canvas rename + array 편집 가능).
   const vaultSelected = (() => {
     if (!selectedId || ephemeralSelected) return null;
     const doc = vault.manifest?.docs.find((d) => d.slug === selectedId);
     if (!doc || typeof doc.frontmatter.kind !== "string") return null;
+    const fm = doc.frontmatter as Record<string, unknown>;
+    const asStrings = (v: unknown): string[] =>
+      Array.isArray(v)
+        ? v.filter((x): x is string => typeof x === "string")
+        : [];
     return {
       slug: doc.slug,
       kind: String(doc.frontmatter.kind),
       title: doc.title || doc.slug,
+      capabilities: asStrings(fm.capabilities),
+      elements: asStrings(fm.elements),
+      dependencies: asStrings(fm.dependencies),
+      relates: asStrings(fm.relates),
     };
   })();
   // cloud approved 모드 fallback — vault 매니페스트 없을 때만. 현재 사용자
@@ -202,6 +212,26 @@ export function OntologyEditPage() {
         toast.show(message, "error");
       } finally {
         setRenamingId(null);
+      }
+    },
+    [toast, vault],
+  );
+
+  // C-5 — vault frontmatter array 키 (capabilities/elements/dependencies/
+  // relates) 편집. 빈 배열은 키 자체를 제거 (null) — frontmatter 깨끗.
+  const editVaultArrayKey = useCallback(
+    async (
+      slug: string,
+      key: "capabilities" | "elements" | "dependencies" | "relates",
+      next: string[],
+    ) => {
+      try {
+        await vault.updateFrontmatter(slug, {
+          [key]: next.length === 0 ? null : next,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "저장 실패";
+        toast.show(message, "error");
       }
     },
     [toast, vault],
@@ -443,6 +473,7 @@ export function OntologyEditPage() {
             onRenameEphemeral={(id, title) => updateNode(id, { title })}
             onSaveEphemeral={saveEphemeral}
             onSaveVaultRename={renameVaultDoc}
+            onEditVaultArrayKey={editVaultArrayKey}
             onDeleteVault={deleteVaultDoc}
             saving={savingId !== null || renamingId !== null}
             onClearSelection={() => setSelectedId(null)}

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -22,13 +22,34 @@ const FADE_MOTION = {
  * - approved 노드: read-only (cloud 모드 legacy)
  * - 미선택: 안내 placeholder
  */
+export type VaultArrayKey =
+  | "capabilities"
+  | "elements"
+  | "dependencies"
+  | "relates";
+
+export interface VaultSelected {
+  slug: string;
+  kind: string;
+  title: string;
+  capabilities: string[];
+  elements: string[];
+  dependencies: string[];
+  relates: string[];
+}
+
 export interface OntologyInspectorProps {
   ephemeralSelected: EphemeralNode | null;
   approvedSelected: { id: string; kind: string; title: string } | null;
-  vaultSelected: { slug: string; kind: string; title: string } | null;
+  vaultSelected: VaultSelected | null;
   onRenameEphemeral: (id: string, title: string) => void;
   onSaveEphemeral?: (id: string) => Promise<void> | void;
   onSaveVaultRename?: (slug: string, nextTitle: string) => Promise<void> | void;
+  onEditVaultArrayKey?: (
+    slug: string,
+    key: VaultArrayKey,
+    next: string[],
+  ) => Promise<void> | void;
   onDeleteVault?: (slug: string) => Promise<void> | void;
   onClearSelection: () => void;
   saving?: boolean;
@@ -49,6 +70,7 @@ export function OntologyInspector({
   onRenameEphemeral,
   onSaveEphemeral,
   onSaveVaultRename,
+  onEditVaultArrayKey,
   onDeleteVault,
   onClearSelection,
   saving,
@@ -93,6 +115,7 @@ export function OntologyInspector({
             <VaultDetail
               node={vaultSelected}
               onSaveRename={onSaveVaultRename}
+              onEditArrayKey={onEditVaultArrayKey}
               onDelete={onDeleteVault}
               saving={Boolean(saving)}
               onDeselect={onClearSelection}
@@ -203,15 +226,28 @@ function EphemeralDetail({
   );
 }
 
+const ARRAY_KEY_LABELS: Record<VaultArrayKey, string> = {
+  capabilities: "역량 (capabilities)",
+  elements: "요소 (elements)",
+  dependencies: "의존 (dependencies)",
+  relates: "관련 (relates)",
+};
+
 function VaultDetail({
   node,
   onSaveRename,
+  onEditArrayKey,
   onDelete,
   saving,
   onDeselect,
 }: {
-  node: { slug: string; kind: string; title: string };
+  node: VaultSelected;
   onSaveRename?: (slug: string, nextTitle: string) => Promise<void> | void;
+  onEditArrayKey?: (
+    slug: string,
+    key: VaultArrayKey,
+    next: string[],
+  ) => Promise<void> | void;
   onDelete?: (slug: string) => Promise<void> | void;
   saving: boolean;
   onDeselect: () => void;
@@ -273,6 +309,21 @@ function VaultDetail({
         제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로
         유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다.
       </p>
+      {onEditArrayKey ? (
+        <div className="flex flex-col gap-3">
+          {(["capabilities", "elements", "dependencies", "relates"] as const).map(
+            (key) => (
+              <ArrayKeyEditor
+                key={key}
+                fieldKey={key}
+                values={node[key]}
+                onChange={(next) => onEditArrayKey(node.slug, key, next)}
+                disabled={saving}
+              />
+            ),
+          )}
+        </div>
+      ) : null}
       {onDelete ? (
         <button
           type="button"
@@ -284,6 +335,86 @@ function VaultDetail({
           ⚠ vault 에서 삭제
         </button>
       ) : null}
+    </div>
+  );
+}
+
+function ArrayKeyEditor({
+  fieldKey,
+  values,
+  onChange,
+  disabled,
+}: {
+  fieldKey: VaultArrayKey;
+  values: string[];
+  onChange: (next: string[]) => void;
+  disabled: boolean;
+}) {
+  const [input, setInput] = useState("");
+  // 노드 변경 시 입력 buffer 초기화 — 다른 노드의 입력이 새 노드에 새 옴 안 함.
+  useEffect(() => {
+    setInput("");
+  }, [values.join("|"), fieldKey]);
+  const submit = () => {
+    const trimmed = input.trim();
+    if (!trimmed || values.includes(trimmed) || disabled) return;
+    onChange([...values, trimmed]);
+    setInput("");
+  };
+  const remove = (slug: string) => {
+    if (disabled) return;
+    onChange(values.filter((v) => v !== slug));
+  };
+  return (
+    <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
+      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        {ARRAY_KEY_LABELS[fieldKey]}
+      </p>
+      {values.length > 0 ? (
+        <ul className="mt-2 flex flex-wrap gap-1">
+          {values.map((slug) => (
+            <li key={slug}>
+              <button
+                type="button"
+                onClick={() => remove(slug)}
+                disabled={disabled}
+                aria-label={`${slug} 제거`}
+                className="inline-flex items-center gap-1 rounded-full border border-[color:rgba(94,106,210,0.32)] bg-[color:rgba(94,106,210,0.10)] px-2 py-0.5 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(229,72,77,0.46)] hover:bg-[color:rgba(229,72,77,0.10)] disabled:opacity-50"
+              >
+                <span className="font-mono break-all">{slug}</span>
+                <span aria-hidden className="text-[color:var(--color-text-tertiary)]">
+                  ×
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="mt-2 flex gap-1">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          disabled={disabled}
+          placeholder="slug 입력 + Enter"
+          className="flex-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 font-mono text-[11px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={disabled || !input.trim() || values.includes(input.trim())}
+          aria-label="추가"
+          className="inline-flex h-7 items-center justify-center rounded-md border border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.18)] px-2 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.66)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          +
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

C-5 follow-up. vault 노드 인스펙터에서 frontmatter 의 array 키 (capabilities · elements · dependencies · relates) 를 chip × / input + Enter 로 직접 편집. 모든 변경은 즉시 \`vault.updateFrontmatter\` — local draft 없이 단일 진실원.

\`+165 / -3\`.

## UI

- 노드 선택 → "vault" 인스펙터 카드 안에 4 개 array 키 섹션
- 각 섹션: 한국어 + 영문 라벨, 기존 chip 리스트 (× 호버 시 빨강 톤), 추가 input + Enter / + 버튼
- 빈 배열 → frontmatter 키 자체 삭제 (null) — vault md 깨끗
- 중복/공백 입력 차단

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass (변동 없음 — UI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)