### PR TITLE
chore(vault): vault:audit script — capability/element path drift 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Vault validate (dogfood frontmatter integrity)
         run: pnpm vault:validate
 
+      - name: Vault paths audit (capability/element 의 path 가 실 코드 일치)
+        run: pnpm vault:audit
+
       # vscode-plugin v0.5.0 (R13 #49–#54). Run unit + MCP-integration
       # tests, headless e2e via @vscode/test-electron, and verify the
       # plugin packages cleanly into a .vsix so we catch

--- a/docs/ontology/capabilities/frontmatter-to-ontology.md
+++ b/docs/ontology/capabilities/frontmatter-to-ontology.md
@@ -4,8 +4,8 @@ kind: capability
 title: Frontmatter → Ontology Stub
 domain: ontology-core
 elements:
-  - src/shared/lib/parse-frontmatter
-  - src/entities/docs-vault/lib/derive-ontology-from-vault
+  - src/shared/lib/parse-frontmatter.ts
+  - src/entities/docs-vault/lib/derive-ontology-from-vault.ts
 relates:
   - domains/vault-local-first
   - domains/ontology-core

--- a/docs/ontology/domains/onboarding-ux.md
+++ b/docs/ontology/domains/onboarding-ux.md
@@ -7,8 +7,8 @@ capabilities:
   - vscode-plugin-ide-entry
 elements:
   - src/features/theme-toggle
-  - src/shared/ui/toast
-  - src/shared/ui/live-announcer
+  - src/shared/ui/toast.tsx
+  - src/shared/ui/live-announcer.tsx
   - src/widgets/bottom-tab-bar
   - src/widgets/gesture-hint
 relates:

--- a/docs/ontology/domains/ontology-core.md
+++ b/docs/ontology/domains/ontology-core.md
@@ -7,7 +7,7 @@ capabilities:
 elements:
   - src/entities/ontology-class
   - src/entities/knowledge-graph
-  - src/entities/docs-vault/lib/derive-ontology-from-vault
+  - src/entities/docs-vault/lib/derive-ontology-from-vault.ts
 relates:
   - domains/vault-local-first
   - domains/views

--- a/docs/ontology/domains/vault-local-first.md
+++ b/docs/ontology/domains/vault-local-first.md
@@ -10,7 +10,7 @@ elements:
   - src/features/docs-vault-local
   - src/entities/local-fs-handle
   - src/entities/docs-vault
-  - src/shared/lib/idb-kv
+  - src/shared/lib/idb-kv.ts
 relates:
   - domains/mode-aware-adapters
   - domains/ontology-core

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs-vault:build": "node scripts/build-docs-vault.mjs",
     "vault:validate": "node scripts/validate-vault.mjs",
     "vault:migrate": "node scripts/migrate-vault.mjs",
+    "vault:audit": "node scripts/audit-vault-paths.mjs",
     "dogfood:walk": "node scripts/dogfood-mcp-walk.mjs",
     "lint": "eslint",
     "bundle:check": "node scripts/check-bundle.mjs",

--- a/scripts/audit-vault-paths.mjs
+++ b/scripts/audit-vault-paths.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// R13 #58 — vault path drift audit.
+//
+// dogfood vault (docs/ontology/) 의 capability/element 노드들이 실 코드
+// path 와 drift 없는지 검증. 각 노드 frontmatter 의:
+//   - `path:` (string)         — element 의 source-file path
+//   - `elements:` (string[])   — capability 가 owns 하는 source paths
+// 가 실제로 fs 에 존재하는지 확인. 못 찾는 path 는 drift.
+//
+// 사용:
+//   node scripts/audit-vault-paths.mjs                    # 기본: docs/ontology vs cwd
+//   node scripts/audit-vault-paths.mjs <vault> <repo>     # 명시
+//   pnpm vault:audit                                       # package.json script
+//
+// exit 1 if drift, 0 if clean — CI gateable.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { parseFrontmatter } from "./lib/parse-frontmatter.mjs";
+
+const COLORS = {
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  reset: "\x1b[0m",
+};
+
+const args = process.argv.slice(2);
+const VAULT = resolve(args[0] ?? "docs/ontology");
+const REPO = resolve(args[1] ?? ".");
+
+if (!existsSync(VAULT)) {
+  process.stderr.write(`vault not found: ${VAULT}\n`);
+  process.exit(2);
+}
+
+function walkMd(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walkMd(full, out);
+    else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+const drifts = []; // { slug, kind, key, missingPath }
+let nodesScanned = 0;
+let pathsChecked = 0;
+
+for (const filePath of walkMd(VAULT)) {
+  const raw = readFileSync(filePath, "utf-8");
+  const { frontmatter } = parseFrontmatter(raw);
+  const kind = String(frontmatter.kind ?? "").trim();
+  if (!kind) continue;
+  const slug = String(frontmatter.slug ?? "").trim() || filePath;
+  nodesScanned += 1;
+
+  // Single `path:` (typically on element nodes)
+  if (typeof frontmatter.path === "string" && frontmatter.path.trim()) {
+    pathsChecked += 1;
+    const abs = resolve(REPO, frontmatter.path.trim());
+    if (!existsSync(abs)) {
+      drifts.push({ slug, kind, key: "path", missingPath: frontmatter.path });
+    }
+  }
+
+  // Array `elements:` (typically on capability nodes — list of source paths
+  // OR ontology slugs). We only flag entries that *look like* a path
+  // (contain `/` or `.`) to avoid false positives on ontology slugs like
+  // "vault-validator" which are valid as cross-references.
+  if (Array.isArray(frontmatter.elements)) {
+    for (const el of frontmatter.elements) {
+      if (typeof el !== "string") continue;
+      const looksLikePath =
+        el.includes("/") || el.endsWith(".ts") || el.endsWith(".js") ||
+        el.endsWith(".mjs") || el.endsWith(".tsx") || el.endsWith(".json");
+      // ontology slug heuristic: contains '/' AND first segment is a kind plural.
+      const isOntologySlug =
+        el.startsWith("capabilities/") ||
+        el.startsWith("domains/") ||
+        el.startsWith("elements/") ||
+        el.startsWith("documents/");
+      if (!looksLikePath || isOntologySlug) continue;
+      pathsChecked += 1;
+      const abs = resolve(REPO, el);
+      if (!existsSync(abs)) {
+        drifts.push({ slug, kind, key: "elements[]", missingPath: el });
+      }
+    }
+  }
+}
+
+if (drifts.length === 0) {
+  console.log(
+    `${COLORS.green}[audit-vault-paths]${COLORS.reset} ${nodesScanned} nodes · ${pathsChecked} paths checked · ${COLORS.bold}drift 0 ✓${COLORS.reset}`,
+  );
+  process.exit(0);
+}
+
+console.log(
+  `${COLORS.bold}[audit-vault-paths]${COLORS.reset} ${nodesScanned} nodes · ${pathsChecked} paths checked · ${COLORS.red}${drifts.length} drift${COLORS.reset}\n`,
+);
+
+// Group by slug for readability
+const bySlug = new Map();
+for (const d of drifts) {
+  if (!bySlug.has(d.slug)) bySlug.set(d.slug, { kind: d.kind, items: [] });
+  bySlug.get(d.slug).items.push(d);
+}
+
+for (const [slug, { kind, items }] of bySlug) {
+  console.log(`  ${COLORS.bold}${slug}${COLORS.reset} ${COLORS.dim}(${kind})${COLORS.reset}`);
+  for (const d of items) {
+    console.log(
+      `    ${COLORS.red}✗${COLORS.reset} ${d.key}: ${COLORS.yellow}${d.missingPath}${COLORS.reset} ${COLORS.dim}— path not found in repo${COLORS.reset}`,
+    );
+  }
+}
+
+console.log(
+  `\n${COLORS.dim}fix: edit the .md to point at a real path, or remove the entry if the code was deleted.${COLORS.reset}`,
+);
+process.exit(1);


### PR DESCRIPTION
## Summary

dogfood graph hygiene 1차 audit. capability/element 노드의 \`path:\` / \`elements:[]\` entry 가 실 코드와 일치하는지 자동 검증 + CI 게이트. 5 stale entry fix.

## What it found

**5 drift** — 모두 확장자 누락. 실 파일은 존재:

| Slug | Stale path | 실 파일 |
|---|---|---|
| capabilities/frontmatter-to-ontology | \`src/shared/lib/parse-frontmatter\` | \`.ts\` |
| capabilities/frontmatter-to-ontology | \`src/entities/docs-vault/lib/derive-ontology-from-vault\` | \`.ts\` |
| domains/onboarding-ux | \`src/shared/ui/toast\` | \`.tsx\` |
| domains/onboarding-ux | \`src/shared/ui/live-announcer\` | \`.tsx\` |
| domains/ontology-core | \`src/entities/docs-vault/lib/derive-ontology-from-vault\` | \`.ts\` |
| domains/vault-local-first | \`src/shared/lib/idb-kv\` | \`.ts\` |

audit re-run 후: **23 nodes · 59 paths · drift 0 ✓**

## scripts/audit-vault-paths.mjs

- 모든 \`.md\` 의 frontmatter \`path:\` (string) + \`elements:\` (array) walk
- 실 fs (repo root 기준) 존재 verify
- ontology slug (\`capabilities/foo\`, \`domains/bar\`) 은 cross-ref 라 verify 안 함
- looksLikePath: \`/\` 또는 \`.ts/.tsx/.mjs/.js/.json\` 확장자
- drift 발견 시 slug 별 그룹화 + ANSI 색상 + exit 1

## CI 통합

- \`package.json\`: \`vault:audit\` script 등록
- \`.github/workflows/ci.yml\`: \`vault:validate\` 다음 step 으로 \`vault:audit\`
- 매 PR drift 즉시 fail

## Test plan

- [x] \`pnpm vault:audit\` — drift 0 (23 nodes · 59 paths)
- [x] \`pnpm vault:validate\` — issue 0
- [x] \`pnpm dogfood:walk\` — 23 nodes (변동 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)