### PR TITLE
chore(vscode-plugin): vsix package gate in CI + LICENSE + install 안내

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,19 @@ jobs:
       - name: Vault validate (dogfood frontmatter integrity)
         run: pnpm vault:validate
 
+      # vscode-plugin v0.4.0 (R13 #49–#52). Run unit + MCP-integration tests
+      # via npm (its own toolchain — TypeScript compile + node --test).
+      # Then verify it packages cleanly into a .vsix so we catch
+      # marketplace-relevant regressions (manifest issues, missing files,
+      # broken contributes) before publish.
+      - name: VSCode plugin — install + test + package
+        run: |
+          cd vscode-plugin
+          npm install --no-audit --no-fund
+          npm test
+          npx @vscode/vsce package --no-yarn --out /tmp/oh-my-ontology-vscode.vsix
+          ls -lh /tmp/oh-my-ontology-vscode.vsix
+
       # R11 #24 — audit-only e2e CI 게이트 시도했으나 CI 환경 navigation race
       # 빈도 높아 reverted (a11y-structure / aria-audit / overflow-sweep
       # mobile-390 등 회귀). audit spec 은 console dump 의도라 실질 가드 0

--- a/vscode-plugin/.gitignore
+++ b/vscode-plugin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+*.vsix
+.vscode-test/

--- a/vscode-plugin/LICENSE
+++ b/vscode-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oh-my-ontology contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -15,9 +15,24 @@ This is the **developer-primary IDE entry** the project's mission has
 always promised. Same vault, same `.md` files, same git repo as the CLI
 and MCP — just rendered next to your code.
 
-## Install (development)
+## Install (pre-marketplace verification)
 
-The plugin is not yet on the VSCode Marketplace. To run it locally:
+The plugin is not yet on the VSCode Marketplace. Two ways to try it:
+
+### Option A — install the packaged `.vsix` (recommended for verification)
+
+This is the closest thing to "what the marketplace would deliver":
+
+```bash
+cd vscode-plugin
+npm install
+npx @vscode/vsce package --no-yarn
+code --install-extension oh-my-ontology-vscode-0.4.0.vsix
+```
+
+Restart VSCode. The extension is now installed across **every** VSCode window the same as a marketplace extension would be. Uninstall via Extensions panel or `code --uninstall-extension wlsdks.oh-my-ontology-vscode`.
+
+### Option B — Extension Development Host (faster iteration)
 
 ```bash
 cd vscode-plugin


### PR DESCRIPTION
## Summary

PR #138/#139/#140 가 plugin v0.4.0 까지 land 후 사용자 질문 *"배포하기 전까지는 실제로 동작 검증할 수 있나?"* 에 대한 답:

✅ **검증 가능**. \`vsce package\` + \`code --install-extension\` 으로 본인 VSCode 에 marketplace 환경 그대로 설치해 일상 사용 = 진짜 검증.

이 PR 은 그 절차를 README 에 명시 + CI 가드 추가.

## What's added

### 1. CI vsix package gate

\`.github/workflows/ci.yml\` 에 새 step:

\`\`\`yaml
- name: VSCode plugin — install + test + package
  run: |
    cd vscode-plugin
    npm install --no-audit --no-fund
    npm test
    npx @vscode/vsce package --no-yarn --out /tmp/oh-my-ontology-vscode.vsix
\`\`\`

매 PR 마다:
- 24/24 unit + MCP integration test 통과 검증
- vsix package 가 manifest / contributes / icon / README 누락 없이 빌드 검증

→ marketplace publish 결정 전 회귀 자동 차단.

### 2. vscode-plugin/LICENSE

root LICENSE (MIT) 를 \`vscode-plugin/LICENSE\` 로 복사. 이전 vsce package 의 \`LICENSE not found\` warning 제거. 패키지마다 LICENSE 동봉이 표준.

### 3. README install 안내 두 옵션

\`vscode-plugin/README.md\` 의 *Install* 섹션 재작성:

- **Option A — \`.vsix\` install**: \`vsce package\` + \`code --install-extension\`. **marketplace 환경에 가장 근접한 검증**. 모든 VSCode 윈도우에서 marketplace extension 처럼 활성.
- **Option B — F5 Dev Host**: 빠른 iteration. (이전 main 옵션)

### 4. .gitignore

\`node_modules/\` / \`out/\` / \`*.vsix\` / \`.vscode-test/\` — 빌드 산출물 commit 방지.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] 로컬에서 \`cd vscode-plugin && npx @vscode/vsce package --no-yarn\` — **14 files / 21.23 KB** 깨끗하게 패키징 (LICENSE warning 사라짐 확인)
- [ ] 사용자 본인 VSCode 에 \`code --install-extension oh-my-ontology-vscode-0.4.0.vsix\` → 4 surface 일상 사용 검증

## Why this PR

> "실제로 동작하는지 검증해볼수는 없는건가? 배포하기 전까지는?"

답: vsix install 이 사실상 marketplace 와 동일 환경. 이 PR 머지 후 사용자가:

\`\`\`bash
cd vscode-plugin && npx @vscode/vsce package --no-yarn
code --install-extension oh-my-ontology-vscode-0.4.0.vsix
\`\`\`

→ Activity Bar 의 oh-my-ontology icon → 4 surface 동작 직접 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)