### PR TITLE
feat(vscode-plugin): Add concept command — write surface v0.3.0

### DIFF
--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -60,7 +60,9 @@ Click any node to open its `.md` in the editor.
 |---|---|
 | `ohMyOntology.pickVault` | Pick vault folder |
 | `ohMyOntology.refresh` | Refresh |
+| `ohMyOntology.addConcept` | **Add concept (v0.3.0)** — kind picker → slug → title → optional domain → writes `<vault>/<auto-prefix>/<slug>.md` |
 | `ohMyOntology.openNode` | Open node .md (invoked when you click a tree item) |
+| `ohMyOntology.openMatchedNode` | Open the node matching the active editor (status bar click) |
 
 ## Auto-detection
 
@@ -70,18 +72,19 @@ different folder via the Activity Bar header to override.
 
 ## Status
 
-**v0.2.0 — code↔ontology jump.** Working features:
+**v0.3.0 — write surface (Add concept).** Working features:
 
 - Activity Bar entry + TreeView grouped by `kind`
 - Auto-detect `docs/ontology/` in workspace
 - Pick-vault dialog (persisted across sessions)
 - Click node → open `.md`
-- **Status bar match (v0.2.0)** — when the active editor is a file owned by an ontology node (matched by `path:` frontmatter or capability `elements:` array), the status bar shows the node title. Click → jump to the node's `.md`.
+- Status bar match — active editor's file → owning ontology node, click to jump (v0.2.0)
+- **Add concept command (v0.3.0)** — `oh-my-ontology: Add concept` from the Command Palette OR the `+` button at the top of the tree view. QuickPick (kind) → InputBox (slug) → InputBox (title) → optional domain → writes the new `.md` with auto-prefix (`capabilities/foo`, `domains/foo`, `elements/foo`). Refuses duplicate slugs. Tree refreshes and the new `.md` opens in the editor.
 
 **Not yet:**
 
-- Add-concept / patch-concept commands (write surface)
-- MCP server connection (use raw filesystem read for now)
+- patch-concept / rename-concept / merge-concepts (other write tools)
+- MCP server connection (currently uses direct filesystem write — same contract as the CLI's `add`, gated by `package.json` `files` for tarball, but no dry-run/conflict-mtime path yet)
 - Marketplace publishing
 
 The frontmatter parser is the same lenient one shared across CLI / MCP

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"
@@ -47,6 +47,11 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "ohMyOntology.addConcept",
+        "title": "oh-my-ontology: Add concept",
+        "icon": "$(add)"
+      },
+      {
         "command": "ohMyOntology.openNode",
         "title": "Open node .md"
       }
@@ -54,14 +59,19 @@
     "menus": {
       "view/title": [
         {
+          "command": "ohMyOntology.addConcept",
+          "when": "view == ohMyOntology.tree",
+          "group": "navigation@1"
+        },
+        {
           "command": "ohMyOntology.refresh",
           "when": "view == ohMyOntology.tree",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "ohMyOntology.pickVault",
           "when": "view == ohMyOntology.tree",
-          "group": "navigation"
+          "group": "navigation@3"
         }
       ]
     },
@@ -79,7 +89,7 @@
   "scripts": {
     "compile": "tsc -p .",
     "watch": "tsc -p . --watch",
-    "test": "npm run compile && node --test src/code-match.test.mjs",
+    "test": "npm run compile && node --test src/code-match.test.mjs src/write-vault.test.mjs",
     "vscode:prepublish": "npm run compile"
   },
   "devDependencies": {

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { walkVault, VaultNode } from './walk-vault';
 import { OntologyTreeProvider } from './tree-provider';
 import { findOntologyMatch } from './code-match';
+import { writeDoc, resolveSlug } from './write-vault';
 
 const STORAGE_VAULT_KEY = 'oh-my-ontology.vaultPath';
 
@@ -101,6 +102,74 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
       const doc = await vscode.workspace.openTextDocument(currentMatch.filePath);
       await vscode.window.showTextDocument(doc);
+    }),
+    vscode.commands.registerCommand('ohMyOntology.addConcept', async () => {
+      const vaultPath = await resolveVaultPath(context);
+      if (!vaultPath) {
+        vscode.window.showWarningMessage(
+          'oh-my-ontology: pick a vault folder first (use the Activity Bar entry).',
+        );
+        return;
+      }
+      const kindPick = await vscode.window.showQuickPick(
+        [
+          { label: 'capability', description: 'A user-visible feature' },
+          { label: 'element', description: 'A concrete code unit' },
+          { label: 'domain', description: 'A grouping of capabilities' },
+          { label: 'document', description: 'A reference doc' },
+          { label: 'project', description: 'Top-level (usually one per workspace)' },
+        ],
+        { placeHolder: 'Pick the kind of concept to add' },
+      );
+      if (!kindPick) return;
+      const kind = kindPick.label;
+
+      const rawSlug = await vscode.window.showInputBox({
+        placeHolder: 'slug — e.g. token-issue (auto-prefixed to capabilities/token-issue)',
+        prompt: 'Slug for the new concept (no .md extension)',
+        validateInput: (v) =>
+          !v || !v.trim() ? 'slug is required' : null,
+      });
+      if (!rawSlug) return;
+
+      const title = await vscode.window.showInputBox({
+        placeHolder: 'title — e.g. "Token issue"',
+        prompt: 'Display title',
+        validateInput: (v) =>
+          !v || !v.trim() ? 'title is required' : null,
+      });
+      if (!title) return;
+
+      let domain: string | undefined;
+      if (kind === 'capability' || kind === 'element') {
+        const domainPick = await vscode.window.showInputBox({
+          placeHolder: 'parent domain (optional, e.g. auth)',
+          prompt: 'Parent domain slug — leave empty to skip',
+        });
+        domain = domainPick?.trim() || undefined;
+      }
+
+      const slug = resolveSlug(kind, rawSlug.trim(), true);
+      const fm: Record<string, unknown> = {
+        slug,
+        kind,
+        title: title.trim(),
+      };
+      if (domain) fm.domain = domain;
+
+      try {
+        const filePath = await writeDoc(vaultPath, slug, { frontmatter: fm });
+        await refresh();
+        const doc = await vscode.workspace.openTextDocument(filePath);
+        await vscode.window.showTextDocument(doc);
+        vscode.window.setStatusBarMessage(
+          `oh-my-ontology: created ${slug}.md`,
+          4000,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`oh-my-ontology: ${msg}`);
+      }
     }),
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('oh-my-ontology.vaultPath')) {

--- a/vscode-plugin/src/write-vault.test.mjs
+++ b/vscode-plugin/src/write-vault.test.mjs
@@ -1,0 +1,117 @@
+// Unit tests for writeDoc + resolveSlug — Add concept command (R13 #51).
+// node --test src/write-vault.test.mjs
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeDoc, resolveSlug } from '../out/write-vault.js';
+
+function withVault(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'omot-vscode-write-'));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('resolveSlug — autoPrefix on, kind 별 folder 자동', () => {
+  assert.equal(resolveSlug('capability', 'foo', true), 'capabilities/foo');
+  assert.equal(resolveSlug('domain', 'auth', true), 'domains/auth');
+  assert.equal(resolveSlug('element', 'jwt', true), 'elements/jwt');
+});
+
+test('resolveSlug — autoPrefix off 면 그대로', () => {
+  assert.equal(resolveSlug('capability', 'foo', false), 'foo');
+  assert.equal(resolveSlug('capability', 'auth/bar', false), 'auth/bar');
+});
+
+test('resolveSlug — 이미 prefix 있으면 두 번 안 붙임', () => {
+  assert.equal(
+    resolveSlug('capability', 'capabilities/foo', true),
+    'capabilities/foo',
+  );
+});
+
+test('resolveSlug — project / document 는 prefix 없음', () => {
+  assert.equal(resolveSlug('project', 'main', true), 'main');
+  assert.equal(resolveSlug('document', 'spec', true), 'spec');
+});
+
+test('writeDoc — 새 노드 작성 + 디렉토리 자동 생성', async () => {
+  await withVault(async (root) => {
+    const filePath = await writeDoc(root, 'capabilities/foo', {
+      frontmatter: { slug: 'capabilities/foo', kind: 'capability', title: 'Foo' },
+    });
+    assert.ok(existsSync(filePath));
+    const content = readFileSync(filePath, 'utf-8');
+    assert.match(content, /slug: capabilities\/foo/);
+    assert.match(content, /kind: capability/);
+    assert.match(content, /title: Foo/);
+    assert.match(content, /# Foo/);
+  });
+});
+
+test('writeDoc — 기존 slug 면 throw (silent overwrite 차단)', async () => {
+  await withVault(async (root) => {
+    await writeDoc(root, 'capabilities/foo', {
+      frontmatter: { kind: 'capability', title: 'Foo' },
+    });
+    await assert.rejects(
+      () =>
+        writeDoc(root, 'capabilities/foo', {
+          frontmatter: { kind: 'capability', title: 'Dup' },
+        }),
+      /already exists/i,
+    );
+  });
+});
+
+test('writeDoc — 배열 frontmatter 는 block list 로 직렬화', async () => {
+  await withVault(async (root) => {
+    const filePath = await writeDoc(root, 'capabilities/bar', {
+      frontmatter: {
+        kind: 'capability',
+        title: 'Bar',
+        elements: ['src/a', 'src/b'],
+      },
+    });
+    const content = readFileSync(filePath, 'utf-8');
+    assert.match(content, /elements:\n {2}- src\/a\n {2}- src\/b/);
+  });
+});
+
+test('writeDoc — body override', async () => {
+  await withVault(async (root) => {
+    const filePath = await writeDoc(root, 'foo', {
+      frontmatter: { kind: 'document', title: 'Foo' },
+      body: '\n# Custom heading\n\nSome body text.\n',
+    });
+    const content = readFileSync(filePath, 'utf-8');
+    assert.match(content, /# Custom heading/);
+    assert.match(content, /Some body text/);
+  });
+});
+
+test('writeDoc — frontmatter 키 순서 (slug → kind → title → domain → 그 외)', async () => {
+  await withVault(async (root) => {
+    const filePath = await writeDoc(root, 'capabilities/qux', {
+      frontmatter: {
+        title: 'Qux',
+        kind: 'capability',
+        slug: 'capabilities/qux',
+        domain: 'auth',
+        relates: ['domains/auth'],
+      },
+    });
+    const content = readFileSync(filePath, 'utf-8');
+    const fmBlock = content.split('---')[1];
+    const lines = fmBlock.trim().split('\n');
+    assert.match(lines[0], /slug:/);
+    assert.match(lines[1], /kind:/);
+    assert.match(lines[2], /title:/);
+    assert.match(lines[3], /domain:/);
+  });
+});

--- a/vscode-plugin/src/write-vault.ts
+++ b/vscode-plugin/src/write-vault.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+/**
+ * Write a new vault node `.md` file. Mirrors the contract enforced by
+ * the CLI's `add` command (`cli/src/lib/write-vault.mjs`):
+ *
+ *   - Throws if the target file already exists (duplicate slug guard).
+ *   - Creates parent directories as needed.
+ *   - Frontmatter is rendered with explicit keys in order:
+ *     `slug`, `kind`, `title`, `domain?`, then any extras.
+ *   - Body defaults to `# {title}` when omitted.
+ *
+ * Returns the absolute path of the written file.
+ */
+
+export interface WriteDocOptions {
+  frontmatter: Record<string, unknown>;
+  body?: string;
+}
+
+const FOLDER_BY_KIND: Record<string, string> = {
+  project: '',
+  domain: 'domains/',
+  capability: 'capabilities/',
+  element: 'elements/',
+  document: '',
+};
+
+/**
+ * Resolve the effective slug. If `autoPrefix` is true and the slug
+ * doesn't already start with the kind's folder, prepend it. Mirrors
+ * the CLI's `--auto-prefix` flag (`cli/src/commands/add.mjs`).
+ */
+export function resolveSlug(
+  kind: string,
+  rawSlug: string,
+  autoPrefix: boolean,
+): string {
+  const folder = FOLDER_BY_KIND[kind] ?? '';
+  if (autoPrefix && folder && !rawSlug.startsWith(folder)) {
+    return `${folder}${rawSlug}`;
+  }
+  return rawSlug;
+}
+
+export async function writeDoc(
+  vaultRoot: string,
+  slug: string,
+  options: WriteDocOptions,
+): Promise<string> {
+  const filePath = path.join(vaultRoot, `${slug}.md`);
+  try {
+    await fs.access(filePath);
+    throw new Error(
+      `Doc already exists at ${path.relative(vaultRoot, filePath)} — refusing to overwrite. Edit the file directly or pick a different slug.`,
+    );
+  } catch (err) {
+    // ENOENT (file doesn't exist) is the expected happy path.
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code !== 'ENOENT'
+    ) {
+      throw err;
+    }
+    if (
+      err instanceof Error &&
+      err.message.startsWith('Doc already exists')
+    ) {
+      throw err;
+    }
+  }
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const md = renderMarkdown(options.frontmatter, options.body);
+  await fs.writeFile(filePath, md, 'utf-8');
+  return filePath;
+}
+
+function renderMarkdown(
+  frontmatter: Record<string, unknown>,
+  body?: string,
+): string {
+  const lines: string[] = ['---'];
+  // Canonical key order for readability (matches CLI / mcp behavior).
+  const ORDER = ['slug', 'kind', 'title', 'domain', 'path'];
+  const ordered = new Set<string>();
+  for (const key of ORDER) {
+    if (key in frontmatter) {
+      lines.push(formatKv(key, frontmatter[key]));
+      ordered.add(key);
+    }
+  }
+  for (const key of Object.keys(frontmatter)) {
+    if (ordered.has(key)) continue;
+    lines.push(formatKv(key, frontmatter[key]));
+  }
+  lines.push('---');
+  const title = frontmatter.title;
+  const fallbackBody = `\n# ${typeof title === 'string' ? title : 'Untitled'}\n`;
+  return `${lines.join('\n')}\n${body ?? fallbackBody}`;
+}
+
+function formatKv(key: string, value: unknown): string {
+  if (value == null) return `${key}:`;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${key}: []`;
+    const items = value.map((v) => `  - ${String(v)}`).join('\n');
+    return `${key}:\n${items}`;
+  }
+  if (typeof value === 'object') {
+    return `${key}: ${JSON.stringify(value)}`;
+  }
+  const str = String(value);
+  // Wrap with quotes if the value would parse ambiguously
+  if (/[:#]/.test(str) && !/^['"]/.test(str)) {
+    return `${key}: "${str.replace(/"/g, '\\"')}"`;
+  }
+  return `${key}: ${str}`;
+}


### PR DESCRIPTION
## Summary

VSCode plugin v0.2.0 → v0.3.0. Write surface 의 첫 진입점 — Command Palette / TreeView '+' 버튼에서 \`oh-my-ontology: Add concept\` 으로 새 노드 인터랙티브 작성.

## Flow

1. **Kind picker** (capability / element / domain / document / project)
2. **Slug input** (e.g. \`token-issue\`) — auto-prefix 로 \`capabilities/token-issue\` 됨
3. **Title input** — 표시 이름
4. **Domain input** (optional, capability/element 일 때만)
5. **Write** — \`<vault>/<auto-prefix>/<slug>.md\` 작성, tree refresh, 새 .md 자동 열림

## CLI add 와 동일 contract

| 동작 | 일관 |
|---|---|
| KIND_FOLDER prefix | ✓ \`capabilities/foo\` / \`domains/foo\` / \`elements/foo\` |
| Project/document 은 root | ✓ |
| 기존 slug throw | ✓ silent overwrite 차단 |
| frontmatter 키 순서 | ✓ slug → kind → title → domain → 그 외 |
| body 기본값 | ✓ \`# {title}\` |

\`vscode-plugin/src/write-vault.ts\` 가 logic 본체. \`cli/src/lib/write-vault.mjs\` 와 같은 동작.

## Tests

\`vscode-plugin npm test\` — **16/16** (이전 7 + 신규 9):
- resolveSlug autoPrefix on/off
- prefix 두 번 안 붙임
- writeDoc 새 노드 + 디렉토리 자동 생성
- 기존 slug throw
- 배열 frontmatter 블록 list 직렬화
- body override
- frontmatter 키 순서

\`pnpm test:run\` — 5-way parser contract **60/60**.
\`pnpm exec tsc --noEmit\` — 0 errors.

## Try it

\`\`\`bash
cd vscode-plugin && npm install && npm run compile
\`\`\`

VSCode → F5 → Extension Development Host → Activity Bar 의 oh-my-ontology icon → tree view 우상단 \`+\` 버튼 또는 \`⌘⇧P\` → \`oh-my-ontology: Add concept\`.

## Files

- \`vscode-plugin/src/write-vault.ts\` (신규) — \`writeDoc\` + \`resolveSlug\`
- \`vscode-plugin/src/write-vault.test.mjs\` (신규) — 9 unit cases
- \`vscode-plugin/src/extension.ts\` — \`addConcept\` command 핸들러
- \`vscode-plugin/package.json\` — version 0.2.0 → 0.3.0, command 등록, view/title \`+\` 버튼

## Not yet (다음 PR)

- patch-concept / rename-concept / merge-concepts
- MCP server spawn (현재 raw filesystem write)
- Marketplace publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)