### PR TITLE
refactor: inline-editable 의 hardcoded rgba 4 군데 → canonical token

### DIFF
--- a/src/shared/ui/inline-editable.tsx
+++ b/src/shared/ui/inline-editable.tsx
@@ -155,7 +155,7 @@ export function InlineEditable({
       "aria-label": ariaLabel,
       "data-testid": dataTestId,
       className: cn(
-        "w-full rounded-md border border-[color:rgba(139,151,255,0.35)] bg-[color:var(--color-elevated)] px-2 py-1 outline-none transition-colors focus:border-[color:rgba(139,151,255,0.6)]",
+        "w-full rounded-md border border-[color:rgba(94,106,210,0.32)] bg-[color:var(--color-elevated)] px-2 py-1 outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]",
         className,
       ),
     };
@@ -177,7 +177,7 @@ export function InlineEditable({
     content: value || placeholder,
     isEmpty: !value,
     className: cn(
-      "cursor-text rounded-md transition-colors hover:bg-[color:var(--color-overlay-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(139,151,255,0.35)]",
+      "cursor-text rounded-md transition-colors hover:bg-[color:var(--color-overlay-1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.32)]",
       className,
     ),
     interactive: true,


### PR DESCRIPTION
## Summary
- shared/ui/inline-editable.tsx (제목 / description 인라인 편집에서 가져다 쓰는 shared primitive) 가 단일 인디고 trio 밖의 #8b97ff (\`rgba(139,151,255,*)\`) 를 input border / focus / focus-ring 4 군데에 박아두고 있었음
- 불변 규칙 #4 + 헌장 §11 위반
- PR #63 (link-list-editor) / PR #71 (chip-list-editor) 와 같은 mapping

## Mapping
- input border #8b97ff/0.35 → \`rgba(94,106,210,0.32)\` (브랜드 alpha)
- input focus border #8b97ff/0.6 → \`var(--color-indigo-brand)\`
- view focus-ring #8b97ff/0.35 → \`rgba(94,106,210,0.32)\`

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 113 / 789 pass
- [x] \`grep "rgba(139,151,255" src/shared/ui/inline-editable.tsx\` — 0 hits 남음