### PR TITLE
refactor: category / status / knowledge-job 의 hasDemoSession 분기 제거

### DIFF
--- a/src/entities/category/api/category-api.ts
+++ b/src/entities/category/api/category-api.ts
@@ -10,8 +10,6 @@ import {
   type Unsubscribe,
 } from 'firebase/firestore';
 import { getDb } from '@/shared/api';
-import { hasDemoSession } from '@/shared/lib/demo-session';
-import { getDemoCategories } from '@/shared/mocks/demo-data';
 import {
   DEFAULT_CATEGORIES,
   fromFirestore,
@@ -33,17 +31,15 @@ function categoryDoc(id: string) {
 /**
  * 전체 카테고리 실시간 구독. order ASC로 정렬해서 반환.
  * 콜백은 Firestore 스냅샷이 올 때마다 호출됨.
+ *
+ * mission v2 — TaxonomyProvider 가 mode-aware 라 cloud 모드에서만 호출.
+ * static / local 모드는 DEFAULT_CATEGORIES 로 즉시 동작. 이전 hasDemoSession
+ * 분기는 PR #37 에서 제거 (mission v2 default 흐름과 misalign).
  */
 export function subscribeCategories(
   callback: (categories: Category[]) => void,
   onError?: (error: Error) => void,
 ): Unsubscribe {
-  if (hasDemoSession()) {
-    const list = getDemoCategories();
-    Promise.resolve().then(() => callback(list));
-    return () => {};
-  }
-
   return onSnapshot(
     categoriesCollection(),
     (snapshot) => {

--- a/src/entities/knowledge-job/api/knowledge-job-api.ts
+++ b/src/entities/knowledge-job/api/knowledge-job-api.ts
@@ -8,7 +8,6 @@ import {
 } from "firebase/firestore";
 import { getDb } from "@/shared/api";
 import { normalizeAccountId } from "@/shared/lib/account-scope";
-import { hasDemoSession } from "@/shared/lib/demo-session";
 import {
   fromFirestoreKnowledgeJob,
   type KnowledgeJob,
@@ -58,11 +57,9 @@ export function subscribeKnowledgeJobsByDocument(
       ? maybeOnError
       : (callbackOrOnError as ((error: Error) => void) | undefined);
 
-  if (hasDemoSession()) {
-    Promise.resolve().then(() => callbackFn([]));
-    return () => {};
-  }
-
+  // mission v2 — knowledge-job 자체가 cloud LLM extraction 흐름 (PR #5/#6 폐기)
+  // 의 잔여 구독자. mission v2 default path (vault-first) 에서는 호출자 0.
+  // 이전 hasDemoSession 분기는 PR #37 에서 제거.
   return onSnapshot(
     query(
       knowledgeJobsCollection(),

--- a/src/entities/status/api/status-api.ts
+++ b/src/entities/status/api/status-api.ts
@@ -10,8 +10,6 @@ import {
   type Unsubscribe,
 } from 'firebase/firestore';
 import { getDb } from '@/shared/api';
-import { hasDemoSession } from '@/shared/lib/demo-session';
-import { getDemoStatuses } from '@/shared/mocks/demo-data';
 import {
   DEFAULT_STATUSES,
   fromFirestore,
@@ -30,16 +28,15 @@ function statusDoc(id: string) {
   return doc(getDb(), COLLECTION, id);
 }
 
+/**
+ * mission v2 — TaxonomyProvider 가 mode-aware 라 cloud 모드에서만 호출.
+ * static / local 모드는 DEFAULT_STATUSES 로 즉시 동작. 이전 hasDemoSession
+ * 분기는 PR #37 에서 제거.
+ */
 export function subscribeStatuses(
   callback: (statuses: Status[]) => void,
   onError?: (error: Error) => void,
 ): Unsubscribe {
-  if (hasDemoSession()) {
-    const list = getDemoStatuses();
-    Promise.resolve().then(() => callback(list));
-    return () => {};
-  }
-
   return onSnapshot(
     statusesCollection(),
     (snapshot) => {


### PR DESCRIPTION
## Summary

PR #33/#34 가 진실원 우선순위를 dogfood 로 옮긴 후 demo session 분기들이 mission v2 default 흐름에서 호출되지 않음. 단순 entity 3 곳의 hasDemoSession 분기 + 관련 import 제거.

## 영향

- \`subscribeCategories\` — \`getDemoCategories()\` 반환 분기 제거
- \`subscribeStatuses\` — \`getDemoStatuses()\` 반환 분기 제거
- \`subscribeKnowledgeJobsByDocument\` — 빈 배열 반환 분기 제거

mission v2 default 흐름에서 호출자 0. demo session viewer 가 admin \`/settings/categories\` 진입 시 데모 데이터를 보던 기능은 사라지지만 demo session 자체가 vault-first 와 misalign 이라 영향 0.

\`knowledge-graph-api.ts\` 의 5 hasDemoSession 분기는 다음 PR (Sigma Layer 0 정리) 에서 같이 처리.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 118 files / 842 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)