### PR TITLE
feat(mcp): 에러 메시지를 actionable 하게 — AI agent 가 다음 액션을 한 호출에 결정

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Changed
 
-- **`find_path` now returns `edges[]` with `via` (relation type) per hop.** 기존 `hops: [slug, ...]` 는 backward compatible 로 유지하면서 같은 응답에 `edges: [{ from, to, via }]` 추가. `via` 는 두 slug 를 연결한 frontmatter 키 (`capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`) — AI agent 가 path 를 받았을 때 *왜* A 와 B 가 연결됐는지 한 hop 단위로 본다. trivial path (`from === to`) 의 경우 `edges: []`.
+- **에러 메시지를 actionable 하게.** AI agent 가 다음 액션을 한 호출에 결정 가능:
+  - `add_concept` 가 dup slug 만나면 `patch_concept` (업데이트) / `rename_concept` (이동) 사용 권장 + "delete-then-add 금지 — backlinks 유실" 명시.
+  - 모든 not-found 에러 (deleteDoc / patchFrontmatter / updateDoc) 가 `list_concepts` / `find_evidence` 안내 + 같은 vault 안의 *비슷한 slug 후보* (substring / prefix 매치) 동봉.
+  - `add_relation` 의 source/target 누락 시 비슷한 slug 후보 또는 `add_concept` 안내. AI agent 가 typo / hallucinated slug 를 받았을 때 즉시 자가 수정 가능.
+- 새 export `suggestSimilarSlugs(rootPath, badSlug, limit=3)` — Levenshtein 없이 tail 정확/substring 양방향/prefix 3-tier 매칭. 큰 vault 에서도 가벼움.
+- 7 신규 unit test (suggest 5 + actionable error 2).
 
 ## 0.9.0 — 2026-05-06 (R17 — import graph → depends_on edges)
 

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -52,6 +52,7 @@ import {
   redirectBacklinks,
   slugToPath,
   patchFrontmatter,
+  suggestSimilarSlugs,
   updateDoc,
   vaultSlugExists,
   writeDoc,
@@ -807,10 +808,18 @@ function addRelation({ from, to, type, expected_mtime }) {
   // 후속에서 어차피 throw 하지만 메시지가 ENOENT raw 라 사용자 친화적
   // 에러로 선검증.
   if (!vaultSlugExists(VAULT_ROOT, from)) {
-    throw new Error(`Source slug does not exist in vault: "${from}"`);
+    const suggestions = suggestSimilarSlugs(VAULT_ROOT, from);
+    const suffix = suggestions.length > 0
+      ? ` Did you mean: ${suggestions.map((s) => `"${s}"`).join(', ')}?`
+      : ' Use list_concepts() to see all slugs, or add_concept(slug, kind, title) to create it first.';
+    throw new Error(`Source slug does not exist in vault: "${from}".${suffix}`);
   }
   if (!vaultSlugExists(VAULT_ROOT, to)) {
-    throw new Error(`Target slug does not exist in vault: "${to}"`);
+    const suggestions = suggestSimilarSlugs(VAULT_ROOT, to);
+    const suffix = suggestions.length > 0
+      ? ` Did you mean: ${suggestions.map((s) => `"${s}"`).join(', ')}?`
+      : ' Use list_concepts() to see all slugs, or add_concept(slug, kind, title) to create it first.';
+    throw new Error(`Target slug does not exist in vault: "${to}".${suffix}`);
   }
   const doc = readDoc(VAULT_ROOT, slugToPath(VAULT_ROOT, from));
   const existing = Array.isArray(doc.frontmatter[key]) ? doc.frontmatter[key] : [];

--- a/mcp/src/vault.mjs
+++ b/mcp/src/vault.mjs
@@ -204,13 +204,76 @@ export function loadVaultDocs(rootPath) {
 }
 
 /**
+ * vault 에서 badSlug 와 비슷한 slug 후보를 반환 — AI agent 가 오타 / 접두 누락
+ * 으로 not-found 를 받았을 때 다음 액션 후보를 제시.
+ *
+ * 매칭 단계 (먼저 hit 되는 게 우선):
+ *  1. tail 정확 일치 — `auth` 입력 → `capabilities/auth`, `domains/auth` 등.
+ *  2. tail substring 양방향 — `auth` ⊂ `auth-platform`, `oauth` ⊃ `auth`.
+ *  3. tail prefix — 사용자가 일부만 친 경우.
+ *
+ * 자기 자신 (badSlug) 은 후보에서 제외. limit (기본 3) 까지 반환.
+ *
+ * 가벼운 substring 비교만 — Levenshtein 같은 distance 는 큰 vault 에서
+ * 비싸고 false positive 도 많다. 이 helper 는 "did you mean" 을 만드는
+ * 게 목표가 아니라 "이런 slug 들이 vault 에 있어요" 를 1 호출에 보여주는 게 목표.
+ */
+export function suggestSimilarSlugs(rootPath, badSlug, limit = 3) {
+  if (typeof badSlug !== 'string' || badSlug.length === 0) return [];
+  const docs = loadVaultDocs(rootPath);
+  const all = docs.map((d) => d.slug).filter((s) => s !== badSlug);
+  const tail = badSlug.split('/').pop() || badSlug;
+  const lowerTail = tail.toLowerCase();
+  const lowerBad = badSlug.toLowerCase();
+  const tier1 = []; // exact tail match
+  const tier2 = []; // substring (either direction)
+  const tier3 = []; // prefix match on tail or full slug
+  for (const slug of all) {
+    const candTail = (slug.split('/').pop() || slug).toLowerCase();
+    if (candTail === lowerTail) {
+      tier1.push(slug);
+      continue;
+    }
+    if (
+      candTail.includes(lowerTail)
+      || lowerTail.includes(candTail)
+      || slug.toLowerCase().includes(lowerBad)
+    ) {
+      tier2.push(slug);
+      continue;
+    }
+    if (candTail.startsWith(lowerTail) || slug.toLowerCase().startsWith(lowerBad)) {
+      tier3.push(slug);
+    }
+  }
+  return [...tier1, ...tier2, ...tier3].slice(0, limit);
+}
+
+/**
+ * AI agent 가 not-found / dup 에러를 받을 때 다음 액션을 곧바로 결정할 수
+ * 있도록 actionable suffix 를 만든다. caller 는 에러 메시지에 이 결과를 붙임.
+ */
+function notFoundSuffix(rootPath, slug) {
+  const suggestions = suggestSimilarSlugs(rootPath, slug);
+  const lines = [
+    'Use list_concepts() to see all slugs, or find_evidence(query) to search by title.',
+  ];
+  if (suggestions.length > 0) {
+    lines.push(`Similar slugs in this vault: ${suggestions.map((s) => `"${s}"`).join(', ')}.`);
+  }
+  return lines.join(' ');
+}
+
+/**
  * 새 doc 작성. 디렉토리 자동 생성. 기존 파일 있으면 throw (덮어쓰기 의도라면
  * 호출자가 명시적으로).
  */
 export function writeDoc(rootPath, slug, { frontmatter, body = '' }) {
   const filePath = slugToPath(rootPath, slug);
   if (existsSync(filePath)) {
-    throw new Error(`Doc already exists: ${slug}`);
+    throw new Error(
+      `Doc already exists at "${slug}". To update fields, use patch_concept(slug, frontmatter, body, expected_mtime). To rename, use rename_concept(oldSlug, newSlug). Never delete-then-add — that loses backlinks.`,
+    );
   }
   mkdirSync(dirname(filePath), { recursive: true });
   const md = buildMarkdown({ frontmatter, body });
@@ -234,7 +297,7 @@ export function writeDoc(rootPath, slug, { frontmatter, body = '' }) {
 export function deleteDoc(rootPath, slug, options = {}) {
   const filePath = slugToPath(rootPath, slug);
   if (!existsSync(filePath)) {
-    throw new Error(`Doc not found: ${slug}`);
+    throw new Error(`Doc not found: "${slug}". ${notFoundSuffix(rootPath, slug)}`);
   }
   assertMtime(slug, filePath, options.expectedMtime);
   const captured = readDoc(rootPath, filePath);
@@ -249,7 +312,7 @@ export function deleteDoc(rootPath, slug, options = {}) {
 export function patchFrontmatter(rootPath, slug, patch, options = {}) {
   const filePath = slugToPath(rootPath, slug);
   if (!existsSync(filePath)) {
-    throw new Error(`Doc not found: ${slug}`);
+    throw new Error(`Doc not found: "${slug}". ${notFoundSuffix(rootPath, slug)}`);
   }
   assertMtime(slug, filePath, options.expectedMtime);
   const raw = readFileSync(filePath, 'utf-8');
@@ -276,7 +339,7 @@ export function patchFrontmatter(rootPath, slug, patch, options = {}) {
 export function updateDoc(rootPath, slug, { frontmatter: patch, body, expectedMtime }) {
   const filePath = slugToPath(rootPath, slug);
   if (!existsSync(filePath)) {
-    throw new Error(`Doc not found: ${slug}`);
+    throw new Error(`Doc not found: "${slug}". ${notFoundSuffix(rootPath, slug)}`);
   }
   assertMtime(slug, filePath, expectedMtime);
   const raw = readFileSync(filePath, 'utf-8');

--- a/mcp/src/vault.test.mjs
+++ b/mcp/src/vault.test.mjs
@@ -4,7 +4,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { findPath, vaultSlugExists } from './vault.mjs';
+import {
+  deleteDoc,
+  findPath,
+  suggestSimilarSlugs,
+  vaultSlugExists,
+  writeDoc,
+} from './vault.mjs';
 
 let root;
 
@@ -97,5 +103,111 @@ describe('findPath — edge metadata (R+)', () => {
     const r = findPath(pathRoot, 'project', 'project');
     assert.deepEqual(r.hops, ['project']);
     assert.deepEqual(r.edges, []);
+  });
+});
+
+describe('suggestSimilarSlugs (R+)', () => {
+  let suggestRoot;
+  beforeEach(() => {
+    suggestRoot = mkdtempSync(join(tmpdir(), 'omot-vault-suggest-'));
+    mkdirSync(join(suggestRoot, 'capabilities'), { recursive: true });
+    mkdirSync(join(suggestRoot, 'domains'), { recursive: true });
+    writeFileSync(
+      join(suggestRoot, 'capabilities', 'mcp-server.md'),
+      '---\nslug: capabilities/mcp-server\nkind: capability\n---\n',
+    );
+    writeFileSync(
+      join(suggestRoot, 'capabilities', 'mcp-conflict-guard.md'),
+      '---\nslug: capabilities/mcp-conflict-guard\nkind: capability\n---\n',
+    );
+    writeFileSync(
+      join(suggestRoot, 'domains', 'ai-agent-partner.md'),
+      '---\nslug: domains/ai-agent-partner\nkind: domain\n---\n',
+    );
+  });
+  afterEach(() => {
+    rmSync(suggestRoot, { recursive: true, force: true });
+  });
+
+  it('tail 정확 일치가 최우선', () => {
+    const r = suggestSimilarSlugs(suggestRoot, 'mcp-server');
+    assert.deepEqual(r[0], 'capabilities/mcp-server');
+  });
+
+  it('substring 매치 — 일부만 친 경우', () => {
+    const r = suggestSimilarSlugs(suggestRoot, 'mcp');
+    assert.ok(r.includes('capabilities/mcp-server'));
+    assert.ok(r.includes('capabilities/mcp-conflict-guard'));
+  });
+
+  it('전혀 안 비슷하면 빈 배열', () => {
+    const r = suggestSimilarSlugs(suggestRoot, 'totally-unrelated-xyz');
+    assert.deepEqual(r, []);
+  });
+
+  it('limit 존중 (default 3)', () => {
+    const r = suggestSimilarSlugs(suggestRoot, 'a', 2);
+    assert.ok(r.length <= 2);
+  });
+
+  it('빈 / null badSlug 는 빈 배열', () => {
+    assert.deepEqual(suggestSimilarSlugs(suggestRoot, ''), []);
+    assert.deepEqual(suggestSimilarSlugs(suggestRoot, null), []);
+  });
+});
+
+describe('actionable 에러 메시지 (R+)', () => {
+  let errRoot;
+  beforeEach(() => {
+    errRoot = mkdtempSync(join(tmpdir(), 'omot-vault-err-'));
+    mkdirSync(join(errRoot, 'capabilities'), { recursive: true });
+    writeFileSync(
+      join(errRoot, 'capabilities', 'mcp-server.md'),
+      '---\nslug: capabilities/mcp-server\nkind: capability\n---\n',
+    );
+  });
+  afterEach(() => {
+    rmSync(errRoot, { recursive: true, force: true });
+  });
+
+  it('writeDoc duplicate slug — patch_concept 사용 권장 + rename 옵션 명시', () => {
+    let caught;
+    try {
+      writeDoc(errRoot, 'capabilities/mcp-server', {
+        frontmatter: { slug: 'capabilities/mcp-server', kind: 'capability', title: 'X' },
+      });
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught, 'should throw');
+    assert.match(caught.message, /already exists/);
+    assert.match(caught.message, /patch_concept/);
+    assert.match(caught.message, /rename_concept/);
+  });
+
+  it('deleteDoc not-found (substring-similar slug) — 비슷한 slug 후보 노출', () => {
+    let caught;
+    try {
+      // bad slug 가 'mcp-server' 를 substring 으로 포함 — 후보 매칭 가능.
+      deleteDoc(errRoot, 'capabilities/mcp-server-x');
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught);
+    assert.match(caught.message, /not found/i);
+    assert.match(caught.message, /list_concepts/);
+    assert.match(caught.message, /capabilities\/mcp-server/);
+  });
+
+  it('deleteDoc not-found (전혀 안 비슷한 slug) — list_concepts fallback 안내만', () => {
+    let caught;
+    try {
+      deleteDoc(errRoot, 'totally/unrelated-xyz');
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught);
+    assert.match(caught.message, /not found/i);
+    assert.match(caught.message, /list_concepts/);
   });
 });


### PR DESCRIPTION
## Summary

AI agent UX 개선 — MCP 도구 호출 실패 시 agent 가 시행착오 없이 다음 액션을 결정할 수 있게.

### Before vs After

| 상황 | Before | After |
|---|---|---|
| `add_concept` dup slug | `Doc already exists: capabilities/mcp-server` | `Doc already exists at "capabilities/mcp-server". To update fields, use **patch_concept**(slug, frontmatter, body, expected_mtime). To rename, use **rename_concept**(oldSlug, newSlug). Never delete-then-add — that loses backlinks.` |
| `delete/patch/update` not-found (typo) | `Doc not found: capabilities/mcp-srver` | `Doc not found: "capabilities/mcp-srver". Use **list_concepts**() to see all slugs, or **find_evidence**(query) to search by title.` |
| `delete/patch/update` not-found (substring 가까움) | (above) | (above) + `Similar slugs in this vault: "capabilities/mcp-server".` |
| `add_relation` source/target 누락 | `Source slug does not exist in vault: "capabilites/auth"` | `Source slug does not exist in vault: "capabilites/auth". Did you mean: "capabilities/auth"?` |

### Helper 추가
- `suggestSimilarSlugs(rootPath, badSlug, limit=3)` — Levenshtein 없이 3-tier 매칭 (tail 정확 / substring 양방향 / prefix). 큰 vault 에서도 가벼움.
- private `notFoundSuffix` — 모든 not-found 에러가 같은 suffix 형식. agent 가 한 번 학습하면 일관 응답.

### Backward compat
- 에러 *타입* 변경 없음 (`Error` 그대로).
- `Doc already exists` / `Doc not found` 같은 stem 유지 — substring 매치하는 caller stable.

## Test plan
- [x] 신규 unit test 7건 (`mcp/src/vault.test.mjs`):
  - `suggestSimilarSlugs` 5건 (tail 정확 / substring / 무관 / limit / null guard)
  - actionable 에러 2건 (writeDoc dup / deleteDoc not-found w/ + w/o similar)
- [x] `node --test mcp/src/vault.test.mjs` — 14/14 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` — 814/814
- [x] `pnpm lint` — 0 errors
- [x] mcp/CHANGELOG.md (Unreleased) 업데이트

## Out of scope (다음 cycle 후보)
- Levenshtein 기반 typo 추천 (substring 매칭 안 되는 일반 typo case)
- `add_relation` 이 vault 에 없는 slug 를 자동 stub 으로 만드는 옵션
- error class 표준화 (`VaultNotFoundError` / `VaultDuplicateError` 등 typed throws)

🤖 Generated with [Claude Code](https://claude.com/claude-code)