### PR TITLE
fix: 랜딩 CTA self-loop 해소 + footer mission v2 정렬

### DIFF
--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -103,10 +103,10 @@ export function LandingPage({ next }: Props) {
           ) : (
             <>
               <Link
-                href="/"
+                href="/ontology/"
                 className={cn(buttonVariants({ size: "lg" }), "rounded-full min-w-[14rem]")}
               >
-                내 ontology 둘러보기
+                ontology 둘러보기
                 <ArrowRight size={16} />
               </Link>
               <Link
@@ -142,7 +142,7 @@ export function LandingPage({ next }: Props) {
           GitHub
         </a>
         <span aria-hidden>·</span>
-        <span className="font-mono">Next.js · TypeScript · Sigma.js · Firebase</span>
+        <span className="font-mono">Local-first · Next.js · TypeScript · Sigma.js · MCP</span>
       </footer>
     </main>
   );


### PR DESCRIPTION
## Summary

PR #41 의 데모 폐기 직후 회귀 — 랜딩의 "내 ontology 둘러보기" CTA 가 \`/\` 로 가게 됐는데, 비인증 사용자는 \`/\` → RootEntryPage → LandingPage 로 self-loop. Domain B 사용자 시점 loop 검증에서 발견.

## 수정

- CTA href \`/\` → \`/ontology/\` (트리 view 직접 진입 — dogfood 23 노드 즉시 노출)
- CTA 텍스트 "내 ontology" → "ontology" (vault 미선택 시 dogfood 인 점 반영)
- footer "Next.js · TypeScript · Sigma.js · Firebase" → "Local-first · Next.js · TypeScript · Sigma.js · MCP" (mission v2 정렬)

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] Playwright MCP 라이브: \`/\` → CTA 클릭 → \`/ontology/\` 도착 (제목 "온톨로지 · oh-my-ontology")

🤖 Generated with [Claude Code](https://claude.com/claude-code)