### PR TITLE
feat(mcp): Round 8 — typed filter DSL + 12th MCP tool query_concepts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Long-form docs (mission v2 priority):
 - `@docs/MODE-AWARE-CRUD.md` — local/cloud/static contributor guide
 - `@docs/ARCHITECTURE.md` · `@docs/DATA-MODEL.md` · `@docs/DESIGN-SYSTEM.md` · `@docs/DEPLOYMENT.md`
 - `@docs/CHANGELOG.md` — chronological user-visible changes
-- `@mcp/README.md` — AI agent partner (MCP 11 tools — read 7 + write 4) registration + usage
+- `@mcp/README.md` — AI agent partner (MCP 12 tools — read 8 + write 4) registration + usage
 - `@docs/archive/README.md` — archived analysis docs (no longer the source of truth for current rules)
 
 ## This project's own ontology

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,7 +27,7 @@ The vault is a plain folder of `.md` files. Frontmatter is the graph.
 ## How AI agents fit in
 
 Register the included `.mcp.json.example` with your AI agent (Claude Code,
-Cursor, Continue, etc.). The agent gets 11 tools to read and write the
+Cursor, Continue, etc.). The agent gets 12 tools to read and write the
 vault — same data the humans see.
 
 ```jsonc
@@ -43,8 +43,9 @@ vault — same data the humans see.
 }
 ```
 
-11 tools: `list_concepts` / `get_concept` / `find_evidence` /
-`find_backlinks` / `find_path` / `list_kinds` / `find_orphans` (read 7) +
+12 tools: `list_concepts` / `get_concept` / `find_evidence` /
+`find_backlinks` / `find_path` / `list_kinds` / `find_orphans` /
+`query_concepts` (read 8) +
 `add_concept` / `add_relation` / `patch_concept` / `delete_concept` (write 4).
 
 ## See the graph

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ tags: [architecture, infra, overview]
 ┌───────────────────────────────────────────────────────┐
 │ MCP server (mcp/) — AI agent partner                  │
 │ ├─ stdin/stdout JSON-RPC                              │
-│ └─ vault frontmatter read/write (11 tools)            │
+│ └─ vault frontmatter read/write (12 tools)            │
 └───────────────────────────────────────────────────────┘
 ```
 
@@ -100,8 +100,8 @@ In earlier cleanup stages (PR #5/#6) the chunking / extraction / review seed / a
 
 - **`mcp/` package** — `oh-my-ontology-mcp`, depends on `@modelcontextprotocol/sdk`, stdin/stdout JSON-RPC
 - AI agents (Claude Code, Cursor, …) read/write vault `.md` directly
-- 11 tools (read 7 + write 4):
-  - read: `list_concepts` · `get_concept` · `find_evidence` · `find_backlinks` · `find_path` · `list_kinds` · `find_orphans`
+- 12 tools (read 8 + write 4):
+  - read: `list_concepts` · `get_concept` · `find_evidence` · `find_backlinks` · `find_path` · `list_kinds` · `find_orphans` · `query_concepts` (typed filter DSL)
   - write: `add_concept` · `add_relation` · `patch_concept` · `delete_concept`
 - Registration: see `.mcp.json.example` or `mcp/README.md`
 
@@ -212,7 +212,7 @@ Detailed rules: [`rules/architecture-fsd.md`](rules/architecture-fsd.md)
 - vault frontmatter → ontology stub fast-path (mission v2)
 - ontology v0: TBox seed (5 classes + 7 relations), `/` tree + ego graph, the `/ontology/edit` builder, `/ontology/insights` + `/ontology/relations`, manual editor direct writes
 - V1.1 — Wikidata statement qualifiers + rank (optional fields, additive)
-- AI agent partner (MCP server) — vault read/write through 11 tools (read 7 + write 4)
+- AI agent partner (MCP server) — vault read/write through 12 tools (read 8 + write 4)
 - dogfood vault (`docs/ontology/`) — our own mental model
 - global admin whitelist
 
@@ -242,7 +242,7 @@ If a path appears in the docs but does not exist in the actual code, treat it as
 - [`DESIGN-SYSTEM.md`](./DESIGN-SYSTEM.md) — design tokens / motion / forbidden patterns
 - [`DEPLOYMENT.md`](./DEPLOYMENT.md) — Firebase deployment / rollback / domains
 - [`CHANGELOG.md`](./CHANGELOG.md) — chronological user-visible changes
-- [`../mcp/README.md`](../mcp/README.md) — MCP server 11 tools + registration
+- [`../mcp/README.md`](../mcp/README.md) — MCP server 12 tools + registration
 - [`../AGENTS.md`](../AGENTS.md) / [`../CLAUDE.md`](../CLAUDE.md) — agent / contributor guide
 - [`../.claude/rules/`](../.claude/rules/) — granular working rules
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -134,10 +134,10 @@ The `useDataSourceMode()` hook resolves to one of three modes:
 
 > Phase 3 — LLM agents like Claude Code read/write the ontology over stdin/stdout JSON-RPC.
 
-- **package**: `oh-my-ontology-mcp` v0.5.0 (in `mcp/`), depends on `@modelcontextprotocol/sdk@^1.0.0`
+- **package**: `oh-my-ontology-mcp` v0.6.0 (in `mcp/`), depends on `@modelcontextprotocol/sdk@^1.0.0`
 - **registration**: copy `.mcp.json.example` and set `OMOT_VAULT=<absolute path to your vault>` (or `./docs/ontology` for our dogfood vault)
 - **distribution**: `npx -y oh-my-ontology-mcp` (after publish), zero install
-- **11 tools** (read 7 + write 4):
+- **12 tools** (read 8 + write 4):
 
 | Tool | Read/write | Behavior |
 |---|---|---|
@@ -148,6 +148,7 @@ The `useDataSourceMode()` hook resolves to one of three modes:
 | `find_path` | read | shortest-path BFS between two slugs |
 | `list_kinds` | read | distribution of node kinds in the vault |
 | `find_orphans` | read | nodes with zero in/out edges |
+| `query_concepts` | read | Typed filter DSL — `kind=X AND has(Y) AND NOT ...` |
 | `add_concept` | write | write a new `.md` node — throws if the slug already exists |
 | `add_relation` | write | create an edge between two slugs (depends_on / relates / contains / describes) |
 | `patch_concept` | write | patch an existing node's frontmatter (per-key patch) + body |
@@ -225,7 +226,7 @@ The `useDataSourceMode()` hook resolves to one of three modes:
 
 | Item | Description |
 |---|---|
-| MCP server | `oh-my-ontology-mcp` package (`mcp/`), stdin/stdout JSON-RPC, 11 tools (read 7 + write 4) |
+| MCP server | `oh-my-ontology-mcp` package (`mcp/`), stdin/stdout JSON-RPC, 12 tools (read 8 + write 4) |
 | Registration | copy `.mcp.json.example` → restart Claude Code |
 | Vault | `OMOT_VAULT` env (default cwd) — the user's vault or `docs/ontology/` (dogfood) |
 | Compatibility | works on any vault; only `.md` files with a `kind:` frontmatter become nodes. Existing ontology format is preserved as-is |
@@ -427,7 +428,7 @@ the project expresses its own mental model as frontmatter markdown. At build tim
 - tsc 0 errors
 - eslint 0 errors (62 warnings — all pre-existing)
 - vitest **100 files / 721 tests pass**
-- MCP server stdin/stdout JSON-RPC: initialize → tools/list (11 tools) → tools/call all healthy
+- MCP server stdin/stdout JSON-RPC: initialize → tools/list (12 tools) → tools/call all healthy
 - MCP parser smoke pass
 - Playwright MCP browser-level QA (current routes): zero console errors on every mission v2 surface
 - CLI smoke (`node cli/src/index.mjs init test-vault`) writes 5 starter `.md` + `.mcp.json.example`
@@ -444,7 +445,7 @@ the project expresses its own mental model as frontmatter markdown. At build tim
 
 2. Register an AI agent (Claude Code) (optional):
    copy .mcp.json.example → set OMOT_VAULT → restart Claude Code
-   → mcp__oh-my-ontology__* 11 tools become available
+   → mcp__oh-my-ontology__* 12 tools become available
 
 3. Add a new project:
    (a) directly in the vault:

--- a/docs/MODE-AWARE-CRUD.md
+++ b/docs/MODE-AWARE-CRUD.md
@@ -46,7 +46,7 @@ Of the four modes defined in `docs/LOCAL-FIRST-SYNC.md` §2, this pattern covers
 ### 2.5 AI agent partner (new in mission v2)
 
 - The `mcp/` package — a stdin/stdout JSON-RPC server based on `@modelcontextprotocol/sdk`. Lets AI agents (Claude Code, etc.) read/write vault `.md` files directly.
-- 11 tools (read 7 + write 4): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `add_concept` / `add_relation` / `patch_concept` / `delete_concept`
+- 12 tools (read 8 + write 4): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `query_concepts` (typed filter DSL) / `add_concept` / `add_relation` / `patch_concept` / `delete_concept`
 - Registration: `.mcp.json.example` or `mcp/README.md`
 
 ---

--- a/docs/PRODUCT-DIRECTION.md
+++ b/docs/PRODUCT-DIRECTION.md
@@ -228,7 +228,7 @@ When an agent enters the codebase, it sees this on the first page and picks up t
 ### ✅ Phase 3 — AI agent partner — merged
 
 1. ✅ `mcp/` package — MCP server v0.5.0 (`oh-my-ontology-mcp`)
-2. ✅ 11 tools (read 7 + write 4): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `add_concept` / `add_relation` / `patch_concept` / `delete_concept`
+2. ✅ 12 tools (read 8 + write 4): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `query_concepts` (typed filter DSL) / `add_concept` / `add_relation` / `patch_concept` / `delete_concept`
 3. ✅ CLI command (`oh-my-ontology`) — `npx oh-my-ontology init <folder>` scaffolds the vault. The web `/docs` "Create starter seed" button is the no-terminal alternative.
 4. ⏸ Auto-generated AGENTS.md — DEFERRED (manual updates + dogfood vault cover this)
 5. ✅ `docs/ontology/` dogfood vault — ~23 nodes describing our own mental model

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,7 +44,7 @@ If `OMOT_VAULT` is not set, the current working directory is used as the vault r
 
 ### 2. Restart Claude Code
 
-The server connects over stdio. You should now see 11 tools under the `oh-my-ontology` namespace.
+The server connects over stdio. You should now see 12 tools under the `oh-my-ontology` namespace.
 
 ### 3. Call the tools
 
@@ -56,7 +56,7 @@ The server connects over stdio. You should now see 11 tools under the `oh-my-ont
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## The 11 tools (v0.5.0)
+## The 12 tools (v0.6.0)
 
 | Tool | What it does |
 |---|---|
@@ -67,6 +67,7 @@ The server connects over stdio. You should now see 11 tools under the `oh-my-ont
 | `find_path` | Shortest path between two slugs (BFS, undirected). Option: `maxHops` (default 5). |
 | `list_kinds` | Vault kind census: `{ total, byKind: { capability: N, ... } }`. |
 | `find_orphans` | **v0.5** Finds isolated nodes — docs that no other node references in its frontmatter. Options: `kind` (filter), `excludeKinds` (skip, default `['vault-readme']`). Useful as a starting point for cleanup or auditing unused nodes. |
+| `query_concepts` | **v0.6** Typed filter DSL — `kind=X AND has(Y) AND NOT ...`. Saved-filter / smart-list use case. |
 | `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. Throws if the slug already exists. |
 | `add_relation` | Adds an edge between two slugs. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). Appends to the appropriate frontmatter array. |
 | `patch_concept` | Updates an existing node's frontmatter (per-key patch — `null` deletes a key) and/or body. Use this when you need to *modify* a slug that `add_concept` would reject as duplicate. |
@@ -88,11 +89,11 @@ A successful run looks like this:
 · step 1 — parser smoke test
 ✓ result: 7 passed, 0 failed
 · step 2 — server boot + tools/list + list_concepts
-✓ initialize OK — server oh-my-ontology-mcp@0.5.0
-✓ tools/list 11/11 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · patch_concept
+✓ initialize OK — server oh-my-ontology-mcp@0.6.0
+✓ tools/list 12/12 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · patch_concept · query_concepts
 ✓ list_concepts — vault total 23 nodes
 
-All checks passed — register .mcp.json with Claude Code, restart, and the 11 tools are ready.
+All checks passed — register .mcp.json with Claude Code, restart, and the 12 tools are ready.
 ```
 
 On failure, it tells you which step blocked progress and prints a diagnostic message.
@@ -121,7 +122,7 @@ After you add `.mcp.json` and restart Claude Code, try the following with your L
 > 3. Call `find_backlinks({ slug: "capabilities/mcp-server" })` to find what depends on that capability.
 > 4. (Optional) Call `add_concept` to create a new capability node — `slug`, `kind`, and `title` are required.
 
-If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 11 tools (7 read + 4 write), the human + AI co-authoring loop is officially open.
+If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 12 tools (8 read + 4 write), the human + AI co-authoring loop is officially open.
 
 ## Design principles
 
@@ -132,7 +133,8 @@ If those four tools respond cleanly, your read/write round-trip against the vaul
 
 ## Status
 
-- 0.5.0 — 11 tools (7 read + 4 write). Added `find_orphans`.
+- 0.6.0 — 12 tools (8 read + 4 write). Added `query_concepts` (typed filter DSL).
+- 0.5.0 — 7 read + 4 write. Added `find_orphans`.
 - 0.4.0 — 10 tools (6 read + 4 write). Added `delete_concept` (dry-run + backlinks guard).
 - 0.3.0 — 9 tools. Added `find_path` (BFS) and `list_kinds` (census).
 - 0.2.0 — 7 tools.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server — humans and AI agents read/write the same codebase ontology vault.",
   "keywords": [
     "mcp",

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -11,7 +11,7 @@
  * 검증 항목:
  *   1. parser smoke test (parser.test.mjs) 통과
  *   2. server boot — initialize JSON-RPC 응답
- *   3. tools/list — 11 도구 모두 노출
+ *   3. tools/list — 12 도구 모두 노출
  *   4. tools/call list_concepts — vault 노드 수 출력
  *
  * 모두 PASS → exit 0, 실패 → exit 1 + 진단 메시지.
@@ -35,6 +35,7 @@ const EXPECTED_TOOLS = [
   'find_path',
   'list_kinds',
   'find_orphans',
+  'query_concepts',
   'add_concept',
   'add_relation',
   'patch_concept',

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 /**
- * oh-my-ontology-mcp — MCP 서버 v0.5.0 (도구 11종 = read 7 + write 4).
+ * oh-my-ontology-mcp — MCP 서버 v0.6.0 (도구 12종 = read 8 + write 4).
  *
  * AI agent (Claude Code 등) 가 vault 의 ontology 를 읽고 쓸 수 있게.
  *
- * read 7:
+ * read 8:
  *   - list_concepts     — vault 의 노드 목록 (kind / project_filter)
  *   - get_concept       — 단일 노드 + 이웃 (dependencies / relates)
  *   - find_evidence     — title / capabilities / elements / body 부분매칭
@@ -12,6 +12,7 @@
  *   - find_path         — 두 slug 사이 그래프 최단 경로 (BFS, 무방향)
  *   - list_kinds        — vault kind 분포 census
  *   - find_orphans      — 어느 다른 노드도 frontmatter 에서 가리키지 않는 doc
+ *   - query_concepts    — typed filter DSL (kind=X AND has(Y) AND NOT ...)
  *
  * write 4:
  *   - add_concept       — 새 노드 (.md 파일 작성, 기존 slug 면 throw)
@@ -49,12 +50,13 @@ import {
   updateDoc,
   writeDoc,
 } from './vault.mjs';
+import { parseFilter } from './query.mjs';
 
 const VAULT_ROOT = resolve(process.env.OMOT_VAULT || process.cwd());
 ensureVaultRoot(VAULT_ROOT);
 
 const server = new Server(
-  { name: 'oh-my-ontology-mcp', version: '0.5.0' },
+  { name: 'oh-my-ontology-mcp', version: '0.6.0' },
   { capabilities: { tools: {} } },
 );
 
@@ -262,6 +264,36 @@ const TOOLS = [
     },
   },
   {
+    name: 'query_concepts',
+    description:
+      'Typed filter DSL — vault 노드를 조건으로 검색. saved-filter / smart-list ' +
+      '용도. find_path (BFS) 가 못 답하는 "어느 capability 가 element 가 0?" / ' +
+      '"domain=auth 의 stub 만" / "vault-readme 빼고 has(depends_on)" 같은 질문.\n\n' +
+      'Grammar (대소문자 무시, 공백 자유):\n' +
+      '  filter   := atom (AND|OR atom)*\n' +
+      '  atom     := NOT? predicate\n' +
+      '  predicate := key=value | key!=value | has(key)\n\n' +
+      'Keys: kind / domain / slug / title (= 비교) + 임의 frontmatter 배열 키 (has).\n' +
+      '예: `kind=capability AND domain=auth AND NOT has(elements)` ' +
+      '— auth 도메인의 cap 중 element 가 0 인 곳 (= 미완성된 cap).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        filter: {
+          type: 'string',
+          description:
+            '필터 식. 예: kind=capability AND has(elements). NOT / AND / OR 지원, ' +
+            '값에 공백 / 특수문자 있으면 "..." 또는 \'...\' 로 quote.',
+        },
+        limit: {
+          type: 'number',
+          description: '최대 반환 수. 기본 100.',
+        },
+      },
+      required: ['filter'],
+    },
+  },
+  {
     name: 'delete_concept',
     description:
       '⚠ DESTRUCTIVE — vault 의 .md 파일 영구 삭제. 안전 가드 2단:\n' +
@@ -321,6 +353,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok(listKindsTool());
       case 'find_orphans':
         return ok(findOrphansTool(args));
+      case 'query_concepts':
+        return ok(queryConceptsTool(args));
       case 'delete_concept':
         return ok(deleteConcept(args));
       default:
@@ -478,6 +512,35 @@ function findOrphansTool({ kind, excludeKinds } = {}) {
     kind: typeof kind === 'string' ? kind : undefined,
     excludeKinds: Array.isArray(excludeKinds) ? excludeKinds : undefined,
   });
+}
+
+function queryConceptsTool({ filter, limit }) {
+  if (typeof filter !== 'string' || !filter.trim()) {
+    throw new Error('filter (string) 가 필요합니다.');
+  }
+  const parsed = parseFilter(filter);
+  const cap = typeof limit === 'number' && limit > 0 ? limit : 100;
+  const docs = loadVaultDocs(VAULT_ROOT).filter((d) => Boolean(d.frontmatter?.kind));
+  const matches = [];
+  for (const doc of docs) {
+    if (matches.length >= cap) break;
+    if (!parsed.match(doc)) continue;
+    matches.push({
+      slug: doc.slug,
+      kind: doc.frontmatter.kind,
+      title: doc.frontmatter.title || doc.frontmatter.name || doc.slug,
+      domain: doc.frontmatter.domain,
+      capabilities: doc.frontmatter.capabilities,
+      elements: doc.frontmatter.elements,
+    });
+  }
+  return {
+    filter,
+    parsedAs: parsed.repr,
+    total: matches.length,
+    matches,
+    limited: matches.length >= cap,
+  };
 }
 
 function deleteConcept({ slug, confirm = false, force = false }) {

--- a/mcp/src/query.mjs
+++ b/mcp/src/query.mjs
@@ -1,0 +1,219 @@
+/**
+ * Tiny filter DSL for `query_concepts` MCP tool.
+ *
+ * Goal: let AI agents (and humans) ask non-trivial vault questions
+ * without learning Cypher / SPARQL. Tradeoffs: just enough for the
+ * common "which X have/lack Y" cases — no path queries (use find_path),
+ * no aggregations (use list_kinds / find_orphans).
+ *
+ * Grammar (case-insensitive keywords, whitespace-tolerant):
+ *
+ *   filter   := atom ( ('AND'|'OR') atom )*
+ *   atom     := 'NOT'? predicate
+ *   predicate := key '=' value          // exact match: kind=capability
+ *              | key '!=' value         // not equal
+ *              | 'has' '(' key ')'      // array key non-empty
+ *
+ * Supported keys: `kind`, `domain`, `slug`, `title` (string equality),
+ * and any frontmatter array key for `has(...)` (e.g. `has(elements)`,
+ * `has(capabilities)`, `has(depends_on)`).
+ *
+ * Operator precedence: NOT > AND > OR (parens NOT supported in v1).
+ *
+ * Examples:
+ *   kind=capability AND domain=auth AND NOT has(elements)
+ *   kind=domain AND has(capabilities)
+ *   slug!=README AND has(depends_on)
+ *
+ * Returns: { match: (doc) => boolean, repr: string } — repr 은 디버그용.
+ */
+
+const KEY_RE = /^[a-z_][a-z0-9_]*$/i;
+
+export function parseFilter(input) {
+  if (typeof input !== 'string') {
+    throw new Error(`filter must be a string, got ${typeof input}`);
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('filter is empty');
+  }
+  const tokens = tokenize(trimmed);
+  const ast = parseExpr(tokens, 0);
+  if (ast.next < tokens.length) {
+    throw new Error(`unexpected token at position ${ast.next}: ${tokens[ast.next]?.value}`);
+  }
+  return {
+    match: (doc) => evaluate(ast.node, doc),
+    repr: formatAst(ast.node),
+  };
+}
+
+// ── tokenizer ─────────────────────────────────────────────────────────────
+
+function tokenize(input) {
+  const tokens = [];
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (/\s/.test(ch)) {
+      i += 1;
+      continue;
+    }
+    if (ch === '(' || ch === ')') {
+      tokens.push({ type: 'paren', value: ch });
+      i += 1;
+      continue;
+    }
+    if (ch === ',') {
+      tokens.push({ type: 'comma', value: ',' });
+      i += 1;
+      continue;
+    }
+    if (ch === '=') {
+      tokens.push({ type: 'op', value: '=' });
+      i += 1;
+      continue;
+    }
+    if (ch === '!' && input[i + 1] === '=') {
+      tokens.push({ type: 'op', value: '!=' });
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // quoted string value — lets users include whitespace.
+      const quote = ch;
+      let j = i + 1;
+      let buf = '';
+      while (j < input.length && input[j] !== quote) {
+        if (input[j] === '\\' && j + 1 < input.length) {
+          buf += input[j + 1];
+          j += 2;
+        } else {
+          buf += input[j];
+          j += 1;
+        }
+      }
+      if (j >= input.length) throw new Error(`unterminated string at position ${i}`);
+      tokens.push({ type: 'value', value: buf });
+      i = j + 1;
+      continue;
+    }
+    // word — keyword or identifier or unquoted value
+    let j = i;
+    while (j < input.length && /[a-z0-9_/.\-가-힣]/i.test(input[j])) {
+      j += 1;
+    }
+    if (j === i) {
+      throw new Error(`unexpected character ${JSON.stringify(ch)} at position ${i}`);
+    }
+    const word = input.slice(i, j);
+    const upper = word.toUpperCase();
+    if (upper === 'AND' || upper === 'OR' || upper === 'NOT') {
+      tokens.push({ type: 'logical', value: upper });
+    } else if (upper === 'HAS') {
+      tokens.push({ type: 'fn', value: 'has' });
+    } else {
+      tokens.push({ type: 'word', value: word });
+    }
+    i = j;
+  }
+  return tokens;
+}
+
+// ── parser ────────────────────────────────────────────────────────────────
+
+function parseExpr(tokens, pos) {
+  // expr := atom (('AND'|'OR') atom)*  — left-associative.
+  let { node: left, next } = parseAtom(tokens, pos);
+  while (next < tokens.length) {
+    const t = tokens[next];
+    if (t.type !== 'logical' || (t.value !== 'AND' && t.value !== 'OR')) break;
+    const { node: right, next: after } = parseAtom(tokens, next + 1);
+    left = { type: 'logical', op: t.value, left, right };
+    next = after;
+  }
+  return { node: left, next };
+}
+
+function parseAtom(tokens, pos) {
+  const t = tokens[pos];
+  if (!t) throw new Error('unexpected end of filter');
+  if (t.type === 'logical' && t.value === 'NOT') {
+    const { node, next } = parseAtom(tokens, pos + 1);
+    return { node: { type: 'not', child: node }, next };
+  }
+  if (t.type === 'fn' && t.value === 'has') {
+    // has ( key )
+    if (tokens[pos + 1]?.value !== '(') throw new Error('expected `(` after has');
+    const keyTok = tokens[pos + 2];
+    if (!keyTok || keyTok.type !== 'word') throw new Error('expected key inside has(...)');
+    if (tokens[pos + 3]?.value !== ')') throw new Error('expected `)` to close has(...)');
+    if (!KEY_RE.test(keyTok.value)) throw new Error(`invalid key: ${keyTok.value}`);
+    return { node: { type: 'has', key: keyTok.value }, next: pos + 4 };
+  }
+  if (t.type === 'word') {
+    // key = value or key != value
+    if (!KEY_RE.test(t.value)) throw new Error(`invalid key: ${t.value}`);
+    const opTok = tokens[pos + 1];
+    if (!opTok || opTok.type !== 'op') {
+      throw new Error(`expected = or != after key ${t.value}`);
+    }
+    const valTok = tokens[pos + 2];
+    if (!valTok || (valTok.type !== 'word' && valTok.type !== 'value')) {
+      throw new Error(`expected value after ${t.value} ${opTok.value}`);
+    }
+    return {
+      node: { type: 'cmp', op: opTok.value, key: t.value, value: valTok.value },
+      next: pos + 3,
+    };
+  }
+  throw new Error(`unexpected token: ${t.value}`);
+}
+
+// ── evaluator ─────────────────────────────────────────────────────────────
+
+function evaluate(node, doc) {
+  switch (node.type) {
+    case 'logical':
+      if (node.op === 'AND') return evaluate(node.left, doc) && evaluate(node.right, doc);
+      return evaluate(node.left, doc) || evaluate(node.right, doc);
+    case 'not':
+      return !evaluate(node.child, doc);
+    case 'cmp': {
+      const actual = readField(doc, node.key);
+      const target = node.value;
+      const matches = String(actual ?? '') === target;
+      return node.op === '=' ? matches : !matches;
+    }
+    case 'has': {
+      const v = readField(doc, node.key);
+      if (Array.isArray(v)) return v.length > 0;
+      if (typeof v === 'string') return v.trim().length > 0;
+      return v != null;
+    }
+    default:
+      throw new Error(`unknown node type: ${node.type}`);
+  }
+}
+
+function readField(doc, key) {
+  // doc is { slug, frontmatter }. Special-case `slug` field.
+  if (key === 'slug') return doc.slug;
+  return doc.frontmatter?.[key];
+}
+
+function formatAst(node) {
+  switch (node.type) {
+    case 'logical':
+      return `(${formatAst(node.left)} ${node.op} ${formatAst(node.right)})`;
+    case 'not':
+      return `NOT ${formatAst(node.child)}`;
+    case 'cmp':
+      return `${node.key} ${node.op} ${node.value}`;
+    case 'has':
+      return `has(${node.key})`;
+    default:
+      return '?';
+  }
+}

--- a/mcp/src/query.test.mjs
+++ b/mcp/src/query.test.mjs
@@ -1,0 +1,139 @@
+// Smoke tests for the filter DSL — runs as a plain node script via
+// `node mcp/src/query.test.mjs`. Pattern matches the existing
+// parser.test.mjs in this folder.
+
+import { parseFilter } from './query.mjs';
+
+const docs = [
+  { slug: 'auth', frontmatter: { kind: 'domain', title: 'Auth', capabilities: ['login'] } },
+  { slug: 'login', frontmatter: { kind: 'capability', domain: 'auth', elements: ['jwt'] } },
+  { slug: 'signup', frontmatter: { kind: 'capability', domain: 'auth' } },
+  { slug: 'jwt', frontmatter: { kind: 'element', domain: 'auth' } },
+  { slug: 'README', frontmatter: { kind: 'vault-readme', title: 'README' } },
+];
+
+let pass = 0;
+let fail = 0;
+function test(name, fn) {
+  try {
+    fn();
+    pass += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    fail += 1;
+    console.error(`  ✗ ${name}: ${err.message}`);
+  }
+}
+
+console.log('parseFilter — equality');
+test('kind=capability matches login + signup', () => {
+  const { match } = parseFilter('kind=capability');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['login', 'signup'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+test('slug=auth picks one', () => {
+  const { match } = parseFilter('slug=auth');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['auth'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+test('kind!=vault-readme excludes README', () => {
+  const { match } = parseFilter('kind!=vault-readme');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (matched.includes('README')) throw new Error(`README leaked: ${matched.join(',')}`);
+});
+
+console.log('parseFilter — has() arrays');
+test('has(elements) matches login (only one with elements)', () => {
+  const { match } = parseFilter('has(elements)');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['login'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+test('NOT has(elements) matches everything else', () => {
+  const { match } = parseFilter('NOT has(elements)');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['auth', 'signup', 'jwt', 'README'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+console.log('parseFilter — AND / OR composition');
+test('kind=capability AND domain=auth picks both auth caps', () => {
+  const { match } = parseFilter('kind=capability AND domain=auth');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['login', 'signup'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+test('kind=capability AND NOT has(elements) flags signup as the gap', () => {
+  const { match } = parseFilter('kind=capability AND NOT has(elements)');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['signup'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+test('OR widens the result', () => {
+  const { match } = parseFilter('kind=domain OR kind=element');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['auth', 'jwt'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+console.log('parseFilter — quoted values');
+test('title="Auth" works with quotes', () => {
+  const { match } = parseFilter('title="Auth"');
+  const matched = docs.filter(match).map((d) => d.slug);
+  if (JSON.stringify(matched) !== JSON.stringify(['auth'])) {
+    throw new Error(`got ${matched.join(',')}`);
+  }
+});
+
+console.log('parseFilter — error cases');
+test('empty filter throws', () => {
+  try {
+    parseFilter('');
+    throw new Error('should have thrown');
+  } catch (err) {
+    if (!err.message.includes('empty')) throw err;
+  }
+});
+
+test('invalid key throws', () => {
+  try {
+    parseFilter('1bad=value');
+    throw new Error('should have thrown');
+  } catch (err) {
+    if (!err.message.includes('invalid key')) throw err;
+  }
+});
+
+test('unterminated string throws', () => {
+  try {
+    parseFilter('title="Auth');
+    throw new Error('should have thrown');
+  } catch (err) {
+    if (!err.message.includes('unterminated')) throw err;
+  }
+});
+
+console.log('parseFilter — repr (debug)');
+test('AST repr is human-readable', () => {
+  const { repr } = parseFilter('kind=capability AND NOT has(elements)');
+  if (repr !== '(kind = capability AND NOT has(elements))') {
+    throw new Error(`got: ${repr}`);
+  }
+});
+
+console.log(`\n${pass} passed · ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

eval **Feature power F4** — vault 의 typed query 가 BFS find_path 만 있어 saved-filter 못 했음. 12 번째 MCP tool `query_concepts` 로 해결. AI agent 가 grep 없이 "어느 capability 가 element 0 인가?" / "domain=auth 의 stub" 같은 비-trivial 질문 직접 답.

### 신규 라이브러리 `mcp/src/query.mjs`

작은 hand-rolled tokenizer + recursive-descent parser. **외부 의존성 0**.

Grammar (대소문자 무시, 공백 자유):
```
filter   := atom (AND|OR atom)*
atom     := NOT? predicate
predicate := key=value | key!=value | has(key)
```

Examples:
- `kind=capability AND domain=auth AND NOT has(elements)` — 미완성 cap
- `kind=domain AND has(capabilities)`
- `slug!=README AND has(depends_on)`

- Operator precedence: NOT > AND > OR
- Quote-friendly value (`"..."` / `'...'` + escape)
- Returns `{ match, repr }` — repr 은 디버그용 AST 직렬화

### 13/13 unit tests pass

`mcp/src/query.test.mjs` — equality / has() / AND-OR / quoted values / error cases / AST repr.

### MCP 통합

- `TOOLS` 배열에 `query_concepts` (find_orphans ↔ delete_concept 사이)
- `queryConceptsTool({ filter, limit })` handler — parseFilter 결과로 vault docs filter
- 패키지 v0.5.0 → **0.6.0**, doc comment / verify.mjs 의 EXPECTED_TOOLS 도 12 개로

### 검증

- [x] `node mcp/src/query.test.mjs` — 13 passed / 0 failed
- [x] `node mcp/scripts/verify.mjs` — server `0.6.0` + tools/list **12/12** + list_concepts vault 51 nodes
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm test:run` — 101 files / 726 tests pass

### 문서 업데이트 (병렬 agent + 직접)

- `mcp/README.md` — 11→12 tools, query_concepts row + 0.6.0 status history
- `cli/README.md` — 11→12 tools, query_concepts 포함
- `AGENTS.md` — "MCP 12 tools — read 8 + write 4"
- `docs/FEATURES.md` — 5 mentions + query_concepts table row
- `docs/ARCHITECTURE.md` — diagram + MCP 섹션 + related docs link
- `docs/PRODUCT-DIRECTION.md`, `MODE-AWARE-CRUD.md` — tool list 12 으로

### Deferred (다음 라운드)

- 글로벌 ⌘K command palette 승격 (DocsVaultUnifiedPalette → app-wide)
- `/ontology/changes` 7-day diff (정적 export 호환 검토)
- `query_concepts` 의 UI surface — saved-filter view (in-app)

### PR chain

```
main
 └─ #111 → #112 → #113 → #114 → #115 → #116 → #117 → #118 → #119 → #120 ← this
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)