### PR TITLE
feat(i18n): round 3b — extract OntologyViewPage / DocsVaultPage / HomePage strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -91,5 +91,273 @@
     "returnTargetTitleEmphasis": "continue",
     "returnTargetSubtitle": "The screen you requested needs sign-in. After you sign in we'll take you straight back.",
     "returnTargetCta": "Sign in and continue"
+  },
+  "ontologyView": {
+    "eyebrow": "Ontology",
+    "title": "Ontology tree",
+    "titleTooltip": {
+      "heading": "Hierarchical view of ontology nodes",
+      "body": "A tree grown directly from the frontmatter of `.md` files in your vault. No review step — changes apply instantly. Expanded in the order <hierarchy>project → domain → capability → element</hierarchy>.",
+      "footer": "Document nodes act as evidence and are excluded from the tree. <strong>To draw the graph yourself, use the ‘Open builder’</strong> button on the right."
+    },
+    "titleTooltipAria": "Explain what the ontology tree is",
+    "actions": {
+      "addNodeTooltip": "Add a new node manually",
+      "addNodeAria": "Add an ontology node manually",
+      "addNode": "Add node",
+      "searchTooltip": "Search (⌘K)",
+      "searchAria": "Open ontology node search",
+      "search": "Search",
+      "builderTooltip": "Builder canvas — pick a kind from the palette on the left, drag handles to add relations",
+      "builderAria": "Ontology builder — draw directly on the canvas",
+      "builder": "Open builder →",
+      "insightsTooltip": "Ontology insights — kind distribution · hub nodes · recent activity · orphans",
+      "insights": "Insights",
+      "relationsTooltip": "Relations — type distribution + strong evidence-rich relations",
+      "relations": "Relations"
+    },
+    "stat": {
+      "treeNodes": "Tree nodes",
+      "totalRelations": "Total relations",
+      "documents": "Evidence docs",
+      "publishedAt": "Published",
+      "publishedAtEmpty": "None yet"
+    },
+    "error": "Something went wrong while loading ontology data. {message}",
+    "loading": "Loading…",
+    "emptyHint": "The ontology hasn't grown yet. Follow the steps below to start your first graph.",
+    "getStarted": {
+      "eyebrow": "Get started",
+      "headingLocal": "Vault is empty — write frontmatter and it grows instantly",
+      "headingDefault": "The tree grows as documents grow",
+      "bodyLocal": "There are 0 `.md` files with ontology frontmatter in the active vault. Take the next 2 steps to create your first node.",
+      "bodyDefault": "An ontology is a graph of concepts and relations from vault frontmatter. Take the next 3 steps to grow your first tree.",
+      "stepLocalFrontmatterTitle": "Write frontmatter",
+      "stepLocalFrontmatterDesc": "Add frontmatter like `kind: capability` to any `.md` file in the vault and a stub node appears immediately.",
+      "stepLocalBuilderTitle": "Tidy in the builder",
+      "stepLocalBuilderDesc": "Use the /ontology/edit canvas to visually polish nodes and relations — saves to the vault and updates the tree.",
+      "stepCloudVaultTitle": "Open a vault",
+      "stepCloudVaultDesc": "From /docs, pick a markdown folder to activate the vault.",
+      "stepCloudFrontmatterTitle": "Add frontmatter",
+      "stepCloudFrontmatterDesc": "Write kind / capabilities / elements / relates in your docs and stub nodes are created automatically.",
+      "stepCloudBuilderTitle": "Tidy in the builder",
+      "stepCloudBuilderDesc": "Polish nodes and relations on the /ontology/edit canvas and they grow right into this tree.",
+      "ctaBuilder": "Open builder →",
+      "ctaBuilderShort": "Open builder",
+      "ctaVault": "Browse vault",
+      "ctaVaultOpen": "Open vault →",
+      "snippetEyebrow": "snippet",
+      "snippetSummary": "Your vault's first node — paste this frontmatter into a `.md` file and it appears in the tree right away",
+      "snippetHelp": "Save the content above into your vault as something like <code>capabilities/auth.md</code>. More frontmatter keys: <code>domain</code> · <code>capabilities</code> · <code>elements</code> · <code>relates</code> · <code>dependencies</code>."
+    },
+    "footer": {
+      "modeLocal": "Local vault",
+      "modeCloud": "Cloud",
+      "modeStatic": "Static demo"
+    },
+    "copyLink": {
+      "tooltip": "Copy a direct link to this node",
+      "ariaCopied": "Node link copied",
+      "ariaCopy": "Copy node link",
+      "toastSuccess": "Node link copied",
+      "toastError": "Copy failed — check browser permissions",
+      "badge": "Copied"
+    },
+    "detail": {
+      "ariaLabel": "Node detail: {title}",
+      "addEdgeTooltip": "Add a new relation from this node",
+      "addEdgeAria": "Add a relation from this node",
+      "addEdgeButton": "Relation",
+      "close": "Close",
+      "manualNote": "Author note",
+      "linkedProjects": "Linked projects",
+      "evidenceCount": "Evidence count",
+      "relations": "Relations {count}",
+      "relationsHopBreakdown": "· 1-hop {one} · 2-hop {two}",
+      "egoDepthAria": "Ego graph depth",
+      "egoTwoHopTooltip": "Includes neighbors one step further — labels may overlap with more nodes",
+      "neighborMissingKind": "Missing",
+      "neighborMissingTitle": "A node with this ID isn't in the graph yet",
+      "collapse": "Collapse",
+      "showMore": "+{count} more",
+      "relatedDocs": "Related documents {count}",
+      "projectDetailCta": "Public detail page →",
+      "stubWarning": "Unresolved reference — the slug pointed to by frontmatter doesn't exist in the vault. Create a node with this name in the builder (/ontology/edit), or remove the reference from frontmatter."
+    }
+  },
+  "docsVault": {
+    "header": {
+      "openTreeAriaLabel": "Open document tree",
+      "openTreeTitle": "Document tree",
+      "backToWorkspaceAriaLabel": "Back to workspace map",
+      "back": "Back",
+      "title": "Docs Vault",
+      "docCount": "{count} docs",
+      "roleTooltip": "Current role: {role}. No edit permission — read-only.",
+      "localBadge": "Local",
+      "audienceAriaLabel": "Document audience",
+      "audienceLabel": "Audience",
+      "audienceAll": "All",
+      "audiencePlanner": "Planner",
+      "audienceEngineer": "Engineer",
+      "paletteTooltip": "Search · commands · tags — Tab to switch audience",
+      "paletteAriaLabel": "Open palette (search · commands · tags)",
+      "advancedTooltip": "Advanced",
+      "advancedAriaLabel": "Open advanced menu"
+    },
+    "advanced": {
+      "viewSection": "View",
+      "viewDoc": "Doc",
+      "viewGraph": "Graph",
+      "viewStats": "Stats",
+      "viewTopology": "Topology",
+      "sourceSection": "Source",
+      "sourceServer": "Server",
+      "sourceLocal": "Local",
+      "ontologyHintPrefix": "First time? Try selecting this repo's ",
+      "ontologyHintSuffix": " — this tool's own ontology (21 nodes) appears in the tree instantly.",
+      "newDoc": "New doc"
+    },
+    "mobileDrawer": {
+      "title": "Document tree",
+      "closeAriaLabel": "Close tree"
+    },
+    "topology": {
+      "addProjectTitle": "Add new project .md (projects/{slug}.md)",
+      "addProjectLabel": "Project",
+      "emptyTitle": "This vault has no `projects/` yet",
+      "emptyBody": "Auto-generate the Folder-Topology file structure (projects/_.md, categories.md, statuses.md) and the topology will show up. Existing files are not overwritten.",
+      "scaffoldCta": "Initialize this folder as a topology vault",
+      "needEditPermission": "Edit permission required (local vault)"
+    },
+    "graph": {
+      "focusAll": "All",
+      "focusLocalEnabled": "Show 2-hop neighborhood of selected doc",
+      "focusLocalDisabled": "Select a doc to enable",
+      "focusLocalLabel": "2-hop neighbors"
+    },
+    "commands": {
+      "openPalette": "Open palette (search · commands · tags)",
+      "findTags": "Find tags",
+      "viewDoc": "View · Document",
+      "viewGraph": "View · Link graph",
+      "viewStats": "View · Vault stats",
+      "viewFolderTopology": "View · Folder topology (projects/*.md)",
+      "scaffoldTopology": "Initialize this folder as a topology vault",
+      "createProject": "Add new project (projects/…md)",
+      "audienceAll": "Audience · All",
+      "audiencePlanner": "Audience · Planner",
+      "audienceEngineer": "Audience · Engineer",
+      "sourceServer": "Source · Server vault",
+      "sourceLocal": "Source · Local PC folder",
+      "pinDoc": "Pin this doc",
+      "unpinDoc": "Unpin",
+      "copyUrl": "Copy current document URL",
+      "print": "Print · Save as PDF",
+      "edit": "Edit this file",
+      "newDoc": "Create new doc",
+      "dailyNote": "Today's note (daily/YYYY-MM-DD)",
+      "rename": "Rename this doc (slug/path)",
+      "insertToc": "Insert table of contents",
+      "deleteDoc": "Delete this doc",
+      "exportDocHtml": "Save current doc as HTML",
+      "exportVault": "Export vault backup (JSON)",
+      "importVault": "Import vault backup (JSON)",
+      "localRefresh": "Rescan local vault",
+      "localClose": "Close local vault",
+      "clearTagFilter": "Clear tag filter",
+      "projectsList": "Go to projects list"
+    },
+    "dialog": {
+      "deleteConfirm": "Really delete?\n\n{title}\n{slug}.md\n\nThis cannot be undone.",
+      "deleteFailed": "Delete failed: {message}",
+      "createProjectPrompt": "New project slug (letters · digits · hyphens):",
+      "invalidSlug": "Not a valid slug.",
+      "alreadyExists": "Already exists: {slug}",
+      "createFailed": "Create failed: {message}",
+      "scaffoldConfirm": "Initialize this folder as a Folder-Topology vault?\n\n- projects/ directory + 2 sample projects\n- categories.md · statuses.md default sets\n- README.md\n\nExisting files are not overwritten.",
+      "scaffoldDone": "Initialization complete — {created} new files · {skipped} skipped\n\nFor field specs, open the freshly generated README.md first. Use the 2 sample projects (sample-hub / sample-leaf) frontmatter as a template.",
+      "scaffoldFailed": "Initialization failed: {message}",
+      "dailyNoteFailed": "Daily note creation failed: {message}",
+      "noHeadings": "This document has no h2/h3 headings.",
+      "notLocalFile": "This document is not a local vault file.",
+      "tocFailed": "TOC insertion failed: {message}",
+      "notRendered": "Document is not rendered yet. Try again.",
+      "jsonParseFailed": "JSON parse failed: {message}",
+      "noValidRaws": "No valid `raws` field.",
+      "importOverwriteConfirm": "{count} documents already exist in the vault.\n\nYes = Overwrite (saveDoc)\nNo = Skip duplicates\n\nProceed?",
+      "importDone": "Import complete — new {created} · overwritten {updated} · skipped {skipped}",
+      "renamePrompt": "New slug (without extension):",
+      "renameAlreadyExists": "Document already exists: {slug}",
+      "renameFailed": "Rename failed: {message}",
+      "newDocPrompt": "New document path (slug, no extension):"
+    }
+  },
+  "topology": {
+    "loadingEngine": "Loading topology engine",
+    "documentTitle": "Topology",
+    "srHeading": "Topology project topology map",
+    "presentationStarted": "Presentation mode started",
+    "selectionAnnouncement": "{name} selected. {deps} dependencies, {referenced} references.",
+    "mobileTagline": "Project dependency map.",
+    "workspace": {
+      "growthThisWeek": " · +{count} this week",
+      "subtitle": "Workspace · {projects} projects · {hubs} hubs{growth}",
+      "eyebrow": "Workspace · {projects} projects",
+      "fallbackTitle": "Topology",
+      "selectedEyebrow": "Selected project",
+      "expandHint": "Expand workspace map",
+      "mapEyebrow": "Workspace map",
+      "description": "{hubs} hubs are at the heart of {projects} projects. Click a node to open its details."
+    },
+    "hero": {
+      "closeSelected": "Close selected project",
+      "expandLeftPanel": "Expand the left panel"
+    },
+    "scene": {
+      "backToWorkspace": "Back to the workspace map",
+      "workspaceMap": "Workspace map"
+    },
+    "controls": {
+      "relayoutToast": "Relaying out the topology",
+      "docsTooltip": "Docs vault quick look (D)",
+      "docsAriaLabel": "Open docs vault quick look (D)",
+      "docsLabel": "Docs",
+      "pinnedDocsCount": "{count} pinned docs",
+      "exitPresentationTooltip": "Exit presentation mode (F)",
+      "exitPresentationAriaLabel": "Exit presentation mode",
+      "close": "Close",
+      "shortcutsTooltip": "Keyboard shortcuts (?)",
+      "shortcutsAriaLabel": "View keyboard shortcuts"
+    },
+    "evidence": {
+      "openLabel": "{name} — open document evidence map",
+      "badge": "Document evidence"
+    },
+    "empty": {
+      "noMatchesBody": "No projects match the current filters.",
+      "clearFilters": "Clear filters",
+      "kicker": "TOPOLOGY · {count, plural, one {# NODE} other {# NODES}}",
+      "titleNoProjects": "No projects yet",
+      "titleNoDeps": "No dependencies to draw yet",
+      "bodyNoProjects": "Connect a markdown folder or create your first project in the builder. Fill in `dependencies:` in the frontmatter and lines appear here automatically.",
+      "bodyNoDeps": "Add a single dependency between two projects (`dependencies:` frontmatter) and a line will appear here automatically. The builder canvas can also draw them via drag.",
+      "ctaBuilder": "Add a dependency in the builder",
+      "ctaOpenVault": "Open my markdown folder"
+    },
+    "hint": {
+      "title": "Project terrain map",
+      "dismissAriaLabel": "Close hint",
+      "body": "Nodes are projects, lines are dependencies. Click to open details, search to narrow.",
+      "click": "Click",
+      "clickDescription": " · open the detail panel",
+      "drag": "Drag",
+      "dragDescription": " · move a node",
+      "searchDescription": " search · ",
+      "shortcutsDescription": " shortcuts"
+    },
+    "errorBanner": {
+      "retry": "Retry"
+    }
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -91,5 +91,273 @@
     "returnTargetTitleEmphasis": "이어보기",
     "returnTargetSubtitle": "요청한 화면은 로그인이 필요합니다. 로그인하면 방금 열려던 화면으로 바로 돌아갑니다.",
     "returnTargetCta": "로그인하고 계속"
+  },
+  "ontologyView": {
+    "eyebrow": "Ontology",
+    "title": "온톨로지 트리",
+    "titleTooltip": {
+      "heading": "ontology 노드의 계층 뷰",
+      "body": "vault 안 .md 파일의 frontmatter 가 그대로 자란 트리. 검수 단계 없이 즉시 반영 — <hierarchy>project → domain → capability → element</hierarchy> 순서로 펼쳐서 보여줍니다.",
+      "footer": "문서 노드는 근거 역할이라 트리에서 제외돼요. <strong>그래프를 직접 그리려면 우측 ‘빌더 열기’</strong> 버튼을 눌러보세요."
+    },
+    "titleTooltipAria": "온톨로지 트리가 무엇인지 설명",
+    "actions": {
+      "addNodeTooltip": "새 노드 직접 추가",
+      "addNodeAria": "ontology 노드 직접 추가",
+      "addNode": "노드 추가",
+      "searchTooltip": "검색 (⌘K)",
+      "searchAria": "ontology 노드 검색 열기",
+      "search": "검색",
+      "builderTooltip": "빌더 캔버스 — 왼쪽 palette 에서 종류 골라 클릭, 핸들 drag 로 관계 추가",
+      "builderAria": "온톨로지 빌더 — 캔버스에서 직접 그리기",
+      "builder": "빌더 열기 →",
+      "insightsTooltip": "ontology 인사이트 — kind 분포 · 허브 노드 · 최근 활동 · 미연결",
+      "insights": "인사이트",
+      "relationsTooltip": "관계 — 종류 분포 + 근거 풍부한 강한 관계",
+      "relations": "관계"
+    },
+    "stat": {
+      "treeNodes": "트리 노드",
+      "totalRelations": "총 관계",
+      "documents": "근거 문서",
+      "publishedAt": "발행 시점",
+      "publishedAtEmpty": "아직 없음"
+    },
+    "error": "ontology 데이터를 불러오는 중 오류가 났어요. {message}",
+    "loading": "불러오는 중…",
+    "emptyHint": "ontology 가 아직 자라지 않았어요. 아래 단계로 첫 그래프를 시작할 수 있어요.",
+    "getStarted": {
+      "eyebrow": "Get started",
+      "headingLocal": "vault 가 비어있어요 — frontmatter 를 적으면 즉시 자라요",
+      "headingDefault": "문서가 자라면 트리도 자라요",
+      "bodyLocal": "활성 vault 에 ontology frontmatter 가 있는 .md 파일이 0 개. 다음 2 단계로 첫 노드를 만들어요.",
+      "bodyDefault": "온톨로지는 vault frontmatter 의 개념·관계가 모인 그래프예요. 다음 3 단계로 첫 트리를 만들어 봐요.",
+      "stepLocalFrontmatterTitle": "frontmatter 적기",
+      "stepLocalFrontmatterDesc": "vault 안 아무 .md 파일에 `kind: capability` 같은 frontmatter 추가하면 즉시 stub 노드로 등장.",
+      "stepLocalBuilderTitle": "빌더에서 정리",
+      "stepLocalBuilderDesc": "/ontology/edit 캔버스에서 시각적으로 노드·관계 다듬으면 그대로 vault 에 저장 + 트리 갱신.",
+      "stepCloudVaultTitle": "vault 열기",
+      "stepCloudVaultDesc": "/docs 에서 마크다운 폴더를 선택해 vault 를 활성화해요.",
+      "stepCloudFrontmatterTitle": "frontmatter 추가",
+      "stepCloudFrontmatterDesc": "문서에 kind / capabilities / elements / relates 를 적으면 자동으로 stub 노드가 만들어져요.",
+      "stepCloudBuilderTitle": "빌더에서 정리",
+      "stepCloudBuilderDesc": "/ontology/edit 캔버스에서 노드와 관계를 다듬으면 여기 트리에 그대로 자라요.",
+      "ctaBuilder": "빌더 열기 →",
+      "ctaBuilderShort": "빌더 열기",
+      "ctaVault": "vault 살펴보기",
+      "ctaVaultOpen": "vault 열기 →",
+      "snippetEyebrow": "snippet",
+      "snippetSummary": "vault 의 첫 노드 — 이 frontmatter 를 `.md` 파일에 붙여넣으면 즉시 트리에 등장",
+      "snippetHelp": "위 내용을 vault 안 어떤 디렉토리에든 <code>capabilities/auth.md</code> 같은 이름으로 저장하세요. 더 자세한 frontmatter 키: <code>domain</code> · <code>capabilities</code> · <code>elements</code> · <code>relates</code> · <code>dependencies</code>."
+    },
+    "footer": {
+      "modeLocal": "로컬 vault",
+      "modeCloud": "클라우드",
+      "modeStatic": "정적 데모"
+    },
+    "copyLink": {
+      "tooltip": "이 노드의 직접 링크 복사",
+      "ariaCopied": "노드 링크 복사됨",
+      "ariaCopy": "노드 링크 복사",
+      "toastSuccess": "노드 링크 복사됨",
+      "toastError": "복사 실패 — 브라우저 권한 확인",
+      "badge": "복사"
+    },
+    "detail": {
+      "ariaLabel": "노드 상세: {title}",
+      "addEdgeTooltip": "이 노드를 from 으로 새 관계 추가",
+      "addEdgeAria": "이 노드에서 관계 추가",
+      "addEdgeButton": "관계",
+      "close": "닫기",
+      "manualNote": "작성 메모",
+      "linkedProjects": "연결 프로젝트",
+      "evidenceCount": "근거 수",
+      "relations": "관계 {count}",
+      "relationsHopBreakdown": "· 1-hop {one} · 2-hop {two}",
+      "egoDepthAria": "ego 그래프 깊이",
+      "egoTwoHopTooltip": "한 다리 건넌 이웃까지 — 노드 수 늘어 라벨 겹침 가능",
+      "neighborMissingKind": "미연결",
+      "neighborMissingTitle": "이 ID 의 노드가 아직 그래프에 없어요",
+      "collapse": "접기",
+      "showMore": "+{count}개 더",
+      "relatedDocs": "관련 문서 {count}",
+      "projectDetailCta": "공개 상세 페이지 →",
+      "stubWarning": "미해결 참조 — frontmatter 가 가리킨 slug 가 vault 안에 없어요. 빌더(/ontology/edit)에서 이 이름으로 노드를 만들거나, frontmatter 에서 참조를 빼세요."
+    }
+  },
+  "docsVault": {
+    "header": {
+      "openTreeAriaLabel": "트리 열기",
+      "openTreeTitle": "문서 트리",
+      "backToWorkspaceAriaLabel": "워크스페이스 지도로 돌아가기",
+      "back": "돌아가기",
+      "title": "Docs Vault",
+      "docCount": "{count} 문서",
+      "roleTooltip": "현재 역할: {role}. 편집 권한이 없어 읽기만 가능합니다.",
+      "localBadge": "로컬",
+      "audienceAriaLabel": "문서 관점",
+      "audienceLabel": "관점",
+      "audienceAll": "전체",
+      "audiencePlanner": "기획자",
+      "audienceEngineer": "개발자",
+      "paletteTooltip": "검색 · 명령 · 태그 — Tab 으로 관점 전환",
+      "paletteAriaLabel": "팔레트 열기 (검색 · 명령 · 태그)",
+      "advancedTooltip": "고급",
+      "advancedAriaLabel": "고급 메뉴 열기"
+    },
+    "advanced": {
+      "viewSection": "보기",
+      "viewDoc": "문서",
+      "viewGraph": "그래프",
+      "viewStats": "통계",
+      "viewTopology": "토폴로지",
+      "sourceSection": "소스",
+      "sourceServer": "서버",
+      "sourceLocal": "로컬",
+      "ontologyHintPrefix": "처음이세요? 이 repo 의 ",
+      "ontologyHintSuffix": "를 선택해 보세요 — 이 도구 자체의 ontology (21 노드) 가 즉시 트리에 등장합니다.",
+      "newDoc": "새 문서"
+    },
+    "mobileDrawer": {
+      "title": "문서 트리",
+      "closeAriaLabel": "트리 닫기"
+    },
+    "topology": {
+      "addProjectTitle": "새 프로젝트 .md 추가 (projects/{slug}.md)",
+      "addProjectLabel": "프로젝트",
+      "emptyTitle": "이 볼트엔 아직 `projects/` 가 없어요",
+      "emptyBody": "Folder-Topology 규격 파일 구조 (projects/_.md, categories.md, statuses.md) 를 자동 생성하면 바로 토폴로지가 보여요. 이미 있는 파일은 덮어쓰지 않습니다.",
+      "scaffoldCta": "이 폴더를 토폴로지 볼트로 초기화",
+      "needEditPermission": "편집 권한이 필요합니다 (로컬 볼트)"
+    },
+    "graph": {
+      "focusAll": "전체",
+      "focusLocalEnabled": "선택 문서 주변 2-hop 만 보기",
+      "focusLocalDisabled": "문서를 선택하면 활성화됩니다",
+      "focusLocalLabel": "이웃 2-hop"
+    },
+    "commands": {
+      "openPalette": "팔레트 열기 (검색 · 명령 · 태그)",
+      "findTags": "태그 찾기",
+      "viewDoc": "뷰 · 문서 보기",
+      "viewGraph": "뷰 · 링크 그래프",
+      "viewStats": "뷰 · 볼트 통계",
+      "viewFolderTopology": "뷰 · Folder Topology (projects/*.md)",
+      "scaffoldTopology": "이 폴더를 Topology 볼트로 초기화",
+      "createProject": "새 프로젝트 추가 (projects/…md)",
+      "audienceAll": "관점 · 전체",
+      "audiencePlanner": "관점 · 기획자",
+      "audienceEngineer": "관점 · 개발자",
+      "sourceServer": "소스 · 서버 볼트",
+      "sourceLocal": "소스 · 로컬 PC 폴더",
+      "pinDoc": "이 문서 고정",
+      "unpinDoc": "고정 해제",
+      "copyUrl": "현재 문서 URL 복사",
+      "print": "인쇄 · PDF 로 저장",
+      "edit": "이 파일 편집",
+      "newDoc": "새 문서 만들기",
+      "dailyNote": "오늘의 노트 (daily/YYYY-MM-DD)",
+      "rename": "이 문서 이름 변경 (slug/경로)",
+      "insertToc": "현재 문서에 목차 삽입",
+      "deleteDoc": "이 문서 삭제",
+      "exportDocHtml": "현재 문서 HTML 로 저장",
+      "exportVault": "볼트 백업 내보내기 (JSON)",
+      "importVault": "볼트 복원 불러오기 (JSON)",
+      "localRefresh": "로컬 볼트 다시 스캔",
+      "localClose": "로컬 볼트 닫기",
+      "clearTagFilter": "태그 필터 해제",
+      "projectsList": "프로젝트 목록으로 이동"
+    },
+    "dialog": {
+      "deleteConfirm": "정말 삭제할까요?\n\n{title}\n{slug}.md\n\n이 작업은 되돌릴 수 없습니다.",
+      "deleteFailed": "삭제 실패: {message}",
+      "createProjectPrompt": "새 프로젝트 slug (영문·숫자·하이픈):",
+      "invalidSlug": "유효한 slug 가 아닙니다.",
+      "alreadyExists": "이미 존재: {slug}",
+      "createFailed": "생성 실패: {message}",
+      "scaffoldConfirm": "이 폴더를 Folder-Topology 규격으로 초기화할까요?\n\n- projects/ 디렉터리 + sample 2개 프로젝트\n- categories.md · statuses.md 기본 세트\n- README.md\n\n이미 존재하는 파일은 덮어쓰지 않습니다.",
+      "scaffoldDone": "초기화 완료 — 새 파일 {created}개 · 스킵 {skipped}개\n\n필드 규격은 방금 생성된 README.md 를 먼저 열어보세요. 샘플 프로젝트 2개 (sample-hub / sample-leaf) 의 frontmatter 를 템플릿으로 참고하면 됩니다.",
+      "scaffoldFailed": "초기화 실패: {message}",
+      "dailyNoteFailed": "daily note 생성 실패: {message}",
+      "noHeadings": "h2/h3 heading 이 없는 문서입니다.",
+      "notLocalFile": "이 문서는 로컬 볼트 파일이 아닙니다.",
+      "tocFailed": "TOC 삽입 실패: {message}",
+      "notRendered": "문서가 아직 렌더링되지 않았습니다. 다시 시도하세요.",
+      "jsonParseFailed": "JSON 파싱 실패: {message}",
+      "noValidRaws": "유효한 raws 필드가 없습니다.",
+      "importOverwriteConfirm": "{count}개 문서가 이미 볼트에 존재합니다.\n\n예 = 덮어쓰기 (saveDoc)\n아니오 = 새 이름으로 건너뛰기 (중복은 스킵)\n\n진행할까요?",
+      "importDone": "Import 완료 — 신규 {created} · 덮어씀 {updated} · 건너뜀 {skipped}",
+      "renamePrompt": "새 slug (확장자 없이):",
+      "renameAlreadyExists": "이미 존재하는 문서입니다: {slug}",
+      "renameFailed": "이름 변경 실패: {message}",
+      "newDocPrompt": "새 문서 경로 (slug, 확장자 없이):"
+    }
+  },
+  "topology": {
+    "loadingEngine": "토폴로지 엔진 불러오는 중",
+    "documentTitle": "토폴로지",
+    "srHeading": "토폴로지 프로젝트 토폴로지 지도",
+    "presentationStarted": "프레젠테이션 모드 시작",
+    "selectionAnnouncement": "{name} 선택됨. 의존 {deps}개, 연결 {referenced}개.",
+    "mobileTagline": "프로젝트 의존도 지도.",
+    "workspace": {
+      "growthThisWeek": " · 이번 주 +{count}",
+      "subtitle": "Workspace · {projects} 프로젝트 · {hubs} 허브{growth}",
+      "eyebrow": "Workspace · {projects} 프로젝트",
+      "fallbackTitle": "토폴로지",
+      "selectedEyebrow": "선택한 프로젝트",
+      "expandHint": "워크스페이스 지도 펼치기",
+      "mapEyebrow": "워크스페이스 지도",
+      "description": "{hubs}개 허브를 중심으로 {projects}개 프로젝트가 엮여 있습니다. 노드를 클릭해 상세를 열어 볼 수 있어요."
+    },
+    "hero": {
+      "closeSelected": "선택한 프로젝트 닫기",
+      "expandLeftPanel": "좌측 패널 펼치기"
+    },
+    "scene": {
+      "backToWorkspace": "워크스페이스 지도로 돌아가기",
+      "workspaceMap": "워크스페이스 지도"
+    },
+    "controls": {
+      "relayoutToast": "토폴로지를 다시 정렬합니다",
+      "docsTooltip": "문서 볼트 빠른 보기 (D)",
+      "docsAriaLabel": "문서 볼트 빠른 보기 열기 (D)",
+      "docsLabel": "문서",
+      "pinnedDocsCount": "고정된 문서 {count}개",
+      "exitPresentationTooltip": "프레젠테이션 모드 종료 (F)",
+      "exitPresentationAriaLabel": "프레젠테이션 모드 종료",
+      "close": "닫기",
+      "shortcutsTooltip": "키보드 단축키 (?)",
+      "shortcutsAriaLabel": "키보드 단축키 보기"
+    },
+    "evidence": {
+      "openLabel": "{name} 문서 근거 지도 보기",
+      "badge": "문서 근거"
+    },
+    "empty": {
+      "noMatchesBody": "현재 필터 조건에 맞는 프로젝트가 없습니다.",
+      "clearFilters": "필터 해제",
+      "kicker": "TOPOLOGY · {count} 노드",
+      "titleNoProjects": "프로젝트가 아직 없어요",
+      "titleNoDeps": "아직 그릴 의존이 없어요",
+      "bodyNoProjects": "마크다운 폴더를 연결하거나 빌더에서 첫 프로젝트를 만들어보세요. frontmatter 의 `dependencies:` 만 채우면 여기에 선이 자동으로 그려져요.",
+      "bodyNoDeps": "프로젝트끼리 의존 관계 (`dependencies:` frontmatter) 을 1개라도 적으면 여기에 선이 자동으로 생겨요. 빌더 캔버스에서 드래그로도 추가 가능.",
+      "ctaBuilder": "빌더에서 의존 추가",
+      "ctaOpenVault": "마크다운 폴더 열기"
+    },
+    "hint": {
+      "title": "프로젝트 지형도",
+      "dismissAriaLabel": "안내 닫기",
+      "body": "노드는 프로젝트, 선은 의존 관계입니다. 클릭해서 상세를 열고 검색으로 좁혀보세요.",
+      "click": "클릭",
+      "clickDescription": " · 상세 패널 열기",
+      "drag": "드래그",
+      "dragDescription": " · 노드 위치 이동",
+      "searchDescription": " 검색 · ",
+      "shortcutsDescription": " 단축키"
+    },
+    "errorBanner": {
+      "retry": "다시 시도"
+    }
   }
 }

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-02T11:56:44.166Z",
+  "generatedAt": "2026-05-02T12:12:31.661Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { AnimatePresence } from 'framer-motion';
 import {
   ArrowLeft,
@@ -119,6 +120,7 @@ import {
 } from "../lib/persistence";
 
 function AdminDocsContent() {
+  const t = useTranslations('docsVault');
   const searchParams = useSearchParams();
   const querySlug = searchParams?.get('slug') ?? null;
   const queryView = parseView(searchParams?.get('view'));
@@ -404,9 +406,7 @@ function AdminDocsContent() {
     const title =
       manifest.docs.find((d) => d.slug === slug)?.title ?? slug;
     if (typeof window === 'undefined') return;
-    const ok = window.confirm(
-      `정말 삭제할까요?\n\n${title}\n${slug}.md\n\n이 작업은 되돌릴 수 없습니다.`,
-    );
+    const ok = window.confirm(t('dialog.deleteConfirm', { title, slug }));
     if (!ok) return;
     try {
       await localVault.deleteDoc(slug);
@@ -431,10 +431,10 @@ function AdminDocsContent() {
       });
     } catch (err) {
       window.alert(
-        `삭제 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.deleteFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, t]);
 
   // Folder-Topology 빌드 — projects/*.md + categories.md + statuses.md 로드
   // → parser 호출. source==='local' 이고 vault 에 projects/ 가 있을 때만.
@@ -508,7 +508,7 @@ function AdminDocsContent() {
   const handleCreateProject = useCallback(async () => {
     if (!canEditCurrent) return;
     if (typeof window === 'undefined') return;
-    const input = window.prompt('새 프로젝트 slug (영문·숫자·하이픈):');
+    const input = window.prompt(t('dialog.createProjectPrompt'));
     if (!input) return;
     const slug = input
       .trim()
@@ -516,12 +516,12 @@ function AdminDocsContent() {
       .replace(/[^a-z0-9-]+/g, '-')
       .replace(/^-+|-+$/g, '');
     if (!slug) {
-      window.alert('유효한 slug 가 아닙니다.');
+      window.alert(t('dialog.invalidSlug'));
       return;
     }
     const fullSlug = `projects/${slug}`;
     if (manifest.docs.some((d) => d.slug === fullSlug)) {
-      window.alert(`이미 존재: ${fullSlug}`);
+      window.alert(t('dialog.alreadyExists', { slug: fullSlug }));
       return;
     }
     const defaultCategory = folderTopo?.categories[0]?.slug ?? 'uncategorized';
@@ -554,30 +554,21 @@ function AdminDocsContent() {
       setView('doc');
     } catch (err) {
       window.alert(
-        `생성 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.createFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, manifest, folderTopo, localVault, recentKey, replaceUrlState]);
+  }, [canEditCurrent, manifest, folderTopo, localVault, recentKey, replaceUrlState, t]);
 
   // Scaffold 실행 헬퍼 — confirm 거쳐 useLocalVault.scaffoldTopology.
   const handleScaffoldTopology = useCallback(async () => {
     if (!canEditCurrent) return;
     if (typeof window === 'undefined') return;
-    const ok = window.confirm(
-      '이 폴더를 Folder-Topology 규격으로 초기화할까요?\n\n' +
-        '- projects/ 디렉터리 + sample 2개 프로젝트\n' +
-        '- categories.md · statuses.md 기본 세트\n' +
-        '- README.md\n\n' +
-        '이미 존재하는 파일은 덮어쓰지 않습니다.',
-    );
+    const ok = window.confirm(t('dialog.scaffoldConfirm'));
     if (!ok) return;
     try {
       const result = await localVault.scaffoldTopology();
       window.alert(
-        `초기화 완료 — 새 파일 ${result.created}개 · 스킵 ${result.skipped}개\n\n` +
-          '필드 규격은 방금 생성된 README.md 를 먼저 열어보세요. ' +
-          '샘플 프로젝트 2개 (sample-hub / sample-leaf) 의 frontmatter 를 ' +
-          '템플릿으로 참고하면 됩니다.',
+        t('dialog.scaffoldDone', { created: result.created, skipped: result.skipped }),
       );
       // scaffold 후 README 를 자동 선택해 규격 인지 도움
       setSelectedSlug('README');
@@ -586,10 +577,10 @@ function AdminDocsContent() {
       setView('folder-topology');
     } catch (err) {
       window.alert(
-        `초기화 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.scaffoldFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, localVault, recentKey, replaceUrlState]);
+  }, [canEditCurrent, localVault, recentKey, replaceUrlState, t]);
 
   const handleDailyNote = useCallback(async () => {
     if (!canEditCurrent) return;
@@ -635,10 +626,10 @@ function AdminDocsContent() {
       setEditing(true);
     } catch (err) {
       window.alert(
-        `daily note 생성 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.dailyNoteFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, manifest, localVault, recentKey]);
+  }, [canEditCurrent, manifest, localVault, recentKey, t]);
 
   const handleInsertToc = useCallback(async () => {
     if (!canEditCurrent || !selectedSlug) return;
@@ -649,7 +640,7 @@ function AdminDocsContent() {
       (h) => h.depth >= 2 && h.depth <= 3,
     );
     if (headings.length === 0) {
-      window.alert('h2/h3 heading 이 없는 문서입니다.');
+      window.alert(t('dialog.noHeadings'));
       return;
     }
     // TOC markdown — h2 는 * indent 없음, h3 는 2-space indent.
@@ -666,7 +657,7 @@ function AdminDocsContent() {
     ].join('\n');
     const fh = localVault.fileHandles.get(selectedSlug);
     if (!fh) {
-      window.alert('이 문서는 로컬 볼트 파일이 아닙니다.');
+      window.alert(t('dialog.notLocalFile'));
       return;
     }
     try {
@@ -692,10 +683,10 @@ function AdminDocsContent() {
       await localVault.saveDoc(selectedSlug, next);
     } catch (err) {
       window.alert(
-        `TOC 삽입 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.tocFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, t]);
 
   const handleExportDocHtml = useCallback(() => {
     if (!selectedSlug || typeof window === 'undefined') return;
@@ -703,7 +694,7 @@ function AdminDocsContent() {
     if (!doc) return;
     const article = document.querySelector('[data-docs-viewer]');
     if (!article) {
-      window.alert('문서가 아직 렌더링되지 않았습니다. 다시 시도하세요.');
+      window.alert(t('dialog.notRendered'));
       return;
     }
     const html = buildDocsVaultPopoutHtml(doc.title, article.outerHTML);
@@ -717,7 +708,7 @@ function AdminDocsContent() {
     a.click();
     document.body.removeChild(a);
     setTimeout(() => URL.revokeObjectURL(url), 1000);
-  }, [selectedSlug, manifest]);
+  }, [selectedSlug, manifest, t]);
 
   const handleImportVault = useCallback(async () => {
     if (!canEditCurrent) return;
@@ -741,14 +732,14 @@ function AdminDocsContent() {
       bundle = JSON.parse(text);
     } catch (err) {
       window.alert(
-        `JSON 파싱 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.jsonParseFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
       return;
     }
     const raws = bundle.raws ?? {};
     const slugs = Object.keys(raws);
     if (slugs.length === 0) {
-      window.alert('유효한 raws 필드가 없습니다.');
+      window.alert(t('dialog.noValidRaws'));
       return;
     }
     const existing = slugs.filter((s) =>
@@ -757,7 +748,7 @@ function AdminDocsContent() {
     let overwrite = false;
     if (existing.length > 0) {
       overwrite = window.confirm(
-        `${existing.length}개 문서가 이미 볼트에 존재합니다.\n\n예 = 덮어쓰기 (saveDoc)\n아니오 = 새 이름으로 건너뛰기 (중복은 스킵)\n\n진행할까요?`,
+        t('dialog.importOverwriteConfirm', { count: existing.length }),
       );
     }
     let created = 0;
@@ -784,9 +775,9 @@ function AdminDocsContent() {
       }
     }
     window.alert(
-      `Import 완료 — 신규 ${created} · 덮어씀 ${updated} · 건너뜀 ${skipped}`,
+      t('dialog.importDone', { created, updated, skipped }),
     );
-  }, [canEditCurrent, manifest, localVault]);
+  }, [canEditCurrent, manifest, localVault, t]);
 
   const handleExportVault = useCallback(async () => {
     if (typeof window === 'undefined') return;
@@ -834,7 +825,7 @@ function AdminDocsContent() {
   const handleRenameCurrent = useCallback(async () => {
     if (!canEditCurrent || !selectedSlug) return;
     if (typeof window === 'undefined') return;
-    const input = window.prompt('새 slug (확장자 없이):', selectedSlug);
+    const input = window.prompt(t('dialog.renamePrompt'), selectedSlug);
     if (!input) return;
     const nextSlug = input
       .trim()
@@ -842,7 +833,7 @@ function AdminDocsContent() {
       .replace(/\.md$/, '');
     if (!nextSlug || nextSlug === selectedSlug) return;
     if (manifest.docs.some((d) => d.slug === nextSlug)) {
-      window.alert(`이미 존재하는 문서입니다: ${nextSlug}`);
+      window.alert(t('dialog.renameAlreadyExists', { slug: nextSlug }));
       return;
     }
     try {
@@ -878,10 +869,10 @@ function AdminDocsContent() {
       });
     } catch (err) {
       window.alert(
-        `이름 변경 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.renameFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, t]);
 
   const handleCreateNewDoc = useCallback(async () => {
     if (!canEditCurrent) return;
@@ -893,10 +884,7 @@ function AdminDocsContent() {
     const suggested = currentDir
       ? `${currentDir}/new-document`
       : 'new-document';
-    const input = window.prompt(
-      '새 문서 경로 (slug, 확장자 없이):',
-      suggested,
-    );
+    const input = window.prompt(t('dialog.newDocPrompt'), suggested);
     if (!input) return;
     const slug = input
       .trim()
@@ -904,7 +892,7 @@ function AdminDocsContent() {
       .replace(/\.md$/, '');
     if (!slug) return;
     if (manifest.docs.some((d) => d.slug === slug)) {
-      window.alert(`이미 존재하는 문서입니다: ${slug}`);
+      window.alert(t('dialog.renameAlreadyExists', { slug }));
       return;
     }
     const title = slug.split('/').pop() ?? slug;
@@ -918,10 +906,10 @@ function AdminDocsContent() {
       replaceUrlState({ slug, view: 'doc' });
     } catch (err) {
       window.alert(
-        `생성 실패: ${err instanceof Error ? err.message : String(err)}`,
+        t('dialog.createFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, replaceUrlState]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, replaceUrlState, t]);
 
   // 마운트 1 회 — 초기 URL 값이 없을 때 localStorage 선호값으로 보강.
   // useRef 로 '실행 여부' 를 가두고 dep 는 컴포넌트 stable 값들만 명시.
@@ -1140,112 +1128,112 @@ function AdminDocsContent() {
     return [
       {
         id: 'palette',
-        label: '팔레트 열기 (검색 · 명령 · 태그)',
+        label: t('commands.openPalette'),
         icon: '🔍',
         shortcut: '⌘K',
         onRun: () => setPaletteQuery(''),
       },
       {
         id: 'palette-tags',
-        label: '태그 찾기',
+        label: t('commands.findTags'),
         icon: '#',
         shortcut: '⌘K #',
         onRun: () => setPaletteQuery('#'),
       },
       {
         id: 'view-doc',
-        label: '뷰 · 문서 보기',
+        label: t('commands.viewDoc'),
         icon: '📄',
         visible: view !== 'doc',
         onRun: () => handleViewChange('doc'),
       },
       {
         id: 'view-graph',
-        label: '뷰 · 링크 그래프',
+        label: t('commands.viewGraph'),
         icon: '🕸️',
         visible: view !== 'graph',
         onRun: () => handleViewChange('graph'),
       },
       {
         id: 'view-stats',
-        label: '뷰 · 볼트 통계',
+        label: t('commands.viewStats'),
         icon: '📊',
         visible: view !== 'stats',
         onRun: () => handleViewChange('stats'),
       },
       {
         id: 'view-folder-topology',
-        label: '뷰 · Folder Topology (projects/*.md)',
+        label: t('commands.viewFolderTopology'),
         icon: '🗺️',
         visible: source === 'local' && view !== 'folder-topology',
         onRun: () => handleViewChange('folder-topology'),
       },
       {
         id: 'scaffold-topology',
-        label: '이 폴더를 Topology 볼트로 초기화',
+        label: t('commands.scaffoldTopology'),
         icon: '🆕',
         visible: canEditCurrent,
         onRun: () => void handleScaffoldTopology(),
       },
       {
         id: 'create-project',
-        label: '새 프로젝트 추가 (projects/…md)',
+        label: t('commands.createProject'),
         icon: '🧩',
         visible: canEditCurrent && source === 'local',
         onRun: () => void handleCreateProject(),
       },
       {
         id: 'audience-all',
-        label: '관점 · 전체',
+        label: t('commands.audienceAll'),
         icon: '◎',
         visible: audience !== 'all',
         onRun: () => handleAudienceChange('all'),
       },
       {
         id: 'audience-planner',
-        label: '관점 · 기획자',
+        label: t('commands.audiencePlanner'),
         icon: '◎',
         visible: audience !== 'planner',
         onRun: () => handleAudienceChange('planner'),
       },
       {
         id: 'audience-engineer',
-        label: '관점 · 개발자',
+        label: t('commands.audienceEngineer'),
         icon: '◎',
         visible: audience !== 'engineer',
         onRun: () => handleAudienceChange('engineer'),
       },
       {
         id: 'source-server',
-        label: '소스 · 서버 볼트',
+        label: t('commands.sourceServer'),
         icon: '☁️',
         visible: source !== 'server',
         onRun: () => handleSourceChange('server'),
       },
       {
         id: 'source-local',
-        label: '소스 · 로컬 PC 폴더',
+        label: t('commands.sourceLocal'),
         icon: '💾',
         visible: source !== 'local' && localVault.isSupported,
         onRun: () => handleSourceChange('local'),
       },
       {
         id: 'pin-toggle',
-        label: pinnedSet.has(selectedSlug ?? '') ? '고정 해제' : '이 문서 고정',
+        label: pinnedSet.has(selectedSlug ?? '') ? t('commands.unpinDoc') : t('commands.pinDoc'),
         icon: '⭐',
         visible: selectedDocExists,
         onRun: () => selectedSlug && handleTogglePin(selectedSlug),
       },
       {
         id: 'copy-url',
-        label: '현재 문서 URL 복사',
+        label: t('commands.copyUrl'),
         icon: '🔗',
         visible: selectedDocExists,
         onRun: () => selectedSlug && void handleCopyUrl(selectedSlug),
       },
       {
         id: 'print',
-        label: '인쇄 · PDF 로 저장',
+        label: t('commands.print'),
         icon: '🖨️',
         visible: selectedDocExists && view === 'doc',
         onRun: () => {
@@ -1254,90 +1242,90 @@ function AdminDocsContent() {
       },
       {
         id: 'edit',
-        label: '이 파일 편집',
+        label: t('commands.edit'),
         icon: '✏️',
         visible: canEditCurrent && selectedDocExists && !editing,
         onRun: () => setEditing(true),
       },
       {
         id: 'new-doc',
-        label: '새 문서 만들기',
+        label: t('commands.newDoc'),
         icon: '➕',
         visible: canEditCurrent,
         onRun: () => void handleCreateNewDoc(),
       },
       {
         id: 'daily-note',
-        label: '오늘의 노트 (daily/YYYY-MM-DD)',
+        label: t('commands.dailyNote'),
         icon: '📅',
         visible: canEditCurrent,
         onRun: () => void handleDailyNote(),
       },
       {
         id: 'rename',
-        label: '이 문서 이름 변경 (slug/경로)',
+        label: t('commands.rename'),
         icon: '✎',
         visible: canEditCurrent && selectedDocExists,
         onRun: () => void handleRenameCurrent(),
       },
       {
         id: 'insert-toc',
-        label: '현재 문서에 목차 삽입',
+        label: t('commands.insertToc'),
         icon: '≡',
         visible: canEditCurrent && selectedDocExists,
         onRun: () => void handleInsertToc(),
       },
       {
         id: 'delete',
-        label: '이 문서 삭제',
+        label: t('commands.deleteDoc'),
         icon: '🗑️',
         visible: canEditCurrent && selectedDocExists,
         onRun: () => void handleDeleteCurrent(),
       },
       {
         id: 'export-doc-html',
-        label: '현재 문서 HTML 로 저장',
+        label: t('commands.exportDocHtml'),
         icon: '📄',
         visible: selectedDocExists && view === 'doc',
         onRun: () => handleExportDocHtml(),
       },
       {
         id: 'export',
-        label: '볼트 백업 내보내기 (JSON)',
+        label: t('commands.exportVault'),
         icon: '⬇',
         onRun: () => void handleExportVault(),
       },
       {
         id: 'import',
-        label: '볼트 복원 불러오기 (JSON)',
+        label: t('commands.importVault'),
         icon: '⬆',
         visible: canEditCurrent,
         onRun: () => void handleImportVault(),
       },
       {
         id: 'local-refresh',
-        label: '로컬 볼트 다시 스캔',
+        label: t('commands.localRefresh'),
         icon: '↻',
         visible: source === 'local' && localVault.status === 'loaded',
         onRun: () => void localVault.refresh(),
       },
       {
         id: 'local-close',
-        label: '로컬 볼트 닫기',
+        label: t('commands.localClose'),
         icon: '✖',
         visible: source === 'local' && localVault.status === 'loaded',
         onRun: () => void localVault.close(),
       },
       {
         id: 'tag-clear',
-        label: '태그 필터 해제',
+        label: t('commands.clearTagFilter'),
         icon: '#',
         visible: activeTag !== null,
         onRun: () => setActiveTag(null),
       },
       {
         id: 'projects-list',
-        label: '프로젝트 목록으로 이동',
+        label: t('commands.projectsList'),
         icon: '←',
         onRun: () => {
           if (typeof window !== 'undefined')
@@ -1371,6 +1359,7 @@ function AdminDocsContent() {
     handleScaffoldTopology,
     handleSourceChange,
     handleTogglePin,
+    t,
   ]);
 
   // 좌측 사이드바 내부 내용 — aside 와 mobile drawer 양쪽에서 재사용.
@@ -1408,28 +1397,28 @@ function AdminDocsContent() {
             type="button"
             onClick={() => setMobileTreeOpen(true)}
             className="inline-flex h-8 w-8 flex-none items-center justify-center rounded-md border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)] md:hidden"
-            aria-label="트리 열기"
-            title="문서 트리"
+            aria-label={t('header.openTreeAriaLabel')}
+            title={t('header.openTreeTitle')}
           >
             <Menu size={14} aria-hidden />
           </button>
           <Link
             href={workspaceHref}
-            aria-label="워크스페이스 지도로 돌아가기"
+            aria-label={t('header.backToWorkspaceAriaLabel')}
             className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-divider)] px-3 text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)]"
           >
             <ArrowLeft size={12} aria-hidden />
-            돌아가기
+            {t('header.back')}
           </Link>
           <div className="flex items-baseline gap-2">
-            <h1 className="text-[14px] font-semibold">Docs Vault</h1>
+            <h1 className="text-[14px] font-semibold">{t('header.title')}</h1>
             <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-              {manifest.docs.length} 문서
+              {t('header.docCount', { count: manifest.docs.length })}
             </span>
             {caps.kind !== 'loading' && !caps.canEdit ? (
               <span
                 className="inline-flex items-center rounded-sm border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)]"
-                title={`현재 역할: ${caps.roleLabel}. 편집 권한이 없어 읽기만 가능합니다.`}
+                title={t('header.roleTooltip', { role: caps.roleLabel })}
               >
                 {caps.roleLabel}
               </span>
@@ -1438,17 +1427,17 @@ function AdminDocsContent() {
           {source === 'local' ? (
             <span className="inline-flex items-center gap-1 rounded-sm border border-[color:rgba(139,151,255,0.24)] bg-[color:rgba(94,106,210,0.08)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:rgba(200,210,255,0.86)]">
               <HardDrive size={10} aria-hidden />
-              로컬
+              {t('header.localBadge')}
             </span>
           ) : null}
         </div>
         <div className="ml-auto flex flex-none flex-wrap items-center justify-end gap-2">
           <div
             className="flex items-center gap-1 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] p-0.5 text-[11px]"
-            aria-label="문서 관점"
+            aria-label={t('header.audienceAriaLabel')}
           >
             <span className="px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-              관점
+              {t('header.audienceLabel')}
             </span>
             {(['all', 'planner', 'engineer'] as const).map((m) => (
               <button
@@ -1462,11 +1451,11 @@ function AdminDocsContent() {
                 }`}
                 aria-pressed={audience === m}
               >
-                {m === 'all' ? '전체' : m === 'planner' ? '기획자' : '개발자'}
+                {m === 'all' ? t('header.audienceAll') : m === 'planner' ? t('header.audiencePlanner') : t('header.audienceEngineer')}
               </button>
             ))}
           </div>
-          <Tooltip content="검색 · 명령 · 태그 — Tab 으로 관점 전환" withProvider={false}>
+          <Tooltip content={t('header.paletteTooltip')} withProvider={false}>
             <button
               type="button"
               onClick={() => {
@@ -1474,7 +1463,7 @@ function AdminDocsContent() {
                 setPaletteQuery('');
               }}
               className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-2 text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.28)] hover:text-[color:var(--color-text-primary)]"
-              aria-label="팔레트 열기 (검색 · 명령 · 태그)"
+              aria-label={t('header.paletteAriaLabel')}
             >
               <Search size={13} aria-hidden />
               <kbd className="hidden rounded border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-1 font-mono text-[9.5px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)] md:inline-flex">
@@ -1483,13 +1472,13 @@ function AdminDocsContent() {
             </button>
           </Tooltip>
           <div className="relative" ref={advancedMenuRef}>
-            <Tooltip content="고급" withProvider={false}>
+            <Tooltip content={t('header.advancedTooltip')} withProvider={false}>
               <button
                 type="button"
                 onClick={() => setAdvancedOpen((open) => !open)}
                 aria-expanded={advancedOpen}
                 aria-haspopup="menu"
-                aria-label="고급 메뉴 열기"
+                aria-label={t('header.advancedAriaLabel')}
                 className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.28)] hover:text-[color:var(--color-text-primary)]"
               >
                 <Settings2 size={13} aria-hidden />
@@ -1501,13 +1490,13 @@ function AdminDocsContent() {
                 className="absolute right-0 top-10 z-30 w-[300px] rounded-md border border-[color:var(--color-divider)] bg-[color:rgba(14,15,18,0.98)] p-2 shadow-[0_18px_48px_rgba(0,0,0,0.38)]"
               >
                 <div className="mb-2 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  보기
+                  {t('advanced.viewSection')}
                 </div>
                 <div className="grid grid-cols-3 gap-1">
                   {[
-                    { value: 'doc' as const, label: '문서', icon: FileText },
-                    { value: 'graph' as const, label: '그래프', icon: Network },
-                    { value: 'stats' as const, label: '통계', icon: BarChart3 },
+                    { value: 'doc' as const, label: t('advanced.viewDoc'), icon: FileText },
+                    { value: 'graph' as const, label: t('advanced.viewGraph'), icon: Network },
+                    { value: 'stats' as const, label: t('advanced.viewStats'), icon: BarChart3 },
                   ].map((item) => {
                     const Icon = item.icon;
                     return (
@@ -1542,7 +1531,7 @@ function AdminDocsContent() {
                     }`}
                   >
                     <Layers size={12} aria-hidden />
-                    토폴로지
+                    {t('advanced.viewTopology')}
                     {folderTopoStatus === 'rebuilding' ? (
                       <span
                         aria-hidden
@@ -1553,7 +1542,7 @@ function AdminDocsContent() {
                 ) : null}
                 <div className="my-2 h-px bg-[color:var(--color-border-soft)]" />
                 <div className="mb-2 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  소스
+                  {t('advanced.sourceSection')}
                 </div>
                 <div className="grid grid-cols-2 gap-1">
                   <button
@@ -1571,7 +1560,7 @@ function AdminDocsContent() {
                     }`}
                   >
                     <Cloud size={12} aria-hidden />
-                    서버
+                    {t('advanced.sourceServer')}
                   </button>
                   <button
                     type="button"
@@ -1589,7 +1578,7 @@ function AdminDocsContent() {
                     }`}
                   >
                     <HardDrive size={12} aria-hidden />
-                    로컬
+                    {t('advanced.sourceLocal')}
                   </button>
                 </div>
                 {source === 'local' ? (
@@ -1611,11 +1600,11 @@ function AdminDocsContent() {
                         터미널 / npm 없이 5 md + .mcp.json.example 시드 작성. */}
                     {localVault.status === 'idle' ? (
                       <p className="text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
-                        처음이세요? 이 repo 의{' '}
+                        {t('advanced.ontologyHintPrefix')}
                         <code className="rounded bg-[color:var(--color-overlay-1)] px-1 py-0.5 font-mono text-[10.5px] text-[color:var(--color-indigo-accent)]">
                           docs/ontology/
                         </code>
-                        를 선택해 보세요 — 이 도구 자체의 ontology (21 노드) 가 즉시 트리에 등장합니다.
+                        {t('advanced.ontologyHintSuffix')}
                       </p>
                     ) : null}
                     {localVault.status === 'loaded' && canEditCurrent ? (
@@ -1631,7 +1620,7 @@ function AdminDocsContent() {
                         className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:rgba(139,151,255,0.35)] bg-[color:rgba(94,106,210,0.08)] px-2.5 py-1.5 text-[11.5px] text-[color:rgba(200,210,255,0.92)] transition-colors hover:border-[color:rgba(139,151,255,0.55)] hover:bg-[color:rgba(94,106,210,0.14)]"
                       >
                         <FilePlus size={12} aria-hidden />
-                        새 문서
+                        {t('advanced.newDoc')}
                       </button>
                     ) : null}
                   </div>
@@ -1659,13 +1648,13 @@ function AdminDocsContent() {
             <aside className="relative flex w-[280px] max-w-[82vw] flex-col overflow-auto bg-[color:var(--color-panel)] shadow-[0_0_24px_rgba(0,0,0,0.5)]">
               <div className="flex h-12 flex-none items-center justify-between border-b border-[color:var(--color-border-soft)] px-3">
                 <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                  문서 트리
+                  {t('mobileDrawer.title')}
                 </span>
                 <button
                   type="button"
                   onClick={() => setMobileTreeOpen(false)}
                   className="flex h-7 w-7 items-center justify-center rounded-sm text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
-                  aria-label="트리 닫기"
+                  aria-label={t('mobileDrawer.closeAriaLabel')}
                 >
                   <X size={14} aria-hidden />
                 </button>
@@ -1686,10 +1675,10 @@ function AdminDocsContent() {
                   type="button"
                   onClick={() => void handleCreateProject()}
                   className="pointer-events-auto absolute left-3 top-[46px] z-10 inline-flex items-center gap-1.5 rounded-md border border-[color:rgba(139,151,255,0.35)] bg-[color:rgba(94,106,210,0.1)] px-2.5 py-1.5 text-[11.5px] text-[color:rgba(200,210,255,0.92)] shadow-[0_4px_14px_rgba(0,0,0,0.25)] transition-colors hover:border-[color:rgba(139,151,255,0.55)] hover:bg-[color:rgba(94,106,210,0.18)]"
-                  title="새 프로젝트 .md 추가 (projects/{slug}.md)"
+                  title={t('topology.addProjectTitle', { slug: '{slug}' })}
                 >
                   <FilePlus size={12} aria-hidden />
-                  프로젝트
+                  {t('topology.addProjectLabel')}
                 </button>
               ) : null}
               {folderTopo && folderTopo.projects.length > 0 ? (
@@ -1720,12 +1709,10 @@ function AdminDocsContent() {
                     aria-hidden
                   />
                   <div className="text-[14px] text-[color:var(--color-text-primary)]">
-                    이 볼트엔 아직 `projects/` 가 없어요
+                    {t('topology.emptyTitle')}
                   </div>
                   <p className="max-w-[440px] text-[12.5px] leading-[1.6] text-[color:var(--color-text-tertiary)]">
-                    Folder-Topology 규격 파일 구조 (projects/_.md, categories.md,
-                    statuses.md) 를 자동 생성하면 바로 토폴로지가 보여요.
-                    이미 있는 파일은 덮어쓰지 않습니다.
+                    {t('topology.emptyBody')}
                   </p>
                   {folderTopoError ? (
                     <p className="font-mono text-[11px] text-[color:rgba(239,180,120,0.9)]">
@@ -1739,11 +1726,11 @@ function AdminDocsContent() {
                       className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[color:rgba(139,151,255,0.4)] bg-[color:rgba(94,106,210,0.08)] px-3 py-1.5 text-[12px] text-[color:rgba(200,210,255,0.95)] transition-colors hover:border-[color:rgba(139,151,255,0.6)] hover:bg-[color:rgba(94,106,210,0.14)]"
                     >
                       <FolderCog size={12} aria-hidden />
-                      이 폴더를 토폴로지 볼트로 초기화
+                      {t('topology.scaffoldCta')}
                     </button>
                   ) : (
                     <p className="font-mono text-[11px] text-[color:var(--color-text-quaternary)]">
-                      편집 권한이 필요합니다 (로컬 볼트)
+                      {t('topology.needEditPermission')}
                     </p>
                   )}
                 </div>
@@ -1774,7 +1761,7 @@ function AdminDocsContent() {
                       : 'text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]'
                   }`}
                 >
-                  전체
+                  {t('graph.focusAll')}
                 </button>
                 <button
                   type="button"
@@ -1788,11 +1775,11 @@ function AdminDocsContent() {
                   }`}
                   title={
                     selectedSlug
-                      ? '선택 문서 주변 2-hop 만 보기'
-                      : '문서를 선택하면 활성화됩니다'
+                      ? t('graph.focusLocalEnabled')
+                      : t('graph.focusLocalDisabled')
                   }
                 >
-                  이웃 2-hop
+                  {t('graph.focusLocalLabel')}
                 </button>
               </div>
               <DocsVaultGraph

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -10,6 +10,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { BookOpen, X } from "lucide-react";
 import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
 import { useProjects } from "@/features/project-data-source";
@@ -36,6 +37,7 @@ import { useTaxonomy } from "@/features/taxonomy";
 // 화면이 그대로 보여 "멈춤" 느낌이라, 데이터 구독 skeleton 과 동일 톤
 // fallback 을 모듈 로드 단계에도 표시.
 function TopologyLoadingFallback() {
+  const t = useTranslations('topology');
   return (
     <div
       className="absolute inset-0 z-10 flex items-center justify-center"
@@ -49,7 +51,7 @@ function TopologyLoadingFallback() {
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:300ms]" />
         </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
-          토폴로지 엔진 불러오는 중
+          {t('loadingEngine')}
         </span>
       </div>
     </div>
@@ -108,6 +110,7 @@ import { useHomeRouteState } from "../model/use-home-route-state";
 const LEFT_PANEL_COLLAPSED_KEY = "demo:left-panel-collapsed:v2";
 
 export function HomePage() {
+  const t = useTranslations('topology');
   const { categories: taxonomyCategories } = useTaxonomy();
   const [sigmaControls, setSigmaControls] = useState<SigmaControlsState>(
     DEFAULT_SIGMA_CONTROLS,
@@ -258,7 +261,7 @@ export function HomePage() {
       new Set(
         [
           selectedProject?.name,
-          "토폴로지",
+          t('documentTitle'),
           "oh-my-ontology",
         ].filter((value): value is string => Boolean(value)),
       ),
@@ -586,20 +589,24 @@ export function HomePage() {
         visible h1 을 두기 어려워 sr-only 로 문서 구조 only 에 보이게 한다.
       */}
       <h1 className="sr-only">
-        토폴로지 프로젝트 토폴로지 지도
+        {t('srHeading')}
       </h1>
       <GestureHint
         disabled={presentationMode || drawerOpen}
       />
       <LiveAnnouncer
         message={(() => {
-          if (presentationMode) return "프레젠테이션 모드 시작";
+          if (presentationMode) return t('presentationStarted');
           if (!selectedProject) return "";
           const deps = selectedProject.dependencies.length;
           const referenced = projects.filter((p) =>
             p.dependencies.includes(selectedProject.slug),
           ).length;
-          return `${selectedProject.name} 선택됨. 의존 ${deps}개, 연결 ${referenced}개.`;
+          return t('selectionAnnouncement', {
+            name: selectedProject.name,
+            deps,
+            referenced,
+          });
         })()}
       />
       {!presentationMode && (
@@ -624,7 +631,7 @@ export function HomePage() {
                     Demo
                   </span>
                   <p className="mt-0.5 max-w-[180px] text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
-                    프로젝트 의존도 지도.
+                    {t('mobileTagline')}
                   </p>
                 </div>
               </div>
@@ -633,34 +640,40 @@ export function HomePage() {
               // 성장 시그널 — 지난 7일 내 updatedAt 된 프로젝트 수.
               // "지식이 자라고 있다" 를 2초 안에 느끼게 하는 카운터. 0 이면 숨김.
               const growthLabel = recentlyUpdatedCount > 0
-                ? ` · 이번 주 +${recentlyUpdatedCount}`
+                ? t('workspace.growthThisWeek', { count: recentlyUpdatedCount })
                 : "";
-              const workspaceSubtitle = `Workspace · ${renderProjects.length} 프로젝트 · ${hubs.length} 허브${growthLabel}`;
-              const workspaceEyebrow = `Workspace · ${renderProjects.length} 프로젝트`;
+              const workspaceSubtitle = t('workspace.subtitle', {
+                projects: renderProjects.length,
+                hubs: hubs.length,
+                growth: growthLabel,
+              });
+              const workspaceEyebrow = t('workspace.eyebrow', {
+                projects: renderProjects.length,
+              });
               return hydrated && (leftPanelCollapsed || drawerOpen) ? (
                 <div className="pointer-events-none absolute left-4 top-4 z-10 hidden md:flex md:flex-col md:items-start md:gap-2 md:left-6 md:top-6 xl:left-8 xl:top-8">
                   <HeroCollapsed
                     onExpand={
                       drawerOpen ? handleClose : toggleLeftPanel
                     }
-                    title={selectedProject?.name ?? "토폴로지"}
+                    title={selectedProject?.name ?? t('workspace.fallbackTitle')}
                     subtitle={
                       selectedProject
-                        ? "선택한 프로젝트"
+                        ? t('workspace.selectedEyebrow')
                         : projects.length > 0
                           ? workspaceSubtitle
-                          : "워크스페이스 지도 펼치기"
+                          : t('workspace.expandHint')
                     }
                     icon={selectedProject?.icon ?? null}
                     ariaLabel={
                       drawerOpen
-                        ? "선택한 프로젝트 닫기"
-                        : "좌측 패널 펼치기"
+                        ? t('hero.closeSelected')
+                        : t('hero.expandLeftPanel')
                     }
                     titleText={
                       drawerOpen
-                        ? "선택한 프로젝트 닫기"
-                        : "좌측 패널 펼치기"
+                        ? t('hero.closeSelected')
+                        : t('hero.expandLeftPanel')
                     }
                     docsVaultHref={"/docs/"}
                     ontologyHref={"/ontology/"}
@@ -674,18 +687,21 @@ export function HomePage() {
                     activePathLabel={null}
                     onOpenSearch={() => setSearchOpen(true)}
                     onCollapse={toggleLeftPanel}
-                    title={selectedProject?.name ?? "토폴로지"}
+                    title={selectedProject?.name ?? t('workspace.fallbackTitle')}
                     eyebrow={
                       selectedProject
-                        ? "선택한 프로젝트"
+                        ? t('workspace.selectedEyebrow')
                         : projects.length > 0
                           ? workspaceEyebrow
-                          : "워크스페이스 지도"
+                          : t('workspace.mapEyebrow')
                     }
                     description={
                       selectedProject?.description ||
                       (projects.length > 0
-                        ? `${hubs.length}개 허브를 중심으로 ${projects.length}개 프로젝트가 엮여 있습니다. 노드를 클릭해 상세를 열어 볼 수 있어요.`
+                        ? t('workspace.description', {
+                            hubs: hubs.length,
+                            projects: projects.length,
+                          })
                         : undefined)
                     }
                     icon={selectedProject?.icon ?? null}
@@ -711,25 +727,25 @@ export function HomePage() {
               }}
               onRelayout={() => {
                 setTopologyRelayoutToken((current) => current + 1);
-                toast.show("토폴로지를 다시 정렬합니다", "info");
+                toast.show(t('controls.relayoutToast'), "info");
               }}
             />
             <div className="absolute right-4 top-4 z-20 flex items-center gap-2 md:right-6 md:top-6 xl:right-8 xl:top-8">
-              <Tooltip content="문서 볼트 빠른 보기 (D)" side="bottom" withProvider={false}>
+              <Tooltip content={t('controls.docsTooltip')} side="bottom" withProvider={false}>
               <button
                 type="button"
                 onClick={() => setDocsDrawerOpen((v) => !v)}
                 aria-expanded={docsDrawerOpen}
-                aria-label="문서 볼트 빠른 보기 열기 (D)"
+                aria-label={t('controls.docsAriaLabel')}
                 className="inline-flex h-11 items-center gap-2 rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3.5 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] shadow-[0_10px_26px_rgba(0,0,0,0.14)] transition-[background-color,border-color,box-shadow,transform] duration-180 ease-out hover:border-[color:rgba(94,106,210,0.38)] hover:bg-[color:var(--color-panel)] active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none motion-reduce:transform-none"
               >
                 <BookOpen size={15} className="text-[color:var(--color-indigo-accent)]" />
-                <span>문서</span>
+                <span>{t('controls.docsLabel')}</span>
                 {docsPinnedCount > 0 ? (
                   <span
                     className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[color:rgba(94,106,210,0.28)] px-1.5 font-mono text-[10px] tabular-nums text-[color:var(--color-indigo-accent)]"
-                    aria-label={`고정된 문서 ${docsPinnedCount}개`}
-                    title={`고정된 문서 ${docsPinnedCount}개`}
+                    aria-label={t('controls.pinnedDocsCount', { count: docsPinnedCount })}
+                    title={t('controls.pinnedDocsCount', { count: docsPinnedCount })}
                   >
                     {docsPinnedCount}
                   </span>
@@ -749,15 +765,15 @@ export function HomePage() {
       )}
       {presentationMode && (
           <>
-            <Tooltip content="프레젠테이션 모드 종료 (F)" side="bottom" withProvider={false}>
+            <Tooltip content={t('controls.exitPresentationTooltip')} side="bottom" withProvider={false}>
             <button
               type="button"
               onClick={() => setPresentationMode(false)}
               className="pointer-events-auto absolute right-4 top-4 z-10 flex h-11 items-center gap-2 rounded-full border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] px-4 font-[var(--font-weight-signature)] text-[13px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] active:bg-[color:var(--color-overlay-1)] md:right-10 md:top-10"
-              aria-label="프레젠테이션 모드 종료"
+              aria-label={t('controls.exitPresentationAriaLabel')}
             >
               <X size={14} />
-              <span className="hidden md:inline">닫기</span>
+              <span className="hidden md:inline">{t('controls.close')}</span>
               <span className="flex items-center rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-elevated)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                 F
               </span>
@@ -784,12 +800,12 @@ export function HomePage() {
                 type="button"
                 onClick={() => setKnowledgeSceneProjectSlug(null)}
                 className="pointer-events-auto absolute left-1/2 top-[96px] z-30 inline-flex max-w-[calc(100vw-32px)] -translate-x-1/2 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-panel)] px-3 py-1.5 text-[12px] text-[color:var(--color-text-secondary)] shadow-[0_10px_28px_rgba(0,0,0,0.36)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
-                aria-label="워크스페이스 지도로 돌아가기"
+                aria-label={t('scene.backToWorkspace')}
               >
                 <span className="break-keep text-[11px] text-[color:var(--color-text-quaternary)]">
                   Evidence
                 </span>
-                <span className="truncate">워크스페이스 지도</span>
+                <span className="truncate">{t('scene.workspaceMap')}</span>
               </button>
             </>
           ) : (
@@ -841,11 +857,11 @@ export function HomePage() {
               {/* 단축키 도움말 진입점 — 우상단 SigmaControls 아래 36×36 아이콘.
                   ? 키로도 열리지만 시각적 affordance 가 없어 발견성 낮았음. */}
               {/* 키보드 단축키 도움말 — 모바일에서는 키보드가 없어 의미 없음. 데스크톱(md+) 에서만 노출. */}
-              <Tooltip content="키보드 단축키 (?)" side="left" withProvider={false}>
+              <Tooltip content={t('controls.shortcutsTooltip')} side="left" withProvider={false}>
               <button
                 type="button"
                 onClick={() => setShortcutsOpen(true)}
-                aria-label="키보드 단축키 보기"
+                aria-label={t('controls.shortcutsAriaLabel')}
                 className="pointer-events-auto absolute right-4 top-[228px] z-20 hidden h-9 w-9 items-center justify-center rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] font-mono text-[14px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)] md:right-6 md:flex xl:right-8"
               >
                 ?
@@ -909,11 +925,11 @@ export function HomePage() {
                   className={`pointer-events-auto absolute left-1/2 z-20 inline-flex max-w-[calc(100vw-32px)] -translate-x-1/2 items-center gap-2 rounded-full border border-[color:rgba(94,106,210,0.32)] bg-[color:var(--color-panel)] px-3 py-1.5 text-[12px] text-[color:var(--color-text-secondary)] shadow-[0_10px_28px_rgba(0,0,0,0.36)] transition-colors hover:border-[color:rgba(139,151,255,0.5)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)] ${
                     localGraphStack.length > 0 ? "top-[144px]" : "top-[96px]"
                   }`}
-                  aria-label={`${selectedProject.name} 문서 근거 지도 보기`}
+                  aria-label={t('evidence.openLabel', { name: selectedProject.name })}
                 >
                   <BookOpen size={13} className="shrink-0 text-[color:var(--color-indigo-accent)]" />
                   <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
-                    문서 근거
+                    {t('evidence.badge')}
                   </span>
                   <span className="truncate">
                     {selectedEvidenceSummary?.counts.documents ?? 0} docs · {selectedEvidenceSummary?.counts.edges ?? 0} links
@@ -937,7 +953,7 @@ export function HomePage() {
                     No matches
                   </p>
                   <p className="text-[13px] text-[color:var(--color-text-secondary)]">
-                    현재 필터 조건에 맞는 프로젝트가 없습니다.
+                    {t('empty.noMatchesBody')}
                   </p>
                   <button
                     type="button"
@@ -950,7 +966,7 @@ export function HomePage() {
                     }
                     className="rounded-md border border-[color:rgba(139,151,255,0.3)] bg-[color:rgba(94,106,210,0.1)] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:rgba(139,151,255,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
                   >
-                    필터 해제
+                    {t('empty.clearFilters')}
                   </button>
                 </div>
               ) : null}
@@ -963,35 +979,35 @@ export function HomePage() {
                 <div className="pointer-events-auto absolute bottom-14 left-4 z-10 hidden max-w-[320px] flex-col gap-2 rounded-2xl border border-[color:rgba(139,151,255,0.32)] bg-[color:var(--color-panel)] px-4 py-3 text-[11px] text-[color:var(--color-text-tertiary)] shadow-[0_12px_28px_rgba(0,0,0,0.45)] sm:flex md:left-6 xl:left-8">
                   <div className="flex items-start justify-between gap-2">
                     <p className="text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-                      프로젝트 지형도
+                      {t('hint.title')}
                     </p>
                     <button
                       type="button"
                       onClick={dismissSigmaHint}
-                      aria-label="안내 닫기"
+                      aria-label={t('hint.dismissAriaLabel')}
                       className="text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
                     >
                       <X size={12} />
                     </button>
                   </div>
                   <p className="leading-5">
-                    노드는 프로젝트, 선은 의존 관계입니다. 클릭해서 상세를 열고 검색으로 좁혀보세요.
+                    {t('hint.body')}
                   </p>
                   <ul className="flex flex-col gap-1 text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
                     <li>
-                      <span className="text-[color:var(--color-text-secondary)]">클릭</span>
-                      <span className="text-[color:var(--color-text-quaternary)]"> · 상세 패널 열기</span>
+                      <span className="text-[color:var(--color-text-secondary)]">{t('hint.click')}</span>
+                      <span className="text-[color:var(--color-text-quaternary)]">{t('hint.clickDescription')}</span>
                     </li>
                     <li>
-                      <span className="text-[color:var(--color-text-secondary)]">드래그</span>
-                      <span className="text-[color:var(--color-text-quaternary)]"> · 노드 위치 이동</span>
+                      <span className="text-[color:var(--color-text-secondary)]">{t('hint.drag')}</span>
+                      <span className="text-[color:var(--color-text-quaternary)]">{t('hint.dragDescription')}</span>
                     </li>
                     <li>
                       <kbd className="rounded border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1 font-mono text-[9px]">⌘</kbd>
                       <kbd className="ml-0.5 rounded border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1 font-mono text-[9px]">K</kbd>
-                      <span className="text-[color:var(--color-text-quaternary)]"> 검색 · </span>
+                      <span className="text-[color:var(--color-text-quaternary)]">{t('hint.searchDescription')}</span>
                       <kbd className="rounded border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1 font-mono text-[9px]">?</kbd>
-                      <span className="text-[color:var(--color-text-quaternary)]"> 단축키</span>
+                      <span className="text-[color:var(--color-text-quaternary)]">{t('hint.shortcutsDescription')}</span>
                     </li>
                   </ul>
                 </div>
@@ -1015,7 +1031,7 @@ export function HomePage() {
               }}
               className="ml-2 rounded-full border border-[color:var(--color-divider)] px-2.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
             >
-              다시 시도
+              {t('errorBanner.retry')}
             </button>
           </div>
         ) : null}

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Info, Link2, X } from "lucide-react";
 import {
   ManualSourceChip,
@@ -39,6 +40,7 @@ import { Tooltip, useToast } from "@/shared/ui";
  * 기본 동작은 noop — 추후 드릴-인 (T-6d 또는 별도 task) 으로 확장.
  */
 export function OntologyViewPage() {
+  const t = useTranslations('ontologyView');
   const searchParams = useSearchParams();
   const router = useRouter();
   const accountId = null;
@@ -158,25 +160,28 @@ export function OntologyViewPage() {
       <div className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-12">
       <section className="mb-8 space-y-3">
         <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
-          Ontology
+          {t('eyebrow')}
         </p>
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
           <h1 className="flex items-center gap-2 break-keep text-2xl font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-            온톨로지 트리
+            {t('title')}
             <Tooltip
               content={
                 <div className="max-w-[320px] space-y-2 text-left">
                   <p className="font-medium text-[color:var(--color-text-primary)]">
-                    ontology 노드의 계층 뷰
+                    {t('titleTooltip.heading')}
                   </p>
                   <p className="text-[color:var(--color-text-tertiary)]">
-                    vault 안 .md 파일의 frontmatter 가 그대로 자란 트리.
-                    검수 단계 없이 즉시 반영 —{" "}
-                    <span className="font-mono text-xs">project → domain → capability → element</span>{" "}
-                    순서로 펼쳐서 보여줍니다.
+                    {t.rich('titleTooltip.body', {
+                      hierarchy: (chunks) => (
+                        <span className="font-mono text-xs">{chunks}</span>
+                      ),
+                    })}
                   </p>
                   <p className="text-[color:var(--color-text-tertiary)]">
-                    문서 노드는 근거 역할이라 트리에서 제외돼요. <strong>그래프를 직접 그리려면 우측 &lsquo;빌더 열기&rsquo;</strong> 버튼을 눌러보세요.
+                    {t.rich('titleTooltip.footer', {
+                      strong: (chunks) => <strong>{chunks}</strong>,
+                    })}
                   </p>
                 </div>
               }
@@ -184,7 +189,7 @@ export function OntologyViewPage() {
             >
               <button
                 type="button"
-                aria-label="온톨로지 트리가 무엇인지 설명"
+                aria-label={t('titleTooltipAria')}
                 className="inline-flex items-center justify-center rounded-full text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
               >
                 <Info size={15} aria-hidden />
@@ -195,39 +200,39 @@ export function OntologyViewPage() {
               flex-wrap + horizontal scroll 보조. md+ 는 한 줄 유지. -mr/-ml
               음수 마진 + px padding 으로 우측 잘림 방지. */}
           <div className="-mx-1 flex w-full items-center gap-2 overflow-x-auto px-1 pb-1 md:w-auto md:flex-wrap md:overflow-visible md:pb-0">
-            <Tooltip content="새 노드 직접 추가" withProvider={false}>
+            <Tooltip content={t('actions.addNodeTooltip')} withProvider={false}>
               <button
                 type="button"
                 onClick={() => setManualOpen(true)}
-                aria-label="ontology 노드 직접 추가"
+                aria-label={t('actions.addNodeAria')}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.16)] px-3 text-xs text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.66)]"
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                   <path d="M12 5v14M5 12h14" />
                 </svg>
-                <span className="hidden sm:inline">노드 추가</span>
+                <span className="hidden sm:inline">{t('actions.addNode')}</span>
               </button>
             </Tooltip>
-            <Tooltip content="검색 (⌘K)" withProvider={false}>
+            <Tooltip content={t('actions.searchTooltip')} withProvider={false}>
               <button
                 type="button"
                 onClick={() => setSearchOpen(true)}
-                aria-label="ontology 노드 검색 열기"
+                aria-label={t('actions.searchAria')}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                   <circle cx="11" cy="11" r="7" />
                   <path d="m20 20-3.5-3.5" />
                 </svg>
-                <span className="hidden sm:inline">검색</span>
+                <span className="hidden sm:inline">{t('actions.search')}</span>
                 <kbd className="hidden font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline">⌘K</kbd>
               </button>
             </Tooltip>
-            <Tooltip content="빌더 캔버스 — 왼쪽 palette 에서 종류 골라 클릭, 핸들 drag 로 관계 추가" withProvider={false}>
+            <Tooltip content={t('actions.builderTooltip')} withProvider={false}>
               <Link
                 href={"/ontology/edit/"}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-brand)] px-4 text-xs font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90"
-                aria-label="온톨로지 빌더 — 캔버스에서 직접 그리기"
+                aria-label={t('actions.builderAria')}
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                   <rect x="3" y="3" width="7" height="7" rx="1" />
@@ -235,25 +240,25 @@ export function OntologyViewPage() {
                   <rect x="14" y="14" width="7" height="7" rx="1" />
                   <path d="M10 6.5h4M17.5 10v4M10 17.5h4" />
                 </svg>
-                빌더 열기 →
+                {t('actions.builder')}
               </Link>
             </Tooltip>
-            <Tooltip content="ontology 인사이트 — kind 분포 · 허브 노드 · 최근 활동 · 미연결" withProvider={false}>
+            <Tooltip content={t('actions.insightsTooltip')} withProvider={false}>
               <Link
                 href={"/ontology/insights/"}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
-                aria-label="ontology 인사이트 — kind 분포 · 허브 노드 · 최근 활동 · 미연결"
+                aria-label={t('actions.insightsTooltip')}
               >
-                인사이트
+                {t('actions.insights')}
               </Link>
             </Tooltip>
-            <Tooltip content="관계 — 종류 분포 + 근거 풍부한 강한 관계" withProvider={false}>
+            <Tooltip content={t('actions.relationsTooltip')} withProvider={false}>
               <Link
                 href={"/ontology/relations/"}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
-                aria-label="관계 — 종류 분포 + 근거 풍부한 강한 관계"
+                aria-label={t('actions.relationsTooltip')}
               >
-                관계
+                {t('actions.relations')}
               </Link>
             </Tooltip>
           </div>
@@ -265,16 +270,16 @@ export function OntologyViewPage() {
       <section
         className={`mb-6 grid gap-3 ${isVaultSentinelMode ? "grid-cols-2" : "grid-cols-2 md:grid-cols-4"}`}
       >
-        <Stat label="트리 노드" value={String(totalNodes)} />
-        <Stat label="총 관계" value={insight ? String(insight.edges.length) : "—"} />
+        <Stat label={t('stat.treeNodes')} value={String(totalNodes)} />
+        <Stat label={t('stat.totalRelations')} value={insight ? String(insight.edges.length) : "—"} />
         {isVaultSentinelMode ? null : (
           <>
             <Stat
-              label="근거 문서"
+              label={t('stat.documents')}
               value={String(docCount)}
             />
             <Stat
-              label="발행 시점"
+              label={t('stat.publishedAt')}
               value={
                 insight?.meta?.publishedAt
                   ? insight.meta.publishedAt.toLocaleDateString("ko-KR", {
@@ -282,7 +287,7 @@ export function OntologyViewPage() {
                       month: "short",
                       day: "numeric",
                     })
-                  : "아직 없음"
+                  : t('stat.publishedAtEmpty')
               }
             />
           </>
@@ -294,13 +299,13 @@ export function OntologyViewPage() {
           role="alert"
           className="mb-6 rounded-2xl border border-[color:rgba(229,72,77,0.32)] bg-[color:rgba(229,72,77,0.08)] px-5 py-4 text-sm text-[color:var(--color-status-danger)]"
         >
-          ontology 데이터를 불러오는 중 오류가 났어요. {error.message}
+          {t('error', { message: error.message })}
         </div>
       ) : null}
 
       {!treeResult ? (
         <div className="rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-6 py-10 text-center text-sm text-[color:var(--color-text-tertiary)]">
-          불러오는 중…
+          {t('loading')}
         </div>
       ) : (
         <>
@@ -312,7 +317,7 @@ export function OntologyViewPage() {
           <OntologyTreeView
             result={treeResult}
             onSelect={(node) => selectNode(node)}
-            emptyHint="ontology 가 아직 자라지 않았어요. 아래 단계로 첫 그래프를 시작할 수 있어요."
+            emptyHint={t('emptyHint')}
           />
           {/* 빈 상태 onboarding — tree / orphans 모두 비었을 때만 노출.
               "온톨로지란 무엇이고, 어떻게 자라는지" 가이드. 데이터 있을 때
@@ -322,28 +327,28 @@ export function OntologyViewPage() {
           {treeResult.roots.length === 0 && treeResult.orphans.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-5 py-5">
               <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-                Get started
+                {t('getStarted.eyebrow')}
               </p>
               <h2 className="mt-1.5 break-keep text-base font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                 {dataSourceMode === 'local'
-                  ? 'vault 가 비어있어요 — frontmatter 를 적으면 즉시 자라요'
-                  : '문서가 자라면 트리도 자라요'}
+                  ? t('getStarted.headingLocal')
+                  : t('getStarted.headingDefault')}
               </h2>
               <p className="mt-2 break-keep text-sm leading-6 text-[color:var(--color-text-secondary)]">
                 {dataSourceMode === 'local'
-                  ? '활성 vault 에 ontology frontmatter 가 있는 .md 파일이 0 개. 다음 2 단계로 첫 노드를 만들어요.'
-                  : '온톨로지는 vault frontmatter 의 개념·관계가 모인 그래프예요. 다음 3 단계로 첫 트리를 만들어 봐요.'}
+                  ? t('getStarted.bodyLocal')
+                  : t('getStarted.bodyDefault')}
               </p>
               <ol className="mt-4 space-y-2 text-sm text-[color:var(--color-text-secondary)]">
                 {(dataSourceMode === 'local'
                   ? [
-                      ["1", "frontmatter 적기", "vault 안 아무 .md 파일에 `kind: capability` 같은 frontmatter 추가하면 즉시 stub 노드로 등장."],
-                      ["2", "빌더에서 정리", "/ontology/edit 캔버스에서 시각적으로 노드·관계 다듬으면 그대로 vault 에 저장 + 트리 갱신."],
+                      ["1", t('getStarted.stepLocalFrontmatterTitle'), t('getStarted.stepLocalFrontmatterDesc')],
+                      ["2", t('getStarted.stepLocalBuilderTitle'), t('getStarted.stepLocalBuilderDesc')],
                     ]
                   : [
-                      ["1", "vault 열기", "/docs 에서 마크다운 폴더를 선택해 vault 를 활성화해요."],
-                      ["2", "frontmatter 추가", "문서에 kind / capabilities / elements / relates 를 적으면 자동으로 stub 노드가 만들어져요."],
-                      ["3", "빌더에서 정리", "/ontology/edit 캔버스에서 노드와 관계를 다듬으면 여기 트리에 그대로 자라요."],
+                      ["1", t('getStarted.stepCloudVaultTitle'), t('getStarted.stepCloudVaultDesc')],
+                      ["2", t('getStarted.stepCloudFrontmatterTitle'), t('getStarted.stepCloudFrontmatterDesc')],
+                      ["3", t('getStarted.stepCloudBuilderTitle'), t('getStarted.stepCloudBuilderDesc')],
                     ]
                 ).map(([step, title, desc]) => (
                   <li key={step} className="flex gap-3">
@@ -364,13 +369,13 @@ export function OntologyViewPage() {
                       href={"/ontology/edit/"}
                       className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-4 py-2 text-sm text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
                     >
-                      빌더 열기 →
+                      {t('getStarted.ctaBuilder')}
                     </Link>
                     <Link
                       href={"/docs/"}
                       className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
                     >
-                      vault 살펴보기
+                      {t('getStarted.ctaVault')}
                     </Link>
                   </>
                 ) : (
@@ -379,13 +384,13 @@ export function OntologyViewPage() {
                       href={"/docs/"}
                       className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-4 py-2 text-sm text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
                     >
-                      vault 열기 →
+                      {t('getStarted.ctaVaultOpen')}
                     </Link>
                     <Link
                       href={"/ontology/edit/"}
                       className="inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 py-2 text-sm text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
                     >
-                      빌더 열기
+                      {t('getStarted.ctaBuilderShort')}
                     </Link>
                   </>
                 )}
@@ -397,8 +402,8 @@ export function OntologyViewPage() {
               {dataSourceMode === 'local' ? (
                 <details className="mt-4 rounded-xl border border-[color:var(--color-divider)] bg-[color:var(--color-canvas)] px-4 py-3">
                   <summary className="cursor-pointer list-none text-[12px] text-[color:var(--color-text-secondary)]">
-                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">snippet</span>
-                    <span className="ml-2">vault 의 첫 노드 — 이 frontmatter 를 `.md` 파일에 붙여넣으면 즉시 트리에 등장</span>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">{t('getStarted.snippetEyebrow')}</span>
+                    <span className="ml-2">{t('getStarted.snippetSummary')}</span>
                   </summary>
                   <pre className="mt-3 overflow-x-auto rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-3 font-mono text-[11.5px] leading-5 text-[color:var(--color-text-secondary)]">{`---
 slug: capabilities/auth
@@ -415,7 +420,9 @@ relates:
 토큰 발급, 권한 검증, 세션 추적 등 사용자 인증 흐름.
 `}</pre>
                   <p className="mt-2 text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
-                    위 내용을 vault 안 어떤 디렉토리에든 <code className="font-mono">capabilities/auth.md</code> 같은 이름으로 저장하세요. 더 자세한 frontmatter 키: <code className="font-mono">domain</code> · <code className="font-mono">capabilities</code> · <code className="font-mono">elements</code> · <code className="font-mono">relates</code> · <code className="font-mono">dependencies</code>.
+                    {t.rich('getStarted.snippetHelp', {
+                      code: (chunks) => <code className="font-mono">{chunks}</code>,
+                    })}
                   </p>
                 </details>
               ) : null}
@@ -508,10 +515,11 @@ function OntologyMetaFooter({
   edgeCount: number;
   mode: 'static' | 'local' | 'cloud';
 }) {
+  const t = useTranslations('ontologyView.footer');
   const formatPublished = (d: Date) =>
     `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
   const modeLabel =
-    mode === 'local' ? '로컬 vault' : mode === 'cloud' ? '클라우드' : '정적 데모';
+    mode === 'local' ? t('modeLocal') : mode === 'cloud' ? t('modeCloud') : t('modeStatic');
   return (
     <footer className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-[color:var(--color-divider)] pt-3 text-[11px] text-[color:var(--color-text-quaternary)]">
       <span className="font-mono uppercase tracking-[0.14em]">
@@ -559,6 +567,7 @@ function CopyNodeLinkButton({
   node: KnowledgeGraphNode;
   accountId: string | null;
 }) {
+  const t = useTranslations('ontologyView.copyLink');
   const { show } = useToast();
   const [copied, setCopied] = useState(false);
 
@@ -571,20 +580,20 @@ function CopyNodeLinkButton({
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);
-      show("노드 링크 복사됨", "success");
+      show(t('toastSuccess'), "success");
       window.setTimeout(() => setCopied(false), 1500);
     } catch (err) {
       console.warn("[CopyNodeLinkButton] clipboard write failed", err);
-      show("복사 실패 — 브라우저 권한 확인", "error");
+      show(t('toastError'), "error");
     }
   };
 
   return (
-    <Tooltip content="이 노드의 직접 링크 복사" withProvider={false}>
+    <Tooltip content={t('tooltip')} withProvider={false}>
       <button
         type="button"
         onClick={() => void handleCopy()}
-        aria-label={copied ? "노드 링크 복사됨" : "노드 링크 복사"}
+        aria-label={copied ? t('ariaCopied') : t('ariaCopy')}
         className={
           copied
             ? "flex h-8 items-center gap-1 rounded-full border border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.16)] px-2.5 text-[11px] text-[color:var(--color-indigo-accent)]"
@@ -592,7 +601,7 @@ function CopyNodeLinkButton({
         }
       >
         <Link2 size={14} aria-hidden />
-        {copied ? <span className="font-mono text-[10px] uppercase tracking-[0.10em]">복사</span> : null}
+        {copied ? <span className="font-mono text-[10px] uppercase tracking-[0.10em]">{t('badge')}</span> : null}
       </button>
     </Tooltip>
   );
@@ -628,6 +637,7 @@ function NodeDetailPanel({
   onClose: () => void;
   onAddEdge: (fromNode: KnowledgeGraphNode) => void;
 }) {
+  const t = useTranslations('ontologyView.detail');
   const kindLabel = getOntologyKindLabel(node.kind);
   const isProject = node.kind === "project";
   const isStub = node.kind === "unknown";
@@ -659,7 +669,7 @@ function NodeDetailPanel({
   return (
     <aside
       role="dialog"
-      aria-label={`노드 상세: ${node.title}`}
+      aria-label={t('ariaLabel', { title: node.title })}
       aria-modal="false"
       data-testid="ontology-node-detail"
       className="fixed inset-x-0 bottom-[calc(56px+env(safe-area-inset-bottom))] z-30 mx-auto flex w-full max-w-md max-h-[min(60vh,520px)] flex-col overflow-y-auto overscroll-contain rounded-t-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] px-5 py-4 shadow-[0_-12px_28px_rgba(0,0,0,0.45)] md:bottom-auto md:right-6 md:top-24 md:left-auto md:mx-0 md:w-[360px] md:max-h-[calc(100vh-7rem)] md:rounded-2xl md:shadow-[0_12px_28px_rgba(0,0,0,0.45)]"
@@ -679,24 +689,24 @@ function NodeDetailPanel({
         <div className="flex shrink-0 items-center gap-1">
           <CopyNodeLinkButton node={node} accountId={accountId} />
           {!isStub ? (
-            <Tooltip content="이 노드를 from 으로 새 관계 추가" withProvider={false}>
+            <Tooltip content={t('addEdgeTooltip')} withProvider={false}>
             <button
               type="button"
               onClick={() => onAddEdge(node)}
-              aria-label="이 노드에서 관계 추가"
+              aria-label={t('addEdgeAria')}
               className="flex h-8 items-center gap-1 rounded-full border border-[color:rgba(94,106,210,0.46)] bg-[color:rgba(94,106,210,0.16)] px-2.5 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.66)]"
             >
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                 <path d="M12 5v14M5 12h14" />
               </svg>
-              <span>관계</span>
+              <span>{t('addEdgeButton')}</span>
             </button>
             </Tooltip>
           ) : null}
           <button
             type="button"
             onClick={onClose}
-            aria-label="닫기"
+            aria-label={t('close')}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
           >
             <X size={16} />
@@ -713,7 +723,7 @@ function NodeDetailPanel({
       {node.source === "manual" && node.manualNote ? (
         <div className="mb-3 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2">
           <p className="mb-1 font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-            작성 메모
+            {t('manualNote')}
           </p>
           <p className="break-keep text-[11px] leading-5 text-[color:var(--color-text-secondary)]">
             {node.manualNote}
@@ -731,11 +741,11 @@ function NodeDetailPanel({
             className={`grid gap-2 text-[11px] ${showEvidence ? "grid-cols-2" : "grid-cols-1"}`}
           >
             <DetailRow
-              label="연결 프로젝트"
+              label={t('linkedProjects')}
               value={node.projectIds.length > 0 ? node.projectIds.join(", ") : "—"}
             />
             {showEvidence ? (
-              <DetailRow label="근거 수" value={String(evidenceCount)} />
+              <DetailRow label={t('evidenceCount')} value={String(evidenceCount)} />
             ) : null}
           </dl>
         );
@@ -748,16 +758,19 @@ function NodeDetailPanel({
         <div className="mt-4">
           <div className="flex items-center justify-between gap-2">
             <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-              관계 {ego.neighbors.length}
+              {t('relations', { count: ego.neighbors.length })}
               {egoHops === 2 && ego.neighbors.some((n) => n.hop === 2) ? (
                 <span className="ml-1 text-[color:var(--color-text-tertiary)]">
-                  · 1-hop {ego.neighbors.filter((n) => n.hop === 1).length} · 2-hop {ego.neighbors.filter((n) => n.hop === 2).length}
+                  {t('relationsHopBreakdown', {
+                    one: ego.neighbors.filter((n) => n.hop === 1).length,
+                    two: ego.neighbors.filter((n) => n.hop === 2).length,
+                  })}
                 </span>
               ) : null}
             </p>
             <div
               role="radiogroup"
-              aria-label="ego 그래프 깊이"
+              aria-label={t('egoDepthAria')}
               className="flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] p-0.5"
             >
               <button
@@ -773,7 +786,7 @@ function NodeDetailPanel({
               >
                 1-hop
               </button>
-              <Tooltip content="한 다리 건넌 이웃까지 — 노드 수 늘어 라벨 겹침 가능" withProvider={false}>
+              <Tooltip content={t('egoTwoHopTooltip')} withProvider={false}>
               <button
                 type="button"
                 role="radio"
@@ -806,7 +819,7 @@ function NodeDetailPanel({
               const arrow = isOutgoing ? "→" : "←";
               const relationLabel = neighbor.edge.label ?? neighbor.edge.type;
               const neighborTitle = neighbor.node?.title ?? neighbor.neighborId;
-              const neighborKindLabel = neighbor.node ? getOntologyKindLabel(neighbor.node.kind) : "미연결";
+              const neighborKindLabel = neighbor.node ? getOntologyKindLabel(neighbor.node.kind) : t('neighborMissingKind');
               const ariaLabel = isOutgoing
                 ? `${node.title} → ${relationLabel} → ${neighborTitle}`
                 : `${neighborTitle} → ${relationLabel} → ${node.title}`;
@@ -842,7 +855,7 @@ function NodeDetailPanel({
                     <div
                       aria-label={ariaLabel}
                       className="flex w-full items-center gap-2 rounded-md border border-[color:rgba(255,179,71,0.20)] bg-[color:rgba(255,179,71,0.04)] px-2.5 py-1.5 text-[11px]"
-                      title="이 ID 의 노드가 아직 그래프에 없어요"
+                      title={t('neighborMissingTitle')}
                     >
                       {content}
                     </div>
@@ -859,8 +872,8 @@ function NodeDetailPanel({
               className="mt-1.5 inline-flex items-center font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-indigo-accent)]"
             >
               {showAllNeighbors
-                ? "접기"
-                : `+${ego.neighbors.length - NEIGHBOR_PREVIEW}개 더`}
+                ? t('collapse')
+                : t('showMore', { count: ego.neighbors.length - NEIGHBOR_PREVIEW })}
             </button>
           ) : null}
         </div>
@@ -869,7 +882,7 @@ function NodeDetailPanel({
       {visibleEvidence.length > 0 ? (
         <div className="mt-4">
           <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-            관련 문서 {evidenceList.length}
+            {t('relatedDocs', { count: evidenceList.length })}
           </p>
           <ul className="mt-2 space-y-1">
             {visibleEvidence.map((evidenceId) => {
@@ -893,8 +906,8 @@ function NodeDetailPanel({
               className="mt-1.5 inline-flex items-center font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-indigo-accent)]"
             >
               {showAllEvidence
-                ? "접기"
-                : `+${hiddenEvidenceCount}개 더`}
+                ? t('collapse')
+                : t('showMore', { count: hiddenEvidenceCount })}
             </button>
           ) : null}
         </div>
@@ -905,12 +918,12 @@ function NodeDetailPanel({
           href={`/project/${projectSlug}/`}
           className="mt-4 inline-flex items-center gap-1.5 break-keep rounded-full border border-[color:rgba(94,106,210,0.35)] bg-[color:rgba(94,106,210,0.10)] px-3.5 py-1.5 text-xs text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.18)]"
         >
-          공개 상세 페이지 →
+          {t('projectDetailCta')}
         </Link>
       ) : null}
       {isStub ? (
         <p className="mt-4 break-keep rounded-md border border-[color:rgba(255,179,71,0.20)] bg-[color:rgba(255,179,71,0.06)] px-3 py-2 text-xs text-[color:rgba(238,198,128,0.95)]">
-          미해결 참조 — frontmatter 가 가리킨 slug 가 vault 안에 없어요. 빌더(/ontology/edit)에서 이 이름으로 노드를 만들거나, frontmatter 에서 참조를 빼세요.
+          {t('stubWarning')}
         </p>
       ) : null}
     </aside>

--- a/src/widgets/topology-map-sigma/ui/TopologyEmptyState.tsx
+++ b/src/widgets/topology-map-sigma/ui/TopologyEmptyState.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { FolderOpen, GitBranch } from 'lucide-react';
 
 /**
@@ -13,23 +14,20 @@ import { FolderOpen, GitBranch } from 'lucide-react';
  * agent specifically called out as Toss/Apple-grade.
  */
 export function TopologyEmptyState({ projectCount }: { projectCount: number }) {
-  const title = projectCount === 0 ? '프로젝트가 아직 없어요' : '아직 그릴 의존이 없어요';
-  const body =
-    projectCount === 0
-      ? '마크다운 폴더를 연결하거나 빌더에서 첫 프로젝트를 만들어보세요. frontmatter 의 `dependencies:` 만 채우면 여기에 선이 자동으로 그려져요.'
-      : '프로젝트끼리 의존 관계 (`dependencies:` frontmatter) 을 1개라도 적으면 여기에 선이 자동으로 생겨요. 빌더 캔버스에서 드래그로도 추가 가능.';
+  const t = useTranslations('topology.empty');
+  const isNoProjects = projectCount === 0;
 
   return (
     <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-6">
       <div className="pointer-events-auto max-w-md rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-8 text-center shadow-[0_18px_48px_rgba(0,0,0,0.35)]">
         <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
-          TOPOLOGY · {projectCount} NODE{projectCount === 1 ? '' : 'S'}
+          {t('kicker', { count: projectCount })}
         </p>
         <h2 className="mt-3 text-[20px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-          {title}
+          {isNoProjects ? t('titleNoProjects') : t('titleNoDeps')}
         </h2>
         <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--color-text-tertiary)]">
-          {body}
+          {isNoProjects ? t('bodyNoProjects') : t('bodyNoDeps')}
         </p>
         <div className="mt-6 flex flex-col items-stretch gap-2 sm:flex-row sm:justify-center">
           <Link
@@ -37,14 +35,14 @@ export function TopologyEmptyState({ projectCount }: { projectCount: number }) {
             className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:rgba(94,106,210,0.4)] bg-[color:rgba(94,106,210,0.14)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(94,106,210,0.6)] hover:bg-[color:rgba(94,106,210,0.2)]"
           >
             <GitBranch size={14} aria-hidden="true" />
-            빌더에서 의존 추가
+            {t('ctaBuilder')}
           </Link>
           <Link
             href="/docs/"
             className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(139,151,255,0.35)] hover:text-[color:var(--color-text-primary)]"
           >
             <FolderOpen size={14} aria-hidden="true" />
-            마크다운 폴더 열기
+            {t('ctaOpenVault')}
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

3 main page surfaces 의 본문 카피 i18n 추출. **199 keys 추가**, 3 namespace 격리로 병렬 agent 가 충돌 없이 진행. Round 3a 위에 누적.

### Surfaces

| Page | Namespace | Keys |
|---|---|---|
| `/ontology/` (OntologyViewPage) | `ontologyView.*` | 77 |
| `/docs/` (DocsVaultPage) | `docsVault.*` | 92 |
| `/topology/` (HomePage) | `topology.*` | ~30 |
| `TopologyEmptyState` widget (Round 2 신규) | `topology.empty.*` | 7 |

### Notable patterns

- **`t.rich()` for inline tags** — OntologyView 의 tooltip body 가 `<hierarchy>` / `<strong>` / `<code>` 포함. next-intl rich text 활용.
- **ICU placeholders** — `error{message}`, `relations{count}`, hop breakdown `{one}/{two}`, ariaLabel `{title}`, kicker `{count, plural, one {# NODE} other {# NODES}}`.
- **Korean ICU plural quirk fix** — 한국어는 `one` 카테고리 없어 ICU plural 가 `1 NODES` 출력. 한국어는 plain `'{count} 노드'` 로 단순화.
- **Sub-component deferral** — widgets/* 의 sub-component 는 Round 3c 로 분리 (audit / refactor 위험 통제).

### Verification

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors (62 warnings 모두 기존)
- [x] `pnpm test:run` — 100 files / 721 pass
- [x] Browser: `/en/ontology/` chrome 영문 (Add node / Search / Open builder → / Insights / Relations / TREE NODES / TOTAL RELATIONS)
- [x] Browser: `/en/topology/` chrome 영문 (Topology / WORKSPACE / Project terrain map / Click·Drag) + empty-state "TOPOLOGY · 1 NODE / No dependencies to draw yet"
- [x] Browser: `/ko/topology/` 한글 회귀 0 + empty-state "TOPOLOGY · 1 노드"

### Screenshots

- `round3b-en-ontology.png` — /en/ontology/ chrome 영문화
- `round3b-en-topology-v2.png` — /en/topology/ chrome + empty-state 영문
- `round3b-ko-topology-fixed.png` — /ko/topology/ ICU plural fix 후 자연스러운 한글

## Round 3c 남은 surface

widgets / sub-components / auth / settings:
- widgets/topology-map-sigma (SigmaControls 자동 정렬 / 검색 / 노드 footer)
- widgets/account-menu (PublicAccountMenu — 내 정보 / 로컬)
- widgets/global-search (search palette placeholder)
- widgets/ontology-tree-view (검색 placeholder / sort options)
- src/views/docs-vault/ui/parts/* (DocMetaBar, DocsSidebarBody)
- src/widgets/docs-vault-* (full vault widgets)
- ProjectSelectorPage / ProjectDetailPage / ProjectEditorPage
- Auth pages (login/signup/reset-password/account)
- Settings sub-pages
- Modals + toasts (50+ callsites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)