### PR TITLE
feat(benchmark): AI agent 답변 품질 측정 인프라 (Claude Code + Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ becoming graph nodes.
 | **AI agent partner via MCP** | `mcp/` package, 14 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
 | **Dogfooding** | `docs/ontology/` is the project's own curated mental model (~21 nodes — domains 6 · capabilities 9 · elements 4 · project 1 · vault-readme 1). |
+| **AI agent quality measurement** *(in progress)* | [`docs/benchmark/`](docs/benchmark/) — 7 tasks across 3 categories (cross-cutting / semantic / negative-control), measured on Claude Code + Codex with MCP off vs on. The single biggest unverified premise: that the ontology actually helps. |
 
 ## Architecture
 

--- a/docs/benchmark/README.md
+++ b/docs/benchmark/README.md
@@ -1,0 +1,81 @@
+# Benchmark — does the ontology actually help AI agents?
+
+> The single biggest unverified premise of this project:
+>
+> **"AI agents work better when they can read and write the codebase ontology vault."**
+>
+> Until we have data, this is a belief, not a claim. This folder is the
+> first attempt to put it on a measurement scale.
+
+## Why this exists
+
+We built CLI · MCP · 14 tools · web workbench all on top of one assumption — that giving an AI agent access to a curated graph of `kind / domain / capability / element` makes it answer codebase questions better. We've never tested whether that's actually true.
+
+If the effect is large, this folder becomes evidence in the README. If small, we re-design — maybe the schema is too thin, maybe agents prefer raw grep, maybe the value is elsewhere.
+
+Either way, **measurement before further investment**.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| [`tasks.md`](tasks.md) | 7 benchmark tasks — 3 categories (cross-cutting / semantic / negative-control). Each task has a known correct answer for human grading. |
+| [`rubric.md`](rubric.md) | How to score: correctness 0–3, tool-call count, hallucination count, subjective utility 1–5. |
+| [`results/2026-05-template.md`](results/2026-05-template.md) | Empty matrix (task × agent × mode). Fill in after each measurement run. |
+
+## How to measure (manual, by the human)
+
+This is **not automated**. We deliberately measure in the same agent shells real users live in (Claude Code, Codex CLI), at subscription pricing — not via raw API calls — because that's the actual user economics.
+
+### Setup
+
+Two agent installs, both with `oh-my-ontology` repo opened:
+
+1. **Claude Code** (Anthropic) — `~/.claude/projects/<project>/<session>.jsonl` is auto-saved.
+2. **Codex CLI** (OpenAI) — transcript path varies; capture by hand if needed.
+
+For each agent, you'll run **two modes**:
+
+- **Mode OFF**: `.mcp.json` does NOT include `oh-my-ontology` (only the agent's default tools — Read / Grep / Bash / etc).
+- **Mode ON**: `.mcp.json` includes `oh-my-ontology-mcp` pointing at `docs/ontology/`.
+
+Toggle by editing `.mcp.json` between runs and restarting the agent.
+
+### Run protocol
+
+For each task in `tasks.md`:
+
+1. **Fresh session** — close any prior session, open a new one. (Avoids context bleed.)
+2. **Paste the task prompt verbatim** — no follow-ups, no nudging. Whatever the agent answers, that's the answer.
+3. **Save the transcript / screenshot** — for Claude Code, the jsonl is enough. For Codex, copy the conversation.
+4. **Score** per `rubric.md`.
+5. **Fill in** `results/2026-05-template.md` (rename to your run's date if needed).
+
+### Run all four cells per task
+
+Each of the 7 tasks should be measured 4 times:
+
+| Cell | Agent | MCP mode |
+|---|---|---|
+| 1 | Claude Code | OFF (Read/Grep only) |
+| 2 | Claude Code | ON (oh-my-ontology MCP) |
+| 3 | Codex | OFF |
+| 4 | Codex | ON |
+
+7 tasks × 4 cells = **28 runs total**. Each run is ~2-5 minutes — total bench time is ~1-2 hours.
+
+## Honest measurement principles
+
+- **Within-agent delta is the primary signal**. Claude Code OFF → ON is meaningful. Claude Code OFF → Codex OFF is comparing different model/tool stacks, not the ontology effect.
+- **No follow-up prompts**. The agent's first complete answer is what scores. Nudging contaminates the result.
+- **Hallucinations count negatively**. If the agent confidently cites a file or slug that doesn't exist, that's worse than "I don't know".
+- **Negative-control tasks (Cat C)** *should* show small or zero delta — they're verifiable by raw grep. If MCP-on is dramatically worse on Cat C, that's a sign MCP is misleading the agent.
+
+## What we're hoping to learn
+
+- **Does Cat A (cross-cutting graph) show a clear MCP-on advantage?** If yes → product validated for the use case it was designed for.
+- **Does Cat B (semantic) show a graded response?** Useful data on where the schema is too thin.
+- **Does Cat C (grep-able) show neutrality?** If MCP-on hurts here, we've over-trained agents to reach for the wrong tool.
+- **Cross-agent consistency** — does the effect hold across Claude Code and Codex, or is it agent-specific?
+
+Results will be summarized in this README and (if signal is strong) in the project's main README under "Verifiable promises".

--- a/docs/benchmark/results/2026-05-template.md
+++ b/docs/benchmark/results/2026-05-template.md
@@ -1,0 +1,130 @@
+# Benchmark run — YYYY-MM-DD
+
+> Rename this file to your actual run date (e.g. `2026-05-10.md`). Each
+> run goes in its own file so we can track effect over time as the
+> ontology evolves.
+
+## Setup
+
+- **Repo HEAD**: `<git rev-parse HEAD>`
+- **Vault size**: `<pnpm dogfood:walk | grep "vault size">` nodes
+- **Claude Code version**: `<claude --version>`
+- **Codex CLI version**: `<codex --version>`
+- **Date / grader**: `<YYYY-MM-DD / Stark>`
+
+## Per-task results
+
+Fill in 4 cells per task: Claude Code OFF / Claude Code ON / Codex OFF / Codex ON.
+
+### A1 — Domain composition
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### A2 — Stub / unfinished detection
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### A3 — Reference graph for a specific node
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### B1 — Validator issue codes
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### B2 — Conflict guard mechanism
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### C1 — Function exports (negative control)
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+### C2 — package.json scripts (negative control)
+
+| Cell | Correctness (0–3) | Tool calls | Hallucinations | Utility (1–5) | Notes |
+|---|---|---|---|---|---|
+| Claude Code OFF | | | | | |
+| Claude Code ON  | | | | | |
+| Codex OFF       | | | | | |
+| Codex ON        | | | | | |
+
+---
+
+## Summary
+
+After all 28 cells are filled in, average per-mode-per-category here.
+
+### Within-agent delta (primary signal)
+
+| | Claude Code OFF avg correctness | Claude Code ON avg correctness | Δ | Codex OFF avg correctness | Codex ON avg correctness | Δ |
+|---|---|---|---|---|---|---|
+| Cat A (3 tasks) | | | | | | |
+| Cat B (2 tasks) | | | | | | |
+| Cat C (2 tasks) | | | | | | |
+| **All 7** | | | | | | |
+
+### Tool-call efficiency
+
+| | Cat A avg calls (OFF / ON) | Cat C avg calls (OFF / ON) |
+|---|---|---|
+| Claude Code | / | / |
+| Codex | / | / |
+
+(Cat A: lower-with-correctness on ON is a win. Cat C: should be roughly equal.)
+
+### Hallucination totals
+
+| Agent | OFF total | ON total |
+|---|---|---|
+| Claude Code | | |
+| Codex | | |
+
+---
+
+## Interpretation
+
+After filling in numbers, write 3–5 sentences here:
+
+1. What did Cat A show? (The hypothesis test.)
+2. What did Cat C show? (The bias check — should be neutral.)
+3. Cross-agent: did Claude Code and Codex agree on the direction of the effect?
+4. Surprises / things to investigate further.
+5. Decision: does this update the project's direction?
+
+## Raw transcripts
+
+Drop links / paths to the raw conversation transcripts here so a third party could re-grade:
+
+- Claude Code transcripts: `~/.claude/projects/-Users-stark-ai-oh-my-ontology/<session-id>.jsonl`
+- Codex transcripts: `<path or pasted>`

--- a/docs/benchmark/rubric.md
+++ b/docs/benchmark/rubric.md
@@ -1,0 +1,80 @@
+# Rubric — how to score each run
+
+> Score each agent × mode × task cell (28 cells total per measurement run).
+> Be strict. If you find yourself wanting to round up because the agent
+> "almost" got it, write the gap in the **Notes** column instead of inflating.
+
+## The four axes
+
+### 1. Correctness (0–3) — primary score
+
+| Score | Meaning |
+|---|---|
+| **3** | Fully correct. Every item the prompt asked for is present and accurate; no false claims. |
+| **2** | Mostly correct. The main answer is right; minor omissions OR one borderline-wrong sub-item. |
+| **1** | Partially correct. The answer addresses the question but is missing material content OR contains a confidently wrong statement. |
+| **0** | Wrong, evasive, or refuses. Includes "I'd need more context" non-answers. |
+
+**Verify against the actual repo state at measurement time** — don't grade from memory. Open the file / run `pnpm dogfood:walk` if needed.
+
+### 2. Tool-call count
+
+Just count. Lower-with-correctness is better. A score-3 answer in 2 tool calls beats a score-3 answer in 15.
+
+For Claude Code: visible in the conversation as tool-use blocks.
+For Codex: count the tool invocations shown in the CLI output.
+
+**Don't penalize MCP-off** for using more Read/Grep calls — that's the cost of not having the graph. The point is to make that cost visible.
+
+### 3. Hallucinations (count)
+
+Count of confidently asserted items that don't exist in the repo.
+
+Examples:
+- "The validator detects `parse-fail-soft`" → no such code exists. **+1**
+- "It's defined in `src/shared/lib/foo.ts`" but that file doesn't exist. **+1**
+- "The `findOrphans` function returns…" but it's actually `find_orphans`. **0** — name typo, not invented behavior.
+
+If unsure whether something's hallucinated, search for it. The cost of a wrong "+1" or "+0" is small; the cost of letting confident fabrication go uncounted is large.
+
+### 4. Subjective utility (1–5) — last, optional
+
+Strictly the human grader's gut feel: "if I'd asked this in real work, would this answer have moved me forward?"
+
+| Score | Meaning |
+|---|---|
+| **5** | Yes, immediately actionable. |
+| **4** | Yes, with one small follow-up. |
+| **3** | Mixed — useful but I'd verify before acting. |
+| **2** | Confusing or so verbose I'd ignore most of it. |
+| **1** | Worse than no answer (misleading or distracting). |
+
+This axis is noisy by design — it captures the texture (terseness, citation, framing) that the other axes miss.
+
+---
+
+## What the data should show
+
+### If the ontology helps (positive result)
+
+- **Cat A**: MCP-on correctness > MCP-off by ≥1 point on average. Tool calls fewer. Hallucinations lower.
+- **Cat B**: MCP-on correctness ≥ MCP-off (small but positive delta).
+- **Cat C**: Roughly neutral. MCP-on shouldn't be worse here.
+
+### If the ontology doesn't help (null result)
+
+- **Cat A**: MCP-on and MCP-off score the same on correctness. Tool calls maybe lower with MCP-on (efficiency win) but no quality difference.
+- This means the AI agent already extracts equivalent structure from raw markdown — the curated graph isn't earning its keep.
+
+### If the ontology hurts (negative result)
+
+- **Cat C**: MCP-on under-performs. Agent over-relies on ontology tools when raw file-read would be faster and more accurate.
+- **Cat A hallucinations** climb because the agent invents slugs based on the schema rather than checking.
+
+Each outcome has a clear next action. That's why we're running the bench.
+
+---
+
+## A note on ties
+
+When MCP-on and MCP-off score identically on correctness, **tie-break on tool-call efficiency**. If a Cat A task is solved in 1 tool call (MCP-on `find_backlinks`) vs 12 (MCP-off recursive grep), that's still a meaningful win for the agent's working economy — sub agents, latency, context budget — even if the final answer is identical.

--- a/docs/benchmark/tasks.md
+++ b/docs/benchmark/tasks.md
@@ -1,0 +1,123 @@
+# Benchmark tasks
+
+> 7 tasks across 3 categories. Each has a known correct answer (verifiable
+> by human against the current `docs/ontology/` vault, code, and PR history)
+> so we can grade independent of the AI's confidence.
+>
+> **Paste the prompt verbatim into a fresh agent session.** No follow-ups.
+
+---
+
+## Category A — cross-cutting graph questions
+
+> Questions where the answer requires reasoning over multiple nodes / edges
+> in the ontology. We expect the MCP-on mode to show a clear advantage:
+> single MCP tool calls return the whole picture, while MCP-off has to
+> grep through markdown files file-by-file and stitch the answer together.
+
+### A1 — Domain composition
+
+**Prompt:**
+> 이 repo 의 ontology vault 에서 `vault-local-first` 도메인 아래에 어떤 capability 와 element 들이 있는지 정리해줘. 도메인 자체의 설명 한 줄도 포함.
+
+**Correct answer (verify against `docs/ontology/`):**
+- The agent should list the domain's `capabilities: [...]` array (currently includes `capabilities/scaffold-vault`, `capabilities/vault-validator`, etc — verify against the actual file at measurement time).
+- Plus elements that have `domain: domains/vault-local-first` in their frontmatter.
+- Plus the domain's title / one-line description from its `.md` body.
+
+**Score axis emphasis:** correctness, tool-call efficiency.
+
+### A2 — Stub / unfinished detection
+
+**Prompt:**
+> 이 repo 의 ontology 에서 `kind: capability` 인데 `elements` 배열이 비어 있는 노드들 (= 미완료 후보) 을 찾아줘.
+
+**Correct answer:**
+- Verifiable via `query_concepts({ filter: "kind=capability AND NOT has(elements)" })` (MCP-on) or by grepping all capability `.md` files (MCP-off).
+- The agent should produce the actual list of slugs, not a heuristic guess.
+
+**Score axis emphasis:** hallucinations (any non-existent slug = -1 per item), correctness.
+
+### A3 — Reference graph for a specific node
+
+**Prompt:**
+> `capabilities/mcp-server` 를 frontmatter 에서 참조하고 있는 모든 노드를 찾아 kind 별로 분류해줘.
+
+**Correct answer:**
+- All nodes whose frontmatter array key (`capabilities`, `elements`, `dependencies`, `relates`, `contains`, `describes`) or inline string key (`domain`) contains `capabilities/mcp-server`.
+- MCP-on: one `find_backlinks` call returns this with `matchedKeys`.
+- MCP-off: must grep recursively and parse YAML mentally.
+
+**Score axis emphasis:** correctness, hallucinations, time-to-answer.
+
+---
+
+## Category B — semantic / design questions
+
+> Questions where the answer is partially in code, partially in docs,
+> partially in the ontology body text. We expect a graded response —
+> MCP-on should help if the ontology covers the question, otherwise neutral.
+
+### B1 — Validator issue codes
+
+**Prompt:**
+> oh-my-ontology 의 vault validator 가 detect 하는 issue code 들을 모두 나열하고 각각의 의미를 한 줄씩 설명해줘.
+
+**Correct answer:**
+- 5 codes: `unclosed-frontmatter`, `empty-kind`, `missing-kind`, `unknown-kind`, `parse-zero-keys`.
+- Defined in `src/shared/lib/validate-vault-document.ts` and `mcp/src/validate.mjs` (cross-package contract test enforces drift).
+- The capability `capabilities/vault-validator` documents this in body — MCP-on agents may find it via `get_concept`.
+
+**Score axis emphasis:** correctness (all 5 codes named), hallucinations (any extra invented codes).
+
+### B2 — Conflict guard mechanism
+
+**Prompt:**
+> oh-my-ontology MCP 의 write 도구들이 사용자의 외부 에디터 변경을 어떻게 감지하는지, 어떤 도구가 어떤 인자를 받는지 설명해줘.
+
+**Correct answer:**
+- mtime-based — `get_concept` returns `mtime` (ms), all write tools (`patch_concept` / `delete_concept` / `add_relation` / `rename_concept` / `merge_concepts`) accept optional `expected_mtime`.
+- Mismatch throws `VaultConflictError`.
+- Documented in `mcp/CHANGELOG.md` (R11) and `capabilities/mcp-conflict-guard`.
+
+**Score axis emphasis:** correctness (lists all 5 write tools, names mtime mechanism), subjective utility.
+
+---
+
+## Category C — negative control (raw grep / read sufficient)
+
+> Questions answerable by simple file-reading. MCP-on should NOT show a
+> meaningful advantage here. If MCP-on dramatically underperforms, it
+> means the ontology is steering the agent toward irrelevant context.
+
+### C1 — Function exports
+
+**Prompt:**
+> `src/shared/lib/validate-vault-document.ts` 에서 export 되는 함수들을 모두 나열해줘.
+
+**Correct answer:**
+- Verifiable by reading the file. Currently exports `validateVaultDocument`, `validateVaultDocFrontmatter`, `summarizeVaultValidation` (verify at measurement time).
+- This is a pure-grep task — no graph reasoning needed.
+
+**Score axis emphasis:** correctness, tool-call efficiency (should be 1-2 reads). MCP-on should not over-use ontology tools here.
+
+### C2 — package.json scripts
+
+**Prompt:**
+> 이 repo 의 `package.json` 의 `scripts:` 객체에 정의된 명령어들을 모두 나열해줘.
+
+**Correct answer:**
+- Read `package.json`, list all keys in `scripts`. Currently includes `dev`, `build`, `lint`, `test`, `test:run`, `vault:validate`, `vault:migrate`, `bundle:check`, `dogfood:walk`, etc.
+- Pure file-read.
+
+**Score axis emphasis:** efficiency, no-MCP-overhead.
+
+---
+
+## How tasks were chosen
+
+- **Cat A (3 tasks)** — designed to play to the ontology's strengths. If MCP-on doesn't win here, the product premise is in trouble.
+- **Cat B (2 tasks)** — semantic questions where the body text and frontmatter both hold partial answers. Tests whether the agent navigates the graph or wanders.
+- **Cat C (2 tasks)** — negative control. If we don't see neutrality here, the test is bias-confounded.
+
+The 3:2:2 ratio biases the bench *toward* showing a positive effect — by design, because that's the hypothesis we're trying to falsify. If the bench leans MCP-on and we still see no effect, the negative result is robust.


### PR DESCRIPTION
## Summary

product 의 **가장 큰 미검증 전제** — "AI agent 가 ontology vault 를 읽고 쓰면 코드 작업을 더 잘 한다" — 를 처음으로 데이터로 검증하는 인프라. 자동화는 일부러 안 함 — 실 사용자 환경 (구독제 Claude Code / Codex CLI) 그대로 측정.

## What's in the bench

- **7 tasks · 3 categories** (`docs/benchmark/tasks.md`):
  - **A 3개 cross-cutting** — graph reasoning 필요한 질문 (도메인 구성, 미완료 capability, backlink). MCP 우위 기대.
  - **B 2개 semantic** — validator issue codes / conflict guard mechanism. graded response 기대.
  - **C 2개 negative-control** — `validate-vault-document.ts` exports / `package.json` scripts. raw grep 충분, MCP 우위 0 기대.
- **Rubric** (`docs/benchmark/rubric.md`) — 정답성 0-3 + tool call 수 + hallucinations + 주관 utility 1-5.
- **Result template** (`docs/benchmark/results/2026-05-template.md`) — 28 cell 매트릭스 (7 task × 4 cell). 매 measurement run 마다 새 파일로 복제.
- README.md 의 "Verifiable promises" 표에 "AI agent quality measurement *(in progress)*" 행 추가.

## Why subscription not API

사용자 95% 는 Claude Code Pro/Max · Codex Plus · Cursor Pro 구독제로 사용 — token 비용은 의사결정 변수가 아님. API simulation 은 mismatch. 사용자 본인 손으로 같은 prompt 를 4 cell 돌려 transcript 분석.

## Run protocol

각 task: fresh session × prompt verbatim × no follow-ups × score per rubric. 28 cell × 2-5분 = 1-2시간 한 라운드.

## What we're hoping to learn

- **Cat A delta 큼** → product premise 검증.
- **Cat C neutral** → bias 없음 확인.
- **Cat A null** → schema 너무 thin 또는 agent 가 이미 raw markdown 으로 충분.
- **Cat C MCP-on 악화** → ontology 가 agent 를 misleading.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors (md 만 추가)
- [x] \`pnpm test:run\` — 759/759 pass
- [x] \`pnpm lint\` — 영향 0 (md 만 추가)

## Next step (사용자 손)

1. PR 머지
2. \`docs/benchmark/results/2026-05-template.md\` 를 \`<run-date>.md\` 로 복제
3. Claude Code 와 Codex CLI 두 환경에서 \`.mcp.json\` toggle 하면서 28 cell 측정
4. 결과 PR 로 push → README 의 "in progress" 가 실제 데이터로 승급

🤖 Generated with [Claude Code](https://claude.com/claude-code)