### PR TITLE
fix: intra-route v1 carrot sweep + theme toggle SSR hydration (6 군데)

### DIFF
--- a/src/entities/knowledge-graph/ui/ManualSourceChip.tsx
+++ b/src/entities/knowledge-graph/ui/ManualSourceChip.tsx
@@ -9,9 +9,9 @@ export interface ManualSourceChipProps {
 /**
  * `source === 'manual'` 인 노드/엣지에만 노출되는 작은 chip.
  *
- * 디자인: warm gray inline 라벨. 인디고 (액센트) / amber (경고) 와 구분되어
- * "정보적 표시" 임을 명확히. extraction 출처는 기본값이라 chip 표시 안 함
- * (signal-to-noise 보호).
+ * mission v2: vault frontmatter / 빌더 / MCP write 모두 사람·AI agent 가
+ * 직접 작성한 출처 — 'manual'. legacy `extraction` (v1 LLM 추출 결과) 은
+ * 기본값이라 chip 표시 안 함 (signal-to-noise 보호).
  */
 export function ManualSourceChip({ source, size = "default" }: ManualSourceChipProps) {
   if (source !== "manual") return null;
@@ -19,7 +19,7 @@ export function ManualSourceChip({ source, size = "default" }: ManualSourceChipP
   const fontSize = size === "compact" ? "text-[9px]" : "text-[10px]";
   return (
     <span
-      title="사용자가 추출 워커 거치지 않고 직접 만든 노드/관계"
+      title="사람 / AI agent 가 vault frontmatter · 빌더 · MCP 로 직접 작성한 노드"
       className={`inline-flex items-center rounded-full border border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-2)] font-mono ${fontSize} uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] ${padding}`}
     >
       manual

--- a/src/features/theme-toggle/ui/ThemeToggle.tsx
+++ b/src/features/theme-toggle/ui/ThemeToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "@/shared/lib/theme";
 import { cn } from "@/shared/lib/cn";
@@ -11,23 +12,39 @@ interface Props {
 /**
  * 라이트/다크 모드 토글 버튼. 한 글자짜리 icon 토글이라 상단 nav 의
  * "프로젝트 →" / "로그아웃" 옆에 자연스럽게 들어간다.
+ *
+ * SSR/CSR 시 \`useTheme\` 의 첫 paint 값이 다를 수 있어 (서버 = 'dark',
+ * 클라이언트 = localStorage 값) icon / aria-label 의 hydration mismatch 가
+ * 발생. mount 전에는 invisible placeholder 만 노출해 방지 — 첫 useEffect 후
+ * theme 값으로 swap.
  */
 export function ThemeToggle({ className }: Props) {
   const [theme, setTheme] = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   const isLight = theme === "light";
 
   return (
     <button
       type="button"
       onClick={() => setTheme(isLight ? "dark" : "light")}
-      aria-label={isLight ? "다크 모드로 전환" : "라이트 모드로 전환"}
-      title={isLight ? "다크 모드로 전환" : "라이트 모드로 전환"}
+      aria-label={mounted ? (isLight ? "다크 모드로 전환" : "라이트 모드로 전환") : "테마 토글"}
+      title={mounted ? (isLight ? "다크 모드로 전환" : "라이트 모드로 전환") : undefined}
       className={cn(
         "inline-flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]",
         className,
       )}
     >
-      {isLight ? <Moon size={14} aria-hidden /> : <Sun size={14} aria-hidden />}
+      {/* mount 전엔 invisible placeholder (sr-only) — SSR 출력과 동일 슬롯 */}
+      {!mounted ? (
+        <span className="h-3.5 w-3.5" aria-hidden />
+      ) : isLight ? (
+        <Moon size={14} aria-hidden />
+      ) : (
+        <Sun size={14} aria-hidden />
+      )}
     </button>
   );
 }

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -227,8 +227,8 @@ function EphemeralDetail({
       ) : null}
       <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
         {titleEmpty
-          ? "이름을 입력하면 manual 노드로 저장할 수 있어요."
-          : "저장 시 knowledgeApprovedNodes 의 manual 항목으로 추가됩니다."}
+          ? "이름을 입력하면 저장할 수 있어요."
+          : "저장 시 vault 의 .md 파일로 (cloud 모드면 Firestore 에) 작성됩니다."}
       </p>
     </div>
   );

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -761,16 +761,25 @@ function NodeDetailPanel({
         </div>
       ) : null}
 
-      <dl className="grid grid-cols-2 gap-2 text-[11px]">
-        <DetailRow
-          label="연결 프로젝트"
-          value={node.projectIds.length > 0 ? node.projectIds.join(", ") : "—"}
-        />
-        <DetailRow
-          label="근거 수"
-          value={String(node.evidenceCount ?? node.evidenceIds.length)}
-        />
-      </dl>
+      {/* "근거 수" stat 은 cloud LLM 추출 산출물 — vault 노드는 evidenceCount 0
+          이라 의미 0. 둘 다 0 이면 row 자체 hide → 1-col grid 로 단순화. */}
+      {(() => {
+        const evidenceCount = node.evidenceCount ?? node.evidenceIds.length;
+        const showEvidence = evidenceCount > 0;
+        return (
+          <dl
+            className={`grid gap-2 text-[11px] ${showEvidence ? "grid-cols-2" : "grid-cols-1"}`}
+          >
+            <DetailRow
+              label="연결 프로젝트"
+              value={node.projectIds.length > 0 ? node.projectIds.join(", ") : "—"}
+            />
+            {showEvidence ? (
+              <DetailRow label="근거 수" value={String(evidenceCount)} />
+            ) : null}
+          </dl>
+        );
+      })()}
       <p className="mt-2 break-all font-mono text-[10px] text-[color:var(--color-text-quaternary)]">
         {node.id}
       </p>

--- a/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
+++ b/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
@@ -149,7 +149,7 @@ function SettingsOntologyContent() {
             role="status"
             className="mb-4 rounded-2xl border border-[color:rgba(94,106,210,0.32)] bg-[color:rgba(94,106,210,0.06)] px-5 py-3 text-[12.5px] leading-5 text-[color:rgba(159,170,235,0.95)]"
           >
-            새 version <span className="font-mono">{recentVersionId}</span> 활성화 완료. 추출 워커 + 매뉴얼 작성이 새 schema 를 자동 사용해요.
+            새 version <span className="font-mono">{recentVersionId}</span> 활성화 완료. 빌더 / MCP / cloud manual 노드 모두 새 schema 를 자동 사용해요.
           </div>
         ) : null}
 

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -198,7 +198,7 @@ export function GlobalSearch({
             value={query}
             onValueChange={setQuery}
             placeholder={
-              documents
+              documents && documents.length > 0
                 ? "개념 · 글 검색 — 한·영 혼합 OK"
                 : "개념 검색 — 한·영 혼합 OK"
             }

--- a/src/widgets/ontology-tree-view/lib/sort-roots.ts
+++ b/src/widgets/ontology-tree-view/lib/sort-roots.ts
@@ -38,7 +38,10 @@ export type OntologyRootSortKey = "kind-title" | "evidence-desc" | "title";
 /** UI label — 정렬 dropdown 표시 텍스트. */
 export const ONTOLOGY_ROOT_SORT_LABEL: Record<OntologyRootSortKey, string> = {
   "kind-title": "Kind 우선",
-  "evidence-desc": "근거 많은 순",
+  // mission v2 vault 모드는 evidenceCount 가 모두 0 이라 결과적으로 가나다
+  // fallback 으로 정렬됨. cloud 모드에서만 의미 있는 정렬이라 라벨은 v1
+  // "근거" 단어 회피 ("참조" 가 vault/cloud 양쪽 의미 통합).
+  "evidence-desc": "참조 많은 순",
   title: "가나다",
 };
 


### PR DESCRIPTION
화면 점검 Phase 2-3 에서 발견한 6 군데 일괄 정리.

| # | 위치 | Before | After |
|---|---|---|---|
| A | NodeDetailPanel "근거 수 0" | 항상 0 표시 | sentinel mode 면 row hide |
| B | ManualSourceChip tooltip | "추출 워커 거치지 않고" | "사람·AI agent 가 vault·빌더·MCP 로" |
| C | 트리 정렬 라벨 | "근거 많은 순" | "참조 많은 순" |
| D | 빌더 인스펙터 안내 | "knowledgeApprovedNodes 의 manual" | "vault .md (cloud 면 Firestore)" |
| E | 검색 placeholder | \`documents\` truthy ⇒ "글" 노출 | \`documents.length > 0\` 명시 |
| F | ThemeToggle hydration | Sun/Moon icon SSR mismatch | mount 후만 icon (placeholder) |

\+ SettingsOntologyPage "추출 워커 + 매뉴얼 작성" stale 카피 정렬

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] 라이브 \`/ontology/?node=...\` NodeDetailPanel 1-col, 콘솔 0 errors