### PR TITLE
fix: /project/[slug] generateStaticParams 에 vault dogfood project 포함

### DIFF
--- a/app/project/[slug]/edit/page.tsx
+++ b/app/project/[slug]/edit/page.tsx
@@ -8,8 +8,18 @@ interface Params {
 
 export async function generateStaticParams(): Promise<Params[]> {
   const { fetchAllProjectsAtBuild } = await import('@/entities/project');
-  const projects = await fetchAllProjectsAtBuild();
-  return projects.map((p) => ({ slug: p.slug }));
+  const {
+    deriveProjectsFromVault,
+    vaultManifest: staticVaultManifestRaw,
+  } = await import('@/entities/docs-vault');
+  const cloudProjects = await fetchAllProjectsAtBuild();
+  const vaultProjects = deriveProjectsFromVault(
+    staticVaultManifestRaw as import('@/entities/docs-vault').VaultManifest,
+  );
+  const slugs = new Set<string>();
+  for (const p of cloudProjects) slugs.add(p.slug);
+  for (const p of vaultProjects) slugs.add(p.slug);
+  return Array.from(slugs).map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({

--- a/app/project/[slug]/opengraph-image.tsx
+++ b/app/project/[slug]/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { ImageResponse } from 'next/og';
 import { fetchAllProjectsAtBuild } from '@/entities/project';
+import {
+  deriveProjectsFromVault,
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+} from '@/entities/docs-vault';
 import { INDIGO_BRAND, INDIGO_HIGHLIGHT } from '@/shared/config/indigo-tokens';
+
+const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
 
 // 정적 export 환경: sitemap.ts 처럼 force-static 으로 고정해 빌드 타임 1회만
 // 실행 후 PNG 를 out/ 에 박히게 한다.
@@ -15,9 +22,13 @@ interface Params {
 }
 
 export async function generateStaticParams(): Promise<Params[]> {
-  const projects = await fetchAllProjectsAtBuild();
-  if (projects.length === 0) return [{ slug: 'iam' }];
-  return projects.map((p) => ({ slug: p.slug }));
+  const cloudProjects = await fetchAllProjectsAtBuild();
+  const vaultProjects = deriveProjectsFromVault(staticVaultManifest);
+  const slugs = new Set<string>();
+  for (const p of cloudProjects) slugs.add(p.slug);
+  for (const p of vaultProjects) slugs.add(p.slug);
+  if (slugs.size === 0) return [{ slug: 'iam' }];
+  return Array.from(slugs).map((slug) => ({ slug }));
 }
 
 export default async function ProjectOgImage({

--- a/app/project/[slug]/page.tsx
+++ b/app/project/[slug]/page.tsx
@@ -2,24 +2,43 @@ import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { fetchAllProjectsAtBuild } from '@/entities/project';
+import {
+  deriveProjectsFromVault,
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+} from '@/entities/docs-vault';
 import { ProjectDetailPage } from '@/views/project-detail';
 import { absoluteUrl } from '@/shared/config';
+
+const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
 
 interface Params {
   slug: string;
 }
 
 /**
- * 빌드 시점에 모든 프로젝트 slug를 수집해 정적 페이지 생성.
- * Firestore REST API 공개 읽기로 인증 없이 fetch.
+ * 빌드 시점에 모든 프로젝트 slug 를 수집해 정적 페이지 생성.
+ *
+ * 두 source 합집합:
+ *   1. Firestore 공개 read (\`fetchAllProjectsAtBuild\`) — cloud 모드 사용자
+ *      가 만든 프로젝트
+ *   2. 빌드타임 vault 매니페스트 의 \`kind: project\` doc — mission v2 dogfood
+ *      자체 project (\`docs/ontology/project.md\`) 도 정적 페이지로 빌드해야
+ *      vault/static 모드 사용자가 \`/project/oh-my-ontology/\` 등 직접 진입 가능.
+ *
+ * dedup 으로 같은 slug 중복 제거. 둘 다 비면 fallback (빌드 실패 방지).
  */
 export async function generateStaticParams(): Promise<Params[]> {
-  const projects = await fetchAllProjectsAtBuild();
-  if (projects.length === 0) {
-    // 빌드 타임에 Firestore 접근 실패 시 최소한의 파라미터 반환 (빌드 실패 방지)
+  const cloudProjects = await fetchAllProjectsAtBuild();
+  const vaultProjects = deriveProjectsFromVault(staticVaultManifest);
+  const slugs = new Set<string>();
+  for (const p of cloudProjects) slugs.add(p.slug);
+  for (const p of vaultProjects) slugs.add(p.slug);
+  if (slugs.size === 0) {
+    // 양쪽 source 다 비면 최소 한 개 라도 있어야 빌드 통과
     return [{ slug: 'iam' }];
   }
-  return projects.map((p) => ({ slug: p.slug }));
+  return Array.from(slugs).map((slug) => ({ slug }));
 }
 
 /**


### PR DESCRIPTION
**CRITICAL fix.** \`/project/oh-my-ontology/\` 같은 vault dogfood project URL 이 정적 export 빌드에서 500 — \`generateStaticParams\` 가 Firestore-only 라 vault \`kind: project\` doc 가 빌드 산출물에 미포함.

3 파일 (page / edit/page / opengraph-image) 모두 Firestore cloud + vault 두 source 합집합으로:
- \`deriveProjectsFromVault(staticVaultManifest)\` 의 vault project slug 추가
- Set 으로 dedup

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] 라이브 \`/project/project/\` (dogfood slug) → 200 + 정상 렌더