### PR TITLE
feat(topology): hub 라벨 항상 노출 + validator self-warning silent

### DIFF
--- a/src/shared/lib/ontology-tree/build-tree.test.ts
+++ b/src/shared/lib/ontology-tree/build-tree.test.ts
@@ -150,6 +150,22 @@ describe("buildOntologyTree — error handling", () => {
     expect(p1.children.find((c) => c.node.id === "d1")).toBeTruthy();
   });
 
+  it("same-parent 중복 contains edge 는 silent (양방향 frontmatter 자기 중복 방어)", () => {
+    // 진짜 다중 부모 (서로 다른 parent) 만 사용자에게 노출되어야 한다.
+    // 같은 (parent, child) 가 두 번 들어오는 건 vault 양방향 frontmatter
+    // 중복일 뿐 정보 가치 없음 — derive-ontology 가 dedup 하지만 외부
+    // manifest 흡수 시 defense-in-depth.
+    const nodes = [makeNode("p1", "project"), makeNode("d1", "domain")];
+    const edges = [
+      makeEdge("e1", "p1", "d1", "contains"),
+      makeEdge("e2", "p1", "d1", "contains"),
+    ];
+    const result = buildOntologyTree(nodes, edges);
+    expect(result.warnings.some((w) => w.includes("multiple parents"))).toBe(false);
+    const p1 = result.roots.find((r) => r.node.id === "p1")!;
+    expect(p1.children.find((c) => c.node.id === "d1")).toBeTruthy();
+  });
+
   it("breaks cycles", () => {
     const nodes = [
       makeNode("a", "domain"),

--- a/src/shared/lib/ontology-tree/build-tree.ts
+++ b/src/shared/lib/ontology-tree/build-tree.ts
@@ -69,10 +69,14 @@ export function buildOntologyTree(
       continue;
     }
     if (parentOf.has(childId)) {
+      const existingParent = parentOf.get(childId)!;
+      // 같은 parent 가 두 번 등장하는 self-warning (양방향 frontmatter 중복)
+      // 은 silent — derive-ontology-from-vault 의 dedup 이 normally 차단하지만
+      // 외부 manifest 가 들어왔을 때를 위한 defense-in-depth. 진짜 다중 부모
+      // (서로 다른 parent) 만 사용자에게 노출.
+      if (existingParent === parentId) continue;
       warnings.push(
-        `node "${childId}" has multiple parents — keeping first (${parentOf.get(
-          childId,
-        )}), ignoring (${parentId})`,
+        `node "${childId}" has multiple parents — keeping first (${existingParent}), ignoring (${parentId})`,
       );
       continue;
     }

--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -83,6 +83,13 @@ const HUB_COLOR = INDIGO_HUB;
 const NODE_OUTER_HALO = 'rgba(0, 0, 0, 0)'; // 비허브는 halo 없음 (투명)
 
 /**
+ * ontology 노드가 forceLabel = true 로 승격되는 degree 기준.
+ * 5 = 한 노드가 다른 노드 5 이상에 연결됨 → "이 도메인/역량 안에 뭔가 많다"
+ * 신호. 이 임계 미만은 fingerprint 기여가 작아 hover 라벨로 충분.
+ */
+const ONTOLOGY_LABEL_DEGREE = 5;
+
+/**
  * 디자인 시스템이 색 추가를 금지(무채색 + 단일 인디고)하므로 도메인 구분은
  * 회색 luminance + 아주 옅은 tint 로 표현. 채도는 최대 ~6% 로 유지해 "무채색
  * 계열" 범위를 깨지 않되 slug prefix 로 도메인 클러스터를 구분할 수 있도록.
@@ -342,6 +349,12 @@ export function buildGraph(
   // degree 기반 크기 재계산 — 연결이 많을수록 커진다.
   // Hub: 10 → 13, Node: 4.5 → 7.5. 화면 픽셀 기준 ~2x 일관 비율.
   // ontology 노드는 base 3.5 를 유지하되 degree 영향은 약하게.
+  //
+  // forceLabel 정책 (R+ usability):
+  //   - domain kind → 항상 라벨. 트리 최상위라 navigation 앵커.
+  //   - 기타 ontology 노드 → degree ≥ ONTOLOGY_LABEL_DEGREE 이면 라벨.
+  //     "어디가 hub-like 인지" 한 눈에 보여 사용자가 80 노드 그래프에서
+  //     fingerprint 잡을 수 있게. element 처럼 1~2 edge 인 leaf 는 hover 의존.
   graph.forEachNode((id, attrs) => {
     const degree = graph.degree(id);
     if (attrs.isHub) {
@@ -356,6 +369,11 @@ export function buildGraph(
         'size',
         3.5 + Math.min(2, Math.log2(Math.max(1, degree)) * 0.4),
       );
+      const isDomain = attrs.ontologyTopKind === 'domain';
+      const isHighDegree = degree >= ONTOLOGY_LABEL_DEGREE;
+      if (isDomain || isHighDegree) {
+        graph.setNodeAttribute(id, 'forceLabel', true);
+      }
     } else {
       graph.setNodeAttribute(
         id,


### PR DESCRIPTION
## Summary

PR #173 후속 — 사용성 백로그 2건.

- **토폴로지 hub 라벨 정책** — 80 노드 그래프에서 라벨이 hover-only 라 어디가 어디인지 식별 불가했던 문제. ontology 노드 중 `domain` kind 는 항상 / 그 외는 degree ≥ 5 일 때 forceLabel = true. element leaf 는 hover 의존 유지해 시각 노이즈 회피.

- **validator multi-parent self-warning 완화** — 같은 (parent, child) contains edge 두 번 → "multiple parents" 경고는 정보 가치 0 (실제 다중 부모 = 다른 parent 의 서로 공유 element 만 노출). derive-ontology 의 dedup 이 normally 차단하지만 외부 manifest 흡수 시 defense-in-depth.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 102 files / 815 / 815 통과 (신규 test 1: same-parent dup silent)
- [ ] `/topology` 다크 모드에서 도메인 6개 라벨 항상 표시 확인 (PR #173 머지 후 누적 검증)

## Out of scope
- 토폴로지 줌 레벨 별 라벨 진입 임계 미세 조정
- ontology 노드 클릭 → vault md 열기 (현재 TODO 주석)
- vault validator UI 의 "30 → 13 → 잔존" 표 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)