### PR TITLE
refactor: static 모드의 진실원을 docs/ontology dogfood 매니페스트로

### DIFF
--- a/src/features/project-data-source/model/use-projects.ts
+++ b/src/features/project-data-source/model/use-projects.ts
@@ -3,7 +3,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useLocalVault } from '@/features/docs-vault-local';
-import { deriveProjectsFromVault } from '@/entities/docs-vault';
+import {
+  deriveProjectsFromVault,
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+} from '@/entities/docs-vault';
+
+// JSON import 가 mode 같은 union 필드를 string 으로 추론. 빌드 시점에 schema
+// 가 안정적이라 runtime 검증 대신 cast.
+const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
 import { subscribeProjects, type Project } from '@/entities/project';
 
 /**
@@ -12,8 +20,10 @@ import { subscribeProjects, type Project } from '@/entities/project';
  * - **local**: vault manifest 의 `projects/*.md` frontmatter 를 동기 매핑.
  *   사용자가 vault 에 .md 추가하면 즉시 list 에 반영. Firebase 의존 없음.
  * - **cloud**: 기존 `subscribeProjects` (Firestore onSnapshot) — 실시간 sync.
- * - **static**: vault 디스크가 없는 빈 데모 진입 — 현재는 cloud 로 흘려보냄
- *   (legacy 데모 호환). 추후 정적 manifest 로 분리 가능.
+ * - **static**: 빌드 타임 docs/ontology/ 매니페스트 = dogfood 진실원.
+ *   사용자가 vault 안 골랐고 인증 안 돼있어도 oh-my-ontology 자체 ontology
+ *   가 즉시 보인다. 이게 mission v2 의 "0 마찰 진입" 약속의 read 측 구현 —
+ *   builder/topology 가 빈 화면 대신 진짜 ontology 를 그린다.
  *
  * mission T7 — local 모드 사용자가 vault 에 추가한 프로젝트가 /projects ·
  * 토폴로지에서 안 보이던 read inconsistency 해결. mutation 측 (`useProjectMutations`)
@@ -39,9 +49,16 @@ export function useProjects(accountId?: string | null): UseProjectsState {
     return deriveProjectsFromVault(vault.manifest);
   }, [mode, vault.manifest]);
 
-  // cloud (또는 static legacy 호환) — Firestore 구독.
+  // static 모드 — 빌드타임 dogfood 매니페스트. Firebase / vault 픽 없이도
+  // oh-my-ontology 자체 ontology 가 즉시 보인다. JSON import 라 동기 derive.
+  const staticProjects = useMemo(() => {
+    if (mode !== 'static') return [];
+    return deriveProjectsFromVault(staticVaultManifest);
+  }, [mode]);
+
+  // cloud — Firestore 구독.
   useEffect(() => {
-    if (mode === 'local') return;
+    if (mode !== 'cloud') return;
     setCloudError(null);
     const unsubscribe = subscribeProjects(
       accountId ?? null,
@@ -61,6 +78,14 @@ export function useProjects(accountId?: string | null): UseProjectsState {
     return {
       projects: localProjects,
       loaded: vault.status === 'loaded',
+      error: null,
+      mode,
+    };
+  }
+  if (mode === 'static') {
+    return {
+      projects: staticProjects,
+      loaded: true,
       error: null,
       mode,
     };


### PR DESCRIPTION
## Summary

mission v2 의 "0 마찰 진입" 약속의 read 측 구현.

이전: vault 안 골랐고 비인증 (static 모드) → firestore subscribe → 빈 배열/에러 (firebase 배포 안 함).
이후: static 모드 → 빌드타임 dogfood 매니페스트 (\`docs/ontology/\` 베이크) → 즉시 oh-my-ontology 자체 ontology 표시.

진실원 우선순위:
\`vault picked (local) > 빌드타임 dogfood (static) > firestore (cloud)\`

demo-blueprint 의존 축소 첫 단계. 후속에서 categories / statuses / ontology insight 도 같은 방식으로 dogfood 우선 전환 가능.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)