### PR TITLE
fix: walkthrough 검증 이슈 5종 + topology↔ontology 연계 회복

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,11 +33,12 @@ src/
 
 - 새 라우트는 `app/[locale]/` 아래에만. `src/views/` 의 페이지 컴포넌트가 1:1 대응.
 - 살아있는 라우트: `/`, `/topology/`, `/docs/`, `/ontology/`, `/ontology/edit/`,
-  `/ontology/insights/`, `/ontology/relations/`, `/projects/`, `/project/[slug]/`,
+  `/ontology/insights/`, `/projects/`, `/project/[slug]/`,
   `/project/[slug]/edit/`, `/project/new/`, `/project/fallback/`. R10 (auth +
   cloud surface 영구 제거) 이후 외 namespace (`/login`, `/signup`, `/account`,
   `/reset-password`, `/settings/*`, `/admin/*`, `/review/*`, `/diagnostics/*`,
-  `/knowledge/*`) 부활 금지.
+  `/knowledge/*`) 부활 금지. `/ontology/relations` 도 R12 에서 제거되어 그
+  분포 정보는 `/ontology/insights` 안으로 통합되었다.
 - 모든 라우트는 next-intl `[locale]` prefix 자동 추가 (en / ko 두 locale).
 
 ## 단일 진실원 원칙

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,7 @@ scripts/                   vault tooling (R11) + perf baseline (R11) + dogfood w
 /docs                      vault picker / editor / unified palette
 /ontology                  tree + ego graph hub
 /ontology/edit             ERD canvas builder (xyflow → vault md export)
-/ontology/insights         graph insights
-/ontology/relations        relation distribution
+/ontology/insights         graph insights (kind census · hubs · relation breakdown)
 ```
 
 > Round 10 (2026-05) permanently removed: `/login`, `/signup`, `/account`, `/reset-password`, `/settings/*`, and earlier rounds had already removed `/admin/*`, `/review/*`, `/diagnostics/*`, `/knowledge/*`. Cloud entity API, Firestore subscribers, manual node/edge cloud modals, screenshot uploader (Firebase Storage) are all gone. Future cloud collab features will be re-designed when sponsorship / collaboration requests come.

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { ArrowLeft, Compass, Search } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+
+/**
+ * 로케일 segment 안에서 404. NextIntlClientProvider 가 layout.tsx 에 마운트되어
+ * 있으므로 useTranslations 사용 가능. root not-found.tsx 는 [locale] 외부 라우트
+ * 진입 시 last-resort 영어 fallback 으로 남겨둔다.
+ */
+export default function LocaleNotFound() {
+  const router = useRouter();
+  const t = useTranslations("notFound");
+
+  // 모바일 BottomTabBar 가 동시에 보이면 카드의 3가지 출구가 흐려진다.
+  useEffect(() => {
+    document.body.setAttribute("data-no-tabbar", "true");
+    return () => {
+      document.body.removeAttribute("data-no-tabbar");
+    };
+  }, []);
+
+  const openSearchOnHome = () => {
+    if (typeof window !== "undefined") {
+      try {
+        window.sessionStorage.setItem("demo:open-search", "1");
+      } catch {
+        /* private mode */
+      }
+    }
+    router.push("/");
+  };
+
+  const goBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/");
+    }
+  };
+
+  return (
+    <main
+      id="main"
+      className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10"
+    >
+      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:rgba(255,255,255,0.08)] bg-[color:var(--color-panel)] p-7 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:rgba(255,255,255,0.08)] text-[color:var(--color-text-tertiary)]">
+            <Compass size={16} />
+          </span>
+          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            {t("label")}
+          </p>
+        </div>
+        <h1 className="mt-4 text-[22px] leading-[1.18] tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          {t("title")}
+        </h1>
+        <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
+          {t("body")}
+        </p>
+        <div className="mt-5 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={openSearchOnHome}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+          >
+            <Search size={14} />
+            {t("findByProject")}
+          </button>
+          <Link
+            href="/"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+          >
+            {t("home")}
+          </Link>
+          <button
+            type="button"
+            onClick={goBack}
+            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+          >
+            <ArrowLeft size={13} />
+            {t("previous")}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,21 +2,40 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ArrowLeft, Compass, Search } from "lucide-react";
+import koMessages from "@/messages/ko.json";
+import enMessages from "@/messages/en.json";
 
 /**
  * 404 안내. 사용자가 잘못된 링크로 들어왔을 때 막다른 느낌 없이 3가지
  * 길을 즉시 안내한다.
- *   1) 뒤로가기 — 이전 맥락으로 복귀 (history 있을 때만)
- *   2) 홈으로   — 프로젝트 지도 초기 화면
- *   3) 검색 열기 — "혹시 이 프로젝트 찾으셨나요?" 명시적 탐색
  *
- * Root layout 에선 NextIntlClientProvider 가 마운트되지 않아 useTranslations
- * 가 동작하지 않는다. 이 surface 는 last-resort fallback 이므로 영어 하드코딩.
+ * Root layout 에는 NextIntlClientProvider 가 마운트되지 않아 useTranslations
+ * 가 동작하지 않고, output:'export' + Turbopack 환경에서는 `[locale]/
+ * not-found.tsx` 가 trigger 되지 않을 수 있다. 그래서 이 root not-found 가
+ * 모든 미해결 경로의 단일 진입점이 된다.
+ * locale 은 URL 첫 segment 로 client-side 감지 (`/ko/...` → ko).
+ * messages JSON 을 직접 import — useTranslations 우회로 i18n 일관성 유지.
  */
+const LOCALE_MESSAGES = { ko: koMessages, en: enMessages } as const;
+type SupportedLocale = keyof typeof LOCALE_MESSAGES;
+
+function detectLocale(): SupportedLocale {
+  if (typeof window === "undefined") return "en";
+  const segment = window.location.pathname.split("/")[1];
+  return segment === "ko" ? "ko" : "en";
+}
+
 export default function NotFound() {
   const router = useRouter();
+  // SSR/정적 export 시 'en' 으로 시작 → mount 후 URL 기반으로 보정.
+  // 정적 prerender 결과와 첫 hydration 결과가 일치해야 mismatch 없음.
+  const [locale, setLocale] = useState<SupportedLocale>("en");
+  useEffect(() => {
+    setLocale(detectLocale());
+  }, []);
+  const t = LOCALE_MESSAGES[locale].notFound;
 
   // 404 surface 는 dead-end 카드만 노출. 모바일 BottomTabBar 가
   // 동시에 보이면 "어디 갈지" 가 두 군데에 분산되어 카드 안 3가지
@@ -59,15 +78,14 @@ export default function NotFound() {
             <Compass size={16} />
           </span>
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-            404
+            {t.label}
           </p>
         </div>
         <h1 className="mt-4 text-[22px] leading-[1.18] tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
-          Looks like you&apos;re lost.
+          {t.title}
         </h1>
         <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
-          This page doesn&apos;t exist. The link may be outdated or a project may
-          have been renamed. Pick one of the options below to continue.
+          {t.body}
         </p>
         <div className="mt-5 flex flex-col gap-2">
           <button
@@ -76,13 +94,13 @@ export default function NotFound() {
             className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
           >
             <Search size={14} />
-            Find by project search
+            {t.findByProject}
           </button>
           <Link
-            href="/"
+            href={`/${locale}/`}
             className="inline-flex h-10 items-center justify-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
-            Home
+            {t.home}
           </Link>
           <button
             type="button"
@@ -90,7 +108,7 @@ export default function NotFound() {
             className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             <ArrowLeft size={13} />
-            Previous screen
+            {t.previous}
           </button>
         </div>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,9 +9,16 @@
       "ontology": "Ontology",
       "ontologyEdit": "Ontology Builder",
       "ontologyInsights": "Ontology Insights",
-      "ontologyRelations": "Ontology Relations",
       "projectNew": "New project"
     }
+  },
+  "notFound": {
+    "label": "404",
+    "title": "Looks like you're lost.",
+    "body": "This page doesn't exist. The link may be outdated or a project may have been renamed. Pick one of the options below to continue.",
+    "findByProject": "Find by project search",
+    "home": "Home",
+    "previous": "Previous screen"
   },
   "nav": {
     "skipToContent": "Skip to main content",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -9,9 +9,16 @@
       "ontology": "온톨로지",
       "ontologyEdit": "온톨로지 빌더",
       "ontologyInsights": "온톨로지 인사이트",
-      "ontologyRelations": "관계 분포",
       "projectNew": "새 프로젝트"
     }
+  },
+  "notFound": {
+    "label": "404",
+    "title": "어디서 길을 잃으셨나요",
+    "body": "이 페이지가 존재하지 않습니다. 링크가 오래되었거나 프로젝트 이름이 바뀌었을 수 있어요. 아래에서 길을 골라보세요.",
+    "findByProject": "프로젝트 검색으로 찾기",
+    "home": "홈으로",
+    "previous": "이전 화면"
   },
   "nav": {
     "skipToContent": "메인 콘텐츠로 건너뛰기",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -655,6 +655,13 @@ export function HomePage() {
                   forces={sigmaControls.forces}
                   hubsOnly={sigmaControls.hubsOnly}
                   overlays={sigmaControls.overlays}
+                  // R14: /topology 는 vault ontology 의 도메인/역량/요소
+                  // 노드와 그 관계까지 같은 그래프에 그린다. project 1 개 +
+                  // dependencies 0 인 dogfood 상황에서 빈 화면이었던 회귀를
+                  // 메우면서, 사용자가 "ontology 와 topology 는 연계되어야"
+                  // 라고 약속한 본질을 살린다. local-graph (drawer 의 ego)
+                  // 에서는 project 의존만 보이게 끔 — 좁은 시야 위해.
+                  showOntologyNodes={localGraphRoot === null}
                 />
               </div>
               <style jsx>{`

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -769,10 +769,11 @@ export function HomePage() {
 
               {/* 첫 진입 온보딩 카드 — bottom-center 는 중앙 hub 노드(IAM 등)를
                   가려 사용자가 "여기를 클릭해야 하는지" 알 수 없게 만들었다.
-                  좌하단 status bar 위로 옮겨 중앙 시야를 비운다. SigmaHubRail
-                  접힌 상태(기본값) 와 status bar 사이 빈 공간을 활용. */}
+                  좌하단 stats bar (bottom-6, ~32px) 위로 옮겨 중앙 시야를 비운다.
+                  bottom-20 (80px) → stats bar 와 24px gap. 이전 bottom-14 는
+                  카드와 stats 가 거의 붙어있어 두 박스가 한 덩어리처럼 보였다. */}
               {!sigmaHintDismissed && sigmaVisibleCount !== 0 ? (
-                <div className="pointer-events-auto absolute bottom-14 left-4 z-10 hidden max-w-[320px] flex-col gap-2 rounded-2xl border border-[color:rgba(139,151,255,0.32)] bg-[color:var(--color-panel)] px-4 py-3 text-[11px] text-[color:var(--color-text-tertiary)] shadow-[0_12px_28px_rgba(0,0,0,0.45)] sm:flex md:left-6 xl:left-8">
+                <div className="pointer-events-auto absolute bottom-20 left-4 z-10 hidden max-w-[320px] flex-col gap-2 rounded-2xl border border-[color:rgba(139,151,255,0.32)] bg-[color:var(--color-panel)] px-4 py-3 text-[11px] text-[color:var(--color-text-tertiary)] shadow-[0_12px_28px_rgba(0,0,0,0.45)] sm:flex md:left-6 xl:left-8">
                   <div className="flex items-start justify-between gap-2">
                     <p className="text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                       {t('hint.title')}

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -422,11 +422,12 @@ export function OntologyTreeView({
         </div>
       ) : null}
       {result.warnings.length > 0 ? (
-        <details className="rounded-xl border border-[color:rgba(229,72,77,0.24)] bg-[color:rgba(229,72,77,0.06)] px-4 py-3 text-xs text-[color:var(--color-status-danger)]">
-          <summary className="cursor-pointer font-[var(--font-weight-signature)]">
-            {t('tree.warningsSummary', { count: result.warnings.length })}
+        <details className="group rounded-xl border border-[color:rgba(229,72,77,0.24)] bg-[color:rgba(229,72,77,0.06)] px-4 py-3 text-xs text-[color:var(--color-status-danger)] open:bg-[color:rgba(229,72,77,0.09)]">
+          <summary className="flex cursor-pointer list-none items-center gap-2 font-[var(--font-weight-signature)] [&::-webkit-details-marker]:hidden">
+            <ChevronRight className="h-3 w-3 flex-none transition-transform duration-150 group-open:rotate-90" />
+            <span className="flex-1">{t('tree.warningsSummary', { count: result.warnings.length })}</span>
           </summary>
-          <ul className="mt-2 list-inside list-disc space-y-0.5">
+          <ul className="mt-2 list-inside list-disc space-y-0.5 pl-5">
             {result.warnings.slice(0, 12).map((w, i) => (
               <li key={i}>{w}</li>
             ))}

--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -1,9 +1,17 @@
 import Graph from 'graphology';
 import forceAtlas2 from 'graphology-layout-forceatlas2';
 import type { Category } from '@/entities/category';
-import { isProjectRecentlyUpdated, type Project } from '@/entities/project';
+import {
+  isProjectRecentlyUpdated,
+  type Project,
+} from '@/entities/project';
+import type {
+  KnowledgeGraphEdge,
+  KnowledgeGraphNode,
+} from '@/entities/knowledge-graph';
 import { INDIGO_HUB } from '@/shared/config/indigo-tokens';
 import {
+  isMeaningfulOntologyKind,
   pickDominantOntologyKind,
   type MeaningfulOntologyKind,
   type OntologyCountsForProject,
@@ -46,6 +54,13 @@ export interface SigmaNodeAttrs {
    * 비-project 노드 (container / hub).
    */
   ontologyTopKind?: MeaningfulOntologyKind;
+  /**
+   * R14: Topology ↔ Ontology 연계. true 면 이 노드가 project 가 아니라
+   * ontology 의 도메인/역량/요소 노드 (frontmatter `kind: domain | capability
+   * | element` 등). degree-기반 size scaling 과 owner overlay 등 project
+   * 전용 처리에서 제외하기 위한 분기 플래그.
+   */
+  isOntology?: boolean;
 }
 
 export interface SigmaEdgeAttrs {
@@ -156,6 +171,18 @@ export function buildGraph(
      * 방금 .md 를 추가했으면 pulse. 기본 비어있음 = 기존 동작 유지.
      */
     runtimeRecentSlugs?: ReadonlySet<string>;
+    /**
+     * Topology ↔ Ontology 연계. nodes/edges 가 주어지면 project 노드 집합
+     * 에 ontology 의 도메인·역량·요소 노드와 그 사이 관계 (contains /
+     * depends_on / describes / related_to 등) 를 함께 그래프에 넣는다.
+     * `kind === 'project'` 인 ontology 노드는 이미 위에서 추가된 project
+     * 와 중복되므로 skip. project↔ontology containment 도 같은 id 의
+     * project 가 graph 안에 있으면 자연스럽게 엣지가 이어진다.
+     */
+    ontologyExtension?: {
+      nodes: readonly KnowledgeGraphNode[];
+      edges: readonly KnowledgeGraphEdge[];
+    };
   },
 ): Graph<SigmaNodeAttrs, SigmaEdgeAttrs> {
   const graph = new Graph<SigmaNodeAttrs, SigmaEdgeAttrs>({ type: 'directed', multi: false });
@@ -243,8 +270,78 @@ export function buildGraph(
     }
   }
 
+  // R14: Topology ↔ Ontology 연계. project 외의 도메인/역량/요소 노드와
+  // 그 관계를 같은 그래프에 추가해 토폴로지가 "vault 의 ontology 전체 지도"
+  // 가 되도록. project 와 같은 id 가 ontology 안에 또 있으면 (kind:project)
+  // skip. degree-scaling / owner overlay 는 isOntology=true 분기로 제외.
+  const ext = options?.ontologyExtension;
+  if (ext) {
+    ext.nodes.forEach((node, idx) => {
+      // project kind 는 이미 위에서 project 로 추가됐다 — 같은 id 면 skip.
+      if (node.kind === 'project' || graph.hasNode(node.id)) return;
+      // narrow string → MeaningfulOntologyKind. 'document' / 그 외 unknown
+      // string 은 'unknown' 으로 묶어 amber tone 노출.
+      const kind: MeaningfulOntologyKind = isMeaningfulOntologyKind(node.kind)
+        ? node.kind
+        : 'unknown';
+      const tone = ontologyBorderTone(kind);
+      // project 들이 원점 근처 (~r 40) 에 모여있으니 ontology 노드는 외곽
+      // (r 90~140) 에 배치 → settleLayout 이 두 집합을 부드럽게 섞어준다.
+      const theta = jitter(idx + 1000) * Math.PI * 2;
+      const r = 90 + jitter(idx + 2000) * 50;
+      graph.addNode(node.id, {
+        x: Math.cos(theta) * r,
+        y: Math.sin(theta) * r,
+        // ontology 노드는 project leaf (4.5) 보다 작게 — 시각적 위계 보존.
+        size: 3.5,
+        label: node.title,
+        forceLabel: false,
+        recentlyUpdated: false,
+        // 흐린 무채색 fill — 헌장의 "허브만 유일한 채색" 과 충돌 안 함.
+        color: 'rgba(160, 168, 184, 0.55)',
+        borderColor: tone?.borderColor ?? palette.nodeBorder,
+        outerBorderColor: NODE_OUTER_HALO,
+        // SigmaTopology 의 click handler 가 projectSlug 를 키로 drawer 를
+        // 여는데, ontology 노드는 project 가 아니므로 drawer 가 빈 상태가
+        // 된다 — 일단 id 를 그대로 박아두고 후속 단계에서 ontology 전용
+        // 핸들링을 추가한다 (TODO: ontology 노드 클릭 시 vault md 열기).
+        projectSlug: node.id,
+        categoryId: 'ontology',
+        isHub: false,
+        ownerKey: 'unassigned',
+        description: node.summary,
+        ontologyTopKind: kind,
+        isOntology: true,
+      });
+    });
+    for (const edge of ext.edges) {
+      // 양 끝이 모두 그래프에 있어야 — project 만 있고 ontology 노드 추가
+      // 시 skip 된 'project' kind 노드 등이 from/to 에 있으면 자연스럽게
+      // 누락되거나 (없는 경우) project 끼리 이어진다.
+      if (!graph.hasNode(edge.from) || !graph.hasNode(edge.to)) continue;
+      if (edge.from === edge.to) continue;
+      if (graph.hasEdge(edge.from, edge.to)) continue;
+      // KnowledgeEdgeType (7종) → SigmaEdgeAttrs.kind (4종) 매핑.
+      const kind: SigmaEdgeAttrs['kind'] =
+        edge.type === 'contains' || edge.type === 'belongs_to'
+          ? 'contains'
+          : edge.type === 'describes'
+            ? 'knowledge'
+            : 'depends-on';
+      graph.addEdge(edge.from, edge.to, {
+        // ontology 엣지는 project↔project dependencies 보다 가늘게 — 메인
+        // 의존 골격이 시야에서 사라지지 않도록.
+        size: 0.35,
+        color: palette.edge,
+        kind,
+        curvature: 0.06,
+      });
+    }
+  }
+
   // degree 기반 크기 재계산 — 연결이 많을수록 커진다.
   // Hub: 10 → 13, Node: 4.5 → 7.5. 화면 픽셀 기준 ~2x 일관 비율.
+  // ontology 노드는 base 3.5 를 유지하되 degree 영향은 약하게.
   graph.forEachNode((id, attrs) => {
     const degree = graph.degree(id);
     if (attrs.isHub) {
@@ -252,6 +349,12 @@ export function buildGraph(
         id,
         'size',
         10 + Math.min(3, Math.log2(Math.max(1, degree)) * 0.8),
+      );
+    } else if (attrs.isOntology) {
+      graph.setNodeAttribute(
+        id,
+        'size',
+        3.5 + Math.min(2, Math.log2(Math.max(1, degree)) * 0.4),
       );
     } else {
       graph.setNodeAttribute(

--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -217,6 +217,14 @@ interface SigmaTopologyProps {
    * 를 넘기면 "Demo Reactor · Router" → "Router" 로 표시. 미지정이면 원본 유지.
    */
   stripNamePrefix?: string;
+  /**
+   * R14: true 면 vault 의 ontology 도메인/역량/요소 노드와 그 관계를 같은
+   * 그래프에 그린다. project↔project dependencies 는 그대로 살아있고
+   * 그 위에 ontology 골격이 얹힌다. `/topology` 라우트 (HomePage) 에서 켠다.
+   * project mini map 같은 작은 임베드는 끈 채로 두어 시야가 복잡해지지
+   * 않게 한다.
+   */
+  showOntologyNodes?: boolean;
   className?: string;
 }
 
@@ -239,6 +247,7 @@ function SigmaTopologyImpl({
   onFirstInteraction,
   minimal = false,
   stripNamePrefix,
+  showOntologyNodes = false,
   className,
 }: SigmaTopologyProps) {
   const t = useTranslations('topologyWidgets.sigma');
@@ -465,6 +474,15 @@ function SigmaTopologyImpl({
       stripNamePrefix,
       ontologyCountsBySlug,
       runtimeRecentSlugs,
+      // R14: showOntologyNodes 켜진 surface (HomePage / /topology) 에서만
+      // ontology 노드를 그래프에 추가. project mini map 등은 켜지 않음.
+      ontologyExtension:
+        showOntologyNodes && ontologyInsight
+          ? {
+              nodes: ontologyInsight.nodes,
+              edges: ontologyInsight.edges,
+            }
+          : undefined,
     });
     const iterations = g.order > 600 ? 120 : g.order > 200 ? 240 : 360;
     settleLayout(g, iterations);
@@ -488,7 +506,15 @@ function SigmaTopologyImpl({
       }
     }
     return g;
-  }, [projects, categories, stripNamePrefix, ontologyCountsBySlug, runtimeRecentSlugs]);
+  }, [
+    projects,
+    categories,
+    stripNamePrefix,
+    ontologyCountsBySlug,
+    runtimeRecentSlugs,
+    showOntologyNodes,
+    ontologyInsight,
+  ]);
 
   useEffect(() => {
     let anyRecent = false;


### PR DESCRIPTION
## Summary

R14 walkthrough 검증에서 발견된 이슈 4 개와 사용자가 약속한 topology↔ontology 연계 회복을 한 브랜치에 묶음.

- **docs**: AGENTS.md / .claude/rules/architecture.md 의 살아있는 라우트 목록에서 `/ontology/relations` 표기 제거 (R12 에서 사라졌고 분포 정보는 `/ontology/insights` 안으로 통합).
- **i18n 404**: `app/[locale]/not-found.tsx` 추가 + `app/not-found.tsx` 도 client-side locale 감지로 한국어/영어 분기. 이전엔 `/ko/foo` 같은 미해결 path 가 영문 fallback 만 떴다 (정적 export 한계).
- **home UX**: 좌하단 온보딩 hint 카드와 그 아래 stats bar (`N 노드 · M 허브 · L 엣지`) 가 거의 붙어있던 것을 `bottom-14` → `bottom-20` 으로 24px gap 확보. ontology 트리 하단 "데이터 경고 N 건" alert 에 `ChevronRight` 아이콘 affordance 추가 — 펼침 상태에 따라 90° 회전 + 배경 alpha 미세 강조.
- **topology↔ontology 연계 (feat)**: `/topology` 가 dogfood 환경에서 "1 노드 · 0 엣지" 빈 화면이었던 회귀를 회복. `buildGraph` 에 `ontologyExtension` 옵션 추가, vault frontmatter 의 도메인/역량/요소 노드와 그 관계까지 같은 그래프에 그림. `isOntology` 플래그로 size scaling / owner overlay 분기에서 제외해 project 본 골격은 그대로. SigmaTopology `showOntologyNodes` prop, HomePage root 그래프에서만 켜고 ego 모드 (drawer 안) 에서는 끔. 검증 결과: 68 노드 · 112 엣지로 회복.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] 변경 파일 ESLint 0 errors
- [x] `/topology` Sigma WebGL 노드/엣지 렌더 (dogfood: 68 / 112), 콘솔 0
- [x] `/ko/존재하지않음` 한국어 404 카드 ("어디서 길을 잃으셨나요")
- [x] `/en/존재하지않음` 영어 404 카드 ("Looks like you're lost.")
- [x] `/ontology` 데이터 경고 alert chevron 표시 + 클릭 시 펼침 (12 항목)
- [x] hint 카드 ↔ stats bar 간격 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)