### PR TITLE
feat(mcp): instructions field on initialize — AI agent 진입 가이드

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — oh-my-ontology-mcp
 
+## 0.7.1 — 2026-05-04
+
+### Added
+
+- **`instructions` field on initialize response** — 연결된 AI agent (Claude Code, Cursor, …) 가 항상 보는 시스템-prompt 수준 안내 추가. (1) kind 계층 (project → domain → capability → element) 의 의미, (2) 첫 연결 시 권장 호출 순서 (`list_kinds` → `list_concepts` → `get_concept` → `find_backlinks` …), (3) write 도구의 dry-run + `confirm: true` 패턴, (4) `expected_mtime` 충돌 가드 패턴, (5) 새 capability/element 발견 시 `add_concept` 으로 vault 동기화 책임. 14 tool description 만으로는 매 세션 agent 가 시행착오로 학습하던 부분을 단번에 해소. integration test (`initialize — instructions 필드`) 1 케이스 추가 — drift 즉시 회귀.
+
+### Tools count
+
+- 14 (8 read + 6 write) — 변동 없음 (instructions 는 기존 도구 보강).
+
 ## 0.7.0 — 2026-05-04
 
 ### Added (R11 라운드)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -56,7 +56,7 @@ The server connects over stdio. You should now see 14 tools under the `oh-my-ont
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## The 14 tools (v0.7.0)
+## The 14 tools (v0.7.1)
 
 | Tool | What it does |
 |---|---|
@@ -135,6 +135,7 @@ If those four tools respond cleanly, your read/write round-trip against the vaul
 
 ## Status
 
+- 0.7.1 — 14 tools. Added `instructions` field on initialize response — Claude Code / Cursor see kind hierarchy + workflow + write-tool dry-run pattern + `expected_mtime` conflict guard guidance on connect, no per-session trial-and-error.
 - 0.7.0 — 14 tools (8 read + 6 write). Added `rename_concept` and `merge_concepts` (graph-level write — atomic backlink redirect across all referrers).
 - 0.6.0 — 12 tools (8 read + 4 write). Added `query_concepts` (typed filter DSL).
 - 0.5.0 — 7 read + 4 write. Added `find_orphans`.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server — humans and AI agents read/write the same codebase ontology vault.",
   "keywords": [
     "mcp",

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
-* oh-my-ontology-mcp — MCP 서버 v0.7.0 (도구 14종 = read 8 + write 6).
+* oh-my-ontology-mcp — MCP 서버 v0.7.1 (도구 14종 = read 8 + write 6).
  *
  * AI agent (Claude Code 등) 가 vault 의 ontology 를 읽고 쓸 수 있게.
  *
@@ -78,9 +78,50 @@ try {
   process.exit(1);
 }
 
+// MCP `instructions` field — initialize 응답에 포함되어 연결된 AI agent
+// (Claude Code, Cursor, …) 가 항상 보는 시스템-prompt 수준 안내. 14 tool
+// description 만으로는 (1) 호출 순서, (2) kind 계층의 의미, (3) write 도구의
+// dry-run/confirm 패턴, (4) mtime 충돌 가드 — 이 4 가지가 누락되어 있어
+// agent UX 가 매번 시행착오로 학습되는 문제를 단번에 해소.
+const SERVER_INSTRUCTIONS = `oh-my-ontology — vault of markdown files where each \`.md\` with a frontmatter \`kind:\` is an ontology node. The graph encodes the codebase's mental model and is shared with the human via plain markdown.
+
+## Kind hierarchy (top → leaf)
+
+- **project** — top-level deliverable (e.g. "auth-platform"). Owns capabilities and elements.
+- **domain** — functional grouping (e.g. "auth", "billing"). Parent of capabilities.
+- **capability** — a coherent unit of behavior (e.g. "token-issue"). Often realized by elements.
+- **element** — concrete piece (library, API, schema, file). Leaf-level.
+- **document** — narrative or reference doc tied to the graph but not a domain object.
+- (\`vault-readme\` is reserved for the auto-generated README.md — agents should not set this kind.)
+
+## First-time workflow (when you connect to a new vault)
+
+1. \`list_kinds\` — see the kind census (how many projects/domains/capabilities/…).
+2. \`list_concepts\` — see all nodes. Watch \`vaultWarnings\` — if non-zero, the vault has frontmatter integrity issues; surface them to the user before making decisions on stale data.
+3. \`get_concept(slug)\` — for any node of interest. Returns frontmatter + body + neighbors (dependencies/relates) + \`mtime\`.
+4. \`find_backlinks(slug)\` — to understand how a node is referenced.
+5. \`find_path(from, to)\` — for "how does A relate to B" questions (BFS, undirected).
+6. \`find_orphans\` — to spot nodes that no other node points to (often unfinished or deletion candidates).
+7. \`query_concepts(filter)\` — for structured questions like \`kind=capability AND domain=auth AND NOT has(elements)\` (= "unfinished caps under auth").
+
+## Write tools — safety patterns
+
+- **\`add_concept\`** throws on duplicate slug — use \`patch_concept\` to update an existing node, never delete-then-add.
+- **\`rename_concept\` / \`merge_concepts\`** are dry-run by default. The first call returns an \`updates\` preview (every affected file's before/after). To commit, repeat the call with \`confirm: true\`.
+- **\`delete_concept\`** refuses by default if any backlinks remain. Pass \`force: true\` only after confirming with the user.
+- **\`expected_mtime\` (all write tools)** — to guard against concurrent edits by the human or another agent: capture \`mtime\` from \`get_concept\`, pass it as \`expected_mtime\` on the next write. If the file changed in between, the call throws \`VaultConflictError\` instead of silently overwriting.
+- **Prefer graph-level writes** — to rename a slug or fold two nodes, use \`rename_concept\` / \`merge_concepts\` (atomic backlink redirect) rather than \`patch_concept\` + N find_backlinks loops.
+
+## What to write back
+
+When you discover a new capability/element/project from code, call \`add_concept\` so the human sees it appear in their workbench. When you fix or rename code, mirror the change in the graph with \`rename_concept\`. The vault is the shared mental model — keeping it in sync is the entire point.`;
+
 const server = new Server(
-  { name: 'oh-my-ontology-mcp', version: '0.7.0' },
-  { capabilities: { tools: {} } },
+  { name: 'oh-my-ontology-mcp', version: '0.7.1' },
+  {
+    capabilities: { tools: {} },
+    instructions: SERVER_INSTRUCTIONS,
+  },
 );
 
 // ── 도구 정의 ─────────────────────────────────────────────────────────────

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -126,6 +126,30 @@ function isErrorResponse(responses, id) {
 
 console.log("integration");
 
+await test("initialize — instructions 필드 (#45) AI agent 안내 노출", async () => {
+  // initialize 응답에 instructions 가 있어야 연결된 agent (Claude Code 등) 가
+  // kind 계층 / 호출 순서 / write 도구 dry-run 패턴을 즉시 인지. 누락 시
+  // agent 는 매 세션 시행착오로 학습 — 명시 가드.
+  const root = makeVault([]);
+  try {
+    const { responses } = await rpc(root, INIT_REQUESTS);
+    const init = responses.find((r) => r.id === 1);
+    assert.ok(init, "initialize 응답이 와야 함");
+    const instructions = init.result?.instructions;
+    assert.equal(typeof instructions, "string", "instructions 가 string 이어야");
+    assert.ok(
+      instructions.length > 200,
+      `instructions 가 의미 있는 길이여야 (got ${instructions.length})`,
+    );
+    // 핵심 키워드 — drift 시 즉시 깨짐
+    assert.match(instructions, /kind hierarchy/i);
+    assert.match(instructions, /dry-run|confirm/i);
+    assert.match(instructions, /expected_mtime/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test("list_concepts — tmp vault 의 노드 수 정확히 보고", async () => {
   const root = makeVault([
     { slug: "a", content: "---\nkind: capability\ntitle: A\n---\n" },


### PR DESCRIPTION
## Summary

- MCP server v0.7.0 → v0.7.1: initialize 응답에 `instructions` 필드 추가 — 연결된 AI agent (Claude Code, Cursor) 가 항상 보는 시스템-prompt 수준 안내.
- 14 tool description 만으론 매 세션 시행착오로 학습되던 (1) kind 계층 의미, (2) 호출 순서, (3) write 도구 dry-run + `confirm: true` 패턴, (4) `expected_mtime` 충돌 가드 — 이 4 가지를 한 번에 surface.
- 행동 변화 0 (pure-additive). 기존 도구 시그니처 / 응답 shape 변경 없음.

## Changes

- `mcp/src/index.js` — `SERVER_INSTRUCTIONS` 상수 + Server options.instructions
- `mcp/package.json` — version 0.7.0 → 0.7.1
- `mcp/CHANGELOG.md` — 0.7.1 entry
- `mcp/README.md` — Status 줄 + tools 헤딩 v0.7.1
- `mcp/src/integration.test.mjs` — initialize 응답 instructions surface + 핵심 키워드 4 개 정합성 test (drift 즉시 회귀)

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors (mcp/ 영역 영향 0)
- [x] `cd mcp && npm test` — 10/10 integration test pass (신규 1 + 기존 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)