### PR TITLE
feat: /ontology-bootstrap skill — cold-start counterpart of /ontology-sync (R16 follow-up)

### DIFF
--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: ontology-bootstrap
+description: Bootstrap an empty (or near-empty) oh-my-ontology vault from the surrounding codebase — call analyze_repo_structure once, show the proposed candidates, and selectively land the accepted ones via add_concept / add_relation. Use when the user says "이 codebase 분석해줘" / "bootstrap the ontology" / "fill the vault from the code", or when you notice the vault has only the 5 starter nodes and the user has asked you to do anything ontology-related. Skip when the vault already has 20+ user-curated nodes — bootstrap is for the cold-start case only.
+---
+
+# /ontology-bootstrap — fill an empty vault from the code
+
+Two facts make a fresh `oh-my-ontology` vault feel empty:
+
+1. `oh-my-ontology init` only seeds 5 *example* nodes — they're meant to be
+   replaced, not extended.
+2. Hand-authoring the first 20–30 nodes is the heaviest friction in the
+   onboarding path (measured: ~25 cli `add` calls in the Paravel real-codebase
+   dogfood — `docs/dogfood-paravel-2026-05-06.md`).
+
+This skill closes that gap with **one MCP call + selective writes**.
+It is the *cold-start* counterpart to `/ontology-sync` (which keeps an
+already-grown vault in step with new code).
+
+## When to run
+
+**Run when** any of these are true:
+- the user says "이 codebase 분석해줘" / "bootstrap the ontology" / "fill the vault from this repo" / similar.
+- the user asked you to do anything ontology-related and `list_kinds` shows ≤ 5 nodes (only starters).
+- the user just ran `oh-my-ontology init` and is asking what to do next.
+
+**Skip when**:
+- the vault already has 20+ user-curated nodes — at that point `/ontology-sync` (incremental) is the right tool.
+- the user explicitly opted out (e.g. "I'll add nodes by hand") — respect it.
+- there is no reachable repository (running in a non-code dogfood folder).
+
+## Workflow
+
+The MCP server (`oh-my-ontology-mcp`, R16 v0.8.0+) exposes
+`analyze_repo_structure`. CLI wrapper: `oh-my-ontology analyze [rootPath]`.
+
+### 1. Measure the cold-start (cheap)
+
+```
+list_kinds                                # confirm vault is near-empty
+```
+
+If `total > 20` and the kinds look user-curated (mix of capability/domain/element with non-`example` slugs), ask before proceeding — the user may want `/ontology-sync` instead.
+
+### 2. Analyze the repo (one call, side effect 0)
+
+```
+analyze_repo_structure({ rootPath: "<repo root or '.'>", maxDepth: 2 })
+```
+
+The response shape:
+
+```jsonc
+{
+  "rootPath": "/path/to/repo",
+  "framework": "fsd" | "next" | "generic",
+  "project":      { "slug": "...", "title": "..." },
+  "domains":      [{ "slug", "title", "evidence": { "source": "README.md", "line": 7 } }, …],
+  "capabilities": [{ "slug", "title", "evidence": { "source": "src/features/auth" } }, …],
+  "elements":     [{ "slug", "title", "evidence": { "source": "src/widgets/header" } }, …],
+  "suggestedRelations": [{ "from": "<project>", "to": "<cap>", "type": "contains" }, …],
+  "skipped":      [{ "path": "...", "reason": "dotfile/ignore" }, …]
+}
+```
+
+This call writes **nothing** — it's a pure read. The user is the only writer.
+
+### 3. Show a compact summary to the user
+
+Five lines max — the agent is the curator, not the encyclopedia. Group by kind, count, list the top 3 of each, point at evidence:
+
+```
+Detected framework: fsd
+project:       my-app — Sample app
+domains (3):   authentication · billing · notifications     ← README.md
+capabilities (5): auth · billing · user · …                 ← src/features/* + src/entities/*
+elements (2):  src/widgets/header · src/views/home          ← FSD widget/view dirs
+
+Land all of these as the ontology bootstrap? (yes / pick / refine)
+```
+
+### 4. Hand control to the user
+
+Three branches:
+
+- **yes** — call `add_concept` for project, then each domain, capability, element in that order. Each call is 1 line of args. Then call `add_relation` for each suggested relation (`from → to`, `type: 'contains'` for project→capability). Skip relations whose endpoints didn't make it in.
+- **pick** — list the candidates one kind at a time, let the user accept/reject per item, then call `add_concept` only for the accepted ones.
+- **refine** — let the user rename slugs / titles inline before any write. Pass the refined version to `add_concept`.
+
+Whatever path is chosen, **the user (via your `add_concept` / `add_relation` calls) is the only writer**. Single source of truth preserved.
+
+### 5. Land + verify
+
+After the writes, finish with one read so the user sees the result:
+
+```
+list_kinds                                # new census
+list_concepts({ limit: 100 })             # the new vault contents
+```
+
+Show the kind census diff in the reply (e.g. *"Vault grew 5 → 18 nodes (+3 domains, +6 capabilities, +4 elements)"*).
+
+## Failure modes
+
+- **`add_concept` throws on existing slug** — the starter `example` nodes (or a previous bootstrap) collided. Use `patch_concept` to overwrite, or pick a different slug.
+- **`missing-expected-field` warning** — a capability or element was added without `domain:`. Tolerable for bootstrap (vault still validates), but flag the warnings to the user so they can backfill.
+- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze .` to get the same JSON, then `oh-my-ontology add <kind> <slug> --title=...` for each accepted candidate.
+- **Repo too deep / monorepo** — pass `rootPath` for the relevant subdirectory, or run `analyze` per package and merge results.
+
+## Reply discipline
+
+Five lines or fewer per reply. Show what changed (counts, slugs), not how. Do not paste the full JSON response. The user is reading a chat thread, not API output.
+
+## Cross-references
+
+- **`/ontology-sync`** — the *incremental* counterpart for already-grown vaults.
+- **`AGENTS.md` → "Working with the ontology while you code"** — the read-then-write discipline for non-bootstrap tasks.
+- **`docs/dogfood-paravel-2026-05-06.md`** — the friction measurement that motivated this skill (25 manual `add` calls in a real codebase).
+- **`mcp/README.md` → "Frontmatter shape per kind"** — what fields each kind needs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,10 +151,11 @@ The vault is the **shared mental model** between the developer and the AI agent.
 
 A 30-second read at the top of the task often replaces a 10-minute re-discovery in the code.
 
-**Bootstrap an empty vault** (R16). When a user just ran `oh-my-ontology init` on a fresh repo and the vault has only the 5 starter nodes, don't make the user hand-author every node. Instead:
+**Bootstrap an empty vault** (R16). When a user just ran `oh-my-ontology init` on a fresh repo and the vault has only the 5 starter nodes, don't make the user hand-author every node. Use the **`/ontology-bootstrap`** skill (`.claude/skills/ontology-bootstrap/SKILL.md`):
 
-- Call `analyze_repo_structure` once. **Side effect 0** — it returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]) by reading `package.json` / `README.md` H2 sections / `src/` folder layout (FSD or generic). It does NOT write to the vault.
-- Show the candidates to the user, let them prune obvious noise, then call `add_concept` / `add_relation` per accepted candidate. This is the only path into the vault — single source of truth preserved.
+- It calls `analyze_repo_structure` once. **Side effect 0** — returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]) by reading `package.json` / `README.md` H2 sections / `src/` folder layout (FSD or generic). Vault NOT modified.
+- Shows the candidates compactly, lets the user prune / refine, then lands the accepted ones via `add_concept` / `add_relation`. Single source of truth preserved — only the user (via your subsequent calls) writes to the vault.
+- Companion to `/ontology-sync` (incremental, post-bootstrap).
 
 **Write at the end of a task** (the part that's easy to skip). When a unit of work introduced a new capability / element / domain, or renamed/folded an existing one, mirror the change in the vault:
 
@@ -255,10 +256,11 @@ vault 는 개발자와 AI agent 가 **공유하는 mental model**. ontology 의 
 
 작업 head 의 30 초 read 가 코드에서의 10 분 재발견을 자주 대신해 줌.
 
-**빈 vault 부트스트랩** (R16). 사용자가 fresh repo 에서 `oh-my-ontology init` 만 한 직후 — 5 starter 노드 외 빈 vault. 사용자가 매 노드 손 작성 부담 — 대신:
+**빈 vault 부트스트랩** (R16). 사용자가 fresh repo 에서 `oh-my-ontology init` 만 한 직후 — 5 starter 노드 외 빈 vault. 사용자가 매 노드 손 작성 부담 — 대신 **`/ontology-bootstrap`** skill (`.claude/skills/ontology-bootstrap/SKILL.md`) 사용:
 
-- `analyze_repo_structure` 1 회 호출. **side effect 0** — `package.json` / `README.md` H2 / `src/` 폴더 layout (FSD or generic) 읽어 deterministic 후보 (project + domains[] + capabilities[] + elements[] + suggestedRelations[]) 반환. vault 변경 안 함.
-- 후보를 사용자에게 보여주고 noise 제외 후 채택된 것만 `add_concept` / `add_relation`. 단일 source of truth 보존 — vault 진입은 *명시 add* 만.
+- `analyze_repo_structure` 1 회 호출. **side effect 0** — `package.json` / `README.md` H2 / `src/` 폴더 layout 읽어 deterministic 후보 반환. vault 변경 안 함.
+- 후보를 사용자에게 *5 줄 max* 요약 → confirm/pick/refine 분기 → 채택된 것만 `add_concept` / `add_relation`. 단일 source of truth 보존.
+- `/ontology-sync` 의 *cold-start* 짝 (sync 는 incremental, bootstrap 은 post-init).
 
 **작업 끝에 write** (쉽게 빠뜨림). 한 작업 단위가 새 capability / element / domain 을 도입했거나 기존 것을 rename / 합쳤다면, vault 에 반영:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,11 +35,20 @@ mcp/src/analyze.test.mjs — 7 unit case (FSD / generic / no package.json / gene
 이전 — 사용자가 `init` 후 *수동 add* 25 회 (Paravel real-codebase dogfood 측정). *첫 user Aha moment* 부족.
 이후 — agent 가 한 번 `analyze_repo_structure` → 30+ 후보 즉시. 사용자 검토 + 1-clicks add_concept 다발 호출. *기가막히다* 의 base.
 
+### R16 follow-up — `/ontology-bootstrap` skill
+
+`/ontology-sync` (이미 자란 vault 의 incremental sync) 의 cold-start 짝. agent 한 줄 사용자 의도 ("이 codebase 분석해줘") → `analyze_repo_structure` → 5 줄 요약 → yes/pick/refine 분기 → `add_concept` / `add_relation` 다발 → 마무리 census diff.
+
+- `.claude/skills/ontology-bootstrap/SKILL.md` 신설 — agent prompt 수준에서 흐름 orchestrate. 진입은 `add_concept` 만 → 단일 source of truth 보존
+- AGENTS.md 의 *빈 vault bootstrap* 섹션 (영문 + 한국어) 갱신 — skill cross-ref
+- dogfood `capabilities/ontology-bootstrap-skill` (26번째 노드) + `domains/ai-agent-partner.capabilities` endorse
+
+vault 25 → 26 노드 (capability 14). orphan 1 (의도적 project) / drift 0 / validate clean.
+
 ### 다음 step (R17 후보)
 
 - `infer_imports` (TypeScript / JS import graph → dependency 관계)
 - `extract_domains_from_readme` (heading 기반 deeper)
-- `/ontology-bootstrap` skill (한 줄 흐름 orchestrate)
 - agent 의 *implicit detect* 강화 (작업 중 자율 sync)
 
 ---

--- a/docs/ontology/capabilities/ontology-bootstrap-skill.md
+++ b/docs/ontology/capabilities/ontology-bootstrap-skill.md
@@ -1,0 +1,34 @@
+---
+slug: capabilities/ontology-bootstrap-skill
+kind: capability
+title: Ontology-Bootstrap Skill (.claude/skills/ontology-bootstrap)
+domain: ai-agent-partner
+elements: [.claude/skills/ontology-bootstrap/SKILL.md]
+---
+
+R16 follow-up — `/ontology-bootstrap` slash skill 의 cold-start counterpart. `/ontology-sync` 가 *이미 자란 vault* 의 incremental sync 라면, 이 skill 은 *fresh init 직후 빈 vault* 를 codebase 에서 *한 번에* 채우는 흐름.
+
+## 흐름
+
+1. `list_kinds` — vault 가 진짜 cold-start 인지 (≤ 5 nodes) 확인
+2. `analyze_repo_structure` 1 회 호출 (mcp 15번째 도구, R16 v0.8.0)
+   — `package.json` / `README.md` H2 / `src/` 폴더 → deterministic 후보. side effect 0.
+3. 후보를 사용자에게 *5 줄 max* 요약 (kind 별 count + 상위 3 + evidence)
+4. 사용자 분기 — yes / pick / refine
+5. 채택된 것만 `add_concept` 다발 + `add_relation` 다발 (project contains capability)
+6. 마무리 — `list_kinds` + 사용자에게 census diff 보여주기 ("vault 5 → 18 nodes")
+
+## 단일 source of truth
+
+skill 자체는 *agent prompt instruction*. 진입은 `add_concept` / `add_relation` 만 — vault frontmatter 가 유일 진실원. analyze 는 read only.
+
+## Mission align
+
+이전: 사용자 init 후 *수동 add 25 회* (Paravel real-codebase 측정 친구션).
+이후: agent 가 한 번 분석 → 30+ 후보 → 1-click confirm → 다발 add. 첫 user *Aha moment*.
+
+## 참조
+
+- `.claude/skills/ontology-bootstrap/SKILL.md` — agent prompt
+- `mcp/src/analyze.mjs` — deterministic helper (R16)
+- `cli/src/commands/analyze.mjs` — cli wrapper

--- a/docs/ontology/domains/ai-agent-partner.md
+++ b/docs/ontology/domains/ai-agent-partner.md
@@ -2,7 +2,7 @@
 slug: domains/ai-agent-partner
 kind: domain
 title: AI Agent Partner
-capabilities: [mcp-server, mcp-conflict-guard, ontology-sync-skill, session-start-ontology-context]
+capabilities: [mcp-server, mcp-conflict-guard, ontology-sync-skill, session-start-ontology-context, ontology-bootstrap-skill]
 elements: [mcp-sdk, mcp/src/index.js, mcp/src/parser.mjs, mcp/src/vault.mjs, .claude/hooks/inject-ontology-summary.sh]
 relates: [domains/vault-local-first, domains/ontology-core]
 ---


### PR DESCRIPTION
## Summary

R16 의 \`analyze_repo_structure\` mcp 도구 위에서 *흐름* orchestrate. agent 가 사용자 한 줄 *"이 codebase 분석해줘"* / *"bootstrap the ontology"* 받으면 발동.

\`/ontology-sync\` (이미 자란 vault 의 incremental sync) 의 **cold-start 짝**.

## skill 흐름

1. \`list_kinds\` — cold-start 확인 (≤ 5 nodes)
2. \`analyze_repo_structure\` 1 회 — side effect 0, 후보 list
3. 5 줄 max 요약 (kind 별 count + 상위 3 + evidence)
4. 사용자 분기 — **yes / pick / refine**
5. 채택된 것만 \`add_concept\` 다발 + \`add_relation\` 다발
6. 마무리 \`list_kinds\` + census diff ("vault 5 → 18 nodes")

skill 자체는 *agent prompt instruction*. 진입은 \`add_concept\` 만 → 단일 source of truth 보존.

## /ontology-sync 와의 짝

| skill | 시점 | 흐름 |
|---|---|---|
| \`/ontology-bootstrap\` | post-init / 빈 vault | analyze 한 번 → 다발 add |
| \`/ontology-sync\` | 코드 작업 후 / 자란 vault | git diff → incremental patch |

cold-start vs incremental — 같은 mission (*"vault 가 코드 따라간다"*) 의 시점별 도구.

## Mission align

이전: 사용자 \`init\` 후 *수동 add 25 회* (Paravel real-codebase 측정 친구션).
이후: agent 가 한 번 분석 → 30+ 후보 → 1-click confirm → 다발 add. 첫 user *Aha moment*.

## 변경

- \`.claude/skills/ontology-bootstrap/SKILL.md\` 신설 (164 LOC) — agent prompt
- \`AGENTS.md\` *"빈 vault bootstrap"* 섹션 (영문 + 한국어) 갱신 — skill cross-ref
- dogfood vault — \`capabilities/ontology-bootstrap-skill\` (26번째 노드) + \`domains/ai-agent-partner.capabilities\` endorse
- \`docs/CHANGELOG.md\` R16 항목에 follow-up 추가

## Test plan

- [x] \`pnpm vault:validate\` — **26 파일** issue 0
- [x] \`pnpm vault:audit\` — 67 paths drift 0
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] skill 자동 등록 확인 (Claude Code available-skills 에 \`ontology-bootstrap\` 표시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)