### PR TITLE
refactor: OperationsNav 의 nav 툴팁 3개 mission v2 진실로

### DIFF
--- a/src/widgets/operations-nav/ui/OperationsNav.tsx
+++ b/src/widgets/operations-nav/ui/OperationsNav.tsx
@@ -36,17 +36,17 @@ function buildItems(mode: 'static' | 'local' | 'cloud'): ReadonlyArray<NavItem> 
       label: '문서',
       description:
         mode === 'local'
-          ? '내 vault 의 .md 들 — 직접 편집하면 즉시 ontology stub 으로 자람'
+          ? '내 vault 의 .md 들 — frontmatter `kind:` 만 적으면 즉시 ontology 노드'
           : '문서 등록 + frontmatter 또는 빌더에서 ontology 노드 추가',
       basePath: docsBase,
       prefixes: ['/knowledge', '/docs'],
     },
-    // ontology view — 승인된 노드/관계의 트리. mission 의 척추.
+    // ontology view — vault frontmatter 노드/관계의 트리. mission 의 척추.
     // / 도 OntologyViewPage 를 렌더하므로 prefix 에 양쪽 포함.
     {
       id: 'ontology',
       label: '온톨로지',
-      description: '승인된 노드·관계의 계층 그래프 (project → domain → capability → element)',
+      description: 'vault frontmatter 의 노드·관계 계층 그래프 (project → domain → capability → element)',
       basePath: '/',
       prefixes: ['/ontology'],
     },
@@ -63,7 +63,7 @@ function buildItems(mode: 'static' | 'local' | 'cloud'): ReadonlyArray<NavItem> 
     {
       id: 'settings',
       label: '정리',
-      description: '카테고리 / 상태 / API 키 / 프로젝트 import 같은 공간 설정',
+      description: '카테고리 / 상태 / 프로젝트 import 같은 공간 설정',
       basePath: '/settings/categories/',
       prefixes: ['/settings'],
     },


### PR DESCRIPTION
## Summary
- 전체 페이지 상단의 운영 nav 툴팁 (mouse hover 안내) 이 mission v1 잔존 표현을 들고 있어 사용자가 nav 클릭 전에 거짓 mental model 받음 — Domain B 직격
- 3 개 항목 정렬:
  - \`knowledge\` (local): "ontology **stub** 으로 자람" → "frontmatter \`kind:\` 만 적으면 즉시 ontology 노드" (PR #67 의 stub 어휘 정리와 정렬)
  - \`ontology\`: "**승인된** 노드·관계" → "vault frontmatter 의 노드·관계" (mission v2 는 검수/승인 단계 없음)
  - \`settings\`: "카테고리 / 상태 / **API 키** / 프로젝트 import" → "카테고리 / 상태 / 프로젝트 import" (\`/settings/\` 하위에 API 키 surface 자체가 없음 — 추출 워커 폐기 후 잔존)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass