### PR TITLE
feat(builder): round 6 — blast-radius confirm modal

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -840,7 +840,20 @@
         "toastDeleteFailed": "Delete failed",
         "confirmDeleteWithBacklinks": "Deleting \"{slug}\" will leave {count} nodes dangling ({preview}{rest}).\n\nDelete anyway?",
         "confirmDeleteWithBacklinksRest": " plus {count} more",
-        "confirmDelete": "Delete \"{slug}\" from the vault? This cannot be undone."
+        "confirmDelete": "Delete \"{slug}\" from the vault? This cannot be undone.",
+        "blastRadius": {
+          "titleClean": "Delete this node?",
+          "titleWithBacklinks": "{count} nodes depend on this — delete anyway?",
+          "bodyClean": "The node and its frontmatter will be removed from the vault. This cannot be undone.",
+          "bodyWithBacklinks": "These nodes reference the one you're about to delete. Their links will become dangling — you can fix them after, but plan a cleanup pass.",
+          "hintClean": "Tip: builder edits write straight to disk. Re-create the node any time.",
+          "hintWithBacklinks": "Tip: open the listed nodes after delete to remove the dangling reference, or rename instead of deleting.",
+          "moreCount": "and {count} more",
+          "cancel": "Cancel",
+          "confirmClean": "Delete",
+          "confirmWithBacklinks": "Delete anyway",
+          "closeAriaLabel": "Close blast-radius dialog"
+        }
       },
       "canvas": {
         "ephemeralEdgeLabel": "related (ephemeral)",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -840,7 +840,20 @@
         "toastDeleteFailed": "삭제 실패",
         "confirmDeleteWithBacklinks": "\"{slug}\" 를 삭제하면 {count} 개 노드가 dangling 됩니다 ({preview}{rest}).\n\n그래도 삭제할까요?",
         "confirmDeleteWithBacklinksRest": " 외 {count}개",
-        "confirmDelete": "\"{slug}\" 를 vault 에서 삭제할까요? 되돌릴 수 없습니다."
+        "confirmDelete": "\"{slug}\" 를 vault 에서 삭제할까요? 되돌릴 수 없습니다.",
+        "blastRadius": {
+          "titleClean": "이 노드를 삭제할까요?",
+          "titleWithBacklinks": "{count} 개 노드가 이 노드를 참조하는데, 그래도 삭제?",
+          "bodyClean": "노드와 frontmatter 가 vault 에서 제거됩니다. 되돌릴 수 없어요.",
+          "bodyWithBacklinks": "아래 노드들이 지금 삭제하는 노드를 참조하고 있어요. 링크가 dangling 상태가 됩니다 — 나중에 고칠 수 있지만, cleanup 한 번 계획하세요.",
+          "hintClean": "Tip: 빌더 편집은 디스크로 바로 저장. 언제든 다시 만들 수 있어요.",
+          "hintWithBacklinks": "Tip: 삭제 후 위 노드들을 열어 dangling 참조를 빼거나, 삭제 대신 rename 을 고려해보세요.",
+          "moreCount": "외 {count} 개",
+          "cancel": "취소",
+          "confirmClean": "삭제",
+          "confirmWithBacklinks": "그래도 삭제",
+          "closeAriaLabel": "blast-radius 다이얼로그 닫기"
+        }
       },
       "canvas": {
         "ephemeralEdgeLabel": "관련 (임시)",

--- a/src/views/ontology-edit/ui/BlastRadiusConfirm.tsx
+++ b/src/views/ontology-edit/ui/BlastRadiusConfirm.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, X } from 'lucide-react';
+import type { VaultBacklinkMatch } from '../lib/find-vault-backlinks';
+
+interface Props {
+  open: boolean;
+  /** Slug being deleted. */
+  slug: string;
+  /** Optional human title — when present, shown next to the slug. */
+  title?: string;
+  /** Backlinks discovered via findVaultBacklinks(). 0 length is a clean delete. */
+  backlinks: VaultBacklinkMatch[];
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Blast-radius confirm modal — replaces the window.confirm() before vault
+ * doc delete. Visualizes the affected nodes (slug + title + which
+ * frontmatter key matched) so the user can decide consciously.
+ *
+ * Eval Feature power F5 ("launch demo's hero moment") — the data was
+ * already in `find-vault-backlinks.ts`; we just promote it from a single
+ * confirm sentence to a richer dialog. Mirrors the MCP `delete_concept`
+ * tool's two-stage guard but with a visual surface humans can act on.
+ *
+ * Pattern matches existing ManualNodeCreateModal / ManualEdgeCreateModal:
+ * focus-trap-light (auto-focus cancel button), Esc to cancel, click
+ * outside the panel to cancel.
+ */
+export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onConfirm }: Props) {
+  const t = useTranslations('ontologyPages.edit.page.blastRadius');
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  // Auto-focus the safe action (cancel) so accidental Enter does not
+  // trigger destructive delete. mirrors browser confirm() default-no.
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const hasBacklinks = backlinks.length > 0;
+  const previewCount = Math.min(backlinks.length, 8);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="blast-radius-title"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-[color:rgba(8,9,10,0.7)] px-4 py-6"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-2xl border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] shadow-[0_24px_64px_rgba(0,0,0,0.5)]">
+        <header className="flex items-start justify-between gap-3 border-b border-[color:var(--color-divider)] px-6 py-4">
+          <div className="flex items-start gap-3">
+            <span
+              className={
+                hasBacklinks
+                  ? 'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[color:rgba(229,72,77,0.4)] bg-[color:rgba(229,72,77,0.14)] text-[color:rgba(255,141,138,0.95)]'
+                  : 'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[color:rgba(244,183,49,0.4)] bg-[color:rgba(244,183,49,0.14)] text-[color:rgba(238,198,128,0.95)]'
+              }
+              aria-hidden
+            >
+              <AlertTriangle size={16} />
+            </span>
+            <div>
+              <p
+                id="blast-radius-title"
+                className="text-[15px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
+              >
+                {hasBacklinks ? t('titleWithBacklinks', { count: backlinks.length }) : t('titleClean')}
+              </p>
+              <p className="mt-1 font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+                {title ? `${title} · ${slug}` : slug}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label={t('closeAriaLabel')}
+            className="shrink-0 rounded-md p-1 text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="px-6 py-4">
+          <p className="text-[13px] leading-relaxed text-[color:var(--color-text-secondary)]">
+            {hasBacklinks ? t('bodyWithBacklinks') : t('bodyClean')}
+          </p>
+
+          {hasBacklinks ? (
+            <div className="mt-4 max-h-64 overflow-y-auto rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)]">
+              <ul className="divide-y divide-[color:var(--color-divider)]">
+                {backlinks.slice(0, previewCount).map((b) => (
+                  <li key={b.slug} className="px-3 py-2.5">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <span className="truncate text-[13px] text-[color:var(--color-text-primary)]">
+                        {b.title}
+                      </span>
+                      <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                        {b.matchedKeys.join(' · ')}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+                      {b.slug}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+              {backlinks.length > previewCount ? (
+                <p className="border-t border-[color:var(--color-divider)] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {t('moreCount', { count: backlinks.length - previewCount })}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          <p className="mt-4 text-[12px] text-[color:var(--color-text-tertiary)]">
+            {hasBacklinks ? t('hintWithBacklinks') : t('hintClean')}
+          </p>
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 border-t border-[color:var(--color-divider)] px-6 py-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(139,151,255,0.32)] hover:text-[color:var(--color-text-primary)]"
+          >
+            {t('cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={
+              hasBacklinks
+                ? 'inline-flex h-9 items-center rounded-md border border-[color:rgba(229,72,77,0.4)] bg-[color:rgba(229,72,77,0.14)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:rgba(255,141,138,0.95)] transition-colors hover:border-[color:rgba(229,72,77,0.6)] hover:bg-[color:rgba(229,72,77,0.2)]'
+                : 'inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:rgba(139,151,255,0.32)]'
+            }
+          >
+            {hasBacklinks ? t('confirmWithBacklinks') : t('confirmClean')}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -21,6 +21,8 @@ import { useEphemeralNodes } from "../lib/use-ephemeral-nodes";
 import { useEphemeralEdges } from "../lib/use-ephemeral-edges";
 import { downloadAtlasFrontmatter } from "../lib/export-frontmatter";
 import { downloadGraphML, downloadJsonLd } from "../lib/export-graph";
+import { BlastRadiusConfirm } from "./BlastRadiusConfirm";
+import type { VaultBacklinkMatch } from "../lib/find-vault-backlinks";
 import { findVaultBacklinks } from "../lib/find-vault-backlinks";
 
 /**
@@ -111,6 +113,14 @@ export function OntologyEditPage() {
   // layout 알고리즘 — dagre (default, kind 계층 LR) 또는 force (organic).
   // 헤더 토글로 사용자가 선택. 변경 시 in-memory layout 만 재계산 (frontmatter 그대로).
   const [layoutMode, setLayoutMode] = useState<"dagre" | "force">("dagre");
+  // Blast-radius modal state — driven by deleteVaultDoc requesting a
+  // confirmation. Stays null when the user is not actively confirming a
+  // delete; opens when delete is clicked and resolves on cancel/confirm.
+  const [pendingDelete, setPendingDelete] = useState<{
+    slug: string;
+    title?: string;
+    backlinks: VaultBacklinkMatch[];
+  } | null>(null);
   const toast = useToast();
 
   const saveEphemeral = useCallback(
@@ -297,48 +307,37 @@ export function OntologyEditPage() {
     [t, toast, vault],
   );
 
-  // vault delete — MCP delete_concept 와 같은 정책: backlinks 가 있으면
-  // confirm 단계에서 list 보여주고 사용자가 의식적으로 진행하게. force 플래그
-  // 는 별도 UI 없이 confirm 한 번 — UI 자체가 사용자 의도 게이트.
+  // vault delete — Round 6: window.confirm() → BlastRadiusConfirm modal.
+  // backlinks 를 visual 카드로 보여주고 의식적인 confirm 받음. 데이터는
+  // 이전과 동일 (findVaultBacklinks) — surface 만 풍부한 다이얼로그로 승격
+  // (eval Feature power F5, "launch demo's hero moment").
   const deleteVaultDoc = useCallback(
-    async (slug: string) => {
+    (slug: string) => {
       if (!vault.manifest) return;
       const backlinks = findVaultBacklinks(vault.manifest, slug);
-      const preview = backlinks
-        .slice(0, 3)
-        .map((b) => b.slug)
-        .join(", ");
-      const rest =
-        backlinks.length > 3
-          ? t("confirmDeleteWithBacklinksRest", { count: backlinks.length - 3 })
-          : "";
-      const message =
-        backlinks.length > 0
-          ? t("confirmDeleteWithBacklinks", {
-              slug,
-              count: backlinks.length,
-              preview,
-              rest,
-            })
-          : t("confirmDelete", { slug });
-      // 정적 export + WebGL 캔버스 환경 — 가장 단순한 confirm dialog 가
-      // SSR/hydration 위험 없음. modal UI 는 후속 PR 에서 OntologyEditPage 자체
-      // dialog 컴포넌트로 통합 가능.
-      if (typeof window !== "undefined" && !window.confirm(message)) return;
-      setRenamingId(slug);
-      try {
-        await vault.deleteDoc(slug);
-        toast.show(t("toastDeleteSuccess", { slug }), "success");
-        setSelectedId(null);
-      } catch (err) {
-        const m = err instanceof Error ? err.message : t("toastDeleteFailed");
-        toast.show(m, "error");
-      } finally {
-        setRenamingId(null);
-      }
+      const doc = vault.manifest.docs.find((d) => d.slug === slug);
+      setPendingDelete({ slug, title: doc?.title, backlinks });
     },
-    [t, toast, vault],
+    [vault],
   );
+
+  // Modal 의 confirm 버튼이 눌린 후 실제 delete 수행.
+  const confirmPendingDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const { slug } = pendingDelete;
+    setPendingDelete(null);
+    setRenamingId(slug);
+    try {
+      await vault.deleteDoc(slug);
+      toast.show(t("toastDeleteSuccess", { slug }), "success");
+      setSelectedId(null);
+    } catch (err) {
+      const m = err instanceof Error ? err.message : t("toastDeleteFailed");
+      toast.show(m, "error");
+    } finally {
+      setRenamingId(null);
+    }
+  }, [pendingDelete, t, toast, vault]);
 
   const treeHref = accountId
     ? `/ontology/?${ACCOUNT_QUERY_KEY}=${encodeURIComponent(accountId)}`
@@ -640,6 +639,14 @@ export function OntologyEditPage() {
           </div>
         </section>
       </main>
+      <BlastRadiusConfirm
+        open={pendingDelete !== null}
+        slug={pendingDelete?.slug ?? ""}
+        title={pendingDelete?.title}
+        backlinks={pendingDelete?.backlinks ?? []}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => void confirmPendingDelete()}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

eval Feature power F5 — **"launch demo's hero moment"**. `window.confirm()` → 풍부한 visual modal 로 승격. backlinks 데이터는 이미 `find-vault-backlinks.ts` 에 있었고 surface 만 카드 형태로.

### 신규 컴포넌트 `BlastRadiusConfirm`

`src/views/ontology-edit/ui/BlastRadiusConfirm.tsx`

- `aria-modal` dialog, **Esc to cancel**, click outside cancel
- **Auto-focus cancel button** (실수로 Enter 눌러도 destructive delete 방지 — browser `confirm()` 의 default-no 미러)
- **Header**: AlertTriangle (backlinks 있으면 빨간 톤, 없으면 amber) + title with count interpolation + close X
- **Body**: 영향 노드 카드 리스트 — slug + title + matchedKeys mono chip. 최대 8 preview, 더 많으면 "and N more". scrollable
- **Footer**: Cancel + Delete. backlinks 있으면 Delete 빨간 강조

### OntologyEditPage 통합

- `pendingDelete` state — `{ slug, title, backlinks } | null`
- `deleteVaultDoc` 즉시 delete 안 하고 modal 열기
- `confirmPendingDelete`: modal Confirm 시 실제 `vault.deleteDoc`
- `BlastRadiusConfirm` 마운트 (main 끝)

### i18n (11 keys × 2 locales)

`ontologyPages.edit.page.blastRadius.*` — titleClean/WithBacklinks, body, hint, moreCount, cancel, confirmClean/WithBacklinks, closeAriaLabel.

이전 `confirmDelete*` key 는 보존 (다른 callsite 보호용) — 이번 modal 만 신규 keys.

## Verification

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test:run` — 101 files / 726 tests pass

## Deferred (별도 PR)

- 글로벌 ⌘K command palette 승격 (DocsVaultUnifiedPalette → app-wide) — architectural change, safer as separate PR
- `/ontology/changes` 7-day diff (git-backed)
- Typed query DSL + 12번째 MCP tool
- Live mini-Sigma hero on landing

## PR chain

```
main
 └─ #111 → #112 → #113 → #114 → #115 → #116 → #117 → #118 ← this
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)