### PR TITLE
chore: PR #99 follow-up — docs + ESLint 룰 + bundle:check 스크립트

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -45,3 +45,51 @@ src/
 - 동일 개념을 두 컬렉션 / 두 화면 / 두 입력 경로에서 동시에 진실원으로 두지 말 것.
 - 새 컬렉션을 추가하기 전에 기존 컬렉션을 확장 가능한지 먼저 검토.
 - 스키마 변경은 docs-first — `docs/DATA-MODEL.md` 와 `firestore.rules` 를 같이 갱신.
+
+## Entity barrel vs api 분리 (PR #99 이후)
+
+mission v2 의 *"local-first 첫 paint firebase 0"* 약속을 코드로 보장하기 위한 import 규율.
+
+### 규칙
+
+- `@/entities/<x>` (메인 barrel) 은 **firebase 의존 0** — type, lib, pure helper, default constants 만 export.
+- `@/entities/<x>/api` 는 firestore subscribe / mutation 함수의 진입점 — 호출자가 명시적으로 이 경로를 적어야 한다.
+- mapper (`<x>/model/mapper.ts`) 는 `instanceof Timestamp` 대신 `@/shared/lib/firestore-timestamp-coerce` 의 `coerceFirestoreDate(value)` 사용. firebase 의존 0 유지.
+
+### import 분기 가이드
+
+```ts
+// ✅ 정적 import — 모든 페이지 첫 paint 청크에 들어가도 OK
+import type { Project } from '@/entities/project';
+import { getProjectDetailHref } from '@/entities/project/lib/detail-href';
+
+// ✅ cloud-mode-only 페이지 (settings/*, knowledge/documents 등) — 정적 import OK
+import { subscribeProjects } from '@/entities/project/api';
+
+// ✅ mode-aware feature / hook — useEffect / 핸들러 안 dynamic import
+useEffect(() => {
+  let unsubscribe: (() => void) | null = null;
+  let cancelled = false;
+  void import('@/entities/project/api')
+    .then(({ subscribeProjects }) => {
+      if (cancelled) return;
+      unsubscribe = subscribeProjects(...);
+    })
+    .catch((err) => {
+      // chunk fetch 실패 시 명시적 fallback (영원히 loading 방지)
+      if (cancelled) return;
+      console.warn('[<call-site>] firebase chunk load failed', err);
+      setError('...');
+    });
+  return () => { cancelled = true; unsubscribe?.(); };
+}, [...]);
+
+// ❌ 금지 — 메인 barrel 에서 api 함수 가져오기 (현재는 export 자체가 없음).
+// 새 api 함수 추가 시 절대 메인 barrel 에 export 하지 말 것.
+import { subscribeProjects } from '@/entities/project';
+```
+
+### 회귀 방지
+
+- ESLint 룰: `eslint.config.ts` 의 `no-restricted-imports` 가 `@/entities/<x>` 의 api 함수 import 패턴을 막는다.
+- 빌드 측정: `pnpm bundle:check` 가 user-facing 라우트 (`/`, `/topology`, `/docs` …) 의 firebase chunk 를 측정. 0 이 아니면 fail.

--- a/.claude/rules/forbidden.md
+++ b/.claude/rules/forbidden.md
@@ -31,6 +31,8 @@
 
 - FSD import 방향 위반 (`entities` 에서 `widgets` import 등). ESLint 가 잡지만 사람이 우회하면 거절.
 - 동일 개념을 두 컬렉션 / 두 진입 경로에서 동시에 진실원으로 두기.
+- **`@/entities/<x>` 메인 barrel 에서 firestore api 함수 export 추가** — local-first 첫 paint 청크에 firebase JS 가 leak. api 는 `@/entities/<x>/api` 로만 진입. 자세히 `@.claude/rules/architecture.md`.
+- **mapper 에서 `instanceof Timestamp` 사용** — firebase/firestore 정적 import 가 entity model 까지 끌고 와 청크 회귀. `@/shared/lib/firestore-timestamp-coerce` 의 `coerceFirestoreDate` 사용.
 - `--no-verify` 로 git hook 우회.
 - `git push --force` 를 main 에.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,33 @@
 
 ---
 
+## 2026-05-02 — local-first 첫 paint firebase 0 (PR #99)
+
+### 사용자 가시 변화
+
+- **첫 페이지 로드 가벼워짐** — `/`, `/topology`, `/docs`, `/ontology/edit`, `/projects`, `/knowledge`, `/login`, `/account` 등 user-facing 진입점이 firebase JS (~773kb chunks) 를 정적으로 로드하지 않는다. cloud 모드 명시 진입 (signin / cloud entity mutation) 시점에만 lazy 로드.
+- **모바일 / 느린 네트워크 LCP 개선** — firebase SDK parse 비용 0.
+- **호스팅 비용 측면**: vault picked 사용자는 firebase 계정 자체가 안 만들어짐. 정적 export 라 origin server 비용은 어차피 0 이고, 이제는 firebase 트래픽도 cloud 모드 진입 전엔 0.
+- **동작은 그대로** — cloud 모드 사용자도 모든 기능 동일 작동 (함수 호출 시점에 firebase chunk 가 다운로드).
+
+### 아키텍처 변화 (개발자 가시)
+
+- **entity barrel 분리 패턴** — `@/entities/<x>` 는 type / lib / pure helper 만. firestore api 는 `@/entities/<x>/api` 로 직접 import. 새 contributor 는 mode-aware feature 작성 시 cloud branch 만 `import('@/entities/<x>/api')` 로 dynamic import.
+- **mapper Timestamp duck-typing** — `instanceof Timestamp` 체크 대신 `coerceFirestoreDate(value)` 헬퍼 (`@/shared/lib/firestore-timestamp-coerce`). entity model 이 firebase 의존 0.
+- **`package.json sideEffects` allowlist** — `*.css` + `firestore-noise-patch` 만 side-effectful 로 표시. 나머지는 webpack tree-shake.
+
+### 새 module
+
+- `src/shared/lib/firestore-noise-patch.ts` — 기존 `FirebaseProvider` 의 console 노이즈 패치를 firebase-deps-free 모듈로 분리. layout 에서 side-effect import 만으로 install.
+- `src/shared/lib/firestore-timestamp-coerce.ts` — Timestamp duck-typing 헬퍼 + 8 케이스 단위 테스트.
+- `src/entities/knowledge-graph/api/index.ts` — knowledge-graph api barrel (전엔 main barrel 에 섞여 있었음).
+
+### 제거
+
+- `src/app/providers/FirebaseProvider.tsx` (-91 줄) — 하던 일이 console 패치 + 불필요한 `getFirebaseApp()` warmup 두 가지였는데, 패치는 pure 모듈로 분리하고 warmup 은 `<link rel="preconnect">` 가 이미 함.
+
+---
+
 ## 2026-05-01 (밤) — UX 1원리 batch + Phase 4 비개발자 친화 + V1.5 cardinality
 
 이전 entry 의 7 PR 외에 추가로 12 PR 머지 (#15-#23). 전 세션 누적 19 PR.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,158 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // local-first 첫 paint firebase 0 약속 회귀 방지 (PR #99 이후).
+  //
+  // `@/entities/<x>` 메인 barrel 은 firebase 의존이 없어야 한다 (type / lib /
+  // pure helper 만). firestore 구독·mutation 함수는 `@/entities/<x>/api` 로
+  // 직접 import 해서 cloud-mode 진입 시점에만 chunk 가 다운로드되게.
+  //
+  // 메인 barrel 에서 아래 names 를 import 하면 "api 경로 사용해" 메시지로
+  // 막는다. 새 api 함수 추가 시 메인 barrel 에 export 도 절대 X — 추가하면
+  // 이 룰에 names 도 같이 추가해 회귀 차단.
+  //
+  // 자세히: `@.claude/rules/architecture.md`.
+  {
+    files: ['src/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@/entities/project',
+              importNames: [
+                'listProjects',
+                'getProject',
+                'upsertProject',
+                'upsertProjectPositions',
+                'deleteProject',
+                'deleteProjects',
+                'subscribeProjects',
+                'fetchAllProjectsAtBuild',
+                'uploadScreenshot',
+                'deleteScreenshot',
+              ],
+              message:
+                "firestore api 는 '@/entities/project/api' 로 직접 import 하세요 (local-first 첫 paint 청크 firebase 0 보장).",
+            },
+            {
+              name: '@/entities/category',
+              importNames: [
+                'subscribeCategories',
+                'upsertCategory',
+                'deleteCategory',
+                'seedDefaultCategoriesIfEmpty',
+              ],
+              message: "firestore api 는 '@/entities/category/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/status',
+              importNames: [
+                'subscribeStatuses',
+                'upsertStatus',
+                'deleteStatus',
+                'seedDefaultStatusesIfEmpty',
+              ],
+              message: "firestore api 는 '@/entities/status/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/admin',
+              importNames: ['isAdmin'],
+              message: "firestore api 는 '@/entities/admin/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/ontology-class',
+              importNames: [
+                'subscribeOntologyClasses',
+                'upsertOntologyClass',
+                'seedDefaultOntologyClassesIfEmpty',
+              ],
+              message: "firestore api 는 '@/entities/ontology-class/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/ontology-relation',
+              importNames: [
+                'subscribeOntologyRelations',
+                'upsertOntologyRelation',
+                'seedDefaultOntologyRelationsIfEmpty',
+              ],
+              message:
+                "firestore api 는 '@/entities/ontology-relation/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/ontology-tbox',
+              importNames: [
+                'loadActiveTBox',
+                'createTBoxVersion',
+                'activateTBoxVersion',
+                'listTBoxVersions',
+                'getActiveTBoxState',
+                'generateTBoxVersionId',
+                'appendClassAndActivate',
+                'appendRelationAndActivate',
+                'updateClassMetadataAndActivate',
+                'ActiveTBox',
+              ],
+              message: "firestore api 는 '@/entities/ontology-tbox/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/knowledge-document',
+              importNames: [
+                'listKnowledgeDocuments',
+                'getKnowledgeDocument',
+                'subscribeKnowledgeDocuments',
+                'subscribeKnowledgeDocumentsByProject',
+                'getPublicDocumentsForProject',
+                'createKnowledgeDocumentWithInitialVersion',
+                'createKnowledgeDocumentVersion',
+                'setKnowledgeDocumentCurrentVersion',
+                'listKnowledgeVersionsByDocument',
+                'subscribeKnowledgeVersionsByDocument',
+                'buildKnowledgeDocumentStoragePath',
+                'downloadKnowledgeMarkdown',
+                'uploadKnowledgeMarkdown',
+                'deleteKnowledgeMarkdown',
+              ],
+              message:
+                "firestore api 는 '@/entities/knowledge-document/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/knowledge-evidence',
+              importNames: ['subscribeKnowledgeEvidenceByDocument'],
+              message:
+                "firestore api 는 '@/entities/knowledge-evidence/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/knowledge-job',
+              importNames: ['subscribeKnowledgeJobsByDocument'],
+              message: "firestore api 는 '@/entities/knowledge-job/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/knowledge-output',
+              importNames: ['subscribeKnowledgeOutputsByDocument'],
+              message:
+                "firestore api 는 '@/entities/knowledge-output/api' 로 직접 import 하세요.",
+            },
+            {
+              name: '@/entities/knowledge-graph',
+              importNames: [
+                'listKnowledgeProjectInsight',
+                'subscribeKnowledgeProjectInsight',
+                'subscribeKnowledgePublicGraph',
+                'subscribeKnowledgeApprovedGraph',
+                'subscribeKnowledgePublicMeta',
+                'addManualKnowledgeNode',
+                'addManualKnowledgeEdge',
+              ],
+              message:
+                "firestore api 는 '@/entities/knowledge-graph/api' 로 직접 import 하세요. (lazy hook `useKnowledgePublic*` 은 메인 barrel 그대로 OK.)",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // 디자인 헌장 §11 (CLAUDE.md) 자동 차단 — Track E-13 (자율 루프).
   // - scale hover 금지 (`hover:scale-*` `active:scale-*` etc)
   // - 보라핑크 그라디언트 금지 (`from-purple-*` `to-pink-*` 조합)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "pnpm docs-vault:build && next build",
     "docs-vault:build": "node scripts/build-docs-vault.mjs",
     "lint": "eslint",
+    "bundle:check": "node scripts/check-bundle.mjs",
     "seed": "node scripts/seed-via-rest.mjs",
     "seed:emulator": "node scripts/seed-emulator.mjs",
     "test": "vitest",

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+// per-route firebase chunk 회귀 차단 (PR #99 이후).
+//
+// mission v2 의 *"local-first 첫 paint firebase 0"* 약속을 build artifact
+// 단위로 보장. user-facing 라우트 (`/`, `/topology`, `/docs`, …) 의 정적
+// 청크에 firebase JS 가 다시 들어가면 exit 1 — CI / 로컬 PR 검증.
+//
+// 사용:
+//   pnpm build                   # out/ 와 .next/static/chunks 생성
+//   node scripts/check-bundle.mjs
+//
+// 룰:
+//   - LOCAL_FIRST_ROUTES: firebase chunk 0 이어야 함. 위반 시 fail.
+//   - CLOUD_ADMIN_ROUTES: firebase chunk 정적 로드 OK (단순 보고).
+//
+// 새 user-facing 라우트 추가 시 LOCAL_FIRST_ROUTES 에 등록.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const CHUNKS_DIR = join(ROOT, '.next/static/chunks');
+const OUT_DIR = join(ROOT, 'out');
+
+// firebase SDK 청크 식별 — 여러 unique 토큰이 *동시에* 등장해야 한다.
+// 단일 `getFirestore` 문자열은 application chunk (Button / icon / route)
+// 에도 `(0,r.getFirestore)` 같이 단편으로 들어가서 false positive.
+// SDK bundle 은 internal class 들 (`Firestore`, `FieldValue`, `DocumentReference`
+// 등) 을 다 갖고 있어 4+ 매치.
+const FIREBASE_SDK_TOKENS = [
+  'getFirestore',
+  'onAuthStateChanged',
+  'getApps',
+  'Firestore',
+  'DocumentReference',
+  'CollectionReference',
+  'FieldValue',
+  '@firebase/firestore',
+  '@firebase/auth',
+];
+const SDK_MIN_TOKEN_HITS = 4;
+
+const LOCAL_FIRST_ROUTES = [
+  '/',
+  '/topology',
+  '/docs',
+  '/ontology',
+  '/ontology/edit',
+  '/ontology/insights',
+  '/ontology/relations',
+  '/projects',
+  '/knowledge',
+  '/login',
+  '/signup',
+  '/account',
+  '/reset-password',
+];
+
+const CLOUD_ADMIN_ROUTES = [
+  '/knowledge/documents',
+  '/knowledge/documents/new',
+  '/settings/categories',
+  '/settings/statuses',
+  '/settings/import',
+  '/settings/ontology',
+  '/settings/ontology/history',
+  '/diagnostics/insights',
+];
+
+function listFirebaseChunks() {
+  const out = [];
+  for (const name of readdirSync(CHUNKS_DIR)) {
+    if (!name.endsWith('.js')) continue;
+    const path = join(CHUNKS_DIR, name);
+    const sz = statSync(path).size;
+    if (sz < 50_000) continue; // SDK 청크는 최소 50KB. 더 작으면 skip.
+    const content = readFileSync(path, 'utf8');
+    const hits = FIREBASE_SDK_TOKENS.filter((t) => content.includes(t)).length;
+    if (hits >= SDK_MIN_TOKEN_HITS) {
+      out.push({ id: basename(name, '.js'), size: sz, hits });
+    }
+  }
+  return out;
+}
+
+function htmlPathForRoute(route) {
+  if (route === '/') return join(OUT_DIR, 'index.html');
+  return join(OUT_DIR, route.replace(/^\//, ''), 'index.html');
+}
+
+function chunksLoadedBy(html, chunkIds) {
+  const loaded = [];
+  for (const id of chunkIds) {
+    if (html.includes(id)) loaded.push(id);
+  }
+  return loaded;
+}
+
+function fmtKb(bytes) {
+  return `${Math.round(bytes / 1024)}K`;
+}
+
+function main() {
+  // 빌드 산출물 존재 확인.
+  try {
+    statSync(CHUNKS_DIR);
+    statSync(OUT_DIR);
+  } catch {
+    console.error('❌ .next/static/chunks 또는 out/ 가 없습니다. 먼저 `pnpm build` 실행.');
+    process.exit(2);
+  }
+
+  const fbChunks = listFirebaseChunks();
+  if (fbChunks.length === 0) {
+    console.log('ℹ️  firebase SDK 청크 0 — 모든 라우트 자동 통과 (의외의 결과면 signature 점검).');
+    return;
+  }
+
+  console.log(`Firebase SDK 청크 ${fbChunks.length} 개 발견:`);
+  for (const c of fbChunks) console.log(`  - ${c.id} (${fmtKb(c.size)})`);
+  console.log();
+
+  let violations = 0;
+
+  console.log('## local-first 라우트 (firebase 0 이어야 함)');
+  for (const route of LOCAL_FIRST_ROUTES) {
+    const path = htmlPathForRoute(route);
+    let html;
+    try {
+      html = readFileSync(path, 'utf8');
+    } catch {
+      console.log(`  ${route}: ⚠️  (HTML 없음 — 해당 라우트 빌드 안 됐거나 dynamic params)`);
+      continue;
+    }
+    const loaded = chunksLoadedBy(
+      html,
+      fbChunks.map((c) => c.id),
+    );
+    if (loaded.length === 0) {
+      console.log(`  ${route}: ✅ 0K`);
+    } else {
+      const total = loaded.reduce(
+        (sum, id) => sum + (fbChunks.find((c) => c.id === id)?.size ?? 0),
+        0,
+      );
+      console.log(`  ${route}: ❌ ${fmtKb(total)} (chunks: ${loaded.join(', ')})`);
+      violations += 1;
+    }
+  }
+
+  console.log();
+  console.log('## cloud-admin 라우트 (firebase 정적 로드 OK — 단순 보고)');
+  for (const route of CLOUD_ADMIN_ROUTES) {
+    const path = htmlPathForRoute(route);
+    let html;
+    try {
+      html = readFileSync(path, 'utf8');
+    } catch {
+      console.log(`  ${route}: (skip — HTML 없음)`);
+      continue;
+    }
+    const loaded = chunksLoadedBy(
+      html,
+      fbChunks.map((c) => c.id),
+    );
+    const total = loaded.reduce(
+      (sum, id) => sum + (fbChunks.find((c) => c.id === id)?.size ?? 0),
+      0,
+    );
+    console.log(`  ${route}: ${fmtKb(total)}`);
+  }
+
+  console.log();
+  if (violations > 0) {
+    console.error(
+      `❌ ${violations} local-first 라우트가 firebase chunk 를 정적 로드합니다. ` +
+        `자세히 \`@.claude/rules/architecture.md\` 의 "Entity barrel vs api 분리" 참조.`,
+    );
+    process.exit(1);
+  }
+  console.log('✅ 모든 local-first 라우트가 firebase chunk 0 — mission v2 약속 유지.');
+}
+
+main();


### PR DESCRIPTION
## Summary

PR #99 가 만든 *"local-first 첫 paint firebase 0"* 약속을 회귀 차단하는 layer 추가. PR #99 위에 stack — base 가 \`refactor/firebase-dynamic-import\`. PR #99 머지 후 자동 rebase.

- **#5 docs**: CHANGELOG 갱신 + entity barrel/api 분리 패턴을 contributor 룰에 명문화
- **#6 ESLint 룰**: \`@/entities/<x>\` 메인 barrel 에서 api 함수 import 시 lint error
- **#7 bundle:check**: 빌드 산출물 단위로 user-facing 라우트의 firebase 청크 측정 + 회귀 시 fail

## 3 commits

1. \`58e4f56\` **docs** — CHANGELOG 2026-05-02 entry, architecture.md 의 새 \"Entity barrel vs api 분리\" 섹션, forbidden.md 두 줄 추가.

2. \`5b5c7be\` **ESLint 룰** — \`no-restricted-imports\` 에 12 entity 의 api 함수 names 등록. negative test 로 동작 확인:
   \`\`\`
   import { subscribeProjects } from '@/entities/project';
   → error: 'subscribeProjects' import from '@/entities/project' is restricted.
     firestore api 는 '@/entities/project/api' 로 직접 import 하세요.
   \`\`\`

3. \`aecaee8\` **bundle:check 스크립트** — \`pnpm bundle:check\` 로 빌드 후 검증. SDK unique 토큰 (\`getFirestore\`, \`Firestore\`, \`DocumentReference\` 등) 4 개 이상 동시 등장하는 청크만 식별 (false positive 0).

## Layered defense

| Layer | 잡는 것 | 도구 |
|---|---|---|
| 1. Code review | 의도적 위반 | 사람 |
| 2. ESLint (PR #100) | 정적 import 회귀 | \`pnpm lint\` |
| 3. bundle:check (PR #100) | dependency 의 indirect 끌어옴 / 빌드 단계 회귀 | \`pnpm bundle:check\` |
| 4. Contributor docs (PR #100) | 새 contributor 가 패턴 모름 | architecture.md / CHANGELOG |

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 797/797 pass (변경 없음, 기존 그대로)
- [x] \`pnpm lint\` — 0 errors. 81 pre-existing warnings.
- [x] ESLint rule negative test — pass (잘못된 import 가 lint error)
- [x] \`pnpm bundle:check\` (PR #99 build artifact 위) — \"✅ 모든 local-first 라우트가 firebase chunk 0\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)