### PR TITLE
feat(vscode-plugin): rename + merge commands v0.7.0

### DIFF
--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -78,8 +78,11 @@ Click any node to open its `.md` in the editor.
 | `ohMyOntology.pickVault` | Pick vault folder |
 | `ohMyOntology.refresh` | Refresh |
 | `ohMyOntology.addConcept` | **Add concept (v0.3.0)** — kind picker → slug → title → optional domain → writes `<vault>/<auto-prefix>/<slug>.md` |
+| `ohMyOntology.renameConcept` | **Rename concept (v0.7.0)** — slug 변경 + atomic backlink redirect (modal preview + confirm) |
+| `ohMyOntology.mergeConcepts` | **Merge concepts (v0.7.0)** — fold one node into another (destructive, modal preview + confirm) |
 | `ohMyOntology.openNode` | Open node .md (invoked when you click a tree item) |
 | `ohMyOntology.openMatchedNode` | Open the node matching the active editor (status bar click) |
+| `ohMyOntology.openBacklink` | Open backlink .md (invoked when you click a backlink) |
 
 ## Auto-detection
 
@@ -89,7 +92,7 @@ different folder via the Activity Bar header to override.
 
 ## Status
 
-**v0.6.0 — informative status bar.** Working features:
+**v0.7.0 — graph-level write commands.** Working features:
 
 - Activity Bar entry + Ontology TreeView grouped by `kind`
 - **Backlinks panel (v0.4.0)** — second TreeView under Activity Bar, populated by `find_backlinks` against the node matching the current editor.
@@ -102,6 +105,7 @@ different folder via the Activity Bar header to override.
 - **Self-match (v0.5.0)** — when you open an ontology node's `.md` file directly (e.g. `docs/ontology/elements/sigma-graphology.md`), the plugin recognizes that as the node and the **Backlinks panel auto-populates with who points to that node**. Status bar also shows the node title. The natural reading flow now works.
 - **Headless e2e harness (v0.5.0)** — `npm run test:e2e` downloads VSCode (cached in `.vscode-test/`) and runs the plugin in a real extension host. Verifies activation, command registration, configuration schema, and contributes. CI runs the same suite under `xvfb-run` so future PRs that break the integration get caught automatically.
 - **Informative status bar (v0.6.0)** — the status bar is no longer hidden when no node owns the active file. Four states surface the plugin's state: (a) no workspace, (b) no vault picked → click to pick, (c) vault loaded · no editor or no match → dim hint with node count, (d) match → kind icon + title (clickable). The plugin always lets you know it's alive.
+- **Rename + merge concepts (v0.7.0)** — `oh-my-ontology: Rename concept` and `oh-my-ontology: Merge concepts` from the Command Palette. Both invoke MCP write tools (`rename_concept` / `merge_concepts`) with the **dry-run + confirm** pattern: first call shows you exactly which files will change, second call (after modal confirm) commits. Atomic backlink redirect for rename. Merge is destructive (deletes `fromSlug.md`) and requires "Confirm merge (destructive)" in the modal.
 
 **Not yet:**
 

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"
@@ -54,6 +54,14 @@
         "command": "ohMyOntology.addConcept",
         "title": "oh-my-ontology: Add concept",
         "icon": "$(add)"
+      },
+      {
+        "command": "ohMyOntology.renameConcept",
+        "title": "oh-my-ontology: Rename concept (atomic backlink redirect)"
+      },
+      {
+        "command": "ohMyOntology.mergeConcepts",
+        "title": "oh-my-ontology: Merge concepts (destructive)"
       },
       {
         "command": "ohMyOntology.openNode",

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -287,6 +287,129 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
     vscode.commands.registerCommand(
+      'ohMyOntology.renameConcept',
+      async () => {
+        if (!mcpClient || !mcpClient.isReady()) {
+          vscode.window.showErrorMessage(
+            'oh-my-ontology rename: MCP server not running. Enable `oh-my-ontology.useMcp` and refresh.',
+          );
+          return;
+        }
+        const seedSlug = currentMatch?.slug;
+        const oldSlug = await vscode.window.showInputBox({
+          value: seedSlug,
+          placeHolder: 'old slug — e.g. capabilities/foo',
+          prompt: 'Slug to rename',
+          validateInput: (v) =>
+            !v || !v.trim() ? 'old slug is required' : null,
+        });
+        if (!oldSlug) return;
+        const newSlug = await vscode.window.showInputBox({
+          placeHolder: 'new slug — e.g. capabilities/bar',
+          prompt: `New slug for ${oldSlug}`,
+          validateInput: (v) =>
+            !v || !v.trim() ? 'new slug is required' : null,
+        });
+        if (!newSlug) return;
+        try {
+          const dry = (await mcpClient.callTool('rename_concept', {
+            oldSlug,
+            newSlug,
+          })) as { updates?: Array<{ file: string }>; ok?: boolean };
+          const count = dry.updates?.length ?? 0;
+          const sample =
+            dry.updates?.slice(0, 5).map((u) => u.file).join('\n  ') ?? '(none)';
+          const confirmed = await vscode.window.showWarningMessage(
+            `Rename ${oldSlug} → ${newSlug}?\n\n${count} file(s) affected:\n  ${sample}${count > 5 ? `\n  ...+${count - 5} more` : ''}`,
+            { modal: true },
+            'Confirm rename',
+          );
+          if (confirmed !== 'Confirm rename') return;
+          await mcpClient.callTool('rename_concept', {
+            oldSlug,
+            newSlug,
+            confirm: true,
+          });
+          vscode.window.setStatusBarMessage(
+            `oh-my-ontology: renamed ${oldSlug} → ${newSlug} (${count} files)`,
+            5000,
+          );
+          await refresh();
+          const newNode = cachedNodes.find((n) => n.slug === newSlug);
+          if (newNode) {
+            const doc = await vscode.workspace.openTextDocument(newNode.filePath);
+            await vscode.window.showTextDocument(doc);
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          vscode.window.showErrorMessage(`oh-my-ontology rename: ${msg}`);
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
+      'ohMyOntology.mergeConcepts',
+      async () => {
+        if (!mcpClient || !mcpClient.isReady()) {
+          vscode.window.showErrorMessage(
+            'oh-my-ontology merge: MCP server not running. Enable `oh-my-ontology.useMcp` and refresh.',
+          );
+          return;
+        }
+        const fromSlug = await vscode.window.showInputBox({
+          value: currentMatch?.slug,
+          placeHolder: 'from slug (will be DELETED) — e.g. capabilities/old',
+          prompt: 'Slug to dissolve into another node',
+          validateInput: (v) =>
+            !v || !v.trim() ? 'from slug is required' : null,
+        });
+        if (!fromSlug) return;
+        const intoSlug = await vscode.window.showInputBox({
+          placeHolder: 'into slug (will absorb backlinks) — e.g. capabilities/keep',
+          prompt: `Merge target — ${fromSlug}'s backlinks redirect here, then ${fromSlug}.md is deleted`,
+          validateInput: (v) =>
+            !v || !v.trim()
+              ? 'into slug is required'
+              : v === fromSlug
+                ? 'into slug must differ from from slug'
+                : null,
+        });
+        if (!intoSlug) return;
+        try {
+          const dry = (await mcpClient.callTool('merge_concepts', {
+            fromSlug,
+            intoSlug,
+          })) as { updates?: Array<{ file: string }> };
+          const count = dry.updates?.length ?? 0;
+          const sample =
+            dry.updates?.slice(0, 5).map((u) => u.file).join('\n  ') ?? '(none)';
+          const confirmed = await vscode.window.showWarningMessage(
+            `Merge ${fromSlug} into ${intoSlug}?\n\n⚠ ${fromSlug}.md will be DELETED.\n\n${count} backlink file(s) redirected:\n  ${sample}${count > 5 ? `\n  ...+${count - 5} more` : ''}`,
+            { modal: true },
+            'Confirm merge (destructive)',
+          );
+          if (confirmed !== 'Confirm merge (destructive)') return;
+          await mcpClient.callTool('merge_concepts', {
+            fromSlug,
+            intoSlug,
+            confirm: true,
+          });
+          vscode.window.setStatusBarMessage(
+            `oh-my-ontology: merged ${fromSlug} → ${intoSlug} (${count} backlinks redirected)`,
+            5000,
+          );
+          await refresh();
+          const intoNode = cachedNodes.find((n) => n.slug === intoSlug);
+          if (intoNode) {
+            const doc = await vscode.workspace.openTextDocument(intoNode.filePath);
+            await vscode.window.showTextDocument(doc);
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          vscode.window.showErrorMessage(`oh-my-ontology merge: ${msg}`);
+        }
+      },
+    ),
+    vscode.commands.registerCommand(
       'ohMyOntology.openBacklink',
       async (b: Backlink) => {
         if (b.filePath) {

--- a/vscode-plugin/src/test/suite/extension.test.ts
+++ b/vscode-plugin/src/test/suite/extension.test.ts
@@ -45,6 +45,8 @@ suite('oh-my-ontology — VSCode integration', () => {
       'ohMyOntology.openNode',
       'ohMyOntology.openMatchedNode',
       'ohMyOntology.addConcept',
+      'ohMyOntology.renameConcept',
+      'ohMyOntology.mergeConcepts',
       'ohMyOntology.openBacklink',
     ];
     const all = await vscode.commands.getCommands(true);


### PR DESCRIPTION
## Summary

VSCode plugin v0.6.0 → v0.7.0. 14 MCP tools 중 graph-level write 도구 (\`rename_concept\`, \`merge_concepts\`) 를 Command Palette 에 노출.

## Two new commands

### \`oh-my-ontology: Rename concept\`

slug 변경 + **atomic backlink redirect**. 모든 frontmatter array entry / inline string key / body wikilink 자동 갱신.

- oldSlug input (현재 매치 노드 seed) → newSlug input
- MCP \`rename_concept\` dry-run → 모달 preview (\`count + 5 sample files\`)
- 'Confirm rename' 클릭 시 \`confirm: true\` commit
- 새 .md 자동 열기 + tree refresh

### \`oh-my-ontology: Merge concepts\` (destructive)

fromSlug 의 backlinks 를 intoSlug 로 redirect 후 fromSlug.md 삭제.

- fromSlug (delete) + intoSlug (absorb) input
- 두 slug 다름 validate
- dry-run preview → '**Confirm merge (destructive)**' 모달
- 삭제 + redirect 후 intoSlug .md 열기 + tree refresh

## Why no patch_concept

VSCode 의 native .md editor 로 직접 편집 가능. 별 가치 없어 skip.

## Test plan

- [x] \`npm test\` — 27 unit pass
- [x] \`npm run test:e2e\` — 5 pass (\`renameConcept\` / \`mergeConcepts\` 명령 등록 verify 포함)
- [x] \`vsce package\` — 14 files / 23.67 KB
- [x] \`antigravity --install-extension\` — success
- [ ] 사용자 본인이 vault 에서 noop rename 으로 dry-run preview 확인 (예: \`capabilities/foo\` → \`capabilities/foo-v2\`)

## How it works

Plugin 의 spawn-based MCP client 가 dry-run + confirm 의 두 단계 모두 호출. **사용자가 modal 거부 시 disk 변경 0** — silent overwrite 방지 보장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)