### PR TITLE
refactor: Firebase SDK dynamic import — local-first 첫 paint 청크 firebase 0

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
-import { FirebaseProvider, MotionProvider } from '@/app-providers/providers';
+import { MotionProvider } from '@/app-providers/providers';
+// 콘솔 노이즈 패치 — firebase 의존 0. side-effect import 로 install.
+// Firebase JS 자체는 cloud 모드 진입 시점에 dynamic import 경로로만 들어와
+// local-first 첫 paint 를 firebase 청크 없이 유지한다.
+import '@/shared/lib/firestore-noise-patch';
 import { TaxonomyProvider } from '@/features/taxonomy';
 import { BottomTabBar } from '@/widgets/bottom-tab-bar';
 import { ToastProvider, TooltipProvider } from '@/shared/ui';
@@ -153,18 +157,16 @@ export default function RootLayout({
           메인 콘텐츠로 건너뛰기
         </a>
         <MotionProvider>
-          <FirebaseProvider>
-            <TaxonomyProvider>
-              <ToastProvider>
-                {/* Fire 5b — Tooltip Provider 전역 1회. 하위 모든
-                    `<Tooltip withProvider={false}>` 가 이 Context 를 공유. */}
-                <TooltipProvider delayDuration={300}>
-                  {children}
-                  <BottomTabBar />
-                </TooltipProvider>
-              </ToastProvider>
-            </TaxonomyProvider>
-          </FirebaseProvider>
+          <TaxonomyProvider>
+            <ToastProvider>
+              {/* Fire 5b — Tooltip Provider 전역 1회. 하위 모든
+                  `<Tooltip withProvider={false}>` 가 이 Context 를 공유. */}
+              <TooltipProvider delayDuration={300}>
+                {children}
+                <BottomTabBar />
+              </TooltipProvider>
+            </ToastProvider>
+          </TaxonomyProvider>
         </MotionProvider>
       </body>
     </html>

--- a/app/project/[slug]/edit/page.tsx
+++ b/app/project/[slug]/edit/page.tsx
@@ -7,7 +7,7 @@ interface Params {
 }
 
 export async function generateStaticParams(): Promise<Params[]> {
-  const { fetchAllProjectsAtBuild } = await import('@/entities/project');
+  const { fetchAllProjectsAtBuild } = await import('@/entities/project/api');
   const {
     deriveProjectsFromVault,
     vaultManifest: staticVaultManifestRaw,
@@ -28,7 +28,7 @@ export async function generateMetadata({
   params: Promise<Params>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const { fetchAllProjectsAtBuild } = await import('@/entities/project');
+  const { fetchAllProjectsAtBuild } = await import('@/entities/project/api');
   const projects = await fetchAllProjectsAtBuild();
   const project = projects.find((p) => p.slug === slug);
   return {

--- a/app/project/[slug]/opengraph-image.tsx
+++ b/app/project/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { fetchAllProjectsAtBuild } from '@/entities/project';
+import { fetchAllProjectsAtBuild } from '@/entities/project/api';
 import {
   deriveProjectsFromVault,
   vaultManifest as staticVaultManifestRaw,

--- a/app/project/[slug]/page.tsx
+++ b/app/project/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { fetchAllProjectsAtBuild } from '@/entities/project';
+import { fetchAllProjectsAtBuild } from '@/entities/project/api';
 import {
   deriveProjectsFromVault,
   vaultManifest as staticVaultManifestRaw,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { fetchAllProjectsAtBuild } from '@/entities/project';
+import { fetchAllProjectsAtBuild } from '@/entities/project/api';
 import { SITE_URL } from '@/shared/config';
 
 // 정적 export 모드에선 빌드 타임에 확정되어야 한다.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "oh-my-ontology",
   "version": "0.1.0",
   "private": true,
+  "sideEffects": [
+    "*.css",
+    "**/firestore-noise-patch*",
+    "**/globals.css"
+  ],
   "scripts": {
     "predev": "pnpm docs-vault:build",
     "dev": "next dev",

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -1,2 +1,1 @@
-export { FirebaseProvider } from './FirebaseProvider';
 export { MotionProvider } from './MotionProvider';

--- a/src/entities/admin/index.ts
+++ b/src/entities/admin/index.ts
@@ -1,1 +1,3 @@
-export { isAdmin } from './api';
+// `isAdmin` 은 `@/entities/admin/api` 로 직접 import — firebase 정적 leak 차단.
+// barrel 자체가 비면 import 자체가 unused 가 되어 webpack 이 erase 하기 더 쉬움.
+export {};

--- a/src/entities/category/index.ts
+++ b/src/entities/category/index.ts
@@ -6,9 +6,4 @@ export type {
   BorderStyle,
 } from './model';
 export { DEFAULT_CATEGORIES, hasRegisteredCategoryRegions } from './model';
-export {
-  subscribeCategories,
-  upsertCategory,
-  deleteCategory,
-  seedDefaultCategoriesIfEmpty,
-} from './api';
+// API 함수는 `@/entities/category/api` 로 분리 — firebase 정적 leak 차단.

--- a/src/entities/category/model/mapper.ts
+++ b/src/entities/category/model/mapper.ts
@@ -1,5 +1,6 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+type DocumentData = Record<string, unknown>;
 import type { Category, CategoryInput } from './types';
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
 
 /**
  * Firestore 문서 → Category.
@@ -43,7 +44,5 @@ export function toFirestore(input: CategoryInput): Record<string, unknown> {
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/entities/knowledge-document/index.ts
+++ b/src/entities/knowledge-document/index.ts
@@ -17,21 +17,7 @@ export {
   toFirestoreKnowledgeDocument,
   toKnowledgeDocumentMetadataInput,
 } from "./model";
-export {
-  listKnowledgeDocuments,
-  getKnowledgeDocument,
-  subscribeKnowledgeDocuments,
-  subscribeKnowledgeDocumentsByProject,
-  getPublicDocumentsForProject,
-  createKnowledgeDocumentWithInitialVersion,
-  createKnowledgeDocumentVersion,
-  setKnowledgeDocumentCurrentVersion,
-  listKnowledgeVersionsByDocument,
-  subscribeKnowledgeVersionsByDocument,
-  buildKnowledgeDocumentStoragePath,
-  downloadKnowledgeMarkdown,
-  uploadKnowledgeMarkdown,
-} from "./api";
+// API 는 `@/entities/knowledge-document/api` 로 분리.
 export {
   getKnowledgeDocumentDetailHref,
   getKnowledgeDocumentListHref,

--- a/src/entities/knowledge-document/model/mapper.ts
+++ b/src/entities/knowledge-document/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from "firebase/firestore";
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from "@/shared/lib/firestore-timestamp-coerce";
 import type {
   KnowledgeDocument,
   KnowledgeDocumentMetadataInput,
@@ -62,7 +63,5 @@ export function toKnowledgeDocumentMetadataInput(
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/entities/knowledge-evidence/index.ts
+++ b/src/entities/knowledge-evidence/index.ts
@@ -1,3 +1,3 @@
 export type { KnowledgeEvidence } from "./model";
 export { fromFirestoreKnowledgeEvidence } from "./model";
-export { subscribeKnowledgeEvidenceByDocument } from "./api";
+// API 함수는 `@/entities/knowledge-evidence/api` 로 분리.

--- a/src/entities/knowledge-evidence/model/mapper.ts
+++ b/src/entities/knowledge-evidence/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from "firebase/firestore";
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from "@/shared/lib/firestore-timestamp-coerce";
 import type { KnowledgeEvidence } from "./types";
 
 export function fromFirestoreKnowledgeEvidence(
@@ -23,7 +24,5 @@ export function fromFirestoreKnowledgeEvidence(
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/entities/knowledge-graph/api/index.ts
+++ b/src/entities/knowledge-graph/api/index.ts
@@ -1,0 +1,19 @@
+// Firestore 구독 / mutation / 훅 — barrel 진입점.
+// `@/entities/knowledge-graph` (lib/types only) 와 분리해 firebase 의존이
+// 정적 그래프로 leak 되지 않게 한다.
+export {
+  listKnowledgeProjectInsight,
+  subscribeKnowledgeProjectInsight,
+  subscribeKnowledgePublicGraph,
+  subscribeKnowledgeApprovedGraph,
+  subscribeKnowledgePublicMeta,
+  addManualKnowledgeNode,
+  addManualKnowledgeEdge,
+} from './knowledge-graph-api';
+export type {
+  AddManualKnowledgeNodeResult,
+  AddManualKnowledgeEdgeResult,
+} from './knowledge-graph-api';
+export { useKnowledgePublicNodes } from './use-knowledge-public-nodes';
+export { useKnowledgePublicInsight } from './use-knowledge-public-insight';
+export type { UseKnowledgePublicInsightResult } from './use-knowledge-public-insight';

--- a/src/entities/knowledge-graph/api/use-knowledge-public-insight.ts
+++ b/src/entities/knowledge-graph/api/use-knowledge-public-insight.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import type { KnowledgeProjectInsight } from "../model/types";
-import { subscribeKnowledgePublicGraph } from "./knowledge-graph-api";
 
 /**
  * `knowledgePublic*` projection 의 full insight (nodes + edges + meta) 구독.
@@ -26,12 +25,23 @@ export function useKnowledgePublicInsight(
   useEffect(() => {
     setInsight(null);
     setError(null);
-    const unsubscribe = subscribeKnowledgePublicGraph(
-      accountId,
-      (next) => setInsight(next),
-      (err) => setError(err),
-    );
-    return () => unsubscribe();
+    // Firestore SDK 는 dynamic import — vault/local 모드에선 cloud 구독을
+    // 호출하지 않아도 (mode-gate) 정적 import 만으로 firebase JS 가
+    // 청크에 박히는 걸 막는다.
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("./knowledge-graph-api").then(({ subscribeKnowledgePublicGraph }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgePublicGraph(
+        accountId,
+        (next) => setInsight(next),
+        (err) => setError(err),
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   return { insight, error };

--- a/src/entities/knowledge-graph/api/use-knowledge-public-nodes.ts
+++ b/src/entities/knowledge-graph/api/use-knowledge-public-nodes.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import type { KnowledgeGraphNode } from "../model/types";
-import { subscribeKnowledgePublicGraph } from "./knowledge-graph-api";
 
 /**
  * `knowledgePublic*` projection 의 nodes 만 client-side 구독.
@@ -22,12 +21,20 @@ export function useKnowledgePublicNodes(accountId: string | null): KnowledgeGrap
   const [nodes, setNodes] = useState<KnowledgeGraphNode[]>([]);
   useEffect(() => {
     setNodes([]);
-    const unsubscribe = subscribeKnowledgePublicGraph(
-      accountId,
-      (insight) => setNodes(insight.nodes),
-      () => setNodes([]),
-    );
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("./knowledge-graph-api").then(({ subscribeKnowledgePublicGraph }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgePublicGraph(
+        accountId,
+        (insight) => setNodes(insight.nodes),
+        () => setNodes([]),
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
   return nodes;
 }

--- a/src/entities/knowledge-graph/index.ts
+++ b/src/entities/knowledge-graph/index.ts
@@ -33,21 +33,17 @@ export {
   validateManualKnowledgeEdgeInput,
   composeManualEdgeId,
 } from "./model";
+// Firestore 구독 훅 (`useKnowledgePublic*`) 은 내부에서 dynamic import 만
+// 사용해 firebase 의존이 없다 — 정적 import 가능. mutation / direct subscribe
+// 함수는 `@/entities/knowledge-graph/api` 경로로 분리.
+export { useKnowledgePublicNodes } from "./api/use-knowledge-public-nodes";
 export {
-  listKnowledgeProjectInsight,
-  subscribeKnowledgeProjectInsight,
-  subscribeKnowledgePublicGraph,
-  subscribeKnowledgeApprovedGraph,
-  subscribeKnowledgePublicMeta,
-  addManualKnowledgeNode,
-  addManualKnowledgeEdge,
-} from "./api/knowledge-graph-api";
+  useKnowledgePublicInsight,
+  type UseKnowledgePublicInsightResult,
+} from "./api/use-knowledge-public-insight";
 export type {
   AddManualKnowledgeNodeResult,
   AddManualKnowledgeEdgeResult,
 } from "./api/knowledge-graph-api";
-export { useKnowledgePublicNodes } from "./api/use-knowledge-public-nodes";
-export { useKnowledgePublicInsight } from "./api/use-knowledge-public-insight";
-export type { UseKnowledgePublicInsightResult } from "./api/use-knowledge-public-insight";
 export { ManualSourceChip } from "./ui/ManualSourceChip";
 export type { ManualSourceChipProps } from "./ui/ManualSourceChip";

--- a/src/entities/knowledge-job/index.ts
+++ b/src/entities/knowledge-job/index.ts
@@ -7,9 +7,7 @@ export {
   fromFirestoreKnowledgeJob,
   resolveKnowledgeJobActionState,
 } from "./model";
-export {
-  subscribeKnowledgeJobsByDocument,
-} from "./api";
+// API 는 `@/entities/knowledge-job/api` 로 분리.
 export {
   KNOWLEDGE_JOB_STATUS_OPTIONS,
   getKnowledgeJobStatusLabel,

--- a/src/entities/knowledge-job/model/mapper.ts
+++ b/src/entities/knowledge-job/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from "firebase/firestore";
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from "@/shared/lib/firestore-timestamp-coerce";
 import type { KnowledgeJob } from "./types";
 
 export function fromFirestoreKnowledgeJob(
@@ -33,15 +34,11 @@ export function fromFirestoreKnowledgeJob(
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }
 
-function toOptionalDate(value: unknown) {
+function toOptionalDate(value: unknown): Date | undefined {
   if (!value) return undefined;
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return undefined;
+  return coerceFirestoreDate(value);
 }
 

--- a/src/entities/knowledge-job/model/mapper.ts
+++ b/src/entities/knowledge-job/model/mapper.ts
@@ -39,6 +39,9 @@ function toDate(value: unknown): Date {
 
 function toOptionalDate(value: unknown): Date | undefined {
   if (!value) return undefined;
-  return coerceFirestoreDate(value);
+  // 매칭 안 되는 값은 coerceFirestoreDate 가 epoch 0 fallback. 호출자
+  // 계약은 "정말 모르면 undefined" 라 epoch 0 은 undefined 로 정상화.
+  const d = coerceFirestoreDate(value);
+  return d.getTime() === 0 ? undefined : d;
 }
 

--- a/src/entities/knowledge-output/index.ts
+++ b/src/entities/knowledge-output/index.ts
@@ -15,4 +15,4 @@ export {
   isAutoApprovable,
   requiresExplicitReview,
 } from "./model";
-export { subscribeKnowledgeOutputsByDocument } from "./api";
+// API 는 `@/entities/knowledge-output/api` 로 분리.

--- a/src/entities/knowledge-output/model/mapper.ts
+++ b/src/entities/knowledge-output/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from "firebase/firestore";
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from "@/shared/lib/firestore-timestamp-coerce";
 import { clampConfidence } from "./confidence";
 import type {
   KnowledgeOutput,
@@ -126,7 +127,5 @@ function mapEdge(value: unknown): KnowledgeOutputEdge | null {
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/entities/knowledge-version/model/mapper.ts
+++ b/src/entities/knowledge-version/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from "firebase/firestore";
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from "@/shared/lib/firestore-timestamp-coerce";
 import type { KnowledgeVersion } from "./types";
 
 export function fromFirestoreKnowledgeVersion(
@@ -44,7 +45,5 @@ export function toFirestoreKnowledgeVersion(
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/entities/ontology-class/index.ts
+++ b/src/entities/ontology-class/index.ts
@@ -11,8 +11,5 @@ export {
   fromFirestore,
   toFirestore,
 } from './model';
-export {
-  subscribeOntologyClasses,
-  upsertOntologyClass,
-  seedDefaultOntologyClassesIfEmpty,
-} from './api';
+// API 함수는 barrel 에서 제외 — `@/entities/ontology-class/api` 로 직접
+// import. 정적 그래프에 firebase/firestore 가 박히지 않게.

--- a/src/entities/ontology-class/model/mapper.ts
+++ b/src/entities/ontology-class/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
 import type {
   OntologyClass,
   OntologyClassInput,
@@ -25,16 +26,12 @@ function toElementType(value: unknown): OntologyElementType | undefined {
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }
 
 function toOptionalDate(value: unknown): Date | undefined {
   if (value === undefined || value === null) return undefined;
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return undefined;
+  return coerceFirestoreDate(value);
 }
 
 export function fromFirestore(id: string, data: DocumentData): OntologyClass {

--- a/src/entities/ontology-class/model/mapper.ts
+++ b/src/entities/ontology-class/model/mapper.ts
@@ -31,7 +31,10 @@ function toDate(value: unknown): Date {
 
 function toOptionalDate(value: unknown): Date | undefined {
   if (value === undefined || value === null) return undefined;
-  return coerceFirestoreDate(value);
+  // 매칭 안 되는 값은 coerceFirestoreDate 가 epoch 0 fallback. 호출자
+  // 계약은 "정말 모르면 undefined" 라 epoch 0 은 undefined 로 정상화.
+  const d = coerceFirestoreDate(value);
+  return d.getTime() === 0 ? undefined : d;
 }
 
 export function fromFirestore(id: string, data: DocumentData): OntologyClass {

--- a/src/entities/ontology-relation/index.ts
+++ b/src/entities/ontology-relation/index.ts
@@ -10,8 +10,4 @@ export {
   fromFirestore,
   toFirestore,
 } from './model';
-export {
-  subscribeOntologyRelations,
-  upsertOntologyRelation,
-  seedDefaultOntologyRelationsIfEmpty,
-} from './api';
+// API 는 `@/entities/ontology-relation/api` 로 분리.

--- a/src/entities/ontology-relation/model/mapper.ts
+++ b/src/entities/ontology-relation/model/mapper.ts
@@ -31,7 +31,10 @@ function toDate(value: unknown): Date {
 
 function toOptionalDate(value: unknown): Date | undefined {
   if (value === undefined || value === null) return undefined;
-  return coerceFirestoreDate(value);
+  // 매칭 안 되는 값은 coerceFirestoreDate 가 epoch 0 fallback. 호출자
+  // 계약은 "정말 모르면 undefined" 라 epoch 0 은 undefined 로 정상화.
+  const d = coerceFirestoreDate(value);
+  return d.getTime() === 0 ? undefined : d;
 }
 
 export function fromFirestore(id: string, data: DocumentData): OntologyRelation {

--- a/src/entities/ontology-relation/model/mapper.ts
+++ b/src/entities/ontology-relation/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
 import type {
   OntologyRelation,
   OntologyRelationCategory,
@@ -25,16 +26,12 @@ function toStringArray(value: unknown): string[] {
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }
 
 function toOptionalDate(value: unknown): Date | undefined {
   if (value === undefined || value === null) return undefined;
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return undefined;
+  return coerceFirestoreDate(value);
 }
 
 export function fromFirestore(id: string, data: DocumentData): OntologyRelation {

--- a/src/entities/ontology-tbox/index.ts
+++ b/src/entities/ontology-tbox/index.ts
@@ -1,2 +1,2 @@
 export * from './model';
-export * from './api';
+// API 는 `@/entities/ontology-tbox/api` 로 분리 — firebase 정적 leak 차단.

--- a/src/entities/ontology-tbox/model/mapper.ts
+++ b/src/entities/ontology-tbox/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
 import {
   fromFirestore as fromClassDoc,
   toFirestore as toClassDoc,
@@ -17,9 +18,7 @@ import type {
 } from './types';
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }
 
 /**

--- a/src/entities/project/index.ts
+++ b/src/entities/project/index.ts
@@ -51,18 +51,10 @@ export type {
   ProjectRelationshipKind,
   ProjectRelationshipMeta,
 } from "./model";
-export {
-  listProjects,
-  getProject,
-  upsertProject,
-  upsertProjectPositions,
-  deleteProject,
-  deleteProjects,
-  subscribeProjects,
-  fetchAllProjectsAtBuild,
-  uploadScreenshot,
-  deleteScreenshot,
-} from "./api";
+// API 함수는 barrel 에서 제외 — `@/entities/project/api` 로 직접 import 한다.
+// 이유: 이 barrel 을 type / lib only 로 import 하는 페이지가 많은데, api/
+// 가 firebase/firestore 를 정적으로 끌어와 local-first 첫 paint 청크에 ~640kb
+// 의 firestore SDK 가 박힌다. 분리해 cloud-mode 페이지만 firebase 다운로드.
 export { getProjectDetailHref, getProjectDetailUrl } from "./lib/detail-href";
 export { getTopologyProjectHref } from "./lib/topology-href";
 export { ProjectCard } from "./ui/ProjectCard";

--- a/src/entities/project/model/mapper.ts
+++ b/src/entities/project/model/mapper.ts
@@ -1,42 +1,56 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+// Firestore `DocumentData` 는 indexable any 라 mapper 안 cast 가 자유롭다.
+// firebase 의존을 끊으려고 local alias 로 동등 타입 정의.
+type DocumentData = { [k: string]: unknown };
 import type { Project, ProjectInput } from './types';
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
+
+type FirestoreRecord = Record<string, unknown>;
+
+function toDateOrUndefined(value: unknown): Date | undefined {
+  if (value === undefined || value === null) return undefined;
+  const d = coerceFirestoreDate(value);
+  return d.getTime() === 0 ? undefined : d;
+}
 
 /**
  * Firestore 문서 데이터를 앱 도메인 모델(Project)로 변환.
  * Timestamp → Date, 누락 필드는 안전한 기본값으로 채운다.
  */
 export function fromFirestore(slug: string, data: DocumentData): Project {
+  const d = data as FirestoreRecord;
+  const timeline = (d.timeline as FirestoreRecord | undefined) ?? {};
+  const position = (d.position as FirestoreRecord | undefined) ?? {};
   return {
-    accountId: data.accountId ?? undefined,
+    accountId: (d.accountId as string | undefined) ?? undefined,
     slug,
-    name: data.name ?? '',
-    nameEn: data.nameEn ?? undefined,
-    category: data.category ?? 'in-progress',
-    status: data.status ?? 'idea',
-    description: data.description ?? '',
-    detail: data.detail ?? undefined,
-    tags: Array.isArray(data.tags) ? data.tags : [],
-    stack: Array.isArray(data.stack) ? data.stack : [],
-    links: Array.isArray(data.links) ? data.links : [],
-    dependencies: Array.isArray(data.dependencies) ? data.dependencies : [],
-    owner: data.owner ?? undefined,
-    icon: data.icon ?? undefined,
-    screenshots: Array.isArray(data.screenshots) ? data.screenshots : [],
+    name: (d.name as string | undefined) ?? '',
+    nameEn: (d.nameEn as string | undefined) ?? undefined,
+    category: ((d.category as string | undefined) ?? 'in-progress') as Project['category'],
+    status: ((d.status as string | undefined) ?? 'idea') as Project['status'],
+    description: (d.description as string | undefined) ?? '',
+    detail: (d.detail as string | undefined) ?? undefined,
+    tags: Array.isArray(d.tags) ? (d.tags as string[]) : [],
+    stack: Array.isArray(d.stack) ? (d.stack as string[]) : [],
+    links: Array.isArray(d.links) ? (d.links as Project['links']) : [],
+    dependencies: Array.isArray(d.dependencies) ? (d.dependencies as Project['dependencies']) : [],
+    owner: (d.owner as Project['owner']) ?? undefined,
+    icon: (d.icon as string | undefined) ?? undefined,
+    screenshots: Array.isArray(d.screenshots) ? (d.screenshots as string[]) : [],
     timeline: {
-      startedAt: data.timeline?.startedAt instanceof Timestamp ? data.timeline.startedAt.toDate() : undefined,
-      launchedAt: data.timeline?.launchedAt instanceof Timestamp ? data.timeline.launchedAt.toDate() : undefined,
+      startedAt: toDateOrUndefined(timeline.startedAt),
+      launchedAt: toDateOrUndefined(timeline.launchedAt),
     },
-    progress: typeof data.progress === 'number' ? data.progress : undefined,
-    isHub: Boolean(data.isHub),
-    hubSlugs: Array.isArray(data.hubSlugs)
-      ? data.hubSlugs.filter((s): s is string => typeof s === 'string' && s.length > 0)
+    progress: typeof d.progress === 'number' ? d.progress : undefined,
+    isHub: Boolean(d.isHub),
+    hubSlugs: Array.isArray(d.hubSlugs)
+      ? (d.hubSlugs as unknown[]).filter((s): s is string => typeof s === 'string' && s.length > 0)
       : undefined,
     position: {
-      x: typeof data.position?.x === 'number' ? data.position.x : 0,
-      y: typeof data.position?.y === 'number' ? data.position.y : 0,
+      x: typeof position.x === 'number' ? position.x : 0,
+      y: typeof position.y === 'number' ? position.y : 0,
     },
-    createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(0),
-    updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(0),
+    createdAt: coerceFirestoreDate(d.createdAt),
+    updatedAt: coerceFirestoreDate(d.updatedAt),
   };
 }
 

--- a/src/entities/status/index.ts
+++ b/src/entities/status/index.ts
@@ -1,8 +1,3 @@
 export type { Status, StatusInput, StatusDotColor } from './model';
 export { DEFAULT_STATUSES } from './model';
-export {
-  subscribeStatuses,
-  upsertStatus,
-  deleteStatus,
-  seedDefaultStatusesIfEmpty,
-} from './api';
+// API 함수는 `@/entities/status/api` 로 분리 — firebase 정적 leak 차단.

--- a/src/entities/status/model/mapper.ts
+++ b/src/entities/status/model/mapper.ts
@@ -1,4 +1,5 @@
-import { Timestamp, type DocumentData } from 'firebase/firestore';
+type DocumentData = Record<string, unknown>;
+import { coerceFirestoreDate } from '@/shared/lib/firestore-timestamp-coerce';
 import type { Status, StatusInput } from './types';
 
 export function fromFirestore(id: string, data: DocumentData): Status {
@@ -24,7 +25,5 @@ export function toFirestore(input: StatusInput): Record<string, unknown> {
 }
 
 function toDate(value: unknown): Date {
-  if (value instanceof Timestamp) return value.toDate();
-  if (value instanceof Date) return value;
-  return new Date(0);
+  return coerceFirestoreDate(value);
 }

--- a/src/features/permissions/model/use-global-admin.ts
+++ b/src/features/permissions/model/use-global-admin.ts
@@ -53,21 +53,34 @@ export function useGlobalAdmin(): GlobalAdminState {
       import('firebase/auth'),
       import('@/shared/api'),
       import('@/entities/admin/api'),
-    ]).then(([{ onAuthStateChanged }, { getFirebaseAuth }, { isAdmin }]) => {
-      if (cancelled) return;
-      const auth = getFirebaseAuth();
-      unsubscribe = onAuthStateChanged(auth, async (user) => {
-        if (!user) {
-          setFirebaseState({ status: 'unauthenticated', user: null });
-          return;
-        }
-        const allowed = await isAdmin(user.email);
-        setFirebaseState({
-          status: allowed ? 'authenticated' : 'not-allowed',
-          user,
+    ])
+      .then(([{ onAuthStateChanged }, { getFirebaseAuth }, { isAdmin }]) => {
+        if (cancelled) return;
+        const auth = getFirebaseAuth();
+        unsubscribe = onAuthStateChanged(auth, async (user) => {
+          if (!user) {
+            setFirebaseState({ status: 'unauthenticated', user: null });
+            return;
+          }
+          const allowed = await isAdmin(user.email);
+          // await 사이에 effect 가 cleanup 되면 setState 가 unmount 컴포넌트에
+          // fire 되니 한 번 더 cancelled 가드.
+          if (cancelled) return;
+          setFirebaseState({
+            status: allowed ? 'authenticated' : 'not-allowed',
+            user,
+          });
         });
+      })
+      .catch((err) => {
+        // chunk fetch 실패 시 (네트워크 끊김 / 광고차단) state 가 영원히
+        // 'loading' 으로 남으면 PermissionGate 가 영영 안 열린다 — 명시적
+        // 'unauthenticated' 로 fallback 해 cloud 기능을 잠그되 vault 모드는
+        // 계속 동작하게.
+        if (cancelled) return;
+        console.warn('[useGlobalAdmin] firebase chunk load failed', err);
+        setFirebaseState({ status: 'unauthenticated', user: null });
       });
-    });
 
     return () => {
       cancelled = true;

--- a/src/features/permissions/model/use-global-admin.ts
+++ b/src/features/permissions/model/use-global-admin.ts
@@ -1,9 +1,7 @@
 'use client';
 
 import { useEffect, useState, useSyncExternalStore } from 'react';
-import { onAuthStateChanged, type User } from 'firebase/auth';
-import { getFirebaseAuth } from '@/shared/api';
-import { isAdmin } from '@/entities/admin';
+import type { User } from 'firebase/auth';
 import { useUserAuth } from '@/features/user-auth';
 
 export type GlobalAdminStatus = 'loading' | 'unauthenticated' | 'not-allowed' | 'authenticated';
@@ -46,20 +44,35 @@ export function useGlobalAdmin(): GlobalAdminState {
   useEffect(() => {
     if (!isClient) return;
 
-    const auth = getFirebaseAuth();
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
-      if (!user) {
-        setFirebaseState({ status: 'unauthenticated', user: null });
-        return;
-      }
-      const allowed = await isAdmin(user.email);
-      setFirebaseState({
-        status: allowed ? 'authenticated' : 'not-allowed',
-        user,
+    // Firebase Auth + Firestore SDK 는 dynamic import — 비-cloud 페이지의 첫
+    // paint 청크에 firebase 가 들어가지 않게.
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+
+    void Promise.all([
+      import('firebase/auth'),
+      import('@/shared/api'),
+      import('@/entities/admin/api'),
+    ]).then(([{ onAuthStateChanged }, { getFirebaseAuth }, { isAdmin }]) => {
+      if (cancelled) return;
+      const auth = getFirebaseAuth();
+      unsubscribe = onAuthStateChanged(auth, async (user) => {
+        if (!user) {
+          setFirebaseState({ status: 'unauthenticated', user: null });
+          return;
+        }
+        const allowed = await isAdmin(user.email);
+        setFirebaseState({
+          status: allowed ? 'authenticated' : 'not-allowed',
+          user,
+        });
       });
     });
 
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [isClient]);
 
   if (!isClient) {

--- a/src/features/project-data-source/model/use-project-mutations.ts
+++ b/src/features/project-data-source/model/use-project-mutations.ts
@@ -7,12 +7,19 @@ import {
   buildProjectMarkdown,
   projectToFrontmatter,
 } from '@/entities/docs-vault';
-import {
-  deleteProject as cloudDeleteProject,
-  getProject,
-  upsertProject as cloudUpsertProject,
-  type ProjectInput,
-} from '@/entities/project';
+import type { ProjectInput } from '@/entities/project';
+
+// Cloud entity api 는 cloud-mode 분기에서만 호출된다. dynamic import 로
+// 분리해 local-first 페이지 (ProjectSelectorPage 등) 의 정적 청크에 firebase
+// 가 박히는 것을 막는다.
+async function loadCloudProjectApi() {
+  const mod = await import('@/entities/project/api');
+  return {
+    cloudDeleteProject: mod.deleteProject,
+    cloudUpsertProject: mod.upsertProject,
+    getProject: mod.getProject,
+  };
+}
 
 /**
  * mode 별로 분기되는 project mutation hook.
@@ -61,6 +68,7 @@ export function useProjectMutations(): ProjectMutations {
         return;
       }
       // cloud
+      const { getProject, cloudUpsertProject } = await loadCloudProjectApi();
       const existing = await getProject(input.slug, input.accountId);
       if (existing) throw new Error('이미 존재하는 slug입니다.');
       await cloudUpsertProject(input);
@@ -86,6 +94,7 @@ export function useProjectMutations(): ProjectMutations {
         return;
       }
       // cloud
+      const { cloudUpsertProject } = await loadCloudProjectApi();
       await cloudUpsertProject(input);
     },
     [mode, vault],
@@ -101,6 +110,7 @@ export function useProjectMutations(): ProjectMutations {
         return;
       }
       // cloud — entity 가 accountId optional, 호출자 책임이 단일 단순 케이스.
+      const { cloudDeleteProject } = await loadCloudProjectApi();
       await cloudDeleteProject(slug);
     },
     [mode, vault],

--- a/src/features/project-data-source/model/use-projects.ts
+++ b/src/features/project-data-source/model/use-projects.ts
@@ -63,20 +63,29 @@ export function useProjects(accountId?: string | null): UseProjectsState {
     setCloudError(null);
     let unsubscribe: (() => void) | null = null;
     let cancelled = false;
-    void import('@/entities/project/api').then(({ subscribeProjects }) => {
-      if (cancelled) return;
-      unsubscribe = subscribeProjects(
-        accountId ?? null,
-        (next) => {
-          setCloudProjects(next);
-          setCloudLoaded(true);
-        },
-        (error) => {
-          setCloudError(error.message?.trim() || '프로젝트를 불러오지 못했습니다.');
-          setCloudLoaded(true);
-        },
-      );
-    });
+    void import('@/entities/project/api')
+      .then(({ subscribeProjects }) => {
+        if (cancelled) return;
+        unsubscribe = subscribeProjects(
+          accountId ?? null,
+          (next) => {
+            setCloudProjects(next);
+            setCloudLoaded(true);
+          },
+          (error) => {
+            setCloudError(error.message?.trim() || '프로젝트를 불러오지 못했습니다.');
+            setCloudLoaded(true);
+          },
+        );
+      })
+      .catch((err) => {
+        // chunk fetch 실패 — spinner 가 영영 안 사라지지 않게 loaded=true +
+        // 에러 메시지로 UX 회복.
+        if (cancelled) return;
+        console.warn('[useProjects] cloud entity api chunk load failed', err);
+        setCloudError('프로젝트를 불러오지 못했습니다. 네트워크 확인 후 새로고침하세요.');
+        setCloudLoaded(true);
+      });
     return () => {
       cancelled = true;
       unsubscribe?.();

--- a/src/features/project-data-source/model/use-projects.ts
+++ b/src/features/project-data-source/model/use-projects.ts
@@ -12,7 +12,7 @@ import {
 // JSON import 가 mode 같은 union 필드를 string 으로 추론. 빌드 시점에 schema
 // 가 안정적이라 runtime 검증 대신 cast.
 const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
-import { subscribeProjects, type Project } from '@/entities/project';
+import type { Project } from '@/entities/project';
 
 /**
  * mode-aware read 어댑터.
@@ -56,22 +56,31 @@ export function useProjects(accountId?: string | null): UseProjectsState {
     return deriveProjectsFromVault(staticVaultManifest);
   }, [mode]);
 
-  // cloud — Firestore 구독.
+  // cloud — Firestore 구독. local-first 첫 paint 청크에 firebase 가 들어가지
+  // 않게 entity api 는 dynamic import (cloud 모드 진입 시점에만 다운로드).
   useEffect(() => {
     if (mode !== 'cloud') return;
     setCloudError(null);
-    const unsubscribe = subscribeProjects(
-      accountId ?? null,
-      (next) => {
-        setCloudProjects(next);
-        setCloudLoaded(true);
-      },
-      (error) => {
-        setCloudError(error.message?.trim() || '프로젝트를 불러오지 못했습니다.');
-        setCloudLoaded(true);
-      },
-    );
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import('@/entities/project/api').then(({ subscribeProjects }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeProjects(
+        accountId ?? null,
+        (next) => {
+          setCloudProjects(next);
+          setCloudLoaded(true);
+        },
+        (error) => {
+          setCloudError(error.message?.trim() || '프로젝트를 불러오지 못했습니다.');
+          setCloudLoaded(true);
+        },
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [mode, accountId]);
 
   if (mode === 'local') {

--- a/src/features/project-edit/ui/ScreenshotUploader.tsx
+++ b/src/features/project-edit/ui/ScreenshotUploader.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react';
 import Image from 'next/image';
 import { Upload, Trash2 } from 'lucide-react';
 import { cn } from '@/shared/lib/cn';
-import { uploadScreenshot, deleteScreenshot } from '@/entities/project';
+import { uploadScreenshot, deleteScreenshot } from '@/entities/project/api';
 
 interface Props {
   slug: string;

--- a/src/features/taxonomy/model/TaxonomyProvider.tsx
+++ b/src/features/taxonomy/model/TaxonomyProvider.tsx
@@ -71,7 +71,8 @@ export function TaxonomyProvider({ children }: Props) {
     void Promise.all([
       import('@/entities/category/api'),
       import('@/entities/status/api'),
-    ]).then(
+    ])
+      .then(
       ([
         { subscribeCategories, seedDefaultCategoriesIfEmpty },
         { subscribeStatuses, seedDefaultStatusesIfEmpty },
@@ -104,7 +105,15 @@ export function TaxonomyProvider({ children }: Props) {
           (err) => console.warn('[TaxonomyProvider] statuses subscribe error', err),
         );
       },
-    );
+    )
+      .catch((err) => {
+        // chunk fetch 실패 — defaults 로 hydrate 해 toolbar/fallback 이라도
+        // 정상화. 실제 동작은 무너져도 UI 가 영영 'loading' 에 갇히는 것 보단 낫다.
+        if (cancelled) return;
+        console.warn('[TaxonomyProvider] entity api chunk load failed', err);
+        setCategoriesHydrated(true);
+        setStatusesHydrated(true);
+      });
     return () => {
       cancelled = true;
       unsubCat?.();

--- a/src/features/taxonomy/model/TaxonomyProvider.tsx
+++ b/src/features/taxonomy/model/TaxonomyProvider.tsx
@@ -9,19 +9,14 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import {
-  subscribeCategories,
-  DEFAULT_CATEGORIES,
-  hasRegisteredCategoryRegions,
-  seedDefaultCategoriesIfEmpty,
-  type Category,
-} from '@/entities/category';
-import {
-  subscribeStatuses,
-  DEFAULT_STATUSES,
-  seedDefaultStatusesIfEmpty,
-  type Status,
-} from '@/entities/status';
+// firebase 의존이 0 인 파일에서만 정적 import — barrel (`@/entities/category`)
+// 을 거치면 mapper.ts (Timestamp 사용) → firebase/firestore 가 따라온다.
+// API 함수 (subscribe*, seed*) 는 cloud 모드 진입 시점 dynamic import 로 분리.
+import { DEFAULT_CATEGORIES } from '@/entities/category/model/defaults';
+import { hasRegisteredCategoryRegions } from '@/entities/category/model/presence';
+import type { Category } from '@/entities/category/model/types';
+import { DEFAULT_STATUSES } from '@/entities/status/model/defaults';
+import type { Status } from '@/entities/status/model/types';
 import { useDataSourceMode } from '@/features/data-source-mode';
 
 export interface TaxonomyContextValue {
@@ -69,35 +64,51 @@ export function TaxonomyProvider({ children }: Props) {
 
   useEffect(() => {
     if (!subscribeCloud) return;
-    const unsubCat = subscribeCategories(
-      (list) => {
-        setCategories(list.length > 0 ? list : defaultCategories);
-        setCategoriesHydrated(true);
-        if (!seededCategoriesRef.current && list.length === 0) {
-          seededCategoriesRef.current = true;
-          void seedDefaultCategoriesIfEmpty().catch((err) => {
-            console.warn('[TaxonomyProvider] categories seed error', err);
-          });
-        }
+    let unsubCat: (() => void) | null = null;
+    let unsubStat: (() => void) | null = null;
+    let cancelled = false;
+
+    void Promise.all([
+      import('@/entities/category/api'),
+      import('@/entities/status/api'),
+    ]).then(
+      ([
+        { subscribeCategories, seedDefaultCategoriesIfEmpty },
+        { subscribeStatuses, seedDefaultStatusesIfEmpty },
+      ]) => {
+        if (cancelled) return;
+        unsubCat = subscribeCategories(
+          (list) => {
+            setCategories(list.length > 0 ? list : defaultCategories);
+            setCategoriesHydrated(true);
+            if (!seededCategoriesRef.current && list.length === 0) {
+              seededCategoriesRef.current = true;
+              void seedDefaultCategoriesIfEmpty().catch((err) => {
+                console.warn('[TaxonomyProvider] categories seed error', err);
+              });
+            }
+          },
+          (err) => console.warn('[TaxonomyProvider] categories subscribe error', err),
+        );
+        unsubStat = subscribeStatuses(
+          (list) => {
+            setStatuses(list.length > 0 ? list : defaultStatuses);
+            setStatusesHydrated(true);
+            if (!seededStatusesRef.current && list.length === 0) {
+              seededStatusesRef.current = true;
+              void seedDefaultStatusesIfEmpty().catch((err) => {
+                console.warn('[TaxonomyProvider] statuses seed error', err);
+              });
+            }
+          },
+          (err) => console.warn('[TaxonomyProvider] statuses subscribe error', err),
+        );
       },
-      (err) => console.warn('[TaxonomyProvider] categories subscribe error', err),
-    );
-    const unsubStat = subscribeStatuses(
-      (list) => {
-        setStatuses(list.length > 0 ? list : defaultStatuses);
-        setStatusesHydrated(true);
-        if (!seededStatusesRef.current && list.length === 0) {
-          seededStatusesRef.current = true;
-          void seedDefaultStatusesIfEmpty().catch((err) => {
-            console.warn('[TaxonomyProvider] statuses seed error', err);
-          });
-        }
-      },
-      (err) => console.warn('[TaxonomyProvider] statuses subscribe error', err),
     );
     return () => {
-      unsubCat();
-      unsubStat();
+      cancelled = true;
+      unsubCat?.();
+      unsubStat?.();
     };
   }, [subscribeCloud]);
 

--- a/src/features/user-auth/model/auth-service.ts
+++ b/src/features/user-auth/model/auth-service.ts
@@ -1,18 +1,6 @@
 'use client';
 
-import {
-  EmailAuthProvider,
-  GoogleAuthProvider,
-  createUserWithEmailAndPassword,
-  reauthenticateWithCredential,
-  sendPasswordResetEmail,
-  signInWithEmailAndPassword,
-  signInWithPopup,
-  updatePassword,
-  updateProfile,
-} from 'firebase/auth';
-import { getFirebaseAuth } from '@/shared/api';
-import { env } from '@/shared/config/env';
+import type { Auth, UserCredential } from 'firebase/auth';
 import {
   fetchSessionProfile,
   signOutCombined,
@@ -35,7 +23,19 @@ export interface PasswordSupportState {
   reason?: string;
 }
 
-const provider = new GoogleAuthProvider();
+/**
+ * Firebase Auth SDK 는 cloud 모드 진입 (login / signup / account / 비밀번호
+ * 재설정) 시점에만 dynamic import 된다. 정적 import 를 두지 않아 local-first
+ * 페이지 (vault, ontology-edit, topology, …) 의 첫 paint 청크에는 firebase
+ * /auth (~150kb gzipped) 가 포함되지 않는다.
+ */
+async function loadFirebaseAuth() {
+  const [authMod, sharedApi] = await Promise.all([
+    import('firebase/auth'),
+    import('@/shared/api'),
+  ]);
+  return { authMod, auth: sharedApi.getFirebaseAuth() };
+}
 
 function mapAuthError(error: unknown) {
   const code =
@@ -76,7 +76,7 @@ function mapAuthError(error: unknown) {
   }
 }
 
-function mapFirebaseUser(user: Awaited<ReturnType<typeof signInWithPopup>>['user']): AuthSessionUser {
+function mapFirebaseUser(user: UserCredential['user']): AuthSessionUser {
   return {
     uid: user.uid,
     email: user.email ?? null,
@@ -86,9 +86,10 @@ function mapFirebaseUser(user: Awaited<ReturnType<typeof signInWithPopup>>['user
 }
 
 export async function signInWithGoogle(): Promise<AuthSessionUser> {
-  const auth = getFirebaseAuth();
+  const { authMod, auth } = await loadFirebaseAuth();
   try {
-    const result = await signInWithPopup(auth, provider);
+    const provider = new authMod.GoogleAuthProvider();
+    const result = await authMod.signInWithPopup(auth, provider);
     const user = mapFirebaseUser(result.user);
     bootstrapWorkspace(user);
     return user;
@@ -101,9 +102,9 @@ export async function signInWithEmail(input: {
   email: string;
   password: string;
 }): Promise<AuthSessionUser> {
-  const auth = getFirebaseAuth();
+  const { authMod, auth } = await loadFirebaseAuth();
   try {
-    const result = await signInWithEmailAndPassword(
+    const result = await authMod.signInWithEmailAndPassword(
       auth,
       input.email.trim(),
       input.password,
@@ -121,15 +122,15 @@ export async function signUpWithEmail(input: {
   password: string;
   displayName: string;
 }): Promise<AuthSessionUser> {
-  const auth = getFirebaseAuth();
+  const { authMod, auth } = await loadFirebaseAuth();
   try {
-    const result = await createUserWithEmailAndPassword(
+    const result = await authMod.createUserWithEmailAndPassword(
       auth,
       input.email.trim(),
       input.password,
     );
     if (input.displayName.trim()) {
-      await updateProfile(result.user, {
+      await authMod.updateProfile(result.user, {
         displayName: input.displayName.trim(),
       });
       await result.user.reload();
@@ -150,10 +151,7 @@ export async function getCurrentAuthProfile(): Promise<AuthSessionUser | null> {
   return fetchSessionProfile();
 }
 
-export function getPasswordSupportState(): PasswordSupportState {
-  const auth = getFirebaseAuth();
-  const currentUser = auth.currentUser;
-
+function inspectPasswordSupport(currentUser: Auth['currentUser']): PasswordSupportState {
   if (!currentUser) {
     return {
       canChangePassword: false,
@@ -183,6 +181,11 @@ export function getPasswordSupportState(): PasswordSupportState {
   };
 }
 
+export async function getPasswordSupportState(): Promise<PasswordSupportState> {
+  const { auth } = await loadFirebaseAuth();
+  return inspectPasswordSupport(auth.currentUser);
+}
+
 export async function changePassword(input: {
   currentPassword: string;
   newPassword: string;
@@ -191,7 +194,7 @@ export async function changePassword(input: {
     throw new Error('비밀번호는 8자 이상으로 입력해주세요.');
   }
 
-  const auth = getFirebaseAuth();
+  const { authMod, auth } = await loadFirebaseAuth();
   const currentUser = auth.currentUser;
 
   if (!currentUser || !currentUser.email) {
@@ -207,12 +210,12 @@ export async function changePassword(input: {
   }
 
   try {
-    const credential = EmailAuthProvider.credential(
+    const credential = authMod.EmailAuthProvider.credential(
       currentUser.email,
       input.currentPassword,
     );
-    await reauthenticateWithCredential(currentUser, credential);
-    await updatePassword(currentUser, input.newPassword);
+    await authMod.reauthenticateWithCredential(currentUser, credential);
+    await authMod.updatePassword(currentUser, input.newPassword);
   } catch (error) {
     throw new Error(mapAuthError(error));
   }
@@ -226,8 +229,8 @@ export async function sendPasswordReset(input: { email: string }): Promise<void>
   }
 
   try {
-    const auth = getFirebaseAuth();
-    await sendPasswordResetEmail(auth, email);
+    const { authMod, auth } = await loadFirebaseAuth();
+    await authMod.sendPasswordResetEmail(auth, email);
   } catch (error) {
     throw new Error(mapAuthError(error));
   }

--- a/src/features/user-auth/model/session-store.ts
+++ b/src/features/user-auth/model/session-store.ts
@@ -76,19 +76,16 @@ export function getUserAuthState() {
  * 호출자 (`useUserAuth`) 는 fire-and-forget 으로 호출. 초기화 완료 전엔
  * `state.status === 'loading'` 으로 시작하며, onAuthStateChanged 또는 2.5s
  * 타임아웃이 도달하면 unauthenticated/authenticated 로 전환된다.
+ *
+ * 2.5s 타이머는 **initializeUserAuthStore 호출 시점부터** 측정 — dynamic
+ * import 가 끝나기 전이라도 deadline 이 지나면 unauthenticated 로 fallback
+ * 한다. 콜드 캐시에서 firebase 청크 다운로드만으로 5–8s 걸리는 환경 보호.
  */
 export async function initializeUserAuthStore() {
   if (initialized || typeof window === 'undefined') return;
   initialized = true;
 
-  const [{ onAuthStateChanged }, { getFirebaseAuth }] = await Promise.all([
-    import('firebase/auth'),
-    import('@/shared/api'),
-  ]);
-  const auth = getFirebaseAuth();
-  // onAuthStateChanged 가 네트워크 지연으로 영원히 fire 안 될 수 있어 2.5 초
-  // 안에 콜 안 오면 unauthenticated 로 낙관 결정. 이후 실제 세션이 도착하면
-  // 그 때 state 가 authenticated 로 전환된다.
+  // 타이머 먼저 — dynamic import 가 끝나기 전 deadline 이 지나도 fallback.
   const AUTH_INIT_TIMEOUT_MS = 2500;
   let firebaseInitTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
     if (!firebaseResolved) {
@@ -97,6 +94,34 @@ export async function initializeUserAuthStore() {
     }
     firebaseInitTimer = null;
   }, AUTH_INIT_TIMEOUT_MS);
+
+  let onAuthStateChanged:
+    | typeof import('firebase/auth').onAuthStateChanged
+    | null = null;
+  let getFirebaseAuth: typeof import('@/shared/api').getFirebaseAuth | null = null;
+  try {
+    const [authMod, sharedApi] = await Promise.all([
+      import('firebase/auth'),
+      import('@/shared/api'),
+    ]);
+    onAuthStateChanged = authMod.onAuthStateChanged;
+    getFirebaseAuth = sharedApi.getFirebaseAuth;
+  } catch (err) {
+    // chunk fetch 실패 — fallback timer 가 어차피 unauthenticated 으로
+    // 전환하지만, 명시적으로 한 번 더 닫아 race 회피.
+    console.warn('[initializeUserAuthStore] firebase chunk load failed', err);
+    if (!firebaseResolved) {
+      firebaseResolved = true;
+      recomputeState();
+    }
+    if (firebaseInitTimer) {
+      clearTimeout(firebaseInitTimer);
+      firebaseInitTimer = null;
+    }
+    return;
+  }
+
+  const auth = getFirebaseAuth();
   onAuthStateChanged(auth, (user) => {
     if (firebaseInitTimer) {
       clearTimeout(firebaseInitTimer);

--- a/src/features/user-auth/model/session-store.ts
+++ b/src/features/user-auth/model/session-store.ts
@@ -1,7 +1,6 @@
 'use client';
 
-import { onAuthStateChanged, signOut as firebaseSignOut, type User as FirebaseUser } from 'firebase/auth';
-import { getFirebaseAuth } from '@/shared/api';
+import type { User as FirebaseUser } from 'firebase/auth';
 
 export type AuthProviderKind = 'firebase';
 export type UserAuthStatus = 'loading' | 'unauthenticated' | 'authenticated';
@@ -70,10 +69,22 @@ export function getUserAuthState() {
   return state;
 }
 
-export function initializeUserAuthStore() {
+/**
+ * Firebase Auth 모듈은 dynamic import 로만 진입한다 — local-first 첫 paint
+ * 에서 auth SDK 청크 (~150kb gzipped) 가 다운로드되지 않게.
+ *
+ * 호출자 (`useUserAuth`) 는 fire-and-forget 으로 호출. 초기화 완료 전엔
+ * `state.status === 'loading'` 으로 시작하며, onAuthStateChanged 또는 2.5s
+ * 타임아웃이 도달하면 unauthenticated/authenticated 로 전환된다.
+ */
+export async function initializeUserAuthStore() {
   if (initialized || typeof window === 'undefined') return;
   initialized = true;
 
+  const [{ onAuthStateChanged }, { getFirebaseAuth }] = await Promise.all([
+    import('firebase/auth'),
+    import('@/shared/api'),
+  ]);
   const auth = getFirebaseAuth();
   // onAuthStateChanged 가 네트워크 지연으로 영원히 fire 안 될 수 있어 2.5 초
   // 안에 콜 안 오면 unauthenticated 로 낙관 결정. 이후 실제 세션이 도착하면
@@ -98,6 +109,10 @@ export function initializeUserAuthStore() {
 }
 
 export async function signOutCombined() {
+  const [{ signOut: firebaseSignOut }, { getFirebaseAuth }] = await Promise.all([
+    import('firebase/auth'),
+    import('@/shared/api'),
+  ]);
   const auth = getFirebaseAuth();
   await firebaseSignOut(auth);
   firebaseResolved = true;

--- a/src/features/user-auth/model/use-user-auth.ts
+++ b/src/features/user-auth/model/use-user-auth.ts
@@ -17,7 +17,7 @@ function getServerSnapshot(): UserAuthState {
 
 export function useUserAuth(): UserAuthState {
   useEffect(() => {
-    initializeUserAuthStore();
+    void initializeUserAuthStore();
   }, []);
 
   return useSyncExternalStore(subscribeUserAuth, getUserAuthState, getServerSnapshot);

--- a/src/shared/lib/firestore-noise-patch.ts
+++ b/src/shared/lib/firestore-noise-patch.ts
@@ -1,23 +1,16 @@
-'use client';
-
-import { type ReactNode, useEffect } from 'react';
-import { getFirebaseApp } from '@/shared/api';
-
-interface Props {
-  children: ReactNode;
-}
-
 /**
+ * Firestore offline / 연결 실패 noise 를 콘솔에서 swallow.
+ *
  * Firebase SDK 의 "Could not reach Cloud Firestore backend" 경고는 SDK
  * 자체 heartbeat probe 가 10초 안에 못 응답받으면 찍고 자동으로 offline
  * mode 로 전환하는 동작. 데모 사용자는 실 Firestore 를 쓰지 않고, 실
  * 사용자도 일시적 네트워크 흔들림에서 자연 복구되므로 UX 노이즈.
  *
- * **module top-level 에서** console.error 를 1회 patch. React effect
- * 가 뛰기 전에 Firebase SDK 가 probe 를 쏠 수 있어, useEffect 기반
- * 패치는 race 로 첫 error 를 놓친다. import 즉시 실행되는 이 IIFE 는
- * 모든 후속 console.error 를 감싸 특정 signature 만 swallow.
+ * 이 모듈은 firebase 의존이 0 — root layout 에서 side-effect import 만
+ * 해도 콘솔 패치가 install 된다. firebase JS 자체는 별도 dynamic import
+ * 경로를 통해서만 번들에 들어와 local-first 첫 paint 를 가볍게 유지.
  */
+
 const FIRESTORE_NOISE_SIGNATURES = [
   'Could not reach Cloud Firestore backend',
   'Connection failed',
@@ -26,7 +19,9 @@ const FIRESTORE_NOISE_SIGNATURES = [
 
 function argMatchesSignature(arg: unknown, signature: string): boolean {
   if (typeof arg === 'string') return arg.includes(signature);
-  if (arg instanceof Error) return arg.message.includes(signature) || (arg.stack?.includes(signature) ?? false);
+  if (arg instanceof Error) {
+    return arg.message.includes(signature) || (arg.stack?.includes(signature) ?? false);
+  }
   if (arg && typeof arg === 'object') {
     try {
       return JSON.stringify(arg).includes(signature);
@@ -41,7 +36,10 @@ function shouldSwallow(args: unknown[]): boolean {
   return args.some((a) => FIRESTORE_NOISE_SIGNATURES.some((sig) => argMatchesSignature(a, sig)));
 }
 
-if (typeof window !== 'undefined' && !(window as unknown as { __firebaseOfflinePatched?: boolean }).__firebaseOfflinePatched) {
+if (
+  typeof window !== 'undefined' &&
+  !(window as unknown as { __firebaseOfflinePatched?: boolean }).__firebaseOfflinePatched
+) {
   (window as unknown as { __firebaseOfflinePatched: boolean }).__firebaseOfflinePatched = true;
   const originalError = console.error.bind(console);
   const originalWarn = console.warn.bind(console);
@@ -76,16 +74,4 @@ if (typeof window !== 'undefined' && !(window as unknown as { __firebaseOfflineP
     },
     true,
   );
-}
-
-export function FirebaseProvider({ children }: Props) {
-  useEffect(() => {
-    try {
-      getFirebaseApp();
-    } catch (err) {
-      console.warn('[FirebaseProvider] 초기화 실패:', err);
-    }
-  }, []);
-
-  return <>{children}</>;
 }

--- a/src/shared/lib/firestore-timestamp-coerce.test.ts
+++ b/src/shared/lib/firestore-timestamp-coerce.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { Timestamp } from 'firebase/firestore';
+import { coerceFirestoreDate } from './firestore-timestamp-coerce';
+
+describe('coerceFirestoreDate', () => {
+  it('Timestamp 인스턴스를 toDate() 로 변환한다 — production hot path', () => {
+    const ts = Timestamp.fromMillis(1_700_000_000_000);
+    const d = coerceFirestoreDate(ts);
+    expect(d).toBeInstanceOf(Date);
+    expect(d.getTime()).toBe(1_700_000_000_000);
+  });
+
+  it('Date 인스턴스는 그대로 반환', () => {
+    const input = new Date('2026-05-02T00:00:00.000Z');
+    const out = coerceFirestoreDate(input);
+    expect(out).toBe(input);
+  });
+
+  it('null / undefined 는 epoch 0 (Date) — 호출자가 별도 가드해야 한다', () => {
+    expect(coerceFirestoreDate(null).getTime()).toBe(0);
+    expect(coerceFirestoreDate(undefined).getTime()).toBe(0);
+  });
+
+  it('seconds 만 있는 Timestamp-like POJO 도 인식 (직렬화 round-trip 케이스)', () => {
+    const fake = { seconds: 1_700_000, nanoseconds: 0 };
+    const d = coerceFirestoreDate(fake);
+    expect(d.getTime()).toBe(1_700_000 * 1000);
+  });
+
+  it('toDate() 가 throw 하면 epoch 0 fallback (silent)', () => {
+    const broken = {
+      toDate() {
+        throw new Error('boom');
+      },
+    };
+    expect(coerceFirestoreDate(broken).getTime()).toBe(0);
+  });
+
+  it('toDate() 가 Date 가 아닌 값을 반환하면 epoch 0 fallback', () => {
+    const liar = { toDate: () => 'not a date' as unknown as Date };
+    expect(coerceFirestoreDate(liar).getTime()).toBe(0);
+  });
+
+  it('알 수 없는 타입 (string / number / boolean) 은 epoch 0', () => {
+    expect(coerceFirestoreDate('2026-05-02').getTime()).toBe(0);
+    expect(coerceFirestoreDate(1_700_000_000_000).getTime()).toBe(0);
+    expect(coerceFirestoreDate(true).getTime()).toBe(0);
+  });
+
+  it('toDate 가 number 인 객체 (function 이 아님) 는 epoch 0', () => {
+    expect(coerceFirestoreDate({ toDate: 42 }).getTime()).toBe(0);
+  });
+});

--- a/src/shared/lib/firestore-timestamp-coerce.ts
+++ b/src/shared/lib/firestore-timestamp-coerce.ts
@@ -1,0 +1,37 @@
+/**
+ * Firestore `Timestamp` → `Date` 변환을 firebase 의존 없이 수행한다.
+ *
+ * 기존 mapper 들은 `instanceof Timestamp` 로 분기해 firebase/firestore 를 정적으로
+ * 끌어왔다 (~640kb). entity model 은 firebase 의존 없이 빌드되어야 local-first
+ * 페이지 (vault, ontology-edit, topology) 의 첫 paint 청크에 firestore SDK 가
+ * 들어가지 않는다 — duck-typing 으로 충분.
+ *
+ * Timestamp 는 `seconds: number` 와 `nanoseconds: number` 그리고 `toDate(): Date`
+ * 를 가진다. 하나라도 매칭되면 Date 로 변환. 매칭 안 되면 `new Date(0)`.
+ */
+export function coerceFirestoreDate(value: unknown): Date {
+  if (value instanceof Date) return value;
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    'toDate' in value &&
+    typeof (value as { toDate: unknown }).toDate === 'function'
+  ) {
+    try {
+      const out = (value as { toDate: () => unknown }).toDate();
+      if (out instanceof Date) return out;
+    } catch {
+      /* fall through */
+    }
+  }
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    'seconds' in value &&
+    typeof (value as { seconds: unknown }).seconds === 'number'
+  ) {
+    const seconds = (value as { seconds: number }).seconds;
+    return new Date(seconds * 1000);
+  }
+  return new Date(0);
+}

--- a/src/shared/lib/ontology-import/apply-tbox.ts
+++ b/src/shared/lib/ontology-import/apply-tbox.ts
@@ -10,15 +10,15 @@
  *   3. 새 versionId 반환
  */
 
-import type { ActiveTBox } from '@/entities/ontology-tbox';
 // shared → entities helper (firestore write) 재사용. P3 Phase 4 cloud function 도입 시
 // features/ 로 옮길 예정. 임시 boundaries 예외.
 /* eslint-disable boundaries/dependencies */
+import type { ActiveTBox } from '@/entities/ontology-tbox/api';
 import {
   createTBoxVersion,
   activateTBoxVersion,
   generateTBoxVersionId,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 /* eslint-enable boundaries/dependencies */
 import type { OntologyClass } from '@/entities/ontology-class';
 import type { OntologyRelation } from '@/entities/ontology-relation';

--- a/src/views/account-settings/ui/AccountSettingsPage.tsx
+++ b/src/views/account-settings/ui/AccountSettingsPage.tsx
@@ -60,8 +60,11 @@ export function AccountSettingsPage() {
       if (cancelled || !profile) return;
       setProfileEmail(profile.email ?? '');
       setResetEmail(profile.email ?? '');
+      // getPasswordSupportState 는 dynamic import — await 사이에 unmount
+      // 가능성. 다시 가드.
       const support = await getPasswordSupportState();
-      if (!cancelled) setPasswordSupport(support);
+      if (cancelled) return;
+      setPasswordSupport(support);
     });
     return () => {
       cancelled = true;

--- a/src/views/account-settings/ui/AccountSettingsPage.tsx
+++ b/src/views/account-settings/ui/AccountSettingsPage.tsx
@@ -30,7 +30,13 @@ export function AccountSettingsPage() {
     PASSWORD_SUPPORT_PLACEHOLDER,
   );
   useEffect(() => {
-    setPasswordSupport(getPasswordSupportState());
+    let cancelled = false;
+    void getPasswordSupportState().then((support) => {
+      if (!cancelled) setPasswordSupport(support);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -50,11 +56,12 @@ export function AccountSettingsPage() {
   useEffect(() => {
     if (status !== 'authenticated') return;
     let cancelled = false;
-    void getCurrentAuthProfile().then((profile) => {
+    void getCurrentAuthProfile().then(async (profile) => {
       if (cancelled || !profile) return;
       setProfileEmail(profile.email ?? '');
       setResetEmail(profile.email ?? '');
-      setPasswordSupport(getPasswordSupportState());
+      const support = await getPasswordSupportState();
+      if (!cancelled) setPasswordSupport(support);
     });
     return () => {
       cancelled = true;

--- a/src/views/diagnostics-insights/ui/InsightsPage.tsx
+++ b/src/views/diagnostics-insights/ui/InsightsPage.tsx
@@ -10,10 +10,10 @@ import {
   detectPromotionCandidates,
   detectStaleProjects,
   getProjectDetailHref,
-  subscribeProjects,
   type Project,
   type PromotionCandidate,
 } from "@/entities/project";
+import { subscribeProjects } from "@/entities/project/api";
 import { DetailCard, EmptyState } from "@/shared/ui";
 import { formatDate } from "@/shared/lib/format-date";
 import {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -87,17 +87,18 @@ const MountedGlobalSearch = dynamic(
 );
 import { GestureHint } from "@/widgets/gesture-hint";
 import { LiveAnnouncer, Tooltip, useToast } from "@/shared/ui";
-import {
-  getProjectDetailHref,
-  type Project,
-  type ProjectImpactMode,
-} from "@/entities/project";
+// Barrel (`@/entities/project`) 은 api/index.ts → firebase/firestore 를 끌어
+// 들이므로 lib/types 만 쓰는 import 는 직접 파일 경로로 우회. Project /
+// ProjectImpactMode 는 type 이라 erase 됐다.
+import { getProjectDetailHref } from "@/entities/project/lib/detail-href";
+import type { Project } from "@/entities/project/model/types";
+import type { ProjectImpactMode } from "@/entities/project/model/insights";
 import { buildDocsVaultHref } from "@/entities/docs-vault";
-import {
-  buildKnowledgeProjectEvidenceSummary,
-  subscribeKnowledgeProjectInsight,
-  type KnowledgeProjectInsight,
-} from "@/entities/knowledge-graph";
+// `buildKnowledgeProjectEvidenceSummary` + 타입은 firebase 의존 0 인 model
+// 경로로 직접. `subscribeKnowledgeProjectInsight` (Firestore 구독) 는
+// useEffect 안 dynamic import 로 분리.
+import { buildKnowledgeProjectEvidenceSummary } from "@/entities/knowledge-graph/model/evidence-summary";
+import type { KnowledgeProjectInsight } from "@/entities/knowledge-graph/model/types";
 import { useHomeRouteState } from "../model/use-home-route-state";
 
 const LEFT_PANEL_COLLAPSED_KEY = "demo:left-panel-collapsed:v2";
@@ -545,22 +546,33 @@ export function HomePage() {
 
   useEffect(() => {
     if (!selectedProject) return;
-
-    const unsubscribe = subscribeKnowledgeProjectInsight(
-      selectedProject.slug,
-      null,
-      (nextInsight) => {
-        setSelectedKnowledgeInsight({
-          projectSlug: selectedProject.slug,
-          insight: nextInsight,
-        });
-      },
-      (error) => {
-        console.warn("[HomePage] knowledge insight subscribe failed", error);
+    // Firestore 구독 — entity api 는 dynamic import 로 first paint 청크에서
+    // 분리. 선택된 project 가 바뀔 때마다 다시 구독한다.
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-graph/api").then(
+      ({ subscribeKnowledgeProjectInsight }) => {
+        if (cancelled) return;
+        unsubscribe = subscribeKnowledgeProjectInsight(
+          selectedProject.slug,
+          null,
+          (nextInsight) => {
+            setSelectedKnowledgeInsight({
+              projectSlug: selectedProject.slug,
+              insight: nextInsight,
+            });
+          },
+          (error) => {
+            console.warn("[HomePage] knowledge insight subscribe failed", error);
+          },
+        );
       },
     );
 
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [selectedProject]);
 
   return (

--- a/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
+++ b/src/views/knowledge-dashboard/ui/KnowledgeDashboardPage.tsx
@@ -11,13 +11,9 @@ import {
   getKnowledgeDocumentListHref,
   getKnowledgeDocumentNewHref,
   getKnowledgeDocumentStatusLabel,
-  subscribeKnowledgeDocuments,
   type KnowledgeDocument,
 } from "@/entities/knowledge-document";
-import {
-  subscribeKnowledgePublicMeta,
-  type KnowledgePublicMeta,
-} from "@/entities/knowledge-graph";
+import type { KnowledgePublicMeta } from "@/entities/knowledge-graph";
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyState, Tooltip } from "@/shared/ui";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { useLocalVault } from "@/features/docs-vault-local";
@@ -42,16 +38,32 @@ function DashboardContent() {
 
   useEffect(() => {
     setDocumentsLoaded(false);
-    const unsubscribe = subscribeKnowledgeDocuments(accountId, (next) => {
-      setDocuments(next);
-      setDocumentsLoaded(true);
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-document/api").then(({ subscribeKnowledgeDocuments }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgeDocuments(accountId, (next) => {
+        setDocuments(next);
+        setDocumentsLoaded(true);
+      });
     });
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   useEffect(() => {
-    const unsubscribe = subscribeKnowledgePublicMeta(accountId, setPublicMeta);
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-graph/api").then(({ subscribeKnowledgePublicMeta }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgePublicMeta(accountId, setPublicMeta);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   const summary = useMemo(() => {

--- a/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
+++ b/src/views/knowledge-document-detail/ui/KnowledgeDocumentDetailPage.tsx
@@ -4,33 +4,32 @@ import { type ChangeEvent, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { PermissionGate, useGlobalAdmin } from "@/features/permissions";
-import { getProjectDetailHref, subscribeProjects, type Project } from "@/entities/project";
-import {
-  subscribeKnowledgeEvidenceByDocument,
-  type KnowledgeEvidence,
-} from "@/entities/knowledge-evidence";
+import { getProjectDetailHref, type Project } from "@/entities/project";
+import { subscribeProjects } from "@/entities/project/api";
+import type { KnowledgeEvidence } from "@/entities/knowledge-evidence";
+import { subscribeKnowledgeEvidenceByDocument } from "@/entities/knowledge-evidence/api";
 import {
   resolveKnowledgeJobActionState,
-  subscribeKnowledgeJobsByDocument,
   type KnowledgeJob,
 } from "@/entities/knowledge-job";
+import { subscribeKnowledgeJobsByDocument } from "@/entities/knowledge-job/api";
+import type { KnowledgeOutput } from "@/entities/knowledge-output";
+import { subscribeKnowledgeOutputsByDocument } from "@/entities/knowledge-output/api";
 import {
-  subscribeKnowledgeOutputsByDocument,
-  type KnowledgeOutput,
-} from "@/entities/knowledge-output";
-import {
-  createKnowledgeDocumentVersion,
   getKnowledgeDocumentDetailHref,
   getKnowledgeDocumentListHref,
-  downloadKnowledgeMarkdown,
   getKnowledgeDocumentKindLabel,
   getKnowledgeDocumentStatusLabel,
   getKnowledgeMetadataFieldLabel,
+  type KnowledgeDocument,
+} from "@/entities/knowledge-document";
+import {
+  createKnowledgeDocumentVersion,
+  downloadKnowledgeMarkdown,
   subscribeKnowledgeDocuments,
   subscribeKnowledgeVersionsByDocument,
   setKnowledgeDocumentCurrentVersion,
-  type KnowledgeDocument,
-} from "@/entities/knowledge-document";
+} from "@/entities/knowledge-document/api";
 import {
   buildKnowledgeVersionMarkdownDiff,
   buildKnowledgeVersionMetadataDiff,

--- a/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
+++ b/src/views/knowledge-document-new/ui/KnowledgeDocumentNewPage.tsx
@@ -7,13 +7,13 @@ import { PermissionGate, useGlobalAdmin } from "@/features/permissions";
 import {
   KNOWLEDGE_DOCUMENT_KIND_OPTIONS,
   buildKnowledgeMetadataPreview,
-  createKnowledgeDocumentWithInitialVersion,
   getKnowledgeDocumentDetailHref,
   getKnowledgeDocumentListHref,
   getKnowledgeMetadataFieldLabel,
   getKnowledgeDocumentKindLabel,
   parseKnowledgeFrontmatter,
 } from "@/entities/knowledge-document";
+import { createKnowledgeDocumentWithInitialVersion } from "@/entities/knowledge-document/api";
 import { type Project } from "@/entities/project";
 import { useProjects } from "@/features/project-data-source";
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, buttonVariants, useToast } from "@/shared/ui";

--- a/src/views/knowledge-documents/ui/KnowledgeDocumentsPage.tsx
+++ b/src/views/knowledge-documents/ui/KnowledgeDocumentsPage.tsx
@@ -13,9 +13,9 @@ import {
   getKnowledgeDocumentKindLabel,
   getKnowledgeDocumentNewHref,
   getKnowledgeDocumentStatusLabel,
-  subscribeKnowledgeDocuments,
   type KnowledgeDocument,
 } from "@/entities/knowledge-document";
+import { subscribeKnowledgeDocuments } from "@/entities/knowledge-document/api";
 import {
   getKnowledgeJobStatusLabel,
   KNOWLEDGE_JOB_STATUS_OPTIONS,

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -7,7 +7,6 @@ import { useSearchParams } from "next/navigation";
 import { Info, Maximize2, Minimize2, Wand2 } from "lucide-react";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { useUserAuth } from "@/features/user-auth";
-import { addManualKnowledgeNode } from "@/entities/knowledge-graph";
 import {
   vaultManifest as staticVaultManifestRaw,
   type VaultManifest,
@@ -152,6 +151,7 @@ export function OntologyEditPage() {
             return;
           }
           const id = `${node.kind}.${slug}`;
+          const { addManualKnowledgeNode } = await import("@/entities/knowledge-graph/api");
           await addManualKnowledgeNode({
             accountId,
             id,

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -7,7 +7,6 @@ import { Info, Link2, X } from "lucide-react";
 import {
   getKnowledgeDocumentDetailHref,
   getKnowledgeDocumentListHref,
-  subscribeKnowledgeDocuments,
   type KnowledgeDocument,
 } from "@/entities/knowledge-document";
 import {
@@ -125,18 +124,26 @@ export function OntologyViewPage() {
   useEffect(() => {
     setDocuments([]);
     setDocumentsAccessError(null);
-    const unsubscribe = subscribeKnowledgeDocuments(
-      accountId,
-      (next) => {
-        setDocuments(next);
-        setDocumentsAccessError(null);
-      },
-      (err) => {
-        setDocuments([]);
-        setDocumentsAccessError(err);
-      },
-    );
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-document/api").then(({ subscribeKnowledgeDocuments }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgeDocuments(
+        accountId,
+        (next) => {
+          setDocuments(next);
+          setDocumentsAccessError(null);
+        },
+        (err) => {
+          setDocuments([]);
+          setDocumentsAccessError(err);
+        },
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   const treeResult: OntologyTreeBuildResult | null = useMemo(() => {

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -26,16 +26,15 @@ import { useScopedAccountAccess } from "@/features/account-scope";
 import { buildServiceEntryHref } from "@/features/user-auth";
 import {
   formatProjectIntegrityIssue,
-  getProject,
   getProjectDetailHref,
   getProjectIntegrityIssues,
   getTopologyProjectHref,
   projectToInput,
   resolveFallbackProjects,
-  upsertProject,
   wouldCreateDependencyCycle,
   type Project,
 } from "@/entities/project";
+import { getProject, upsertProject } from "@/entities/project/api";
 import { useProjects } from "@/features/project-data-source";
 import { resolveSubscribeUpdate } from "../model/resolve-subscribe-update";
 import { DependencyPicker } from "@/features/project-edit/ui/DependencyPicker";
@@ -69,9 +68,9 @@ import {
 } from "@/entities/knowledge-document";
 import {
   buildKnowledgeProjectEvidenceSummary,
-  subscribeKnowledgeProjectInsight,
   type KnowledgeProjectInsight,
 } from "@/entities/knowledge-graph";
+import { subscribeKnowledgeProjectInsight } from "@/entities/knowledge-graph/api";
 
 interface Props {
   slug: string;

--- a/src/views/project-editor/ui/ProjectEditorPage.tsx
+++ b/src/views/project-editor/ui/ProjectEditorPage.tsx
@@ -8,11 +8,10 @@ import { ProjectForm } from "@/features/project-edit";
 import { useProjectMutations } from "@/features/project-data-source";
 import {
   getProjectDetailHref,
-  getProject,
-  subscribeProjects,
   type Project,
   type ProjectInput,
 } from "@/entities/project";
+import { getProject, subscribeProjects } from "@/entities/project/api";
 import {
   getKnowledgeDocumentListHref,
   getKnowledgeDocumentNewHref,

--- a/src/views/settings-categories/ui/CategoriesPage.tsx
+++ b/src/views/settings-categories/ui/CategoriesPage.tsx
@@ -11,19 +11,18 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ArrowLeft, Plus, SquareArrowOutUpRight, Trash2 } from "lucide-react";
 import { PermissionGate } from "@/features/permissions";
+import type { Category } from "@/entities/category";
 import {
   deleteCategory,
   subscribeCategories,
   upsertCategory,
-  type Category,
-} from "@/entities/category";
+} from "@/entities/category/api";
+import { projectToInput, type Project } from "@/entities/project";
 import {
-  projectToInput,
   subscribeProjects,
   upsertProject,
   upsertProjectPositions,
-  type Project,
-} from "@/entities/project";
+} from "@/entities/project/api";
 import { findProjectPlacement } from "@/features/project-edit/model";
 import { computeInitialLayout } from "@/features/topology-layout";
 import { Button } from "@/shared/ui";

--- a/src/views/settings-ontology-history/ui/SettingsOntologyHistoryPage.tsx
+++ b/src/views/settings-ontology-history/ui/SettingsOntologyHistoryPage.tsx
@@ -5,12 +5,14 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { PermissionGate } from '@/features/permissions';
+import type {
+  OntologyTBoxActiveState,
+  OntologyTBoxVersion,
+} from '@/entities/ontology-tbox';
 import {
   getActiveTBoxState,
   listTBoxVersions,
-  type OntologyTBoxActiveState,
-  type OntologyTBoxVersion,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import {
   ACCOUNT_QUERY_KEY,
 } from '@/shared/lib/account-scope';

--- a/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
+++ b/src/views/settings-ontology/ui/SettingsOntologyPage.tsx
@@ -8,7 +8,7 @@ import { PermissionGate } from '@/features/permissions';
 import {
   loadActiveTBox,
   type ActiveTBox,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import { getOntologyKindLabel } from '@/entities/ontology-class';
 import {
   ACCOUNT_QUERY_KEY,

--- a/src/views/settings-project-import/ui/ProjectImportPage.tsx
+++ b/src/views/settings-project-import/ui/ProjectImportPage.tsx
@@ -9,7 +9,8 @@ import {
   parseProjectsCsv,
   type CsvParseError,
 } from "@/features/project-import";
-import { getProject, upsertProject, type ProjectInput } from "@/entities/project";
+import type { ProjectInput } from "@/entities/project";
+import { getProject, upsertProject } from "@/entities/project/api";
 import { STARTER_SAMPLE_PROJECTS } from "@/shared/config/starter-samples";
 import { Button, DetailCard, EmptyState, useToast } from "@/shared/ui";
 import {

--- a/src/views/settings-statuses/ui/StatusesPage.tsx
+++ b/src/views/settings-statuses/ui/StatusesPage.tsx
@@ -11,20 +11,14 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ArrowLeft, Plus, SquareArrowOutUpRight, Trash2 } from "lucide-react";
 import { PermissionGate } from "@/features/permissions";
+import type { Status, StatusDotColor, StatusInput } from "@/entities/status";
 import {
   deleteStatus,
   subscribeStatuses,
   upsertStatus,
-  type Status,
-  type StatusDotColor,
-  type StatusInput,
-} from "@/entities/status";
-import {
-  projectToInput,
-  subscribeProjects,
-  upsertProject,
-  type Project,
-} from "@/entities/project";
+} from "@/entities/status/api";
+import { projectToInput, type Project } from "@/entities/project";
+import { subscribeProjects, upsertProject } from "@/entities/project/api";
 import { Button } from "@/shared/ui";
 import { OperationsNav } from "@/widgets/operations-nav";
 import { cn } from "@/shared/lib/cn";

--- a/src/widgets/global-search/ui/MountedGlobalSearch.tsx
+++ b/src/widgets/global-search/ui/MountedGlobalSearch.tsx
@@ -4,13 +4,9 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   getKnowledgeDocumentDetailHref,
-  subscribeKnowledgeDocuments,
   type KnowledgeDocument,
 } from "@/entities/knowledge-document";
-import {
-  subscribeKnowledgePublicGraph,
-  type KnowledgeGraphNode,
-} from "@/entities/knowledge-graph";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
 import { type Project, getProjectDetailHref } from "@/entities/project";
 import { useProjects } from "@/features/project-data-source";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
@@ -86,23 +82,39 @@ export function MountedGlobalSearch({
   // ontology approved nodes — public projection. 권한 없으면 빈 배열.
   useEffect(() => {
     setNodes([]);
-    const unsubscribe = subscribeKnowledgePublicGraph(
-      accountId,
-      (insight) => setNodes(insight.nodes),
-      () => setNodes([]),
-    );
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-graph/api").then(({ subscribeKnowledgePublicGraph }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgePublicGraph(
+        accountId,
+        (insight) => setNodes(insight.nodes),
+        () => setNodes([]),
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   // knowledge documents — 권한 게이팅은 Firestore rules. 권한 없으면 빈 배열.
   useEffect(() => {
     setDocuments([]);
-    const unsubscribe = subscribeKnowledgeDocuments(
-      accountId,
-      (next) => setDocuments(next),
-      () => setDocuments([]),
-    );
-    return () => unsubscribe();
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import("@/entities/knowledge-document/api").then(({ subscribeKnowledgeDocuments }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeKnowledgeDocuments(
+        accountId,
+        (next) => setDocuments(next),
+        () => setDocuments([]),
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [accountId]);
 
   return (

--- a/src/widgets/manual-edge-create-modal/ui/ManualEdgeCreateModal.tsx
+++ b/src/widgets/manual-edge-create-modal/ui/ManualEdgeCreateModal.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { X } from "lucide-react";
 import {
-  addManualKnowledgeEdge,
   composeManualEdgeId,
   KNOWLEDGE_EDGE_TYPES,
   validateManualKnowledgeEdgeInput,
@@ -145,6 +144,7 @@ export function ManualEdgeCreateModal({
         // 프로젝트 그래프에 묶임. 둘 다 합집합 하는 게 더 정확하지만 v0 단순화.
         projectIds: fromNode?.projectIds ?? [],
       };
+      const { addManualKnowledgeEdge } = await import("@/entities/knowledge-graph/api");
       const result = await addManualKnowledgeEdge(input);
       if (result.alreadyExists) {
         setAlreadyExistsId(result.id);

--- a/src/widgets/manual-node-create-modal/ui/ManualNodeCreateModal.tsx
+++ b/src/widgets/manual-node-create-modal/ui/ManualNodeCreateModal.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import {
-  addManualKnowledgeNode,
   MANUAL_NODE_KINDS,
   validateManualKnowledgeNodeInput,
   type AddManualKnowledgeNodeInput,
@@ -133,6 +132,7 @@ export function ManualNodeCreateModal({
         summary: form.summary.trim() ? form.summary.trim() : undefined,
         manualNote: form.manualNote.trim() ? form.manualNote.trim() : undefined,
       };
+      const { addManualKnowledgeNode } = await import("@/entities/knowledge-graph/api");
       const result = await addManualKnowledgeNode(input);
       if (result.alreadyExists) {
         setAlreadyExistsId(result.id);

--- a/src/widgets/ontology-export-modal/ui/OntologyExportModal.tsx
+++ b/src/widgets/ontology-export-modal/ui/OntologyExportModal.tsx
@@ -2,15 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import { Download, X } from 'lucide-react';
+import type { KnowledgeProjectInsight } from '@/entities/knowledge-graph';
 import {
   subscribeKnowledgeApprovedGraph,
   subscribeKnowledgePublicGraph,
-  type KnowledgeProjectInsight,
-} from '@/entities/knowledge-graph';
+} from '@/entities/knowledge-graph/api';
 import {
   loadActiveTBox,
   type ActiveTBox,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import { getFirebaseAuth } from '@/shared/api';
 import {
   exportPayloadToJson,

--- a/src/widgets/ontology-import-modal/ui/OntologyImportModal.tsx
+++ b/src/widgets/ontology-import-modal/ui/OntologyImportModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { Upload, X } from 'lucide-react';
-import { type ActiveTBox } from '@/entities/ontology-tbox';
+import { type ActiveTBox } from '@/entities/ontology-tbox/api';
 import {
   applyTBoxImport,
   detectImportConflicts,

--- a/src/widgets/project-documents-list/ui/ProjectDocumentsList.tsx
+++ b/src/widgets/project-documents-list/ui/ProjectDocumentsList.tsx
@@ -7,10 +7,12 @@ import {
   getKnowledgeDocumentDetailHref,
   getKnowledgeDocumentKindLabel,
   getKnowledgeDocumentStatusLabel,
-  getPublicDocumentsForProject,
-  subscribeKnowledgeDocumentsByProject,
   type KnowledgeDocument,
 } from '@/entities/knowledge-document';
+import {
+  getPublicDocumentsForProject,
+  subscribeKnowledgeDocumentsByProject,
+} from '@/entities/knowledge-document/api';
 import { DetailCard, EmptyState } from '@/shared/ui';
 
 interface ProjectDocumentsListProps {

--- a/src/widgets/tbox-class-create-modal/ui/TBoxClassCreateModal.tsx
+++ b/src/widgets/tbox-class-create-modal/ui/TBoxClassCreateModal.tsx
@@ -5,7 +5,7 @@ import { X } from 'lucide-react';
 import {
   appendClassAndActivate,
   type ActiveTBox,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import type { OntologyClass } from '@/entities/ontology-class';
 import { getFirebaseAuth } from '@/shared/api';
 

--- a/src/widgets/tbox-class-edit-modal/ui/TBoxClassEditModal.tsx
+++ b/src/widgets/tbox-class-edit-modal/ui/TBoxClassEditModal.tsx
@@ -5,7 +5,7 @@ import { X } from 'lucide-react';
 import {
   updateClassMetadataAndActivate,
   type ActiveTBox,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import type { OntologyClass } from '@/entities/ontology-class';
 import { getFirebaseAuth } from '@/shared/api';
 

--- a/src/widgets/tbox-relation-create-modal/ui/TBoxRelationCreateModal.tsx
+++ b/src/widgets/tbox-relation-create-modal/ui/TBoxRelationCreateModal.tsx
@@ -5,7 +5,7 @@ import { X } from 'lucide-react';
 import {
   appendRelationAndActivate,
   type ActiveTBox,
-} from '@/entities/ontology-tbox';
+} from '@/entities/ontology-tbox/api';
 import type {
   OntologyRelation,
   OntologyRelationCategory,


### PR DESCRIPTION
## Summary

mission v2 의 핵심 약속 — `vault 기반 local-first 페이지는 firebase JS 없이 첫 paint` — 을 코드로 보장. cloud 모드를 안 쓰는 사용자가 `~773kb` 의 firebase chunks 를 다운로드하지 않게 만든다.

- **before**: `/`, `/topology`, `/docs`, `/ontology/edit`, `/projects`, `/knowledge` 등 모든 페이지가 firebase 청크 (628K + 152K + 0K) 를 정적으로 로드
- **after**: 같은 페이지들 0K. `/login`, `/account` 같은 auth 페이지조차 함수 호출 시점에 lazy 로드

## Phases (commit 단위)

1. **`8f89bdb` FirebaseProvider 정리** — 콘솔 노이즈 패치를 firebase-deps-free 모듈로 분리, layout 의 정적 firebase 체인 차단
2. **`cbe4ba4` user-auth + global-admin dynamic** — `firebase/auth` 정적 import 를 함수 안 dynamic import 로 (session-store, auth-service, use-global-admin)
3. **`8804b17` mapper Timestamp duck-typing** — 11 entity mapper 의 `Timestamp instanceof` 를 firebase-free `coerceFirestoreDate` 헬퍼로 대체
4. **`cb1e53d` entity barrel 분리 + lazy hooks/widgets** — 12 entity barrel 에서 api 함수 분리, `@/entities/<x>/api` 로 직접 import. mode-aware hook / mutation handler 들의 cloud branch 를 dynamic import 로
5. **`b244838` PR review 후속** — `toOptionalDate` 회귀 fix, `coerceFirestoreDate` 단위 테스트, dynamic-import `.catch()` + race 가드 추가, session-store 타이머 안정화

## per-route firebase 청크 (실측)

| Route | Before | After |
|---|---|---|
| `/` | 773K | **0K** ✅ |
| `/topology` | 773K | **0K** ✅ |
| `/docs` | 773K | **0K** ✅ |
| `/ontology/edit` | 773K | **0K** ✅ |
| `/projects` | 773K | **0K** ✅ |
| `/knowledge` | 773K | **0K** ✅ |
| `/ontology/insights` | 773K | **0K** ✅ |
| `/ontology/relations` | 773K | **0K** ✅ |
| `/login`, `/account` | 773K | **0K** ✅ |
| cloud-admin (`/knowledge/documents`, `/settings/{categories,statuses,import,ontology}`, `/diagnostics/insights`) | 773K | 773K (의도된 동작) |

cloud-admin 라우트는 본질적으로 cloud 모드 전용이라 정적 firebase 로드를 유지. 나머지 user-facing 페이지는 mission v2 의 `로그인 없이 0 마찰 진입` 약속을 코드로 보장.

## 변경 패턴 요약

- **barrel 분리**: `@/entities/<x>/index.ts` 에서 api 함수 제거 → `@/entities/<x>/api` 로 직접 import
- **mapper duck-typing**: `instanceof Timestamp` → `coerceFirestoreDate` (firebase-free)
- **hook lazy**: `useKnowledgePublic*`, `useProjects`, `TaxonomyProvider` 등의 useEffect 안 dynamic import (모두 cancellation + `.catch()` fallback 포함)
- **widget mutation lazy**: 클릭 핸들러 안 dynamic import (ManualNodeCreateModal, OntologyEditPage 등)
- **`package.json sideEffects`**: tree-shaking allowlist (firestore-noise-patch + css 만 side-effectful)

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm test:run` — 797/797 pass (114 test files, +8 from `coerceFirestoreDate` test)
- [x] `pnpm lint` — 0 errors (warnings 81 — 전부 pre-existing)
- [x] `pnpm build` — 정적 export 성공
- [x] per-route firebase chunk 실측 — 위 표대로
- [ ] 로그인 후 cloud 모드 진입 시 정상 동작 (firebase chunk 가 그제서야 다운로드되는지) — manual
- [ ] vault picked local 모드 진입 시 firebase 청크 0 이 그대로 유지되는지 — manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)