### PR TITLE
chore: R14 closeout — 검증 + dogfood sync + 문서 baseline 회복

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "oh-my-ontology": {
+      "command": "node",
+      "args": ["./mcp/src/index.js"],
+      "env": {
+        "OMOT_VAULT": "./docs/ontology"
+      }
+    }
+  }
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,214 +3,181 @@
 > 작업 *순번* 만. user 가 "T?? 진행해" 하면 그것만 분해해서 실행.
 > 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제.
 >
-> **갱신 (2026-05-01 저녁)**: mission v2 cleanup 7 PR 머지 후 전면 재정렬.
+> **갱신 (2026-05-06)**: R12/R13/R14 wave 묶음 정리 후 전면 재정렬. 4 surface 완성, dogfood 25 노드, AI agent ↔ vault 자동 sync 도달.
 
 ---
 
-## ✅ 완료 (mission v2 phase, 2026-05-01)
+## ✅ 완료 (R12-R14, 2026-05-04 ~ 2026-05-05)
 
-### Phase 3 (AI agent partner) + mission v2 cleanup 7 PR 머지
+### R14 (#155-#163, 2026-05-05) — AI agent ↔ vault 자동 sync + 웹 즉시 반영
+
+| PR | 항목 | 결과 |
+|---|---|---|
+| #155 | vault polling 5s | ✅ visible-only `setInterval`, fingerprint diff |
+| #156 | graph diff pulse | ✅ 새 노드 amber sine 5s on `/topology` |
+| #157 | added toast | ✅ 모든 페이지 'Added: <slug>' |
+| #158 | modified toast | ✅ slug 동일 + mtime 변화 'Edited: <slug>' |
+| #159 | walkthrough 5 fix + topology↔ontology 회복 | ✅ /topology 1 노드 → 68 노드 112 엣지 |
+| #160 | frontmatter schema 양식 (3 entry points 동기화) | ✅ `mcp/cli/src/lib/schema.mjs` single source |
+| #161 | CLI `import` — 외부 .md 정규화 후 vault 정착 | ✅ cli 5 → 6 명령 |
+| #162 | `/ontology-sync` skill + AGENTS read-while-coding 룰 | ✅ 명시 trigger 갈래 |
+| #163 | SessionStart hook — vault census 자동 inject | ✅ 암시 trigger 갈래 |
+
+### R13 (#43-#67, 2026-05-04) — AI agent quality 첫 측정 + VSCode plugin
+
+| PR | 항목 | 결과 |
+|---|---|---|
+| #47 #48 | AI agent benchmark 7 task × 3 카테고리 cross-agent (Claude Code + Codex) | ✅ n=2, MCP 가치 measurable (CC: hallucination 9→0, Codex: tool calls -76%) |
+| #45 | MCP `instructions` field (v0.7.1) | ✅ 매 세션 prompt 수준 안내 |
+| #49-#67 | VSCode plugin v0.1.0 → v0.9.0 | ✅ status bar / backlinks / add concept / MCP connect (graph webview는 v0.9 에서 제거) |
+
+### R12 (#27-#42, 2026-05-04) — developer-primary 결정 + CLI 5 명령 + dogfood graph 완전화
 
 | 항목 | 결과 |
 |---|---|
-| **Phase 3 — MCP 서버** | ✅ PR #5/#7 — `mcp/` 패키지 v0.2.0, 7 도구 (`list_concepts` · `get_concept` · `find_evidence` · `find_backlinks` · `add_concept` · `add_relation` · `patch_concept`) |
-| **dogfood vault** | ✅ PR #5/#7/#10 — `docs/ontology/` 21 노드 (1 project + 8 domain + 7 capability + 4 element + 1 vault-readme) |
-| **Stage 1 — UI "분석 시작" CTA 제거** | ✅ PR #5 — 3 view 정리 |
-| **Stage 2 — entity httpsCallable 제거** | ✅ PR #5 — `enqueueKnowledgeExtractionJob` |
-| **Stage 3 — functions/ extraction 제거** | ✅ PR #5 — 1080 → 543 줄, 3 LLM lib 삭제 |
-| **Stage 4 light + full — review queue surface** | ✅ PR #5/#6 — `/review/knowledge`, `applyReviewAction`, 6 view caller, 2 callable, helper 통째 제거 |
-| **Stage 5 / Q1=(a) — `/` ontology hub auto-vault** | ✅ PR #6 — `useOntologyInsight` 신설 |
-| **빈 vault empty-state mode-aware** | ✅ PR #8 |
-| **README + AGENTS mission v2 동기화** | ✅ PR #9 |
-| **V1.1 Wikidata spec 구현** | ✅ PR #10 — `qualifiers?[]` + `rank?` 옵셔널 (additive, breakage 0) |
-| **stale "Demo" title 잔재 정리** | ✅ PR #11 — Playwright MCP QA 발견 |
+| Primary audience = developer + AI agent (PM drop) | ✅ PRODUCT-DIRECTION v3 |
+| CLI 4 새 명령 (`list / validate / add / find`) | ✅ cli v0.2.0 |
+| Cross-package contract 4-way (parser) / 3-way (validator) | ✅ 12fix×4 + 8fix×3 = 72 case |
+| dogfood graph orphan 8 → 1 (의도적 1) | ✅ |
 
-### 그 이전 (refactor/first-principles-slim-1 PR #1, 23 commits)
+### R11 (2026-05-04) — vault tooling + parser contract + MCP graph-level write
 
-| # | 항목 | 결과 |
-|---|---|---|
-| T3+T4 | share-doc 시스템 제거 | ✅ |
-| T5+T6 | AI 추출 client + functions path 제거 | ✅ (mission v2 cleanup 으로 마무리) |
-| T7-T9 | mode-aware (`useProjects` / Drawer / Form / 검수큐 banner) | ✅ |
-| T10 | 빌더 fullscreen | ✅ |
-| T11 | 빌더 트리 시각 위계 | ✅ |
-| T14 | account-settings 단순화 | ✅ |
-| T15 | dev-admin-bypass 제거 | ✅ |
-| T16 | frontmatter parser nested | ✅ |
-| T17 | 빌더 onboarding 카피 | ✅ |
-| T18 | V1.1 qualifiers + rank | ✅ (PR #10) |
-| T25 | client-error 단순화 | ✅ |
-| T26 | dagre layout 단순화 | ✅ |
+| 항목 | 결과 |
+|---|---|
+| `pnpm vault:validate` / `vault:migrate` | ✅ |
+| MCP v0.7.0 — 14 tools (8 read + 6 write, `rename_concept` / `merge_concepts` 추가) | ✅ |
+| 3-way frontmatter parser contract | ✅ |
+| MCP conflict guard (mtime 기반 silent overwrite 차단) | ✅ |
 
 ### Open questions 해소
 
 - **Q1** — `/` 자동 vault 전환 → ✅ (a) 채택, useOntologyInsight 도입
-- **Q2** — share-doc 시스템 제거 → ✅ 이미 제거됨 (commit d27e3d0). `CopyProjectLinkButton` 만 보존
+- **Q2** — share-doc 시스템 제거 → ✅ commit d27e3d0
+- **T30** MCP `find_path(from, to)` → ✅ R11 v0.7.0
+- **T31** MCP `list_kinds` → ✅ R11 v0.7.0 (`list_domains` 는 `list_concepts({ kind: 'domain' })` 으로 cover)
 
 ---
 
-## 결정 필요 (user input 후 unblock)
+## ~~결정 필요 (user input 후 unblock)~~ — Q3-Q8 자체 무효
 
-### V2 spec Open questions Q3-Q8
+`docs/archive/ONTOLOGY-MODEL-V2-DRAFT.md` 의 head 표 (2026-05-02 갱신) 가 답을 이미 확정:
 
-`docs/ONTOLOGY-MODEL-V2-DRAFT.md` §11 의 8 질문 중 Q1·Q2 해소, Q3-Q8 대기:
+- **Q1·Q2** — 해소 (mission v2 cleanup)
+- **Q3-Q7** — 답 확정 (2026-05-02, user 추천 기본 채택)
+- **Q8** — V1.4 자체 N/A (functions/ 폐기로 server-side action 사라짐) → 즉시 영향 0
 
-- **Q3** — V1.x dual-read 기간 (마이그레이션 안전망 길이)
-- **Q4** — V1.4 ActionType 인증 모델 (V1.4 차단)
-- **Q5** — extractionModelId 검증 정책 (V1.3 의 일부)
-- **Q6** — summary 마이그레이션 방식 (V1.2 의 일부)
-- **Q7** — literal naming scope (V1.2 의 일부)
-- **Q8** — ActionInvocation 보존 기간 (V1.4 의 일부)
-- **Q (multi-vault)** — 다중 vault 활성 시점 (v0.x = single 가정 vs 처음부터 multi)
-
-### T13. OperationsNav 온톨로지 탭 분기 결정
-
-mission v2 후 4탭 (문서 / 온톨로지 / 토폴로지 / 정리) 정리 완료. 추가 분기는 user UX 결정 — defer.
+V2 통합 자체도 `mission v2 default path 에서 invisible` 한 cloud 컬렉션 합병이라 ⏸ N/A. **R10b (firebase 영구 제거) 후 V1.x 진화 cloud-side 컨텍스트 자체 dead**. spec 은 *향후 서버 도입 결정 시 재활성* 위해 archive 보존.
 
 ---
 
-## P0 — 즉시 실행 가능 (mission v2 정렬, 위험 낮음, 가치 큼)
+## P0 — 즉시 실행 가능 (위험 낮음, 가치 큼)
 
-### T28. demo blueprint mission v2 정렬
+### ~~T28. demo blueprint mission v2 정렬~~ — VOID
 
-- **현재**: `src/shared/mocks/demo-blueprint.ts` 의 CONTAINER_THEMES 에 "검수 큐", "frontmatter 추출", "stub 승격" 같은 mission v1 잔재 capability
-- **변경**: mission v2 정렬 (vault frontmatter / AI agent partner / MCP / mode-aware)
-- **est**: 1 commit, 데이터 변경만
+`src/shared/mocks/demo-blueprint.ts` 자체가 이미 제거됨 (어느 라운드에 사라졌는지 git log 미확인 — 이미 cleanup 완료). manifest.json 의 잔재 텍스트는 build-time generated docs 인용이라 직접 손볼 대상 아님.
 
 ### T29. /docs/ first-time UX — dogfood vault hint
 
 - **현재**: `/docs/` LocalVaultPicker 가 vault 미활성일 때 generic 안내
 - **개선**: "이 repo 자체의 ontology 를 보려면 `docs/ontology/` 를 선택하세요" 같은 dogfood hint
-- **est**: 1 commit, 위젯 카피 갱신
+- **est**: 1 commit, 위젯 카피 갱신 (en/ko)
 
-### ~~T30. MCP `find_path(from, to)`~~ — ✅ R11 v0.7.0
+### F1. dogfood vscode-plugin capability v0.5.0 → v0.9.0 갱신
 
-mcp 14 도구의 read 8 에 포함. BFS, undirected, maxHops default 5.
+- **현재**: `docs/ontology/capabilities/vscode-plugin-ide-entry.md` 가 v0.5.0 (R13 중반 snapshot). 트리에 그대로 노출
+- **변경**: v0.9.0 (graph webview 제거 후) 반영. status bar / backlinks / add concept / MCP connect 4 surface
+- **est**: 1 commit, capability frontmatter + body 갱신
 
-### ~~T31. MCP `list_kinds` / `list_domains`~~ — ✅ R11 v0.7.0
+### F2. VaultDiffToaster diff logic 단위 test
 
-`list_kinds` 구현. `list_domains` 는 `list_concepts({ kind: 'domain' })` 으로 cover (별도 도구 불필요).
+- **현재**: `src/features/docs-vault-local/model/VaultDiffToaster.tsx` 의 added/modified 분류 + mtime 비교 + null guard 가 unit test 부재. 사용자 강조한 "웹 즉시 반응" 의 핵심 회귀 risk
+- **변경**: diff 계산을 pure helper 로 추출, 8+ case (첫 mount baseline / added / modified / 둘 다 / null mtime skip / overflow PREVIEW)
+- **est**: 2 commit, helper 추출 + test 추가
 
----
+### C3. AI agent benchmark scale n=2 → n=5+ — *user-triggered*
 
-## P1 — V1.x 진화 (additive, breakage 0)
-
-### T19. V1.5 — Relation Cardinality
-
-- "belongs_to.sourceCardinality = 'one'" 같은 1:1 / 1:N 제약
-- spec: `docs/ONTOLOGY-MODEL-V2-DRAFT.md` §6
-- 의존: 없음 (T18 ✅ 후 가능)
-- est: 3-5 commit
-
-### T20. V1.3 — Rich References
-
-- evidence 에 `retrievedAt` / `extractionModelId` / `confidence`
-- spec: §4
-- 의존: Q5 답변 (extractionModelId 검증 정책)
-- est: 3-5 commit
-
-### T21. V1.2 — Literal Properties
-
-- node 에 `description` / `color` / `releasedAt` 같은 atomic property
-- 새 컬렉션 `knowledgeApprovedLiterals/{literalId}`
-- spec: §3
-- 의존: Q6 (summary 마이그레이션) + Q7 (literal naming scope)
-- est: 7-10 commit
-
-### T32. V1.4 — Action Type — DEFERRED
-
-- spec: §5 + `docs/ACTION-TYPE-SECURITY-DRAFT.md`
-- 의존: Q4 (인증 모델) + 보안 sub-spec 통과
-- est: TBD — DEFERRED 명시
-
-### T22. V2 통합 KnowledgeStatement (5-phase)
-
-- 의존: T18 ✅ + T19 + T20 + T21 모두 stable + 90일 dual-read soak
-- est: 30+ commit, 9-12 개월
+- **현재**: R13 의 cross-agent (Claude Code + Codex) benchmark n=2. 강한 confirming evidence
+- **상태**: R14 closeout 에서 `docs/benchmark/README.md` 에 "Current measurement status" + 재측정 가이드 (`pnpm benchmark --bypass` 등) 추가. 실제 측정은 user 가 explicit trigger
+  - Codex 자동: `--dangerously-bypass-approvals-and-sandbox` 가 필요해 user 명시 승인
+  - Claude Code self: 새 session 에서 manual walk
+- **재측정 가치 시점**: vault 25 → 50 노드 도달 시점 (effect 가 scale 되는지 saturate 되는지)
 
 ---
 
-## ~~P2 — Phase 4 (비개발자 surface 다듬기)~~ — DROPPED (R12 #33)
+## ~~P1 — V1.x 진화 (cloud-first 가정)~~ — 모두 N/A 또는 머지됨
 
-PRODUCT-DIRECTION v3 (R12 fire #25 / #33) 에서 PM-primary 결정 reverted.
-> Primary audience = developer + their AI agent. PM-친화 surface = bonus, not target.
+R10b (firebase / functions / firestore 영구 제거) 후 cloud-side 진화 컨텍스트 자체 사라짐. archive spec 의 진행 상태표 (2026-05-02):
 
-T33-36 는 *if-bonus* 로 격하. 사용자 explicit 요청 들어오면 재평가.
+| Track | 상태 |
+|---|---|
+| V1.1 — Statement Qualifiers + Rank | ✅ 머지 (PR #10) |
+| V1.5 — Relation Cardinality | ✅ 머지 (PR #23) |
+| V1.2 — Literal Properties | 🟡 vault-adaptation (cloud collection 신설 안 함, frontmatter scalar 직접 편집 PR 진행 중) |
+| V1.3 — Rich References | ⏸ N/A — cloud LLM 추출 흐름 폐기 |
+| V1.4 — Action Type | ⏸ N/A — server-side action 게이트 폐기 |
+| V2 — 통합 KnowledgeStatement | ⏸ N/A — cloud 컬렉션 invisible |
 
-### ~~T33. 빌더 onboarding "ERD 이상" 카피 정렬~~ — dropped
-### ~~T34. 기술 용어 ↔ 한국어 일반 용어 매핑 layer~~ — dropped
-### ~~T35. 노드 색 / 아이콘 — kind 별 친숙~~ — dropped
-### ~~T36. 검색 시 "코드 / 문서 / 사람" 분류~~ — dropped
+미래 cloud collab 단계 재도입 시 archive 로부터 재활성. 현재 P1 무.
 
 ---
 
 ## P3 — 인프라 / 회귀 차단
 
-### T23. mode-aware e2e tests
-
-- local / cloud / static 시나리오로 각 surface 검증
-- needs: Firebase emulator 셋업 (m4 와 같은 의존)
-- est: 3-5 commit + 인프라
-
-### T37. mode-aware Playwright MCP routine QA
+### T37. Playwright MCP routine QA
 
 - 매 PR 또는 nightly 로 핵심 라우트 navigate + console error check
 - needs: CI runner 가 Playwright MCP 실행 가능한가 확인
 - est: 1-2 commit
 
+### F3. .mcp.json git-tracked (✅ 이번 R14 closeout 에서 추가)
+
+- 사용자가 git clone 후 Claude Code 열면 즉시 14 tools 자동 등록.
+
+### ~~T23. mode-aware e2e tests~~ — VOID (R10b)
+
+R10b 에서 firebase 제거. cloud / static 모드 구분 자체가 사라짐.
+
 ### ~~T38. functions Firestore 컬렉션 archival~~ — VOID (R10b)
-
-R10b 에서 firebase / functions / firestore 의존 통째 삭제. archival 대상 자체 사라짐.
-
 ### ~~T24. knowledge-* 컬렉션 통합 검토~~ — VOID (R10b)
-
-knowledge-* 컬렉션 자체가 사라짐. vault frontmatter 가 단일 진실원.
 
 ---
 
 ## P4 — Marginal value (defer)
 
-### ~~MCP `delete_concept`~~ — ✅ R11 v0.4 + v0.7
-
-R11 v0.4 에 dry-run + backlinks 가드 + force 추가. R11 v0.7 에 expected_mtime conflict guard 통합. mcp 14 도구의 write 6 에 포함.
-
-### MCP `rename_concept` / `merge_concepts` — ✅ R11 v0.7.0 (NEW)
-
-graph-level write 도구. atomic backlink redirect (frontmatter array · inline string · body links). dry-run default + expected_mtime guard. 14 도구의 write 6.
-- 결정: defer
-
 ### CHANGELOG batch cleanup
-- 완료된 ✅ 항목들을 BACKLOG 에서 제거 + CHANGELOG 로 이동
-- 운영 작업, 가치 marginal
+완료된 ✅ 항목들을 BACKLOG 에서 제거 + CHANGELOG 로 이동. 운영 작업, 가치 marginal.
 
 ### T12. NodeDetailPanel evidence excerpt modal
-- 트리 row evidence chip 클릭 시 markdown 발췌 modal
-- AI 영역 의존 — T20 (rich references) 후
+T20 (rich references) 후.
 
 ### T27. 큰 view 파일 정리
-- `KnowledgeDocumentDetailPage` (이미 -300 줄 정리됨, 1100+ 줄 잔여)
-- mission v2 후 정리 가치 marginal — defer
+- `KnowledgeDocumentDetailPage` (이미 -300 줄 정리됨, 1100+ 줄 잔여) — defer
 
-### m4. 비활성화된 e2e 재활성화
-- T23 와 같은 의존 (Firebase emulator)
+---
+
+## ~~P2 — Phase 4 (비개발자 surface 다듬기)~~ — DROPPED (R12 #33)
+
+PRODUCT-DIRECTION v3 에서 PM-primary 결정 reverted.
+> Primary audience = developer + their AI agent. PM-친화 surface = bonus, not target.
+
+T33-36 는 *if-bonus* 로 격하. 사용자 explicit 요청 들어오면 재평가.
 
 ---
 
 ## 추천 진행 순서
 
-1. **P0 (T28-T31)** — mission v2 정렬 + MCP ergonomics 즉시 처리
-2. **Q3-Q8 user 답** — V1.2/V1.3 차단 풀기
-3. **T19 (V1.5)** — Q 답 무관, 즉시 가능
-4. **T20 (V1.3)** + **T21 (V1.2)** — Q5/Q6/Q7 답 후
-5. **P2 (T33-T36)** — 비개발자 surface 다듬기 (Phase 4)
-6. **T23 / T37** — 인프라 (Firebase emulator, Playwright MCP CI)
-7. **T22 V2 통합** — 마지막
+P1 V1.x 진화가 모두 ✅/N/A 로 닫혔고, 4 surface 도 모두 작동. 현재는 *signal-driven* — user 명시 product call 또는 사용자 보고 들어오는 것 위주.
+
+1. **P0 잔여 (C3 user-trigger)** — 사용자 시간 날 때 `pnpm benchmark --bypass` 실행
+2. **T37** — 인프라 (Playwright MCP CI) — nightly QA 가치 검토
+3. **V1.2 vault-adaptation** — frontmatter literal property (description / color / releasedAt) 빌더 인스펙터 직접 편집 — PR 진행 중이면 closure
+4. **사용자 product call** — 비개발자 surface (R12 dropped) 재평가 / VSCode plugin marketplace publish / npm publish 등은 사용자 명시 트리거
 
 ## 참조 문서
 
-- `docs/PRODUCT-DIRECTION.md` — mission v2 방향, 4 phase
+- `docs/PRODUCT-DIRECTION.md` — mission v3 방향
 - `docs/FEATURES.md` — 사용자가 *지금* 사용 가능한 기능 전수
-- `docs/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x → V2 spec
-- `docs/MISSION-CLEANUP-CANDIDATES.md` — 4 stage cleanup 진행 (모두 ✅)
+- `docs/archive/ONTOLOGY-MODEL-V2-DRAFT.md` — V1.x 진화 spec (cloud 부분 N/A archive)
 - `docs/CHANGELOG.md` — 시간순 사용자 가시 변화
-- `mcp/README.md` — MCP 서버 7 도구 + 등록
+- `mcp/README.md` — MCP 서버 14 도구 + 등록
+- `docs/benchmark/` — AI agent quality 측정 매트릭스

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,107 @@
 
 ---
 
+## 2026-05-05 — Round 14: AI agent ↔ vault 자동 sync + 웹 즉시 반영 + frontmatter schema
+
+R13 closure 후 *"개발자와 AI agent 가 같이 키운다"* 미션의 자동성 강화. 두 갈래 — agent 가 vault 를 알아서 읽고/쓰고, 그 변화가 웹에 즉시 흘러오고. 9 PR 묶음 (#155-#163).
+
+### Web 즉시 반영 — polling → 그래프 pulse → 두 toast (#155 #156 #157 #158)
+
+사용자 명시 *"웹에서나 잘 반영되면 좋겠는데? 그걸 강화하는건 어때"* 의 4 단계 완성.
+
+| Step | What | Where 인지 |
+|---|---|---|
+| #155 polling | 5s 간격 fingerprint check + visible-only 자동 reload | 백그라운드 |
+| #156 graph diff pulse | 새 노드 amber sine 5s | `/topology` 그래프 |
+| #157 added toast | `Added: <slug>` info toast | 모든 페이지 |
+| #158 modified toast | `Edited: <slug>` success toast (mtime 변화) | 모든 페이지 |
+
+이제 IDE / AI agent / CLI 어느 surface 가 vault 만지면 웹 탭 *focus 안 해도* ~5s 안에 그래프 + toast. `prevSlugsRef Set` → `prevMapRef Map<slug, mtime|null>` 로 확장해 added/modified 분기. static manifest (mtime null) 은 비교 skip 으로 false-positive 차단.
+
+- `use-local-vault.ts` — `setInterval(tryReload, 5000)` visible-only, hidden 시 dispose
+- `widgets/topology-map-sigma` — `runtimeRecentSlugs` 5s set, 기존 `recentPulse` 인프라 재사용
+- `features/docs-vault-local/model/VaultDiffToaster.tsx` 신설 — 첫 mount baseline, 이후 added/modified 분류, PREVIEW 3 + "+N more"
+- 사용자 검증 단계: dev server → IDE 에서 `oh-my-ontology add` 또는 `.md` 편집 → 5s 안 toast + 그래프 pulse
+
+### Walkthrough 검증 + topology↔ontology 회복 (#159)
+
+R14 walkthrough 에서 발견된 4 이슈 + 사용자 약속한 topology↔ontology 연계 회복.
+
+- **i18n 404** — `app/[locale]/not-found.tsx` 추가, client-side locale 감지로 ko/en 분기. 이전엔 정적 export 한계로 `/ko/foo` 가 영문 fallback 만 떴다.
+- **home UX 간격** — 좌하단 hint 카드와 stats bar 가 거의 붙어 있던 것을 `bottom-14` → `bottom-20` 으로 24px gap. 데이터 경고 alert 에 `ChevronRight` affordance.
+- **stale doc** — AGENTS.md / .claude/rules/architecture.md 의 살아있는 라우트 목록에서 `/ontology/relations` 표기 제거 (R12 에서 사라졌고 분포 정보는 `/ontology/insights` 안으로 통합).
+- **🚨 topology↔ontology 연계 회복** — `/topology` 가 dogfood 환경에서 *"1 노드 · 0 엣지"* 빈 화면이었던 회귀를 회복. `buildGraph` 에 `ontologyExtension` 옵션 추가, vault frontmatter 의 도메인 / 역량 / 요소 노드와 그 관계까지 같은 그래프에 그림. `isOntology` 플래그로 size scaling / owner overlay 분기에서 제외 → project 본 골격 보존. 결과 1 노드 → **68 노드 · 112 엣지** 로 회복.
+
+### Frontmatter schema 양식 — three entry points 동기화 (#160)
+
+사용자 질문 *"AI agent 가 같은 양식으로 작성하게 인식 가능한 구조"* 의 1차 답변. 두 진입점 (`add_concept` MCP · `add` CLI) 이 같은 schema 모듈을 통해 .md 만들고, 같은 advisory warnings 노출.
+
+이전: `cli/templates/vault/` 에 kind 별 견본은 있었지만 `cli init` 만 사용. `add_concept` / `cli add` 는 `slug + kind + title` 만 박고 arrayDefaults 미채움 → AI agent 가 만든 capability 가 `elements: []` 슬롯조차 없는 .md 로 disk 에 남았다.
+
+- **`mcp/src/schema.mjs` · `cli/src/lib/schema.mjs`** — single source. kind 별 `arrayDefaults` (project: domains/capabilities/elements, domain: capabilities, capability: elements), `requiredExtras` (capability/element 의 domain), `folder`, kind 별 starter body. 두 파일 lock-step.
+- **3-way validator** 가 새 issue code `missing-expected-field` 동시에 인식. severity=warning (error 아님) → pre-existing vault 호환 보존.
+- **Contract test** `tests/contract/vault-schema.contract.test.ts` — mcp/cli 두 schema 가 같은 결과 + UI 측 `KIND_EXPECTED_EXTRAS` 일치 강제.
+
+### CLI `import` — 외부 .md schema 정규화 후 vault 정착 (#161)
+
+#160 위에 분기, 사용자 약속의 *"우리 양식을 주면 그대로 작성해서 md import"* 답변. 세 진입점 (`add_concept` MCP · `add` CLI · 새 `import` CLI) 이 모두 같은 schema 모듈 통해 .md 만든다.
+
+```bash
+oh-my-ontology import <path...> [options]
+  --vault path          target vault root (default: cwd)
+  --kind K              fallback kind when input has no frontmatter kind:
+  --auto-prefix         kind→folder (capability → capabilities/)
+  --rename              slug clash 시 -2 / -3 ... 자동 회피
+  --dry-run             디스크 변경 0, plan 만 출력
+```
+
+처리: `parseFrontmatter` → kind/slug/title resolve (입력 frontmatter > flag > basename) → `buildFrontmatter` → 충돌 detect → `writeDoc`. 입력의 다른 키 (depends_on / 사용자 정의 …) 보존, 빈 body 면 schema starter. `.git` / `node_modules` / dotfile 디렉토리 walk skip.
+
+cli integration test 13 → **20 case**. cli `init / list / validate / add / find / import` **6 명령** 으로 확장.
+
+### `/ontology-sync` agent skill + AGENTS read-while-coding 룰 (#162)
+
+사용자 의도 *"AI agent 가 작업 중간 ontology 읽어서 도움받고, 끝나면 알아서 vault 에 기록"* 의 자동성 강화.
+
+- **AGENTS.md 의 'Working with the ontology while you code' 섹션** 추가 — Read at start (`list_kinds` / `list_concepts` / `get_concept` / `find_backlinks` / `find_path`) + Write at end (`add_concept` / `add_relation` / `rename_concept` / `merge_concepts` / `patch_concept`) + skip 케이스 (typo, style, fixture). agent 시스템 prompt 수준에 박혀 매 prompt 활성.
+- **`.claude/skills/ontology-sync/SKILL.md`** — `/ontology-sync` slash command. 사용자 명시 invoke 시 git diff + 컨텍스트로 ontology delta 식별 → MCP write 도구로 반영. reply 5 줄 max, failure mode 4 종 (duplicate slug / dangling parent / mtime conflict / backlink rot) cover.
+
+Demo: 자연 prompt — *"password reset 추가하려고 plan"* — 만으로 agent 가 11 → 13 노드, frontmatter R14 양식 정확, validate 0 issue 로 자율 작성. 사용자가 "ontology" 단어 0 회 사용.
+
+### SessionStart hook — vault 요약 자동 inject (#163)
+
+#162 의 후속. 명시 호출 없이 *읽기 면* 활성. Claude Code 가 vault 있는 repo 에 attach 하면 한 번 census 를 system context 에 자동 inject — agent 가 매 prompt message #1 부터 ontology 인지.
+
+vault 결정 우선순위: `OMOT_VAULT` env → `<cwd>/docs/ontology` → `<cwd>/vault` → cwd 의 `kind:` 가진 `.md` → 못 잡으면 silent exit. **vault 없는 repo 에서 noise 0**.
+
+| 진입점 | 시점 | 효과 |
+|---|---|---|
+| **SessionStart hook** (#163) | 새 세션 시작 시 1회 | vault 인지가 message #1 부터 |
+| **`/ontology-sync` skill** (#162) | 사용자 명시 invoke | git diff 기반 변경 추출 + write back |
+
+암시적 + 명시적 두 갈래 활성. 메타 검증: dogfood vault 가 자기 자신의 새 hook 을 자기 ontology 에 자율 박음 — *"방금 추가한 SessionStart hook, ontology 에 sync 해줘"* 한 줄에 24 → 25 노드, dependencies/relates 자동 추론.
+
+### Dogfood vault 갱신
+
+R14 의 새 capability 2 노드 추가:
+- `capabilities/ontology-sync-skill` (`.claude/skills/ontology-sync`)
+- `capabilities/session-start-ontology-context` (`.claude/hooks/inject-ontology-summary.sh`)
+
+23 → **25 노드** (capability 13 · domain 6 · element 4 · project 1 · vault-readme 1). `pnpm vault:validate` clean.
+
+### 4 surface 모두 작동
+
+| Surface | 진입 | 상태 |
+|---|---|---|
+| **CLI** | `oh-my-ontology init / list / validate / add / find / import` | v0.2.x (6 명령) |
+| **MCP** | 14 tools (8 read + 6 write) | v0.7.1 |
+| **Web** | `/`, `/topology`, `/docs`, `/ontology`, `/ontology/edit`, `/ontology/insights`, `/projects`, `/project/[slug]` | R10 surface diet 후 |
+| **VSCode plugin** | status bar match · backlinks · add concept · MCP connect (graph webview R13 #67 에서 제거) | v0.9.0 |
+
+→ "개발자가 어디 있든 같은 vault, 같이 자라남" 의 read 자동 + write 자동 + 즉시 반영 까지 도달.
+
+---
+
 ## 2026-05-04 — Round 13: AI agent quality 첫 측정 + VSCode plugin MVP
 
 R12 closure 후 *제품 핵심 가설* 첫 측정. 측정 결과 강한 confirming evidence 위에 README 약속의 미완성 surface (VSCode plugin) 첫 구현.

--- a/docs/benchmark/README.md
+++ b/docs/benchmark/README.md
@@ -100,3 +100,27 @@ Each of the 7 tasks should be measured 4 times:
 - **Cross-agent consistency** — does the effect hold across Claude Code and Codex, or is it agent-specific?
 
 Results will be summarized in this README and (if signal is strong) in the project's main README under "Verifiable promises".
+
+## Current measurement status
+
+| Run | Vault | Agents (n) | Result file | Headline |
+|---|---|---|---|---|
+| R13 first | 22 nodes | Claude Code self + Codex bypass (n=2) | `results/2026-05-04-claude-code.md` · `results/2026-05-04-codex.md` | CC: hallucination 9→0, +1.0 correctness · Codex: tool calls 7.0→1.67 (-76%), correctness saturated |
+
+R14 (post-2026-05-05) note: vault grew **22 → 25 nodes** (added `capabilities/ontology-sync-skill` + `capabilities/session-start-ontology-context`). Re-measurement is **user-triggered** since Codex bypass requires explicit `--dangerously-bypass-approvals-and-sandbox` and Claude Code self-run requires a manual session.
+
+### Re-measurement triggers (user runs these manually)
+
+```bash
+# Codex 14-cell automated re-measurement (full bypass, ~20 min)
+pnpm benchmark --bypass
+
+# Codex ON-only 7 cells (faster, ~10 min)
+pnpm benchmark --bypass --on-only
+
+# Claude Code self-measurement is manual — open a new session and walk
+# the 7 prompts in tasks.md, recording transcripts into a new
+# results/<date>-claude-code.md.
+```
+
+Aim: when the vault grows another ~25 nodes (≈50 total), re-measure to test whether the MCP advantage **scales** (graph reasoning gain widens) or **saturates** (raw grep also works fine at 50 nodes).

--- a/docs/ontology/capabilities/vault-live-updates.md
+++ b/docs/ontology/capabilities/vault-live-updates.md
@@ -1,0 +1,48 @@
+---
+slug: capabilities/vault-live-updates
+kind: capability
+title: Vault Live Updates (5s polling + diff toast + graph pulse)
+domain: vault-local-first
+elements:
+  - src/features/docs-vault-local/model/use-local-vault.ts
+  - src/features/docs-vault-local/model/VaultDiffToaster.tsx
+  - src/features/docs-vault-local/lib/diff-manifest.ts
+  - src/widgets/topology-map-sigma/lib/graph-build.ts
+relates:
+  - capabilities/builder-vault-write
+  - capabilities/mcp-conflict-guard
+  - capabilities/topology-sigma-render
+  - domains/vault-local-first
+---
+
+# Vault Live Updates (5s polling + diff toast + graph pulse)
+
+R14 (#155-#158, 2026-05-04 ~ 2026-05-05) 에 도입된 *web 즉시 반영* 능력. 사용자 명시 *"웹에서나 잘 반영되면 좋겠는데? 그걸 강화하는건 어때"* 의 4 단계 답. IDE / AI agent / CLI 어느 surface 가 vault `.md` 만지면 웹 탭이 *focus 안 해도* ~5s 안에 반영.
+
+## 4 단계 흐름
+
+| Step | What | Where 인지 |
+|---|---|---|
+| #155 polling | 5s 간격 fingerprint check + visible-only 자동 reload | 백그라운드 |
+| #156 graph diff pulse | 새 노드 amber sine 5s | `/topology` 그래프 |
+| #157 added toast | `Added: <slug>` info toast | 모든 페이지 |
+| #158 modified toast | `Edited: <slug>` success toast (mtime 변화) | 모든 페이지 |
+
+## 핵심 결정
+
+- **5초 간격** — 사람의 인지 갱신 속도 (≈"몇 초 안에 반영") 와 fingerprint 비용 (큰 vault 도 수십 ms) 의 sweet spot. 10s 면 답답, 1s 면 과한 cpu.
+- **visibility-aware** — 탭 hidden 일 때 `clearInterval` 로 polling dispose (배터리 / cpu 절약). visible 복귀 시 재시작.
+- **첫 mount baseline** — `prevMapRef.current === null` 일 때는 baseline 만 저장, toast 띄우지 않음 (false-positive 차단).
+- **mtime null skip** — static manifest (build-time, mtime 없음) 와 비교는 의미 없으니 modified 판정 skip.
+- **removed 무시** — 사용자 명시 `delete_concept` 명령은 자체 toast. polling 결과로 또 띄우면 noise.
+
+## diff helper 분리
+
+`lib/diff-manifest.ts` 의 `diffVaultManifest(prev, current)` 는 React 외 dependency 없는 pure helper. 9 단위 case 로 added / modified / mtime 단조성 / null guard / overflow 분기 회귀 차단.
+
+## 참조 PR
+
+- #155 polling 5s
+- #156 graph diff pulse
+- #157 added toast (Set → Map<slug, mtime|null> 확장)
+- #158 modified toast (mtime 비교)

--- a/docs/ontology/capabilities/vscode-plugin-ide-entry.md
+++ b/docs/ontology/capabilities/vscode-plugin-ide-entry.md
@@ -1,7 +1,7 @@
 ---
 slug: capabilities/vscode-plugin-ide-entry
 kind: capability
-title: VSCode Plugin (IDE Entry, v0.5.0)
+title: VSCode Plugin (IDE Entry, v0.9.0)
 domain: onboarding-ux
 elements:
   - vscode-plugin/src/extension.ts
@@ -19,15 +19,13 @@ relates:
   - domains/onboarding-ux
 ---
 
-# VSCode Plugin (IDE Entry, v0.5.0)
+# VSCode Plugin (IDE Entry, v0.9.0)
 
-R13 (2026-05-04) 에 도입된 *developer-primary IDE* 진입점. README 가
-약속해 둔 "(planned) VSCode plugin" 의 first MVP 부터 v0.5.0 까지. CLI 가
-터미널 진입, MCP 가 AI agent 진입이라면 이 plugin 은 **VSCode 안에서
-직접 vault 노드 보고, 코드 ↔ ontology 점프하고, 새 노드 생성하고,
-backlinks 탐색**.
+R13 (2026-05-04) 에 도입된 *developer-primary IDE* 진입점. CLI 가 터미널, MCP 가 AI agent 진입이라면 이 plugin 은 **VSCode 안에서 직접 vault 노드 보고, 코드 ↔ ontology 점프하고, 새 노드 생성/이름변경/병합하고, backlinks 탐색**.
 
-## v0.5.0 의 4 surface
+v0.1.0 MVP → v0.5.0 (e2e + self-match) → v0.6.0 (informative status bar) → v0.7.0 (rename / merge commands) → v0.8.0-v0.8.2 (graph webview 시도) → **v0.9.0 (graph webview 제거 — 웹의 강점 영역으로 위임)**.
+
+## v0.9.0 의 4 surface
 
 ### 1. Ontology TreeView (v0.1.0)
 
@@ -37,47 +35,49 @@ backlinks 탐색**.
 - workspace 의 `docs/ontology/` 자동 detect, 다른 폴더는 picker (`ohMyOntology.pickVault`)
 - vault path 영속 (`globalState` + 설정 `oh-my-ontology.vaultPath`)
 
-### 2. 코드 ↔ ontology 점프 (v0.2.0 + v0.5.0 self-match)
+### 2. 코드 ↔ ontology 점프 + informative status bar (v0.2.0 + v0.5.0 self-match + v0.6.0)
 
 - 활성 editor 의 파일 path 와 vault 노드 매치 시 status bar (좌측) 에 노드 title 표시
+- v0.6.0: 매치 종류 (self / exact / ancestor / element-array) 와 노드 kind 가 status bar tooltip 에 명시 — 사용자가 *왜 이 노드와 매치됐는지* 즉시 파악
 - 매치 우선순위: self-match (활성 파일이 ontology .md 자체) > exact path > directory ancestor > capability.elements 배열
 - status bar 클릭 → `ohMyOntology.openMatchedNode` → 해당 .md 열기
 
-### 3. Add concept (v0.3.0 — write surface)
+### 3. Add concept + Rename / Merge (v0.3.0 → v0.7.0 — write surface)
 
-- Command Palette: `oh-my-ontology: Add concept` 또는 TreeView 헤더 `+` 버튼
-- QuickPick (kind) → InputBox (slug) → InputBox (title) → optional domain
-- KIND_FOLDER auto-prefix (`capabilities/foo`, `domains/foo`, `elements/foo`) — CLI `add` 와 동일 contract
-- 기존 slug throw — silent overwrite 차단
-- 작성 후 tree refresh + 새 .md 자동 열림
+- **Add concept** — Command Palette: `oh-my-ontology: Add concept` 또는 TreeView 헤더 `+` 버튼. QuickPick (kind) → InputBox (slug) → InputBox (title) → optional domain → KIND_FOLDER auto-prefix. CLI `add` 와 동일 contract.
+- **Rename concept (v0.7.0)** — TreeView context menu 또는 Command Palette. dry-run preview (영향 받는 backlink 개수) → confirm → MCP `rename_concept` 로 atomic 갱신.
+- **Merge concepts (v0.7.0)** — 두 노드 합치기. 같은 dry-run / confirm 패턴. 두 명령 모두 silent overwrite 차단 + mtime conflict guard.
+- 작성/변경 후 tree refresh + 결과 .md 자동 열림.
 
 ### 4. Backlinks panel (v0.4.0 — MCP server connect)
 
 - 두 번째 TreeView 'Backlinks (current file)' — 활성 editor 매치 노드의 backlinks 표시
-- v0.5.0: ontology .md 직접 열어도 자동 populate (self-match 가 트리거)
+- ontology .md 직접 열어도 자동 populate (self-match 가 트리거)
 - 데이터 소스: `oh-my-ontology-mcp` 의 `find_backlinks` 도구 (plugin 이 spawn)
 - MCP 실패 시 raw filesystem scan (`computeBacklinksLocally`) 으로 graceful fallback
 - `useMcp` 설정으로 끄기 가능
 
+## v0.8 → v0.9 — graph webview 제거 결정
+
+v0.8.0-v0.8.2 에서 IDE 안에서 vault 그래프 시각화를 webview 로 시도. CSP nonce 이슈 (#66 fix) 를 해결한 후에도 *웹의 Sigma WebGL 그래프 대비 가치 marginal* 판단 → v0.9.0 (#67) 에서 제거. 그래프 시각화는 `pnpm dev` → `/topology` 에서 보고, IDE 안에서는 트리 + 점프 + 작성에 집중.
+
+대신 빈 Backlinks 패널 placeholder 에 *"For a graph view of the whole vault, run `pnpm dev` and open `/topology` in the browser."* 안내 link 추가.
+
 ## 5-way parser contract 편입
 
-`vscode-plugin/src/parse-frontmatter.ts` 가 5-way 계약 5번째 진입점
-(이전 4: src/shared, mcp, scripts/lib, cli). 12 fixture × 5 parser = 60
-case 가 매 PR 마다 drift 차단. 동일 lenient 파서 = vault 호환성 보장.
+`vscode-plugin/src/parse-frontmatter.ts` 가 5-way 계약 5번째 진입점 (이전 4: src/shared, mcp, scripts/lib, cli). 12 fixture × 5 parser = 60 case 가 매 PR 마다 drift 차단. 동일 lenient 파서 = vault 호환성 보장.
 
 ## 4-layer 자동 검증
 
 | Layer | 기법 | 무엇 검증 |
 |---|---|---|
-| 단위 logic | `node --test` × 27 case (code-match / write-vault / backlinks-local) | parser / matcher / writer / fallback logic |
-| MCP integration | spawn `mcp/src/index.js` × 3 case (mcp-client.test.mjs) | wire protocol drift |
-| VSCode integration | `@vscode/test-electron` × 5 case (extension.test.ts) | activation / commands / config / contributes |
+| 단위 logic | `node --test` (code-match / write-vault / backlinks-local) | parser / matcher / writer / fallback logic |
+| MCP integration | spawn `mcp/src/index.js` (mcp-client.test.mjs) | wire protocol drift |
+| VSCode integration | `@vscode/test-electron` (extension.test.ts) | activation / commands / config / contributes |
 | Marketplace 준비 | `vsce package` (CI step) | manifest / icon / files / contributes shape |
 
 CI 매 PR 마다 1–4 자동 — plugin 깨지면 즉시 fail.
 
 ## Marketplace 미발행
 
-사용자가 `code --install-extension oh-my-ontology-vscode-0.5.0.vsix` 로
-본인 VSCode (또는 fork — Cursor / Antigravity 호환) 에 설치해 일상 사용.
-Marketplace 발행 결정은 본인이 충분히 사용해본 후 명시 승인.
+사용자가 `code --install-extension oh-my-ontology-vscode-0.9.0.vsix` 로 본인 VSCode (또는 fork — Cursor / Antigravity 호환) 에 설치해 일상 사용. Marketplace 발행 결정은 본인이 충분히 사용해본 후 명시 승인.

--- a/docs/ontology/domains/vault-local-first.md
+++ b/docs/ontology/domains/vault-local-first.md
@@ -5,6 +5,7 @@ title: Vault — Local-First
 capabilities:
   - vault-validator
   - vault-migrator
+  - vault-live-updates
 elements:
   - file-system-access-api
   - src/features/docs-vault-local
@@ -19,6 +20,7 @@ relates:
 # Vault — Local-First
 
 사용자 디스크 폴더를 진실원으로. File System Access API + IndexedDB 기반 핸들 영속.
-focus / visibility 시 fingerprint 비교로 재스캔 short-circuit.
+focus / visibility 시 fingerprint 비교로 재스캔 short-circuit. R14 부터는 visible
+인 동안 5s polling 으로 *focus 안 해도* 자동 반영 (`vault-live-updates`).
 
 자세한 원칙: `.claude/rules/local-first.md`. 사용자 surface: `docs/FEATURES.md`.

--- a/messages/en.json
+++ b/messages/en.json
@@ -1000,7 +1000,7 @@
       "sourceServer": "Sample",
       "sourceLocal": "Local",
       "ontologyHintPrefix": "First time? Try selecting this repo's ",
-      "ontologyHintSuffix": " — this tool's own ontology (18 nodes) appears in the tree instantly.",
+      "ontologyHintSuffix": " — this tool's own ontology vault appears in the tree instantly (dogfooding).",
       "newDoc": "New doc"
     },
     "mobileDrawer": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1000,7 +1000,7 @@
       "sourceServer": "샘플",
       "sourceLocal": "로컬",
       "ontologyHintPrefix": "처음이세요? 이 repo 의 ",
-      "ontologyHintSuffix": "를 선택해 보세요 — 이 도구 자체의 ontology (18 노드) 가 즉시 트리에 등장합니다.",
+      "ontologyHintSuffix": "를 선택해 보세요 — 이 도구 자체의 ontology vault 가 즉시 트리에 등장합니다 (dogfood).",
       "newDoc": "새 문서"
     },
     "mobileDrawer": {

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-04T04:06:28.207Z",
+  "generatedAt": "2026-05-05T23:07:01.220Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",
@@ -76,9 +76,9 @@
           "slug": "source-of-truth-files"
         }
       ],
-      "excerpt": "202605 update — Round 10 permanently removed all auth + cloud surface. This doc reflects the postR10 state. Earlier cloudmode design notes are in docs/archive/. There is no backend, no database, no auth provider. The user's markdown folder is the single source of truth. Import direction: app → views → widgets → feature",
-      "wordCount": 795,
-      "updatedAt": "2026-05-04T01:27:35.682Z",
+      "excerpt": "202605 update — Round 10 permanently removed all auth + cloud surface. This doc reflects the postR10 state. Earlier cloudmode design notes are in docs/archive/. There is no backend, no database, no auth provider. The user's markdown folder is the single source of truth. Both the MCP server (AI agent) and the CLI (devel",
+      "wordCount": 939,
+      "updatedAt": "2026-05-04T07:25:28.161Z",
       "linksOut": [
         "../AGENTS",
         "PRODUCT-DIRECTION",
@@ -1589,13 +1589,13 @@
         },
         {
           "depth": 3,
-          "text": "T30. MCP `find_path(from, to)` — 두 노드 사이 graph 경로",
-          "slug": "t30-mcp-find_pathfrom-to-두-노드-사이-graph-경로"
+          "text": "~~T30. MCP `find_path(from, to)`~~ — ✅ R11 v0.7.0",
+          "slug": "t30-mcp-find_pathfrom-to-r11-v070"
         },
         {
           "depth": 3,
-          "text": "T31. MCP `list_kinds` / `list_domains` — kind 분포 요약",
-          "slug": "t31-mcp-list_kinds-list_domains-kind-분포-요약"
+          "text": "~~T31. MCP `list_kinds` / `list_domains`~~ — ✅ R11 v0.7.0",
+          "slug": "t31-mcp-list_kinds-list_domains-r11-v070"
         },
         {
           "depth": 2,
@@ -1629,28 +1629,28 @@
         },
         {
           "depth": 2,
-          "text": "P2 — Phase 4 (비개발자 surface 다듬기)",
-          "slug": "p2-phase-4-비개발자-surface-다듬기"
+          "text": "~~P2 — Phase 4 (비개발자 surface 다듬기)~~ — DROPPED (R12 #33)",
+          "slug": "p2-phase-4-비개발자-surface-다듬기-dropped-r12-33"
         },
         {
           "depth": 3,
-          "text": "T33. 빌더 onboarding \"ERD 이상 — 도메인 지도\" 카피 정렬",
-          "slug": "t33-빌더-onboarding-erd-이상-도메인-지도-카피-정렬"
+          "text": "~~T33. 빌더 onboarding \"ERD 이상\" 카피 정렬~~ — dropped",
+          "slug": "t33-빌더-onboarding-erd-이상-카피-정렬-dropped"
         },
         {
           "depth": 3,
-          "text": "T34. 기술 용어 ↔ 한국어 일반 용어 매핑 layer",
-          "slug": "t34-기술-용어-한국어-일반-용어-매핑-layer"
+          "text": "~~T34. 기술 용어 ↔ 한국어 일반 용어 매핑 layer~~ — dropped",
+          "slug": "t34-기술-용어-한국어-일반-용어-매핑-layer-dropped"
         },
         {
           "depth": 3,
-          "text": "T35. 노드 색 / 아이콘 — kind 별 친숙",
-          "slug": "t35-노드-색-아이콘-kind-별-친숙"
+          "text": "~~T35. 노드 색 / 아이콘 — kind 별 친숙~~ — dropped",
+          "slug": "t35-노드-색-아이콘-kind-별-친숙-dropped"
         },
         {
           "depth": 3,
-          "text": "T36. 검색 시 \"코드 / 문서 / 사람\" 분류 (PM 친화)",
-          "slug": "t36-검색-시-코드-문서-사람-분류-pm-친화"
+          "text": "~~T36. 검색 시 \"코드 / 문서 / 사람\" 분류~~ — dropped",
+          "slug": "t36-검색-시-코드-문서-사람-분류-dropped"
         },
         {
           "depth": 2,
@@ -1684,8 +1684,13 @@
         },
         {
           "depth": 3,
-          "text": "MCP `delete_concept`",
-          "slug": "mcp-delete_concept"
+          "text": "~~MCP `delete_concept`~~ — ✅ R11 v0.4 + v0.7",
+          "slug": "mcp-delete_concept-r11-v04-v07"
+        },
+        {
+          "depth": 3,
+          "text": "MCP `rename_concept` / `merge_concepts` — ✅ R11 v0.7.0 (NEW)",
+          "slug": "mcp-rename_concept-merge_concepts-r11-v070-new"
         },
         {
           "depth": 3,
@@ -1719,8 +1724,595 @@
         }
       ],
       "excerpt": "작업 순번 만. user 가 \"T?? 진행해\" 하면 그것만 분해해서 실행. 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제. 갱신 (20260501 저녁): mission v2 cleanup 7 PR 머지 후 전면 재정렬. | 항목 | 결과 | ||| | Phase 3 — MCP 서버 | ✅ PR 5/7 — mcp/ 패키지 v0.2.0, 7 도구 (listconcepts · getconcept · findevidence · findbacklinks · addconcept · addrelation · patchconcept) | | dogfood vaul",
-      "wordCount": 1423,
-      "updatedAt": "2026-05-04T01:27:35.683Z",
+      "wordCount": 1360,
+      "updatedAt": "2026-05-04T07:36:28.715Z",
+      "linksOut": []
+    },
+    {
+      "slug": "benchmark/README",
+      "path": "docs/benchmark/README.md",
+      "title": "Benchmark — does the ontology actually help AI agents?",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark — does the ontology actually help AI agents?",
+          "slug": "benchmark-does-the-ontology-actually-help-ai-agents"
+        },
+        {
+          "depth": 2,
+          "text": "Why this exists",
+          "slug": "why-this-exists"
+        },
+        {
+          "depth": 2,
+          "text": "What's in here",
+          "slug": "whats-in-here"
+        },
+        {
+          "depth": 2,
+          "text": "How to measure",
+          "slug": "how-to-measure"
+        },
+        {
+          "depth": 3,
+          "text": "Codex automated run",
+          "slug": "codex-automated-run"
+        },
+        {
+          "depth": 3,
+          "text": "Manual run protocol",
+          "slug": "manual-run-protocol"
+        },
+        {
+          "depth": 3,
+          "text": "Setup",
+          "slug": "setup"
+        },
+        {
+          "depth": 3,
+          "text": "Run protocol",
+          "slug": "run-protocol"
+        },
+        {
+          "depth": 3,
+          "text": "Run all four cells per task",
+          "slug": "run-all-four-cells-per-task"
+        },
+        {
+          "depth": 2,
+          "text": "Honest measurement principles",
+          "slug": "honest-measurement-principles"
+        },
+        {
+          "depth": 2,
+          "text": "What we're hoping to learn",
+          "slug": "what-were-hoping-to-learn"
+        }
+      ],
+      "excerpt": "The single biggest unverified premise of this project: \"AI agents work better when they can read and write the codebase ontology vault.\" Until we have data, this is a belief, not a claim. This folder is the first attempt to put it on a measurement scale. We built CLI · MCP · 14 tools · web workbench all on top of one a",
+      "wordCount": 862,
+      "updatedAt": "2026-05-04T11:40:08.267Z",
+      "linksOut": [
+        "benchmark/tasks",
+        "benchmark/rubric",
+        "benchmark/results/2026-05-template"
+      ]
+    },
+    {
+      "slug": "benchmark/results/2026-05-04-claude-code",
+      "path": "docs/benchmark/results/2026-05-04-claude-code.md",
+      "title": "Benchmark run — 2026-05-04 — Claude Code (self-measurement)",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark run — 2026-05-04 — Claude Code (self-measurement)",
+          "slug": "benchmark-run-2026-05-04-claude-code-self-measurement"
+        },
+        {
+          "depth": 2,
+          "text": "Setup",
+          "slug": "setup"
+        },
+        {
+          "depth": 2,
+          "text": "Per-task results",
+          "slug": "per-task-results"
+        },
+        {
+          "depth": 3,
+          "text": "A1 — Domain composition (vault-local-first)",
+          "slug": "a1-domain-composition-vault-local-first"
+        },
+        {
+          "depth": 3,
+          "text": "A2 — Stub / unfinished detection (kind=capability AND NOT has(elements))",
+          "slug": "a2-stub-unfinished-detection-kindcapability-and-not-haselements"
+        },
+        {
+          "depth": 3,
+          "text": "A3 — Reference graph for capabilities/mcp-server",
+          "slug": "a3-reference-graph-for-capabilitiesmcp-server"
+        },
+        {
+          "depth": 3,
+          "text": "B1 — Validator issue codes",
+          "slug": "b1-validator-issue-codes"
+        },
+        {
+          "depth": 3,
+          "text": "B2 — Conflict guard mechanism",
+          "slug": "b2-conflict-guard-mechanism"
+        },
+        {
+          "depth": 3,
+          "text": "C1 — Function exports of validate-vault-document.ts (negative control)",
+          "slug": "c1-function-exports-of-validate-vault-documentts-negative-control"
+        },
+        {
+          "depth": 3,
+          "text": "C2 — package.json scripts (negative control)",
+          "slug": "c2-packagejson-scripts-negative-control"
+        },
+        {
+          "depth": 2,
+          "text": "Summary",
+          "slug": "summary"
+        },
+        {
+          "depth": 3,
+          "text": "Within-agent delta (Claude Code OFF → ON, primary signal)",
+          "slug": "within-agent-delta-claude-code-off-on-primary-signal"
+        },
+        {
+          "depth": 3,
+          "text": "Hallucination totals",
+          "slug": "hallucination-totals"
+        },
+        {
+          "depth": 2,
+          "text": "Interpretation",
+          "slug": "interpretation"
+        },
+        {
+          "depth": 3,
+          "text": "Decision implications",
+          "slug": "decision-implications"
+        },
+        {
+          "depth": 2,
+          "text": "Raw transcripts",
+          "slug": "raw-transcripts"
+        },
+        {
+          "depth": 2,
+          "text": "What's next",
+          "slug": "whats-next"
+        }
+      ],
+      "excerpt": "Caveat — read this before the numbers. This run was performed by Claude Code (Opus 4.7, 1M context) measuring itself. The MCPoff mode was simulated by deliberately using only Read/Grep/Bash/Edit. The MCPon mode was simulated by spawning mcp/src/index.js with stdio JSONRPC (the real protocol path Claude Code uses when o",
+      "wordCount": 1775,
+      "updatedAt": "2026-05-04T08:29:49.277Z",
+      "linksOut": []
+    },
+    {
+      "slug": "benchmark/results/2026-05-04-codex",
+      "path": "docs/benchmark/results/2026-05-04-codex.md",
+      "title": "Benchmark run — 2026-05-04 — Codex CLI",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark run — 2026-05-04 — Codex CLI",
+          "slug": "benchmark-run-2026-05-04-codex-cli"
+        },
+        {
+          "depth": 2,
+          "text": "Setup",
+          "slug": "setup"
+        },
+        {
+          "depth": 2,
+          "text": "A surprising finding before the table",
+          "slug": "a-surprising-finding-before-the-table"
+        },
+        {
+          "depth": 2,
+          "text": "Per-task results",
+          "slug": "per-task-results"
+        },
+        {
+          "depth": 3,
+          "text": "A1 — Domain composition",
+          "slug": "a1-domain-composition"
+        },
+        {
+          "depth": 3,
+          "text": "A2 — Stub / unfinished detection",
+          "slug": "a2-stub-unfinished-detection"
+        },
+        {
+          "depth": 3,
+          "text": "A3 — Reference graph for capabilities/mcp-server",
+          "slug": "a3-reference-graph-for-capabilitiesmcp-server"
+        },
+        {
+          "depth": 3,
+          "text": "B1 — Validator issue codes",
+          "slug": "b1-validator-issue-codes"
+        },
+        {
+          "depth": 3,
+          "text": "B2 — Conflict guard mechanism",
+          "slug": "b2-conflict-guard-mechanism"
+        },
+        {
+          "depth": 3,
+          "text": "C1 — Function exports (negative control)",
+          "slug": "c1-function-exports-negative-control"
+        },
+        {
+          "depth": 3,
+          "text": "C2 — package.json scripts (negative control)",
+          "slug": "c2-packagejson-scripts-negative-control"
+        },
+        {
+          "depth": 2,
+          "text": "Summary",
+          "slug": "summary"
+        },
+        {
+          "depth": 3,
+          "text": "Within-agent delta (Codex OFF → ON)",
+          "slug": "within-agent-delta-codex-off-on"
+        },
+        {
+          "depth": 3,
+          "text": "Hallucination totals",
+          "slug": "hallucination-totals"
+        },
+        {
+          "depth": 2,
+          "text": "Cross-agent comparison (Claude Code vs Codex)",
+          "slug": "cross-agent-comparison-claude-code-vs-codex"
+        },
+        {
+          "depth": 2,
+          "text": "Honest interpretation",
+          "slug": "honest-interpretation"
+        },
+        {
+          "depth": 2,
+          "text": "Decision implications",
+          "slug": "decision-implications"
+        },
+        {
+          "depth": 2,
+          "text": "Caveats",
+          "slug": "caveats"
+        },
+        {
+          "depth": 2,
+          "text": "Re-measurement attempt (same day, structural finding)",
+          "slug": "re-measurement-attempt-same-day-structural-finding"
+        },
+        {
+          "depth": 3,
+          "text": "Structural finding",
+          "slug": "structural-finding"
+        },
+        {
+          "depth": 3,
+          "text": "What this means for the benchmark",
+          "slug": "what-this-means-for-the-benchmark"
+        },
+        {
+          "depth": 3,
+          "text": "Updated cross-agent conclusion",
+          "slug": "updated-cross-agent-conclusion"
+        },
+        {
+          "depth": 2,
+          "text": "Re-measurement — bypass authorized (same day, n=2 attempt)",
+          "slug": "re-measurement-bypass-authorized-same-day-n2-attempt"
+        },
+        {
+          "depth": 3,
+          "text": "Per-task results (Codex MCP-on with bypass)",
+          "slug": "per-task-results-codex-mcp-on-with-bypass"
+        },
+        {
+          "depth": 3,
+          "text": "Headline metrics — Codex bypass run (Codex OFF → ON-bypass)",
+          "slug": "headline-metrics-codex-bypass-run-codex-off-on-bypass"
+        },
+        {
+          "depth": 3,
+          "text": "Final cross-agent conclusion (n=2 measured)",
+          "slug": "final-cross-agent-conclusion-n2-measured"
+        },
+        {
+          "depth": 3,
+          "text": "Important caveat for Codex automation",
+          "slug": "important-caveat-for-codex-automation"
+        },
+        {
+          "depth": 2,
+          "text": "Raw data",
+          "slug": "raw-data"
+        }
+      ],
+      "excerpt": "Companion to 20260504claudecode.md. Same 7 tasks, same rubric, different agent stack. Repo HEAD: post PR 130–133 merge Vault: 22 nodes, 5% orphans (project root) Codex CLI: codexcli 0.128.0 (model: gpt5.5, sandbox: readonly, approval: never) MCP registration: codex mcp add ohmyontology env OMOTVAULT=... node mcp/src/in",
+      "wordCount": 2629,
+      "updatedAt": "2026-05-04T08:58:33.017Z",
+      "linksOut": [
+        "benchmark/results/2026-05-04-claude-code"
+      ]
+    },
+    {
+      "slug": "benchmark/results/2026-05-04-codex-scale-N100-summary",
+      "path": "docs/benchmark/results/2026-05-04-codex-scale-N100-summary.md",
+      "title": "Benchmark scale — 2026-05-04 — Codex (N=100)",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark scale — 2026-05-04 — Codex (N=100)",
+          "slug": "benchmark-scale-2026-05-04-codex-n100"
+        },
+        {
+          "depth": 2,
+          "text": "Result",
+          "slug": "result"
+        },
+        {
+          "depth": 2,
+          "text": "Interpretation",
+          "slug": "interpretation"
+        }
+      ],
+      "excerpt": "Tmp vault: /var/folders/4y/kbv6fs2g9fmpp7236t79rc0000gn/T/omotscale1001hNgIV (N=100 nodes, 32 reference elements/hub). Single highMCPadvantage task (findbacklinks(elements/hub)). | Mode | Shell exec | MCP calls | Duration | ||||| | OFF | 3 | 0 | 21.6s | | ON | 8 | 0 | 35.0s | Δ shell calls: 5 (negative = MCP saved exec",
+      "wordCount": 105,
+      "updatedAt": "2026-05-04T11:45:31.991Z",
+      "linksOut": []
+    },
+    {
+      "slug": "benchmark/results/2026-05-template",
+      "path": "docs/benchmark/results/2026-05-template.md",
+      "title": "Benchmark run — YYYY-MM-DD",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark run — YYYY-MM-DD",
+          "slug": "benchmark-run-yyyy-mm-dd"
+        },
+        {
+          "depth": 2,
+          "text": "Setup",
+          "slug": "setup"
+        },
+        {
+          "depth": 2,
+          "text": "Per-task results",
+          "slug": "per-task-results"
+        },
+        {
+          "depth": 3,
+          "text": "A1 — Domain composition",
+          "slug": "a1-domain-composition"
+        },
+        {
+          "depth": 3,
+          "text": "A2 — Stub / unfinished detection",
+          "slug": "a2-stub-unfinished-detection"
+        },
+        {
+          "depth": 3,
+          "text": "A3 — Reference graph for a specific node",
+          "slug": "a3-reference-graph-for-a-specific-node"
+        },
+        {
+          "depth": 3,
+          "text": "B1 — Validator issue codes",
+          "slug": "b1-validator-issue-codes"
+        },
+        {
+          "depth": 3,
+          "text": "B2 — Conflict guard mechanism",
+          "slug": "b2-conflict-guard-mechanism"
+        },
+        {
+          "depth": 3,
+          "text": "C1 — Function exports (negative control)",
+          "slug": "c1-function-exports-negative-control"
+        },
+        {
+          "depth": 3,
+          "text": "C2 — package.json scripts (negative control)",
+          "slug": "c2-packagejson-scripts-negative-control"
+        },
+        {
+          "depth": 2,
+          "text": "Summary",
+          "slug": "summary"
+        },
+        {
+          "depth": 3,
+          "text": "Within-agent delta (primary signal)",
+          "slug": "within-agent-delta-primary-signal"
+        },
+        {
+          "depth": 3,
+          "text": "Tool-call efficiency",
+          "slug": "tool-call-efficiency"
+        },
+        {
+          "depth": 3,
+          "text": "Hallucination totals",
+          "slug": "hallucination-totals"
+        },
+        {
+          "depth": 2,
+          "text": "Interpretation",
+          "slug": "interpretation"
+        },
+        {
+          "depth": 2,
+          "text": "Raw transcripts",
+          "slug": "raw-transcripts"
+        }
+      ],
+      "excerpt": "Rename this file to your actual run date (e.g. 20260510.md). Each run goes in its own file so we can track effect over time as the ontology evolves. Repo HEAD: <git revparse HEAD Vault size: <pnpm dogfood:walk | grep \"vault size\" nodes Claude Code version: <claude version Codex CLI version: <codex version Date / grader",
+      "wordCount": 787,
+      "updatedAt": "2026-05-04T08:22:28.421Z",
+      "linksOut": []
+    },
+    {
+      "slug": "benchmark/rubric",
+      "path": "docs/benchmark/rubric.md",
+      "title": "Rubric — how to score each run",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Rubric — how to score each run",
+          "slug": "rubric-how-to-score-each-run"
+        },
+        {
+          "depth": 2,
+          "text": "The four axes",
+          "slug": "the-four-axes"
+        },
+        {
+          "depth": 3,
+          "text": "1. Correctness (0–3) — primary score",
+          "slug": "1-correctness-03-primary-score"
+        },
+        {
+          "depth": 3,
+          "text": "2. Tool-call count",
+          "slug": "2-tool-call-count"
+        },
+        {
+          "depth": 3,
+          "text": "3. Hallucinations (count)",
+          "slug": "3-hallucinations-count"
+        },
+        {
+          "depth": 3,
+          "text": "4. Subjective utility (1–5) — last, optional",
+          "slug": "4-subjective-utility-15-last-optional"
+        },
+        {
+          "depth": 2,
+          "text": "What the data should show",
+          "slug": "what-the-data-should-show"
+        },
+        {
+          "depth": 3,
+          "text": "If the ontology helps (positive result)",
+          "slug": "if-the-ontology-helps-positive-result"
+        },
+        {
+          "depth": 3,
+          "text": "If the ontology doesn't help (null result)",
+          "slug": "if-the-ontology-doesnt-help-null-result"
+        },
+        {
+          "depth": 3,
+          "text": "If the ontology hurts (negative result)",
+          "slug": "if-the-ontology-hurts-negative-result"
+        },
+        {
+          "depth": 2,
+          "text": "A note on ties",
+          "slug": "a-note-on-ties"
+        }
+      ],
+      "excerpt": "Score each agent × mode × task cell (28 cells total per measurement run). Be strict. If you find yourself wanting to round up because the agent \"almost\" got it, write the gap in the Notes column instead of inflating. | Score | Meaning | ||| | 3 | Fully correct. Every item the prompt asked for is present and accurate; n",
+      "wordCount": 638,
+      "updatedAt": "2026-05-04T08:22:28.421Z",
+      "linksOut": []
+    },
+    {
+      "slug": "benchmark/tasks",
+      "path": "docs/benchmark/tasks.md",
+      "title": "Benchmark tasks",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Benchmark tasks",
+          "slug": "benchmark-tasks"
+        },
+        {
+          "depth": 2,
+          "text": "Category A — cross-cutting graph questions",
+          "slug": "category-a-cross-cutting-graph-questions"
+        },
+        {
+          "depth": 3,
+          "text": "A1 — Domain composition",
+          "slug": "a1-domain-composition"
+        },
+        {
+          "depth": 3,
+          "text": "A2 — Stub / unfinished detection",
+          "slug": "a2-stub-unfinished-detection"
+        },
+        {
+          "depth": 3,
+          "text": "A3 — Reference graph for a specific node",
+          "slug": "a3-reference-graph-for-a-specific-node"
+        },
+        {
+          "depth": 2,
+          "text": "Category B — semantic / design questions",
+          "slug": "category-b-semantic-design-questions"
+        },
+        {
+          "depth": 3,
+          "text": "B1 — Validator issue codes",
+          "slug": "b1-validator-issue-codes"
+        },
+        {
+          "depth": 3,
+          "text": "B2 — Conflict guard mechanism",
+          "slug": "b2-conflict-guard-mechanism"
+        },
+        {
+          "depth": 2,
+          "text": "Category C — negative control (raw grep / read sufficient)",
+          "slug": "category-c-negative-control-raw-grep-read-sufficient"
+        },
+        {
+          "depth": 3,
+          "text": "C1 — Function exports",
+          "slug": "c1-function-exports"
+        },
+        {
+          "depth": 3,
+          "text": "C2 — package.json scripts",
+          "slug": "c2-packagejson-scripts"
+        },
+        {
+          "depth": 2,
+          "text": "How tasks were chosen",
+          "slug": "how-tasks-were-chosen"
+        }
+      ],
+      "excerpt": "7 tasks across 3 categories. Each has a known correct answer (verifiable by human against the current docs/ontology/ vault, code, and PR history) so we can grade independent of the AI's confidence. Paste the prompt verbatim into a fresh agent session. No followups. Questions where the answer requires reasoning over mul",
+      "wordCount": 796,
+      "updatedAt": "2026-05-04T08:22:28.422Z",
       "linksOut": []
     },
     {
@@ -1734,6 +2326,96 @@
           "depth": 1,
           "text": "CHANGELOG",
           "slug": "changelog"
+        },
+        {
+          "depth": 2,
+          "text": "2026-05-04 — Round 13: AI agent quality 첫 측정 + VSCode plugin MVP",
+          "slug": "2026-05-04-round-13-ai-agent-quality-첫-측정-vscode-plugin-mvp"
+        },
+        {
+          "depth": 3,
+          "text": "AI agent quality benchmark (#47, #48)",
+          "slug": "ai-agent-quality-benchmark-47-48"
+        },
+        {
+          "depth": 3,
+          "text": "MCP `instructions` field (#45)",
+          "slug": "mcp-instructions-field-45"
+        },
+        {
+          "depth": 3,
+          "text": "VSCode plugin v0.1.0 MVP (#49)",
+          "slug": "vscode-plugin-v010-mvp-49"
+        },
+        {
+          "depth": 3,
+          "text": "Scaffold drift 정정 (#46)",
+          "slug": "scaffold-drift-정정-46"
+        },
+        {
+          "depth": 3,
+          "text": "VSCode plugin v0.2.0 → v0.5.0 (#50 #51 #52 #54 #55)",
+          "slug": "vscode-plugin-v020-v050-50-51-52-54-55"
+        },
+        {
+          "depth": 3,
+          "text": "4-layer 자동 검증 (#53 #55)",
+          "slug": "4-layer-자동-검증-53-55"
+        },
+        {
+          "depth": 3,
+          "text": "4 surface 완성",
+          "slug": "4-surface-완성"
+        },
+        {
+          "depth": 2,
+          "text": "2026-05-04 — Round 12: developer-primary 방향 + CLI 5 명령 + dogfood graph 강화",
+          "slug": "2026-05-04-round-12-developer-primary-방향-cli-5-명령-dogfood-graph-강화"
+        },
+        {
+          "depth": 3,
+          "text": "Primary audience 결정 (#33)",
+          "slug": "primary-audience-결정-33"
+        },
+        {
+          "depth": 3,
+          "text": "CLI 4 새 명령 (#32 #34 #35) — developer 매일 진입점",
+          "slug": "cli-4-새-명령-32-34-35-developer-매일-진입점"
+        },
+        {
+          "depth": 3,
+          "text": "Cross-package contract 4-way / 3-way (#32 #27 후속)",
+          "slug": "cross-package-contract-4-way-3-way-32-27-후속"
+        },
+        {
+          "depth": 3,
+          "text": "AI agent dogfood walk + graph 완전화 (#38 #39)",
+          "slug": "ai-agent-dogfood-walk-graph-완전화-38-39"
+        },
+        {
+          "depth": 3,
+          "text": "영구 가드 추가 (R11 8 → R12 10)",
+          "slug": "영구-가드-추가-r11-8-r12-10"
+        },
+        {
+          "depth": 3,
+          "text": "Tarball 정밀화",
+          "slug": "tarball-정밀화"
+        },
+        {
+          "depth": 3,
+          "text": "신규 file (R12)",
+          "slug": "신규-file-r12"
+        },
+        {
+          "depth": 3,
+          "text": "Test count",
+          "slug": "test-count"
+        },
+        {
+          "depth": 3,
+          "text": "다음 (R13 candidates, 신호 대기)",
+          "slug": "다음-r13-candidates-신호-대기"
         },
         {
           "depth": 2,
@@ -2341,9 +3023,9 @@
           "slug": "before-2026-04-30"
         }
       ],
-      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. 분석 기반 1원칙 라운드. silent corruption / parser drift / schema 진화 부재 / AI agent write 비대칭 4 갭을 한",
-      "wordCount": 8818,
-      "updatedAt": "2026-05-04T03:39:22.419Z",
+      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. R12 closure 후 제품 핵심 가설 첫 측정. 측정 결과 강한 confirming evidence 위에 README 약속의 미완성 surface (VSCod",
+      "wordCount": 10022,
+      "updatedAt": "2026-05-04T11:25:09.018Z",
       "linksOut": [
         "slug"
       ]
@@ -3123,8 +3805,8 @@
         }
       ],
       "excerpt": "Complete inventory of features users can actually use right now. Last updated: 20260503 (postRound9 — surface diet 8 rounds + LocalVaultProvider + robustness audit) Update trigger: reflect immediately when surfaces are added or removed. Update alongside the PR body and CHANGELOG. Mission v2: \"an ontology of the codebas",
-      "wordCount": 4053,
-      "updatedAt": "2026-05-04T02:20:35.054Z",
+      "wordCount": 4061,
+      "updatedAt": "2026-05-04T05:38:08.586Z",
       "linksOut": [
         "slug",
         "project:slug",
@@ -3414,6 +4096,41 @@
       "linksOut": []
     },
     {
+      "slug": "ontology/capabilities/cli-developer-entry",
+      "path": "docs/ontology/capabilities/cli-developer-entry.md",
+      "title": "CLI Developer Entry (init / list / validate / add / find)",
+      "tags": [],
+      "frontmatter": {
+        "slug": "capabilities/cli-developer-entry",
+        "kind": "capability",
+        "title": "CLI Developer Entry (init / list / validate / add / find)",
+        "domain": "onboarding-ux",
+        "elements": [
+          "cli/src/index.mjs",
+          "cli/src/commands/list.mjs",
+          "cli/src/commands/validate.mjs",
+          "cli/src/commands/add.mjs",
+          "cli/src/commands/find.mjs"
+        ],
+        "relates": [
+          "capabilities/mcp-server",
+          "capabilities/vault-validator",
+          "domains/onboarding-ux"
+        ]
+      },
+      "headings": [
+        {
+          "depth": 1,
+          "text": "CLI Developer Entry",
+          "slug": "cli-developer-entry"
+        }
+      ],
+      "excerpt": "R12 (20260504) 에 도입된 developerprimary 진입점. 5 명령으로 사용자가 vault 만든 후 터미널 즉시 ontology 작업 가능 — 웹 UI / MCP 등록 불필요. | Command | What it does | ||| | ohmyontology init [folder] | Scaffold vault (5 starter .md + .mcp.json.example) | | ohmyontology list [vault] | List ontology nodes (color table, kind X filter, json) | | ohmyont",
+      "wordCount": 181,
+      "updatedAt": "2026-05-04T07:32:33.448Z",
+      "linksOut": []
+    },
+    {
       "slug": "ontology/capabilities/frontmatter-to-ontology",
       "path": "docs/ontology/capabilities/frontmatter-to-ontology.md",
       "title": "Frontmatter → Ontology Stub",
@@ -3424,8 +4141,8 @@
         "title": "Frontmatter → Ontology Stub",
         "domain": "ontology-core",
         "elements": [
-          "src/shared/lib/parse-frontmatter",
-          "src/entities/docs-vault/lib/derive-ontology-from-vault"
+          "src/shared/lib/parse-frontmatter.ts",
+          "src/entities/docs-vault/lib/derive-ontology-from-vault.ts"
         ],
         "relates": [
           "domains/vault-local-first",
@@ -3441,7 +4158,7 @@
       ],
       "excerpt": "vault 의 .md 파일 frontmatter 를 직접 읽어 OntologyStub (nodes + edges + warnings) 으로 변환. AI 추출 / 검수 큐 거치지 않는 fastpath. 이게 mission \"frontmatter 가 자기승인\" 의 코드 표현. 지원 frontmatter 키: kind: — canonical 5: project / domain / capability / element / document title:, domain: capabilities: [], elements: [] — 배열 노드 relates: [], dependenc",
       "wordCount": 79,
-      "updatedAt": "2026-05-04T01:27:35.685Z",
+      "updatedAt": "2026-05-04T11:37:08.799Z",
       "linksOut": []
     },
     {
@@ -3588,6 +4305,82 @@
       "linksOut": []
     },
     {
+      "slug": "ontology/capabilities/ontology-sync-skill",
+      "path": "docs/ontology/capabilities/ontology-sync-skill.md",
+      "title": "Ontology-Sync Agent Skill (.claude/skills/ontology-sync)",
+      "tags": [],
+      "frontmatter": {
+        "slug": "capabilities/ontology-sync-skill",
+        "kind": "capability",
+        "title": "Ontology-Sync Agent Skill (.claude/skills/ontology-sync)",
+        "domain": "ai-agent-partner",
+        "elements": [
+          ".claude/skills/ontology-sync/SKILL.md"
+        ],
+        "dependencies": [
+          "capabilities/mcp-server"
+        ]
+      },
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Ontology-Sync Agent Skill",
+          "slug": "ontology-sync-agent-skill"
+        },
+        {
+          "depth": 2,
+          "text": "어디에 매여 있나",
+          "slug": "어디에-매여-있나"
+        }
+      ],
+      "excerpt": "Claude Code 가 코드 변경 후 자동으로 호출하는 userinvocable skill. .claude/skills/ontologysync/SKILL.md 한 파일이 곧 surface — 새 capability / element / domain 가 등장하면 MCP write 도구 (addconcept / patchconcept / addrelation) 로 vault 에 반영하라는 워크플로를 LLM 에게 지시한다. MCP 서버가 런타임 도구 라면 이 skill 은 사용 규약 — readthenwrite, 중복 slug 회피, 5 줄 changelog reply,",
+      "wordCount": 105,
+      "updatedAt": "2026-05-05T15:22:53.804Z",
+      "linksOut": []
+    },
+    {
+      "slug": "ontology/capabilities/session-start-ontology-context",
+      "path": "docs/ontology/capabilities/session-start-ontology-context.md",
+      "title": "SessionStart Ontology Context Injection (.claude/hooks/inject-ontology-summary.sh)",
+      "tags": [],
+      "frontmatter": {
+        "slug": "capabilities/session-start-ontology-context",
+        "kind": "capability",
+        "title": "SessionStart Ontology Context Injection (.claude/hooks/inject-ontology-summary.sh)",
+        "domain": "ai-agent-partner",
+        "elements": [
+          ".claude/hooks/inject-ontology-summary.sh"
+        ],
+        "dependencies": [
+          "capabilities/cli-developer-entry"
+        ],
+        "relates": [
+          "capabilities/ontology-sync-skill"
+        ]
+      },
+      "headings": [
+        {
+          "depth": 1,
+          "text": "SessionStart Ontology Context Injection",
+          "slug": "sessionstart-ontology-context-injection"
+        },
+        {
+          "depth": 2,
+          "text": "어디에 매여 있나",
+          "slug": "어디에-매여-있나"
+        },
+        {
+          "depth": 2,
+          "text": "Vault 결정 우선순위",
+          "slug": "vault-결정-우선순위"
+        }
+      ],
+      "excerpt": "Claude Code 가 새 세션을 열 때 한 번 실행되어 현재 디렉토리의 ontology vault 요약 (총 노드 수 · kind 분포 · 첫 8 노드 샘플) 을 agent system context 에 inject 한다. 매 prompt 마다 사용자가 \"ontology 활용해\" 라고 알려주지 않아도 agent 가 작업 첫 순간부터 vault 를 인지한다. domains/aiagentpartner — agent 가 vault 와 상호작용하는 surface 군. capabilities/clideveloperentry — vault 요약을 만들 때 ohmyontolo",
+      "wordCount": 152,
+      "updatedAt": "2026-05-05T15:29:33.665Z",
+      "linksOut": []
+    },
+    {
       "slug": "ontology/capabilities/topology-sigma-render",
       "path": "docs/ontology/capabilities/topology-sigma-render.md",
       "title": "Topology — Sigma WebGL Render",
@@ -3711,6 +4504,85 @@
       "linksOut": []
     },
     {
+      "slug": "ontology/capabilities/vscode-plugin-ide-entry",
+      "path": "docs/ontology/capabilities/vscode-plugin-ide-entry.md",
+      "title": "VSCode Plugin (IDE Entry, v0.5.0)",
+      "tags": [],
+      "frontmatter": {
+        "slug": "capabilities/vscode-plugin-ide-entry",
+        "kind": "capability",
+        "title": "VSCode Plugin (IDE Entry, v0.5.0)",
+        "domain": "onboarding-ux",
+        "elements": [
+          "vscode-plugin/src/extension.ts",
+          "vscode-plugin/src/walk-vault.ts",
+          "vscode-plugin/src/tree-provider.ts",
+          "vscode-plugin/src/parse-frontmatter.ts",
+          "vscode-plugin/src/code-match.ts",
+          "vscode-plugin/src/write-vault.ts",
+          "vscode-plugin/src/mcp-client.ts",
+          "vscode-plugin/src/backlinks-provider.ts"
+        ],
+        "relates": [
+          "capabilities/cli-developer-entry",
+          "capabilities/mcp-server",
+          "capabilities/mcp-conflict-guard",
+          "domains/onboarding-ux"
+        ]
+      },
+      "headings": [
+        {
+          "depth": 1,
+          "text": "VSCode Plugin (IDE Entry, v0.5.0)",
+          "slug": "vscode-plugin-ide-entry-v050"
+        },
+        {
+          "depth": 2,
+          "text": "v0.5.0 의 4 surface",
+          "slug": "v050-의-4-surface"
+        },
+        {
+          "depth": 3,
+          "text": "1. Ontology TreeView (v0.1.0)",
+          "slug": "1-ontology-treeview-v010"
+        },
+        {
+          "depth": 3,
+          "text": "2. 코드 ↔ ontology 점프 (v0.2.0 + v0.5.0 self-match)",
+          "slug": "2-코드-ontology-점프-v020-v050-self-match"
+        },
+        {
+          "depth": 3,
+          "text": "3. Add concept (v0.3.0 — write surface)",
+          "slug": "3-add-concept-v030-write-surface"
+        },
+        {
+          "depth": 3,
+          "text": "4. Backlinks panel (v0.4.0 — MCP server connect)",
+          "slug": "4-backlinks-panel-v040-mcp-server-connect"
+        },
+        {
+          "depth": 2,
+          "text": "5-way parser contract 편입",
+          "slug": "5-way-parser-contract-편입"
+        },
+        {
+          "depth": 2,
+          "text": "4-layer 자동 검증",
+          "slug": "4-layer-자동-검증"
+        },
+        {
+          "depth": 2,
+          "text": "Marketplace 미발행",
+          "slug": "marketplace-미발행"
+        }
+      ],
+      "excerpt": "R13 (20260504) 에 도입된 developerprimary IDE 진입점. README 가 약속해 둔 \"(planned) VSCode plugin\" 의 first MVP 부터 v0.5.0 까지. CLI 가 터미널 진입, MCP 가 AI agent 진입이라면 이 plugin 은 VSCode 안에서 직접 vault 노드 보고, 코드 ↔ ontology 점프하고, 새 노드 생성하고, backlinks 탐색. Activity Bar 좌측 entry — graph 모티브 SVG icon vault 노드 kind 별 그룹화 (project / domain / capab",
+      "wordCount": 460,
+      "updatedAt": "2026-05-04T11:25:09.019Z",
+      "linksOut": []
+    },
+    {
       "slug": "ontology/domains/ai-agent-partner",
       "path": "docs/ontology/domains/ai-agent-partner.md",
       "title": "AI Agent Partner",
@@ -3720,12 +4592,17 @@
         "kind": "domain",
         "title": "AI Agent Partner",
         "capabilities": [
-          "mcp-server"
+          "mcp-server",
+          "mcp-conflict-guard",
+          "ontology-sync-skill",
+          "session-start-ontology-context"
         ],
         "elements": [
+          "mcp-sdk",
           "mcp/src/index.js",
           "mcp/src/parser.mjs",
-          "mcp/src/vault.mjs"
+          "mcp/src/vault.mjs",
+          ".claude/hooks/inject-ontology-summary.sh"
         ],
         "relates": [
           "domains/vault-local-first",
@@ -3741,7 +4618,7 @@
       ],
       "excerpt": "Claude Code 같은 LLM agent 가 같은 ontology 를 read/write 하는 surface. MCP 서버 (mcp/) 가 14 도구 (read 8 + write 6) 를 stdin/stdout JSONRPC 로 노출. 등록 가이드: mcp/README.md. 사용자 LLM 비용을 cloud 로 옮기지 않음 — agent 가 자기 LLM 으로 호출.",
       "wordCount": 49,
-      "updatedAt": "2026-05-04T02:12:02.434Z",
+      "updatedAt": "2026-05-05T15:29:33.665Z",
       "linksOut": []
     },
     {
@@ -3780,16 +4657,20 @@
     {
       "slug": "ontology/domains/onboarding-ux",
       "path": "docs/ontology/domains/onboarding-ux.md",
-      "title": "Onboarding & UX (theme · toast · a11y · mobile)",
+      "title": "Onboarding & UX (theme · toast · a11y · mobile · CLI)",
       "tags": [],
       "frontmatter": {
         "slug": "domains/onboarding-ux",
         "kind": "domain",
-        "title": "Onboarding & UX (theme · toast · a11y · mobile)",
+        "title": "Onboarding & UX (theme · toast · a11y · mobile · CLI)",
+        "capabilities": [
+          "cli-developer-entry",
+          "vscode-plugin-ide-entry"
+        ],
         "elements": [
           "src/features/theme-toggle",
-          "src/shared/ui/toast",
-          "src/shared/ui/live-announcer",
+          "src/shared/ui/toast.tsx",
+          "src/shared/ui/live-announcer.tsx",
           "src/widgets/bottom-tab-bar",
           "src/widgets/gesture-hint"
         ],
@@ -3806,7 +4687,7 @@
       ],
       "excerpt": "crosscutting. 라이트/다크 토글 (html[datatheme=\"light\"]), Sonner기반 toast, arialive 스크린리더 announce, 모바일 BottomTabBar + gesture hint, ⌘K · ⇧⌘K · ? · F · N · Esc 단축키, prefersreducedmotion 자동 존중. 자세한 디자인 룰: docs/DESIGNSYSTEM.md.",
       "wordCount": 37,
-      "updatedAt": "2026-05-04T01:27:35.686Z",
+      "updatedAt": "2026-05-04T11:37:08.799Z",
       "linksOut": []
     },
     {
@@ -3824,7 +4705,7 @@
         "elements": [
           "src/entities/ontology-class",
           "src/entities/knowledge-graph",
-          "src/entities/docs-vault/lib/derive-ontology-from-vault"
+          "src/entities/docs-vault/lib/derive-ontology-from-vault.ts"
         ],
         "relates": [
           "domains/vault-local-first",
@@ -3840,7 +4721,7 @@
       ],
       "excerpt": "4layer class hierarchy (Project · Domain · Capability · Element + Document) + 7 edge types (KNOWLEDGEEDGETYPES) + evidencegrounded statements. Vault frontmatter is the single source of truth — deriveontologyfromvault turns \\.md\\ frontmatter into the inmemory graph. Architecture overview: \\docs/ARCHITECTURE.md\\.",
       "wordCount": 43,
-      "updatedAt": "2026-05-04T01:27:35.686Z",
+      "updatedAt": "2026-05-04T11:37:08.799Z",
       "linksOut": []
     },
     {
@@ -3852,11 +4733,16 @@
         "slug": "domains/vault-local-first",
         "kind": "domain",
         "title": "Vault — Local-First",
+        "capabilities": [
+          "vault-validator",
+          "vault-migrator"
+        ],
         "elements": [
+          "file-system-access-api",
           "src/features/docs-vault-local",
           "src/entities/local-fs-handle",
           "src/entities/docs-vault",
-          "src/shared/lib/idb-kv"
+          "src/shared/lib/idb-kv.ts"
         ],
         "relates": [
           "domains/mode-aware-adapters",
@@ -3872,7 +4758,7 @@
       ],
       "excerpt": "사용자 디스크 폴더를 진실원으로. File System Access API + IndexedDB 기반 핸들 영속. focus / visibility 시 fingerprint 비교로 재스캔 shortcircuit. 자세한 원칙: .claude/rules/localfirst.md. 사용자 surface: docs/FEATURES.md.",
       "wordCount": 31,
-      "updatedAt": "2026-05-04T01:27:35.686Z",
+      "updatedAt": "2026-05-04T11:37:08.800Z",
       "linksOut": []
     },
     {
@@ -3890,6 +4776,8 @@
           "builder-vault-write"
         ],
         "elements": [
+          "sigma-graphology",
+          "xyflow",
           "src/views/home",
           "src/views/ontology-view",
           "src/views/ontology-edit",
@@ -3897,7 +4785,8 @@
           "src/widgets/global-search"
         ],
         "relates": [
-          "domains/ontology-core"
+          "domains/ontology-core",
+          "domains/onboarding-ux"
         ]
       },
       "headings": [
@@ -3909,7 +4798,7 @@
       ],
       "excerpt": "같은 ontology 그래프의 세 출구. 토폴로지 (Sigma + ForceAtlas2 spatial network), 둘러보기 (/ontology 트리 계층 + ego graph + 노드 detail), 빌더 (xyflow ERD canvas + md 내보내기). 검색 — ⌘K 프로젝트 / ⇧⌘K 노드+프로젝트 통합.",
       "wordCount": 38,
-      "updatedAt": "2026-05-04T01:27:35.686Z",
+      "updatedAt": "2026-05-04T06:15:02.628Z",
       "linksOut": []
     },
     {
@@ -4117,8 +5006,13 @@
         },
         {
           "depth": 2,
-          "text": "TL;DR — first principle in one line (v2)",
-          "slug": "tldr-first-principle-in-one-line-v2"
+          "text": "TL;DR — first principle in one line (v3, 2026-05-04)",
+          "slug": "tldr-first-principle-in-one-line-v3-2026-05-04"
+        },
+        {
+          "depth": 3,
+          "text": "Why developer-primary",
+          "slug": "why-developer-primary"
         },
         {
           "depth": 2,
@@ -4137,8 +5031,8 @@
         },
         {
           "depth": 2,
-          "text": "2. Two audiences, one ontology",
-          "slug": "2-two-audiences-one-ontology"
+          "text": "2. One primary audience (v3 — PM dropped)",
+          "slug": "2-one-primary-audience-v3-pm-dropped"
         },
         {
           "depth": 2,
@@ -4222,8 +5116,13 @@
         },
         {
           "depth": 3,
-          "text": "⏳ Phase 4 — Polish for non-developers — upcoming",
-          "slug": "phase-4-polish-for-non-developers-upcoming"
+          "text": "🚫 Phase 4 — Polish for non-developers — **dropped (R11 fire #25)**",
+          "slug": "phase-4-polish-for-non-developers-dropped-r11-fire-25"
+        },
+        {
+          "depth": 3,
+          "text": "⏳ Phase 4 (replacement) — Developer + AI agent depth",
+          "slug": "phase-4-replacement-developer-ai-agent-depth"
         },
         {
           "depth": 2,
@@ -4261,9 +5160,9 @@
           "slug": "option-c-review-this-doc-extra-decisions"
         }
       ],
-      "excerpt": "Written (v2): 20260501 Decisions captured: the user confirmed Direction A (ontologyfirst) and added dogfooding + AIagent partnership as a new direction. This file overlays v2 on top of v1's strategic diagnosis (left in place); the decisions and the new direction below are what's current. This project is an ontology wor",
-      "wordCount": 1576,
-      "updatedAt": "2026-05-04T02:11:02.394Z",
+      "excerpt": "Written (v2): 20260501 Decisions captured: the user confirmed Direction A (ontologyfirst) and added dogfooding + AIagent partnership as a new direction. This file overlays v2 on top of v1's strategic diagnosis (left in place); the decisions and the new direction below are what's current. One codebase, one ontology, tha",
+      "wordCount": 1766,
+      "updatedAt": "2026-05-04T05:38:04.751Z",
       "linksOut": []
     },
     {
@@ -4398,6 +5297,36 @@
         },
         {
           "depth": 2,
+          "text": "CLI commands (R12 — list / validate / add / find)",
+          "slug": "cli-commands-r12-list-validate-add-find"
+        },
+        {
+          "depth": 3,
+          "text": "`oh-my-ontology validate` exits 1 with `unclosed-frontmatter`",
+          "slug": "oh-my-ontology-validate-exits-1-with-unclosed-frontmatter"
+        },
+        {
+          "depth": 3,
+          "text": "`oh-my-ontology validate` warns `missing-kind` / `unknown-kind`",
+          "slug": "oh-my-ontology-validate-warns-missing-kind-unknown-kind"
+        },
+        {
+          "depth": 3,
+          "text": "`oh-my-ontology add` throws `Doc already exists`",
+          "slug": "oh-my-ontology-add-throws-doc-already-exists"
+        },
+        {
+          "depth": 3,
+          "text": "`pnpm vault:migrate <id> --write` refuses with \"commit 안 된 .md 변경\"",
+          "slug": "pnpm-vaultmigrate-id---write-refuses-with-commit-안-된-md-변경"
+        },
+        {
+          "depth": 3,
+          "text": "`pnpm dogfood:walk` fails with `Vault path does not exist`",
+          "slug": "pnpm-dogfoodwalk-fails-with-vault-path-does-not-exist"
+        },
+        {
+          "depth": 2,
           "text": "MCP server (Claude Code, Cursor, etc.)",
           "slug": "mcp-server-claude-code-cursor-etc"
         },
@@ -4503,8 +5432,8 @@
         }
       ],
       "excerpt": "Common issues users hit when starting with ohmyontology. If your case isn't here, open an issue: https://github.com/wlsdks/ohmyontology/issues npm caches the package locally. Force a fresh fetch: The target folder already has README.md / project.md / etc. — the CLI never overwrites existing files. Either: Delete the co",
-      "wordCount": 854,
-      "updatedAt": "2026-05-04T01:27:35.683Z",
+      "wordCount": 1126,
+      "updatedAt": "2026-05-04T07:37:50.220Z",
       "linksOut": []
     }
   ],
@@ -4617,6 +5546,34 @@
         "fromSlug": "archive/ONTOLOGY-MODEL-V2-DRAFT",
         "context": "le: 결제 시스템 parents: [] projects: [checkout] summary: 결제 요청부터 정산까지의 흐름 --- # 결제 시스템 [[doc:payment-spec]] 에 명시된 흐름을 구현. **[capability:tax]** 에 의존. ``` → Firestore: - `knowledgeApprovedNodes/project:checkout` ← frontmatter + summary - `knowledgeApprovedEdges/<",
         "linkText": "capability:tax"
+      }
+    ],
+    "benchmark/tasks": [
+      {
+        "fromSlug": "benchmark/README",
+        "context": "s elsewhere. Either way, **measurement before further investment**. ## What's in here | File | Purpose | |---|---| | **[`tasks.md`]** | 7 benchmark tasks — 3 categories (cross-cutting / semantic / negative-control). Each task has a known correct answer",
+        "linkText": "`tasks.md`"
+      }
+    ],
+    "benchmark/rubric": [
+      {
+        "fromSlug": "benchmark/README",
+        "context": "3 categories (cross-cutting / semantic / negative-control). Each task has a known correct answer for human grading. | | **[`rubric.md`]** | How to score: correctness 0–3, tool-call count, hallucination count, subjective utility 1–5. | | [`results/2026-05-te",
+        "linkText": "`rubric.md`"
+      }
+    ],
+    "benchmark/results/2026-05-template": [
+      {
+        "fromSlug": "benchmark/README",
+        "context": "bric.md`](rubric.md) | How to score: correctness 0–3, tool-call count, hallucination count, subjective utility 1–5. | | **[`results/2026-05-template.md`]** | Empty matrix (task × agent × mode). Fill in after each measurement run. | ## How to measure Two paths, depending on",
+        "linkText": "`results/2026-05-template.md`"
+      }
+    ],
+    "benchmark/results/2026-05-04-claude-code": [
+      {
+        "fromSlug": "benchmark/results/2026-05-04-codex",
+        "context": "# Benchmark run — 2026-05-04 — Codex CLI > Companion to **[`2026-05-04-claude-code.md`]**. > Same 7 tasks, same rubric, different agent stack. ## Setup - **Repo HEAD**: post PR #130–#133 merge - **Vault**: 2",
+        "linkText": "`2026-05-04-claude-code.md`"
       }
     ]
   },
@@ -4733,6 +5690,69 @@
         ]
       },
       {
+        "name": "benchmark",
+        "path": "benchmark",
+        "type": "dir",
+        "children": [
+          {
+            "name": "results",
+            "path": "benchmark/results",
+            "type": "dir",
+            "children": [
+              {
+                "name": "2026-05-04-claude-code",
+                "path": "benchmark/results/2026-05-04-claude-code",
+                "type": "doc",
+                "slug": "benchmark/results/2026-05-04-claude-code",
+                "title": "Benchmark run — 2026-05-04 — Claude Code (self-measurement)"
+              },
+              {
+                "name": "2026-05-04-codex",
+                "path": "benchmark/results/2026-05-04-codex",
+                "type": "doc",
+                "slug": "benchmark/results/2026-05-04-codex",
+                "title": "Benchmark run — 2026-05-04 — Codex CLI"
+              },
+              {
+                "name": "2026-05-04-codex-scale-N100-summary",
+                "path": "benchmark/results/2026-05-04-codex-scale-N100-summary",
+                "type": "doc",
+                "slug": "benchmark/results/2026-05-04-codex-scale-N100-summary",
+                "title": "Benchmark scale — 2026-05-04 — Codex (N=100)"
+              },
+              {
+                "name": "2026-05-template",
+                "path": "benchmark/results/2026-05-template",
+                "type": "doc",
+                "slug": "benchmark/results/2026-05-template",
+                "title": "Benchmark run — YYYY-MM-DD"
+              }
+            ]
+          },
+          {
+            "name": "README",
+            "path": "benchmark/README",
+            "type": "doc",
+            "slug": "benchmark/README",
+            "title": "Benchmark — does the ontology actually help AI agents?"
+          },
+          {
+            "name": "rubric",
+            "path": "benchmark/rubric",
+            "type": "doc",
+            "slug": "benchmark/rubric",
+            "title": "Rubric — how to score each run"
+          },
+          {
+            "name": "tasks",
+            "path": "benchmark/tasks",
+            "type": "doc",
+            "slug": "benchmark/tasks",
+            "title": "Benchmark tasks"
+          }
+        ]
+      },
+      {
         "name": "design-references",
         "path": "design-references",
         "type": "dir",
@@ -4806,6 +5826,13 @@
                 "title": "Builder ↔ Vault md write (mode-aware)"
               },
               {
+                "name": "cli-developer-entry",
+                "path": "ontology/capabilities/cli-developer-entry",
+                "type": "doc",
+                "slug": "ontology/capabilities/cli-developer-entry",
+                "title": "CLI Developer Entry (init / list / validate / add / find)"
+              },
+              {
                 "name": "frontmatter-to-ontology",
                 "path": "ontology/capabilities/frontmatter-to-ontology",
                 "type": "doc",
@@ -4841,6 +5868,20 @@
                 "title": "Ontology Hub — Mode-Aware (Q1=(a))"
               },
               {
+                "name": "ontology-sync-skill",
+                "path": "ontology/capabilities/ontology-sync-skill",
+                "type": "doc",
+                "slug": "ontology/capabilities/ontology-sync-skill",
+                "title": "Ontology-Sync Agent Skill (.claude/skills/ontology-sync)"
+              },
+              {
+                "name": "session-start-ontology-context",
+                "path": "ontology/capabilities/session-start-ontology-context",
+                "type": "doc",
+                "slug": "ontology/capabilities/session-start-ontology-context",
+                "title": "SessionStart Ontology Context Injection (.claude/hooks/inject-ontology-summary.sh)"
+              },
+              {
                 "name": "topology-sigma-render",
                 "path": "ontology/capabilities/topology-sigma-render",
                 "type": "doc",
@@ -4860,6 +5901,13 @@
                 "type": "doc",
                 "slug": "ontology/capabilities/vault-validator",
                 "title": "Vault Validator (Silent Corruption 가시화)"
+              },
+              {
+                "name": "vscode-plugin-ide-entry",
+                "path": "ontology/capabilities/vscode-plugin-ide-entry",
+                "type": "doc",
+                "slug": "ontology/capabilities/vscode-plugin-ide-entry",
+                "title": "VSCode Plugin (IDE Entry, v0.5.0)"
               }
             ]
           },
@@ -4887,7 +5935,7 @@
                 "path": "ontology/domains/onboarding-ux",
                 "type": "doc",
                 "slug": "ontology/domains/onboarding-ux",
-                "title": "Onboarding & UX (theme · toast · a11y · mobile)"
+                "title": "Onboarding & UX (theme · toast · a11y · mobile · CLI)"
               },
               {
                 "name": "ontology-core",

--- a/src/features/docs-vault-local/lib/diff-manifest.test.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { diffVaultManifest } from './diff-manifest';
+
+describe('diffVaultManifest', () => {
+  it('첫 mount 와 동일 → added/modified 모두 빈 배열', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+      ['domains/bar', 2000],
+    ]);
+    const current = new Map(prev);
+    expect(diffVaultManifest(prev, current)).toEqual({
+      added: [],
+      modified: [],
+    });
+  });
+
+  it('prev 에 없는 slug → added', () => {
+    const prev = new Map<string, number | null>([['capabilities/foo', 1000]]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+      ['capabilities/baz', 3000],
+    ]);
+    const result = diffVaultManifest(prev, current);
+    expect(result.added).toEqual(['capabilities/baz']);
+    expect(result.modified).toEqual([]);
+  });
+
+  it('mtime 증가 → modified', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 1500],
+    ]);
+    const result = diffVaultManifest(prev, current);
+    expect(result.added).toEqual([]);
+    expect(result.modified).toEqual(['capabilities/foo']);
+  });
+
+  it('mtime 감소 / 동일 → modified 아님 (단조 증가만 인지)', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 2000],
+      ['capabilities/bar', 1000],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 2000], // 동일
+      ['capabilities/bar', 500], // 감소 (외부 git pull 등)
+    ]);
+    expect(diffVaultManifest(prev, current).modified).toEqual([]);
+  });
+
+  it('prev mtime null → modified 비교 skip (static manifest)', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', null],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 5000],
+    ]);
+    expect(diffVaultManifest(prev, current).modified).toEqual([]);
+  });
+
+  it('current mtime null → modified 비교 skip', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', null],
+    ]);
+    expect(diffVaultManifest(prev, current).modified).toEqual([]);
+  });
+
+  it('added + modified 동시 — 분리해서 반환', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+      ['capabilities/bar', 2000],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 1500], // modified
+      ['capabilities/bar', 2000], // 그대로
+      ['capabilities/baz', 3000], // added
+      ['domains/qux', 4000], // added
+    ]);
+    const result = diffVaultManifest(prev, current);
+    expect(result.added.sort()).toEqual([
+      'capabilities/baz',
+      'domains/qux',
+    ]);
+    expect(result.modified).toEqual(['capabilities/foo']);
+  });
+
+  it('removed slug 는 의도적으로 무시', () => {
+    const prev = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+      ['capabilities/bar', 2000],
+    ]);
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+    ]);
+    const result = diffVaultManifest(prev, current);
+    expect(result.added).toEqual([]);
+    expect(result.modified).toEqual([]);
+  });
+
+  it('빈 prev (첫 polling 후 두 번째) → 모든 current 는 already-known, added 0', () => {
+    // 실제 사용처는 첫 mount baseline 후 호출. 빈 prev 는 이론 케이스지만
+    // 모든 slug 가 added 로 분류되는지 명세 — caller 가 baseline 보호.
+    const prev = new Map<string, number | null>();
+    const current = new Map<string, number | null>([
+      ['capabilities/foo', 1000],
+    ]);
+    expect(diffVaultManifest(prev, current).added).toEqual([
+      'capabilities/foo',
+    ]);
+  });
+});

--- a/src/features/docs-vault-local/lib/diff-manifest.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.ts
@@ -1,0 +1,33 @@
+/**
+ * R14 #157 + #158 — vault polling 결과를 *added* / *modified* 두 부류로
+ * 분류하는 pure helper. VaultDiffToaster 가 React 외 dependency 없이 호출.
+ *
+ * 입력: 이전 / 현재 manifest 의 (slug, mtime|null) Map.
+ * 출력: 새로 등장한 slug + mtime 변화 slug.
+ *
+ * 정책:
+ *   - prev 에 없는 slug → added.
+ *   - 같은 slug 가 양쪽 다 mtime != null 이고 current > prev → modified.
+ *   - 한쪽이라도 mtime == null (static manifest) → 비교 의미 없음. modified
+ *     판정 skip (false-positive 차단).
+ *   - removed 는 의도적으로 제외 — 사용자 명시 액션 (`delete_concept` 등)
+ *     이 자체 toast 띄움. polling 결과로 다시 띄우면 noise.
+ */
+export function diffVaultManifest(
+  prev: Map<string, number | null>,
+  current: Map<string, number | null>,
+): { added: string[]; modified: string[] } {
+  const added: string[] = [];
+  const modified: string[] = [];
+  for (const [slug, mtime] of current) {
+    const prevMtime = prev.get(slug);
+    if (prevMtime === undefined) {
+      added.push(slug);
+      continue;
+    }
+    if (prevMtime !== null && mtime !== null && mtime > prevMtime) {
+      modified.push(slug);
+    }
+  }
+  return { added, modified };
+}

--- a/src/features/docs-vault-local/model/VaultDiffToaster.tsx
+++ b/src/features/docs-vault-local/model/VaultDiffToaster.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useToast } from '@/shared/ui/toast';
+import { diffVaultManifest } from '../lib/diff-manifest';
 import { useLocalVault } from './LocalVaultProvider';
 
 /**
@@ -43,20 +44,10 @@ export function VaultDiffToaster() {
       return;
     }
 
-    const prev = prevMapRef.current;
-    const added: string[] = [];
-    const modified: string[] = [];
-    for (const [slug, mtime] of currentMap) {
-      const prevMtime = prev.get(slug);
-      if (prevMtime === undefined) {
-        added.push(slug);
-        continue;
-      }
-      // mtime 비교: 둘 중 하나가 null (static manifest) 이면 비교 의미 없으니 skip
-      if (prevMtime !== null && mtime !== null && mtime > prevMtime) {
-        modified.push(slug);
-      }
-    }
+    const { added, modified } = diffVaultManifest(
+      prevMapRef.current,
+      currentMap,
+    );
     prevMapRef.current = currentMap;
 
     if (added.length === 0 && modified.length === 0) return;


### PR DESCRIPTION
## Summary

R14 wave (#155-#163, 9 PR 묶음) 의 closeout. 사용자 강조 두 핵심 — *"Claude Code 에서 바로 mcp 로 연결해서 사용 가능"* + *"웹에서도 바로바로 반응되어서 업데이트"* — 검증하고 발견된 stale / 회귀 risk 정리.

## 검증 결과

- ✅ **MCP spawn** — `OMOT_VAULT=./docs/ontology node mcp/scripts/verify.mjs` 통과. 14 tools 등록, 26 노드 로드. JSON-RPC 라운드트립 정상.
- ✅ **`.mcp.json` 추가** (이전엔 `.mcp.json.example` 만 있어 cp 단계 마찰) — git clone 후 Claude Code 가 이 repo 의 자체 `mcp/src/index.js` 를 즉시 14 tools 로 인식.
- ✅ **웹 polling/diff/modify 코드** — `use-local-vault.ts` 5s `setInterval` visible-only, `VaultDiffToaster` slug→mtime Map diff. `/`, `/ontology` static 모드 정상 렌더 (74 노드 142 관계, console 0 error).
- ⚠ **VaultDiffToaster 단위 test 부재** — 회귀 risk → 이번 PR 에서 fix.
- ⚠ **dogfood drift** — 트리에 "VSCode Plugin (v0.5.0)" 표기 (실제는 v0.9.0) → 이번 PR 에서 fix.

## Commits (4)

1. `chore(docs): R14 closeout` — CHANGELOG R14 항목 + BACKLOG 전면 재정렬 + benchmark 측정 가이드 + `.mcp.json` 추가
2. `feat: VaultDiffToaster diff logic helper 추출` — `lib/diff-manifest.ts` pure function + 9 단위 case (added / modified / mtime null guard / 단조성 / removed 무시 등)
3. `docs(vault): R14 capability + vscode-plugin v0.9 갱신` — `capabilities/vault-live-updates` 신규 + `domains/vault-local-first` endorse + vscode-plugin v0.5 → v0.9 (graph webview 제거 결정 반영). 25 → 26 노드
4. `chore(i18n): /docs hint 카피` — stale "18 노드" 제거, dogfood 명시

## 정책 변화

- **Q3-Q8 차단 해제** — `docs/archive/ONTOLOGY-MODEL-V2-DRAFT.md` head 가 2026-05-02 에 이미 답 확정. R10b (firebase 영구 제거) 후 V1.x 진화 cloud-side 컨텍스트 자체 dead. BACKLOG P1 무.
- **C3 benchmark scale** → user-trigger 로 격하 (`pnpm benchmark --bypass` 또는 새 Claude Code 세션 walk). vault 25 → 50 노드 도달 시점이 진짜 가치.
- **T28 demo blueprint** — VOID. `src/shared/mocks/demo-blueprint.ts` 자체가 이미 cleanup 완료.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` — **826 / 826** (817 + 9 신규)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm vault:validate` — 26 파일, issue 0
- [x] `OMOT_VAULT=./docs/ontology node mcp/scripts/verify.mjs` — All passed (14 tools, 26 노드)
- [x] `pnpm dev` — `/`, `/ontology` 렌더 + console 0 error (Sigma 트리 74 노드 142 관계)
- [x] pre-push tsc gate 통과
- [ ] 사용자: 새 Claude Code 세션 열어 mcp tools 자동 인식 (`mcp__oh-my-ontology__list_concepts` 등) 확인
- [ ] 사용자: `pnpm dev` 후 IDE 에서 vault `.md` 추가/편집 → 5s 안 toast + amber pulse 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)