### PR TITLE
fix: /topology/ hydration mismatch (sigmaHintDismissed SSR/CSR 정합)

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -112,14 +112,19 @@ export function HomePage() {
     localGraphStack.length > 0 ? localGraphStack[localGraphStack.length - 1] : null;
   const [fitViewToken, setFitViewToken] = useState(0);
   const [sigmaVisibleCount, setSigmaVisibleCount] = useState<number | null>(null);
-  const [sigmaHintDismissed, setSigmaHintDismissed] = useState(() => {
-    if (typeof window === 'undefined') return true;
+  // SSR 시 true (hint 숨김) 으로 시작해 첫 paint 안정 — 이후 useEffect 로
+  // localStorage 와 sync. 이전 useState(() => typeof window === 'undefined') 패턴은
+  // 서버 / 클라이언트 hint 표시 여부가 다를 수 있어 hydration mismatch 발생.
+  const [sigmaHintDismissed, setSigmaHintDismissed] = useState(true);
+  useEffect(() => {
     try {
-      return window.localStorage.getItem('demo:sigma-hint-dismissed:v1') === '1';
+      const dismissed =
+        window.localStorage.getItem('demo:sigma-hint-dismissed:v1') === '1';
+      if (!dismissed) setSigmaHintDismissed(false);
     } catch {
-      return true;
+      /* private mode — keep dismissed=true */
     }
-  });
+  }, []);
   const dismissSigmaHint = useCallback(() => {
     setSigmaHintDismissed(true);
     try {


### PR DESCRIPTION
## Summary
콘솔 1 error: \"Hydration failed because the server rendered HTML didn't match the client\" — HomePage 의 SigmaHint 카드 (\`bottom-14 left-4\` 컨테이너) 가 SSR vs 클라이언트 render 다름.

## 원인
\`useState(() => { if (typeof window === 'undefined') return true; else window.localStorage.getItem(...) === '1' })\` 패턴이 서버 (true) ≠ 클라이언트 (localStorage 값 = false 가능) 결과 → SSR HTML 에 hint 없는데 hydrate 첫 render 에서 hint 그리려다 mismatch.

## 수정 (표준 패턴)
- \`useState(true)\` SSR-safe 시작 (hint 숨김 default)
- \`useEffect\` 로 localStorage sync (이후 dismissed=false 면 hint 노출)
- 첫 paint 안정 + flash 회피 + hydration mismatch 0

## Test plan
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 113 / 789 pass
- [x] 라이브: \`/topology/\` 콘솔 0 errors (before: 1 error)