### PR TITLE
fix: v1 user-visible carrot 일괄 sweep (5 surface)

### DIFF
--- a/src/features/account-scope/model/use-scoped-account-access.ts
+++ b/src/features/account-scope/model/use-scoped-account-access.ts
@@ -54,9 +54,9 @@ export function useScopedAccountAccess(): UseScopedAccountAccessResult {
         canEditDocuments: false,
         canReviewAndPublish: false,
         hasWorkspaceAccess: true,
-        roleLabel: "게스트",
+        roleLabel: "로컬",
         description:
-          "로컬 폴더는 자유롭게 사용할 수 있고, 서버 발행은 로그인 후 가능합니다.",
+          "로컬 vault 는 자유롭게 사용할 수 있고, cloud 동기화는 로그인 후 가능합니다.",
         membership: null,
         user: null,
       };

--- a/src/features/permissions/ui/PermissionFallback.tsx
+++ b/src/features/permissions/ui/PermissionFallback.tsx
@@ -39,7 +39,7 @@ const SURFACE_HINTS: ReadonlyArray<{
     unauthenticated: {
       eyebrow: '문서',
       title: '문서를 다루려면 로그인이 필요해요',
-      body: '문서를 올리고, 분석 결과를 골라내고, 공개 지도에 보입니다. 로그인하면 바로 이 화면으로 돌아옵니다.',
+      body: 'cloud 모드 문서 surface 입니다. 로그인하면 바로 이 화면으로 돌아옵니다. (로그인 없이 vault 만 쓰려면 /docs 에서 폴더 선택)',
     },
     denied: {
       eyebrow: '문서',

--- a/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
+++ b/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
@@ -134,7 +134,7 @@ function DashboardContent() {
               {user?.email}
             </p>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-[color:var(--color-text-secondary)]">
-              문서를 올리고, 분석 결과를 골라내고, 공개 화면에 보입니다.
+              cloud 모드 문서 surface — 마크다운 등록 + 프로젝트 연결. 로컬 vault 우선이라면 /docs 에서 폴더 선택.
             </p>
           </div>
         </header>

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -79,7 +79,7 @@ export function LandingPage({ next }: Props) {
             <p className="max-w-xl text-base leading-7 text-[color:var(--color-text-secondary)]">
               {hasReturnTarget
                 ? "요청한 화면은 로그인이 필요합니다. 로그인하면 방금 열려던 화면으로 바로 돌아갑니다."
-                : "사람과 AI agent 가 같이 자라게 하는 codebase ontology. 마크다운 문서가 곧 개념·관계·근거 — *트리·토폴로지·ERD* 세 시각으로 본다. Obsidian/Notion 처럼 폴더만 가리키면 시작."}
+                : "사람과 AI agent 가 같이 자라게 하는 codebase ontology. 마크다운 frontmatter 가 곧 노드와 관계 — *트리·토폴로지·ERD* 세 시각으로 본다. Obsidian/Notion 처럼 폴더만 가리키면 시작."}
             </p>
           </div>
 

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -29,7 +29,11 @@ import { ManualNodeCreateModal } from "@/widgets/manual-node-create-modal";
 import { OntologyEgoGraph } from "@/widgets/ontology-ego-graph";
 import { OntologyTreeView } from "@/widgets/ontology-tree-view";
 import { useDataSourceMode } from "@/features/data-source-mode";
-import { VaultOntologyStubsPanel, useOntologyInsight } from "@/features/vault-ontology";
+import {
+  VaultOntologyStubsPanel,
+  useOntologyInsight,
+  isVaultSentinelDate,
+} from "@/features/vault-ontology";
 import { OperationsNav } from "@/widgets/operations-nav";
 import { Tooltip, useToast } from "@/shared/ui";
 
@@ -48,6 +52,12 @@ export function OntologyViewPage() {
   // ?account= 가 비었으면 인증 사용자의 owned membership 첫 번째로 자동 보강.
 
   const { insight, error } = useOntologyInsight(accountId);
+  // vault / dogfood 모드는 노드 lastApprovedAt 이 sentinel — "근거 문서" /
+  // "발행 시점" stat 도 의미 0. mode 감지해서 stat strip / search 안내 hide.
+  const isVaultSentinelMode =
+    insight !== null &&
+    insight.nodes.length > 0 &&
+    insight.nodes.every((n) => isVaultSentinelDate(n.lastApprovedAt));
   // documents 는 글로벌 검색 두 번째 source — 권한 게이팅은 Firestore rules 가
   // 처리. 권한 없으면 빈 배열, 검색 결과에서도 자동 제외.
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
@@ -274,31 +284,39 @@ export function OntologyViewPage() {
         </div>
       </section>
 
-      <section className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+      {/* vault / dogfood 모드는 "근거 문서" + "발행 시점" stat 의미 0 (cloud LLM
+          추출/publish flow 의존) — 2 col grid. cloud 모드만 4 col stat strip. */}
+      <section
+        className={`mb-6 grid gap-3 ${isVaultSentinelMode ? "grid-cols-2" : "grid-cols-2 md:grid-cols-4"}`}
+      >
         <Stat label="트리 노드" value={String(totalNodes)} />
         <Stat label="총 관계" value={insight ? String(insight.edges.length) : "—"} />
-        <Stat
-          label="근거 문서"
-          value={String(docCount)}
-          hint={docCount > 0 ? "문서 목록 열기" : undefined}
-          href={
-            docCount > 0
-              ? getKnowledgeDocumentListHref(accountId)
-              : undefined
-          }
-        />
-        <Stat
-          label="발행 시점"
-          value={
-            insight?.meta?.publishedAt
-              ? insight.meta.publishedAt.toLocaleDateString("ko-KR", {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })
-              : "아직 없음"
-          }
-        />
+        {isVaultSentinelMode ? null : (
+          <>
+            <Stat
+              label="근거 문서"
+              value={String(docCount)}
+              hint={docCount > 0 ? "문서 목록 열기" : undefined}
+              href={
+                docCount > 0
+                  ? getKnowledgeDocumentListHref(accountId)
+                  : undefined
+              }
+            />
+            <Stat
+              label="발행 시점"
+              value={
+                insight?.meta?.publishedAt
+                  ? insight.meta.publishedAt.toLocaleDateString("ko-KR", {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })
+                  : "아직 없음"
+              }
+            />
+          </>
+        )}
       </section>
 
       {error ? (
@@ -310,7 +328,9 @@ export function OntologyViewPage() {
         </div>
       ) : null}
 
-      {documentsAccessError ? (
+      {/* vault / dogfood 모드는 cloud Firestore 문서 검색 자체가 비활성 —
+          "권한 없음" 안내는 cloud 모드 전용 (vault 사용자에게 어색). */}
+      {documentsAccessError && !isVaultSentinelMode ? (
         <p className="mb-4 break-keep text-[11px] text-[color:var(--color-text-quaternary)]">
           문서에 접근 권한이 없어 글로벌 검색에 문서가 포함되지 않아요. ontology 노드 검색만 가능해요.
         </p>


### PR DESCRIPTION
## Summary
화면 점검에서 발견한 mission v1 잔존 카피 5 군데를 mission v2 정렬:

| 위치 | Before | After |
|---|---|---|
| Landing subtitle | "마크다운 문서가 곧 개념·관계·근거" | "마크다운 frontmatter 가 곧 노드와 관계" |
| /ontology stat | "근거 문서 N" + "발행 시점 아직 없음" | vault sentinel mode 면 hide (2-col) |
| /ontology 검색 안내 | "접근 권한이 없어..." | sentinel mode hide |
| /knowledge 부제 | "분석 결과를 골라내고, 공개 지도에 보입니다" | "cloud 모드 문서 surface ... 로컬은 /docs" |
| /topology "게스트" | v1 guest 모델 | "로컬" (single-user + local-first) |

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] / · /ontology · /topology 라이브 모두 정상 + 콘솔 0 errors