### PR TITLE
test: e2e suite 의 mission v2 라우트 정렬 (review/knowledge 제거 + 신 surface 추가)

### DIFF
--- a/tests/e2e/a11y-structure.spec.ts
+++ b/tests/e2e/a11y-structure.spec.ts
@@ -13,9 +13,12 @@ const ROUTES = [
   "/signup",
   "/reset-password",
   "/project/sample/",
-  // admin namespace 폐기 — 운영 surface 는 /knowledge/ + /review/ + /settings/
+  // mission v2 정렬: admin namespace + /review/knowledge 폐기 (PR #5/#6).
+  // 살아있는 운영 surface 는 /knowledge/ · /settings/* · /diagnostics/*.
   "/knowledge/",
-  "/review/knowledge/",
+  "/topology/",
+  "/ontology/",
+  "/ontology/edit/",
 ];
 
 interface Finding {

--- a/tests/e2e/account-scope-auto-resolve.spec.ts
+++ b/tests/e2e/account-scope-auto-resolve.spec.ts
@@ -91,34 +91,18 @@ test.describe("PR #190 회귀 — /ontology 워크스페이스 복귀", () => {
 });
 
 /**
- * Fire 1 — useAutoResolveAccountId 7 surface 확장.
+ * Fire 1 — useAutoResolveAccountId surface.
  *
- * PR #190 의 4 surface (/, /projects/, /project/[slug]/, /docs/) 에 누락된
- * 운영 surface 3 개 추가:
- *   - /knowledge/ (대시보드)
- *   - /review/knowledge/ (검수 큐)
- *   - /diagnostics/insights/ (운영 인사이트)
+ * mission v2 정렬: /review/knowledge/ 폐기 (PR #5/#6 cleanup) 으로 인해
+ * 이 그룹은 /knowledge/ + /diagnostics/insights/ 만 검증.
  *
  * 회귀 시나리오: 진안 본인 계정으로 OperationsNav 의 탭 클릭 시 ?account=
- * 가 다음 페이지에도 흘러야 한다. 이전엔 위 3 surface 가 hook 미적용이라
- * legacy 전역 collection 으로 새었다.
+ * 가 다음 페이지에도 흘러야 한다. legacy 전역 collection 으로 새는 것 방지.
  */
-test.describe("Fire 1 회귀 — useAutoResolveAccountId 7 surface 확장", () => {
+test.describe("Fire 1 회귀 — useAutoResolveAccountId surface", () => {
   test("/knowledge/ 진입 시 URL 에 ?account= 자동 추가", async ({ page }) => {
     await loginAsDemo(page);
     await page.goto("/knowledge/");
-    await page.waitForURL(
-      new RegExp(`account=${DEMO_ACCOUNT_ID}`),
-      { timeout: 10_000 },
-    );
-    expect(page.url()).toContain(`account=${DEMO_ACCOUNT_ID}`);
-  });
-
-  test("/review/knowledge/ 진입 시 URL 에 ?account= 자동 추가", async ({
-    page,
-  }) => {
-    await loginAsDemo(page);
-    await page.goto("/review/knowledge/");
     await page.waitForURL(
       new RegExp(`account=${DEMO_ACCOUNT_ID}`),
       { timeout: 10_000 },

--- a/tests/e2e/overflow-sweep.spec.ts
+++ b/tests/e2e/overflow-sweep.spec.ts
@@ -20,10 +20,15 @@ const ROUTES = [
   "/account",
   "/projects/",
   "/project/sample/",
-  // admin namespace 폐기 (PR #195~ 이후) — 신 경로로 교체.
+  // mission v2 정렬: admin + /review/knowledge 폐기 (PR #5/#6).
+  // 살아있는 mission v2 surface 추가 — /topology · /ontology · /ontology/edit
+  // · /docs · /settings/*.
   "/knowledge/",
   "/knowledge/documents/",
-  "/review/knowledge/",
+  "/topology/",
+  "/ontology/",
+  "/ontology/edit/",
+  "/docs/",
 ];
 
 for (const vp of VIEWPORTS) {


### PR DESCRIPTION
## Summary

PR #5/#6 의 \`/review/knowledge\` 페이지 폐기 후 e2e suite 가 stale reference 를 들고 있었음. 같이 mission v2 의 살아있는 라우트 (vault-first) 를 sweep 에 추가.

## 변경

\`a11y-structure.spec.ts\` · \`overflow-sweep.spec.ts\`:
- \`/review/knowledge/\` 제거
- 추가: \`/topology/\` · \`/ontology/\` · \`/ontology/edit/\` · \`/docs/\` (mission v2 default surface)

\`account-scope-auto-resolve.spec.ts\`:
- /review/knowledge/ surface 검증 케이스 제거 (페이지 폐기 → N/A)

\`knowledge-ui.spec.ts\` 의 stale /review/knowledge 호출 2건은 이미 \`.describe.skip\` 안에 있어 dormant — 별도 정리 안 함.

## 라이브 검증

\`pnpm dev\` 띄운 후 mission v2 default 흐름의 6 라우트 모두 정상:

| Route | Status | Time |
|---|---|---|
| \`/\` | 200 | 0.44s |
| \`/ontology/\` | 200 | 0.08s |
| \`/ontology/edit/\` | 200 | 0.09s |
| \`/projects/\` | 200 | 0.06s |
| \`/topology/\` | 200 | 0.08s |
| \`/docs/\` | 200 | 0.10s |

PR #39 의 Sigma 컨테이너 hover preview / edge dim 제거 회귀 0.

## Test plan

- [x] \`pnpm test:run\` — 117 files / 825 tests pass
- [x] dev server smoke — 6 라우트 200 OK
- [x] turbopack hydration warning 1건 (mission v2 PR 시리즈 이전부터 존재, recoverable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)