### PR TITLE
fix: eval round 2 — UX critical (topology empty-state · /projects nav · ⇧⌘K · CTA · mobile)

### DIFF
--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-02T11:15:34.817Z",
+  "generatedAt": "2026-05-02T11:42:07.498Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -168,7 +168,11 @@ function AdminDocsContent() {
   const [recentSlugs, setRecentSlugs] = useState<string[]>([]);
   const [pinnedSlugs, setPinnedSlugs] = useState<string[]>([]);
   const [activeTag, setActiveTag] = useState<string | null>(null);
-  const [source, setSource] = useState<Source>('server');
+  // ?intent=local — landing CTA "내 마크다운 폴더 열기" 의 진입 query.
+  // source 초기값을 'local' 로 박아 처음부터 picker UI 가 우측 sidebar 에
+  // 보이게 (eval B4 finding — 이전엔 picker 가 4-단계 깊숙이 묻혀 있었음).
+  const initialIntentLocal = searchParams?.get('intent') === 'local';
+  const [source, setSource] = useState<Source>(initialIntentLocal ? 'local' : 'server');
   const [mobileTreeOpen, setMobileTreeOpen] = useState(false);
   const [radarConfirmedKeys, setRadarConfirmedKeys] = useState<Set<string>>(
     () => new Set(),

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -68,6 +68,10 @@ const SigmaHubRail = dynamic(
   () => import("@/widgets/topology-map-sigma").then((m) => m.SigmaHubRail),
   { ssr: false },
 );
+const TopologyEmptyState = dynamic(
+  () => import("@/widgets/topology-map-sigma").then((m) => m.TopologyEmptyState),
+  { ssr: false },
+);
 const SearchPalette = dynamic(
   () => import("@/widgets/search-palette").then((m) => m.SearchPalette),
   { ssr: false },
@@ -794,6 +798,13 @@ export function HomePage() {
                 key={localGraphRoot ?? '__root__'}
                 className="absolute inset-0 animate-[sigmaFade_220ms_ease-out]"
               >
+                {/* Empty-state overlay when the visible Sigma graph has 0–1
+                    nodes (eval B3 finding) — the lone Sigma dot reads as
+                    broken. sigmaVisibleCount 은 Sigma 가 첫 mount 후 reports.
+                    null 일 땐 가짠 카드 깜빡임 회피 위해 mount 만 기다림. */}
+                {sigmaVisibleCount !== null && sigmaVisibleCount <= 1 ? (
+                  <TopologyEmptyState projectCount={sigmaVisibleCount} />
+                ) : null}
                 <SigmaTopology
                   projects={localGraphProjects}
                   categories={taxonomyCategories}

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -37,7 +37,9 @@ export function LandingPage({ next }: Props) {
   return (
     <main
       id="main"
-      className="relative flex min-h-screen flex-col bg-[color:var(--color-canvas)] px-[max(1.5rem,env(safe-area-inset-left))] py-[max(1.5rem,env(safe-area-inset-top))] pr-[max(1.5rem,env(safe-area-inset-right))] pb-[max(2rem,env(safe-area-inset-bottom))] md:px-10 md:py-10"
+      // 모바일 BottomTabBar (56px) + safe-area 만큼 더 padding-bottom 확보 —
+      // eval H3 finding: 모바일에서 '01' 카드를 탭바가 가리던 회귀.
+      className="relative flex min-h-screen flex-col bg-[color:var(--color-canvas)] px-[max(1.5rem,env(safe-area-inset-left))] py-[max(1.5rem,env(safe-area-inset-top))] pr-[max(1.5rem,env(safe-area-inset-right))] pb-[calc(56px+env(safe-area-inset-bottom)+1rem)] md:px-10 md:py-10 md:pb-10"
     >
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div className="inline-flex items-center gap-3">
@@ -110,7 +112,7 @@ export function LandingPage({ next }: Props) {
                 <ArrowRight size={16} />
               </Link>
               <Link
-                href="/docs/"
+                href="/docs/?intent=local"
                 className={cn(
                   buttonVariants({ variant: "outline", size: "lg" }),
                   "rounded-full",

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -17,7 +17,7 @@ import {
   type OntologyEgoSubgraph,
   type OntologyTreeBuildResult,
 } from "@/shared/lib/ontology-tree";
-import { GlobalSearch, useGlobalSearchHotkey } from "@/widgets/global-search";
+import { GlobalSearch, MountedGlobalSearch, useGlobalSearchHotkey } from "@/widgets/global-search";
 import { ManualEdgeCreateModal } from "@/widgets/manual-edge-create-modal";
 import { ManualNodeCreateModal } from "@/widgets/manual-node-create-modal";
 import { OntologyEgoGraph } from "@/widgets/ontology-ego-graph";
@@ -90,8 +90,13 @@ export function OntologyViewPage() {
     return () => window.removeEventListener("keydown", handler);
   }, [selectedNode]);
 
-  // ⌘K / Ctrl+K — 검색 토글. 같은 hook 을 다른 surface 도 쓰므로 단일 진입점.
+  // ⌘K / Ctrl+K — 페이지-스코프 concept search 토글.
   useGlobalSearchHotkey(searchOpen, setSearchOpen);
+  // ⇧⌘K — global search (ontology + projects + docs). eval H2 finding —
+  // /topology, /ontology/insights, /ontology/relations 는 ⇧⌘K 가 동작하는데
+  // /ontology/ (ontology hub, 가장 많이 들르는 페이지) 만 안 됐음. 일관성 회복.
+  const [globalSearchOpen, setGlobalSearchOpen] = useState(false);
+  useGlobalSearchHotkey(globalSearchOpen, setGlobalSearchOpen, { shift: true });
 
   // deeplink — `?node=<id>` 를 selectedNode 와 양방향 동기화. URL 이 source
   // of truth: 외부 surface (검색 / 문서 / 직접 입력) 에서 URL 만 바뀌어도
@@ -440,6 +445,14 @@ relates:
         open={searchOpen}
         onOpenChange={setSearchOpen}
         nodes={insight?.nodes ?? []}
+        onSelectNode={(node) => selectNode(node)}
+      />
+
+      {/* ⇧⌘K — global search (ontology + projects). 다른 surface 와 일관성. */}
+      <MountedGlobalSearch
+        accountId={accountId}
+        open={globalSearchOpen}
+        onOpenChange={setGlobalSearchOpen}
         onSelectNode={(node) => selectNode(node)}
       />
 

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -17,6 +17,7 @@ import { downloadProjectsCsv } from "@/features/project-export";
 import { useKnowledgePublicNodes } from "@/entities/knowledge-graph";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { PublicAccountMenu } from "@/widgets/account-menu";
+import { OperationsNav } from "@/widgets/operations-nav";
 import { WorkspaceOntologyStrip } from "@/widgets/workspace-ontology-strip";
 import {
   ACCOUNT_QUERY_KEY,
@@ -219,8 +220,13 @@ export function ProjectSelectorPage() {
   }
 
   return (
-    <main className="min-h-screen bg-[color:var(--color-canvas)] px-5 py-6 md:px-10 md:py-14">
-      <div className="mx-auto max-w-6xl">
+    <main id="main" className="min-h-screen bg-[color:var(--color-canvas)]">
+      {/* OperationsNav surface 일관성 (eval H1 finding) — 다른 운영 surface
+          (/docs, /ontology/edit, /ontology/insights, /settings/*) 와 같은
+          탭 + ModeBadge + LocaleSwitch + ThemeToggle. /projects 만 제외돼
+          있어 사용자가 cross-surface 점프 못 했음. */}
+      <OperationsNav />
+      <div className="mx-auto max-w-6xl px-5 py-6 md:px-10 md:py-14">
         <div className="mb-5 flex items-center justify-end gap-3">
           <Link
             href={overviewHref}

--- a/src/widgets/topology-map-sigma/index.ts
+++ b/src/widgets/topology-map-sigma/index.ts
@@ -1,6 +1,7 @@
 export { SigmaTopology } from './ui/SigmaTopology';
 export { SigmaControls } from './ui/SigmaControls';
 export { SigmaHubRail } from './ui/SigmaHubRail';
+export { TopologyEmptyState } from './ui/TopologyEmptyState';
 export {
   DEFAULT_SIGMA_CONTROLS,
   type SigmaControlsState,

--- a/src/widgets/topology-map-sigma/ui/TopologyEmptyState.tsx
+++ b/src/widgets/topology-map-sigma/ui/TopologyEmptyState.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { FolderOpen, GitBranch } from 'lucide-react';
+
+/**
+ * Topology empty-state — when the graph has 0–1 projects, showing the
+ * lone Sigma dot tells the user "this page is broken" rather than "this
+ * page has no edges yet" (eval finding B3, 2026-05-02). Displays a
+ * Toss-quality card with one explanatory sentence and two recovery CTAs.
+ *
+ * Mirrors the mobile builder empty-state copy pattern that the eval
+ * agent specifically called out as Toss/Apple-grade.
+ */
+export function TopologyEmptyState({ projectCount }: { projectCount: number }) {
+  const title = projectCount === 0 ? '프로젝트가 아직 없어요' : '아직 그릴 의존이 없어요';
+  const body =
+    projectCount === 0
+      ? '마크다운 폴더를 연결하거나 빌더에서 첫 프로젝트를 만들어보세요. frontmatter 의 `dependencies:` 만 채우면 여기에 선이 자동으로 그려져요.'
+      : '프로젝트끼리 의존 관계 (`dependencies:` frontmatter) 을 1개라도 적으면 여기에 선이 자동으로 생겨요. 빌더 캔버스에서 드래그로도 추가 가능.';
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-6">
+      <div className="pointer-events-auto max-w-md rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-8 text-center shadow-[0_18px_48px_rgba(0,0,0,0.35)]">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
+          TOPOLOGY · {projectCount} NODE{projectCount === 1 ? '' : 'S'}
+        </p>
+        <h2 className="mt-3 text-[20px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          {title}
+        </h2>
+        <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--color-text-tertiary)]">
+          {body}
+        </p>
+        <div className="mt-6 flex flex-col items-stretch gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/ontology/edit/"
+            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:rgba(94,106,210,0.4)] bg-[color:rgba(94,106,210,0.14)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.6)] hover:bg-[color:rgba(94,106,210,0.2)]"
+          >
+            <GitBranch size={14} aria-hidden="true" />
+            빌더에서 의존 추가
+          </Link>
+          <Link
+            href="/docs/"
+            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)]"
+          >
+            <FolderOpen size={14} aria-hidden="true" />
+            마크다운 폴더 열기
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

eval 결과 4-agent 가 발견한 UX critical findings (B3, H1, H2, B4, H3, H4). PR #111 (Round 1) 위에 누적 — Round 1 머지 시 자동 main 위로 이어집니다 (base = fix/eval-round1-bundle-leaks-localeswitch).

### B3 — `/topology` empty-state 신규 widget
"visual hero" surface 가 1 project + 0 dependencies 일 때 가운데 4px 점만 그려 망가져 보이던 회귀.

신규 `src/widgets/topology-map-sigma/ui/TopologyEmptyState.tsx` — z-20 overlay, "TOPOLOGY · N NODE" eyebrow + 한 문장 설명 + 두 recovery CTA (빌더 / 폴더). pointer-events 분리로 카드 영역만 클릭 가능, 빈 영역은 Sigma pan/zoom 통과.

`HomePage.tsx` — `sigmaVisibleCount !== null && sigmaVisibleCount <= 1` 일 때 overlay (renderProjects.length 가 아니라 실제 Sigma 가 그린 노드 기준).

### H1 — `/projects` 에 OperationsNav 추가
다른 surface 와 일관성. EN/KO LocaleSwitch 가 자연스럽게 surface 됨.

### H2 — ⇧⌘K 전역 일관성
`/ontology/` 가 ⇧⌘K 미바인딩이던 회귀 — `OntologyViewPage` 에 `globalSearchOpen` state + `useGlobalSearchHotkey({ shift: true })` + `MountedGlobalSearch` 마운트.

### B4 — `/docs` "내 마크다운 폴더 열기" CTA dead-end 완화
- Landing CTA href: `/docs/` → `/docs/?intent=local`
- `DocsVaultPage` source 초기값을 query 에 따라 `'local'` 로 박아 picker 가 sidebar 에 처음부터 visible
- 더 큰 fix (picker → primary body promote) 는 Round 3+

### H3 — 모바일 BottomTabBar 가 landing 첫 카드 가리던 회귀
LandingPage `<main>` pb 를 `[max(2rem,...)]` (32px) → `[calc(56px+env(safe-area-inset-bottom)+1rem)]` (~88px) 로 교체. `md:pb-10` 로 데스크톱 reset.

### H4 — auto-redirect mid-paint 자동 해소
Round 1 의 Firestore subscription leak fix (3 곳 mode-gate) 로 redirect 회귀 자체가 사라짐. 검증: `/ko/ontology/insights/` URL 유지, redirect 없음.

## Verification

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors (63 warnings 모두 기존)
- [x] `pnpm test:run` — 100 files / 721 tests pass
- [x] Browser 1440×900: /ko/topology/ empty-state 카드 정상 / /ko/projects/ OperationsNav + LocaleSwitch
- [x] Browser 375×812: landing 카드 02/03 + CTAs + footer + LocaleSwitch 모두 BottomTabBar 위 노출
- [x] Console error 0 across 4 surfaces

## Screenshots

- `round2-topology-empty-state-v3.png` — B3 fix 검증
- `round2-projects-with-nav.png` — H1 fix 검증

## Rounds remaining

- **Round 3**: Phase C-2 + C-3 (shared widget + page 카피 추출 → 진짜 영문 UI)
- **Round 4**: polish (motion · auth spinner · live mini-Sigma · scaffold guard)
- **Round 5**: feature power (global ⌘K palette · /ontology/changes · JSON-LD/GraphML export · typed query DSL · builder blast-radius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)