### PR TITLE
refactor: ProjectOntologyOverview 를 dogfood-priority hook 으로 (mission v2 효과 가시화)

### DIFF
--- a/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
+++ b/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
@@ -2,13 +2,14 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { ManualSourceChip, useKnowledgePublicNodes } from "@/entities/knowledge-graph";
+import { ManualSourceChip } from "@/entities/knowledge-graph";
 import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyInsight } from "@/features/vault-ontology";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { buildMeaningfulOntologyStats } from "@/shared/lib/ontology-tree";
 
 export interface ProjectOntologyOverviewProps {
-  /** 공개 surface — accountId 는 보통 null (projection 은 accountId 없으면 demo). */
+  /** 공개 surface — accountId 는 보통 null (vault/static 사용자는 항상 null). */
   accountId: string | null;
   projectSlug: string;
   /** 옵션 — sample 노드 표시 limit. 기본 6. */
@@ -18,9 +19,10 @@ export interface ProjectOntologyOverviewProps {
 /**
  * 프로젝트 상세 페이지 inline 카드 — "이 프로젝트에 자란 ontology 노드 N".
  *
- * `knowledgePublicNodes` 자체 구독 + `projectIds.includes(projectSlug)` 필터.
- * project / document kind 는 메타라 sample 에서 제외 (capability / element / domain
- * 위주). 매치 0 은 자체 숨김.
+ * `useOntologyInsight` (vault > 빌드타임 dogfood > Firestore 진실원 우선순위)
+ * 의 nodes 를 `projectIds.includes(projectSlug)` 로 필터. project / document
+ * kind 는 메타라 sample 에서 제외 (capability / element / domain 위주). 매치
+ * 0 은 자체 숨김 — vault / dogfood / cloud 어느 모드든 매치만 있으면 surface.
  *
  * 클릭 시 `/ontology/?account=...` 점프 — 트리에서 해당 프로젝트 root 로 진입.
  */
@@ -29,7 +31,8 @@ export function ProjectOntologyOverview({
   projectSlug,
   limit = 6,
 }: ProjectOntologyOverviewProps) {
-  const nodes = useKnowledgePublicNodes(accountId);
+  const { insight } = useOntologyInsight(accountId);
+  const nodes = insight?.nodes ?? [];
 
   const matched = useMemo(
     () => nodes.filter((n) => n.projectIds.includes(projectSlug)),


### PR DESCRIPTION
## Summary
- \`/project/[slug]\` 페이지 inline 카드 ("이 프로젝트에 자란 ontology 노드 N") 가 cloud-only legacy \`useKnowledgePublicNodes\` 를 직접 호출 → vault 활성 사용자 + 빌드타임 dogfood 사용자 모두 카드가 빈 카운트로 자동 숨김 → 프로젝트 페이지에서 ontology 효과 가시 0
- PR #57 (insights / relations) 와 같은 패턴 — cloud-only → dogfood-priority \`useOntologyInsight\` (\`vault > 빌드타임 dogfood > Firestore\`)
- vault 활성 사용자가 자기 프로젝트 페이지에서 ontology 노드 카운트 + sample + kind 분포 chip 즉시 보임 — Domain G "ontology 효과 5분 안에 체감" 약속이 project 상세 surface 에 확장

## 남은 \`useKnowledgePublicNodes\` 콜러 (별도 atomic)
- DashboardOntologySummary (\`/knowledge\` dashboard)
- DocumentOntologyEvidenceSection (document 상세)
- DocumentNewOntologyHints (cloud-only 페이지 — migration 가치 낮음)
- SigmaTopology (project borderColor 보조 시각화)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass
- 라이브 smoke: dogfood project URL 은 정적 export 에서 generateStaticParams (Firestore-only) 미포함이라 우회 — 패턴이 PR #57 (이미 라이브 smoke 통과) 과 동일하므로 typecheck + tests 로 충분