### PR TITLE
benchmark: Codex bypass rerun — n=2 measured, MCP value cross-agent confirmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ becoming graph nodes.
 | **AI agent partner via MCP** | `mcp/` package, 14 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
 | **Dogfooding** | `docs/ontology/` is the project's own curated mental model (~21 nodes — domains 6 · capabilities 9 · elements 4 · project 1 · vault-readme 1). |
-| **AI agent quality measurement** *(cross-agent, n=1 confirmed + 1 unmeasurable)* | [`docs/benchmark/`](docs/benchmark/) — 7 tasks × 3 categories × 2 agents. **Claude Code**: MCP-on cuts hallucinations 9 → 0, Cat A correctness +1.0 ([results](docs/benchmark/results/2026-05-04-claude-code.md)). **Codex**: `codex exec` (non-interactive) structurally default-denies MCP tool calls regardless of `--sandbox` setting — needs interactive mode or explicit bypass to genuinely measure ([results](docs/benchmark/results/2026-05-04-codex.md)). |
+| **AI agent quality measurement** *(cross-agent, n=2 measured)* | [`docs/benchmark/`](docs/benchmark/) — 7 tasks × 3 categories × 2 agents. **Claude Code**: MCP-on cuts hallucinations 9 → 0, Cat A correctness +1.0 (quality win) ([results](docs/benchmark/results/2026-05-04-claude-code.md)). **Codex** (bypass-authorized): MCP-on cuts Cat A tool calls 7.0 → 1.67 (76% reduction; efficiency win), correctness already saturated OFF ([results](docs/benchmark/results/2026-05-04-codex.md)). MCP delivers value to both agents through *different mechanisms*. Negative control (Cat C) passes for both — agents correctly defer to Read/Grep on file-read tasks. |
 
 ## Architecture
 

--- a/docs/benchmark/results/2026-05-04-codex.md
+++ b/docs/benchmark/results/2026-05-04-codex.md
@@ -180,6 +180,61 @@ The original conclusion stands but with a cleaner attribution:
 
 This is itself a **product finding for Codex users**: even if our MCP server is excellent, *Codex's CLI design default-denies all MCP calls in automated workflows*. Anyone wanting to use `oh-my-ontology-mcp` with Codex needs to know they have to either run interactively or accept the bypass risk. **This is worth documenting in the Codex setup section of the README.**
 
+---
+
+## Re-measurement — bypass authorized (same day, n=2 attempt)
+
+User explicitly authorized `--dangerously-bypass-approvals-and-sandbox` for one measurement run. All 7 tasks re-run on Codex with bypass enabled. **MCP tool calls now actually execute**; sandbox shows `danger-full-access` and tool calls return `(completed)` instead of `(failed)` / `cancelled`.
+
+### Per-task results (Codex MCP-on with bypass)
+
+| Task | MCP calls | Result | Tool calls (incl. shell) | Correctness | Hallucinations | Notes |
+|---|---|---|---|---|---|---|
+| **A1** | 3 (1 wrong slug `vault-local-first` → `list_concepts` → `get_concept(domains/vault-local-first)`) | All capabilities + elements + description | 3 | 3 | 0 | Slug guessing cost 1 extra call. Honest about the slug correction. |
+| **A2** | 1 (`query_concepts({filter: "kind=capability AND NOT has(elements)"})`) | `total: 0, matches: []` | 1 | 3 | 0 | One-shot, exact answer. **Compare to A2 Codex OFF: 11 shell calls + inline node YAML parser.** |
+| **A3** | 1 (`find_backlinks(slug: capabilities/mcp-server)`) | 4 backlinks correctly grouped by kind, all `matchedKey` annotated | 1 | 3 | 0 | **Includes the `domains/ai-agent-partner: capabilities` tail reference that Codex OFF missed.** |
+| **B1** | 1 (`get_concept(slug: capabilities/vault-validator)`) | All 5 codes + severity + meaning + CLI/UI surface split | 1 | 3 | 0 | Body excerpt directly answers the question. |
+| **B2** | 1 (`get_concept(slug: capabilities/mcp-conflict-guard)`) | mtime mechanism + write tools + retry flow + compatibility | 1 | 3 | 0 | Same — body excerpt is the documentation. |
+| **C1** | **0** (used `rg ^export`) | 4 exports (KNOWN_VAULT_KINDS + 3 functions) | 1 | 3 | 0 | **Negative control: Codex correctly did NOT use MCP for a TS file question.** |
+| **C2** | **0** (used `node -e ...`) | All 12 scripts | 1 | 3 | 0 | **Negative control passes.** Codex defaults to raw read for non-vault questions. |
+
+### Headline metrics — Codex bypass run (Codex OFF → ON-bypass)
+
+| | OFF | ON-bypass | Δ |
+|---|---|---|---|
+| **Cat A correctness avg** | 2.67 | **3.0** | +0.33 |
+| **Cat A tool calls avg** | 7.0 | **1.67** | **−5.3 (76% reduction)** |
+| **Cat A hallucinations** | 0 | 0 | 0 |
+| **Cat B correctness** | 3.0 | 3.0 | 0 |
+| **Cat B tool calls avg** | many | **1.0** | large reduction |
+| **Cat C correctness** | 3.0 | 3.0 | 0 |
+| **Cat C MCP usage** | n/a | 0 | (negative control passes — Codex did not over-reach) |
+| **All 7 hallucinations** | 0 | 0 | 0 |
+
+### Final cross-agent conclusion (n=2 measured)
+
+| | Claude Code | Codex (bypass) |
+|---|---|---|
+| **MCP value type** | **Hallucination elimination** (9 → 0 on Cat A) | **Efficiency** (Cat A tool calls 7.0 → 1.67) |
+| **Cat A correctness OFF→ON** | 2.0 → 3.0 (**+1.0**) | 2.67 → 3.0 (**+0.33**) |
+| **Negative control (C1/C2) MCP usage** | 0 (correctly defers to Read/Grep) | 0 (correctly defers to rg/node) |
+| **A3 tail reference detection** | OFF false positive (README) | OFF missed; ON catches |
+
+**MCP delivers value to both agents — through different mechanisms:**
+
+- **Claude Code**: raw grep is hallucination-prone on YAML edge cases. MCP's proper YAML parser eliminates false positives. Quality is the win.
+- **Codex**: raw grep is robust (no hallucinations OFF) but inefficient (averages 7 shell calls per Cat A task). MCP collapses graph queries to single tool calls. Efficiency is the win.
+
+Both agents correctly handle the negative control (Cat C) — neither over-reaches for ontology tools when raw file-read is appropriate. **The benchmark's bias check passes for both.**
+
+### Important caveat for Codex automation
+
+Even with bypass authorized, **automated batch use of `oh-my-ontology-mcp` from Codex requires either**:
+1. Repeated `--dangerously-bypass-approvals-and-sandbox` invocations (security trade-off documented per call), or
+2. An interactive `codex` session with a human approving each MCP call.
+
+This is a Codex-side default, not a limitation of our MCP server. Should be surfaced in any future "Codex setup" section of the project README.
+
 ## Raw data
 
 Codex transcripts saved at `/tmp/codex_<task>_<mode>.txt` during the run. Codex's own session log: `~/.codex/sessions/`.


### PR DESCRIPTION
## Summary

사용자가 \`--dangerously-bypass-approvals-and-sandbox\` 명시 승인. Codex 7 task 재측정 — **MCP tool 실제 실행됨**.

## Headline finding — MCP delivers value to both agents, through different mechanisms

| | Claude Code | Codex (bypass) |
|---|---|---|
| **MCP value type** | **Hallucination elimination** (9 → 0 on Cat A) | **Efficiency** (Cat A tool calls 7.0 → 1.67, 76% 감소) |
| **Cat A correctness OFF→ON** | 2.0 → 3.0 (+1.0) | 2.67 → 3.0 (+0.33; OFF already saturated) |
| **Negative control (C1/C2) MCP usage** | 0 (correctly defers to Read/Grep) | 0 (correctly defers to rg/node) |

### Per-task Codex bypass results

| Task | MCP calls | Correctness | Hallucinations |
|---|---|---|---|
| A1 | 3 (slug guess + recover) | 3 | 0 |
| A2 | 1 (\`query_concepts\`) | 3 | 0 |
| A3 | 1 (\`find_backlinks\`) | 3 (incl. tail reference!) | 0 |
| B1 | 1 (\`get_concept\`) | 3 | 0 |
| B2 | 1 (\`get_concept\`) | 3 | 0 |
| C1 | **0** (used rg) | 3 | 0 |
| C2 | **0** (used node -e) | 3 | 0 |

C1 / C2 가 **0 MCP calls** — Codex 가 negative control 정확히 인식, raw read 적절한 task 에 ontology 도구 over-reach 안 함. **벤치 bias 검증 통과**.

## What this means

**Cross-agent product premise 검증 완료**:
- Claude Code 사용자: MCP 가 raw grep 의 YAML mis-parse hallucination 차단
- Codex 사용자: MCP 가 graph 질문 efficiency 향상 (tool calls 4× 감소)

두 agent 모두 *다른 mechanism* 으로 MCP 의 가치 전달. 단일 mechanism 가설 보다 풍부한 결과.

## Caveat for Codex automation

Codex 의 batch 자동화는 매 호출 \`--dangerously-bypass-approvals-and-sandbox\` 또는 interactive 사람 승인 필요. **이건 Codex CLI 측 default — 우리 MCP 서버 문제 아님**.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors

## Files

- \`docs/benchmark/results/2026-05-04-codex.md\` — "Re-measurement — bypass authorized" 섹션 추가
- \`README.md\` — Verifiable promises 표 \"n=2 measured + cross-agent value confirmed\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)