### PR TITLE
feat: 빌더 헤더 '자동 정렬' 버튼 — drag 후 dagre 다시 적용

### DIFF
--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -22,11 +22,24 @@ import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
  * slug 또는 마지막 segment 와 매칭되면 edge 추가. unresolved 항목은
  * 무시 — vault 외부 reference 는 dangling 으로 두고 노출 안 함.
  */
-export function useVaultGraphFlow(manifest: VaultManifest | null) {
+export interface UseVaultGraphFlowOptions {
+  /**
+   * true 면 \`frontmatter.canvasPosition\` 을 무시하고 dagre layered 결과만
+   * 사용. "자동 정렬" 버튼이 사용자 drag 결과를 reset (in-memory only —
+   * frontmatter 자체는 안 건드림) 할 때 활용.
+   */
+  ignorePersistedPosition?: boolean;
+}
+
+export function useVaultGraphFlow(
+  manifest: VaultManifest | null,
+  options?: UseVaultGraphFlowOptions,
+) {
+  const ignorePersistedPosition = options?.ignorePersistedPosition ?? false;
   return useMemo(() => {
     if (!manifest) return { nodes: [] as Node[], edges: [] as Edge[] };
-    return buildVaultGraphFlow(manifest);
-  }, [manifest]);
+    return buildVaultGraphFlow(manifest, { ignorePersistedPosition });
+  }, [manifest, ignorePersistedPosition]);
 }
 
 const NODE_WIDTH = 200;
@@ -43,8 +56,15 @@ const NEIGHBOR_KEYS = [
 
 /**
  * 순수 함수 — manifest → xyflow Node[] / Edge[]. 테스트용 export.
+ *
+ * options.ignorePersistedPosition: true 면 frontmatter.canvasPosition 무시
+ * 하고 모든 노드를 dagre 자동 layout 결과로. "자동 정렬" 버튼 용도.
  */
-export function buildVaultGraphFlow(manifest: VaultManifest) {
+export function buildVaultGraphFlow(
+  manifest: VaultManifest,
+  options?: { ignorePersistedPosition?: boolean },
+) {
+  const ignorePersistedPosition = options?.ignorePersistedPosition ?? false;
   const ontologyDocs = manifest.docs.filter(
     (doc) => typeof doc.frontmatter.kind === "string" && doc.frontmatter.kind,
   );
@@ -91,13 +111,15 @@ export function buildVaultGraphFlow(manifest: VaultManifest) {
   // 우선 (수동 배치 보존). grid fallback 보다 가독성 큰 차이.
   const fallbackPositions = computeDagreLayout(ontologyDocs, rawEdgePairs);
   const nodes: Node[] = ontologyDocs.map((doc) => {
-    // frontmatter.canvasPosition: { x, y } 가 있으면 우선. 없으면 grid fallback.
+    // frontmatter.canvasPosition: { x, y } 가 있으면 우선. 없으면 dagre fallback.
     // 사용자가 빌더에서 drag-stop 시 canvasPosition patch — 다음 mount 부터
     // 같은 좌표 복원. AI agent (MCP) 도 같은 frontmatter 키 read 가능.
+    // \`ignorePersistedPosition\` 이 true 면 강제로 dagre 결과 사용 — "자동
+    // 정렬" 버튼이 in-memory 만 reset 할 때 활용 (frontmatter 자체는 그대로).
     const fm = doc.frontmatter as Record<string, unknown>;
     const cp = fm.canvasPosition;
     const persistedPos =
-      cp && typeof cp === "object" && cp !== null
+      !ignorePersistedPosition && cp && typeof cp === "object" && cp !== null
         ? (() => {
             const x = (cp as Record<string, unknown>).x;
             const y = (cp as Record<string, unknown>).y;

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -45,6 +45,7 @@ export function OntologyEditCanvas({
   onSelectionChange,
   onConnect,
   onVaultNodeDragStop,
+  autoLayoutToken = 0,
 }: {
   vaultManifest: VaultManifest | null;
   ephemeralNodes: EphemeralNode[];
@@ -53,12 +54,20 @@ export function OntologyEditCanvas({
   onConnect?: (connection: Connection) => void;
   /** vault 노드 drag-stop 시 호출 — 좌표를 frontmatter.canvasPosition 으로 patch. */
   onVaultNodeDragStop?: (slug: string, position: { x: number; y: number }) => void;
+  /**
+   * 헤더의 "자동 정렬" 버튼이 눌릴 때마다 increment 되는 token.
+   * 0 보다 크면 \`frontmatter.canvasPosition\` 무시하고 dagre 결과로 reset.
+   * frontmatter 자체는 안 건드리는 in-memory only 동작.
+   */
+  autoLayoutToken?: number;
 }) {
   // 진실원: live vault.manifest 우선, 없으면 빌드타임 dogfood 매니페스트.
   // 빌더에 진입한 사용자는 vault 폴더 안 골랐어도 oh-my-ontology 자체 ontology
   // 23 노드를 즉시 본다 — "0 마찰 진입" 약속의 캔버스 측 구현.
   const effectiveManifest = vaultManifest ?? staticVaultManifest;
-  const vaultFlow = useVaultGraphFlow(effectiveManifest);
+  const vaultFlow = useVaultGraphFlow(effectiveManifest, {
+    ignorePersistedPosition: autoLayoutToken > 0,
+  });
   const approvedNodes = vaultFlow.nodes;
   const approvedEdges = vaultFlow.edges;
 

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Info, Maximize2, Minimize2 } from "lucide-react";
+import { Info, Maximize2, Minimize2, Wand2 } from "lucide-react";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { useUserAuth } from "@/features/user-auth";
 import { addManualKnowledgeNode } from "@/entities/knowledge-graph";
@@ -69,6 +69,7 @@ const OntologyEditCanvas = dynamic<{
   onSelectionChange?: (selectedId: string | null) => void;
   onConnect?: (connection: import("@xyflow/react").Connection) => void;
   onVaultNodeDragStop?: (slug: string, position: { x: number; y: number }) => void;
+  autoLayoutToken?: number;
 }>(
   () => import("./OntologyEditCanvas").then((m) => m.OntologyEditCanvas),
   { ssr: false, loading: () => <CanvasSkeleton /> },
@@ -98,6 +99,11 @@ export function OntologyEditPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [fullscreen, setFullscreen] = useState(false);
+  // 자동 정렬 토큰 — increment 마다 캔버스가 frontmatter.canvasPosition
+  // 무시하고 dagre layout 으로 노드 위치 reset (in-memory only). frontmatter
+  // 자체는 그대로라 다음 mount 부터 다시 사용자 좌표 복원 (선호 보존). 사용자가
+  // 다시 drag-stop 하면 그때부터 새 frontmatter 좌표로 갱신.
+  const [autoLayoutToken, setAutoLayoutToken] = useState(0);
   const toast = useToast();
 
   const saveEphemeral = useCallback(
@@ -452,6 +458,20 @@ export function OntologyEditPage() {
                 </button>
               </>
             ) : null}
+            <Tooltip
+              content="모든 노드 위치를 dagre 자동 레이아웃으로 초기화 (frontmatter 의 canvasPosition 은 그대로 — 다음 진입 시 사용자 좌표 복원)"
+              withProvider={false}
+            >
+              <button
+                type="button"
+                onClick={() => setAutoLayoutToken((n) => n + 1)}
+                aria-label="캔버스 노드 자동 정렬"
+                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
+              >
+                <Wand2 size={12} />
+                자동 정렬
+              </button>
+            </Tooltip>
             <Link
               href={treeHref}
               className="inline-flex h-8 shrink-0 items-center gap-1 px-2 text-[11px] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
@@ -490,6 +510,7 @@ export function OntologyEditPage() {
               onSelectionChange={setSelectedId}
               onConnect={addEphemeralEdge}
               onVaultNodeDragStop={persistVaultPosition}
+              autoLayoutToken={autoLayoutToken}
             />
             <BuilderOnboarding
               empty={ephemeralNodes.length === 0 && ephemeralEdges.length === 0}


### PR DESCRIPTION
PR #91 dagre 가 첫 mount fallback 으로만 적용. 사용자 drag → \`frontmatter.canvasPosition\` 박혀 다음 진입부터 그 좌표 복원. 빌더 어수선해졌을 때 "다시 정렬" 방법 없었음.

## 변경
- \`useVaultGraphFlow\` + \`buildVaultGraphFlow\` 에 \`ignorePersistedPosition\` 옵션
- \`OntologyEditCanvas\` 에 \`autoLayoutToken\` prop
- \`OntologyEditPage\` 헤더에 Wand2 + "자동 정렬" 버튼. 클릭 마다 token increment

## 동작 모델 (사용자 선호 보존)
- 클릭 → in-memory 만 reset (frontmatter 안 건드림)
- 다음 mount / 새로고침 → 사용자 좌표 복원
- destructive 0 — 토글식 깔끔한 reset

## Test plan
- [x] tsc 0 / vitest 113 / 789 pass
- [x] 라이브: 헤더 "자동 정렬" 버튼 노출 + 클릭 동작