### PR TITLE
refactor: OperationsNav 의 dead accountId prop + searchParams · resolvedAccountId 제거

### DIFF
--- a/src/views/diagnostics-insights/ui/InsightsPage.tsx
+++ b/src/views/diagnostics-insights/ui/InsightsPage.tsx
@@ -102,7 +102,7 @@ function InsightsContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">오늘 챙길 곳</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-5xl px-5 py-6 md:px-12 md:py-10">
         <header className="flex flex-col gap-2">
           <h1 className="break-keep text-[28px] font-[var(--font-weight-signature)] tracking-[var(--tracking-section)] text-[color:var(--color-text-primary)] md:text-3xl">

--- a/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
+++ b/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
@@ -121,7 +121,7 @@ function DashboardContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">문서</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       {/* ⌘K 글로벌 검색 — 대시보드에서도 ontology · 문서 빠르게 점프. */}
       <MountedGlobalSearch accountId={accountId} returnTo="/knowledge/" />
       <div className="mx-auto max-w-6xl px-5 py-6 md:px-12 md:py-10">

--- a/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
+++ b/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
@@ -471,7 +471,7 @@ function DetailContent({ documentId, returnTo }: Props) {
 
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       {/* ⌘K 글로벌 검색 — 문서 보다가 ontology · 다른 문서 빠르게 점프. */}
       <MountedGlobalSearch
         accountId={accountId}

--- a/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
+++ b/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
@@ -293,7 +293,7 @@ function NewDocumentContent() {
 
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
-      <OperationsNav accountId={null} />
+      <OperationsNav />
       <div className="mx-auto max-w-3xl px-5 py-6 md:px-12 md:py-10">
         <div>
           <h1 className="text-2xl font-[var(--font-weight-signature)] tracking-[var(--tracking-section)] text-[color:var(--color-text-primary)] md:text-4xl">

--- a/src/views/knowledge-documents/ui/KnowledgeDocumentsPage.tsx
+++ b/src/views/knowledge-documents/ui/KnowledgeDocumentsPage.tsx
@@ -189,7 +189,7 @@ function DocumentsContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">문서 목록</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       {/* ⌘K 글로벌 검색 — accountId 만 받고 ontology + documents 자체 구독.
           기본 동작 = ontology 노드는 /ontology 점프, document 는 view 페이지 점프. */}
       <MountedGlobalSearch accountId={accountId} returnTo="/knowledge/documents/" />

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -127,7 +127,7 @@ export function OntologyInsightsPage() {
 
   return (
     <div>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-12">
       <MountedGlobalSearch accountId={accountId} returnTo="/ontology/insights/" />
 

--- a/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
+++ b/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
@@ -65,7 +65,7 @@ export function OntologyRelationsPage() {
 
   return (
     <div>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-12">
       <MountedGlobalSearch accountId={accountId} returnTo="/ontology/relations/" />
 

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -168,7 +168,7 @@ export function OntologyViewPage() {
       {/* OperationsNav 는 풀폭으로 (다른 운영 페이지 — /knowledge 등 — 과
           동일 정렬). 이전엔 본문 max-w 안에 같이 갇혀 좌우 여백이 크게 잡혀
           가운데로 몰려 보이는 회귀가 있었음. */}
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-12">
       <section className="mb-8 space-y-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">

--- a/src/views/settings-categories/ui/CategoriesPage.tsx
+++ b/src/views/settings-categories/ui/CategoriesPage.tsx
@@ -430,7 +430,7 @@ function CategoriesContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">카테고리 관리</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-6xl px-5 py-6 md:px-12 md:py-10">
         <Link
           href={safeReturnTo}

--- a/src/views/settings-hub/ui/SettingsHubPage.tsx
+++ b/src/views/settings-hub/ui/SettingsHubPage.tsx
@@ -88,7 +88,7 @@ function SettingsHubContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">정리</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
 
       <div className="mx-auto w-full max-w-3xl px-5 py-6 md:px-10 md:py-10">
         <header>

--- a/src/views/settings-ontology-history/ui/SettingsOntologyHistoryPage.tsx
+++ b/src/views/settings-ontology-history/ui/SettingsOntologyHistoryPage.tsx
@@ -63,7 +63,7 @@ function SettingsOntologyHistoryContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">온톨로지 schema 히스토리</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
 
       <div className="mx-auto w-full max-w-3xl px-5 py-6 md:px-10 md:py-10">
         <header className="mb-6">

--- a/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
+++ b/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
@@ -71,7 +71,7 @@ function SettingsOntologyContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">온톨로지 schema</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
 
       <div className="mx-auto w-full max-w-3xl px-5 py-6 md:px-10 md:py-10">
         <header className="mb-6 flex flex-wrap items-start justify-between gap-3">

--- a/src/views/settings-statuses/ui/StatusesPage.tsx
+++ b/src/views/settings-statuses/ui/StatusesPage.tsx
@@ -409,7 +409,7 @@ function StatusesContent() {
   return (
     <main className="min-h-screen bg-[color:var(--color-canvas)]">
       <h1 className="sr-only">상태 관리</h1>
-      <OperationsNav accountId={accountId} />
+      <OperationsNav />
       <div className="mx-auto max-w-5xl px-5 py-6 md:px-12 md:py-10">
         <Link
           href={safeReturnTo}

--- a/src/widgets/operations-nav/ui/OperationsNav.tsx
+++ b/src/widgets/operations-nav/ui/OperationsNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { signOut } from '@/features/user-auth';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useLocalVault } from '@/features/docs-vault-local';
@@ -9,8 +9,6 @@ import { ThemeToggle } from '@/features/theme-toggle';
 import { Button, Tooltip } from '@/shared/ui';
 
 interface OperationsNavProps {
-  /** 명시 accountId. 미지정 시 ?account 쿼리에서 자동 해석. */
-  accountId?: string | null;
   /** 우측 보조 컨트롤 (예: 워크스페이스 selector). 미지정 시 생략. */
   rightSlot?: React.ReactNode;
 }
@@ -145,16 +143,11 @@ function ModeBadge({ mode }: { mode: 'static' | 'local' | 'cloud' }) {
   );
 }
 
-export function OperationsNav({ accountId, rightSlot }: OperationsNavProps) {
+export function OperationsNav({ rightSlot }: OperationsNavProps) {
   const pathname = usePathname() ?? '';
-  const searchParams = useSearchParams();
   const router = useRouter();
   const dataSourceMode = useDataSourceMode();
   const items = buildItems(dataSourceMode);
-  // hook 은 조건부 호출 금지 — prop 우선 분기는 호출 후에 적용.
-  const queryAccountId = null;
-  const resolvedAccountId =
-    accountId !== undefined ? accountId : queryAccountId;
 
   // 로그아웃 후 /login/ 으로 명시 redirect — 이전엔 같은 페이지에 머물러 데이터가
   // 조용히 사라지는 회귀. PermissionGate 가 있는 페이지는 자동 fallback


### PR DESCRIPTION
## Summary
- OperationsNav 가 (1) \`accountId\` prop 을 받아 \`resolvedAccountId\` 로 가공한 뒤 어디서도 안 쓰고 (2) \`searchParams\` 도 호출만 하고 안 쓰는 잔존 dead code. mission v2 single-user 전환에서 multi-account scope 분기가 폐기됐는데 이 파일만 정리 안 된 상태였음. lint 가 두 줄 모두 no-unused-vars 경고 중이었음
- 14 파일 정리 (위젯 1 + caller 13). 각 페이지의 \`accountId\` 자체는 다른 컴포넌트가 쓰므로 그대로 둠

## 변경
- \`OperationsNavProps.accountId\` 폐기
- \`useSearchParams\` import + 호출 제거
- \`queryAccountId = null\` + \`resolvedAccountId\` 5 줄 제거
- "hook 은 조건부 호출 금지..." misleading comment 제거 (실제 조건부 호출 0)
- 13 caller 페이지에서 \`<OperationsNav accountId={...} />\` 의 prop pass 제거

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass
- [x] \`pnpm lint\` — OperationsNav 관련 경고 0 (\`grep operations-nav\` 0 hit), 전체 lint 0 errors