### PR TITLE
refactor: 인스펙터 vault > dogfood fallback + read-only 모드 + ApprovedDetail 폐기

### DIFF
--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-01T17:39:03.571Z",
+  "generatedAt": "2026-05-01T17:55:38.566Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -8,6 +8,10 @@ import { Info, Maximize2, Minimize2 } from "lucide-react";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { useUserAuth } from "@/features/user-auth";
 import { addManualKnowledgeNode } from "@/entities/knowledge-graph";
+import {
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+} from "@/entities/docs-vault";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { useLocalVault } from "@/features/docs-vault-local";
 import { slugify } from "@/shared/lib/slugify";
@@ -167,9 +171,16 @@ export function OntologyEditPage() {
   // C-5 — vault 모드에서는 selectedId 가 vault slug. manifest 에서 lookup
   // 해 인스펙터에 frontmatter + array 키 (capabilities/elements/...) 까지
   // 함께 전달 (in-canvas rename + array 편집 가능).
+  // 빌더 진실원 우선순위 (PR #43): live vault.manifest > 빌드타임 dogfood
+  // 매니페스트. 인스펙터 lookup 도 같은 우선순위 — vault 안 고른 사용자가
+  // dogfood 노드 클릭 시 정확한 frontmatter 를 본다 (PR #45 fix 의 인스펙터
+  // 측 보완). hasLiveVault 가 false 면 인스펙터는 read-only — patch 시도하면
+  // disk 권한 없어 어차피 fail.
+  const hasLiveVault = vault.manifest !== null;
+  const effectiveManifest = vault.manifest ?? (staticVaultManifestRaw as VaultManifest);
   const vaultSelected = (() => {
     if (!selectedId || ephemeralSelected) return null;
-    const doc = vault.manifest?.docs.find((d) => d.slug === selectedId);
+    const doc = effectiveManifest.docs.find((d) => d.slug === selectedId);
     if (!doc || typeof doc.frontmatter.kind !== "string") return null;
     const fm = doc.frontmatter as Record<string, unknown>;
     const asStrings = (v: unknown): string[] =>
@@ -182,7 +193,6 @@ export function OntologyEditPage() {
       slug: doc.slug,
       kind: String(doc.frontmatter.kind),
       title: doc.title || doc.slug,
-      // V1.2 vault-adaptation — frontmatter scalar literals.
       description: asString(fm.description),
       domain: asString(fm.domain),
       capabilities: asStrings(fm.capabilities),
@@ -191,13 +201,6 @@ export function OntologyEditPage() {
       relates: asStrings(fm.relates),
     };
   })();
-  // cloud approved 모드 fallback — vault 매니페스트 없을 때만. 현재 사용자
-  // 흐름에서는 vault 모드가 default 라 사실상 dead 지만 cloud 모드 잔존
-  // 사용자 보호용으로 placeholder 유지.
-  const approvedSelected =
-    selectedId && !ephemeralSelected && !vaultSelected && !vault.manifest
-      ? { id: selectedId, kind: "(승인)", title: selectedId }
-      : null;
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const renameVaultDoc = useCallback(
@@ -490,8 +493,8 @@ export function OntologyEditPage() {
           </div>
           <OntologyInspector
             ephemeralSelected={ephemeralSelected}
-            approvedSelected={approvedSelected}
             vaultSelected={vaultSelected}
+            vaultReadOnly={!hasLiveVault}
             onRenameEphemeral={(id, title) => updateNode(id, { title })}
             onSaveEphemeral={saveEphemeral}
             onSaveVaultRename={renameVaultDoc}

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -45,8 +45,10 @@ export interface VaultSelected {
 
 export interface OntologyInspectorProps {
   ephemeralSelected: EphemeralNode | null;
-  approvedSelected: { id: string; kind: string; title: string } | null;
   vaultSelected: VaultSelected | null;
+  /** true 면 vault 가 read-only (빌드타임 dogfood 매니페스트 기반). 인스펙터의
+   *  rename/array/literal/delete 모두 disabled — disk 권한 없어 patch 불가. */
+  vaultReadOnly?: boolean;
   onRenameEphemeral: (id: string, title: string) => void;
   onSaveEphemeral?: (id: string) => Promise<void> | void;
   onSaveVaultRename?: (slug: string, nextTitle: string) => Promise<void> | void;
@@ -75,8 +77,8 @@ const KIND_LABEL_MAP: Record<string, string> = {
 
 export function OntologyInspector({
   ephemeralSelected,
-  approvedSelected,
   vaultSelected,
+  vaultReadOnly = false,
   onRenameEphemeral,
   onSaveEphemeral,
   onSaveVaultRename,
@@ -86,7 +88,7 @@ export function OntologyInspector({
   onClearSelection,
   saving,
 }: OntologyInspectorProps) {
-  const selected = ephemeralSelected ?? vaultSelected ?? approvedSelected;
+  const selected = ephemeralSelected ?? vaultSelected;
   return (
     <aside
       aria-label="선택한 ontology 노드 상세"
@@ -125,18 +127,12 @@ export function OntologyInspector({
           <motion.div key={`vault-${vaultSelected.slug}`} {...FADE_MOTION}>
             <VaultDetail
               node={vaultSelected}
+              readOnly={vaultReadOnly}
               onSaveRename={onSaveVaultRename}
               onEditArrayKey={onEditVaultArrayKey}
               onEditLiteral={onEditVaultLiteral}
               onDelete={onDeleteVault}
               saving={Boolean(saving)}
-              onDeselect={onClearSelection}
-            />
-          </motion.div>
-        ) : approvedSelected ? (
-          <motion.div key={`appr-${approvedSelected.id}`} {...FADE_MOTION}>
-            <ApprovedDetail
-              node={approvedSelected}
               onDeselect={onClearSelection}
             />
           </motion.div>
@@ -247,6 +243,7 @@ const ARRAY_KEY_LABELS: Record<VaultArrayKey, string> = {
 
 function VaultDetail({
   node,
+  readOnly,
   onSaveRename,
   onEditArrayKey,
   onEditLiteral,
@@ -255,6 +252,7 @@ function VaultDetail({
   onDeselect,
 }: {
   node: VaultSelected;
+  readOnly: boolean;
   onSaveRename?: (slug: string, nextTitle: string) => Promise<void> | void;
   onEditArrayKey?: (
     slug: string,
@@ -277,12 +275,12 @@ function VaultDetail({
   }, [node.slug, node.title]);
   const trimmed = draft.trim();
   const dirty = trimmed !== "" && trimmed !== node.title;
-  const canSave = dirty && Boolean(onSaveRename) && !saving;
+  const canSave = !readOnly && dirty && Boolean(onSaveRename) && !saving;
   return (
     <div className="flex flex-col gap-3 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] p-3">
       <div className="flex items-center justify-between gap-2">
         <span className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
-          vault · {KIND_LABEL_MAP[node.kind] ?? node.kind}
+          {readOnly ? "dogfood" : "vault"} · {KIND_LABEL_MAP[node.kind] ?? node.kind}
         </span>
         <button
           type="button"
@@ -301,7 +299,8 @@ function VaultDetail({
           type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[13px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
+          disabled={readOnly}
+          className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[13px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-60"
         />
       </label>
       <div>
@@ -312,7 +311,7 @@ function VaultDetail({
           {node.slug}
         </p>
       </div>
-      {onSaveRename ? (
+      {!readOnly && onSaveRename ? (
         <button
           type="button"
           onClick={() => onSaveRename(node.slug, draft)}
@@ -324,10 +323,11 @@ function VaultDetail({
         </button>
       ) : null}
       <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
-        제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로
-        유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다.
+        {readOnly
+          ? "dogfood 매니페스트 — 빌드타임 baked. 직접 수정하려면 /docs 에서 vault 폴더를 여세요."
+          : "제목만 frontmatter `title:` 에 patch 됩니다. 본문이나 다른 키는 그대로 유지돼요. AI agent (MCP) 도 동일 vault 를 보고 있어 즉시 반영됩니다."}
       </p>
-      {onEditLiteral ? (
+      {!readOnly && onEditLiteral ? (
         <div className="flex flex-col gap-2">
           <LiteralEditor
             fieldKey="domain"
@@ -347,7 +347,7 @@ function VaultDetail({
           />
         </div>
       ) : null}
-      {onEditArrayKey ? (
+      {!readOnly && onEditArrayKey ? (
         <div className="flex flex-col gap-3">
           {(["capabilities", "elements", "dependencies", "relates"] as const).map(
             (key) => (
@@ -361,8 +361,10 @@ function VaultDetail({
             ),
           )}
         </div>
+      ) : readOnly ? (
+        <ReadOnlyArraySummary node={node} />
       ) : null}
-      {onDelete ? (
+      {!readOnly && onDelete ? (
         <button
           type="button"
           onClick={() => onDelete(node.slug)}
@@ -533,39 +535,39 @@ function ArrayKeyEditor({
   );
 }
 
-function ApprovedDetail({
-  node,
-  onDeselect,
-}: {
-  node: { id: string; kind: string; title: string };
-  onDeselect: () => void;
-}) {
+/**
+ * read-only 모드 (dogfood 매니페스트 기반) 의 array 키 요약. 편집 input 없이
+ * chip 만 노출 — 사용자에게 "이 노드는 어떤 의존/역량을 갖는지" 정보만 전달.
+ */
+function ReadOnlyArraySummary({ node }: { node: VaultSelected }) {
+  const sections: Array<{ key: VaultArrayKey; values: string[] }> = (
+    ["capabilities", "elements", "dependencies", "relates"] as const
+  )
+    .map((key) => ({ key, values: node[key] }))
+    .filter((s) => s.values.length > 0);
+  if (sections.length === 0) return null;
   return (
-    <div className="flex flex-col gap-3 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] p-3">
-      <div className="flex items-center justify-between gap-2">
-        <span className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
-          승인 · {KIND_LABEL_MAP[node.kind] ?? node.kind}
-        </span>
-        <button
-          type="button"
-          onClick={onDeselect}
-          aria-label="선택 해제"
-          className="rounded-md p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+    <div className="flex flex-col gap-2">
+      {sections.map(({ key, values }) => (
+        <div
+          key={key}
+          className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5"
         >
-          ×
-        </button>
-      </div>
-      <div>
-        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-          이름
-        </p>
-        <p className="mt-1 text-[13px] text-[color:var(--color-text-primary)]">
-          {node.title}
-        </p>
-      </div>
-      <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
-        승인된 노드 — 편집은 별도 fire (C-6) 에서. 트리 화면에서도 볼 수 있어요.
-      </p>
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            {ARRAY_KEY_LABELS[key]}
+          </p>
+          <ul className="mt-2 flex flex-wrap gap-1">
+            {values.map((slug) => (
+              <li
+                key={slug}
+                className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--color-text-tertiary)]"
+              >
+                {slug}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PR #43 의 빌더 캔버스 vault > dogfood 정합을 인스펙터 측에도 확장. PR #45 이후 dogfood 노드가 캔버스에 보이지만 클릭 시 \`approvedSelected\` placeholder ("(승인)") 가 노출되던 misalign 회귀.

Domain D 코드 품질 검증 (loop iter#4) 에서 발견.

## 변경

**OntologyEditPage**:
- \`effectiveManifest = vault.manifest ?? staticVaultManifest\` — dogfood 노드 클릭 시도 정확한 frontmatter lookup
- \`hasLiveVault\` flag 추가 → Inspector 에 read-only 모드 전달
- \`approvedSelected\` placeholder 분기 통째 제거 (dead path)

**OntologyInspector**:
- \`vaultReadOnly\` prop 추가 — input/edit/delete disabled + 시각 hint
- \`approvedSelected\` + \`ApprovedDetail\` 컴포넌트 (37줄) 제거
- \`ReadOnlyArraySummary\` 컴포넌트 추가 (35줄) — capabilities/elements/dependencies/relates chip 만 노출
- chip 라벨 "vault" → "dogfood" (read-only 시) — 사용자에게 mode 명시

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] dev server \`/ontology/edit/\` 200 (0.44s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)