### PR TITLE
refactor(palette): 비개발자 친화 한국어 예시로 hints 교체

### DIFF
--- a/src/views/ontology-edit/ui/OntologyKindPalette.tsx
+++ b/src/views/ontology-edit/ui/OntologyKindPalette.tsx
@@ -18,19 +18,19 @@ const PALETTE_KINDS: Array<{
 }> = [
   {
     kind: "project",
-    hint: "최상위 단위 — 전체 워크스페이스의 한 prj",
+    hint: "최상위 단위 — 전체 워크스페이스의 한 프로젝트",
   },
   {
     kind: "domain",
-    hint: "프로젝트 안의 큰 영역 — auth / billing / ingest 등",
+    hint: "프로젝트 안의 큰 영역 — 인증 / 결제 / 알림 등",
   },
   {
     kind: "capability",
-    hint: "도메인 안의 한 기능 — 'JWT 발급' 같은 동사형",
+    hint: "도메인 안의 한 기능 — '사용자 로그인' 같은 동사형",
   },
   {
     kind: "element",
-    hint: "역량 안의 작은 구성 — 클래스 / 함수 / API endpoint",
+    hint: "역량 안의 작은 구성 — 화면 / 버튼 / API 등 구체 단위",
   },
 ];
 


### PR DESCRIPTION
## Summary

\`OntologyKindPalette\` 의 hint 4개가 줄임말 (\`prj\`) + 영어 약어 (\`auth / billing / ingest\`, \`JWT\`) + 코드 식별자 (\`클래스 / 함수 / API endpoint\`) 를 사용 중. mission v2 의 "비전문가 (PM·디자이너·운영) 도 직접 그릴 수 있어요" 약속과 어긋남.

Domain F 용어 명확성 loop iter#6.

## 변경 (사용자 가시 텍스트만 4 라인)

| kind | before | after |
|---|---|---|
| project | "한 prj" | "한 프로젝트" |
| domain | "auth / billing / ingest 등" | "인증 / 결제 / 알림 등" |
| capability | "'JWT 발급' 같은 동사형" | "'사용자 로그인' 같은 동사형" |
| element | "클래스 / 함수 / API endpoint" | "화면 / 버튼 / API 등 구체 단위" |

코드 식별자 (project / domain / capability / element) 는 그대로 — frontmatter key + kind enum 으로 일관 유지.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)