### PR TITLE
fix(vscode-plugin): graph CSP nonce — 'loading…' stuck bug

### DIFF
--- a/vscode-plugin/media/graph.html
+++ b/vscode-plugin/media/graph.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${CSP_SOURCE}; style-src ${CSP_SOURCE} 'unsafe-inline'; font-src ${CSP_SOURCE};" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${CSP_SOURCE} 'nonce-${NONCE}'; style-src ${CSP_SOURCE} 'unsafe-inline'; font-src ${CSP_SOURCE}; img-src ${CSP_SOURCE} data:;" />
     <style>
       :root {
         color-scheme: light dark;
@@ -53,10 +53,10 @@
     </div>
     <div id="cy"></div>
     <div id="tooltip" role="tooltip"></div>
-    <script src="${CYTOSCAPE_URI}"></script>
-    <script src="${DAGRE_URI}"></script>
-    <script src="${CY_DAGRE_URI}"></script>
-    <script>
+    <script nonce="${NONCE}" src="${CYTOSCAPE_URI}"></script>
+    <script nonce="${NONCE}" src="${DAGRE_URI}"></script>
+    <script nonce="${NONCE}" src="${CY_DAGRE_URI}"></script>
+    <script nonce="${NONCE}">
       const vscode = acquireVsCodeApi();
       cytoscape.use(cytoscapeDagre);
 

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-ontology-vscode",
   "displayName": "oh-my-ontology",
   "description": "View and navigate the ontology vault from inside VSCode — sibling of the CLI and MCP server.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "publisher": "wlsdks",
   "engines": {
     "vscode": "^1.85.0"

--- a/vscode-plugin/src/graph-view.ts
+++ b/vscode-plugin/src/graph-view.ts
@@ -106,12 +106,27 @@ function renderHtml(
   const cytoscapeUri = mediaUri("cytoscape.min.js").toString();
   const dagreUri = mediaUri("dagre.min.js").toString();
   const cyDagreUri = mediaUri("cytoscape-dagre.js").toString();
+  // R13 #66 — CSP fix. Inline scripts need a nonce; without it, the
+  // webview shows the toolbar (HTML loads fine) but the cytoscape init
+  // script is silently blocked → graph stays at "loading…".
+  const nonce = generateNonce();
 
   const templatePath = path.join(extensionUri.fsPath, "media", "graph.html");
   const template = fs.readFileSync(templatePath, "utf-8");
   return template
     .replaceAll("${CSP_SOURCE}", webview.cspSource)
+    .replaceAll("${NONCE}", nonce)
     .replaceAll("${CYTOSCAPE_URI}", cytoscapeUri)
     .replaceAll("${DAGRE_URI}", dagreUri)
     .replaceAll("${CY_DAGRE_URI}", cyDagreUri);
+}
+
+function generateNonce(): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let out = "";
+  for (let i = 0; i < 32; i += 1) {
+    out += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

사용자 스크린샷이 결정적 bug 발견: graph webview 가 열리지만 actual 그래프 안 그려짐. toolbar 만 보이고 'loading…' 영구 stuck.

## Root cause

\`\`\`html
<!-- 이전 CSP -->
<meta ... script-src ${CSP_SOURCE}; ...>

<!-- external — OK (cspSource 매치) -->
<script src="${CYTOSCAPE_URI}"></script>

<!-- inline — 🚫 silently 차단 -->
<script>
  cytoscape.use(cytoscapeDagre);
  const cy = cytoscape({...});
  vscode.postMessage({ type: 'ready' });
</script>
\`\`\`

CSP \`script-src ${CSP_SOURCE}\` 는 external src 매치만 허용. **inline \`<script>\` block 은 \`'unsafe-inline'\` 또는 nonce 없으면 차단**.

→ cytoscape lib 는 메모리에 있지만 init 코드가 안 돌아감 → 'ready' 안 보내짐 → \`setData\` 안 호출 → graph 영구 빈 상태.

## Fix (canonical VSCode pattern)

\`\`\`html
<meta ... script-src ${CSP_SOURCE} 'nonce-${NONCE}'; ...>

<script nonce="${NONCE}" src="${CYTOSCAPE_URI}"></script>
<script nonce="${NONCE}" src="${DAGRE_URI}"></script>
<script nonce="${NONCE}">
  // inline init now allowed by nonce
</script>
\`\`\`

\`generateNonce()\` 가 매 webview 마다 32-char alphanum nonce 생성.

## Test plan

- [x] \`npx tsc\` — 0 errors
- [x] \`npm run test:e2e\` — 6 pass (panel mount 자동 verify)
- [x] \`vsce package\` — 20 files / 232.35 KB
- [x] \`antigravity --install-extension oh-my-ontology-vscode-0.8.3.vsix\` — success
- [ ] **사용자 본인 Antigravity 재시작 후 graph icon 클릭 → 23 노드 그래프 렌더 확인**

## Bonus

\`img-src ${CSP_SOURCE} data:\` 도 CSP 에 추가 — 미래 SVG/PNG 노드 아이콘 대비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)