### PR TITLE
refactor: 빌더 4 UI 파일의 Track C-X ephemeral marker 정리

### DIFF
--- a/src/views/ontology-edit/ui/AtlasNode.tsx
+++ b/src/views/ontology-edit/ui/AtlasNode.tsx
@@ -3,7 +3,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 
 /**
- * Atlas custom node — C-8 디자인 폴리시.
+ * Atlas custom node — kind 별 디자인 폴리시.
  *
  * 디자인 헌장 §11 호환:
  * - 단일 인디고 alpha (hue 살짝 다름 — kind 별 차별화)

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -71,7 +71,7 @@ export function OntologyEditCanvas({
   );
 
   const allNodes: Node[] = useMemo(() => {
-    // C-8 — approved 노드도 atlas custom type 으로 변환 (kind 별 시각 톤)
+    // approved 노드도 atlas custom type 으로 변환 (kind 별 시각 톤)
     const approvedAtlas: Node[] = approvedNodes.map((n) => {
       // n.data.label 형식: "{kindLabel} · {title}". kind 추출 위해 변환.
       const data = n.data as { label?: string };
@@ -100,7 +100,7 @@ export function OntologyEditCanvas({
       width: 220,
       height: 64,
       draggable: true,
-      // C-6 — ephemeral 노드는 핸들 drag 로 edge 생성 가능
+      // ephemeral 노드는 핸들 drag 로 edge 생성 가능
       connectable: true,
       selectable: true,
     }));

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -57,7 +57,7 @@ import { OntologyInspector } from "./OntologyInspector";
 import { BuilderOnboarding } from "./BuilderOnboarding";
 
 /**
- * `/ontology/edit` — ERD canvas editor v1 (Track C-1~C-3).
+ * `/ontology/edit` — ERD canvas editor v1.
  *
  * SSR 회피: xyflow 내부 ResizeObserver / window 의존성 → `next/dynamic`
  * + `ssr: false` 로 client-only mount. Next.js 16 정적 export 와 호환.
@@ -168,7 +168,7 @@ export function OntologyEditPage() {
     [accountId, dataSourceMode, findById, removeNode, toast, vault],
   );
   const ephemeralSelected = findById(selectedId);
-  // C-5 — vault 모드에서는 selectedId 가 vault slug. manifest 에서 lookup
+  // vault 모드에서는 selectedId 가 vault slug. manifest 에서 lookup
   // 해 인스펙터에 frontmatter + array 키 (capabilities/elements/...) 까지
   // 함께 전달 (in-canvas rename + array 편집 가능).
   // 빌더 진실원 우선순위 (PR #43): live vault.manifest > 빌드타임 dogfood
@@ -224,7 +224,7 @@ export function OntologyEditPage() {
     [toast, vault],
   );
 
-  // C-5 — vault frontmatter array 키 (capabilities/elements/dependencies/
+  // vault frontmatter array 키 (capabilities/elements/dependencies/
   // relates) 편집. 빈 배열은 키 자체를 제거 (null) — frontmatter 깨끗.
   const editVaultArrayKey = useCallback(
     async (
@@ -263,7 +263,7 @@ export function OntologyEditPage() {
     [toast, vault],
   );
 
-  // C-5 fire — vault 노드 drag 좌표를 frontmatter.canvasPosition 으로 patch.
+  // vault 노드 drag 좌표를 frontmatter.canvasPosition 으로 patch.
   // 같은 사용자가 재방문 시 + AI agent (MCP) 가 같은 vault read 시 동일 좌표.
   // skipRefresh 로 manifest 재빌드 생략 — drag 직후 사용자 시각엔 캔버스 위치
   // 그대로라 깜빡임 없게. 다음 cold load 부터 canvasPosition 반영.
@@ -283,7 +283,7 @@ export function OntologyEditPage() {
     [toast, vault],
   );
 
-  // C-5 vault delete — MCP delete_concept 와 같은 정책: backlinks 가 있으면
+  // vault delete — MCP delete_concept 와 같은 정책: backlinks 가 있으면
   // confirm 단계에서 list 보여주고 사용자가 의식적으로 진행하게. force 플래그
   // 는 별도 UI 없이 confirm 한 번 — UI 자체가 사용자 의도 게이트.
   const deleteVaultDoc = useCallback(
@@ -323,7 +323,7 @@ export function OntologyEditPage() {
     ? `/ontology/?${ACCOUNT_QUERY_KEY}=${encodeURIComponent(accountId)}`
     : "/ontology/";
 
-  // C-14 keyboard shortcuts — Atlas 캔버스 단축키.
+  // Atlas 캔버스 단축키.
   // 스코프: input/textarea 포커스 시 비활성. 항상 ephemeral 만 영향.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -13,12 +13,12 @@ const FADE_MOTION = {
 };
 
 /**
- * Track C-4 + C-5 — 우측 inspector 패널.
+ * 우측 inspector 패널.
  *
  * 선택된 노드의 상세를 보여주고 편집 가능한 필드는 inline 편집.
  * v1 범위:
  * - ephemeral 노드: 이름 inline 편집 (local state, 저장 시 vault.md 작성)
- * - vault 노드 (C-5 신규): 이름 inline 편집, 저장 시 vault.updateFrontmatter
+ * - vault 노드: 이름 inline 편집, 저장 시 vault.updateFrontmatter
  * - approved 노드: read-only (cloud 모드 legacy)
  * - 미선택: 안내 placeholder
  */


### PR DESCRIPTION
## Summary
- forbidden.md §"문서" 의 *작업 history 주석 (\`audit A2\`, \`iter 18\`, \`Track D-cont-1\` 같은 ephemeral marker) 을 코드에 남기기 금지* 룰 위반
- PR #53 에서 palette 모듈 JSDoc 부분만 정리했고 나머지 빌더 UI 파일에 11 군데 (\`Track C-1~C-3\`, \`C-4 + C-5\`, \`C-5 신규\`, \`C-5 vault delete\`, \`C-5 fire\`, \`C-6\`, \`C-8\`, \`C-14\`) 가 남아있어 mission v2 cleanup 의 일관된 마무리로 일괄 제거
- 각 코멘트의 "왜 / 무엇" 본문은 그대로 유지, 트랙 prefix 만 제거 — 동작 변화 0

## 대상 (4 파일 / 11 라인)
- AtlasNode.tsx — module JSDoc \`C-8 디자인 폴리시\` → \`kind 별 디자인 폴리시\`
- OntologyInspector.tsx — module JSDoc \`Track C-4 + C-5\`, inline \`(C-5 신규)\`
- OntologyEditPage.tsx — JSDoc \`(Track C-1~C-3)\` + 5 줄 코멘트
- OntologyEditCanvas.tsx — 2 줄 코멘트

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 / 814 pass
- [x] \`grep "C-[0-9]\|Track C" src/views/ontology-edit/ui/*.tsx\` — 0 hits 남음