### PR TITLE
fix: /topology 좌상단 workspace 부제 v1 demo 시드 카피 정렬

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -608,7 +608,7 @@ export function HomePage() {
                     Demo
                   </span>
                   <p className="mt-0.5 max-w-[180px] text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
-                    제품·인증·에이전트.
+                    프로젝트 의존도 지도.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
좌상단 "Demo / 제품·인증·에이전트" 부제 → "프로젝트 의존도 지도". mode 무관 일반 부제. tsc 0 / vitest 113·789 pass.