### PR TITLE
refactor: 문서 등록 toast 의 자동 추출 거짓말 제거 (mission v2 정렬)

### DIFF
--- a/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
+++ b/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
@@ -262,12 +262,12 @@ function NewDocumentContent() {
         sourceType: "manual",
         createdBy: user?.email ?? "unknown-admin",
       });
-      // 문서 등록 직후 추출 작업을 자동으로 큐에 올린다. "업로드 → 수동 시작"을
-      // 한 단계 없애 사용자 약속 "등록하면 노드로 쪼개진다"를 이행한다.
-      // 추출 실행은 document-detail 페이지의 autostart effect가 담당.
-      // 라우터 이동 전에 성공 toast 로 "등록됐구나" 확신 제공 — 페이지 전환
-      // 후 auto-extract 가 시작되기까지 몇 초는 blank 로 보일 수 있어 UX 중요.
-      toast.show(`"${title.trim()}" 등록 완료 · 자동 추출 시작합니다`, "success");
+      // 등록 후 detail 라우팅. jobStatus=autostart 는 detail 페이지의 activePanel
+      // 을 result 탭으로 자동 전환만 한다 (mission v2 에서 cloud LLM 추출 큐
+      // enqueueExtractionJob 흐름 제거 — 추출 자체가 사라진 자리에 결과 탭 자동
+      // 노출만 남음). ontology 노드 자체는 vault frontmatter 또는 빌더에서 직접
+      // 추가.
+      toast.show(`"${title.trim()}" 등록 완료`, "success");
       router.push(
         getKnowledgeDocumentDetailHref(documentId, null, {
           projectId: seededProjectId || projectIds[0] || undefined,


### PR DESCRIPTION
## Summary
- KnowledgeDocumentNewPage 의 등록 성공 toast 가 \`"\${title}" 등록 완료 · 자동 추출 시작합니다\` 인데 mission v2 에서 cloud LLM 추출 큐 (\`enqueueExtractionJob\` 등) 가 제거된 후로 추출 작업은 실제로 큐잉되지 않음
- \`jobStatus=autostart\` URL param 은 살아있지만 detail 페이지의 \`activePanel\` 을 result 탭으로 자동 전환하는 역할만 — 추출과 무관
- toast 카피를 \`"\${title}" 등록 완료\` 로 단축, 위쪽 stale 코멘트 5줄을 mission v2 사실 기술로 교체
- ontology 노드 추가 안내는 다른 surface (KnowledgeDashboardPage, KnowledgeDocumentDetailPage) 에서 이미 카피로 노출되므로 toast 에 더 얹지 않음

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] \`grep "자동 추출"\` user-visible — manifest excerpt 외 0 (코드 잔존 0)