### PR TITLE
feat(web): runtime diff highlight — 새 노드 amber pulse (#70)

### DIFF
--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -149,6 +149,13 @@ export function buildGraph(
      * 방지). 일반 project 만 받음.
      */
     ontologyCountsBySlug?: Map<string, OntologyCountsForProject>;
+    /**
+     * R13 #70 — runtime diff highlight. polling 으로 방금 들어온 (또는
+     * 갱신된) project slug 들. 이 set 안의 노드는 calendar-time 기준의
+     * recentlyUpdated 와 OR — 그래서 매우 오래 전 만든 노드여도 사용자가
+     * 방금 .md 를 추가했으면 pulse. 기본 비어있음 = 기존 동작 유지.
+     */
+    runtimeRecentSlugs?: ReadonlySet<string>;
   },
 ): Graph<SigmaNodeAttrs, SigmaEdgeAttrs> {
   const graph = new Graph<SigmaNodeAttrs, SigmaEdgeAttrs>({ type: 'directed', multi: false });
@@ -174,7 +181,9 @@ export function buildGraph(
   projects.forEach((project, index) => {
     const theta = jitter(index) * Math.PI * 2;
     const r = jitter(index + 7) * 40;
-    const recent = isProjectRecentlyUpdated(project, 7);
+    const recent =
+      isProjectRecentlyUpdated(project, 7) ||
+      options?.runtimeRecentSlugs?.has(project.slug) === true;
 
     // O-9b: 일반 project 노드 (hub 제외) 만 ontology 도미넌트 kind 에 따라
     // borderColor 분기. fill 은 분기 안 함 — 헌장 "허브만 유일한 채색" +

--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -423,10 +423,48 @@ function SigmaTopologyImpl({
     return buildProjectOntologyCounts(ontologyInsight.nodes);
   }, [ontologyInsight]);
 
+  // R13 #70 — runtime diff highlight. polling 으로 새로 들어오거나 갱신된
+  // project slug 들을 5s 간 'recently changed' 로 마크 → buildGraph 가 그
+  // slug 의 노드를 recentlyUpdated:true 로 빌드 → 기존 recent pulse 가
+  // amber sine 진동. AI agent / IDE 가 vault 만지면 그래프에서 직접 느껴짐.
+  const RUNTIME_RECENT_TTL_MS = 5000;
+  const [runtimeRecentSlugs, setRuntimeRecentSlugs] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const prevSlugsRef = useRef<Set<string>>(new Set());
+  const initializedRef = useRef(false);
+  useEffect(() => {
+    const currentSlugs = new Set(projects.map((p) => p.slug));
+    // 첫 mount — projects 가 처음 로드될 때 모든 slug 가 added 처럼 보이지
+    // 않게 baseline 만 저장하고 끝.
+    if (!initializedRef.current) {
+      prevSlugsRef.current = currentSlugs;
+      initializedRef.current = true;
+      return;
+    }
+    const added = [...currentSlugs].filter((s) => !prevSlugsRef.current.has(s));
+    prevSlugsRef.current = currentSlugs;
+    if (added.length === 0) return;
+    setRuntimeRecentSlugs((prev) => {
+      const next = new Set(prev);
+      for (const s of added) next.add(s);
+      return next;
+    });
+    const timer = setTimeout(() => {
+      setRuntimeRecentSlugs((prev) => {
+        const next = new Set(prev);
+        for (const s of added) next.delete(s);
+        return next;
+      });
+    }, RUNTIME_RECENT_TTL_MS);
+    return () => clearTimeout(timer);
+  }, [projects]);
+
   const graph = useMemo(() => {
     const g = buildGraph(projects, categories, {
       stripNamePrefix,
       ontologyCountsBySlug,
+      runtimeRecentSlugs,
     });
     const iterations = g.order > 600 ? 120 : g.order > 200 ? 240 : 360;
     settleLayout(g, iterations);
@@ -450,7 +488,7 @@ function SigmaTopologyImpl({
       }
     }
     return g;
-  }, [projects, categories, stripNamePrefix, ontologyCountsBySlug]);
+  }, [projects, categories, stripNamePrefix, ontologyCountsBySlug, runtimeRecentSlugs]);
 
   useEffect(() => {
     let anyRecent = false;


### PR DESCRIPTION
## Summary

\#69 의 polling 결과를 **시각적 인지** 가능하게. AI agent / IDE 가 vault 만지면 5s 안에 그래프에 새 노드 나타나고, 그 노드가 5s 간 amber sine pulse → 사용자 변화 즉시 인지.

## How

기존 \`recentlyUpdated\` + \`recentPulse\` 인프라 활용:

\`\`\`typescript
// graph-build.ts
const recent =
  isProjectRecentlyUpdated(project, 7)  // calendar-time
  || options?.runtimeRecentSlugs?.has(project.slug);  // runtime diff
\`\`\`

SigmaTopology 가 \`projects[]\` diff 추적:
- 첫 mount → baseline 저장 (false positive 방지)
- 이후 새로 등장한 slug → 5s 간 \`runtimeRecentSlugs\` set
- 5s 후 자동 expire (setTimeout cleanup)

기존 \`recentPulse\` (sine size 변조) 가 그대로 적용 — 새 코드 없음.

## UX flow

\`\`\`
[user IDE]                              [web tab]
oh-my-ontology add capability foo  →   (5s 안 polling 으로 detect)
                                    →   ◯ project ╱── ◯ NEW (amber pulsing)
                                                              (5s 후 정상)
\`\`\`

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — **771/771**
- [ ] 사용자 본인 \`pnpm dev\` 후 IDE 에서 \`oh-my-ontology add capability foo --vault=docs/ontology\` → 웹 탭 그래프에 5s 안에 새 노드 + amber pulse

## What this completes

- ✅ #69 vault polling — 변경 즉시 fetch
- ✅ #70 diff highlight — 변경 즉시 인지

이제 vault = "살아있는 그래프". 사용자 / AI agent / IDE 변경이 웹 그래프에 자연스럽게 흘러옴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)