### PR TITLE
refactor: ontology 트리 카피 mission v2 정렬 (승인/검수 stale 제거)

### DIFF
--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -181,10 +181,11 @@ export function OntologyViewPage() {
               content={
                 <div className="max-w-[320px] space-y-2 text-left">
                   <p className="font-medium text-[color:var(--color-text-primary)]">
-                    승인된 ontology 노드의 계층 뷰
+                    ontology 노드의 계층 뷰
                   </p>
                   <p className="text-[color:var(--color-text-tertiary)]">
-                    문서에서 추출한 개념·관계 중 <strong>검수에서 승인된 것</strong>을{" "}
+                    vault 안 .md 파일의 frontmatter 가 그대로 자란 트리.
+                    검수 단계 없이 즉시 반영 —{" "}
                     <span className="font-mono text-xs">project → domain → capability → element</span>{" "}
                     순서로 펼쳐서 보여줍니다.
                   </p>
@@ -329,7 +330,7 @@ export function OntologyViewPage() {
           <OntologyTreeView
             result={treeResult}
             onSelect={(node) => selectNode(node)}
-            emptyHint="아직 승인된 ontology 노드가 없어요. 아래 단계로 첫 그래프를 자라게 할 수 있어요."
+            emptyHint="ontology 가 아직 자라지 않았어요. 아래 단계로 첫 그래프를 시작할 수 있어요."
           />
           {/* 빈 상태 onboarding — tree / orphans 모두 비었을 때만 노출.
               "온톨로지란 무엇이고, 어떻게 자라는지" 가이드. 데이터 있을 때

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
@@ -255,7 +255,7 @@ describe("OntologyTreeView — empty state", () => {
       <OntologyTreeView result={{ roots: [], orphans: [], warnings: [] }} />,
     );
     expect(screen.getByTestId("ontology-tree-empty")).toBeInTheDocument();
-    expect(screen.getByText(/아직 승인된 ontology 노드가 없어요/)).toBeInTheDocument();
+    expect(screen.getByText(/ontology 가 아직 자라지 않았어요/)).toBeInTheDocument();
   });
 
   it("uses custom emptyHint", () => {

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -211,7 +211,7 @@ function ProjectIdChip({
 
 export function OntologyTreeView({
   result,
-  emptyHint = "아직 승인된 ontology 노드가 없어요.",
+  emptyHint = "ontology 가 아직 자라지 않았어요.",
   defaultExpanded = true,
   onSelect,
 }: OntologyTreeViewProps) {


### PR DESCRIPTION
## Summary
- vault frontmatter 가 곧 그래프인 mission v2 모델인데도 OntologyView 의 tooltip 과 emptyHint 가 옛날 admin/review 흐름 어휘 ("승인된 노드", "검수에서 승인된 것") 를 남기고 있어 첫 사용자가 "어디서 뭘 승인하지?" 하고 막히는 마찰 제거
- tooltip 본문은 "vault 안 .md 파일의 frontmatter 가 그대로 자란 트리. 검수 단계 없이 즉시 반영" 로 mission v2 promise 를 제일 노출 강한 자리에서 직접 설명
- OntologyTreeView 컴포넌트의 default emptyHint 도 같이 갱신해서 어떤 caller 든 stale 카피가 새지 않게

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm test:run` — 115 files / 814 tests pass (test expect 문자열 1줄 동기화)
- [x] `grep -rn "승인" src/views/ontology-view src/widgets/ontology-tree-view` — 0 hit