### PR TITLE
feat(vscode-plugin): code↔ontology jump v0.2.0

### DIFF
--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -70,16 +70,16 @@ different folder via the Activity Bar header to override.
 
 ## Status
 
-**v0.1.0 — minimal viable plugin.** Working features:
+**v0.2.0 — code↔ontology jump.** Working features:
 
 - Activity Bar entry + TreeView grouped by `kind`
 - Auto-detect `docs/ontology/` in workspace
 - Pick-vault dialog (persisted across sessions)
 - Click node → open `.md`
+- **Status bar match (v0.2.0)** — when the active editor is a file owned by an ontology node (matched by `path:` frontmatter or capability `elements:` array), the status bar shows the node title. Click → jump to the node's `.md`.
 
 **Not yet:**
 
-- File-link backlinks (open the source file an element points at)
 - Add-concept / patch-concept commands (write surface)
 - MCP server connection (use raw filesystem read for now)
 - Marketplace publishing

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"
@@ -79,6 +79,7 @@
   "scripts": {
     "compile": "tsc -p .",
     "watch": "tsc -p . --watch",
+    "test": "npm run compile && node --test src/code-match.test.mjs",
     "vscode:prepublish": "npm run compile"
   },
   "devDependencies": {

--- a/vscode-plugin/src/code-match.test.mjs
+++ b/vscode-plugin/src/code-match.test.mjs
@@ -1,0 +1,126 @@
+// Unit tests for findOntologyMatch — code↔ontology jump (R13 #50).
+// node --test src/code-match.test.mjs
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findOntologyMatch } from '../out/code-match.js';
+
+const ROOT = '/abs/repo';
+
+const NODES = [
+  {
+    slug: 'elements/file-system-access-api',
+    kind: 'element',
+    title: 'File System Access API',
+    filePath: '/abs/repo/docs/ontology/elements/file-system-access-api.md',
+    path: 'src/features/docs-vault-local',
+  },
+  {
+    slug: 'elements/sigma-graphology',
+    kind: 'element',
+    title: 'sigma-graphology',
+    filePath: '/abs/repo/docs/ontology/elements/sigma-graphology.md',
+    path: 'package.json',
+  },
+  {
+    slug: 'capabilities/builder-vault-write',
+    kind: 'capability',
+    title: 'Builder ↔ Vault md write',
+    filePath: '/abs/repo/docs/ontology/capabilities/builder-vault-write.md',
+    elements: [
+      'src/views/ontology-edit/ui/OntologyEditPage.tsx',
+      'src/features/docs-vault-local/model/use-local-vault.ts',
+    ],
+  },
+];
+
+test('정확 path 매치 (element.path === relative)', () => {
+  const match = findOntologyMatch(ROOT, '/abs/repo/package.json', NODES);
+  assert.equal(match?.slug, 'elements/sigma-graphology');
+});
+
+test('directory ancestor 매치 (element.path 가 prefix)', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/src/features/docs-vault-local/lib/foo.ts',
+    NODES,
+  );
+  assert.equal(match?.slug, 'elements/file-system-access-api');
+});
+
+test('capability.elements 배열 안의 정확 path 매치', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/src/views/ontology-edit/ui/OntologyEditPage.tsx',
+    NODES,
+  );
+  assert.equal(match?.slug, 'capabilities/builder-vault-write');
+});
+
+test('매치 없으면 null', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/some/random/unlabeled-file.ts',
+    NODES,
+  );
+  assert.equal(match, null);
+});
+
+test('workspace root 외부 파일은 null (rel 이 ".." 로 시작)', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/other/repo/file.ts',
+    NODES,
+  );
+  assert.equal(match, null);
+});
+
+test('가장 specific 한 매치가 우선 (longer path score 높음)', () => {
+  const nestedNodes = [
+    {
+      slug: 'elements/wide',
+      kind: 'element',
+      title: 'wide',
+      filePath: '/x.md',
+      path: 'src',
+    },
+    {
+      slug: 'elements/specific',
+      kind: 'element',
+      title: 'specific',
+      filePath: '/y.md',
+      path: 'src/features/auth',
+    },
+  ];
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/src/features/auth/login.ts',
+    nestedNodes,
+  );
+  assert.equal(match?.slug, 'elements/specific');
+});
+
+test('exact file path 매치가 directory ancestor 보다 우선', () => {
+  const mixedNodes = [
+    {
+      slug: 'elements/folder',
+      kind: 'element',
+      title: 'folder',
+      filePath: '/x.md',
+      path: 'src/features',
+    },
+    {
+      slug: 'elements/file',
+      kind: 'element',
+      title: 'file',
+      filePath: '/y.md',
+      path: 'src/features/auth.ts',
+    },
+  ];
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/src/features/auth.ts',
+    mixedNodes,
+  );
+  assert.equal(match?.slug, 'elements/file');
+});

--- a/vscode-plugin/src/code-match.ts
+++ b/vscode-plugin/src/code-match.ts
@@ -1,0 +1,71 @@
+import * as path from 'path';
+import { VaultNode } from './walk-vault';
+
+/**
+ * Find the best vault node match for a given source-file path.
+ *
+ * Match sources, in priority order:
+ *   1. Element nodes whose `path:` frontmatter exactly equals the file's
+ *      workspace-relative path (e.g. `path: package.json` matches
+ *      `<workspace>/package.json`).
+ *   2. Element nodes whose `path:` is a directory ancestor of the file
+ *      (e.g. `path: src/features/docs-vault-local` matches anything
+ *      under that directory).
+ *   3. Capability nodes whose `elements: [...]` array contains the
+ *      workspace-relative path (e.g. `elements: [src/views/foo/bar.tsx]`).
+ *
+ * Returns the longest-matching node so that more-specific node wins when
+ * multiple match (e.g. file `src/features/docs-vault-local/lib/foo.ts`
+ * picks the element with `path: src/features/docs-vault-local` over a
+ * capability that lists the whole feature folder).
+ *
+ * Returns `null` when no node owns the file. That's fine — most files in
+ * a real codebase are unlabeled.
+ */
+export function findOntologyMatch(
+  workspaceRoot: string,
+  absoluteFilePath: string,
+  nodes: ReadonlyArray<VaultNode>,
+): VaultNode | null {
+  const rel = relativeForwardSlash(workspaceRoot, absoluteFilePath);
+  if (!rel || rel.startsWith('..')) return null;
+
+  const candidates: Array<{ node: VaultNode; score: number }> = [];
+
+  for (const node of nodes) {
+    if (node.path) {
+      if (rel === node.path) {
+        candidates.push({ node, score: 1_000_000 });
+        continue;
+      }
+      if (isInside(rel, node.path)) {
+        candidates.push({ node, score: node.path.length });
+      }
+    }
+    if (node.elements && Array.isArray(node.elements)) {
+      for (const el of node.elements) {
+        if (typeof el !== 'string') continue;
+        if (el === rel) {
+          candidates.push({ node, score: 999_999 });
+        } else if (isInside(rel, el)) {
+          // capability.elements[] can list a folder too
+          candidates.push({ node, score: el.length });
+        }
+      }
+    }
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates[0].node;
+}
+
+function relativeForwardSlash(root: string, abs: string): string {
+  return path.relative(root, abs).split(path.sep).join('/');
+}
+
+function isInside(filePath: string, dirPath: string): boolean {
+  if (!dirPath) return false;
+  const normalized = dirPath.endsWith('/') ? dirPath : dirPath + '/';
+  return filePath.startsWith(normalized);
+}

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { walkVault, VaultNode } from './walk-vault';
 import { OntologyTreeProvider } from './tree-provider';
+import { findOntologyMatch } from './code-match';
 
 const STORAGE_VAULT_KEY = 'oh-my-ontology.vaultPath';
 
@@ -8,19 +9,62 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const treeProvider = new OntologyTreeProvider();
   vscode.window.registerTreeDataProvider('ohMyOntology.tree', treeProvider);
 
+  // R13 #50 — code↔ontology jump: surface the matching node for the active
+  // editor in the status bar. Click → open the node's .md.
+  const matchStatusBar = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100,
+  );
+  matchStatusBar.command = 'ohMyOntology.openMatchedNode';
+  context.subscriptions.push(matchStatusBar);
+
+  let cachedNodes: VaultNode[] = [];
+  let currentMatch: VaultNode | null = null;
+
+  const updateMatchForActiveEditor = (): void => {
+    const editor = vscode.window.activeTextEditor;
+    const folders = vscode.workspace.workspaceFolders;
+    if (!editor || !folders || folders.length === 0 || cachedNodes.length === 0) {
+      currentMatch = null;
+      matchStatusBar.hide();
+      return;
+    }
+    // Pick the workspace folder that owns the active document, fall back to first.
+    const workspace =
+      vscode.workspace.getWorkspaceFolder(editor.document.uri) ?? folders[0];
+    const match = findOntologyMatch(
+      workspace.uri.fsPath,
+      editor.document.uri.fsPath,
+      cachedNodes,
+    );
+    currentMatch = match;
+    if (!match) {
+      matchStatusBar.hide();
+      return;
+    }
+    const icon = iconForKind(match.kind);
+    matchStatusBar.text = `${icon} ${match.title}`;
+    matchStatusBar.tooltip = `oh-my-ontology · ${match.kind} · ${match.slug}\nClick to open ${match.slug}.md`;
+    matchStatusBar.show();
+  };
+
   const refresh = async (): Promise<void> => {
     const vaultPath = await resolveVaultPath(context);
     if (!vaultPath) {
+      cachedNodes = [];
       treeProvider.setNodes([]);
+      updateMatchForActiveEditor();
       return;
     }
     try {
       const nodes = await walkVault(vaultPath);
+      cachedNodes = nodes;
       treeProvider.setNodes(nodes);
       vscode.window.setStatusBarMessage(
         `oh-my-ontology: ${nodes.length} ${nodes.length === 1 ? 'node' : 'nodes'} from ${vaultPath}`,
         4000,
       );
+      updateMatchForActiveEditor();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       vscode.window.showErrorMessage(`oh-my-ontology: ${msg}`);
@@ -48,14 +92,44 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await vscode.window.showTextDocument(doc);
       },
     ),
+    vscode.commands.registerCommand('ohMyOntology.openMatchedNode', async () => {
+      if (!currentMatch?.filePath) {
+        vscode.window.showInformationMessage(
+          'oh-my-ontology: no ontology node owns this file.',
+        );
+        return;
+      }
+      const doc = await vscode.workspace.openTextDocument(currentMatch.filePath);
+      await vscode.window.showTextDocument(doc);
+    }),
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('oh-my-ontology.vaultPath')) {
         void refresh();
       }
     }),
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      updateMatchForActiveEditor();
+    }),
   );
 
   await refresh();
+}
+
+function iconForKind(kind: string): string {
+  switch (kind) {
+    case 'project':
+      return '$(rocket)';
+    case 'domain':
+      return '$(symbol-namespace)';
+    case 'capability':
+      return '$(symbol-function)';
+    case 'element':
+      return '$(symbol-file)';
+    case 'document':
+      return '$(file-text)';
+    default:
+      return '$(circle-outline)';
+  }
 }
 
 export function deactivate(): void {

--- a/vscode-plugin/src/walk-vault.ts
+++ b/vscode-plugin/src/walk-vault.ts
@@ -8,6 +8,12 @@ export interface VaultNode {
   title: string;
   filePath: string;
   domain?: string;
+  /**
+   * Source-code path the node represents (e.g. `src/features/docs-vault-local`).
+   * Usually present on `kind: element`. Used for code↔ontology jump — when the
+   * developer opens a file under this path, the plugin surfaces this node.
+   */
+  path?: string;
   capabilities?: string[];
   elements?: string[];
 }
@@ -55,6 +61,7 @@ async function walk(
           title: String(frontmatter.title ?? slug),
           filePath: full,
           domain: optionalString(frontmatter.domain),
+          path: optionalString(frontmatter.path),
           capabilities: optionalArray(frontmatter.capabilities),
           elements: optionalArray(frontmatter.elements),
         });


### PR DESCRIPTION
## Summary

VSCode plugin **v0.1.0 → v0.2.0**. 현재 active editor 의 파일이 vault 의 ontology 노드와 매치되면 status bar 에 노드 title 표시 + 클릭 → 해당 .md 점프.

> 코드 보면서 옆 ontology 컨텍스트 즉시 인지 — IDE 본질의 가치.

## Match logic

\`vscode-plugin/src/code-match.ts\` 의 \`findOntologyMatch\`:

1. \`element.path === relative file\` (정확 매치, score 1M)
2. \`element.path\` 가 directory ancestor (longest path 우선)
3. \`capability.elements[]\` 배열 안 정확 매치 (score 999K)
4. \`capability.elements[]\` 배열 안 directory ancestor
5. **가장 specific (longest path) 한 매치 우승** — 작은 이미지 \`src/features/auth\` 가 큰 이미지 \`src\` 를 이김

\`element.path\` 는 vault frontmatter 에 이미 4 노드 있음 (\`file-system-access-api\`, \`sigma-graphology\`, \`mcp-sdk\`, \`xyflow\`). \`capability.elements[]\` 배열도 path-like — 둘 다 cover.

## Status bar UX

| Kind | Codicon | Display |
|---|---|---|
| project | \$(rocket) | 🚀 Project Name |
| domain | \$(symbol-namespace) | namespace icon + Title |
| capability | \$(symbol-function) | function icon + Title |
| element | \$(symbol-file) | file icon + Title |
| document | \$(file-text) | text icon + Title |

매치 없으면 status bar item hidden — silent.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` contract — **60/60** (5-way parser drift 가드 유지)
- [x] \`vscode-plugin\` npm test — **7/7** 단위 케이스:
  - 정확 path 매치 (element.path === relative)
  - directory ancestor 매치
  - capability.elements 배열 정확 매치
  - 매치 없으면 null
  - workspace root 외부 파일 null
  - 가장 specific 한 매치 우선
  - exact file path > directory ancestor
- [x] vscode-plugin/package.json 0.1.0 → 0.2.0, scripts.test 추가

## Changes

- \`vscode-plugin/src/walk-vault.ts\` — \`VaultNode.path\` 필드 추가
- \`vscode-plugin/src/code-match.ts\` — 신규 (matching logic)
- \`vscode-plugin/src/code-match.test.mjs\` — 신규 (7 unit cases)
- \`vscode-plugin/src/extension.ts\` — status bar item + onDidChangeActiveTextEditor + ohMyOntology.openMatchedNode command
- \`vscode-plugin/package.json\` — version bump + test script
- \`vscode-plugin/README.md\` — Status 섹션 v0.2.0 갱신

## Try it

\`\`\`bash
cd vscode-plugin && npm install && npm run compile
\`\`\`

VSCode 에서 \`vscode-plugin/\` 폴더 → F5 → Extension Development Host. dogfood vault 가 자동 detect 된 후 \`mcp/src/index.js\` 같은 파일을 열면 status bar 에 "📄 @modelcontextprotocol/sdk" (=elements/mcp-sdk) 표시. 클릭 → \`mcp-sdk.md\` 열림.

🤖 Generated with [Claude Code](https://claude.com/claude-code)