### PR TITLE
refactor: link-list-editor 의 hardcoded rgba 7 군데 → canonical token

### DIFF
--- a/src/shared/ui/link-list-editor.tsx
+++ b/src/shared/ui/link-list-editor.tsx
@@ -122,7 +122,7 @@ export function LinkListEditor({
       ))}
       {editable ? (
         adding ? (
-          <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-[color:rgba(139,151,255,0.35)] bg-[color:rgba(18,20,26,0.5)] px-3 py-3 md:flex-row md:items-center">
+          <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-[color:rgba(94,106,210,0.32)] bg-[color:var(--color-overlay-1)] px-3 py-3 md:flex-row md:items-center">
             <input
               ref={labelRef}
               type="text"
@@ -130,7 +130,7 @@ export function LinkListEditor({
               onChange={(e) => setDraftLabel(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="라벨 (예: 운영 대시보드)"
-              className="flex-1 rounded-md border border-[color:var(--color-divider)] bg-[color:rgba(11,12,14,0.6)] px-2 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:rgba(139,151,255,0.5)]"
+              className="flex-1 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-canvas)] px-2 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:var(--color-indigo-brand)]"
             />
             <input
               type="url"
@@ -138,7 +138,7 @@ export function LinkListEditor({
               onChange={(e) => setDraftUrl(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="https://..."
-              className="flex-1 rounded-md border border-[color:var(--color-divider)] bg-[color:rgba(11,12,14,0.6)] px-2 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:rgba(139,151,255,0.5)]"
+              className="flex-1 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-canvas)] px-2 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:var(--color-indigo-brand)]"
             />
             <div className="flex shrink-0 items-center gap-1">
               <button
@@ -161,7 +161,7 @@ export function LinkListEditor({
           <button
             type="button"
             onClick={() => setAdding(true)}
-            className="inline-flex items-center justify-center gap-1 self-start rounded-2xl border border-dashed border-[color:var(--color-border-strong)] bg-transparent px-3 py-2 text-xs text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex items-center justify-center gap-1 self-start rounded-2xl border border-dashed border-[color:var(--color-border-strong)] bg-transparent px-3 py-2 text-xs text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
             aria-label="링크 추가"
           >
             <Plus size={11} />


### PR DESCRIPTION
## Summary
- shared/ui/link-list-editor.tsx (form surface 가 가져다 쓰는 shared primitive) 가 디자인 헌장 단일 인디고 trio 밖의 #8b97ff (\`rgba(139,151,255,*)\`) + 하드코딩 surface bg (\`rgba(18,20,26,0.5)\`, \`rgba(11,12,14,0.6)\`) 를 7 군데에 박아두고 있었음
- 불변 규칙 #4 ("hardcoded hex 금지 — \`var(--color-*)\` 만") + 헌장 §11 단일 채색 시스템 위반
- 이 파일 안에서만 정리 — shared/ui 다른 primitive (chip-list-editor / inline-editable / toast) 는 별도 atomic

## Mapping
- 외곽 dashed border #8b97ff/0.35 → \`rgba(94,106,210,0.32)\` (브랜드 alpha, 같은 파일 line 95 와 일치)
- panel bg \`rgba(18,20,26,0.5)\` → \`var(--color-overlay-1)\`
- input bg \`rgba(11,12,14,0.6)\` (×2) → \`var(--color-canvas)\`
- focus border #8b97ff/0.5 (×2) → \`var(--color-indigo-brand)\` (OntologyInspector focus pattern 과 일치)
- "+ 링크 추가" 버튼 hover border #8b97ff/0.35 → \`rgba(94,106,210,0.32)\`

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 115 / 814 pass
- [x] \`grep "rgba(139,151,255\|rgba(18,20,26\|rgba(11,12,14)" src/shared/ui/link-list-editor.tsx\` — 0 hits 남음