### PR TITLE
feat: 빌더 캔버스 자동 레이아웃 — dagre LR layered

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:public-account-menu": "node scripts/run-public-account-menu-e2e.mjs"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.74.0(react@19.2.5))
@@ -313,6 +316,12 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@electric-sql/pglite-tools@0.2.21':
     resolution: {integrity: sha512-kv8Z7UmmBVECHud63VblgQLp4A+qSklNP7H22VQqFQGrWFTodc73bubcjgmBqThFsIIiEeAEQQYwWGaK2lSDtA==}
@@ -6325,6 +6334,12 @@ snapshots:
       '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@electric-sql/pglite-tools@0.2.21(@electric-sql/pglite@0.3.16)':
     dependencies:

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -2,6 +2,7 @@
 
 import { type CSSProperties, useMemo } from "react";
 import type { Edge, Node } from "@xyflow/react";
+import dagre from "@dagrejs/dagre";
 import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
 
 /**
@@ -64,7 +65,31 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
     return null;
   }
 
-  const fallbackPositions = computeGridLayout(ontologyDocs);
+  // Edge 페어 (sourceSlug → targetSlug) 를 layout 전에 한 번 모은다.
+  // dagre / 미래의 다른 layout 알고리즘 모두 이 raw 페어 list 가 필요.
+  const rawEdgePairs: Array<[string, string]> = [];
+  const seenPair = new Set<string>();
+  for (const doc of ontologyDocs) {
+    for (const key of NEIGHBOR_KEYS) {
+      const value = doc.frontmatter[key];
+      if (!Array.isArray(value)) continue;
+      for (const ref of value) {
+        if (typeof ref !== "string") continue;
+        const resolved = resolveRef(ref);
+        if (!resolved || resolved === doc.slug) continue;
+        const pairKey = `${doc.slug}->${resolved}`;
+        if (seenPair.has(pairKey)) continue;
+        seenPair.add(pairKey);
+        rawEdgePairs.push([doc.slug, resolved]);
+      }
+    }
+  }
+
+  // 자동 layout — dagre 의 layered LR 그래프. ontology 의 project → domain →
+  // capability → element 흐름이 자연스럽게 좌→우 계층으로 정렬되어 엣지 겹침
+  // 최소화. 사용자가 drag 로 frontmatter.canvasPosition 지정한 노드는 그것
+  // 우선 (수동 배치 보존). grid fallback 보다 가독성 큰 차이.
+  const fallbackPositions = computeDagreLayout(ontologyDocs, rawEdgePairs);
   const nodes: Node[] = ontologyDocs.map((doc) => {
     // frontmatter.canvasPosition: { x, y } 가 있으면 우선. 없으면 grid fallback.
     // 사용자가 빌더에서 drag-stop 시 canvasPosition patch — 다음 mount 부터
@@ -104,6 +129,9 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
     };
   });
 
+  // edge style / label 풍부 결정 — frontmatter array 키별 톤. raw pair 는
+  // 이미 위에서 dedup 됐고, 여기서 같은 (source,target) 에 대해 처음 매칭된
+  // key 의 style 적용. 같은 페어가 두 키에 있으면 첫 번째만.
   const seenEdges = new Set<string>();
   const edges: Edge[] = [];
   for (const doc of ontologyDocs) {
@@ -137,18 +165,39 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
   return { nodes, edges };
 }
 
-function computeGridLayout(
+/**
+ * dagre 로 layered LR 자동 레이아웃. ontology 의 project → domain →
+ * capability → element 계층이 좌→우 흐름. 노드 ID = vault slug. edges
+ * 는 (source, target) 페어. dagre 는 동기 함수, 수십 ms.
+ */
+function computeDagreLayout(
   docs: VaultDoc[],
+  edges: ReadonlyArray<readonly [string, string]>,
 ): Map<string, { x: number; y: number }> {
-  const COLS = Math.max(1, Math.ceil(Math.sqrt(docs.length)));
-  const COL_GAP = NODE_WIDTH + 40;
-  const ROW_GAP = NODE_HEIGHT + 40;
   const map = new Map<string, { x: number; y: number }>();
-  docs.forEach((d, idx) => {
-    const col = idx % COLS;
-    const row = Math.floor(idx / COLS);
-    map.set(d.slug, { x: col * COL_GAP, y: row * ROW_GAP });
-  });
+  if (docs.length === 0) return map;
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  // rankdir LR — 좌→우 계층 흐름. nodesep / ranksep 은 노드 간 여백 +
+  // 계층 간 여백. NODE_WIDTH/HEIGHT 보다 약간 크게 잡아 라벨 chip 이
+  // 다른 노드 가려지지 않도록.
+  g.setGraph({ rankdir: "LR", nodesep: 32, ranksep: 80, marginx: 24, marginy: 24 });
+  for (const doc of docs) {
+    g.setNode(doc.slug, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+  for (const [from, to] of edges) {
+    if (g.hasNode(from) && g.hasNode(to)) g.setEdge(from, to);
+  }
+  dagre.layout(g);
+  for (const doc of docs) {
+    const node = g.node(doc.slug);
+    if (!node) continue;
+    // dagre 는 노드 *중심* 좌표를 반환. xyflow position 은 좌상단이라 변환.
+    map.set(doc.slug, {
+      x: node.x - NODE_WIDTH / 2,
+      y: node.y - NODE_HEIGHT / 2,
+    });
+  }
   return map;
 }
 


### PR DESCRIPTION
빌더 (/ontology/edit) 의 vault 노드 fallback 위치가 정사각형 grid 라 엣지가 격자 사이 지그재그 → 가독성 0. ontology 의 project → domain → capability → element 계층 흐름 시각적으로 안 보임.

## 변경
- \`@dagrejs/dagre\` (~80kb gzipped, 동기 함수 수십 ms) 추가
- \`buildVaultGraphFlow\` 안 raw edge 페어 한 번 계산 후 layout 에 전달
- \`computeDagreLayout\`: rankdir=LR · nodesep=32 · ranksep=80 · margin=24
- 노드 중심 좌표 → xyflow 좌상단으로 변환
- 사용자 drag 한 \`frontmatter.canvasPosition\` 우선 (수동 배치 보존)
- 기존 \`computeGridLayout\` 폐기

## 결과
project → domain → capability → element 흐름이 좌→우 계층, 엣지 겹침 최소화. 비-개발자도 한 눈에 의존 흐름 인지.

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] 라이브: /ontology/edit/ vault 30+ 노드 layered 배치 확인 (이전 격자 vs 후 자유 흐름)