### PR TITLE
refactor: DashboardOntologySummary 를 dogfood-priority hook 으로 (mission v2 효과 가시화)

### DIFF
--- a/src/widgets/dashboard-ontology-summary/ui/DashboardOntologySummary.tsx
+++ b/src/widgets/dashboard-ontology-summary/ui/DashboardOntologySummary.tsx
@@ -3,8 +3,9 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { Network } from "lucide-react";
-import { ManualSourceChip, useKnowledgePublicNodes } from "@/entities/knowledge-graph";
+import { ManualSourceChip } from "@/entities/knowledge-graph";
 import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyInsight } from "@/features/vault-ontology";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import {
   buildMeaningfulOntologyStats,
@@ -18,14 +19,16 @@ export interface DashboardOntologySummaryProps {
 /**
  * `/knowledge` 대시보드 inline 카드 — ontology 의 큰 요약.
  *
- * 자체 `subscribeKnowledgePublicGraph` 구독. kind 분포 grid + 최근 활동 5 +
- * "전체 트리 →" / "인사이트 →" 두 진입점. 권한 없거나 빈 ontology 면 자동 숨김.
+ * `useOntologyInsight` (vault > 빌드타임 dogfood > Firestore 진실원
+ * 우선순위) 구독. kind 분포 grid + 최근 활동 5 + "전체 트리 →" / "인사이트 →"
+ * 두 진입점. 빈 ontology 면 자동 숨김.
  *
- * `WorkspaceOntologyStrip` (한 줄 stat) 와 다르게 — 이 카드는 dashboard 의
- * 큰 panel 단위, 사용자가 ontology 상태를 dashboard 에서 깊게 본다.
+ * `WorkspaceOntologyStrip` (한 줄 stat) 와 다르게 — 이 카드는 dashboard
+ * 의 큰 panel 단위, 사용자가 ontology 상태를 dashboard 에서 깊게 본다.
  */
 export function DashboardOntologySummary({ accountId }: DashboardOntologySummaryProps) {
-  const nodes = useKnowledgePublicNodes(accountId);
+  const { insight } = useOntologyInsight(accountId);
+  const nodes = insight?.nodes ?? [];
 
   const stats = useMemo(() => buildMeaningfulOntologyStats(nodes), [nodes]);
   const recent = useMemo(() => selectRecentNodes(nodes, 5), [nodes]);


### PR DESCRIPTION
## Summary
- \`/knowledge\` 대시보드 inline 카드 (kind 분포 grid + 최근 활동 5 + 트리·인사이트 진입) 가 cloud-only legacy \`useKnowledgePublicNodes\` 직접 호출 → vault/static 사용자 모두 대시보드에서 빈 카운트로 자체 숨김 → ontology 효과 가시 0
- PR #57 (insights/relations) / PR #65 (project overview) 와 같은 패턴 — \`useOntologyInsight\` (\`vault > 빌드타임 dogfood > Firestore\`) drop-in 교체

## 남은 cloud-only \`useKnowledgePublicNodes\` 콜러 (별도 atomic)
- DocumentOntologyEvidenceSection (document 상세)
- DocumentNewOntologyHints (cloud-only 페이지 — migration 가치 낮음)
- SigmaTopology (project borderColor 보조 시각화)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass
- [x] 라이브 smoke: \`/knowledge/\` → 200, 카드 정상 렌더