### PR TITLE
refactor: 프로젝트·문서 인라인 ontology 카드의 v1 carrot 을 mission v2 진실로

### DIFF
--- a/src/widgets/document-ontology-evidence/ui/DocumentOntologyEvidenceSection.tsx
+++ b/src/widgets/document-ontology-evidence/ui/DocumentOntologyEvidenceSection.tsx
@@ -81,7 +81,7 @@ export function DocumentOntologyEvidenceSection({
         </p>
       ) : null}
       <p className="mt-3 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
-        검수 → 승인 흐름의 결과 — 이 문서가 어떤 개념·역량·요소의 evidence 로 반영되었는지 보여줍니다.
+        이 문서가 어떤 개념·역량·요소의 evidence 로 frontmatter 에서 참조되는지 보여줍니다.
       </p>
     </section>
   );

--- a/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
+++ b/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
@@ -105,7 +105,7 @@ export function ProjectOntologyOverview({
       ) : null}
 
       <p className="mt-3 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
-        문서로부터 추출 → 검수 → 승인된 개념·역량·요소. 이 프로젝트의 두 번째 척추.
+        vault frontmatter (또는 빌더) 가 키워낸 개념·역량·요소. 이 프로젝트의 두 번째 척추.
       </p>
     </section>
   );


### PR DESCRIPTION
## Summary
- ProjectOntologyOverview (project 상세 inline) 와 DocumentOntologyEvidenceSection (document 상세 inline) 의 하단 설명 카피가 mission v1 의 *"문서 → LLM 추출 → 검수 → 승인"* 4단계 약속을 그대로 들고 있음
- mission v2 는 "vault frontmatter 가 곧 그래프, 검수 단계 없음" — 두 카피 모두 지금 일어나지 않는 흐름을 사용자에게 약속하는 dead promise. 1원리 사고로 명백한 거짓말 surface
- 수정 2 줄 (사용자 가시 카피만):
  - ProjectOntologyOverview: \`문서로부터 추출 → 검수 → 승인된\` → \`vault frontmatter (또는 빌더) 가 키워낸\`
  - DocumentOntologyEvidenceSection: \`검수 → 승인 흐름의 결과 — ... evidence 로 반영\` → \`이 문서가 어떤 ... evidence 로 frontmatter 에서 참조되는지\`

## 남은 v1 carrot (이 PR scope 밖)
- FrontmatterGradeBadge (\`A · 자동 승인\` / \`B · 검수 후 승인\`)
- FrontmatterOnboarding (\`추출은 시도되지만 검수자 직접 검토 필수\`)
- 둘 다 v1 cloud LLM 추출 grade A/B/C 워크플로 자체의 surface — 위젯 자체 폐기 vs 의미 재정의 결정 필요한 상위 atomic

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 / 814 pass
- [x] \`grep "문서로부터 추출\|검수 → 승인"\` — 0 hits 남음