### PR TITLE
feat: /ontology-sync skill + AGENTS 의 read-while-coding 룰

### DIFF
--- a/.claude/skills/ontology-sync/SKILL.md
+++ b/.claude/skills/ontology-sync/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ontology-sync
+description: After a code change, sync the project's ontology vault — read what's already there, identify new capabilities / elements / domains introduced by the change, and write them back via the MCP server (or fall back to the CLI). Use this at the end of any task that introduces a new feature, refactors a module, or renames a unit. Skip when the change is purely a typo, style nudge, or test fixture tweak.
+---
+
+# /ontology-sync — keep the vault in step with the code
+
+The vault under `docs/ontology/` (this repo's dogfood) — or the user's own
+vault when one is selected — is the **shared mental model** between the
+developer and the AI agent. When code grows or shifts, the vault has to
+follow, otherwise the graph drifts and stops being a useful map.
+
+This skill runs after a unit of code work (new feature, refactor, rename,
+notable cleanup) and produces the corresponding ontology updates so the
+human sees the change appear in their workbench.
+
+## When to run
+
+**Run when**:
+- a new user-visible capability landed (login flow, checkout flow, …)
+- a new concrete element landed (jwt-token, indexeddb-adapter, sigma-canvas, …)
+- a domain was reshaped (auth → split into auth + session, …)
+- a slug-level rename happened in code that should mirror in the graph
+
+**Skip when**:
+- the change is a typo, comment tweak, or single-line style nudge
+- the change is purely test fixture / lint config / docs prose
+- the change reverts something already in the graph
+
+## Workflow
+
+The MCP server `oh-my-ontology-local` (or the published `oh-my-ontology-mcp`)
+is the primary path. Fall back to the `cli/` binary (`oh-my-ontology add` /
+`import` / `validate`) if MCP is unavailable in the current session.
+
+### 1. Read what's already there (cheap)
+
+```
+list_kinds                                # how many of each kind
+list_concepts                             # full node table (paginated)
+get_concept(slug)                         # for any node you might extend
+find_backlinks(slug)                      # before renaming or merging
+```
+
+Don't write anything before reading. The vault often already has the node
+under a different slug (e.g. `capabilities/auth-login` vs
+`capabilities/login`); duplicating is the worst failure mode here.
+
+### 2. Look at the actual code change
+
+Use `git diff` and the conversation context to identify, for the unit of
+work just completed:
+
+- **new capabilities** — user-visible features added
+- **new elements** — concrete pieces (libraries, schemas, helpers, files)
+- **new domains** — only if a whole new functional area opened up
+- **edge changes** — `dependencies`, `relates`, `contains` arrays that
+  should now point somewhere new
+
+If the diff is large, ask: "what would a teammate need to know is now
+*part of* this codebase that wasn't yesterday?" That's the ontology
+delta — most diffs add 0–2 nodes; very few add 5+.
+
+### 3. Write back
+
+For each delta, prefer one tool:
+
+| Situation | Tool |
+|---|---|
+| New node | `add_concept` (frontmatter is auto-normalized to the per-kind shape — slug, kind, title, then arrays/domain — so don't hand-shape it) |
+| Existing node, new field or refined body | `patch_concept` (pass `expected_mtime` from a prior `get_concept`) |
+| Slug rename in code → mirror in graph | `rename_concept` (dry-run first; commit with `confirm: true`) |
+| Two near-duplicates collapse | `merge_concepts` (dry-run; commit with `confirm: true`) |
+| Edge between existing nodes | `add_relation(from, to, type)` |
+
+`add_concept` returns `warnings: ["expected field \"domain\" missing for kind \"capability\""]` when a strongly-expected field is absent. Treat that as a follow-up `patch_concept` to fill it in, not a hard error.
+
+### 4. Verify
+
+```
+list_kinds                                # the count moved as expected
+find_orphans                              # nothing got accidentally orphaned
+```
+
+If the vault is the user's own (selected via the web `/docs` picker), the
+web's polling layer will pick up the changes within ~5 seconds — the
+human sees new nodes pulse and a toast appear without reloading.
+
+## Reply shape
+
+Five lines max. Cover:
+
+1. What you read (`list_kinds` summary or the slug you focused on).
+2. What you added — slug + kind + parent.
+3. What you patched / renamed — old → new.
+4. Any `warnings` returned (and whether you'll address them in a follow-up).
+5. Verify line — node count delta, orphan count delta.
+
+Don't paste the full frontmatter back; the workbench shows it. The reply
+is a changelog.
+
+## Failure modes worth catching
+
+- **Duplicate slugs**: `add_concept` throws on duplicate. Switch to `patch_concept`.
+- **Dangling parent**: `domain: domains/foo` where `domains/foo.md` doesn't
+  exist. Either add the parent first, or accept the
+  `missing-expected-field` warning and tell the human.
+- **Concurrent edits**: every write tool accepts `expected_mtime` from
+  `get_concept`. Use it on `patch_concept` / `rename_concept` /
+  `merge_concepts` / `delete_concept` so a parallel human edit isn't
+  silently overwritten.
+- **Backlink rot**: after `rename_concept`, the tool atomically rewrites
+  every backlink. Don't do `find_backlinks` + N `patch_concept` manually.
+
+## Example one-liner the agent might generate
+
+> Read 13 nodes (5 capability / 3 domain / 4 element / project / readme).
+> Added `capabilities/password-reset` (parent `domains/auth`) and
+> `elements/password-reset-token` (linked as its element).
+> No patches, no renames. No warnings. find_orphans: unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,32 @@ This project describes its own mental model in `docs/ontology/` as frontmatter m
 - AI agents query it via the `mcp/` MCP server — registration guide in `mcp/README.md`, example in `.mcp.json.example`
 - When you discover a new domain / capability / element, add it to the same directory (with the MCP `add_concept` tool, or by hand)
 
+## Working with the ontology while you code
+
+The vault is the **shared mental model** between the developer and the AI agent. Treat reading and writing the ontology as part of any non-trivial code task — not as a separate chore. Two patterns:
+
+**Read at the start of a task** (cheap, often skipped). Before opening a feature you don't fully know, ask the vault:
+
+- `list_kinds` — what's in the codebase, by kind?
+- `list_concepts` (filter by kind / project) — full node table
+- `get_concept(slug)` — fetch the node + its neighbors before extending it
+- `find_backlinks(slug)` — who depends on this? (run *before* you rename or merge)
+- `find_path(from, to)` — does a relation already exist?
+
+A 30-second read at the top of the task often replaces a 10-minute re-discovery in the code.
+
+**Write at the end of a task** (the part that's easy to skip). When a unit of work introduced a new capability / element / domain, or renamed/folded an existing one, mirror the change in the vault:
+
+- new node → `add_concept(slug, kind, title, domain?, …)` — frontmatter is auto-normalized per kind, body defaults to a kind-specific starter, and missing strongly-expected fields come back as `warnings` so you know what to follow up
+- new edge between existing nodes → `add_relation(from, to, type)`
+- node moved or renamed in code → `rename_concept(oldSlug, newSlug)` (dry-run first, then `confirm: true`) — atomically rewrites every backlink
+- two near-duplicates collapse → `merge_concepts(fromSlug, intoSlug)` (same dry-run pattern)
+- existing node refined → `patch_concept(slug, frontmatter, body, expected_mtime)` — pass `expected_mtime` from a prior `get_concept` so a concurrent human edit isn't silently overwritten
+
+For the explicit "I'm done with this task — please sync the ontology now" loop, invoke the **`/ontology-sync`** skill (see `.claude/skills/ontology-sync/SKILL.md`). It bundles the read-then-write pattern with a checklist for when to skip (typos, style nudges).
+
+**Skip the ontology** for: typo fixes, comment tweaks, single-line style nudges, lint config, test fixtures with no shape change. Anything that changes "what the codebase *is*" goes into the vault; anything that doesn't, stays out.
+
 ## Frontmatter shape per kind (R14)
 
 When an AI agent (`add_concept`) or a developer (`oh-my-ontology add` / `oh-my-ontology import`) creates a new node, the frontmatter is normalized per `kind` so external `.md` ingestion stays consistent. See `mcp/README.md` for the full table and `mcp/src/schema.mjs` (mirror at `cli/src/lib/schema.mjs`) for the source. Contract test: `tests/contract/vault-schema.contract.test.ts`. Validator surfaces missing strongly-expected fields (e.g. capability/element without `domain:`) as the `missing-expected-field` warning — advisory only, not a hard error, so pre-existing vaults still pass.

--- a/docs/ontology/capabilities/ontology-sync-skill.md
+++ b/docs/ontology/capabilities/ontology-sync-skill.md
@@ -1,0 +1,26 @@
+---
+slug: capabilities/ontology-sync-skill
+kind: capability
+title: Ontology-Sync Agent Skill (.claude/skills/ontology-sync)
+domain: ai-agent-partner
+elements: [.claude/skills/ontology-sync/SKILL.md]
+dependencies: [capabilities/mcp-server]
+---
+
+# Ontology-Sync Agent Skill
+
+Claude Code 가 코드 변경 후 자동으로 호출하는 user-invocable skill.
+`.claude/skills/ontology-sync/SKILL.md` 한 파일이 곧 surface — 새 capability /
+element / domain 가 등장하면 MCP write 도구 (`add_concept` /
+`patch_concept` / `add_relation`) 로 vault 에 반영하라는 워크플로를 LLM 에게
+지시한다.
+
+MCP 서버가 *런타임 도구* 라면 이 skill 은 *사용 규약* — read-then-write,
+중복 slug 회피, 5 줄 changelog reply, dry-run rename 같은 실패 모드 가드를
+명시적으로 박아둬서 매번 LLM 이 재발견하지 않게 한다.
+
+## 어디에 매여 있나
+
+- `domains/ai-agent-partner` — agent 가 vault 와 상호작용하는 surface 군.
+- `capabilities/mcp-server` — 이 skill 이 호출하는 14 도구의 출처.
+- `.claude/skills/ontology-sync/SKILL.md` — 본문.


### PR DESCRIPTION
## Summary

사용자 의도 — *"AI agent 가 작업 중간 ontology 읽어서 도움받고, 끝나면 알아서 vault 에 기록"* — 의 자동성을 강화. demo 검증으로 이미 부분 작동 확인 (자연 prompt → agent 가 자율 read + 정확한 위계 추론 + write back). 이 PR 은 매 작업마다 더 일관되게 트리거되도록 두 가지 추가:

1. **AGENTS.md 의 'Working with the ontology while you code' 섹션** — Read at start / Write at end 의 두 패턴 + skip 케이스 (typo, style nudge, test fixture). agent 시스템 prompt 수준에 박혀 매 prompt 에서 활성.

2. **`.claude/skills/ontology-sync/SKILL.md`** — `/ontology-sync` slash command. 사용자 명시 invoke 시 git diff + 컨텍스트로 ontology delta 식별 → MCP write 도구로 반영. reply 5 줄 max, failure modes 4 종 (duplicate slug / dangling parent / mtime conflict / backlink rot) cover.

## 흐름

| 시점 | Agent 동작 |
|---|---|
| 작업 시작 | `list_kinds` → `list_concepts` → `get_concept(관련 슬러그)` 자동 |
| 작업 중 | `find_backlinks(slug)` 로 영향 범위 파악, `find_path(from, to)` 로 기존 관계 확인 |
| 작업 종료 | `add_concept` / `add_relation` / `rename_concept` / `patch_concept` 로 vault 갱신 |
| 명시 trigger | `/ontology-sync` 로 git diff 기반 변경 추출 + 일괄 sync |

## Demo (이번 round)

`~/Desktop/omot-vault` 에 자연 prompt — *"password reset 추가하려고 plan"* — 만:

```
Read: vault has domains/auth with one capability capabilities/login.
Added: capabilities/password-reset (parent domains/auth)
       + elements/password-reset-token (linked as its element).
Why parent: domains/auth is the existing functional grouping for auth flows.
Why element: a single-purpose token artifact is the minimal concrete piece.
```

11 → 13 노드, frontmatter R14 양식 정확, validate 0 issue. 사용자가 "ontology" 단어 0 회 사용.

## Test plan

- [x] AGENTS.md / SKILL.md 작성
- [x] Demo: 자연 prompt → agent 자율 read + write 동작 (위 결과)
- [x] vault validate clean
- [x] frontmatter preferredOrder 정확
- [ ] 사용자 후속 검증: 실제 코드 task 에서 agent 가 ontology 자동 갱신 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)