### PR TITLE
feat: vault frontmatter 양식 정의 + AI agent/CLI 동기화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,10 @@ This project describes its own mental model in `docs/ontology/` as frontmatter m
 - AI agents query it via the `mcp/` MCP server — registration guide in `mcp/README.md`, example in `.mcp.json.example`
 - When you discover a new domain / capability / element, add it to the same directory (with the MCP `add_concept` tool, or by hand)
 
+## Frontmatter shape per kind (R14)
+
+When an AI agent (`add_concept`) or a developer (`oh-my-ontology add`) creates a new node, the frontmatter is normalized per `kind` so external `.md` ingestion stays consistent. See `mcp/README.md` for the full table and `mcp/src/schema.mjs` (mirror at `cli/src/lib/schema.mjs`) for the source. Contract test: `tests/contract/vault-schema.contract.test.ts`. Validator surfaces missing strongly-expected fields (e.g. capability/element without `domain:`) as the `missing-expected-field` warning — advisory only, not a hard error, so pre-existing vaults still pass.
+
 ## CLAUDE.md / AGENTS.md sync
 
 - **AGENTS.md** (this file) is canonical — the cross-tool standard.

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,7 @@ and AI agents (Claude Code, Cursor, etc.) can read and write together.
 |---|---|
 | `oh-my-ontology init [folder]` | Scaffold a new vault (project / domain / capability / element starter .md + `.mcp.json.example`) |
 | `oh-my-ontology list [vault]` | List ontology nodes (color table; `--kind X` filter, `--json`) |
-| `oh-my-ontology validate [vault]` | Frontmatter integrity (5 issue codes; `exit 1` on errors — usable as a CI gate) |
+| `oh-my-ontology validate [vault]` | Frontmatter integrity (6 issue codes incl. R14 `missing-expected-field`; `exit 1` on errors — usable as a CI gate) |
 | `oh-my-ontology add <kind> <slug> --title="..."` | Scaffold a new node (`--domain X --body "..." --vault path`); throws on duplicate slug |
 | `oh-my-ontology find <query> [vault]` | Search slug + title (case-insensitive, `--kind X --json`) |
 

--- a/cli/src/commands/add.mjs
+++ b/cli/src/commands/add.mjs
@@ -1,25 +1,20 @@
 import { resolve, relative } from 'node:path';
 import { writeDoc } from '../lib/write-vault.mjs';
+import {
+  VAULT_KINDS,
+  buildFrontmatter,
+  defaultBody,
+  folderForKind,
+  missingExpectedFields,
+} from '../lib/schema.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
   red: '\x1b[31m',
+  yellow: '\x1b[33m',
   dim: '\x1b[2m',
   bold: '\x1b[1m',
   reset: '\x1b[0m',
-};
-
-const KNOWN_KINDS = ['project', 'domain', 'capability', 'element', 'document'];
-
-// R12 #37 — `--auto-prefix` opt-in 시 kind → folder 자동 prefix.
-// dogfood vault 패턴 (`capabilities/foo`, `domains/auth`, `elements/jwt`) 따름.
-// project / document 는 prefix 없음 (root level).
-const KIND_FOLDER = {
-  project: '',
-  domain: 'domains/',
-  capability: 'capabilities/',
-  element: 'elements/',
-  document: '',
 };
 
 /**
@@ -41,29 +36,36 @@ export function runAdd(args) {
 
   // R12 #37 — opt-in folder prefix (capability → capabilities/foo).
   // 사용자가 이미 prefix 명시 (`capabilities/foo`) 한 경우 두 번 적용 회피.
-  const folder = KIND_FOLDER[kind] || '';
+  // R14 — folder mapping 은 schema.mjs 의 single source 사용 (mcp 와 일치).
+  const folder = folderForKind(kind);
   const slug =
     autoPrefix && folder && !rawSlug.startsWith(folder)
       ? `${folder}${rawSlug}`
       : rawSlug;
 
-  const fm = {
-    slug,
-    kind,
-    title,
-  };
-  if (domain) fm.domain = domain;
+  // R14 — schema 가 kind 별 양식 (project: domains/capabilities/elements 빈
+  // 배열, capability: elements 빈 배열) 자동 채움. AI agent 의 add_concept
+  // 과 동일 결과 → 두 진입점이 항상 같은 frontmatter 모양 만든다.
+  const fm = buildFrontmatter({ slug, kind, title, domain });
 
   try {
     const filePath = writeDoc(vaultPath, slug, {
       frontmatter: fm,
-      body: body || `# ${title}\n`,
+      body: body || defaultBody(kind, title),
     });
     const rel = relative(process.cwd(), filePath);
     console.log(
       `${COLORS.green}ok${COLORS.reset}    ${rel}\n` +
         `${COLORS.dim}      ${kind} · ${slug}${domain ? ` · domain=${domain}` : ''}${COLORS.reset}`,
     );
+    // schema 의 requiredExtras 누락 (capability/element 의 domain 등) 은
+    // advisory warning 으로 출력 — 사용자가 후속에 채울 수 있게.
+    const missing = missingExpectedFields(kind, fm);
+    for (const key of missing) {
+      process.stderr.write(
+        `${COLORS.yellow}warn${COLORS.reset}  expected field "${key}" missing for kind "${kind}" — add it later with --domain or by editing the file.\n`,
+      );
+    }
     return 0;
   } catch (err) {
     process.stderr.write(
@@ -97,9 +99,9 @@ function parseArgs(args) {
     return { error: 'kind and slug are required' };
   }
   const [kind, slug] = positional;
-  if (!KNOWN_KINDS.includes(kind)) {
+  if (!VAULT_KINDS.includes(kind)) {
     return {
-      error: `unknown kind: ${kind}. one of ${KNOWN_KINDS.join(' / ')}`,
+      error: `unknown kind: ${kind}. one of ${VAULT_KINDS.join(' / ')}`,
     };
   }
   if (!flags.title || flags.title.trim() === '') {
@@ -120,7 +122,7 @@ function printAddUsage() {
   process.stderr.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
       `  oh-my-ontology add <kind> <slug> --title="..." [--domain X] [--body "..."] [--vault path]\n` +
-      `\n${COLORS.bold}kind:${COLORS.reset} ${KNOWN_KINDS.join(' / ')}\n` +
+      `\n${COLORS.bold}kind:${COLORS.reset} ${VAULT_KINDS.join(' / ')}\n` +
       `\nExample:\n` +
       `  oh-my-ontology add capability auth/token-issue --title="Token issue" --domain=auth\n`,
   );

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -107,8 +107,10 @@ await test('list --json — JSON 머신 가독', async () => {
 });
 
 await test('validate — clean vault: exit 0', async () => {
+  // R14 — capability/element 는 domain 까지 박아야 missing-expected-field
+  // warning 없이 clean. canonical kind 인식 자체를 보는 fixture 라 domain 추가.
   const root = withVault([
-    { slug: 'a', content: '---\nkind: capability\n---\n' },
+    { slug: 'a', content: '---\nkind: capability\ndomain: domains/auth\n---\n' },
   ]);
   try {
     const r = await run(['validate', root]);

--- a/cli/src/lib/schema.mjs
+++ b/cli/src/lib/schema.mjs
@@ -1,0 +1,117 @@
+/**
+ * Vault kind schema — mirror copy of `mcp/src/schema.mjs`. The MCP server
+ * (`add_concept`) and this CLI (`oh-my-ontology add`) must produce the same
+ * frontmatter shape so an AI agent and a developer working side-by-side never
+ * leave behind half-shaped nodes.
+ *
+ * `tests/contract/vault-schema.contract.test.ts` keeps the two copies in
+ * lock-step; if you change anything here, mirror it in `mcp/src/schema.mjs`
+ * (and vice versa) — the contract test will fail otherwise.
+ *
+ * See the documentation in `mcp/src/schema.mjs` for the field-category
+ * conventions (arrayDefaults / optional / requiredExtras).
+ */
+
+export const VAULT_KINDS = ['project', 'domain', 'capability', 'element', 'document'];
+
+export const VAULT_KIND_SCHEMA = {
+  project: {
+    folder: '',
+    arrayDefaults: ['domains', 'capabilities', 'elements'],
+    optional: ['dependencies', 'relates', 'description', 'status'],
+    requiredExtras: [],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `One- or two-line summary of this project — *what / for whom / why*.\n\n` +
+      `## How it grows\n\n` +
+      `- Fill \`domains: [...]\` in the frontmatter and the domain nodes hang\n` +
+      `  off the project tree automatically.\n` +
+      `- Each domain's capabilities and elements follow the same pattern.\n`,
+  },
+  domain: {
+    folder: 'domains/',
+    arrayDefaults: ['capabilities'],
+    optional: ['depends_on', 'relates', 'description'],
+    requiredExtras: [],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `A *domain* is a large area of the project (auth, billing, search, …). ` +
+      `Describe in one or two paragraphs what it covers and which capabilities live inside.\n`,
+  },
+  capability: {
+    folder: 'capabilities/',
+    arrayDefaults: ['elements'],
+    optional: ['depends_on', 'relates', 'description'],
+    requiredExtras: ['domain'],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `A *capability* is one user-visible feature within a domain. Describe what it does and one or two user scenarios.\n`,
+  },
+  element: {
+    folder: 'elements/',
+    arrayDefaults: [],
+    optional: ['path', 'depends_on', 'relates', 'description'],
+    requiredExtras: ['domain'],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `An *element* is a smaller unit a capability uses (jwt-token, indexeddb-adapter, sigma-canvas, …). Cover *what / why / which interface*.\n`,
+  },
+  document: {
+    folder: '',
+    arrayDefaults: [],
+    optional: ['describes', 'relates'],
+    requiredExtras: [],
+    bodyTemplate: (title) => `# ${title}\n`,
+  },
+};
+
+export function buildFrontmatter({ slug, kind, title, ...extras }) {
+  if (!VAULT_KIND_SCHEMA[kind]) {
+    throw new Error(
+      `Unknown kind: ${kind}. Expected one of ${VAULT_KINDS.join(' / ')}.`,
+    );
+  }
+  const schema = VAULT_KIND_SCHEMA[kind];
+  const fm = { slug, kind, title };
+  for (const key of schema.arrayDefaults) {
+    fm[key] = Array.isArray(extras[key]) ? extras[key] : [];
+  }
+  for (const [key, value] of Object.entries(extras)) {
+    if (value === undefined || value === null) continue;
+    if (key in fm && Array.isArray(fm[key]) && Array.isArray(value)) {
+      fm[key] = value;
+      continue;
+    }
+    fm[key] = value;
+  }
+  return fm;
+}
+
+export function defaultBody(kind, title) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) throw new Error(`Unknown kind: ${kind}`);
+  return schema.bodyTemplate(title);
+}
+
+export function folderForKind(kind) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) return '';
+  return schema.folder;
+}
+
+export function missingExpectedFields(kind, frontmatter) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) return [];
+  const missing = [];
+  for (const key of schema.requiredExtras) {
+    const value = frontmatter[key];
+    if (value === undefined || value === null) {
+      missing.push(key);
+      continue;
+    }
+    if (typeof value === 'string' && value.trim() === '') {
+      missing.push(key);
+    }
+  }
+  return missing;
+}

--- a/cli/src/lib/validate.mjs
+++ b/cli/src/lib/validate.mjs
@@ -4,6 +4,7 @@
 // contract.test.ts 의 fixture 매트릭스 (3-way 강제).
 
 import { parseFrontmatter } from './parse-frontmatter.mjs';
+import { missingExpectedFields } from './schema.mjs';
 
 export const KNOWN_VAULT_KINDS = [
   'project',
@@ -68,6 +69,17 @@ export function validateVaultDocument(raw) {
       severity: 'warning',
       message: `\`kind: ${rawKind.trim()}\` 는 인식되지 않는 값입니다.`,
     });
+  } else {
+    // R14 — kind 별 expected 필드 (capability/element 의 domain) advisory.
+    // mcp/src/validate.mjs 와 동일 schema 모듈 사용.
+    const trimmedKind = rawKind.trim();
+    for (const key of missingExpectedFields(trimmedKind, frontmatter)) {
+      issues.push({
+        code: 'missing-expected-field',
+        severity: 'warning',
+        message: `\`${key}:\` 가 비어있습니다 — kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
+      });
+    }
   }
 
   return {

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -68,12 +68,36 @@ The server connects over stdio. You should now see 14 tools under the `oh-my-ont
 | `list_kinds` | Vault kind census: `{ total, byKind: { capability: N, ... } }`. |
 | `find_orphans` | **v0.5** Finds isolated nodes — docs that no other node references in its frontmatter. Options: `kind` (filter), `excludeKinds` (skip, default `['vault-readme']`). Useful as a starting point for cleanup or auditing unused nodes. |
 | `query_concepts` | **v0.6** Typed filter DSL — `kind=X AND has(Y) AND NOT ...`. Saved-filter / smart-list use case. |
-| `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. Throws if the slug already exists. |
+| `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. **R14**: frontmatter is normalized per kind (project gets `domains/capabilities/elements: []`; capability gets `elements: []`; capability/element should set `domain` — missing extras come back in `warnings`). Body defaults to a kind-specific starter. Throws if the slug already exists. |
 | `add_relation` | Adds an edge between two slugs. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). Appends to the appropriate frontmatter array. **R11**: optional `expected_mtime` on the source slug for conflict detection. |
 | `patch_concept` | Updates an existing node's frontmatter (per-key patch — `null` deletes a key) and/or body. Use this when you need to *modify* a slug that `add_concept` would reject as duplicate. **R11**: optional `expected_mtime` for conflict detection — pass the `mtime` from `get_concept`; throws `VaultConflictError` if the file has been modified externally since you read it. |
 | `delete_concept` | **v0.4 ⚠ DESTRUCTIVE** Permanently deletes a node. Two-stage safety: ① without `confirm:true`, runs as a dry-run (with a backlinks preview); ② if backlinks exist, throws unless `force:true`. The response captures the deleted frontmatter + body so you can recover from mistakes. **R11**: optional `expected_mtime` for conflict detection. |
 | `rename_concept` | **v0.7 ⚠ MULTI-FILE** Atomically renames a slug — moves the .md file, updates the moved file's `slug:` key, and rewrites every backlink (frontmatter array entries, inline string keys like `domain`, body links `[[oldSlug]]` / `(oldSlug.md)`). Tail-only references (`mcp-server` for `capabilities/mcp-server`) are also redirected. Without `confirm:true`, runs as a dry-run with a full update preview. Replaces the manual loop of `find_backlinks` + N `patch_concept` calls. **R11**: optional `expected_mtime` for the source slug. |
 | `merge_concepts` | **v0.7 ⚠ DESTRUCTIVE MULTI-FILE** Folds `fromSlug` into `intoSlug` — every backlink to `fromSlug` is redirected, then `fromSlug.md` is deleted. The `intoSlug` node is preserved as-is (frontmatter / body are not auto-merged — use `patch_concept` after if you want to combine descriptions). Without `confirm:true`, runs as a dry-run. **R11**: optional `expected_mtime` for `fromSlug`. |
+
+## Frontmatter shape per kind (R14)
+
+When `add_concept` writes a new `.md`, the frontmatter is normalized by
+`mcp/src/schema.mjs` so the AI agent and the CLI always emit the same shape.
+Empty arrays are kept (not stripped) so a human can see the slot and fill it
+later.
+
+| kind | required | always emitted | strongly expected |
+|---|---|---|---|
+| `project` | `slug`, `kind`, `title` | `domains: []`, `capabilities: []`, `elements: []` | — |
+| `domain` | `slug`, `kind`, `title` | `capabilities: []` | — |
+| `capability` | `slug`, `kind`, `title` | `elements: []` | `domain` |
+| `element` | `slug`, `kind`, `title` | — | `domain` |
+| `document` | `slug`, `kind`, `title` | — | — |
+
+“Strongly expected” fields don’t throw — they come back in the response under
+`warnings`, and the validator (`mcp:validate`) flags them with the
+`missing-expected-field` issue code so users see them in the workbench banner
+without breaking pre-existing vaults.
+
+The same schema is mirrored at `cli/src/lib/schema.mjs`. A contract test
+(`tests/contract/vault-schema.contract.test.ts`) keeps the two in lock-step;
+if you change one, mirror the other.
 
 ## Local verification (UX-3)
 

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -62,6 +62,11 @@ import { mkdirSync } from 'node:fs';
 import { buildMarkdown } from './parser.mjs';
 import { parseFilter } from './query.mjs';
 import { isValidVaultTitle, validateVaultDocument } from './validate.mjs';
+import {
+  buildFrontmatter,
+  defaultBody,
+  missingExpectedFields,
+} from './schema.mjs';
 
 const VAULT_ROOT = resolve(process.env.OMOT_VAULT || process.cwd());
 // import-time throw 면 stdio transport 가 붙기 전 stack trace 가 stderr 로
@@ -183,7 +188,11 @@ const TOOLS = [
     description:
       'Create a new ontology node (.md file). Call when an AI agent finds a new ' +
       'capability / element / project from code analysis. Throws if the slug ' +
-      'already exists — use patch_concept in that case.',
+      'already exists — use patch_concept in that case. The frontmatter is ' +
+      'normalized per kind (project gets `domains/capabilities/elements` empty ' +
+      'arrays; capability gets `elements: []`; capability/element should also ' +
+      'set `domain:` so the tree has a parent — missing extras come back as ' +
+      '`warnings` in the response, not as an error.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -194,20 +203,24 @@ const TOOLS = [
           description: 'project / domain / capability / element / document. (vault-readme is reserved for the auto-generated README.md and should not be set by agents.)',
         },
         title: { type: 'string', description: 'Display title for the node.' },
-        domain: { type: 'string', description: 'Parent domain slug (optional).' },
+        domain: {
+          type: 'string',
+          description:
+            'Parent domain slug. Strongly expected for kind=capability and kind=element — without it the node floats orphaned in the tree.',
+        },
         capabilities: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Capability slugs this node owns (project nodes).',
+          description: 'Capability slugs this node owns (project / domain).',
         },
         elements: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Element slugs this node uses (project nodes).',
+          description: 'Element slugs this node uses (project / capability).',
         },
         body: {
           type: 'string',
-          description: 'Markdown body (optional). Defaults to `# {title}` when omitted.',
+          description: 'Markdown body (optional). When omitted a kind-specific starter body is written so the file is self-explanatory in the editor.',
         },
       },
       required: ['slug', 'kind', 'title'],
@@ -660,15 +673,32 @@ function addConcept({ slug, kind, title, domain, capabilities, elements, body })
       `Unknown kind: ${kind}. project / domain / capability / element / document 중 하나여야 합니다.`,
     );
   }
-  const fm = { slug, kind, title };
-  if (domain) fm.domain = domain;
-  if (capabilities && capabilities.length > 0) fm.capabilities = capabilities;
-  if (elements && elements.length > 0) fm.elements = elements;
+  // R14 — schema 가 kind 별 양식 (project: domains/capabilities/elements 빈
+  // 배열, capability: elements 빈 배열, …) 을 채워 호출자가 부분 정보만 줘도
+  // 일관된 frontmatter 가 디스크에 남도록. CLI add 와 같은 schema 모듈을
+  // 공유 (contract test 가 drift 차단).
+  const fm = buildFrontmatter({
+    slug,
+    kind,
+    title,
+    domain,
+    capabilities,
+    elements,
+  });
   const filePath = writeDoc(VAULT_ROOT, slug, {
     frontmatter: fm,
-    body: body || `# ${title}\n`,
+    body: body || defaultBody(kind, title),
   });
-  return { ok: true, slug, filePath };
+  // schema 의 requiredExtras 누락 검사 → 응답에 advisory 로 포함.
+  // throw 하지 않음 — agent 흐름 자연스럽게, 사용자가 후속 patch_concept 로
+  // 보완 가능. (capability/element 의 domain 누락 등이 흔한 케이스)
+  const missing = missingExpectedFields(kind, fm);
+  return {
+    ok: true,
+    slug,
+    filePath,
+    ...(missing.length > 0 ? { warnings: missing.map((k) => `expected field "${k}" missing for kind "${kind}"`) } : {}),
+  };
 }
 
 const RELATION_KEY = {

--- a/mcp/src/schema.mjs
+++ b/mcp/src/schema.mjs
@@ -1,0 +1,161 @@
+/**
+ * Vault kind schema — per-kind frontmatter shape that AI agents and the CLI
+ * both follow when they create new ontology nodes. Single source of truth for
+ * `add_concept` (MCP) and `oh-my-ontology add` (CLI).
+ *
+ * The mirror copy lives at `cli/src/lib/schema.mjs`; a contract test
+ * (`tests/contract/vault-schema.contract.test.ts`) keeps the two in lock-step.
+ *
+ * Why a schema beyond the existing templates?
+ *
+ *   - The example .md templates under `cli/templates/vault/` are seeds for
+ *     `cli init` only — they don't constrain `cli add` or `add_concept`.
+ *   - Without per-kind defaults, an agent calling `add_concept(kind:
+ *     'capability', slug, title)` produced a node missing `domain:` and
+ *     `elements: []`, which silently degraded downstream tooling.
+ *   - This schema makes "what fields belong on what kind" explicit and
+ *     mechanically applied so external `.md` ingestion later (cli import)
+ *     can normalize the same way.
+ *
+ * Two field categories:
+ *   - `arrayDefaults`: keys that should be present as an empty array if not
+ *     supplied. Always emitted so AI agents and humans can read/edit them.
+ *   - `optional`: keys that may appear but are not auto-emitted.
+ *
+ * `requiredExtras` is the *expected* set beyond `slug/kind/title`. Missing
+ * extras are surfaced as validator warnings (not hard errors) — they are
+ * advisory in v0.x to avoid breaking pre-existing vaults.
+ */
+
+export const VAULT_KINDS = ['project', 'domain', 'capability', 'element', 'document'];
+
+export const VAULT_KIND_SCHEMA = {
+  project: {
+    folder: '',
+    arrayDefaults: ['domains', 'capabilities', 'elements'],
+    optional: ['dependencies', 'relates', 'description', 'status'],
+    requiredExtras: [],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `One- or two-line summary of this project — *what / for whom / why*.\n\n` +
+      `## How it grows\n\n` +
+      `- Fill \`domains: [...]\` in the frontmatter and the domain nodes hang\n` +
+      `  off the project tree automatically.\n` +
+      `- Each domain's capabilities and elements follow the same pattern.\n`,
+  },
+  domain: {
+    folder: 'domains/',
+    arrayDefaults: ['capabilities'],
+    optional: ['depends_on', 'relates', 'description'],
+    requiredExtras: [],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `A *domain* is a large area of the project (auth, billing, search, …). ` +
+      `Describe in one or two paragraphs what it covers and which capabilities live inside.\n`,
+  },
+  capability: {
+    folder: 'capabilities/',
+    arrayDefaults: ['elements'],
+    optional: ['depends_on', 'relates', 'description'],
+    // `domain` 은 트리 위계의 부모 — 비어 있으면 capability 가 orphan 으로
+    // 떠다니며 사용자 인사이트에 분포 노이즈를 만든다. validator 가 경고.
+    requiredExtras: ['domain'],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `A *capability* is one user-visible feature within a domain. Describe what it does and one or two user scenarios.\n`,
+  },
+  element: {
+    folder: 'elements/',
+    arrayDefaults: [],
+    optional: ['path', 'depends_on', 'relates', 'description'],
+    // element 는 어느 domain 안의 어느 capability 가 쓰는 단위 — domain 누락 시
+    // 트리에서 sink 로 떠다닌다.
+    requiredExtras: ['domain'],
+    bodyTemplate: (title) =>
+      `# ${title}\n\n` +
+      `An *element* is a smaller unit a capability uses (jwt-token, indexeddb-adapter, sigma-canvas, …). Cover *what / why / which interface*.\n`,
+  },
+  document: {
+    folder: '',
+    arrayDefaults: [],
+    optional: ['describes', 'relates'],
+    requiredExtras: [],
+    bodyTemplate: (title) => `# ${title}\n`,
+  },
+};
+
+/**
+ * Build a normalized frontmatter object for a new node.
+ *
+ *   - Always: { slug, kind, title }
+ *   - Add arrayDefaults as [] if not provided.
+ *   - Pass-through any other supplied keys (so callers can also set
+ *     `domain`, `capabilities`, `elements`, `dependencies`, custom keys …).
+ *
+ * Throws if kind is unknown.
+ */
+export function buildFrontmatter({ slug, kind, title, ...extras }) {
+  if (!VAULT_KIND_SCHEMA[kind]) {
+    throw new Error(
+      `Unknown kind: ${kind}. Expected one of ${VAULT_KINDS.join(' / ')}.`,
+    );
+  }
+  const schema = VAULT_KIND_SCHEMA[kind];
+  const fm = { slug, kind, title };
+  // Caller-supplied keys win over arrayDefaults — explicit values aren't
+  // overwritten by an empty array.
+  for (const key of schema.arrayDefaults) {
+    fm[key] = Array.isArray(extras[key]) ? extras[key] : [];
+  }
+  for (const [key, value] of Object.entries(extras)) {
+    if (value === undefined || value === null) continue;
+    if (key in fm && Array.isArray(fm[key]) && Array.isArray(value)) {
+      fm[key] = value;
+      continue;
+    }
+    fm[key] = value;
+  }
+  return fm;
+}
+
+/**
+ * Body 보조 — 호출자가 명시적으로 body 안 줬을 때 schema 의 kind 별 ‘starter
+ * markdown’ 채워서 사용자가 첫 .md 만으로도 어떤 게 들어가야 하는지 감을 잡게.
+ */
+export function defaultBody(kind, title) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) throw new Error(`Unknown kind: ${kind}`);
+  return schema.bodyTemplate(title);
+}
+
+/**
+ * 자동 folder prefix — `oh-my-ontology add capability foo` 일 때 사용자가
+ * `--auto-prefix` 켜면 slug 가 `capabilities/foo` 로 정규화. project /
+ * document 는 root level (prefix 없음).
+ */
+export function folderForKind(kind) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) return '';
+  return schema.folder;
+}
+
+/**
+ * Validator helper — 기존 frontmatter 가 schema 의 requiredExtras 누락 했는지.
+ * 누락된 키 배열 반환 (없으면 빈 배열). hard error 가 아니라 advisory.
+ */
+export function missingExpectedFields(kind, frontmatter) {
+  const schema = VAULT_KIND_SCHEMA[kind];
+  if (!schema) return [];
+  const missing = [];
+  for (const key of schema.requiredExtras) {
+    const value = frontmatter[key];
+    if (value === undefined || value === null) {
+      missing.push(key);
+      continue;
+    }
+    if (typeof value === 'string' && value.trim() === '') {
+      missing.push(key);
+    }
+  }
+  return missing;
+}

--- a/mcp/src/validate.mjs
+++ b/mcp/src/validate.mjs
@@ -20,10 +20,11 @@ export function isValidVaultTitle(value) {
 }
 
 import { parseFrontmatter } from './parser.mjs';
+import { missingExpectedFields } from './schema.mjs';
 
 /**
  * R11 #23 — vault frontmatter silent corruption 검출. src/shared/lib/
- * validate-vault-document.ts 와 같은 5 issue codes 보장 (drift 시 contract
+ * validate-vault-document.ts 와 같은 issue codes 보장 (drift 시 contract
  * test 가 차단). raw 까지 보고 unclosed/parse-zero 검출.
  *
  * issue codes:
@@ -31,6 +32,7 @@ import { parseFrontmatter } from './parser.mjs';
  *  - empty-kind (error)
  *  - missing-kind (warning)
  *  - unknown-kind (warning)
+ *  - missing-expected-field (warning) — R14
  *  - parse-zero-keys (warning)
  *
  * @param {string} raw
@@ -99,6 +101,17 @@ export function validateVaultDocument(raw) {
       severity: 'warning',
       message: `\`kind: ${rawKind.trim()}\` 는 인식되지 않는 값입니다.`,
     });
+  } else {
+    // R14 — kind 별 expected 필드 누락 (capability/element 의 domain) advisory.
+    // schema.mjs 가 single source — UI/CLI/MCP 셋이 같은 dict 사용.
+    const trimmedKind = rawKind.trim();
+    for (const key of missingExpectedFields(trimmedKind, frontmatter)) {
+      issues.push({
+        code: 'missing-expected-field',
+        severity: 'warning',
+        message: `\`${key}:\` 가 비어있습니다 — kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
+      });
+    }
   }
 
   return {

--- a/mcp/src/validate.test.mjs
+++ b/mcp/src/validate.test.mjs
@@ -67,18 +67,31 @@ describe('validateVaultDocument (R11 #23)', () => {
     assert.equal(r.issues.some((i) => i.code === 'unknown-kind'), true);
   });
 
-  it('canonical kind 6 종 모두 인식', () => {
-    for (const k of [
-      'project',
-      'domain',
-      'capability',
-      'element',
-      'document',
-      'vault-readme',
-    ]) {
-      const r = validateVaultDocument(`---\nkind: ${k}\n---\n`);
+  it('canonical kind 6 종 모두 인식 (capability/element 는 domain 채워야 clean)', () => {
+    // R14 — capability/element 는 domain 누락 시 missing-expected-field warn.
+    // canonical kind 가 인식 자체는 되는지 보는 테스트라 domain 까지 박아 clean.
+    const cases = [
+      { k: 'project' },
+      { k: 'domain' },
+      { k: 'capability', extra: 'domain: domains/auth' },
+      { k: 'element', extra: 'domain: domains/auth' },
+      { k: 'document' },
+      { k: 'vault-readme' },
+    ];
+    for (const { k, extra } of cases) {
+      const extraLine = extra ? `\n${extra}` : '';
+      const r = validateVaultDocument(`---\nkind: ${k}${extraLine}\n---\n`);
       assert.equal(r.ok, true, `kind=${k}`);
       assert.equal(r.issues.length, 0, `kind=${k}`);
     }
+  });
+
+  it('R14 — capability without domain → missing-expected-field warning', () => {
+    const r = validateVaultDocument('---\nkind: capability\ntitle: X\n---\n');
+    assert.equal(r.ok, true);
+    assert.equal(
+      r.issues.some((i) => i.code === 'missing-expected-field'),
+      true,
+    );
   });
 });

--- a/src/shared/lib/validate-vault-document.test.ts
+++ b/src/shared/lib/validate-vault-document.test.ts
@@ -59,27 +59,38 @@ describe("validateVaultDocument", () => {
     expect(r.issues.map((i) => i.code)).toContain("parse-zero-keys");
   });
 
-  it("trim 된 kind 가 canonical 이면 ok", () => {
-    const raw = `---\nkind:    capability   \n---\n`;
+  it("trim 된 kind 가 canonical 이면 ok (capability + domain)", () => {
+    // R14 — capability/element 는 domain 누락 시 missing-expected-field
+    // warning. canonical kind 인식 자체를 보는 케이스라 domain 까지 박아 clean.
+    const raw = `---\nkind:    capability   \ndomain: domains/auth\n---\n`;
     const r = validateVaultDocument(raw);
     expect(r.ok).toBe(true);
     expect(r.issues).toHaveLength(0);
   });
 
   it("6 종 모두 인식 (project / domain / capability / element / document / vault-readme)", () => {
-    const kinds = [
-      "project",
-      "domain",
-      "capability",
-      "element",
-      "document",
-      "vault-readme",
+    // capability/element 는 domain 까지 박아야 clean — R14 schema 가 부모
+    // 누락에 advisory warn.
+    const cases: Array<{ kind: string; extra?: string }> = [
+      { kind: "project" },
+      { kind: "domain" },
+      { kind: "capability", extra: "domain: domains/auth" },
+      { kind: "element", extra: "domain: domains/auth" },
+      { kind: "document" },
+      { kind: "vault-readme" },
     ];
-    for (const k of kinds) {
-      const r = validateVaultDocument(`---\nkind: ${k}\n---\n`);
-      expect(r.ok, `kind=${k}`).toBe(true);
-      expect(r.issues, `kind=${k}`).toHaveLength(0);
+    for (const c of cases) {
+      const extraLine = c.extra ? `\n${c.extra}` : "";
+      const r = validateVaultDocument(`---\nkind: ${c.kind}${extraLine}\n---\n`);
+      expect(r.ok, `kind=${c.kind}`).toBe(true);
+      expect(r.issues, `kind=${c.kind}`).toHaveLength(0);
     }
+  });
+
+  it("R14 — capability/element 가 domain 없으면 missing-expected-field warning", () => {
+    const r = validateVaultDocument(`---\nkind: capability\ntitle: X\n---\n`);
+    expect(r.ok).toBe(true);
+    expect(r.issues.map((i) => i.code)).toContain("missing-expected-field");
   });
 
   it("error 와 warning 이 동시에 있으면 ok=false (error 우선)", () => {
@@ -123,10 +134,20 @@ describe("validateVaultDocFrontmatter (parsed-only fast path)", () => {
     expect(r.issues.map((i) => i.code)).toContain("empty-kind");
   });
 
-  it("canonical kind 는 ok", () => {
-    const r = validateVaultDocFrontmatter({ kind: "capability", title: "X" });
+  it("canonical kind 는 ok (capability with domain)", () => {
+    const r = validateVaultDocFrontmatter({
+      kind: "capability",
+      title: "X",
+      domain: "domains/auth",
+    });
     expect(r.ok).toBe(true);
     expect(r.issues).toHaveLength(0);
+  });
+
+  it("R14 — capability without domain → missing-expected-field warning", () => {
+    const r = validateVaultDocFrontmatter({ kind: "capability", title: "X" });
+    expect(r.ok).toBe(true);
+    expect(r.issues.map((i) => i.code)).toContain("missing-expected-field");
   });
 
   it("non-canonical kind 는 unknown-kind warning", () => {

--- a/src/shared/lib/validate-vault-document.ts
+++ b/src/shared/lib/validate-vault-document.ts
@@ -19,7 +19,22 @@ export type VaultIssueCode =
   | "empty-kind"
   | "missing-kind"
   | "unknown-kind"
+  | "missing-expected-field"
   | "parse-zero-keys";
+
+/**
+ * R14 — kind 별 "있어야 좋은" 필드 dict. mcp/src/schema.mjs &
+ * cli/src/lib/schema.mjs 의 `requiredExtras` 와 일치 — contract test 가
+ * 동기화 강제. UI/Web 측에서 advisory warning 출력에 쓰인다 (hard error
+ * 아님 — pre-existing vault 호환).
+ */
+export const KIND_EXPECTED_EXTRAS: Readonly<Record<string, readonly string[]>> = {
+  project: [],
+  domain: [],
+  capability: ["domain"],
+  element: ["domain"],
+  document: [],
+};
 
 export interface VaultDocumentIssue {
   code: VaultIssueCode;
@@ -106,9 +121,36 @@ export function validateVaultDocument(raw: string): VaultDocumentReport {
       severity: "warning",
       message: `\`kind: ${rawKind.trim()}\` 는 인식되지 않는 값입니다. 인식되는 값: ${KNOWN_VAULT_KINDS.join(" / ")}.`,
     });
+  } else {
+    // R14 — kind 별 expected 필드 (capability/element 의 domain 등) 누락
+    // 시 advisory warning. parser 가 raw 도 봤으니 frontmatter 객체 그대로 검사.
+    const trimmedKind = rawKind.trim();
+    pushMissingExpectedExtrasIssues(trimmedKind, frontmatter, issues);
   }
 
   return { ok: issuesHaveNoErrors(issues), issues };
+}
+
+function pushMissingExpectedExtrasIssues(
+  kind: string,
+  frontmatter: Record<string, unknown>,
+  issues: VaultDocumentIssue[],
+): void {
+  const expected = KIND_EXPECTED_EXTRAS[kind] ?? [];
+  for (const key of expected) {
+    const value = frontmatter[key];
+    const isMissing =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim() === "");
+    if (isMissing) {
+      issues.push({
+        code: "missing-expected-field",
+        severity: "warning",
+        message: `\`${key}:\` 가 비어있습니다 — kind=${kind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
+      });
+    }
+  }
 }
 
 function issuesHaveNoErrors(issues: readonly VaultDocumentIssue[]): boolean {
@@ -176,6 +218,11 @@ export function validateVaultDocFrontmatter(
       severity: "warning",
       message: `\`kind: ${rawKind.trim()}\` 는 인식되지 않는 값입니다. 인식되는 값: ${KNOWN_VAULT_KINDS.join(" / ")}.`,
     });
+  } else {
+    // R14 — kind 별 expected 필드 누락 시 advisory warning. parser
+    // 결과만 보는 fast path 에서도 동일 동작.
+    const trimmedKind = rawKind.trim();
+    pushMissingExpectedExtrasIssues(trimmedKind, frontmatter, issues);
   }
 
   return { ok: issuesHaveNoErrors(issues), issues };

--- a/tests/contract/vault-schema.contract.test.ts
+++ b/tests/contract/vault-schema.contract.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILD_FM_CASES,
+  MISSING_FIELDS_CASES,
+  FOLDER_CASES,
+} from "../fixtures/vault-schema-cases.mjs";
+import {
+  buildFrontmatter as buildMcp,
+  missingExpectedFields as missingMcp,
+  folderForKind as folderMcp,
+} from "../../mcp/src/schema.mjs";
+import {
+  buildFrontmatter as buildCli,
+  missingExpectedFields as missingCli,
+  folderForKind as folderCli,
+} from "../../cli/src/lib/schema.mjs";
+import { KIND_EXPECTED_EXTRAS } from "@/shared/lib/validate-vault-document";
+
+/**
+ * 2-way + 1 cross-check vault schema contract:
+ *
+ *   - mcp/src/schema.mjs (AI agent surface — `add_concept`)
+ *   - cli/src/lib/schema.mjs (developer CLI — `oh-my-ontology add`)
+ *   - src/shared/lib/validate-vault-document.ts 의 KIND_EXPECTED_EXTRAS
+ *     (web/UI advisory)
+ *
+ * 양 schema 가 같은 frontmatter 모양을 만들고 같은 missing-field 결정을
+ * 내려야 한다. 한 쪽 drift 시 이 test 가 즉시 fail. UI 측 dict 도 같은
+ * requiredExtras 들고 있는지 cross-check.
+ */
+
+describe("vault kind schema contract — mcp & cli agree", () => {
+  describe("buildFrontmatter", () => {
+    for (const c of BUILD_FM_CASES) {
+      it(`${c.name} (mcp)`, () => {
+        expect(buildMcp(c.input)).toEqual(c.expected);
+      });
+      it(`${c.name} (cli)`, () => {
+        expect(buildCli(c.input)).toEqual(c.expected);
+      });
+    }
+  });
+
+  describe("missingExpectedFields", () => {
+    for (const c of MISSING_FIELDS_CASES) {
+      it(`${c.name} (mcp)`, () => {
+        expect(missingMcp(c.kind, c.frontmatter)).toEqual(c.expected);
+      });
+      it(`${c.name} (cli)`, () => {
+        expect(missingCli(c.kind, c.frontmatter)).toEqual(c.expected);
+      });
+    }
+  });
+
+  describe("folderForKind", () => {
+    for (const c of FOLDER_CASES) {
+      it(`${c.kind} (mcp)`, () => {
+        expect(folderMcp(c.kind)).toBe(c.expected);
+      });
+      it(`${c.kind} (cli)`, () => {
+        expect(folderCli(c.kind)).toBe(c.expected);
+      });
+    }
+  });
+
+  describe("UI KIND_EXPECTED_EXTRAS aligns with mcp/cli requiredExtras", () => {
+    // UI dict 가 mcp 의 missing-fields 결정과 같은 결과를 내야 한다.
+    // capability/element 둘 다 ['domain'] 을 expected 로 둔다.
+    it("capability requires domain", () => {
+      expect(KIND_EXPECTED_EXTRAS.capability).toEqual(["domain"]);
+      expect(missingMcp("capability", { slug: "x", kind: "capability", title: "X" })).toEqual([
+        "domain",
+      ]);
+    });
+    it("element requires domain", () => {
+      expect(KIND_EXPECTED_EXTRAS.element).toEqual(["domain"]);
+      expect(missingMcp("element", { slug: "x", kind: "element", title: "X" })).toEqual([
+        "domain",
+      ]);
+    });
+    it("project / domain / document have no extras", () => {
+      expect(KIND_EXPECTED_EXTRAS.project).toEqual([]);
+      expect(KIND_EXPECTED_EXTRAS.domain).toEqual([]);
+      expect(KIND_EXPECTED_EXTRAS.document).toEqual([]);
+    });
+  });
+});

--- a/tests/fixtures/validate-vault-cases.mjs
+++ b/tests/fixtures/validate-vault-cases.mjs
@@ -21,9 +21,17 @@ export const VALIDATE_CASES = [
     expectedOk: true,
   },
   {
-    name: 'canonical kind = capability — clean',
-    input: '---\nkind: capability\ntitle: Cap\n---\n',
+    // R14 — capability/element 는 domain 없으면 missing-expected-field warning.
+    // domain 까지 채운 경우가 'clean' baseline.
+    name: 'canonical kind = capability — clean (with domain)',
+    input: '---\nkind: capability\ntitle: Cap\ndomain: domains/auth\n---\n',
     expectedCodes: [],
+    expectedOk: true,
+  },
+  {
+    name: 'capability without domain → missing-expected-field warning',
+    input: '---\nkind: capability\ntitle: Cap\n---\n',
+    expectedCodes: ['missing-expected-field'],
     expectedOk: true,
   },
   {

--- a/tests/fixtures/vault-schema-cases.mjs
+++ b/tests/fixtures/vault-schema-cases.mjs
@@ -1,0 +1,153 @@
+/**
+ * Vault kind schema fixtures — buildFrontmatter / missingExpectedFields /
+ * folderForKind 가 mcp/cli 두 패키지에서 같은 결과를 낸다는 걸 강제하기 위한
+ * shared input matrix.
+ *
+ * 한 쪽 schema 모듈이 drift 하면 contract test 가 즉시 fail.
+ */
+
+export const BUILD_FM_CASES = [
+  {
+    name: 'project — arrayDefaults 빈 배열로 채워짐',
+    input: { slug: 'demo', kind: 'project', title: 'Demo' },
+    expected: {
+      slug: 'demo',
+      kind: 'project',
+      title: 'Demo',
+      domains: [],
+      capabilities: [],
+      elements: [],
+    },
+  },
+  {
+    name: 'project — 호출자가 capabilities 명시하면 그 값 보존',
+    input: {
+      slug: 'demo',
+      kind: 'project',
+      title: 'Demo',
+      capabilities: ['cap-a', 'cap-b'],
+    },
+    expected: {
+      slug: 'demo',
+      kind: 'project',
+      title: 'Demo',
+      domains: [],
+      capabilities: ['cap-a', 'cap-b'],
+      elements: [],
+    },
+  },
+  {
+    name: 'domain — capabilities 빈 배열만',
+    input: { slug: 'domains/auth', kind: 'domain', title: 'Auth' },
+    expected: {
+      slug: 'domains/auth',
+      kind: 'domain',
+      title: 'Auth',
+      capabilities: [],
+    },
+  },
+  {
+    name: 'capability — domain 명시 + elements 빈 배열',
+    input: {
+      slug: 'capabilities/login',
+      kind: 'capability',
+      title: 'Login',
+      domain: 'domains/auth',
+    },
+    expected: {
+      slug: 'capabilities/login',
+      kind: 'capability',
+      title: 'Login',
+      elements: [],
+      domain: 'domains/auth',
+    },
+  },
+  {
+    name: 'capability — domain 미지정 (orphan, validator 가 warn)',
+    input: { slug: 'capabilities/checkout', kind: 'capability', title: 'Checkout' },
+    expected: {
+      slug: 'capabilities/checkout',
+      kind: 'capability',
+      title: 'Checkout',
+      elements: [],
+    },
+  },
+  {
+    name: 'element — domain 명시',
+    input: {
+      slug: 'elements/jwt-token',
+      kind: 'element',
+      title: 'JWT token',
+      domain: 'domains/auth',
+    },
+    expected: {
+      slug: 'elements/jwt-token',
+      kind: 'element',
+      title: 'JWT token',
+      domain: 'domains/auth',
+    },
+  },
+  {
+    name: 'document — minimal',
+    input: { slug: 'docs/decision-1', kind: 'document', title: 'Decision 1' },
+    expected: {
+      slug: 'docs/decision-1',
+      kind: 'document',
+      title: 'Decision 1',
+    },
+  },
+];
+
+export const MISSING_FIELDS_CASES = [
+  {
+    name: 'capability without domain → ["domain"]',
+    kind: 'capability',
+    frontmatter: { slug: 'capabilities/x', kind: 'capability', title: 'X', elements: [] },
+    expected: ['domain'],
+  },
+  {
+    name: 'capability with domain → []',
+    kind: 'capability',
+    frontmatter: {
+      slug: 'capabilities/x',
+      kind: 'capability',
+      title: 'X',
+      domain: 'domains/auth',
+    },
+    expected: [],
+  },
+  {
+    name: 'element without domain → ["domain"]',
+    kind: 'element',
+    frontmatter: { slug: 'elements/x', kind: 'element', title: 'X' },
+    expected: ['domain'],
+  },
+  {
+    name: 'element with empty-string domain → ["domain"]',
+    kind: 'element',
+    frontmatter: { slug: 'elements/x', kind: 'element', title: 'X', domain: '   ' },
+    expected: ['domain'],
+  },
+  {
+    name: 'project never requires extras → []',
+    kind: 'project',
+    frontmatter: { slug: 'demo', kind: 'project', title: 'Demo' },
+    expected: [],
+  },
+  {
+    name: 'unknown kind → []',
+    kind: 'no-such',
+    frontmatter: { slug: 'x', kind: 'no-such', title: 'X' },
+    expected: [],
+  },
+];
+
+export const FOLDER_CASES = [
+  { kind: 'project', expected: '' },
+  { kind: 'domain', expected: 'domains/' },
+  { kind: 'capability', expected: 'capabilities/' },
+  { kind: 'element', expected: 'elements/' },
+  { kind: 'document', expected: '' },
+  // unknown kind — `''` (no prefix), CLI 가 raw slug 로 통과시키게.
+  { kind: 'no-such', expected: '' },
+];


### PR DESCRIPTION
## Summary

사용자 질문 — *"AI agent 가 같은 양식으로 작성하게 인식 가능한 구조"* — 에 대한 1차 답변. 두 진입점 (MCP `add_concept` · CLI `oh-my-ontology add`) 이 같은 schema 모듈을 통해 .md 를 만들고, 같은 advisory warnings 를 노출하도록 정렬.

기존 상태:
- `cli/templates/vault/` 에 kind 별 견본은 있었지만 `cli init` 만 사용. `cli add` 와 MCP `add_concept` 는 둘 다 `slug + kind + title` 만 박고 arrayDefaults 미채움 → AI agent 가 capability 만들면 `elements: []` 슬롯조차 없는 .md 가 disk 에 남아 사용자가 "여기 뭐 채우면 돼?" 를 알 수 없었다.

이번 PR:
- **`mcp/src/schema.mjs` · `cli/src/lib/schema.mjs`** — single source. kind 별 `arrayDefaults` (project: domains/capabilities/elements, domain: capabilities, capability: elements), `requiredExtras` (capability/element 의 domain), `folder`, kind 별 starter body. 두 파일 lock-step.
- **MCP `add_concept`** 가 `buildFrontmatter` 사용 → 항상 일관된 양식 emit. `requiredExtras` 누락 시 응답에 `warnings`.
- **CLI `oh-my-ontology add`** 동일 schema 적용 + stderr `warn` 라인.
- **3-way validator** (`src/shared/lib`, `mcp/src`, `cli/src/lib`) 가 새 issue code `missing-expected-field` 동시에 인식. severity=warning (error 아님) — pre-existing vault 호환 보존.
- **Contract test** `tests/contract/vault-schema.contract.test.ts` — mcp/cli 두 schema 가 같은 결과 + UI 측 `KIND_EXPECTED_EXTRAS` 일치 강제.
- **docs**: AGENTS.md / mcp/README.md / cli/README.md 에 frontmatter shape 표 + 안내.

후속 (별 PR): `oh-my-ontology import <path>` — 외부 .md 받아 frontmatter 정규화 후 vault 안으로 정착시키는 워크플로.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run tests/contract/ src/shared/lib/validate-vault-document.test.ts` — 158 tests pass (41 new contract cases)
- [x] `node mcp/src/validate.test.mjs` · `node mcp/src/integration.test.mjs` — 모두 pass
- [x] `node cli/src/integration.test.mjs` — 13 pass / 0 fail
- [x] `pnpm vault:validate` — dogfood vault 23 docs · 0 issues (기존 capability/element 들이 모두 domain 채워져 있어 R14 advisory 도 trigger 안 함)
- [x] pre-push tsc gate 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)