### PR TITLE
fix: /settings 게이트 카피의 'API 키' stale 잔존 제거

### DIFF
--- a/src/features/permissions/ui/PermissionFallback.tsx
+++ b/src/features/permissions/ui/PermissionFallback.tsx
@@ -65,7 +65,7 @@ const SURFACE_HINTS: ReadonlyArray<{
     unauthenticated: {
       eyebrow: '카테고리',
       title: '카테고리를 정리하려면 로그인이 필요해요',
-      body: '지도의 카테고리·상태·API 키를 정리합니다. 로그인하면 바로 이 화면으로 돌아옵니다.',
+      body: '지도의 카테고리·상태·프로젝트 import 를 정리합니다. 로그인하면 바로 이 화면으로 돌아옵니다.',
     },
     denied: {
       eyebrow: '카테고리',


### PR DESCRIPTION
PR #68 (OperationsNav nav 툴팁) 에서 \`/settings\` 의 "API 키" 제거했지만 \`PermissionFallback\` 의 \`/settings\` variant body 는 정렬 안 됨. surface 자체가 없는 항목이라 카피 거짓.

"카테고리·상태·**API 키**" → "카테고리·상태·**프로젝트 import**".

- [x] tsc 0 / vitest 113 / 789 pass