### PR TITLE
feat: OSS launch readiness — scaffold button + npm publish guard + English docs

### DIFF
--- a/.claude/hooks/block-npm-publish.sh
+++ b/.claude/hooks/block-npm-publish.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PreToolUse hook — Bash 명령에서 npm/pnpm/yarn publish 류를 차단한다.
+#
+# Claude Code 가 PreToolUse hook 으로 호출. stdin 으로 tool_input JSON 을 받고,
+# 명령에 publish 키워드가 들어 있으면 deny 하는 JSON 을 출력 (exit 0).
+#
+# 통과시키는 경우는 출력 없이 exit 0 — Claude Code 가 그대로 진행.
+#
+# 차단 규칙:
+# - `npm publish`, `pnpm publish`, `yarn publish` (실제 발행)
+# - `npm publish` 류가 chain (`&&`, `||`, `;`, `|`) 안에 섞여 있어도 차단
+# - `npm pack` (단순 dry-run 은 통과 — 키워드 `--dry-run` 포함 시)
+# - `npm version <patch|minor|major>` 가 자동 publish 와 결합된 경우 (`postversion` script)
+# - `npm whoami`, `npm view`, `npm pack --dry-run` 같은 read-only 는 통과
+#
+# 사용자가 명시 승인을 줘서 publish 를 실행하려면, 이 파일을 임시로 비활성화 (`mv block-npm-publish.sh block-npm-publish.sh.off`) 하거나, 사용자가 직접 터미널에서 실행한다.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+
+# tool_name 이 Bash 가 아니면 패스
+TOOL_NAME=$(printf '%s' "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+  exit 0
+fi
+
+# tool_input.command 추출 (JSON 안에 escape 된 따옴표 처리)
+COMMAND=$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    cmd = data.get("tool_input", {}).get("command", "")
+    sys.stdout.write(cmd)
+except Exception:
+    sys.exit(0)
+' 2>/dev/null || echo "")
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# 정규식 매칭: publish 류 패턴
+# - (npm|pnpm|yarn) publish — 단어 경계 포함
+# - npm pack (dry-run 아닌 경우)
+BLOCKED=0
+REASON=""
+
+if echo "$COMMAND" | grep -E '(^|[[:space:]&|;])(npm|pnpm|yarn)[[:space:]]+publish([[:space:]]|$)' >/dev/null; then
+  BLOCKED=1
+  REASON="npm/pnpm/yarn publish 명령이 감지됐습니다. 외부 npm 레지스트리에 영구 발행되는 작업이라 사용자의 명시적 승인이 필수입니다."
+fi
+
+if [[ $BLOCKED -eq 0 ]] && echo "$COMMAND" | grep -E '(^|[[:space:]&|;])npm[[:space:]]+pack([[:space:]]|$)' >/dev/null; then
+  if ! echo "$COMMAND" | grep -E -- '--dry-run' >/dev/null; then
+    BLOCKED=1
+    REASON="'npm pack' 이 --dry-run 없이 실행되려고 합니다. 실제 tarball 생성/발행은 사용자 승인이 필수입니다 (감사용이면 --dry-run 추가)."
+  fi
+fi
+
+if [[ $BLOCKED -eq 1 ]]; then
+  # PreToolUse deny 형식 (Claude Code 1.x): JSON 으로 reason 전달
+  cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "🚫 npm publish 가드: ${REASON}\n\n사용자가 명시적으로 'publish 해줘' 라고 지시한 경우에만 실행 가능합니다.\n.claude/rules/forbidden.md 와 CLAUDE.md 의 'npm publish' 섹션 참조.\n\n사용자 본인이 터미널에서 직접 실행하거나, .claude/hooks/block-npm-publish.sh 를 비활성화 후 실행하세요."
+  }
+}
+JSON
+  exit 0
+fi
+
+exit 0

--- a/.claude/rules/forbidden.md
+++ b/.claude/rules/forbidden.md
@@ -60,6 +60,18 @@
 - `firebase` 외에 별도 백엔드 SDK 도입 (v0.x 범위 밖).
 - node_modules 에 직접 patch (use `pnpm patch` instead).
 
+## 🚫 npm publish — 사용자 명시 승인 없이 실행 절대 금지
+
+`npm publish`, `pnpm publish`, `yarn publish` 등 **외부 레지스트리 발행 명령**은:
+
+- 사용자가 직접 "publish 해줘" / "npm 에 올려줘" 같이 *명시적* 지시를 하기 전엔 절대 실행하지 않는다.
+- "정리하자" · "다음 뭐 할까" · "마무리하자" 같은 모호한 지시는 publish 승인이 아니다.
+- `.claude/settings.json` 의 PreToolUse hook 이 1차 차단하고 있고, hook 이 비활성이어도 행동 규칙으로 금지.
+- *제안* 은 가능 — "이제 publish 가능합니다, 실행할까요?" 라고 묻고 사용자 답을 기다린 다음 실행.
+- `npm pack --dry-run` 같은 *읽기 전용 audit* 명령은 OK. 실제 발행 (`npm publish`, `npm pack` 의 tarball 업로드, `npm version` + 자동 publish chain) 은 금지.
+
+**왜**: npm 패키지는 영구 발행. 잘못된 버전이 나가면 24h 이후엔 되돌릴 수 없고, 사용자 본인 계정으로 발행되므로 평판이 직접 걸린다. 자동 publish 를 막아야 사용자가 PR/diff/audit 를 거쳐 의도적으로 발행할 수 있다.
+
 ## "왜" 를 물을 것
 
 위 룰을 어겨야 한다고 느낄 때는 PR 본문에 *왜* 를 적고, 룰 자체를 갱신하는 PR 을 먼저 올려라.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-npm-publish.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,35 @@
 # AGENTS.md — oh-my-ontology
 
 > Canonical contributor guide for AI agents (Claude Code, Cursor, Copilot, Codex, Aider, …) and humans alike. Read once before touching the codebase.
+>
+> 한국어 안내는 아래 [한국어 가이드](#한국어-가이드) 섹션 참조.
 
 ## Project overview
 
-`oh-my-ontology` 는 **사람과 AI agent 가 같이 저작하는 codebase ontology workbench** 다 (mission v2 — 2026-05-01). vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — frontmatter 자체가 자기-승인이라 별도 검수 단계 없음. 사람은 빌더 캔버스 또는 직접 `.md` 편집으로, AI agent (Claude Code 등) 는 `mcp/` MCP 서버로 같은 graph 를 read/write.
+`oh-my-ontology` is **a codebase ontology workbench that humans and AI agents author together** (mission v2 — 2026-05-01). The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, so there is no separate review step. Humans edit through the builder canvas or directly in `.md` files; AI agents (Claude Code, …) read/write the same graph through the `mcp/` MCP server.
 
-자세한 방향: `docs/PRODUCT-DIRECTION.md`. 사용자 가시 기능 전수: `docs/FEATURES.md`.
+For direction, see `docs/PRODUCT-DIRECTION.md`. For a full list of user-visible features, see `docs/FEATURES.md`.
 
-핵심 원칙 한 줄:
+The single guiding principle:
 
-> **md frontmatter 가 곧 그래프. 사람도 AI agent 도 같은 vault 에 쓴다.**
+> **Markdown frontmatter is the graph. Humans and AI agents write to the same vault.**
 
 ## Quick start
 
 ```bash
 pnpm install
-pnpm dev                          # http://localhost:3000 — 로그인 0, vault 폴더 선택만으로 즉시 동작
+pnpm dev                          # http://localhost:3000 — no login required; pick a vault folder and you're in
 
-# Firebase 사용 시 (옵션 — cloud sync 필요할 때만)
+# Firebase (optional — only when you want cloud sync)
 cp .env.example .env.local
 
-# 검증
-pnpm test:run                     # vitest 104 files / 740 tests
+# Verify
+pnpm test:run                     # vitest 100 files / 721 tests
 pnpm exec tsc --noEmit
 pnpm lint
-pnpm build                        # 정적 export → out/
+pnpm build                        # static export → out/
 
-# AI agent (Claude Code) 등록 — .mcp.json.example 복사 + 가이드: mcp/README.md
+# Register an AI agent (Claude Code) — copy .mcp.json.example, follow mcp/README.md
 ```
 
 ## Tech stack
@@ -36,11 +38,11 @@ pnpm build                        # 정적 export → out/
 - **Language** TypeScript 5
 - **Style** Tailwind CSS 4 (`@theme` CSS-based tokens)
 - **Visualization** Sigma.js (WebGL) · Graphology · ForceAtlas2 · xyflow
-- **Local-first** File System Access API + IndexedDB (vault handle 영속)
-- **AI agent** `@modelcontextprotocol/sdk` (stdin/stdout JSON-RPC server, `mcp/` 패키지)
-- **Backend** Firebase (Firestore · Storage · Auth · Hosting) — **옵션**. local-first 가 default
-- **State** Firestore `onSnapshot` (cloud) 또는 in-memory + IndexedDB (local) · React local state · URL state
-- **Architecture** Feature-Sliced Design (ESLint boundaries 로 import 방향 강제)
+- **Local-first** File System Access API + IndexedDB (vault handle persistence)
+- **AI agent** `@modelcontextprotocol/sdk` (stdin/stdout JSON-RPC server, `mcp/` package)
+- **Backend** Firebase (Firestore · Storage · Auth · Hosting) — **optional**. Local-first is the default.
+- **State** Firestore `onSnapshot` (cloud) or in-memory + IndexedDB (local) · React local state · URL state
+- **Architecture** Feature-Sliced Design (ESLint boundaries enforce the import direction)
 - **Test** Vitest + Testing Library + jsdom · Playwright (E2E)
 - **Lint** ESLint 9 flat config
 - **Package** pnpm
@@ -48,85 +50,139 @@ pnpm build                        # 정적 export → out/
 ## Folder map
 
 ```
-app/                       Next.js 라우팅 (얇은 래퍼)
-src/                       FSD 레이어
-  ├── app/                 providers · 초기화
-  ├── views/               페이지 컴포넌트
-  ├── widgets/             복합 UI
-  ├── features/            인터랙션 단위
-  ├── entities/            비즈니스 엔티티
-  └── shared/              UI · lib · config · api 재사용 기반
-mcp/                       MCP 서버 (AI agent partner surface)
-docs/                      장기 문서 (architecture / data-model / design / deployment)
-docs/ontology/             이 프로젝트 자기 ontology vault (dogfood, 23 노드)
-tests/                     Vitest 단위 + Playwright E2E
-scripts/                   시드 / 배포 / 검증 보조
-.claude/rules/             세부 작업 규율 (자동 로드)
+app/                       Next.js routes (thin wrappers)
+src/                       FSD layers
+  ├── app/                 providers · initialization
+  ├── views/               page-level components
+  ├── widgets/             composite UI
+  ├── features/            interaction units
+  ├── entities/            business entities
+  └── shared/              UI · lib · config · api primitives
+mcp/                       MCP server (the AI agent's surface)
+docs/                      long-form docs (architecture / data-model / design / deployment)
+docs/ontology/             this project's own ontology vault (dogfood, ~23 nodes)
+tests/                     Vitest unit + Playwright E2E
+scripts/                   seed / deploy / verification helpers
+.claude/rules/             granular working rules (auto-loaded)
 ```
 
-**Import 방향**: `app → views → widgets → features → entities → shared`. 역방향 import 는 ESLint 가 막는다.
+**Import direction**: `app → views → widgets → features → entities → shared`. ESLint blocks the reverse.
 
 ## Routes
 
 ```
-/                          ontology 트리 hub (vault 활성 시 자동 vault 데이터)
-/topology                  토폴로지 view (Sigma WebGL)
-/projects                  프로젝트 목록 (mode-aware)
-/project/[slug]            프로젝트 상세 (권한 시 인라인 편집)
-/docs                      vault picker / vault 활성 시 문서 surface
-/knowledge · /knowledge/*  cloud 모드 문서 등록 / 목록
-/ontology/edit             ERD 캔버스 빌더 (xyflow + .md 내보내기)
-/ontology/insights         그래프 인사이트
-/ontology/relations        관계 분포
-/settings/*                카테고리 / 상태 / 가져오기
-/diagnostics/insights      운영 인사이트
-/login · /signup · /reset-password · /account   Firebase Auth surface (옵션)
+/                          ontology tree hub (auto-uses vault data when active)
+/topology                  topology view (Sigma WebGL)
+/projects                  project list (mode-aware)
+/project/[slug]            project detail (inline edit when permitted)
+/docs                      vault picker / document surface when vault is active
+/ontology/edit             ERD canvas builder (xyflow + .md export)
+/ontology/insights         graph insights
+/ontology/relations        relation distribution
+/settings/*                categories / status / import
+/diagnostics/insights      operations insights
+/login · /signup · /reset-password · /account   Firebase Auth surface (optional)
 ```
 
-> mission v2 정렬: `/review/knowledge` 검수 큐 라우트 + `/admin/*` 네임스페이스는 폐기됨 (vault frontmatter 가 자기-승인). cloud LLM 추출 흐름 (`enqueueExtractionJob` 등) 도 entity layer 에서 제거됐고, `functions/` 폴더 자체도 폐기됨 (firebase 배포 안 함) — 자세히 `docs/MISSION-CLEANUP-CANDIDATES.md`.
+> mission v2 alignment: the `/review/knowledge` review queue, the entire `/knowledge/*` document subsystem (page + entities `KnowledgeDocument`/`KnowledgeDocumentVersion`), the `/admin/*` namespace, the `/diagnostics/*` namespace, and the TBox surfaces (`/settings/ontology[/history]`) have all been removed (vault frontmatter is self-approving). The cloud LLM extraction flow (`enqueueExtractionJob`, …) was removed from the entity layer, and the `functions/` folder itself was removed (we no longer deploy Firebase Functions). Details: `docs/MISSION-CLEANUP-CANDIDATES.md`.
 
 ## Working principles
 
-세부 룰은 `.claude/rules/*.md` 에 분리해두었고 Claude Code 는 자동으로 로드한다. 다른 도구는 아래를 참조해 같은 룰을 인용한다.
+The detailed rules live in `.claude/rules/*.md` and Claude Code auto-loads them. Other tools should reference the same rules from there.
 
-- **Architecture · FSD 경계** — `@.claude/rules/architecture.md`
-- **Design system** — 무채색 + 단일 인디고, 금지 패턴 — `@.claude/rules/design.md` · `@docs/DESIGN-SYSTEM.md`
-- **Git workflow** — conventional prefix + 한국어 본문 — `@.claude/rules/git.md`
-- **Testing & verification** — TDD-first, 단위 → e2e — `@.claude/rules/testing.md`
-- **Local-first / offline-first** — Notion 처럼 폴더만 선택해도 사용 가능 — `@.claude/rules/local-first.md`
-- **Authentication** — Firebase Auth (email/password + Google) 만 — `@.claude/rules/auth.md`
-- **금지 패턴 / Do-Not list** — `@.claude/rules/forbidden.md`
+- **Architecture · FSD boundaries** — `@.claude/rules/architecture.md`
+- **Design system** — neutrals + a single indigo, forbidden patterns — `@.claude/rules/design.md` · `@docs/DESIGN-SYSTEM.md`
+- **Git workflow** — conventional prefix + Korean (or English) body — `@.claude/rules/git.md`
+- **Testing & verification** — TDD-first, unit → e2e — `@.claude/rules/testing.md`
+- **Local-first / offline-first** — Notion-style: pick a folder and use it — `@.claude/rules/local-first.md`
+- **Authentication** — Firebase Auth (email/password + Google) only — `@.claude/rules/auth.md`
+- **Forbidden patterns / Do-Not list** — `@.claude/rules/forbidden.md`
+
+## 🚫 npm publish guard
+
+`npm publish` / `pnpm publish` / `yarn publish` is **never** run automatically. A PreToolUse hook in `.claude/settings.json` blocks it; the rules in `CLAUDE.md` and `.claude/rules/forbidden.md` document why. Only execute publish commands when the user explicitly asks ("publish it", "ship it to npm"). Even then, run `npm pack --dry-run` first to audit the tarball.
 
 ## Source-of-truth files
 
-문서와 코드가 충돌하면 코드가 먼저다. 프레임워크·빌드·라우팅 사실 관계는 다음 3 개로:
+When docs and code disagree, the code wins. For framework / build / routing facts, trust these three:
 
 - `package.json`
 - `next.config.ts`
 - `app/layout.tsx`
 
-장기 문서 (mission v2 우선):
+Long-form docs (mission v2 priority):
 
-- `@docs/PRODUCT-DIRECTION.md` — mission v2 방향
-- `@docs/FEATURES.md` — 사용자가 *지금* 사용 가능한 기능 전수
-- `@docs/MISSION-CLEANUP-CANDIDATES.md` — mission 정렬 cleanup 진행 (4 stage 완료)
-- `@docs/MODE-AWARE-CRUD.md` — local/cloud/static 분기 contributor 가이드
+- `@docs/PRODUCT-DIRECTION.md` — mission v2 direction
+- `@docs/FEATURES.md` — features users can use *right now*
+- `@docs/MISSION-CLEANUP-CANDIDATES.md` — mission alignment cleanup progress (4 stages complete)
+- `@docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x → V2 ontology model evolution spec
+- `@docs/MODE-AWARE-CRUD.md` — local/cloud/static contributor guide
 - `@docs/ARCHITECTURE.md` · `@docs/DATA-MODEL.md` · `@docs/DESIGN-SYSTEM.md` · `@docs/DEPLOYMENT.md`
-- `@docs/CHANGELOG.md` — 사용자 가시 변화 시간순
-- `@mcp/README.md` — AI agent partner (MCP 11 도구 — read 7 + write 4) 등록 + 사용
-- `@docs/archive/README.md` — 과거 분석 문서 보관 (현재 룰의 진실원 아님)
+- `@docs/CHANGELOG.md` — chronological user-visible changes
+- `@mcp/README.md` — AI agent partner (MCP 11 tools — read 7 + write 4) registration + usage
+- `@docs/archive/README.md` — archived analysis docs (no longer the source of truth for current rules)
 
-## 이 프로젝트의 ontology
+## This project's own ontology
+
+This project describes its own mental model in `docs/ontology/` as frontmatter markdown (dogfooding — we describe ourselves in our own data format).
+
+- Entry points: `docs/ontology/README.md` · `docs/ontology/project.md`
+- 8 domains + 5 capabilities + 4 elements + 1 project ≈ 19 nodes
+- AI agents query it via the `mcp/` MCP server — registration guide in `mcp/README.md`, example in `.mcp.json.example`
+- When you discover a new domain / capability / element, add it to the same directory (with the `add_concept` tool, or by hand)
+
+## CLAUDE.md / AGENTS.md sync
+
+- **AGENTS.md** (this file) is canonical — the cross-tool standard read by every AI coding tool.
+- **CLAUDE.md** imports AGENTS.md and only adds Claude-Code-specific bits (skills, hooks).
+- When you change one, sync the other — or just keep CLAUDE.md's `@AGENTS.md` import and they stay consistent automatically.
+
+---
+
+## 한국어 가이드
+
+> AI agent (Claude Code, Cursor, Copilot, Codex, Aider 등) 와 사람 모두를 위한 contributor guide. 코드 만지기 전에 한 번 읽고 시작.
+
+### 프로젝트 개요
+
+`oh-my-ontology` 는 **사람과 AI agent 가 같이 저작하는 codebase ontology workbench** 다 (mission v2 — 2026-05-01). vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — frontmatter 자체가 자기-승인이라 별도 검수 단계 없음. 사람은 빌더 캔버스 또는 직접 `.md` 편집으로, AI agent (Claude Code 등) 는 `mcp/` MCP 서버로 같은 graph 를 read/write.
+
+핵심 원칙 한 줄:
+
+> **md frontmatter 가 곧 그래프. 사람도 AI agent 도 같은 vault 에 쓴다.**
+
+### Quick start
+
+```bash
+pnpm install
+pnpm dev                          # http://localhost:3000 — 로그인 0, vault 폴더 선택만으로 즉시 동작
+pnpm test:run                     # vitest 100 files / 721 tests
+pnpm exec tsc --noEmit
+pnpm lint
+pnpm build                        # 정적 export → out/
+```
+
+### Working principles
+
+세부 룰은 `.claude/rules/*.md` 에 분리해두었고 Claude Code 는 자동으로 로드한다. 다른 도구는 같은 룰을 참조.
+
+- Architecture · FSD 경계 — `@.claude/rules/architecture.md`
+- Design system — 무채색 + 단일 인디고, 금지 패턴 — `@.claude/rules/design.md`
+- Git workflow — conventional prefix + 한국어 본문 — `@.claude/rules/git.md`
+- Testing & verification — TDD-first, 단위 → e2e — `@.claude/rules/testing.md`
+- Local-first / offline-first — Notion 처럼 폴더만 선택해도 사용 가능 — `@.claude/rules/local-first.md`
+- Authentication — Firebase Auth (email/password + Google) 만 — `@.claude/rules/auth.md`
+- 금지 패턴 / Do-Not list — `@.claude/rules/forbidden.md`
+
+### 🚫 npm publish 가드
+
+`npm publish` / `pnpm publish` / `yarn publish` 는 **자동 실행 절대 금지**. `.claude/settings.json` 의 PreToolUse hook 이 차단하고, `CLAUDE.md` 와 `.claude/rules/forbidden.md` 에 규칙으로 명시. 사용자가 직접 "publish 해줘" 라고 *명시적으로* 지시한 경우에만 실행 가능 — 그 경우에도 먼저 `npm pack --dry-run` 으로 audit.
+
+### 이 프로젝트의 ontology
 
 이 프로젝트 자신의 mental model 은 `docs/ontology/` 에 frontmatter md 로 표현되어 있다 (dogfooding — 우리 데이터 형식으로 우리 자신을 기술).
 
 - 진입점: `docs/ontology/README.md` · `docs/ontology/project.md`
-- 도메인 8 + capability 5 + element 4 + project 1 = 약 19 노드
+- 도메인 8 + capability 5 + element 4 + project 1 ≈ 19 노드
 - AI agent 는 `mcp/` MCP 서버로 query 가능 — 등록 가이드 `mcp/README.md` · 예시 `.mcp.json.example`
 - 새 도메인/capability/element 가 생기면 같은 디렉토리에 추가 (`add_concept` 도구로 또는 직접 작성)
-
-## CLAUDE.md / AGENTS.md 동기화
-
-- **AGENTS.md** (이 파일) 가 canonical. 모든 AI 코딩 도구가 읽는 cross-tool 표준.
-- **CLAUDE.md** 는 AGENTS.md 를 import 하고 Claude Code 전용 추가만 명시 (skills, hooks).
-- 한쪽을 바꾸면 다른 쪽 동기화 — 또는 CLAUDE.md 의 `@AGENTS.md` import 만 유지하면 자동 일관.

--- a/cli/templates/vault/README.md
+++ b/cli/templates/vault/README.md
@@ -6,56 +6,58 @@ title: My ontology vault
 
 # My ontology vault
 
-이 폴더는 **사람과 AI agent 가 같이 키우는 codebase mental model** 입니다.
-각 `.md` 파일은 한 노드 (project / domain / capability / element / concept)
-이고, 파일 위 frontmatter 가 그래프의 키 (slug / kind / depends_on /
-capabilities / elements / domain) 입니다.
+This folder is **a codebase mental model that humans and AI agents grow
+together**. Every `.md` file is one node (project / domain / capability /
+element / concept), and the frontmatter at the top of each file is the
+graph's keys (slug / kind / depends_on / capabilities / elements / domain).
 
-## 시작 방법 (5분)
+## Get started in 5 minutes
 
-1. `project.md` 를 열어 프로젝트 이름과 설명을 적습니다.
-2. 새 도메인이 떠오르면 `domains/` 안에 `<slug>.md` 추가:
+1. Open `project.md` and write your project's name and description.
+2. When a new domain comes to mind, add `<slug>.md` under `domains/`:
    ```markdown
    ---
    slug: domains/auth
    kind: domain
-   title: 인증
+   title: Authentication
    capabilities:
      - capabilities/login
      - capabilities/signup
    ---
 
-   사용자 인증·세션·권한을 담당.
+   Owns user authentication, sessions, and permissions.
    ```
-3. capability / element 도 같은 패턴 — `capabilities/` 와 `elements/`.
-4. AI agent (Claude Code 등) 를 등록하면 같은 vault 를 읽고 쓰며 같이 키워갑니다.
-5. 그래프로 보고 싶으면 `https://oh-my-ontology.web.app` 또는 직접 클론한
-   workbench 의 `/docs` picker.
+3. Same pattern for capability and element — under `capabilities/` and `elements/`.
+4. Register an AI agent (Claude Code, Cursor, …) and it reads/writes the
+   same vault, growing it alongside you.
+5. To see the graph, visit `https://oh-my-ontology.web.app` or point a
+   self-hosted workbench's `/docs` picker at this folder.
 
-## 관계 (frontmatter 키)
+## Relations (frontmatter keys)
 
-| 키 | 어떤 관계 |
+| Key | What it expresses |
 |---|---|
-| `depends_on: [<slug>, ...]` | 이 노드가 다른 노드에 의존 |
-| `capabilities: [...]` | 이 도메인 / 프로젝트가 가진 역량 |
-| `elements: [...]` | 이 역량 / 도메인이 사용하는 요소 |
-| `domain: <slug>` | 이 capability/element 의 상위 도메인 |
-| `evidenceIds: [doc-1, ...]` | 이 노드의 근거 문서 ID |
+| `depends_on: [<slug>, ...]` | This node depends on other nodes |
+| `capabilities: [...]` | Capabilities this domain / project provides |
+| `elements: [...]` | Elements this capability / domain uses |
+| `domain: <slug>` | Parent domain of this capability/element |
+| `evidenceIds: [doc-1, ...]` | Evidence document IDs backing this node |
 
-## kind 종류
+## Kinds
 
-- `project` — 최상위. 워크스페이스 1개당 보통 1.
-- `domain` — 큰 영역 (인증, 결제, 빌더 등).
-- `capability` — 도메인의 한 역량 (로그인, 회원가입, …).
-- `element` — capability 가 쓰는 작은 요소 (jwt-token, otp-store, …).
-- `concept` — 이 외 자유로운 개념 (프로토콜·표준·외부 시스템 등).
+- `project` — Top-level. Usually one per workspace.
+- `domain` — A large area (auth, billing, builder, …).
+- `capability` — A user-visible feature inside a domain (login, signup, …).
+- `element` — A smaller unit a capability uses (jwt-token, otp-store, …).
+- `concept` — Anything else (protocols, standards, external systems).
 
-## AI agent 가 자동으로 할 수 있는 일
+## What an AI agent can do for you
 
-`oh-my-ontology-mcp` 서버를 등록하면 다음 11 도구로 vault read/write:
+Once you register the `oh-my-ontology-mcp` server, the agent gets 11
+tools to read/write this vault:
 
 - **read 7**: list_concepts / get_concept / find_evidence / find_backlinks /
   find_path / list_kinds / find_orphans
 - **write 4**: add_concept / add_relation / patch_concept / delete_concept
 
-자세히: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp
+Details: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp

--- a/cli/templates/vault/capabilities/example.md
+++ b/cli/templates/vault/capabilities/example.md
@@ -1,24 +1,26 @@
 ---
 slug: capabilities/example
 kind: capability
-title: 예시 역량
+title: Example capability
 domain: domains/example
 elements:
   - elements/example
 ---
 
-# 예시 역량
+# Example capability
 
-Capability = 도메인의 한 사용자-가시 기능 단위 (로그인, 회원가입, 결제,
-검색, 빌더 캔버스 등). 이 파일을 본인 역량 이름으로 rename 하고
-(`capabilities/login.md`, `capabilities/checkout.md`) 위 frontmatter
-`domain:` 과 `elements:` 를 본인 환경에 맞게 적어주세요.
+A *capability* is one user-visible feature within a domain (login,
+signup, checkout, search, builder canvas, …). Rename this file to match
+one of your real capabilities (`capabilities/login.md`,
+`capabilities/checkout.md`) and update the `domain:` and `elements:`
+keys above accordingly.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 본문에 *이 capability 가 무엇을 하는지* + 사용자 시나리오 한두 줄.
-- frontmatter 키:
-  - `domain: <slug>` — 상위 도메인 한 개
-  - `elements: [...]` — 이 capability 가 사용하는 element slug 들
-  - `depends_on: [...]` — 다른 capability 에 의존하면
-  - `evidenceIds: [...]` — 명세 / 결정문서 ID (선택)
+- In the body, describe *what this capability does* and one or two user
+  scenarios.
+- Frontmatter keys:
+  - `domain: <slug>` — the single parent domain
+  - `elements: [...]` — slugs of elements this capability uses
+  - `depends_on: [...]` — other capabilities this depends on
+  - `evidenceIds: [...]` — spec / decision document IDs (optional)

--- a/cli/templates/vault/domains/example.md
+++ b/cli/templates/vault/domains/example.md
@@ -1,29 +1,29 @@
 ---
 slug: domains/example
 kind: domain
-title: 예시 도메인
+title: Example domain
 capabilities:
   - capabilities/example
 ---
 
-# 예시 도메인
+# Example domain
 
-도메인 = 프로젝트의 큰 영역 (인증·결제·빌더·실시간·검색 같은 하위 시스템).
-이 파일을 본인 도메인 이름으로 rename 하고 (`domains/auth.md`,
-`domains/billing.md` 등) 그 도메인이 가진 capability 를 위 frontmatter
-`capabilities:` 에 적어주세요.
+A *domain* is a large area of your project (subsystems like auth,
+billing, builder, realtime, search). Rename this file to match one of
+your real domains (`domains/auth.md`, `domains/billing.md`, …) and list
+the capabilities it owns under `capabilities:` in the frontmatter above.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 한두 단락의 본문은 *그 도메인이 무엇인지* 설명.
-- 본문에 다른 도메인 / capability 의 markdown link 를 넣으면 backlink
-  로 인식됩니다.
-- frontmatter 키:
-  - `capabilities: [...]` — 이 도메인이 가진 역량 slug 들
-  - `depends_on: [...]` — 이 도메인이 의존하는 다른 도메인 / 외부 시스템
-  - `evidenceIds: [...]` — 이 노드의 근거 문서 ID (선택)
+- Use one or two paragraphs of body text to describe *what this domain is*.
+- Markdown links to other domains / capabilities in the body register as
+  backlinks automatically.
+- Frontmatter keys:
+  - `capabilities: [...]` — slugs of capabilities this domain owns
+  - `depends_on: [...]` — other domains or external systems this depends on
+  - `evidenceIds: [...]` — evidence document IDs backing this node (optional)
 
-## 살릴까 지울까
+## Keep it or delete it?
 
-- 살릴 거면 위 가이드대로 채우기
-- 안 쓸 거면 이 파일 삭제 — 그냥 starter 입니다
+- Keep it: fill it in following the guide above.
+- Don't need it: just delete this file — it's only a starter.

--- a/cli/templates/vault/elements/example.md
+++ b/cli/templates/vault/elements/example.md
@@ -1,21 +1,20 @@
 ---
 slug: elements/example
 kind: element
-title: 예시 요소
+title: Example element
 domain: domains/example
 ---
 
-# 예시 요소
+# Example element
 
-Element = capability 가 쓰는 더 작은 단위 (jwt-token, otp-store,
-indexeddb-adapter, sigma-canvas, …). 이 파일을 본인 element 이름으로
-rename 하고 (`elements/jwt-token.md`) 위 frontmatter `domain:` 을
-정확한 도메인으로 적어주세요.
+An *element* is a smaller unit a capability uses (jwt-token, otp-store,
+indexeddb-adapter, sigma-canvas, …). Rename this file to match a real
+element (`elements/jwt-token.md`) and set `domain:` to the right parent.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 본문은 *무엇을 / 왜 / 어떤 인터페이스* 한두 단락.
-- frontmatter 키:
-  - `domain: <slug>` — 상위 도메인 한 개
-  - `depends_on: [...]` — 다른 element / capability 에 의존하면
-  - `evidenceIds: [...]` — 라이브러리 docs / 결정 문서 ID (선택)
+- One or two paragraphs in the body covering *what / why / which interface*.
+- Frontmatter keys:
+  - `domain: <slug>` — the single parent domain
+  - `depends_on: [...]` — other elements / capabilities this depends on
+  - `evidenceIds: [...]` — library docs or decision document IDs (optional)

--- a/cli/templates/vault/project.md
+++ b/cli/templates/vault/project.md
@@ -12,21 +12,25 @@ elements:
 
 # My project
 
-여기서 프로젝트의 한두 줄 요약을 적습니다 — *"무엇을 / 누구에게 / 왜"*.
+Write a one- or two-line summary of your project here — *what / for whom / why*.
 
-## 한 줄 mission
+## One-line mission
 
-이 프로젝트가 해결하는 문제 / 만드는 가치를 한 줄로.
+The problem this project solves, or the value it creates, in a single sentence.
 
-## 어떻게 자라는가
+## How it grows
 
-- frontmatter 의 `domains: [...]` 를 채우면 도메인 노드가 트리에 매달립니다.
-- 각 도메인 안 capability / element 도 같은 패턴.
-- AI agent 가 새 노드를 만들 때 이 파일의 `depends_on` / `domains` 가
-  자동 갱신될 수 있어요 — frontmatter 가 진실원이라 충돌 안 납니다.
+- Fill in `domains: [...]` in the frontmatter and the domain nodes hang
+  off your project tree automatically.
+- Each domain's capabilities and elements follow the same pattern.
+- When an AI agent adds a new node, this file's `depends_on` / `domains`
+  may auto-update — frontmatter is the source of truth, so there are no
+  conflicts.
 
-## 다음 단계
+## Next steps
 
-1. 이 파일의 `title` 과 `kind: project` 외 frontmatter 를 본인 프로젝트에 맞게 수정
-2. `domains/example.md` 같은 starter 를 본인 영역으로 rename / 복제
-3. AI agent (Claude Code 등) 등록 후 "이 vault 의 ontology 좀 정리해줘" 라고 요청
+1. Edit this file's `title` (and any other frontmatter besides `kind: project`)
+   to match your project.
+2. Rename or copy starters like `domains/example.md` into your real domains.
+3. Register an AI agent (Claude Code, Cursor, …) and ask it to "tidy up
+   the ontology in this vault."

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,111 +5,111 @@ tags: [architecture, infra, overview]
 
 # Architecture
 
-> 이 문서는 현재 제품의 도메인 모델과 공개/운영 구조를 설명한다. 이 서비스는 더 이상 단순 공개 포트폴리오가 아니라, 작업 공간 안에서 문서 기반 온톨로지를 키우고 공개 화면에서 읽고 편집하는 구조를 기준으로 한다.
+> This document describes the current product's domain model and its public/operational structure. The service is no longer a simple public portfolio — it is now built around growing a document-based ontology inside a workspace and reading/editing it from public surfaces.
 
-## 1. 현재 제품 구조
+## 1. Current product structure
 
 ```text
 ┌───────────────────────────────────────────────────────┐
-│ Next.js 정적 앱 (output: 'export')                   │
-│ ├─ /                     ontology 트리 hub (mission v2)│
-│ ├─ /topology             Sigma WebGL 토폴로지         │
-│ ├─ /projects             프로젝트 목록 (mode-aware)   │
-│ ├─ /project/[slug]       개별 프로젝트 (인라인 편집)  │
-│ ├─ /docs                 vault picker / 문서 surface  │
-│ ├─ /knowledge/*          cloud 모드 문서 등록 / 목록  │
-│ ├─ /ontology/edit        xyflow ERD 빌더              │
-│ ├─ /ontology/insights    그래프 인사이트              │
-│ ├─ /ontology/relations   관계 분포                    │
-│ ├─ /settings/*           카테고리 / 상태 / 가져오기   │
-│ ├─ /diagnostics/insights 운영 인사이트                │
-│ ├─ /account              사용자 계정 설정            │
-│ └─ /login, /signup       Firebase Auth (옵션)         │
+│ Next.js static app (output: 'export')                │
+│ ├─ /                     ontology tree hub (mission v2)│
+│ ├─ /topology             Sigma WebGL topology         │
+│ ├─ /projects             project list (mode-aware)    │
+│ ├─ /project/[slug]       project detail (inline edit) │
+│ ├─ /docs                 vault picker / docs surface  │
+│ ├─ /knowledge/*          cloud-mode doc register/list │
+│ ├─ /ontology/edit        xyflow ERD builder           │
+│ ├─ /ontology/insights    graph insights               │
+│ ├─ /ontology/relations   relation distribution        │
+│ ├─ /settings/*           categories / statuses / import│
+│ ├─ /diagnostics/insights operations insights          │
+│ ├─ /account              user account settings        │
+│ └─ /login, /signup       Firebase Auth (optional)     │
 └───────────────────────────────────────────────────────┘
                     ↓ Firebase Web SDK
 ┌───────────────────────────────────────────────────────┐
-│ Firebase (옵션 — cloud sync 필요할 때만)              │
+│ Firebase (optional — only when cloud sync is needed)  │
 │ ├─ Firestore  (global + account scoped data)          │
 │ ├─ Storage    (screenshots, knowledge markdown)       │
 │ ├─ Auth       (email/password, Google, admin Google)  │
-│ └─ Hosting    (정적 사이트 배포)                      │
+│ └─ Hosting    (static site deployment)                │
 └───────────────────────────────────────────────────────┘
-                    ↑ 별도 trusted boundary
+                    ↑ separate trusted boundary
 ┌───────────────────────────────────────────────────────┐
-│ MCP 서버 (mcp/) — AI agent partner                    │
+│ MCP server (mcp/) — AI agent partner                  │
 │ ├─ stdin/stdout JSON-RPC                              │
-│ └─ vault frontmatter read/write (10 도구)             │
+│ └─ vault frontmatter read/write (10 tools)            │
 └───────────────────────────────────────────────────────┘
 ```
 
-> **mission v2 정렬**: Cloud LLM extraction 흐름 (`enqueueExtractionJob` / `processExtractionJob` / `applyReviewAction` 등) 은 제거됨. AI 추출은 user-side AI agent (Claude Code 등) 가 MCP 서버로 직접 vault 갱신. Cloud Functions 폴더 (`functions/`) 도 폐기 — firebase 배포 안 함 정책 + mission v2 가 vault 자기-승인이라 publish/promote/dismiss 서버 사이드 게이트 불필요.
+> **mission v2 alignment**: The cloud LLM extraction flow (`enqueueExtractionJob` / `processExtractionJob` / `applyReviewAction`, etc.) has been removed. AI extraction is now performed by user-side AI agents (Claude Code, etc.) writing directly to the vault through the MCP server. The Cloud Functions folder (`functions/`) has also been retired — both because of the no-firebase-deploy policy and because mission v2's vault self-approval makes server-side publish/promote/dismiss gates unnecessary.
 
-## 2. 도메인 모델
+## 2. Domain model
 
-현재 제품은 아래 모델을 기준으로 설명해야 한다.
+The product should now be described in terms of the model below.
 
-- **작업 공간(Account / Workspace)**: 데이터와 권한의 최상위 묶음
-- **전체 지도**: 작업 공간 안의 모든 프로젝트를 묶어 보여주는 공개 화면
-- **프로젝트 목록**: 프로젝트를 고르고 시작하는 허브
-- **개별 프로젝트**: 프로젝트 내부 연결과 관련 문서를 읽는 화면
-- **프로젝트 내부**: 영역, 노드, 관련 문서가 프로젝트를 설명하는 층위
-- **문서 운영**: 문서 등록, 버전 업로드, 추출, 연결 검토, 공개 반영
+- **Workspace (Account / Workspace)**: the top-level grouping of data and permissions
+- **Global map**: a public surface that aggregates every project inside a workspace
+- **Project list**: the hub for picking and starting a project
+- **Project detail**: a surface for reading a project's internal connections and related documents
+- **Project internals**: the area, node, and related-document layers that describe a project
+- **Document operations**: registering documents, uploading versions, extraction, reviewing connections, and publishing
 
-즉 `프로젝트`가 가장 큰 작업 단위이고, 프로젝트 안에서 다시 문서와 노드가 자라야 한다. 프로젝트 안에서 또 새 프로젝트를 만드는 식의 액션은 잘못된 문맥이다.
+In other words, a `project` is the largest unit of work, and documents and nodes grow inside a project. Creating a new project from inside another project is the wrong context.
 
-## 3. 데이터와 권한 경계
+## 3. Data and permission boundaries
 
-핵심은 다음이다.
+The essentials are:
 
-- 브라우저는 backend-owned 컬렉션에 직접 쓰지 않는다.
-- raw markdown는 Firestore가 아니라 Storage에 저장한다.
-- private approved graph와 public projection을 분리한다.
-- 전역 공개 데이터와 account-scoped 데이터는 분리한다.
-- 공개 화면은 읽기 기본, owner/editor는 같은 공개 화면에서 바로 수정 흐름으로 이어진다.
+- The browser does not write directly to backend-owned collections.
+- Raw markdown is stored in Storage, not Firestore.
+- The private approved graph and the public projection are separated.
+- Globally public data and account-scoped data are separated.
+- Public surfaces are read-by-default; for owners/editors, the same public surface flows directly into editing.
 
-## 4. 책임 분리
+## 4. Responsibility split
 
-### Next.js 앱
+### Next.js app
 
-- 전체 지도, 프로젝트 목록, 개별 프로젝트 렌더
-- 로그인/회원가입과 작업 공간 선택
-- 공개 surface에서 본인/멤버의 인라인 편집(같은 URL에서 권한 따라 액션 노출)
-- 프로젝트 상세 (`/project/[slug]`) 가 모든 관련 작업의 허브 — 토폴로지 이동, 연관 문서 보기/편집, 프로젝트 자체 수정이 한 화면에서 가능
-- 문서 등록, 버전 업로드, 추출 요청은 `/knowledge/*`, 검토는 `/review`, 시스템 설정은 `/settings/*`, 진단 도구는 `/diagnostics/*`로 기능별 분리
-- 공개 화면에서는 `knowledgePublic*` projection을 읽고, 본인 계정 surface에서는 private 문서/추출/검토 상태를 읽는다
-- "admin" 네임스페이스는 더 이상 존재하지 않는다. "운영자 / 관리자"라는 별도 역할도 없다. 권한은 Firestore rules + 클라이언트 capability 훅으로 결정한다
+- Renders the global map, project list, and project detail
+- Handles login/sign-up and workspace selection
+- Provides inline editing on public surfaces for the owner/members (actions are revealed by permission on the same URL)
+- Project detail (`/project/[slug]`) is the hub for all related work — jumping into the topology, viewing/editing related documents, and editing the project itself all happen on a single screen
+- Document registration, version upload, and extraction requests live under `/knowledge/*`; review under `/review`; system settings under `/settings/*`; diagnostics under `/diagnostics/*` — split by feature
+- Public surfaces read the `knowledgePublic*` projection; the user's account surfaces read private documents/extractions/review state
+- The "admin" namespace no longer exists. There is no separate "operator / administrator" role either. Permissions are determined by Firestore rules plus client-side capability hooks.
 
 ### Firestore / Storage
 
-- 공개 제품 canonical 데이터 저장
-- account-scoped 프로젝트와 문서 저장
-- knowledge 문서/버전 메타 저장
-- raw markdown 원문 저장
-- evidence / audit / publish log 저장
-- canonical approved graph 저장
-- public projection 저장
+- Stores the canonical public-product data
+- Stores account-scoped projects and documents
+- Stores knowledge document/version metadata
+- Stores the raw markdown source
+- Stores the evidence / audit / publish log
+- Stores the canonical approved graph
+- Stores the public projection
 
 ### Cloud Functions
 
-폐기됨. 이유:
-- firebase 배포 안 함 정책
-- mission v2 의 vault 자기-승인 (publish projection 게이트 불필요)
-- stub 흐름은 cloud LLM 추출의 산물 — 그게 사라지며 promote/dismiss 도 dead
+Retired. Reasons:
+- No-firebase-deploy policy
+- Mission v2's vault self-approval (publish projection gate not needed)
+- The stub flow was a byproduct of cloud LLM extraction — once that disappeared, promote/dismiss became dead too
 
-이전 cleanup 단계 (PR #5/#6) 에 chunking / extraction / review seed / approval audit 가 제거됐고, 마지막으로 `functions/` 폴더 자체와 `firebase.json` 의 functions 키도 제거됨. 클라이언트 측 `httpsCallable` 코드는 남아있을 수 있으나 deploy 안 된 환경에서 호출 시 fail — 사용자 흐름 영향 0 (cloud 모드 사용 안 함).
+In earlier cleanup stages (PR #5/#6) the chunking / extraction / review seed / approval audit were removed; finally the `functions/` folder itself and the `functions` key in `firebase.json` were removed too. Some client-side `httpsCallable` code may still exist, but calling it on a deploy-less environment fails — with zero impact on the user flow (cloud mode is unused).
 
-### MCP 서버 (mission v2 신설)
+### MCP server (introduced in mission v2)
 
-- **`mcp/` 패키지** — `@modelcontextprotocol/sdk` 의존, stdin/stdout JSON-RPC
-- AI agent (Claude Code 등) 가 직접 vault `.md` read/write
-- 10 도구 (read 6 + write 4): list_concepts · get_concept · find_evidence · find_backlinks · find_path · list_kinds · add_concept · add_relation · patch_concept · delete_concept
-- 등록: `.mcp.json.example` 또는 `mcp/README.md` 참고
+- **`mcp/` package** — depends on `@modelcontextprotocol/sdk`, stdin/stdout JSON-RPC
+- AI agents (Claude Code, etc.) read/write vault `.md` directly
+- 10 tools (read 6 + write 4): list_concepts · get_concept · find_evidence · find_backlinks · find_path · list_kinds · add_concept · add_relation · patch_concept · delete_concept
+- Registration: see `.mcp.json.example` or `mcp/README.md`
 
-## 5. 데이터 경계
+## 5. Data boundaries
 
-### 공개 read model
+### Public read model
 
-아래는 공개 읽기 가능 데이터다.
+The data below is publicly readable.
 
 - `projects`
 - `accounts/{accountId}/projects`
@@ -118,150 +118,150 @@ tags: [architecture, infra, overview]
 - `meta`
 - `knowledgePublicNodes`
 - `knowledgePublicEdges`
-- `accounts/{accountId}/knowledgeDocuments` **조건부** — 계정
-  `isPublic == true` + 문서 `status == 'published'` 일 때만 비인증 read
-  허용. 공개 detail 페이지가 "이 프로젝트를 설명하는 문서" 섹션을 그리기
-  위한 경로.
+- `accounts/{accountId}/knowledgeDocuments` **conditional** — unauthenticated
+  reads are allowed only when the account has `isPublic == true` and the
+  document has `status == 'published'`. This path is what the public detail
+  page uses to render the "documents that describe this project" section.
 
-### 자기 계정 private model (계정 주인 / 멤버 only)
+### Self-account private model (account owner / members only)
 
-아래는 본인 계정 또는 본인이 멤버로 있는 계정만 읽을 수 있다.
+The data below is readable only by the account owner or a member of that account.
 
-- `knowledgeDocuments` (전역 canonical)
+- `knowledgeDocuments` (global canonical)
 - `knowledgeDocumentVersions`
 - `knowledgeReviews`
 - Storage `knowledge-documents/*`
-- `accounts/{accountId}/knowledgeDocuments/*` — status 가 `published` 이
-  아니거나 계정이 private 이면 본인/멤버 만
+- `accounts/{accountId}/knowledgeDocuments/*` — owner/members only when
+  the status is not `published` or the account is private
 - `accounts/{accountId}/knowledgeDocumentVersions/*`
 
-### backend-owned model
+### Backend-owned model
 
-아래는 backend가 쓰고 사용자는 읽기만 한다.
+The collections below are written by the backend; users only read them.
 
-- `knowledgeApprovedNodes` — manual editor 또는 publish 결과 canonical
-- `knowledgeApprovedEdges` — V1.1 qualifiers + rank 옵셔널 필드 추가
+- `knowledgeApprovedNodes` — canonical from the manual editor or publish
+- `knowledgeApprovedEdges` — V1.1 adds optional qualifiers + rank fields
 - `knowledgePublishes` — publish event log
 - `knowledgePublicNodes` — public projection
 - `knowledgePublicEdges` — public projection (V1.1 fields-pass-through)
 
-#### Cold storage (mission v2 cleanup 후 read-only)
+#### Cold storage (read-only after mission v2 cleanup)
 
-아래는 mission v2 cleanup 으로 더 이상 callable 가 없어 read-only:
+The following are read-only after mission v2 cleanup since no callable writes them anymore:
 
-- `knowledgeExtractionJobs` — extraction enqueue 끊김
-- `knowledgeExtractionOutputs` — extraction worker 끊김
-- `knowledgeReviewEvents` — review queue 페이지 삭제
-- `knowledgeApprovalEvents` — applyReviewAction 제거
-- `knowledgeDocumentChunks` — chunking 제거
-- `knowledgeEvidence` — extraction worker 끊김
+- `knowledgeExtractionJobs` — extraction enqueue path is gone
+- `knowledgeExtractionOutputs` — extraction worker is gone
+- `knowledgeReviewEvents` — review queue page removed
+- `knowledgeApprovalEvents` — applyReviewAction removed
+- `knowledgeDocumentChunks` — chunking removed
+- `knowledgeEvidence` — extraction worker is gone
 
-## 6. 권한 모델
+## 6. Permission model
 
-본 제품은 Notion / Obsidian 모델을 따른다. 자기 계정의 주인이 곧 자기 계정의 모든 작업을 직접 한다 — 별도 "운영자 / 관리자" 역할은 없다. 협업이 필요할 때만 다른 사용자에게 멤버 권한이 부여된다.
+This product follows the Notion / Obsidian model. The owner of an account does every operation on that account themselves — there is no separate "operator / administrator" role. Membership is granted to other users only when collaboration is needed.
 
-- **게스트**: 링크로 들어와 읽기만 가능
-- **로그인 사용자**: 본인 계정의 모든 작업 (프로젝트, 문서, 시스템 설정) 직접 가능
-- **다른 계정의 멤버**: 그 계정의 owner/editor membership 을 받은 사용자. 해당 계정 안에서 본인 계정과 동일한 권한
-- **다른 계정의 viewer**: 그 계정의 읽기 전용 멤버
-- **global admin (`admins/{email}`)**: 시스템 차원의 데이터 (전역 카테고리/상태) 와 진단 도구 접근. 일상 사용에서는 거의 의미가 없음 — 본인 계정 안에서는 모든 사용자가 자기 자산을 풀 컨트롤
+- **Guest**: arrives via a link and can only read
+- **Logged-in user**: can perform every operation on their own account directly (projects, documents, system settings)
+- **Member of another account**: a user with owner/editor membership in that account. Inside that account they have the same permissions as in their own
+- **Viewer of another account**: a read-only member of that account
+- **Global admin (`admins/{email}`)**: access to system-level data (global categories/statuses) and diagnostics tooling. Largely irrelevant for everyday use — within their own account, every user has full control of their own assets
 
-권한 모델은 더 이상 URL 네임스페이스(과거 `/admin/*`)에 의존하지 않는다. 같은 공개 surface에서 권한에 따라 인라인 액션이 노출되고, 시스템 설정/검토/진단은 기능별 라우트(`/settings`, `/review`, `/diagnostics`)로 분리한다. 권한의 진짜 게이트는 Firestore Security Rules다.
+The permission model no longer depends on URL namespaces (the old `/admin/*`). Inline actions are revealed by permission on the same public surface, while system settings/review/diagnostics are split into feature routes (`/settings`, `/review`, `/diagnostics`). The real permission gate is Firestore Security Rules.
 
-## 7. FSD 레이어 구성
+## 7. FSD layer layout
 
 ```text
-app/                 ← Next.js 라우팅 전용 (얇은 래퍼)
+app/                 ← Next.js routing only (thin wrappers)
 src/
-  app/               ← FSD app 레이어 (providers, 초기화)
-  views/             ← 페이지 컴포넌트
-  widgets/           ← 복합 UI 블록
-  features/          ← 사용자 인터랙션 단위
-  entities/          ← 비즈니스 엔티티
-  shared/            ← 재사용 기반
+  app/               ← FSD app layer (providers, initialization)
+  views/             ← page components
+  widgets/           ← composite UI blocks
+  features/          ← user interaction units
+  entities/          ← business entities
+  shared/            ← reusable foundations
 ```
 
-**Import 방향**: `app → views → widgets → features → entities → shared`
+**Import direction**: `app → views → widgets → features → entities → shared`
 
-상세 규칙: [`rules/architecture-fsd.md`](rules/architecture-fsd.md)
+Detailed rules: [`rules/architecture-fsd.md`](rules/architecture-fsd.md)
 
-## 8. 페이지와 운영 경로
+## 8. Pages and operational paths
 
-| 경로 | 역할 | 접근 |
+| Path | Role | Access |
 | --- | --- | --- |
-| `/` | ontology 트리 hub (project → domain → capability → element) + 검색 + ego graph (mission v2). vault 활성 시 vault frontmatter 자동 사용 (Q1=(a)) | 전체 공개 |
-| `/topology` | Sigma WebGL 토폴로지 (출구 view) | 전체 공개 |
-| `/projects` | 프로젝트 목록 (권한 시 "새 프로젝트" 버튼) | 전체 공개 |
-| `/project/[slug]` | 개별 프로젝트 canonical route (권한 시 인라인 편집) | 전체 공개 |
-| `/project/new` · `/project/[slug]/edit` | 프로젝트 에디터 | editor 이상 |
-| `/docs` | vault picker / vault 활성 시 문서 surface | 전체 공개 (vault 는 사용자 디스크) |
-| `/login` · `/signup` · `/reset-password` | Firebase Auth surface | 전체 공개 |
-| `/account` | 사용자 자기 계정 설정 | 로그인 사용자 |
-| `/knowledge` | 문서 대시보드 | viewer 이상 |
-| `/knowledge/documents` | 문서 목록 | viewer 이상 |
-| `/knowledge/documents/new` | 새 문서 등록 (mode-aware) | editor 이상 |
-| `/knowledge/documents/view?id=...` | 문서 상세 (2단계 stepper: 올리기 → 공개) | editor 이상 |
-| `/ontology/edit` | xyflow ERD 빌더 + frontmatter md 내보내기 | editor 이상 |
-| `/ontology/insights` | 4 패널 통계 — 허브 / 최근 활동 / 30일 타임라인 / 미연결 | viewer 이상 |
-| `/ontology/relations` | edge 단위 뷰 — 관계 타입별 필터 + 분포 | viewer 이상 |
-| `/settings/categories` · `/settings/statuses` · `/settings/import` | 카테고리/상태/CSV import | editor 이상 |
-| `/settings/ontology` · `/settings/ontology/history` | TBox read-only + version 이력 | viewer 이상 |
-| `/diagnostics/insights` | 운영 지표 (stale / orphan / promote 후보) | editor 이상 |
+| `/` | ontology tree hub (project → domain → capability → element) + search + ego graph (mission v2). Automatically uses vault frontmatter when the vault is active (Q1=(a)) | fully public |
+| `/topology` | Sigma WebGL topology (exit view) | fully public |
+| `/projects` | project list ("New project" button when permitted) | fully public |
+| `/project/[slug]` | canonical route for a single project (inline editing when permitted) | fully public |
+| `/project/new` · `/project/[slug]/edit` | project editor | editor or above |
+| `/docs` | vault picker / docs surface when the vault is active | fully public (vault lives on the user's disk) |
+| `/login` · `/signup` · `/reset-password` | Firebase Auth surface | fully public |
+| `/account` | user's own account settings | logged-in user |
+| `/knowledge` | document dashboard | viewer or above |
+| `/knowledge/documents` | document list | viewer or above |
+| `/knowledge/documents/new` | register a new document (mode-aware) | editor or above |
+| `/knowledge/documents/view?id=...` | document detail (2-step stepper: upload → publish) | editor or above |
+| `/ontology/edit` | xyflow ERD builder + frontmatter md export | editor or above |
+| `/ontology/insights` | 4 panels — hubs / recent activity / 30-day timeline / unconnected | viewer or above |
+| `/ontology/relations` | edge-level view — filter and distribution by relation type | viewer or above |
+| `/settings/categories` · `/settings/statuses` · `/settings/import` | categories / statuses / CSV import | editor or above |
+| `/settings/ontology` · `/settings/ontology/history` | TBox read-only + version history | viewer or above |
+| `/diagnostics/insights` | operational metrics (stale / orphan / promote candidates) | editor or above |
 
-> mission v2 cleanup 후 폐기: `/review` / `/review/knowledge` / `/settings/api-keys` / `/diagnostics/migrate` / `/admin/*` / `/project/topology` / `/project/view` 등 모두 제거됨.
-| `/dev/login` | 개발 빌드 한정 우회 로그인 | dev only |
+> Retired after mission v2 cleanup: `/review` / `/review/knowledge` / `/settings/api-keys` / `/diagnostics/migrate` / `/admin/*` / `/project/topology` / `/project/view`, etc. — all removed.
+| `/dev/login` | bypass login limited to dev builds | dev only |
 
-> 권한 모델은 URL 네임스페이스가 아닌 Firestore Security Rules 와 capability 훅으로 갈린다. 같은 공개 surface 안에서 권한에 따라 인라인 액션이 노출된다.
+> The permission model is decided by Firestore Security Rules and capability hooks rather than URL namespaces. Inline actions are revealed by permission on the same public surface.
 
-## 9. 현재 구현됨 vs 계획됨
+## 9. Currently implemented vs planned
 
-### 이미 구현된 것
+### Already implemented
 
-- 전체 지도 / 프로젝트 목록 / 개별 프로젝트
-- 공개 로그인 / 회원가입
-- account-scoped workspace와 membership(role: owner/editor/viewer)
-- 공개 화면에서 owner/editor의 빠른 수정 흐름
-- 프로젝트 CRUD (mode-aware: local vault / cloud Firestore)
-- 문서 등록 / 버전 업로드 / 공개 반영 (cloud 모드)
+- Global map / project list / project detail
+- Public login / sign-up
+- Account-scoped workspaces and membership (role: owner/editor/viewer)
+- Quick edit flow for owners/editors on the public surface
+- Project CRUD (mode-aware: local vault / cloud Firestore)
+- Document registration / version upload / publish (cloud mode)
 - vault frontmatter → ontology stub fast-path (mission v2)
-- ontology v0: TBox 시드 (5 클래스 + 7 관계), `/` 트리 + ego graph, `/ontology/edit` 빌더, `/ontology/insights` + `/ontology/relations`, manual editor 직접 쓰기
-- V1.1 — Wikidata statement qualifiers + rank (옵셔널 필드, additive)
-- AI agent partner (MCP 서버) — 7 도구로 vault read/write
-- dogfood vault (`docs/ontology/`) — 자기 자신 mental model
+- ontology v0: TBox seed (5 classes + 7 relations), `/` tree + ego graph, the `/ontology/edit` builder, `/ontology/insights` + `/ontology/relations`, manual editor direct writes
+- V1.1 — Wikidata statement qualifiers + rank (optional fields, additive)
+- AI agent partner (MCP server) — vault read/write through 7 tools
+- dogfood vault (`docs/ontology/`) — our own mental model
 - global admin whitelist
 
-### 아직 계획 단계인 것
+### Still in the planning stage
 
 - V1.2 — literal properties (`knowledgeApprovedLiterals`)
 - V1.3 — rich references (retrievedAt / extractionModelId / confidence)
-- V1.4 — ActionType (Palantir 영감, DEFERRED)
+- V1.4 — ActionType (Palantir-inspired, DEFERRED)
 - V1.5 — relation cardinality
-- V2 — 통합 KnowledgeStatement (RDF-star 호환)
-- multi-vault — 여러 vault 동시 활성
-- Phase 4 비개발자 surface (kind 별 아이콘, 한국어 매핑 layer 등)
+- V2 — unified KnowledgeStatement (RDF-star compatible)
+- multi-vault — multiple vaults active simultaneously
+- Phase 4 non-developer surface (per-kind icons, Korean mapping layer, etc.)
 
-자세히: `docs/BACKLOG.md` (T19-T38).
+Details: `docs/BACKLOG.md` (T19-T38).
 
-문서에 경로가 있어도, 해당 경로가 실제 코드에 없으면 아직 계획 단계로 본다.
+If a path appears in the docs but does not exist in the actual code, treat it as still in the planning stage.
 
-## 10. 연관 문서
+## 10. Related documents
 
-- [`PRODUCT-DIRECTION.md`](./PRODUCT-DIRECTION.md) — mission v2 방향
-- [`FEATURES.md`](./FEATURES.md) — 사용자가 *지금* 사용 가능한 기능 전수
-- [`BACKLOG.md`](./BACKLOG.md) — next-work 통합 (T28-T38)
-- [`MODE-AWARE-CRUD.md`](./MODE-AWARE-CRUD.md) — local/cloud/static 분기 가이드
+- [`PRODUCT-DIRECTION.md`](./PRODUCT-DIRECTION.md) — mission v2 direction
+- [`FEATURES.md`](./FEATURES.md) — exhaustive list of features users can use *right now*
+- [`BACKLOG.md`](./BACKLOG.md) — unified next-work (T28-T38)
+- [`MODE-AWARE-CRUD.md`](./MODE-AWARE-CRUD.md) — local/cloud/static branching guide
 - [`ONTOLOGY-MODEL-V2-DRAFT.md`](./ONTOLOGY-MODEL-V2-DRAFT.md) — V1.x → V2 spec
-- [`MISSION-CLEANUP-CANDIDATES.md`](./MISSION-CLEANUP-CANDIDATES.md) — 4 stage cleanup 진행 (모두 ✅)
-- [`DATA-MODEL.md`](./DATA-MODEL.md) — Firestore 컬렉션 + Storage 경로 + Security Rules
-- [`DESIGN-SYSTEM.md`](./DESIGN-SYSTEM.md) — 디자인 토큰 / 모션 / 금지 규칙
-- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Firebase 배포 / 롤백 / 도메인
-- [`CHANGELOG.md`](./CHANGELOG.md) — 시간순 사용자 가시 변화
-- [`../mcp/README.md`](../mcp/README.md) — MCP 서버 7 도구 + 등록
-- [`../AGENTS.md`](../AGENTS.md) / [`../CLAUDE.md`](../CLAUDE.md) — 에이전트 / 컨트리뷰터 가이드
-- [`../.claude/rules/`](../.claude/rules/) — 세부 작업 규율
+- [`MISSION-CLEANUP-CANDIDATES.md`](./MISSION-CLEANUP-CANDIDATES.md) — 4-stage cleanup progress (all done)
+- [`DATA-MODEL.md`](./DATA-MODEL.md) — Firestore collections + Storage paths + Security Rules
+- [`DESIGN-SYSTEM.md`](./DESIGN-SYSTEM.md) — design tokens / motion / forbidden patterns
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Firebase deployment / rollback / domains
+- [`CHANGELOG.md`](./CHANGELOG.md) — chronological user-visible changes
+- [`../mcp/README.md`](../mcp/README.md) — MCP server 7 tools + registration
+- [`../AGENTS.md`](../AGENTS.md) / [`../CLAUDE.md`](../CLAUDE.md) — agent / contributor guide
+- [`../.claude/rules/`](../.claude/rules/) — granular working rules
 
-## 11. 확장성 트리거
+## 11. Scaling triggers
 
-- 컨테이너 수 증가 시 단일 캔버스 → 탭 분리 재검토
-- vault 문서 수 증가 시 fingerprint diff + worker 분리 검토
-- 이미지 / 문서 업로드 증가 시 Storage lifecycle 및 리전 재검토
+- As the number of containers grows, reconsider the single canvas in favor of tab-splitting
+- As the number of vault documents grows, evaluate fingerprint diff + worker separation
+- As image / document uploads grow, revisit Storage lifecycle and region choices

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,232 +1,286 @@
 # CHANGELOG
 
-> 주요 변경 이력. 코드 commit 메시지가 *왜* 를 답하고, 이 파일은 *언제 / 어떤 surface 가 바뀌었는지* 를 답한다. PR 단위가 아닌 **사용자 가시 변화** 위주.
+> Major change history. Code commit messages answer *why*; this file answers *when / which surface changed*. Focused on **user-visible changes**, not PR-level granularity.
 >
-> 최신이 위. semver 도입 전 v0.x 단계라 날짜 기반.
+> Newest at the top. Date-based since we're pre-semver in the v0.x stage.
 
 ---
 
-## 2026-05-02 — local-first 첫 paint firebase 0 (PR #99)
+## 2026-05-02 — OSS launch readiness: English-first docs + npm publish guard
 
-### 사용자 가시 변화
+### User-visible changes
 
-- **첫 페이지 로드 가벼워짐** — `/`, `/topology`, `/docs`, `/ontology/edit`, `/projects`, `/knowledge`, `/login`, `/account` 등 user-facing 진입점이 firebase JS (~773kb chunks) 를 정적으로 로드하지 않는다. cloud 모드 명시 진입 (signin / cloud entity mutation) 시점에만 lazy 로드.
-- **모바일 / 느린 네트워크 LCP 개선** — firebase SDK parse 비용 0.
-- **호스팅 비용 측면**: vault picked 사용자는 firebase 계정 자체가 안 만들어짐. 정적 export 라 origin server 비용은 어차피 0 이고, 이제는 firebase 트래픽도 cloud 모드 진입 전엔 0.
-- **동작은 그대로** — cloud 모드 사용자도 모든 기능 동일 작동 (함수 호출 시점에 firebase chunk 가 다운로드).
+- **All OSS-facing docs are now English-first** — global contributors can read the full project from README → AGENTS → docs/* without Korean. README.md and AGENTS.md keep a Korean sub-section (`한국어 가이드`) at the bottom for native readers.
+- **Vault starter templates ship in English** — `npx oh-my-ontology init` and the `/docs` "Create starter seed" button now write English `README.md` / `project.md` / `domains/example.md` / `capabilities/example.md` / `elements/example.md`, so non-Korean users get a coherent first experience.
+- **`mcp/README.md` is the npm package face** — when published, https://www.npmjs.com/package/oh-my-ontology-mcp will display polished English copy.
+- **New `docs/TROUBLESHOOTING.md`** — a single English doc covering scaffold / MCP / build / publish issues for OSS users.
 
-### 아키텍처 변화 (개발자 가시)
+### Translated to English (in-place)
 
-- **entity barrel 분리 패턴** — `@/entities/<x>` 는 type / lib / pure helper 만. firestore api 는 `@/entities/<x>/api` 로 직접 import. 새 contributor 는 mode-aware feature 작성 시 cloud branch 만 `import('@/entities/<x>/api')` 로 dynamic import.
-- **mapper Timestamp duck-typing** — `instanceof Timestamp` 체크 대신 `coerceFirestoreDate(value)` 헬퍼 (`@/shared/lib/firestore-timestamp-coerce`). entity model 이 firebase 의존 0.
-- **`package.json sideEffects` allowlist** — `*.css` + `firestore-noise-patch` 만 side-effectful 로 표시. 나머지는 webpack tree-shake.
+- `mcp/README.md` (npm publish face)
+- `docs/PUBLISH-NPM.md` · `docs/PRODUCT-DIRECTION.md` · `docs/FEATURES.md` · `docs/ARCHITECTURE.md` · `docs/DATA-MODEL.md` · `docs/DESIGN-SYSTEM.md` · `docs/MODE-AWARE-CRUD.md` · `docs/DEPLOY-FIREBASE.md` · `docs/DEPLOYMENT.md` · `docs/CHANGELOG.md`
+- `cli/templates/vault/*.md` (5 starter files) + the in-app `src/features/docs-vault-local/lib/ontology-starter.ts` mirror
 
-### 새 module
+### Kept Korean intentionally
 
-- `src/shared/lib/firestore-noise-patch.ts` — 기존 `FirebaseProvider` 의 console 노이즈 패치를 firebase-deps-free 모듈로 분리. layout 에서 side-effect import 만으로 install.
-- `src/shared/lib/firestore-timestamp-coerce.ts` — Timestamp duck-typing 헬퍼 + 8 케이스 단위 테스트.
-- `src/entities/knowledge-graph/api/index.ts` — knowledge-graph api barrel (전엔 main barrel 에 섞여 있었음).
+- `docs/BACKLOG.md` · `docs/MISSION-CLEANUP-CANDIDATES.md` · `docs/launch/*` — internal trackers / draft material (the maintainer is the only reader)
+- `README.md` · `AGENTS.md` · `CLAUDE.md` — bilingual sub-section for Korean contributors
+- Seed data values in `docs/DATA-MODEL.md` and design-rule examples in `docs/DESIGN-SYSTEM.md` — these are literal data, not prose
 
-### 제거
+### npm publish guard (3 layers)
 
-- `src/app/providers/FirebaseProvider.tsx` (-91 줄) — 하던 일이 console 패치 + 불필요한 `getFirebaseApp()` warmup 두 가지였는데, 패치는 pure 모듈로 분리하고 warmup 은 `<link rel="preconnect">` 가 이미 함.
+`npm publish` / `pnpm publish` / `yarn publish` is now blocked from running unless the user explicitly authorizes it:
+
+1. `.claude/rules/forbidden.md` — auto-loaded behavioral rule
+2. `.claude/settings.json` PreToolUse hook + `.claude/hooks/block-npm-publish.sh` — intercepts Bash commands matching publish patterns and returns `permissionDecision: "deny"`
+3. `CLAUDE.md` — high-level Claude-specific reminder; CLAUDE.md remains a thin wrapper, the rule lives in `forbidden.md`
+
+Tested with 7 input shapes: `npm publish`, `cd mcp && npm publish`, `pnpm publish`, `npm pack --dry-run` (allowed), `npm whoami` (allowed), `npm pack` without `--dry-run` (blocked), `ls -la` (allowed).
+
+### FEATURES.md drift sync
+
+Brought `docs/FEATURES.md` back in line with the actual codebase:
+
+- **Removed** stale references: `/knowledge` / `/knowledge/documents/*` routes (entity removed in commit `a906635`), `KnowledgeDocumentNewPage`, `node --check functions/index.js` (the `functions/` folder itself is gone), the outdated "Cumulative cleanup stats" block.
+- **Updated** numbers: MCP tool table 7 → 11 (read 7 + write 4), dogfood vault 21 → 23 nodes, vitest counts 118/848 → 100/721.
+- **Added** new sections: `/docs` scaffold button (`OntologyStarterCta`), CLI package, npm publish guard, "Removed by mission v2 cleanup" expanded entries, and a brand-new **Section 8 "OSS distribution surfaces"** documenting npm packages, Firebase Hosting, GitHub OSS surfaces, and the publish guard.
+- `AGENTS.md` got the same drift fix (route list + test counts + cleanup note).
+
+### Tooling
+
+- `scripts/audit-data-model.mjs` — accept either Korean or English `## 5. Storage 구조|layout` heading so the data-model audit test passes after translation.
+
+### Verification
+
+- `pnpm exec tsc --noEmit` — 0 errors
+- `pnpm lint` — 0 errors (62 pre-existing warnings)
+- `pnpm test:run` — 100 files / 721 tests pass
+- CLI smoke (`node cli/src/index.mjs init test-vault`) writes 5 English `.md` + `.mcp.json.example`
+- Hook smoke — 7/7 input shapes behave as expected
 
 ---
 
-## 2026-05-01 (밤) — UX 1원리 batch + Phase 4 비개발자 친화 + V1.5 cardinality
+## 2026-05-02 — local-first first paint firebase 0 (PR #99)
 
-이전 entry 의 7 PR 외에 추가로 12 PR 머지 (#15-#23). 전 세션 누적 19 PR.
+### User-visible changes
 
-### 사용자 가시 변화
+- **First page load is lighter** — user-facing entry points like `/`, `/topology`, `/docs`, `/ontology/edit`, `/projects`, `/knowledge`, `/login`, `/account` no longer statically load firebase JS (~773kb chunks). The lazy load only happens when explicitly entering cloud mode (signin / cloud entity mutation).
+- **Better LCP on mobile / slow networks** — zero firebase SDK parse cost.
+- **Hosting cost angle**: users who pick a vault never get a firebase account created. Origin server cost was already 0 (static export), and now firebase traffic is also 0 until cloud mode is entered.
+- **Behavior is unchanged** — cloud-mode users get all features identically (the firebase chunk is downloaded at function-call time).
 
-- **`/`** 빈 vault empty-state — local 모드일 때 inline `frontmatter snippet` 추가 (사용자가 빌더 진입 없이 직접 `.md` 만들 수 있게, copy-paste 가능). 외부 mode 는 기존 3-step 안내.
-- **`/docs/`** dogfood vault hint — LocalVaultPicker 의 idle 상태에 "처음이세요? 이 repo 의 `docs/ontology/` 를 선택해 보세요" 안내. 비전 검증의 가장 빠른 path.
-- **OperationsNav mode badge** (UX-2 신규) — 데스크톱 + 모바일 nav 의 우측에 현재 모드 chip 항상 표시 (`vault · NN docs` / `cloud sync` / `데모`). 사용자가 데이터가 어디로 가는지 한눈에.
-- **빌더 (`/ontology/edit`) onboarding 카피** — "ERD 이상 — 도메인 지도" 비개발자 친화. mission v2 의 *AI agent partner* 도 명시.
-- **빌더 vault md write** (P1-1 / UX-4) — 빌더에서 노드 저장 시 mode 분기: local 모드면 `vault/${kind}s/${slug}.md` 직접 작성, cloud 모드면 Firestore upsert. mission v2 의 *사람 + AI agent 양립* 약속의 핵심 missing piece 해소.
-- **kind 별 lucide 아이콘** — Tree / Builder palette 에 직관적 metaphor (project=Folder, domain=Layers, capability=Cog, element=Box, …). 색은 단일 인디고 + 무채색 헌장 그대로.
-- **검색 PM 친화 분류** (`⇧⌘K`) — group heading "Ontology / Documents / Projects" → "개념 / 글 / 프로젝트". placeholder + aria-label 도 한국어.
-- **UI 영문 transliteration 정리** — "edge type 분포" → "관계 종류 분포", "evidence 풍부" → "근거 문서 많은" 등. 코드 식별자 (`kind` / `node` / `edge`) 는 그대로.
-- **데모 데이터 mission v2 정렬** — `Demo Knowledge` 컨테이너 capabilities 가 mission v1 잔재 ("검수 큐", "frontmatter 추출") → mission v2 ("vault frontmatter 진실원", "AI agent partner") 로 교체.
+### Architecture changes (developer-visible)
 
-### 새 entity / feature / module
+- **entity barrel split pattern** — `@/entities/<x>` is now type / lib / pure helper only. firestore api lives at `@/entities/<x>/api` and must be imported directly. New contributors writing mode-aware features should `import('@/entities/<x>/api')` dynamically only on the cloud branch.
+- **mapper Timestamp duck-typing** — instead of `instanceof Timestamp` checks, use the `coerceFirestoreDate(value)` helper (`@/shared/lib/firestore-timestamp-coerce`). entity model has zero firebase dependency.
+- **`package.json sideEffects` allowlist** — only `*.css` + `firestore-noise-patch` are marked side-effectful. Everything else is webpack tree-shakeable.
 
-- `mcp/scripts/verify.mjs` — 1줄 verify CLI. parser smoke + server boot + tools/list + list_concepts 통합 검증. 실패 시 어느 step 인지 진단.
-- `mcp/src` v0.2 → **v0.3** — `find_path(from, to, maxHops?)` BFS + `list_kinds()` census 추가. 7 → 9 도구.
+### New modules
+
+- `src/shared/lib/firestore-noise-patch.ts` — extracted the existing `FirebaseProvider`'s console noise patch into a firebase-deps-free module. Installed in layout via a side-effect import alone.
+- `src/shared/lib/firestore-timestamp-coerce.ts` — Timestamp duck-typing helper + 8-case unit tests.
+- `src/entities/knowledge-graph/api/index.ts` — knowledge-graph api barrel (previously mixed into the main barrel).
+
+### Removed
+
+- `src/app/providers/FirebaseProvider.tsx` (-91 lines) — its responsibilities were a console patch + an unnecessary `getFirebaseApp()` warmup. The patch moved to a pure module, and `<link rel="preconnect">` already handles warmup.
+
+---
+
+## 2026-05-01 (night) — UX first-principles batch + Phase 4 non-developer friendliness + V1.5 cardinality
+
+In addition to the 7 PRs in the previous entry, 12 more PRs (#15-#23) merged. 19 PRs total this session.
+
+### User-visible changes
+
+- **`/`** empty-vault empty-state — in local mode, an inline `frontmatter snippet` was added so users can create a `.md` directly without entering the builder (copy-paste ready). Other modes keep the existing 3-step guidance.
+- **`/docs/`** dogfood vault hint — the LocalVaultPicker idle state now suggests "First time? Try selecting `docs/ontology/` from this repo." The fastest path for vision validation.
+- **OperationsNav mode badge** (UX-2 new) — the right side of both desktop and mobile nav now always shows the current mode chip (`vault · NN docs` / `cloud sync` / `demo`). Users see at a glance where data is going.
+- **Builder (`/ontology/edit`) onboarding copy** — "more than ERD — a domain map", written for non-developers. Mission v2's *AI agent partner* is also called out.
+- **Builder vault md write** (P1-1 / UX-4) — saving a node in the builder now branches by mode: in local mode it writes `vault/${kind}s/${slug}.md` directly; in cloud mode it upserts to Firestore. This closes the key missing piece in mission v2's *human + AI agent coexistence* promise.
+- **lucide icons per kind** — Tree / Builder palette now uses intuitive metaphors (project=Folder, domain=Layers, capability=Cog, element=Box, …). Color stays single-indigo + neutral per the design charter.
+- **PM-friendly search categories** (`⇧⌘K`) — group headings "Ontology / Documents / Projects" → "Concepts / Writing / Projects". Placeholder + aria-label translated to Korean too.
+- **UI English-transliteration cleanup** — "edge type distribution" → "relation kind distribution", "evidence rich" → "documents with many citations", etc. Code identifiers (`kind` / `node` / `edge`) are kept as is.
+- **Demo data aligned to mission v2** — the `Demo Knowledge` container's capabilities replaced mission v1 leftovers ("review queue", "frontmatter extraction") with mission v2 ("vault frontmatter as source of truth", "AI agent partner").
+
+### New entities / features / modules
+
+- `mcp/scripts/verify.mjs` — one-line verify CLI. Integrated check of parser smoke + server boot + tools/list + list_concepts. Diagnoses which step failed.
+- `mcp/src` v0.2 → **v0.3** — added `find_path(from, to, maxHops?)` BFS + `list_kinds()` census. 7 → 9 tools.
 - `src/entities/ontology-class/model/icons.ts` — `getOntologyKindIcon(kind)` shared helper.
-- `src/widgets/operations-nav` 의 `ModeBadge` 컴포넌트.
-- `docs/ATOMIC-AUDIT-2026-05-01.md` — 13 도메인 1원리 audit 결과 (438 줄).
-- `docs/UX-FIRST-PRINCIPLES.md` — 7-step user journey 마찰 분석 + P0/P1/P2 매트릭스.
+- `ModeBadge` component in `src/widgets/operations-nav`.
+- `docs/ATOMIC-AUDIT-2026-05-01.md` — first-principles audit results across 13 domains (438 lines).
+- `docs/UX-FIRST-PRINCIPLES.md` — 7-step user journey friction analysis + P0/P1/P2 matrix.
 
-### 제거
+### Removed
 
-- `src/widgets/ontology-output-badges/` 통째 (-425 줄, 0 imports — extraction review-queue 의존 잔재).
+- All of `src/widgets/ontology-output-badges/` (-425 lines, 0 imports — leftover from extraction review-queue dependency).
 
-### Ontology 모델 진화 (V1.x)
+### Ontology model evolution (V1.x)
 
-- **V1.1** ✅ qualifiers + rank 머지 (이전 entry 에 기록, 본 entry 에는 후속 dogfood 만)
-- **V1.5** ✅ Relation Cardinality 머지 — `OntologyRelation` 에 `sourceCardinality?` + `targetCardinality?` 옵셔널 (additive, breakage 0). 5 새 단위 test.
+- **V1.1** ✅ qualifiers + rank merged (recorded in the previous entry; this entry only covers follow-up dogfooding)
+- **V1.5** ✅ Relation Cardinality merged — added `sourceCardinality?` + `targetCardinality?` optionals to `OntologyRelation` (additive, zero breakage). 5 new unit tests.
 
 ### Documentation
 
-- `README.md` + `AGENTS.md` mission v2 동기화 (이전 entry).
-- `docs/FEATURES.md` 전면 재작성, `docs/ARCHITECTURE.md` / `docs/DATA-MODEL.md` / `docs/MODE-AWARE-CRUD.md` mission v2 정렬.
-- `docs/BACKLOG.md` mission v2 phase 후 next-work 통합 (T28-T38 + UX-1/2/3/4).
-- `docs/MISSION-CLEANUP-CANDIDATES.md` 압축 (4 stage 모두 ✅, archived analysis).
-- `docs/PRODUCT-DIRECTION.md` Phase 1-4 status 표시 (1 ✅ / 2 ⏸ / 3 ✅ / 4 ⏳).
-- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` 진행 상황 표 — V1.1 + V1.5 ✅, V1.2/V1.3/V1.4 대기.
-- `mcp/README.md` v0.3 (9 도구) 갱신 + sample LLM prompt + verify CLI 안내.
-- `docs/ontology/` dogfood vault — `capabilities/builder-vault-write` + `capabilities/v1-5-cardinality` 추가, `capabilities/mcp-server` 9 도구로 갱신. 22 노드.
+- `README.md` + `AGENTS.md` synced to mission v2 (previous entry).
+- `docs/FEATURES.md` fully rewritten; `docs/ARCHITECTURE.md` / `docs/DATA-MODEL.md` / `docs/MODE-AWARE-CRUD.md` aligned to mission v2.
+- `docs/BACKLOG.md` consolidated next-work after mission v2 phase (T28-T38 + UX-1/2/3/4).
+- `docs/MISSION-CLEANUP-CANDIDATES.md` compressed (all 4 stages ✅, archived analysis).
+- `docs/PRODUCT-DIRECTION.md` shows Phase 1-4 status (1 ✅ / 2 ⏸ / 3 ✅ / 4 ⏳).
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` progress table — V1.1 + V1.5 ✅, V1.2/V1.3/V1.4 pending.
+- `mcp/README.md` updated to v0.3 (9 tools) + sample LLM prompt + verify CLI guide.
+- `docs/ontology/` dogfood vault — added `capabilities/builder-vault-write` + `capabilities/v1-5-cardinality`, updated `capabilities/mcp-server` to 9 tools. 22 nodes.
 
-### 검증 통과 상태
+### Verification status
 
 - **117 test files / 839 tests passing** (V1.5 +5)
 - tsc 0 errors
-- lint 0 errors (warnings 79 pre-existing)
+- lint 0 errors (79 pre-existing warnings)
 - `node --check functions/index.js` syntax OK
-- MCP `npm run verify` end-to-end 9 도구 + 22 노드 dogfood vault 정상
-- Playwright MCP browser-level QA (15 라우트) — mission v2 surface 정상, console error 0, mode badge "데모" 노출, stale "Demo" title 0
+- MCP `npm run verify` end-to-end: 9 tools + 22-node dogfood vault healthy
+- Playwright MCP browser-level QA (15 routes) — mission v2 surfaces healthy, 0 console errors, mode badge "demo" visible, 0 stale "Demo" titles
 
 ### Open questions
 
-- **Q1, Q2** — ✅ 답완료
-- **Q3-Q8 (V2 spec)** — V1.2 (Q6+Q7), V1.3 (Q5), V1.4 (Q4) 차단
+- **Q1, Q2** — ✅ answered
+- **Q3-Q8 (V2 spec)** — blocked by V1.2 (Q6+Q7), V1.3 (Q5), V1.4 (Q4)
 
-### 누적 통계 (이번 세션 19 PR)
+### Cumulative stats (19 PRs this session)
 
-- 약 -5,833 줄 mission cleanup (PR #5-#11)
-- +438 줄 audit / +210 줄 UX 분석 / +245 줄 BACKLOG · FEATURES 동기화
-- +574 줄 신기능 (MCP v0.3 / mode badge / vault md write / V1.5 / kind icons / frontmatter snippet / verify CLI)
+- Roughly -5,833 lines from mission cleanup (PR #5-#11)
+- +438 lines audit / +210 lines UX analysis / +245 lines BACKLOG · FEATURES sync
+- +574 lines new features (MCP v0.3 / mode badge / vault md write / V1.5 / kind icons / frontmatter snippet / verify CLI)
 
 ---
 
-## 2026-05-01 (저녁) — Phase 3 (AI agent partner) + mission v2 cleanup
+## 2026-05-01 (evening) — Phase 3 (AI agent partner) + mission v2 cleanup
 
-PRODUCT-DIRECTION v2 의 mission "사람과 AI agent 가 같이 저작하는 codebase ontology" 를 코드 + functions + dogfood vault 까지 일관시킨 큰 cleanup. 누적 PR #5 / #6 / #7 머지.
+A large cleanup that aligns PRODUCT-DIRECTION v2's mission ("a codebase ontology authored together by humans and AI agents") across code + functions + dogfood vault. PR #5 / #6 / #7 merged cumulatively.
 
-### 사용자 가시 변화
+### User-visible changes
 
-- **AI agent partner 신설** — `mcp/` MCP 서버 (`@modelcontextprotocol/sdk@^1.0.0`). Claude Code 같은 LLM agent 가 stdin/stdout JSON-RPC 로 vault ontology 를 read/write. v0.2.0 7 도구: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`. 등록: `.mcp.json.example` 또는 `mcp/README.md`.
-- **`docs/ontology/` dogfood vault** — 이 프로젝트 자기 자신의 mental model 을 frontmatter md 로 표현. 1 project + 8 domain + 6 capability + 4 element = 20 노드.
-- **`/` ontology hub mode-aware** (Q1=(a)) — vault 활성 시 `/` 가 자동으로 vault frontmatter 의 stub 노드를 트리·ego graph·검색에 표시 (LOOP-TASK Open question #1 답).
-- **빈 vault UX** — local 모드에서 vault 가 활성됐는데 ontology 노드가 없으면 "vault 가 비어있어요" 안내 + 2-step (frontmatter / 빌더) CTA. local 모드면 "vault 열기" step skip.
-- **"분석 시작" cloud LLM 추출 흐름 제거** — mission v2 의 비용 모델이 *user-side AI agent (Claude Code)* 로 옮겨감. 영향 surface:
-  - `/knowledge/documents/[id]` 상세 — 4 단계 stepper → 2 단계 (upload → publish), `ExtractorVersionToggle` / "분석 시작" / "다시 분석" CTA 4곳 제거 → "vault 열기" / "빌더 열기" CTA
-  - `/review/knowledge` 검수 큐 — 페이지 + 라우트 통째 삭제. `OperationsNav` '문서 확인' 탭 제거 (5탭 → 4탭). 6 view 의 review 링크 제거
-  - `/ontology` toolbar 의 "검수 큐" pill 제거, "미해결 참조" Stat 의 review 큐 링크 → 페이지 안 stub 리스트로 변경
-  - `WorkspaceOntologyStrip` 의 stub chip target → `/ontology` 트리 stub 리스트로
-  - landing onboarding ValueChainRail "추출 돌리기" → "frontmatter 자체가 자기 승인"
+- **AI agent partner introduced** — `mcp/` MCP server (`@modelcontextprotocol/sdk@^1.0.0`). LLM agents like Claude Code can read/write the vault ontology over stdin/stdout JSON-RPC. v0.2.0 ships 7 tools: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`. Register via `.mcp.json.example` or `mcp/README.md`.
+- **`docs/ontology/` dogfood vault** — this project's own mental model expressed as frontmatter md. 1 project + 8 domains + 6 capabilities + 4 elements = 20 nodes.
+- **`/` ontology hub is mode-aware** (Q1=(a)) — when a vault is active, `/` automatically surfaces the vault's frontmatter stub nodes in the tree, ego graph, and search (LOOP-TASK Open question #1 answered).
+- **Empty-vault UX** — in local mode when a vault is active but has no ontology nodes, show a "vault is empty" guide + 2-step (frontmatter / builder) CTA. The "open vault" step is skipped in local mode.
+- **"Start analysis" cloud LLM extraction flow removed** — mission v2's cost model shifted to *user-side AI agents (Claude Code)*. Affected surfaces:
+  - `/knowledge/documents/[id]` detail — 4-step stepper → 2 steps (upload → publish); 4 sites of `ExtractorVersionToggle` / "start analysis" / "re-analyze" CTAs removed → "open vault" / "open builder" CTAs
+  - `/review/knowledge` review queue — page + route deleted entirely. `OperationsNav` 'Document review' tab removed (5 tabs → 4 tabs). Review links removed from 6 views
+  - `/ontology` toolbar's "review queue" pill removed; the "unresolved references" Stat's review-queue link → in-page stub list
+  - `WorkspaceOntologyStrip`'s stub chip target → `/ontology` tree stub list
+  - landing onboarding ValueChainRail "run extraction" → "frontmatter is self-approving"
 
-### 새 entity / feature / module
+### New entities / features / modules
 
-- `mcp/` 통째 — MCP 서버 패키지 (parser.mjs / vault.mjs / index.js / parser.test.mjs). v0.1.0 (5 도구) → v0.2.0 (7 도구).
-- `src/features/vault-ontology/model/use-ontology-insight.ts` — mode-aware ontology insight. local: vault frontmatter stub 변환, cloud: knowledgePublic projection.
-- `docs/ontology/` 통째 — 자기 ontology vault.
-- `docs/MISSION-CLEANUP-CANDIDATES.md` — 4 stage cleanup staging plan (Stage 1+2+3+4 모두 완료).
-- `.mcp.json.example` — Claude Code 등록 템플릿.
+- `mcp/` in its entirety — MCP server package (parser.mjs / vault.mjs / index.js / parser.test.mjs). v0.1.0 (5 tools) → v0.2.0 (7 tools).
+- `src/features/vault-ontology/model/use-ontology-insight.ts` — mode-aware ontology insight. local: vault frontmatter stub conversion; cloud: knowledgePublic projection.
+- `docs/ontology/` in its entirety — own ontology vault.
+- `docs/MISSION-CLEANUP-CANDIDATES.md` — 4-stage cleanup staging plan (Stages 1+2+3+4 all complete).
+- `.mcp.json.example` — Claude Code registration template.
 
-### 제거 / 정리
+### Removed / cleanup
 
-- **functions/index.js: 2,012 → 543 줄 (-73%)**
-  - `enqueueExtractionJob` / `processExtractionJob` / `reclaimStaleExtractionJobs` (extraction 흐름 3 handler) 제거
-  - `applyReviewAction` (검수 큐 callable) 제거
-  - 의존 cores + helpers 약 20 함수 정리
-  - `extract-gemini.js` (224 줄) + `ontology-extract.js` (1,295 줄) + `ontology-extract.test.mjs` (812 줄) 삭제
-  - secrets `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` 제거. `@google/generative-ai` 의존성 제거
-- **`src/views/knowledge-review-workspace/` 통째 삭제** (1,357 줄 view + barrel)
-- **`app/review/` 통째 삭제** (page + redirect + sub-route)
-- **entity layer**: `enqueueKnowledgeExtractionJob` httpsCallable wrapper, `approveKnowledgeOutput` / `rejectKnowledgeOutput` callable + 6 type, `getKnowledgeReviewWorkspaceHref` helper 제거. 각 barrel export 정리.
-- **6 view caller**: KnowledgeDocumentDetailPage / (지운 KnowledgeReviewWorkspacePage) / KnowledgeDocumentsPage / KnowledgeDashboardPage / ProjectSelectorPage / ProjectEditorPage 의 review 큐 링크 정리
-- **누적 정리**: PR #5 -3,729 줄 + PR #6 -2,096 줄 + PR #7 -8 줄 = **약 -5,833 라인**
+- **functions/index.js: 2,012 → 543 lines (-73%)**
+  - removed `enqueueExtractionJob` / `processExtractionJob` / `reclaimStaleExtractionJobs` (3 extraction-flow handlers)
+  - removed `applyReviewAction` (review-queue callable)
+  - cleaned up ~20 dependent core + helper functions
+  - deleted `extract-gemini.js` (224 lines) + `ontology-extract.js` (1,295 lines) + `ontology-extract.test.mjs` (812 lines)
+  - removed secrets `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`. Removed `@google/generative-ai` dependency
+- **`src/views/knowledge-review-workspace/` deleted entirely** (1,357-line view + barrel)
+- **`app/review/` deleted entirely** (page + redirect + sub-route)
+- **entity layer**: removed `enqueueKnowledgeExtractionJob` httpsCallable wrapper, `approveKnowledgeOutput` / `rejectKnowledgeOutput` callables + 6 types, `getKnowledgeReviewWorkspaceHref` helper. Each barrel export cleaned up.
+- **6 view callers**: review-queue links cleaned up in KnowledgeDocumentDetailPage / (deleted KnowledgeReviewWorkspacePage) / KnowledgeDocumentsPage / KnowledgeDashboardPage / ProjectSelectorPage / ProjectEditorPage
+- **Cumulative cleanup**: PR #5 -3,729 lines + PR #6 -2,096 lines + PR #7 -8 lines = **about -5,833 lines**
 
-### 검증 통과 상태
+### Verification status
 
 - **117 test files / 843 tests passing**
 - tsc 0 errors
-- lint 0 errors (warnings 79 pre-existing)
+- lint 0 errors (79 pre-existing warnings)
 - `node --check functions/index.js` syntax OK
-- MCP 서버 stdin/stdout JSON-RPC: initialize → tools/list (7 도구) → tools/call (`add_concept` / `patch_concept` / `find_backlinks` / `find_evidence` / `get_concept` / `list_concepts`) end-to-end 정상
-- dev server (port 3210) 핵심 라우트 200, 삭제된 `/review/knowledge/` 404, HTML 에 Error 마커 0
+- MCP server stdin/stdout JSON-RPC: initialize → tools/list (7 tools) → tools/call (`add_concept` / `patch_concept` / `find_backlinks` / `find_evidence` / `get_concept` / `list_concepts`) end-to-end healthy
+- dev server (port 3210): core routes return 200, deleted `/review/knowledge/` returns 404, 0 Error markers in HTML
 
 ### Open questions
 
-- **Q1** — ✅ 답완료 ((a) 채택, useOntologyInsight 도입)
-- **Q2 (share-doc 제거)** — 여전히 대기
-- **Q3-Q8 (V2 spec)** — 여전히 대기
+- **Q1** — ✅ answered ((a) chosen, useOntologyInsight introduced)
+- **Q2 (share-doc removal)** — still pending
+- **Q3-Q8 (V2 spec)** — still pending
 
-### 운영 노트
+### Operations notes
 
-- `firebase deploy --only functions` 는 user 가 실행 안 함 (firebase 배포 안 함 정책). functions/ 변경은 코드만 정리, deploy 안 됨. 기존 cloud functions 가 살아있어도 호출자 0 이라 dead.
-- 기존 `knowledgeExtractionJobs` / `knowledgeExtractionOutputs` / `knowledgeReviews` / `knowledgeApprovalEvents` Firestore 컬렉션 데이터 — cold storage (read-only), 더 이상 callable 없어 archive-only.
+- The user does not run `firebase deploy --only functions` (no-firebase-deploy policy). Changes to functions/ are code-only cleanup, not deployed. Existing cloud functions are still alive but have 0 callers — dead.
+- Existing `knowledgeExtractionJobs` / `knowledgeExtractionOutputs` / `knowledgeReviews` / `knowledgeApprovalEvents` Firestore collection data — cold storage (read-only); no callable remains, so archive-only.
 
 ---
 
 ## 2026-05-01 — Mode-aware CRUD + Builder rebrand
 
-### 사용자 가시 변화
+### User-visible changes
 
-- `/` Landing — 정적 미니 토폴로지 SVG (14 노드 / 21 relations) + 3-step rail (markdown → 추출 → 토폴로지·트리·ERD) + Obsidian/Notion 비교 카피 + footer (MIT licensed · GitHub · 기술 스택). Marketing 섹션 (Why / Coming soon roadmap / Stats / framer-motion 애니메이션 / Sigma drift 배경) 은 모두 제거.
-- `/projects/` — 비로그인 사용자 redirect 제거. list 즉시 노출. 비로그인 + vault 활성 사용자가 ProjectQuickCreatePanel 로 *vault 의 .md 직접 생성* 가능 (mode-aware).
-- `/ontology/edit/` — '온톨로지 아틀라스' → **'온톨로지 빌더'** 로 rebrand. 헤더 5줄 → 1줄 + ⓘ 툴팁. max-w 1400 → 1800 으로 캔버스 확장. 비로그인 시 'Missing or insufficient permissions' raw 에러 안 보이고 ephemeral 캔버스만 자유.
-- `/ontology/` — 'i' 아이콘 hover 툴팁 동작 + 카피 강화 (계층 + 빌더 진입 안내). '편집기' 버튼 → **'빌더 열기 →'** 인디고 fill prominent. 하단 footer 에 nodes/relations + mode + projection version 노출 (V1.0 강점 가시화).
-- `/ontology/` 의 vault 모드 — `VaultOntologyStubsPanel` 노출. frontmatter (`kind`, `capabilities`, `elements`, `relates`, `dependencies`, `domain`) 가 즉시 stub 노드/엣지로 자라는 모습 시각화.
-- OperationsNav '문서' 탭 — vault 활성 시 `/docs/` 로, 그 외 `/knowledge/` 로 분기.
-- Landing / app 전체의 'Demo' 브랜드 잔재 → **`oh-my-ontology`** 로 정리 (page title / OG / twitter / PWA manifest).
+- `/` Landing — static mini topology SVG (14 nodes / 21 relations) + 3-step rail (markdown → extract → topology·tree·ERD) + Obsidian/Notion comparison copy + footer (MIT licensed · GitHub · tech stack). Marketing sections (Why / Coming-soon roadmap / Stats / framer-motion animation / Sigma drift background) all removed.
+- `/projects/` — non-logged-in user redirect removed. List is shown immediately. Non-logged-in users with an active vault can use ProjectQuickCreatePanel to *create .md directly in the vault* (mode-aware).
+- `/ontology/edit/` — 'Ontology Atlas' → **'Ontology Builder'** rebrand. Header trimmed from 5 lines → 1 line + ⓘ tooltip. Canvas widened from max-w 1400 → 1800. Non-logged-in users no longer see the raw 'Missing or insufficient permissions' error — the ephemeral canvas is fully usable.
+- `/ontology/` — 'i' icon hover tooltip works + copy strengthened (hierarchy + builder entry guidance). 'Editor' button → **'Open Builder →'** prominent indigo fill. Footer at the bottom now shows nodes/relations + mode + projection version (surfacing V1.0 strengths).
+- `/ontology/` vault mode — `VaultOntologyStubsPanel` is shown. Visualizes how frontmatter (`kind`, `capabilities`, `elements`, `relates`, `dependencies`, `domain`) immediately grows into stub nodes/edges.
+- OperationsNav 'Documents' tab — branches to `/docs/` when a vault is active, otherwise `/knowledge/`.
+- 'Demo' brand leftovers across landing / app → cleaned up to **`oh-my-ontology`** (page title / OG / twitter / PWA manifest).
 
-### 새 entity / feature / shared 모듈
+### New entities / features / shared modules
 
-- `src/shared/lib/data-source-mode.ts` + `src/features/data-source-mode/` — 4 운영 모드 (Static / Local / Cloud / Hybrid) 인지 hook.
-- `src/features/project-data-source/` — `useProjectMutations` mode-aware hook (local 은 vault 직접 쓰기, cloud 는 Firestore).
-- `src/entities/docs-vault/lib/project-frontmatter.ts` — Project ↔ frontmatter 양방향 매퍼 + `buildProjectMarkdown`.
-- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — frontmatter → ontology stub 변환 (fast path, AI 추출 거치지 않음).
+- `src/shared/lib/data-source-mode.ts` + `src/features/data-source-mode/` — hook that recognizes 4 operating modes (Static / Local / Cloud / Hybrid).
+- `src/features/project-data-source/` — `useProjectMutations` mode-aware hook (local writes vault directly; cloud writes Firestore).
+- `src/entities/docs-vault/lib/project-frontmatter.ts` — bidirectional Project ↔ frontmatter mapper + `buildProjectMarkdown`.
+- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — frontmatter → ontology stub conversion (fast path, bypasses AI extraction).
 - `src/features/vault-ontology/` — useVaultOntology hook + VaultOntologyStubsPanel widget.
-- `src/entities/local-fs-handle/` — File System Access 핸들의 entity 화 (multi-vault forward-compat).
-- `src/entities/local-fs-handle/api/permission.ts` — `verifyHandlePermission(handle, mode, {ask})` 일반화 유틸.
-- `src/entities/docs-vault/lib/build-local-manifest.ts` — `computeLocalVaultFingerprint` 함수 추가 (auto-refresh skip).
+- `src/entities/local-fs-handle/` — entity-ization of File System Access handles (forward-compat for multi-vault).
+- `src/entities/local-fs-handle/api/permission.ts` — generalized `verifyHandlePermission(handle, mode, {ask})` utility.
+- `src/entities/docs-vault/lib/build-local-manifest.ts` — added `computeLocalVaultFingerprint` function (auto-refresh skip).
 
-### 제거 / 정리
+### Removed / cleanup
 
-- `src/features/workspace-project-bridge/` — 통째 삭제 (771 줄 / 9 파일 / 50 tests). multi-account 컨테이너 어댑터 single-user 모드 전환 후 dead.
-- `src/widgets/workspace-project-selector/ui/WorkspaceProjectSelector.tsx` — dead UI 230 줄 삭제.
-- `src/shared/lib/account-scope.ts` — `appendWorkspaceProjectQuery` / `readRuntimeWorkspaceProjectId` stub 함수 제거.
-- `src/shared/lib/use-workspace-project-query.ts` — 통째 삭제 + 3 consumer 의 dead destructure 정리.
-- `useScopedAccountAccess` 의 `_accountId` 파라미터 제거 (11 call site 동시 정리).
-- `src/views/account-settings/` 의 일부 + `src/widgets/account-menu/` 일부 — 더 이상 사용 안 되는 코드 path 정리.
-- e2e audit spec 4 개의 dead `/admin/*` URL 7개 제거.
-- LocalVaultPicker 의 off-canon palette (peachy / muted-red / indigo 변종) → 캐논 warning(244,183,49) / danger(229,72,77) / indigo(94,106,210) + 시멘틱 토큰으로 통일.
-- LocalVaultPicker error 상태에 actionable 안내 한 줄 추가.
+- `src/features/workspace-project-bridge/` — deleted entirely (771 lines / 9 files / 50 tests). Multi-account container adapter — dead after switching to single-user mode.
+- `src/widgets/workspace-project-selector/ui/WorkspaceProjectSelector.tsx` — 230 lines of dead UI deleted.
+- `src/shared/lib/account-scope.ts` — removed `appendWorkspaceProjectQuery` / `readRuntimeWorkspaceProjectId` stub functions.
+- `src/shared/lib/use-workspace-project-query.ts` — deleted entirely + dead destructure cleanup in 3 consumers.
+- removed `_accountId` parameter from `useScopedAccountAccess` (cleaned up 11 call sites at once).
+- parts of `src/views/account-settings/` + parts of `src/widgets/account-menu/` — cleaned up no-longer-used code paths.
+- 7 dead `/admin/*` URLs removed from 4 e2e audit specs.
+- LocalVaultPicker's off-canon palette (peachy / muted-red / indigo variants) → unified to canonical warning(244,183,49) / danger(229,72,77) / indigo(94,106,210) + semantic tokens.
+- LocalVaultPicker error state — added a one-line actionable hint.
 
-### 버그 fix
+### Bug fixes
 
-- `OntologyEditPage` 의 `accountId = null` 하드코드 제거 — ERD 캔버스 manual node 저장 가능 회복 (이전엔 항상 "계정이 확인되지 않았어요" 토스트로 fail).
-- `useApprovedGraphFlow` 가 비로그인 시 Firestore 구독 시도 → raw permissions error — accountId === null 면 구독 skip + 빈 그래프 + loaded:true.
-- frontmatter parser 가 multi-line YAML list (`capabilities:\n  - x`) 미지원 → 지원 추가.
-- `useLocalVault` 의 manual `refresh` 도 fingerprint skip 적용 (auto-refresh 만 됐던 것).
+- Removed the `accountId = null` hardcode in `OntologyEditPage` — restored manual node saving on the ERD canvas (previously always failed with the "account not confirmed" toast).
+- `useApprovedGraphFlow` was attempting Firestore subscription when not logged in → raw permissions error — now skips subscription when accountId === null + returns empty graph + loaded:true.
+- frontmatter parser didn't support multi-line YAML lists (`capabilities:\n  - x`) → support added.
+- `useLocalVault`'s manual `refresh` now also applies the fingerprint skip (previously only auto-refresh did).
 
-### 신설 spec / docs (untracked, user review 대기)
+### New specs / docs (untracked, awaiting user review)
 
-- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.0 강점 + V1.1~V1.5 단계별 진화 (qualifiers / literals / rich-refs / ActionType / cardinality) + V2 통합 statement 모델 + 90+ 항목 체크리스트 + Mermaid 도식 2개 + Glossary 50+ 용어 + 8 Open questions + 13 섹션.
-- `docs/LOCAL-FIRST-SYNC.md` — 4 운영 모드 + 충돌 해소 5 원칙 + Hybrid 도입 전 4 open questions.
-- `docs/OFFLINE-FIRST-UX-FLOW.md` — 6 사용자 상태 × 11 라우트 매트릭스 + 5-step 온보딩.
-- `docs/ACTION-TYPE-SECURITY-DRAFT.md` — V1.4 ActionType 의 8 보안 항목 deepen.
-- `docs/MODE-AWARE-CRUD.md` — 오늘 도입한 mode-aware 패턴 contributor 가이드 + anti-pattern 4 종.
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.0 strengths + V1.1~V1.5 staged evolution (qualifiers / literals / rich-refs / ActionType / cardinality) + V2 unified statement model + 90+ checklist items + 2 Mermaid diagrams + 50+ Glossary terms + 8 Open questions + 13 sections.
+- `docs/LOCAL-FIRST-SYNC.md` — 4 operating modes + 5 conflict-resolution principles + 4 open questions before introducing Hybrid.
+- `docs/OFFLINE-FIRST-UX-FLOW.md` — 6 user states × 11 routes matrix + 5-step onboarding.
+- `docs/ACTION-TYPE-SECURITY-DRAFT.md` — V1.4 ActionType's 8 security items, deeper.
+- `docs/MODE-AWARE-CRUD.md` — contributor guide for the mode-aware pattern introduced today + 4 anti-patterns.
 
-### 검증 통과 상태
+### Verification status
 
 - 927 tests passing (131 test files)
 - tsc 0 errors
-- lint 0 errors (warnings 모두 pre-existing)
-- Playwright 시각: `/`, `/projects/`, `/ontology/`, `/ontology/edit/`, `/docs/`, 8 라우트 audit 모두 console errors 0.
-- 누적 commit: 약 30+ (이날 단일 세션). 누적 diff: -3000+ / +1500+ 라인 (정리 위주).
+- lint 0 errors (all warnings pre-existing)
+- Playwright visual: `/`, `/projects/`, `/ontology/`, `/ontology/edit/`, `/docs/` and 8 routes audited — all 0 console errors.
+- Cumulative commits: ~30+ (single session today). Cumulative diff: -3000+ / +1500+ lines (mostly cleanup).
 
-### Open questions (user 답 대기)
+### Open questions (awaiting user answers)
 
-1. `/` 토폴로지가 활성 vault 가 있을 때 자동 전환되어야 하는가? (a/b/c)
-2. share-doc 시스템 (`/share/[token]` + sharedDocs Firestore) 제거해도 되는가? (a/b)
-3. V2 spec 의 P0/P1 Open questions Q1~Q8 (multi-vault 시점 / ActionType 인증 / dual-read 기간 / none vs unknown / extractionModelId 검증 / summary 마이그레이션 / literal naming scope / ActionInvocation 보존)
+1. Should `/` topology auto-switch when an active vault exists? (a/b/c)
+2. Can the share-doc system (`/share/[token]` + sharedDocs Firestore) be removed? (a/b)
+3. V2 spec P0/P1 Open questions Q1~Q8 (multi-vault timing / ActionType auth / dual-read window / none vs unknown / extractionModelId validation / summary migration / literal naming scope / ActionInvocation retention)
 
 ---
 
-## 2026-04-30 이전
+## Before 2026-04-30
 
-이전 변경은 이 CHANGELOG 도입 전 — git log 참조 (`git log --oneline 7b16945..ba1e102`).
+Earlier changes predate this CHANGELOG — see git log (`git log --oneline 7b16945..ba1e102`).

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -5,20 +5,20 @@ tags: [data-model, firestore, schema]
 
 # Data Model
 
-> 이 문서는 현재 공개 제품과 설계 승인된 `knowledge subsystem v2`의 저장 계약을 함께 다룬다. 컬렉션 스키마 변경 시 반드시 이 문서를 먼저 갱신한다. 변경 프로세스는 [`rules/firestore-schema.md`](rules/firestore-schema.md)를 따른다.
+> This document covers the storage contracts of both the current public product and the design-approved `knowledge subsystem v2`. Whenever a collection schema changes, update this document first. The change process follows [`rules/firestore-schema.md`](rules/firestore-schema.md).
 >
-> **single-user 모드 (현재):** 1 명의 로그인 사용자가 자기 워크스페이스의 owner. account / membership 개념 없음. 모든 컬렉션은 root path. v2 협업 단계에서 multi-account 가 필요해지면 별도 ADR 로 도입.
+> **Single-user mode (current):** A single logged-in user is the owner of their own workspace. There is no account / membership concept. All collections live at the root path. If multi-account support becomes necessary during the v2 collaboration phase, it will be introduced via a separate ADR.
 
-## 1. 원칙
+## 1. Principles
 
-1. 현재 공개 제품의 canonical 데이터는 여전히 `projects`다.
-2. knowledge subsystem은 공개 제품과 분리된 인증-필수 subsystem으로 도입한다.
-3. knowledge의 canonical graph는 private store에 저장하고, 공개 화면은 projection만 읽는다.
-4. raw markdown는 Firestore가 아니라 Firebase Storage에 저장한다.
-5. backend-owned 컬렉션은 브라우저 클라이언트가 직접 쓰지 않는다.
-6. PostgreSQL/Prisma 전환 대비용 관계형 계약은 `database/ddl/postgres/`에 함께 유지한다.
+1. The canonical data of the current public product is still `projects`.
+2. The knowledge subsystem is introduced as an authentication-required subsystem, separate from the public product.
+3. The canonical graph of the knowledge subsystem is stored in a private store, and public surfaces read only from a projection.
+4. Raw markdown is stored in Firebase Storage, not in Firestore.
+5. Backend-owned collections are not written to directly by browser clients.
+6. Relational contracts in `database/ddl/postgres/` are kept in sync as preparation for a potential PostgreSQL/Prisma migration.
 
-## 2. Firestore 컬렉션
+## 2. Firestore collections
 
 ```text
 firestore/
@@ -30,19 +30,19 @@ firestore/
 │   └── {id}/
 ├── meta/
 │   └── site/
-├── knowledgeDocuments/              private 문서 헤더
+├── knowledgeDocuments/              private document headers
 │   └── {documentId}/
-├── knowledgeDocumentVersions/       private 원문 버전
+├── knowledgeDocumentVersions/       private source-text versions
 │   └── {versionId}/
-├── knowledgeDocumentChunks/         ⚠️ cold storage (mission v2 cleanup 후 read-only)
+├── knowledgeDocumentChunks/         ⚠️ cold storage (read-only after mission v2 cleanup)
 │   └── {chunkId}/
 ├── knowledgeEvidence/               ⚠️ cold storage (mission v2 cleanup)
 │   └── {evidenceId}/
-├── knowledgeExtractionJobs/         ⚠️ cold storage (extraction handler 제거됨, PR #5)
+├── knowledgeExtractionJobs/         ⚠️ cold storage (extraction handler removed, PR #5)
 │   └── {jobId}/
-├── knowledgeExtractionOutputs/      ⚠️ cold storage (extraction handler 제거됨)
+├── knowledgeExtractionOutputs/      ⚠️ cold storage (extraction handler removed)
 │   └── {outputId}/
-├── knowledgeReviews/                ⚠️ cold storage (applyReviewAction 제거됨, PR #6)
+├── knowledgeReviews/                ⚠️ cold storage (applyReviewAction removed, PR #6)
 │   └── {reviewId}/
 ├── knowledgeReviewEvents/           ⚠️ cold storage
 │   └── {eventId}/
@@ -60,443 +60,443 @@ firestore/
 │   └── {nodeId}/
 ├── knowledgePublicEdges/            public projection
 │   └── {edgeId}/
-├── ontologyClasses/                 ontology TBox — 노드 클래스 정의 (authed write, public read)
+├── ontologyClasses/                 ontology TBox — node class definitions (authed write, public read)
 │   └── {classId}/
-├── ontologyRelations/               ontology TBox — 관계 타입 정의 (authed write, public read)
+├── ontologyRelations/               ontology TBox — relation type definitions (authed write, public read)
 │   └── {relationId}/
 ├── ontologyTBoxVersions/            ontology TBox snapshot (immutable, append-only)
 │   └── {versionId}/
-└── ontologyTBoxState/               활성 TBox version 포인터
+└── ontologyTBoxState/               active TBox version pointer
     └── current/                     versionId + activatedAt + activatedBy
 ```
 
-## 3. 공개 제품 컬렉션
+## 3. Public product collections
 
 ### `projects/{slug}`
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `slug` | string | ✅ | URL용 kebab-case, 문서 ID와 동일 |
-| `name` | string | ✅ | 한글 이름 |
-| `nameEn` | string |  | 영문 이름 |
-| `category` | string | ✅ | `categories/{id}` 참조 |
-| `status` | string | ✅ | `statuses/{id}` 참조 |
-| `description` | string | ✅ | 1~2줄 요약 |
-| `detail` | string (markdown) |  | 상세 본문 |
-| `tags` | string[] |  | 태그 배열 |
-| `stack` | string[] |  | 기술 스택 |
-| `links` | `Array<{ label: string; url: string }>` |  | 외부 링크 |
-| `dependencies` | string[] |  | 의존 프로젝트 slug 배열 |
-| `owner` | string |  | 담당자 |
-| `icon` | string |  | 이모지 또는 URL |
-| `screenshots` | string[] |  | Storage URL 배열 |
-| `timeline.startedAt` | Timestamp |  | 시작일 |
-| `timeline.launchedAt` | Timestamp |  | 출시일 |
-| `progress` | number (0-100) |  | 진행도 |
-| `isHub` | boolean | ✅ | 허브 노드 여부 |
-| `position.x` | number | ✅ | 토폴로지 레이아웃 좌표 X |
-| `position.y` | number | ✅ | 토폴로지 레이아웃 좌표 Y |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
+| `slug` | string | ✅ | URL-friendly kebab-case; identical to the document ID |
+| `name` | string | ✅ | Korean name |
+| `nameEn` | string |  | English name |
+| `category` | string | ✅ | Reference to `categories/{id}` |
+| `status` | string | ✅ | Reference to `statuses/{id}` |
+| `description` | string | ✅ | One- or two-line summary |
+| `detail` | string (markdown) |  | Long-form body |
+| `tags` | string[] |  | Tag array |
+| `stack` | string[] |  | Tech stack |
+| `links` | `Array<{ label: string; url: string }>` |  | External links |
+| `dependencies` | string[] |  | Array of dependent project slugs |
+| `owner` | string |  | Owner |
+| `icon` | string |  | Emoji or URL |
+| `screenshots` | string[] |  | Array of Storage URLs |
+| `timeline.startedAt` | Timestamp |  | Start date |
+| `timeline.launchedAt` | Timestamp |  | Launch date |
+| `progress` | number (0-100) |  | Progress |
+| `isHub` | boolean | ✅ | Whether the node is a hub |
+| `position.x` | number | ✅ | Topology layout coordinate X |
+| `position.y` | number | ✅ | Topology layout coordinate Y |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
 
 ### `categories/{id}`
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | 문서 ID와 동일 |
-| `label` | string | ✅ | 한글 라벨 |
-| `labelEn` | string |  | 영문 라벨 |
-| `order` | number | ✅ | 정렬 순서 |
-| `position.x` | number | ✅ | 클러스터 중심 X |
-| `position.y` | number | ✅ | 클러스터 중심 Y |
-| `size.width` | number | ✅ | 클러스터 폭 |
-| `size.height` | number | ✅ | 클러스터 높이 |
-| `radius` | number | ✅ | 네비게이션 zoom 계산용 반경 |
-| `borderStyle` | `"underline" \| "dashed" \| "sideLabel" \| "solid"` | ✅ | 카테고리 보더 표현 |
-| `sideLabelText` | string |  | `sideLabel`일 때 좌측 라벨 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
+| `id` | string | ✅ | Identical to the document ID |
+| `label` | string | ✅ | Korean label |
+| `labelEn` | string |  | English label |
+| `order` | number | ✅ | Sort order |
+| `position.x` | number | ✅ | Cluster center X |
+| `position.y` | number | ✅ | Cluster center Y |
+| `size.width` | number | ✅ | Cluster width |
+| `size.height` | number | ✅ | Cluster height |
+| `radius` | number | ✅ | Radius used for navigation zoom calculation |
+| `borderStyle` | `"underline" \| "dashed" \| "sideLabel" \| "solid"` | ✅ | Category border representation |
+| `sideLabelText` | string |  | Left-side label when `sideLabel` is used |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
 
 ### `statuses/{id}`
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | 문서 ID와 동일 |
-| `label` | string | ✅ | 한글 라벨 |
-| `labelEn` | string |  | 영문 라벨 |
-| `order` | number | ✅ | 정렬 순서 |
-| `dotColor` | `"success" \| "warning" \| "paused" \| "neutral"` | ✅ | 상태 점 색상 preset |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
+| `id` | string | ✅ | Identical to the document ID |
+| `label` | string | ✅ | Korean label |
+| `labelEn` | string |  | English label |
+| `order` | number | ✅ | Sort order |
+| `dotColor` | `"success" \| "warning" \| "paused" \| "neutral"` | ✅ | Status-dot color preset |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
 
 ### `meta/site`
 
-| 필드 | 타입 | 설명 |
+| Field | Type | Description |
 | --- | --- | --- |
-| `title` | string | 사이트 타이틀 |
-| `description` | string | 사이트 설명 |
-| `lastUpdated` | Timestamp | 마지막 변경 시점 |
-| `viewCount` | number | 방문 카운트 (선택) |
+| `title` | string | Site title |
+| `description` | string | Site description |
+| `lastUpdated` | Timestamp | Last change time |
+| `viewCount` | number | Visit count (optional) |
 
-## 4. Knowledge subsystem 컬렉션
+## 4. Knowledge subsystem collections
 
 ### `knowledgeDocuments/{documentId}`
 
-문서 헤더와 현재 상태를 담는 admin private 엔트리.
+Admin-private entry that holds the document header and current state.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | 문서 ID |
-| `title` | string | ✅ | 현재 canonical 제목 |
-| `kind` | string | ✅ | 현재 canonical 문서 kind |
-| `projectIds` | string[] | ✅ | 연결된 프로젝트 slug 목록 |
-| `sourceType` | `"upload" \| "manual" \| "import"` | ✅ | 생성 경로 |
-| `currentVersionId` | string | ✅ | 현재 기준 version ID |
-| `formatScore` | number |  | 규격 적합도 |
-| `status` | `"draft" \| "ready" \| "processing" \| "reviewing" \| "published" \| "error"` | ✅ | 문서 운영 상태 |
-| `latestJobStatus` | string |  | 최근 추출 job 상태 요약 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
-| `createdBy` | string | ✅ | 생성 admin 이메일 |
+| `id` | string | ✅ | Document ID |
+| `title` | string | ✅ | Current canonical title |
+| `kind` | string | ✅ | Current canonical document kind |
+| `projectIds` | string[] | ✅ | List of linked project slugs |
+| `sourceType` | `"upload" \| "manual" \| "import"` | ✅ | Creation path |
+| `currentVersionId` | string | ✅ | Current reference version ID |
+| `formatScore` | number |  | Specification conformance score |
+| `status` | `"draft" \| "ready" \| "processing" \| "reviewing" \| "published" \| "error"` | ✅ | Document operational state |
+| `latestJobStatus` | string |  | Summary of the latest extraction job status |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
+| `createdBy` | string | ✅ | Email of the creating admin |
 
-`knowledgeDocuments`는 `currentVersionId`의 파생 헤더를 담는다. `title`, `kind`, `projectIds`는 version canonical metadata를 반영한다.
+`knowledgeDocuments` carries the derived header for `currentVersionId`. `title`, `kind`, and `projectIds` reflect the version's canonical metadata.
 
 ### `knowledgeDocumentVersions/{versionId}`
 
-원문 버전 메타. append-only로 취급한다.
+Source-text version metadata. Treated as append-only.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | version ID |
-| `documentId` | string | ✅ | 상위 문서 ID |
-| `title` | string | ✅ | version metadata 제목 |
-| `kind` | string | ✅ | version metadata kind |
-| `projectIds` | string[] | ✅ | version metadata project 연결 |
-| `frontmatter` | map |  | 파싱된 frontmatter |
-| `storagePath` | string | ✅ | Storage 원문 경로 |
-| `mimeType` | string | ✅ | `text/markdown` 또는 허용 MIME |
-| `sizeBytes` | number | ✅ | 원문 크기 |
-| `hash` | string | ✅ | version 해시 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `createdBy` | string | ✅ | 생성 admin 이메일 |
+| `id` | string | ✅ | Version ID |
+| `documentId` | string | ✅ | Parent document ID |
+| `title` | string | ✅ | Version metadata title |
+| `kind` | string | ✅ | Version metadata kind |
+| `projectIds` | string[] | ✅ | Version metadata project links |
+| `frontmatter` | map |  | Parsed frontmatter |
+| `storagePath` | string | ✅ | Storage path of the source text |
+| `mimeType` | string | ✅ | `text/markdown` or another allowed MIME type |
+| `sizeBytes` | number | ✅ | Source-text size |
+| `hash` | string | ✅ | Version hash |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `createdBy` | string | ✅ | Email of the creating admin |
 
 ### `knowledgeDocumentChunks/{chunkId}`
 
-trusted backend가 생성하는 chunk 인덱스.
+Chunk index produced by the trusted backend.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | chunk ID |
-| `documentId` | string | ✅ | 문서 ID |
-| `documentVersionId` | string | ✅ | 기준 version ID |
-| `headingPath` | string[] |  | heading 경로 |
-| `markdown` | string | ✅ | chunk markdown |
-| `charStart` | number | ✅ | 원문 시작 오프셋 |
-| `charEnd` | number | ✅ | 원문 끝 오프셋 |
-| `chunkHash` | string | ✅ | chunk 내용 해시 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
+| `id` | string | ✅ | Chunk ID |
+| `documentId` | string | ✅ | Document ID |
+| `documentVersionId` | string | ✅ | Reference version ID |
+| `headingPath` | string[] |  | Heading path |
+| `markdown` | string | ✅ | Chunk markdown |
+| `charStart` | number | ✅ | Source-text start offset |
+| `charEnd` | number | ✅ | Source-text end offset |
+| `chunkHash` | string | ✅ | Hash of the chunk content |
+| `createdAt` | Timestamp | ✅ | Created at |
 
 ### `knowledgeExtractionJobs/{jobId}`
 
-job queue 엔트리. admin UI는 enqueue를 요청하고, 실제 job 문서는 trusted backend가 생성/처리한다.
+Job queue entry. The admin UI requests an enqueue, and the actual job document is created and processed by the trusted backend.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | job ID |
-| `documentId` | string | ✅ | 대상 문서 ID |
-| `documentVersionId` | string | ✅ | 대상 version ID |
-| `extractorVersion` | string | ✅ | 추출기 버전 |
-| `idempotencyKey` | string | ✅ | 멱등 키. `(documentVersionId, extractorVersion)` 기반 |
-| `status` | `"queued" \| "leased" \| "processing" \| "succeeded" \| "failed" \| "superseded"` | ✅ | 상태 |
-| `attemptCount` | number | ✅ | 시도 횟수 |
-| `maxAttempts` | number | ✅ | 허용 최대 시도 횟수 |
-| `retryable` | boolean | ✅ | 재시도 가능 여부 |
-| `nextAttemptAt` | Timestamp |  | 다음 재시도 가능 시각 |
-| `leaseOwner` | string |  | 처리중인 worker 식별자 |
-| `leaseExpiresAt` | Timestamp |  | lease 만료 시점 |
-| `generation` | number | ✅ | lease 세대. stale 완료 방지용 |
-| `errorCode` | string |  | 마지막 에러 코드 |
-| `errorMessage` | string |  | 마지막 에러 메시지 |
-| `supersededByJobId` | string |  | 대체 job ID |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
-| `requestedBy` | string | ✅ | enqueue한 admin 이메일 |
+| `id` | string | ✅ | Job ID |
+| `documentId` | string | ✅ | Target document ID |
+| `documentVersionId` | string | ✅ | Target version ID |
+| `extractorVersion` | string | ✅ | Extractor version |
+| `idempotencyKey` | string | ✅ | Idempotency key, derived from `(documentVersionId, extractorVersion)` |
+| `status` | `"queued" \| "leased" \| "processing" \| "succeeded" \| "failed" \| "superseded"` | ✅ | Status |
+| `attemptCount` | number | ✅ | Number of attempts |
+| `maxAttempts` | number | ✅ | Maximum allowed attempts |
+| `retryable` | boolean | ✅ | Whether retry is allowed |
+| `nextAttemptAt` | Timestamp |  | Next allowed retry time |
+| `leaseOwner` | string |  | Identifier of the worker currently processing the job |
+| `leaseExpiresAt` | Timestamp |  | Lease expiration time |
+| `generation` | number | ✅ | Lease generation; prevents stale completions |
+| `errorCode` | string |  | Last error code |
+| `errorMessage` | string |  | Last error message |
+| `supersededByJobId` | string |  | ID of the superseding job |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
+| `requestedBy` | string | ✅ | Email of the admin who enqueued the job |
 
-`jobId`는 가능하면 `idempotencyKey` 기반 deterministic ID를 사용한다. 브라우저는 중복 job을 직접 생성하지 않고 backend enqueue 경계로 요청한다.
+Wherever possible, `jobId` uses a deterministic ID derived from `idempotencyKey`. Browsers do not create duplicate jobs directly; they request one through the backend enqueue boundary.
 
 ### `knowledgeExtractionOutputs/{outputId}`
 
-trusted backend가 저장하는 raw extraction 결과.
+Raw extraction results stored by the trusted backend.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | output ID |
-| `jobId` | string | ✅ | 생성한 job ID |
-| `documentId` | string | ✅ | 문서 ID |
-| `documentVersionId` | string | ✅ | 문서 version ID |
-| `extractorVersion` | string | ✅ | 추출기 버전 |
-| `provider` | string | ✅ | 예: `gemini` |
-| `summary` | string |  | 문서 요약 |
-| `nodes` | `OutputNode[]` | ✅ | node 후보 목록 (아래 sub-schema) |
-| `edges` | `OutputEdge[]` | ✅ | edge 후보 목록 (아래 sub-schema) |
-| `warnings` | string[] |  | 경고 목록 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
+| `id` | string | ✅ | Output ID |
+| `jobId` | string | ✅ | ID of the job that produced this output |
+| `documentId` | string | ✅ | Document ID |
+| `documentVersionId` | string | ✅ | Document version ID |
+| `extractorVersion` | string | ✅ | Extractor version |
+| `provider` | string | ✅ | e.g., `gemini` |
+| `summary` | string |  | Document summary |
+| `nodes` | `OutputNode[]` | ✅ | Candidate node list (sub-schema below) |
+| `edges` | `OutputEdge[]` | ✅ | Candidate edge list (sub-schema below) |
+| `warnings` | string[] |  | List of warnings |
+| `createdAt` | Timestamp | ✅ | Created at |
 
 `OutputNode` sub-schema:
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `tempId` | string | ✅ | output 내부 임시 ID. approval 시 canonical node ID 로 매핑됨 |
-| `title` | string | ✅ | 노드 제목 |
-| `kind` | string | ✅ | `ontologyClasses` 의 합법 값 (project / domain / capability / element / document) |
-| `projectIds` | string[] | ✅ | 연결 프로젝트 |
-| `summary` | string |  | 내부 요약 |
-| `confidence` | number | ✅ | LLM 신뢰도 0~1. 보류 스펙 §6.3 정책: `≥ 0.85` 자동 승인 후보 / `0.60~0.84` 검수 / `< 0.60` 자동 반영 금지 |
-| `warnings` | string[] |  | 후보별 경고 |
+| `tempId` | string | ✅ | Output-internal temporary ID; mapped to a canonical node ID on approval |
+| `title` | string | ✅ | Node title |
+| `kind` | string | ✅ | Legal value from `ontologyClasses` (project / domain / capability / element / document) |
+| `projectIds` | string[] | ✅ | Linked projects |
+| `summary` | string |  | Internal summary |
+| `confidence` | number | ✅ | LLM confidence 0–1. Pending-spec §6.3 policy: `≥ 0.85` auto-approval candidate / `0.60–0.84` requires review / `< 0.60` cannot be applied automatically |
+| `warnings` | string[] |  | Per-candidate warnings |
 
 `OutputEdge` sub-schema:
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `tempId` | string | ✅ | output 내부 임시 ID |
-| `fromTempId` | string | ✅ | source 노드의 tempId |
-| `toTempId` | string | ✅ | target 노드의 tempId |
-| `type` | `KnowledgeEdgeType` | ✅ | 7 종 enum (T-2). `ontologyRelations` 컬렉션과 정합 |
-| `label` | string |  | UI 표시용 라벨 |
-| `confidence` | number | ✅ | LLM 신뢰도 0~1. node 와 동일 정책 |
+| `tempId` | string | ✅ | Output-internal temporary ID |
+| `fromTempId` | string | ✅ | tempId of the source node |
+| `toTempId` | string | ✅ | tempId of the target node |
+| `type` | `KnowledgeEdgeType` | ✅ | One of 7 enum values (T-2). Aligned with the `ontologyRelations` collection |
+| `label` | string |  | Display label for the UI |
+| `confidence` | number | ✅ | LLM confidence 0–1; same policy as nodes |
 
-> **신뢰도 정책 (보류 스펙 §6.3 채택)**:
-> - `≥ 0.85` — high. 규격 문서 + 명시적 관계. 자동 승인 후보.
-> - `0.60 ~ 0.84` — medium. 문맥상 유력. 검수 큐로.
-> - `< 0.60` — low. 자동 반영 금지. 사용자 명시 승인 필요.
+> **Confidence policy (pending-spec §6.3 adopted)**:
+> - `≥ 0.85` — high. Conformant document with explicit relations. Auto-approval candidate.
+> - `0.60 – 0.84` — medium. Likely from context. Routed to the review queue.
+> - `< 0.60` — low. Cannot be applied automatically. Requires explicit user approval.
 
 ### `knowledgeEvidence/{evidenceId}`
 
-immutable evidence reference store.
+Immutable evidence reference store.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | evidence ID |
-| `documentId` | string | ✅ | 문서 ID |
-| `documentVersionId` | string | ✅ | version ID |
-| `versionHash` | string | ✅ | version 해시 |
-| `chunkId` | string | ✅ | chunk ID |
-| `chunkHash` | string | ✅ | chunk 해시 |
-| `charStart` | number | ✅ | 원문 시작 위치 |
-| `charEnd` | number | ✅ | 원문 끝 위치 |
-| `excerpt` | string | ✅ | 표시용 인용 텍스트 |
-| `locatorVersion` | string | ✅ | locator 계산 버전 |
-| `extractorVersion` | string | ✅ | 추출기 버전 |
-| `sourceOutputId` | string | ✅ | 생성한 extraction output ID |
-| `createdAt` | Timestamp | ✅ | 생성일 |
+| `id` | string | ✅ | Evidence ID |
+| `documentId` | string | ✅ | Document ID |
+| `documentVersionId` | string | ✅ | Version ID |
+| `versionHash` | string | ✅ | Version hash |
+| `chunkId` | string | ✅ | Chunk ID |
+| `chunkHash` | string | ✅ | Chunk hash |
+| `charStart` | number | ✅ | Source-text start position |
+| `charEnd` | number | ✅ | Source-text end position |
+| `excerpt` | string | ✅ | Quoted text for display |
+| `locatorVersion` | string | ✅ | Locator computation version |
+| `extractorVersion` | string | ✅ | Extractor version |
+| `sourceOutputId` | string | ✅ | ID of the extraction output that produced this evidence |
+| `createdAt` | Timestamp | ✅ | Created at |
 
 ### `knowledgeReviews/{reviewId}`
 
-운영자가 검수하는 리뷰 엔트리.
+Review entries for operators.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | review ID |
-| `documentId` | string | ✅ | 관련 문서 ID |
-| `documentVersionId` | string | ✅ | 관련 version ID |
-| `jobId` | string |  | 관련 job ID |
-| `type` | `"document-batch" \| "merge" \| "low-confidence"` | ✅ | 리뷰 버킷 |
-| `status` | `"open" \| "approved" \| "rejected" \| "snoozed" \| "superseded"` | ✅ | 상태 |
-| `payload` | map | ✅ | 리뷰 대상 데이터 |
-| `assignedTo` | string |  | 담당 admin 이메일 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
-| `updatedAt` | Timestamp | ✅ | 수정일 |
+| `id` | string | ✅ | Review ID |
+| `documentId` | string | ✅ | Related document ID |
+| `documentVersionId` | string | ✅ | Related version ID |
+| `jobId` | string |  | Related job ID |
+| `type` | `"document-batch" \| "merge" \| "low-confidence"` | ✅ | Review bucket |
+| `status` | `"open" \| "approved" \| "rejected" \| "snoozed" \| "superseded"` | ✅ | Status |
+| `payload` | map | ✅ | Review target data |
+| `assignedTo` | string |  | Email of the assigned admin |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `updatedAt` | Timestamp | ✅ | Updated at |
 
 ### `knowledgeReviewEvents/{eventId}`
 
-review 감사 추적용 append-only 이벤트.
+Append-only events for review audit trails.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | event ID |
-| `reviewId` | string | ✅ | 대상 review ID |
-| `documentId` | string | ✅ | 관련 문서 ID |
-| `action` | string | ✅ | 예: `approve`, `reject`, `snooze`, `comment` |
-| `actor` | string | ✅ | 수행자 이메일 |
-| `fromStatus` | string |  | 이전 상태 |
-| `toStatus` | string | ✅ | 변경 후 상태 |
-| `decisionPayload` | map |  | 결정 세부 내용 |
-| `comment` | string |  | 운영 메모 |
-| `createdAt` | Timestamp | ✅ | 생성일 |
+| `id` | string | ✅ | Event ID |
+| `reviewId` | string | ✅ | Target review ID |
+| `documentId` | string | ✅ | Related document ID |
+| `action` | string | ✅ | e.g., `approve`, `reject`, `snooze`, `comment` |
+| `actor` | string | ✅ | Actor email |
+| `fromStatus` | string |  | Previous status |
+| `toStatus` | string | ✅ | New status |
+| `decisionPayload` | map |  | Decision details |
+| `comment` | string |  | Operations note |
+| `createdAt` | Timestamp | ✅ | Created at |
 
 ### `knowledgeApprovalEvents/{eventId}`
 
-approved graph 변경 이력.
+Change history for the approved graph.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | event ID |
-| `entityType` | `"node" \| "edge"` | ✅ | 대상 유형 |
-| `entityId` | string | ✅ | 대상 canonical ID |
-| `reviewId` | string |  | 근거 review ID |
-| `before` | map |  | 변경 전 스냅샷 |
-| `after` | map | ✅ | 변경 후 스냅샷 |
-| `approvedBy` | string | ✅ | 승인자 이메일 |
-| `approvedAt` | Timestamp | ✅ | 승인 시각 |
-| `revertsEventId` | string |  | 롤백 대상 event ID |
+| `id` | string | ✅ | Event ID |
+| `entityType` | `"node" \| "edge"` | ✅ | Target type |
+| `entityId` | string | ✅ | Target canonical ID |
+| `reviewId` | string |  | Source review ID |
+| `before` | map |  | Snapshot before the change |
+| `after` | map | ✅ | Snapshot after the change |
+| `approvedBy` | string | ✅ | Approver email |
+| `approvedAt` | Timestamp | ✅ | Approval time |
+| `revertsEventId` | string |  | ID of the event being rolled back |
 
 ### `knowledgeApprovedNodes/{nodeId}`
 
-knowledge canonical node store. admin-private이며 publish의 입력이다.
+Knowledge canonical node store. Admin-private and the input to publish.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | node ID. ontology 추출의 경우 `<kind>:<frontmatterId>` 형식 (id-resolution.md §1) |
-| `title` | string | ✅ | canonical 제목 |
-| `kind` | string | ✅ | node kind. `ontologyClasses` 의 합법 값. `unknown` = stub placeholder |
-| `projectIds` | string[] | ✅ | 연결 프로젝트. stub 은 빈 배열 |
-| `parentId` | string |  | canonical hierarchy parent |
-| `summary` | string |  | 내부 요약 |
-| `evidenceIds` | string[] | ✅ | 승인 근거 식별자 목록 |
-| `currentRevisionId` | string |  | 최근 approval event ID |
-| `lastApprovedAt` | Timestamp | ✅ | 최근 승인 시점 |
-| `lastApprovedBy` | string | ✅ | 최근 승인 admin 이메일 |
-| `isStub` | boolean |  | true 면 placeholder. 검수 큐가 별도 섹션에 노출 (id-resolution.md §2) |
-| `pendingType` | string |  | stub 일 때 frontmatter 가 명시한 edge type. promote 시 edge 복원에 사용 |
-| `pendingFromId` | string |  | stub 일 때 promote 시 복원할 source canonical ID |
-| `source` | `"manual" \| "extraction"` |  | 출처. legacy 데이터는 `undefined` (UI 가 `extraction` 으로 처리). manual editor v0 (B 라인) 부터 사용자 직접 작성 = `"manual"` |
-| `manualAuthor` | string |  | `source === "manual"` 시 작성자 uid. Firestore rules 가 author 본인만 update/delete 허용 |
-| `manualNote` | string |  | `source === "manual"` 시 작성자 자유 메모 (옵션) |
-| `tboxVersionId` | string |  | (P1 Phase 1) 이 노드 생성·검수 시점의 활성 TBox version ID (`ontologyTBoxVersions/{versionId}`). legacy = undefined → loader 가 `legacy-v0` 으로 처리 |
+| `id` | string | ✅ | Node ID. For ontology extraction, the format is `<kind>:<frontmatterId>` (id-resolution.md §1) |
+| `title` | string | ✅ | Canonical title |
+| `kind` | string | ✅ | Node kind. Legal value from `ontologyClasses`. `unknown` = stub placeholder |
+| `projectIds` | string[] | ✅ | Linked projects. Stubs are an empty array |
+| `parentId` | string |  | Canonical hierarchy parent |
+| `summary` | string |  | Internal summary |
+| `evidenceIds` | string[] | ✅ | List of identifiers backing the approval |
+| `currentRevisionId` | string |  | Most recent approval event ID |
+| `lastApprovedAt` | Timestamp | ✅ | Time of the most recent approval |
+| `lastApprovedBy` | string | ✅ | Email of the most recent approving admin |
+| `isStub` | boolean |  | When true, a placeholder. Surfaced separately in the review queue (id-resolution.md §2) |
+| `pendingType` | string |  | When stub, the edge type declared in frontmatter; used to restore the edge on promote |
+| `pendingFromId` | string |  | When stub, the source canonical ID to restore on promote |
+| `source` | `"manual" \| "extraction"` |  | Origin. Legacy data is `undefined` (the UI treats it as `extraction`). Manual editor v0 (B-line) onward, user-authored = `"manual"` |
+| `manualAuthor` | string |  | When `source === "manual"`, the author's uid. Firestore rules allow update/delete only by the author |
+| `manualNote` | string |  | When `source === "manual"`, an optional free-form note from the author |
+| `tboxVersionId` | string |  | (P1 Phase 1) Active TBox version ID at the time this node was created/reviewed (`ontologyTBoxVersions/{versionId}`). Legacy = undefined → loader treats as `legacy-v0` |
 
 ### `knowledgeApprovedEdges/{edgeId}`
 
-knowledge canonical edge store. admin-private이며 publish의 입력이다.
+Knowledge canonical edge store. Admin-private and the input to publish.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | edge ID |
-| `from` | string | ✅ | source node ID |
-| `to` | string | ✅ | target node ID |
-| `type` | `"contains" \| "belongs_to" \| "depends_on" \| "implements" \| "uses" \| "describes" \| "related_to"` | ✅ | 관계 타입. ontology TBox `ontologyRelations` 7 종과 일치. 카테고리: `contains`/`belongs_to`=structure, `depends_on`/`implements`/`uses`=behavior, `describes`=evidence, `related_to`=weak. 합법 값은 `ontologyRelations` 컬렉션에서 진리값. |
-| `projectIds` | string[] | ✅ | 연결 프로젝트 |
-| `evidenceIds` | string[] | ✅ | 승인 근거 식별자 목록 |
-| `currentRevisionId` | string |  | 최근 approval event ID |
-| `lastApprovedAt` | Timestamp | ✅ | 최근 승인 시점 |
-| `lastApprovedBy` | string | ✅ | 최근 승인 admin 이메일 |
-| `source` | `"manual" \| "extraction"` |  | node 와 동일 의미 (manual editor v0) |
-| `manualAuthor` | string |  | `source === "manual"` 시 작성자 uid |
-| `manualNote` | string |  | `source === "manual"` 시 작성자 자유 메모 |
-| `tboxVersionId` | string |  | (P1 Phase 1) 이 엣지 생성·검수 시점의 활성 TBox version ID. legacy = undefined |
-| `qualifiers` | `Array<{propertyId: string; value: QualifierValue}>` |  | **V1.1 (PR #10)** Wikidata 영감 statement 한정자. additive, breakage 0. legacy = undefined. `QualifierValue` union: `{kind:'string', raw}` / `{kind:'time', iso, precision}` / `{kind:'quantity', value, unit?}` / `{kind:'nodeRef', nodeId}`. |
-| `rank` | `"preferred" \| "normal" \| "deprecated"` |  | **V1.1 (PR #10)** 같은 (from, to, type) 의 다중 statement 우선순위. legacy = undefined → `rank ?? 'normal'` 폴백. |
+| `id` | string | ✅ | Edge ID |
+| `from` | string | ✅ | Source node ID |
+| `to` | string | ✅ | Target node ID |
+| `type` | `"contains" \| "belongs_to" \| "depends_on" \| "implements" \| "uses" \| "describes" \| "related_to"` | ✅ | Relation type. Aligned with the 7 entries of the ontology TBox `ontologyRelations`. Categories: `contains`/`belongs_to` = structure, `depends_on`/`implements`/`uses` = behavior, `describes` = evidence, `related_to` = weak. The source of truth for legal values is the `ontologyRelations` collection. |
+| `projectIds` | string[] | ✅ | Linked projects |
+| `evidenceIds` | string[] | ✅ | List of identifiers backing the approval |
+| `currentRevisionId` | string |  | Most recent approval event ID |
+| `lastApprovedAt` | Timestamp | ✅ | Time of the most recent approval |
+| `lastApprovedBy` | string | ✅ | Email of the most recent approving admin |
+| `source` | `"manual" \| "extraction"` |  | Same meaning as on nodes (manual editor v0) |
+| `manualAuthor` | string |  | When `source === "manual"`, the author's uid |
+| `manualNote` | string |  | When `source === "manual"`, an optional free-form note from the author |
+| `tboxVersionId` | string |  | (P1 Phase 1) Active TBox version ID at the time this edge was created/reviewed. Legacy = undefined |
+| `qualifiers` | `Array<{propertyId: string; value: QualifierValue}>` |  | **V1.1 (PR #10)** Wikidata-inspired statement qualifiers. Additive, zero breakage. Legacy = undefined. `QualifierValue` union: `{kind:'string', raw}` / `{kind:'time', iso, precision}` / `{kind:'quantity', value, unit?}` / `{kind:'nodeRef', nodeId}`. |
+| `rank` | `"preferred" \| "normal" \| "deprecated"` |  | **V1.1 (PR #10)** Priority among multiple statements with the same (from, to, type). Legacy = undefined → falls back to `rank ?? 'normal'`. |
 
 ### `knowledgePublishes/{publishId}`
 
-public projection publish 실행 이력.
+Execution history of public projection publishes.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | publish ID |
-| `status` | `"running" \| "succeeded" \| "failed" \| "rolled-back"` | ✅ | publish 상태 |
-| `initiatedBy` | string | ✅ | 실행 요청자 |
-| `startedAt` | Timestamp | ✅ | 시작 시각 |
-| `completedAt` | Timestamp |  | 완료 시각 |
-| `sourceApprovedRevision` | string | ✅ | 기준 canonical revision 또는 snapshot ID |
-| `nodeCount` | number |  | 반영 node 수 |
-| `edgeCount` | number |  | 반영 edge 수 |
-| `projectionVersion` | string | ✅ | projection schema 버전 |
-| `errorCode` | string |  | 실패 코드 |
-| `errorMessage` | string |  | 실패 메시지 |
-| `rollbackOfPublishId` | string |  | 롤백 대상 publish ID |
+| `id` | string | ✅ | Publish ID |
+| `status` | `"running" \| "succeeded" \| "failed" \| "rolled-back"` | ✅ | Publish status |
+| `initiatedBy` | string | ✅ | Initiator |
+| `startedAt` | Timestamp | ✅ | Start time |
+| `completedAt` | Timestamp |  | Completion time |
+| `sourceApprovedRevision` | string | ✅ | Reference canonical revision or snapshot ID |
+| `nodeCount` | number |  | Number of applied nodes |
+| `edgeCount` | number |  | Number of applied edges |
+| `projectionVersion` | string | ✅ | Projection schema version |
+| `errorCode` | string |  | Failure code |
+| `errorMessage` | string |  | Failure message |
+| `rollbackOfPublishId` | string |  | ID of the publish being rolled back |
 
 ### `knowledgePublicNodes/{nodeId}`
 
-공개용 projection node.
+Public projection node.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | node ID |
-| `title` | string | ✅ | 공개 제목 |
-| `kind` | string | ✅ | 공개 kind |
-| `projectIds` | string[] | ✅ | 연결 프로젝트 |
-| `parentId` | string |  | 공개용 계층 parent |
-| `summary` | string |  | 공개 요약 |
-| `evidenceCount` | number | ✅ | 공개 근거 수 |
-| `publishId` | string | ✅ | 생성한 publish ID |
-| `projectionVersion` | string | ✅ | projection schema 버전 |
-| `publishedAt` | Timestamp | ✅ | publish 반영 시각 |
-| `lastApprovedAt` | Timestamp | ✅ | 승인 반영 시점 |
+| `id` | string | ✅ | Node ID |
+| `title` | string | ✅ | Public title |
+| `kind` | string | ✅ | Public kind |
+| `projectIds` | string[] | ✅ | Linked projects |
+| `parentId` | string |  | Public hierarchy parent |
+| `summary` | string |  | Public summary |
+| `evidenceCount` | number | ✅ | Number of public evidence items |
+| `publishId` | string | ✅ | ID of the publish that produced this node |
+| `projectionVersion` | string | ✅ | Projection schema version |
+| `publishedAt` | Timestamp | ✅ | Time the publish was applied |
+| `lastApprovedAt` | Timestamp | ✅ | Time the approval was applied |
 
 ### `knowledgePublicEdges/{edgeId}`
 
-공개용 projection edge.
+Public projection edge.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | edge ID |
-| `from` | string | ✅ | source node ID |
-| `to` | string | ✅ | target node ID |
-| `type` | string | ✅ | 공개 관계 타입 |
-| `projectIds` | string[] | ✅ | 연결 프로젝트 |
-| `publishId` | string | ✅ | 생성한 publish ID |
-| `projectionVersion` | string | ✅ | projection schema 버전 |
-| `publishedAt` | Timestamp | ✅ | publish 반영 시각 |
-| `lastApprovedAt` | Timestamp | ✅ | 승인 반영 시점 |
+| `id` | string | ✅ | Edge ID |
+| `from` | string | ✅ | Source node ID |
+| `to` | string | ✅ | Target node ID |
+| `type` | string | ✅ | Public relation type |
+| `projectIds` | string[] | ✅ | Linked projects |
+| `publishId` | string | ✅ | ID of the publish that produced this edge |
+| `projectionVersion` | string | ✅ | Projection schema version |
+| `publishedAt` | Timestamp | ✅ | Time the publish was applied |
+| `lastApprovedAt` | Timestamp | ✅ | Time the approval was applied |
 
 ### `knowledgePublicMeta/current`
 
-현재 공개 projection pointer 문서.
+Pointer document for the currently public projection.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `currentPublishId` | string | ✅ | 현재 공개 snapshot publish ID |
-| `publishedAt` | Timestamp | ✅ | pointer 전환 시각 |
-| `projectionVersion` | string | ✅ | projection schema 버전 |
+| `currentPublishId` | string | ✅ | ID of the currently public snapshot publish |
+| `publishedAt` | Timestamp | ✅ | Pointer cutover time |
+| `projectionVersion` | string | ✅ | Projection schema version |
 
 ### `ontologyClasses/{classId}`
 
-ontology TBox — 노드 클래스 정의. `knowledgeApprovedNodes.kind` 의 합법 값 + 의미 메타. admin write, public read (공개 surface 가 클래스 라벨을 표시하기 위함).
+Ontology TBox — node class definitions. Legal values for `knowledgeApprovedNodes.kind` plus semantic metadata. Admin write, public read (so that public surfaces can display class labels).
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | class ID. kebab-case (예: `project`, `domain`, `capability`, `element`, `document`) |
-| `name` | string | ✅ | display name (한글 OK) |
-| `description` | string |  | 클래스가 무엇을 표현하는지 |
-| `parentClassId` | string |  | 상위 클래스 ID. 클래스 계층을 표현 (예: `element` < `capability`). 없으면 root |
-| `elementType` | string |  | `id` 가 `element` 인 경우 세부 분류 (`service` / `api` / `agent` / `workflow` / `schema` / `data-store` / `ui` / `prompt` / `integration`). 다른 클래스에는 사용 안 함 |
-| `version` | number | ✅ | TBox 버전 — schema 변경 추적용 |
-| `createdAt` | Timestamp | ✅ | 생성 시각 |
-| `createdBy` | string | ✅ | 생성자 이메일 또는 `system` |
-| `updatedAt` | Timestamp |  | 마지막 수정 시각 |
+| `id` | string | ✅ | Class ID. kebab-case (e.g., `project`, `domain`, `capability`, `element`, `document`) |
+| `name` | string | ✅ | Display name (Korean OK) |
+| `description` | string |  | What the class represents |
+| `parentClassId` | string |  | Parent class ID. Expresses the class hierarchy (e.g., `element` < `capability`). None means root |
+| `elementType` | string |  | Sub-classification when `id` is `element` (`service` / `api` / `agent` / `workflow` / `schema` / `data-store` / `ui` / `prompt` / `integration`). Not used for other classes |
+| `version` | number | ✅ | TBox version, used to track schema changes |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `createdBy` | string | ✅ | Creator email or `system` |
+| `updatedAt` | Timestamp |  | Last updated at |
 
-C-1 시드 (T-1):
+C-1 seed (T-1):
 
-| `id` | `name` | `parentClassId` | 비고 |
+| `id` | `name` | `parentClassId` | Notes |
 | --- | --- | --- | --- |
-| `project` | 프로젝트 | (root) | 외부에 드러나는 제품/시스템/이니셔티브 |
-| `domain` | 도메인 | (root) | 프로젝트 안의 큰 문제 영역 |
-| `capability` | 역량 | (root) | 도메인이 제공하는 기능적 능력 |
-| `element` | 요소 | (root) | 실제 구현체·자산·인터페이스·데이터 구조 (`elementType` 으로 세분화) |
-| `document` | 문서 | (root) | 근거 노드. 계층 트리에 매달지 않고 `describes` 관계로 연결 |
-| `unknown` | 미지 | (root) | stub placeholder — frontmatter `relates.target` 미존재 시 자동 생성. 검수 큐에서 promote/dismiss (id-resolution.md §2) |
+| `project` | 프로젝트 | (root) | Externally visible product/system/initiative |
+| `domain` | 도메인 | (root) | A large problem area within a project |
+| `capability` | 역량 | (root) | Functional ability provided by a domain |
+| `element` | 요소 | (root) | Actual implementation/asset/interface/data structure (sub-classified via `elementType`) |
+| `document` | 문서 | (root) | Evidence node. Not attached to the hierarchy tree; connected via `describes` |
+| `unknown` | 미지 | (root) | Stub placeholder — auto-created when frontmatter `relates.target` does not exist. Promoted/dismissed from the review queue (id-resolution.md §2) |
 
 ### `ontologyRelations/{relationId}`
 
-ontology TBox — 관계 타입 정의. `knowledgeApprovedEdges.type` 의 합법 값 + 제약. admin write, public read.
+Ontology TBox — relation type definitions. Legal values for `knowledgeApprovedEdges.type` plus constraints. Admin write, public read.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | ✅ | relation ID (예: `depends_on`) |
-| `name` | string | ✅ | display name (한글 OK) |
-| `inverseName` | string |  | 역방향 표시명 (예: `depended-on-by`) |
-| `description` | string |  | 관계의 의미 |
-| `sourceClassIds` | string[] | ✅ | source 로 허용되는 class ID 목록 (TBox 제약). 빈 배열 = 모든 클래스 허용 |
-| `targetClassIds` | string[] | ✅ | target 으로 허용되는 class ID 목록 |
-| `category` | `"structure" \| "behavior" \| "evidence" \| "weak"` | ✅ | 관계 카테고리. `structure` = 구조 관계 (`contains`, `belongs_to`), `behavior` = 동작 관계 (`depends_on`, `implements`, `uses`), `evidence` = 근거 관계 (`describes`), `weak` = 약 연관 (`related_to`) |
-| `symmetric` | boolean | ✅ | A→B 가 B→A 와 동치인가 (예: `related_to` 는 true, `depends_on` 은 false) |
-| `transitive` | boolean | ✅ | A→B + B→C ⇒ A→C 가 성립하는가 (예: `contains` 는 true, `uses` 는 false) |
-| `version` | number | ✅ | TBox 버전 |
-| `createdAt` | Timestamp | ✅ | 생성 시각 |
-| `createdBy` | string | ✅ | 생성자 이메일 또는 `system` |
-| `updatedAt` | Timestamp |  | 마지막 수정 시각 |
+| `id` | string | ✅ | Relation ID (e.g., `depends_on`) |
+| `name` | string | ✅ | Display name (Korean OK) |
+| `inverseName` | string |  | Reverse-direction display name (e.g., `depended-on-by`) |
+| `description` | string |  | Meaning of the relation |
+| `sourceClassIds` | string[] | ✅ | Class IDs allowed as the source (TBox constraint). Empty array = all classes allowed |
+| `targetClassIds` | string[] | ✅ | Class IDs allowed as the target |
+| `category` | `"structure" \| "behavior" \| "evidence" \| "weak"` | ✅ | Relation category. `structure` = structural relations (`contains`, `belongs_to`), `behavior` = behavioral relations (`depends_on`, `implements`, `uses`), `evidence` = evidence relation (`describes`), `weak` = weak association (`related_to`) |
+| `symmetric` | boolean | ✅ | Whether A→B is equivalent to B→A (e.g., `related_to` is true, `depends_on` is false) |
+| `transitive` | boolean | ✅ | Whether A→B + B→C ⇒ A→C holds (e.g., `contains` is true, `uses` is false) |
+| `version` | number | ✅ | TBox version |
+| `createdAt` | Timestamp | ✅ | Created at |
+| `createdBy` | string | ✅ | Creator email or `system` |
+| `updatedAt` | Timestamp |  | Last updated at |
 
-C-1 시드 (T-1, 7 종):
+C-1 seed (T-1, 7 entries):
 
 | `id` | `name` | `category` | `sourceClassIds` | `targetClassIds` | `symmetric` | `transitive` |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -506,40 +506,40 @@ C-1 시드 (T-1, 7 종):
 | `implements` | 구현 | behavior | `element` | `capability` | false | false |
 | `uses` | 사용 | behavior | `element`, `capability` | `element` | false | false |
 | `describes` | 설명 | evidence | `document` | `project`, `domain`, `capability`, `element` | false | false |
-| `related_to` | 연관 | weak | `[]` (모든 클래스) | `[]` | true | false |
+| `related_to` | 연관 | weak | `[]` (all classes) | `[]` | true | false |
 
-> 주의: `knowledgeApprovedEdges.type` enum 은 T-2 에서 5 → 7 종으로 확장된다. T-1 시드만으로는 데이터 정합성을 강제할 수 없으니 T-2 와 함께 적용해야 의미 있다.
+> Note: the `knowledgeApprovedEdges.type` enum is expanded from 5 → 7 in T-2. The T-1 seed alone cannot enforce data integrity; it becomes meaningful only when applied alongside T-2.
 
 ### `ontologyTBoxVersions/{versionId}`
 
-(P1 Phase 1) 한 시점의 TBox snapshot. `ontologyClasses` / `ontologyRelations` (활성, mutable) 가 변경될 때마다 immutable copy 를 박는다. fact node/edge 가 어느 시점 schema 로 만들어졌는지 추적해 audit trail + 추출 결과 재현 보존.
+(P1 Phase 1) Point-in-time TBox snapshot. Whenever `ontologyClasses` / `ontologyRelations` (active, mutable) change, an immutable copy is taken. This tracks which schema version a fact node/edge was created against, preserving the audit trail and the ability to reproduce extraction results.
 
-read = 인증 사용자, create = 인증 사용자 (createdBy 가 자기 uid 일치), update/delete 차단.
+read = authenticated users, create = authenticated users (createdBy must equal their own uid), update/delete blocked.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `versionId` | string | ✅ | doc ID. `v1` / `v2` / ... 또는 ISO timestamp. 형식 자유 — 정렬은 `createdAt` 기준 |
-| `classes` | object[] | ✅ | snapshot 시점 클래스 정의 배열. 각 항목은 `ontologyClasses` doc 와 동일 schema |
-| `relations` | object[] | ✅ | snapshot 시점 관계 정의 배열. 각 항목은 `ontologyRelations` doc 와 동일 schema |
-| `changeNote` | string |  | 사람이 읽는 변경 요약 (예: "concept 클래스 추가") |
-| `createdAt` | Timestamp | ✅ | snapshot 시각 |
-| `createdBy` | string | ✅ | 생성자 uid |
+| `versionId` | string | ✅ | Doc ID. `v1` / `v2` / ... or an ISO timestamp. Format is free-form — sorting is by `createdAt` |
+| `classes` | object[] | ✅ | Array of class definitions at snapshot time. Each entry has the same schema as an `ontologyClasses` doc |
+| `relations` | object[] | ✅ | Array of relation definitions at snapshot time. Each entry has the same schema as an `ontologyRelations` doc |
+| `changeNote` | string |  | Human-readable change summary (e.g., "added concept class") |
+| `createdAt` | Timestamp | ✅ | Snapshot time |
+| `createdBy` | string | ✅ | Creator uid |
 
 ### `ontologyTBoxState/current`
 
-(P1 Phase 1) 활성 TBox version 포인터. single-user 모드에선 `current` 단일 doc. 새 version 활성화는 `setDoc` 으로 swap — `ontologyTBoxVersions/{versionId}` 가 존재해야 의미 있음.
+(P1 Phase 1) Active TBox version pointer. In single-user mode this is a single doc named `current`. Activating a new version is done by `setDoc` swap — the corresponding `ontologyTBoxVersions/{versionId}` must already exist for it to be meaningful.
 
-read = 인증 사용자, create/update = 인증 사용자 (activatedBy 가 자기 uid 일치), delete 차단.
+read = authenticated users, create/update = authenticated users (activatedBy must equal their own uid), delete blocked.
 
-| 필드 | 타입 | 필수 | 설명 |
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `versionId` | string | ✅ | 현재 활성 version. `ontologyTBoxVersions/{versionId}` 에 존재해야 함 |
-| `activatedAt` | Timestamp | ✅ | 활성화 시각 |
-| `activatedBy` | string | ✅ | 활성화한 uid |
+| `versionId` | string | ✅ | Currently active version. Must exist in `ontologyTBoxVersions/{versionId}` |
+| `activatedAt` | Timestamp | ✅ | Activation time |
+| `activatedBy` | string | ✅ | uid of the activator |
 
-> Phase 1 = 데이터 모델 + rules 토대만. UI (`/settings/ontology`) 는 Phase 2 에서. fact node 의 `tboxVersionId` writer 도 Phase 2 (UI 가 활성 versionId 구독해서 manual create 시 박는 흐름).
+> Phase 1 = data model + rules foundation only. The UI (`/settings/ontology`) lands in Phase 2. The `tboxVersionId` writer for fact nodes also lands in Phase 2 (the UI subscribes to the active versionId and stamps it on manual create).
 
-## 5. Storage 구조
+## 5. Storage layout
 
 ```text
 storage/
@@ -552,11 +552,11 @@ storage/
         └── {versionId}.md
 ```
 
-`knowledge-documents/*`는 append-only 원문 저장 경로로 사용한다 (`storage.rules` 참조).
+`knowledge-documents/*` is used as an append-only path for source-text storage (see `storage.rules`).
 
-## 6. Trusted backend 계약
+## 6. Trusted backend contract
 
-knowledge subsystem에서 아래 데이터는 trusted backend가 소유한다.
+Within the knowledge subsystem, the following data is owned by the trusted backend.
 
 - `knowledgeDocumentChunks`
 - `knowledgeEvidence`
@@ -569,33 +569,33 @@ knowledge subsystem에서 아래 데이터는 trusted backend가 소유한다.
 - `knowledgePublicNodes`
 - `knowledgePublicEdges`
 
-실행 경계는 **Cloud Functions for Firebase (2nd gen)** 또는 동급의 Firebase Admin SDK 기반 executor로 둔다.
+The execution boundary is **Cloud Functions for Firebase (2nd gen)** or an equivalent Firebase Admin SDK–based executor.
 
-브라우저 클라이언트는 이 컬렉션들에 직접 쓰지 않는다.
+Browser clients do not write to these collections directly.
 
-## 7. Security 요약
+## 7. Security summary
 
 - `projects`, `categories`, `statuses`, `meta`, `knowledgePublicMeta`, `knowledgePublicNodes`, `knowledgePublicEdges`:
-  - 공개 읽기
+  - Public read
 - `admins`:
-  - 본인 문서만 읽기, 쓰기 금지
+  - Read own document only; no writes
 - `knowledgeDocuments`, `knowledgeDocumentVersions`, `knowledgeReviews`:
-  - admin 읽기/쓰기
+  - Admin read/write
 - `knowledgeExtractionJobs`:
-  - admin 읽기, 브라우저 직접 쓰기 금지
+  - Admin read; no direct browser writes
 - `knowledgeDocumentChunks`, `knowledgeEvidence`, `knowledgeExtractionOutputs`, `knowledgeReviewEvents`, `knowledgeApprovalEvents`, `knowledgeApprovedNodes`, `knowledgeApprovedEdges`, `knowledgePublishes`:
-  - admin 읽기, 클라이언트 쓰기 금지
+  - Admin read; no client writes
 - `knowledge-documents/*` Storage:
-  - admin 읽기/쓰기
+  - Admin read/write
 
-## 8. Retention / Backup 원칙
+## 8. Retention / Backup principles
 
 - `knowledgeDocumentVersions`, `knowledgeEvidence`, `knowledgeApprovalEvents`, `knowledgePublishes`:
-  - 기본 영구 보존
+  - Retained indefinitely by default
 - `knowledgeDocumentChunks`, `knowledgeExtractionOutputs`, `knowledgeExtractionJobs`, `knowledgeReviewEvents`:
-  - archive/export 정책을 둔 뒤 정리 가능
-- publish rollback은 logical rollback이고, 재해 복구는 Firestore/Storage 백업 복구로 분리한다.
+  - Eligible for cleanup once an archive/export policy is in place
+- Publish rollback is a logical rollback; disaster recovery is handled separately via Firestore/Storage backup restores.
 
-## 9. 변경 이력
+## 9. Change history
 
-`oh-my-ontology` 로 코드베이스가 새로 출발한 시점부터의 변경만 기록한다. 본격적인 changelog 는 첫 release 후 별도 운영.
+Records only changes from the point at which the codebase relaunched as `oh-my-ontology`. A proper changelog will be operated separately after the first release.

--- a/docs/DEPLOY-FIREBASE.md
+++ b/docs/DEPLOY-FIREBASE.md
@@ -1,73 +1,76 @@
-# Firebase Hosting 배포 가이드
+# Firebase Hosting deployment guide
 
-oh-my-ontology 의 hosted demo 는 Firebase Hosting (project:
-`oh-my-ontology`) 으로 정적 export 를 호스팅한다. Next.js
-`output: 'export'` 라 서버 런타임 없음 — 무료 Spark plan 으로 충분.
+The hosted demo for oh-my-ontology runs on Firebase Hosting (project:
+`oh-my-ontology`) and serves a static export. Since Next.js is configured with
+`output: 'export'`, there is no server runtime — the free Spark plan is more
+than enough.
 
-## 1회 setup (이미 완료된 항목)
+## One-time setup (already done)
 
-- [x] Firebase project `oh-my-ontology` 생성
-- [x] `.firebaserc` 의 `default: oh-my-ontology` 설정
-- [x] `firebase.json` 의 `hosting` 블록 — `public: out`, cleanUrls,
+- [x] Firebase project `oh-my-ontology` created
+- [x] `.firebaserc` configured with `default: oh-my-ontology`
+- [x] `hosting` block in `firebase.json` — `public: out`, cleanUrls,
       trailingSlash, security headers, project/** rewrite
 
-## 배포 명령
+## Deploy commands
 
 ```bash
-# 처음 한 번만
+# First time only
 npm install -g firebase-tools
 firebase login
 
-# 매 배포 시
+# Every deploy
 pnpm build                          # static export → out/
-firebase deploy --only hosting      # firebase.json 의 hosting 블록만 배포
+firebase deploy --only hosting      # deploy only the hosting block in firebase.json
 ```
 
-`predeploy` hook 이 `pnpm build` 를 자동 실행하므로
-`firebase deploy --only hosting` 만 쳐도 빌드부터 한다.
+The `predeploy` hook runs `pnpm build` automatically, so just running
+`firebase deploy --only hosting` will build first and then deploy.
 
-## 배포 url
+## Deployment URLs
 
 - Default: `https://oh-my-ontology.web.app`
 - Alt: `https://oh-my-ontology.firebaseapp.com`
-- Custom domain 원하면: Firebase 콘솔 → Hosting → Add custom domain
+- Want a custom domain? Firebase console → Hosting → Add custom domain
 
-## 배포 후 smoke 검증
+## Post-deploy smoke checks
 
 ```bash
-# 핵심 라우트 응답 확인
+# Check that the core routes respond
 for path in / /topology/ /docs/ /ontology/edit/ /ontology/insights/ /projects/; do
   curl -s -o /dev/null -w "%{http_code} %{size_download}b $path\n" \
     https://oh-my-ontology.web.app$path
 done
 ```
 
-기대: 모두 200, 크기 50KB+ (정상 HTML).
+Expected: all 200, size 50KB+ (healthy HTML).
 
-브라우저 spot-check:
-- `/` LandingPage 카피 + 로그인 링크
-- `/topology` Sigma 노드 (dogfood 1 project)
-- `/ontology/insights` "총 ~130 노드 / 165 관계"
-- DevTools Network: firebase JS chunk 가 user-facing 첫 paint 에 0KB
+Browser spot-check:
+- `/` LandingPage copy + sign-in link
+- `/topology` Sigma node (dogfood 1 project)
+- `/ontology/insights` "Total ~130 nodes / 165 relations"
+- DevTools Network: 0KB of firebase JS chunk on the user-facing first paint
 
-## 회귀 차단
+## Regression guard
 
-배포 전 `pnpm bundle:check` 통과 확인. local-first 라우트 11 개에
-firebase 청크 0KB 유지가 약속이다 (PR #99 의 핵심).
+Before deploying, make sure `pnpm bundle:check` passes. The promise is to keep
+the firebase chunk at 0KB on all 11 local-first routes (the core of PR #99).
 
-## 비용
+## Cost
 
-Firebase Hosting Spark plan = $0. 정적 export 는 cdn 캐시만 — 트래픽이
-GB/일 수준까지 무료. 그 이상은 Blaze plan (pay-as-you-go).
+Firebase Hosting Spark plan = $0. A static export only uses the CDN cache —
+free up to GB/day of traffic. Beyond that, switch to the Blaze plan
+(pay-as-you-go).
 
-## Firestore / Auth / Storage 도 같이 쓸 거면
+## If you also want Firestore / Auth / Storage
 
-mission v2 는 cloud 모드를 옵션으로 두지만, 사용자가 cloud sync 를
-실제로 쓸 경우:
+Mission v2 treats cloud mode as optional, but if a user actually relies on
+cloud sync:
 
 ```bash
 firebase deploy --only hosting,firestore,storage
 ```
 
-`firestore.rules` / `storage.rules` 가 이미 repo 에 있어 함께 배포된다.
-Functions 는 mission v2 가 폐기 → `functions/` 디렉토리 자체 없음.
+`firestore.rules` and `storage.rules` are already in the repo and ship together
+with the deploy. Functions are deprecated under mission v2 — the `functions/`
+directory no longer exists.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,266 +1,266 @@
 # Deployment Guide
 
-> Firebase Hosting 기반 정적 배포 가이드. **Live**: https://
+> Static deployment guide based on Firebase Hosting. **Live**: https://
 >
-> 이 문서는 Firebase에 배포할 때 필요한 모든 단계를 한 곳에 모아놓은 체크리스트다. 처음 세팅하는 경우부터 일상 배포, 롤백, 커스텀 도메인까지 커버한다.
+> This document is a single-place checklist of every step you need when deploying to Firebase. It covers everything from first-time setup to daily deploys, rollbacks, and custom domains.
 >
-> **운영 정책 (2026-05-01)**: 현재 user 정책상 firebase 배포 안 함. local-first vault + AI agent partner (MCP) 가 default 사용 흐름. 본 문서는 future-ref 로 보관 + emulator 로컬 테스트는 여전히 유효.
+> **Operating policy (2026-05-01)**: Per current user policy, we do not deploy to Firebase. The local-first vault + AI agent partner (MCP) is the default usage flow. This document is kept for future reference, and emulator-based local testing remains valid.
 
-## 목차
+## Table of contents
 
-1. [최초 세팅 (한 번만)](#1-최초-세팅-한-번만)
-2. [일상 배포 플로우](#2-일상-배포-플로우)
-3. [부분 배포 (hosting만 / rules만)](#3-부분-배포)
-4. [환경변수](#4-환경변수)
-5. [Firebase 프로젝트 구성](#5-firebase-프로젝트-구성)
-6. [커스텀 도메인 연결](#6-커스텀-도메인-연결)
-7. [롤백 · 버전 관리](#7-롤백--버전-관리)
-8. [배포 전 체크리스트](#8-배포-전-체크리스트)
-9. [트러블슈팅](#9-트러블슈팅)
+1. [Initial setup (one-time)](#1-initial-setup-one-time)
+2. [Daily deploy flow](#2-daily-deploy-flow)
+3. [Partial deploys (hosting only / rules only)](#3-partial-deploys-hosting-only--rules-only)
+4. [Environment variables](#4-environment-variables)
+5. [Firebase project configuration](#5-firebase-project-configuration)
+6. [Custom domain hookup](#6-custom-domain-hookup)
+7. [Rollback and version management](#7-rollback-and-version-management)
+8. [Pre-deploy checklist](#8-pre-deploy-checklist)
+9. [Troubleshooting](#9-troubleshooting)
 
 ---
 
-## 1. 최초 세팅 (한 번만)
+## 1. Initial setup (one-time)
 
 ```bash
-# 1. Firebase CLI 설치 (전역)
+# 1. Install the Firebase CLI (global)
 pnpm add -g firebase-tools
 
-# 2. Google 계정으로 로그인
+# 2. Sign in with your Google account
 firebase login
 
-# 3. 프로젝트 연결 (이 repo에선 이미 .firebaserc에 기록되어 있음)
+# 3. Connect to the project (this repo already records it in .firebaserc)
 firebase use oh-my-ontology
 
-# 4. 접근 권한 확인
+# 4. Verify access
 firebase projects:list
 ```
 
-**`.env.local` 파일 생성** — `.env.example`을 복사해 실제 값 입력:
+**Create the `.env.local` file** — copy `.env.example` and fill in the real values:
 
 ```bash
 cp .env.example .env.local
-# 편집기로 열어서 Firebase Console → 프로젝트 설정 → 일반 → 내 앱의 값 붙여넣기
+# Open it in your editor and paste the values from Firebase Console → Project settings → General → Your apps
 ```
 
-**Google 로그인 도메인 허용** — Firebase Console → Authentication → Settings → Authorized domains:
-- `localhost` (개발)
-- `` (기본)
-- `oh-my-ontology.firebaseapp.com` (대체 도메인)
-- 커스텀 도메인 (있다면)
+**Allow Google sign-in domains** — Firebase Console → Authentication → Settings → Authorized domains:
+- `localhost` (development)
+- `` (default)
+- `oh-my-ontology.firebaseapp.com` (alternate domain)
+- Custom domain (if any)
 
-**admin 화이트리스트 등록** — Firebase Console → Firestore → `admins` 컬렉션:
-- 문서 ID: 이메일 (예: `you@example.com`)
-- 문서 내용은 비워도 됨 (존재 여부만 체크)
+**Register the admin allowlist** — Firebase Console → Firestore → `admins` collection:
+- Document ID: the email (e.g. `you@example.com`)
+- The document body can be empty (only existence is checked)
 
 ---
 
-## 2. 일상 배포 플로우
+## 2. Daily deploy flow
 
 ```bash
-# 1. 최신 main 받기
+# 1. Pull the latest main
 git checkout main
 git pull
 
-# 2. 검증
-pnpm tsc --noEmit           # 타입 체크
-pnpm lint                   # ESLint + FSD 경계 검증
-pnpm test:run               # 유닛 테스트
-pnpm build                  # 정적 빌드 → out/
+# 2. Verify
+pnpm tsc --noEmit           # type check
+pnpm lint                   # ESLint + FSD boundary checks
+pnpm test:run               # unit tests
+pnpm build                  # static build → out/
 
-# 3. 배포
-pnpm firebase deploy        # hosting + firestore.rules + storage.rules 전부
+# 3. Deploy
+pnpm firebase deploy        # hosting + firestore.rules + storage.rules — everything
 ```
 
-배포 완료 후 Firebase CLI가 호스팅 URL을 출력한다. 바로 확인.
+When the deploy finishes, the Firebase CLI prints the hosting URL. Open it right away and verify.
 
-> **Tip**: `firebase` 커맨드를 자주 친다면 전역 설치(`pnpm add -g firebase-tools`) 해두는 게 편함. 설치 안 했으면 `pnpm firebase ...`로 로컬 devDep 실행.
+> **Tip**: If you run `firebase` often, install it globally (`pnpm add -g firebase-tools`) for convenience. Without the global install, fall back to `pnpm firebase ...` to run the local devDep.
 
 ---
 
-## 3. 부분 배포
+## 3. Partial deploys
 
-전부 올릴 필요 없을 때:
+When you don't need to ship everything:
 
 ```bash
-# 호스팅만 (정적 파일만 바뀐 경우)
+# Hosting only (when only static files changed)
 pnpm firebase deploy --only hosting
 
-# Firestore 룰만 (보안 규칙 수정한 경우)
+# Firestore rules only (when security rules were edited)
 pnpm firebase deploy --only firestore:rules
 
-# Storage 룰만 (스크린샷 업로드 규칙 수정한 경우)
+# Storage rules only (when screenshot upload rules were edited)
 pnpm firebase deploy --only storage
 
-# hosting + storage 룰 둘 다
+# Both hosting and storage rules
 pnpm firebase deploy --only hosting,storage
 ```
 
-룰만 바뀐 경우 build 없이 바로 deploy 해도 된다 (hosting 대상이 아님).
+If only the rules changed, you can deploy directly without a build (hosting is not the target).
 
 ---
 
-## 4. 환경변수
+## 4. Environment variables
 
-`.env.local`에 다음이 모두 채워져야 한다:
+Every entry below must be filled in `.env.local`:
 
-| Key | 설명 |
+| Key | Description |
 |---|---|
 | `NEXT_PUBLIC_FIREBASE_API_KEY` | Web API Key |
 | `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | `xxx.firebaseapp.com` |
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | `oh-my-ontology` |
-| `ASLAN_BUILD_PROJECT_SOURCE` | 선택값. 기본값은 비워둔다. `firestore`로 설정하면 정적 빌드 중 Firestore REST에서 프로젝트 목록을 읽는다. |
+| `ASLAN_BUILD_PROJECT_SOURCE` | Optional. Leave empty by default. When set to `firestore`, the static build reads the project list from the Firestore REST API. |
 | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | `xxx.appspot.com` |
-| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | 숫자 |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | numeric |
 | `NEXT_PUBLIC_FIREBASE_APP_ID` | `1:xxx:web:xxx` |
 
-> Firebase Web `apiKey`는 공개 값이다. Git에 올려도 보안 위험 아님 (실제 보안은 Firestore Security Rules + admins 화이트리스트가 담당). 다만 `.env.local`은 `.gitignore`에 있어 로컬 전용이다.
+> The Firebase Web `apiKey` is a public value. Committing it to Git is not a security risk (real security is enforced by Firestore Security Rules + the admins allowlist). Even so, `.env.local` is in `.gitignore` and stays local-only.
 
-**빌드 시점에 주입됨** — `NEXT_PUBLIC_*` 접두사가 붙은 값만 클라이언트 번들에 포함된다. `.env.local` 수정 후엔 반드시 `pnpm build`를 다시 돌려야 새 값이 반영된다.
+**Injected at build time** — only values prefixed with `NEXT_PUBLIC_` are bundled into the client. After editing `.env.local`, you must rerun `pnpm build` for the new values to take effect.
 
 ---
 
-## 5. Firebase 프로젝트 구성
+## 5. Firebase project configuration
 
-- **프로젝트 ID**: `oh-my-ontology`
-- **Firestore 리전**: `asia-northeast3` (Seoul)
-- **Storage 리전**: `US-EAST1` (무료 티어)
-- **Auth Provider**: Google (`admins/{email}` 화이트리스트)
-- **Hosting**: 정적 파일 `out/` (Next.js `output: 'export'`)
+- **Project ID**: `oh-my-ontology`
+- **Firestore region**: `asia-northeast3` (Seoul)
+- **Storage region**: `US-EAST1` (free tier)
+- **Auth provider**: Google (`admins/{email}` allowlist)
+- **Hosting**: static files in `out/` (Next.js `output: 'export'`)
 
-### Firestore 컬렉션
+### Firestore collections
 
-| 컬렉션 | 쓰기 권한 |
+| Collection | Write permission |
 |---|---|
-| `projects` | admins 화이트리스트 |
-| `categories` | admins 화이트리스트 |
-| `statuses` | admins 화이트리스트 |
-| `admins` | **쓰기 완전 금지** — Firebase Console에서 수동 관리 |
+| `projects` | admins allowlist |
+| `categories` | admins allowlist |
+| `statuses` | admins allowlist |
+| `admins` | **all writes blocked** — managed manually in the Firebase Console |
 
-Security Rules 정의는 [`firestore.rules`](../firestore.rules), [`storage.rules`](../storage.rules) 참고.
+For the security rules definitions, see [`firestore.rules`](../firestore.rules) and [`storage.rules`](../storage.rules).
 
 ---
 
-## 6. 커스텀 도메인 연결
+## 6. Custom domain hookup
 
-### 준비물
+### Prerequisites
 
-- **도메인 소유권** — 레지스트라(가비아/Cloudflare/Namecheap 등)에서 구매해 DNS 관리 가능해야 함. Firebase는 도메인 판매 안 함.
-- Firebase Hosting 자체 · SSL 인증서는 무료.
+- **Domain ownership** — you must have purchased the domain from a registrar (Gabia / Cloudflare / Namecheap, etc.) and be able to manage its DNS. Firebase does not sell domains.
+- Firebase Hosting itself and the SSL certificate are free.
 
-### 연결 절차
+### Hookup steps
 
-1. **Firebase Console → Hosting → 커스텀 도메인 추가**
-2. 원하는 도메인 입력 (예: `map.demo.io` 또는 `demo.io`)
-3. Firebase가 소유권 검증용 `TXT` 레코드 제공 → 레지스트라 DNS에 추가
-4. Firebase가 검증 완료되면 최종 DNS 레코드를 제공:
-   - **서브도메인** (`map.demo.io`): `CNAME` 레코드 하나 추가하면 끝
+1. **Firebase Console → Hosting → Add custom domain**
+2. Enter the desired domain (e.g. `map.demo.io` or `demo.io`)
+3. Firebase provides a `TXT` record for ownership verification → add it to the DNS at your registrar
+4. Once Firebase finishes verification, it provides the final DNS records:
+   - **Subdomain** (`map.demo.io`): a single `CNAME` record is enough
      ```
      Type   Name   Value
      CNAME  map    
      ```
-   - **apex 도메인** (`demo.io`): `A` 레코드 2개 추가 (IPv4)
+   - **apex domain** (`demo.io`): two `A` records (IPv4)
      ```
      Type   Name   Value
      A      @      151.101.x.x
      A      @      151.101.y.y
      ```
-     (Firebase가 제공하는 실제 IP로 교체)
-5. DNS 전파 대기 (10분–24시간) → Firebase가 자동으로 Let's Encrypt SSL 발급
-6. 완료되면 `https://map.demo.io`로 접속 가능
+     (replace with the actual IPs Firebase gives you)
+5. Wait for DNS propagation (10 minutes to 24 hours) → Firebase automatically issues a Let's Encrypt SSL certificate
+6. Once it's done, you can reach the site at `https://map.demo.io`
 
-### 연결 후 반드시 할 일
+### What you must do after hookup
 
-- Firebase Console → **Authentication → Settings → Authorized domains**에 새 도메인 추가 (안 하면 Google 로그인 팝업에서 에러)
-- `src/app/layout.tsx`의 `SITE_URL` metadata 업데이트 (SEO · OpenGraph 때문에)
-- `.env.local`의 `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`은 `xxx.firebaseapp.com` 유지 — 커스텀 도메인으로 바꾸면 OAuth 리다이렉트 깨진다
+- Add the new domain under Firebase Console → **Authentication → Settings → Authorized domains** (otherwise the Google sign-in popup will throw an error)
+- Update the `SITE_URL` metadata in `src/app/layout.tsx` (for SEO and OpenGraph)
+- Keep `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` in `.env.local` set to `xxx.firebaseapp.com` — switching it to the custom domain breaks the OAuth redirect
 
-### apex 도메인 지원 여부
+### apex domain support
 
-`map.demo.io` 같은 서브도메인은 CNAME으로 간단히 되고, `demo.io` 같은 apex는 레지스트라가 **ALIAS/ANAME** 레코드를 지원해야 깔끔하게 된다. Cloudflare는 "CNAME flattening"으로 자동 지원. 가비아는 A 레코드만 되므로 Firebase가 제공하는 정적 IP를 써야 한다.
+A subdomain like `map.demo.io` is straightforward via CNAME. An apex like `demo.io` requires the registrar to support **ALIAS / ANAME** records to work cleanly. Cloudflare handles this automatically via "CNAME flattening". Gabia only supports `A` records, so you have to use the static IPs Firebase gives you.
 
 ---
 
-## 7. 롤백 · 버전 관리
+## 7. Rollback and version management
 
-Firebase Hosting은 배포 히스토리를 자동 보관한다.
+Firebase Hosting automatically retains deploy history.
 
 ```bash
-# 이전 릴리스 목록 확인
+# List previous releases
 pnpm firebase hosting:releases:list
 
-# 특정 버전으로 롤백 (Console에서도 클릭 한 번으로 가능)
+# Roll back to a specific version (also possible with one click in the Console)
 pnpm firebase hosting:rollback
 ```
 
-Firebase Console → Hosting → 릴리스 탭에서 타임라인·크기·작성자 확인 및 원클릭 롤백 가능. **배포 실수했을 때 가장 빠른 복구법**.
+Firebase Console → Hosting → Releases tab shows the timeline, size, and author, and supports one-click rollback. **The fastest recovery path when a deploy goes wrong**.
 
-Firestore/Storage 룰은 롤백 대상 아님 — Git에서 이전 버전 체크아웃 후 재배포.
+Firestore and Storage rules are not subject to rollback — check out the previous version from Git and redeploy.
 
 ---
 
-## 8. 배포 전 체크리스트
+## 8. Pre-deploy checklist
 
-- [ ] `git status` 깨끗한가? 커밋 안 된 변경 없나?
+- [ ] Is `git status` clean? Any uncommitted changes?
 - [ ] `pnpm tsc --noEmit` → 0 errors
-- [ ] `pnpm lint` → 0 errors (FSD 경계 포함)
+- [ ] `pnpm lint` → 0 errors (including FSD boundaries)
 - [ ] `pnpm test:run` → all passing
-- [ ] `pnpm build` → 성공 + `out/` 생성
-- [ ] 로컬에서 `pnpm dev`로 한 번 돌려봤나? (특히 UI 변경)
-- [ ] `firestore.rules` 변경했으면 Firestore Emulator로 테스트해봤나?
-- [ ] admin 기능 건드렸으면 실제 admin 계정으로 테스트해봤나?
-- [ ] CHANGELOG.md · 관련 docs 업데이트했나?
+- [ ] `pnpm build` → succeeded and `out/` produced
+- [ ] Did you run `pnpm dev` locally at least once? (especially for UI changes)
+- [ ] If `firestore.rules` changed, did you test it against the Firestore Emulator?
+- [ ] If you touched admin features, did you test with a real admin account?
+- [ ] Did you update CHANGELOG.md and the related docs?
 
 ---
 
-## 9. 트러블슈팅
+## 9. Troubleshooting
 
-**Q. 배포 후 빈 화면 또는 "아직 등록된 프로젝트가 없습니다"가 3초 이상 지속**
-- Firestore 초기 연결이 느릴 수 있음. 새로고침 후에도 지속되면 환경변수 확인.
-- Dev Console → Network 탭에서 Firestore 요청 실패(401/403) 여부 확인.
-- `.env.local`이 `pnpm build` 시점에 로드됐는지 확인 (`NEXT_PUBLIC_*`만 번들됨).
+**Q. After deploying, the screen is blank or "No projects registered yet" persists for more than 3 seconds**
+- The initial Firestore connection can be slow. If it persists after a refresh, check the env vars.
+- In Dev Console → Network tab, check whether Firestore requests fail with 401/403.
+- Confirm that `.env.local` was loaded at `pnpm build` time (only `NEXT_PUBLIC_*` is bundled).
 
-**Q. Google 로그인 팝업이 뜨지 않음 (운영 환경)**
-- Firebase Console → Authentication → Settings → **Authorized domains**에 현재 도메인 포함되어 있는지 확인.
-- Firebase가 기본 도메인은 자동 추가하지만 커스텀 도메인은 수동 등록 필요.
-- 팝업 차단기 끈 상태에서 테스트.
+**Q. The Google sign-in popup doesn't appear (production)**
+- Make sure the current domain is included under Firebase Console → Authentication → Settings → **Authorized domains**.
+- Firebase auto-adds the default domain, but custom domains must be registered manually.
+- Test with the popup blocker turned off.
 
-**Q. Google 로그인은 되는데 admin 접근 거부**
-- Firestore → `admins` 컬렉션에 해당 이메일 문서 있는지 확인. 문서 ID = 이메일이어야 함.
-- Firestore 리전 확인 — `asia-northeast3`가 맞는지.
+**Q. Google sign-in works, but admin access is denied**
+- Check whether the email document exists in Firestore → `admins` collection. The document ID must equal the email.
+- Verify the Firestore region — it should be `asia-northeast3`.
 
-**Q. 정적 빌드 실패 (`pnpm build`)**
-- `output: 'export'` 모드에서 서버 컴포넌트가 서버 전용 API를 사용하면 실패.
-- `shared/api/firebase.ts`는 lazy getter 패턴이라 빌드 시점엔 초기화 안 됨 (의도한 동작).
-- 기본 `pnpm build`는 `entities/project/api/build-time-fetch.ts`에서 seed/demo 데이터를 사용해 네트워크에 의존하지 않는다.
-- 운영 빌드에서 Firestore를 정적 페이지 source로 삼아야 하면 `ASLAN_BUILD_PROJECT_SOURCE=firestore`를 명시한다. 이 경우 Firestore 공개 읽기 권한과 `NEXT_PUBLIC_FIREBASE_PROJECT_ID`가 맞는지 확인.
+**Q. Static build fails (`pnpm build`)**
+- In `output: 'export'` mode, server components that use server-only APIs will fail.
+- `shared/api/firebase.ts` uses a lazy getter pattern, so it is not initialized at build time (intended behavior).
+- The default `pnpm build` uses seed/demo data in `entities/project/api/build-time-fetch.ts` and does not depend on the network.
+- If a production build needs Firestore as the source for static pages, set `ASLAN_BUILD_PROJECT_SOURCE=firestore` explicitly. In that case, verify Firestore public read permissions and that `NEXT_PUBLIC_FIREBASE_PROJECT_ID` is correct.
 
-**Q. `firebase deploy` 시 "HTTP Error: 403"**
-- `firebase login --reauth`로 재로그인.
-- `firebase projects:list`에 `oh-my-ontology`이 보이는지 확인 — 안 보이면 접근권한 없음.
-- 프로젝트 소유자에게 IAM 권한 요청 (Firebase Admin 또는 Hosting Admin 이상).
+**Q. `firebase deploy` returns "HTTP Error: 403"**
+- Re-authenticate with `firebase login --reauth`.
+- Check whether `oh-my-ontology` shows up in `firebase projects:list` — if not, you don't have access.
+- Ask the project owner for IAM permissions (Firebase Admin or Hosting Admin or higher).
 
-**Q. `firebase deploy --only hosting` 시 "No HTTP hosts found for site"**
-- `firebase.json`의 `hosting.public`이 `out`인지 확인.
-- `pnpm build`를 먼저 돌렸는지 확인 (`out/` 디렉토리가 있어야 함).
+**Q. `firebase deploy --only hosting` says "No HTTP hosts found for site"**
+- Verify `firebase.json` → `hosting.public` is `out`.
+- Verify you ran `pnpm build` first (the `out/` directory must exist).
 
-**Q. Storage 업로드 403 (스크린샷 업로드 실패)**
-- [`storage.rules`](../storage.rules) 확인 — admin 화이트리스트 체크 함수가 Firestore `admins` 컬렉션을 참조한다.
-- 로그인 세션 확인. 로그아웃 후 재로그인.
+**Q. Storage upload returns 403 (screenshot upload fails)**
+- Check [`storage.rules`](../storage.rules) — the admin allowlist check function references the Firestore `admins` collection.
+- Check the login session. Sign out and sign in again.
 
-**Q. Firestore 룰 변경이 안 먹음**
-- `pnpm firebase deploy --only firestore:rules`로 룰만 재배포했는지 확인.
-- Console → Firestore → 규칙 탭에서 최신 버전 타임스탬프 확인.
-- 에뮬레이터에서 테스트한 룰이 실제 파일과 싱크되어 있는지 확인.
+**Q. Firestore rules changes don't take effect**
+- Verify you redeployed only the rules with `pnpm firebase deploy --only firestore:rules`.
+- Check Console → Firestore → Rules tab for the latest version timestamp.
+- Make sure the rules you tested in the emulator are in sync with the actual file.
 
-**Q. 캐시가 너무 강해서 새 배포가 반영 안 됨**
-- `firebase.json`의 Cache-Control은 JS/CSS/폰트에 1년 immutable 설정 — 이건 파일명 해시 기반이라 정상.
-- HTML은 no-cache가 기본이라 즉시 반영됨. 안 되면 브라우저 하드 리프레시(⌘+Shift+R).
-- 정적 폰트/이미지를 같은 파일명으로 교체한 경우엔 파일명을 바꿔야 무효화됨.
+**Q. Caching is too aggressive — new deploys are not reflected**
+- The Cache-Control in `firebase.json` sets `1 year immutable` for JS / CSS / fonts — this is intentional because filenames are content-hashed.
+- HTML defaults to `no-cache` and is reflected immediately. If not, do a browser hard refresh (⌘+Shift+R).
+- If you replaced static fonts/images while keeping the same filename, you must change the filename to invalidate the cache.
 
 ---
 
-## 변경 이력
+## Change log
 
-- 2026-04-13: 커스텀 도메인 · 롤백 · 체크리스트 · 부분 배포 · 확장 트러블슈팅 추가
-- 2026-04-12: 초기 작성 (Phase 0)
+- 2026-04-13: Added custom domain, rollback, checklist, partial deploys, and expanded troubleshooting
+- 2026-04-12: Initial draft (Phase 0)

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -5,91 +5,89 @@ tags: [design, ux, linear, overview]
 
 # Design System
 
-> 이 문서는 설계 문서 섹션 3을 기반으로 유지된다. Linear 원본 사양은 [`design-references/DESIGN-linear.md`](design-references/DESIGN-linear.md)를 참고.
+> This document is maintained based on Section 3 of the design spec. For the original Linear specification, see [`design-references/DESIGN-linear.md`](design-references/DESIGN-linear.md).
 
-## 선택 이유
+## Why this direction
 
-Linear의 "어둠에서 떠오르는 별빛" 미학이 토폴로지의 별자리 메타포와 정확히 일치. 흑백 + 단일 인디고 악센트라는 극단적 제약이 **AI 생성 클리셰를 배제하는 최상의 방어책**이다. 허브 노드(IAM/Reactor)를 인디고로 표현하면 시스템에서 유일한 채색이 되어 시각적 중심이 자연스럽게 형성된다.
+Linear's "starlight rising from darkness" aesthetic aligns precisely with the constellation metaphor of the topology. The extreme constraint of black-and-white plus a single indigo accent is **the strongest defense against AI-generated UI clichés**. Rendering hub nodes (IAM/Reactor) in indigo makes them the only colored elements in the system, naturally forming the visual focal point.
 
-## 디자인 토큰
+## Design tokens
 
-Tailwind 4의 CSS 기반 `@theme`로 정의. 실제 구현은 `app/globals.css`를 본다.
+Defined via Tailwind 4's CSS-based `@theme`. See `app/globals.css` for the actual implementation.
 
-### 배경
+### Backgrounds
 
 - `--color-canvas`: `#08090a`
 - `--color-panel`: `#0f1011`
 - `--color-elevated`: `#191a1b`
 - `--color-secondary-surface`: `#28282c`
 
-### 텍스트
+### Text
 
 - `--color-text-primary`: `#f7f8f8`
 - `--color-text-secondary`: `#d0d6e0`
 - `--color-text-tertiary`: `#8a8f98`
 - `--color-text-quaternary`: `#62666d`
 
-### 악센트 (유일한 채색)
+### Accent (the only color)
 
 - `--color-indigo-brand`: `#5e6ad2`
 - `--color-indigo-accent`: `#7170ff`
 - `--color-indigo-hover`: `#828fff`
 
-### 보더
+### Borders
 
 - `rgba(255,255,255,0.05)` — subtle
 - `rgba(255,255,255,0.08)` — default
 - `rgba(255,255,255,0.12)` — strong
 
-### 타이포
+### Typography
 
-- Primary: `Inter Variable` (OpenType `"cv01", "ss03"` 전역)
-- Signature weight: `510` (Linear 고유)
+- Primary: `Inter Variable` (OpenType `"cv01", "ss03"` applied globally)
+- Signature weight: `510` (Linear's signature)
 - Mono: `JetBrains Mono`
 
-## 카테고리 구분 전략
+## Category differentiation strategy
 
-색이 아닌 **보더 스타일**로 구분 — 유일한 채색(인디고)은 허브 노드에 양보:
+Differentiate by **border style**, not color — the only color (indigo) is reserved for hub nodes:
 
-| 카테고리           | 표식                           |
-| ------------------ | ------------------------------ |
-| 작업중             | 인디고 언더라인                |
-| 예정               | dashed 보더                    |
-| 허브 (IAM/Reactor) | 인디고 배경·보더 (유일한 채색) |
+| Category           | Marker                                    |
+| ------------------ | ----------------------------------------- |
+| In progress        | Indigo underline                          |
+| Planned            | Dashed border                             |
+| Hub (IAM/Reactor)  | Indigo background and border (only color) |
 
-## 절대 규칙 (Don'ts)
+## Absolute rules (Don'ts)
 
-- ❌ 보라→핑크 그라디언트
-- ❌ glassmorphism (`backdrop-blur`)
-- ❌ glow pulse / neon 효과
-- ❌ 움직이는 그라디언트 배경 / 오로라
-- ❌ scale 기반 호버 효과
-- ❌ 둘 이상의 채색 시스템
+- ❌ Purple → pink gradients
+- ❌ Glassmorphism (`backdrop-blur`)
+- ❌ Glow pulse / neon effects
+- ❌ Animated gradient backgrounds / aurora
+- ❌ Scale-based hover effects
+- ❌ More than one color system
 
-## 모션 원칙
+## Motion principles
 
-- 초기 로드: `opacity 0 → 1` + `translateY 8px → 0` (스프링)
-- 호버: 보더 opacity 상승, 연결 엣지 밝기 증가 — scale·glow 금지
-- 드로어: 우측 `x: 100% → 0` 스프링
-- 필터 토글: 비선택 카테고리 `opacity 0.15`
-- 배경: 완전 정적
-- `prefers-reduced-motion` 존중
+- Initial load: `opacity 0 → 1` + `translateY 8px → 0` (spring)
+- Hover: border opacity rises, connected edges brighten — no scale or glow
+- Drawer: right-side `x: 100% → 0` spring
+- Filter toggle: deselected categories fade to `opacity 0.15`
+- Background: fully static
+- Respect `prefers-reduced-motion`
 
-## 페이지 헤더 — 영문 caption + 한글 h1
+## Page header — English caption + Korean h1
 
-각 운영 페이지 (ontology / knowledge / review / settings 등) 의 헤더는
-**두 라인 패턴**을 따른다. 사용자 facing 한글이 본 제목이고, 영문 카테고리
-caption 은 micro 식별자로 시각 위계를 한 단계 양보한다.
+The header on each operations page (ontology / knowledge / review / settings, etc.) follows a **two-line pattern**. The user-facing Korean title is the primary heading, and the English category caption serves as a micro identifier that yields one step in the visual hierarchy.
 
-### 패턴
+### Pattern
 
 ```
-[영문 카테고리 caption — 9~10px / mono / uppercase / tracking 0.14em / quaternary 색]
-[한글 h1 — text-2xl / signature weight / primary 색]
-[보조 설명 — 한글 / sm / secondary 색 (옵션)]
+[English category caption — 9~10px / mono / uppercase / tracking 0.14em / quaternary color]
+[Korean h1 — text-2xl / signature weight / primary color]
+[Subtitle — Korean / sm / secondary color (optional)]
 ```
 
-예: `/ontology` 페이지
+Example: `/ontology` page
 
 ```tsx
 <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
@@ -103,41 +101,30 @@ caption 은 micro 식별자로 시각 위계를 한 단계 양보한다.
 </p>
 ```
 
-### 의도
+### Intent
 
-- **영문 caption** — 페이지의 카테고리 영역 식별자. 빠른 시선 인식 (모노+
-  대문자+간격) 으로 "어디에 있는지" 알리되, 본 제목보다 약하게 표시해
-  한국어 h1 이 가장 읽힘.
-- **한글 h1** — 사용자가 실제로 부르는 이름. 한글이 본 제목이라 모든 본문
-  / 설명 / CTA 가 한글 일관 톤.
-- **두 라인 분리** — 한 줄에 영문/한글 섞기 (예: "온톨로지 Ontology") 는
-  금지. 각 라인이 한 언어로 단일 톤을 유지.
+- **English caption** — A category-area identifier for the page. The mono + uppercase + spacing combo enables fast visual recognition of "where you are," but stays weaker than the main heading so the Korean h1 reads first.
+- **Korean h1** — The name users actually call it. Korean is the primary heading, so all body copy / descriptions / CTAs maintain a consistent Korean tone.
+- **Two-line separation** — Mixing English and Korean on a single line (e.g. "온톨로지 Ontology") is forbidden. Each line stays in a single language with a single tone.
 
-### 합법 영문 caption 사례
+### Legitimate English caption examples
 
-- 페이지 카테고리: `Ontology`, `Knowledge`, `Review`, `Settings`,
-  `Diagnostics`, `Account`, `Workspace`, `Manual node`, `Get started`.
-- 시스템 메타: `ID 추천`, `Beta` 등 — 의도된 영문 식별자만. 문장형 영문은
-  금지 (한글로 번역).
+- Page categories: `Ontology`, `Knowledge`, `Review`, `Settings`, `Diagnostics`, `Account`, `Workspace`, `Manual node`, `Get started`.
+- System metadata: `ID 추천`, `Beta`, etc. — only intentional English identifiers. Sentence-style English is forbidden (translate to Korean).
 
-### 일관성 규칙
+### Consistency rules
 
-- caption 의 폰트 크기는 `9px ~ 10px` 범위. tracking 은 `0.10em ~ 0.18em`.
-- 한 페이지 안에서 동일 caption 토큰 (mono / uppercase / tracking / 색) 을
-  유지. 시스템 토큰은 추후 `--font-caption-mono` 같은 CSS var 로 통일 예정.
-- 영문 caption 은 페이지 한 곳 (top header) 만 사용. 본문 안에 영문
-  카테고리 라벨을 또 넣지 않는다 — 시각 위계 이중화 차단.
+- Caption font size stays in the `9px ~ 10px` range. Tracking ranges from `0.10em ~ 0.18em`.
+- Within a single page, keep caption tokens consistent (mono / uppercase / tracking / color). System tokens will eventually be unified under a CSS var like `--font-caption-mono`.
+- Use the English caption only once per page (top header). Don't repeat English category labels in the body — avoid duplicating the visual hierarchy.
 
-### 적용 surface (현재)
+### Surfaces where this applies (current)
 
-`/ontology`, `/ontology/insights`, `/ontology/relations`, `/knowledge`,
-`/knowledge/documents`, `/knowledge/documents/new`, `/review/knowledge`,
-`/settings/*`, `/diagnostics/insights`, `/account` — 모두 같은 패턴.
+`/ontology`, `/ontology/insights`, `/ontology/relations`, `/knowledge`, `/knowledge/documents`, `/knowledge/documents/new`, `/review/knowledge`, `/settings/*`, `/diagnostics/insights`, `/account` — all follow the same pattern.
 
-`/`, `/projects`, `/project/[slug]` 의 공개 surface 는 사용자가 한국어로
-브라우징 — 영문 caption 없이 한글 h1 단독.
+The public surfaces `/`, `/projects`, `/project/[slug]` are browsed by users in Korean — Korean h1 alone, without an English caption.
 
-## 변경 이력
+## Changelog
 
-- 2026-04-13: 컨설팅 카테고리 제거
-- 2026-04-12: 초기 작성 (Phase 0)
+- 2026-04-13: Removed the consulting category
+- 2026-04-12: Initial draft (Phase 0)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,264 +1,250 @@
 # FEATURES — oh-my-ontology
 
-> 사용자가 **지금 실제로 사용 가능한** 기능 전수 인벤토리.
-> 작성일: 2026-05-01 (mission v2 cleanup 7 PR 머지 후)
-> 갱신 trigger: 새 surface 추가 / 기존 surface 제거 시 즉시 반영. PR 본문 + CHANGELOG 와 같이 업데이트.
+> Complete inventory of features users can **actually use right now**.
+> Last updated: 2026-05-02 (post-OSS-launch readiness — CLI scaffold, web scaffold button, npm publish guard)
+> Update trigger: reflect immediately when surfaces are added or removed. Update alongside the PR body and CHANGELOG.
 
 ---
 
-## 0. 한눈에
+## 0. At a glance
 
-> **mission v2**: "사람과 AI agent 가 같이 저작하는 codebase 의 ontology."
-> **운영 모델**: 1인 도구. local-first vault. 로그인은 옵션. AI agent (Claude Code 등) 는 MCP 서버로 직접 read/write.
+> **Mission v2**: "an ontology of the codebase, authored together by humans and AI agents."
+> **Operating model**: single-user tool. Local-first vault. Login is optional. AI agents (Claude Code, etc.) read/write directly through the MCP server.
 
 ```
-입력 (사람 + AI agent)        파싱             저장              출력
+input (humans + AI agents)     parse           store              output
         │                       │                │                │
         ▼                       ▼                ▼                ▼
-  vault 의 .md  →          frontmatter   →  vault 또는    →  트리 (/) [hub]
-  (frontmatter)                              Firestore        토폴로지 (/topology Sigma)
-  + AI agent (MCP)                                            빌더 (/ontology/edit xyflow)
+  .md in vault  →          frontmatter   →  vault or       →  tree (/) [hub]
+  (frontmatter)                              Firestore        topology (/topology Sigma)
+  + AI agent (MCP)                                            builder (/ontology/edit xyflow)
 ```
 
 ---
 
-## 1. 모드 분기 (data source)
+## 1. Mode branching (data source)
 
-`useDataSourceMode()` hook 이 셋 중 하나를 결정:
+The `useDataSourceMode()` hook resolves to one of three modes:
 
-| 모드 | 조건 | 동작 |
+| Mode | Condition | Behavior |
 |---|---|---|
-| **local** | vault 폴더 활성 | vault manifest 가 진실원, Firebase 호출 0 |
-| **cloud** | Firebase 로그인 + vault 미활성 | Firestore onSnapshot 실시간 sync |
-| **static** | 둘 다 없음 | 빌드 타임 demo manifest |
+| **local** | vault folder active | vault manifest is the source of truth, zero Firebase calls |
+| **cloud** | Firebase login + no active vault | Firestore onSnapshot live sync |
+| **static** | neither | build-time demo manifest |
 
-**효과**: 사용자가 vault 폴더를 열면 `/` (ontology hub) · `/topology` · `/projects` · `/project/[slug]` 모든 곳에서 즉시 vault 데이터로 바뀜. mutation (생성/편집/삭제) 도 동일하게 mode-aware.
+**Effect**: when a user opens a vault folder, `/` (ontology hub), `/topology`, `/projects`, and `/project/[slug]` all switch to vault data instantly. Mutations (create / edit / delete) are mode-aware in exactly the same way.
 
 ---
 
-## 2. 라우트별 기능
+## 2. Features per route
 
-### Ontology hub + 시각화
+### Ontology hub + visualization
 
-#### `/` — Ontology Tree Hub (mission v2 의 척추)
+#### `/` — Ontology Tree Hub (the spine of mission v2)
 
-- **mode-aware** (Q1=(a) 채택, `useOntologyInsight`):
-  - local: vault frontmatter stub 노드/엣지를 즉시 트리·ego graph·검색에 노출
-  - cloud: `knowledgePublicNodes/Edges` projection 구독
+- **mode-aware** (Q1=(a) adopted, `useOntologyInsight`):
+  - local: vault frontmatter stub nodes/edges surface immediately in tree, ego graph, and search
+  - cloud: subscribes to the `knowledgePublicNodes/Edges` projection
   - static: demo manifest
-- **계층 트리**: project → domain → capability → element (문서 노드는 근거로만 기여, 트리 제외)
-- **노드 클릭** → 우측 detail 패널: kind / title / 요약 / project 연결 / 근거 문서 / **ego 그래프** (1-hop / 2-hop SVG) / 이웃 리스트 / "+ 관계 추가" / "노드 링크 복사"
-- **상단 toolbar pills**: 노드 추가 / 검색 (⌘K / ⇧⌘K) / 빌더 열기 → / 인사이트 / 관계
-- **통계 카드**: 트리 노드 / 관계 / 근거 문서 / 미해결 stub / 마지막 발행
-- **stub 처리**: 미해결 참조 → 트리 하단 `OntologyStubList` 위젯에서 "승격" (kind 선택) / "폐기" 액션 (cloud 모드에서 `promoteStubNode` / `dismissStubNode` callable)
-- **빈 vault empty-state** (mode-aware): vault 활성 시 "frontmatter 적기 → 빌더에서 정리" 2-step. 그 외엔 "vault 열기 → frontmatter → 빌더" 3-step.
-- **단축키**: `⌘K` 검색 · `⇧⌘K` 글로벌 검색 · `?` 단축키 시트
+- **hierarchy tree**: project → domain → capability → element (document nodes contribute as evidence only and are excluded from the tree)
+- **node click** → right-side detail panel: kind / title / summary / project link / evidence documents / **ego graph** (1-hop / 2-hop SVG) / neighbor list / "+ add relation" / "copy node link"
+- **top toolbar pills**: add node / search (⌘K / ⇧⌘K) / open builder → / insights / relations
+- **stat cards**: tree nodes / relations / evidence documents / unresolved stubs / last published
+- **stub handling**: unresolved references → in the `OntologyStubList` widget at the bottom of the tree, take "promote" (kind selection) / "dismiss" actions (cloud mode triggers the `promoteStubNode` / `dismissStubNode` callables)
+- **empty-vault empty-state** (mode-aware): when a vault is active, a 2-step "write frontmatter → tidy in builder". Otherwise, a 3-step "open vault → frontmatter → builder".
+- **shortcuts**: `⌘K` search · `⇧⌘K` global search · `?` shortcut sheet
 
-#### `/topology` — Sigma WebGL 토폴로지 (mission v2 출구 view)
+#### `/topology` — Sigma WebGL topology (the mission v2 exit view)
 
-- **렌더**: Sigma.js + Graphology + ForceAtlas2 — 전체 프로젝트를 공간 네트워크로 펼침
-- **인터랙션**: 노드 클릭 → ProjectDrawer · hover → tooltip + 1-hop 이웃 강조 · 드래그 / 휠 → pan/zoom
-- **사이드 widgets**: 좌측 Legend (kind 색 범례) · 우측 SigmaHubRail (degree 상위 허브 빠른 점프) · 하단 RegionNavigator (minimap)
-- **단축키**: `⌘K` 검색 · `?` 단축키 시트
-- **모드**: 모든 모드에서 동작 — 데이터 소스만 다름
+- **render**: Sigma.js + Graphology + ForceAtlas2 — lays the entire project out as a spatial network
+- **interaction**: node click → ProjectDrawer · hover → tooltip + 1-hop neighbor highlight · drag / wheel → pan/zoom
+- **side widgets**: left-side Legend (kind color legend) · right-side SigmaHubRail (quick jump to top-degree hubs) · bottom RegionNavigator (minimap)
+- **shortcuts**: `⌘K` search · `?` shortcut sheet
+- **modes**: works in every mode — only the data source differs
 
 #### `/ontology/edit` — Builder (xyflow ERD)
 
-- **palette (좌)**: 4 kind 클릭 → 캔버스 가운데에 새 임시 노드 (인디고 dashed)
-- **연결**: 노드 가장자리 점에서 drag → 다른 노드에 drop → 임시 관계 edge
-- **Inspector (우)**: 임시 노드 선택 시 이름 + 저장 → `knowledgeApprovedNodes/Edges` (cloud) 또는 vault `.md` (local) 로 commit
-- **md 내보내기**: ephemeral 노드/엣지를 frontmatter 마크다운으로 download
-- **fullscreen toggle**: F 키 또는 우상단 Maximize 버튼 — OperationsNav 숨김 + 풀 viewport
-- **단축키**: N (새 project 노드) · F (전체 화면) · Del (선택 삭제) · Esc (선택 해제 / 전체 화면 종료)
-- **빌더 onboarding**: 첫 진입 + 빈 캔버스에 3-step coach mark (다시 보지 않기 토글)
-- **layout**: 단순 grid
+- **palette (left)**: click one of the 4 kinds → a new ephemeral node (indigo dashed) appears at the canvas center
+- **connect**: drag from the dot at a node's edge → drop on another node → ephemeral relation edge
+- **Inspector (right)**: when an ephemeral node is selected, name it + save → commits to `knowledgeApprovedNodes/Edges` (cloud) or vault `.md` (local)
+- **md export**: download ephemeral nodes/edges as frontmatter markdown
+- **fullscreen toggle**: F key or the Maximize button at the top right — hides OperationsNav + uses the full viewport
+- **shortcuts**: N (new project node) · F (fullscreen) · Del (delete selection) · Esc (clear selection / exit fullscreen)
+- **builder onboarding**: a 3-step coach mark on first entry with an empty canvas (with a "don't show again" toggle)
+- **layout**: simple grid
 
-#### `/ontology/insights` — 인사이트
-- **kind 분포** (막대), **프로젝트별 분포** (정렬), **관계 type 분포**
-- **cross-project 관계** 비율 / 절대값
-- **허브 노드 top 10** (degree, 문서·project 제외)
-- **최근 활동 10건** (상대 시간)
-- **30일 활동 타임라인** (일자별 승인 막대)
-- **미연결 노드** (orphan, amber 강조)
-- 모든 항목 클릭 → `/ontology/?node=<id>` 로 점프
+#### `/ontology/insights` — Insights
+- **kind distribution** (bars), **distribution per project** (sorted), **relation type distribution**
+- **cross-project relation** ratio / absolute count
+- **top 10 hub nodes** (by degree, excluding documents and projects)
+- **10 most recent activities** (relative time)
+- **30-day activity timeline** (per-day approval bars)
+- **disconnected nodes** (orphans, highlighted in amber)
+- every entry click → jumps to `/ontology/?node=<id>`
 
-#### `/ontology/relations` — 관계 분포
-- **edge type 분포** (좌) — 클릭 toggle 필터
-- **강한 관계 top 12** (evidence 풍부한 순) — from → type → to + cross chip + evidence count
+#### `/ontology/relations` — Relation distribution
+- **edge type distribution** (left) — click to toggle filter
+- **top 12 strongest relations** (sorted by evidence richness) — from → type → to + cross chip + evidence count
 
 ### Vault Local-First
 
 #### `/docs` — Vault Picker / Doc Vault
-- **로컬 폴더 선택** (File System Access API):
-  - 폴더 선택 → 전체 `.md` 자동 스캔 → manifest 빌드
-  - 파일 수 + 마지막 스캔 시각 ("방금 / 5초 전 / 3분 전")
-  - 새로고침 / 닫기 / 재승인 버튼
-  - 미지원 브라우저 / 권한 거부 / 접근 오류 사용자 친화 메시지
-- **vault 활성 시 surface**:
-  - 폴더 트리 + 사이드바 (pinned · 최근 · 태그)
-  - 본문 viewer (마크다운 + frontmatter 메타바)
-  - 폴더 토폴로지 view (Sigma) — 문서 간 링크 그래프
-  - "vault frontmatter ontology" 패널 — frontmatter 만으로 추출된 stub 노드/엣지
-  - 백링크 / 관련 문서 / 관계 레이더
-  - 명령 팔레트 (vault 전용 — Daily Note, Scaffold Topology, 내보내기 등)
-- **scaffoldTopology()**: 빈 vault 에 `projects/`, `README.md`, `categories.md`, `statuses.md`, 샘플 프로젝트 hub/leaf 자동 생성
+- **local folder picker** (File System Access API):
+  - pick a folder → auto-scan all `.md` → build manifest
+  - file count + last scan time ("just now / 5s ago / 3m ago")
+  - refresh / close / re-authorize buttons
+  - friendly messages for unsupported browsers, denied permissions, and access errors
+- **surfaces when a vault is active**:
+  - folder tree + sidebar (pinned · recent · tags)
+  - body viewer (markdown + frontmatter metabar)
+  - folder topology view (Sigma) — link graph between documents
+  - "vault frontmatter ontology" panel — stub nodes/edges extracted from frontmatter alone
+  - backlinks / related documents / relation radar
+  - command palette (vault-only — Daily Note, Scaffold Topology, exports, etc.)
+- **scaffoldTopology()**: in an empty vault, auto-generates `projects/`, `README.md`, `categories.md`, `statuses.md`, and a sample project hub/leaf
+- **OntologyStarterCta** (mission v2): when the picked vault has read+write permission, a top-of-page "Create starter seed" button writes 5 starter `.md` files (`README.md`, `project.md`, `domains/example.md`, `capabilities/example.md`, `elements/example.md`) plus `.mcp.json.example` — same template that `npx oh-my-ontology init` writes from the CLI. **Designed for non-developers** so they don't need a terminal to begin.
 
-### 프로젝트
+### Projects
 
-#### `/projects` — 프로젝트 목록
-- **mode-aware**: local 모드면 vault 의 `projects/*.md`, cloud 면 Firestore
-- **검색 / 필터**: query · category · status · 표시 개수
-- **카드별**: ontology 노드 카운트 배지, 빠른 작업 (편집)
-- **ProjectQuickCreatePanel** — 페이지 안에서 인라인 빠른 생성 (mode-aware)
-- **CSV 내보내기** — 전체 다운로드
-- **WorkspaceOntologyStrip** — 상단 ontology 요약 strip
+#### `/projects` — Project list
+- **mode-aware**: local mode reads `projects/*.md` from the vault; cloud reads Firestore
+- **search / filter**: query · category · status · displayed count
+- **per card**: ontology node count badge, quick actions (edit)
+- **ProjectQuickCreatePanel** — inline quick creation directly in the page (mode-aware)
+- **CSV export** — full download
+- **WorkspaceOntologyStrip** — top-of-page ontology summary strip
 
-#### `/project/[slug]` — 프로젝트 상세
-- **렌더**: 메타 (이름·설명·태그·스택·상태·카테고리·시작/완료일·진행도·소유자·아이콘) + 의존성 그래프 + 토폴로지 미리보기
-- **인라인 편집** (권한 시): description / status 등 즉시 수정
-- **DependencyPicker**: 의존성 칩 multi-select + 검색 + cycle/missing 경고
-- **CopyProjectLinkButton**: 단순 URL 복사 (mission v2 정렬, share-doc 시스템과 별개)
-- **Mission 7 원자 정합**: vault 의 `projects/<slug>.md` 로부터 모든 정보 자동 매핑
+#### `/project/[slug]` — Project detail
+- **render**: metadata (name · description · tags · stack · status · category · start/end date · progress · owner · icon) + dependency graph + topology preview
+- **inline edit** (when permitted): edit description / status etc. on the spot
+- **DependencyPicker**: dependency chip multi-select + search + cycle/missing warnings
+- **CopyProjectLinkButton**: simple URL copy (mission v2 alignment, distinct from the share-doc system)
+- **Mission 7 atomic alignment**: every piece of information maps automatically from the vault's `projects/<slug>.md`
 
-#### `/project/new` · `/project/[slug]/edit` — 에디터
-- **풀 폼**: 이름·slug·설명·detail (markdown)·태그·스택·링크·의존성·아이콘·상태·카테고리·진행도·timeline·screenshots
-- **자동 추천**: description 에서 다른 프로젝트 이름 발견 시 dependency 추천 chip
-- **mode-aware mutation**: local → vault `.md` 작성/패치, cloud → Firestore upsert
-- **저장 후 동작 선택**: "저장하고 계속 보기" / "저장하고 목록으로" / "저장하고 공개 화면으로"
+#### `/project/new` · `/project/[slug]/edit` — Editor
+- **full form**: name · slug · description · detail (markdown) · tags · stack · links · dependencies · icon · status · category · progress · timeline · screenshots
+- **auto-suggest**: when other project names appear in the description, a dependency suggestion chip is offered
+- **mode-aware mutations**: local → write/patch vault `.md`; cloud → Firestore upsert
+- **post-save action choice**: "save and keep viewing" / "save and back to list" / "save and go to public view"
 
-#### `/project/fallback` — 정적 export 폴백
-- Firebase Hosting rewrite 가 unknown slug 를 client-side Firestore 조회로 라우팅. 빌드타임에 모르는 동적 slug 도 정상 렌더.
-
-### 문서 (cloud-mode 옵션)
-
-> mission v2 정렬: cloud LLM extraction 흐름 (`enqueueExtractionJob` 등) 은 제거됨. user-side AI agent (Claude Code) 가 MCP 로 직접 ontology 갱신.
-
-#### `/knowledge` — 대시보드
-- 문서 통계 카드, 빠른 진입 액션
-- vault 모드 활성 시 "vault summary" 카드 노출
-- 미공개 문서 안내 → "vault 열기" / 빌더 CTA
-
-#### `/knowledge/documents`
-- 목록 + 검색 + 필터 (project / 문서 유형 / 상태 / 분석 상태)
-- 행 액션: 문서 상세
-
-#### `/knowledge/documents/new`
-- 새 문서 등록 — 제목 / 마크다운 본문 / 프로젝트 다중 태깅
-- **mode-aware projects**: vault 프로젝트도 picker 에 등장
-- 템플릿 (명세 / 결정 기록), 입력 규칙 안내
-
-#### `/knowledge/documents/view?id=...`
-- 문서 상세 — 메타 / 마크다운 렌더 / 버전 이력 / **historical** 추출 결과 (cold storage)
-- **2단계 stepper** (mission v2 정렬): 올리기 → 공개 — "분석 stage" 는 vault frontmatter 가 자기-승인이라 별도 stage 없음
-- **빈 ontology 안내**: "vault 열기" / "빌더 열기" CTA — cloud LLM 추출 trigger 없음
+#### `/project/fallback` — Static export fallback
+- A Firebase Hosting rewrite routes unknown slugs to a client-side Firestore lookup. Dynamic slugs that were unknown at build time still render correctly.
 
 ### AI agent partner (`mcp/`)
 
-> Phase 3 — Claude Code 같은 LLM agent 가 stdin/stdout JSON-RPC 로 ontology 를 read/write.
+> Phase 3 — LLM agents like Claude Code read/write the ontology over stdin/stdout JSON-RPC.
 
-- **패키지**: `mcp/` v0.5.0, `@modelcontextprotocol/sdk@^1.0.0` 의존
-- **등록**: `.mcp.json.example` 복사 후 `OMOT_VAULT=./docs/ontology` (또는 사용자 vault) 설정
-- **11 도구**:
+- **package**: `oh-my-ontology-mcp` v0.5.0 (in `mcp/`), depends on `@modelcontextprotocol/sdk@^1.0.0`
+- **registration**: copy `.mcp.json.example` and set `OMOT_VAULT=<absolute path to your vault>` (or `./docs/ontology` for our dogfood vault)
+- **distribution**: `npx -y oh-my-ontology-mcp` (after publish), zero install
+- **11 tools** (read 7 + write 4):
 
-| 도구 | 동작 |
-|---|---|
-| `list_concepts` | vault 의 모든 노드 (kind 필터 + limit) |
-| `get_concept` | 단일 slug 의 frontmatter + body excerpt + 이웃 |
-| `find_evidence` | title 부분매칭 — frontmatter + body 검색 |
-| `find_backlinks` | 특정 slug 를 가리키는 노드들 (frontmatter array 키 + body wikilink/mdlink) |
-| `add_concept` | 새 `.md` 노드 작성 — 기존 slug 면 throw |
-| `add_relation` | 두 slug 사이 edge (depends_on / relates / contains / describes) |
-| `patch_concept` | 기존 노드 frontmatter (key 단위 patch) + body 갱신 |
+| Tool | Read/write | Behavior |
+|---|---|---|
+| `list_concepts` | read | every node in the vault (kind filter + limit) |
+| `get_concept` | read | a single slug's frontmatter + body excerpt + neighbors |
+| `find_evidence` | read | partial title match — searches frontmatter + body |
+| `find_backlinks` | read | nodes that point to a given slug (frontmatter array keys + body wikilink/mdlink) |
+| `find_path` | read | shortest-path BFS between two slugs |
+| `list_kinds` | read | distribution of node kinds in the vault |
+| `find_orphans` | read | nodes with zero in/out edges |
+| `add_concept` | write | write a new `.md` node — throws if the slug already exists |
+| `add_relation` | write | create an edge between two slugs (depends_on / relates / contains / describes) |
+| `patch_concept` | write | patch an existing node's frontmatter (per-key patch) + body |
+| `delete_concept` | write | remove a node and its inbound/outbound references |
 
-- **Dogfood vault**: `docs/ontology/` — 이 프로젝트 자기 mental model. 1 project + 8 domain + 7 capability + 4 element + 1 vault-readme = 21 노드.
+- **Dogfood vault**: `docs/ontology/` — this project's own mental model. 1 project + 8 domains + 9 capabilities + 4 elements + 1 vault-readme ≈ 23 nodes.
 
-### 인증 / 계정
+### Auth / account
 
 #### `/login`
 - email + password
 - Google OAuth (popup)
-- 비밀번호 재설정 link
+- password reset link
 
 #### `/signup`
-- displayName + email + password (8자+) + 확인
-- 회원가입 후 자동 로그인
+- displayName + email + password (8+ chars) + confirmation
+- automatic login after signup
 
 #### `/reset-password`
-- 이메일 → Firebase 비밀번호 재설정 메일 발송
+- email → sends a Firebase password reset email
 
-#### `/account` (게스트는 `/login?next=/account` 로 redirect)
-- **내 정보**: 이름 · 이메일 · 로그인 방식 (provider)
-- **비밀번호 변경**: 현재 + 신규 + 확인 (Firebase email/password 사용자만)
-- **비밀번호 재설정 메일** 재전송
-- 로그아웃은 PublicAccountMenu 에서
+#### `/account` (guests are redirected to `/login?next=/account`)
+- **my info**: name · email · login provider
+- **change password**: current + new + confirm (Firebase email/password users only)
+- **resend password reset** email
+- sign-out lives in the PublicAccountMenu
 
-### 운영 / 설정
+### Operations / settings
 
-#### `/settings` — 정리 허브
-- iOS Settings 결의 grouped list, drill-in
-- 그룹: 지도 정비 (categories · statuses · 가져오기)
+#### `/settings` — Tidy hub
+- iOS-Settings-style grouped list with drill-in
+- groups: map maintenance (categories · statuses · import)
 
 #### `/settings/categories` · `/settings/statuses` · `/settings/import`
-- 카테고리 라벨 / 설명 / 톤 (indigo · amber · neutral) / 캔버스 영역 편집
-- 상태 lifecycle 라벨 / dot 색 / 정렬
-- CSV 일괄 업로드 (mode-aware)
+- edit category label / description / tone (indigo · amber · neutral) / canvas region
+- edit status lifecycle label / dot color / sort order
+- bulk CSV upload (mode-aware)
 
-> mission v2 정렬: TBox surface (`/settings/ontology[/history]`) 는 제거됨 —
-> frontmatter `kind:` 가 곧 schema. `/diagnostics/insights` 도 제거됨 —
-> 사용자 가시 인사이트는 `/ontology/insights` 가 담당.
+> Mission v2 alignment: TBox surfaces (`/settings/ontology[/history]`) have been removed —
+> frontmatter `kind:` *is* the schema. `/diagnostics/insights` was removed too —
+> user-visible insights are now owned by `/ontology/insights`.
 
 ---
 
-## 3. 기능 그룹별 정리
+## 3. By feature group
 
 ### 3.1 Vault Local-First
 
-| 기능 | 진입점 | 효과 |
+| Feature | Entry point | Effect |
 |---|---|---|
-| 폴더 선택 (FSA) | `/docs` LocalVaultPicker | OS 폴더 → manifest |
-| Manifest 빌드 | 자동 (선택 시) | 프론트매터 · 백링크 · 헤딩 · excerpt |
-| Fingerprint 변경 감지 | 자동 (탭 포커스 시) | IDE 편집 후 돌아오면 재스캔 (debounce 2s) |
-| Handle 영속화 | IndexedDB (`local-fs-handle`) | 새로고침 후 재승인만 누르면 복원 |
-| createDoc / saveDoc / deleteDoc / renameDoc | 명령 팔레트 / 인라인 편집 | mode-aware mutation |
-| `updateFrontmatter` | useProjectMutations | 본문 보존 + frontmatter 패치 |
-| Backlink rewrite | renameDoc 시 best-effort | 다른 파일의 `[[oldSlug]]`, `[text](old.md)` 자동 치환 |
-| Scaffold | 명령 팔레트 | 빈 vault 에 README + projects/ + 샘플 |
+| Folder picker (FSA) | `/docs` LocalVaultPicker | OS folder → manifest |
+| Manifest build | automatic (on selection) | frontmatter · backlinks · headings · excerpt |
+| Fingerprint change detection | automatic (on tab focus) | rescans (debounced 2s) when you return after editing in an IDE |
+| Handle persistence | IndexedDB (`local-fs-handle`) | restore after refresh by clicking re-authorize |
+| createDoc / saveDoc / deleteDoc / renameDoc | command palette / inline edit | mode-aware mutation |
+| `updateFrontmatter` | useProjectMutations | preserves the body and patches frontmatter |
+| Backlink rewrite | best-effort on renameDoc | auto-replaces `[[oldSlug]]` and `[text](old.md)` in other files |
+| Scaffold | command palette | seeds an empty vault with README + projects/ + samples |
 
 ### 3.2 Mode-Aware Adapters
 
-| Hook | 책임 |
+| Hook | Responsibility |
 |---|---|
-| `useDataSourceMode()` | local / cloud / static 결정 |
-| `useProjects(accountId)` | mode 별 프로젝트 read (sync local / subscribe cloud) |
-| `useProjectMutations()` | mode 별 CRUD (vault file write / Firestore upsert) |
-| `useOntologyInsight(accountId)` | **mission v2 신설** — local: vault frontmatter stub 변환, cloud: knowledgePublic projection. `/` ontology hub 가 vault 활성 시 자동 vault 모드로 |
-| `TaxonomyProvider` | local/static 모드는 defaults, cloud 만 subscribe |
-| `useLocalVault()` | manifest + handle + 명령들 |
-| `useVaultOntology()` | vault 매니페스트 → OntologyStubNode/Edge 변환 |
+| `useDataSourceMode()` | resolves local / cloud / static |
+| `useProjects(accountId)` | mode-specific project read (sync local / subscribe cloud) |
+| `useProjectMutations()` | mode-specific CRUD (vault file write / Firestore upsert) |
+| `useOntologyInsight(accountId)` | **new in mission v2** — local: converts vault frontmatter stubs; cloud: knowledgePublic projection. The `/` ontology hub auto-switches to vault mode when a vault is active |
+| `TaxonomyProvider` | local/static modes use defaults, cloud subscribes |
+| `useLocalVault()` | manifest + handle + commands |
+| `useVaultOntology()` | converts a vault manifest → OntologyStubNode/Edge |
 
-**적용 surface**: HomePage / OntologyViewPage (`/`) / ProjectSelectorPage / ProjectDetailPage / ProjectForm / KnowledgeDocumentNewPage / MountedGlobalSearch / DependencyPicker / TaxonomyProvider
+**Surfaces using these**: HomePage / OntologyViewPage (`/`) / ProjectSelectorPage / ProjectDetailPage / ProjectForm / MountedGlobalSearch / DependencyPicker / TaxonomyProvider
 
-### 3.3 AI Agent Partner (mission v2 신설)
+### 3.3 AI Agent Partner (new in mission v2)
 
-| 항목 | 설명 |
+| Item | Description |
 |---|---|
-| MCP 서버 | `mcp/` 패키지, stdin/stdout JSON-RPC, 11 도구 |
-| 등록 | `.mcp.json.example` 복사 → Claude Code 재시작 |
-| Vault | `OMOT_VAULT` env (default cwd) — 사용자 vault 또는 `docs/ontology/` (dogfood) |
-| 호환 | 어떤 vault 든 `kind:` frontmatter 가진 `.md` 만 노드. 기존 ontology format 그대로 |
+| MCP server | `oh-my-ontology-mcp` package (`mcp/`), stdin/stdout JSON-RPC, 11 tools (read 7 + write 4) |
+| Registration | copy `.mcp.json.example` → restart Claude Code |
+| Vault | `OMOT_VAULT` env (default cwd) — the user's vault or `docs/ontology/` (dogfood) |
+| Compatibility | works on any vault; only `.md` files with a `kind:` frontmatter become nodes. Existing ontology format is preserved as-is |
+| **CLI** (`oh-my-ontology`) | `cli/` package — `npx oh-my-ontology init my-vault` scaffolds 5 starter `.md` + `.mcp.json.example`. Identical templates to the web `/docs` scaffold button so CLI and web converge on the same starter |
+| **Web scaffold** (`OntologyStarterCta`) | `/docs` button — same 5 starter files, no terminal required (non-developer entry) |
+| **npm publish guard** | 3 layers (`CLAUDE.md` rule + `.claude/rules/forbidden.md` + PreToolUse Bash hook in `.claude/settings.json`). AI agents cannot run `npm publish` without explicit user approval — protects the maintainer's npm account from accidental releases |
 
-### 3.4 검색
+### 3.4 Search
 
-| 종류 | 단축키 | 진입점 |
+| Kind | Shortcut | Entry point |
 |---|---|---|
-| 프로젝트 SearchPalette | `⌘K` (홈) | 토폴로지 / 프로젝트 화면 |
-| 글로벌 검색 (ontology + 문서 + 프로젝트) | `⇧⌘K` | 모든 페이지 |
+| Project SearchPalette | `⌘K` (home) | topology / project screens |
+| Global search (ontology + docs + projects) | `⇧⌘K` | every page |
 
-**기능**: 한·영 fuzzy match · kind 필터 칩 · project 필터 칩 · 키보드 nav (↑↓ Enter Esc) · 빈 query 시 source 별 샘플 표시.
+**Capabilities**: Korean/English fuzzy match · kind filter chips · project filter chips · keyboard nav (↑↓ Enter Esc) · sample entries per source when the query is empty.
 
-### 3.5 Frontmatter 파서
+### 3.5 Frontmatter parser
 
-| 형식 | 예시 |
+| Form | Example |
 |---|---|
 | Scalar | `name: foo` / `count: 42` / `active: true` |
 | Quoted | `desc: "hello: world"` |
@@ -267,235 +253,296 @@
 | **Inline object** | `pos: { x: 1, y: 2 }` |
 | **Block object** | `pos:\n  x: 1\n  y: 2` |
 
-object value 안에서는 `'true'/'false'/숫자` 자동 typed. `applyFrontmatterUpdates()` 로 본문 보존하며 패치 (null = key 삭제).
+Inside an object value, `'true'/'false'/numbers` are typed automatically. `applyFrontmatterUpdates()` patches frontmatter while preserving the body (null = delete the key).
 
-scripts/build-docs-vault.mjs 와 src/shared/lib/parse-frontmatter.ts 와 mcp/src/parser.mjs 가 capability 동기화.
+scripts/build-docs-vault.mjs, src/shared/lib/parse-frontmatter.ts, and mcp/src/parser.mjs keep this capability in sync.
 
-### 3.6 Vault Frontmatter → Ontology Stub
+### 3.6 Vault frontmatter → Ontology stub
 
-frontmatter 키:
+frontmatter keys:
 - `kind:` (project / capability / element / domain / decision / workflow / ...)
-- `title:` (또는 # 첫 헤딩 / 파일명 fallback)
-- `domain:` (단일 domain 노드 후보)
-- `capabilities: []` / `elements: []` (배열 노드)
-- `relates: []` / `dependencies: []` (edge 후보)
+- `title:` (or the first `#` heading / filename fallback)
+- `domain:` (single-domain node candidate)
+- `capabilities: []` / `elements: []` (array node candidates)
+- `relates: []` / `dependencies: []` (edge candidates)
 
-→ 출력: `OntologyStubNode[]` + `OntologyStubEdge[]` + warnings. AI 추출 거치지 않은 fast-path. `/`, `/docs`, `/ontology/edit` 모두에서 즉시 가시화.
+→ output: `OntologyStubNode[]` + `OntologyStubEdge[]` + warnings. A fast path that bypasses AI extraction. Visible immediately on `/`, `/docs`, and `/ontology/edit`.
 
-### 3.7 V1.1 Wikidata Statement Annotation (mission v2 신설)
+### 3.7 V1.1 Wikidata Statement Annotation (new in mission v2)
 
-`KnowledgeGraphEdge` 에 옵셔널 필드 추가 (additive, breakage 0):
+Optional fields added to `KnowledgeGraphEdge` (additive, zero breakage):
 
 - `qualifiers?: Array<{ propertyId: string; value: QualifierValue }>`
 - `rank?: 'preferred' | 'normal' | 'deprecated'`
 
 `QualifierValue` union: string / time (precision year-month-day) / quantity (value+unit) / nodeRef.
 
-legacy edge 는 두 필드 undefined → 코드는 `rank ?? 'normal'` 폴백. `publishKnowledgeProjectionCore` 가 approved → public projection 시 fields-pass-through. 자세히: `docs/ONTOLOGY-MODEL-V2-DRAFT.md` §2.
+Legacy edges leave both fields undefined → the code falls back to `rank ?? 'normal'`. `publishKnowledgeProjectionCore` passes the fields through during the approved → public projection. Details: `docs/ONTOLOGY-MODEL-V2-DRAFT.md` §2.
 
-### 3.8 권한
+### 3.8 Permissions
 
-| 역할 | 동작 |
+| Role | Behavior |
 |---|---|
-| 비로그인 / guest | 공개 surface (홈 트리 read) + vault 모드 풀 사용 가능 |
-| 데모 세션 | `/login` 데모 버튼 → read-only 데모 데이터 |
-| Firebase 인증 사용자 | 자기 데이터 풀 권한 (1인 도구) |
-| `admins/{email}` 화이트리스트 | 전역 카테고리 / 진단 / TBox 운영 — 일반 사용자는 자기 공간 풀권 |
+| Anonymous / guest | public surfaces (read the home tree) + full vault-mode usage |
+| Demo session | `/login` demo button → read-only demo data |
+| Firebase-authenticated user | full rights over their own data (single-user tool) |
+| `admins/{email}` allowlist | reserved for future global operations — the TBox / diagnostics operations it used to gate were retired in mission v2 |
 
-`PermissionGate` 컴포넌트가 own-space / membership / admin 분기 처리.
+The `PermissionGate` component branches on own-space / membership / admin.
 
-### 3.9 모바일 / 반응형
+### 3.9 Mobile / responsive
 
-| 기능 | 위치 | 동작 |
+| Feature | Location | Behavior |
 |---|---|---|
-| **BottomTabBar** | `src/widgets/bottom-tab-bar/` | 모바일 (md 미만) 화면 하단 고정 탭바 — 지도 · 프로젝트 · 문서 · 정리. 데스크톱은 OperationsNav 가 같은 destination 제공 |
-| **GestureHint** | `src/widgets/gesture-hint/` | 터치 디바이스에 토폴로지 첫 진입 시 swipe 제스처 안내 |
-| **safe-area / 안전 영역** | OperationsNav 모바일 모드 | iOS 노치 + BottomTabBar 와 충돌 회피 |
-| 모바일 detail sheet | `/` 트리 | 데스크톱은 우측 panel, 모바일은 화면 하단 고정 sheet |
+| **BottomTabBar** | `src/widgets/bottom-tab-bar/` | a fixed bottom tab bar on mobile (below md) — map · projects · docs · settings. On desktop, OperationsNav exposes the same destinations |
+| **GestureHint** | `src/widgets/gesture-hint/` | shows swipe-gesture guidance the first time touch devices land on the topology |
+| **safe-area** | OperationsNav mobile mode | avoids collisions with the iOS notch + BottomTabBar |
+| Mobile detail sheet | `/` tree | desktop uses the right-side panel; mobile uses a bottom-fixed sheet |
 
-### 3.10 테마 / 접근성 / 알림
+### 3.10 Theme / accessibility / notifications
 
-| 기능 | 위치 | 동작 |
+| Feature | Location | Behavior |
 |---|---|---|
-| **ThemeToggle (Light/Dark)** | OperationsNav 우측 + `src/features/theme-toggle/` | `html[data-theme="light"]` toggle. 기본 다크. localStorage 영속 |
-| **Toast** | `useToast()` (`src/shared/ui/toast.tsx`, sonner 기반) | 50+ 호출처. `show(message, tone)` API. success / error / warning / info |
-| **LiveAnnouncer** | `src/shared/ui/live-announcer.tsx` | aria-live region — 토폴로지 노드 선택 / 검색 결과 변경 등을 스크린리더에 announce |
-| **Tooltip** | `src/shared/ui` (Radix 기반) | 모든 아이콘 / 단축키 안내 |
-| **prefers-reduced-motion** | globals.css base layer | 자동 존중 — Sigma pulse / framer-motion 모두 |
+| **ThemeToggle (Light/Dark)** | right side of OperationsNav + `src/features/theme-toggle/` | toggles `html[data-theme="light"]`. Defaults to dark. Persisted in localStorage |
+| **Toast** | `useToast()` (`src/shared/ui/toast.tsx`, sonner-based) | 50+ call sites. `show(message, tone)` API. success / error / warning / info |
+| **LiveAnnouncer** | `src/shared/ui/live-announcer.tsx` | aria-live region — announces topology node selection / search result changes etc. to screen readers |
+| **Tooltip** | `src/shared/ui` (Radix-based) | every icon / shortcut hint |
+| **prefers-reduced-motion** | globals.css base layer | automatically respected — for both Sigma pulses and framer-motion |
 
-### 3.11 부가 위젯
+### 3.11 Auxiliary widgets
 
-| 위젯 | 진입점 | 역할 |
+| Widget | Entry point | Role |
 |---|---|---|
-| **DocsQuickDrawer** | `/topology` 토폴로지 (📁 아이콘) | vault 문서 빠른 미리보기 drawer — pin 한 문서 / 최근 / 트리 inline |
-| **WorkspaceOntologyStrip** | `/` `/projects` 헤더 | 현재 ontology 통계 strip — 매치 0 자동 숨김. 미해결 stub chip → `/ontology` (트리 stub list) |
-| **ProjectKnowledgeTopologyScene** | `/topology` 노드 선택 시 | 해당 프로젝트의 knowledge graph 상세 scene |
-| **OntologyStubList** | `/` (트리 하단) | 미해결 stub 노드 list + 승격 / 폐기 액션 (cloud 모드 callable) |
-| **VaultOntologyStubsPanel** | `/` (vault 모드 활성 시 트리 위) | vault frontmatter 만으로 추출된 stub 노드/엣지 시각화 |
+| **DocsQuickDrawer** | `/topology` topology (folder icon) | a vault document quick-preview drawer — pinned docs / recent / inline tree |
+| **WorkspaceOntologyStrip** | `/` `/projects` header | a strip with current ontology stats — auto-hidden when there are zero matches. The unresolved-stub chip jumps to `/ontology` (the tree's stub list) |
+| **ProjectKnowledgeTopologyScene** | shown when a node is selected on `/topology` | a detailed scene of the project's knowledge graph |
+| **OntologyStubList** | `/` (bottom of the tree) | list of unresolved stub nodes + promote / dismiss actions (cloud-mode callable) |
+| **VaultOntologyStubsPanel** | `/` (above the tree when vault mode is active) | visualizes stub nodes/edges extracted from vault frontmatter alone |
 
-### 3.12 단축키
+### 3.12 Shortcuts
 
-| 키 | 위치 | 효과 |
+| Key | Where | Effect |
 |---|---|---|
-| `⌘K` / `Ctrl+K` | 어디서나 | 검색 팔레트 (프로젝트) |
-| `⇧⌘K` | 어디서나 | 글로벌 검색 (ontology + 문서 + 프로젝트) |
-| `?` | 어디서나 | 단축키 시트 |
-| `Esc` | 모달 / 빌더 | 닫기 / 선택 해제 |
-| `N` | `/ontology/edit` | 새 project 노드 |
-| `F` | `/ontology/edit` | 전체 화면 toggle |
-| `Del` / `Backspace` | `/ontology/edit` | 선택 노드 삭제 |
-| `↑` / `↓` | 검색 / 트리 | 항목 이동 |
+| `⌘K` / `Ctrl+K` | anywhere | search palette (projects) |
+| `⇧⌘K` | anywhere | global search (ontology + docs + projects) |
+| `?` | anywhere | shortcut sheet |
+| `Esc` | modal / builder | close / clear selection |
+| `N` | `/ontology/edit` | new project node |
+| `F` | `/ontology/edit` | toggle fullscreen |
+| `Del` / `Backspace` | `/ontology/edit` | delete selected node |
+| `↑` / `↓` | search / tree | move between items |
 
 ---
 
-## 4. 데이터 흐름 (mission v2 single-source)
+## 4. Data flow (mission v2 single-source)
 
 ```
-md 파일 (vault 또는 cloud)              MCP 서버 (AI agent)
+md files (vault or cloud)               MCP server (AI agents)
   │                                          │
   ├─→ manifest (vault) / Firestore (cloud)   │
   │                                          │ (read/write)
   ├─→ Project[] ← useProjects (mode-aware)   │
   │                                          ▼
   ├─→ frontmatter → derive-ontology-from-vault → OntologyStub[] (local)
-  │                       또는
-  │   manual editor / 빌더 → knowledgeApprovedNodes/Edges (cloud)
-  │                       또는
+  │                       or
+  │   manual editor / builder → knowledgeApprovedNodes/Edges (cloud)
+  │                       or
   │   AI agent (Claude Code) → MCP add_concept / patch_concept → vault .md (local)
   │
-  └─→ 트리 (`/`) / 토폴로지 (`/topology` Sigma) / 빌더 (`/ontology/edit` xyflow)
+  └─→ tree (`/`) / topology (`/topology` Sigma) / builder (`/ontology/edit` xyflow)
 ```
 
-**Mission v2 cleanup 후 사라진 path**:
-- ❌ AI 추출 (cloud LLM Gemini/Claude) → knowledgeExtractionJobs/Outputs
-- ❌ 검수 큐 (`/review/knowledge`) → knowledgeReviews/ApprovalEvents
+**Paths removed by mission v2 cleanup**:
+- ❌ AI extraction (cloud LLM Gemini/Claude) → knowledgeExtractionJobs/Outputs
+- ❌ Review queue (`/review/knowledge`) → knowledgeReviews/ApprovalEvents
 
-이전 데이터는 cold storage 로 보존되지만 더 이상 callable 없어 read-only.
+Earlier data is preserved in cold storage but is read-only since the callables are gone.
 
 ---
 
-## 4-A. static 데이터 (mission v2)
+## 4-A. Static data (mission v2)
 
-mission v2 의 `static` 모드 진실원은 `docs/ontology/` dogfood vault 다 —
-프로젝트 자기 자신의 mental model 을 frontmatter md 로 표현. 빌드타임에
-`scripts/build-docs-vault.mjs` 가 vault 를 스캔해 `src/entities/docs-vault/data/manifest.json`
-으로 박는다.
+In mission v2, the source of truth for `static` mode is the `docs/ontology/` dogfood vault —
+the project expresses its own mental model as frontmatter markdown. At build time,
+`scripts/build-docs-vault.mjs` scans the vault and bakes it into
+`src/entities/docs-vault/data/manifest.json`.
 
-- **1 project + 8 domain + 9 capability + 4 element + 1 README ≈ 23 노드**
-- 사용자가 vault 안 골랐고 비로그인 (static) 모드면 이 manifest 로 즉시
-  topology / ontology / projects 가 그려짐 — 0 마찰 진입.
-- v1 의 `src/shared/mocks/demo-blueprint.ts` (6 컨테이너, ~50 projects) 는
-  PR #33/#34 (2026-04~05) 에서 폐기. 새 진실원은 dogfood vault.
+- **1 project + 8 domains + 9 capabilities + 4 elements + 1 README ≈ 23 nodes**
+- When a user has not selected a vault and is anonymous (static) mode, this manifest
+  immediately renders topology / ontology / projects — zero-friction entry.
+- The v1 `src/shared/mocks/demo-blueprint.ts` (6 containers, ~50 projects) was
+  retired in PR #33/#34 (2026-04 to 2026-05). The new source of truth is the dogfood vault.
 
-## 4-B. 프레임워크 / 빌드타임 surface
+## 4-B. Framework / build-time surfaces
 
-| 항목 | 위치 | 동작 |
+| Item | Location | Behavior |
 |---|---|---|
-| **app/layout.tsx** | root layout | TaxonomyProvider + ToastProvider + 글로벌 스타일. title template `'%s · oh-my-ontology'` |
-| **app/page.tsx** | `/` 진입 | RootEntryPage — 비로그인이면 LandingPage, 그 외 OntologyViewPage |
-| **app/topology/page.tsx** | `/topology` 진입 | HomePage (Sigma topology) |
+| **app/layout.tsx** | root layout | TaxonomyProvider + ToastProvider + global styles. Title template `'%s · oh-my-ontology'` |
+| **app/page.tsx** | `/` entry | RootEntryPage — anonymous users see the LandingPage; otherwise the OntologyViewPage |
+| **app/topology/page.tsx** | `/topology` entry | HomePage (Sigma topology) |
 | **app/manifest.ts** | `/manifest.webmanifest` | PWA manifest |
-| **app/sitemap.ts** | `/sitemap.xml` | 정적 export 라우트 노출 |
-| **app/robots.ts** | `/robots.txt` | 검색엔진 크롤 정책 |
-| **app/not-found.tsx** | 404 페이지 | "길을 잃은" 카피 + 홈 CTA |
-| **app/error.tsx** | route-level error boundary | "예기치 않은 오류" + 재시도 / 토폴로지 홈 |
-| **app/global-error.tsx** | layout-level error boundary | 최후 방어 |
-| **app/project/[slug]/opengraph-image.tsx** | OG 이미지 | 프로젝트 상세 공유 시 동적 카드 |
-| **app/project/fallback/** | 정적 export 폴백 | unknown slug → client-side Firestore 조회 |
+| **app/sitemap.ts** | `/sitemap.xml` | exposes static-export routes |
+| **app/robots.ts** | `/robots.txt` | search engine crawl policy |
+| **app/not-found.tsx** | 404 page | "lost your way" copy + home CTA |
+| **app/error.tsx** | route-level error boundary | "unexpected error" + retry / topology home |
+| **app/global-error.tsx** | layout-level error boundary | last line of defense |
+| **app/project/[slug]/opengraph-image.tsx** | OG image | dynamic share card on the project detail |
+| **app/project/fallback/** | static-export fallback | unknown slug → client-side Firestore lookup |
 
 ---
 
-## 5. 제약 / 의도된 부재
+## 5. Constraints / intentional absences
 
-### Mission v1 시대 제거 (이미 완료)
-- **share link** (commit "share-doc cascade 제거" — v2 협업)
-- **GitHub webhook 활동 이력** (commit "docs-vault-activity 제거")
-- **AI 추출 클라이언트** (commit "ontology-extraction 클라이언트 제거")
-- **HTTP push API** (commit "api-keys + receive-doc cascade 제거")
-- **dev-admin-bypass** (commit "dev-admin-bypass 인프라 + 41 callsite 정리")
-- **/admin/*** 라우트 (deprecated)
-- **legacy redirect** (/project/topology, /project/view)
+### Removed in the mission v1 era (already done)
+- **share link** (commit "share-doc cascade removed" — pushed to v2 collaboration)
+- **GitHub webhook activity history** (commit "docs-vault-activity removed")
+- **AI extraction client** (commit "ontology-extraction client removed")
+- **HTTP push API** (commit "api-keys + receive-doc cascade removed")
+- **dev-admin-bypass** (commit "dev-admin-bypass infra + 41 callsites cleaned up")
+- **/admin/*** routes (deprecated)
+- **legacy redirects** (/project/topology, /project/view)
 
-### Mission v2 cleanup 후 사라진 것
-- **`/review/knowledge` 검수 큐** — 페이지 + 라우트 + entity callable + functions handler 통째 제거 (Stage 4)
-- **AI Cloud Functions** — `extract-gemini.js` + `ontology-extract.js` 통째 삭제 (Stage 3)
-- **Cloud LLM 추출 흐름** — `enqueueExtractionJob` / `processExtractionJob` / `reclaimStaleExtractionJobs` 제거 (Stage 3)
-- **`applyReviewAction` callable** — 제거 (Stage 4)
-- **"분석 시작" UI CTA** — 4 view 에서 모두 제거 (Stage 1)
-- **`approveKnowledgeOutput` / `rejectKnowledgeOutput` httpsCallable wrapper** — 제거 (Stage 4)
-- **dual stepper 의 "분석 stage"** — KnowledgeDocumentDetailPage 4단계 → 2단계 (Stage 4)
+### Removed by mission v2 cleanup
+- **`/review/knowledge` review queue** — page + route + entity callables + functions handler all removed (Stage 4)
+- **AI Cloud Functions** — `extract-gemini.js` + `ontology-extract.js` deleted entirely (Stage 3)
+- **Cloud LLM extraction flow** — `enqueueExtractionJob` / `processExtractionJob` / `reclaimStaleExtractionJobs` removed (Stage 3)
+- **`applyReviewAction` callable** — removed (Stage 4)
+- **"Start analysis" UI CTA** — removed from all 4 views (Stage 1)
+- **`approveKnowledgeOutput` / `rejectKnowledgeOutput` httpsCallable wrappers** — removed (Stage 4)
+- **the dual stepper's "analysis stage"** — KnowledgeDocumentDetailPage went from 4 steps to 2 (Stage 4)
+- **`/knowledge/*` routes + `KnowledgeDocument` / `KnowledgeDocumentVersion` entities** — entire surface retired (commit `a906635`). The vault is the single source of truth; cloud-mode users still read existing `knowledgeApprovedNodes/Edges` from the builder, but document-style upload/preview is gone
+- **`/diagnostics/*` routes + Firestore seed scripts** — operations insights are now owned by `/ontology/insights` (commit `b323571`)
+- **TBox surface (`/settings/ontology[/history]`)** — `kind:` in frontmatter *is* the schema (commit `3a46c78`)
+- **`functions/` folder itself** — `firebase.json` now omits a Functions deploy (commit `8eac23e`); the project ships as a static export to Firebase Hosting only
 
-### 의도된 부재
-- **Multi-account**: 없음 — `accountId = null` 고정 (v2 협업 단계로 보류)
-- **외부 IAM**: 없음 — Firebase Auth (email/password + Google OAuth) 만
-- **firebase deploy**: user 정책상 안 함. mission v2 추가 cleanup 으로 `functions/` 폴더 자체 폐기 (vault 자기-승인이라 publish/promote/dismiss 게이트 불필요)
+### Intentional absences
+- **Multi-account**: none — `accountId = null` is fixed (held back for the v2 collaboration phase)
+- **External IAM**: none — Firebase Auth (email/password + Google OAuth) only
+- **firebase deploy**: not run, by user policy. Further mission v2 cleanup retired the `functions/` folder itself (since vault frontmatter is self-approving, publish/promote/dismiss gates are unnecessary)
 
 ---
 
-## 6. 검증 (mission v2 phase 머지 시점, 2026-05-01)
+## 6. Verification (post-OSS-launch readiness, 2026-05-02)
 
 - tsc 0 errors
-- eslint 0 errors (warnings 79 — 거의 모두 기존)
-- vitest **118 files / 848 tests pass** (V1.1 5 새 test 포함)
-- MCP server stdin/stdout JSON-RPC: initialize → tools/list (11 도구) → tools/call 모두 정상
-- MCP parser smoke 7/7 pass
-- `node --check functions/index.js` syntax OK
-- Playwright MCP browser-level QA (15 라우트): 모든 mission v2 surface console error 0, mission v2 title 정렬
-
-## 누적 cleanup 통계 (mission v2 phase)
-
-- 7 PR 머지 (#5-#11)
-- 누적 -5,833 라인 정리 (PR #5 -3,729 + PR #6 -2,096 + PR #7 -8 + 작은 PR 합산)
-- functions/index.js: 2,012 → 543 줄 (-73%)
+- eslint 0 errors (62 warnings — all pre-existing)
+- vitest **100 files / 721 tests pass**
+- MCP server stdin/stdout JSON-RPC: initialize → tools/list (11 tools) → tools/call all healthy
+- MCP parser smoke pass
+- Playwright MCP browser-level QA (current routes): zero console errors on every mission v2 surface
+- CLI smoke (`node cli/src/index.mjs init test-vault`) writes 5 starter `.md` + `.mcp.json.example`
+- `npm pack --dry-run` audit: 0 secrets / 0 PII / 0 absolute paths in either tarball
 
 ---
 
-## 7. 어디서부터 손대야 할지 — 사용자 워크플로
+## 7. Where to start — user workflows
 
 ```
-1. 새 사용자 (로그인 없이):
-   /docs → "내 PC 마크다운 폴더 열기"
-   → vault 활성 → / 트리 + /topology 토폴로지 + /projects 자동 인지
+1. New user (no login):
+   /docs → "open a markdown folder on my PC"
+   → vault active → /, /topology, /projects all auto-recognize it
 
-2. AI agent (Claude Code) 등록 (옵션):
-   .mcp.json.example 복사 → OMOT_VAULT 설정 → Claude Code 재시작
-   → mcp__oh-my-ontology__* 11 도구 사용 가능
+2. Register an AI agent (Claude Code) (optional):
+   copy .mcp.json.example → set OMOT_VAULT → restart Claude Code
+   → mcp__oh-my-ontology__* 11 tools become available
 
-3. 새 프로젝트 추가:
-   (a) vault 직접:
-       projects/my-project.md 작성
+3. Add a new project:
+   (a) directly in the vault:
+       write projects/my-project.md
        ---
        kind: project
-       title: 내 프로젝트
+       title: my project
        category: in-progress
        status: developing
        dependencies: [auth, billing]
        ---
-       → 자동으로 /, /topology, /projects 에 등장
+       → automatically appears on /, /topology, /projects
 
-   (b) UI 빠른 생성:
-       /projects → "새 프로젝트" 클릭 → ProjectQuickCreatePanel
-       → vault `.md` 자동 생성 (mode-aware)
+   (b) UI quick create:
+       /projects → click "new project" → ProjectQuickCreatePanel
+       → vault `.md` is auto-generated (mode-aware)
 
    (c) AI agent (MCP):
-       agent 가 코드 분석 후 mcp__oh-my-ontology__add_concept 호출
-       → vault `.md` 직접 작성
+       the agent analyzes the code and calls mcp__oh-my-ontology__add_concept
+       → writes the vault `.md` directly
 
-4. 온톨로지 개념 추가:
-   (a) frontmatter 기반 (사람):
-       문서에 kind: capability + relates: [...] 추가
-       → / 트리에 stub 으로 자동 등장
+4. Add an ontology concept:
+   (a) frontmatter-based (human):
+       add kind: capability + relates: [...] to a document
+       → appears in the / tree as a stub automatically
 
-   (b) 빌더 직접 (사람):
-       /ontology/edit → palette → 노드 클릭 → 핸들 drag → 저장
+   (b) directly in the builder (human):
+       /ontology/edit → palette → click a node → drag a handle → save
 
    (c) AI agent (MCP):
        mcp__oh-my-ontology__add_concept / add_relation / patch_concept
-       → vault frontmatter 자동 갱신 → / 트리 자동 갱신
+       → vault frontmatter updates → / tree updates automatically
 
-5. 둘러보기:
-   ⇧⌘K (글로벌 검색) → kind 필터 → 점프
-   / → 트리 + ego graph 탐색
-   /topology → Sigma 시각 네트워크
-   /ontology/insights → 활동 / 허브 / orphan
+5. Explore:
+   ⇧⌘K (global search) → kind filter → jump
+   / → tree + ego graph exploration
+   /topology → Sigma visual network
+   /ontology/insights → activity / hubs / orphans
 ```
+
+---
+
+## 8. OSS distribution surfaces (post-launch readiness)
+
+What ships outside the running app — designed so global users can adopt the project without reading Korean.
+
+### 8.1 npm packages
+
+| Package | Path | Required for | Distribution |
+|---|---|---|---|
+| `oh-my-ontology-mcp` | `mcp/` | AI agent integration (Claude Code, Cursor, …) | Public, MIT, free; install via `npx -y oh-my-ontology-mcp` |
+| `oh-my-ontology` | `cli/` | CLI vault scaffold (`init` subcommand) | Optional — the web `/docs` scaffold button is the alternative |
+
+Both go through `npm pack --dry-run` audit before any publish — 0 secrets / 0 PII / 0 absolute paths verified.
+
+### 8.2 Hosting
+
+- **Firebase Hosting** at `https://oh-my-ontology.web.app` (free Spark plan)
+- Static export only (`output: 'export'` → `out/`); no Firebase Functions runtime needed
+- `firebase.json` defines the deploy with `predeploy: pnpm build` and a `/project/[slug]` rewrite to `/project/fallback`
+- `docs/DEPLOY-FIREBASE.md` — step-by-step deploy guide (English)
+
+### 8.3 GitHub OSS surfaces
+
+| Surface | What |
+|---|---|
+| `README.md` | English first + Korean sub-section, hero hosted-demo link, MCP / CLI / scaffold quickstart |
+| `AGENTS.md` | English first + Korean sub-section — canonical contributor guide for every AI tool |
+| `CONTRIBUTING.md` | English — branch naming, conventional commits, FSD boundaries reminder |
+| `LICENSE` | MIT |
+| `.github/ISSUE_TEMPLATE/*.yml` | 3 bilingual issue forms (bug report / feature request / question) + config disabling blank issues |
+| `.github/PULL_REQUEST_TEMPLATE.md` | Bilingual PR template (Summary / Test plan / Screenshots) |
+| `.github/DISCUSSIONS-CATEGORIES.md` | Discussion category taxonomy (Korean — internal admin reference) |
+| GitHub Discussions | Activated programmatically via `gh api PATCH ... has_discussions=true`; welcome post #108 created |
+
+### 8.4 OSS docs
+
+All English unless noted:
+
+| Doc | Purpose |
+|---|---|
+| `docs/PUBLISH-NPM.md` | step-by-step npm publish guide for maintainers, includes the publish-guard explanation |
+| `docs/TROUBLESHOOTING.md` | common issues for end users — vault scaffold / MCP / build·test / publish |
+| `docs/PRODUCT-DIRECTION.md` | mission v2 direction |
+| `docs/FEATURES.md` | this file |
+| `docs/ARCHITECTURE.md` | architecture and FSD boundaries |
+| `docs/DATA-MODEL.md` | Firestore schema + Storage layout |
+| `docs/DESIGN-SYSTEM.md` | tokens / motion / forbidden visual patterns |
+| `docs/MODE-AWARE-CRUD.md` | local / cloud / static branching guide |
+| `docs/DEPLOY-FIREBASE.md` | hosting deploy |
+| `docs/launch/*.md` | HN / Reddit / X drafts (Korean — internal launch material; published only after maintainer review) |
+
+### 8.5 npm publish guard (3 layers)
+
+A defense-in-depth block against accidental `npm publish` by AI agents:
+
+1. **`CLAUDE.md` rule** (Claude-specific guidance): never run publish without explicit user approval
+2. **`.claude/rules/forbidden.md`**: same rule in the auto-loaded forbidden-patterns file
+3. **`.claude/settings.json` PreToolUse hook** + `.claude/hooks/block-npm-publish.sh`: actually intercepts Bash commands matching `npm/pnpm/yarn publish` (and `npm pack` without `--dry-run`) and returns `permissionDecision: "deny"`
+
+Tested against 7 input shapes (publish variants blocked; `npm whoami` / `npm pack --dry-run` / regular commands allowed).

--- a/docs/MODE-AWARE-CRUD.md
+++ b/docs/MODE-AWARE-CRUD.md
@@ -1,61 +1,61 @@
-# Mode-aware CRUD 패턴
+# Mode-aware CRUD pattern
 
-> **Status**: 도입 완료 (Phase 2-3, 2026-05-01).
-> **Why**: 기획자 audit 의 root cause 1 — *모드 인지 hook 부재로 모든 게이트가 auth role 만 봄*. local vault 활성 비로그인 사용자가 mutation 불가.
-> **Spec 의 위치**: `.claude/rules/local-first.md` 헌장 + `docs/LOCAL-FIRST-SYNC.md` § "운영 모드" 의 *코드 레이어 implementation*.
+> **Status**: Adopted (Phase 2-3, 2026-05-01).
+> **Why**: Root cause #1 from the planner audit — *no mode-aware hook existed, so every gate looked only at auth role*. Non-logged-in users with an active local vault could not perform mutations.
+> **Spec location**: *Code-layer implementation* of the `.claude/rules/local-first.md` charter and `docs/LOCAL-FIRST-SYNC.md` § "Operational modes".
 
-이 문서는 *어떤 entity 가 mutation 을 받는지가 사용자의 진실원 모드에 따라 다른 흐름* 을 갖도록 하는 패턴이다. 새 entity 에 mutation 을 추가할 때 이 가이드를 따라 mode-aware 로 만든다.
+This document describes a pattern where *which entity accepts mutations follows a different flow depending on the user's source-of-truth mode*. When you add mutations to a new entity, follow this guide to make it mode-aware.
 
 ---
 
-## 1. 운영 모드 (data source mode)
+## 1. Operational modes (data source mode)
 
-`docs/LOCAL-FIRST-SYNC.md` §2 의 4 모드 중 본 패턴이 다루는 것:
+Of the four modes defined in `docs/LOCAL-FIRST-SYNC.md` §2, this pattern covers:
 
-| Mode | 진실원 | mutation 가능? | 인증 필요? |
+| Mode | Source of truth | Mutations allowed? | Auth required? |
 |---|---|---|---|
-| **static** | `data/manifest.json` (빌드타임) | ❌ no-op + 거절 | — |
-| **local** | 사용자 디스크의 `.md` (vault) | ✅ 디스크 직접 쓰기 | ❌ 비로그인 OK |
-| **cloud** | Firestore `*` 컬렉션 | ✅ Firestore 쓰기 | ✅ Firebase Auth |
+| **static** | `data/manifest.json` (build-time) | ❌ no-op + reject | — |
+| **local** | `.md` files on the user's disk (vault) | ✅ direct disk writes | ❌ no login needed |
+| **cloud** | Firestore `*` collections | ✅ Firestore writes | ✅ Firebase Auth |
 
-(hybrid 는 v1.0+ 별도 spec.)
+(hybrid is a separate spec, v1.0+.)
 
 ---
 
-## 2. 도입된 핵심 모듈
+## 2. Core modules introduced
 
-### 2.1 모드 자체를 보는 hook
+### 2.1 Hook that observes the mode itself
 
-- `src/shared/lib/data-source-mode.ts` — 순수 함수 `getDataSourceMode({vaultLoaded, isAuthenticated}): DataSourceMode`. 우선순위: vault loaded > authenticated > static.
-- `src/features/data-source-mode/model/use-data-source-mode.ts` — `useUserAuth` + `useLocalVault` 합성 hook. `window.__ohMyOntologyMode` 디버그 expose.
+- `src/shared/lib/data-source-mode.ts` — pure function `getDataSourceMode({vaultLoaded, isAuthenticated}): DataSourceMode`. Priority: vault loaded > authenticated > static.
+- `src/features/data-source-mode/model/use-data-source-mode.ts` — hook composing `useUserAuth` + `useLocalVault`. Exposes `window.__ohMyOntologyMode` for debugging.
 
-### 2.2 entity 별 mode-aware mutation hook
+### 2.2 Per-entity mode-aware mutation hooks
 
-- `src/features/project-data-source/model/use-project-mutations.ts` — Project 의 create/update/delete + canCreate/canEdit/canDelete capability. local 분기는 `useLocalVault.createDoc` / `updateFrontmatter` / `deleteDoc`, cloud 분기는 entity API.
+- `src/features/project-data-source/model/use-project-mutations.ts` — Project create/update/delete + canCreate/canEdit/canDelete capabilities. The local branch uses `useLocalVault.createDoc` / `updateFrontmatter` / `deleteDoc`; the cloud branch uses the entity API.
 
-### 2.3 entity ↔ frontmatter 매퍼
+### 2.3 entity ↔ frontmatter mappers
 
-- `src/entities/docs-vault/lib/project-frontmatter.ts` — `projectToFrontmatter(project)` + `buildProjectMarkdown(project)`. local 모드 mutation 의 직렬화 유틸.
+- `src/entities/docs-vault/lib/project-frontmatter.ts` — `projectToFrontmatter(project)` + `buildProjectMarkdown(project)`. Serialization utilities for local-mode mutations.
 
 ### 2.4 vault → ontology fast path
 
-- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — frontmatter `kind / capabilities / elements / relates / dependencies / domain` 에서 stub 노드/엣지 추출. 검수 큐 거치지 않은 *fast path* (mission v2 = frontmatter 자체가 자기-승인).
-- `src/features/vault-ontology/model/use-vault-ontology.ts` — useLocalVault + derive 합성 hook.
-- `src/features/vault-ontology/model/use-ontology-insight.ts` — **mission v2 신설** mode-aware ontology insight. local: vault frontmatter stub 변환, cloud: knowledgePublic projection. `/` ontology hub 가 vault 활성 시 자동 vault 모드.
+- `src/entities/docs-vault/lib/derive-ontology-from-vault.ts` — extracts stub nodes/edges from frontmatter `kind / capabilities / elements / relates / dependencies / domain`. A *fast path* that bypasses the review queue (mission v2 = frontmatter is self-approving).
+- `src/features/vault-ontology/model/use-vault-ontology.ts` — hook composing useLocalVault + derive.
+- `src/features/vault-ontology/model/use-ontology-insight.ts` — **new in mission v2**, mode-aware ontology insight. local: vault frontmatter stub conversion; cloud: knowledgePublic projection. The `/` ontology hub automatically switches to vault mode when a vault is active.
 
-### 2.5 AI agent partner (mission v2 신설)
+### 2.5 AI agent partner (new in mission v2)
 
-- `mcp/` 패키지 — `@modelcontextprotocol/sdk` 기반 stdin/stdout JSON-RPC 서버. AI agent (Claude Code 등) 가 vault `.md` 직접 read/write
-- 7 도구: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`
-- 등록: `.mcp.json.example` 또는 `mcp/README.md`
+- The `mcp/` package — a stdin/stdout JSON-RPC server based on `@modelcontextprotocol/sdk`. Lets AI agents (Claude Code, etc.) read/write vault `.md` files directly.
+- 7 tools: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`
+- Registration: `.mcp.json.example` or `mcp/README.md`
 
 ---
 
-## 3. 새 entity mutation 을 mode-aware 로 만드는 절차
+## 3. How to make a new entity's mutations mode-aware
 
-예: `Tag` 엔티티에 mode-aware CRUD 를 추가한다고 가정.
+Example: assume you want to add mode-aware CRUD for a `Tag` entity.
 
-### 3.1 entity 의 frontmatter 직렬화 추가
+### 3.1 Add frontmatter serialization for the entity
 
 ```ts
 // src/entities/docs-vault/lib/tag-frontmatter.ts
@@ -68,9 +68,9 @@ export function tagToFrontmatter(t: TagFrontmatterShape): Record<string, ...> { 
 export function buildTagMarkdown(t: TagFrontmatterShape): string { ... }
 ```
 
-local 모드의 `.md` 가 어디 (`tags/<slug>.md`) 에 저장될지도 결정.
+Also decide where the local-mode `.md` will live (e.g. `tags/<slug>.md`).
 
-### 3.2 mode-aware mutation hook 신설
+### 3.2 Create a mode-aware mutation hook
 
 ```ts
 // src/features/tag-data-source/model/use-tag-mutations.ts
@@ -82,100 +82,100 @@ export function useTagMutations(): TagMutations {
     if (mode === 'static') throw new Error(STATIC_REJECTION);
     if (mode === 'local') {
       const path = `tags/${input.slug}`;
-      if (vault.fileHandles.has(path)) throw new Error('이미 존재');
+      if (vault.fileHandles.has(path)) throw new Error('already exists');
       await vault.createDoc(path, buildTagMarkdown(input));
       return;
     }
     // cloud
     await cloudUpsertTag(input);
   };
-  // ... updateTag / deleteTag 비슷한 분기
+  // ... updateTag / deleteTag follow the same branching
   return { createTag, updateTag, deleteTag, canCreate: mode !== 'static', mode };
 }
 ```
 
-### 3.3 UI 컴포넌트에서 hook 사용
+### 3.3 Use the hook from UI components
 
 ```tsx
 function TagCreateForm() {
   const { createTag, canCreate, mode } = useTagMutations();
 
   if (!canCreate) {
-    return <p>정적 데모 모드. 폴더 열기 또는 로그인 후.</p>;
+    return <p>Static demo mode. Open a folder or sign in first.</p>;
   }
   // ... form
   await createTag(input);
 }
 ```
 
-### 3.4 게이트는 *mode* 기준, *role* 기준 X
+### 3.4 Gate on *mode*, not on *role*
 
-❌ 잘못된 패턴 (audit 가 발견한 문제):
+❌ Wrong pattern (the issue the audit surfaced):
 ```tsx
 const { canManage } = useScopedAccountAccess(); // = isLoggedIn
-return canManage ? <CreateButton /> : null;     // local 사용자 차단됨
+return canManage ? <CreateButton /> : null;     // local users get blocked
 ```
 
-✅ 올바른 패턴:
+✅ Correct pattern:
 ```tsx
 const { canCreate } = useTagMutations();        // = mode !== 'static'
-return canCreate ? <CreateButton /> : null;     // local 도 OK
+return canCreate ? <CreateButton /> : null;     // local users work too
 ```
 
 ---
 
-## 4. List subscribe 도 mode-aware (TODO — Phase 6+ 후속)
+## 4. List subscribe should be mode-aware too (TODO — Phase 6+ follow-up)
 
-현재는 mutation 만 mode-aware. **Read 측 (subscribe)** 은 아직 Firestore 우선:
-- `subscribeProjects(accountId, ...)` — Firestore 만 본다.
-- 결과: local 모드 사용자가 새 vault project 추가해도 list 에 안 나옴 (vault manifest 변경은 별도 surface).
+Today only mutations are mode-aware. **Reads (subscribe)** still default to Firestore:
+- `subscribeProjects(accountId, ...)` — looks at Firestore only.
+- Result: when a local-mode user adds a new vault project, it doesn't appear in the list (vault manifest changes show up on a separate surface).
 
-향후 도입 권장:
+Recommended direction:
 ```ts
 // src/features/project-data-source/model/use-projects.ts
 export function useProjects() {
   const mode = useDataSourceMode();
-  // mode === 'local' → useLocalVault().manifest 의 projects/*.md 를 buildTopologyFromVault 로
+  // mode === 'local' → run buildTopologyFromVault over useLocalVault().manifest projects/*.md
   // mode === 'cloud' → subscribeProjects (entity API)
-  // mode === 'static' → vaultManifest static
+  // mode === 'static' → static vaultManifest
 }
 ```
 
-이렇게 하면 *consumer 가 mode 인지 없이* 동일 hook 사용. 현재는 view 가 직접 entity API 호출 — 점진 swap 필요.
+Doing this lets *consumers use the same hook without knowing the mode*. Today, views call the entity API directly — this needs to be swapped out incrementally.
 
 ---
 
-## 5. e2e 테스트 가이드
+## 5. e2e test guidance
 
-각 mode-aware mutation 마다 3 시나리오 e2e:
-- **static**: createX 호출 시 거절 (toast or throw).
-- **local**: vault picker mock 후 vault active → createX → 디스크 .md 생성 확인.
-- **cloud**: Firebase Auth emulator 로 로그인 → createX → Firestore doc 생성 확인.
+For each mode-aware mutation, write three e2e scenarios:
+- **static**: calling createX is rejected (toast or throw).
+- **local**: mock the vault picker so a vault is active → call createX → verify the `.md` is created on disk.
+- **cloud**: sign in via the Firebase Auth emulator → call createX → verify the Firestore doc is created.
 
-본 시점 (2026-05-01) 의 e2e 는 local/cloud 시나리오가 미구현. Phase 6+ 후속.
-
----
-
-## 6. 관련 spec / 룰
-
-- `.claude/rules/local-first.md` — 헌장
-- `docs/LOCAL-FIRST-SYNC.md` — 4 모드 정의 + 충돌 모델
-- `docs/OFFLINE-FIRST-UX-FLOW.md` — UI 흐름 가이드 (5 페이지 게이트 분류 §5)
-- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x ontology 진화 (V1.4 ActionType 도 mode-aware capability 받음)
+As of writing (2026-05-01), the local/cloud e2e scenarios are not yet implemented. Phase 6+ follow-up.
 
 ---
 
-## 7. anti-pattern 모음 (회귀 차단)
+## 6. Related specs / rules
 
-도입 전에 발견된 (그리고 fix 된) 안티 패턴:
+- `.claude/rules/local-first.md` — the charter
+- `docs/LOCAL-FIRST-SYNC.md` — definition of the four modes + conflict model
+- `docs/OFFLINE-FIRST-UX-FLOW.md` — UI flow guide (5-page gate classification §5)
+- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x ontology evolution (V1.4 ActionType also gains a mode-aware capability)
 
-| ❌ | 해결 |
+---
+
+## 7. anti-pattern catalog (regression guard)
+
+Anti-patterns we found (and fixed) before adopting this pattern:
+
+| ❌ | Fix |
 |---|---|
-| `const accountId = null; useScopedAccountAccess(accountId)` 식 항상 null 하드코드 | `accountId` 파라미터 제거 (B4) |
-| Firestore 의 `Missing or insufficient permissions` raw 메시지가 사용자에게 그대로 노출 | accountId === null 면 구독 자체 skip + 빈 그래프 + loaded:true |
-| `<PermissionGate>` 가 페이지 entry 통째 차단 | 진입 게이트 → submit 시점 게이트 (Phase 3.2) |
-| entity API 가 `upsertProject(input)` 만 — Firestore 외 path 없음 | 호출자 (UI) 가 mode-aware hook 거쳐 분기. entity 는 그대로 cloud-only 유지하되 새 hook 이 wrapper 로 동작. |
+| `const accountId = null; useScopedAccountAccess(accountId)` — always-null hardcode | Removed the `accountId` parameter (B4) |
+| Firestore's raw `Missing or insufficient permissions` message leaked to the user | When accountId === null, skip the subscription itself + return an empty graph + loaded:true |
+| `<PermissionGate>` blocked the entire page entry | Moved from entry gate to submit-time gate (Phase 3.2) |
+| Entity API only had `upsertProject(input)` — no path outside Firestore | The caller (UI) branches via the mode-aware hook. The entity stays cloud-only, with the new hook acting as a wrapper. |
 
 ---
 
-> **결론**: mode-aware CRUD 는 *local-first 헌장의 코드 레이어 표현*. 새 entity 에 mutation 을 추가할 때 §3 의 4 단계를 따라 mode-aware 로. 이 패턴이 깨지면 *비로그인 + vault 사용자가 다시 dead-end* 회귀 — 헌장 위반.
+> **Bottom line**: mode-aware CRUD is *the code-layer expression of the local-first charter*. When you add mutations to a new entity, follow the four steps in §3 to make it mode-aware. Breaking this pattern regresses *non-logged-in + vault users back to a dead end* — a charter violation.

--- a/docs/PRODUCT-DIRECTION.md
+++ b/docs/PRODUCT-DIRECTION.md
@@ -1,169 +1,176 @@
-# PRODUCT DIRECTION — 온톨로지 워크벤치 (사람 + AI agent 공동 저작)
+# PRODUCT DIRECTION — Ontology workbench (humans + AI agents co-author)
 
-> 작성일 (v2): 2026-05-01
-> 결정 반영: user 가 **Direction A** (온톨로지 first) 확정 + **dogfooding + AI agent 협업** 방향 추가
-> 본 문서는 [PRODUCT-DIRECTION.md](./PRODUCT-DIRECTION.md) v1 의 strategic 진단을 그대로 두고, **결정 + 새 방향**을 v2 로 덮음.
-
----
-
-## TL;DR — 1원리 한 줄 (v2)
-
-> **이 프로젝트는 온톨로지 워크벤치다 — 비개발자와 AI agent 가 같이 한 codebase 의 mental model 을 함께 저작한다.**
-
-- 토폴로지 = 출구 (view) 중 하나
-- 척추 = md 문서 → 자라는 ontology
-- 비개발자 (PM · 디자이너 · 운영) 도 ERD 보다 친숙한 surface
-- AI agent (Claude Code 같은) 도 같은 ontology 를 읽고 쓰는 *partner* — generic 한 ontology 도구와 차별화되는 angle
+> Written (v2): 2026-05-01
+> Decisions captured: the user confirmed **Direction A** (ontology-first) and added **dogfooding + AI-agent partnership** as a new direction.
+> This file overlays v2 on top of v1's strategic diagnosis (left in place); **the decisions and the new direction** below are what's current.
 
 ---
 
-## 1. user 결정 요약
+## TL;DR — first principle in one line (v2)
 
-### 결정 1 — Direction A (온톨로지 first)
+> **This project is an ontology workbench — non-developers and AI agents co-author the mental model of one codebase.**
 
-`/` 가 **온톨로지 hub** 가 됨:
-- 첫 진입: 트리 + ego graph (현재 `/ontology` 의 핵심을 끌어올림)
-- 토폴로지는 sub view — `/topology` 또는 `/?view=topology`
-- 사용자가 "이 서비스는 내 도메인 지식을 정리하는 곳" 으로 즉시 인지
-
-근거 (user 인용):
-> "온톨로지 서비스니까 말이지? 특히 이 온톨로지는 ERD 이상으로 비개발자를 위함이기도 하잖아?"
-
-### 결정 2 — Self-hosting + AI agent 협업
-
-핵심 통찰:
-> "지금 만들고 있는 이 서비스 자체를 우리가 서비스를 만들면서 해보는건 어떨까? 내 로컬에 패키지 하나 만들고 그거보고 오프라인으로 실행하게 해서 계속 채워나가고 검토하면서 이 온톨로지 서비스 자체가 개발하는 ai agent 에도 도움이 되도록 할 수 있을까?"
-
-해독:
-1. **Dogfooding** — 우리가 이 프로젝트의 docs/ 를 본 서비스의 vault 로 사용
-2. **로컬 패키지** — 사용자 디스크에 install, 오프라인으로 실행 (Firebase 없이도)
-3. **AI agent 가 partner** — 코드를 읽는 Claude Code 가 같은 ontology 를 읽고 쓸 수 있어야 함
-
-이게 차별화 포인트. **generic ontology workbench (Protégé 등) → "AI 와 사람이 같이 저작하는 codebase mental model"**.
+- Topology = one of the *exits* (a view), not the spine.
+- Spine = `.md` documents → a growing ontology.
+- Non-developers (PM · designer · ops) get a surface that's friendlier than ERDs.
+- AI agents (Claude Code, …) read and write the same ontology — that *partner* angle is what differentiates us from generic ontology tools.
 
 ---
 
-## 2. 두 청중, 한 ontology
+## 1. User decisions, summary
 
-| 청중 | 이 서비스로 무엇을 함 |
+### Decision 1 — Direction A (ontology-first)
+
+`/` becomes the **ontology hub**:
+
+- First load: tree + ego graph (lifting today's `/ontology` core to the root).
+- Topology becomes a sub-view — `/topology` or `/?view=topology`.
+- Users immediately understand "this is where I organize my domain knowledge."
+
+User quote:
+
+> "It's an ontology service, right? Especially this one — it's meant for non-developers, beyond an ERD, isn't it?"
+
+### Decision 2 — Self-hosting + AI-agent collaboration
+
+Key insight (user):
+
+> "What if we build the service while using the service ourselves? Make a local package, run it offline, fill it in and review continuously, and have the ontology service itself help the AI agent that's developing it?"
+
+What this decodes to:
+
+1. **Dogfooding** — use this project's own `docs/` as the vault for this service.
+2. **Local package** — installable on the user's disk, runs offline (no Firebase needed).
+3. **AI agent as partner** — Claude Code (which already reads source) should also be able to read and write the ontology.
+
+This is the differentiator. **Generic ontology workbench (Protégé etc.) → "where AI and humans co-author a codebase mental model."**
+
+---
+
+## 2. Two audiences, one ontology
+
+| Audience | What they do with this service |
 |---|---|
-| **개발자** | 코드 ↔ 개념 매핑 — "이 capability 는 어느 service 가 구현?" |
-| **PM / 디자이너 / 운영** | 코드 안 읽고 시스템 mental model 이해 — "어떤 도메인 / 어떤 element 들" |
-| **AI agent** (Claude Code 등) | codebase 의 사전 지식. "이 프로젝트에서 'auth' 이 무엇을 의미하는가" 문답 가능 |
+| **Developers** | Map code ↔ concepts — "which service implements this capability?" |
+| **PM / designer / ops** | Build a mental model without reading source — "which domain, which elements" |
+| **AI agents** (Claude Code, …) | Codebase prior knowledge — answer "what does 'auth' mean in this project?" |
 
-같은 ontology 가 세 청중 모두 만족시킨다는 것이 새 mission.
+The new mission claims one ontology can satisfy all three.
 
 ---
 
-## 3. AI agent 협업 — 구체적으로 무엇
+## 3. AI-agent collaboration — what it concretely means
 
-### 3-A. 읽기 path (이미 가능)
+### 3-A. Read path (already works)
 
-AI agent 가 vault (`projects/*.md`) 를 읽으면 frontmatter 가 ontology 를 직접 표현:
+When an AI agent reads vault files (`projects/*.md`), the frontmatter directly expresses the ontology:
 
 ```yaml
 ---
 slug: auth-platform
 kind: project
-domain: 인증
+domain: Authentication
 capabilities:
-  - 토큰 발급
-  - 권한 검증
-  - 사용자 상태 추적
+  - Token issue
+  - Permission check
+  - Session tracking
 elements: [JWT, Postgres, refresh-token]
 dependencies: [user-service, audit-trail]
 ---
 
 # Auth Platform
 
-사용자 인증·세션·권한을 한 곳에서 ...
+Owns user authentication, sessions, and permissions in one place ...
 ```
 
-→ frontmatter 만으로 capabilities + elements + edges 자동 stub 생성됨 (이미 구현). AI agent 가 이 vault 를 읽으면 즉시 mental model 획득.
+Frontmatter alone auto-stubs capabilities + elements + edges (already implemented). When an AI agent reads this vault, it gets the mental model immediately.
 
-### 3-B. 쓰기 path (필요)
+### 3-B. Write path (needed)
 
-AI agent 가 코드를 분석하면서 새로 발견한 사실을 ontology 에 commit:
+While analyzing code, the AI agent commits newly discovered facts to the ontology:
 
 ```bash
-# 예: AI agent 가 파일을 분석한 후
+# example: after the agent inspects a file
 $ ohmy add element src/features/billing/lib/cycle-rule.ts \
     --kind element \
-    --capability "구독 주기 계산" \
+    --capability "Subscription cycle calculation" \
     --project billing-service
 ```
 
-방법 (옵션):
-1. **CLI** — `npx oh-my-ontology add ...` (frontmatter 자동 작성)
-2. **MCP 서버** — Claude Code 가 직접 도구 호출 (`mcp__oh-my-ontology__add_node`)
-3. **프로그래매틱 API** — 패키지에서 `addNode({...})` import
+Options:
 
-가장 ergonomic 한 건 **3 (MCP 서버)**. AI agent 가 codebase 탐색 → 발견한 개념을 ontology 에 *직접* 추가. 인간 검수자가 빌더에서 본다.
+1. **CLI** — `npx oh-my-ontology add ...` (auto-writes frontmatter)
+2. **MCP server** — Claude Code calls tools directly (`mcp__oh-my-ontology__add_node`)
+3. **Programmatic API** — `import { addNode }` from the package
 
-### 3-C. 양방향 sync
+Most ergonomic: **option 3 (MCP server)**. The agent navigates the codebase and adds discovered concepts to the ontology *directly*. Humans review them in the builder.
+
+### 3-C. Two-way sync
 
 ```
 human edits builder canvas
         │
         ▼
-ontology 그래프 (vault frontmatter)
+ontology graph (vault frontmatter)
         ▲
         │
 AI agent reads codebase → adds nodes via MCP/CLI
 ```
 
-같은 graph. 같은 vault. 다른 입력 경로.
+Same graph. Same vault. Different input paths.
 
 ---
 
-## 4. 로컬 패키지 — 어떻게 distribute
+## 4. Local package — how to distribute
 
-### 옵션 A — npm 패키지 + CLI
+### Option A — npm package + CLI
 
 ```bash
-# 사용자가 자기 프로젝트 root 에서
+# user, from any project root
 $ npx oh-my-ontology@latest
 
-# 시작:
-# - 현재 디렉토리를 vault 로 인식
-# - localhost:3210 에 web UI 띄움
-# - 브라우저 자동 열림
-# - Firebase 미설정 → local 모드 자동 활성
+# starts:
+# - treats the current directory as the vault
+# - serves the web UI on localhost:3210
+# - opens the browser
+# - if Firebase isn't configured, falls back to local mode automatically
 ```
 
-장점:
-- 설치 0 마찰 (npm/pnpm 만 있으면 됨)
-- 모든 프로젝트가 잠재 vault
-- offline-first 기본
-- Next.js 빌드 산출을 그대로 distribute 가능 (정적 export + 미니 서버)
+Pros:
 
-단점:
-- Node.js 의존
-- 배포 후 패키지 사이즈 (Sigma + xyflow + 등 무거움)
+- Zero install friction (just `npm` / `pnpm`).
+- Any project becomes a potential vault.
+- Offline-first by default.
+- Next.js build output ships as-is (static export + tiny server).
 
-### 옵션 B — Electron 데스크톱 앱
+Cons:
 
-장점: 진짜 native 느낌
-단점: 빌드 복잡, 배포 무거움, "AI agent 가 같이 쓰는" 컨셉과 안 맞음 (CLI 가 더 자연)
+- Requires Node.js.
+- Bundle is heavy after publish (Sigma + xyflow + …).
 
-### 옵션 C — 그대로 Next.js 정적 export + 가이드만
+### Option B — Electron desktop app
 
-`pnpm dev` 후 사용. 패키지화 X. 가이드 + 환경 변수 옵션화.
+Pros: feels truly native.
+Cons: complex build, heavy distribution, mismatched with the "AI agent shares this" concept (CLI fits better).
 
-장점: 가장 빠름. 새 dependency 0.
-단점: 배포 차단 (clone 부담).
+### Option C — Just Next.js static export + a guide
 
-### 권장: A 옵션 (CLI + npx)
+Use after `pnpm dev`. No packaging. Document with environment variables.
 
-`oh-my-ontology` 라는 npm 패키지로 publish. 사용자는 어떤 프로젝트의 root 에서든 `npx oh-my-ontology` 로 띄울 수 있게. AI agent 도 같은 패키지의 MCP 서버 또는 CLI 호출로 참여.
+Pros: fastest. Zero new deps.
+Cons: blocks distribution (clone overhead).
+
+### Recommendation: option A
+
+Publish `oh-my-ontology` as an npm package. Users run `npx oh-my-ontology` from any project root. AI agents participate via the same package's MCP server or CLI.
 
 ---
 
-## 5. AI agent 가 partner 가 되는 surface
+## 5. The agent-as-partner surface
 
-### 5-A. MCP 서버
+### 5-A. MCP server
 
-`oh-my-ontology-mcp` 별도 패키지. Claude Code 와 호환:
+Separate package, `oh-my-ontology-mcp`. Claude Code-compatible:
 
 ```json
 // .mcp.json or settings
@@ -178,106 +185,111 @@ $ npx oh-my-ontology@latest
 }
 ```
 
-도구:
-- `list_concepts` — vault 의 모든 노드 (kind 별 필터)
-- `get_concept` — 단일 노드 + 이웃
-- `add_concept` — 새 노드 (frontmatter 작성)
-- `add_relation` — 두 노드 사이 edge
-- `find_evidence` — 어떤 코드가 이 concept 의 근거인지
+Tools:
 
-이게 있으면 AI agent 가 codebase 탐색 시 **"이 파일이 어느 concept 의 element 인가?"** 을 직접 알 수 있음. 매번 다시 추론 X.
+- `list_concepts` — every node in the vault (filter by kind)
+- `get_concept` — a single node + its neighbors
+- `add_concept` — new node (writes frontmatter)
+- `add_relation` — edge between two nodes
+- `find_evidence` — which code grounds this concept
 
-### 5-B. AGENTS.md / CLAUDE.md 에 ontology 인덱스 자동 생성
+With this in place, the agent can answer **"which concept is this file an element of?"** directly during code exploration. No re-inferring every conversation.
 
-빌드 타임에 ontology 의 high-level 구조를 markdown 으로 dump:
+### 5-B. Auto-generated ontology index in AGENTS.md / CLAUDE.md
+
+At build time, dump the ontology's high-level structure as markdown:
 
 ```markdown
 # This project's ontology (auto-generated)
 
 ## Domains
-- 인증: 토큰 발급 · 권한 검증 · 사용자 상태 추적
-- 결제: 구독 · 사용량 · 청구
+- Authentication: Token issue · Permission check · Session tracking
+- Billing: Subscription · Usage · Invoicing
 
 ## Capabilities
-- 토큰 발급 [auth-platform/iam-core]
+- Token issue [auth-platform/iam-core]
 - ...
 ```
 
-AI agent 가 codebase 진입 시 첫 페이지에서 이걸 보면 mental model 즉시 형성.
+When an agent enters the codebase, it sees this on the first page and picks up the mental model instantly.
 
 ---
 
-## 6. 단계 — 실행 가능 하게 분해
+## 6. Phases — broken into executable steps
 
-### ✅ Phase 1 — 정체성 정렬 (UI) — 머지 완료
+### ✅ Phase 1 — Identity alignment (UI) — merged
 
-1. ✅ `/` 를 ontology hub 로
-2. ✅ `/topology` 신규 라우트
-3. ✅ 랜딩 카피 — "AI 와 함께 자라는 codebase ontology"
-4. ✅ demo 슬림 — 21 → 6 컨테이너, ~50 flat projects, ontology 노드 ~42
+1. ✅ `/` becomes the ontology hub
+2. ✅ New `/topology` route
+3. ✅ Landing copy — "Codebase ontology that grows with AI"
+4. ✅ Slim demo — 21 → 6 containers, ~50 flat projects, ~42 ontology nodes
 
 ### ⏸ Phase 2 — Self-hosting — DEFERRED
 
-`bin` + CLI 패키지화. **user 정책상 firebase 배포 안 함** + `pnpm dev` 로 충분히 검증 가능 → DEFERRED. 추후 재검토.
+`bin` + CLI packaging. **Per user policy, Firebase deploy is on hold** and `pnpm dev` covers verification → DEFERRED. Revisit later.
 
-### ✅ Phase 3 — AI agent partner — 머지 완료
+### ✅ Phase 3 — AI agent partner — merged
 
-1. ✅ `mcp/` 패키지 — MCP 서버 v0.2.0 (PR #5/#7)
-2. ✅ 7 도구: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`
-3. ⏸ CLI 명령 (`ohmy`) — DEFERRED (MCP 가 충분, CLI 는 Phase 2 의존)
-4. ⏸ AGENTS.md 자동 생성 — DEFERRED (수동 갱신 + dogfood vault 가 대체)
-5. ✅ `docs/ontology/` dogfood vault — 21 노드, 자기 mental model 표현
+1. ✅ `mcp/` package — MCP server v0.2.0 (PR #5/#7)
+2. ✅ 7 tools: `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `add_concept` / `add_relation` / `patch_concept`
+3. ⏸ CLI command (`ohmy`) — DEFERRED (MCP suffices; CLI depends on Phase 2)
+4. ⏸ Auto-generated AGENTS.md — DEFERRED (manual updates + dogfood vault cover this)
+5. ✅ `docs/ontology/` dogfood vault — 21 nodes describing our own mental model
 
-### ⏳ Phase 4 — 비개발자 surface 다듬기 — 진행 예정
+### ⏳ Phase 4 — Polish for non-developers — upcoming
 
-자세히: `docs/BACKLOG.md` T33-T36.
+Details: `docs/BACKLOG.md` T33-T36.
 
-1. ⏳ 빌더 onboarding "ERD 이상 — 도메인 지도" 카피 정렬
-2. ⏳ 기술 용어 ↔ 한국어 일반 용어 매핑 layer
-3. ⏳ 노드 색 / 아이콘 — kind 별 친숙
-4. ⏳ 검색 시 "코드 / 문서 / 사람" 분류 (PM 친화)
+1. ⏳ Builder onboarding copy aligned with "more than an ERD — a domain map"
+2. ⏳ Mapping layer between technical jargon and everyday language
+3. ⏳ Per-kind node colors / icons (more familiar)
+4. ⏳ Search results categorized by "code / doc / person" (PM-friendly)
 
 ---
 
-## 7. 신구 mission 비교
+## 7. Old vs. new mission
 
-### 구 mission (AGENTS.md, 현재)
+### Old mission (per AGENTS.md, current)
 
-> 사용자가 글을 쓰면 시스템이 개념·관계·근거를 추출해 검수·승인하면 토폴로지·트리·ERD 세 가지 view 로 자라난다.
+> The user writes prose; the system extracts concepts, relations, evidence; humans review and approve; the result grows into three views (topology, tree, ERD).
 
-### 신 mission (이 문서로 제안)
+### New mission (proposed in this doc)
 
-> **사람과 AI agent 가 같이 저작하는 codebase 의 ontology.**
+> **An ontology of one codebase, co-authored by humans and AI agents.**
 >
-> - 사람: vault frontmatter 또는 빌더에서 직접 노드/관계 추가
-> - AI agent (Claude Code 등): MCP 또는 CLI 로 코드 탐색 결과를 ontology 에 commit
-> - 모두 같은 vault 그래프. 모두 같은 view 들 (트리 hub / 토폴로지 sub-view / ERD)
-> - 패키지로 distribute — 어느 codebase 에서든 `npx oh-my-ontology`
+> - Humans: add nodes/edges directly from the vault frontmatter or the builder canvas.
+> - AI agents (Claude Code, …): commit code-exploration findings to the ontology via MCP or CLI.
+> - All inputs share one vault graph. All views (tree hub / topology sub-view / ERD).
+> - Distributed as a package — `npx oh-my-ontology` from any codebase.
 
-차이:
-- "AI 가 추출" 이라는 cloud-extraction 약속 → "AI agent 가 partner" 라는 협업 약속
-- 비용 모델 — cloud LLM 비용 자체가 사라짐 (Claude Code 가 이미 user 의 LLM 비용 부담)
-- 정체성 명확 — generic ontology 도구가 아니라 **codebase 와 AI agent 가 만나는 워크벤치**
+What changed:
+
+- Cloud-extraction promise ("AI extracts") → collaboration promise ("AI agent partners").
+- Cost model — the cloud LLM cost disappears (Claude Code already covers user's LLM cost).
+- Identity sharpened — not a generic ontology tool, but **the workbench where codebases meet AI agents**.
 
 ---
 
-## 8. 즉시 다음 액션 (user 명령 대기 중)
+## 8. Immediate next actions (waiting on user)
 
-이 v2 문서는 *방향* 만 정렬. 어느 단계부터 진행할지 결정 필요:
+This v2 doc only aligns *direction*. We still need to pick which phase to execute:
 
-### 옵션 A — Phase 1 즉시 시작 (UI 정체성 정렬)
+### Option A — Start Phase 1 immediately (UI identity alignment)
+
 - `/` ↔ `/topology` swap
-- demo 슬림
-- 랜딩 카피
-- est: 1-2 일 (commit 5-7 개)
+- Demo slim
+- Landing copy
+- Est: 1–2 days, 5–7 commits
 
-### 옵션 B — Phase 2 먼저 (self-hosting)
-- npm 패키지화 + CLI
-- 가장 큰 기술 변경 — 다른 작업 가속됨
-- est: 1-2 일
+### Option B — Phase 2 first (self-hosting)
 
-### 옵션 C — 이 문서 review + 추가 결정
-- v2 의 가정 (비용 / 청중 / 우선순위) 더 다듬기
-- 그 다음 Phase 결정
+- npm packaging + CLI
+- Biggest tech change — accelerates everything else.
+- Est: 1–2 days
 
-내 1원리 의견: **A** 부터. UI 정체성이 정렬돼야 self-hosting 시작 시 사용자가 보는 첫 화면이 "올바른 mission" 표현. self-hosting 은 그 다음.
+### Option C — Review this doc + extra decisions
+
+- Refine v2 assumptions (cost / audience / priority)
+- Pick a phase afterwards.
+
+My first-principle take: **A first**. Once the UI identity is aligned, the first screen users see when self-hosting will already express the right mission. Self-hosting comes after.

--- a/docs/PUBLISH-NPM.md
+++ b/docs/PUBLISH-NPM.md
@@ -1,134 +1,136 @@
-# npm publish 단계별 가이드
+# npm publish — step-by-step guide
 
-이 프로젝트는 두 npm 패키지를 publish 합니다:
+This project publishes two npm packages:
 
-| 패키지 | 위치 | 무엇 | publish 필수성 |
+| Package | Path | What | Required? |
 |---|---|---|---|
-| `oh-my-ontology-mcp` | `mcp/` | MCP 서버 (AI agent 가 vault read/write) | **필수** — AI agent 통합의 핵심 |
-| `oh-my-ontology` | `cli/` | `init` CLI (vault scaffold) | **선택** — web workbench 의 scaffold 버튼이 대체 가능 |
+| `oh-my-ontology-mcp` | `mcp/` | MCP server (AI agents read/write the vault) | **Required** — the core of the AI agent integration |
+| `oh-my-ontology` | `cli/` | `init` CLI (vault scaffold) | **Optional** — the web workbench's scaffold button does the same thing |
 
-> **비용**: $0 — npm 의 public package 는 영구 무료. 다운로드/사용자 무제한.
-> 단, npm 계정 + 2FA 가 필요 (계정도 무료).
+> **Cost**: $0. Public npm packages are permanently free. Unlimited downloads / users.
+> You do need an npm account with 2FA (free).
+
+> 🚫 **AI agent guard**: This project blocks `npm publish` / `pnpm publish` / `yarn publish` from being run by Claude Code or any AI agent — see `.claude/settings.json`, `CLAUDE.md`, `.claude/rules/forbidden.md`. You (the human maintainer) run these commands yourself, in a real terminal, after deliberate review.
 
 ---
 
-## 사전 점검 (이미 끝남, 참고용)
+## Pre-flight check (already done, kept for reference)
 
-`pnpm` 의 npm pack dry-run 으로 어떤 파일이 publish 될지 사전 확인 가능:
+`npm pack --dry-run` shows exactly which files would be published:
 
 ```bash
 cd mcp
 npm pack --dry-run
-# Tarball Contents 표시 — README.md, package.json, src/*, scripts/verify.mjs
-# 이 외 파일은 publish 안 됨
+# Tarball Contents — README.md, package.json, src/*, scripts/verify.mjs
+# Anything else is excluded.
 
 cd ../cli
 npm pack --dry-run
 # README.md, package.json, src/index.mjs, templates/vault/*.md
 ```
 
-이미 audit 끝 — secret/PII 0, 절대경로 0.
+We've audited: 0 secrets, 0 PII, 0 absolute paths.
 
 ---
 
-## 1단계: npm 계정 만들고 로그인
+## Step 1 — npm account and login
 
-### a) npm 계정 만들기 (이미 가입했다면 skip)
+### a) Create an npm account (skip if you already have one)
 
-1. https://www.npmjs.com/signup — 이메일 + 패스워드 (비번은 강하게)
-2. 이메일 인증 (메일에서 링크 클릭)
-3. **2FA 설정 강력 권장** — 계정 lock 방지:
-   - 로그인 후 https://www.npmjs.com/settings/{username}/account
-   - "Two-Factor Authentication" 섹션 → "Enable 2FA"
-   - "auth-only" 모드 선택 (publish 시점에만 OTP 입력) — 모바일 OTP 앱 (1Password / Authy / Google Authenticator) 으로 QR 스캔
-   - **recovery codes 안전한 곳에 저장**
+1. https://www.npmjs.com/signup — email + password (use a strong one).
+2. Verify the email link npm sends.
+3. **Strongly recommended: enable 2FA** to protect against account lockout / takeover:
+   - After login, visit https://www.npmjs.com/settings/{username}/account
+   - "Two-Factor Authentication" → "Enable 2FA"
+   - Pick "auth-only" (OTP only at publish time) and scan the QR with a mobile OTP app (1Password / Authy / Google Authenticator).
+   - **Save the recovery codes somewhere safe.**
 
-### b) 터미널에서 로그인
+### b) Login from the terminal
 
 ```bash
 npm login
-# 브라우저가 열리고 npm 로그인 페이지로 이동
-# 로그인 후 OTP 입력
-# "Logged in as <username>" 메시지 뜨면 성공
+# Browser opens to the npm login page.
+# After you log in, enter the OTP.
+# "Logged in as <username>" means success.
 ```
 
-확인:
+Verify:
 
 ```bash
 npm whoami
-# 본인 username 출력되면 OK
+# prints your username
 ```
 
 ---
 
-## 2단계: 패키지 이름 사용 가능한지 확인
+## Step 2 — Check the package names are available
 
 ```bash
 npm view oh-my-ontology
-# 만약 "404 Not Found" 면 사용 가능 (✅)
-# 만약 패키지 정보가 나오면 이미 다른 사람이 사용 중 — 다른 이름 필요
+# "404 Not Found" = name available ✅
+# Any other output = someone else owns this name
 
 npm view oh-my-ontology-mcp
-# 동일 체크
+# Same check
 ```
 
-만약 충돌하면:
-- 옵션 A: 다른 이름 (예: `wlsdks-oh-my-ontology`)
-- 옵션 B: scope 사용 (`@wlsdks/oh-my-ontology`) — 공개 scope 도 무료
+If a name is taken:
+
+- Option A: pick another name (e.g. `wlsdks-oh-my-ontology`)
+- Option B: use a scope (`@wlsdks/oh-my-ontology`) — public scopes are also free
 
 ---
 
-## 3단계: MCP 서버 publish (먼저, 핵심이므로)
+## Step 3 — Publish the MCP server (this is the important one)
 
 ```bash
 cd mcp
 npm publish --access=public
-# OTP 입력 (2FA 활성화한 경우)
-# "+ oh-my-ontology-mcp@0.5.0" 출력되면 성공
+# Enter OTP when prompted (if 2FA enabled)
+# "+ oh-my-ontology-mcp@0.5.0" = success
 ```
 
-확인:
-- https://www.npmjs.com/package/oh-my-ontology-mcp 페이지가 뜸
-- `npx -y oh-my-ontology-mcp` 가 어디서든 동작 (테스트해보려면 다른 디렉토리에서):
+Verify:
+
+- https://www.npmjs.com/package/oh-my-ontology-mcp shows the package page
+- `npx -y oh-my-ontology-mcp` works from any folder. Test from a fresh shell:
 
 ```bash
 cd /tmp
 OMOT_VAULT=/path/to/some/folder npx -y oh-my-ontology-mcp
-# 서버가 시작되며 stdin 대기 — Ctrl+C 로 종료
+# Server starts, waits on stdin. Ctrl+C to exit.
 ```
 
 ---
 
-## 4단계: CLI publish (선택)
+## Step 4 — Publish the CLI (optional)
 
 ```bash
 cd cli
 npm publish --access=public
-# OTP 입력
+# OTP if needed
 ```
 
-확인:
+Verify:
 
 ```bash
 cd /tmp
 npx oh-my-ontology --help
-# Help 메시지 출력
+# prints help
 npx oh-my-ontology init test-vault
-# test-vault 폴더에 5 md + .mcp.json.example 시드
+# creates test-vault/ with 5 .md files + .mcp.json.example
 rm -rf test-vault
 ```
 
-CLI 를 publish *안* 하려면? — 사용자는 web workbench 의 `/docs` 페이지에서
-"starter 시드 만들기" 버튼으로 같은 결과 얻을 수 있음. CLI 는 *AI-native
-developer 의 1줄 setup* 편의용.
+Don't want to publish the CLI? Users can get the same scaffold from the web workbench's `/docs` page → "Create starter seed" button. The CLI is just a convenience for AI-native developers who prefer one-line setup.
 
 ---
 
-## 5단계: 동작 확인
+## Step 5 — Confirm everything works
 
-### A) AI agent 등록 (Claude Code 예시)
+### A) Register with an AI agent (Claude Code example)
 
-`~/.config/claude-code/mcp.json` (또는 적절한 경로) 에:
+In `~/.config/claude-code/mcp.json` (or wherever your agent reads MCP config):
 
 ```json
 {
@@ -144,90 +146,90 @@ developer 의 1줄 setup* 편의용.
 }
 ```
 
-Claude Code 재시작 → tool 목록에 `oh-my-ontology__list_concepts` 등 11
-도구가 나타나면 성공.
+Restart Claude Code. The tool list should show `oh-my-ontology__list_concepts` and 10 others.
 
-### B) 사용자 vault 시작 (CLI 사용 케이스)
+### B) Start a user vault (CLI path)
 
 ```bash
-# 어디서든
+# from anywhere
 npx oh-my-ontology init my-vault
 cd my-vault
 ls -la
-# 5 md + .mcp.json.example
+# 5 .md files + .mcp.json.example
 ```
 
-### C) 사용자 vault 시작 (workbench 사용 케이스)
+### C) Start a user vault (workbench path)
 
-1. https://oh-my-ontology.web.app/docs (Firebase 배포 후)
-2. "내 PC 의 마크다운 폴더 열기" → 빈 폴더 선택
-3. "starter 시드 만들기" 버튼 클릭
-4. 5 md + .mcp.json.example 자동 작성
+1. https://oh-my-ontology.web.app/docs (after Firebase deploy)
+2. "Open my markdown folder" → pick an empty folder
+3. Click "Create starter seed"
+4. 5 .md files + .mcp.json.example are written automatically
 
 ---
 
-## Unpublish / 패키지 삭제
+## Unpublish / remove a package
 
-publish 후 24시간 안에는 unpublish 가능 (실수로 잘못 올렸을 때):
+Within 24 hours of publish, you can unpublish (for honest mistakes):
 
 ```bash
 npm unpublish oh-my-ontology-mcp@0.5.0
 ```
 
-24시간 후엔 unpublish 불가 — `deprecate` 만 가능 (사용자 install 시 경고만):
+After 24 hours, unpublish is no longer allowed — only `deprecate` (installers see a warning, the version stays):
 
 ```bash
-npm deprecate oh-my-ontology-mcp@0.5.0 "version 0.5.0 has critical bug, use 0.5.1+"
+npm deprecate oh-my-ontology-mcp@0.5.0 "0.5.0 has a critical bug, use 0.5.1+"
 ```
 
-> 따라서 첫 publish 전에 `npm pack --dry-run` 으로 한 번 더 확인 권장.
-> 우리는 이미 audit 끝.
+> So always run `npm pack --dry-run` once more before the first publish.
+> We've already audited.
 
 ---
 
-## 버전 올리기 (다음 publish 부터)
+## Bumping the version (every subsequent publish)
 
-코드 변경 후 다시 publish 하려면 버전 bump 필수 (npm 은 같은 버전 재publish 막음):
+After code changes, you must bump the version — npm rejects republishing the same one:
 
 ```bash
 cd mcp
 # Patch (bug fix): 0.5.0 → 0.5.1
 npm version patch
-# 또는 minor: 0.5.0 → 0.6.0
+# Or minor: 0.5.0 → 0.6.0
 npm version minor
-# 또는 major: 0.5.0 → 1.0.0
+# Or major: 0.5.0 → 1.0.0
 npm version major
 
 npm publish --access=public
 ```
 
-버전 bump 는 자동으로 `package.json` 의 version 갱신 + git commit + tag 생성.
+`npm version` automatically updates `package.json`, creates a git commit, and tags it.
 
 ---
 
-## 트러블슈팅
+## Troubleshooting
 
-| 증상 | 원인 / 해결 |
+| Symptom | Cause / fix |
 |---|---|
-| `403 Forbidden` | 2FA OTP 잘못 또는 만료. 다시 시도. |
-| `404 Not Found` (publish 시) | scope 패키지인데 `--access=public` 안 줬을 때. 추가. |
-| `EEXIST` (`oh-my-ontology` already exists) | 이름 충돌. 다른 이름 또는 scope 사용. |
-| `npx oh-my-ontology` 안 됨 | publish 후 npm CDN 반영에 1-2분 걸림. 잠시 후 재시도. |
+| `403 Forbidden` | 2FA OTP wrong or expired. Try again. |
+| `404 Not Found` (on publish) | Scoped package without `--access=public`. Add the flag. |
+| `EEXIST` (`oh-my-ontology` already exists) | Name conflict. Pick a different name or use a scope. |
+| `npx oh-my-ontology` doesn't work right after publish | npm CDN takes 1–2 min to propagate. Wait and retry. |
+| Claude Code blocks the publish command | Expected — see "AI agent guard" up top. Run from a real terminal yourself. |
 
 ---
 
-## 한 줄 요약
+## One-line summary
 
 ```bash
-# 한 번만 (계정 + 로그인)
+# Once (account + login)
 npm login
 
-# 매 publish 시
+# Each publish
 cd mcp && npm publish --access=public
 cd ../cli && npm publish --access=public
 
-# 동작 확인
+# Smoke test
 cd /tmp && npx oh-my-ontology init test-vault && rm -rf test-vault
 ```
 
-전부 무료. 24시간 안에 실수 되돌리기 가능. 평생 사용자 무제한.
+Free. Reversible within 24h. Unlimited users forever.

--- a/docs/PUBLISH-NPM.md
+++ b/docs/PUBLISH-NPM.md
@@ -1,0 +1,233 @@
+# npm publish 단계별 가이드
+
+이 프로젝트는 두 npm 패키지를 publish 합니다:
+
+| 패키지 | 위치 | 무엇 | publish 필수성 |
+|---|---|---|---|
+| `oh-my-ontology-mcp` | `mcp/` | MCP 서버 (AI agent 가 vault read/write) | **필수** — AI agent 통합의 핵심 |
+| `oh-my-ontology` | `cli/` | `init` CLI (vault scaffold) | **선택** — web workbench 의 scaffold 버튼이 대체 가능 |
+
+> **비용**: $0 — npm 의 public package 는 영구 무료. 다운로드/사용자 무제한.
+> 단, npm 계정 + 2FA 가 필요 (계정도 무료).
+
+---
+
+## 사전 점검 (이미 끝남, 참고용)
+
+`pnpm` 의 npm pack dry-run 으로 어떤 파일이 publish 될지 사전 확인 가능:
+
+```bash
+cd mcp
+npm pack --dry-run
+# Tarball Contents 표시 — README.md, package.json, src/*, scripts/verify.mjs
+# 이 외 파일은 publish 안 됨
+
+cd ../cli
+npm pack --dry-run
+# README.md, package.json, src/index.mjs, templates/vault/*.md
+```
+
+이미 audit 끝 — secret/PII 0, 절대경로 0.
+
+---
+
+## 1단계: npm 계정 만들고 로그인
+
+### a) npm 계정 만들기 (이미 가입했다면 skip)
+
+1. https://www.npmjs.com/signup — 이메일 + 패스워드 (비번은 강하게)
+2. 이메일 인증 (메일에서 링크 클릭)
+3. **2FA 설정 강력 권장** — 계정 lock 방지:
+   - 로그인 후 https://www.npmjs.com/settings/{username}/account
+   - "Two-Factor Authentication" 섹션 → "Enable 2FA"
+   - "auth-only" 모드 선택 (publish 시점에만 OTP 입력) — 모바일 OTP 앱 (1Password / Authy / Google Authenticator) 으로 QR 스캔
+   - **recovery codes 안전한 곳에 저장**
+
+### b) 터미널에서 로그인
+
+```bash
+npm login
+# 브라우저가 열리고 npm 로그인 페이지로 이동
+# 로그인 후 OTP 입력
+# "Logged in as <username>" 메시지 뜨면 성공
+```
+
+확인:
+
+```bash
+npm whoami
+# 본인 username 출력되면 OK
+```
+
+---
+
+## 2단계: 패키지 이름 사용 가능한지 확인
+
+```bash
+npm view oh-my-ontology
+# 만약 "404 Not Found" 면 사용 가능 (✅)
+# 만약 패키지 정보가 나오면 이미 다른 사람이 사용 중 — 다른 이름 필요
+
+npm view oh-my-ontology-mcp
+# 동일 체크
+```
+
+만약 충돌하면:
+- 옵션 A: 다른 이름 (예: `wlsdks-oh-my-ontology`)
+- 옵션 B: scope 사용 (`@wlsdks/oh-my-ontology`) — 공개 scope 도 무료
+
+---
+
+## 3단계: MCP 서버 publish (먼저, 핵심이므로)
+
+```bash
+cd mcp
+npm publish --access=public
+# OTP 입력 (2FA 활성화한 경우)
+# "+ oh-my-ontology-mcp@0.5.0" 출력되면 성공
+```
+
+확인:
+- https://www.npmjs.com/package/oh-my-ontology-mcp 페이지가 뜸
+- `npx -y oh-my-ontology-mcp` 가 어디서든 동작 (테스트해보려면 다른 디렉토리에서):
+
+```bash
+cd /tmp
+OMOT_VAULT=/path/to/some/folder npx -y oh-my-ontology-mcp
+# 서버가 시작되며 stdin 대기 — Ctrl+C 로 종료
+```
+
+---
+
+## 4단계: CLI publish (선택)
+
+```bash
+cd cli
+npm publish --access=public
+# OTP 입력
+```
+
+확인:
+
+```bash
+cd /tmp
+npx oh-my-ontology --help
+# Help 메시지 출력
+npx oh-my-ontology init test-vault
+# test-vault 폴더에 5 md + .mcp.json.example 시드
+rm -rf test-vault
+```
+
+CLI 를 publish *안* 하려면? — 사용자는 web workbench 의 `/docs` 페이지에서
+"starter 시드 만들기" 버튼으로 같은 결과 얻을 수 있음. CLI 는 *AI-native
+developer 의 1줄 setup* 편의용.
+
+---
+
+## 5단계: 동작 확인
+
+### A) AI agent 등록 (Claude Code 예시)
+
+`~/.config/claude-code/mcp.json` (또는 적절한 경로) 에:
+
+```json
+{
+  "mcpServers": {
+    "oh-my-ontology": {
+      "command": "npx",
+      "args": ["-y", "oh-my-ontology-mcp"],
+      "env": {
+        "OMOT_VAULT": "/Users/me/my-vault"
+      }
+    }
+  }
+}
+```
+
+Claude Code 재시작 → tool 목록에 `oh-my-ontology__list_concepts` 등 11
+도구가 나타나면 성공.
+
+### B) 사용자 vault 시작 (CLI 사용 케이스)
+
+```bash
+# 어디서든
+npx oh-my-ontology init my-vault
+cd my-vault
+ls -la
+# 5 md + .mcp.json.example
+```
+
+### C) 사용자 vault 시작 (workbench 사용 케이스)
+
+1. https://oh-my-ontology.web.app/docs (Firebase 배포 후)
+2. "내 PC 의 마크다운 폴더 열기" → 빈 폴더 선택
+3. "starter 시드 만들기" 버튼 클릭
+4. 5 md + .mcp.json.example 자동 작성
+
+---
+
+## Unpublish / 패키지 삭제
+
+publish 후 24시간 안에는 unpublish 가능 (실수로 잘못 올렸을 때):
+
+```bash
+npm unpublish oh-my-ontology-mcp@0.5.0
+```
+
+24시간 후엔 unpublish 불가 — `deprecate` 만 가능 (사용자 install 시 경고만):
+
+```bash
+npm deprecate oh-my-ontology-mcp@0.5.0 "version 0.5.0 has critical bug, use 0.5.1+"
+```
+
+> 따라서 첫 publish 전에 `npm pack --dry-run` 으로 한 번 더 확인 권장.
+> 우리는 이미 audit 끝.
+
+---
+
+## 버전 올리기 (다음 publish 부터)
+
+코드 변경 후 다시 publish 하려면 버전 bump 필수 (npm 은 같은 버전 재publish 막음):
+
+```bash
+cd mcp
+# Patch (bug fix): 0.5.0 → 0.5.1
+npm version patch
+# 또는 minor: 0.5.0 → 0.6.0
+npm version minor
+# 또는 major: 0.5.0 → 1.0.0
+npm version major
+
+npm publish --access=public
+```
+
+버전 bump 는 자동으로 `package.json` 의 version 갱신 + git commit + tag 생성.
+
+---
+
+## 트러블슈팅
+
+| 증상 | 원인 / 해결 |
+|---|---|
+| `403 Forbidden` | 2FA OTP 잘못 또는 만료. 다시 시도. |
+| `404 Not Found` (publish 시) | scope 패키지인데 `--access=public` 안 줬을 때. 추가. |
+| `EEXIST` (`oh-my-ontology` already exists) | 이름 충돌. 다른 이름 또는 scope 사용. |
+| `npx oh-my-ontology` 안 됨 | publish 후 npm CDN 반영에 1-2분 걸림. 잠시 후 재시도. |
+
+---
+
+## 한 줄 요약
+
+```bash
+# 한 번만 (계정 + 로그인)
+npm login
+
+# 매 publish 시
+cd mcp && npm publish --access=public
+cd ../cli && npm publish --access=public
+
+# 동작 확인
+cd /tmp && npx oh-my-ontology init test-vault && rm -rf test-vault
+```
+
+전부 무료. 24시간 안에 실수 되돌리기 가능. 평생 사용자 무제한.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,171 @@
+# Troubleshooting
+
+Common issues users hit when starting with `oh-my-ontology`. If your case isn't here, open an issue: https://github.com/wlsdks/oh-my-ontology/issues
+
+---
+
+## Vault scaffold (`npx oh-my-ontology init`, web `/docs` button)
+
+### `npx oh-my-ontology` runs an old version
+
+npm caches the package locally. Force a fresh fetch:
+
+```bash
+npx --yes oh-my-ontology@latest init my-vault
+# or clear the npx cache
+rm -rf ~/.npm/_npx
+```
+
+### "no new files written — target already has matching files"
+
+The target folder already has `README.md` / `project.md` / etc. — the CLI never overwrites existing files. Either:
+
+- Delete the conflicting files, or
+- Use a fresh folder: `npx oh-my-ontology init another-folder`
+
+### Web scaffold button stays grayed out
+
+The button only enables when:
+
+1. You picked a folder via "Open my markdown folder" *and*
+2. The picked handle has read+write permission.
+
+If the browser asked only for "view files" permission, click the picker again and approve "edit files."
+
+### Browser refuses to write to the picked folder
+
+The File System Access API requires:
+
+- A user gesture (click) that called `showDirectoryPicker` — refresh and click again.
+- HTTPS or `localhost`. Some browsers block on plain HTTP.
+- A non-system folder. Try a folder under `~/Documents` or `~/Desktop`.
+
+---
+
+## MCP server (Claude Code, Cursor, etc.)
+
+### Agent doesn't see `oh-my-ontology__list_concepts` etc.
+
+1. Confirm the package is reachable: `npx -y oh-my-ontology-mcp` (it should start a stdio server and wait — Ctrl+C to exit).
+2. Check the agent's MCP config — `command` should be `npx`, `args: ["-y", "oh-my-ontology-mcp"]`.
+3. Set `env.OMOT_VAULT` to the **absolute path** of the vault folder (the browser app's `.mcp.json.example` ships a placeholder; you must replace it).
+4. Restart the agent (Claude Code / Cursor pickup MCP config at start).
+
+### "Vault path does not exist" / `EACCES`
+
+`OMOT_VAULT` must be:
+
+- An absolute path, not relative or `~/...`. Expand `~` yourself.
+- Readable and writable by the user running the agent.
+- A directory (not a file).
+
+### Agent reads but can't write (`add_concept` fails)
+
+Check the directory's write permission with `ls -ld $OMOT_VAULT`. The agent runs under your shell user; if a parent dir is read-only, writes fail.
+
+### MCP server starts then exits immediately
+
+Usually a Node version mismatch. The server requires Node 20+:
+
+```bash
+node --version            # must print v20.x or higher
+```
+
+If you use `nvm`, set the agent to invoke `npx` from a v20+ shim.
+
+---
+
+## Web workbench (dev / prod)
+
+### `pnpm dev` 500 error after `pnpm build`
+
+`pnpm build` produces a static `out/` folder, but it can leave `.next/` in an incompatible state. Reset:
+
+```bash
+rm -rf .next
+pnpm dev
+```
+
+### Topology view is blank
+
+The vault may have no edges yet. Add a relation:
+
+```yaml
+# in some capability's frontmatter
+depends_on:
+  - capabilities/login
+```
+
+…or use the builder canvas (`/ontology/edit`) and connect two nodes with a drag.
+
+### Search palette returns "no results" for everything
+
+Check your vault has at least one `.md` with frontmatter `slug:` and `kind:`. The search index ignores files without frontmatter.
+
+---
+
+## npm publish (maintainer-only)
+
+> If you are *using* the package, you don't need to publish. This section is for project maintainers.
+
+### `403 Forbidden` on `npm publish`
+
+- 2FA OTP wrong or expired — re-run with a fresh OTP.
+- Your account doesn't own the package name — try `--access=public` for scoped packages, or use a different name.
+
+### `npm publish` says nothing happened
+
+Likely you forgot to bump the version. npm rejects republishing the same version. Bump first:
+
+```bash
+cd mcp
+npm version patch                    # 0.5.0 → 0.5.1
+npm publish --access=public
+```
+
+### "I published the wrong thing"
+
+- Within 24h of publish: `npm unpublish oh-my-ontology-mcp@<version>` removes it.
+- After 24h: `npm deprecate oh-my-ontology-mcp@<version> "reason"` — installers see a warning but the version stays.
+
+### Why doesn't Claude Code just run `npm publish` for me?
+
+It can't. `.claude/settings.json` ships a PreToolUse hook that blocks `npm publish` / `pnpm publish` / `yarn publish` until you explicitly type "publish it" in chat. This is intentional — npm publishes are permanent (after 24h) and tied to *your* npm account. See `CLAUDE.md` and `.claude/rules/forbidden.md` for the full rule.
+
+---
+
+## Build / test / lint
+
+### `pnpm exec tsc --noEmit` fails after a vault change
+
+Vault is `.md` only — TypeScript shouldn't care. If it errors, you probably changed `src/features/docs-vault-local/lib/ontology-starter.ts` (the in-app scaffold mirror). Make sure the strings match `cli/templates/vault/`.
+
+### `pnpm lint` complains about FSD boundaries
+
+Don't import `widgets/*` from `entities/*` or `features/*`. Direction is one-way: `app → views → widgets → features → entities → shared`. See `.claude/rules/architecture.md`.
+
+### Vitest hangs on `pnpm test`
+
+Use `pnpm test:run` for one-shot mode. `pnpm test` is watch mode.
+
+---
+
+## Firebase (optional)
+
+Local-first works without Firebase. If you opted into cloud sync:
+
+### "Permission denied" reading `knowledgeApprovedNodes`
+
+Firestore rules require auth + project membership. Sign in (`/login`) first.
+
+### Hosted demo at oh-my-ontology.web.app shows your old data
+
+The hosted demo serves *our* dogfood vault (the project's own `docs/ontology/`). Your data only appears when you self-host or run the workbench locally pointed at your own folder.
+
+---
+
+## Still stuck?
+
+- Open an issue: https://github.com/wlsdks/oh-my-ontology/issues
+- Discussions: https://github.com/wlsdks/oh-my-ontology/discussions
+- Include: OS, Node version (`node --version`), pnpm version, browser (for web issues), exact error message.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,14 +1,14 @@
 # oh-my-ontology-mcp
 
-> MCP 서버 — AI agent (Claude Code 등) 가 oh-my-ontology vault 의 ontology 를
-> read/write 한다. mission "사람과 AI agent 가 같이 저작하는 codebase ontology"
-> 의 AI 측 surface.
+> An MCP server that lets AI agents (Claude Code, Cursor, …) read and write the
+> ontology stored in an oh-my-ontology vault. The AI-side surface for the mission
+> "a codebase ontology that humans and AI agents author together."
 
-## 빠르게
+## Quick start
 
-### 1. Claude Code 에 등록
+### 1. Register with Claude Code
 
-프로젝트 root 에 `.mcp.json` 작성:
+Create a `.mcp.json` at your project root:
 
 ```json
 {
@@ -24,7 +24,7 @@
 }
 ```
 
-또는 npm publish 후 `npx`:
+Or, once published to npm, via `npx`:
 
 ```json
 {
@@ -40,48 +40,48 @@
 }
 ```
 
-`OMOT_VAULT` 미지정 시 `cwd` 가 vault root.
+If `OMOT_VAULT` is not set, the current working directory is used as the vault root.
 
-### 2. Claude Code 재시작
+### 2. Restart Claude Code
 
-서버가 stdio 로 연결됨. tool 목록에 `oh-my-ontology` namespace 11 도구 등장.
+The server connects over stdio. You should now see 11 tools under the `oh-my-ontology` namespace.
 
-### 3. 호출
+### 3. Call the tools
 
 ```
-"이 프로젝트의 모든 capability 노드를 list 해줘"
+"List every capability node in this project."
 → mcp__oh-my-ontology__list_concepts({ kind: 'capability' })
 
-"capabilities/mcp-server 가 의존하는 element 가 뭐야?"
+"What elements does capabilities/mcp-server depend on?"
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## 도구 11종 (v0.5.0)
+## The 11 tools (v0.5.0)
 
-| 도구 | 동작 |
+| Tool | What it does |
 |---|---|
-| `list_concepts` | vault 의 모든 노드 (`kind:` frontmatter 가진 .md). 옵션 `kind`, `limit`. |
-| `get_concept` | 단일 `slug` (확장자 제외) 의 frontmatter + body excerpt + 이웃 (dependencies / relates) |
-| `find_evidence` | `title` 부분매칭 — frontmatter title/capabilities/elements + body 본문 검색 |
-| `find_backlinks` | 특정 `slug` 를 가리키는 다른 노드들. frontmatter array 키 (capabilities / elements / dependencies / relates / …) + body wikilink/mdlink 모두 검사. |
-| `find_path` | 두 slug 사이 그래프 최단 경로 (BFS, 무방향). 옵션 `maxHops` (기본 5). |
-| `list_kinds` | vault kind 분포 census `{ total, byKind: { capability: N, ... } }`. |
-| `find_orphans` | **v0.5** vault 의 고립 노드 (어느 다른 노드도 frontmatter 에서 가리키지 않는 doc). 옵션 `kind` (필터), `excludeKinds` (제외, 기본 `['vault-readme']`). cleanup 시작점 / "안 쓰이는 노드" 점검. |
-| `add_concept` | 새 `.md` 노드 작성. 필수: `slug` `kind` `title`. 옵션: `domain` `capabilities` `elements` `body`. 기존 slug 면 throw. |
-| `add_relation` | 두 slug 사이 edge. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). frontmatter 배열에 append. |
-| `patch_concept` | 기존 노드 frontmatter (key 단위 patch — null = 삭제) + body 갱신. `add_concept` 가 throw 한 기존 slug 를 *수정* 할 때 사용. |
-| `delete_concept` | **v0.4 ⚠ DESTRUCTIVE** 노드 영구 삭제. 안전 가드 2단: ① `confirm:true` 미지정 시 dry-run (backlinks 미리보기), ② backlinks 있으면 throw — `force:true` 만 강행. 응답에 frontmatter+body 캡처 — 실수 복구용. |
+| `list_concepts` | Lists every node in the vault (any `.md` with a `kind:` frontmatter). Options: `kind`, `limit`. |
+| `get_concept` | Fetches a single node by `slug` (no extension): frontmatter + body excerpt + neighbors (dependencies / relates). |
+| `find_evidence` | Partial-match search by `title` — scans frontmatter title/capabilities/elements as well as body content. |
+| `find_backlinks` | Finds every node that points to a given `slug`. Inspects all frontmatter array keys (capabilities / elements / dependencies / relates / …) plus body wikilinks/markdown links. |
+| `find_path` | Shortest path between two slugs (BFS, undirected). Option: `maxHops` (default 5). |
+| `list_kinds` | Vault kind census: `{ total, byKind: { capability: N, ... } }`. |
+| `find_orphans` | **v0.5** Finds isolated nodes — docs that no other node references in its frontmatter. Options: `kind` (filter), `excludeKinds` (skip, default `['vault-readme']`). Useful as a starting point for cleanup or auditing unused nodes. |
+| `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. Throws if the slug already exists. |
+| `add_relation` | Adds an edge between two slugs. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). Appends to the appropriate frontmatter array. |
+| `patch_concept` | Updates an existing node's frontmatter (per-key patch — `null` deletes a key) and/or body. Use this when you need to *modify* a slug that `add_concept` would reject as duplicate. |
+| `delete_concept` | **v0.4 ⚠ DESTRUCTIVE** Permanently deletes a node. Two-stage safety: ① without `confirm:true`, runs as a dry-run (with a backlinks preview); ② if backlinks exist, throws unless `force:true`. The response captures the deleted frontmatter + body so you can recover from mistakes. |
 
-## 로컬 검증 (UX-3)
+## Local verification (UX-3)
 
-### 1줄 verify CLI
+### One-line verify CLI
 
 ```bash
 cd mcp && npm install
 OMOT_VAULT=../docs/ontology npm run verify
 ```
 
-verify 가 성공하면 다음 출력:
+A successful run looks like this:
 
 ```
 [oh-my-ontology-mcp verify]
@@ -90,20 +90,20 @@ verify 가 성공하면 다음 출력:
 · step 2 — server boot + tools/list + list_concepts
 ✓ initialize OK — server oh-my-ontology-mcp@0.5.0
 ✓ tools/list 11/11 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · patch_concept
-✓ list_concepts — vault total 23 노드
+✓ list_concepts — vault total 23 nodes
 
-전체 통과 — Claude Code 에 .mcp.json 등록 후 재시작하면 11 도구 사용 가능합니다.
+All checks passed — register .mcp.json with Claude Code, restart, and the 11 tools are ready.
 ```
 
-실패 시 어느 step 에서 막혔는지 + 진단 메시지 노출.
+On failure, it tells you which step blocked progress and prints a diagnostic message.
 
-### 수동 (참고)
+### Manual verification (reference)
 
 ```bash
 # parser smoke
 node src/parser.test.mjs
 
-# 실 서버 stdin/stdout JSON-RPC
+# Real server over stdin/stdout JSON-RPC
 printf '%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
   '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
@@ -111,35 +111,35 @@ printf '%s\n' \
   | OMOT_VAULT=../docs/ontology node src/index.js
 ```
 
-## Claude Code 등록 후 첫 호출 (sample prompt)
+## First call after registering with Claude Code (sample prompt)
 
-`.mcp.json` 등록 + Claude Code 재시작 후 LLM 에게 다음을 시도하세요:
+After you add `.mcp.json` and restart Claude Code, try the following with your LLM:
 
-> **첫 탐색 — vault 의 ontology 가 보이는지 확인**
-> 1. `mcp__oh-my-ontology__list_concepts` 호출해 vault 의 모든 노드를 list 해줘
-> 2. `get_concept({ slug: "project" })` 로 root 노드의 frontmatter + 이웃을 보여줘
-> 3. `find_backlinks({ slug: "capabilities/mcp-server" })` 로 그 capability 의 의존자를 찾아줘
-> 4. (선택) `add_concept` 로 새 capability 노드 만들어줘 — slug, kind, title 필요
+> **First exploration — confirm the vault's ontology is visible**
+> 1. Call `mcp__oh-my-ontology__list_concepts` to list every node in the vault.
+> 2. Call `get_concept({ slug: "project" })` to see the root node's frontmatter and neighbors.
+> 3. Call `find_backlinks({ slug: "capabilities/mcp-server" })` to find what depends on that capability.
+> 4. (Optional) Call `add_concept` to create a new capability node — `slug`, `kind`, and `title` are required.
 
-위 4 도구가 정상 응답하면 vault read/write 양쪽 라운드트립 OK. agent 가 자기 codebase 분석 결과를 11 도구 (read 7 + write 4) 로 ontology 에 *commit* 하면 사람·AI agent 양립 저작 흐름 시작.
+If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 11 tools (7 read + 4 write), the human + AI co-authoring loop is officially open.
 
-## 설계 원칙
+## Design principles
 
-- **stdin/stdout JSON-RPC** — Claude Code 가 child process 로 spawn. stdout 은 *프로토콜 전용*, log 는 stderr 로만.
-- **Sync fs** — MCP 호출 빈도가 낮아 async 오버헤드 불필요.
-- **frontmatter 보존** — `add_relation` 은 기존 frontmatter 유지하며 배열 키만 patch (idempotent — 이미 있으면 `alreadyExists: true`).
-- **vault root sandbox** — `slug` 는 vault-relative. 서버는 `OMOT_VAULT` 밖에 쓰지 않는다.
+- **stdin/stdout JSON-RPC** — Claude Code spawns the server as a child process. stdout is *protocol-only*; logs go to stderr.
+- **Synchronous fs** — MCP call frequency is low enough that async overhead isn't worth it.
+- **Frontmatter preservation** — `add_relation` keeps the existing frontmatter intact and only patches the relevant array key (idempotent — duplicates respond with `alreadyExists: true`).
+- **Vault-root sandbox** — `slug` is always vault-relative. The server never writes outside `OMOT_VAULT`.
 
-## 상태
+## Status
 
-- 0.5.0 — 11 도구 (read 7 + write 4). `find_orphans` 추가.
-- 0.4.0 — 10 도구 (read 6 + write 4). `delete_concept` 추가 (dry-run + backlinks 가드).
-- 0.3.0 — 9 도구. `find_path` (BFS) + `list_kinds` (census).
-- 0.2.0 — 7 도구.
-- 0.1.0 — 5 도구.
+- 0.5.0 — 11 tools (7 read + 4 write). Added `find_orphans`.
+- 0.4.0 — 10 tools (6 read + 4 write). Added `delete_concept` (dry-run + backlinks guard).
+- 0.3.0 — 9 tools. Added `find_path` (BFS) and `list_kinds` (census).
+- 0.2.0 — 7 tools.
+- 0.1.0 — 5 tools.
 
-## 문제 해결
+## Troubleshooting
 
-- **Tool 목록에 안 보임**: Claude Code 재시작. `.mcp.json` syntax 검증 (`jq . .mcp.json`).
-- **vault 인식 0**: `OMOT_VAULT` 절대 경로 시도. 또는 `pwd` 로 실제 cwd 확인.
-- **`Doc already exists`**: `add_concept` 은 기존 파일 덮어쓰기 안 함. 직접 편집 또는 `patch_concept` 으로 frontmatter / body 부분 갱신.
+- **Tools don't show up**: Restart Claude Code. Validate `.mcp.json` syntax with `jq . .mcp.json`.
+- **Vault appears empty**: Try an absolute path for `OMOT_VAULT`, or run `pwd` to confirm the actual working directory.
+- **`Doc already exists`**: `add_concept` won't overwrite an existing file. Edit the file directly, or use `patch_concept` to update frontmatter or body in place.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,12 +1,29 @@
 {
   "name": "oh-my-ontology-mcp",
   "version": "0.5.0",
-  "description": "MCP server — sample/사람과 AI agent 가 같이 vault ontology 를 read/write",
+  "description": "MCP server — humans and AI agents read/write the same codebase ontology vault.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "ontology",
+    "codebase",
+    "ai-agent",
+    "claude-code",
+    "cursor",
+    "knowledge-graph",
+    "markdown",
+    "frontmatter"
+  ],
   "type": "module",
   "bin": {
     "oh-my-ontology-mcp": "./src/index.js"
   },
   "main": "./src/index.js",
+  "files": [
+    "src",
+    "scripts/verify.mjs",
+    "README.md"
+  ],
   "scripts": {
     "start": "node src/index.js",
     "test:smoke": "node src/parser.test.mjs",
@@ -17,6 +34,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wlsdks/oh-my-ontology.git",
+    "directory": "mcp"
   },
   "license": "MIT",
   "private": false

--- a/scripts/audit-data-model.mjs
+++ b/scripts/audit-data-model.mjs
@@ -59,7 +59,8 @@ export function parseDocumentedCollections(md) {
  */
 export function parseDocumentedStoragePaths(md) {
   const paths = new Set();
-  const section = md.match(/## 5\. Storage 구조[\s\S]*?(?=^## |\Z)/m);
+  // "## 5. Storage 구조" (legacy Korean) or "## 5. Storage layout" (English).
+  const section = md.match(/## 5\. Storage (?:구조|layout)[\s\S]*?(?=^## |\Z)/m);
   if (!section) return paths;
   // top-level 항목은 `├── name/` / `└── name/`. 루트 라벨 "storage/"나 중첩
   // 항목("│   └── …")은 제외하기 위해 트리 진입 기호 ├/└ 로 시작하는 행만 본다.

--- a/src/features/docs-vault-local/index.ts
+++ b/src/features/docs-vault-local/index.ts
@@ -1,2 +1,3 @@
 export { useLocalVault } from './model/use-local-vault';
 export { LocalVaultPicker } from './ui/LocalVaultPicker';
+export { OntologyStarterCta } from './ui/OntologyStarterCta';

--- a/src/features/docs-vault-local/lib/ontology-starter.ts
+++ b/src/features/docs-vault-local/lib/ontology-starter.ts
@@ -1,12 +1,12 @@
 /**
- * mission v2 ontology starter — 빈 폴더에 scaffold 할 5 md + .mcp.json.
+ * mission v2 ontology starter — 5 .md files + .mcp.json scaffolded into an empty folder.
  *
- * cli/templates/vault/ 와 동일한 시드. CLI 와 web workbench 가 같은 결과를
- * 보여줘 사용자 혼동 없게. 변경 시 둘 다 갱신.
+ * Mirrors cli/templates/vault/. Keep both in sync so the CLI and the web
+ * workbench produce the same starter files.
  */
 
 interface StarterFile {
-  /** 폴더 안 상대 경로. README.md 같은 단일 파일 또는 domains/example.md 같은 nested. */
+  /** Relative path inside the vault (e.g. README.md, domains/example.md). */
   relPath: string;
   content: string;
 }
@@ -19,58 +19,60 @@ title: My ontology vault
 
 # My ontology vault
 
-이 폴더는 **사람과 AI agent 가 같이 키우는 codebase mental model** 입니다.
-각 \`.md\` 파일은 한 노드 (project / domain / capability / element / concept)
-이고, 파일 위 frontmatter 가 그래프의 키 (slug / kind / depends_on /
-capabilities / elements / domain) 입니다.
+This folder is **a codebase mental model that humans and AI agents grow
+together**. Every \`.md\` file is one node (project / domain / capability /
+element / concept), and the frontmatter at the top of each file is the
+graph's keys (slug / kind / depends_on / capabilities / elements / domain).
 
-## 시작 방법 (5분)
+## Get started in 5 minutes
 
-1. \`project.md\` 를 열어 프로젝트 이름과 설명을 적습니다.
-2. 새 도메인이 떠오르면 \`domains/\` 안에 \`<slug>.md\` 추가:
+1. Open \`project.md\` and write your project's name and description.
+2. When a new domain comes to mind, add \`<slug>.md\` under \`domains/\`:
    \`\`\`markdown
    ---
    slug: domains/auth
    kind: domain
-   title: 인증
+   title: Authentication
    capabilities:
      - capabilities/login
      - capabilities/signup
    ---
 
-   사용자 인증·세션·권한을 담당.
+   Owns user authentication, sessions, and permissions.
    \`\`\`
-3. capability / element 도 같은 패턴 — \`capabilities/\` 와 \`elements/\`.
-4. AI agent (Claude Code 등) 를 등록하면 같은 vault 를 읽고 쓰며 같이 키워갑니다.
-5. 그래프로 보고 싶으면 이 web workbench 의 토폴로지 / 트리 / 빌더 view 참고.
+3. Same pattern for capability and element — under \`capabilities/\` and \`elements/\`.
+4. Register an AI agent (Claude Code, Cursor, …) and it reads/writes the
+   same vault, growing it alongside you.
+5. To see the graph, use the topology / tree / builder views in this web workbench.
 
-## 관계 (frontmatter 키)
+## Relations (frontmatter keys)
 
-| 키 | 어떤 관계 |
+| Key | What it expresses |
 |---|---|
-| \`depends_on: [<slug>, ...]\` | 이 노드가 다른 노드에 의존 |
-| \`capabilities: [...]\` | 이 도메인 / 프로젝트가 가진 역량 |
-| \`elements: [...]\` | 이 역량 / 도메인이 사용하는 요소 |
-| \`domain: <slug>\` | 이 capability/element 의 상위 도메인 |
-| \`evidenceIds: [doc-1, ...]\` | 이 노드의 근거 문서 ID |
+| \`depends_on: [<slug>, ...]\` | This node depends on other nodes |
+| \`capabilities: [...]\` | Capabilities this domain / project provides |
+| \`elements: [...]\` | Elements this capability / domain uses |
+| \`domain: <slug>\` | Parent domain of this capability/element |
+| \`evidenceIds: [doc-1, ...]\` | Evidence document IDs backing this node |
 
-## kind 종류
+## Kinds
 
-- \`project\` — 최상위. 워크스페이스 1개당 보통 1.
-- \`domain\` — 큰 영역 (인증, 결제, 빌더 등).
-- \`capability\` — 도메인의 한 역량 (로그인, 회원가입, …).
-- \`element\` — capability 가 쓰는 작은 요소 (jwt-token, otp-store, …).
-- \`concept\` — 이 외 자유로운 개념 (프로토콜·표준·외부 시스템 등).
+- \`project\` — Top-level. Usually one per workspace.
+- \`domain\` — A large area (auth, billing, builder, …).
+- \`capability\` — A user-visible feature inside a domain (login, signup, …).
+- \`element\` — A smaller unit a capability uses (jwt-token, otp-store, …).
+- \`concept\` — Anything else (protocols, standards, external systems).
 
-## AI agent 가 자동으로 할 수 있는 일
+## What an AI agent can do for you
 
-\`oh-my-ontology-mcp\` 서버를 등록하면 다음 11 도구로 vault read/write:
+Once you register the \`oh-my-ontology-mcp\` server, the agent gets 11
+tools to read/write this vault:
 
 - **read 7**: list_concepts / get_concept / find_evidence / find_backlinks /
   find_path / list_kinds / find_orphans
 - **write 4**: add_concept / add_relation / patch_concept / delete_concept
 
-자세히: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp
+Details: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp
 `;
 
 const PROJECT_MD = `---
@@ -87,104 +89,109 @@ elements:
 
 # My project
 
-여기서 프로젝트의 한두 줄 요약을 적습니다 — *"무엇을 / 누구에게 / 왜"*.
+Write a one- or two-line summary of your project here — *what / for whom / why*.
 
-## 한 줄 mission
+## One-line mission
 
-이 프로젝트가 해결하는 문제 / 만드는 가치를 한 줄로.
+The problem this project solves, or the value it creates, in a single sentence.
 
-## 어떻게 자라는가
+## How it grows
 
-- frontmatter 의 \`domains: [...]\` 를 채우면 도메인 노드가 트리에 매달립니다.
-- 각 도메인 안 capability / element 도 같은 패턴.
-- AI agent 가 새 노드를 만들 때 이 파일의 \`depends_on\` / \`domains\` 가
-  자동 갱신될 수 있어요 — frontmatter 가 진실원이라 충돌 안 납니다.
+- Fill in \`domains: [...]\` in the frontmatter and the domain nodes hang
+  off your project tree automatically.
+- Each domain's capabilities and elements follow the same pattern.
+- When an AI agent adds a new node, this file's \`depends_on\` / \`domains\`
+  may auto-update — frontmatter is the source of truth, so there are no
+  conflicts.
 
-## 다음 단계
+## Next steps
 
-1. 이 파일의 \`title\` 과 \`kind: project\` 외 frontmatter 를 본인 프로젝트에 맞게 수정
-2. \`domains/example.md\` 같은 starter 를 본인 영역으로 rename / 복제
-3. AI agent (Claude Code 등) 등록 후 "이 vault 의 ontology 좀 정리해줘" 라고 요청
+1. Edit this file's \`title\` (and any other frontmatter besides \`kind: project\`)
+   to match your project.
+2. Rename or copy starters like \`domains/example.md\` into your real domains.
+3. Register an AI agent (Claude Code, Cursor, …) and ask it to "tidy up
+   the ontology in this vault."
 `;
 
 const DOMAIN_MD = `---
 slug: domains/example
 kind: domain
-title: 예시 도메인
+title: Example domain
 capabilities:
   - capabilities/example
 ---
 
-# 예시 도메인
+# Example domain
 
-도메인 = 프로젝트의 큰 영역 (인증·결제·빌더·실시간·검색 같은 하위 시스템).
-이 파일을 본인 도메인 이름으로 rename 하고 (\`domains/auth.md\`,
-\`domains/billing.md\` 등) 그 도메인이 가진 capability 를 위 frontmatter
-\`capabilities:\` 에 적어주세요.
+A *domain* is a large area of your project (subsystems like auth,
+billing, builder, realtime, search). Rename this file to match one of
+your real domains (\`domains/auth.md\`, \`domains/billing.md\`, …) and list
+the capabilities it owns under \`capabilities:\` in the frontmatter above.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 한두 단락의 본문은 *그 도메인이 무엇인지* 설명.
-- 본문에 다른 도메인 / capability 의 markdown link 를 넣으면 backlink
-  로 인식됩니다.
-- frontmatter 키:
-  - \`capabilities: [...]\` — 이 도메인이 가진 역량 slug 들
-  - \`depends_on: [...]\` — 이 도메인이 의존하는 다른 도메인 / 외부 시스템
-  - \`evidenceIds: [...]\` — 이 노드의 근거 문서 ID (선택)
+- Use one or two paragraphs of body text to describe *what this domain is*.
+- Markdown links to other domains / capabilities in the body register as
+  backlinks automatically.
+- Frontmatter keys:
+  - \`capabilities: [...]\` — slugs of capabilities this domain owns
+  - \`depends_on: [...]\` — other domains or external systems this depends on
+  - \`evidenceIds: [...]\` — evidence document IDs backing this node (optional)
 
-## 살릴까 지울까
+## Keep it or delete it?
 
-- 살릴 거면 위 가이드대로 채우기
-- 안 쓸 거면 이 파일 삭제 — 그냥 starter 입니다
+- Keep it: fill it in following the guide above.
+- Don't need it: just delete this file — it's only a starter.
 `;
 
 const CAPABILITY_MD = `---
 slug: capabilities/example
 kind: capability
-title: 예시 역량
+title: Example capability
 domain: domains/example
 elements:
   - elements/example
 ---
 
-# 예시 역량
+# Example capability
 
-Capability = 도메인의 한 사용자-가시 기능 단위 (로그인, 회원가입, 결제,
-검색, 빌더 캔버스 등). 이 파일을 본인 역량 이름으로 rename 하고
-(\`capabilities/login.md\`, \`capabilities/checkout.md\`) 위 frontmatter
-\`domain:\` 과 \`elements:\` 를 본인 환경에 맞게 적어주세요.
+A *capability* is one user-visible feature within a domain (login,
+signup, checkout, search, builder canvas, …). Rename this file to match
+one of your real capabilities (\`capabilities/login.md\`,
+\`capabilities/checkout.md\`) and update the \`domain:\` and \`elements:\`
+keys above accordingly.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 본문에 *이 capability 가 무엇을 하는지* + 사용자 시나리오 한두 줄.
-- frontmatter 키:
-  - \`domain: <slug>\` — 상위 도메인 한 개
-  - \`elements: [...]\` — 이 capability 가 사용하는 element slug 들
-  - \`depends_on: [...]\` — 다른 capability 에 의존하면
-  - \`evidenceIds: [...]\` — 명세 / 결정문서 ID (선택)
+- In the body, describe *what this capability does* and one or two user
+  scenarios.
+- Frontmatter keys:
+  - \`domain: <slug>\` — the single parent domain
+  - \`elements: [...]\` — slugs of elements this capability uses
+  - \`depends_on: [...]\` — other capabilities this depends on
+  - \`evidenceIds: [...]\` — spec / decision document IDs (optional)
 `;
 
 const ELEMENT_MD = `---
 slug: elements/example
 kind: element
-title: 예시 요소
+title: Example element
 domain: domains/example
 ---
 
-# 예시 요소
+# Example element
 
-Element = capability 가 쓰는 더 작은 단위 (jwt-token, otp-store,
-indexeddb-adapter, sigma-canvas, …). 이 파일을 본인 element 이름으로
-rename 하고 (\`elements/jwt-token.md\`) 위 frontmatter \`domain:\` 을
-정확한 도메인으로 적어주세요.
+An *element* is a smaller unit a capability uses (jwt-token, otp-store,
+indexeddb-adapter, sigma-canvas, …). Rename this file to match a real
+element (\`elements/jwt-token.md\`) and set \`domain:\` to the right parent.
 
-## 어떻게 채우나
+## How to fill it in
 
-- 본문은 *무엇을 / 왜 / 어떤 인터페이스* 한두 단락.
-- frontmatter 키:
-  - \`domain: <slug>\` — 상위 도메인 한 개
-  - \`depends_on: [...]\` — 다른 element / capability 에 의존하면
-  - \`evidenceIds: [...]\` — 라이브러리 docs / 결정 문서 ID (선택)
+- One or two paragraphs in the body covering *what / why / which interface*.
+- Frontmatter keys:
+  - \`domain: <slug>\` — the single parent domain
+  - \`depends_on: [...]\` — other elements / capabilities this depends on
+  - \`evidenceIds: [...]\` — library docs or decision document IDs (optional)
 `;
 
 export const ONTOLOGY_STARTER_FILES: ReadonlyArray<StarterFile> = [
@@ -196,8 +203,9 @@ export const ONTOLOGY_STARTER_FILES: ReadonlyArray<StarterFile> = [
 ];
 
 /**
- * AI agent (Claude Code 등) 등록용 MCP config — 사용자가 자기 agent
- * 설정으로 복사. `OMOT_VAULT` 환경변수는 vault 폴더 절대경로로 사용자가 채워야 한다 (브라우저는 절대경로 모름).
+ * MCP config to register an AI agent (Claude Code, Cursor, …). Users
+ * copy this into their agent's config. `OMOT_VAULT` must be the
+ * absolute path to the vault folder — the browser cannot know it.
  */
 export function buildMcpConfigJson(vaultName: string): string {
   return (

--- a/src/features/docs-vault-local/lib/ontology-starter.ts
+++ b/src/features/docs-vault-local/lib/ontology-starter.ts
@@ -1,0 +1,220 @@
+/**
+ * mission v2 ontology starter — 빈 폴더에 scaffold 할 5 md + .mcp.json.
+ *
+ * cli/templates/vault/ 와 동일한 시드. CLI 와 web workbench 가 같은 결과를
+ * 보여줘 사용자 혼동 없게. 변경 시 둘 다 갱신.
+ */
+
+interface StarterFile {
+  /** 폴더 안 상대 경로. README.md 같은 단일 파일 또는 domains/example.md 같은 nested. */
+  relPath: string;
+  content: string;
+}
+
+const README_MD = `---
+slug: README
+kind: vault-readme
+title: My ontology vault
+---
+
+# My ontology vault
+
+이 폴더는 **사람과 AI agent 가 같이 키우는 codebase mental model** 입니다.
+각 \`.md\` 파일은 한 노드 (project / domain / capability / element / concept)
+이고, 파일 위 frontmatter 가 그래프의 키 (slug / kind / depends_on /
+capabilities / elements / domain) 입니다.
+
+## 시작 방법 (5분)
+
+1. \`project.md\` 를 열어 프로젝트 이름과 설명을 적습니다.
+2. 새 도메인이 떠오르면 \`domains/\` 안에 \`<slug>.md\` 추가:
+   \`\`\`markdown
+   ---
+   slug: domains/auth
+   kind: domain
+   title: 인증
+   capabilities:
+     - capabilities/login
+     - capabilities/signup
+   ---
+
+   사용자 인증·세션·권한을 담당.
+   \`\`\`
+3. capability / element 도 같은 패턴 — \`capabilities/\` 와 \`elements/\`.
+4. AI agent (Claude Code 등) 를 등록하면 같은 vault 를 읽고 쓰며 같이 키워갑니다.
+5. 그래프로 보고 싶으면 이 web workbench 의 토폴로지 / 트리 / 빌더 view 참고.
+
+## 관계 (frontmatter 키)
+
+| 키 | 어떤 관계 |
+|---|---|
+| \`depends_on: [<slug>, ...]\` | 이 노드가 다른 노드에 의존 |
+| \`capabilities: [...]\` | 이 도메인 / 프로젝트가 가진 역량 |
+| \`elements: [...]\` | 이 역량 / 도메인이 사용하는 요소 |
+| \`domain: <slug>\` | 이 capability/element 의 상위 도메인 |
+| \`evidenceIds: [doc-1, ...]\` | 이 노드의 근거 문서 ID |
+
+## kind 종류
+
+- \`project\` — 최상위. 워크스페이스 1개당 보통 1.
+- \`domain\` — 큰 영역 (인증, 결제, 빌더 등).
+- \`capability\` — 도메인의 한 역량 (로그인, 회원가입, …).
+- \`element\` — capability 가 쓰는 작은 요소 (jwt-token, otp-store, …).
+- \`concept\` — 이 외 자유로운 개념 (프로토콜·표준·외부 시스템 등).
+
+## AI agent 가 자동으로 할 수 있는 일
+
+\`oh-my-ontology-mcp\` 서버를 등록하면 다음 11 도구로 vault read/write:
+
+- **read 7**: list_concepts / get_concept / find_evidence / find_backlinks /
+  find_path / list_kinds / find_orphans
+- **write 4**: add_concept / add_relation / patch_concept / delete_concept
+
+자세히: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp
+`;
+
+const PROJECT_MD = `---
+slug: project
+kind: project
+title: My project
+domains:
+  - domains/example
+capabilities:
+  - capabilities/example
+elements:
+  - elements/example
+---
+
+# My project
+
+여기서 프로젝트의 한두 줄 요약을 적습니다 — *"무엇을 / 누구에게 / 왜"*.
+
+## 한 줄 mission
+
+이 프로젝트가 해결하는 문제 / 만드는 가치를 한 줄로.
+
+## 어떻게 자라는가
+
+- frontmatter 의 \`domains: [...]\` 를 채우면 도메인 노드가 트리에 매달립니다.
+- 각 도메인 안 capability / element 도 같은 패턴.
+- AI agent 가 새 노드를 만들 때 이 파일의 \`depends_on\` / \`domains\` 가
+  자동 갱신될 수 있어요 — frontmatter 가 진실원이라 충돌 안 납니다.
+
+## 다음 단계
+
+1. 이 파일의 \`title\` 과 \`kind: project\` 외 frontmatter 를 본인 프로젝트에 맞게 수정
+2. \`domains/example.md\` 같은 starter 를 본인 영역으로 rename / 복제
+3. AI agent (Claude Code 등) 등록 후 "이 vault 의 ontology 좀 정리해줘" 라고 요청
+`;
+
+const DOMAIN_MD = `---
+slug: domains/example
+kind: domain
+title: 예시 도메인
+capabilities:
+  - capabilities/example
+---
+
+# 예시 도메인
+
+도메인 = 프로젝트의 큰 영역 (인증·결제·빌더·실시간·검색 같은 하위 시스템).
+이 파일을 본인 도메인 이름으로 rename 하고 (\`domains/auth.md\`,
+\`domains/billing.md\` 등) 그 도메인이 가진 capability 를 위 frontmatter
+\`capabilities:\` 에 적어주세요.
+
+## 어떻게 채우나
+
+- 한두 단락의 본문은 *그 도메인이 무엇인지* 설명.
+- 본문에 다른 도메인 / capability 의 markdown link 를 넣으면 backlink
+  로 인식됩니다.
+- frontmatter 키:
+  - \`capabilities: [...]\` — 이 도메인이 가진 역량 slug 들
+  - \`depends_on: [...]\` — 이 도메인이 의존하는 다른 도메인 / 외부 시스템
+  - \`evidenceIds: [...]\` — 이 노드의 근거 문서 ID (선택)
+
+## 살릴까 지울까
+
+- 살릴 거면 위 가이드대로 채우기
+- 안 쓸 거면 이 파일 삭제 — 그냥 starter 입니다
+`;
+
+const CAPABILITY_MD = `---
+slug: capabilities/example
+kind: capability
+title: 예시 역량
+domain: domains/example
+elements:
+  - elements/example
+---
+
+# 예시 역량
+
+Capability = 도메인의 한 사용자-가시 기능 단위 (로그인, 회원가입, 결제,
+검색, 빌더 캔버스 등). 이 파일을 본인 역량 이름으로 rename 하고
+(\`capabilities/login.md\`, \`capabilities/checkout.md\`) 위 frontmatter
+\`domain:\` 과 \`elements:\` 를 본인 환경에 맞게 적어주세요.
+
+## 어떻게 채우나
+
+- 본문에 *이 capability 가 무엇을 하는지* + 사용자 시나리오 한두 줄.
+- frontmatter 키:
+  - \`domain: <slug>\` — 상위 도메인 한 개
+  - \`elements: [...]\` — 이 capability 가 사용하는 element slug 들
+  - \`depends_on: [...]\` — 다른 capability 에 의존하면
+  - \`evidenceIds: [...]\` — 명세 / 결정문서 ID (선택)
+`;
+
+const ELEMENT_MD = `---
+slug: elements/example
+kind: element
+title: 예시 요소
+domain: domains/example
+---
+
+# 예시 요소
+
+Element = capability 가 쓰는 더 작은 단위 (jwt-token, otp-store,
+indexeddb-adapter, sigma-canvas, …). 이 파일을 본인 element 이름으로
+rename 하고 (\`elements/jwt-token.md\`) 위 frontmatter \`domain:\` 을
+정확한 도메인으로 적어주세요.
+
+## 어떻게 채우나
+
+- 본문은 *무엇을 / 왜 / 어떤 인터페이스* 한두 단락.
+- frontmatter 키:
+  - \`domain: <slug>\` — 상위 도메인 한 개
+  - \`depends_on: [...]\` — 다른 element / capability 에 의존하면
+  - \`evidenceIds: [...]\` — 라이브러리 docs / 결정 문서 ID (선택)
+`;
+
+export const ONTOLOGY_STARTER_FILES: ReadonlyArray<StarterFile> = [
+  { relPath: 'README.md', content: README_MD },
+  { relPath: 'project.md', content: PROJECT_MD },
+  { relPath: 'domains/example.md', content: DOMAIN_MD },
+  { relPath: 'capabilities/example.md', content: CAPABILITY_MD },
+  { relPath: 'elements/example.md', content: ELEMENT_MD },
+];
+
+/**
+ * AI agent (Claude Code 등) 등록용 MCP config — 사용자가 자기 agent
+ * 설정으로 복사. `OMOT_VAULT` 환경변수는 vault 폴더 절대경로로 사용자가 채워야 한다 (브라우저는 절대경로 모름).
+ */
+export function buildMcpConfigJson(vaultName: string): string {
+  return (
+    JSON.stringify(
+      {
+        mcpServers: {
+          'oh-my-ontology': {
+            command: 'npx',
+            args: ['-y', 'oh-my-ontology-mcp'],
+            env: {
+              OMOT_VAULT: `<absolute path to your ${vaultName} folder>`,
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ) + '\n'
+  );
+}

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -15,6 +15,10 @@ import {
   touchLocalFsHandle,
   verifyHandlePermission,
 } from '@/entities/local-fs-handle';
+import {
+  ONTOLOGY_STARTER_FILES,
+  buildMcpConfigJson,
+} from '../lib/ontology-starter';
 /** 탭 포커스 복귀 시 자동 refresh 의 최소 간격 (ms). 너무 자주 돌면
  *  사용자가 IDE 로 짧게 오갈 때마다 번쩍이므로 2초 간격으로 throttle. */
 const AUTO_REFRESH_DEBOUNCE_MS = 2000;
@@ -668,6 +672,59 @@ export function useLocalVault() {
     return { created, skipped };
   }, [state.fileHandles, state.handle, getParentAndName, load]);
 
+  /**
+   * mission v2 ontology starter — `npx oh-my-ontology init` 과 동일한
+   * 5 md + .mcp.json.example 시드를 vault 에 작성. 비개발자가 터미널 없이
+   * web workbench 의 picker → "starter 만들기" 버튼만으로 시작 가능하게.
+   *
+   * 이미 존재하는 파일은 덮어쓰지 않고 skip. 사용자가 기존 vault 에 호출해도
+   * 안전.
+   */
+  const scaffoldOntology = useCallback(async () => {
+    if (!state.handle) {
+      throw new Error('볼트가 열려있지 않습니다');
+    }
+    await ensureReadWrite(state.handle);
+    let created = 0;
+    let skipped = 0;
+    for (const { relPath, content } of ONTOLOGY_STARTER_FILES) {
+      // slug 는 .md 확장자 제거한 경로로. createDoc / saveDoc 의 규칙 따름.
+      const slug = relPath.replace(/\.md$/, '');
+      if (state.fileHandles.has(slug)) {
+        skipped += 1;
+        continue;
+      }
+      try {
+        const resolved = await getParentAndName(slug, true);
+        if (!resolved) continue;
+        const fh = await resolved.parent.getFileHandle(resolved.fileName, {
+          create: true,
+        });
+        const writable = await fh.createWritable();
+        await writable.write(content);
+        await writable.close();
+        created += 1;
+      } catch {
+        skipped += 1;
+      }
+    }
+    // .mcp.json.example — 사용자가 AI agent 설정으로 복사. vault 폴더의
+    // 절대경로는 브라우저가 모르니 placeholder 로 두고 안내.
+    try {
+      const fh = await state.handle.getFileHandle('.mcp.json.example', {
+        create: true,
+      });
+      const writable = await fh.createWritable();
+      await writable.write(buildMcpConfigJson(state.handle.name));
+      await writable.close();
+      created += 1;
+    } catch {
+      skipped += 1;
+    }
+    if (state.handle) await load(state.handle);
+    return { created, skipped };
+  }, [state.fileHandles, state.handle, getParentAndName, load]);
+
   return {
     status: state.status,
     handle: state.handle,
@@ -686,6 +743,7 @@ export function useLocalVault() {
     deleteDoc,
     renameDoc,
     scaffoldTopology,
+    scaffoldOntology,
     updateFrontmatter,
   };
 }

--- a/src/features/docs-vault-local/ui/OntologyStarterCta.tsx
+++ b/src/features/docs-vault-local/ui/OntologyStarterCta.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
+
+interface Props {
+  /** 클릭 시 useLocalVault.scaffoldOntology() 호출. created/skipped 반환. */
+  onScaffold: () => Promise<{ created: number; skipped: number }>;
+  /** 현재 vault 의 doc 수 — 0 이면 빈 vault. 0 보다 크면 "기존 vault 에
+   *  starter 추가" 톤으로 보조 메시지 표시. */
+  docCount: number;
+}
+
+/**
+ * mission v2 ontology starter CTA — vault 폴더 선택 후 비어 있으면 prominent
+ * 카드, 이미 있으면 작은 보조 버튼. 사용자 비전 ("비개발자도 같이") 의
+ * 핵심 진입점 — 터미널 / npm 없이 5 md 시드 + .mcp.json 작성.
+ *
+ * AI agent (Claude Code 등) 등록 안내는 scaffold 후 toast 로 띄우는 게
+ * 자연스럽지만 이 컴포넌트는 결과만 emit — 호출자 (DocsVaultPage) 가 toast.
+ */
+export function OntologyStarterCta({ onScaffold, docCount }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isEmpty = docCount === 0;
+
+  async function handleClick() {
+    setError(null);
+    setBusy(true);
+    try {
+      await onScaffold();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'starter 만들기 실패');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (isEmpty) {
+    // 빈 vault — 큰 카드로 "여기서 시작" 안내
+    return (
+      <section
+        aria-label="ontology starter 시드"
+        className="rounded-2xl border border-dashed border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.06)] px-5 py-6 text-center"
+      >
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-indigo-accent)]">
+          빈 폴더 감지됨
+        </p>
+        <h2 className="mt-2 break-keep text-lg font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          ontology starter 만들기
+        </h2>
+        <p className="mt-2 break-keep text-[12px] leading-6 text-[color:var(--color-text-secondary)]">
+          5 개의 starter markdown 파일 (project / domain / capability / element + README)
+          과 AI agent 등록용 <code className="rounded bg-[color:var(--color-overlay-2)] px-1 font-mono text-[10.5px]">.mcp.json.example</code> 을 이 폴더에 만듭니다.
+          <br />
+          그 다음 frontmatter 를 본인 프로젝트에 맞게 수정하면 즉시 트리·토폴로지·빌더에 반영돼요.
+        </p>
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={busy}
+          className="mt-4 inline-flex items-center gap-2 rounded-md border border-[color:var(--color-indigo-brand)] bg-[color:rgba(94,106,210,0.18)] px-4 py-2 text-[12.5px] text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:rgba(94,106,210,0.28)] disabled:opacity-60"
+        >
+          <Sparkles size={13} aria-hidden />
+          {busy ? '만드는 중…' : 'starter 시드 만들기'}
+        </button>
+        {error ? (
+          <p
+            role="alert"
+            className="mt-3 break-keep text-[11.5px] text-[color:var(--color-status-danger)]"
+          >
+            {error}
+          </p>
+        ) : null}
+      </section>
+    );
+  }
+
+  // 이미 vault 에 .md 가 있는 경우 — 작은 보조 옵션
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      title="ontology starter 5 파일을 추가합니다 (이미 있는 파일은 안 건드립니다)"
+      className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-3 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.46)] hover:text-[color:var(--color-text-primary)] disabled:opacity-60"
+    >
+      <Sparkles size={12} aria-hidden />
+      {busy ? '추가 중…' : 'ontology starter 추가'}
+    </button>
+  );
+}

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -28,7 +28,11 @@ import {
   X,
 } from 'lucide-react';
 import { useDocsVaultCapabilities } from '@/features/docs-vault-access';
-import { LocalVaultPicker, useLocalVault } from '@/features/docs-vault-local';
+import {
+  LocalVaultPicker,
+  OntologyStarterCta,
+  useLocalVault,
+} from '@/features/docs-vault-local';
 import { useTypingShortcuts } from '@/shared/lib/use-typing-shortcut';
 import { usePrevious } from '@/shared/lib/use-previous';
 import { Tooltip } from '@/shared/ui';
@@ -1597,10 +1601,10 @@ function AdminDocsContent() {
                       onRefresh={localVault.refresh}
                       onRequestPermission={localVault.requestPermission}
                     />
-                    {/* T29 dogfood hint — vault 미활성 사용자에게 *어떤
-                        폴더를 골라야 하는지* 답. 이 repo 자체의 ontology 가
-                        `docs/ontology/` 에 21 노드로 표현돼 있어 첫 시도
-                        path 로 적합. */}
+                    {/* dogfood hint + ontology starter CTA — vault 가 *비어 있으면*
+                        scaffold 버튼 prominent 노출 (Option D), 기존 vault 면 작은
+                        보조 버튼. 사용자 비전 ("비개발자도 같이") 의 핵심 진입점 —
+                        터미널 / npm 없이 5 md + .mcp.json.example 시드 작성. */}
                     {localVault.status === 'idle' ? (
                       <p className="text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
                         처음이세요? 이 repo 의{' '}
@@ -1609,6 +1613,12 @@ function AdminDocsContent() {
                         </code>
                         를 선택해 보세요 — 이 도구 자체의 ontology (21 노드) 가 즉시 트리에 등장합니다.
                       </p>
+                    ) : null}
+                    {localVault.status === 'loaded' && canEditCurrent ? (
+                      <OntologyStarterCta
+                        onScaffold={localVault.scaffoldOntology}
+                        docCount={localVault.manifest?.docs.length ?? 0}
+                      />
                     ) : null}
                     {canEditCurrent ? (
                       <button


### PR DESCRIPTION
## Summary

OSS launch readiness — bundles three concerns under one branch since they all gate the same goal (publishing to npm + welcoming a global audience).

### 1. `/docs` scaffold button + CLI parity (PR #109 original scope)
- `OntologyStarterCta` writes 5 starter `.md` files + `.mcp.json.example` directly to a vault folder picked via the File System Access API — non-developers don't need a terminal.
- `cli/` package mirrors the same templates, so `npx oh-my-ontology init my-vault` and the web button produce identical output.
- `mcp/package.json` polished for publish (keywords, repository.directory, files allowlist).

### 2. npm publish guard (3 layers)
AI agents must not run `npm publish` unless the user explicitly approves.
- `.claude/rules/forbidden.md` — auto-loaded behavioral rule
- `.claude/settings.json` PreToolUse hook + `.claude/hooks/block-npm-publish.sh` — intercepts Bash commands matching `npm/pnpm/yarn publish` (and `npm pack` without `--dry-run`) and returns `permissionDecision: "deny"`
- `CLAUDE.md` is intentionally a thin wrapper — the rule lives in `forbidden.md`
- Hook tested on 7 input shapes (publish variants blocked; `npm whoami` / `npm pack --dry-run` / regular commands allowed)

### 3. English-first docs + FEATURES.md drift sync
- All public-facing docs translated in-place: `mcp/README.md` (npm package face), `docs/PUBLISH-NPM.md`, `docs/PRODUCT-DIRECTION.md`, `docs/FEATURES.md`, `docs/ARCHITECTURE.md`, `docs/DATA-MODEL.md`, `docs/DESIGN-SYSTEM.md`, `docs/MODE-AWARE-CRUD.md`, `docs/DEPLOY-FIREBASE.md`, `docs/DEPLOYMENT.md`, `docs/CHANGELOG.md`, `cli/templates/vault/*.md` + the in-app mirror.
- New `docs/TROUBLESHOOTING.md` (English-only).
- README.md, AGENTS.md, CLAUDE.md keep a Korean sub-section (`한국어 가이드`) for native readers.
- FEATURES.md and AGENTS.md drift-synced against the actual codebase: removed `/knowledge/*` routes / `KnowledgeDocumentNewPage` / `node --check functions/index.js` / stale "Cumulative cleanup stats"; updated MCP tool count 7→11 / dogfood vault 21→23 nodes / vitest 118/848 → 100/721; added scaffold button / CLI / publish guard / new "OSS distribution surfaces" Section 8.
- `scripts/audit-data-model.mjs` accepts both Korean and English `## 5. Storage` headings — fixes the test that broke after translation.

### Kept Korean intentionally
- `docs/BACKLOG.md` · `docs/MISSION-CLEANUP-CANDIDATES.md` · `docs/launch/*` — internal trackers / draft material (only the maintainer reads these)
- README / AGENTS / CLAUDE bilingual sub-sections — a courtesy for Korean contributors

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors (62 warnings, all pre-existing)
- [x] `pnpm test:run` — 100 files / 721 tests pass
- [x] CLI smoke: `node cli/src/index.mjs init test-vault` writes 5 English `.md` + `.mcp.json.example`
- [x] Hook smoke: 7 input shapes (publish variants blocked; whoami / dry-run / regular commands pass)
- [x] DATA-MODEL audit test passes after the `parseDocumentedStoragePaths` regex update
- [ ] Browser smoke: `/docs` scaffold button writes English starters into a picked folder (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)