### PR TITLE
feat(vscode-plugin): graph 발견성 + UX 폴리시 v0.8.2

### DIFF
--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"
@@ -47,6 +47,10 @@
       {
         "view": "ohMyOntology.tree",
         "contents": "Pick a vault folder (a directory containing .md files with `kind:` frontmatter).\n\n[Open vault folder](command:ohMyOntology.pickVault)\n\nOr set `oh-my-ontology.vaultPath` in your settings."
+      },
+      {
+        "view": "ohMyOntology.backlinks",
+        "contents": "Backlinks for the active editor's matching node will appear here.\n\nOpen a code file owned by an ontology node, or open an ontology `.md` directly.\n\n— or —\n\n[$(graph) Open the graph view](command:ohMyOntology.openGraph)\n\n[$(add) Add a new concept](command:ohMyOntology.addConcept)"
       }
     ],
     "commands": [
@@ -132,6 +136,11 @@
           "type": "string",
           "default": "",
           "description": "Absolute path to `mcp/src/index.js`. Empty = auto-detect `<workspace>/mcp/src/index.js`."
+        },
+        "oh-my-ontology.autoOpenGraph": {
+          "type": "boolean",
+          "default": false,
+          "description": "Open the graph view automatically on first vault load. Off by default — flip to true if you always want the graph next to your editor."
         }
       }
     }

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -62,9 +62,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
     if (!editor) {
       currentMatch = null;
-      matchStatusBar.text = `$(circle-outline) oh-my-ontology · ${cachedNodes.length} nodes`;
-      matchStatusBar.tooltip = `oh-my-ontology · ${cachedNodes.length} nodes loaded · no editor active.`;
-      matchStatusBar.command = 'ohMyOntology.refresh';
+      matchStatusBar.text = `$(graph) oh-my-ontology · ${cachedNodes.length} nodes`;
+      matchStatusBar.tooltip = `oh-my-ontology · ${cachedNodes.length} nodes loaded · click to open the graph view.`;
+      matchStatusBar.command = 'ohMyOntology.openGraph';
       matchStatusBar.show();
       backlinksProvider.clear();
       return;
@@ -79,9 +79,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
     currentMatch = match;
     if (!match) {
-      matchStatusBar.text = `$(circle-outline) oh-my-ontology · ${cachedNodes.length} nodes · no match`;
-      matchStatusBar.tooltip = `oh-my-ontology · this file isn't owned by any ontology node.\n${cachedNodes.length} nodes loaded · click to refresh.`;
-      matchStatusBar.command = 'ohMyOntology.refresh';
+      matchStatusBar.text = `$(graph) oh-my-ontology · ${cachedNodes.length} nodes · no match`;
+      matchStatusBar.tooltip = `oh-my-ontology · this file isn't owned by any ontology node.\n${cachedNodes.length} nodes loaded · click to open the graph view.`;
+      matchStatusBar.command = 'ohMyOntology.openGraph';
       matchStatusBar.show();
       backlinksProvider.clear();
       return;
@@ -164,6 +164,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   };
 
+  let firstVaultLoadDone = false;
+
   const refresh = async (): Promise<void> => {
     const vaultPath = await resolveVaultPath(context);
     if (!vaultPath) {
@@ -186,6 +188,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         graphPanel.update(nodes);
       } else {
         graphPanel = null;
+      }
+      // R13 #65 — auto-open graph on first vault load (opt-in setting)
+      if (!firstVaultLoadDone && nodes.length > 0) {
+        firstVaultLoadDone = true;
+        const auto = vscode.workspace
+          .getConfiguration('oh-my-ontology')
+          .get<boolean>('autoOpenGraph', false);
+        if (auto && !graphPanel) {
+          await vscode.commands.executeCommand('ohMyOntology.openGraph');
+        }
       }
       updateMatchForActiveEditor();
     } catch (err) {


### PR DESCRIPTION
## Summary

사용자 스크린샷 finding: *"근데 이거 암만봐도 그래프 없는데? 어디에 그래프가 있다는거야?"* — graph view 발견성 0 의 직접 증거. v0.8.2 가 fix.

## 4 발견성 개선

### 1. Backlinks panel welcome view

비어있을 때 (대부분 시간) 안내:

\`\`\`
Backlinks for the active editor's matching node will appear here.

Open a code file owned by an ontology node, or open an ontology .md directly.

— or —

[📊 Open the graph view]
[+ Add a new concept]
\`\`\`

→ 사용자가 panel 만 봐도 graph 명령 발견 가능.

### 2. Status bar → graph entry point

| 이전 | 신규 |
|---|---|
| ◯ ... · click to refresh | **📊 ... · click to open the graph view** |

매치 없을 때 / 에디터 없을 때 status bar 의 click 이 \`refresh\` → **\`openGraph\`**. 사용자가 status bar 보는 모든 시점에 graph 한 번 클릭으로 접근.

### 3. Auto-open setting

신규 설정 \`oh-my-ontology.autoOpenGraph\` (default false). true 로 flip 하면 첫 vault load 시 graph 자동 open. 항상 옆에 graph 두는 사용자에게 편의.

### 4. TreeView graph icon

\`v0.8.0\` 부터 navigation@1 위치 (제일 왼쪽). 사용자가 못 발견 → tooltip 강화 + 링크 안내 (위 1, 2 번).

## Test plan

- [x] \`npx tsc\` — 0 errors
- [x] \`npm test\` — 33 unit
- [x] \`npm run test:e2e\` — 6 pass
- [x] \`vsce package\` — 20 files / 232 KB
- [x] \`antigravity --install-extension\` — success
- [ ] 사용자 본인 Antigravity 재시작 → 4 가지 graph entry point 중 하나로 graph 발견

## How to verify

Antigravity 완전 재시작 (\`⌘Q\`) 후:

1. **Activity Bar 의 oh-my-ontology icon 클릭**
2. **하단의 Backlinks panel** 보면 'Open the graph view' 링크 보임
3. **하단 status bar** 의 \`📊 oh-my-ontology · 23 nodes\` 클릭
4. → 그래프 webview 열림

🤖 Generated with [Claude Code](https://claude.com/claude-code)