### PR TITLE
refactor: AtlasExportInput.approvedNodeIds dead prop + C-13 marker 제거

### DIFF
--- a/src/views/ontology-edit/lib/export-frontmatter.ts
+++ b/src/views/ontology-edit/lib/export-frontmatter.ts
@@ -2,22 +2,16 @@ import type { EphemeralNode } from "./use-ephemeral-nodes";
 import type { EphemeralEdge } from "./use-ephemeral-edges";
 
 /**
- * Atlas frontmatter export — C-13.
- *
- * 캔버스의 ephemeral + approved 노드/엣지를 단일 md 파일로 변환.
- * spec `2026-04-27-ontology-frontmatter-contract.md` 의 등급 A 형식과 호환:
+ * Atlas frontmatter export — 캔버스의 ephemeral 노드/엣지를 단일 md 파일로
+ * 변환. spec `2026-04-27-ontology-frontmatter-contract.md` 의 등급 A 형식과
+ * 호환:
  *
  * - 노드별 yaml frontmatter + 빈 본문 (사용자가 채울 수 있게)
  * - 엣지는 별도 `## 관계` 섹션에 list 로
- *
- * approved 노드 detail 은 page 단에서 미접근이라 ephemeral 만 본격 export.
- * approved 는 id 만 알 수 있어 reference 로만 표시.
  */
 export interface AtlasExportInput {
   ephemeralNodes: EphemeralNode[];
   ephemeralEdges: EphemeralEdge[];
-  /** approved 노드 id 목록 (선택, edge 의 from/to 가 approved 일 때만 reference). */
-  approvedNodeIds?: ReadonlyArray<string>;
   /** account id — 추적용 metadata. */
   accountId: string;
 }


### PR DESCRIPTION
## Summary
- \`AtlasExportInput.approvedNodeIds?: ReadonlyArray<string>\` 가 함수 body 에서 한 번도 안 읽히고 caller (OntologyEditPage 의 \`downloadAtlasFrontmatter\` 호출) 도 안 넘김 — declared but unused dead prop
- 옛 v1 cloud-approved 노드 reference 의도가 있었으나 wiring 없이 남음
- module JSDoc 의 \`C-13\` track marker (PR #61 sweep 누락 — lib/ 파일이라 ui/ 글롭에 안 잡혔음) + "ephemeral + approved" 표현 + "approved 노드 detail 은 page 단에서 미접근…" 두 줄 같이 정리

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 / 814 pass
- [x] \`grep "approvedNodeIds\|C-13" src/\` — 0 hits 남음