### PR TITLE
docs: similarity.ts JSDoc 을 mission v2 truth 로

### DIFF
--- a/src/shared/lib/ontology-tree/similarity.ts
+++ b/src/shared/lib/ontology-tree/similarity.ts
@@ -1,10 +1,11 @@
 import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
 
 /**
- * 검수 후보 (candidate) 와 기존 ontology approved 노드의 비슷도 매칭.
+ * 새 노드 후보와 기존 ontology 노드의 비슷도 매칭.
  *
- * 검수자가 후보를 promote 할지 결정하기 전에 "이미 비슷한 노드가 있는가?"
- * 를 답하는 데 사용. dedup 회피 + 같은 개념의 중복 분기 방지.
+ * 사용자 / AI agent 가 새 노드를 만들기 전에 "이미 비슷한 노드가 있는가?"
+ * 를 답하는 데 사용 — dedup 회피 + 같은 개념의 중복 분기 방지.
+ * (빌더 ManualNodeCreateModal · 문서 작성 시 DocumentNewOntologyHints 등.)
  *
  * 점수 규칙 (높을수록 강한 매치):
  *   100 — title 정확 일치 (lower-case 비교) + 같은 kind


### PR DESCRIPTION
## Summary
- \`findSimilarOntologyNodes\` 의 module JSDoc 이 v1 mental model — "검수 후보 (candidate) 와 기존 ontology *approved* 노드의 비슷도 매칭", "검수자가 후보를 promote 할지 결정..." — 을 들고 있어 contributor / AI agent 가 함수를 처음 읽을 때 검수 → approval flow 를 사실로 받음
- 실제 mission v2 사용처는 \`ManualNodeCreateModal\` (빌더 + 노드 만들기 전 dedup 체크) + \`DocumentNewOntologyHints\` (문서 작성 시 hint) — 검수와 무관
- JSDoc 만 정렬, 함수 동작 / 시그니처 / 점수 규칙 그대로 (동작 변화 0)

## After
- "검수 후보 / approved 노드의 비슷도 매칭" → "새 노드 후보와 기존 ontology 노드의 비슷도 매칭"
- "검수자가 후보를 promote 할지" → "사용자 / AI agent 가 새 노드를 만들기 전에 'similar 한 게 이미 있나?' 답"
- 사용처 명시 (ManualNodeCreateModal · DocumentNewOntologyHints)

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 113 / 789 pass