### PR TITLE
docs(landing): ValueChainRail 카피 효과 중심 rewrite (ontology 만의 가치 surface)

### DIFF
--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-01T17:55:38.566Z",
+  "generatedAt": "2026-05-01T18:36:41.148Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -248,21 +248,23 @@ function MiniTopology() {
  * 디자인 헌장 안 (보더 + 단일 인디고 + 무채색 텍스트).
  */
 function ValueChainRail() {
+  // 효과 (사용자가 얻는 것) 중심 copy. 단순 flow 가 아닌 "ontology 가
+  // 마크다운만으로는 못 하는 것" 의 3 가지 답.
   const steps: Array<{ index: string; title: string; sub: string }> = [
     {
       index: "01",
-      title: "마크다운 작성",
-      sub: "내가 쓰거나 AI agent 가 같이 — .md frontmatter 가 그대로 노드/관계",
+      title: "마크다운 한 곳에 적기",
+      sub: "frontmatter 키만 넣으면 노드/관계가 자동으로. AI agent (MCP) 도 같은 vault 에 read/write.",
     },
     {
       index: "02",
-      title: "ontology 자동 자라남",
-      sub: "frontmatter 자체가 자기 승인 — 검수 단계 없이 바로 그래프",
+      title: "역추적 + 의존 분석 즉시",
+      sub: "'이 기능 누가 쓰나?' '이거 바꾸면 뭐 깨지나?' — 마크다운에선 grep 인데, ontology 면 0 클릭에 답.",
     },
     {
       index: "03",
-      title: "트리·토폴로지·ERD",
-      sub: "같은 ontology 를 세 시각으로",
+      title: "한눈 탐색 — 트리·토폴로지·ERD",
+      sub: "같은 ontology 를 세 시각으로. 도메인 census, 영향 범위, 의존 chain 한 화면.",
     },
   ];
 


### PR DESCRIPTION
## Summary

이전 카피는 *flow* (markdown → ontology → view) 만 설명. 사용자가 첫 진입에서 "ontology 가 markdown 만으론 못 하는 것이 뭐냐?" 의 답을 못 얻음. Domain G 온톨로지 개념 설명 / 효과 가시화 loop iter#7.

## 변경 (사용자 가시 텍스트)

| step | before title | after title | after sub |
|---|---|---|---|
| 01 | 마크다운 작성 | 마크다운 한 곳에 적기 | frontmatter 키만 넣으면 노드/관계가 자동으로. AI agent (MCP) 도 같은 vault 에 read/write. |
| 02 | ontology 자동 자라남 | 역추적 + 의존 분석 즉시 | '이 기능 누가 쓰나?' '이거 바꾸면 뭐 깨지나?' — 마크다운에선 grep 인데, ontology 면 0 클릭에 답. |
| 03 | 트리·토폴로지·ERD | 한눈 탐색 — 트리·토폴로지·ERD | 같은 ontology 를 세 시각으로. 도메인 census, 영향 범위, 의존 chain 한 화면. |

같은 layout, 같은 정보량 (3 step + 제목 + sub). 변경은 텍스트만.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] Playwright MCP 라이브 \`/\` 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)