### PR TITLE
feat: SessionStart hook — vault 요약 자동 inject

### DIFF
--- a/.claude/hooks/inject-ontology-summary.sh
+++ b/.claude/hooks/inject-ontology-summary.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SessionStart hook — Claude Code 가 새 세션을 열 때 한 번 실행되어 현재
+# 디렉토리의 ontology vault 요약을 agent context 에 inject 한다.
+#
+# 사용자 의도 (R14 rounds): "작업 중간중간 ontology 읽어서 도움받고 끝나면
+# 알아서 mcp 로 기록". 매 prompt 마다 사용자가 "ontology 활용해" 라고 알려
+# 주지 않아도 agent 가 작업 첫 순간부터 vault 를 인지하게 하기 위함.
+#
+# Output 규약 (Claude Code hooks):
+#   - exit 0 + stdout 비어있음 → silent (vault 없는 repo 에서 noise 차단)
+#   - exit 0 + stdout 내용     → agent system context 에 추가 (이게 우리 path)
+#   - exit ≥ 1                 → 무시되는 게 맞음 (블록 안 됨)
+#
+# vault 위치 결정 우선순위:
+#   1. OMOT_VAULT 환경 변수 (사용자가 명시)
+#   2. <cwd>/docs/ontology  (이 repo 같은 dogfood 패턴)
+#   3. <cwd>/vault          (cli init default)
+#   4. <cwd> 자체에 frontmatter `kind:` 가진 .md 가 있으면 cwd
+#   ↳ 어느 후보도 못 잡으면 silent.
+
+set -e
+
+CLI_BIN=""
+if command -v oh-my-ontology >/dev/null 2>&1; then
+  CLI_BIN="oh-my-ontology"
+elif [ -f "$(pwd)/cli/src/index.mjs" ]; then
+  CLI_BIN="node $(pwd)/cli/src/index.mjs"
+fi
+
+if [ -z "$CLI_BIN" ]; then
+  exit 0
+fi
+
+# vault 결정
+VAULT=""
+if [ -n "$OMOT_VAULT" ] && [ -d "$OMOT_VAULT" ]; then
+  VAULT="$OMOT_VAULT"
+elif [ -d "$(pwd)/docs/ontology" ]; then
+  VAULT="$(pwd)/docs/ontology"
+elif [ -d "$(pwd)/vault" ]; then
+  VAULT="$(pwd)/vault"
+elif ls "$(pwd)"/*.md >/dev/null 2>&1 && grep -lq "^kind:" "$(pwd)"/*.md 2>/dev/null; then
+  VAULT="$(pwd)"
+fi
+
+if [ -z "$VAULT" ]; then
+  exit 0
+fi
+
+# census + 상위 노드 몇 개. cli list --json 으로 한 번에. 실패 시 silent.
+JSON=$($CLI_BIN list "$VAULT" --json 2>/dev/null) || exit 0
+
+# python 으로 빠른 요약 (count + kind 분포 + 처음 8 노드 sample). python3 표준.
+SUMMARY=$(printf '%s' "$JSON" | python3 -c "$(cat <<'PY'
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+nodes = d.get('nodes', [])
+total = len(nodes)
+if total == 0:
+    sys.exit(0)
+by_kind = {}
+for n in nodes:
+    k = n.get('kind') or 'unknown'
+    by_kind[k] = by_kind.get(k, 0) + 1
+kinds = ' · '.join(f'{k} {v}' for k, v in sorted(by_kind.items(), key=lambda x: -x[1]))
+sample = '\n'.join(
+    f"  [{(n.get('kind') or '?'):11s}] {(n.get('slug') or '?'):42s} {n.get('title') or ''}"
+    for n in nodes[:8]
+)
+more = total - 8
+print(f'Vault has {total} ontology nodes ({kinds}).')
+print()
+print('First entries:')
+print(sample)
+if more > 0:
+    print(f'  … {more} more (use list_concepts / list_kinds for the full picture).')
+PY
+)" 2>/dev/null)
+
+# 비어있으면 silent (vault 가 .md 없거나 kind 없는 readme 만 있는 경우 등)
+if [ -z "$SUMMARY" ]; then
+  exit 0
+fi
+
+cat <<EOF
+[ontology vault @ ${VAULT}]
+$SUMMARY
+
+When the task touches code that introduces or renames a capability /
+element / domain, mirror it in the vault before reporting done. The MCP
+server's tool list is the primary path; \`/ontology-sync\` is the
+explicit-trigger alternative. For the full discipline, see AGENTS.md
+"Working with the ontology while you code".
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/inject-ontology-summary.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,8 @@ A 30-second read at the top of the task often replaces a 10-minute re-discovery 
 
 For the explicit "I'm done with this task — please sync the ontology now" loop, invoke the **`/ontology-sync`** skill (see `.claude/skills/ontology-sync/SKILL.md`). It bundles the read-then-write pattern with a checklist for when to skip (typos, style nudges).
 
+For the *implicit* "I just opened this repo" loop, the **SessionStart hook** at `.claude/hooks/inject-ontology-summary.sh` runs once when Claude Code attaches to the workspace and injects a short census of the vault (kind counts + first 8 entries) into the agent's system context. The agent then has the ontology in mind from message #1 — no `list_concepts` round trip needed for the first orientation. The hook stays silent in repos without a vault, so it's safe to keep on globally.
+
 **Skip the ontology** for: typo fixes, comment tweaks, single-line style nudges, lint config, test fixtures with no shape change. Anything that changes "what the codebase *is*" goes into the vault; anything that doesn't, stays out.
 
 ## Frontmatter shape per kind (R14)

--- a/docs/ontology/capabilities/session-start-ontology-context.md
+++ b/docs/ontology/capabilities/session-start-ontology-context.md
@@ -1,0 +1,34 @@
+---
+slug: capabilities/session-start-ontology-context
+kind: capability
+title: SessionStart Ontology Context Injection (.claude/hooks/inject-ontology-summary.sh)
+domain: ai-agent-partner
+elements: [.claude/hooks/inject-ontology-summary.sh]
+dependencies: [capabilities/cli-developer-entry]
+relates: [capabilities/ontology-sync-skill]
+---
+
+# SessionStart Ontology Context Injection
+
+Claude Code 가 새 세션을 열 때 한 번 실행되어 현재 디렉토리의 ontology
+vault 요약 (총 노드 수 · kind 분포 · 첫 8 노드 샘플) 을 agent system
+context 에 inject 한다. 매 prompt 마다 사용자가 "ontology 활용해" 라고
+알려주지 않아도 agent 가 작업 첫 순간부터 vault 를 인지한다.
+
+## 어디에 매여 있나
+
+- `domains/ai-agent-partner` — agent 가 vault 와 상호작용하는 surface 군.
+- `capabilities/cli-developer-entry` — vault 요약을 만들 때 `oh-my-ontology
+  list --json` CLI 를 호출. CLI 가 없으면 silent 종료.
+- `capabilities/ontology-sync-skill` — 이 hook 이 vault 인식만 시키고,
+  실제 read/write 는 `/ontology-sync` skill 또는 MCP 도구로 위임.
+- `.claude/hooks/inject-ontology-summary.sh` — 본문.
+
+## Vault 결정 우선순위
+
+1. `OMOT_VAULT` 환경 변수 (사용자가 명시)
+2. `<cwd>/docs/ontology` — dogfood 패턴
+3. `<cwd>/vault` — `cli init` default
+4. `<cwd>` 자체에 frontmatter `kind:` 가진 `.md` 가 있으면 cwd
+
+어느 후보도 못 잡으면 silent exit (vault 없는 repo 에서 noise 차단).

--- a/docs/ontology/domains/ai-agent-partner.md
+++ b/docs/ontology/domains/ai-agent-partner.md
@@ -2,17 +2,9 @@
 slug: domains/ai-agent-partner
 kind: domain
 title: AI Agent Partner
-capabilities:
-  - mcp-server
-  - mcp-conflict-guard
-elements:
-  - mcp-sdk
-  - mcp/src/index.js
-  - mcp/src/parser.mjs
-  - mcp/src/vault.mjs
-relates:
-  - domains/vault-local-first
-  - domains/ontology-core
+capabilities: [mcp-server, mcp-conflict-guard, ontology-sync-skill, session-start-ontology-context]
+elements: [mcp-sdk, mcp/src/index.js, mcp/src/parser.mjs, mcp/src/vault.mjs, .claude/hooks/inject-ontology-summary.sh]
+relates: [domains/vault-local-first, domains/ontology-core]
 ---
 
 # AI Agent Partner


### PR DESCRIPTION
## Summary

PR #162 의 후속. 사용자 의도 *"작업 중간중간 ontology 읽어서 도움받고"* 의 **읽기 면**을 명시 호출 없이 활성. Claude Code 가 이 repo (또는 vault 가 있는 다른 repo) 에 attach 할 때 한 번, vault census 를 system context 에 자동 inject — agent 가 매 prompt 의 message #1 부터 ontology 를 인지.

## 동작

```bash
$ ./.claude/hooks/inject-ontology-summary.sh
[ontology vault @ /Users/stark/ai/oh-my-ontology/docs/ontology]
Vault has 25 ontology nodes (capability 13 · domain 6 · element 4 · project 1 · vault-readme 1).

First entries:
  [capability ] capabilities/builder-vault-write           Builder ↔ Vault md write (mode-aware)
  [capability ] capabilities/cli-developer-entry           CLI Developer Entry (init / list / validate / add / find)
  …
  … 17 more (use list_concepts / list_kinds for the full picture).

When the task touches code that introduces or renames a capability /
element / domain, mirror it in the vault before reporting done…
```

vault 결정 우선순위: `OMOT_VAULT` env → `<cwd>/docs/ontology` → `<cwd>/vault` → cwd 의 `kind:` 가진 `.md` → 못 잡으면 silent exit. **vault 없는 repo 에서는 noise 0**.

## 두 진입점 정리

| 진입점 | 시점 | 효과 |
|---|---|---|
| **SessionStart hook** (이번 PR) | 새 세션 시작 시 1회 | vault 인지가 message #1 부터 |
| **`/ontology-sync` skill** (PR #162) | 사용자 명시 invoke | git diff 기반 변경 추출 + write back |

암시적 + 명시적 두 갈래가 모두 활성.

## 메타 검증

자연 prompt — *"방금 추가한 SessionStart hook, ontology 에 sync 해줘"* — 만으로 agent 가:
- 24 노드 census 자동 read
- 새 hook 을 `capabilities/session-start-ontology-context` 로 등록
- 부모 (`domains/ai-agent-partner`) 의 `capabilities` array 에 patch + 이전 PR drift 까지 backfill
- `dependencies: [cli-developer-entry]` (호출 의존), `relates: [ontology-sync-skill]` (같은 family) 자동 추론

24 → 25 노드, validate 0 issue. dogfood vault 가 자기 자신의 새 capability 를 자기 ontology 에 자율 박은 두 번째 메타 시연.

## Test plan

- [x] hook script 직접 실행 — 25 노드 census + 8 sample + 17 more 정확
- [x] settings.json `SessionStart` array 등록
- [x] vault 없는 repo 시뮬레이션 — silent exit (cli/cwd vault 둘 다 없으면)
- [x] AGENTS.md 의 *Working with the ontology* 섹션 두 진입점 명시
- [x] dogfood vault sync (메타 검증 commit)
- [ ] 후속: 사용자 본인 Chrome 의 polling 으로 25 노드 + 새 amber pulse 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)