### PR TITLE
docs: KnowledgeGraphSource JSDoc 을 mission v2 truth 로

### DIFF
--- a/src/entities/knowledge-graph/model/types.ts
+++ b/src/entities/knowledge-graph/model/types.ts
@@ -39,9 +39,15 @@ export function isKnowledgeEdgeType(value: unknown): value is KnowledgeEdgeType 
 }
 
 /**
- * 노드/엣지의 출처. v0 백본은 모두 추출-검수-승인 거친 결과 (`extraction`).
- * Manual editor v0 (B 라인) 부터 사용자가 직접 만든 `manual` 값이 추가된다.
- * 옵션 필드 — legacy 데이터는 `undefined`, UI 가 `extraction` 기본값으로 처리.
+ * 노드/엣지의 출처.
+ *
+ * - `manual` — mission v2 의 표준 값. vault frontmatter 자체 + 빌더 추가 +
+ *   MCP write 모두 사람/AI agent 의 *직접 작성* 이라 동일 출처로 분류.
+ * - `extraction` — v1 cloud LLM 추출 워커의 결과 표식. mission v2 에서
+ *   추출 큐 (\`enqueueExtractionJob\` 등) 가 폐기되어 신규 할당은 일어나지
+ *   않으나, Firestore legacy 데이터에 남은 값을 호환 위해 enum 에 보존.
+ *
+ * 옵션 필드 — legacy 데이터는 \`undefined\`, UI 가 \`extraction\` 기본값으로 처리.
  */
 export type KnowledgeGraphSource = 'manual' | 'extraction';
 


### PR DESCRIPTION
## Summary
- \`KnowledgeGraphSource\` (entity 타입) 의 JSDoc 이 v0 mental model — "v0 백본은 모두 추출-검수-승인 거친 결과 (\`extraction\`)" — 을 들고 있어 entity 타입을 처음 읽는 contributor / AI agent 가 그 시퀀스를 사실로 받아들이게 됨
- mission v2: 추출 큐 (\`enqueueExtractionJob\` 등) 폐기, frontmatter 자체-승인 정책으로 전환. type 헤더만 동기화 안 됨

## After
- \`manual\` — vault frontmatter / 빌더 / MCP write 의 통합 *사람·AI agent 직접 작성* 출처 (mission v2 표준 값)
- \`extraction\` — *legacy 호환 보존*. 신규 할당 0, Firestore 옛 데이터에만 존재
- v1 의 "추출-검수-승인" 시퀀스 표현 제거

타입/enum 값 자체는 그대로 (legacy 데이터 호환). 동작 변화 0.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass