### PR TITLE
refactor: ontology insight dogfood 우선 진실원 확장 + Layer 0 정리 결정

### DIFF
--- a/src/features/vault-ontology/model/use-ontology-insight.ts
+++ b/src/features/vault-ontology/model/use-ontology-insight.ts
@@ -8,22 +8,69 @@ import {
   type KnowledgeGraphEdge,
   type KnowledgeProjectInsight,
 } from '@/entities/knowledge-graph';
+import {
+  deriveOntologyFromVault,
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+  type VaultOntologyDerivation,
+} from '@/entities/docs-vault';
 import { useVaultOntology } from './use-vault-ontology';
 
 const VAULT_SENTINEL_DATE = new Date(0);
 const VAULT_SENTINEL_AUTHOR = 'vault-frontmatter';
 
+// 빌드타임 dogfood 매니페스트 — JSON import. mode === 'static' 일 때
+// 진실원. local/cloud 와는 별 path.
+const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
+const STATIC_DERIVATION: VaultOntologyDerivation =
+  deriveOntologyFromVault(staticVaultManifest);
+
+function derivationToInsight(
+  d: VaultOntologyDerivation,
+): KnowledgeProjectInsight {
+  const nodes: KnowledgeGraphNode[] = d.nodes.map((stub) => ({
+    id: stub.id,
+    title: stub.title,
+    kind: stub.kind,
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: VAULT_SENTINEL_DATE,
+    lastApprovedBy: VAULT_SENTINEL_AUTHOR,
+    summary: stub.summary,
+    source: 'manual',
+  }));
+  const edges: KnowledgeGraphEdge[] = d.edges.map((stub) => ({
+    id: stub.id,
+    from: stub.from,
+    to: stub.to,
+    type: stub.type,
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: VAULT_SENTINEL_DATE,
+    lastApprovedBy: VAULT_SENTINEL_AUTHOR,
+    source: 'manual',
+  }));
+  return { nodes, edges, meta: null };
+}
+
+const STATIC_INSIGHT: { insight: KnowledgeProjectInsight; error: null } = {
+  insight: derivationToInsight(STATIC_DERIVATION),
+  error: null,
+};
+
 /**
  * Mode-aware ontology insight 구독.
  *
- * mission v2 — `/` (ontology hub) 가 vault 활성 시 vault frontmatter 의 stub
- * 노드를, 그 외에는 Firestore `knowledgePublic*` projection 을 진실원으로 본다.
+ * mission v2 진실원 우선순위 — `vault picked (local) > 빌드타임 dogfood
+ * (static) > Firestore (cloud)`. PR #33 이 projects 측에 적용한 정책을 ontology
+ * insight 에도 확장: 사용자가 vault 안 골랐고 비인증 (static) 이어도
+ * oh-my-ontology 자체 ontology 가 즉시 보임.
  *
  * - `local` → `useVaultOntology` 결과를 `KnowledgeProjectInsight` shape 로 변환
  *   (sourceSlug 는 sentinel 값으로 채움 — 검수 chain 의 시작점은 vault 그 자체).
+ * - `static` → 빌드타임 dogfood 매니페스트 derivation. JSON import 라 module-load
+ *   에 1 회 derive (메모이즈) — 첫 paint 부터 즉시 노드/엣지 표시.
  * - `cloud` → 기존 `useKnowledgePublicInsight` 그대로.
- * - `static` → 기존 fallback (cloud subscribe 가 빈 결과 반환 → demo 대체는
- *   homepage 가 따로 처리). 본 hook 은 cloud 와 동일 path 로 진행.
  */
 export function useOntologyInsight(
   accountId: string | null,
@@ -33,34 +80,10 @@ export function useOntologyInsight(
   const vault = useVaultOntology();
 
   return useMemo(() => {
+    if (mode === 'static') return STATIC_INSIGHT;
     if (mode !== 'local') return cloud;
-
-    const nodes: KnowledgeGraphNode[] = vault.nodes.map((stub) => ({
-      id: stub.id,
-      title: stub.title,
-      kind: stub.kind,
-      projectIds: [],
-      evidenceIds: [],
-      lastApprovedAt: VAULT_SENTINEL_DATE,
-      lastApprovedBy: VAULT_SENTINEL_AUTHOR,
-      summary: stub.summary,
-      source: 'manual',
-    }));
-
-    const edges: KnowledgeGraphEdge[] = vault.edges.map((stub) => ({
-      id: stub.id,
-      from: stub.from,
-      to: stub.to,
-      type: stub.type,
-      projectIds: [],
-      evidenceIds: [],
-      lastApprovedAt: VAULT_SENTINEL_DATE,
-      lastApprovedBy: VAULT_SENTINEL_AUTHOR,
-      source: 'manual',
-    }));
-
     return {
-      insight: { nodes, edges, meta: null },
+      insight: derivationToInsight(vault),
       error: null,
     };
   }, [mode, cloud, vault]);


### PR DESCRIPTION
## Summary

PR #33 이 projects 에 적용한 진실원 우선순위 (\`vault > dogfood > firestore\`) 를 \`/ontology\` ontology insight 에도 확장. 사용자가 vault 안 골랐고 비인증 (static) 이어도 oh-my-ontology 자체 ontology 트리 + ego 그래프가 즉시 보임.

## 변경
- \`useOntologyInsight\` static 모드 → 빌드타임 dogfood 매니페스트 derivation 사용.
- \`derivationToInsight\` helper 추출 — local (live vault) / static (build-time) 모두 같은 shape 변환.

## Layer 0 정리 결정

audit P2 의 "Sigma Layer 0 컨테이너 정리" 는 적극 제거하지 않음. 이유:
- 컨테이너 시스템은 demo session 활성화 사용자만 트리거. mission v2 default 진입 (vault → dogfood) 에서는 컨테이너 0 → Layer 0 분기 자동 dormant.
- PR #33/#34 로 default path 가 dogfood 정렬 — 새 사용자에게 사실상 invisible. 적극 제거의 회귀 위험 vs 보존 라인 trade-off 기울어짐.
- 코드 자체 제거는 demo session 자체 폐기 결정 후 자연스럽게 진행 가능.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)