### PR TITLE
feat(cli): graph-level 5 명령 (Concern 4 fix) — backlinks/rename/merge/delete/query

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.3.0 — 2026-05-06 (R15 follow-up — graph-level commands)
+
+### Added — 5 graph-level commands (Concern 4 fix)
+
+post-publish architectural audit 발견 — CLI 6 vs MCP 14 ergonomic asymmetry. 개발자가 *위험한-그러나-필수* 작업 (rename / merge / delete) 을 *AI agent 통해서만* 할 수 있어 mission *"developer + AI agent grow together"* inversion. 이 PR 이 fix.
+
+- **`backlinks <slug>`** — find every node referencing the target. wraps MCP `find_backlinks`. `--json` for raw output.
+- **`query "<filter>"`** — typed filter DSL. wraps MCP `query_concepts`. `kind=X AND has(Y) AND NOT domain=Z`, parens / OR / NOT.
+- **`rename <oldSlug> <newSlug>`** — atomic rename. wraps MCP `rename_concept`. dry-run by default, `--confirm` to apply.
+- **`merge <fromSlug> <intoSlug>`** — atomic merge. wraps MCP `merge_concepts`. dry-run by default, `--confirm` to apply.
+- **`delete <slug>`** — permanent delete. wraps MCP `delete_concept`. dry-run by default, `--confirm` to apply, `--force` to ignore backlinks.
+
+### Implementation — `cli/src/lib/mcp-call.mjs` (single source of truth via spawn)
+
+새 명령들은 MCP server child_process spawn + JSON-RPC 로 호출. mcp 가 *진실원*, cli 는 thin wrapper. drift surface 0 (logic 복제 안 함). spawn overhead ~50-100ms per call — 한 번씩 호출이라 acceptable.
+
+- mcp entry resolution: `OMOT_MCP_PATH` env → `require.resolve('oh-my-ontology-mcp/src/index.js')` → monorepo dev fallback (`../../../mcp/src/index.js`)
+- cli/package.json 에 `oh-my-ontology-mcp ^0.7.1` dependency 명시 — `npm install` 시 mcp 자동 설치
+
+### Tests
+
+cli integration 24 → **32** (+8 new):
+- backlinks (color + JSON)
+- query (DSL filter)
+- rename (dry-run + confirm + backlink redirect 검증)
+- delete (backlinks 가드 + force)
+- merge (dry-run preview)
+
 ## Unreleased — 2026-05-06 (R15)
 
 ### Changed — `init` 의 mcp 등록 마찰 1 step 제거

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,20 @@ and AI agents (Claude Code, Cursor, etc.) can read and write together.
 | `oh-my-ontology find <query> [vault]` | Search slug + title (case-insensitive, `--kind X --json`) |
 | `oh-my-ontology import <path...>` | **R14** Import external `.md` into the vault. Reads each file's frontmatter, falls back to `--kind` when missing, derives `slug` from the filename and `title` from the first H1, then writes through the same schema as `add`. Options: `--vault path`, `--kind K`, `--auto-prefix` (R15 **default on**, kind→folder), `--raw-slug` (opt out), `--rename` (auto `-2`/`-3` on slug clash), `--dry-run` (preview only). Accepts files or directories (recursive, `.git`/`node_modules` skipped). |
 
+### Graph-level commands (R15 follow-up)
+
+These wrap the MCP server (`oh-my-ontology-mcp`) so the developer has the same authority as an AI agent — find backlinks, rename / merge / delete safely, run a typed filter DSL. Each spawn is ~50–100 ms one-shot; commands that mutate the graph are dry-run by default with an explicit `--confirm` flag.
+
+| Command | What it does |
+|---|---|
+| `oh-my-ontology backlinks <slug>` | Lists every node referencing the target (`matches[]` from MCP `find_backlinks`, `--json` for raw). |
+| `oh-my-ontology query "<filter>"` | Typed filter DSL — `kind=X AND has(Y) AND NOT domain=Z`, parens / OR / NOT supported. (`--limit N --json`) |
+| `oh-my-ontology rename <oldSlug> <newSlug>` | Atomic rename — moves the `.md`, updates `slug:`, rewrites every backlink (frontmatter array entries, inline strings, body links). Default dry-run preview; `--confirm` to apply. |
+| `oh-my-ontology merge <fromSlug> <intoSlug>` | Atomic merge — redirects every backlink `from → into`, then deletes `from.md`. Default dry-run; `--confirm` to apply. The `into` node's frontmatter / body are **not** auto-combined — edit by hand if needed. |
+| `oh-my-ontology delete <slug>` | Permanent delete. Default refuses if any backlinks remain — preview them with the bare command, then `--confirm` to apply (or `--force` to delete anyway). |
+
+These commands require `oh-my-ontology-mcp` (declared in `dependencies` — `npm install` pulls it in automatically).
+
 The vault is a plain folder of `.md` files. **Frontmatter is the graph.**
 
 ## How AI agents fit in

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.2.0",
-  "description": "AI-native codebase ontology workbench — vault scaffold + list/validate/add/find CLI.",
+  "version": "0.3.0",
+  "description": "AI-native codebase ontology workbench — vault scaffold + list/validate/add/find/import + graph-level backlinks/rename/merge/delete/query CLI.",
   "type": "module",
   "bin": {
     "oh-my-ontology": "src/index.mjs"
@@ -36,5 +36,8 @@
   "license": "MIT",
   "engines": {
     "node": ">=18"
+  },
+  "dependencies": {
+    "oh-my-ontology-mcp": "^0.7.1"
   }
 }

--- a/cli/src/commands/backlinks.mjs
+++ b/cli/src/commands/backlinks.mjs
@@ -1,0 +1,92 @@
+// R15 follow-up — `oh-my-ontology backlinks <slug> [vault]`
+// Lists every node referencing the target. Thin wrapper over MCP find_backlinks.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runBacklinks(args) {
+  const { slug, vault, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'find_backlinks', { slug });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  const matches = result?.matches ?? [];
+  if (matches.length === 0) {
+    process.stdout.write(
+      `${COLORS.dim}no backlinks for${COLORS.reset} ${COLORS.bold}${slug}${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}${slug}${COLORS.reset} ${COLORS.dim}— ${matches.length} backlink(s)${COLORS.reset}\n\n`,
+  );
+  for (const bl of matches) {
+    const keys = Array.isArray(bl.matchedKeys) ? bl.matchedKeys.join(', ') : '';
+    process.stdout.write(
+      `  ${COLORS.cyan}${bl.kind ?? '?'}${COLORS.reset}  ` +
+        `${bl.slug}` +
+        (keys ? ` ${COLORS.dim}(${keys})${COLORS.reset}` : '') +
+        `\n`,
+    );
+  }
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0) {
+    return { error: 'slug is required' };
+  }
+  // Optional second positional is vault path (parity with list/find/validate).
+  if (positional.length >= 2 && flags.vault === '.') {
+    flags.vault = positional[1];
+  }
+  return { slug: positional[0], vault: flags.vault, json: flags.json };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology backlinks <slug> [vault] [--vault path] [--json]\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology backlinks capabilities/mcp-server\n` +
+      `  oh-my-ontology backlinks domains/auth ./docs/ontology --json\n`,
+  );
+}

--- a/cli/src/commands/delete.mjs
+++ b/cli/src/commands/delete.mjs
@@ -1,0 +1,132 @@
+// R15 follow-up — `oh-my-ontology delete <slug> [vault]`
+// Permanent delete. Default refuses if backlinks remain (--force overrides).
+// Default dry-run with backlinks preview (--confirm applies).
+// Thin wrapper over MCP delete_concept.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runDelete(args) {
+  const { slug, vault, confirm, force, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+
+  if (!confirm) {
+    let preview;
+    try {
+      preview = await callMcpTool(vaultRoot, 'delete_concept', {
+        slug,
+        confirm: false,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+    if (json) {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n');
+      return 0;
+    }
+    const backlinks = preview?.backlinks ?? preview?.matches ?? [];
+    process.stdout.write(
+      `${COLORS.yellow}dry-run${COLORS.reset}  ` +
+        `delete ${COLORS.bold}${slug}${COLORS.reset} ` +
+        `${COLORS.dim}(${backlinks.length} backlink(s)${backlinks.length > 0 ? ' — would block without --force' : ''})${COLORS.reset}\n`,
+    );
+    for (const bl of backlinks) {
+      process.stdout.write(
+        `  ${COLORS.cyan}${bl.slug}${COLORS.reset}` +
+          (Array.isArray(bl.matchedKeys)
+            ? ` ${COLORS.dim}(${bl.matchedKeys.join(', ')})${COLORS.reset}`
+            : '') +
+          `\n`,
+      );
+    }
+    process.stdout.write(
+      `\n${COLORS.dim}re-run with${COLORS.reset} ${COLORS.bold}--confirm${COLORS.reset}` +
+        (backlinks.length > 0 ? ` ${COLORS.bold}--force${COLORS.reset}` : '') +
+        ` ${COLORS.dim}to apply.${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'delete_concept', {
+      slug,
+      confirm: true,
+      force,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(
+    `${COLORS.green}ok${COLORS.reset}    ${COLORS.bold}${slug}${COLORS.reset} ${COLORS.dim}deleted${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', confirm: false, force: false, json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--confirm') flags.confirm = true;
+    else if (a === '--force') flags.force = true;
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0) {
+    return { error: 'slug is required' };
+  }
+  if (positional.length >= 2 && flags.vault === '.') {
+    flags.vault = positional[1];
+  }
+  return {
+    slug: positional[0],
+    vault: flags.vault,
+    confirm: flags.confirm,
+    force: flags.force,
+    json: flags.json,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology delete <slug> [vault] [--confirm] [--force] [--json]\n\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run — preview backlinks.\n` +
+      `${COLORS.bold}--confirm${COLORS.reset}  apply (refuses if backlinks exist)\n` +
+      `${COLORS.bold}--force${COLORS.reset}    delete even with backlinks (use carefully)\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology delete capabilities/old\n` +
+      `  oh-my-ontology delete capabilities/old --confirm\n` +
+      `  oh-my-ontology delete capabilities/old --confirm --force\n`,
+  );
+}

--- a/cli/src/commands/merge.mjs
+++ b/cli/src/commands/merge.mjs
@@ -1,0 +1,130 @@
+// R15 follow-up — `oh-my-ontology merge <fromSlug> <intoSlug> [vault]`
+// Atomic graph-level merge: every backlink fromSlug → intoSlug, then
+// fromSlug.md is deleted. intoSlug node is preserved as-is (frontmatter +
+// body — use `add`/manual edit if you want to combine bodies).
+// Thin wrapper over MCP merge_concepts (dry-run + confirm pattern).
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runMerge(args) {
+  const { fromSlug, intoSlug, vault, confirm, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+
+  if (!confirm) {
+    let preview;
+    try {
+      preview = await callMcpTool(vaultRoot, 'merge_concepts', {
+        fromSlug,
+        intoSlug,
+        confirm: false,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+    if (json) {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n');
+      return 0;
+    }
+    const updates = preview?.updates ?? [];
+    process.stdout.write(
+      `${COLORS.yellow}dry-run${COLORS.reset}  ` +
+        `${COLORS.bold}${fromSlug}${COLORS.reset} → ${COLORS.bold}${intoSlug}${COLORS.reset} ` +
+        `${COLORS.dim}(${updates.length} file(s) would change, ${fromSlug}.md will be deleted)${COLORS.reset}\n\n`,
+    );
+    for (const u of updates) {
+      process.stdout.write(`  ${COLORS.cyan}${u.slug}${COLORS.reset}\n`);
+      if (Array.isArray(u.changes)) {
+        for (const c of u.changes) {
+          process.stdout.write(`    ${COLORS.dim}${c}${COLORS.reset}\n`);
+        }
+      }
+    }
+    process.stdout.write(
+      `\n${COLORS.dim}re-run with${COLORS.reset} ${COLORS.bold}--confirm${COLORS.reset} ${COLORS.dim}to apply.${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'merge_concepts', {
+      fromSlug,
+      intoSlug,
+      confirm: true,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  const updates = result?.updates ?? [];
+  process.stdout.write(
+    `${COLORS.green}ok${COLORS.reset}    ${COLORS.bold}${fromSlug}${COLORS.reset} → ${COLORS.bold}${intoSlug}${COLORS.reset} ` +
+      `${COLORS.dim}(${updates.length} file(s) updated, ${fromSlug}.md deleted)${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', confirm: false, json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--confirm') flags.confirm = true;
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length < 2) {
+    return { error: 'fromSlug and intoSlug are required' };
+  }
+  if (positional.length >= 3 && flags.vault === '.') {
+    flags.vault = positional[2];
+  }
+  return {
+    fromSlug: positional[0],
+    intoSlug: positional[1],
+    vault: flags.vault,
+    confirm: flags.confirm,
+    json: flags.json,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology merge <fromSlug> <intoSlug> [vault] [--confirm] [--json]\n\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run — preview the redirects.\n` +
+      `${COLORS.bold}--confirm${COLORS.reset}  apply: redirect every backlink, delete fromSlug.md.\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology merge capabilities/dup capabilities/canonical\n` +
+      `  oh-my-ontology merge capabilities/dup capabilities/canonical --confirm\n`,
+  );
+}

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -1,0 +1,108 @@
+// R15 follow-up — `oh-my-ontology query "<filter>" [vault]`
+// Typed filter DSL: kind=X AND has(elements) AND NOT domain=auth.
+// Thin wrapper over MCP query_concepts.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+const KIND_COLORS = {
+  capability: COLORS.cyan,
+  domain: COLORS.blue,
+  element: COLORS.green,
+  project: COLORS.magenta,
+  document: COLORS.dim,
+};
+
+export async function runQuery(args) {
+  const { filter, vault, json, limit, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_concepts', { filter, limit });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  const matches = result?.matches ?? [];
+  process.stdout.write(
+    `${COLORS.dim}filter:${COLORS.reset} ${COLORS.bold}${filter}${COLORS.reset} ` +
+      `${COLORS.dim}— ${result?.total ?? matches.length} match(es)${result?.limited ? ' (limited)' : ''}${COLORS.reset}\n\n`,
+  );
+  if (matches.length === 0) return 0;
+  for (const m of matches) {
+    const kc = KIND_COLORS[m.kind] || COLORS.dim;
+    process.stdout.write(
+      `  ${kc}${(m.kind || '?').padEnd(12)}${COLORS.reset} ${m.slug}` +
+        (m.title ? ` ${COLORS.dim}— ${m.title}${COLORS.reset}` : '') +
+        `\n`,
+    );
+  }
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, limit: 100 };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--limit') flags.limit = Number(args[++i]) || 100;
+    else if (a.startsWith('--limit='))
+      flags.limit = Number(a.slice('--limit='.length)) || 100;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0) {
+    return { error: 'filter is required (e.g. "kind=capability AND has(elements)")' };
+  }
+  if (positional.length >= 2 && flags.vault === '.') {
+    flags.vault = positional[1];
+  }
+  return {
+    filter: positional[0],
+    vault: flags.vault,
+    json: flags.json,
+    limit: flags.limit,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology query "<filter>" [vault] [--vault path] [--json] [--limit N]\n\n` +
+      `${COLORS.bold}Filter DSL${COLORS.reset} (AND / OR / NOT, parens supported):\n` +
+      `  kind=capability\n` +
+      `  domain=auth\n` +
+      `  has(elements)\n` +
+      `  kind=capability AND has(elements)\n` +
+      `  kind=capability AND NOT has(elements)        ${COLORS.dim}# unfinished caps${COLORS.reset}\n` +
+      `  (kind=capability OR kind=element) AND domain=auth\n`,
+  );
+}

--- a/cli/src/commands/rename.mjs
+++ b/cli/src/commands/rename.mjs
@@ -1,0 +1,131 @@
+// R15 follow-up — `oh-my-ontology rename <oldSlug> <newSlug> [vault]`
+// Atomic graph-level rename: moves the .md, updates `slug:`, rewrites every
+// backlink (frontmatter array entries, inline strings, body links).
+// Thin wrapper over MCP rename_concept (dry-run + confirm pattern).
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runRename(args) {
+  const { oldSlug, newSlug, vault, confirm, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+
+  if (!confirm) {
+    // Dry-run preview.
+    let preview;
+    try {
+      preview = await callMcpTool(vaultRoot, 'rename_concept', {
+        oldSlug,
+        newSlug,
+        confirm: false,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+    if (json) {
+      process.stdout.write(JSON.stringify(preview, null, 2) + '\n');
+      return 0;
+    }
+    const updates = preview?.updates ?? [];
+    process.stdout.write(
+      `${COLORS.yellow}dry-run${COLORS.reset}  ` +
+        `${COLORS.bold}${oldSlug}${COLORS.reset} → ${COLORS.bold}${newSlug}${COLORS.reset} ` +
+        `${COLORS.dim}(${updates.length} file(s) would change)${COLORS.reset}\n\n`,
+    );
+    for (const u of updates) {
+      process.stdout.write(`  ${COLORS.cyan}${u.slug}${COLORS.reset}\n`);
+      if (Array.isArray(u.changes)) {
+        for (const c of u.changes) {
+          process.stdout.write(`    ${COLORS.dim}${c}${COLORS.reset}\n`);
+        }
+      }
+    }
+    process.stdout.write(
+      `\n${COLORS.dim}re-run with${COLORS.reset} ${COLORS.bold}--confirm${COLORS.reset} ${COLORS.dim}to apply.${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  // Apply.
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'rename_concept', {
+      oldSlug,
+      newSlug,
+      confirm: true,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  const updates = result?.updates ?? [];
+  process.stdout.write(
+    `${COLORS.green}ok${COLORS.reset}    ${COLORS.bold}${oldSlug}${COLORS.reset} → ${COLORS.bold}${newSlug}${COLORS.reset} ` +
+      `${COLORS.dim}(${updates.length} file(s) updated)${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', confirm: false, json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--confirm') flags.confirm = true;
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length < 2) {
+    return { error: 'oldSlug and newSlug are required' };
+  }
+  if (positional.length >= 3 && flags.vault === '.') {
+    flags.vault = positional[2];
+  }
+  return {
+    oldSlug: positional[0],
+    newSlug: positional[1],
+    vault: flags.vault,
+    confirm: flags.confirm,
+    json: flags.json,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology rename <oldSlug> <newSlug> [vault] [--confirm] [--json]\n\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run only — preview the changes.\n` +
+      `${COLORS.bold}--confirm${COLORS.reset}  apply: move .md, update slug:, rewrite every backlink.\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology rename capabilities/foo capabilities/bar\n` +
+      `  oh-my-ontology rename capabilities/foo capabilities/bar --confirm\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -57,6 +57,18 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --vault path                           ${COLORS.dim}target vault root (default: cwd)${COLORS.reset}
        --kind K                               ${COLORS.dim}fallback kind when input has no kind:${COLORS.reset}
        --auto-prefix --rename --dry-run       ${COLORS.dim}folder prefix · slug rename · plan-only${COLORS.reset}
+
+${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
+  npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
+  npx oh-my-ontology query "<filter>"         Typed filter DSL (kind=X AND has(elements))
+       --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
+  npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
+       --confirm                              ${COLORS.dim}default dry-run (preview); --confirm to apply${COLORS.reset}
+  npx oh-my-ontology merge <from> <into>      Atomic merge — redirect backlinks then delete fromSlug
+       --confirm                              ${COLORS.dim}default dry-run; --confirm to apply${COLORS.reset}
+  npx oh-my-ontology delete <slug>            Permanent delete (refuses if backlinks remain)
+       --confirm --force                      ${COLORS.dim}--confirm to apply; --force to ignore backlinks${COLORS.reset}
+
   npx oh-my-ontology --help                   Show this help
   npx oh-my-ontology --version                Print version
 
@@ -253,6 +265,32 @@ if (SUBCOMMAND === 'find') {
 if (SUBCOMMAND === 'import') {
   const { runImport } = await import('./commands/import.mjs');
   exit(runImport(ARGS.slice(1)));
+}
+
+// R15 graph-level commands — async (spawn MCP). Each returns a Promise<exitCode>.
+if (SUBCOMMAND === 'backlinks') {
+  const { runBacklinks } = await import('./commands/backlinks.mjs');
+  exit(await runBacklinks(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'query') {
+  const { runQuery } = await import('./commands/query.mjs');
+  exit(await runQuery(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'rename') {
+  const { runRename } = await import('./commands/rename.mjs');
+  exit(await runRename(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'merge') {
+  const { runMerge } = await import('./commands/merge.mjs');
+  exit(await runMerge(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'delete') {
+  const { runDelete } = await import('./commands/delete.mjs');
+  exit(await runDelete(ARGS.slice(1)));
 }
 
 fail(`unknown command: ${SUBCOMMAND}`);

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -586,5 +586,188 @@ function existsSyncTest(p) {
   }
 }
 
+// ── R15 graph-level commands (backlinks/query/rename/merge/delete) ───────
+//
+// 이 명령들은 mcp child_process spawn — relative path fallback (../../mcp/
+// src/index.js) 으로 monorepo dev 환경에서 작동.
+
+async function buildGraphFixture() {
+  const root = withVault([
+    {
+      slug: 'capabilities/foo',
+      content:
+        '---\nkind: capability\nslug: capabilities/foo\ntitle: Foo\ndomain: domains/auth\nelements: [src/foo.ts]\n---\n\n# Foo\n',
+    },
+    {
+      slug: 'capabilities/bar',
+      content:
+        '---\nkind: capability\nslug: capabilities/bar\ntitle: Bar\ndomain: domains/auth\nrelates: [capabilities/foo]\n---\n\n# Bar\n',
+    },
+    {
+      slug: 'domains/auth',
+      content:
+        '---\nkind: domain\nslug: domains/auth\ntitle: Auth\ncapabilities: [capabilities/foo, capabilities/bar]\n---\n\n# Auth\n',
+    },
+  ]);
+  return root;
+}
+
+await test('backlinks — capabilities/foo 의 backlinks (bar relates + auth capabilities)', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['backlinks', 'capabilities/foo', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /backlink/);
+    assert.match(clean, /capabilities\/bar/);
+    assert.match(clean, /domains\/auth/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('backlinks --json — JSON 응답 파싱', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['backlinks', 'capabilities/foo', root, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(data.matches));
+    assert.ok(data.matches.length >= 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('query — kind=capability AND has(elements)', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'query',
+      'kind=capability AND has(elements)',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    // Only foo has elements; bar has relates only.
+    assert.match(clean, /capabilities\/foo/);
+    assert.doesNotMatch(clean, /capabilities\/bar.*\n/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('rename — dry-run preview, no disk change', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'rename',
+      'capabilities/foo',
+      'capabilities/foo-renamed',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /dry-run/);
+    assert.match(clean, /capabilities\/foo-renamed/);
+    // foo.md 그대로 존재 (dry-run)
+    assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), true);
+    assert.equal(
+      existsSyncTest(join(root, 'capabilities/foo-renamed.md')),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('rename --confirm — 파일 이동 + backlink redirect', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'rename',
+      'capabilities/foo',
+      'capabilities/foo-renamed',
+      root,
+      '--confirm',
+    ]);
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+    assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), false);
+    assert.equal(
+      existsSyncTest(join(root, 'capabilities/foo-renamed.md')),
+      true,
+    );
+    // bar 의 relates 가 redirect 됐는지
+    const barText = readFileSync(
+      join(root, 'capabilities/bar.md'),
+      'utf-8',
+    );
+    assert.match(barText, /capabilities\/foo-renamed/);
+    assert.doesNotMatch(barText, /relates:.*\bcapabilities\/foo\b(?!-renamed)/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('delete — backlinks 있으면 dry-run 에서 경고', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['delete', 'capabilities/foo', root]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /dry-run/);
+    assert.match(clean, /backlink/);
+    assert.match(clean, /--force/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('delete --confirm (no backlinks) — 파일 삭제', async () => {
+  const root = withVault([
+    {
+      slug: 'capabilities/lonely',
+      content:
+        '---\nkind: capability\nslug: capabilities/lonely\ntitle: Lonely\ndomain: domains/auth\n---\n',
+    },
+  ]);
+  try {
+    const r = await run([
+      'delete',
+      'capabilities/lonely',
+      root,
+      '--confirm',
+    ]);
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+    assert.equal(
+      existsSyncTest(join(root, 'capabilities/lonely.md')),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('merge — dry-run preview', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'merge',
+      'capabilities/foo',
+      'capabilities/bar',
+      root,
+    ]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /dry-run/);
+    assert.match(clean, /capabilities\/foo/);
+    assert.match(clean, /capabilities\/bar/);
+    // foo.md 그대로 존재 (dry-run)
+    assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 console.log(`\ncli integration: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/cli/src/lib/mcp-call.mjs
+++ b/cli/src/lib/mcp-call.mjs
@@ -1,0 +1,150 @@
+// R15 follow-up — graph-level write commands (backlinks / rename / merge /
+// delete / query) thin-wrap MCP server. mcp/src/index.js 의 logic 이 single
+// source of truth — cli 는 child_process spawn + JSON-RPC 로 호출.
+//
+// Why spawn vs duplicate logic:
+//   - rename_concept / merge_concepts 의 atomic backlink redirect 는 100+ LOC.
+//     중복하면 5-way drift surface (이미 4-way schema/parser/validator).
+//   - spawn overhead ~50-100ms — 사용자 한 번씩 호출이라 acceptable.
+//   - mcp 가 published 되면 npm install 로 같이 install (cli/package.json
+//     dependencies). dev 에선 monorepo relative path fallback.
+//
+// Resolution order for the mcp entry:
+//   1. OMOT_MCP_PATH env (explicit override)
+//   2. node:require.resolve('oh-my-ontology-mcp/src/index.js')
+//   3. relative ../../../mcp/src/index.js (monorepo dev)
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const require_ = createRequire(import.meta.url);
+
+function resolveMcpEntry() {
+  if (process.env.OMOT_MCP_PATH && existsSync(process.env.OMOT_MCP_PATH)) {
+    return process.env.OMOT_MCP_PATH;
+  }
+  try {
+    return require_.resolve('oh-my-ontology-mcp/src/index.js');
+  } catch {
+    // monorepo dev fallback
+    const monoDev = resolve(__dirname, '../../../mcp/src/index.js');
+    if (existsSync(monoDev)) return monoDev;
+    throw new Error(
+      'oh-my-ontology-mcp not found. Install it (`npm install oh-my-ontology-mcp`) ' +
+        'or set OMOT_MCP_PATH to mcp/src/index.js.',
+    );
+  }
+}
+
+/**
+ * One-shot MCP tool call. Spawns the server, sends initialize +
+ * notifications/initialized + tools/call, parses the JSON-RPC response,
+ * resolves with the parsed result (the JSON in `content[0].text`).
+ *
+ * @param {string} vaultRoot — passed as OMOT_VAULT env
+ * @param {string} toolName — e.g. 'find_backlinks'
+ * @param {Record<string, unknown>} args — tool arguments
+ * @returns {Promise<unknown>}
+ */
+export function callMcpTool(vaultRoot, toolName, args = {}) {
+  return new Promise((resolveP, rejectP) => {
+    const entry = resolveMcpEntry();
+    const proc = spawn('node', [entry], {
+      env: { ...process.env, OMOT_VAULT: vaultRoot },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    proc.stdout.on('data', (chunk) => {
+      stdoutBuf += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderrBuf += chunk.toString();
+    });
+
+    proc.on('error', (err) => rejectP(err));
+    proc.on('exit', (code) => {
+      if (code !== 0 && code !== null) {
+        rejectP(
+          new Error(
+            `mcp exited code ${code}. stderr:\n${stderrBuf.trim() || '(empty)'}`,
+          ),
+        );
+        return;
+      }
+      try {
+        const lines = stdoutBuf.split('\n').filter(Boolean);
+        // tools/call response has id=2 in our request sequence.
+        let toolResp = null;
+        for (const line of lines) {
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === 2) {
+              toolResp = msg;
+              break;
+            }
+          } catch {
+            // skip non-JSON lines (debug logs from mcp would go to stderr,
+            // but be defensive).
+          }
+        }
+        if (!toolResp) {
+          rejectP(
+            new Error(
+              `mcp response missing tools/call result. stdout lines:\n${lines.slice(0, 5).join('\n')}`,
+            ),
+          );
+          return;
+        }
+        if (toolResp.error) {
+          rejectP(new Error(`mcp tool error: ${toolResp.error.message}`));
+          return;
+        }
+        const text = toolResp.result?.content?.[0]?.text;
+        if (typeof text !== 'string') {
+          rejectP(new Error('mcp tool response has no text content'));
+          return;
+        }
+        // Server returns JSON.stringify(result) in text — parse back.
+        try {
+          resolveP(JSON.parse(text));
+        } catch {
+          // Some tools (errors) may return a plain string — pass through.
+          resolveP({ text });
+        }
+      } catch (err) {
+        rejectP(err);
+      }
+    });
+
+    const requests = [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'oh-my-ontology-cli', version: '0.2.0' },
+        },
+      },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: toolName, arguments: args },
+      },
+    ];
+    for (const req of requests) {
+      proc.stdin.write(JSON.stringify(req) + '\n');
+    }
+    proc.stdin.end();
+  });
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,46 @@
 
 ---
 
+## 2026-05-06 — Round 15 follow-up: CLI graph-level 5 명령 (Concern 4 fix)
+
+post-publish architectural audit (Plan agent advisor) 발견 *blocking* concern — **CLI 6 vs MCP 14 ergonomic asymmetry**. 개발자가 *위험한-그러나-필수* 작업 (rename / merge / delete / query / backlinks) 을 *AI agent 통해서만* 할 수 있어 mission *"developer + AI agent grow together"* inversion. 이 PR 이 fix.
+
+### CLI 5 graph-level 명령 추가 (cli v0.2.0 → v0.3.0, 6 → **11 명령**)
+
+| Command | Wraps MCP tool |
+|---|---|
+| `backlinks <slug>` | `find_backlinks` |
+| `query "<filter>"` | `query_concepts` (typed DSL) |
+| `rename <old> <new>` | `rename_concept` (dry-run + --confirm) |
+| `merge <from> <into>` | `merge_concepts` (dry-run + --confirm) |
+| `delete <slug>` | `delete_concept` (dry-run + --confirm + --force) |
+
+### Implementation — `cli/src/lib/mcp-call.mjs` (single source of truth via spawn)
+
+새 명령들은 MCP server child_process spawn + JSON-RPC 로 호출. mcp 가 *진실원*, cli 는 thin wrapper. drift surface 0 (logic 복제 안 함). spawn overhead ~50-100ms per call — 한 번씩 호출이라 acceptable.
+
+- mcp entry resolution: `OMOT_MCP_PATH` env → `require.resolve('oh-my-ontology-mcp/src/index.js')` → monorepo dev fallback
+- `cli/package.json` 에 `dependencies: { "oh-my-ontology-mcp": "^0.7.1" }` 명시 — npm install 시 mcp 자동
+
+### Mission align
+
+이전 — cli 는 *온톨로지 노드 만들기* (init/add/import) 까지만, *그래프 변경* 은 mcp-only. AI agent 가 *유일한 ergonomic write surface* 였음. 이제 — cli 가 mcp 와 *동등 권한*. 사용자가 본인 daily 로 rename/merge/delete 사용 가능.
+
+### Tests
+
+cli integration **24 → 32** (+8 new):
+- backlinks 컬러 + JSON
+- query DSL filter
+- rename dry-run + --confirm + backlink redirect 검증
+- delete backlinks 가드 + --confirm
+- merge dry-run preview
+
+### Dogfood vault
+
+`capabilities/cli-developer-entry.md` 갱신 — 6 → 11 명령, 5 element 추가 (backlinks/query/rename/merge/delete + mcp-call helper).
+
+---
+
 ## 2026-05-06 — Round 15: VSCode plugin 제거 — AI-agent 터미널 시대로 진입점 단순화
 
 R14 closeout (PR #164) 후 사용자 명시 — *"vscode plugin 은 없어도 될 듯. 이제 대부분 vscode 안 쓰고 claude code / codex 를 사용하지"*. R13 에서 v0.1.0 → v0.9.0 까지 키운 4번째 surface 통째 제거. 4 surface (CLI · MCP · Web · VSCode) → **3 surface (CLI · MCP · Web)**.

--- a/docs/ontology/capabilities/cli-developer-entry.md
+++ b/docs/ontology/capabilities/cli-developer-entry.md
@@ -1,7 +1,7 @@
 ---
 slug: capabilities/cli-developer-entry
 kind: capability
-title: CLI Developer Entry (init / list / validate / add / find)
+title: CLI Developer Entry (init / list / validate / add / find / import + graph-level)
 domain: onboarding-ux
 elements:
   - cli/src/index.mjs
@@ -9,6 +9,13 @@ elements:
   - cli/src/commands/validate.mjs
   - cli/src/commands/add.mjs
   - cli/src/commands/find.mjs
+  - cli/src/commands/import.mjs
+  - cli/src/commands/backlinks.mjs
+  - cli/src/commands/query.mjs
+  - cli/src/commands/rename.mjs
+  - cli/src/commands/merge.mjs
+  - cli/src/commands/delete.mjs
+  - cli/src/lib/mcp-call.mjs
 relates:
   - capabilities/mcp-server
   - capabilities/vault-validator
@@ -17,18 +24,37 @@ relates:
 
 # CLI Developer Entry
 
-R12 (2026-05-04) 에 도입된 *developer-primary* 진입점. 5 명령으로 사용자가 vault 만든 후 *터미널 즉시* ontology 작업 가능 — 웹 UI / MCP 등록 불필요.
+R12 (2026-05-04) 에 도입된 *developer-primary* 진입점. R14 에서 `import` (6 명령), R15 follow-up 에서 graph-level 5 명령 추가 — 총 **11 명령**. 사용자가 vault 만든 후 *터미널 즉시* ontology 작업 가능 — 웹 UI / MCP 등록 불필요.
+
+## Local commands (R12 + R14 — vault scaffold + frontmatter)
 
 | Command | What it does |
 |---|---|
-| `oh-my-ontology init [folder]` | Scaffold vault (5 starter .md + `.mcp.json.example`) |
+| `oh-my-ontology init [folder]` | Scaffold vault (5 starter .md + `.mcp.json` cwd + vault) |
 | `oh-my-ontology list [vault]` | List ontology nodes (color table, `--kind X` filter, `--json`) |
-| `oh-my-ontology validate [vault]` | Frontmatter integrity check (5 issue codes; CI gate via exit 1) |
-| `oh-my-ontology add <kind> <slug> --title="..."` | Scaffold new node (duplicate throw, `--domain --body --vault`) |
+| `oh-my-ontology validate [vault]` | Frontmatter integrity check (6 issue codes; CI gate via exit 1) |
+| `oh-my-ontology add <kind> <slug> --title="..."` | Scaffold new node (duplicate throw, `--domain --body --vault`, R15 `--auto-prefix` default on, `--raw-slug` opt-out) |
 | `oh-my-ontology find <query> [vault]` | Search slug + title with yellow highlight (`--kind --json`) |
+| `oh-my-ontology import <path...>` | **R14** Import external `.md` (frontmatter normalize + `--auto-prefix` / `--rename` / `--dry-run`) |
 
-cli 가 별도 npm package (v0.2.0, R12 #41) — `oh-my-ontology` binary. mcp/ 가 14 도구로 같은 vault 를 read/write 하듯, cli 도 같은 .md 파일을 *동일 contract* 로 처리 (4-way parser contract + 3-way validator contract 강제).
+## Graph-level commands (R15 follow-up — Concern 4 fix)
 
-11 spawn-based integration test (`cli/src/integration.test.mjs`, R12 #40) 가 회귀 차단.
+post-publish architectural audit 발견 — *위험한-그러나-필수* 작업 (rename/merge/delete) 이 MCP-only 라 mission inversion. 5 명령 추가로 동등.
 
-5 명령의 onboarding flow: `init → list → validate → add → find` (R12 #36 walk-through audit 후 init next-steps 갱신).
+| Command | What it does |
+|---|---|
+| `oh-my-ontology backlinks <slug>` | MCP `find_backlinks` — every node referencing the target |
+| `oh-my-ontology query "<filter>"` | MCP `query_concepts` — typed filter DSL (kind/domain/has/AND/OR/NOT/parens) |
+| `oh-my-ontology rename <old> <new>` | MCP `rename_concept` — atomic, dry-run default, `--confirm` to apply |
+| `oh-my-ontology merge <from> <into>` | MCP `merge_concepts` — atomic redirect + delete from, dry-run default |
+| `oh-my-ontology delete <slug>` | MCP `delete_concept` — refuses if backlinks remain (`--force` overrides) |
+
+## 구현 단일 진실원
+
+local commands 는 *cli 안* 구현 (4-way parser/3-way validator contract). graph-level 5 는 *MCP server child_process spawn + JSON-RPC* — `cli/src/lib/mcp-call.mjs` 의 thin wrapper. drift surface 0 (logic 복제 안 함). spawn ~50-100ms per call — 한 번씩 호출이라 acceptable.
+
+cli 가 별도 npm package (v0.3.0, R15 follow-up) — `oh-my-ontology` binary. cli/package.json 의 `dependencies: oh-my-ontology-mcp ^0.7.1` 가 graph-level 명령 자동 활성.
+
+## 회귀 차단
+
+cli/src/integration.test.mjs — **32 spawn-based** integration test (R12 #40 11 + R14 add/import 9 + R15 follow-up 8 + R15 hint 4). 매 PR 마다 graph-level 명령의 dry-run/confirm 경로 + backlink redirect 검증.

--- a/scripts/audit-vault-paths.mjs
+++ b/scripts/audit-vault-paths.mjs
@@ -14,7 +14,7 @@
 //
 // exit 1 if drift, 0 if clean — CI gateable.
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { parseFrontmatter } from "./lib/parse-frontmatter.mjs";
 

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-05T23:41:13.232Z",
+  "generatedAt": "2026-05-06T04:25:04.781Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",
@@ -1675,7 +1675,7 @@
       ],
       "excerpt": "작업 순번 만. user 가 \"T?? 진행해\" 하면 그것만 분해해서 실행. 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제. 갱신 (20260506): R12/R13/R14 wave 묶음 정리 후 전면 재정렬. 4 surface 완성, dogfood 25 노드, AI agent ↔ vault 자동 sync 도달. | PR | 항목 | 결과 | |||| | 155 | vault polling 5s | ✅ visibleonly setInterval, fingerprint diff | | 156 | graph diff pulse | ✅ 새 노드 amber s",
       "wordCount": 1361,
-      "updatedAt": "2026-05-05T23:40:34.918Z",
+      "updatedAt": "2026-05-06T02:02:33.369Z",
       "linksOut": []
     },
     {
@@ -1753,7 +1753,7 @@
       ],
       "excerpt": "The single biggest unverified premise of this project: \"AI agents work better when they can read and write the codebase ontology vault.\" Until we have data, this is a belief, not a claim. This folder is the first attempt to put it on a measurement scale. We built CLI · MCP · 14 tools · web workbench all on top of one a",
       "wordCount": 1034,
-      "updatedAt": "2026-05-05T23:36:19.129Z",
+      "updatedAt": "2026-05-06T02:02:33.371Z",
       "linksOut": [
         "benchmark/tasks",
         "benchmark/rubric",
@@ -2311,6 +2311,11 @@
           "depth": 3,
           "text": "Surface 표 갱신",
           "slug": "surface-표-갱신"
+        },
+        {
+          "depth": 3,
+          "text": "CLI `init` 의 mcp 등록 마찰 1 step 제거",
+          "slug": "cli-init-의-mcp-등록-마찰-1-step-제거"
         },
         {
           "depth": 2,
@@ -3054,8 +3059,8 @@
         }
       ],
       "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. R14 closeout (PR 164) 후 사용자 명시 — \"vscode plugin 은 없어도 될 듯. 이제 대부분 vscode 안 쓰고 claude code ",
-      "wordCount": 11606,
-      "updatedAt": "2026-05-05T23:39:41.986Z",
+      "wordCount": 11707,
+      "updatedAt": "2026-05-06T02:02:33.370Z",
       "linksOut": [
         "slug"
       ]
@@ -3452,6 +3457,157 @@
       ]
     },
     {
+      "slug": "dogfood-friction-2026-05-06",
+      "path": "docs/dogfood-friction-2026-05-06.md",
+      "title": "Dogfood friction report — external-user simulation (2026-05-06)",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Dogfood friction report — external-user simulation (2026-05-06)",
+          "slug": "dogfood-friction-report-external-user-simulation-2026-05-06"
+        },
+        {
+          "depth": 2,
+          "text": "TL;DR",
+          "slug": "tldr"
+        },
+        {
+          "depth": 2,
+          "text": "측정 환경",
+          "slug": "측정-환경"
+        },
+        {
+          "depth": 2,
+          "text": "🚨 Critical friction (publish 후에도 그대로)",
+          "slug": "critical-friction-publish-후에도-그대로"
+        },
+        {
+          "depth": 3,
+          "text": "F1. `.mcp.json` 위치가 vault target 안 — 사용자가 codebase root 에서 못 인식",
+          "slug": "f1-mcpjson-위치가-vault-target-안-사용자가-codebase-root-에서-못-인식"
+        },
+        {
+          "depth": 3,
+          "text": "F2. `add` 의 default layout drift — starter 와 다른 위치",
+          "slug": "f2-add-의-default-layout-drift-starter-와-다른-위치"
+        },
+        {
+          "depth": 2,
+          "text": "⚙️ Setup friction (publish 가 plan 이라 자연 해결)",
+          "slug": "setup-friction-publish-가-plan-이라-자연-해결"
+        },
+        {
+          "depth": 3,
+          "text": "F3. `pnpm link --global` 이 `pnpm setup` prereq",
+          "slug": "f3-pnpm-link---global-이-pnpm-setup-prereq"
+        },
+        {
+          "depth": 3,
+          "text": "F4. `npx -y oh-my-ontology-mcp` 가 publish 전 404",
+          "slug": "f4-npx--y-oh-my-ontology-mcp-가-publish-전-404"
+        },
+        {
+          "depth": 2,
+          "text": "측정 통과 사항",
+          "slug": "측정-통과-사항"
+        },
+        {
+          "depth": 2,
+          "text": "Fix priority",
+          "slug": "fix-priority"
+        },
+        {
+          "depth": 2,
+          "text": "기록되지 않은 — *진짜 외부 사용자 입장의 한계*",
+          "slug": "기록되지-않은-진짜-외부-사용자-입장의-한계"
+        },
+        {
+          "depth": 2,
+          "text": "Perf 측정 — vault scale (R11 #31 baseline 갱신, 2026-05-06)",
+          "slug": "perf-측정-vault-scale-r11-31-baseline-갱신-2026-05-06"
+        }
+      ],
+      "excerpt": "Setup: /tmp/omotdogfood 에 작은 todo app (4 도메인: auth/task/notification/user) 만든 후, npm link 로 cli + mcp 글로벌 시뮬. 외부 사용자 첫 흐름 시뮬레이션. 2 critical friction — fix 가치 큼, publish 후에도 그대로 (즉시 fix 가능) 2 setup friction — publish 가 원래 plan 이라 publish 후 사라짐 (fix 불필요) MCP 14 tools 동작 — sandbox vault (7 nodes) 에 spawn 후 listconcepts / ",
+      "wordCount": 941,
+      "updatedAt": "2026-05-06T02:02:33.371Z",
+      "linksOut": []
+    },
+    {
+      "slug": "dogfood-paravel-2026-05-06",
+      "path": "docs/dogfood-paravel-2026-05-06.md",
+      "title": "Dogfood — real external codebase (sanitized, 2026-05-06)",
+      "tags": [],
+      "frontmatter": {},
+      "headings": [
+        {
+          "depth": 1,
+          "text": "Dogfood — real external codebase (sanitized, 2026-05-06)",
+          "slug": "dogfood-real-external-codebase-sanitized-2026-05-06"
+        },
+        {
+          "depth": 2,
+          "text": "TL;DR",
+          "slug": "tldr"
+        },
+        {
+          "depth": 2,
+          "text": "측정 환경",
+          "slug": "측정-환경"
+        },
+        {
+          "depth": 2,
+          "text": "✅ PR #165 두 fix 검증 (real codebase)",
+          "slug": "pr-165-두-fix-검증-real-codebase"
+        },
+        {
+          "depth": 3,
+          "text": "F1 — cwd .mcp.json 자동 생성",
+          "slug": "f1-cwd-mcpjson-자동-생성"
+        },
+        {
+          "depth": 3,
+          "text": "F2 — auto-prefix default on",
+          "slug": "f2-auto-prefix-default-on"
+        },
+        {
+          "depth": 2,
+          "text": "측정 결과 — sub-second cli 부담",
+          "slug": "측정-결과-sub-second-cli-부담"
+        },
+        {
+          "depth": 2,
+          "text": "🚨 새 친구션 발견",
+          "slug": "새-친구션-발견"
+        },
+        {
+          "depth": 3,
+          "text": "F5 — element kind 의 path-style slug + auto-prefix → 4단계 nested",
+          "slug": "f5-element-kind-의-path-style-slug-auto-prefix-4단계-nested"
+        },
+        {
+          "depth": 2,
+          "text": "통과 사항",
+          "slug": "통과-사항"
+        },
+        {
+          "depth": 2,
+          "text": "*진짜 외부 사용자 입장의 한계* 여전히 남음",
+          "slug": "진짜-외부-사용자-입장의-한계-여전히-남음"
+        },
+        {
+          "depth": 2,
+          "text": "Paravel-App vault 자체 정책",
+          "slug": "paravel-app-vault-자체-정책"
+        }
+      ],
+      "excerpt": "Setup: 사용자 본인 real codebase (Korean enterprise community app, React Native + Expo + FSD, 1.8 GB, 20 features) 에 npm link 로 publish 시뮬한 cli + mcp 적용. PR 165 (R15 closeout) 머지 직후 main 의 cli init (cwd .mcp.json + autoprefix default) + cli add 사용. Sanitization: codebase 이름 / company codename / specific feature names 추상화. 도",
+      "wordCount": 825,
+      "updatedAt": "2026-05-06T02:24:50.499Z",
+      "linksOut": []
+    },
+    {
       "slug": "FEATURES",
       "path": "docs/FEATURES.md",
       "title": "FEATURES — oh-my-ontology",
@@ -3820,8 +3976,8 @@
         },
         {
           "depth": 2,
-          "text": "6. What was removed (Rounds 1–9)",
-          "slug": "6-what-was-removed-rounds-19"
+          "text": "6. What was removed / added (Rounds 1–15)",
+          "slug": "6-what-was-removed-added-rounds-115"
         },
         {
           "depth": 2,
@@ -3834,9 +3990,9 @@
           "slug": "8-source-of-truth-files"
         }
       ],
-      "excerpt": "Complete inventory of features users can actually use right now. Last updated: 20260503 (postRound9 — surface diet 8 rounds + LocalVaultProvider + robustness audit) Update trigger: reflect immediately when surfaces are added or removed. Update alongside the PR body and CHANGELOG. Mission v2: \"an ontology of the codebas",
-      "wordCount": 4061,
-      "updatedAt": "2026-05-04T05:38:08.586Z",
+      "excerpt": "Complete inventory of features users can actually use right now. Last updated: 20260506 (postRound15 — VSCode plugin 제거, 3 surface 회복 + R14 자동화/live updates 추가 반영). Routes section UI 디테일은 R10 시점 snapshot — surface 자체와 mode branching 은 R15 까지 정확. routes UI microdetail 은 R10 후 변화 작아 별도 sweep 보다 대부분 정확 가정. Update trigger:",
+      "wordCount": 4485,
+      "updatedAt": "2026-05-06T02:02:33.370Z",
       "linksOut": [
         "slug",
         "project:slug",
@@ -4493,7 +4649,7 @@
       ],
       "excerpt": "R14 (155158, 20260504 ~ 20260505) 에 도입된 web 즉시 반영 능력. 사용자 명시 \"웹에서나 잘 반영되면 좋겠는데? 그걸 강화하는건 어때\" 의 4 단계 답. IDE / AI agent / CLI 어느 surface 가 vault .md 만지면 웹 탭이 focus 안 해도 ~5s 안에 반영. | Step | What | Where 인지 | |||| | 155 polling | 5s 간격 fingerprint check + visibleonly 자동 reload | 백그라운드 | | 156 graph diff pulse | 새 노드 amber ",
       "wordCount": 289,
-      "updatedAt": "2026-05-05T23:36:19.129Z",
+      "updatedAt": "2026-05-06T02:02:33.371Z",
       "linksOut": []
     },
     {
@@ -4692,7 +4848,7 @@
       ],
       "excerpt": "crosscutting. 라이트/다크 토글 (html[datatheme=\"light\"]), Sonner기반 toast, arialive 스크린리더 announce, 모바일 BottomTabBar + gesture hint, ⌘K · ⇧⌘K · ? · F · N · Esc 단축키, prefersreducedmotion 자동 존중. 자세한 디자인 룰: docs/DESIGNSYSTEM.md.",
       "wordCount": 37,
-      "updatedAt": "2026-05-05T23:37:41.046Z",
+      "updatedAt": "2026-05-06T02:02:33.372Z",
       "linksOut": []
     },
     {
@@ -4764,7 +4920,7 @@
       ],
       "excerpt": "사용자 디스크 폴더를 진실원으로. File System Access API + IndexedDB 기반 핸들 영속. focus / visibility 시 fingerprint 비교로 재스캔 shortcircuit. R14 부터는 visible 인 동안 5s polling 으로 focus 안 해도 자동 반영 (vaultliveupdates). 자세한 원칙: .claude/rules/localfirst.md. 사용자 surface: docs/FEATURES.md.",
       "wordCount": 45,
-      "updatedAt": "2026-05-05T23:36:19.129Z",
+      "updatedAt": "2026-05-06T02:02:33.372Z",
       "linksOut": []
     },
     {
@@ -5168,7 +5324,7 @@
       ],
       "excerpt": "Written (v2): 20260501 Decisions captured: the user confirmed Direction A (ontologyfirst) and added dogfooding + AIagent partnership as a new direction. This file overlays v2 on top of v1's strategic diagnosis (left in place); the decisions and the new direction below are what's current. One codebase, one ontology, tha",
       "wordCount": 1788,
-      "updatedAt": "2026-05-05T23:38:39.906Z",
+      "updatedAt": "2026-05-06T02:02:33.370Z",
       "linksOut": []
     },
     {
@@ -6051,6 +6207,20 @@
         "type": "doc",
         "slug": "DESIGN-SYSTEM",
         "title": "Design System"
+      },
+      {
+        "name": "dogfood-friction-2026-05-06",
+        "path": "dogfood-friction-2026-05-06",
+        "type": "doc",
+        "slug": "dogfood-friction-2026-05-06",
+        "title": "Dogfood friction report — external-user simulation (2026-05-06)"
+      },
+      {
+        "name": "dogfood-paravel-2026-05-06",
+        "path": "dogfood-paravel-2026-05-06",
+        "type": "doc",
+        "slug": "dogfood-paravel-2026-05-06",
+        "title": "Dogfood — real external codebase (sanitized, 2026-05-06)"
       },
       {
         "name": "FEATURES",

--- a/src/shared/ui/error-boundary.tsx
+++ b/src/shared/ui/error-boundary.tsx
@@ -59,7 +59,6 @@ export class ErrorBoundary extends Component<
   componentDidCatch(error: Error) {
     this.props.onError?.(error);
     if (typeof console !== 'undefined') {
-      // eslint-disable-next-line no-console
       console.error('[ErrorBoundary]', error);
     }
   }


### PR DESCRIPTION
## Summary

post-publish architectural audit (Plan agent advisor) 의 *blocking* Concern 4 fix. **CLI 6 vs MCP 14 ergonomic asymmetry** — 개발자가 위험한-그러나-필수 작업 (rename / merge / delete / backlinks / query) 을 *AI agent 통해서만* 가능 → mission *"developer + AI agent grow together"* inversion. 이 PR 이 fix.

**CLI v0.2.0 → v0.3.0 (6 → 11 명령)**.

## 새 명령

| Command | Wraps MCP tool | Pattern |
|---|---|---|
| `backlinks <slug>` | `find_backlinks` | read, --json |
| `query "<filter>"` | `query_concepts` | typed DSL (kind=X AND has(Y) AND NOT ...) |
| `rename <old> <new>` | `rename_concept` | dry-run default, --confirm |
| `merge <from> <into>` | `merge_concepts` | dry-run default, --confirm |
| `delete <slug>` | `delete_concept` | dry-run default, --confirm, --force |

## Implementation — single source of truth

\`cli/src/lib/mcp-call.mjs\` — mcp child_process spawn + JSON-RPC. mcp 가 *진실원*, cli 는 thin wrapper. **drift surface 0** (logic 복제 안 함, 4-way schema 패턴 확장 안 함). spawn overhead ~50-100ms per call — 한 번씩 호출이라 acceptable.

mcp entry resolution: \`OMOT_MCP_PATH\` env → \`require.resolve('oh-my-ontology-mcp/src/index.js')\` → monorepo dev fallback (\`../../../mcp/src/index.js\`).

\`cli/package.json\` 에 \`dependencies: { "oh-my-ontology-mcp": "^0.7.1" }\` 명시 — npm install 시 mcp 자동 설치.

## 부수 fix (lint baseline 19 → 17)

- \`scripts/audit-vault-paths.mjs:17\` — unused statSync import 제거
- \`src/shared/ui/error-boundary.tsx:62\` — unused eslint-disable directive 제거

남은 17 = 16 idiomatic floor (\`react-hooks/set-state-in-effect\`) + 1 lib 호환 (TanStack Virtual).

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test:run\` — 814 / 814
- [x] \`node cli/src/integration.test.mjs\` — **32 / 32** (이전 24 + 8 new):
  - backlinks 컬러 + JSON (matches[] 정확)
  - query DSL filter (kind=X AND has(elements))
  - rename dry-run + --confirm + backlink redirect 검증
  - delete backlinks 가드 + --confirm
  - merge dry-run preview
- [x] \`pnpm vault:validate\` — 25 노드 issue 0
- [x] \`pnpm vault:audit\` — 65 paths drift 0
- [x] \`pnpm lint\` — 17 warnings (19 → 17 trivial fix)
- [x] manual: 5 명령 모두 정확 (rename/delete confirm path 디스크 변경 검증)

## Dogfood vault

\`capabilities/cli-developer-entry.md\` 갱신 — 5 → 11 명령, 5 element 추가 (backlinks/query/rename/merge/delete + mcp-call helper). manifest.json 자동 재빌드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)