### PR TITLE
feat(vscode-plugin): self-match v0.5.0 — ontology .md 열면 backlinks

### DIFF
--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -89,7 +89,7 @@ different folder via the Activity Bar header to override.
 
 ## Status
 
-**v0.4.0 — MCP server connect.** Working features:
+**v0.5.0 — self-match.** Working features:
 
 - Activity Bar entry + Ontology TreeView grouped by `kind`
 - **Backlinks panel (v0.4.0)** — second TreeView under Activity Bar, populated by `find_backlinks` against the node matching the current editor.
@@ -99,6 +99,7 @@ different folder via the Activity Bar header to override.
 - Status bar match — active editor's file → owning ontology node, click to jump (v0.2.0)
 - Add concept command — Command Palette / TreeView `+` button (v0.3.0)
 - **MCP server spawn (v0.4.0)** — plugin spawns `mcp/src/index.js` on activate, sends JSON-RPC over stdio to populate the backlinks panel. **Falls back to in-process scan** when the server is unavailable, so the plugin still works in offline / standalone mode. Same wire protocol as Claude Code uses.
+- **Self-match (v0.5.0)** — when you open an ontology node's `.md` file directly (e.g. `docs/ontology/elements/sigma-graphology.md`), the plugin recognizes that as the node and the **Backlinks panel auto-populates with who points to that node**. Status bar also shows the node title. The natural reading flow now works.
 
 **Not yet:**
 

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"

--- a/vscode-plugin/src/code-match.test.mjs
+++ b/vscode-plugin/src/code-match.test.mjs
@@ -100,6 +100,35 @@ test('가장 specific 한 매치가 우선 (longer path score 높음)', () => {
   assert.equal(match?.slug, 'elements/specific');
 });
 
+test('R13 #54 self-match — vault .md 자체 열면 그 노드 반환 (최우선)', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/docs/ontology/elements/file-system-access-api.md',
+    NODES,
+  );
+  assert.equal(match?.slug, 'elements/file-system-access-api');
+});
+
+test('R13 #54 self-match — node.path 가 매치돼도 self-match 가 우선', () => {
+  // edge: 어떤 element 의 .md 자체가 다른 element 의 path 안에 있어도
+  // self-match 가 항상 이긴다 (loop order independent).
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/docs/ontology/elements/sigma-graphology.md',
+    NODES,
+  );
+  assert.equal(match?.slug, 'elements/sigma-graphology');
+});
+
+test('R13 #54 self-match — vault 외부의 .md 는 영향 없음', () => {
+  const match = findOntologyMatch(
+    ROOT,
+    '/abs/repo/docs/ARCHITECTURE.md', // not a vault node
+    NODES,
+  );
+  assert.equal(match, null);
+});
+
 test('exact file path 매치가 directory ancestor 보다 우선', () => {
   const mixedNodes = [
     {

--- a/vscode-plugin/src/code-match.ts
+++ b/vscode-plugin/src/code-match.ts
@@ -2,9 +2,14 @@ import * as path from 'path';
 import { VaultNode } from './walk-vault';
 
 /**
- * Find the best vault node match for a given source-file path.
+ * Find the best vault node match for a given file path.
  *
  * Match sources, in priority order:
+ *   0. **Self-match (R13 #54)** — if the active file IS the ontology
+ *      `.md` itself (e.g. `docs/ontology/elements/sigma-graphology.md`),
+ *      return that node directly. Highest priority — when the user is
+ *      reading the ontology directly, that's exactly what the plugin
+ *      should surface (and the Backlinks panel can show who points to it).
  *   1. Element nodes whose `path:` frontmatter exactly equals the file's
  *      workspace-relative path (e.g. `path: package.json` matches
  *      `<workspace>/package.json`).
@@ -27,6 +32,14 @@ export function findOntologyMatch(
   absoluteFilePath: string,
   nodes: ReadonlyArray<VaultNode>,
 ): VaultNode | null {
+  // R13 #54 — self-match: the active file IS an ontology node's .md.
+  // Highest priority because the user is literally looking at the node.
+  for (const node of nodes) {
+    if (samePath(node.filePath, absoluteFilePath)) {
+      return node;
+    }
+  }
+
   const rel = relativeForwardSlash(workspaceRoot, absoluteFilePath);
   if (!rel || rel.startsWith('..')) return null;
 
@@ -58,6 +71,12 @@ export function findOntologyMatch(
   if (candidates.length === 0) return null;
   candidates.sort((a, b) => b.score - a.score);
   return candidates[0].node;
+}
+
+function samePath(a: string, b: string): boolean {
+  // Defensive: VSCode sometimes hands paths with mixed separators or
+  // resolved symlinks. Normalize both before comparison.
+  return path.resolve(a) === path.resolve(b);
 }
 
 function relativeForwardSlash(root: string, abs: string): string {


### PR DESCRIPTION
## Summary

사용자 피드백: \`sigma-graphology.md\` 직접 열었는데 Backlinks panel 비어있음. 이 PR fix.

## Before vs After

**v0.4.0 (이전)**: \`findOntologyMatch\` 가 source file 의 \`path:\` / \`elements[]\` 매치만 봄. \`.md\` 자체는 source file 아니라서 무시 → 사용자가 ontology 노드 보고 있어도 plugin 인식 못함.

**v0.5.0 (이 PR)**: priority 0 self-match — 활성 파일 absolute path 가 어떤 vault 노드의 \`filePath\` 와 일치하면 그 노드 직접 반환. 결과:

- ✅ Status bar 에 노드 title 표시 (예: 📄 Sigma + Graphology + ForceAtlas2)
- ✅ Backlinks panel 자동 채워짐 (그 노드를 참조하는 다른 노드들)
- ✅ 가장 자연스러운 \"이 노드 누가 가리키나?\" 질문에 답

## Test plan

- [x] \`vscode-plugin npm test\` — **27/27** (이전 24 + 신규 3 self-match case)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] vsix repackage — 14 files / 21.88 KB
- [x] \`antigravity --install-extension oh-my-ontology-vscode-0.5.0.vsix\` — success
- [ ] 사용자 본인이 sigma-graphology.md 다시 열어서 Backlinks panel populated 검증

## Try it

이미 Antigravity 에 v0.5.0 설치 완료. Antigravity 재시작 후:

1. \`docs/ontology/elements/sigma-graphology.md\` 열기
2. **Status bar (좌측)** — \`📄 Sigma + Graphology + ForceAtlas2\` 표시되어야
3. **Backlinks panel** — \`capabilities/topology-sigma-render\` 표시되어야 (이 element 를 \`relates\` 로 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)