### PR TITLE
docs: vscode-plugin capability + R13 CHANGELOG v0.5.0 sync

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,35 @@ dogfood vault 에 `capabilities/vscode-plugin-ide-entry` 추가 (23 노드).
 
 `cli/templates/vault/README.md` + `src/features/docs-vault-local/lib/ontology-starter.ts` 의 "12 tools / write 4" stale 표기 → "14 tools / write 6" + rename_concept · merge_concepts 명시. 신규 사용자 첫 README 거짓말 차단.
 
+### VSCode plugin v0.2.0 → v0.5.0 (#50 #51 #52 #54 #55)
+
+MVP 후 5 PR 으로 v0.5.0 까지 — practically complete + 자동 회귀 가드.
+
+- **v0.2.0 코드 ↔ ontology 점프 (#50)** — 활성 editor 의 파일이 vault 노드와 매치되면 status bar 좌측에 노드 title (kind icon + 제목). 클릭 → `.md` 점프. 매치 우선순위: exact path > directory ancestor > capability.elements 배열, longest-specific 한 매치 우승.
+- **v0.3.0 Add concept (#51)** — Command Palette / TreeView `+` 버튼. kind picker → slug → title → optional domain → vault 에 새 `.md` 작성 + tree refresh + 새 .md 자동 열림. CLI `add` 와 동일 contract (auto-prefix, duplicate throw).
+- **v0.4.0 MCP server connect + Backlinks panel (#52)** — plugin 이 `mcp/src/index.js` 를 child_process 로 spawn, stdio JSON-RPC 로 통신. 두 번째 TreeView 'Backlinks (current file)' 가 매치 노드의 `find_backlinks` 결과 표시. MCP 실패 시 raw filesystem scan (`computeBacklinksLocally`) 으로 graceful fallback. `useMcp` 설정으로 끄기 가능.
+- **v0.5.0 self-match + e2e (#54 #55)** — ontology `.md` 직접 열어도 그 노드를 매치 결과로 surface (status bar + Backlinks 자동). `@vscode/test-electron` 으로 headless VSCode 띄워 5 e2e (activation / commands / config / contributes) 자동 검증. CI 매 PR 마다 `xvfb-run npm run test:e2e`.
+
+### 4-layer 자동 검증 (#53 #55)
+
+| Layer | 검증 |
+|---|---|
+| 단위 logic | `node --test` × 27 case |
+| MCP integration | spawn `mcp/src/index.js` × 3 case |
+| VSCode integration | `@vscode/test-electron` × 5 case |
+| Marketplace 준비 | `vsce package` (CI step) |
+
+총 35+ case 자동 — plugin 깨지면 즉시 fail. 사용자가 vsix 직접 install 해 검증한 후 marketplace publish 결정.
+
+### 4 surface 완성
+
+- **CLI** — `init / list / validate / add / find` (v0.2.0, R12)
+- **MCP** — 14 tools (v0.7.1, R11+R13)
+- **웹 workbench** — `/topology / /docs / /ontology` 등 (R10 surface diet 후)
+- **VSCode plugin** — 4 surface in v0.5.0 (R13)
+
+> "개발자가 어디 있든 같은 vault, 같이 자라남" 미션의 모든 진입점이 처음으로 다 존재.
+
 ---
 
 ## 2026-05-04 — Round 12: developer-primary 방향 + CLI 5 명령 + dogfood graph 강화

--- a/docs/ontology/capabilities/vscode-plugin-ide-entry.md
+++ b/docs/ontology/capabilities/vscode-plugin-ide-entry.md
@@ -1,49 +1,83 @@
 ---
 slug: capabilities/vscode-plugin-ide-entry
 kind: capability
-title: VSCode Plugin (IDE Entry)
+title: VSCode Plugin (IDE Entry, v0.5.0)
 domain: onboarding-ux
 elements:
   - vscode-plugin/src/extension.ts
   - vscode-plugin/src/walk-vault.ts
   - vscode-plugin/src/tree-provider.ts
   - vscode-plugin/src/parse-frontmatter.ts
+  - vscode-plugin/src/code-match.ts
+  - vscode-plugin/src/write-vault.ts
+  - vscode-plugin/src/mcp-client.ts
+  - vscode-plugin/src/backlinks-provider.ts
 relates:
   - capabilities/cli-developer-entry
   - capabilities/mcp-server
+  - capabilities/mcp-conflict-guard
   - domains/onboarding-ux
 ---
 
-# VSCode Plugin (IDE Entry)
+# VSCode Plugin (IDE Entry, v0.5.0)
 
 R13 (2026-05-04) 에 도입된 *developer-primary IDE* 진입점. README 가
-약속해 둔 "(planned) VSCode plugin" 의 first MVP. CLI 가 터미널 진입,
-MCP 가 AI agent 진입이라면 이 plugin 은 **VSCode 안에서 직접 vault 노드
-보고 .md 점프**.
+약속해 둔 "(planned) VSCode plugin" 의 first MVP 부터 v0.5.0 까지. CLI 가
+터미널 진입, MCP 가 AI agent 진입이라면 이 plugin 은 **VSCode 안에서
+직접 vault 노드 보고, 코드 ↔ ontology 점프하고, 새 노드 생성하고,
+backlinks 탐색**.
 
-## v0.1.0 MVP
+## v0.5.0 의 4 surface
 
-- **Activity Bar entry** — 'oh-my-ontology' icon (graph 모티브 SVG)
-- **TreeView** — vault 노드를 `kind` 별 그룹화 (project / domain / capability / element / document / vault-readme)
-- **노드 클릭 → .md 열기** — \`ohMyOntology.openNode\` command
-- **vault 자동 인식** — workspace 의 \`docs/ontology/\` 자동 detect, 다른 폴더는 picker 로 선택
-- **vault path 영속** — \`globalState\` + 설정 \`oh-my-ontology.vaultPath\`
+### 1. Ontology TreeView (v0.1.0)
+
+- Activity Bar 좌측 entry — graph 모티브 SVG icon
+- vault 노드 `kind` 별 그룹화 (project / domain / capability / element / document / vault-readme)
+- 노드 클릭 → 해당 `.md` 열기 (`ohMyOntology.openNode`)
+- workspace 의 `docs/ontology/` 자동 detect, 다른 폴더는 picker (`ohMyOntology.pickVault`)
+- vault path 영속 (`globalState` + 설정 `oh-my-ontology.vaultPath`)
+
+### 2. 코드 ↔ ontology 점프 (v0.2.0 + v0.5.0 self-match)
+
+- 활성 editor 의 파일 path 와 vault 노드 매치 시 status bar (좌측) 에 노드 title 표시
+- 매치 우선순위: self-match (활성 파일이 ontology .md 자체) > exact path > directory ancestor > capability.elements 배열
+- status bar 클릭 → `ohMyOntology.openMatchedNode` → 해당 .md 열기
+
+### 3. Add concept (v0.3.0 — write surface)
+
+- Command Palette: `oh-my-ontology: Add concept` 또는 TreeView 헤더 `+` 버튼
+- QuickPick (kind) → InputBox (slug) → InputBox (title) → optional domain
+- KIND_FOLDER auto-prefix (`capabilities/foo`, `domains/foo`, `elements/foo`) — CLI `add` 와 동일 contract
+- 기존 slug throw — silent overwrite 차단
+- 작성 후 tree refresh + 새 .md 자동 열림
+
+### 4. Backlinks panel (v0.4.0 — MCP server connect)
+
+- 두 번째 TreeView 'Backlinks (current file)' — 활성 editor 매치 노드의 backlinks 표시
+- v0.5.0: ontology .md 직접 열어도 자동 populate (self-match 가 트리거)
+- 데이터 소스: `oh-my-ontology-mcp` 의 `find_backlinks` 도구 (plugin 이 spawn)
+- MCP 실패 시 raw filesystem scan (`computeBacklinksLocally`) 으로 graceful fallback
+- `useMcp` 설정으로 끄기 가능
 
 ## 5-way parser contract 편입
 
-\`vscode-plugin/src/parse-frontmatter.ts\` 가 5-way 계약 5번째 진입점
+`vscode-plugin/src/parse-frontmatter.ts` 가 5-way 계약 5번째 진입점
 (이전 4: src/shared, mcp, scripts/lib, cli). 12 fixture × 5 parser = 60
 case 가 매 PR 마다 drift 차단. 동일 lenient 파서 = vault 호환성 보장.
 
-## 다음 단계 (이 MVP 외)
+## 4-layer 자동 검증
 
-- 코드 ↔ ontology 점프 (현재 열린 source 의 element 매치 → side panel)
-- Add concept inline command (write surface)
-- MCP 서버 connect (mcp/src/index.js spawn)
-- Marketplace publish
+| Layer | 기법 | 무엇 검증 |
+|---|---|---|
+| 단위 logic | `node --test` × 27 case (code-match / write-vault / backlinks-local) | parser / matcher / writer / fallback logic |
+| MCP integration | spawn `mcp/src/index.js` × 3 case (mcp-client.test.mjs) | wire protocol drift |
+| VSCode integration | `@vscode/test-electron` × 5 case (extension.test.ts) | activation / commands / config / contributes |
+| Marketplace 준비 | `vsce package` (CI step) | manifest / icon / files / contributes shape |
 
-## 검증
+CI 매 PR 마다 1–4 자동 — plugin 깨지면 즉시 fail.
 
-\`pnpm test:run\` — 5-way contract test 60/60 통과 (\`tests/contract/parse-frontmatter.contract.test.ts\`).
-\`vscode-plugin/\` 안에서 \`npm install && npm run compile\` → \`out/extension.js\` 생성.
-F5 (Extension Development Host) 실행 시 dogfood vault 가 22 노드로 표시.
+## Marketplace 미발행
+
+사용자가 `code --install-extension oh-my-ontology-vscode-0.5.0.vsix` 로
+본인 VSCode (또는 fork — Cursor / Antigravity 호환) 에 설치해 일상 사용.
+Marketplace 발행 결정은 본인이 충분히 사용해본 후 명시 승인.


### PR DESCRIPTION
## Summary

dogfood graph hygiene + R13 CHANGELOG sync. capability/vscode-plugin-ide-entry 가 v0.1.0 시점 작성돼서 v0.2.0~v0.5.0 의 surface 와 자동 검증 layer 반영 안 돼 있었음. 사용자 / AI agent 가 vault 만 보고 plugin 현재 상태 정확 파악 가능하도록.

## Changes

### \`docs/ontology/capabilities/vscode-plugin-ide-entry.md\`

- elements 4 → 8 (code-match, write-vault, mcp-client, backlinks-provider 추가)
- relates 에 capabilities/mcp-conflict-guard 추가 (v0.4.0 mtime guard 와 plugin 의 future write surface 연결)
- 본문 v0.5.0 의 4 surface 표시:
  - Ontology TreeView (v0.1.0)
  - 코드 ↔ ontology 점프 (v0.2.0 + self-match v0.5.0)
  - Add concept (v0.3.0)
  - Backlinks panel (v0.4.0)
- 4-layer 자동 검증 표 추가 (단위 27 / MCP 3 / e2e 5 / vsce package)

### \`docs/CHANGELOG.md\` R13 entry 확장

- VSCode plugin 5 PR 요약 (#50 #51 #52 #54 #55)
- 4-layer 검증 표
- **4 surface 완성** 표 — CLI / MCP / 웹 workbench / VSCode plugin

> "개발자가 어디 있든 같은 vault, 같이 자라남" 미션의 모든 진입점이 처음으로 다 존재.

## Test plan

- [x] \`pnpm vault:validate\` — 23 파일 issue 0
- [x] \`pnpm dogfood:walk\` — vault size 23, orphans 1 (root project, intentional)

## Why this PR

dogfood vault 의 capability 노드들이 실 코드와 drift 안 하게 유지하는 게 product 본질. v0.5.0 까지 5 PR 의 진화가 capability 본문에 안 보이면 vault 만 보는 사람 (AI agent 포함) 이 stale 정보 받음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)