### PR TITLE
fix: insights/relations 의 vault sentinel 회귀 — mode-aware panel hide

### DIFF
--- a/src/features/vault-ontology/index.ts
+++ b/src/features/vault-ontology/index.ts
@@ -1,3 +1,7 @@
 export { useVaultOntology } from './model/use-vault-ontology';
-export { useOntologyInsight } from './model/use-ontology-insight';
+export {
+  useOntologyInsight,
+  isVaultSentinelDate,
+  VAULT_SENTINEL_DATE,
+} from './model/use-ontology-insight';
 export { VaultOntologyStubsPanel } from './ui/VaultOntologyStubsPanel';

--- a/src/features/vault-ontology/model/use-ontology-insight.ts
+++ b/src/features/vault-ontology/model/use-ontology-insight.ts
@@ -16,8 +16,19 @@ import {
 } from '@/entities/docs-vault';
 import { useVaultOntology } from './use-vault-ontology';
 
-const VAULT_SENTINEL_DATE = new Date(0);
+export const VAULT_SENTINEL_DATE = new Date(0);
 const VAULT_SENTINEL_AUTHOR = 'vault-frontmatter';
+
+/**
+ * 한 노드의 \`lastApprovedAt\` 이 vault sentinel 값 (epoch 0 = 1970-01-01) 인지.
+ *
+ * vault / dogfood 모드 노드는 frontmatter 가 진실원이라 시간 정보를 갖지 않아
+ * sentinel 로 채움. UI 가 sentinel 을 감지하면 timestamp / timeline 패널을 mode
+ * 기반 hide / 변형 가능 (1970-01-01 같은 어색한 표시 회피).
+ */
+export function isVaultSentinelDate(d: Date | null | undefined): boolean {
+  return d instanceof Date && d.getTime() === 0;
+}
 
 // 빌드타임 dogfood 매니페스트 — JSON import. mode === 'static' 일 때
 // 진실원. local/cloud 와는 별 path.

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -7,7 +7,7 @@ import {
   KNOWLEDGE_EDGE_TYPES,
   ManualSourceChip,
 } from "@/entities/knowledge-graph";
-import { useOntologyInsight } from "@/features/vault-ontology";
+import { useOntologyInsight, isVaultSentinelDate } from "@/features/vault-ontology";
 import { getOntologyKindLabel } from "@/entities/ontology-class";
 import {
   buildActivityTimeline,
@@ -71,6 +71,15 @@ export function OntologyInsightsPage() {
 
   const totalNodes = insight?.nodes.length ?? 0;
   const totalEdges = insight?.edges.length ?? 0;
+  // vault / dogfood 모드는 lastApprovedAt 이 sentinel (epoch 0 = 1970-01-01).
+  // 30일 활동 timeline + 노드별 timestamp 표시는 의미 0 이라 mode-aware hide.
+  const isVaultSentinelMode = useMemo(
+    () =>
+      insight !== null &&
+      insight.nodes.length > 0 &&
+      insight.nodes.every((n) => isVaultSentinelDate(n.lastApprovedAt)),
+    [insight],
+  );
 
   // kind 분포 — sorted desc + 시각용 합계.
   const kindRows = useMemo(() => {
@@ -380,8 +389,15 @@ export function OntologyInsightsPage() {
             )}
           </Panel>
 
-          {/* 최근 활동 */}
-          <Panel title="최근 활동" subtitle="가장 최근 승인된 노드 10">
+          {/* 최근 노드 (vault sentinel mode 면 timestamp 의미 0 — chip / 제목만) */}
+          <Panel
+            title={isVaultSentinelMode ? "노드 미리보기" : "최근 활동"}
+            subtitle={
+              isVaultSentinelMode
+                ? `vault frontmatter 노드 ${recent.length}`
+                : "가장 최근 갱신된 노드 10"
+            }
+          >
             <ol className="space-y-1">
               {recent.map((node) => (
                 <li key={node.id}>
@@ -396,21 +412,24 @@ export function OntologyInsightsPage() {
                       {node.title}
                     </span>
                     <ManualSourceChip source={node.source} size="compact" />
-                    <span className="shrink-0 font-mono text-[10px] text-[color:var(--color-text-quaternary)]">
-                      {formatRelativeDate(node.lastApprovedAt)}
-                    </span>
+                    {isVaultSentinelMode ? null : (
+                      <span className="shrink-0 font-mono text-[10px] text-[color:var(--color-text-quaternary)]">
+                        {formatRelativeDate(node.lastApprovedAt)}
+                      </span>
+                    )}
                   </Link>
                 </li>
               ))}
             </ol>
           </Panel>
 
-          {/* 30일 활동 타임라인 — full width (col-span-2 데스크톱) */}
+          {/* 30일 활동 타임라인 — vault sentinel mode 에서는 timeline 의미 0 이라 hide */}
+          {isVaultSentinelMode ? null : (
           <div className="md:col-span-2">
-            <Panel title="30일 활동" subtitle={`지난 30일 동안 승인된 노드 ${activityTotal}`}>
+            <Panel title="30일 활동" subtitle={`지난 30일 동안 갱신된 노드 ${activityTotal}`}>
               {activityTotal === 0 ? (
                 <p className="text-[12px] text-[color:var(--color-text-tertiary)]">
-                  지난 30일에 승인된 노드가 없어요.
+                  지난 30일에 갱신된 노드가 없어요.
                 </p>
               ) : (
                 <div>
@@ -438,6 +457,7 @@ export function OntologyInsightsPage() {
               )}
             </Panel>
           </div>
+          )}
 
           {/* 미연결 노드 */}
           <Panel

--- a/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
+++ b/src/views/ontology-relations/ui/OntologyRelationsPage.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { KNOWLEDGE_EDGE_TYPES } from "@/entities/knowledge-graph";
-import { useOntologyInsight } from "@/features/vault-ontology";
+import { useOntologyInsight, isVaultSentinelDate } from "@/features/vault-ontology";
 import {
   computeEdgeTypeDistribution,
   selectStrongEdges,
@@ -62,6 +62,15 @@ export function OntologyRelationsPage() {
   }, [typeDist]);
   const typeMax = typeRows.reduce((m, r) => Math.max(m, r.count), 0);
   const totalEdges = insight?.edges.length ?? 0;
+  // vault / dogfood 모드는 노드 evidenceCount 0 → "강한 관계" 정렬 의미 0.
+  // sentinel 모드면 panel 자체 hide.
+  const isVaultSentinelMode = useMemo(
+    () =>
+      insight !== null &&
+      insight.nodes.length > 0 &&
+      insight.nodes.every((n) => isVaultSentinelDate(n.lastApprovedAt)),
+    [insight],
+  );
 
   return (
     <div>
@@ -103,7 +112,7 @@ export function OntologyRelationsPage() {
           </div>
         </div>
         <p className="break-keep text-sm leading-7 text-[color:var(--color-text-secondary)]">
-          노드는 트리, 통계는 인사이트. 관계는 *의미 관계 종류* 의 분포와 근거 풍부한 관계를 보여줍니다.
+          노드는 트리, 통계는 인사이트. 관계는 *의미 관계 종류* 의 분포를 보여줍니다.
         </p>
       </section>
 
@@ -205,7 +214,9 @@ export function OntologyRelationsPage() {
             ) : null}
           </section>
 
-          {/* 강한 관계 top */}
+          {/* 강한 관계 top — vault sentinel mode 는 노드 evidenceCount 0 이라
+              "강한" 정렬 의미 0 → panel 자체 hide. cloud 모드에서만 노출. */}
+          {isVaultSentinelMode ? null : (
           <section className="rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-5 py-4">
             <header className="mb-3">
               <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
@@ -261,6 +272,7 @@ export function OntologyRelationsPage() {
               })}
             </ol>
           </section>
+          )}
         </div>
       )}
       </div>


### PR DESCRIPTION
## Summary
**CRITICAL UX 회귀.** vault / dogfood 모드에서 /ontology/insights · /relations 페이지가 \`lastApprovedAt = VAULT_SENTINEL_DATE (epoch 0)\` + \`evidenceCount = 0\` 라:
- 모든 노드 timestamp "1970년 1월" 표시
- "30일 활동 = 0" + "지난 30일에 승인된 노드가 없어요"
- "강한 관계" 12 row 모두 우측 = 0

vault user 가 페이지 열면 broken 처럼 보임.

## 수정
- vault-ontology 에 \`isVaultSentinelDate\` + \`VAULT_SENTINEL_DATE\` export 추가
- InsightsPage:
  - sentinel mode 면 "최근 활동" → "노드 미리보기 / vault frontmatter 노드 N"
  - 노드별 timestamp hide
  - "30일 활동" panel 전체 hide
  - 일반 모드 라벨 "승인된" → "갱신된"
- RelationsPage:
  - sentinel mode 면 "강한 관계" panel hide
  - 부제 v1 carrot "근거 풍부한 관계" 제거

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] /ontology/insights/ 1970-01-01 사라짐, 30일 panel hide, 정상 렌더
- [x] /ontology/relations/ Edge Type 분포만 노출, 강한 관계 panel hide