### PR TITLE
refactor: ProjectEditorPage 의 toast 3 개를 noun-form 으로 (OntologyEditPage 컨벤션 정렬)

### DIFF
--- a/src/views/project-editor/ui/ProjectEditorPage.tsx
+++ b/src/views/project-editor/ui/ProjectEditorPage.tsx
@@ -141,7 +141,7 @@ function EditorContent({
     if (mode === "create") {
       await projectMutations.createProject(payload);
       if (options.behavior === "stay") {
-        toast.show(`"${input.name}" 만들었습니다 · 이제 보강하세요`, "success");
+        toast.show(`"${input.name}" 생성 · 편집 화면에서 세부 정보 채우기`, "success");
         router.replace(buildEditHref(input.slug));
         return;
       }
@@ -158,7 +158,7 @@ function EditorContent({
   const handleDelete = async () => {
     if (!slug) return;
     await projectMutations.deleteProject(slug);
-    toast.show("프로젝트를 삭제했습니다", "success");
+    toast.show("프로젝트 삭제", "success");
     router.push(safeReturnTo);
   };
 


### PR DESCRIPTION
## Summary
- ProjectEditorPage 의 3 개 toast 가 honorific 양식이 섞여 있고 첫 번째는 "이제 보강하세요" 라는 vague 한 다음-단계 안내
- 같은 페이지에 \`-습니다\` 양식 (생성·삭제) + noun-form (저장 완료) + \`-하세요\` 양식 (보강하세요) 3 종 혼용
- 같은 \`/edit/\` 패턴인 OntologyEditPage 의 noun-form 컨벤션 ("저장 완료" / "삭제") 으로 정렬 + 구체 next-step 안내

## 변경
- 생성: "...만들었습니다 · 이제 보강하세요" → "...생성 · 편집 화면에서 세부 정보 채우기" (사용자가 router.replace 로 막 들어선 편집 화면에서 *무엇을 할지* 구체적)
- 저장: 그대로 "저장 완료"
- 삭제: "프로젝트를 삭제했습니다" → "프로젝트 삭제"

규칙 #B "토스트 메시지 정확? vague 한 message 대신 구체" 정렬.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 113 / 789 pass