### PR TITLE
feat(cli): path 명령 추가 — find_path edges[] 의 CLI 노출 (14th command)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — oh-my-ontology (CLI)
 
+## Unreleased
+
+### Added — `path` command (14th)
+
+- `oh-my-ontology path <from> <to> [vault]` — 두 slug 사이 최단 경로 (BFS, 무방향). MCP `find_path` 의 thin wrapper.
+- 각 hop 사이에 `via` (frontmatter 키 = relation type) 를 한 줄로 표시 — `capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`. AI agent 가 path 를 받아 *왜* A 와 B 가 연결됐는지 한 호출에 본다.
+- 옵션: `--max-hops N` (기본 5), `--json` (raw 응답).
+- trivial path (`from === to`) 는 0 hops 안내.
+- 누락 인자 시 usage + exit 1.
+- 신규 integration test 4건 (1-hop / json edges / trivial / arg validation).
+
 ## 0.5.0 — 2026-05-06 (R17 — import graph → depends_on)
 
 ### Added — `infer-imports` command (13th, mcp v0.9.0 spawn wrapper)

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,6 +29,7 @@ These wrap the MCP server (`oh-my-ontology-mcp`) so the developer has the same a
 | Command | What it does |
 |---|---|
 | `oh-my-ontology backlinks <slug>` | Lists every node referencing the target (`matches[]` from MCP `find_backlinks`, `--json` for raw). |
+| `oh-my-ontology path <from> <to>` | Shortest path (BFS, undirected) between two slugs. Each hop is annotated with the frontmatter key (`capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`) that linked the pair, so you see *why* A and B are connected. (`--max-hops N --json`) |
 | `oh-my-ontology query "<filter>"` | Typed filter DSL — `kind=X AND has(Y) AND NOT domain=Z`, parens / OR / NOT supported. (`--limit N --json`) |
 | `oh-my-ontology rename <oldSlug> <newSlug>` | Atomic rename — moves the `.md`, updates `slug:`, rewrites every backlink (frontmatter array entries, inline strings, body links). Default dry-run preview; `--confirm` to apply. |
 | `oh-my-ontology merge <fromSlug> <intoSlug>` | Atomic merge — redirects every backlink `from → into`, then deletes `from.md`. Default dry-run; `--confirm` to apply. The `into` node's frontmatter / body are **not** auto-combined — edit by hand if needed. |

--- a/cli/src/commands/path.mjs
+++ b/cli/src/commands/path.mjs
@@ -1,0 +1,131 @@
+// R+ — `oh-my-ontology path <from> <to> [vault]`
+// Shortest path between two slugs (BFS, undirected). Thin wrapper over MCP
+// find_path — same authority as a coding AI agent. R17 후속의 find_path
+// `edges[]` (relation type per hop) 도 함께 사용자에게 노출해, 두 노드가
+// *왜* 연결됐는지 한 줄로 본다.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runPath(args) {
+  const { from, to, vault, maxHops, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'find_path', {
+      from,
+      to,
+      ...(typeof maxHops === 'number' ? { maxHops } : {}),
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  if (!result || result.found === false || !Array.isArray(result.hops) || result.hops.length === 0) {
+    process.stdout.write(
+      `${COLORS.dim}no path${COLORS.reset} ${COLORS.bold}${from}${COLORS.reset} ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${to}${COLORS.reset}` +
+        ` ${COLORS.dim}(maxHops ${maxHops ?? 5} 초과 또는 vault 에 slug 없음)${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  const hops = result.hops;
+  const edges = Array.isArray(result.edges) ? result.edges : [];
+  const hopCount = typeof result.hopCount === 'number' ? result.hopCount : hops.length - 1;
+
+  // Trivial path (from === to).
+  if (hopCount === 0) {
+    process.stdout.write(
+      `${COLORS.bold}${hops[0]}${COLORS.reset} ${COLORS.dim}(same slug — 0 hops)${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}${from}${COLORS.reset} ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${to}${COLORS.reset}` +
+      ` ${COLORS.dim}— ${hopCount} hop${hopCount === 1 ? '' : 's'}${COLORS.reset}\n\n`,
+  );
+
+  // Render: hop i  --(via)-->  hop i+1
+  for (let i = 0; i < hops.length; i += 1) {
+    process.stdout.write(`  ${COLORS.cyan}${hops[i]}${COLORS.reset}\n`);
+    if (i < hops.length - 1) {
+      const via = edges[i]?.via;
+      const viaLabel = via ? `${COLORS.yellow}${via}${COLORS.reset}` : `${COLORS.dim}(unknown)${COLORS.reset}`;
+      process.stdout.write(`    ${COLORS.dim}↓ via${COLORS.reset} ${viaLabel}\n`);
+    }
+  }
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, maxHops: undefined };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--max-hops') {
+      const next = args[++i];
+      const n = Number.parseInt(next, 10);
+      if (!Number.isFinite(n) || n < 1) {
+        return { error: `--max-hops requires a positive integer, got "${next}"` };
+      }
+      flags.maxHops = n;
+    } else if (a.startsWith('--max-hops=')) {
+      const n = Number.parseInt(a.slice('--max-hops='.length), 10);
+      if (!Number.isFinite(n) || n < 1) {
+        return { error: `--max-hops requires a positive integer` };
+      }
+      flags.maxHops = n;
+    } else if (a.startsWith('--')) {
+      return { error: `unknown flag: ${a}` };
+    } else {
+      positional.push(a);
+    }
+  }
+  if (positional.length < 2) {
+    return { error: 'both <from> and <to> are required' };
+  }
+  // 3rd positional = vault path (parity with list/find/validate/backlinks).
+  const [from, to, maybeVault] = positional;
+  if (maybeVault && flags.vault === '.') {
+    flags.vault = maybeVault;
+  }
+  return { from, to, vault: flags.vault, json: flags.json, maxHops: flags.maxHops };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology path <from> <to> [vault] [--max-hops N] [--vault path] [--json]\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology path capabilities/cli-developer-entry capabilities/mcp-server\n` +
+      `  oh-my-ontology path project elements/sigma-graphology --max-hops 8 --json\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -66,6 +66,8 @@ ${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous inge
 
 ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
+  npx oh-my-ontology path <from> <to>         Shortest path (BFS) with relation type per hop
+       --max-hops N --json                    ${COLORS.dim}default 5${COLORS.reset}
   npx oh-my-ontology query "<filter>"         Typed filter DSL (kind=X AND has(elements))
        --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
@@ -277,6 +279,11 @@ if (SUBCOMMAND === 'import') {
 if (SUBCOMMAND === 'backlinks') {
   const { runBacklinks } = await import('./commands/backlinks.mjs');
   exit(await runBacklinks(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'path') {
+  const { runPath } = await import('./commands/path.mjs');
+  exit(await runPath(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -639,6 +639,64 @@ await test('backlinks --json — JSON 응답 파싱', async () => {
   }
 });
 
+await test('path — capabilities/bar → capabilities/foo (1 hop, via relates)', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['path', 'capabilities/bar', 'capabilities/foo', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /1 hop/);
+    assert.match(clean, /capabilities\/bar/);
+    assert.match(clean, /capabilities\/foo/);
+    // bar.relates 가 foo 를 가리키므로 via=relates 로 노출
+    assert.match(clean, /relates/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path --json — edges[] 포함된 raw 응답 파싱', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'path',
+      'capabilities/bar',
+      'capabilities/foo',
+      root,
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(data.hops), 'hops 배열');
+    assert.ok(Array.isArray(data.edges), 'edges 배열');
+    assert.equal(data.edges.length, data.hops.length - 1, 'edges 길이는 hops - 1');
+    assert.equal(data.found, true);
+    // first edge 의 via 는 frontmatter key (capabilities/bar 의 relates 로
+    // capabilities/foo 를 가리킨다 — bar 가 from, foo 가 to).
+    assert.equal(data.edges[0].via, 'relates');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path — same slug → 0 hops trivial', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['path', 'capabilities/foo', 'capabilities/foo', root]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /same slug|0 hops/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path — 두 인자 누락 시 usage + exit 1', async () => {
+  const r = await run(['path', 'only-one']);
+  assert.equal(r.code, 1);
+  assert.match(stripAnsi(r.stderr), /from.*to.*required|both/);
+});
+
 await test('query — kind=capability AND has(elements)', async () => {
   const root = await buildGraphFixture();
   try {


### PR DESCRIPTION
## Summary

PR #175 (find_path edges[]) 위에 stack — CLI 사용자가 같은 정보 (path + relation type per hop) 를 ergonomic 하게 본다.

```
$ oh-my-ontology path capabilities/cli-developer-entry capabilities/mcp-server

capabilities/cli-developer-entry → capabilities/mcp-server — 1 hop

  capabilities/cli-developer-entry
    ↓ via relates
  capabilities/mcp-server
```

추가:
- `oh-my-ontology path <from> <to> [vault]` — find_path BFS 의 thin wrapper.
- 각 hop 사이 `via` (frontmatter key) 한 줄 표시.
- `--max-hops N` (default 5), `--json` (raw 응답), `--vault <path>` 옵션.
- trivial path (`from === to`) — "0 hops" 안내.
- 인자 누락 시 usage + exit 1.

## Test plan
- [x] 신규 integration test 4건 (`cli/src/integration.test.mjs`):
  - 1-hop via relates 표시 검증
  - --json 응답에 edges[] 포함 + length === hops.length-1
  - same slug → 0 hops trivial
  - arg 누락 → exit 1 + usage
- [x] `node --test cli/src/integration.test.mjs` 통과
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors
- [x] cli/README.md + cli/CHANGELOG.md (Unreleased) 갱신

## Depends on
- **PR #175** (`feat: find_path 응답에 edges[] (relation type) 추가`) — `via` 정보가 그 PR 의 변경에 의존. base 가 그 브랜치.

## Out of scope
- `path` 결과를 `add_relation` 후보로 넘기는 단축 (예: `path A B --confirm-add depends_on`).
- 노드 metadata (kind/title) 도 hop 별 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)