### PR TITLE
feat(vscode-plugin): informative status bar v0.6.0

### DIFF
--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -89,7 +89,7 @@ different folder via the Activity Bar header to override.
 
 ## Status
 
-**v0.5.0 — self-match + e2e harness.** Working features:
+**v0.6.0 — informative status bar.** Working features:
 
 - Activity Bar entry + Ontology TreeView grouped by `kind`
 - **Backlinks panel (v0.4.0)** — second TreeView under Activity Bar, populated by `find_backlinks` against the node matching the current editor.
@@ -101,6 +101,7 @@ different folder via the Activity Bar header to override.
 - **MCP server spawn (v0.4.0)** — plugin spawns `mcp/src/index.js` on activate, sends JSON-RPC over stdio to populate the backlinks panel. **Falls back to in-process scan** when the server is unavailable, so the plugin still works in offline / standalone mode. Same wire protocol as Claude Code uses.
 - **Self-match (v0.5.0)** — when you open an ontology node's `.md` file directly (e.g. `docs/ontology/elements/sigma-graphology.md`), the plugin recognizes that as the node and the **Backlinks panel auto-populates with who points to that node**. Status bar also shows the node title. The natural reading flow now works.
 - **Headless e2e harness (v0.5.0)** — `npm run test:e2e` downloads VSCode (cached in `.vscode-test/`) and runs the plugin in a real extension host. Verifies activation, command registration, configuration schema, and contributes. CI runs the same suite under `xvfb-run` so future PRs that break the integration get caught automatically.
+- **Informative status bar (v0.6.0)** — the status bar is no longer hidden when no node owns the active file. Four states surface the plugin's state: (a) no workspace, (b) no vault picked → click to pick, (c) vault loaded · no editor or no match → dim hint with node count, (d) match → kind icon + title (clickable). The plugin always lets you know it's alive.
 
 **Not yet:**
 

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -22,11 +22,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // R13 #50 — code↔ontology jump: surface the matching node for the active
   // editor in the status bar. Click → open the node's .md.
+  // R13 #61 — informative even when no match (see updateMatchForActiveEditor).
+  // The command is set per-state, not statically.
   const matchStatusBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
     100,
   );
-  matchStatusBar.command = 'ohMyOntology.openMatchedNode';
   context.subscriptions.push(matchStatusBar);
 
   let cachedNodes: VaultNode[] = [];
@@ -36,9 +37,33 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const updateMatchForActiveEditor = (): void => {
     const editor = vscode.window.activeTextEditor;
     const folders = vscode.workspace.workspaceFolders;
-    if (!editor || !folders || folders.length === 0 || cachedNodes.length === 0) {
+
+    // R13 #61 — informative status bar even when no node owns the active
+    // file. Three states: (a) no vault picked → "pick a vault" hint,
+    // (b) vault loaded but no match → dim "<N> nodes · no match" so the
+    // developer sees the plugin is alive, (c) match → kind icon + title.
+    if (!folders || folders.length === 0) {
       currentMatch = null;
       matchStatusBar.hide();
+      backlinksProvider.clear();
+      return;
+    }
+    if (cachedNodes.length === 0) {
+      currentMatch = null;
+      matchStatusBar.text = '$(folder-opened) oh-my-ontology';
+      matchStatusBar.tooltip =
+        'oh-my-ontology · no vault loaded.\nClick to pick a vault folder.';
+      matchStatusBar.command = 'ohMyOntology.pickVault';
+      matchStatusBar.show();
+      backlinksProvider.clear();
+      return;
+    }
+    if (!editor) {
+      currentMatch = null;
+      matchStatusBar.text = `$(circle-outline) oh-my-ontology · ${cachedNodes.length} nodes`;
+      matchStatusBar.tooltip = `oh-my-ontology · ${cachedNodes.length} nodes loaded · no editor active.`;
+      matchStatusBar.command = 'ohMyOntology.refresh';
+      matchStatusBar.show();
       backlinksProvider.clear();
       return;
     }
@@ -52,13 +77,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
     currentMatch = match;
     if (!match) {
-      matchStatusBar.hide();
+      matchStatusBar.text = `$(circle-outline) oh-my-ontology · ${cachedNodes.length} nodes · no match`;
+      matchStatusBar.tooltip = `oh-my-ontology · this file isn't owned by any ontology node.\n${cachedNodes.length} nodes loaded · click to refresh.`;
+      matchStatusBar.command = 'ohMyOntology.refresh';
+      matchStatusBar.show();
       backlinksProvider.clear();
       return;
     }
     const icon = iconForKind(match.kind);
     matchStatusBar.text = `${icon} ${match.title}`;
     matchStatusBar.tooltip = `oh-my-ontology · ${match.kind} · ${match.slug}\nClick to open ${match.slug}.md`;
+    matchStatusBar.command = 'ohMyOntology.openMatchedNode';
     matchStatusBar.show();
     void loadBacklinksFor(match.slug);
   };


### PR DESCRIPTION
## Summary

이전 (v0.5.0): 매치 노드 없으면 status bar 비어있음 → 사용자가 plugin alive 한지 헷갈림.

신규 (v0.6.0): 4 state 모두 명시. plugin 이 항상 alive 신호.

## States

| State | Status bar text | Click |
|---|---|---|
| no workspace | hidden | — |
| vault 미선택 | \`📂 oh-my-ontology\` | → pickVault |
| vault loaded · no editor | \`◯ oh-my-ontology · N nodes\` | → refresh |
| vault loaded · no match | \`◯ oh-my-ontology · N nodes · no match\` | → refresh |
| **match** | \`📄 Node Title\` (kind icon + title) | → openMatchedNode (기존) |

## Test plan

- [x] \`npm test\` — 27 pass
- [x] \`npm run test:e2e\` — 5 pass
- [x] \`vsce package\` — 14 files / 22.57 KB clean
- [x] \`antigravity --install-extension\` — success
- [ ] 사용자 본인 vault 미선택 / 매치 없는 파일 / 매치되는 파일 각각 보면서 status bar text 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)