### PR TITLE
fix(scaffold): "12 tools / write 4" → "14 tools / write 6" stale 정정

### DIFF
--- a/cli/templates/vault/README.md
+++ b/cli/templates/vault/README.md
@@ -53,11 +53,12 @@ graph's keys (slug / kind / depends_on / capabilities / elements / domain).
 
 ## What an AI agent can do for you
 
-Once you register the `oh-my-ontology-mcp` server, the agent gets 12
+Once you register the `oh-my-ontology-mcp` server, the agent gets 14
 tools to read/write this vault:
 
 - **read 8**: list_concepts / get_concept / find_evidence / find_backlinks /
   find_path / list_kinds / find_orphans / query_concepts
-- **write 4**: add_concept / add_relation / patch_concept / delete_concept
+- **write 6**: add_concept / add_relation / patch_concept / delete_concept /
+  rename_concept / merge_concepts
 
 Details: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp

--- a/src/features/docs-vault-local/lib/ontology-starter.ts
+++ b/src/features/docs-vault-local/lib/ontology-starter.ts
@@ -65,12 +65,13 @@ graph's keys (slug / kind / depends_on / capabilities / elements / domain).
 
 ## What an AI agent can do for you
 
-Once you register the \`oh-my-ontology-mcp\` server, the agent gets 12
+Once you register the \`oh-my-ontology-mcp\` server, the agent gets 14
 tools to read/write this vault:
 
 - **read 8**: list_concepts / get_concept / find_evidence / find_backlinks /
   find_path / list_kinds / find_orphans / query_concepts
-- **write 4**: add_concept / add_relation / patch_concept / delete_concept
+- **write 6**: add_concept / add_relation / patch_concept / delete_concept /
+  rename_concept / merge_concepts
 
 Details: https://github.com/wlsdks/oh-my-ontology/tree/main/mcp
 `;


### PR DESCRIPTION
## Summary

- 신규 사용자가 \`npx oh-my-ontology init\` 으로 vault 만들 때 첫 README (`cli/templates/vault/README.md`) 와 웹 워크벤치 scaffold mirror (`src/features/docs-vault-local/lib/ontology-starter.ts`) 가 MCP tool 수 "12 tools / write 4" 라고 stale.
- R11 에서 \`rename_concept\` · \`merge_concepts\` 추가되어 실제는 14 tools / write 6.
- 첫 onboarding 거짓말 차단.

## Changes

- \`cli/templates/vault/README.md\` — 12 → 14, write 4 → write 6 (`rename_concept` · `merge_concepts` 명시 추가)
- \`src/features/docs-vault-local/lib/ontology-starter.ts\` — 같은 수정 (string template, 웹 scaffold)

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 759/759 pass (test fixture 가 tool 수 hardcode 안 함, drift 가드 안전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)