### PR TITLE
feat: V1.2 vault-adaptation — 인스펙터에 frontmatter scalar 편집 (description / domain)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -177,10 +177,15 @@ export function OntologyEditPage() {
       Array.isArray(v)
         ? v.filter((x): x is string => typeof x === "string")
         : [];
+    const asString = (v: unknown): string =>
+      typeof v === "string" ? v : "";
     return {
       slug: doc.slug,
       kind: String(doc.frontmatter.kind),
       title: doc.title || doc.slug,
+      // V1.2 vault-adaptation — frontmatter scalar literals.
+      description: asString(fm.description),
+      domain: asString(fm.domain),
       capabilities: asStrings(fm.capabilities),
       elements: asStrings(fm.elements),
       dependencies: asStrings(fm.dependencies),
@@ -228,6 +233,25 @@ export function OntologyEditPage() {
       try {
         await vault.updateFrontmatter(slug, {
           [key]: next.length === 0 ? null : next,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "저장 실패";
+        toast.show(message, "error");
+      }
+    },
+    [toast, vault],
+  );
+
+  // V1.2 vault-adaptation — frontmatter scalar literals (description / domain).
+  // 빈 string 은 키 자체 제거 (null) — frontmatter 깨끗 유지. trim 후 빈 값이면
+  // 명시적 삭제로 처리해 사용자가 의도적으로 비웠을 때 frontmatter 에 빈 문자열
+  // 잔존 안 함.
+  const editVaultLiteral = useCallback(
+    async (slug: string, key: "description" | "domain", next: string) => {
+      const trimmed = next.trim();
+      try {
+        await vault.updateFrontmatter(slug, {
+          [key]: trimmed === "" ? null : trimmed,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : "저장 실패";
@@ -474,6 +498,7 @@ export function OntologyEditPage() {
             onSaveEphemeral={saveEphemeral}
             onSaveVaultRename={renameVaultDoc}
             onEditVaultArrayKey={editVaultArrayKey}
+            onEditVaultLiteral={editVaultLiteral}
             onDeleteVault={deleteVaultDoc}
             saving={savingId !== null || renamingId !== null}
             onClearSelection={() => setSelectedId(null)}

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -28,10 +28,15 @@ export type VaultArrayKey =
   | "dependencies"
   | "relates";
 
+export type VaultLiteralKey = "description" | "domain";
+
 export interface VaultSelected {
   slug: string;
   kind: string;
   title: string;
+  /** V1.2 vault-adaptation — frontmatter scalar literals. */
+  description: string;
+  domain: string;
   capabilities: string[];
   elements: string[];
   dependencies: string[];
@@ -49,6 +54,11 @@ export interface OntologyInspectorProps {
     slug: string,
     key: VaultArrayKey,
     next: string[],
+  ) => Promise<void> | void;
+  onEditVaultLiteral?: (
+    slug: string,
+    key: VaultLiteralKey,
+    next: string,
   ) => Promise<void> | void;
   onDeleteVault?: (slug: string) => Promise<void> | void;
   onClearSelection: () => void;
@@ -71,6 +81,7 @@ export function OntologyInspector({
   onSaveEphemeral,
   onSaveVaultRename,
   onEditVaultArrayKey,
+  onEditVaultLiteral,
   onDeleteVault,
   onClearSelection,
   saving,
@@ -116,6 +127,7 @@ export function OntologyInspector({
               node={vaultSelected}
               onSaveRename={onSaveVaultRename}
               onEditArrayKey={onEditVaultArrayKey}
+              onEditLiteral={onEditVaultLiteral}
               onDelete={onDeleteVault}
               saving={Boolean(saving)}
               onDeselect={onClearSelection}
@@ -237,6 +249,7 @@ function VaultDetail({
   node,
   onSaveRename,
   onEditArrayKey,
+  onEditLiteral,
   onDelete,
   saving,
   onDeselect,
@@ -247,6 +260,11 @@ function VaultDetail({
     slug: string,
     key: VaultArrayKey,
     next: string[],
+  ) => Promise<void> | void;
+  onEditLiteral?: (
+    slug: string,
+    key: VaultLiteralKey,
+    next: string,
   ) => Promise<void> | void;
   onDelete?: (slug: string) => Promise<void> | void;
   saving: boolean;
@@ -309,6 +327,26 @@ function VaultDetail({
         제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로
         유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다.
       </p>
+      {onEditLiteral ? (
+        <div className="flex flex-col gap-2">
+          <LiteralEditor
+            fieldKey="domain"
+            value={node.domain}
+            onCommit={(next) => onEditLiteral(node.slug, "domain", next)}
+            disabled={saving}
+            placeholder="예: workbench"
+            multiline={false}
+          />
+          <LiteralEditor
+            fieldKey="description"
+            value={node.description}
+            onCommit={(next) => onEditLiteral(node.slug, "description", next)}
+            disabled={saving}
+            placeholder="이 노드를 한 줄로 설명"
+            multiline
+          />
+        </div>
+      ) : null}
       {onEditArrayKey ? (
         <div className="flex flex-col gap-3">
           {(["capabilities", "elements", "dependencies", "relates"] as const).map(
@@ -335,6 +373,82 @@ function VaultDetail({
           ⚠ vault 에서 삭제
         </button>
       ) : null}
+    </div>
+  );
+}
+
+const LITERAL_LABELS: Record<VaultLiteralKey, string> = {
+  description: "설명 (description)",
+  domain: "도메인 (domain)",
+};
+
+function LiteralEditor({
+  fieldKey,
+  value,
+  onCommit,
+  disabled,
+  placeholder,
+  multiline,
+}: {
+  fieldKey: VaultLiteralKey;
+  value: string;
+  onCommit: (next: string) => void;
+  disabled: boolean;
+  placeholder?: string;
+  multiline?: boolean;
+}) {
+  // local draft — 입력 중엔 vault 에 patch 안 함. blur 또는 Enter (single-line)
+  // 시 commit. 사용자 변경이 file write 빈도를 결정 — 너무 자주 쓰면 IDE/editor
+  // 가 잡고 있을 때 race.
+  const [draft, setDraft] = useState(value);
+  useEffect(() => {
+    setDraft(value);
+  }, [fieldKey, value]);
+  const dirty = draft !== value;
+  const commit = () => {
+    if (!dirty || disabled) return;
+    onCommit(draft);
+  };
+  const sharedClass =
+    "w-full rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50";
+  return (
+    <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
+      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        {LITERAL_LABELS[fieldKey]}
+      </p>
+      {multiline ? (
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          disabled={disabled}
+          placeholder={placeholder}
+          rows={2}
+          className={`mt-1.5 ${sharedClass} resize-y leading-snug`}
+        />
+      ) : (
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          disabled={disabled}
+          placeholder={placeholder}
+          className={`mt-1.5 ${sharedClass}`}
+        />
+      )}
+      <p className="mt-1 text-[10px] text-[color:var(--color-text-quaternary)]">
+        {dirty
+          ? "포커스 해제 시 vault 에 자동 저장."
+          : "비우고 저장하면 frontmatter 키 자체가 삭제됩니다."}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

mission v2 정합 V1.2 (PR #35 의 평가 매트릭스에서 'vault-adaptation' 으로 분류된 항목) 구현.

cloud-only literal collection 신설 대신 vault frontmatter 의 기존 scalar 키 (\`description\` / \`domain\`) 를 빌더 인스펙터에서 직접 편집. 진실원 단일 (vault md) — backfill / 마이그레이션 N/A.

## UI

- VaultDetail 안에 LiteralEditor 2 개:
  - \`domain\` — single-line input
  - \`description\` — textarea (2 rows)
- 입력 중엔 vault 에 patch 안 함 (다른 editor 와 race 방지). **blur 또는 Enter** 에서 commit.
- 빈 값 저장 시 frontmatter 키 자체 삭제 (frontmatter 깨끗 유지).

## 향후 확장 후보

V1.2 spec 의 \`color\` / \`status\` / \`displayOrder\` 등은 사용 빈도 보고 추가. 지금은 가장 일반적인 description / domain 만.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)