### PR TITLE
refactor: insights / relations 페이지를 dogfood-priority hook 으로 (mission v2 효과 가시화)

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -6,8 +6,8 @@ import { useSearchParams } from "next/navigation";
 import {
   KNOWLEDGE_EDGE_TYPES,
   ManualSourceChip,
-  useKnowledgePublicInsight,
 } from "@/entities/knowledge-graph";
+import { useOntologyInsight } from "@/features/vault-ontology";
 import { getOntologyKindLabel } from "@/entities/ontology-class";
 import {
   buildActivityTimeline,
@@ -44,7 +44,7 @@ export function OntologyInsightsPage() {
   const searchParams = useSearchParams();
   const accountId = null;
 
-  const { insight, error } = useKnowledgePublicInsight(accountId);
+  const { insight, error } = useOntologyInsight(accountId);
 
   const kindDist = useMemo(
     () => (insight ? computeKindDistribution(insight.nodes) : new Map<string, number>()),

--- a/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
+++ b/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
@@ -3,10 +3,8 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import {
-  KNOWLEDGE_EDGE_TYPES,
-  useKnowledgePublicInsight,
-} from "@/entities/knowledge-graph";
+import { KNOWLEDGE_EDGE_TYPES } from "@/entities/knowledge-graph";
+import { useOntologyInsight } from "@/features/vault-ontology";
 import {
   computeEdgeTypeDistribution,
   selectStrongEdges,
@@ -35,7 +33,7 @@ export function OntologyRelationsPage() {
   const searchParams = useSearchParams();
   const accountId = null;
 
-  const { insight, error } = useKnowledgePublicInsight(accountId);
+  const { insight, error } = useOntologyInsight(accountId);
 
   // type 필터 — null 이면 전체. 분포 panel 의 행 클릭으로 toggle.
   const [selectedType, setSelectedType] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- \`/ontology/insights\` (kind 분포 · 허브 · 활동 · orphans · cross-project edges) 와 \`/ontology/relations\` (edge type 분포 · 강한 관계) 두 페이지가 mission v2 의 *"ontology 효과 가시화"* 핵심 surface 인데도 cloud-only legacy \`useKnowledgePublicInsight\` 를 직접 호출 → vault 안 고른 사용자도 빌드타임 dogfood 23 노드 가 surface 안 되고 빈 EmptyState 만 노출되던 회귀
- 이미 OntologyView (PR 진행 시점 이전) / WorkspaceOntologyStrip (PR #51) 이 옮겨간 \`useOntologyInsight\` (\`vault > 빌드타임 dogfood > Firestore\` 진실원 우선순위) 로 두 페이지도 교체. 시그니처 동일 — drop-in
- 결과: vault 비활성 / 비로그인 사용자도 첫 진입에 dogfood ontology 의 통계 / 분포 / 허브 / 관계가 즉시 보임 — Domain G ("ontology 효과를 5분 안에 체감") 약속 실현

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 files / 814 tests pass
- [x] \`curl /ontology/insights/\` → 200
- [x] \`curl /ontology/relations/\` → 200