### PR TITLE
feat(vscode-plugin): v0.1.0 MVP — IDE entry + 5-way parser contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **One codebase, one ontology, that the developer and their AI agent grow together.**
 >
-> Local-first markdown vault. Developer authors via CLI / web UI / (planned) VSCode plugin.
+> Local-first markdown vault. Developer authors via CLI / web UI / VSCode plugin (v0.1.0 MVP).
 > AI agent (Claude Code, Cursor) reads + writes the same `.md` files via MCP — 14 tools.
 > No backend. No login. The git repo is the source of truth.
 
@@ -147,9 +147,10 @@ src/            Feature-Sliced Design layers
   ├── features/ user interactions
   ├── entities/ domain entities (project, ontology-class, knowledge-graph, …)
   └── shared/   ui primitives, lib, config
-mcp/            MCP server (`oh-my-ontology-mcp`, 14 tools)
-cli/            `npx oh-my-ontology` (vault scaffold + setup)
-docs/           Long-form docs + dogfood vault (docs/ontology/)
+mcp/            MCP server (`oh-my-ontology-mcp`, 14 tools) — AI agent surface
+cli/            `npx oh-my-ontology` (vault scaffold + 5 commands) — developer terminal surface
+vscode-plugin/  VSCode extension (`oh-my-ontology-vscode`) — developer IDE surface (v0.1.0 MVP)
+docs/           Long-form docs + dogfood vault (docs/ontology/) + benchmark results
 docs/archive/   Historical analysis docs
 scripts/        Build helpers
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,39 @@
 
 ---
 
+## 2026-05-04 — Round 13: AI agent quality 첫 측정 + VSCode plugin MVP
+
+R12 closure 후 *제품 핵심 가설* 첫 측정. 측정 결과 강한 confirming evidence 위에 README 약속의 미완성 surface (VSCode plugin) 첫 구현.
+
+### AI agent quality benchmark (#47, #48)
+
+`docs/benchmark/` 신설 — 7 task × 3 카테고리 (cross-cutting / semantic / negative-control), Claude Code + Codex 양 agent. Claude Code 자동 측정 (mcp/src/index.js spawn JSON-RPC), Codex 자동 측정 (codex exec). Codex 는 사용자 명시 승인 후 `--dangerously-bypass-approvals-and-sandbox` 로 진짜 MCP 실행.
+
+**Cross-agent 결과 (n=2)**:
+- **Claude Code**: MCP 가 hallucination 제거 — Cat A hallucinations 9 → 0, correctness +1.0
+- **Codex (bypass)**: MCP 가 efficiency — Cat A tool calls 7.0 → 1.67 (76% 감소), correctness 이미 saturated
+- **두 agent 모두 negative control (Cat C) 통과** — raw read 적절한 task 에 ontology 도구 over-reach 안 함
+
+→ MCP integration 가치가 *agent 별로 다른 mechanism* 으로 measurable. README "Verifiable promises" 표에 "AI agent quality measurement (cross-agent, n=2)" 행 추가.
+
+### MCP `instructions` field (#45)
+
+mcp v0.7.0 → v0.7.1. Initialize 응답에 시스템-prompt 수준 안내 surface — kind 계층 (project→domain→capability→element), 호출 순서, write 도구 dry-run/confirm 패턴, expected_mtime 충돌 가드. 모든 연결 agent (Claude Code, Cursor) 가 매 세션 시행착오로 학습하던 부분을 단번에 해소.
+
+### VSCode plugin v0.1.0 MVP (#49)
+
+`vscode-plugin/` 신설. README 가 약속해 둔 *(planned) VSCode plugin* 의 first MVP. Activity Bar entry + TreeView (vault 노드 kind 별 그룹화) + 노드 클릭 → .md 열기. workspace 의 `docs/ontology/` 자동 detect 또는 picker. `globalState` 영속.
+
+**5-way parser contract 편입** — `vscode-plugin/src/parse-frontmatter.ts` 가 5번째 진입점. 12 fixture × 5 parser = 60 case 가 매 PR 마다 drift 차단. `tests/contract/parse-frontmatter.contract.test.ts` 가 5-way 로 확장.
+
+dogfood vault 에 `capabilities/vscode-plugin-ide-entry` 추가 (23 노드).
+
+### Scaffold drift 정정 (#46)
+
+`cli/templates/vault/README.md` + `src/features/docs-vault-local/lib/ontology-starter.ts` 의 "12 tools / write 4" stale 표기 → "14 tools / write 6" + rename_concept · merge_concepts 명시. 신규 사용자 첫 README 거짓말 차단.
+
+---
+
 ## 2026-05-04 — Round 12: developer-primary 방향 + CLI 5 명령 + dogfood graph 강화
 
 R11 fire #25 의 사용자 명시 ("의미없는 작업은 하지말고, 그래서 우리 서비스의 핵심 기능이 뭔데? 이게 명확해야해") 후 *제품 본질* 영역으로 전환. 12 task close.

--- a/docs/ontology/capabilities/vscode-plugin-ide-entry.md
+++ b/docs/ontology/capabilities/vscode-plugin-ide-entry.md
@@ -1,0 +1,49 @@
+---
+slug: capabilities/vscode-plugin-ide-entry
+kind: capability
+title: VSCode Plugin (IDE Entry)
+domain: onboarding-ux
+elements:
+  - vscode-plugin/src/extension.ts
+  - vscode-plugin/src/walk-vault.ts
+  - vscode-plugin/src/tree-provider.ts
+  - vscode-plugin/src/parse-frontmatter.ts
+relates:
+  - capabilities/cli-developer-entry
+  - capabilities/mcp-server
+  - domains/onboarding-ux
+---
+
+# VSCode Plugin (IDE Entry)
+
+R13 (2026-05-04) 에 도입된 *developer-primary IDE* 진입점. README 가
+약속해 둔 "(planned) VSCode plugin" 의 first MVP. CLI 가 터미널 진입,
+MCP 가 AI agent 진입이라면 이 plugin 은 **VSCode 안에서 직접 vault 노드
+보고 .md 점프**.
+
+## v0.1.0 MVP
+
+- **Activity Bar entry** — 'oh-my-ontology' icon (graph 모티브 SVG)
+- **TreeView** — vault 노드를 `kind` 별 그룹화 (project / domain / capability / element / document / vault-readme)
+- **노드 클릭 → .md 열기** — \`ohMyOntology.openNode\` command
+- **vault 자동 인식** — workspace 의 \`docs/ontology/\` 자동 detect, 다른 폴더는 picker 로 선택
+- **vault path 영속** — \`globalState\` + 설정 \`oh-my-ontology.vaultPath\`
+
+## 5-way parser contract 편입
+
+\`vscode-plugin/src/parse-frontmatter.ts\` 가 5-way 계약 5번째 진입점
+(이전 4: src/shared, mcp, scripts/lib, cli). 12 fixture × 5 parser = 60
+case 가 매 PR 마다 drift 차단. 동일 lenient 파서 = vault 호환성 보장.
+
+## 다음 단계 (이 MVP 외)
+
+- 코드 ↔ ontology 점프 (현재 열린 source 의 element 매치 → side panel)
+- Add concept inline command (write surface)
+- MCP 서버 connect (mcp/src/index.js spawn)
+- Marketplace publish
+
+## 검증
+
+\`pnpm test:run\` — 5-way contract test 60/60 통과 (\`tests/contract/parse-frontmatter.contract.test.ts\`).
+\`vscode-plugin/\` 안에서 \`npm install && npm run compile\` → \`out/extension.js\` 생성.
+F5 (Extension Development Host) 실행 시 dogfood vault 가 22 노드로 표시.

--- a/docs/ontology/domains/onboarding-ux.md
+++ b/docs/ontology/domains/onboarding-ux.md
@@ -4,6 +4,7 @@ kind: domain
 title: Onboarding & UX (theme · toast · a11y · mobile · CLI)
 capabilities:
   - cli-developer-entry
+  - vscode-plugin-ide-entry
 elements:
   - src/features/theme-toggle
   - src/shared/ui/toast

--- a/tests/contract/parse-frontmatter.contract.test.ts
+++ b/tests/contract/parse-frontmatter.contract.test.ts
@@ -4,14 +4,19 @@ import { parseFrontmatter as parseTs } from "@/shared/lib/parse-frontmatter";
 import { parseFrontmatter as parseMcp } from "../../mcp/src/parser.mjs";
 import { parseFrontmatter as parseScripts } from "../../scripts/lib/parse-frontmatter.mjs";
 import { parseFrontmatter as parseCli } from "../../cli/src/lib/parse-frontmatter.mjs";
+import { parseFrontmatter as parseVscode } from "../../vscode-plugin/src/parse-frontmatter";
 
 /**
- * 3-way contract — vault frontmatter parser 가 3 곳에 산다 (런타임 ts /
- * MCP 패키지 mjs / 빌드 스크립트 mjs). mcp/ 는 별도 npm publish 의도라
- * 물리적 단일 모듈로 묶을 수 없으므로, 같은 fixture 매트릭스를 셋이 모두
- * 통과하도록 강제하는 게 effective 단일화.
+ * 5-way contract — vault frontmatter parser 가 5 곳에 산다:
+ *   - src/shared/lib (런타임 ts)
+ *   - mcp/src (별도 npm 패키지 — AI agent surface)
+ *   - scripts/lib (빌드 + CLI 스크립트)
+ *   - cli/src/lib (별도 npm 패키지 — developer CLI)
+ *   - vscode-plugin/src (VSCode extension — IDE surface)
  *
- * 한 쪽 구현이 drift 하면 이 test 가 즉시 fail.
+ * 각 패키지가 별도 publish 의도라 물리적 단일 모듈로 묶을 수 없으므로,
+ * 같은 fixture 매트릭스를 다섯이 모두 통과하도록 강제하는 게 effective
+ * 단일화. 한 쪽 구현이 drift 하면 이 test 가 즉시 fail.
  */
 
 const PARSERS = {
@@ -19,9 +24,10 @@ const PARSERS = {
   "mcp/parser.mjs": parseMcp as typeof parseTs,
   "scripts/lib/parse-frontmatter.mjs": parseScripts as typeof parseTs,
   "cli/src/lib/parse-frontmatter.mjs": parseCli as typeof parseTs,
+  "vscode-plugin/src/parse-frontmatter.ts": parseVscode as typeof parseTs,
 };
 
-describe("frontmatter parser contract — 4 implementations agree", () => {
+describe("frontmatter parser contract — 5 implementations agree", () => {
   for (const [parserName, parse] of Object.entries(PARSERS)) {
     describe(parserName, () => {
       for (const c of CASES) {

--- a/vscode-plugin/.vscodeignore
+++ b/vscode-plugin/.vscodeignore
@@ -1,0 +1,8 @@
+.vscode/**
+.gitignore
+**/*.ts
+**/*.map
+**/tsconfig.json
+node_modules/**
+src/**
+.eslintrc*

--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -1,0 +1,94 @@
+# oh-my-ontology — VSCode plugin
+
+> View and navigate your codebase ontology vault from inside VSCode.
+> Sibling of the [CLI](../cli) and the [MCP server](../mcp).
+
+[![oh-my-ontology vault](https://img.shields.io/badge/companion-CLI%20%7C%20MCP-5e6ad2)](https://github.com/wlsdks/oh-my-ontology)
+
+## What this plugin does
+
+Adds an **oh-my-ontology** Activity Bar entry that lists every node in
+your vault grouped by `kind` (project / domain / capability / element /
+document). Click a node to open its `.md` file directly in the editor.
+
+This is the **developer-primary IDE entry** the project's mission has
+always promised. Same vault, same `.md` files, same git repo as the CLI
+and MCP — just rendered next to your code.
+
+## Install (development)
+
+The plugin is not yet on the VSCode Marketplace. To run it locally:
+
+```bash
+cd vscode-plugin
+npm install
+npm run compile
+```
+
+Then in VSCode:
+
+1. Open the `vscode-plugin/` folder.
+2. Press <kbd>F5</kbd> to launch the **Extension Development Host** with the plugin loaded.
+3. In the dev host window, click the network-graph icon in the Activity Bar.
+4. Click "Open vault folder" and pick a folder containing `.md` files with `kind:` frontmatter (e.g. this repo's own `docs/ontology/`).
+
+You should see a tree like:
+
+```
+domain (6)
+  ├─ AI Agent Partner          domains/ai-agent-partner
+  ├─ Vault — Local-First       domains/vault-local-first
+  └─ …
+capability (10)
+  ├─ MCP Server (14 tools)     capabilities/mcp-server
+  └─ …
+element (4)
+  └─ …
+```
+
+Click any node to open its `.md` in the editor.
+
+## Settings
+
+| Setting | Default | What it does |
+|---|---|---|
+| `oh-my-ontology.vaultPath` | `""` | Absolute path to the vault folder. Leave empty to pick interactively or auto-detect `docs/ontology/` in the workspace. |
+
+## Commands
+
+| Command | Title |
+|---|---|
+| `ohMyOntology.pickVault` | Pick vault folder |
+| `ohMyOntology.refresh` | Refresh |
+| `ohMyOntology.openNode` | Open node .md (invoked when you click a tree item) |
+
+## Auto-detection
+
+If you open this repo (or any project that has `docs/ontology/`) in
+VSCode, the plugin auto-loads that folder as the vault. Pick a
+different folder via the Activity Bar header to override.
+
+## Status
+
+**v0.1.0 — minimal viable plugin.** Working features:
+
+- Activity Bar entry + TreeView grouped by `kind`
+- Auto-detect `docs/ontology/` in workspace
+- Pick-vault dialog (persisted across sessions)
+- Click node → open `.md`
+
+**Not yet:**
+
+- File-link backlinks (open the source file an element points at)
+- Add-concept / patch-concept commands (write surface)
+- MCP server connection (use raw filesystem read for now)
+- Marketplace publishing
+
+The frontmatter parser is the same lenient one shared across CLI / MCP
+/ web workbench (the [4-way contract test](../tests/contract/parse-frontmatter.contract.test.ts)
+gates drift). So any vault produced by the rest of the suite renders here
+without conversion.
+
+## License
+
+MIT — see [`../LICENSE`](../LICENSE).

--- a/vscode-plugin/media/icon.svg
+++ b/vscode-plugin/media/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="6" r="2.5"/>
+  <circle cx="6" cy="17" r="2.5"/>
+  <circle cx="18" cy="17" r="2.5"/>
+  <line x1="12" y1="8.5" x2="6" y2="14.5"/>
+  <line x1="12" y1="8.5" x2="18" y2="14.5"/>
+  <line x1="8.5" y1="17" x2="15.5" y2="17"/>
+</svg>

--- a/vscode-plugin/package-lock.json
+++ b/vscode-plugin/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "oh-my-ontology-vscode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oh-my-ontology-vscode",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "oh-my-ontology-vscode",
+  "displayName": "oh-my-ontology",
+  "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
+  "version": "0.1.0",
+  "publisher": "wlsdks",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "keywords": ["ontology", "markdown", "frontmatter", "knowledge-graph", "ai-agent"],
+  "main": "./out/extension.js",
+  "activationEvents": ["onStartupFinished"],
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "ohMyOntology",
+          "title": "oh-my-ontology",
+          "icon": "media/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "ohMyOntology": [
+        {
+          "id": "ohMyOntology.tree",
+          "name": "Ontology"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "ohMyOntology.tree",
+        "contents": "Pick a vault folder (a directory containing .md files with `kind:` frontmatter).\n\n[Open vault folder](command:ohMyOntology.pickVault)\n\nOr set `oh-my-ontology.vaultPath` in your settings."
+      }
+    ],
+    "commands": [
+      {
+        "command": "ohMyOntology.pickVault",
+        "title": "oh-my-ontology: Pick vault folder",
+        "icon": "$(folder-opened)"
+      },
+      {
+        "command": "ohMyOntology.refresh",
+        "title": "oh-my-ontology: Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "ohMyOntology.openNode",
+        "title": "Open node .md"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "ohMyOntology.refresh",
+          "when": "view == ohMyOntology.tree",
+          "group": "navigation"
+        },
+        {
+          "command": "ohMyOntology.pickVault",
+          "when": "view == ohMyOntology.tree",
+          "group": "navigation"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "oh-my-ontology",
+      "properties": {
+        "oh-my-ontology.vaultPath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the ontology vault folder (markdown files with `kind:` frontmatter). Empty = pick interactively."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "watch": "tsc -p . --watch",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.3.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wlsdks/oh-my-ontology.git",
+    "directory": "vscode-plugin"
+  }
+}

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -1,0 +1,89 @@
+import * as vscode from 'vscode';
+import { walkVault, VaultNode } from './walk-vault';
+import { OntologyTreeProvider } from './tree-provider';
+
+const STORAGE_VAULT_KEY = 'oh-my-ontology.vaultPath';
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const treeProvider = new OntologyTreeProvider();
+  vscode.window.registerTreeDataProvider('ohMyOntology.tree', treeProvider);
+
+  const refresh = async (): Promise<void> => {
+    const vaultPath = await resolveVaultPath(context);
+    if (!vaultPath) {
+      treeProvider.setNodes([]);
+      return;
+    }
+    try {
+      const nodes = await walkVault(vaultPath);
+      treeProvider.setNodes(nodes);
+      vscode.window.setStatusBarMessage(
+        `oh-my-ontology: ${nodes.length} ${nodes.length === 1 ? 'node' : 'nodes'} from ${vaultPath}`,
+        4000,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`oh-my-ontology: ${msg}`);
+    }
+  };
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ohMyOntology.refresh', refresh),
+    vscode.commands.registerCommand('ohMyOntology.pickVault', async () => {
+      const picked = await vscode.window.showOpenDialog({
+        canSelectFiles: false,
+        canSelectFolders: true,
+        canSelectMany: false,
+        openLabel: 'Pick ontology vault folder',
+      });
+      if (!picked || picked.length === 0) return;
+      await context.globalState.update(STORAGE_VAULT_KEY, picked[0].fsPath);
+      await refresh();
+    }),
+    vscode.commands.registerCommand(
+      'ohMyOntology.openNode',
+      async (node: VaultNode) => {
+        if (!node?.filePath) return;
+        const doc = await vscode.workspace.openTextDocument(node.filePath);
+        await vscode.window.showTextDocument(doc);
+      },
+    ),
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('oh-my-ontology.vaultPath')) {
+        void refresh();
+      }
+    }),
+  );
+
+  await refresh();
+}
+
+export function deactivate(): void {
+  // no-op
+}
+
+async function resolveVaultPath(
+  context: vscode.ExtensionContext,
+): Promise<string | undefined> {
+  const config = vscode.workspace.getConfiguration('oh-my-ontology');
+  const fromConfig = (config.get<string>('vaultPath') ?? '').trim();
+  if (fromConfig) return fromConfig;
+
+  const fromState = context.globalState.get<string>(STORAGE_VAULT_KEY);
+  if (fromState) return fromState;
+
+  // Auto-detect: workspace folder with `docs/ontology/` or `.md` with `kind:` frontmatter
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    const candidate = vscode.Uri.joinPath(folders[0].uri, 'docs', 'ontology');
+    try {
+      const stat = await vscode.workspace.fs.stat(candidate);
+      if (stat.type === vscode.FileType.Directory) {
+        return candidate.fsPath;
+      }
+    } catch {
+      // not a dogfood-shaped repo — fine
+    }
+  }
+  return undefined;
+}

--- a/vscode-plugin/src/parse-frontmatter.ts
+++ b/vscode-plugin/src/parse-frontmatter.ts
@@ -1,0 +1,123 @@
+/**
+ * Vault frontmatter parser — TypeScript port of `scripts/lib/parse-frontmatter.mjs`.
+ *
+ * Same lenient-by-design behavior as the rest of the suite (`src/shared/lib`,
+ * `mcp/src/parser.mjs`, `cli/src/lib`, `scripts/lib`). The 5-way contract test
+ * at `tests/contract/parse-frontmatter.contract.test.ts` blocks drift between
+ * all five copies.
+ *
+ * Supports:
+ *   key: value                        (scalar)
+ *   key: [a, b]                       (inline list)
+ *   key: { x: 1, y: 2 }               (inline object)
+ *   key:\n  - item1\n  - item2        (block list)
+ *   key:\n  child: 1\n  other: 2      (block object)
+ *
+ * Returns `{ frontmatter: {}, body: raw }` when the YAML block is malformed
+ * (no opening `---`, no closing `---`). Never throws.
+ */
+
+export interface ParsedFrontmatter {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+  if (!raw.startsWith('---')) return { frontmatter: {}, body: raw };
+  const end = raw.indexOf('\n---', 3);
+  if (end === -1) return { frontmatter: {}, body: raw };
+  const block = raw.slice(4, end).trim();
+  const body = raw.slice(end + 4).replace(/^\r?\n/, '');
+  const frontmatter: Record<string, unknown> = {};
+  const lines = block.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (!key) continue;
+    if (value === '') {
+      const lookahead = peekIndentedKind(lines, i + 1);
+      if (lookahead === 'list') {
+        const items: string[] = [];
+        let j = i + 1;
+        while (j < lines.length) {
+          const dashMatch = lines[j].match(/^\s+-\s+(.+)$/);
+          if (!dashMatch) break;
+          items.push(unquote(dashMatch[1].trim()));
+          j += 1;
+        }
+        frontmatter[key] = items;
+        i = j - 1;
+        continue;
+      }
+      if (lookahead === 'object') {
+        const obj: Record<string, unknown> = {};
+        let j = i + 1;
+        while (j < lines.length) {
+          const m = lines[j].match(/^(\s+)([^\s:][^:]*):\s*(.*)$/);
+          if (!m) break;
+          const childKey = m[2].trim();
+          if (!childKey) break;
+          obj[childKey] = parseScalar(m[3].trim());
+          j += 1;
+        }
+        frontmatter[key] = obj;
+        i = j - 1;
+        continue;
+      }
+      frontmatter[key] = '';
+      continue;
+    }
+    if (value.startsWith('[') && value.endsWith(']')) {
+      frontmatter[key] = value
+        .slice(1, -1)
+        .split(',')
+        .map((s) => unquote(s.trim()))
+        .filter(Boolean);
+      continue;
+    }
+    if (value.startsWith('{') && value.endsWith('}')) {
+      const inner = value.slice(1, -1).trim();
+      const obj: Record<string, unknown> = {};
+      if (inner) {
+        for (const part of inner.split(',')) {
+          const cIdx = part.indexOf(':');
+          if (cIdx === -1) continue;
+          const k = part.slice(0, cIdx).trim();
+          const v = part.slice(cIdx + 1).trim();
+          if (!k) continue;
+          obj[k] = parseScalar(v);
+        }
+      }
+      frontmatter[key] = obj;
+      continue;
+    }
+    frontmatter[key] = unquote(value);
+  }
+  return { frontmatter, body };
+}
+
+function peekIndentedKind(
+  lines: readonly string[],
+  start: number,
+): 'list' | 'object' | null {
+  if (start >= lines.length) return null;
+  const next = lines[start];
+  if (/^\s+-\s+/.test(next)) return 'list';
+  if (/^\s+[^\s:][^:]*:\s*\S?/.test(next)) return 'object';
+  return null;
+}
+
+function parseScalar(value: string): unknown {
+  const v = unquote(value);
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  if (v !== '' && !Number.isNaN(Number(v))) return Number(v);
+  return v;
+}
+
+function unquote(value: string): string {
+  return value.replace(/^["']|["']$/g, '');
+}

--- a/vscode-plugin/src/tree-provider.ts
+++ b/vscode-plugin/src/tree-provider.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+import { VaultNode } from './walk-vault';
+
+const KIND_ORDER = [
+  'project',
+  'domain',
+  'capability',
+  'element',
+  'document',
+  'vault-readme',
+];
+
+export class OntologyTreeProvider
+  implements vscode.TreeDataProvider<TreeItem>
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<
+    TreeItem | undefined | null | void
+  >();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private nodes: VaultNode[] = [];
+
+  setNodes(nodes: VaultNode[]): void {
+    this.nodes = nodes;
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: TreeItem): TreeItem[] {
+    if (!element) {
+      // root → kind groups
+      const counts = new Map<string, number>();
+      for (const n of this.nodes) {
+        counts.set(n.kind, (counts.get(n.kind) ?? 0) + 1);
+      }
+      const orderedKinds = [
+        ...KIND_ORDER.filter((k) => counts.has(k)),
+        ...[...counts.keys()].filter((k) => !KIND_ORDER.includes(k)).sort(),
+      ];
+      return orderedKinds.map(
+        (kind) =>
+          new TreeItem(
+            `${kind} (${counts.get(kind) ?? 0})`,
+            vscode.TreeItemCollapsibleState.Expanded,
+            { kind },
+          ),
+      );
+    }
+    if (element.payload?.kind) {
+      const kind = element.payload.kind;
+      return this.nodes
+        .filter((n) => n.kind === kind)
+        .sort((a, b) => a.slug.localeCompare(b.slug))
+        .map((n) => {
+          const item = new TreeItem(
+            n.title,
+            vscode.TreeItemCollapsibleState.None,
+            { node: n },
+          );
+          item.description = n.slug;
+          item.tooltip = `${n.kind} · ${n.slug}${n.domain ? ` · domain=${n.domain}` : ''}`;
+          item.command = {
+            command: 'ohMyOntology.openNode',
+            title: 'Open node .md',
+            arguments: [n],
+          };
+          return item;
+        });
+    }
+    return [];
+  }
+}
+
+class TreeItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    state: vscode.TreeItemCollapsibleState,
+    public payload?: { kind?: string; node?: VaultNode },
+  ) {
+    super(label, state);
+  }
+}

--- a/vscode-plugin/src/walk-vault.ts
+++ b/vscode-plugin/src/walk-vault.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { parseFrontmatter } from './parse-frontmatter';
+
+export interface VaultNode {
+  slug: string;
+  kind: string;
+  title: string;
+  filePath: string;
+  domain?: string;
+  capabilities?: string[];
+  elements?: string[];
+}
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.next', 'out', 'dist']);
+
+export async function walkVault(vaultRoot: string): Promise<VaultNode[]> {
+  const out: VaultNode[] = [];
+  await walk(vaultRoot, vaultRoot, out);
+  return out;
+}
+
+async function walk(
+  root: string,
+  dir: string,
+  out: VaultNode[],
+): Promise<void> {
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(root, full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      try {
+        const raw = await fs.readFile(full, 'utf-8');
+        const { frontmatter } = parseFrontmatter(raw);
+        const kind = String(frontmatter.kind ?? '').trim();
+        if (!kind) continue;
+        const slug =
+          String(frontmatter.slug ?? '').trim() ||
+          path
+            .relative(root, full)
+            .replace(/\.md$/, '')
+            .replace(/\\/g, '/');
+        out.push({
+          slug,
+          kind,
+          title: String(frontmatter.title ?? slug),
+          filePath: full,
+          domain: optionalString(frontmatter.domain),
+          capabilities: optionalArray(frontmatter.capabilities),
+          elements: optionalArray(frontmatter.elements),
+        });
+      } catch {
+        // skip unreadable file silently
+      }
+    }
+  }
+}
+
+function optionalString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+}
+
+function optionalArray(v: unknown): string[] | undefined {
+  return Array.isArray(v) ? v.map(String) : undefined;
+}

--- a/vscode-plugin/tsconfig.json
+++ b/vscode-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "out", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

README의 "(planned) VSCode plugin" 약속의 **first MVP**. Cross-agent benchmark (PR #136) 가 MCP value 검증한 위에서 developer-primary 의 IDE 진입점.

CLI 가 터미널 surface, MCP 가 AI agent surface 라면 이 plugin 은 **VSCode 안에서 vault 노드 보고 .md 점프**.

## What works (v0.1.0)

- **Activity Bar entry** — 'oh-my-ontology' icon (graph 모티브 SVG)
- **TreeView** — vault 노드를 \`kind\` 별 그룹화 (project / domain / capability / element / document / vault-readme)
- **노드 클릭 → .md 열기** (\`ohMyOntology.openNode\`)
- **Vault 자동 인식** — workspace 의 \`docs/ontology/\` auto-detect, 다른 폴더는 picker
- **Vault path 영속** — \`globalState\` + 설정 \`oh-my-ontology.vaultPath\`

## 5-way parser contract

\`vscode-plugin/src/parse-frontmatter.ts\` 가 5번째 진입점 — 이전 4 (src/shared + mcp + scripts/lib + cli) 에 추가.

| | 설명 |
|---|---|
| **이전** | 12 fixture × 4 parser = 48 case |
| **현재** | 12 fixture × 5 parser = **60 case** |

매 PR 마다 5 곳 어디서든 frontmatter 파서 drift 시 즉시 fail.

## Dogfood graph

\`capabilities/vscode-plugin-ide-entry.md\` 신규 — vscode-plugin 자체가 ontology 의 노드. \`domains/onboarding-ux\` 의 \`capabilities\` 배열에도 endorse. **vault 23 노드 (이전 22), validator clean (issue 0)**.

## How to try locally

\`\`\`bash
cd vscode-plugin && npm install && npm run compile
\`\`\`

VSCode 에서 \`vscode-plugin/\` 폴더 열고 F5 → Extension Development Host 에서 oh-my-ontology Activity Bar icon 확인. dogfood vault 가 자동 detect 되어 23 노드 표시.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — **771/771** (이전 759 + 12 contract case)
- [x] \`pnpm vault:validate\` — 23 파일 issue 0
- [x] \`vscode-plugin\` smoke test — dogfood vault 22 노드 (22+1 시점 23노드 commit 후) 정확 detect
- [x] \`vscode-plugin/out/extension.js\` 컴파일 성공

## Not yet (다음 PR)

- 코드 ↔ ontology 점프 (현재 source 의 element 매치 → side panel)
- Add concept inline command (write surface)
- MCP server connect (\`mcp/src/index.js\` spawn — 지금은 raw filesystem read)
- Marketplace publish

## Why this matters

Cross-agent benchmark (#136) 데이터 기반의 결정:
- Claude Code MCP 가 hallucination 9 → 0 차단 → product 가 실제 가치 줌 confirmed
- 그 위에 신규 IDE surface 투자 정당화

CLI · MCP · 웹 workbench · VSCode plugin = **4 surface**. \"개발자가 어디 있든 같은 vault 같이 자라남\" 약속의 IDE 부분 첫 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)