### PR TITLE
refactor: 빌더 인스펙터 빈 상태 카피를 actionable 로

### DIFF
--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -99,7 +99,7 @@ export function OntologyInspector({
           Inspector
         </p>
         <p className="mt-1 text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
-          캔버스에서 노드를 클릭하면 상세가 여기에 보여요.
+          선택한 노드의 상세 + 인라인 편집.
         </p>
       </header>
       <AnimatePresence mode="wait">
@@ -110,7 +110,7 @@ export function OntologyInspector({
             className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-elevated)] p-3"
           >
             <p className="text-[12px] leading-5 text-[color:var(--color-text-quaternary)]">
-              아직 선택된 노드가 없어요.
+              왼쪽 palette 에서 종류를 클릭해 첫 노드를 만들거나, 캔버스의 노드를 클릭하면 상세가 여기에 보여요.
             </p>
           </motion.div>
         ) : ephemeralSelected ? (


### PR DESCRIPTION
## Summary
- 빌더 인스펙터의 header subtitle ("캔버스에서 노드를 클릭하면 상세가 여기에 보여요") 와 빈 상태 placeholder ("아직 선택된 노드가 없어요") 가 같은 정보를 두 번 말하면서, 정작 첫 사용자가 *어떻게 첫 노드를 만들지* 는 안내 0
- BuilderOnboarding modal 이 닫히면 인스펙터 한쪽만 들여다보는 사용자는 막힘

## 변경
- header subtitle → 중립 부제 ("선택한 노드의 상세 + 인라인 편집.")
- 빈 placeholder → create + select 양쪽 안내 ("왼쪽 palette 에서 종류를 클릭해 첫 노드를 만들거나, 캔버스의 노드를 클릭하면 상세가 여기에 보여요.")

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass
- [x] 라이브 smoke: \`/ontology/edit/\` → 200