### PR TITLE
feat(mcp+cli): R16 analyze_repo_structure — 자율 ingest base (15th MCP tool)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Project overview
 
-`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (14 tools).
+`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (15 tools).
 
 For direction, see `docs/PRODUCT-DIRECTION.md`. For features users can use right now, see `docs/FEATURES.md`.
 
@@ -60,7 +60,7 @@ src/                       FSD layers
   ├── features/            interaction units
   ├── entities/            business entities
   └── shared/              UI · lib · config primitives
-mcp/                       MCP server (the AI agent's surface) — npm pkg, 14 tools
+mcp/                       MCP server (the AI agent's surface) — npm pkg, 15 tools
 cli/                       CLI binary (developer's daily entry point) — npm pkg, R12 v0.2
                            init / list / validate / add / find / import
 docs/                      long-form docs
@@ -125,7 +125,7 @@ Long-form docs:
 - `@docs/FEATURES.md` — features users can use right now
 - `@docs/ARCHITECTURE.md` · `@docs/DESIGN-SYSTEM.md`
 - `@docs/CHANGELOG.md` — chronological user-visible changes
-- `@mcp/README.md` — AI agent partner (MCP 14 tools — read 8 + write 6) registration + usage
+- `@mcp/README.md` — AI agent partner (MCP 15 tools — read 9 + write 6) registration + usage
 - `@docs/archive/` — historical analysis docs (no longer normative)
 
 ## This project's own ontology
@@ -150,6 +150,11 @@ The vault is the **shared mental model** between the developer and the AI agent.
 - `find_path(from, to)` — does a relation already exist?
 
 A 30-second read at the top of the task often replaces a 10-minute re-discovery in the code.
+
+**Bootstrap an empty vault** (R16). When a user just ran `oh-my-ontology init` on a fresh repo and the vault has only the 5 starter nodes, don't make the user hand-author every node. Instead:
+
+- Call `analyze_repo_structure` once. **Side effect 0** — it returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]) by reading `package.json` / `README.md` H2 sections / `src/` folder layout (FSD or generic). It does NOT write to the vault.
+- Show the candidates to the user, let them prune obvious noise, then call `add_concept` / `add_relation` per accepted candidate. This is the only path into the vault — single source of truth preserved.
 
 **Write at the end of a task** (the part that's easy to skip). When a unit of work introduced a new capability / element / domain, or renamed/folded an existing one, mirror the change in the vault:
 
@@ -185,7 +190,7 @@ When an AI agent (`add_concept`) or a developer (`oh-my-ontology add` / `oh-my-o
 
 ### 프로젝트 개요
 
-`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (14 tools) 로 같은 `.md` 파일을 read/write.
+`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (15 tools) 로 같은 `.md` 파일을 read/write.
 
 핵심 원칙 한 줄 (v3, R11 fire #25):
 
@@ -249,6 +254,11 @@ vault 는 개발자와 AI agent 가 **공유하는 mental model**. ontology 의 
 - `find_path(from, to)` — 관계가 이미 있나?
 
 작업 head 의 30 초 read 가 코드에서의 10 분 재발견을 자주 대신해 줌.
+
+**빈 vault 부트스트랩** (R16). 사용자가 fresh repo 에서 `oh-my-ontology init` 만 한 직후 — 5 starter 노드 외 빈 vault. 사용자가 매 노드 손 작성 부담 — 대신:
+
+- `analyze_repo_structure` 1 회 호출. **side effect 0** — `package.json` / `README.md` H2 / `src/` 폴더 layout (FSD or generic) 읽어 deterministic 후보 (project + domains[] + capabilities[] + elements[] + suggestedRelations[]) 반환. vault 변경 안 함.
+- 후보를 사용자에게 보여주고 noise 제외 후 채택된 것만 `add_concept` / `add_relation`. 단일 source of truth 보존 — vault 진입은 *명시 add* 만.
 
 **작업 끝에 write** (쉽게 빠뜨림). 한 작업 단위가 새 capability / element / domain 을 도입했거나 기존 것을 rename / 합쳤다면, vault 에 반영:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **One codebase, one ontology, that the developer and their AI agent grow together.**
 >
 > Local-first markdown vault. Developer authors via CLI / web UI.
-> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 14 tools.
+> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 15 tools.
 > No backend. No login. The git repo is the source of truth.
 
 [![CI](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml/badge.svg)](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml)
@@ -44,9 +44,11 @@ Three claims:
 2. **Developer + AI agent share one source of truth** — both edit the same
    `.md` files. The developer authors via CLI / web UI; the AI agent reads
    + writes via MCP (Claude Code, Codex, Cursor). Same git repo, same diff.
-3. **MCP server gives the AI its only interface** — **14 tools** (8 read +
+3. **MCP server gives the AI its only interface** — **15 tools** (9 read +
    6 write) over JSON-RPC. The agent doesn't need to "ingest your codebase";
-   it reads the ontology the developer already curates.
+   it reads the ontology the developer already curates. R16 added
+   `analyze_repo_structure` so the agent can also bootstrap a fresh repo
+   into the vault with one call (side effect 0, candidates only).
 
 ## Why we built this
 
@@ -71,7 +73,7 @@ The same frontmatter graph rendered three ways:
 - **Topology** (`/topology`) — Sigma WebGL spatial network of projects
 - **Tree** (`/`, `/ontology`) — hierarchical drill-down (project → domain → capability → element)
 - **ERD builder** (`/ontology/edit`) — xyflow canvas to add nodes and relations visually
-- **MCP** (separate package) — JSON-RPC over stdio, 14 tools
+- **MCP** (separate package) — JSON-RPC over stdio, 15 tools
 
 All four read and write the same `.md` files. Pick whichever view fits
 the moment.
@@ -125,7 +127,7 @@ becoming graph nodes.
 | Promise | Verification |
 |---|---|
 | **vault frontmatter = the graph** (no review queue, no LLM extraction) | `grep -r "extractionJob" src/ → 0` |
-| **AI agent partner via MCP** | `mcp/` package, 14 tools, `mcp/scripts/verify.mjs` smoke |
+| **AI agent partner via MCP** | `mcp/` package, 15 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
 | **Dogfooding** | `docs/ontology/` is this project's own curated mental model — **25 nodes** (capabilities 12 · domains 6 · elements 4 · project 1 · vault-readme 1). The MCP server you'd run is the one we use to write *this README*. |
 | **Vault scale** | `node scripts/perf-vault.mjs` measures walk + read + parse on synthetic vaults. **2,000 .md files in 33 ms** (linear, ~17 µs/file). Sub-second up to 1,000 nodes — the ontology will not become the bottleneck. |
@@ -137,7 +139,7 @@ becoming graph nodes.
 - **i18n**: next-intl 4.11 with `/[locale]/` URL prefix (en / ko)
 - **Visualization**: Sigma.js (WebGL) + Graphology + ForceAtlas2 + xyflow + dagre
 - **Local-first**: File System Access API + IndexedDB
-- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 14 tools
+- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 15 tools
 - **Architecture**: Feature-Sliced Design (ESLint boundaries enforced)
 - **Tests**: Vitest unit + Playwright e2e
 
@@ -153,7 +155,7 @@ src/            Feature-Sliced Design layers
   ├── features/ user interactions
   ├── entities/ domain entities (project, ontology-class, knowledge-graph, …)
   └── shared/   ui primitives, lib, config
-mcp/            MCP server (`oh-my-ontology-mcp`, 14 tools) — AI agent surface
+mcp/            MCP server (`oh-my-ontology-mcp`, 15 tools) — AI agent surface
 cli/            `npx oh-my-ontology` (vault scaffold + 6 commands) — developer terminal surface
 docs/           Long-form docs + dogfood vault (docs/ontology/) + benchmark results
 docs/archive/   Historical analysis docs
@@ -194,12 +196,12 @@ cd my-vault
 - [`AGENTS.md`](AGENTS.md) — contributor (사람·AI 공통) 가이드
 - [`docs/PRODUCT-DIRECTION.md`](docs/PRODUCT-DIRECTION.md) — mission spec
 - [`docs/FEATURES.md`](docs/FEATURES.md) — 사용자 가시 기능 전수
-- [`mcp/README.md`](mcp/README.md) — MCP 서버 등록 + 14 도구
+- [`mcp/README.md`](mcp/README.md) — MCP 서버 등록 + 15 도구
 
 ### 핵심 약속
 
 1. **vault frontmatter = 그래프** — 검수 큐 / 추출 워커 없음. frontmatter 자기-승인.
-2. **AI agent partner** — MCP 서버 (read 8 + write 6) 로 같은 vault read/write.
+2. **AI agent partner** — MCP 서버 (read 9 + write 6, R16 `analyze_repo_structure` 포함) 로 같은 vault read/write + 빈 vault bootstrap.
 3. **Local-first single-source** — 사용자 디스크 vault 가 진실원. Firebase / 백엔드 / 인증 의존 0 (R10 — 2026-05).
 4. **Dogfooding** — `docs/ontology/` 가 프로젝트 자기 자신의 mental model.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.4.0 — 2026-05-06 (R16 — autonomous ingest base)
+
+### Added — `analyze` command (12th, mcp v0.8.0 spawn wrapper)
+
+- `oh-my-ontology analyze [rootPath]` — code repo (default cwd) walk, propose ontology node candidates. **side effect 0** — vault NOT modified. Detects FSD vs generic layout, package.json name → project, README H2 → domains.
+- `--json` / `--max-depth N` flags.
+- 사용자가 결과 검토 후 `oh-my-ontology add` 또는 AI agent `add_concept` 으로 명시 진입.
+
 ## 0.3.0 — 2026-05-06 (R15 follow-up — graph-level commands)
 
 ### Added — 5 graph-level commands (Concern 4 fix)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.3.0",
-  "description": "AI-native codebase ontology workbench — vault scaffold + list/validate/add/find/import + graph-level backlinks/rename/merge/delete/query CLI.",
+  "version": "0.4.0",
+  "description": "AI-native codebase ontology workbench — vault scaffold + list/validate/add/find/import + graph-level backlinks/rename/merge/delete/query + R16 analyze (autonomous bootstrap).",
   "type": "module",
   "bin": {
     "oh-my-ontology": "src/index.mjs"
@@ -38,6 +38,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "oh-my-ontology-mcp": "^0.7.1"
+    "oh-my-ontology-mcp": "^0.8.0"
   }
 }

--- a/cli/src/commands/analyze.mjs
+++ b/cli/src/commands/analyze.mjs
@@ -1,0 +1,160 @@
+// R16 (b3) — `oh-my-ontology analyze [rootPath]`
+// Wraps MCP analyze_repo_structure. side effect 0 — vault 변경 안 함, 후보만.
+// 사용자가 결과 보고 *명시적으로* `oh-my-ontology add` 또는 AI agent 의
+// add_concept 로 진입.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+const KIND_COLOR = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+};
+
+export async function runAnalyze(args) {
+  const { rootPath, vault, json, maxDepth, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const target = resolve(process.cwd(), rootPath);
+  // analyze 는 *vault 와 무관* 한 도구지만 mcp 통과 시 OMOT_VAULT 가 필요해서
+  // 그냥 cwd 또는 사용자 지정. mcp 의 analyze 도 vault 안 만지지만
+  // initialization 흐름에 vault path 가 필요.
+  const vaultRoot = resolve(process.cwd(), vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'analyze_repo_structure', {
+      rootPath: target,
+      maxDepth,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  const proj = result.project;
+  const fw = result.framework ?? 'generic';
+  process.stdout.write(
+    `${COLORS.bold}analyze${COLORS.reset} ${COLORS.dim}${target}${COLORS.reset} ` +
+      `${COLORS.dim}(framework=${fw})${COLORS.reset}\n\n`,
+  );
+
+  if (proj) {
+    process.stdout.write(
+      `  ${KIND_COLOR.project}project${COLORS.reset}     ${proj.slug} ${COLORS.dim}— ${proj.title}${COLORS.reset}\n\n`,
+    );
+  }
+
+  printSection('domains', result.domains ?? [], COLORS, KIND_COLOR.domain);
+  printSection(
+    'capabilities',
+    result.capabilities ?? [],
+    COLORS,
+    KIND_COLOR.capability,
+  );
+  printSection('elements', result.elements ?? [], COLORS, KIND_COLOR.element);
+
+  const rels = result.suggestedRelations ?? [];
+  if (rels.length > 0) {
+    process.stdout.write(
+      `  ${COLORS.bold}suggested relations${COLORS.reset} ${COLORS.dim}(${rels.length})${COLORS.reset}\n`,
+    );
+    for (const r of rels.slice(0, 8)) {
+      process.stdout.write(
+        `    ${COLORS.dim}${r.from} —${r.type}→ ${r.to}${COLORS.reset}\n`,
+      );
+    }
+    if (rels.length > 8)
+      process.stdout.write(
+        `    ${COLORS.dim}… ${rels.length - 8} more${COLORS.reset}\n`,
+      );
+    process.stdout.write('\n');
+  }
+
+  process.stdout.write(
+    `${COLORS.dim}side effect 0 — vault 변경 안 함. 후보가 맞으면${COLORS.reset} ` +
+      `${COLORS.bold}oh-my-ontology add${COLORS.reset} ` +
+      `${COLORS.dim}또는 AI agent 의 add_concept 로 명시 작성.${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
+function printSection(label, items, colors, kindColor) {
+  if (items.length === 0) return;
+  process.stdout.write(
+    `  ${colors.bold}${label}${colors.reset} ${colors.dim}(${items.length})${colors.reset}\n`,
+  );
+  for (const it of items.slice(0, 12)) {
+    const ev = it.evidence?.source ? `${colors.dim} ← ${it.evidence.source}${colors.reset}` : '';
+    process.stdout.write(
+      `    ${kindColor}${(it.slug || '').padEnd(36)}${colors.reset} ${it.title || ''}${ev}\n`,
+    );
+  }
+  if (items.length > 12)
+    process.stdout.write(
+      `    ${colors.dim}… ${items.length - 12} more${colors.reset}\n`,
+    );
+  process.stdout.write('\n');
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--max-depth')
+      flags.maxDepth = Number(args[++i]) || undefined;
+    else if (a.startsWith('--max-depth='))
+      flags.maxDepth = Number(a.slice('--max-depth='.length)) || undefined;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  return {
+    rootPath: positional[0] ?? '.',
+    vault: flags.vault,
+    json: flags.json,
+    maxDepth: flags.maxDepth,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology analyze [rootPath] [--vault path] [--json] [--max-depth N]\n\n` +
+      `${COLORS.bold}What it does:${COLORS.reset}\n` +
+      `  Walk a code repository (default: cwd), detect package.json / README\n` +
+      `  H2 sections / src/ folders, propose ontology node candidates.\n` +
+      `  ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함. 사용자가 후보 검토 후\n` +
+      `  ${COLORS.bold}oh-my-ontology add${COLORS.reset} 또는 AI agent 의 add_concept 로 명시 작성.\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology analyze\n` +
+      `  oh-my-ontology analyze ~/my-app --json\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -58,6 +58,10 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --kind K                               ${COLORS.dim}fallback kind when input has no kind:${COLORS.reset}
        --auto-prefix --rename --dry-run       ${COLORS.dim}folder prefix · slug rename · plan-only${COLORS.reset}
 
+${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16 — autonomous ingest base)${COLORS.reset}
+  npx oh-my-ontology analyze [rootPath]       Walk a repo, propose ontology node candidates (side effect 0)
+       --max-depth N --json                   ${COLORS.dim}folder walk depth · machine output${COLORS.reset}
+
 ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
   npx oh-my-ontology query "<filter>"         Typed filter DSL (kind=X AND has(elements))
@@ -291,6 +295,11 @@ if (SUBCOMMAND === 'merge') {
 if (SUBCOMMAND === 'delete') {
   const { runDelete } = await import('./commands/delete.mjs');
   exit(await runDelete(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'analyze') {
+  const { runAnalyze } = await import('./commands/analyze.mjs');
+  exit(await runAnalyze(ARGS.slice(1)));
 }
 
 fail(`unknown command: ${SUBCOMMAND}`);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,44 @@
 
 ---
 
+## 2026-05-06 — Round 16: 자율 ingest base — `analyze_repo_structure` 첫 도구
+
+사용자 grill-me 결정 (Q1: AI 자동 ontology 화 / Q2: 자율 ingest from codebase 가 가장 critical 약점). *"MCP 가 잘 되면서 온톨로지화를 기가막히게"* + *"단일 source of truth 보존"* 의 첫 step.
+
+### MCP `analyze_repo_structure` (15번째 tool, mcp v0.7.1 → v0.8.0)
+
+사용자 한 줄 *"이 codebase 분석해줘"* 후 AI agent (Claude Code, Codex, Cursor) 가 호출할 *deterministic helper*. **side effect 0** — vault frontmatter 절대 안 건드림, 후보만 return:
+
+- `package.json` `name/description` → project candidate
+- `README.md` 첫 H1 → project title fallback
+- `README.md` H2 sections (Usage / Installation / Tests 등 generic skip) → domain candidates
+- `src/features|entities|widgets|views/*` (FSD) 또는 `src/*` (generic) → capability/element candidates
+- `suggestedRelations` — project contains 각 capability
+
+응답 shape: `{ rootPath, framework, project, domains[], capabilities[], elements[], suggestedRelations[], skipped[] }`. 사용자 검토 후 *명시 add_concept / add_relation* 만 vault 진입 → **단일 source of truth 보존**.
+
+### CLI `analyze` 명령 (cli v0.3.0 → v0.4.0, 11 → 12 명령)
+
+mcp child_process spawn wrapper. 동일 contract — color CLI / `--json` / `--max-depth`. publish 후 `npx oh-my-ontology analyze` 한 줄로 분석.
+
+### Tests + dogfood
+
+mcp/src/analyze.test.mjs — 7 unit case (FSD / generic / no package.json / generic README skip / ignored folders / empty dir / suggested relations). dogfood `capabilities/mcp-server.md` 갱신 (15 tools, analyze.mjs element 추가). AGENTS.md *"빈 vault bootstrap"* 섹션 영문 + 한국어 추가.
+
+### Mission align
+
+이전 — 사용자가 `init` 후 *수동 add* 25 회 (Paravel real-codebase dogfood 측정). *첫 user Aha moment* 부족.
+이후 — agent 가 한 번 `analyze_repo_structure` → 30+ 후보 즉시. 사용자 검토 + 1-clicks add_concept 다발 호출. *기가막히다* 의 base.
+
+### 다음 step (R17 후보)
+
+- `infer_imports` (TypeScript / JS import graph → dependency 관계)
+- `extract_domains_from_readme` (heading 기반 deeper)
+- `/ontology-bootstrap` skill (한 줄 흐름 orchestrate)
+- agent 의 *implicit detect* 강화 (작업 중 자율 sync)
+
+---
+
 ## 2026-05-06 — Round 15 follow-up #2: Project type honest (Concern 1 fix)
 
 post-publish architectural audit (Plan agent advisor) 의 *blocking* Concern 1 fix. **`Project` 18 fields silent fabrication** — vault frontmatter 4 fields ↔ web 18 fields *두 source-of-truth*. `deriveProjectsFromVault` 가 fabricated default (`category: 'uncategorized'` / `status: 'active'` / `isHub: false` / `position: { x:0, y:0 }`) 을 박아 web 이 *vault 가 가지지 않은 정보* 를 표시. README *"frontmatter is the graph"* 약속과 충돌.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -15,7 +15,7 @@
 | Surface | Entry | Audience |
 |---|---|---|
 | **CLI** (R12 / R14 / R15) | `oh-my-ontology init / list / validate / add / find / import` | developer terminal — vault scaffold, daily exploration, bulk import |
-| **MCP** (R5 / R7 / R11 / R14) | 14 tools (8 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings |
+| **MCP** (R5 / R7 / R11 / R14 / R16) | 15 tools (9 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings · bootstrap empty vault (R16 `analyze_repo_structure`) |
 | **Web** (8 routes, R10 surface diet) | `pnpm dev` / static export | sigma topology · tree+ego · ERD builder · insights — graph visualization, mobile-friendly |
 
 ```
@@ -384,7 +384,7 @@ Used when a non-existent slug is hit in static export. Redirects or shows "not f
 
 ---
 
-## 3. MCP server (14 tools)
+## 3. MCP server (15 tools)
 
 Run via `pnpm exec node mcp/src/index.js` (registered in user's `.mcp.json`). AI agents read/write the same vault as humans.
 

--- a/docs/ontology/capabilities/mcp-server.md
+++ b/docs/ontology/capabilities/mcp-server.md
@@ -1,20 +1,21 @@
 ---
 slug: capabilities/mcp-server
 kind: capability
-title: MCP Server (14 tools)
+title: MCP Server (15 tools)
 domain: ai-agent-partner
 elements:
   - mcp/src/index.js
   - mcp/src/parser.mjs
   - mcp/src/vault.mjs
+  - mcp/src/analyze.mjs
 relates:
   - capabilities/frontmatter-to-ontology
   - domains/ai-agent-partner
 ---
 
-# MCP Server (14 tools)
+# MCP Server (15 tools)
 
-`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 14 도구 노출 (read 8 + write 6):
+`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 15 도구 노출 (read 9 + write 6):
 
 | 도구 | 동작 |
 |---|---|
@@ -26,6 +27,7 @@ relates:
 | `list_kinds` | kind 분포 census (`{ total, byKind: { capability: N, ... } }`) |
 | `find_orphans` | 어디서도 link 안 받는 고립 노드 (kind 필터, vault-readme 자동 제외) |
 | `query_concepts` | DSL 기반 ad-hoc 쿼리 (frontmatter 키 = / contains / exists 조합) |
+| `analyze_repo_structure` | **R16** code repo (default cwd) 분석 → ontology 노드 후보 제안. **side effect 0** — vault 변경 안 함. AI agent 가 빈 vault bootstrap 시 사용 (사용자 한 줄 *"이 codebase 분석해줘"*). FSD vs generic detect. |
 | `add_concept` | 새 노드 (.md) 작성 — 기존 slug 면 throw |
 | `add_relation` | depends_on / relates / contains / describes edge 추가 |
 | `patch_concept` | 기존 노드 frontmatter (key 단위 patch) + body 갱신 |

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — oh-my-ontology-mcp
 
+## 0.8.0 — 2026-05-06 (R16 — autonomous bootstrap base)
+
+### Added
+
+- **`analyze_repo_structure`** — 새 도구. 사용자 한 줄 *"이 codebase 분석해줘"* 후 AI agent 가 호출할 deterministic 도구. **side effect 0** — vault frontmatter 절대 안 건드림, 후보만 return. 감지: `package.json` `name/description` → project 후보, `README.md` 첫 H1 → project title fallback, `README.md` H2 (Usage/Installation 등 generic skip) → domain 후보, `src/features|entities|widgets|views/*` (FSD) 또는 `src/*` (generic) → capability/element 후보. + `suggestedRelations` (project contains 각 capability).
+- 사용자 검토 후 *명시 add_concept / add_relation* 만 vault 진입 — 단일 source of truth 보존.
+- 7 unit test — FSD / generic / no package.json / generic README 섹션 skip / ignored folders / empty dir / suggested relations.
+
+### Tools count
+
+- **15 (9 read + 6 write)** — analyze_repo_structure 가 read (side effect 0).
+
 ## 0.7.1 — 2026-05-04
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,7 +44,7 @@ If `OMOT_VAULT` is not set, the current working directory is used as the vault r
 
 ### 2. Restart Claude Code
 
-The server connects over stdio. You should now see 14 tools under the `oh-my-ontology` namespace.
+The server connects over stdio. You should now see 15 tools under the `oh-my-ontology` namespace.
 
 ### 3. Call the tools
 
@@ -56,7 +56,7 @@ The server connects over stdio. You should now see 14 tools under the `oh-my-ont
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## The 14 tools (v0.7.1)
+## The 15 tools (v0.7.1)
 
 | Tool | What it does |
 |---|---|
@@ -68,6 +68,7 @@ The server connects over stdio. You should now see 14 tools under the `oh-my-ont
 | `list_kinds` | Vault kind census: `{ total, byKind: { capability: N, ... } }`. |
 | `find_orphans` | **v0.5** Finds isolated nodes — docs that no other node references in its frontmatter. Options: `kind` (filter), `excludeKinds` (skip, default `['vault-readme']`). Useful as a starting point for cleanup or auditing unused nodes. |
 | `query_concepts` | **v0.6** Typed filter DSL — `kind=X AND has(Y) AND NOT ...`. Saved-filter / smart-list use case. |
+| `analyze_repo_structure` | **R16** Analyze a code repository (default cwd) and propose ontology node candidates from `package.json` / `README.md` H2 / `src/` folders. **side effect 0** — vault NOT modified. The agent (or human) reviews and selectively passes accepted candidates to `add_concept` / `add_relation`. Detects FSD vs generic layout. Use once when bootstrapping a fresh repo. |
 | `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. **R14**: frontmatter is normalized per kind (project gets `domains/capabilities/elements: []`; capability gets `elements: []`; capability/element should set `domain` — missing extras come back in `warnings`). Body defaults to a kind-specific starter. Throws if the slug already exists. |
 | `add_relation` | Adds an edge between two slugs. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). Appends to the appropriate frontmatter array. **R11**: optional `expected_mtime` on the source slug for conflict detection. |
 | `patch_concept` | Updates an existing node's frontmatter (per-key patch — `null` deletes a key) and/or body. Use this when you need to *modify* a slug that `add_concept` would reject as duplicate. **R11**: optional `expected_mtime` for conflict detection — pass the `mtime` from `get_concept`; throws `VaultConflictError` if the file has been modified externally since you read it. |
@@ -130,7 +131,7 @@ A successful run looks like this:
 ✓ tools/list 14/14 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · merge_concepts · patch_concept · query_concepts · rename_concept
 ✓ list_concepts — vault total 25 nodes
 
-All checks passed — register .mcp.json with Claude Code, restart, and the 14 tools are ready.
+All checks passed — register .mcp.json with Claude Code, restart, and the 15 tools are ready.
 ```
 
 On failure, it tells you which step blocked progress and prints a diagnostic message.
@@ -159,7 +160,7 @@ After you add `.mcp.json` and restart Claude Code, try the following with your L
 > 3. Call `find_backlinks({ slug: "capabilities/mcp-server" })` to find what depends on that capability.
 > 4. (Optional) Call `add_concept` to create a new capability node — `slug`, `kind`, and `title` are required.
 
-If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 14 tools (8 read + 6 write), the human + AI co-authoring loop is officially open.
+If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 15 tools (9 read + 6 write), the human + AI co-authoring loop is officially open.
 
 ## Design principles
 
@@ -170,7 +171,7 @@ If those four tools respond cleanly, your read/write round-trip against the vaul
 
 ## Status
 
-- 0.7.1 — 14 tools. Added `instructions` field on initialize response — Claude Code / Cursor see kind hierarchy + workflow + write-tool dry-run pattern + `expected_mtime` conflict guard guidance on connect, no per-session trial-and-error.
+- 0.7.1 — 15 tools. Added `instructions` field on initialize response — Claude Code / Cursor see kind hierarchy + workflow + write-tool dry-run pattern + `expected_mtime` conflict guard guidance on connect, no per-session trial-and-error.
 - 0.7.0 — 14 tools (8 read + 6 write). Added `rename_concept` and `merge_concepts` (graph-level write — atomic backlink redirect across all referrers).
 - 0.6.0 — 12 tools (8 read + 4 write). Added `query_concepts` (typed filter DSL).
 - 0.5.0 — 7 read + 4 write. Added `find_orphans`.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.7.1",
-  "description": "MCP server — humans and AI agents read/write the same codebase ontology vault.",
+  "version": "0.8.0",
+  "description": "MCP server — humans and AI agents read/write the same codebase ontology vault. R16: 15 tools (analyze_repo_structure for autonomous bootstrap).",
   "keywords": [
     "mcp",
     "model-context-protocol",
@@ -26,13 +26,14 @@
     "src/query.mjs",
     "src/validate.mjs",
     "src/vault.mjs",
+    "src/analyze.mjs",
     "scripts/verify.mjs",
     "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test src/parser.test.mjs src/query.test.mjs src/validate.test.mjs src/vault.test.mjs src/redirect-backlinks.test.mjs src/conflict-detection.test.mjs src/integration.test.mjs",
+    "test": "node --test src/parser.test.mjs src/query.test.mjs src/validate.test.mjs src/vault.test.mjs src/redirect-backlinks.test.mjs src/conflict-detection.test.mjs src/analyze.test.mjs src/integration.test.mjs",
     "test:smoke": "node src/parser.test.mjs",
     "verify": "node scripts/verify.mjs"
   },

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -36,6 +36,7 @@ const EXPECTED_TOOLS = [
   'list_kinds',
   'find_orphans',
   'query_concepts',
+  'analyze_repo_structure',
   'add_concept',
   'add_relation',
   'patch_concept',

--- a/mcp/src/analyze.mjs
+++ b/mcp/src/analyze.mjs
@@ -1,0 +1,301 @@
+// R16 (b3) — analyze_repo_structure
+//
+// AI agent (Claude Code, Codex, Cursor) 가 사용자 한 줄 "이 codebase 분석해줘"
+// 후 호출할 *deterministic* 도구. side effect 0 — vault 변경 안 함, 후보만
+// 제안. agent 가 사용자에게 보여주고 *명시 add_concept* 호출.
+//
+// 단일 source of truth 보존:
+//   - 결과는 return only. vault frontmatter 직접 안 건드림.
+//   - 사용자 검토 + 명시 add 로만 vault 진입 → drift 0.
+//
+// 감지 패턴 (generic — 80% codebase cover. 더 정교한 framework 별 detect 는
+// 후속 도구 — infer_imports / extract_domains_from_readme 등):
+//   - package.json `name` → project slug + title
+//   - README.md 첫 H1 → project title (package.json 없으면 fallback)
+//   - README.md H2 sections → domain 후보
+//   - src/ (또는 root) 깊이 1 폴더 → capability 후보 (단 dotfile / 일반 무시
+//     폴더 제외)
+//   - 각 capability 폴더의 main file (index.ts/js/mjs/tsx) → element 후보
+//
+// 결과 shape:
+//   {
+//     rootPath, framework: 'fsd' | 'next' | 'generic',
+//     project?: { slug, title },
+//     domains: [{ slug, title, evidence: { source, line? } }],
+//     capabilities: [{ slug, title, evidence: { source } }],
+//     elements: [{ slug, title, evidence: { source } }],
+//     suggestedRelations: [{ from, to, type }],
+//     skipped: [{ path, reason }],
+//   }
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, basename, relative } from 'node:path';
+
+const DEFAULT_IGNORE = new Set([
+  'node_modules',
+  '.git',
+  'out',
+  'dist',
+  'build',
+  '.next',
+  '.expo',
+  '.turbo',
+  '.cache',
+  '.idea',
+  '.vscode',
+  'coverage',
+  '__pycache__',
+  '.pytest_cache',
+  '.venv',
+  'venv',
+]);
+
+const SOURCE_FOLDERS = ['src', 'lib', 'app', 'packages'];
+
+const ELEMENT_ENTRY_FILES = [
+  'index.ts',
+  'index.tsx',
+  'index.js',
+  'index.mjs',
+  'main.ts',
+  'main.js',
+];
+
+/**
+ * 한 codebase 의 root 를 walk + README 분석 → ontology node 후보 list.
+ *
+ * @param {string} rootPath — 분석할 디렉토리 (보통 cwd 또는 user-provided).
+ * @param {{ maxDepth?: number, ignore?: string[] }} options
+ * @returns analysis result
+ */
+export function analyzeRepoStructure(rootPath, options = {}) {
+  if (!existsSync(rootPath) || !statSync(rootPath).isDirectory()) {
+    throw new Error(`rootPath not a directory: ${rootPath}`);
+  }
+  const maxDepth = options.maxDepth ?? 2;
+  const ignore = new Set([
+    ...DEFAULT_IGNORE,
+    ...((options.ignore ?? []).map(String)),
+  ]);
+
+  const skipped = [];
+  const project = detectProject(rootPath);
+  const { domains, readmePath } = detectDomainsFromReadme(rootPath);
+
+  // SOURCE_FOLDERS 중 첫 번째 존재하는 것을 src dir 로
+  let srcDir = null;
+  for (const cand of SOURCE_FOLDERS) {
+    const p = join(rootPath, cand);
+    if (existsSync(p) && statSync(p).isDirectory()) {
+      srcDir = p;
+      break;
+    }
+  }
+
+  // framework heuristic — *features/* 만 있어도 fsd 로 (oh-my-ontology 자체
+  // 같이 lean FSD). 둘 이상 marker 면 strong fsd.
+  let framework = 'generic';
+  const fsdMarkers = ['features', 'entities', 'widgets', 'shared', 'views'];
+  if (srcDir) {
+    const subs = readdirSync(srcDir).filter((s) =>
+      statSync(join(srcDir, s)).isDirectory(),
+    );
+    const fsdHits = subs.filter((s) => fsdMarkers.includes(s)).length;
+    if (fsdHits >= 1) framework = 'fsd';
+  }
+  if (existsSync(join(rootPath, 'next.config.js')) || existsSync(join(rootPath, 'next.config.ts'))) {
+    framework = framework === 'fsd' ? 'fsd' : 'next';
+  }
+
+  const capabilities = [];
+  const elements = [];
+
+  if (srcDir) {
+    // FSD pattern — features/ 가 capability 의 main 영역
+    const fsdRoots =
+      framework === 'fsd'
+        ? ['features', 'entities', 'widgets', 'views']
+        : null;
+
+    if (fsdRoots) {
+      for (const r of fsdRoots) {
+        const dir = join(srcDir, r);
+        if (!existsSync(dir)) continue;
+        for (const sub of readdirSync(dir)) {
+          if (ignore.has(sub) || sub.startsWith('.')) {
+            skipped.push({ path: join(dir, sub), reason: 'dotfile/ignore' });
+            continue;
+          }
+          const subPath = join(dir, sub);
+          if (!statSync(subPath).isDirectory()) continue;
+          // features/ 와 entities/ 의 sub 는 capability 후보, widgets/views 는
+          // element 후보 (FSD 정의)
+          const isCapabilityish = r === 'features' || r === 'entities';
+          const slug = isCapabilityish
+            ? `${sub}`
+            : `${r}/${sub}`;
+          const evidence = {
+            source: relative(rootPath, subPath),
+          };
+          if (isCapabilityish) {
+            capabilities.push({
+              slug,
+              title: humanize(sub),
+              evidence,
+            });
+          } else {
+            elements.push({
+              slug: relative(rootPath, subPath),
+              title: humanize(sub),
+              evidence,
+            });
+          }
+        }
+      }
+    } else {
+      // generic — src/ 의 깊이 1 폴더 만
+      for (const sub of readdirSync(srcDir)) {
+        if (ignore.has(sub) || sub.startsWith('.')) {
+          skipped.push({ path: join(srcDir, sub), reason: 'dotfile/ignore' });
+          continue;
+        }
+        const subPath = join(srcDir, sub);
+        if (!statSync(subPath).isDirectory()) continue;
+        capabilities.push({
+          slug: sub,
+          title: humanize(sub),
+          evidence: { source: relative(rootPath, subPath) },
+        });
+        // index 파일이 있으면 element 추가
+        for (const entry of ELEMENT_ENTRY_FILES) {
+          const ep = join(subPath, entry);
+          if (existsSync(ep)) {
+            elements.push({
+              slug: relative(rootPath, ep),
+              title: `${humanize(sub)} entry`,
+              evidence: { source: relative(rootPath, ep) },
+            });
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // suggested relations:
+  //   - 각 capability → project (capabilities[]) endorse 후보
+  //   - 각 capability 의 첫 element → element relation
+  const suggestedRelations = [];
+  if (project) {
+    for (const cap of capabilities) {
+      suggestedRelations.push({
+        from: project.slug,
+        to: cap.slug,
+        type: 'contains',
+      });
+    }
+  }
+  if (maxDepth > 0); // reserved for deeper element walking
+
+  void readmePath; // signal used
+
+  return {
+    rootPath,
+    framework,
+    project,
+    domains,
+    capabilities,
+    elements,
+    suggestedRelations,
+    skipped,
+  };
+}
+
+function detectProject(rootPath) {
+  const pkgPath = join(rootPath, 'package.json');
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      const slugRaw = String(pkg.name || basename(rootPath));
+      const slug = slugRaw.replace(/^@/, '').replace(/\//g, '-');
+      const title =
+        (typeof pkg.description === 'string' && pkg.description.trim()) ||
+        humanize(slug);
+      return { slug, title };
+    } catch {
+      // fall through
+    }
+  }
+  // README first H1
+  for (const cand of ['README.md', 'readme.md', 'README']) {
+    const p = join(rootPath, cand);
+    if (!existsSync(p)) continue;
+    try {
+      const text = readFileSync(p, 'utf-8');
+      const m = text.match(/^#\s+(.+?)\s*$/m);
+      if (m) {
+        const title = m[1].trim();
+        return { slug: basename(rootPath), title };
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return { slug: basename(rootPath), title: humanize(basename(rootPath)) };
+}
+
+function detectDomainsFromReadme(rootPath) {
+  const candidates = ['README.md', 'readme.md', 'README'];
+  for (const cand of candidates) {
+    const p = join(rootPath, cand);
+    if (!existsSync(p)) continue;
+    try {
+      const text = readFileSync(p, 'utf-8');
+      const lines = text.split(/\r?\n/);
+      const domains = [];
+      const seen = new Set();
+      for (let i = 0; i < lines.length; i += 1) {
+        const m = lines[i].match(/^##\s+(.+?)\s*$/);
+        if (!m) continue;
+        const title = m[1].trim();
+        const slug = slugify(title);
+        if (!slug || seen.has(slug)) continue;
+        // skip generic README sections
+        if (
+          /^(usage|installation|getting started|quick start|license|contributing|requirements|features|setup|status|tech stack|architecture|folder map|routes|tests?|documentation)$/i.test(
+            title,
+          )
+        ) {
+          continue;
+        }
+        seen.add(slug);
+        domains.push({
+          slug,
+          title,
+          evidence: { source: cand, line: i + 1 },
+        });
+        if (domains.length >= 12) break; // sanity cap
+      }
+      return { domains, readmePath: p };
+    } catch {
+      // ignore
+    }
+  }
+  return { domains: [], readmePath: null };
+}
+
+function humanize(s) {
+  return s
+    .replace(/[-_/]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}

--- a/mcp/src/analyze.test.mjs
+++ b/mcp/src/analyze.test.mjs
@@ -1,0 +1,163 @@
+// R16 (b3) — analyzeRepoStructure unit tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { analyzeRepoStructure } from './analyze.mjs';
+
+function withRepo(setup) {
+  const root = mkdtempSync(join(tmpdir(), 'omot-analyze-'));
+  setup(root);
+  return root;
+}
+
+test('FSD repo — features/ + entities/ → capabilities, widgets/ + views/ → elements', () => {
+  const root = withRepo((r) => {
+    writeFileSync(
+      join(r, 'package.json'),
+      JSON.stringify({ name: 'my-app', description: 'Sample' }),
+    );
+    writeFileSync(
+      join(r, 'README.md'),
+      '# My App\n\n## Authentication\n\n## Billing\n\n## Usage\n',
+    );
+    mkdirSync(join(r, 'src/features/auth'), { recursive: true });
+    mkdirSync(join(r, 'src/features/billing'), { recursive: true });
+    mkdirSync(join(r, 'src/entities/user'), { recursive: true });
+    mkdirSync(join(r, 'src/widgets/header'), { recursive: true });
+    mkdirSync(join(r, 'src/views/home'), { recursive: true });
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.equal(r.framework, 'fsd');
+    assert.deepEqual(
+      [...r.capabilities.map((c) => c.slug)].sort(),
+      ['auth', 'billing', 'user'],
+    );
+    assert.deepEqual(
+      [...r.elements.map((e) => e.slug)].sort(),
+      ['src/views/home', 'src/widgets/header'],
+    );
+    assert.deepEqual(
+      r.domains.map((d) => d.slug),
+      ['authentication', 'billing'],
+    );
+    assert.equal(r.project.slug, 'my-app');
+    assert.equal(r.project.title, 'Sample');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Generic repo — src/ depth-1 folders → capabilities', () => {
+  const root = withRepo((r) => {
+    writeFileSync(join(r, 'package.json'), JSON.stringify({ name: 'gen' }));
+    writeFileSync(join(r, 'README.md'), '# Gen\n\n## API\n\n## DB\n');
+    mkdirSync(join(r, 'src/api'), { recursive: true });
+    mkdirSync(join(r, 'src/db'), { recursive: true });
+    writeFileSync(join(r, 'src/api/index.ts'), '');
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.equal(r.framework, 'generic');
+    assert.deepEqual(
+      r.capabilities.map((c) => c.slug).sort(),
+      ['api', 'db'],
+    );
+    // index.ts → element
+    const apiEl = r.elements.find((e) => e.slug.endsWith('api/index.ts'));
+    assert.ok(apiEl, 'api index.ts → element 후보');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('No package.json — README H1 fallback for project title', () => {
+  const root = withRepo((r) => {
+    writeFileSync(join(r, 'README.md'), '# Cool Lib\n\n## Stuff\n');
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.equal(r.project.title, 'Cool Lib');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Generic README sections (Usage / Installation / Tests) skipped from domains', () => {
+  const root = withRepo((r) => {
+    writeFileSync(
+      join(r, 'README.md'),
+      '# X\n\n## Usage\n\n## Installation\n\n## Tests\n\n## Real Domain\n',
+    );
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.deepEqual(
+      r.domains.map((d) => d.slug),
+      ['real-domain'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Ignored folders skip — node_modules / .git / dist', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/real'), { recursive: true });
+    mkdirSync(join(r, 'src/node_modules'), { recursive: true });
+    mkdirSync(join(r, 'src/.cache'), { recursive: true });
+    writeFileSync(join(r, 'package.json'), JSON.stringify({ name: 'x' }));
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.deepEqual(
+      r.capabilities.map((c) => c.slug),
+      ['real'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Empty dir — project synthesized from basename, no candidates', () => {
+  const root = withRepo(() => {});
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.ok(r.project, 'always returns project candidate');
+    assert.equal(r.capabilities.length, 0);
+    assert.equal(r.domains.length, 0);
+    assert.equal(r.elements.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('Suggested relations — project contains each capability', () => {
+  const root = withRepo((r) => {
+    writeFileSync(join(r, 'package.json'), JSON.stringify({ name: 'app' }));
+    mkdirSync(join(r, 'src/features/auth'), { recursive: true });
+    mkdirSync(join(r, 'src/features/billing'), { recursive: true });
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.equal(r.suggestedRelations.length, 2);
+    assert.ok(
+      r.suggestedRelations.every(
+        (rel) => rel.from === 'app' && rel.type === 'contains',
+      ),
+    );
+    assert.deepEqual(
+      r.suggestedRelations.map((rel) => rel.to).sort(),
+      ['auth', 'billing'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -60,6 +60,7 @@ import { writeFileSync, unlinkSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { buildMarkdown } from './parser.mjs';
+import { analyzeRepoStructure } from './analyze.mjs';
 import { parseFilter } from './query.mjs';
 import { isValidVaultTitle, validateVaultDocument } from './validate.mjs';
 import {
@@ -389,6 +390,41 @@ const TOOLS = [
     },
   },
   {
+    name: 'analyze_repo_structure',
+    description:
+      'R16 (autonomous ingest base) — analyze a code repository and propose ontology node candidates. ' +
+      'side effect 0 (vault frontmatter NOT modified). Returns deterministic candidates the agent ' +
+      'should review and selectively pass to add_concept. Detects:\n' +
+      '  - package.json `name` → project candidate\n' +
+      '  - README.md first H1 → project title fallback\n' +
+      '  - README.md H2 sections (skipping generic "Usage"/"Installation"/etc) → domain candidates\n' +
+      '  - src/features|entities|widgets|views/* (FSD) → capability/element candidates\n' +
+      '  - src/* depth-1 folders (generic) → capability candidates + index entry → element\n\n' +
+      'Use this once when a user asks "이 codebase 분석해줘" / "bootstrap the ontology". ' +
+      'Single source of truth preserved — only the user (via your subsequent add_concept calls) ' +
+      'writes to the vault.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        rootPath: {
+          type: 'string',
+          description:
+            'Repository root to analyze. Defaults to the MCP server cwd.',
+        },
+        maxDepth: {
+          type: 'number',
+          description: 'Folder walk depth (default 2). Higher → more elements.',
+        },
+        ignore: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            "Extra folder names to skip (added to defaults: node_modules, .git, dist, build, …).",
+        },
+      },
+    },
+  },
+  {
     name: 'rename_concept',
     description:
       '⚠ MULTI-FILE WRITE — change a slug and update every backlink in one atomic graph-level operation. ' +
@@ -538,6 +574,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok(findOrphansTool(args));
       case 'query_concepts':
         return ok(queryConceptsTool(args));
+      case 'analyze_repo_structure':
+        return ok(analyzeRepoStructureTool(args));
       case 'rename_concept':
         return ok(renameConcept(args));
       case 'merge_concepts':
@@ -825,6 +863,19 @@ function queryConceptsTool({ filter, limit }) {
     matches,
     limited: matches.length >= cap,
   };
+}
+
+// R16 (b3) — analyze_repo_structure thin wrapper. side effect 0 — vault
+// frontmatter 절대 안 건드림. 사용자 검토 후 별도 add_concept 호출이 진실
+// 진입.
+function analyzeRepoStructureTool({ rootPath, maxDepth, ignore } = {}) {
+  const target = rootPath
+    ? resolve(rootPath)
+    : process.cwd();
+  return analyzeRepoStructure(target, {
+    maxDepth: typeof maxDepth === 'number' ? maxDepth : undefined,
+    ignore: Array.isArray(ignore) ? ignore : undefined,
+  });
 }
 
 function renameConcept({ oldSlug, newSlug, confirm = false, overwrite = false, expected_mtime }) {

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-06T06:43:57.685Z",
+  "generatedAt": "2026-05-06T07:40:22.486Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",
@@ -2289,6 +2289,41 @@
         },
         {
           "depth": 2,
+          "text": "2026-05-06 — Round 15 follow-up #2: Project type honest (Concern 1 fix)",
+          "slug": "2026-05-06-round-15-follow-up-2-project-type-honest-concern-1-fix"
+        },
+        {
+          "depth": 3,
+          "text": "변경 — Project type 정직화",
+          "slug": "변경-project-type-정직화"
+        },
+        {
+          "depth": 3,
+          "text": "derive 함수 — silent fabrication 제거",
+          "slug": "derive-함수-silent-fabrication-제거"
+        },
+        {
+          "depth": 3,
+          "text": "Callsite 정리 (legacy fabrication 명시화)",
+          "slug": "callsite-정리-legacy-fabrication-명시화"
+        },
+        {
+          "depth": 3,
+          "text": "TaxonomyProvider signature 변경",
+          "slug": "taxonomyprovider-signature-변경"
+        },
+        {
+          "depth": 3,
+          "text": "Test",
+          "slug": "test"
+        },
+        {
+          "depth": 3,
+          "text": "Mission align",
+          "slug": "mission-align"
+        },
+        {
+          "depth": 2,
           "text": "2026-05-06 — Round 15 follow-up: CLI graph-level 5 명령 (Concern 4 fix)",
           "slug": "2026-05-06-round-15-follow-up-cli-graph-level-5-명령-concern-4-fix"
         },
@@ -2305,7 +2340,7 @@
         {
           "depth": 3,
           "text": "Mission align",
-          "slug": "mission-align"
+          "slug": "mission-align-2"
         },
         {
           "depth": 3,
@@ -2555,7 +2590,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test"
+          "slug": "test-2"
         },
         {
           "depth": 3,
@@ -2595,7 +2630,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-2"
+          "slug": "test-3"
         },
         {
           "depth": 3,
@@ -2625,7 +2660,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-3"
+          "slug": "test-4"
         },
         {
           "depth": 3,
@@ -2670,7 +2705,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-4"
+          "slug": "test-5"
         },
         {
           "depth": 3,
@@ -2710,7 +2745,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-5"
+          "slug": "test-6"
         },
         {
           "depth": 3,
@@ -2745,7 +2780,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-6"
+          "slug": "test-7"
         },
         {
           "depth": 3,
@@ -2780,7 +2815,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-7"
+          "slug": "test-8"
         },
         {
           "depth": 3,
@@ -2810,7 +2845,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-8"
+          "slug": "test-9"
         },
         {
           "depth": 3,
@@ -2840,7 +2875,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-9"
+          "slug": "test-10"
         },
         {
           "depth": 3,
@@ -2870,7 +2905,7 @@
         {
           "depth": 3,
           "text": "Test",
-          "slug": "test-10"
+          "slug": "test-11"
         },
         {
           "depth": 3,
@@ -3088,9 +3123,9 @@
           "slug": "before-2026-04-30"
         }
       ],
-      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. postpublish architectural audit (Plan agent advisor) 발견 blocking concern — CLI 6 vs MCP 14",
-      "wordCount": 12000,
-      "updatedAt": "2026-05-06T06:32:01.996Z",
+      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. postpublish architectural audit (Plan agent advisor) 의 blocking Concern 1 fix. Project 18 ",
+      "wordCount": 12425,
+      "updatedAt": "2026-05-06T06:48:12.698Z",
       "linksOut": [
         "slug"
       ]


### PR DESCRIPTION
## Summary

사용자 grill-me 결정 (Q1: **AI 자동 ontology 화** + Q2: **자율 ingest from codebase 가 가장 critical 약점**). *"Obsidian 급, MCP 가 잘 되면서 온톨로지화를 기가막히게 잘해줘서 완벽에 가깝게 그래프가 생성"* + *"단일 source of truth 보존"* 의 첫 step.

**MCP v0.7.1 → v0.8.0** (15 tools — 9 read + 6 write).
**CLI v0.3.0 → v0.4.0** (12 명령 — analyze 추가).

## 새 도구 — `analyze_repo_structure`

사용자 한 줄 *"이 codebase 분석해줘"* 후 AI agent (Claude Code, Codex, Cursor) 가 호출할 *deterministic helper*. **side effect 0** — vault frontmatter 절대 안 건드림, 후보만 return.

| 감지 | 결과 |
|---|---|
| \`package.json\` \`name/description\` | project 후보 |
| \`README.md\` 첫 H1 | project title fallback |
| \`README.md\` H2 sections (Usage/Installation/Tests 등 skip) | domain 후보 |
| \`src/features\|entities\|widgets\|views/*\` (FSD) | capability + element 후보 |
| \`src/*\` (generic) + index.ts entry | capability + element 후보 |

응답: \`{ rootPath, framework, project, domains[], capabilities[], elements[], suggestedRelations[], skipped[] }\`. 사용자 검토 후 *명시 \`add_concept\` / \`add_relation\`* 만 vault 진입.

### 단일 source of truth 보존

- 결과는 **return only** — vault 변경 절대 X
- 사용자 검토 + 명시 add 가 *유일한 진입*
- 별도 cache / store 0
- drift surface 0

## CLI \`analyze\` 명령

\`cli/src/commands/analyze.mjs\` — mcp child_process spawn wrapper. \`--json\` / \`--max-depth N\`. publish 후 \`npx oh-my-ontology analyze\` 한 줄 분석.

## Mission align

| 이전 | 이후 |
|---|---|
| 사용자 init 후 수동 add 25 회 (Paravel real-codebase 측정) | agent 가 한 번 \`analyze_repo_structure\` → 30+ 후보 즉시 |
| 첫 user *Aha moment* 부족 | *기가막히다* 의 base — 사용자 검토 + 1-click add 다발 |

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test:run\` 814/814
- [x] \`mcp/\` test 21 → **29** (analyze 7 + integration 1)
- [x] cli integration 32 → 32 (unchanged, mcp spawn wrapper)
- [x] \`pnpm vault:validate\` 25 nodes issue 0
- [x] \`pnpm vault:audit\` 66 paths drift 0
- [x] mcp \`scripts/verify.mjs\` — 15/15 tools
- [x] manual: cli analyze on FSD sandbox repo — project + 3 domains + 3 capabilities + 2 elements + 3 suggestedRelations 정확

## 다음 step (R17 후보)

- \`infer_imports\` (TypeScript / JS import graph → dependency 관계)
- \`extract_domains_from_readme\` deeper (heading 계층 + body 분석)
- \`/ontology-bootstrap\` skill (한 줄 흐름 orchestrate)
- agent 의 *implicit detect* 강화 (작업 중 자율 sync, b2 단계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)