### PR TITLE
refactor: chip-list-editor 의 hardcoded rgba 3 군데 → canonical token

### DIFF
--- a/src/shared/ui/chip-list-editor.tsx
+++ b/src/shared/ui/chip-list-editor.tsx
@@ -139,13 +139,13 @@ export function ChipListEditor({
             onBlur={commit}
             onKeyDown={handleKeyDown}
             placeholder={placeholder}
-            className="rounded-full border border-[color:rgba(139,151,255,0.35)] bg-[color:var(--color-elevated)] px-3 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:rgba(139,151,255,0.6)]"
+            className="rounded-full border border-[color:rgba(94,106,210,0.32)] bg-[color:var(--color-elevated)] px-3 py-1.5 text-xs text-[color:var(--color-text-primary)] outline-none focus:border-[color:var(--color-indigo-brand)]"
           />
         ) : (
           <button
             type="button"
             onClick={() => setAdding(true)}
-            className="inline-flex items-center gap-1 rounded-full border border-dashed border-[color:var(--color-border-strong)] bg-transparent px-3 py-1.5 text-xs text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex items-center gap-1 rounded-full border border-dashed border-[color:var(--color-border-strong)] bg-transparent px-3 py-1.5 text-xs text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
             aria-label="새 항목 추가"
           >
             <Plus size={11} />


### PR DESCRIPTION
## Summary
- shared/ui/chip-list-editor.tsx (taxonomy chip 입력 등 form surface 에서 가져다 쓰는 shared primitive) 가 단일 인디고 trio 밖의 #8b97ff (\`rgba(139,151,255,*)\`) 를 input border / focus / button hover 3 군데에 박아두고 있었음
- 불변 규칙 #4 ("hardcoded hex 금지 — \`var(--color-*)\` 만") + 헌장 §11 위반
- PR #63 (link-list-editor) 와 같은 mapping 적용

## Mapping
- input border #8b97ff/0.35 → \`rgba(94,106,210,0.32)\` (브랜드 alpha)
- input focus border #8b97ff/0.6 → \`var(--color-indigo-brand)\`
- "+ 추가" 버튼 hover border #8b97ff/0.35 → \`rgba(94,106,210,0.32)\`

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass
- [x] \`grep "rgba(139,151,255" src/shared/ui/chip-list-editor.tsx\` — 0 hits 남음