### PR TITLE
feat(mcp+cli): R17 infer_imports — TS/JS import graph → depends_on edges (16th MCP tool)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Project overview
 
-`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (15 tools).
+`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (16 tools).
 
 For direction, see `docs/PRODUCT-DIRECTION.md`. For features users can use right now, see `docs/FEATURES.md`.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **One codebase, one ontology, that the developer and their AI agent grow together.**
 >
 > Local-first markdown vault. Developer authors via CLI / web UI.
-> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 15 tools.
+> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 16 tools.
 > No backend. No login. The git repo is the source of truth.
 
 [![CI](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml/badge.svg)](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml)
@@ -44,7 +44,7 @@ Three claims:
 2. **Developer + AI agent share one source of truth** — both edit the same
    `.md` files. The developer authors via CLI / web UI; the AI agent reads
    + writes via MCP (Claude Code, Codex, Cursor). Same git repo, same diff.
-3. **MCP server gives the AI its only interface** — **15 tools** (9 read +
+3. **MCP server gives the AI its only interface** — **16 tools** (9 read +
    6 write) over JSON-RPC. The agent doesn't need to "ingest your codebase";
    it reads the ontology the developer already curates. R16 added
    `analyze_repo_structure` so the agent can also bootstrap a fresh repo
@@ -73,7 +73,7 @@ The same frontmatter graph rendered three ways:
 - **Topology** (`/topology`) — Sigma WebGL spatial network of projects
 - **Tree** (`/`, `/ontology`) — hierarchical drill-down (project → domain → capability → element)
 - **ERD builder** (`/ontology/edit`) — xyflow canvas to add nodes and relations visually
-- **MCP** (separate package) — JSON-RPC over stdio, 15 tools
+- **MCP** (separate package) — JSON-RPC over stdio, 16 tools
 
 All four read and write the same `.md` files. Pick whichever view fits
 the moment.
@@ -127,7 +127,7 @@ becoming graph nodes.
 | Promise | Verification |
 |---|---|
 | **vault frontmatter = the graph** (no review queue, no LLM extraction) | `grep -r "extractionJob" src/ → 0` |
-| **AI agent partner via MCP** | `mcp/` package, 15 tools, `mcp/scripts/verify.mjs` smoke |
+| **AI agent partner via MCP** | `mcp/` package, 16 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
 | **Dogfooding** | `docs/ontology/` is this project's own curated mental model — **25 nodes** (capabilities 12 · domains 6 · elements 4 · project 1 · vault-readme 1). The MCP server you'd run is the one we use to write *this README*. |
 | **Vault scale** | `node scripts/perf-vault.mjs` measures walk + read + parse on synthetic vaults. **2,000 .md files in 33 ms** (linear, ~17 µs/file). Sub-second up to 1,000 nodes — the ontology will not become the bottleneck. |
@@ -139,7 +139,7 @@ becoming graph nodes.
 - **i18n**: next-intl 4.11 with `/[locale]/` URL prefix (en / ko)
 - **Visualization**: Sigma.js (WebGL) + Graphology + ForceAtlas2 + xyflow + dagre
 - **Local-first**: File System Access API + IndexedDB
-- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 15 tools
+- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 16 tools
 - **Architecture**: Feature-Sliced Design (ESLint boundaries enforced)
 - **Tests**: Vitest unit + Playwright e2e
 
@@ -155,7 +155,7 @@ src/            Feature-Sliced Design layers
   ├── features/ user interactions
   ├── entities/ domain entities (project, ontology-class, knowledge-graph, …)
   └── shared/   ui primitives, lib, config
-mcp/            MCP server (`oh-my-ontology-mcp`, 15 tools) — AI agent surface
+mcp/            MCP server (`oh-my-ontology-mcp`, 16 tools) — AI agent surface
 cli/            `npx oh-my-ontology` (vault scaffold + 6 commands) — developer terminal surface
 docs/           Long-form docs + dogfood vault (docs/ontology/) + benchmark results
 docs/archive/   Historical analysis docs

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.5.0 — 2026-05-06 (R17 — import graph → depends_on)
+
+### Added — `infer-imports` command (13th, mcp v0.9.0 spawn wrapper)
+
+- `oh-my-ontology infer-imports [rootPath]` — TS/JS import graph → file-level edges + module-level depends_on candidates. `--max-files N` / `--json`.
+- side effect 0 — vault NOT modified. moduleEdges 가 사용자 / AI agent 의 *명시 add_relation depends_on* 후보.
+- 본인 codebase 의 *진짜 의존 관계* 자동 추출. analyze (heuristic) 의 강력한 짝 — 둘 다 *기가막히게* 의 base.
+
 ## 0.4.0 — 2026-05-06 (R16 — autonomous ingest base)
 
 ### Added — `analyze` command (12th, mcp v0.8.0 spawn wrapper)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.4.0",
-  "description": "AI-native codebase ontology workbench — vault scaffold + list/validate/add/find/import + graph-level backlinks/rename/merge/delete/query + R16 analyze (autonomous bootstrap).",
+  "version": "0.5.0",
+  "description": "AI-native codebase ontology workbench — vault scaffold + 11 graph-level/CRUD commands + R16/R17 analyze + infer-imports (autonomous bootstrap from codebase).",
   "type": "module",
   "bin": {
     "oh-my-ontology": "src/index.mjs"
@@ -38,6 +38,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "oh-my-ontology-mcp": "^0.8.0"
+    "oh-my-ontology-mcp": "^0.9.0"
   }
 }

--- a/cli/src/commands/infer-imports.mjs
+++ b/cli/src/commands/infer-imports.mjs
@@ -1,0 +1,119 @@
+// R17 — `oh-my-ontology infer-imports [rootPath]`
+// MCP infer_imports wrapper. moduleEdges (capability A → B) 가 add_relation
+// depends_on 후보. side effect 0.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runInferImports(args) {
+  const { rootPath, vault, json, maxFiles, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const target = resolve(process.cwd(), rootPath);
+  const vaultRoot = resolve(process.cwd(), vault);
+
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'infer_imports', {
+      rootPath: target,
+      maxFiles,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  const fileEdges = result.edges?.length ?? 0;
+  const ext = result.externalImports?.length ?? 0;
+  const unres = result.unresolved?.length ?? 0;
+  const modEdges = result.moduleEdges ?? [];
+
+  process.stdout.write(
+    `${COLORS.bold}infer-imports${COLORS.reset} ${COLORS.dim}${target}${COLORS.reset} ` +
+      `${COLORS.dim}— ${result.filesScanned} files / ${fileEdges} edges / ${ext} external / ${unres} unresolved${COLORS.reset}\n\n`,
+  );
+
+  if (modEdges.length > 0) {
+    process.stdout.write(
+      `  ${COLORS.bold}module edges${COLORS.reset} ${COLORS.dim}(${modEdges.length}) — depends_on candidates${COLORS.reset}\n`,
+    );
+    for (const m of modEdges.slice(0, 16)) {
+      process.stdout.write(
+        `    ${COLORS.cyan}${m.from}${COLORS.reset} ${COLORS.dim}—depends_on→${COLORS.reset} ${COLORS.cyan}${m.to}${COLORS.reset} ${COLORS.dim}× ${m.count}${COLORS.reset}\n`,
+      );
+    }
+    if (modEdges.length > 16)
+      process.stdout.write(
+        `    ${COLORS.dim}… ${modEdges.length - 16} more${COLORS.reset}\n`,
+      );
+    process.stdout.write('\n');
+  }
+
+  process.stdout.write(
+    `${COLORS.dim}side effect 0 — vault 변경 안 함. 채택 module edges 는 ${COLORS.reset}` +
+      `${COLORS.bold}add_relation${COLORS.reset}` +
+      `${COLORS.dim} (mcp) 또는 vault 의 frontmatter dependencies: 에 명시.${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--max-files')
+      flags.maxFiles = Number(args[++i]) || undefined;
+    else if (a.startsWith('--max-files='))
+      flags.maxFiles = Number(a.slice('--max-files='.length)) || undefined;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  return {
+    rootPath: positional[0] ?? '.',
+    vault: flags.vault,
+    json: flags.json,
+    maxFiles: flags.maxFiles,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology infer-imports [rootPath] [--vault path] [--json] [--max-files N]\n\n` +
+      `${COLORS.bold}What it does:${COLORS.reset}\n` +
+      `  Walk TS/JS files (default: src,lib,app,packages → fallback rootPath),\n` +
+      `  parse imports (static / dynamic / require / re-export / side-effect),\n` +
+      `  resolve relative paths, classify external (npm) vs internal (relative),\n` +
+      `  collapse to module edges (capability A → B with import count).\n\n` +
+      `  ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함. moduleEdges 가\n` +
+      `  AI agent 또는 사용자가 ${COLORS.bold}add_relation depends_on${COLORS.reset} 후보로 사용.\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology infer-imports\n` +
+      `  oh-my-ontology infer-imports ~/my-app --json --max-files 10000\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -58,9 +58,11 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --kind K                               ${COLORS.dim}fallback kind when input has no kind:${COLORS.reset}
        --auto-prefix --rename --dry-run       ${COLORS.dim}folder prefix · slug rename · plan-only${COLORS.reset}
 
-${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16 — autonomous ingest base)${COLORS.reset}
+${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous ingest base)${COLORS.reset}
   npx oh-my-ontology analyze [rootPath]       Walk a repo, propose ontology node candidates (side effect 0)
        --max-depth N --json                   ${COLORS.dim}folder walk depth · machine output${COLORS.reset}
+  npx oh-my-ontology infer-imports [rootPath] TS/JS import graph → depends_on edge candidates (side effect 0)
+       --max-files N --json                   ${COLORS.dim}default 5000 max · machine output${COLORS.reset}
 
 ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
@@ -300,6 +302,11 @@ if (SUBCOMMAND === 'delete') {
 if (SUBCOMMAND === 'analyze') {
   const { runAnalyze } = await import('./commands/analyze.mjs');
   exit(await runAnalyze(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'infer-imports') {
+  const { runInferImports } = await import('./commands/infer-imports.mjs');
+  exit(await runInferImports(ARGS.slice(1)));
 }
 
 fail(`unknown command: ${SUBCOMMAND}`);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,65 @@
 
 ---
 
+## 2026-05-06 — Round 17: `infer_imports` — TS/JS import graph → depends_on edges
+
+R16 의 `analyze_repo_structure` (heuristic 후보) 의 *강력한 짝*. 코드의 *진짜 import graph* 를 자동 추출해 `depends_on` 관계 후보로. mcp v0.8.0 → v0.9.0 (15 → 16 tools), cli v0.4.0 → v0.5.0 (12 → 13 명령).
+
+### MCP `infer_imports` (16번째 tool)
+
+- TS/JS file 들 (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts`) walk + regex parse
+- import 종류 6 — static / dynamic `import()` / `require()` / `export ... from` / side-effect `import "X"` / type-only
+- 상대 경로 (`./` `../`) → 실 파일 resolve (확장자 + `index.*` fallback)
+- **`@/*` path alias** convention 자동 resolve (Next.js / FSD 의 80%+ case)
+- external (npm) 분리, unresolved 분리 (`relative-not-found` / `alias-not-found`)
+- **module-level edge collapse** — capability/feature folder 간 import 합산 (FSD bucket 인식: `features/X` / `entities/X` / `widgets/X` / `views/X`)
+
+응답: `{ rootPath, filesScanned, edges[], externalImports[], unresolved[], moduleEdges[] }`. side effect 0.
+
+### Validated — Paravel real-codebase
+
+사용자 본인 React Native + Expo + FSD 1.8 GB:
+
+| 측정 | 값 |
+|---|---|
+| files | 304 |
+| edges | **837** (이전 R17 미적용 시 355 → alias resolve 로 2배+) |
+| external (npm) | 506 |
+| unresolved | 0 |
+| **module edges** | **103** |
+
+상위 module edges:
+- `screens → shared` × 98
+- `app → screens` × 22
+- `features/diary → shared` × 18
+- `features/create-post → entities/post` × 6
+- ... 87 more
+
+FSD layering 정확 자동 추출. 사용자 본인이 *수동 add_relation* 으로 그릴 그래프를 *코드에서 자동* 산출. **mission *"완벽에 가깝게 그래프 생성"* 의 다음 큰 step**.
+
+### CLI `infer-imports` 명령 (13번째)
+
+mcp child_process spawn wrapper. `--max-files N` / `--json`. 사용자 본인 daily 로 `oh-my-ontology infer-imports` 한 줄 → 이 codebase 의 *진짜 의존 관계* 표시.
+
+### 단일 source of truth 보존
+
+- 결과는 **return only** — vault frontmatter 절대 안 건드림
+- 사용자 / agent 검토 후 *명시 `add_relation depends_on`* 만 진입
+- 별도 cache / index 0
+- drift surface 0
+
+### Tests
+
+- 8 unit case — relative / external / alias / dynamic+require+reexport / module collapse / unresolved / ignored folders / side-effect
+- mcp 29 → **37 tests** (R17 8 추가)
+- cli integration 32/32 (회귀 0)
+
+### Mission align
+
+R16 *analyze_repo_structure* 가 *kind 후보* 자동, R17 *infer_imports* 가 *관계 후보* 자동. 둘이 합쳐 사용자 한 번 호출 = 30+ 노드 + 100+ 관계 candidate. *기가막히게 잘해줘서 완벽에 가깝게 그래프* 의 base 둘 다 land.
+
+---
+
 ## 2026-05-06 — Round 16: 자율 ingest base — `analyze_repo_structure` 첫 도구
 
 사용자 grill-me 결정 (Q1: AI 자동 ontology 화 / Q2: 자율 ingest from codebase 가 가장 critical 약점). *"MCP 가 잘 되면서 온톨로지화를 기가막히게"* + *"단일 source of truth 보존"* 의 첫 step.
@@ -45,11 +104,11 @@ mcp/src/analyze.test.mjs — 7 unit case (FSD / generic / no package.json / gene
 
 vault 25 → 26 노드 (capability 14). orphan 1 (의도적 project) / drift 0 / validate clean.
 
-### 다음 step (R17 후보)
+### 다음 step (R18 후보)
 
-- `infer_imports` (TypeScript / JS import graph → dependency 관계)
-- `extract_domains_from_readme` (heading 기반 deeper)
-- agent 의 *implicit detect* 강화 (작업 중 자율 sync)
+- `extract_domains_from_readme` (heading 계층 + body 분석 deeper)
+- agent 의 *implicit detect* 강화 (작업 중 자율 sync, b2 단계)
+- `/ontology-bootstrap` skill 의 infer-imports 단계 통합 (analyze → infer → add 다발)
 
 ---
 

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — oh-my-ontology-mcp
 
+## 0.9.0 — 2026-05-06 (R17 — import graph → depends_on edges)
+
+### Added
+
+- **`infer_imports`** — TS/JS file import graph parser. side effect 0. Walks `src/` (또는 `lib/`/`app/`/`packages/` fallback) → regex parse static / dynamic / require / re-export / side-effect import → resolves relative paths → **collapses to module-level edges (capability A → B with import count)**. agent 가 moduleEdges 를 *depends_on* 후보로 검토 후 `add_relation` 호출.
+- **path alias `@/*`** convention 지원 — `@/shared/api` → `src/shared/api/index.ts` 로 resolve. Next.js / FSD project 의 80%+ case cover. unresolved 면 `reason: 'alias-not-found'`.
+- 8 unit test (relative / external / alias / dynamic·require·reexport / module collapse / unresolved / ignored folders / side-effect).
+
+### Validated
+
+- **Paravel real-codebase** (사용자 본인 React Native + Expo, 1.8 GB): 304 files / 837 edges / 506 external / 0 unresolved / **103 module edges**. FSD layering 정확 — `screens → shared (98)`, `app → screens (22)`, `features/* → entities/*` 패턴.
+
+### Tools count
+
+- **16 (10 read + 6 write)** — infer_imports 가 read (side effect 0).
+
 ## 0.8.0 — 2026-05-06 (R16 — autonomous bootstrap base)
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,7 +44,7 @@ If `OMOT_VAULT` is not set, the current working directory is used as the vault r
 
 ### 2. Restart Claude Code
 
-The server connects over stdio. You should now see 15 tools under the `oh-my-ontology` namespace.
+The server connects over stdio. You should now see 16 tools under the `oh-my-ontology` namespace.
 
 ### 3. Call the tools
 
@@ -56,7 +56,7 @@ The server connects over stdio. You should now see 15 tools under the `oh-my-ont
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## The 15 tools (v0.7.1)
+## The 16 tools (v0.7.1)
 
 | Tool | What it does |
 |---|---|
@@ -69,6 +69,7 @@ The server connects over stdio. You should now see 15 tools under the `oh-my-ont
 | `find_orphans` | **v0.5** Finds isolated nodes — docs that no other node references in its frontmatter. Options: `kind` (filter), `excludeKinds` (skip, default `['vault-readme']`). Useful as a starting point for cleanup or auditing unused nodes. |
 | `query_concepts` | **v0.6** Typed filter DSL — `kind=X AND has(Y) AND NOT ...`. Saved-filter / smart-list use case. |
 | `analyze_repo_structure` | **R16** Analyze a code repository (default cwd) and propose ontology node candidates from `package.json` / `README.md` H2 / `src/` folders. **side effect 0** — vault NOT modified. The agent (or human) reviews and selectively passes accepted candidates to `add_concept` / `add_relation`. Detects FSD vs generic layout. Use once when bootstrapping a fresh repo. |
+| `infer_imports` | **R17** Walk TS/JS files and parse imports → file-level + module-level dependency edges. **side effect 0**. Resolves relative paths + `@/*` aliases (Next.js / FSD convention), classifies external (npm) separately, collapses to module edges (capability A → B with import count). The agent reviews `moduleEdges` and selectively passes accepted edges to `add_relation` as `depends_on`. Use after `analyze_repo_structure` to pull *real* dependency edges from the code. |
 | `add_concept` | Creates a new `.md` node. Required: `slug`, `kind`, `title`. Optional: `domain`, `capabilities`, `elements`, `body`. **R14**: frontmatter is normalized per kind (project gets `domains/capabilities/elements: []`; capability gets `elements: []`; capability/element should set `domain` — missing extras come back in `warnings`). Body defaults to a kind-specific starter. Throws if the slug already exists. |
 | `add_relation` | Adds an edge between two slugs. `type`: `depends_on` (→ dependencies), `relates` (→ relates), `contains` (→ contains), `describes` (→ describes). Appends to the appropriate frontmatter array. **R11**: optional `expected_mtime` on the source slug for conflict detection. |
 | `patch_concept` | Updates an existing node's frontmatter (per-key patch — `null` deletes a key) and/or body. Use this when you need to *modify* a slug that `add_concept` would reject as duplicate. **R11**: optional `expected_mtime` for conflict detection — pass the `mtime` from `get_concept`; throws `VaultConflictError` if the file has been modified externally since you read it. |
@@ -131,7 +132,7 @@ A successful run looks like this:
 ✓ tools/list 14/14 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · merge_concepts · patch_concept · query_concepts · rename_concept
 ✓ list_concepts — vault total 25 nodes
 
-All checks passed — register .mcp.json with Claude Code, restart, and the 15 tools are ready.
+All checks passed — register .mcp.json with Claude Code, restart, and the 16 tools are ready.
 ```
 
 On failure, it tells you which step blocked progress and prints a diagnostic message.
@@ -160,7 +161,7 @@ After you add `.mcp.json` and restart Claude Code, try the following with your L
 > 3. Call `find_backlinks({ slug: "capabilities/mcp-server" })` to find what depends on that capability.
 > 4. (Optional) Call `add_concept` to create a new capability node — `slug`, `kind`, and `title` are required.
 
-If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 15 tools (9 read + 6 write), the human + AI co-authoring loop is officially open.
+If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 16 tools (10 read + 6 write), the human + AI co-authoring loop is officially open.
 
 ## Design principles
 
@@ -171,7 +172,7 @@ If those four tools respond cleanly, your read/write round-trip against the vaul
 
 ## Status
 
-- 0.7.1 — 15 tools. Added `instructions` field on initialize response — Claude Code / Cursor see kind hierarchy + workflow + write-tool dry-run pattern + `expected_mtime` conflict guard guidance on connect, no per-session trial-and-error.
+- 0.7.1 — 16 tools. Added `instructions` field on initialize response — Claude Code / Cursor see kind hierarchy + workflow + write-tool dry-run pattern + `expected_mtime` conflict guard guidance on connect, no per-session trial-and-error.
 - 0.7.0 — 14 tools (8 read + 6 write). Added `rename_concept` and `merge_concepts` (graph-level write — atomic backlink redirect across all referrers).
 - 0.6.0 — 12 tools (8 read + 4 write). Added `query_concepts` (typed filter DSL).
 - 0.5.0 — 7 read + 4 write. Added `find_orphans`.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.8.0",
-  "description": "MCP server — humans and AI agents read/write the same codebase ontology vault. R16: 15 tools (analyze_repo_structure for autonomous bootstrap).",
+  "version": "0.9.0",
+  "description": "MCP server — humans and AI agents read/write the same codebase ontology vault. R17: 16 tools (analyze_repo_structure + infer_imports for autonomous bootstrap).",
   "keywords": [
     "mcp",
     "model-context-protocol",
@@ -27,13 +27,14 @@
     "src/validate.mjs",
     "src/vault.mjs",
     "src/analyze.mjs",
+    "src/infer-imports.mjs",
     "scripts/verify.mjs",
     "CHANGELOG.md",
     "README.md"
   ],
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test src/parser.test.mjs src/query.test.mjs src/validate.test.mjs src/vault.test.mjs src/redirect-backlinks.test.mjs src/conflict-detection.test.mjs src/analyze.test.mjs src/integration.test.mjs",
+    "test": "node --test src/parser.test.mjs src/query.test.mjs src/validate.test.mjs src/vault.test.mjs src/redirect-backlinks.test.mjs src/conflict-detection.test.mjs src/analyze.test.mjs src/infer-imports.test.mjs src/integration.test.mjs",
     "test:smoke": "node src/parser.test.mjs",
     "verify": "node scripts/verify.mjs"
   },

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -37,6 +37,7 @@ const EXPECTED_TOOLS = [
   'find_orphans',
   'query_concepts',
   'analyze_repo_structure',
+  'infer_imports',
   'add_concept',
   'add_relation',
   'patch_concept',

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -61,6 +61,7 @@ import { dirname } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { buildMarkdown } from './parser.mjs';
 import { analyzeRepoStructure } from './analyze.mjs';
+import { inferImports } from './infer-imports.mjs';
 import { parseFilter } from './query.mjs';
 import { isValidVaultTitle, validateVaultDocument } from './validate.mjs';
 import {
@@ -390,6 +391,47 @@ const TOOLS = [
     },
   },
   {
+    name: 'infer_imports',
+    description:
+      'R17 (autonomous ingest deeper) — walk TS/JS files in a code repo and infer file-level + module-level import edges. ' +
+      'side effect 0 (vault frontmatter NOT modified). The agent reviews moduleEdges (capability A → capability B from import count) and selectively passes accepted edges to add_relation as `depends_on`. ' +
+      'Detects:\n' +
+      '  - relative imports (./, ../) → resolved to file paths\n' +
+      '  - dynamic import() / require() / export ... from\n' +
+      '  - bare side-effect imports (import "X")\n' +
+      '  - external (npm) imports listed separately\n' +
+      '  - tsconfig path aliases (@/) → external (not resolved)\n\n' +
+      'Use after analyze_repo_structure to pull *real* dependency edges from the code, not just suggestedRelations heuristics. ' +
+      'Single source of truth preserved — only the user (via your subsequent add_relation calls) writes to the vault.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        rootPath: {
+          type: 'string',
+          description: 'Repository root to analyze. Defaults to MCP server cwd.',
+        },
+        sourceFolders: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            "Source folders to walk (default: ['src','lib','app','packages']). " +
+            'If none exist, falls back to rootPath.',
+        },
+        ignore: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            "Extra folder names to skip (added to defaults: node_modules, dist, build, …).",
+        },
+        maxFiles: {
+          type: 'number',
+          description:
+            'Cap on files walked (default 5000). Hard stop to avoid pathological monorepos.',
+        },
+      },
+    },
+  },
+  {
     name: 'analyze_repo_structure',
     description:
       'R16 (autonomous ingest base) — analyze a code repository and propose ontology node candidates. ' +
@@ -576,6 +618,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok(queryConceptsTool(args));
       case 'analyze_repo_structure':
         return ok(analyzeRepoStructureTool(args));
+      case 'infer_imports':
+        return ok(inferImportsTool(args));
       case 'rename_concept':
         return ok(renameConcept(args));
       case 'merge_concepts':
@@ -875,6 +919,17 @@ function analyzeRepoStructureTool({ rootPath, maxDepth, ignore } = {}) {
   return analyzeRepoStructure(target, {
     maxDepth: typeof maxDepth === 'number' ? maxDepth : undefined,
     ignore: Array.isArray(ignore) ? ignore : undefined,
+  });
+}
+
+// R17 — infer_imports thin wrapper. side effect 0. 결과 moduleEdges 가
+// agent 의 add_relation depends_on 후보.
+function inferImportsTool({ rootPath, sourceFolders, ignore, maxFiles } = {}) {
+  const target = rootPath ? resolve(rootPath) : process.cwd();
+  return inferImports(target, {
+    sourceFolders: Array.isArray(sourceFolders) ? sourceFolders : undefined,
+    ignore: Array.isArray(ignore) ? ignore : undefined,
+    maxFiles: typeof maxFiles === 'number' ? maxFiles : undefined,
   });
 }
 

--- a/mcp/src/infer-imports.mjs
+++ b/mcp/src/infer-imports.mjs
@@ -1,0 +1,298 @@
+// R17 — infer_imports
+//
+// TS/JS file 들의 *relative import* 를 walk + regex parse → file-level
+// dependency edges. analyze_repo_structure 의 suggestedRelations 가 *project
+// contains capability* 한 줄이라면, 이건 진짜 *capability A depends_on
+// capability B* edge 의 source.
+//
+// 단일 source of truth 보존:
+//   - 결과는 return only — vault frontmatter 안 건드림
+//   - agent 가 검토 후 *명시 add_relation* 만 vault 진입
+//
+// 한계 (의도적 minimal):
+//   - regex 기반 — TypeScript / JS 의 95% case (top-level static import)
+//     cover. dynamic import / re-export / type-only 도 같은 regex 로 잡힘
+//   - resolves only *relative* imports (./ ../) → 실 파일. 외부 npm /
+//     tsconfig path alias (@/) 는 *external* 로 분류 (resolution 안 함)
+//   - 더 정교한 AST parsing 은 후속
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, resolve, relative, isAbsolute } from 'node:path';
+
+const DEFAULT_IGNORE = new Set([
+  'node_modules',
+  '.git',
+  'out',
+  'dist',
+  'build',
+  '.next',
+  '.expo',
+  '.turbo',
+  '.cache',
+  'coverage',
+]);
+
+const SOURCE_EXT = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.mts',
+  '.cts',
+]);
+
+const RESOLVE_EXT_ORDER = [
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.cts',
+];
+
+// matches: import ... from "X", import("X"), require("X"), export ... from "X"
+const IMPORT_RE =
+  /(?:\bimport\s+(?:[\s\S]*?)\s+from\s+|\bimport\s*\(\s*|\brequire\s*\(\s*|\bexport\s+(?:[\s\S]*?)\s+from\s+)['"]([^'"]+)['"]/g;
+// also bare `import "X"` (side-effect import) — separate to avoid bloat
+const SIDE_IMPORT_RE = /\bimport\s+['"]([^'"]+)['"]/g;
+
+/**
+ * Walk a code repo and infer file-level import edges.
+ *
+ * @param {string} rootPath — repo root (must exist)
+ * @param {{ sourceFolders?: string[], ignore?: string[], maxFiles?: number }} options
+ * @returns {{
+ *   rootPath: string,
+ *   filesScanned: number,
+ *   edges: Array<{ from: string, to: string, kind: 'static'|'dynamic'|'require'|'reexport'|'side' }>,
+ *   externalImports: Array<{ from: string, spec: string }>,
+ *   unresolved: Array<{ from: string, spec: string, reason: string }>,
+ *   moduleEdges: Array<{ from: string, to: string, count: number }>,
+ * }}
+ */
+export function inferImports(rootPath, options = {}) {
+  if (!existsSync(rootPath) || !statSync(rootPath).isDirectory()) {
+    throw new Error(`rootPath not a directory: ${rootPath}`);
+  }
+  const ignore = new Set([
+    ...DEFAULT_IGNORE,
+    ...(options.ignore ?? []).map(String),
+  ]);
+  const maxFiles = typeof options.maxFiles === 'number' ? options.maxFiles : 5000;
+  const sourceFolders = options.sourceFolders ?? ['src', 'lib', 'app', 'packages'];
+
+  // Resolve search roots — defined source folders that exist, plus rootPath
+  // itself if no source folder exists (so simple repos still work).
+  const roots = [];
+  for (const f of sourceFolders) {
+    const p = join(rootPath, f);
+    if (existsSync(p) && statSync(p).isDirectory()) roots.push(p);
+  }
+  if (roots.length === 0) roots.push(rootPath);
+
+  const files = [];
+  for (const r of roots) walk(r, ignore, files, maxFiles);
+
+  const edges = [];
+  const externalImports = [];
+  const unresolved = [];
+
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    const dir = dirname(file);
+
+    for (const match of content.matchAll(IMPORT_RE)) {
+      const spec = match[1];
+      classify(spec, file, dir, rootPath, edges, externalImports, unresolved);
+    }
+    for (const match of content.matchAll(SIDE_IMPORT_RE)) {
+      // SIDE_IMPORT_RE matches a superset of IMPORT_RE in some cases —
+      // dedup by checking we haven't already added this exact (from, to, spec).
+      // Cheap heuristic: only count `import "X"` lines that AREN'T also
+      // matched by `import ... from "X"`.
+      const idx = match.index;
+      // Quick context check: is the prior char an `m` of "from"? then skip.
+      const window = content.slice(Math.max(0, idx - 10), idx + 2);
+      if (/from\s*$/.test(window.replace(/\s+$/, ''))) continue;
+      const spec = match[1];
+      classify(spec, file, dir, rootPath, edges, externalImports, unresolved, 'side');
+    }
+  }
+
+  // Module-level edge collapse — capability/feature folder is the
+  // first segment under one of the source folders.
+  const moduleCount = new Map();
+  for (const e of edges) {
+    const fm = moduleOf(e.from, sourceFolders);
+    const tm = moduleOf(e.to, sourceFolders);
+    if (!fm || !tm || fm === tm) continue;
+    const key = `${fm} → ${tm}`;
+    moduleCount.set(key, (moduleCount.get(key) ?? 0) + 1);
+  }
+  const moduleEdges = [...moduleCount.entries()].map(([key, count]) => {
+    const [from, to] = key.split(' → ');
+    return { from, to, count };
+  });
+  moduleEdges.sort((a, b) => b.count - a.count);
+
+  return {
+    rootPath,
+    filesScanned: files.length,
+    edges,
+    externalImports,
+    unresolved,
+    moduleEdges,
+  };
+}
+
+function walk(dir, ignore, out, maxFiles) {
+  if (out.length >= maxFiles) return;
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (ignore.has(name)) continue;
+    if (name.startsWith('.') && name !== '.') continue;
+    const p = join(dir, name);
+    let st;
+    try {
+      st = statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      walk(p, ignore, out, maxFiles);
+      if (out.length >= maxFiles) return;
+    } else if (st.isFile()) {
+      const dot = name.lastIndexOf('.');
+      if (dot < 0) continue;
+      const ext = name.slice(dot);
+      if (SOURCE_EXT.has(ext)) {
+        out.push(p);
+        if (out.length >= maxFiles) return;
+      }
+    }
+  }
+}
+
+function classify(spec, file, dir, rootPath, edges, external, unresolved, kindOverride) {
+  const kind = kindOverride ?? (spec.match(/^import\s*\(/) ? 'dynamic' : 'static');
+  if (!spec) {
+    unresolved.push({ from: relative(rootPath, file), spec, reason: 'empty' });
+    return;
+  }
+  if (spec.startsWith('.') || isAbsolute(spec)) {
+    const resolved = resolveRelativeImport(spec, dir);
+    if (resolved && existsSync(resolved)) {
+      edges.push({
+        from: relative(rootPath, file),
+        to: relative(rootPath, resolved),
+        kind,
+      });
+    } else {
+      unresolved.push({
+        from: relative(rootPath, file),
+        spec,
+        reason: 'relative-not-found',
+      });
+    }
+    return;
+  }
+  // R17 follow-up — `@/X` alias is the de-facto Next.js / FSD convention
+  // for `src/X`. Resolve it *as internal* so feature→entity/shared edges
+  // appear in moduleEdges instead of being lost in externalImports.
+  if (spec.startsWith('@/')) {
+    const aliasResolved = resolveAliasImport(spec, rootPath);
+    if (aliasResolved) {
+      edges.push({
+        from: relative(rootPath, file),
+        to: relative(rootPath, aliasResolved),
+        kind,
+      });
+      return;
+    }
+    // alias detected but not resolvable — track separately so the user
+    // sees what their tsconfig path is missing.
+    unresolved.push({
+      from: relative(rootPath, file),
+      spec,
+      reason: 'alias-not-found',
+    });
+    return;
+  }
+  external.push({ from: relative(rootPath, file), spec });
+}
+
+function resolveAliasImport(spec, rootPath) {
+  // Strip the `@/` prefix.
+  const subPath = spec.slice(2);
+  // Try common src-root mappings in order. (We don't read tsconfig.json
+  // — most projects use `@/*` → `src/*`. If a project uses something
+  // exotic, the user can still see edges via direct relative imports.)
+  for (const root of ['src', 'lib', 'app']) {
+    const base = join(rootPath, root, subPath);
+    if (existsSync(base) && statSync(base).isFile()) return base;
+    for (const ext of RESOLVE_EXT_ORDER) {
+      const cand = base + ext;
+      if (existsSync(cand) && statSync(cand).isFile()) return cand;
+    }
+    if (existsSync(base) && statSync(base).isDirectory()) {
+      for (const ext of RESOLVE_EXT_ORDER) {
+        const cand = join(base, 'index' + ext);
+        if (existsSync(cand) && statSync(cand).isFile()) return cand;
+      }
+    }
+  }
+  return null;
+}
+
+function resolveRelativeImport(spec, fromDir) {
+  const base = resolve(fromDir, spec);
+  // exact file
+  if (existsSync(base) && statSync(base).isFile()) return base;
+  // try extensions
+  for (const ext of RESOLVE_EXT_ORDER) {
+    const cand = base + ext;
+    if (existsSync(cand) && statSync(cand).isFile()) return cand;
+  }
+  // try base/index.* (folder)
+  if (existsSync(base) && statSync(base).isDirectory()) {
+    for (const ext of RESOLVE_EXT_ORDER) {
+      const cand = join(base, 'index' + ext);
+      if (existsSync(cand) && statSync(cand).isFile()) return cand;
+    }
+  }
+  return null;
+}
+
+function moduleOf(filePath, sourceFolders) {
+  // filePath is relative to rootPath. Find first segment that's a source
+  // folder, then take the next segment as the "module" id.
+  const parts = filePath.split(/[\\/]/);
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    if (sourceFolders.includes(parts[i])) {
+      // for FSD: src/features/auth/x.ts → module = features/auth
+      // generic: src/api/x.ts → module = api
+      // Heuristic: skip 'src/', take first sub-folder unless it's an FSD bucket
+      const next = parts[i + 1];
+      const fsdBuckets = new Set(['features', 'entities', 'widgets', 'views']);
+      if (fsdBuckets.has(next) && parts[i + 2]) {
+        return `${next}/${parts[i + 2]}`;
+      }
+      return next;
+    }
+  }
+  return null;
+}

--- a/mcp/src/infer-imports.test.mjs
+++ b/mcp/src/infer-imports.test.mjs
@@ -1,0 +1,178 @@
+// R17 — inferImports unit tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { inferImports } from './infer-imports.mjs';
+
+function withRepo(setup) {
+  const root = mkdtempSync(join(tmpdir(), 'omot-imports-'));
+  setup(root);
+  return root;
+}
+
+test('relative import resolved to file path', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/a'), { recursive: true });
+    mkdirSync(join(r, 'src/b'), { recursive: true });
+    writeFileSync(
+      join(r, 'src/a/index.ts'),
+      'import { foo } from "../b/foo";\nexport const a = 1;\n',
+    );
+    writeFileSync(join(r, 'src/b/foo.ts'), 'export const foo = 2;\n');
+  });
+  try {
+    const r = inferImports(root);
+    const e = r.edges.find(
+      (x) => x.from === 'src/a/index.ts' && x.to === 'src/b/foo.ts',
+    );
+    assert.ok(e, `expected edge a/index.ts → b/foo.ts, got: ${JSON.stringify(r.edges)}`);
+    assert.equal(e.kind, 'static');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('external (npm) import classified separately', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src'), { recursive: true });
+    writeFileSync(
+      join(r, 'src/main.ts'),
+      'import React from "react";\nimport { z } from "zod";\n',
+    );
+  });
+  try {
+    const r = inferImports(root);
+    assert.equal(r.edges.length, 0);
+    const specs = r.externalImports.map((x) => x.spec).sort();
+    assert.deepEqual(specs, ['react', 'zod']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('tsconfig path alias (@/) — resolves to src/ when target exists, else unresolved', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/lib'), { recursive: true });
+    writeFileSync(join(r, 'src/lib/foo.ts'), 'export const foo = 1;');
+    writeFileSync(
+      join(r, 'src/main.ts'),
+      'import { foo } from "@/lib/foo";\nimport { gone } from "@/missing";\n',
+    );
+  });
+  try {
+    const r = inferImports(root);
+    // @/lib/foo → resolved to src/lib/foo.ts (internal edge)
+    const e = r.edges.find((x) => x.to === 'src/lib/foo.ts');
+    assert.ok(e, `expected alias-resolved edge to src/lib/foo.ts, got: ${JSON.stringify(r.edges)}`);
+    // @/missing → unresolved with alias-not-found
+    assert.ok(
+      r.unresolved.some(
+        (u) => u.spec === '@/missing' && u.reason === 'alias-not-found',
+      ),
+      `expected alias-not-found, got: ${JSON.stringify(r.unresolved)}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('dynamic import + require + reexport detected', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/a'), { recursive: true });
+    mkdirSync(join(r, 'src/b'), { recursive: true });
+    writeFileSync(join(r, 'src/b/x.ts'), 'export const x = 1;');
+    writeFileSync(
+      join(r, 'src/a/index.ts'),
+      [
+        'const m = await import("../b/x");',
+        'const r = require("../b/x");',
+        'export { x } from "../b/x";',
+      ].join('\n'),
+    );
+  });
+  try {
+    const r = inferImports(root);
+    const toX = r.edges.filter((e) => e.to === 'src/b/x.ts');
+    assert.ok(toX.length >= 1, `expected edges to b/x.ts, got: ${JSON.stringify(r.edges)}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('module-level edge collapse (FSD: features/ 안 module 합산)', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/features/auth'), { recursive: true });
+    mkdirSync(join(r, 'src/features/billing'), { recursive: true });
+    writeFileSync(
+      join(r, 'src/features/auth/index.ts'),
+      'import { invoice } from "../billing/index";\nimport { token } from "../billing/token";\n',
+    );
+    writeFileSync(join(r, 'src/features/billing/index.ts'), 'export const invoice = 1;');
+    writeFileSync(join(r, 'src/features/billing/token.ts'), 'export const token = 1;');
+  });
+  try {
+    const r = inferImports(root);
+    const e = r.moduleEdges.find(
+      (x) => x.from === 'features/auth' && x.to === 'features/billing',
+    );
+    assert.ok(e, `expected module edge features/auth → features/billing, got: ${JSON.stringify(r.moduleEdges)}`);
+    assert.equal(e.count, 2, '두 import 합산');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('unresolved relative — 누락 파일 reason: relative-not-found', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src'), { recursive: true });
+    writeFileSync(
+      join(r, 'src/main.ts'),
+      'import { gone } from "./missing";\n',
+    );
+  });
+  try {
+    const r = inferImports(root);
+    assert.equal(r.edges.length, 0);
+    assert.equal(r.unresolved[0]?.reason, 'relative-not-found');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('node_modules / dist / .next ignored', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/a'), { recursive: true });
+    mkdirSync(join(r, 'node_modules/foo'), { recursive: true });
+    mkdirSync(join(r, 'dist'), { recursive: true });
+    writeFileSync(join(r, 'src/a/index.ts'), 'export const a = 1;');
+    writeFileSync(join(r, 'node_modules/foo/index.js'), 'should not be scanned');
+    writeFileSync(join(r, 'dist/build.js'), 'also not scanned');
+  });
+  try {
+    const r = inferImports(root);
+    assert.equal(r.filesScanned, 1, 'node_modules / dist 안 의 파일 walk 안 됨');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('side-effect import (import "X") 감지', () => {
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/a'), { recursive: true });
+    mkdirSync(join(r, 'src/b'), { recursive: true });
+    writeFileSync(join(r, 'src/b/setup.ts'), 'console.log("setup");');
+    writeFileSync(join(r, 'src/a/main.ts'), 'import "../b/setup";\nexport const a = 1;\n');
+  });
+  try {
+    const r = inferImports(root);
+    const sideEdge = r.edges.find((e) => e.kind === 'side');
+    assert.ok(
+      sideEdge,
+      `expected side import edge, got: ${JSON.stringify(r.edges)}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

R16 \`analyze_repo_structure\` (heuristic 후보) 의 **강력한 짝**. 코드의 *진짜 import graph* 를 자동 추출해 \`depends_on\` 관계 후보로.

**MCP v0.8.0 → v0.9.0** (16 tools — 10 read + 6 write).
**CLI v0.4.0 → v0.5.0** (13 명령 — infer-imports 추가).

## Validated — Paravel real-codebase (사용자 본인)

React Native + Expo + FSD 1.8 GB:

| 측정 | 값 |
|---|---|
| files | 304 |
| edges | **837** (alias resolve 로 이전 355 → 2배+) |
| external (npm) | 506 |
| unresolved | 0 |
| **module edges** | **103** |

상위 module edges:
- \`screens → shared\` × 98
- \`app → screens\` × 22
- \`features/diary → shared\` × 18
- \`features/create-post → entities/post\` × 6
- … 87 more

FSD layering **정확 자동 추출**. 사용자 본인이 수동 add_relation 으로 그릴 그래프를 *코드에서 자동* 산출. mission *"완벽에 가깝게 그래프 생성"* 의 다음 큰 step.

## 동작

- TS/JS 파일 walk + regex parse — static / dynamic / require / re-export / side-effect
- 상대 경로 (\`./\` \`../\`) → 실 파일 resolve (확장자 + \`index.*\` fallback)
- **\`@/*\` path alias** convention 자동 resolve (Next.js / FSD 의 80%+ case)
- external (npm) 분리, unresolved 분리 (\`relative-not-found\` / \`alias-not-found\`)
- **module-level edge collapse** — FSD bucket (\`features/X\` / \`entities/X\` / \`widgets/X\` / \`views/X\`) 인식

응답: \`{ rootPath, filesScanned, edges[], externalImports[], unresolved[], moduleEdges[] }\`. **side effect 0** — vault 절대 안 건드림.

## 단일 source of truth

결과는 *return only*. 사용자 / agent 검토 후 *명시 \`add_relation depends_on\`* 만 진입. 별도 cache / index 0. drift surface 0.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm test:run\` 814/814
- [x] \`mcp/\` test 29 → **37** (infer-imports 8 추가)
- [x] \`pnpm vault:validate\` 26 nodes issue 0
- [x] \`mcp/scripts/verify.mjs\` 16/16 tools
- [x] **Paravel real-codebase manual sanity**: 837 edges, 103 module edges, 0 unresolved, FSD layering 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)