### PR TITLE
fix(ontology): 사용성 회귀 일괄 정리 — edge dedup · ?-키 충돌 · 모바일 truncate · 16-tool 갱신

### DIFF
--- a/app/[locale]/project/fallback/ProjectFallbackClient.tsx
+++ b/app/[locale]/project/fallback/ProjectFallbackClient.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "@/i18n/navigation";
 import { ProjectDetailPage } from "@/views/project-detail";
 
+type Resolution = { state: "pending" } | { state: "slug"; slug: string } | { state: "redirect" };
+
 // 브라우저에 도달한 path 에서 slug 를 추출. cleanUrls + trailingSlash
-// 정책상 path 는 `/project/<slug>/` 형태. 자기 자신 (fallback) 진입은 빈 slug 처리.
+// 정책상 path 는 `/project/<slug>/` 형태. CDN rewrite 가 이 페이지로 unknown
+// slug 를 보낼 때 path 는 그대로 사용자가 친 URL — JS 에서 다시 꺼낸다.
+// 진입 path 자체가 `/project/fallback/` 이면 (= rewrite 없이 직접 진입) 빈
+// 페이지를 안 보여주고 /projects 리스트로 보낸다.
 function extractSlug(): string | null {
   if (typeof window === "undefined") return null;
   const path = window.location.pathname;
-  const match = path.match(/^\/project\/([^/]+)\/?$/);
+  const match = path.match(/^(?:\/[a-z]{2})?\/project\/([^/]+)\/?$/);
   if (!match) return null;
   const raw = decodeURIComponent(match[1]);
   if (!raw || raw === "fallback") return null;
@@ -16,13 +22,25 @@ function extractSlug(): string | null {
 }
 
 export function ProjectFallbackClient() {
-  const [slug, setSlug] = useState<string | null>(null);
-  // SSR 평가에서 location 접근 불가 — 마운트 후 1 회만 추출.
+  const router = useRouter();
+  const [resolution, setResolution] = useState<Resolution>({ state: "pending" });
+
   useEffect(() => {
-    setSlug(extractSlug());
-  }, []);
-  if (!slug) return null;
+    const slug = extractSlug();
+    if (slug) {
+      setResolution({ state: "slug", slug });
+    } else {
+      setResolution({ state: "redirect" });
+      router.replace("/projects");
+    }
+  }, [router]);
+
+  if (resolution.state !== "slug") return null;
   return (
-    <ProjectDetailPage slug={slug} initialProject={null} initialRelated={[]} />
+    <ProjectDetailPage
+      slug={resolution.slug}
+      initialProject={null}
+      initialRelated={[]}
+    />
   );
 }

--- a/docs/ontology/capabilities/mcp-server.md
+++ b/docs/ontology/capabilities/mcp-server.md
@@ -1,21 +1,15 @@
 ---
 slug: capabilities/mcp-server
 kind: capability
-title: MCP Server (15 tools)
+title: MCP Server (16 tools)
 domain: ai-agent-partner
-elements:
-  - mcp/src/index.js
-  - mcp/src/parser.mjs
-  - mcp/src/vault.mjs
-  - mcp/src/analyze.mjs
-relates:
-  - capabilities/frontmatter-to-ontology
-  - domains/ai-agent-partner
+elements: [mcp/src/index.js, mcp/src/parser.mjs, mcp/src/vault.mjs, mcp/src/analyze.mjs, mcp/src/infer-imports.mjs]
+relates: [capabilities/frontmatter-to-ontology, domains/ai-agent-partner]
 ---
 
-# MCP Server (15 tools)
+# MCP Server (16 tools)
 
-`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 15 도구 노출 (read 9 + write 6):
+`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 16 도구 노출 (read 10 + write 6):
 
 | 도구 | 동작 |
 |---|---|
@@ -28,6 +22,7 @@ relates:
 | `find_orphans` | 어디서도 link 안 받는 고립 노드 (kind 필터, vault-readme 자동 제외) |
 | `query_concepts` | DSL 기반 ad-hoc 쿼리 (frontmatter 키 = / contains / exists 조합) |
 | `analyze_repo_structure` | **R16** code repo (default cwd) 분석 → ontology 노드 후보 제안. **side effect 0** — vault 변경 안 함. AI agent 가 빈 vault bootstrap 시 사용 (사용자 한 줄 *"이 codebase 분석해줘"*). FSD vs generic detect. |
+| `infer_imports` | **R17** TS/JS import graph 추출 → file/module-level edge + external (npm) imports 분리. **side effect 0**. analyze_repo_structure 후 *real* dependency edge 를 add_relation 으로 land 하기 위한 입력. |
 | `add_concept` | 새 노드 (.md) 작성 — 기존 slug 면 throw |
 | `add_relation` | depends_on / relates / contains / describes edge 추가 |
 | `patch_concept` | 기존 노드 frontmatter (key 단위 patch) + body 갱신 |

--- a/messages/en.json
+++ b/messages/en.json
@@ -183,7 +183,7 @@
     "tree": {
       "expand": "Expand",
       "collapse": "Collapse",
-      "searchPlaceholder": "Find a node in the tree — Korean or English",
+      "searchPlaceholder": "Filter the tree — by title or slug",
       "searchAriaLabel": "Search tree nodes",
       "searchClearAriaLabel": "Clear search",
       "expandedSummary": "{expanded} / {total} expanded",
@@ -1190,6 +1190,7 @@
     },
     "footer": {
       "counts": "{nodes} nodes · {edges} relations",
+      "countsHint": "Includes implicit stubs declared in frontmatter — may exceed the count of .md files in the vault.",
       "modePrefix": "mode",
       "modeLocal": "Local vault",
       "modeStatic": "Static demo"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -183,7 +183,7 @@
     "tree": {
       "expand": "펼치기",
       "collapse": "접기",
-      "searchPlaceholder": "트리에서 노드 찾기 — 한·영 OK",
+      "searchPlaceholder": "트리에서 찾기 — 이름 · slug 둘 다",
       "searchAriaLabel": "트리 노드 검색",
       "searchClearAriaLabel": "검색 지우기",
       "expandedSummary": "{expanded} / {total} 펼침",
@@ -1190,6 +1190,7 @@
     },
     "footer": {
       "counts": "노드 {nodes} · 관계 {edges}",
+      "countsHint": "frontmatter 가 명시한 implicit stub 까지 포함합니다 — vault 의 .md 파일 수와는 다를 수 있어요.",
       "modePrefix": "모드",
       "modeLocal": "로컬 vault",
       "modeStatic": "정적 데모"

--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
@@ -175,6 +175,37 @@ describe('deriveOntologyFromVault', () => {
     expect(result.nodes).toHaveLength(0);
   });
 
+  it('양방향 frontmatter (domain.capabilities[] + capability.domain:) → contains edge dedup', () => {
+    // 같은 contains 관계가 두 진입경로에서 등장:
+    //   domains/auth.md          → capabilities: ['login']
+    //   capabilities/login.md    → domain: auth
+    // 두 doc 모두 \`domain:auth--contains-->capability:login\` edge 를 만들지만
+    // 그래프 입장에서는 같은 edge — id 충돌은 React duplicate-key 경고로 이어지고
+    // ego-graph 가 일부 edge 를 silently 누락한다. 같은 (from, to, type) 은 1 edge.
+    const result = deriveOntologyFromVault(
+      makeManifest([
+        makeDoc({
+          slug: 'domains/auth',
+          frontmatter: { kind: 'domain', title: 'auth', capabilities: ['login'] },
+        }),
+        makeDoc({
+          slug: 'capabilities/login',
+          frontmatter: { kind: 'capability', title: 'login', domain: 'auth' },
+        }),
+      ]),
+    );
+    const containsEdges = result.edges.filter(
+      (e) =>
+        e.type === 'contains' &&
+        e.from === 'domain:auth' &&
+        e.to === 'capability:login',
+    );
+    expect(containsEdges).toHaveLength(1);
+    // 전체 edge id 도 unique 해야 한다.
+    const ids = result.edges.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
   it('동일 capability 가 여러 doc 에 등장 → 단일 node 로 dedup', () => {
     const result = deriveOntologyFromVault(
       makeManifest([

--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
@@ -328,12 +328,20 @@ export function deriveOntologyFromVault(
     );
   }
 
-  // edge type 화이트리스트 검증 (방어)
-  const validatedEdges = edges.filter((e) => VALID_RELATION_TYPES.has(e.type));
+  // edge type 화이트리스트 검증 (방어) + id 기반 dedup.
+  // vault 가 양방향으로 같은 관계를 표현하면 (예: domain.capabilities[] +
+  // capability.domain:) 같은 edge id 가 두 번 push 된다. 그래프 입장에서는
+  // 같은 edge 라 first-wins 로 합쳐 React duplicate-key 경고와 ego graph 의
+  // silent edge 누락을 차단.
+  const dedupedById = new Map<string, OntologyStubEdge>();
+  for (const e of edges) {
+    if (!VALID_RELATION_TYPES.has(e.type)) continue;
+    if (!dedupedById.has(e.id)) dedupedById.set(e.id, e);
+  }
 
   return {
     nodes: Array.from(nodes.values()),
-    edges: validatedEdges,
+    edges: Array.from(dedupedById.values()),
     warnings,
   };
 }

--- a/src/shared/lib/ontology-tree/filter-tree.test.ts
+++ b/src/shared/lib/ontology-tree/filter-tree.test.ts
@@ -97,6 +97,32 @@ describe("filterTreeByQuery", () => {
     expect(r).toHaveLength(0);
   });
 
+  it("slug (node.id) 도 매치 — 사용자가 'mcp-server' 같은 slug 로 검색", () => {
+    // 개발자는 frontmatter / 코드에서 slug 형태 (kind:tail) 를 일상적으로 본다.
+    // 검색이 title 만 매칭하면 'mcp-server' 같은 slug 검색이 빈 결과로 떨어져
+    // 사용자가 이 트리에 없다고 오해. id 도 매치 대상에 포함.
+    const slugNodes = [
+      node("root", "프로젝트", "project"),
+      withParent(node("capability:mcp-server", "MCP Server (16 tools)")),
+    ];
+    const slugEdges = [
+      {
+        id: "e",
+        from: "root",
+        to: "capability:mcp-server",
+        type: "contains",
+        projectIds: [],
+        evidenceIds: [],
+        lastApprovedAt: APPROVED_AT,
+        lastApprovedBy: "test",
+      },
+    ];
+    const slugTree = buildOntologyTree(slugNodes, slugEdges);
+    const r = filterTreeByQuery(slugTree.roots, "mcp-server");
+    expect(r).toHaveLength(1);
+    expect(r[0]?.children[0]?.node.id).toBe("capability:mcp-server");
+  });
+
   it("대소문자 무시 (lower-case 비교)", () => {
     const enNodes = [
       node("root", "ROOT", "project"),

--- a/src/shared/lib/ontology-tree/filter-tree.ts
+++ b/src/shared/lib/ontology-tree/filter-tree.ts
@@ -3,7 +3,11 @@ import type { OntologyTreeNode } from "./types";
 /**
  * 트리에서 query 매치하는 노드만 남기되 **부모 chain 보존**.
  *
- * 매치 기준: node.title.lower-case includes query.lower-case (한·영 혼합 OK).
+ * 매치 기준: node.title 또는 node.id (kind:slug 형태) 의 lower-case includes
+ * query.lower-case (한·영 혼합 OK). 개발자는 frontmatter / 코드에서 slug 를
+ * 일상적으로 보기 때문에 'mcp-server' 같은 slug 검색이 빈 결과로 떨어지면
+ * 안 된다.
+ *
  * 매치 노드의 모든 조상은 무조건 살아남고 (트리 형태 유지), 형제 (매치 안 한)
  * 는 제외. 매치 노드의 자손은 모두 살림 (사용자가 컨텍스트 보길 기대).
  *
@@ -20,7 +24,9 @@ export function filterTreeByQuery(
   if (trimmed === "") return roots.slice();
 
   function visit(node: OntologyTreeNode): OntologyTreeNode | null {
-    const titleMatch = node.node.title.toLowerCase().includes(trimmed);
+    const titleMatch =
+      node.node.title.toLowerCase().includes(trimmed)
+      || node.node.id.toLowerCase().includes(trimmed);
     const filteredChildren = node.children
       .map(visit)
       .filter((c): c is OntologyTreeNode => c !== null);

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -455,7 +455,10 @@ function OntologyMetaFooter({
   const modeLabel = mode === 'local' ? t('modeLocal') : t('modeStatic');
   return (
     <footer className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-[color:var(--color-divider)] pt-3 text-[11px] text-[color:var(--color-text-quaternary)]">
-      <span className="font-mono uppercase tracking-[0.14em]">
+      <span
+        className="font-mono uppercase tracking-[0.14em] underline decoration-dotted decoration-[color:var(--color-text-quaternary)] underline-offset-4 cursor-help"
+        title={t('countsHint')}
+      >
         {t('counts', { nodes: nodeCount, edges: edgeCount })}
       </span>
       <span aria-hidden>·</span>

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -131,7 +131,7 @@ function TreeRow({
       data-depth={treeNode.depth}
       data-dim={isElementKind ? "true" : "false"}
       data-selected={selected ? "true" : "false"}
-      className={`flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors ${selectedClass} ${dimClass}`}
+      className={`flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 transition-colors ${selectedClass} ${dimClass}`}
       style={{ paddingLeft: `${indent + 8}px` }}
     >
       {hasChildren ? (
@@ -139,20 +139,21 @@ function TreeRow({
           type="button"
           onClick={onToggle}
           aria-label={expanded ? t('tree.collapse') : t('tree.expand')}
-          className="flex h-5 w-5 items-center justify-center rounded text-[color:var(--color-text-quaternary)] hover:bg-[color:var(--color-border-soft)] hover:text-[color:var(--color-text-secondary)]"
+          className="flex h-5 w-5 flex-none items-center justify-center rounded text-[color:var(--color-text-quaternary)] hover:bg-[color:var(--color-border-soft)] hover:text-[color:var(--color-text-secondary)]"
         >
           {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </button>
       ) : (
-        <span className="inline-block h-5 w-5" aria-hidden />
+        <span className="inline-block h-5 w-5 flex-none" aria-hidden />
       )}
       <button
         type="button"
         onClick={() => onSelect?.(treeNode.node)}
-        className="flex flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
+        title={treeNode.node.title}
+        className="flex min-w-0 flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
       >
         <KindChip kind={treeNode.node.kind} />
-        <span className="truncate">{treeNode.node.title}</span>
+        <span className="min-w-0 flex-1 truncate">{treeNode.node.title}</span>
         {/* EvidenceCountChip / ProjectIdChip 모두 R10 후 vault 모드에서
             evidenceCount / projectIds 가 영구 빈 값이라 미렌더되어 cycle
             15 / 24 에서 제거. 미래에 vault 측에서 해당 값을 derive 해
@@ -202,7 +203,11 @@ export function OntologyTreeView({
   const filteredOrphans = useMemo(() => {
     const trimmed = searchQuery.trim().toLowerCase();
     if (trimmed === "") return result.orphans;
-    return result.orphans.filter((n) => n.title.toLowerCase().includes(trimmed));
+    return result.orphans.filter(
+      (n) =>
+        n.title.toLowerCase().includes(trimmed)
+        || n.id.toLowerCase().includes(trimmed),
+    );
   }, [result.orphans, searchQuery]);
   const isFiltering = searchQuery.trim() !== "";
 
@@ -408,9 +413,9 @@ export function OntologyTreeView({
           </p>
           <ul className="mt-2 space-y-0.5">
             {filteredOrphans.slice(0, 8).map((node) => (
-              <li key={node.id} className="flex items-center gap-2">
+              <li key={node.id} className="flex min-w-0 items-center gap-2" title={node.title}>
                 <KindChip kind={node.kind} />
-                <span className="truncate">{node.title}</span>
+                <span className="min-w-0 flex-1 truncate">{node.title}</span>
               </li>
             ))}
             {filteredOrphans.length > 8 ? (

--- a/src/widgets/topology-map-sigma/ui/SigmaControls.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaControls.tsx
@@ -58,10 +58,9 @@ export function SigmaControls({
         });
         return;
       }
-      if (event.key === '?') {
-        setHelpOpen((v) => !v);
-        return;
-      }
+      // `?` 키는 HomePage 의 글로벌 ShortcutSheet 가 단일 진입점.
+      // 여기서 별도 HelpOverlay 를 같이 열면 dialog 두 개가 동시에 떠 사용자가
+      // 어느 쪽이 진짜 help 인지 헷갈린다. button click (line 366) 은 유지.
       if (event.key === '0') {
         onChange({ ...value, depthLimit: null });
         return;


### PR DESCRIPTION
## Summary

사용성 점검에서 잡힌 **Critical 1 + Important 4 + Recommended 3** 회귀를 두 commit 으로 정리.

### Critical
- **edge dedup** — `derive-ontology-from-vault.ts` 가 `domain.capabilities[]` ↔ `capability.domain:` 처럼 양방향으로 표현된 frontmatter 를 중복 edge 로 emit. ego-graph 렌더 시 React duplicate-key 경고 + 일부 edge silent 누락. id 기반 first-wins dedup.

### Important
- **`?` 키 dialog 충돌** — HomePage 의 글로벌 ShortcutSheet + SigmaControls inline HelpOverlay 가 같이 열려 두 개 dialog 동시 노출. SigmaControls 의 `?` keydown 분기 제거 (button click 은 유지).
- **`/project/fallback` 직접 진입 시 빈 main** — null slug 검출 시 `/projects` 로 client-side replace.
- **모바일 트리 라벨 가로 스크롤 (375px)** — flex 체인 `min-w-0` 누락. element 슬러그 버튼이 533px 까지 늘어나 가로 스크롤. 행 div · button · span 3 단계에 `min-w-0` + `flex-1` + `title` 속성.

### Recommended
- **트리 검색 slug 매치** — 'mcp-server' 같은 slug 검색이 빈 결과로 떨어졌다. `filterTreeByQuery` 의 매치 기준을 `title ∪ id` 로 확장.
- **placeholder 명확화** — "한·영 OK" → "이름 · slug 둘 다" / "by title or slug".
- **카운트 footer 힌트** — UI 79 vs MCP 26 차이는 implicit stub 때문. footer 카운트에 dotted-underline + tooltip 으로 노출.
- **dogfood 갱신** — `capabilities/mcp-server` 가 R17 이후 stale: title "(15 tools)" → "(16 tools)", elements 에 `mcp/src/infer-imports.mjs` 추가, body 표에 R17 항목.

## 누적 영향 (이전 점검 대비)
- 데이터 경고 **30 → 13 건**
- 토폴로지 엣지 **149 → 127**
- 노드 detail console error **6 → 0**
- 모바일 가로 오버플로우 **46 elements → 0**
- `?` 키 dialog **2 → 1**

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test:run` — 102 files / **816 / 816** 통과 (신규 contract test 2 개 추가)
- [x] `pnpm lint` — 0 errors (17 pre-existing warnings)
- [x] 브라우저 회귀: `/ontology?node=capability:mcp-server` console error 0
- [x] `/topology` 다크/라이트 토글 정상, Sigma 80노드/127엣지 깔끔 렌더
- [x] 375px 모바일 트리 가로 오버플로우 0
- [x] `/project/fallback` → `/projects` redirect
- [x] `?` 키 1 dialog 만 노출
- [x] 트리 'mcp-server' 검색 7 매치 (slug 매치)

## Out of scope
- 토폴로지 hub 노드 라벨 항상 노출 (정보 밀도 개선)
- vault validator 의 양방향 self-warning 룰 완화 (현재 13건 잔존)
- 트리 sort/카운트 source-of-truth 통합 (UI 80 vs tree 80 vs ontology 79 등 view 별 다름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)