### PR TITLE
feat(cli): add element path-style slug 시 cyan hint advisory

### DIFF
--- a/cli/src/commands/add.mjs
+++ b/cli/src/commands/add.mjs
@@ -12,6 +12,7 @@ const COLORS = {
   green: '\x1b[32m',
   red: '\x1b[31m',
   yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
   dim: '\x1b[2m',
   bold: '\x1b[1m',
   reset: '\x1b[0m',
@@ -64,6 +65,17 @@ export function runAdd(args) {
     for (const key of missing) {
       process.stderr.write(
         `${COLORS.yellow}warn${COLORS.reset}  expected field "${key}" missing for kind "${kind}" — add it later with --domain or by editing the file.\n`,
+      );
+    }
+    // R15 (post-Paravel dogfood) — element + path-style slug + auto-prefix
+    // 시 4단계 nested. 의도일 수도 있어 error 아닌 advisory hint.
+    // 두 패턴 (flat / path-style) 모두 valid — mcp/README "Element slug —
+    // two valid patterns" 참조.
+    if (kind === 'element' && autoPrefix && rawSlug.includes('/')) {
+      process.stderr.write(
+        `${COLORS.cyan}hint${COLORS.reset}  element slug "${rawSlug}" is path-style → nested at "${slug}.md" (4 levels). ` +
+          `If the path is intended (concrete code module), keep it. ` +
+          `For a flat element (library / abstract concept), use --raw-slug or a non-path slug.\n`,
       );
     }
     return 0;

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -262,6 +262,78 @@ await test('add --raw-slug — auto-prefix 명시 opt-out (R15)', async () => {
   }
 });
 
+await test('add element path-style → cyan hint advisory (post-Paravel dogfood)', async () => {
+  const root = withVault([]);
+  try {
+    const r = await run([
+      'add',
+      'element',
+      'src/features/auth',
+      '--title',
+      'Auth module',
+      '--domain',
+      'identity',
+      '--vault',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    // 4단계 nested 작성 자체는 valid
+    const written = readFileSync(
+      join(root, 'elements/src/features/auth.md'),
+      'utf-8',
+    );
+    assert.match(written, /kind: element/);
+    // stderr 에 path-style hint
+    assert.match(r.stderr, /path-style/);
+    assert.match(r.stderr, /4 levels/);
+    assert.match(r.stderr, /--raw-slug/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('add element flat slug → hint 없음 (정상 case)', async () => {
+  const root = withVault([]);
+  try {
+    const r = await run([
+      'add',
+      'element',
+      'zod',
+      '--title',
+      'Zod library',
+      '--domain',
+      'identity',
+      '--vault',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    assert.doesNotMatch(r.stderr, /path-style/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('add capability path slug → hint 없음 (element 만 적용)', async () => {
+  const root = withVault([]);
+  try {
+    const r = await run([
+      'add',
+      'capability',
+      'auth/login',
+      '--title',
+      'Login',
+      '--domain',
+      'identity',
+      '--vault',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    assert.doesNotMatch(r.stderr, /path-style/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('find — title 부분매칭', async () => {
   const root = withVault([
     {


### PR DESCRIPTION
## Summary

PR #166 의 Paravel dogfood 에서 발견된 friction F5 의 *behavioral* fix. PR #166 은 docs-only (mcp/README 의 element slug 두 패턴 명시) 였고, 이 PR 은 *cli 자체* 가 advisory hint 띄우게.

## 변경

\`oh-my-ontology add element <path-style-slug>\` 시 stderr 에 cyan hint:

\`\`\`
$ oh-my-ontology add element src/features/auth --title="Auth" --domain=identity
ok    elements/src/features/auth.md
      element · elements/src/features/auth · domain=identity
hint  element slug "src/features/auth" is path-style → nested at
      "elements/src/features/auth.md" (4 levels). If the path is intended
      (concrete code module), keep it. For a flat element (library /
      abstract concept), use --raw-slug or a non-path slug.
\`\`\`

조건: \`kind === 'element' && autoPrefix && rawSlug.includes('/')\`. capability/domain/project path-style slug 은 hint 없음 (element 만 4단계 nested).

advisory 만 — exit code 0, vault validate 통과. 사용자 무시 가능.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test:run\` — 814/814
- [x] \`node cli/src/integration.test.mjs\` — 24/24 (이전 21 + 3 new):
  - element path-style → cyan hint stderr ✓
  - element flat slug → hint 없음 ✓
  - capability path slug → hint 없음 (element 만 적용) ✓
- [x] manual: 4 case (path / flat / --raw-slug / capability) 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)