### PR TITLE
refactor: 빌더 palette footer 를 사용자 다음-단계 안내로 (C-4/C-5 마커 제거)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyKindPalette.tsx
+++ b/src/views/ontology-edit/ui/OntologyKindPalette.tsx
@@ -4,13 +4,12 @@ import { getOntologyKindIcon, getOntologyKindLabel } from "@/entities/ontology-c
 import type { ManualNodeKind } from "@/entities/knowledge-graph";
 
 /**
- * Track C-3 + C-10 폴리시 — 좌측 palette. kind chip 4개.
+ * 빌더 좌측 palette — kind 4종 클릭 시 캔버스 가운데에 임시 노드 추가.
  *
- * C-10 추가:
- * - kind 별 미니 아이콘 (lucide). T35 (Phase 4) — `getOntologyKindIcon`
- *   shared helper 사용해 Tree / Stub / Search 와 같은 매핑.
- * - hover 시 인디고 alpha bg 톤 변화 (헌장 §11 — scale 없이 색만)
- * - 더 풍부한 시각 hierarchy (label + hint 분리)
+ * 시각:
+ * - kind 별 미니 아이콘 (`getOntologyKindIcon` 공용 — Tree / Stub / Search 와 같음)
+ * - hover 시 인디고 alpha 톤만 변화 (헌장 §11 — scale 없이 색만)
+ * - label + hint 2-line hierarchy
  */
 const PALETTE_KINDS: Array<{
   kind: Exclude<ManualNodeKind, "document">;
@@ -85,7 +84,7 @@ export function OntologyKindPalette({ onAddNode }: OntologyKindPaletteProps) {
       </ul>
       <footer className="mt-auto pt-3">
         <p className="text-[10px] leading-4 text-[color:var(--color-text-quaternary)]">
-          ephemeral — 아직 저장은 별도 단계 (C-4/C-5).
+          새 노드는 임시 — 오른쪽 인스펙터에서 이름 입력 + 저장해야 vault/.md 로 들어가요.
         </p>
       </footer>
     </aside>


### PR DESCRIPTION
## Summary
- 빌더 좌측 palette 하단의 "ephemeral — 아직 저장은 별도 단계 (C-4/C-5)" 가 (1) 내부 트랙 마커 노출, (2) "그래서 어떻게 저장?" 라는 질문 그대로 남겨두는 dead-end 텍스트라 사용자 다음-단계 안내로 교체
- 새 카피: "새 노드는 임시 — 오른쪽 인스펙터에서 이름 입력 + 저장해야 vault/.md 로 들어가요." (vault 모드 기준 — 실제 동작과 일치)
- 파일 상단 module JSDoc 도 같이 mission v2 어휘로 정돈 (Track C-3 / C-10 ephemeral 마커 폐기). 코드 동작·시각 변화 0
- forbidden.md §"문서" 의 *Track / iter / audit ephemeral marker 금지* 룰 위반이기도

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm test:run` — 115 files / 814 tests pass
- [x] palette 컴포넌트는 클릭 핸들러만 prop, 시각 layout 변화 0