### PR TITLE
feat(web): vault diff toast — 새 노드 추가 시 즉시 알림 (#71)

### DIFF
--- a/src/features/docs-vault-local/model/LocalVaultProvider.tsx
+++ b/src/features/docs-vault-local/model/LocalVaultProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 import { useLocalVaultInternal } from "./use-local-vault";
+import { VaultDiffToaster } from "./VaultDiffToaster";
 
 type LocalVaultValue = ReturnType<typeof useLocalVaultInternal>;
 
@@ -25,6 +26,7 @@ export function LocalVaultProvider({ children }: { children: ReactNode }) {
   const value = useLocalVaultInternal();
   return (
     <LocalVaultContext.Provider value={value}>
+      <VaultDiffToaster />
       {children}
     </LocalVaultContext.Provider>
   );

--- a/src/features/docs-vault-local/model/VaultDiffToaster.tsx
+++ b/src/features/docs-vault-local/model/VaultDiffToaster.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useToast } from '@/shared/ui/toast';
+import { useLocalVault } from './LocalVaultProvider';
+
+/**
+ * R13 #71 — vault polling 결과 *시각적 알림*. polling 으로 새 노드가
+ * 들어오면 toast 로 명시 (예: "Added: capabilities/foo").
+ *
+ * polling (#69) + diff highlight (#70) 가 그래프 안 변화는 만들었지만,
+ * 사용자가 그래프 안 보고 다른 페이지 (/docs / /ontology 등) 보고 있으면
+ * 변화 인지 못함. toast 는 어느 페이지에서든 보여 *cross-page* alive
+ * 신호 가 됨.
+ *
+ * 동작:
+ *   - LocalVaultProvider 안에 mount, manifest.docs slug set 추적
+ *   - 첫 mount 는 baseline 만 저장 (false-positive 방지)
+ *   - 이후 새로 등장한 slug 가 1+ 개면 sonner info toast
+ *   - 3+ 개 동시 추가면 처음 3 + "+N more"
+ *
+ * 삭제 / 수정 detection 은 일단 제외 — slug 가 같으면 같은 노드라 가정.
+ * 추후 mtime / fingerprint diff 로 확장 가능.
+ */
+export function VaultDiffToaster() {
+  const { status, manifest } = useLocalVault();
+  const toast = useToast();
+  const prevSlugsRef = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (status !== 'loaded' || !manifest) return;
+    const currentSlugs = new Set<string>(
+      manifest.docs.map((d: { slug: string }) => d.slug),
+    );
+
+    // 첫 load — baseline 저장만 하고 끝
+    if (prevSlugsRef.current === null) {
+      prevSlugsRef.current = currentSlugs;
+      return;
+    }
+
+    const prev = prevSlugsRef.current;
+    const added: string[] = [];
+    for (const s of currentSlugs) {
+      if (!prev.has(s)) added.push(s);
+    }
+    prevSlugsRef.current = currentSlugs;
+    if (added.length === 0) return;
+
+    // 처음 3 명시, 나머지는 합산
+    const PREVIEW = 3;
+    const preview = added.slice(0, PREVIEW);
+    for (const slug of preview) {
+      toast.show(`Added: ${slug}`, 'info');
+    }
+    if (added.length > PREVIEW) {
+      toast.show(`+${added.length - PREVIEW} more node(s)`, 'info');
+    }
+  }, [status, manifest, toast]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

#69 polling + #70 graph pulse 다음 단계 — **cross-page alive 신호**. 사용자가 그래프 보고 있지 않아도 toast 로 변화 즉시 인지.

## What

\`VaultDiffToaster\` 컴포넌트를 \`LocalVaultProvider\` 안에 mount. \`manifest.docs\` slug set 추적 → 새로 등장한 slug 시 sonner info toast.

\`\`\`
[user IDE]                                      [웹 어디서든]
oh-my-ontology add capability foo  →  (5s polling)
                                    →  toast: "Added: capabilities/foo"
                                       (우측 하단)
\`\`\`

## Behavior

- 첫 mount → baseline 저장만 (false positive 차단)
- 이후 added slug 1+ → toast
- 3+ 동시 추가 → 처음 3 + "+N more node(s)"
- modified / removed 는 제외 (IDE 직접 편집은 toast noise)

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 771/771
- [ ] 사용자 본인: \`pnpm dev\` 후 IDE 에서 \`oh-my-ontology add capability foo\` → 웹 어떤 페이지에서든 우측 하단 toast 등장

## 3 단계 완성 (#69 + #70 + #71)

| Step | What | Where 인지 |
|---|---|---|
| #69 polling | 5s 간격 fingerprint check + reload | 백그라운드 |
| #70 diff pulse | 새 노드 amber sine 5s | /topology 그래프 |
| **#71 diff toast** | 추가 시 toast | **모든 페이지** |

이제 사용자가 어디 있든 vault 변화 인지 가능 — IDE / AI agent / CLI 어느 surface 가 만져도 알림 흘러옴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)