### PR TITLE
refactor: 내부 코드 코멘트 mission v1 carrot sweep (8 파일)

### DIFF
--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
@@ -15,9 +15,10 @@ import type { VaultDoc, VaultManifest } from '../model/types';
  * - `relates` — string[] (related_to edge 후보)
  * - `dependencies` — string[] (depends_on edge 후보)
  *
- * 출력은 evidence-ungrounded *stub* — 사용자가 검수 큐 또는 ontology view 에서
- * promote 하면 정식 fact 가 된다. 현재는 in-memory 데이터 (Phase 4.2 가 UI 에
- * 노출, IndexedDB 영속화는 후속).
+ * mission v2: vault frontmatter 자체가 진실원이라 별도 promote / 승격 단계
+ * 없음. 출력 stub 은 즉시 ontology 그래프로 surface (\`/ontology\` 트리,
+ * 빌더 캔버스, /insights / /relations 등). cloud Firestore 와의 sync 는
+ * 옵션 — \`useDataSourceMode\` 가 cloud 일 때만 mutation 이 cloud 로.
  */
 
 export type OntologyStubSource = 'frontmatter';

--- a/src/entities/knowledge-graph/api/knowledge-graph-api.ts
+++ b/src/entities/knowledge-graph/api/knowledge-graph-api.ts
@@ -318,17 +318,17 @@ export function subscribeKnowledgeApprovedGraph(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Manual editor v0 (B 라인) — 사용자가 추출 워커 거치지 않고 직접 노드 작성.
+// Manual editor — 사용자가 직접 ontology 노드 작성하는 cloud-mode 경로.
+// (mission v2 default 흐름은 vault frontmatter 직접 작성 — vault.createDoc.
+// 이 함수는 cloud 모드에서 동등 동작.)
 //
 // 동작:
 // - runTransaction 으로 같은 ID 노드 존재 여부 확인 → 있으면 alreadyExists=true
-//   반환 (§6.3.2 케이스 B). UI 가 "기존 보기 / 다른 ID" 두 옵션 제시.
+//   반환. UI 가 "기존 보기 / 다른 ID" 두 옵션 제시.
 // - 없으면 setDoc with source="manual" + manualAuthor=auth.uid + serverTimestamp.
-// - Firestore rules (firestore.rules `knowledgeApprovedNodes` create) 가 같은
-//   제약을 서버에서도 강제 — kind 화이트리스트, manualAuthor==auth.uid,
-//   account member, title 비어있지 않음.
-//
-// 참조: 2026-04-27-ontology-manual-editor-v0.md §3 / §6.3
+// - Firestore rules (`knowledgeApprovedNodes` create) 가 같은 제약을 서버에서도
+//   강제 — kind 화이트리스트, manualAuthor==auth.uid, account member, title
+//   비어있지 않음.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface AddManualKnowledgeNodeResult {

--- a/src/entities/knowledge-output/model/confidence.ts
+++ b/src/entities/knowledge-output/model/confidence.ts
@@ -1,12 +1,14 @@
 /**
- * Knowledge extraction confidence — 보류 스펙 §6.3 신뢰도 정책 구현.
+ * Knowledge extraction confidence — v1 cloud LLM 추출 워커의 신뢰도 정책.
+ * mission v2 에서 추출 워커 자체가 폐기되어 신규 사용처 0 — Firestore
+ * legacy 데이터 의 신뢰도 값을 호환 해석할 때만 사용.
  *
- *   ≥ 0.85   high    — 규격 문서 + 명시적 관계. 자동 승인 후보.
- *   0.60~0.84 medium  — 문맥상 유력. 검수 큐로.
- *   < 0.60   low     — 자동 반영 금지. 사용자 명시 승인 필요.
+ *   ≥ 0.85   high    — 규격 문서 + 명시적 관계
+ *   0.60~0.84 medium  — 문맥상 유력
+ *   < 0.60   low     — 자동 반영 금지
  *
- * 임계값은 결정 §3.3 cutover 기준에 영향을 미치는 핵심 숫자.
- * 변경 시 보류 스펙 §6.3 + 본 파일 + 검수 UI / 추출 워커 prompt 동시 갱신.
+ * 임계값은 cloud-mode legacy fact 의 tier 분류용. 새 흐름은 vault
+ * frontmatter 직접 작성이라 confidence 자체가 적용되지 않음.
  */
 
 export const CONFIDENCE_HIGH_THRESHOLD = 0.85;
@@ -15,8 +17,7 @@ export const CONFIDENCE_MEDIUM_THRESHOLD = 0.6;
 export type ConfidenceTier = 'high' | 'medium' | 'low';
 
 /**
- * 신뢰도 값을 [0, 1] 로 클램프 + 비숫자 fallback.
- * mapper / 추출 워커 / 검수 UI 어디서나 안전하게 사용 가능.
+ * 신뢰도 값을 [0, 1] 로 클램프 + 비숫자 fallback. 어디서든 안전하게 사용 가능.
  */
 export function clampConfidence(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 0;

--- a/src/entities/ontology-tbox/model/types.ts
+++ b/src/entities/ontology-tbox/model/types.ts
@@ -43,7 +43,7 @@ export type OntologyTBoxVersionInput = Omit<OntologyTBoxVersion, 'createdAt'>;
  * 활성 TBox version 포인터. account 당 한 doc.
  *
  * Firestore 구조: `ontologyTBoxState/{accountId}` → 이 객체.
- * fact node 생성 / 추출 워커는 이 포인터를 읽어 활성 versionId 식별.
+ * fact node 생성 시 이 포인터를 읽어 활성 versionId 식별 (cloud 모드).
  */
 export interface OntologyTBoxActiveState {
   accountId: string;

--- a/src/features/vault-ontology/model/use-vault-ontology.ts
+++ b/src/features/vault-ontology/model/use-vault-ontology.ts
@@ -8,11 +8,11 @@ import {
 } from '@/entities/docs-vault';
 
 /**
- * 활성 로컬 vault 의 frontmatter 에서 추출한 ontology stub 을 라이브로 노출.
+ * 활성 로컬 vault 의 frontmatter 에서 derive 한 ontology 노드/엣지를 라이브로 노출.
  *
  * vault 가 활성화 ('loaded') 되어 있어야 실제 derivation 을 반환. 그 외에는
- * 빈 결과 + warning 한 줄. UI 는 이 결과를 *AI 추출 거치지 않은 fast path*
- * stub 으로 인지하고, 검수 큐로 promote 가능한 후보로 표시.
+ * 빈 결과 + warning 한 줄. mission v2: frontmatter 자체가 진실원이라 별도
+ * promote / 승격 단계 없이 그대로 ontology 그래프로 surface.
  */
 export function useVaultOntology(): VaultOntologyDerivation {
   const vault = useLocalVault();

--- a/src/views/knowledge-document-detail/ui/parts/labels.ts
+++ b/src/views/knowledge-document-detail/ui/parts/labels.ts
@@ -25,7 +25,8 @@ export function resolveNodeKindLabel(kind: string): string {
  * `KnowledgeOutput.edges[].sourceTempId / targetTempId` 가 가리키는 노드의 사람
  * 친화 title 을 lookup. 매치되는 노드가 없으면 tempId 를 그대로 반환 (fallback).
  *
- * Output 의 edge 표시 / 검수 큐 후보 라인 / 알림 toast 등에서 ID 대신 title 표시.
+ * Output 의 edge 표시 / 알림 toast 등에서 ID 대신 title 표시 (legacy cloud
+ * extraction output viewer 잔존 헬퍼 — mission v2 에서 추출 자체 폐기).
  */
 export function resolveOutputNodeTitle(
   output: KnowledgeOutput,

--- a/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
+++ b/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
@@ -302,8 +302,10 @@ function NewDocumentContent() {
           <p className="mt-3 max-w-xl text-sm leading-6 text-[color:var(--color-text-secondary)]">
             제목, 프로젝트, 원문만 넣고 먼저 등록할 수 있습니다.
           </p>
-          {/* 워크플로 컨텍스트 — 첫 사용자가 등록 후 무엇이 일어나는지 알 수 있게.
-              검수 큐 stepper (B-2) 와 동일한 4단계 모델. 현재는 1단계 ('올리기'). */}
+          {/* 워크플로 컨텍스트 — 첫 사용자가 등록 후 무엇이 일어나는지 알 수
+              있게. cloud 모드 4단계 (올리기 → 분류 → 표현 → 발행) 의 "1.
+              올리기" 단계. mission v2 의 default 흐름은 vault frontmatter 라
+              이 cloud 4단계는 cloud-mode 사용자에게만 의미. */}
           <ol
             aria-label="문서 라이프사이클 4단계 — 현재 1. 올리기"
             className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -83,7 +83,7 @@ export function OntologyViewPage() {
     const qs = params.toString();
     router.replace(qs ? `/ontology/?${qs}` : "/ontology/", { scroll: false });
   };
-  // manual node create — 추출 워커 거치지 않고 사용자가 직접 노드 작성 (B 라인).
+  // manual node create — 사용자가 트리 surface 에서 직접 노드 추가하는 modal.
   const [manualOpen, setManualOpen] = useState(false);
   // manual edge create — 노드 상세 패널 "+ 관계 추가" 진입.
   const [edgeOpen, setEdgeOpen] = useState(false);
@@ -215,9 +215,9 @@ export function OntologyViewPage() {
               </button>
             </Tooltip>
           </h1>
-          {/* UX-3: 모바일에서 5 pill row 가 375 폭에 안 들어가 "검수 큐" 가
-              잘렸음. flex-wrap + horizontal scroll 보조로 안전하게. md+ 는
-              한 줄 유지. -mr/-ml 음수 마진 + px padding 으로 우측 잘림 방지. */}
+          {/* 모바일에서 pill row 가 375 폭에 안 들어가 잘릴 때를 위해
+              flex-wrap + horizontal scroll 보조. md+ 는 한 줄 유지. -mr/-ml
+              음수 마진 + px padding 으로 우측 잘림 방지. */}
           <div className="-mx-1 flex w-full items-center gap-2 overflow-x-auto px-1 pb-1 md:w-auto md:flex-wrap md:overflow-visible md:pb-0">
             <Tooltip content="새 노드 직접 추가" withProvider={false}>
               <button

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -19,7 +19,7 @@ import { matchKnowledgeDocuments, matchOntologyNodes, matchProjects } from "../l
 export interface GlobalSearchProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** ontology approved 노드 — 첫 검색 source. */
+  /** ontology 노드 — 첫 검색 source (vault frontmatter / 빌더 / cloud 모두 통합). */
   nodes: readonly KnowledgeGraphNode[];
   /** ontology 노드 선택 콜백. */
   onSelectNode: (node: KnowledgeGraphNode) => void;


### PR DESCRIPTION
contributor / AI agent 가 코드 읽을 때 보는 내부 JSDoc + inline 코멘트의 v1 mental model 정렬. 8 파일. user-visible 영향 0. tsc 0 / 113·789 pass.