### PR TITLE
refactor: 로딩 pulse dot 을 canonical indigo accent 토큰으로 (헌장 §11 정렬)

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -1541,7 +1541,7 @@ function AdminDocsContent() {
                     {folderTopoStatus === 'rebuilding' ? (
                       <span
                         aria-hidden
-                        className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.9)]"
+                        className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)]"
                       />
                     ) : null}
                   </button>

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -44,9 +44,9 @@ function TopologyLoadingFallback() {
     >
       <div className="flex items-center gap-3 rounded-full border border-[color:rgba(139,151,255,0.28)] bg-[color:var(--color-panel)] px-4 py-2 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
         <span className="flex gap-1">
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:0ms]" />
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:150ms]" />
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:300ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:0ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:150ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:300ms]" />
         </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
           토폴로지 엔진 불러오는 중

--- a/src/views/root-entry/ui/RootEntryPage.tsx
+++ b/src/views/root-entry/ui/RootEntryPage.tsx
@@ -64,9 +64,9 @@ function AuthLoadingSpinner() {
     >
       <div className="flex items-center gap-3 rounded-full border border-[color:rgba(139,151,255,0.24)] bg-[color:var(--color-panel)] px-4 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.35)]">
         <span className="flex gap-1" aria-hidden>
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:0ms]" />
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:150ms]" />
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:rgba(139,151,255,0.8)] [animation-delay:300ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:0ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:150ms]" />
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:300ms]" />
         </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
           확인 중


### PR DESCRIPTION
## Summary
- HomePage \`TopologyLoadingFallback\`, RootEntryPage \`AuthLoadingSpinner\`, DocsVaultPage 토폴로지 rebuilding chip — 3 군데의 pulse dot 이 outside-of-system 인디고 톤 (#8b97ff = \`rgba(139,151,255,*)\`) 을 hardcoded 로 박고 있었음
- 디자인 헌장의 단일 인디고 trio (brand #5e6ad2 / accent #7170ff / hover #828fff) 에서 벗어난 4번째 톤이라 불변 규칙 #4 ("hardcoded hex 금지 — \`var(--color-*)\` 만") + 헌장 §11 단일 채색 시스템 위반
- 7 callsite 모두 \`var(--color-indigo-accent)\` 로 교체. \`animate-pulse\` 자체가 opacity 1→0.5→1 키프레임을 주기 때문에 0.8/0.9 alpha 를 떼도 사용자 체감 깜빡임 동일

## Scope
- 솔리드 fill (pulse dot bg) 만. border alpha (0.24~0.6 6 variants) 는 다음 atomic
- popout-template.ts (별도 HTML 문서, 메인 앱 CSS var 미전파) 는 그대로 둠

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] \`grep "h-1.5 w-1.5 animate-pulse rounded-full bg-\[color:rgba(139"\` — 0 hits 남음