### PR TITLE
fix: round 9a — T0 silent-breakage blockers (vault edit / firebase leak / locale Link / canvas i18n)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -793,6 +793,7 @@
     "edit": {
       "page": {
         "canvasLoading": "Loading canvas…",
+        "untitledPlaceholder": "(enter a name)",
         "eyebrow": "Ontology Builder",
         "title": "Ontology Builder",
         "helpAriaLabel": "Builder help",
@@ -857,7 +858,15 @@
       },
       "canvas": {
         "ephemeralEdgeLabel": "related (ephemeral)",
-        "emptyHint": "Click a kind in the left palette to create your first node."
+        "emptyHint": "Click a kind in the left palette to create your first node.",
+        "edgeLabels": {
+          "capabilities": "capability",
+          "elements": "element",
+          "dependencies": "depends",
+          "relates": "relates",
+          "contains": "contains",
+          "describes": "describes"
+        }
       },
       "inspector": {
         "ariaLabel": "Selected ontology node detail",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -793,6 +793,7 @@
     "edit": {
       "page": {
         "canvasLoading": "캔버스 불러오는 중…",
+        "untitledPlaceholder": "(이름 입력)",
         "eyebrow": "Ontology Builder",
         "title": "온톨로지 빌더",
         "helpAriaLabel": "빌더 사용법 안내",
@@ -857,7 +858,15 @@
       },
       "canvas": {
         "ephemeralEdgeLabel": "관련 (임시)",
-        "emptyHint": "왼쪽 palette 에서 종류를 골라 클릭하면 첫 노드가 생겨요."
+        "emptyHint": "왼쪽 palette 에서 종류를 골라 클릭하면 첫 노드가 생겨요.",
+        "edgeLabels": {
+          "capabilities": "역량",
+          "elements": "요소",
+          "dependencies": "의존",
+          "relates": "관련",
+          "contains": "포함",
+          "describes": "설명"
+        }
       },
       "inspector": {
         "ariaLabel": "선택한 ontology 노드 상세",

--- a/src/views/account-settings/ui/AccountSettingsPage.tsx
+++ b/src/views/account-settings/ui/AccountSettingsPage.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { ArrowLeft, MailCheck, ShieldCheck, UserRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { ArrowRight, FolderOpen, Orbit } from "lucide-react";

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { AuthGoogleButton, signInWithEmail, useUserAuth } from '@/features/user-auth';
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui';
 
-function resolveNextHref(nextParam: string | null, accountId?: string | null) {
+function resolveNextHref(nextParam: string | null) {
   // 로그인 기본 도착지 = 워크스페이스 지도 (Layer 0). 사용자가 전체
   // 조망부터 보도록 `/projects` 리스트 대신 `/` 홈으로.
   if (!nextParam) return '/';
@@ -18,10 +18,9 @@ export function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations('authPages.login');
-  const accountId = null;
   const nextHref = useMemo(
-    () => resolveNextHref(searchParams.get('next'), accountId),
-    [accountId, searchParams],
+    () => resolveNextHref(searchParams.get('next')),
+    [searchParams],
   );
   const { status } = useUserAuth();
   const [email, setEmail] = useState('');
@@ -36,18 +35,18 @@ export function LoginPage() {
   }, [nextHref, router, status]);
 
   const signupHref = useMemo(() => {
-    const url = new URL('/signup', 'http://local.test');
     const next = searchParams.get('next');
-    if (next) url.searchParams.set('next', next);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, searchParams]);
+    const params = new URLSearchParams();
+    if (next) params.set('next', next);
+    const qs = params.toString();
+    return qs ? `/signup?${qs}` : '/signup';
+  }, [searchParams]);
   const passwordResetHref = useMemo(() => {
-    const url = new URL('/reset-password', 'http://local.test');
-    if (email.trim()) {
-      url.searchParams.set('email', email.trim());
-    }
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, email]);
+    const params = new URLSearchParams();
+    if (email.trim()) params.set('email', email.trim());
+    const qs = params.toString();
+    return qs ? `/reset-password?${qs}` : '/reset-password';
+  }, [email]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/views/ontology-edit/lib/use-ephemeral-nodes.test.ts
+++ b/src/views/ontology-edit/lib/use-ephemeral-nodes.test.ts
@@ -8,7 +8,7 @@ describe('useEphemeralNodes', () => {
     expect(result.current.nodes).toEqual([]);
   });
 
-  it('addNode returns new id and appends to nodes', () => {
+  it('addNode returns new id and appends to nodes — defaults to raw kind label + empty title (Round 9a T0-4: i18n 라벨은 caller 가 주입)', () => {
     const { result } = renderHook(() => useEphemeralNodes());
     let id = '';
     act(() => {
@@ -19,9 +19,19 @@ describe('useEphemeralNodes', () => {
     expect(result.current.nodes[0]).toMatchObject({
       id,
       kind: 'domain',
-      kindLabel: '도메인',
-      title: '(이름 입력)',
+      kindLabel: 'domain',
+      title: '',
     });
+  });
+
+  it('addNode accepts caller-provided locale labels (Round 9a T0-4)', () => {
+    const { result } = renderHook(() => useEphemeralNodes());
+    act(() => {
+      result.current.addNode('domain', { kindLabel: '도메인', defaultTitle: '(이름 입력)' });
+      result.current.addNode('domain', { kindLabel: 'Domain', defaultTitle: '(Untitled)' });
+    });
+    expect(result.current.nodes[0]).toMatchObject({ kindLabel: '도메인', title: '(이름 입력)' });
+    expect(result.current.nodes[1]).toMatchObject({ kindLabel: 'Domain', title: '(Untitled)' });
   });
 
   it('multiple addNode produces unique ids + offset stack', () => {
@@ -43,7 +53,7 @@ describe('useEphemeralNodes', () => {
     expect(ys[2]).toBeGreaterThan(ys[1]!);
   });
 
-  it('kind label mapping covers 4 kinds', () => {
+  it('kind enum is preserved for all 4 kinds (Round 9a T0-4: kindLabel default = raw kind)', () => {
     const { result } = renderHook(() => useEphemeralNodes());
     act(() => {
       result.current.addNode('project');
@@ -51,8 +61,11 @@ describe('useEphemeralNodes', () => {
       result.current.addNode('capability');
       result.current.addNode('element');
     });
+    const kinds = result.current.nodes.map((n) => n.kind);
+    expect(kinds).toEqual(['project', 'domain', 'capability', 'element']);
+    // default kindLabel — caller 가 i18n 안 주입했을 때 raw enum 그대로 노출.
     const labels = result.current.nodes.map((n) => n.kindLabel);
-    expect(labels).toEqual(['프로젝트', '도메인', '역량', '요소']);
+    expect(labels).toEqual(['project', 'domain', 'capability', 'element']);
   });
 
   it('updateNode partial title — leaves others unchanged', () => {

--- a/src/views/ontology-edit/lib/use-ephemeral-nodes.ts
+++ b/src/views/ontology-edit/lib/use-ephemeral-nodes.ts
@@ -9,22 +9,26 @@ import type { ManualNodeKind } from "@/entities/knowledge-graph";
  * 캔버스 안 in-memory 상태 — 새로고침 시 사라짐 (의도). 영구화는 인스펙터에서
  * 이름 입력 + 저장 시 vault 의 \`{kind}s/{slug}.md\` 작성 (mission v2: vault
  * frontmatter 가 진실원). id 충돌 회피 위해 timestamp + random suffix.
+ *
+ * Round 9a T0-4: kindLabel / 기본 title 은 caller (`OntologyEditCanvas`) 가
+ * locale 별 문자열을 주입. hook 자체는 i18n 무지 (lib 레이어).
  */
 export interface EphemeralNode {
   id: string;
   kind: Exclude<ManualNodeKind, "document">;
+  /** 캔버스 라벨 prefix — caller 가 t() 로 만든 locale-aware 문자열. */
   kindLabel: string;
   title: string;
   x: number;
   y: number;
 }
 
-const KIND_LABELS: Record<EphemeralNode["kind"], string> = {
-  project: "프로젝트",
-  domain: "도메인",
-  capability: "역량",
-  element: "요소",
-};
+export interface AddNodeOptions {
+  /** caller 의 t() 결과 — `프로젝트` / `Project` 등. 미주입 시 raw kind. */
+  kindLabel?: string;
+  /** 새 노드 placeholder 제목 — `(이름 입력)` / `(Untitled)` 등. */
+  defaultTitle?: string;
+}
 
 export function useEphemeralNodes() {
   const [nodes, setNodes] = useState<EphemeralNode[]>([]);
@@ -33,13 +37,16 @@ export function useEphemeralNodes() {
 
   // 새로 추가한 노드의 id 를 반환 → caller 가 inspector 자동 select 가능.
   const addNode = useCallback(
-    (kind: Exclude<ManualNodeKind, "document">): string => {
+    (
+      kind: Exclude<ManualNodeKind, "document">,
+      options?: AddNodeOptions,
+    ): string => {
       setOffset((prev) => prev + 1);
       const next: EphemeralNode = {
         id: `ephemeral-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
         kind,
-        kindLabel: KIND_LABELS[kind],
-        title: "(이름 입력)",
+        kindLabel: options?.kindLabel ?? kind,
+        title: options?.defaultTitle ?? "",
         // 캔버스 중앙 (대략) + offset 으로 stack 회피.
         x: 240 + offset * 24,
         y: 160 + offset * 24,

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -11,6 +11,15 @@ import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
 export type VaultGraphLayoutMode = "dagre" | "force";
 
 /**
+ * 라벨 해석기 — kind enum / edge frontmatter key 를 사용자 locale 에 맞춰
+ * 변환. 호출자가 `useTranslations` 으로 만들어 주입한다 (Round 9a T0-4 —
+ * 이 lib 가 React 컴포넌트가 아니라 직접 `useTranslations` 못 쓰므로
+ * 함수 주입 패턴). resolver 없으면 raw key 노출.
+ */
+export type KindLabelResolver = (kind: string) => string;
+export type EdgeLabelResolver = (edgeKey: string) => string;
+
+/**
  * mission v2 빌더 — 로컬 vault 의 .md 노드를 캔버스 background 로 노출.
  *
  * cloud `useApprovedGraphFlow` 와 동일한 shape (xyflow Node[]/Edge[]) 를
@@ -40,6 +49,10 @@ export interface UseVaultGraphFlowOptions {
    * 와 같은 organic 분포). 사용자 선호 토글.
    */
   layoutMode?: VaultGraphLayoutMode;
+  /** Round 9a T0-4 — 노드 라벨 i18n. 미주입 시 raw kind enum 노출. */
+  kindLabelOf?: KindLabelResolver;
+  /** Round 9a T0-4 — 엣지 라벨 i18n. 미주입 시 raw frontmatter key 노출. */
+  edgeLabelOf?: EdgeLabelResolver;
 }
 
 export function useVaultGraphFlow(
@@ -48,13 +61,17 @@ export function useVaultGraphFlow(
 ) {
   const ignorePersistedPosition = options?.ignorePersistedPosition ?? false;
   const layoutMode = options?.layoutMode ?? "dagre";
+  const kindLabelOf = options?.kindLabelOf;
+  const edgeLabelOf = options?.edgeLabelOf;
   return useMemo(() => {
     if (!manifest) return { nodes: [] as Node[], edges: [] as Edge[] };
     return buildVaultGraphFlow(manifest, {
       ignorePersistedPosition,
       layoutMode,
+      kindLabelOf,
+      edgeLabelOf,
     });
-  }, [manifest, ignorePersistedPosition, layoutMode]);
+  }, [manifest, ignorePersistedPosition, layoutMode, kindLabelOf, edgeLabelOf]);
 }
 
 const NODE_WIDTH = 200;
@@ -81,10 +98,14 @@ export function buildVaultGraphFlow(
   options?: {
     ignorePersistedPosition?: boolean;
     layoutMode?: VaultGraphLayoutMode;
+    kindLabelOf?: KindLabelResolver;
+    edgeLabelOf?: EdgeLabelResolver;
   },
 ) {
   const ignorePersistedPosition = options?.ignorePersistedPosition ?? false;
   const layoutMode = options?.layoutMode ?? "dagre";
+  const resolveKindLabel = options?.kindLabelOf ?? ((kind: string) => kind);
+  const resolveEdgeLabel = options?.edgeLabelOf ?? ((key: string) => key);
   const ontologyDocs = manifest.docs.filter(
     (doc) => typeof doc.frontmatter.kind === "string" && doc.frontmatter.kind,
   );
@@ -160,7 +181,7 @@ export function buildVaultGraphFlow(
       type: "atlas",
       position: pos,
       data: {
-        label: `${kindLabel(kind)} · ${title}`,
+        label: `${resolveKindLabel(kind)} · ${title}`,
         kind,
         ephemeral: false,
         vault: true,
@@ -196,7 +217,7 @@ export function buildVaultGraphFlow(
           source: doc.slug,
           target: resolved,
           type: "default",
-          label: edgeLabel(key),
+          label: resolveEdgeLabel(key),
           labelStyle: edgeLabelStyle,
           labelBgStyle: edgeLabelBgStyle,
           labelBgPadding: [6, 4] as [number, number],
@@ -301,42 +322,6 @@ function computeForceLayout(
     });
   }
   return map;
-}
-
-function kindLabel(kind: string): string {
-  switch (kind) {
-    case "project":
-      return "프로젝트";
-    case "domain":
-      return "도메인";
-    case "capability":
-      return "역량";
-    case "element":
-      return "요소";
-    case "document":
-      return "문서";
-    default:
-      return kind;
-  }
-}
-
-function edgeLabel(key: string): string {
-  switch (key) {
-    case "capabilities":
-      return "역량";
-    case "elements":
-      return "요소";
-    case "dependencies":
-      return "의존";
-    case "relates":
-      return "관련";
-    case "contains":
-      return "포함";
-    case "describes":
-      return "설명";
-    default:
-      return key;
-  }
 }
 
 const edgeLabelStyle = {

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -69,13 +69,39 @@ export function OntologyEditCanvas({
   layoutMode?: "dagre" | "force";
 }) {
   const t = useTranslations("ontologyPages.edit.canvas");
+  const tKinds = useTranslations("kinds");
+  const tEdges = useTranslations("ontologyPages.edit.canvas.edgeLabels");
   // 진실원: live vault.manifest 우선, 없으면 빌드타임 dogfood 매니페스트.
   // 빌더에 진입한 사용자는 vault 폴더 안 골랐어도 oh-my-ontology 자체 ontology
   // 23 노드를 즉시 본다 — "0 마찰 진입" 약속의 캔버스 측 구현.
   const effectiveManifest = vaultManifest ?? staticVaultManifest;
+  // Round 9a T0-4 — kindLabel / edgeLabel resolver 주입. lib 가 React 가
+  // 아니라 직접 t() 못 씀 → 함수로 위임.
+  const kindLabelOf = useCallback(
+    (kind: string) => {
+      try {
+        return tKinds(kind as 'project' | 'domain' | 'capability' | 'element' | 'document' | 'unknown');
+      } catch {
+        return kind;
+      }
+    },
+    [tKinds],
+  );
+  const edgeLabelOf = useCallback(
+    (key: string) => {
+      try {
+        return tEdges(key as 'capabilities' | 'elements' | 'dependencies' | 'relates' | 'contains' | 'describes');
+      } catch {
+        return key;
+      }
+    },
+    [tEdges],
+  );
   const vaultFlow = useVaultGraphFlow(effectiveManifest, {
     ignorePersistedPosition: autoLayoutToken > 0,
     layoutMode,
+    kindLabelOf,
+    edgeLabelOf,
   });
   const approvedNodes = vaultFlow.nodes;
   const approvedEdges = vaultFlow.edges;
@@ -89,13 +115,13 @@ export function OntologyEditCanvas({
   );
 
   const allNodes: Node[] = useMemo(() => {
-    // approved 노드도 atlas custom type 으로 변환 (kind 별 시각 톤)
+    // approved 노드도 atlas custom type 으로 변환 (kind 별 시각 톤).
+    // Round 9a T0-4: 이전엔 라벨 문자열 ("{kindLabel} · {title}") 을
+    // 한국어 매칭으로 reverse-parse 했는데, locale 바뀌면 깨짐. 이제
+    // `useVaultGraphFlow` 가 `data.kind` 를 enum 으로 직접 박아주므로 그대로 사용.
     const approvedAtlas: Node[] = approvedNodes.map((n) => {
-      // n.data.label 형식: "{kindLabel} · {title}". kind 추출 위해 변환.
-      const data = n.data as { label?: string };
-      const labelParts = data.label?.split(" · ") ?? [];
-      const kindLabel = labelParts[0] ?? "";
-      const kind = inferKindFromLabel(kindLabel);
+      const data = n.data as { label?: string; kind?: string };
+      const kind = (data.kind ?? "element") as "project" | "domain" | "capability" | "element";
       return {
         ...n,
         type: "atlas",
@@ -175,16 +201,6 @@ export function OntologyEditCanvas({
     },
     [onVaultNodeDragStop, hasLiveVault],
   );
-
-  // kind 추출 — '{kindLabel} · {title}' 형식에서 kindLabel → kind enum 매핑.
-  function inferKindFromLabel(
-    label: string,
-  ): "project" | "domain" | "capability" | "element" {
-    if (label.startsWith("프로젝트")) return "project";
-    if (label.startsWith("도메인")) return "domain";
-    if (label.startsWith("역량")) return "capability";
-    return "element";
-  }
 
   return (
     <div

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 import { Info, Maximize2, Minimize2, Wand2 } from "lucide-react";
 import { ACCOUNT_QUERY_KEY } from "@/shared/lib/account-scope";
@@ -90,6 +90,7 @@ function CanvasSkeleton() {
 
 export function OntologyEditPage() {
   const t = useTranslations("ontologyPages.edit.page");
+  const tKinds = useTranslations("kinds");
   const searchParams = useSearchParams();
   // single-user 모드: account scope 가 곧 로그인 사용자 uid. 비로그인 사용자는
   // 캔버스 자체를 볼 수 있지만 manual node 저장 시 toast 로 막힌다.
@@ -98,8 +99,18 @@ export function OntologyEditPage() {
   const dataSourceMode = useDataSourceMode();
   const vault = useLocalVault();
 
-  const { nodes: ephemeralNodes, addNode, clearAll, updateNode, findById, removeNode } =
+  const { nodes: ephemeralNodes, addNode: addNodeRaw, clearAll, updateNode, findById, removeNode } =
     useEphemeralNodes();
+  // Round 9a T0-4: ephemeral 노드의 kindLabel/placeholder 도 locale 별로
+  // 만들어서 hook 에 주입. hook 자체는 i18n 무지.
+  const addNode = useCallback(
+    (kind: 'project' | 'domain' | 'capability' | 'element') =>
+      addNodeRaw(kind, {
+        kindLabel: tKinds(kind),
+        defaultTitle: t('untitledPlaceholder'),
+      }),
+    [addNodeRaw, tKinds, t],
+  );
   const { edges: ephemeralEdges, addEdge: addEphemeralEdge, clearAll: clearEphemeralEdges } =
     useEphemeralEdges();
   const [selectedId, setSelectedId] = useState<string | null>(null);

--- a/src/views/password-reset/ui/PasswordResetPage.tsx
+++ b/src/views/password-reset/ui/PasswordResetPage.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import Link from 'next/link';
+import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { Link } from '@/i18n/navigation';
 import { ArrowLeft, MailCheck } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { sendPasswordReset } from '@/features/user-auth';
@@ -11,13 +11,10 @@ import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } fro
 export function PasswordResetPage() {
   const searchParams = useSearchParams();
   const t = useTranslations('authPages.resetPassword');
-  const accountId = null;
   const [email, setEmail] = useState(searchParams.get('email') ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-
-  const loginHref = useMemo(() => '/login', [accountId]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -39,7 +36,7 @@ export function PasswordResetPage() {
     <main className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-6 md:px-10">
       <h1 className="sr-only">{t('srHeading')}</h1>
       <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-        <Link href={loginHref} className="inline-flex">
+        <Link href="/login" className="inline-flex">
           <Button variant="outline" type="button" className="gap-2 rounded-full">
             <ArrowLeft size={15} />
             {t('backToLogin')}

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -35,8 +35,8 @@ import {
   wouldCreateDependencyCycle,
   type Project,
 } from "@/entities/project";
-import { getProject, upsertProject } from "@/entities/project/api";
-import { useProjects } from "@/features/project-data-source";
+import { useProjects, useProjectMutations } from "@/features/project-data-source";
+import { useDataSourceMode } from "@/features/data-source-mode";
 import { resolveSubscribeUpdate } from "../model/resolve-subscribe-update";
 import { DependencyPicker } from "@/features/project-edit/ui/DependencyPicker";
 import { CopyProjectLinkButton } from "@/features/project-share";
@@ -66,7 +66,6 @@ import {
   buildKnowledgeProjectEvidenceSummary,
   type KnowledgeProjectInsight,
 } from "@/entities/knowledge-graph";
-import { subscribeKnowledgeProjectInsight } from "@/entities/knowledge-graph/api";
 
 interface Props {
   slug: string;
@@ -376,6 +375,8 @@ export function ProjectDetailPage({
   // + 실시간 구독을 통합. (이전엔 listProjects + subscribeProjects 두 effect 가
   // race 했지만 hook 이 항상 최신 snapshot 을 들고 있어 race 자체가 사라짐.)
   const projectsQuery = useProjects(accountId);
+  const dataSourceMode = useDataSourceMode();
+  const projectMutations = useProjectMutations();
   useEffect(() => {
     if (!slug) return;
     const { next, related: nextRelated } = resolveSubscribeUpdate(
@@ -388,13 +389,15 @@ export function ProjectDetailPage({
     if (projectsQuery.loaded || projectsQuery.error !== null) setResolved(true);
   }, [projectsQuery.projects, projectsQuery.loaded, projectsQuery.error, slug, fallbackProjects]);
 
-  // initial fetch — fallback 가 없는 경우 직접 getProject 로 한 번 더 시도.
-  // local 모드에선 useProjects 가 vault manifest 를 sync 로 들고 있어 별도
-  // fetch 불필요 + Firebase 미초기화 시 console 잡음 회피.
+  // initial fetch — fallback 가 없는 경우 cloud 모드에서만 직접 getProject 로
+  // 한 번 더 시도. local 모드에선 useProjects 가 vault manifest 를 sync 로
+  // 들고 있어 별도 fetch 불필요. static 모드는 fallbackProjects 가 진실원이라
+  // 추가 cloud 호출 자체가 firebase chunk 를 끌고 와 회귀를 만든다.
   useEffect(() => {
-    if (!slug || fallbackProject || projectsQuery.mode === 'local') return;
+    if (!slug || fallbackProject || projectsQuery.mode !== 'cloud') return;
     let cancelled = false;
-    void getProject(slug, accountId)
+    void import('@/entities/project/api')
+      .then(({ getProject }) => getProject(slug, accountId))
       .then((fetched) => {
         if (cancelled) return;
         if (fetched) setProject(fetched);
@@ -411,22 +414,31 @@ export function ProjectDetailPage({
 
   useEffect(() => {
     if (!slug) return;
-    // knowledgePublicNodes/Edges/Meta 는 Firestore rule 이 `allow read: if true`
-    // 로 열려 있어 게스트도 읽을 수 있다 (published projection). 과거 게스트
-    // 가드가 있었지만 rule 이 공개된 이후에도 남아 있어 공개 독자가 문서
-    // 기반 개념/연결을 못 보는 회귀 존재 — 제거.
-    const unsubscribe = subscribeKnowledgeProjectInsight(
-      slug,
-      accountId,
-      (nextInsight) => {
-        setKnowledgeInsight(nextInsight);
-      },
-      (error) => {
-        console.warn("[ProjectDetailPage] knowledge insight subscribe failed", error);
-      },
-    );
-    return () => unsubscribe();
-  }, [accountId, slug]);
+    // mode-gate (Round 9a T0-2): cloud 모드일 때만 firestore 구독. local/static
+    // 모드 사용자가 detail 페이지를 열 때 firebase JS chunk 가 열리고 listener
+    // 가 트래픽을 만들던 회귀를 차단. (Round 1 leak gate 의 ProjectDetail 누락분.)
+    if (dataSourceMode !== 'cloud') {
+      setKnowledgeInsight({ nodes: [], edges: [], meta: null });
+      return;
+    }
+    let unsubscribe: (() => void) | null = null;
+    let cancelled = false;
+    void import('@/entities/knowledge-graph/api').then((mod) => {
+      if (cancelled) return;
+      unsubscribe = mod.subscribeKnowledgeProjectInsight(
+        slug,
+        accountId,
+        (nextInsight) => setKnowledgeInsight(nextInsight),
+        (error) => {
+          console.warn("[ProjectDetailPage] knowledge insight subscribe failed", error);
+        },
+      );
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [accountId, slug, dataSourceMode]);
 
   // 공개 상세(/project/[slug]/)는 누구나 읽을 수 있어야 한다. CLAUDE.md에도
   // "공개 상세"로 명시된 계약. 단 account 파라미터가 붙은 scoped URL
@@ -552,12 +564,13 @@ export function ProjectDetailPage({
         : insightDocumentNodes.length > 0
           ? t("ontologyReasonDocs", { count: insightDocumentNodes.length })
           : t("ontologyReasonEmpty"));
-  const canManageProject = scopedAccess.canManage;
-  // owner/editor 가 자기 공간 프로젝트를 보면 h1·description 등을 inline 에서
-  // 바로 고친다. subscribeProjects 가 snapshot 으로 로컬 project state 를
-  // 갱신해 optimistic update 는 불필요.
-  const persistProject = (input: Parameters<typeof upsertProject>[0]) =>
-    upsertProject(input);
+  const canManageProject = scopedAccess.canManage && projectMutations.canEdit;
+  // mode-aware persistence (Round 9a T0-1). 이전엔 cloud-only `upsertProject`
+  // 을 직접 호출해 vault 모드에서 인라인 편집이 firestore 로 silently 흘러갔다
+  // (편집 후 새로고침하면 사라지는 회귀). useProjectMutations 가 mode 에 따라
+  // vault patch 또는 cloud upsert 로 분기.
+  const persistProject = (input: Parameters<typeof projectMutations.updateProject>[0]) =>
+    projectMutations.updateProject(input);
   const saveProjectField = async (
     field: "name" | "description",
     next: string,

--- a/src/views/signup/ui/SignupPage.tsx
+++ b/src/views/signup/ui/SignupPage.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { AuthGoogleButton, signUpWithEmail, useUserAuth } from '@/features/user-auth';
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui';
 
-function resolveNextHref(nextParam: string | null, accountId?: string | null) {
+function resolveNextHref(nextParam: string | null) {
   // 회원가입 직후 기본 도착지 = 자기 워크스페이스 지도 (Layer 0).
   if (!nextParam) return '/';
   return nextParam;
@@ -19,10 +19,9 @@ export function SignupPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations('authPages.signup');
-  const accountId = null;
   const nextHref = useMemo(
-    () => resolveNextHref(searchParams.get('next'), accountId),
-    [accountId, searchParams],
+    () => resolveNextHref(searchParams.get('next')),
+    [searchParams],
   );
   const { status } = useUserAuth();
   const [displayName, setDisplayName] = useState('');
@@ -39,11 +38,12 @@ export function SignupPage() {
   }, [nextHref, router, status]);
 
   const loginHref = useMemo(() => {
-    const url = new URL('/login', 'http://local.test');
     const next = searchParams.get('next');
-    if (next) url.searchParams.set('next', next);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, searchParams]);
+    const params = new URLSearchParams();
+    if (next) params.set('next', next);
+    const qs = params.toString();
+    return qs ? `/login?${qs}` : '/login';
+  }, [searchParams]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/widgets/account-menu/ui/PublicAccountMenu.tsx
+++ b/src/widgets/account-menu/ui/PublicAccountMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { Link, usePathname } from "@/i18n/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { BookOpen, ChevronDown, Compass, FolderKanban, LogOut, Moon, Shield, Sun, UserRound } from "lucide-react";
@@ -71,20 +71,17 @@ export function PublicAccountMenu({
     return `${pathname || "/"}${search ? `?${search}` : ""}`;
   }, [pathname, searchParams]);
   const loginHref = useMemo(() => {
-    const url = new URL("/login", "http://local.test");
-    url.searchParams.set("next", currentPath);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, currentPath]);
+    const params = new URLSearchParams({ next: currentPath });
+    return `/login?${params.toString()}`;
+  }, [currentPath]);
   const signupHref = useMemo(() => {
-    const url = new URL("/signup", "http://local.test");
-    url.searchParams.set("next", currentPath);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, currentPath]);
+    const params = new URLSearchParams({ next: currentPath });
+    return `/signup?${params.toString()}`;
+  }, [currentPath]);
   const projectsHref = useMemo(() => {
-    const url = new URL("/projects", "http://local.test");
-    url.searchParams.set("returnTo", currentPath);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }, [accountId, currentPath]);
+    const params = new URLSearchParams({ returnTo: currentPath });
+    return `/projects?${params.toString()}`;
+  }, [currentPath]);
   const accountSettingsHref = "/account";
   const docsVaultHref = "/docs/";
   const settingsHref = scopedAccess.canManage


### PR DESCRIPTION
## Summary

QA Panel A/B/D 가 공통으로 지목한 **출시 블로커 4개** (silent breakage — 사용자가 만져서 깨지는 것을 모름) 일괄 수정.

- **T0-1** `ProjectDetail` 인라인 편집이 vault 모드에서 silent 데이터 유실 — `upsertProject` 직접 호출이라 vault 사용자가 이름/설명/deps/tags/stack/links 편집해도 firestore 로 흘러갔음. 새로고침하면 vault 가 진실원이라 편집 사라짐. `useProjectMutations` (mode-aware) 로 라우팅.
- **T0-2** `ProjectDetail` Firestore listener leak — Round 1 fix 누락분. `subscribeKnowledgeProjectInsight` 가 mode-gate 없이 항상 가동 → local/static 사용자에게 firebase chunk leak. `dataSourceMode === 'cloud'` 일 때만 dynamic import.
- **T0-3** Auth 5 surface + PublicAccountMenu 가 `next/link`, `next/navigation` 직접 import. `localePrefix:'always'` 인데 /ko 사용자가 어떤 CTA 든 누르면 locale 떨어져 정적 export 에서 404. `@/i18n/navigation` 의 locale-aware export 로 교체. 부수로 dead `accountId` 매개변수 정리.
- **T0-4** ERD 캔버스 i18n 미적용 — `use-vault-graph-flow.ts` / `use-ephemeral-nodes.ts` 가 한국어 라벨 하드코딩. `OntologyEditCanvas` 의 한국어 prefix 로 enum 추출하는 reverse parser 도 locale 바뀌면 깨지므로 제거. lib 에 `KindLabelResolver` / `EdgeLabelResolver` 주입 패턴 도입.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test:run\` 727/727 통과
- [x] \`pnpm lint\` 0 errors (warnings 는 사전 존재)
- [x] \`pnpm bundle:check\` — 25개 local-first 라우트 (en + ko) 모두 firebase 0KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)