### PR TITLE
refactor: MCP vault.mjs 의 NEIGHBOR_KEYS 를 module-level 상수로 hoist

### DIFF
--- a/mcp/src/vault.mjs
+++ b/mcp/src/vault.mjs
@@ -15,6 +15,21 @@ import { join, relative, dirname } from 'node:path';
 import { parseFrontmatter, buildMarkdown } from './parser.mjs';
 
 /**
+ * frontmatter 의 array 키 중 *그래프 엣지로 해석되는* 6 개. 새 edge 타입을
+ * 추가하면 (e.g. 'aggregates', 'implements') 여기만 갱신하면 findOrphans /
+ * findPath 등 모두 자동 cover. 예전에 두 함수가 각자 로컬로 같은 배열을
+ * 들고 있어 drift 위험.
+ */
+const NEIGHBOR_KEYS = Object.freeze([
+  'capabilities',
+  'elements',
+  'dependencies',
+  'relates',
+  'contains',
+  'describes',
+]);
+
+/**
  * vault root 안의 모든 `.md` 파일 walk. dotfile / node_modules 등 제외.
  * 반환: 각 파일의 절대 경로.
  */
@@ -211,14 +226,6 @@ export function findOrphans(rootPath, options = {}) {
       ? options.excludeKinds
       : ['vault-readme'],
   );
-  const NEIGHBOR_KEYS = [
-    'capabilities',
-    'elements',
-    'dependencies',
-    'relates',
-    'contains',
-    'describes',
-  ];
   const slugs = new Set(docs.map((d) => d.slug));
   const tailToFull = new Map();
   for (const slug of slugs) {
@@ -300,14 +307,6 @@ export function findPath(rootPath, fromSlug, toSlug, maxHops = 5) {
     }
     return null;
   }
-  const NEIGHBOR_KEYS = [
-    'capabilities',
-    'elements',
-    'dependencies',
-    'relates',
-    'contains',
-    'describes',
-  ];
   const adj = new Map();
   function addEdge(a, b) {
     if (!adj.has(a)) adj.set(a, new Set());


### PR DESCRIPTION
## Summary
- \`findOrphans\` 와 \`findPath\` 두 함수가 동일한 6 개 frontmatter array 키 배열 (\`capabilities\`, \`elements\`, \`dependencies\`, \`relates\`, \`contains\`, \`describes\`) 을 각자 *로컬* 로 들고 있어 새 edge 타입 추가 시 두 군데 모두 바꿔야 하는 drift 위험
- mission v2 가 향후 다른 edge 타입 (e.g. \`aggregates\`, \`implements\`) 추가할 가능성 있어 미리 정리 — Domain H "MCP cover 영역" 의 maintainability 정렬

## 수정
- module-level \`NEIGHBOR_KEYS = Object.freeze([...])\` 로 hoist (immutable)
- 두 함수 안의 로컬 정의 제거, 같은 const 참조

## Test plan
- [x] MCP verify CLI: 11/11 tools + 23 노드 — find_orphans / find_path 모두 정상 (둘 다 NEIGHBOR_KEYS 의존)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 114 / 807 pass