### PR TITLE
refactor: 빌더 lib/ 의 Track C-X marker + Firestore persist 카피 sweep

### DIFF
--- a/src/views/ontology-edit/lib/use-ephemeral-edges.ts
+++ b/src/views/ontology-edit/lib/use-ephemeral-edges.ts
@@ -4,9 +4,11 @@ import { useCallback, useState } from "react";
 import type { Connection } from "@xyflow/react";
 
 /**
- * Track C-6 — palette 노드 핸들에서 drag 해 만드는 임시 edge.
+ * palette 노드 핸들에서 drag 해 만드는 임시 edge.
  *
- * Firestore persist 는 C-7 fire 에서. 새로고침 시 사라짐 (의도).
+ * 캔버스 안 in-memory 상태 — 새로고침 시 사라짐 (의도). 영구화는 인스펙터에서
+ * 저장 시 vault 의 .md frontmatter 배열 키 (capabilities / elements /
+ * dependencies / relates) 에 직접 append.
  */
 export interface EphemeralEdge {
   id: string;

--- a/src/views/ontology-edit/lib/use-ephemeral-nodes.ts
+++ b/src/views/ontology-edit/lib/use-ephemeral-nodes.ts
@@ -4,10 +4,11 @@ import { useCallback, useState } from "react";
 import type { ManualNodeKind } from "@/entities/knowledge-graph";
 
 /**
- * Track C-3 — palette 클릭으로 추가하는 임시 노드 상태.
+ * palette 클릭으로 추가하는 임시 노드 상태.
  *
- * Firestore persist 는 C-4/C-5 fire 에서. 새로고침 시 사라짐 (의도).
- * id 충돌 회피 위해 timestamp + random suffix.
+ * 캔버스 안 in-memory 상태 — 새로고침 시 사라짐 (의도). 영구화는 인스펙터에서
+ * 이름 입력 + 저장 시 vault 의 \`{kind}s/{slug}.md\` 작성 (mission v2: vault
+ * frontmatter 가 진실원). id 충돌 회피 위해 timestamp + random suffix.
  */
 export interface EphemeralNode {
   id: string;

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -96,7 +96,7 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
       },
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
-      // C-5 fire — drag 활성. drag-stop 시 page 가 frontmatter.canvasPosition patch.
+      // drag 활성. drag-stop 시 page 가 frontmatter.canvasPosition patch.
       draggable: true,
       // edge 재생성은 vault 진실원 보호 위해 비활성. 인스펙터/frontmatter 수정.
       connectable: false,


### PR DESCRIPTION
## Summary
- PR #61 (UI files) + PR #62 (export-frontmatter.ts) 가 정리한 Track C-X sweep 의 잔존: \`ontology-edit/lib/\` 의 3 파일이 \`Track C-3\`, \`Track C-6\`, \`C-5 fire\`, \`C-7 fire\` 등 ephemeral 트랙 마커 + *"Firestore persist 는 C-4/C-5/C-7 fire 에서"* stale 약속을 코드 코멘트로 들고 있었음
- mission v2 는 ephemeral 노드 영구화가 vault \`.md\` 작성 (Firestore 아님) — 약속이 틀렸음. AI agent 가 lib/ 읽을 때 잘못된 사실 받음

## 수정 (3 파일)
- \`use-ephemeral-edges.ts\` JSDoc — "Track C-6"·"Firestore persist 는 C-7 fire 에서" → in-memory + vault 저장 path 명시
- \`use-ephemeral-nodes.ts\` JSDoc — "Track C-3"·"Firestore persist 는 C-4/C-5" → \`{kind}s/{slug}.md\` 작성 path 명시
- \`use-vault-graph-flow.ts\` inline — "C-5 fire" prefix 제거

## Test plan
- [x] \`grep "Track C\|C-[0-9]+\sfire\|Firestore persist"\` — 0 hits
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 113 / 789 pass