### PR TITLE
refactor: Sigma container visual styling 분기 통째 제거 (-220 라인)

### DIFF
--- a/src/widgets/search-palette/ui/SearchPalette.tsx
+++ b/src/widgets/search-palette/ui/SearchPalette.tsx
@@ -140,7 +140,7 @@ interface DialogProps {
   accountId?: string | null;
 }
 
-type LayerFilter = 'all' | 'container' | 'hub' | 'node';
+type LayerFilter = 'all' | 'hub' | 'node';
 type ProjectSearchResult = ReturnType<typeof searchProjects>[number];
 type PaletteRow =
   | { kind: 'doc'; doc: VaultDoc }
@@ -148,17 +148,14 @@ type PaletteRow =
 
 const LAYER_FILTERS: { value: LayerFilter; label: string }[] = [
   { value: 'all', label: '전체' },
-  { value: 'container', label: '컨테이너' },
   { value: 'hub', label: '허브' },
   { value: 'node', label: '노드' },
 ];
 
 function matchesLayerFilter(project: Project, filter: LayerFilter): boolean {
   if (filter === 'all') return true;
-  const isContainer = project.category === '__container__';
-  if (filter === 'container') return isContainer;
-  if (filter === 'hub') return !isContainer && project.isHub;
-  return !isContainer && !project.isHub; // 'node'
+  if (filter === 'hub') return project.isHub;
+  return !project.isHub; // 'node'
 }
 
 function SearchPaletteDialog({
@@ -604,29 +601,18 @@ function SearchPaletteDialog({
                         )}
                       />
                       <div className="min-w-0 flex-1">
-                        {(() => {
-                          const isContainer =
-                            r.project.category === '__container__';
-                          return (
-                        <>
                         <div className="flex items-center gap-2">
                           <span
                             className={cn(
                               'truncate text-sm font-[var(--font-weight-signature)]',
-                              isContainer
-                                ? 'text-[color:rgba(224,196,140,0.95)]'
-                                : r.project.isHub
-                                  ? 'text-[color:var(--color-indigo-accent)]'
-                                  : 'text-[color:var(--color-text-primary)]',
+                              r.project.isHub
+                                ? 'text-[color:var(--color-indigo-accent)]'
+                                : 'text-[color:var(--color-text-primary)]',
                             )}
                           >
                             {highlightMatch(r.project.name, query)}
                           </span>
-                          {isContainer ? (
-                            <span className="rounded-full border border-[color:rgba(224,196,140,0.45)] bg-[color:rgba(224,196,140,0.12)] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[color:rgba(224,196,140,0.95)]">
-                              컨테이너
-                            </span>
-                          ) : r.project.isHub ? (
+                          {r.project.isHub ? (
                             <span className="rounded-full bg-[color:var(--color-indigo-brand)] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]">
                               허브
                             </span>
@@ -636,28 +622,18 @@ function SearchPaletteDialog({
                           {r.project.description}
                         </p>
                         <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                          {/* Container 의 category=__container__ · status=
-                              developing 은 lifecycle 의미 없는 sentinel.
-                              Container 일 때 두 chip 다 숨김. */}
-                          {!isContainer && (
-                            <>
-                              <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
-                                {categoryLabel(r.project.category)}
-                              </span>
-                              <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
-                                {statusLabel(r.project.status)}
-                              </span>
-                            </>
-                          )}
+                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                            {categoryLabel(r.project.category)}
+                          </span>
+                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                            {statusLabel(r.project.status)}
+                          </span>
                           {query.trim() && (
                             <span className="rounded-full border border-[color:rgba(94,106,210,0.3)] bg-[color:rgba(94,106,210,0.08)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)]">
                               {MATCH_FIELD_LABELS[r.matchedField]}
                             </span>
                           )}
                         </div>
-                        </>
-                          );
-                        })()}
                       </div>
                       <div className="hidden shrink-0 self-center text-right sm:block">
                         <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">

--- a/src/widgets/topology-map-sigma/lib/graph-build.test.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.test.ts
@@ -100,20 +100,6 @@ describe("buildGraph — ontologyCountsBySlug", () => {
     expect(graph.getNodeAttribute("h-1", "ontologyTopKind")).toBeUndefined();
   });
 
-  it("container 노드는 ontology 분기 적용 안 함 (CONTAINER_BORDER 유지)", () => {
-    const projects = [
-      project({ slug: "c-1", category: "__container__", isHub: false }),
-    ];
-    const ontologyCountsBySlug = new Map<string, OntologyCountsForProject>([
-      ["c-1", counts({ capability: 50 })],
-    ]);
-    const graph = buildGraph(projects, [], { ontologyCountsBySlug });
-    expect(graph.getNodeAttribute("c-1", "borderColor")).toBe(
-      "rgba(224, 196, 140, 0.62)",
-    );
-    expect(graph.getNodeAttribute("c-1", "ontologyTopKind")).toBeUndefined();
-  });
-
   it("ontologyCountsBySlug 미제공 시 모든 노드 NODE_BORDER (현행 유지)", () => {
     const projects = [project({ slug: "p-1", isHub: false })];
     const graph = buildGraph(projects, []);

--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -67,12 +67,6 @@ export interface SigmaEdgeAttrs {
 const HUB_COLOR = INDIGO_HUB;
 const NODE_OUTER_HALO = 'rgba(0, 0, 0, 0)'; // 비허브는 halo 없음 (투명)
 
-// 워크스페이스 맵(Layer 0) 의 컨테이너 노드 — 인디고 hub 와 명확히 구분되는
-// 웜 앰버/샌드. 디자인 시스템의 "단일 인디고" 원칙을 Layer 1(프로젝트 내부)
-// 에서 유지하되, Layer 0 에서는 계층 구분을 위해 보조 강조 한 색 허용.
-const CONTAINER_CATEGORY_SENTINEL = '__container__';
-const CONTAINER_COLOR = '#d4b478';                         // 웜 앰버
-
 /**
  * 디자인 시스템이 색 추가를 금지(무채색 + 단일 인디고)하므로 도메인 구분은
  * 회색 luminance + 아주 옅은 tint 로 표현. 채도는 최대 ~6% 로 유지해 "무채색
@@ -136,21 +130,6 @@ function jitter(seed: number) {
   return x - Math.floor(x);
 }
 
-/**
- * names 배열에서 모두가 공유하는 "첫 단어" brand prefix 를 감지.
- * 예: ["Demo IAM", "Demo Knowledge", "Demo Observability"] → "Demo".
- * 안 맞는 게 하나라도 있으면 '' 반환.
- */
-function detectBrandPrefix(names: string[]): string {
-  if (names.length < 2) return '';
-  const firstWord = names[0].split(' ')[0];
-  if (!firstWord) return '';
-  for (const name of names) {
-    if (!name.startsWith(firstWord + ' ') && name !== firstWord) return '';
-  }
-  return firstWord;
-}
-
 export function buildGraph(
   projects: Project[],
   categories: Category[],
@@ -183,36 +162,12 @@ export function buildGraph(
     return rest.length > 0 ? rest : name;
   };
 
-  // Layer 감지 — Container 가 있으면 Layer 0 (Workspace 지도), 없으면
-  // Layer 1 (컨테이너 내부). Layer 0 에선 Container 만 forceLabel 로 고정
-  // 노출, Hub/Node 는 hover/선택/근접 줌에서만 라벨 노출 (사용자 요청:
-  // "각 프로젝트만 이름이 나오고 나머지는 확장했을 때랑 마우스 올렸을 때만").
-  // Layer 1 에선 containers 가 없으므로 Hub 가 primary anchor → Hub
-  // forceLabel 유지.
-  const hasContainers = projects.some(
-    (p) => p.category === CONTAINER_CATEGORY_SENTINEL,
-  );
+  // mission v2 후 Layer 0 컨테이너 시스템 폐기 (PR #41/#42). 이제 모든
+  // 토폴로지가 단일 layer — Hub 가 primary anchor 로 forceLabel 노출.
 
   // build 시점 테마 팔레트. 토글 후엔 SigmaTopology 의 mutation observer 가
   // 그래프 attr 을 새 팔레트 값으로 다시 바르고 sigma.refresh() 한다.
   const palette = resolveTopologyPalette();
-
-  // Container 공통 brand prefix 감지 — 모든 container 이름이 같은 접두어 +
-  // 공백 으로 시작하면 해당 접두어를 label 에서 제거해 공간 절약 ("Demo
-  // Observability" → "Observability"). tooltip/drawer/검색 은 full name
-  // 유지. 3개 미만 이면 축약 의미 없으므로 skip.
-  const containerNames = projects
-    .filter((p) => p.category === CONTAINER_CATEGORY_SENTINEL)
-    .map((p) => p.name);
-  const brandPrefix =
-    containerNames.length >= 3 ? detectBrandPrefix(containerNames) : '';
-  const stripContainerBrand = (name: string): string => {
-    if (!brandPrefix) return name;
-    const brandWithSpace = `${brandPrefix} `;
-    if (!name.startsWith(brandWithSpace)) return name;
-    const rest = name.slice(brandWithSpace.length).trim();
-    return rest.length > 0 ? rest : name;
-  };
 
   // 고립 노드가 카테고리 앵커에 남아 튕겨 나오지 않도록 모든 seed를 작은
   // 원반 안에서 시작. 카테고리별 분리는 edge + gravity가 만들어 낸다.
@@ -220,17 +175,11 @@ export function buildGraph(
     const theta = jitter(index) * Math.PI * 2;
     const r = jitter(index + 7) * 40;
     const recent = isProjectRecentlyUpdated(project, 7);
-    const isContainer = project.category === CONTAINER_CATEGORY_SENTINEL;
-    // Layer 0 에서 hub 는 "컨테이너 주변 위성" 으로 축소 — 수백개가 동시에
-    // 큰 원으로 찍혀 환공포증 유발하던 문제 해소. 크기 3, alpha 0.3 로
-    // 존재감만 남기고 시선은 container 쪽에 쏠리게. focus/hover 시엔
-    // nodeReducer 가 size·color 를 원복해 다시 보인다.
-    const isLayer0Hub = hasContainers && project.isHub;
 
-    // O-9b: 일반 project 노드 (container / hub / Layer 0 satellite hub 제외)
-    // 만 ontology 도미넌트 kind 에 따라 borderColor 분기. fill 은 분기 안 함
-    // — 헌장 "허브만 유일한 채색" + "size 변동 최소" 정책.
-    const isPlainProject = !isContainer && !project.isHub;
+    // O-9b: 일반 project 노드 (hub 제외) 만 ontology 도미넌트 kind 에 따라
+    // borderColor 분기. fill 은 분기 안 함 — 헌장 "허브만 유일한 채색" +
+    // "size 변동 최소" 정책.
+    const isPlainProject = !project.isHub;
     const ontologyCounts = isPlainProject
       ? options?.ontologyCountsBySlug?.get(project.slug)
       : undefined;
@@ -240,46 +189,18 @@ export function buildGraph(
     graph.addNode(project.slug, {
       x: Math.cos(theta) * r,
       y: Math.sin(theta) * r,
-      // 크기 위계: Container 10 → Hub 10 → Node 5.5. 2nd pass 에서
-      // degree 스케일로 미세 조정. 이전엔 container 20 으로 과도하게 커
-      // 노란 원이 화면을 지배했고, satellite hub (3) 와 비율도 ~7:1 로
-      // 과함 (사용자 피드백). container 를 절반 (10~13) 으로 축소해
-      // 전체 균형 개선 — hub 와 같은 사이즈 범위에서 amber 색으로 위계 구분.
-      size: isContainer ? 10 : isLayer0Hub ? 3 : project.isHub ? 10 : 5.5,
-      // Container 는 brand prefix 축약 ("Demo Observability" → "Observability")
-      // 으로 라벨 공간 절약. project.name 은 attrs 의 label 만 단축하므로
-      // drawer/tooltip/검색 등은 여전히 full name 으로 조회됨.
-      label: isContainer
-        ? stripContainerBrand(project.name)
-        : shortenName(project.name),
-      // Layer 0 (hasContainers=true): Container 만 forceLabel, Hub 는 hover/
-      //   선택/확대 시에만 라벨 (labelRenderedSizeThreshold 보조).
-      // Layer 1 (hasContainers=false): 기존대로 Hub 가 forceLabel.
-      // Node 는 어느 Layer 에서도 threshold 로 점진 노출 (forceLabel false).
-      forceLabel: isContainer || (!hasContainers && project.isHub),
+      // 크기 위계: Hub 10 → Node 5.5. 2nd pass 에서 degree 스케일 미세 조정.
+      size: project.isHub ? 10 : 5.5,
+      label: shortenName(project.name),
+      // Hub 는 forceLabel — 토폴로지 상시 노출 anchor. Node 는 threshold 로
+      // 점진 노출.
+      forceLabel: project.isHub,
       recentlyUpdated: recent,
-      color:
-        project.category === CONTAINER_CATEGORY_SENTINEL
-          ? CONTAINER_COLOR
-          : isLayer0Hub
-            ? 'rgba(139, 151, 255, 0.32)'
-            : project.isHub
-              ? HUB_COLOR
-              : toneForSlug(project.slug),
-      borderColor:
-        project.category === CONTAINER_CATEGORY_SENTINEL
-          ? palette.containerBorder
-          : isLayer0Hub
-            ? 'rgba(139, 151, 255, 0.18)'
-            : project.isHub
-              ? palette.hubBorder
-              : ontologyTone?.borderColor ?? palette.nodeBorder,
-      outerBorderColor:
-        project.category === CONTAINER_CATEGORY_SENTINEL
-          ? palette.containerOuterHalo
-          : project.isHub
-            ? palette.hubOuterHalo
-            : NODE_OUTER_HALO,
+      color: project.isHub ? HUB_COLOR : toneForSlug(project.slug),
+      borderColor: project.isHub
+        ? palette.hubBorder
+        : ontologyTone?.borderColor ?? palette.nodeBorder,
+      outerBorderColor: project.isHub ? palette.hubOuterHalo : NODE_OUTER_HALO,
       projectSlug: project.slug,
       categoryId: project.category,
       isHub: project.isHub,
@@ -299,11 +220,9 @@ export function buildGraph(
       if (graph.hasNode(dep) && dep !== project.slug && !graph.hasEdge(project.slug, dep)) {
         const depProject = projects.find((p) => p.slug === dep);
         const hubToHub = project.isHub && depProject?.isHub === true;
-        // 대상이 container 카테고리면 "소속" 관계 (hub → container, node → hub).
-        // 그 외는 같은 레벨 엔티티 간 cross-project 의존성 (depends-on).
+        // node → hub 는 "소속" 관계 (contains). 그 외는 같은 레벨 의존성.
         const isContainsRelation =
-          depProject?.category === CONTAINER_CATEGORY_SENTINEL ||
-          (project.isHub === false && depProject?.isHub === true);
+          project.isHub === false && depProject?.isHub === true;
         graph.addEdge(project.slug, dep, {
           // 두께 기본값 — degree 가중은 아래 2nd pass에서 적용
           size: hubToHub ? 0.9 : 0.5,
@@ -316,29 +235,10 @@ export function buildGraph(
   }
 
   // degree 기반 크기 재계산 — 연결이 많을수록 커진다.
-  // Container: 20 → 26 (고정 ~20 에 degree 부스트), Hub: 10 → 13, Node: 4.5 → 7.5.
-  // 화면 픽셀 기준 Container > Hub > Node 가 ~2x, ~2x 의 일관된 비율이 되도록.
+  // Hub: 10 → 13, Node: 4.5 → 7.5. 화면 픽셀 기준 ~2x 일관 비율.
   graph.forEachNode((id, attrs) => {
     const degree = graph.degree(id);
-    const isContainer = attrs.categoryId === CONTAINER_CATEGORY_SENTINEL;
-    const isLayer0Hub = hasContainers && attrs.isHub;
-    if (isContainer) {
-      // 절반 축소: 10 → 13 (degree 가중). hub 와 거의 같은 사이즈
-      // 범위지만 amber 색 + 중앙 위치로 충분히 구분.
-      graph.setNodeAttribute(
-        id,
-        'size',
-        10 + Math.min(3, Math.log2(Math.max(1, degree)) * 0.9),
-      );
-    } else if (isLayer0Hub) {
-      // Layer 0 위성 — degree 스케일 최소만. 3 ~ 4.5 사이 유지해 환공포증
-      // 재현 없이도 "연결 많은 허브는 살짝 커 보임" 이라는 시그널만.
-      graph.setNodeAttribute(
-        id,
-        'size',
-        3 + Math.min(1.5, Math.log2(Math.max(1, degree)) * 0.35),
-      );
-    } else if (attrs.isHub) {
+    if (attrs.isHub) {
       graph.setNodeAttribute(
         id,
         'size',

--- a/src/widgets/topology-map-sigma/lib/reducer-overlay-flags.test.ts
+++ b/src/widgets/topology-map-sigma/lib/reducer-overlay-flags.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CONTAINER_CATEGORY_ID,
   HUB_BOOST_MAX_SCALE,
   HUB_BOOST_RATIO_THRESHOLD,
   HUB_SMALL_SIZE_THRESHOLD,
@@ -106,19 +105,7 @@ describe('applyOverlaySize — recent pulse', () => {
     expect(out.size).toBe(4);
   });
 
-  it('container 노드는 pulse 제외', () => {
-    const out = applyOverlaySize(
-      attrs({
-        size: 4,
-        recentlyUpdated: true,
-        categoryId: CONTAINER_CATEGORY_ID,
-      }),
-      { cameraRatio: 1, recentPulseEnabled: true, pulsePhase: Math.PI / 2 },
-    );
-    expect(out.size).toBe(4);
-  });
-
-  it('비-container + recentlyUpdated + pulse on → sin(phase) * amplitude 만큼 변조', () => {
+  it('recentlyUpdated + pulse on → sin(phase) * amplitude 만큼 변조', () => {
     const out = applyOverlaySize(
       attrs({ size: 4, recentlyUpdated: true }),
       { cameraRatio: 1, recentPulseEnabled: true, pulsePhase: Math.PI / 2 },

--- a/src/widgets/topology-map-sigma/lib/reducer-overlay-flags.ts
+++ b/src/widgets/topology-map-sigma/lib/reducer-overlay-flags.ts
@@ -20,7 +20,6 @@ export const HUB_BOOST_MAX_SCALE = 2.5;
 export const HUB_BOOST_BASE_BOOST_RATE = 3.5;
 export const HUB_SMALL_SIZE_THRESHOLD = 5;
 export const PULSE_AMPLITUDE = 0.1;
-export const CONTAINER_CATEGORY_ID = '__container__';
 
 export interface OverlayFlagsContext {
   hubsOnly: boolean;
@@ -53,7 +52,7 @@ export function shouldHideNode(
  * 건드림). caller 가 결과를 그대로 다음 분기로 넘김.
  *
  * 적용 순서:
- *   1. recent pulse (container 제외) — recentlyUpdated 노드 sine 변조
+ *   1. recent pulse — recentlyUpdated 노드 sine 변조
  *   2. hub boost — 작은 허브 줌인 시 최대 2.5x
  */
 export function applyOverlaySize(
@@ -65,13 +64,8 @@ export function applyOverlaySize(
 ): SigmaNodeAttrs {
   let next = attrs;
 
-  // 1) recent pulse — container 제외
-  const isContainerNode = next.categoryId === CONTAINER_CATEGORY_ID;
-  if (
-    ctx.recentPulseEnabled &&
-    next.recentlyUpdated &&
-    !isContainerNode
-  ) {
+  // 1) recent pulse
+  if (ctx.recentPulseEnabled && next.recentlyUpdated) {
     next = {
       ...next,
       size: next.size * (1 + PULSE_AMPLITUDE * Math.sin(ctx.pulsePhase)),

--- a/src/widgets/topology-map-sigma/lib/topology-palette.ts
+++ b/src/widgets/topology-map-sigma/lib/topology-palette.ts
@@ -19,18 +19,12 @@ export interface TopologyPalette {
   hubBorder: string;
   /** 허브 노드 외곽 halo. 선택 / hover 시 reducer 가 강화. */
   hubOuterHalo: string;
-  /** 컨테이너 노드 테두리 (웜 앰버 톤). */
-  containerBorder: string;
-  /** 컨테이너 노드 외곽 halo. */
-  containerOuterHalo: string;
   /** 기본 엣지 색 (graph build 시 모든 엣지에 적용). */
   edge: string;
   /** `kind: contains` 엣지 — 계층 표현용 옅은 neutral. */
   edgeContains: string;
   /** `kind: depends-on` 엣지 — cross-project 의존 인디고 톤. */
   edgeDependsOn: string;
-  /** focus 없을 때 cross-hub depends-on 엣지를 거의 투명으로 dim. */
-  edgeDependsOnIdle: string;
   /** 검색/depth/category 필터로 가려진 엣지. */
   edgeDim: string;
   /** 카드/툴팁 배경 톤 (텍스트 라벨이 sigma label 영역과 어울리게). */
@@ -41,12 +35,9 @@ const DARK: TopologyPalette = {
   nodeBorder: 'rgba(200, 210, 230, 0.3)',
   hubBorder: 'rgba(139, 151, 255, 0.55)',
   hubOuterHalo: 'rgba(139, 151, 255, 0.08)',
-  containerBorder: 'rgba(224, 196, 140, 0.62)',
-  containerOuterHalo: 'rgba(224, 196, 140, 0.10)',
   edge: 'rgba(170, 185, 210, 0.08)',
   edgeContains: 'rgba(170, 185, 210, 0.10)',
   edgeDependsOn: 'rgba(139, 151, 255, 0.16)',
-  edgeDependsOnIdle: 'rgba(139, 151, 255, 0.04)',
   edgeDim: 'rgba(255, 255, 255, 0.005)',
   labelText: 'rgba(235, 240, 250, 0.95)',
 };
@@ -56,13 +47,10 @@ const LIGHT: TopologyPalette = {
   nodeBorder: 'rgba(60, 72, 96, 0.6)',
   hubBorder: 'rgba(70, 86, 200, 0.85)',
   hubOuterHalo: 'rgba(70, 86, 200, 0.18)',
-  containerBorder: 'rgba(150, 110, 50, 0.85)',
-  containerOuterHalo: 'rgba(150, 110, 50, 0.18)',
   // 다크는 0.08 인데 그건 검은 배경에서 작동. 라이트 흰 배경엔 0.55+ 필요.
   edge: 'rgba(60, 72, 96, 0.55)',
   edgeContains: 'rgba(60, 72, 96, 0.6)',
   edgeDependsOn: 'rgba(70, 86, 200, 0.7)',
-  edgeDependsOnIdle: 'rgba(70, 86, 200, 0.42)',
   // dim 은 "거의 안 보임" 의미를 유지하되 흰 배경에서 노이즈 없게 어두운 톤 +
   // 낮은 알파.
   edgeDim: 'rgba(20, 30, 50, 0.06)',

--- a/src/widgets/topology-map-sigma/ui/SigmaHubRail.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaHubRail.tsx
@@ -83,22 +83,16 @@ export function SigmaHubRail({
       degreeBySlug.set(dep, (degreeBySlug.get(dep) ?? 0) + 1);
     }
   }
-  // Layer 0 (Workspace map) 에선 "hub" 가 아니라 Container 가 주요 정거장.
-  // 21 container 만 rail 에 깔끔하게 노출해 사용자가 스캔하기 쉽게. Layer 1
-  // (project 내부) 에선 containers 가 안 섞여 들어오므로 fallthrough 동작.
-  const hasContainers = projects.some(
-    (p) => p.category === '__container__',
-  );
+  // mission v2 후 Layer 0 컨테이너 시스템 폐기 (PR #41/#42). hub 만 rail 에
+  // 노출.
   const hubs = projects
-    .filter((p) =>
-      hasContainers ? p.category === '__container__' : p.isHub,
-    )
+    .filter((p) => p.isHub)
     .slice()
     .sort(
       (a, b) => (degreeBySlug.get(b.slug) ?? 0) - (degreeBySlug.get(a.slug) ?? 0),
     );
   if (hubs.length === 0) return null;
-  const railLabel = hasContainers ? '프로젝트' : '허브';
+  const railLabel = '허브';
 
   if (!open) {
     return (
@@ -145,12 +139,9 @@ export function SigmaHubRail({
       {hubs.map((hub, idx) => {
         const active = selectedSlug === hub.slug;
         const degree = degreeBySlug.get(hub.slug) ?? 0;
-        const isContainer = hub.category === '__container__';
-        // Rail dot 색도 토폴로지 색 체계 맞춤: Container 앰버 · Hub 인디고.
-        // active 시 채도를 더 올려 선택 상태 시각 강조.
-        const dotColor = isContainer
-          ? active ? 'rgba(224,196,140,0.95)' : 'rgba(224,196,140,0.62)'
-          : active ? 'var(--color-indigo-accent)' : 'rgba(139,151,255,0.5)';
+        const dotColor = active
+          ? 'var(--color-indigo-accent)'
+          : 'rgba(139,151,255,0.5)';
         return (
           <button
             key={hub.slug}
@@ -190,12 +181,7 @@ export function SigmaHubRail({
             {active ? (
               <span
                 aria-hidden
-                className="pointer-events-none absolute inset-y-1 left-0 w-[2px] rounded-full"
-                style={{
-                  backgroundColor: isContainer
-                    ? 'rgba(224,196,140,0.95)'
-                    : 'var(--color-indigo-accent)',
-                }}
+                className="pointer-events-none absolute inset-y-1 left-0 w-[2px] rounded-full bg-[color:var(--color-indigo-accent)]"
               />
             ) : null}
             <span

--- a/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
@@ -136,10 +136,7 @@ export function SigmaMinimap({ sigma, graph }: SigmaMinimapProps) {
   const sampleStep = Math.max(1, Math.floor(totalNodes / 40));
   let idx = 0;
   let hubCount = 0;
-  let containerCount = 0;
   graph.forEachNode((id, attrs) => {
-    const isContainer = attrs.categoryId === '__container__';
-    if (isContainer) containerCount += 1;
     if (attrs.isHub) {
       hubCount += 1;
       hubPositions.set(id, {
@@ -158,8 +155,8 @@ export function SigmaMinimap({ sigma, graph }: SigmaMinimapProps) {
     }
     idx += 1;
   });
-  const primaryCount = containerCount > 0 ? containerCount : hubCount;
-  const primaryLabel = containerCount > 0 ? 'projects' : 'hubs';
+  const primaryCount = hubCount;
+  const primaryLabel = 'hubs';
 
   // 허브-허브 엣지 — 미니맵에서 전체 구조 힌트. 엣지 수가 많지 않아 렌더
   // 부하 경미. 방향성은 무시하고 연결 여부만 표기.

--- a/src/widgets/topology-map-sigma/ui/SigmaNodeTooltip.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaNodeTooltip.tsx
@@ -9,10 +9,6 @@ export interface SigmaNodeTooltipData {
   statusId?: string;
   tags?: string[];
   isHub: boolean;
-  /** Layer 0 컨테이너(__container__) 노드 여부. 인디고 허브와 구분해 앰버
-   *  칩 + 앰버 제목으로 표기. 컨테이너는 lifecycle status 가 의미 없어
-   *  statusId 칩도 자동 숨김. */
-  isContainer?: boolean;
   /** 해당 노드의 총 연결 수 (in + out degree). undefined 면 배지 숨김. */
   degree?: number;
   x: number;
@@ -56,39 +52,29 @@ export function SigmaNodeTooltip({ data }: Props) {
         />
       ) : null}
       <div className="flex items-center gap-2">
-        {dotColor && !data.isContainer ? (
+        {dotColor ? (
           <span
             className="inline-block h-1.5 w-1.5 flex-none rounded-full"
             style={{ backgroundColor: dotColor }}
             aria-hidden
           />
         ) : null}
-        <span
-          className={`text-[13px] font-medium leading-tight ${
-            data.isContainer
-              ? 'text-[color:rgba(224,196,140,0.95)]'
-              : 'text-[color:var(--color-text-primary)]'
-          }`}
-        >
+        <span className="text-[13px] font-medium leading-tight text-[color:var(--color-text-primary)]">
           {data.name}
         </span>
-        {data.isContainer ? (
-          <span className="ml-auto rounded-sm border border-[color:rgba(224,196,140,0.45)] bg-[color:rgba(224,196,140,0.1)] px-1 py-0.5 font-mono text-[8px] uppercase tracking-[0.16em] text-[color:rgba(224,196,140,0.95)]">
-            컨테이너
-          </span>
-        ) : data.isHub ? (
+        {data.isHub ? (
           <span className="ml-auto rounded-sm border border-[color:rgba(139,151,255,0.35)] px-1 py-0.5 font-mono text-[8px] uppercase tracking-[0.16em] text-[color:rgba(139,151,255,0.9)]">
             허브
           </span>
         ) : null}
       </div>
       <div className="flex items-center gap-2">
-        {data.domain && !data.isContainer ? (
+        {data.domain ? (
           <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:rgba(139,151,255,0.85)]">
             {data.domain}
           </span>
         ) : null}
-        {data.statusId && !data.isContainer ? (
+        {data.statusId ? (
           <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {statusLabel(data.statusId)}
           </span>

--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -612,14 +612,7 @@ export function SigmaTopology({
       });
     };
     renderer.setSetting('nodeReducer', (node, attrs) => {
-      const result = baseNodeReducer(node, attrs);
-      // Container 노드는 라벨 폰트도 한 단계 키워 위계 강조. Sigma per-node
-      // labelSize 지원. Hub 는 글로벌 11px 유지, Container 만 14px.
-      const isContainer = attrs.categoryId === '__container__';
-      // Container 라벨: 700 (heavy) → 600 (semibold). 700 은 브랜드 강조
-      // 뉘앙스가 강해 "topology map 읽기" 의 차분함과 어울리지 않음.
-      // Apple SF Pro Display semibold 감성 + Inter 600 의 실제 가독성.
-      const base = isContainer ? { ...result, labelSize: 14, labelWeight: '600' as const } : result;
+      const base = baseNodeReducer(node, attrs);
       // minimal 모드: 솎아내기 없이 모든 노드에 이름 고정 노출.
       // hidden 된 노드는 건드리지 않음 (허브 전용 모드 등).
       const hidden = (base as { hidden?: boolean }).hidden;
@@ -627,7 +620,6 @@ export function SigmaTopology({
         return { ...base, label: attrs.label, forceLabel: true };
       }
       // Label strategy — 라벨 밀집 방지:
-      // - Container 는 Workspace 지도에서 항상 라벨 노출.
       // - Hub/Node 는 줌아웃 상태에서 label 자체를 제거한다. forceLabel 만
       //   끄면 Sigma size threshold 때문에 큰 hub 라벨이 계속 남아 화면을
       //   덮는다.
@@ -637,7 +629,7 @@ export function SigmaTopology({
         focus === node || (focus !== null && neighbors.has(node));
       const ratio = cameraRatioRef.current;
 
-      if (!hidden && !isContainer && !isFocusOrNeighbor) {
+      if (!hidden && !isFocusOrNeighbor) {
         if (attrs.isHub) {
           const HUB_LABEL_RATIO = 0.55;
           if (ratio > HUB_LABEL_RATIO) {
@@ -934,8 +926,6 @@ export function SigmaTopology({
         statusId: attrs.statusId,
         tags: attrs.tags,
         isHub: attrs.isHub,
-        // Container(__container__) 는 tooltip 에서 앰버 identity + statusId 숨김.
-        isContainer: attrs.categoryId === '__container__',
         degree: graph.degree(node),
         x: event.x,
         y: event.y,
@@ -1022,10 +1012,7 @@ export function SigmaTopology({
       appliedPalette = palette;
       paletteRefLocal.current = palette;
       graph.forEachNode((id, attrs) => {
-        if (attrs.categoryId === '__container__') {
-          graph.setNodeAttribute(id, 'borderColor', palette.containerBorder);
-          graph.setNodeAttribute(id, 'outerBorderColor', palette.containerOuterHalo);
-        } else if (attrs.isHub) {
+        if (attrs.isHub) {
           graph.setNodeAttribute(id, 'borderColor', palette.hubBorder);
           graph.setNodeAttribute(id, 'outerBorderColor', palette.hubOuterHalo);
         } else {
@@ -1341,19 +1328,15 @@ export function SigmaTopology({
 
   const stats = useMemo(() => {
     let hubs = 0;
-    let containers = 0;
     graph.forEachNode((_, attrs) => {
-      if (attrs.categoryId === '__container__') containers += 1;
       if (attrs.isHub) hubs += 1;
     });
     return {
       nodes: graph.order,
       hubs,
-      containers,
       edges: graph.size,
     };
   }, [graph]);
-  const isWorkspaceLayer = stats.containers > 0;
 
   return (
     <div className={`relative h-full w-full overflow-hidden ${className ?? ''}`}>
@@ -1528,10 +1511,7 @@ export function SigmaTopology({
         </span>
         <span className="h-2 w-px bg-[color:var(--color-overlay-3)]" />
         <span>
-          <span className="text-[color:var(--color-indigo-accent)]">
-            {isWorkspaceLayer ? stats.containers : stats.hubs}
-          </span>{' '}
-          {isWorkspaceLayer ? '프로젝트' : '허브'}
+          <span className="text-[color:var(--color-indigo-accent)]">{stats.hubs}</span> 허브
         </span>
         <span className="h-2 w-px bg-[color:var(--color-overlay-3)]" />
         <span>


### PR DESCRIPTION
## Summary

PR #41 (demo session 폐기) 후 vault 데이터에 \`categoryId='__container__'\` 노드가 영원히 안 만들어짐. dormant 였던 visual styling 분기들 적극 정리.

\`-277 / +57 = -220\` 라인.

## 영향 surface

| 파일 | 변경 |
|---|---|
| \`graph-build.ts\` | CONTAINER_CATEGORY_SENTINEL / CONTAINER_COLOR / detectBrandPrefix · hasContainers · isContainer · isLayer0Hub 모두 제거. Hub vs Node 단일 layer |
| \`SigmaTopology.tsx\` | nodeReducer isContainer labelSize / mutation observer repaint / stats.containers / isWorkspaceLayer 토글 모두 제거 |
| \`SigmaHubRail.tsx\` | hasContainers fallthrough + container 색 분기 제거 — hub 만 rail 노출 |
| \`SigmaMinimap.tsx\` | containerCount + primaryCount/Label 분기 제거 |
| \`SigmaNodeTooltip.tsx\` | isContainer prop / 컨테이너 chip 분기 제거 |
| \`reducer-overlay-flags.ts\` | CONTAINER_CATEGORY_ID + isContainerNode pulse 제외 분기 제거 |
| \`topology-palette.ts\` | containerBorder / containerOuterHalo 키 제거 (DARK + LIGHT) |
| \`SearchPalette.tsx\` | LayerFilter 'container' 옵션 제거 |
| 2 test files | container 관련 test 케이스 제거 |

## 시각 회귀 0

vault dogfood 데이터에 컨테이너 노드가 원래 없어 분기 자체가 unreachable. 시각적 변화 없음.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] dev server 7 라우트 (\`/\` · \`/ontology/\` · \`/ontology/edit/\` · \`/projects/\` · \`/topology/\` · \`/docs/\` · \`/knowledge/\`) 모두 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)