### PR TITLE
feat: round 4 polish — KIND label i18n + auth spinner + scaffold guard + account scope

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -92,6 +92,14 @@
     "returnTargetSubtitle": "The screen you requested needs sign-in. After you sign in we'll take you straight back.",
     "returnTargetCta": "Sign in and continue"
   },
+  "kinds": {
+    "project": "Project",
+    "domain": "Domain",
+    "capability": "Capability",
+    "element": "Element",
+    "document": "Document",
+    "unknown": "Unresolved"
+  },
   "topologyWidgets": {
     "sigma": {
       "ariaLabel": "Project topology map — jump to individual projects from the hub bar on the left",
@@ -1626,6 +1634,17 @@
     }
   },
   "featuresMisc": {
+    "authLoading": {
+      "label": "Verifying"
+    },
+    "accountScope": {
+      "loadingRole": "Verifying",
+      "loadingDescription": "Checking what you can do right now.",
+      "guestRole": "Local",
+      "guestDescription": "Use the local vault freely; sign in for cloud sync.",
+      "ownerRole": "Owner",
+      "ownerDescription": "You own this space — every action runs against your data."
+    },
     "permissionGate": {
       "loadingTitle": "Checking…",
       "loadingBody": "Verifying your account status.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -92,6 +92,14 @@
     "returnTargetSubtitle": "요청한 화면은 로그인이 필요합니다. 로그인하면 방금 열려던 화면으로 바로 돌아갑니다.",
     "returnTargetCta": "로그인하고 계속"
   },
+  "kinds": {
+    "project": "프로젝트",
+    "domain": "도메인",
+    "capability": "역량",
+    "element": "요소",
+    "document": "문서",
+    "unknown": "미지"
+  },
   "topologyWidgets": {
     "sigma": {
       "ariaLabel": "프로젝트 토폴로지 지도 — 좌측 허브 바에서 개별 프로젝트 바로가기",
@@ -1626,6 +1634,17 @@
     }
   },
   "featuresMisc": {
+    "authLoading": {
+      "label": "확인 중"
+    },
+    "accountScope": {
+      "loadingRole": "확인 중",
+      "loadingDescription": "지금 어떤 작업을 할 수 있는지 확인하고 있습니다.",
+      "guestRole": "로컬",
+      "guestDescription": "로컬 vault 는 자유롭게 사용할 수 있고, cloud 동기화는 로그인 후 가능합니다.",
+      "ownerRole": "주인",
+      "ownerDescription": "이 공간의 주인으로 모든 작업을 직접 수행합니다."
+    },
     "permissionGate": {
       "loadingTitle": "확인 중입니다…",
       "loadingBody": "계정 상태를 확인하고 있습니다.",

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-02T13:15:02.901Z",
+  "generatedAt": "2026-05-02T13:34:58.374Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",

--- a/src/entities/ontology-class/index.ts
+++ b/src/entities/ontology-class/index.ts
@@ -11,5 +11,6 @@ export {
   fromFirestore,
   toFirestore,
 } from './model';
+export { useOntologyKindLabel } from './model/use-kind-label';
 // API 함수는 barrel 에서 제외 — `@/entities/ontology-class/api` 로 직접
 // import. 정적 그래프에 firebase/firestore 가 박히지 않게.

--- a/src/entities/ontology-class/model/use-kind-label.ts
+++ b/src/entities/ontology-class/model/use-kind-label.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+const KNOWN_KINDS = ['project', 'domain', 'capability', 'element', 'document', 'unknown'] as const;
+type KnownKind = (typeof KNOWN_KINDS)[number];
+
+function isKnown(kind: string): kind is KnownKind {
+  return (KNOWN_KINDS as ReadonlyArray<string>).includes(kind);
+}
+
+/**
+ * Locale-aware ontology kind label resolver.
+ *
+ * Returns a `(kind: string) => string` function that maps the canonical
+ * kind id (`project` / `domain` / `capability` / `element` / `document` /
+ * `unknown`) to the localized display label. Unknown kinds (e.g. user-
+ * defined custom kinds) fall through to the raw kind string so we never
+ * render an empty chip.
+ *
+ * Use this hook from any client component that renders a kind label —
+ * tree chips, ego graph, search results, builder palette, inspector,
+ * insights breakdown. The pure `getOntologyKindLabel` is kept for vault
+ * data / non-i18n contexts (tests, build scripts).
+ */
+export function useOntologyKindLabel() {
+  const t = useTranslations('kinds');
+  return (kind: string): string => {
+    if (isKnown(kind)) return t(kind);
+    return kind;
+  };
+}

--- a/src/features/account-scope/model/use-scoped-account-access.ts
+++ b/src/features/account-scope/model/use-scoped-account-access.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useUserAuth } from "@/features/user-auth";
 import {
   type ScopedAccountAccess,
@@ -22,9 +23,13 @@ export interface UseScopedAccountAccessResult extends ScopedAccountAccess {
  *
  * 로그인 안 한 사용자는 게스트 — local-first 흐름에서 폴더 선택만으로
  * 사용 가능하지만, 서버와 동기화하는 액션 (publish 등) 은 로그인 후에만.
+ *
+ * Round 4 polish: roleLabel / description 이 t() 에서 와 locale 인식.
+ * 이전엔 Korean hardcode 라 /en/ 진입에도 "로컬" / "주인" 으로 노출.
  */
 export function useScopedAccountAccess(): UseScopedAccountAccessResult {
   const { status, user } = useUserAuth();
+  const t = useTranslations("featuresMisc.accountScope");
 
   return useMemo<UseScopedAccountAccessResult>(() => {
     const profile = user
@@ -39,8 +44,8 @@ export function useScopedAccountAccess(): UseScopedAccountAccessResult {
         canEditDocuments: false,
         canReviewAndPublish: false,
         hasWorkspaceAccess: false,
-        roleLabel: "확인 중",
-        description: "지금 어떤 작업을 할 수 있는지 확인하고 있습니다.",
+        roleLabel: t("loadingRole"),
+        description: t("loadingDescription"),
         membership: null,
         user: profile,
       };
@@ -54,9 +59,8 @@ export function useScopedAccountAccess(): UseScopedAccountAccessResult {
         canEditDocuments: false,
         canReviewAndPublish: false,
         hasWorkspaceAccess: true,
-        roleLabel: "로컬",
-        description:
-          "로컬 vault 는 자유롭게 사용할 수 있고, cloud 동기화는 로그인 후 가능합니다.",
+        roleLabel: t("guestRole"),
+        description: t("guestDescription"),
         membership: null,
         user: null,
       };
@@ -69,10 +73,10 @@ export function useScopedAccountAccess(): UseScopedAccountAccessResult {
       canEditDocuments: true,
       canReviewAndPublish: true,
       hasWorkspaceAccess: true,
-      roleLabel: "주인",
-      description: "이 공간의 주인으로 모든 작업을 직접 수행합니다.",
+      roleLabel: t("ownerRole"),
+      description: t("ownerDescription"),
       membership: null,
       user: profile,
     };
-  }, [status, user]);
+  }, [status, user, t]);
 }

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -710,14 +710,30 @@ export function useLocalVault() {
     }
     // .mcp.json.example — 사용자가 AI agent 설정으로 복사. vault 폴더의
     // 절대경로는 브라우저가 모르니 placeholder 로 두고 안내.
+    //
+    // overwrite guard (eval round 4 — perf agent finding):
+    // 사용자가 .mcp.json.example 을 customize 했을 수도 있으니 기존 파일이
+    // 있으면 skip. 처음 scaffold 일 때만 생성.
     try {
-      const fh = await state.handle.getFileHandle('.mcp.json.example', {
-        create: true,
-      });
-      const writable = await fh.createWritable();
-      await writable.write(buildMcpConfigJson(state.handle.name));
-      await writable.close();
-      created += 1;
+      let alreadyExists = false;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- existence probe
+        const _existing = await state.handle.getFileHandle('.mcp.json.example');
+        alreadyExists = true;
+      } catch {
+        // NotFoundError — 파일 없음, 정상.
+      }
+      if (alreadyExists) {
+        skipped += 1;
+      } else {
+        const fh = await state.handle.getFileHandle('.mcp.json.example', {
+          create: true,
+        });
+        const writable = await fh.createWritable();
+        await writable.write(buildMcpConfigJson(state.handle.name));
+        await writable.close();
+        created += 1;
+      }
     } catch {
       skipped += 1;
     }

--- a/src/views/ontology-edit/ui/OntologyKindPalette.tsx
+++ b/src/views/ontology-edit/ui/OntologyKindPalette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { getOntologyKindIcon, getOntologyKindLabel } from "@/entities/ontology-class";
+import { getOntologyKindIcon, useOntologyKindLabel } from "@/entities/ontology-class";
 import type { ManualNodeKind } from "@/entities/knowledge-graph";
 
 /**
@@ -28,6 +28,7 @@ export interface OntologyKindPaletteProps {
 
 export function OntologyKindPalette({ onAddNode }: OntologyKindPaletteProps) {
   const t = useTranslations("ontologyPages.edit.palette");
+  const kindLabel = useOntologyKindLabel();
   return (
     <aside
       aria-label={t("ariaLabel")}
@@ -44,7 +45,7 @@ export function OntologyKindPalette({ onAddNode }: OntologyKindPaletteProps) {
       <ul className="flex flex-col gap-1.5">
         {PALETTE_KINDS.map((entry) => {
           const Icon = getOntologyKindIcon(entry.kind);
-          const label = getOntologyKindLabel(entry.kind);
+          const label = kindLabel(entry.kind);
           const hint = t(entry.hintKey);
           return (
             <li key={entry.kind}>

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -9,7 +9,7 @@ import {
   ManualSourceChip,
 } from "@/entities/knowledge-graph";
 import { useOntologyInsight, isVaultSentinelDate } from "@/features/vault-ontology";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import {
   buildActivityTimeline,
   buildOntologyTree,
@@ -57,6 +57,7 @@ function getEdgeTypeLabel(
  */
 export function OntologyInsightsPage() {
   const t = useTranslations("ontologyPages.insights");
+  const kindLabel = useOntologyKindLabel();
   const searchParams = useSearchParams();
   const accountId = null;
 
@@ -233,7 +234,7 @@ export function OntologyInsightsPage() {
                   <li key={kind} className="text-[12px]">
                     <div className="flex items-baseline justify-between gap-2">
                       <span className="text-[color:var(--color-text-secondary)]">
-                        {getOntologyKindLabel(kind)}
+                        {kindLabel(kind)}
                       </span>
                       <span className="font-mono text-[10px] tabular-nums text-[color:var(--color-text-quaternary)]">
                         {count}
@@ -402,7 +403,7 @@ export function OntologyInsightsPage() {
                         {idx + 1}
                       </span>
                       <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-                        {getOntologyKindLabel(node.kind)}
+                        {kindLabel(node.kind)}
                       </span>
                       <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                         {node.title}
@@ -435,7 +436,7 @@ export function OntologyInsightsPage() {
                     className="flex items-center gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 text-[12px] transition-colors hover:border-[color:rgba(94,106,210,0.32)]"
                   >
                     <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-                      {getOntologyKindLabel(node.kind)}
+                      {kindLabel(node.kind)}
                     </span>
                     <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                       {node.title}
@@ -511,7 +512,7 @@ export function OntologyInsightsPage() {
                     className="flex items-center gap-2 rounded-md border border-[color:rgba(255,179,71,0.18)] bg-[color:rgba(255,179,71,0.04)] px-2.5 py-1.5 text-[12px]"
                   >
                     <span className="inline-flex shrink-0 items-center rounded-full border border-[color:rgba(255,179,71,0.30)] bg-[color:rgba(255,179,71,0.08)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:rgba(238,198,128,0.95)]">
-                      {getOntologyKindLabel(node.kind)}
+                      {kindLabel(node.kind)}
                     </span>
                     <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                       {node.title}

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -9,7 +9,7 @@ import {
   ManualSourceChip,
   type KnowledgeGraphNode,
 } from "@/entities/knowledge-graph";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import {
   buildOntologyEgoSubgraph,
@@ -638,7 +638,8 @@ function NodeDetailPanel({
   onAddEdge: (fromNode: KnowledgeGraphNode) => void;
 }) {
   const t = useTranslations('ontologyView.detail');
-  const kindLabel = getOntologyKindLabel(node.kind);
+  const getKindLabel = useOntologyKindLabel();
+  const kindLabel = getKindLabel(node.kind);
   const isProject = node.kind === "project";
   const isStub = node.kind === "unknown";
   const isDocument = node.kind === "document";
@@ -819,7 +820,7 @@ function NodeDetailPanel({
               const arrow = isOutgoing ? "→" : "←";
               const relationLabel = neighbor.edge.label ?? neighbor.edge.type;
               const neighborTitle = neighbor.node?.title ?? neighbor.neighborId;
-              const neighborKindLabel = neighbor.node ? getOntologyKindLabel(neighbor.node.kind) : t('neighborMissingKind');
+              const neighborKindLabel = neighbor.node ? getKindLabel(neighbor.node.kind) : t('neighborMissingKind');
               const ariaLabel = isOutgoing
                 ? `${node.title} → ${relationLabel} → ${neighborTitle}`
                 : `${neighborTitle} → ${relationLabel} → ${node.title}`;

--- a/src/views/root-entry/ui/RootEntryPage.tsx
+++ b/src/views/root-entry/ui/RootEntryPage.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useGlobalAdmin } from "@/features/permissions";
 import { useUserAuth } from "@/features/user-auth";
 import { OntologyViewPage } from "@/views/ontology-view";
@@ -19,19 +21,64 @@ import { LandingPage } from "@/views/landing";
  * 폐기 — `accountId` 는 항상 null. ontology 데이터는 vault > 빌드타임 dogfood
  * > Firestore 우선순위 (`useOntologyInsight`) 로 결정되므로 라우팅 단계에서
  * 계정 분기 불필요.
+ *
+ * Round 4 polish: firebase Auth 의 localStorage 흔적이 없으면 spinner 가
+ * 의미 0 — 첫 방문자가 무조건 2.5s 대기하던 회귀 (eval Perf agent finding).
+ * synchronous heuristic 으로 단축. firebase token 이 있으면 fully resolve
+ * 되도록 기존 loading 분기 보존.
  */
+const FIREBASE_AUTH_LS_PREFIX = 'firebase:authUser:';
+
+function hasAnyFirebaseAuthArtifact(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (key && key.startsWith(FIREBASE_AUTH_LS_PREFIX)) return true;
+    }
+  } catch {
+    // private mode — assume artifact may exist; let normal loading run.
+    return true;
+  }
+  return false;
+}
+
+function useHasFirebaseAuthArtifact(): boolean {
+  // SSR 평가 시 항상 true 로 fallback (loading spinner 정상 표시) → 클라이언트
+  // hydration 후 동기 검사 결과로 update. mismatch 없는 useSyncExternalStore
+  // 패턴.
+  return useSyncExternalStore(
+    () => () => {},
+    () => hasAnyFirebaseAuthArtifact(),
+    () => true,
+  );
+}
+
 export function RootEntryPage() {
   const searchParams = useSearchParams();
   const next = searchParams.get("next");
   const userAuth = useUserAuth();
   const globalAdmin = useGlobalAdmin();
+  const hasArtifact = useHasFirebaseAuthArtifact();
 
-  if (userAuth.status === "loading" || globalAdmin.status === "loading") {
+  // First-visit short-circuit: no firebase auth artifact in localStorage means
+  // the eventual answer is `unauthenticated` regardless of how long Firebase
+  // SDK init takes. Render LandingPage immediately. Existing users with a
+  // saved session still hit the proper loading state.
+  const definitelyUnauthenticated =
+    !hasArtifact &&
+    userAuth.status === "loading" &&
+    globalAdmin.status !== "authenticated";
+
+  if (
+    !definitelyUnauthenticated &&
+    (userAuth.status === "loading" || globalAdmin.status === "loading")
+  ) {
     return <AuthLoadingSpinner />;
   }
   if (
-    userAuth.status === "unauthenticated" &&
-    globalAdmin.status !== "authenticated"
+    definitelyUnauthenticated ||
+    (userAuth.status === "unauthenticated" && globalAdmin.status !== "authenticated")
   ) {
     return <LandingPage next={next} />;
   }
@@ -39,6 +86,15 @@ export function RootEntryPage() {
 }
 
 function AuthLoadingSpinner() {
+  const t = useTranslations('featuresMisc.authLoading');
+  // Show the spinner only after a short delay so first-paint isn't
+  // flashed for users whose auth resolves in <100ms (cached session).
+  const [showSpinner, setShowSpinner] = useState(false);
+  useEffect(() => {
+    const handle = window.setTimeout(() => setShowSpinner(true), 120);
+    return () => window.clearTimeout(handle);
+  }, []);
+  if (!showSpinner) return null;
   return (
     <div
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)]"
@@ -52,7 +108,7 @@ function AuthLoadingSpinner() {
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--color-indigo-accent)] [animation-delay:300ms]" />
         </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
-          확인 중
+          {t('label')}
         </span>
       </div>
     </div>

--- a/src/widgets/dashboard-ontology-summary/ui/DashboardOntologySummary.tsx
+++ b/src/widgets/dashboard-ontology-summary/ui/DashboardOntologySummary.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import Link from "next/link";
 import { Network } from "lucide-react";
 import { ManualSourceChip } from "@/entities/knowledge-graph";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { useOntologyInsight } from "@/features/vault-ontology";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import {
@@ -28,6 +28,7 @@ export interface DashboardOntologySummaryProps {
  */
 export function DashboardOntologySummary({ accountId }: DashboardOntologySummaryProps) {
   const { insight } = useOntologyInsight(accountId);
+  const kindLabel = useOntologyKindLabel();
   const nodes = insight?.nodes ?? [];
 
   const stats = useMemo(() => buildMeaningfulOntologyStats(nodes), [nodes]);
@@ -91,7 +92,7 @@ export function DashboardOntologySummary({ accountId }: DashboardOntologySummary
                     : "text-[color:var(--color-text-quaternary)]"
                 }`}
               >
-                {getOntologyKindLabel(kind)}
+                {kindLabel(kind)}
               </p>
               <p className="mt-1 break-keep text-base font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                 {count}
@@ -114,7 +115,7 @@ export function DashboardOntologySummary({ accountId }: DashboardOntologySummary
                   className="flex items-center gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 text-[12px] transition-colors hover:border-[color:rgba(94,106,210,0.32)]"
                 >
                   <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-                    {getOntologyKindLabel(node.kind)}
+                    {kindLabel(node.kind)}
                   </span>
                   <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                     {node.title}

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -8,7 +8,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { ManualSourceChip, type KnowledgeGraphNode } from "@/entities/knowledge-graph";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import type { Project } from "@/entities/project";
 import {
   MEANINGFUL_ONTOLOGY_KINDS,
@@ -50,6 +50,7 @@ export function GlobalSearch({
   onSelectProject,
 }: GlobalSearchProps) {
   const t = useTranslations("searchWidgets.globalSearch");
+  const kindLabel = useOntologyKindLabel();
   const [query, setQuery] = useState("");
   // Fire 2 — kind / project filter chip 으로 ontology 결과 좁히기. set 으로
   // 다중 선택 (toggle) 모델. 닫을 때 query 와 함께 초기화.
@@ -224,7 +225,7 @@ export function GlobalSearch({
                       : "shrink-0 rounded-full border border-[color:var(--color-divider)] bg-transparent px-2 py-0.5 text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]"
                   }
                 >
-                  {getOntologyKindLabel(kind)}
+                  {kindLabel(kind)}
                 </button>
               );
             })}
@@ -331,7 +332,7 @@ export function GlobalSearch({
                     className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-[color:var(--color-text-secondary)] aria-selected:bg-[color:rgba(94,106,210,0.14)] aria-selected:text-[color:var(--color-text-primary)]"
                   >
                     <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-                      {getOntologyKindLabel(node.kind)}
+                      {kindLabel(node.kind)}
                     </span>
                     <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                       {node.title}

--- a/src/widgets/manual-node-create-modal/ui/ManualNodeCreateModal.tsx
+++ b/src/widgets/manual-node-create-modal/ui/ManualNodeCreateModal.tsx
@@ -11,7 +11,7 @@ import {
   type ManualNodeKind,
 } from "@/entities/knowledge-graph";
 import { findSimilarOntologyNodes, recommendDocumentSlug } from "@/shared/lib/ontology-tree";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 
 export interface ManualNodeCreateModalProps {
   open: boolean;
@@ -57,6 +57,7 @@ export function ManualNodeCreateModal({
   onCreated,
 }: ManualNodeCreateModalProps) {
   const t = useTranslations('ontologyWidgets');
+  const kindLabel = useOntologyKindLabel();
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -213,7 +214,7 @@ export function ManualNodeCreateModal({
             >
               {MANUAL_NODE_KINDS.map((kind) => (
                 <option key={kind} value={kind}>
-                  {kind} · {getOntologyKindLabel(kind)}
+                  {kind} · {kindLabel(kind)}
                 </option>
               ))}
             </select>

--- a/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.tsx
+++ b/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import {
   buildRadialEgoLayout,
   UNKNOWN_TONE,
@@ -47,6 +47,7 @@ export function OntologyEgoGraph({
   height = 200,
 }: OntologyEgoGraphProps) {
   const t = useTranslations('ontologyWidgets');
+  const kindLabel = useOntologyKindLabel();
   const layout = useMemo(
     () => buildRadialEgoLayout(ego, width, height, { padding: 36 }),
     [ego, width, height],
@@ -117,7 +118,7 @@ export function OntologyEgoGraph({
         const neighbor = ego.neighbors[i]!;
         const node = neighbor.node;
         const title = node?.title ?? neighbor.neighborId;
-        const kindLabel = node ? getOntologyKindLabel(node.kind) : t('egoGraph.neighborMissingKind');
+        const neighborKindLabel = node ? kindLabel(node.kind) : t('egoGraph.neighborMissingKind');
         const truncated = title.length > LABEL_MAX_CHARS ? `${title.slice(0, LABEL_MAX_CHARS - 1)}…` : title;
         const isHop2 = neighbor.hop === 2;
         const showLabel = shouldShowEgoLabel(neighbor.hop, i, density, hoveredIndex);
@@ -153,7 +154,7 @@ export function OntologyEgoGraph({
             tabIndex={clickable ? 0 : undefined}
             aria-label={t('egoGraph.neighborTitleAria', {
               title,
-              kind: kindLabel,
+              kind: neighborKindLabel,
               direction:
                 neighbor.direction === "outgoing"
                   ? t('egoGraph.directionOutgoing')
@@ -179,7 +180,7 @@ export function OntologyEgoGraph({
           >
             {/* native SVG <title> — dense ring 에서 라벨 숨겨도 hover/focus
                 툴팁으로 노드 정체 인지 가능. 스크린리더도 읽음. */}
-            <title>{`${title} (${kindLabel})`}</title>
+            <title>{`${title} (${neighborKindLabel})`}</title>
             <circle
               cx={point.x}
               cy={point.y}

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -3,7 +3,7 @@
 import { createElement, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { ChevronDown, ChevronRight, ChevronsDownUp, ChevronsUpDown, Search, X } from "lucide-react";
-import { getOntologyKindIcon, getOntologyKindLabel } from "@/entities/ontology-class";
+import { getOntologyKindIcon, useOntologyKindLabel } from "@/entities/ontology-class";
 import { ManualSourceChip } from "@/entities/knowledge-graph";
 import {
   filterTreeByQuery,
@@ -75,6 +75,7 @@ const KIND_TONE: Record<
 
 function KindChip({ kind }: { kind: string }) {
   const tone = KIND_TONE[kind] ?? KIND_TONE.element!;
+  const kindLabel = useOntologyKindLabel();
   // kind → 정적 lucide 컴포넌트 매핑. createElement 로 직접 호출해서
   // local alias (`const Icon = …; <Icon />`) 가 react-hooks/static-components
   // 룰을 트리거하는 패턴 회피. KIND_ICON 자체가 정적 record 라 element type
@@ -85,7 +86,7 @@ function KindChip({ kind }: { kind: string }) {
       style={{ backgroundColor: tone.bg, color: tone.text, borderColor: tone.border }}
     >
       {createElement(getOntologyKindIcon(kind), { size: 10, "aria-hidden": true })}
-      {getOntologyKindLabel(kind)}
+      {kindLabel(kind)}
     </span>
   );
 }

--- a/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
+++ b/src/widgets/project-ontology-overview/ui/ProjectOntologyOverview.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { ManualSourceChip } from "@/entities/knowledge-graph";
-import { getOntologyKindLabel } from "@/entities/ontology-class";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { useOntologyInsight } from "@/features/vault-ontology";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
 import { buildMeaningfulOntologyStats } from "@/shared/lib/ontology-tree";
@@ -32,6 +32,7 @@ export function ProjectOntologyOverview({
   limit = 6,
 }: ProjectOntologyOverviewProps) {
   const { insight } = useOntologyInsight(accountId);
+  const kindLabel = useOntologyKindLabel();
   const nodes = insight?.nodes ?? [];
 
   const matched = useMemo(
@@ -79,7 +80,7 @@ export function ProjectOntologyOverview({
               key={kind}
               className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-tertiary)]"
             >
-              {getOntologyKindLabel(kind)} {count}
+              {kindLabel(kind)} {count}
             </span>
           ))}
         </div>
@@ -93,7 +94,7 @@ export function ProjectOntologyOverview({
               className="flex items-center gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 text-[12px]"
             >
               <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
-                {getOntologyKindLabel(node.kind)}
+                {kindLabel(node.kind)}
               </span>
               <span
                 className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]"


### PR DESCRIPTION
## Summary

eval round 4 의 polish 항목 — 잔여 한국어 카피 + UX 이슈 fix. 4 round 위에 누적.

### KIND 라벨 i18n (entity-level)

`entities/ontology-class` 가 hardcoded Korean 반환하던 회귀 — `/en/` 진입에도 PALETTE / tree chip / ego graph / search result / 빌더 inspector 에서 한글 라벨 ("프로젝트 / 도메인 / 역량 / 요소") 노출.

- 신규 hook `useOntologyKindLabel()` (`src/entities/ontology-class/model/use-kind-label.ts`) — locale-aware 라벨 반환.
- pure `getOntologyKindLabel` 보존 (tests / build scripts / vault data 용).
- `messages.kinds.*` 6 keys (project/domain/capability/element/document/unknown) — en + ko.
- **9 callers 병렬 migrate** (sub-agent): OntologyKindPalette / OntologyTreeView / OntologyViewPage / GlobalSearch / ProjectOntologyOverview / OntologyInsightsPage / OntologyEgoGraph / ManualNodeCreateModal / DashboardOntologySummary.

**Result**: `/en/ontology/edit/` PALETTE → "Project · Domain · Capability · Element". `/ko/` 회귀 0.

### Auth spinner short-circuit

`RootEntryPage` 가 첫 방문자에게 무조건 2.5s spinner 보이던 회귀 (Perf agent finding).

- `useSyncExternalStore` 로 localStorage `firebase:authUser:*` prefix 동기 검사.
- SSR `true` (정상 spinner) → hydration 후 `false` 면 LandingPage 로 즉시 단축.
- spinner 자체 120ms 지연 표시 — 빠른 cached session 에선 flicker 0.
- "확인 중" hardcode → `t('featuresMisc.authLoading.label')`.

### scaffoldOntology .mcp.json.example overwrite guard

scaffold 함수가 `.mcp.json.example` 무조건 overwrite — customize 한 사용자 손실 위험. existence probe 후 없을 때만 작성.

### PublicAccountMenu "로컬" 라벨 fix (Wave1-C 잔재)

`useScopedAccountAccess` 가 hardcoded 한국어 ("로컬" / "주인" / "확인 중") 반환 — `/en/` 진입에도 노출. `t('featuresMisc.accountScope.<key>')` 로 locale-aware. 6 keys.

## Verification

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors (62 warnings 모두 기존)
- [x] `pnpm test:run` — 100 files / 721 tests pass
- [x] Browser: `/en/ontology/edit/` PALETTE → "Project · Domain · Capability · Element" 영문 (`round4-en-builder-kinds.png`)
- [x] Browser: `/ko/ontology/edit/` PALETTE → "프로젝트 · 도메인 · 역량 · 요소" 한글 (회귀 0, `round4-ko-builder-regression.png`)

## Round 5 deferred (bigger / design quality)

- StaggeredFadeIn motion (Aesthetic finding P1) — opacity + translateY stagger
- Live mini-Sigma hero on landing (P2)
- Builder dense seed anti-collision auto-layout (P3)
- Feature power: global ⌘K palette / `/ontology/changes` / JSON-LD/GraphML / typed query DSL / blast-radius

## PR chain

```
main
 └─ #111 Round 1 → #112 Round 2 → #113 Round 3a → #114 Round 3b
     → #115 Round 3c → #116 Round 4 ← this
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)