### PR TITLE
docs(mcp): SERVER_INSTRUCTIONS + tool count 갱신 — AI agent 가 첫 메시지부터 정확한 가이드

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -15,7 +15,7 @@ and AI agents (Claude Code, Cursor, etc.) can read and write together.
 
 | Command | What it does |
 |---|---|
-| `oh-my-ontology init [folder]` | Scaffold a new vault (project / domain / capability / element starter .md). **R15**: also drops a wired `.mcp.json` in *both* cwd (codebase root, `OMOT_VAULT='./<vault>'`) and the vault folder (`OMOT_VAULT='.'`) — open either in an AI agent and the 14 MCP tools auto-register. Existing `.mcp.json` is preserved (`.mcp.json.example` falls back instead). |
+| `oh-my-ontology init [folder]` | Scaffold a new vault (project / domain / capability / element starter .md). **R15**: also drops a wired `.mcp.json` in *both* cwd (codebase root, `OMOT_VAULT='./<vault>'`) and the vault folder (`OMOT_VAULT='.'`) — open either in an AI agent and the 16 MCP tools auto-register. Existing `.mcp.json` is preserved (`.mcp.json.example` falls back instead). |
 | `oh-my-ontology list [vault]` | List ontology nodes (color table; `--kind X` filter, `--json`) |
 | `oh-my-ontology validate [vault]` | Frontmatter integrity (6 issue codes incl. R14 `missing-expected-field`; `exit 1` on errors — usable as a CI gate). Same code 가 2+ file 에서 등장하면 끝에 *grouped by code* 요약 섹션이 자동으로 붙어 *어느 종류 경고가 얼마나 많은지* 한눈에 파악. |
 | `oh-my-ontology add <kind> <slug> --title="..."` | Scaffold a new node (`--domain X --body "..." --vault path`); throws on duplicate slug. **R15**: `--auto-prefix` is now **default on** (kind→folder, e.g. `add capability foo` → `capabilities/foo.md`) for consistency with the `init` starter layout. Use `--raw-slug` (or `--no-auto-prefix`) to opt out. |
@@ -42,7 +42,7 @@ The vault is a plain folder of `.md` files. **Frontmatter is the graph.**
 
 `init` (R15) automatically writes a wired `.mcp.json` to both your codebase
 root and the vault folder. Open either in an AI agent (Claude Code, Codex,
-Cursor) and the agent gets **14 tools** (8 read + 6 write) to read and
+Cursor) and the agent gets **16 tools** (10 read + 6 write) to read and
 write the vault — same data the developer sees.
 
 ```jsonc
@@ -58,10 +58,10 @@ write the vault — same data the developer sees.
 }
 ```
 
-14 tools (R11 v0.7.0):
+16 tools (R17):
 `list_concepts` / `get_concept` / `find_evidence` /
 `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` /
-`query_concepts` (read 8) +
+`query_concepts` / `analyze_repo_structure` / `infer_imports` (read 10) +
 `add_concept` / `add_relation` / `patch_concept` / `delete_concept` /
 `rename_concept` / `merge_concepts` (write 6).
 

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -10,6 +10,12 @@
   - `add_relation` 의 source/target 누락 시 비슷한 slug 후보 또는 `add_concept` 안내. AI agent 가 typo / hallucinated slug 를 받았을 때 즉시 자가 수정 가능.
 - 새 export `suggestSimilarSlugs(rootPath, badSlug, limit=3)` — Levenshtein 없이 tail 정확/substring 양방향/prefix 3-tier 매칭. 큰 vault 에서도 가벼움.
 - 7 신규 unit test (suggest 5 + actionable error 2).
+- **`SERVER_INSTRUCTIONS` (initialize 응답) 갱신.** AI agent 가 첫 message 에 보는 system-prompt 수준 안내. stale 항목 (14 tool 표기, R16/R17 누락, find_path edges[via] 미언급) 보정. 추가 섹션:
+  - **Tool inventory** — 16 tools = read 10 (analyze_repo_structure / infer_imports 포함) + write 6.
+  - **Two starting workflows** — A) 기존 vault 오리엔트, B) 빈 vault 부트스트랩 (R16 analyze → R17 infer → review → add_*).
+  - **find_path edges[via] 명시** — agent 가 *왜* 두 노드가 연결됐는지 한 호출에 안다.
+  - **"When a tool throws — read the error suffix"** — actionable 에러 메시지가 다음 tool 을 직접 가리킨다는 사실을 안내.
+- 헤더 코멘트 (도구 14종 → 16종) 동기화.
 
 ## 0.9.0 — 2026-05-06 (R17 — import graph → depends_on edges)
 

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 /**
-* oh-my-ontology-mcp — MCP 서버 v0.7.1 (도구 14종 = read 8 + write 6).
+ * oh-my-ontology-mcp — MCP 서버 (도구 16종 = read 10 + write 6).
  *
  * AI agent (Claude Code 등) 가 vault 의 ontology 를 읽고 쓸 수 있게.
  *
- * read 8:
- *   - list_concepts     — vault 의 노드 목록 (kind / project_filter)
- *   - get_concept       — 단일 노드 + 이웃 (dependencies / relates)
- *   - find_evidence     — title / capabilities / elements / body 부분매칭
- *   - find_backlinks    — 특정 slug 를 가리키는 다른 노드들
- *   - find_path         — 두 slug 사이 그래프 최단 경로 (BFS, 무방향)
- *   - list_kinds        — vault kind 분포 census
- *   - find_orphans      — 어느 다른 노드도 frontmatter 에서 가리키지 않는 doc
- *   - query_concepts    — typed filter DSL (kind=X AND has(Y) AND NOT ...)
+ * read 10:
+ *   - list_concepts          — vault 의 노드 목록 (kind / project_filter)
+ *   - get_concept            — 단일 노드 + 이웃 (dependencies / relates) + mtime
+ *   - find_evidence          — title / capabilities / elements / body 부분매칭
+ *   - find_backlinks         — 특정 slug 를 가리키는 다른 노드들
+ *   - find_path              — 두 slug 사이 BFS 최단 경로 + edges[via] (R+)
+ *   - list_kinds             — vault kind 분포 census
+ *   - find_orphans           — 어느 다른 노드도 frontmatter 에서 가리키지 않는 doc
+ *   - query_concepts         — typed filter DSL (kind=X AND has(Y) AND NOT ...)
+ *   - analyze_repo_structure — R16, code repo 분석 → ontology 후보 (side effect 0)
+ *   - infer_imports          — R17, TS/JS import graph → depends_on 후보 (side effect 0)
  *
  * write 6:
  *   - add_concept       — 새 노드 (.md 파일 작성, 기존 slug 면 throw)
@@ -87,42 +89,66 @@ try {
 }
 
 // MCP `instructions` field — initialize 응답에 포함되어 연결된 AI agent
-// (Claude Code, Cursor, …) 가 항상 보는 시스템-prompt 수준 안내. 14 tool
+// (Claude Code, Cursor, …) 가 항상 보는 시스템-prompt 수준 안내. 16 tool
 // description 만으로는 (1) 호출 순서, (2) kind 계층의 의미, (3) write 도구의
-// dry-run/confirm 패턴, (4) mtime 충돌 가드 — 이 4 가지가 누락되어 있어
-// agent UX 가 매번 시행착오로 학습되는 문제를 단번에 해소.
+// dry-run/confirm 패턴, (4) mtime 충돌 가드, (5) R16/R17 bootstrap workflow,
+// (6) error message 가 다음 tool 을 직접 가리킨다는 사실 — agent UX 가
+// 매번 시행착오로 학습되는 문제를 단번에 해소.
 const SERVER_INSTRUCTIONS = `oh-my-ontology — vault of markdown files where each \`.md\` with a frontmatter \`kind:\` is an ontology node. The graph encodes the codebase's mental model and is shared with the human via plain markdown.
+
+## Tool inventory (16 tools = read 10 + write 6)
+
+**read** — \`list_concepts\` · \`get_concept\` · \`find_evidence\` · \`find_backlinks\` · \`find_path\` · \`list_kinds\` · \`find_orphans\` · \`query_concepts\` · \`analyze_repo_structure\` · \`infer_imports\`.
+**write** — \`add_concept\` · \`add_relation\` · \`patch_concept\` · \`delete_concept\` · \`rename_concept\` · \`merge_concepts\`.
 
 ## Kind hierarchy (top → leaf)
 
-- **project** — top-level deliverable (e.g. "auth-platform"). Owns capabilities and elements.
+- **project** — top-level deliverable (e.g. "auth-platform"). Owns domains / capabilities / elements.
 - **domain** — functional grouping (e.g. "auth", "billing"). Parent of capabilities.
 - **capability** — a coherent unit of behavior (e.g. "token-issue"). Often realized by elements.
 - **element** — concrete piece (library, API, schema, file). Leaf-level.
 - **document** — narrative or reference doc tied to the graph but not a domain object.
 - (\`vault-readme\` is reserved for the auto-generated README.md — agents should not set this kind.)
 
-## First-time workflow (when you connect to a new vault)
+## Two starting workflows
+
+### A. Vault already has nodes (typical) — orient first
 
 1. \`list_kinds\` — see the kind census (how many projects/domains/capabilities/…).
-2. \`list_concepts\` — see all nodes. Watch \`vaultWarnings\` — if non-zero, the vault has frontmatter integrity issues; surface them to the user before making decisions on stale data.
-3. \`get_concept(slug)\` — for any node of interest. Returns frontmatter + body + neighbors (dependencies/relates) + \`mtime\`.
-4. \`find_backlinks(slug)\` — to understand how a node is referenced.
-5. \`find_path(from, to)\` — for "how does A relate to B" questions (BFS, undirected).
-6. \`find_orphans\` — to spot nodes that no other node points to (often unfinished or deletion candidates).
-7. \`query_concepts(filter)\` — for structured questions like \`kind=capability AND domain=auth AND NOT has(elements)\` (= "unfinished caps under auth").
+2. \`list_concepts\` — full node table. Watch \`vaultWarnings\` — if non-zero, surface it to the user before making decisions on stale data.
+3. \`get_concept(slug)\` — frontmatter + body excerpt + neighbors (dependencies / relates) + \`mtime\`. **Capture the \`mtime\`** if you plan to write later.
+4. \`find_backlinks(slug)\` — understand how a node is referenced (run *before* rename / merge).
+5. \`find_path(from, to)\` — "how does A relate to B?" (BFS, undirected). Returns \`hops: [slug...]\` **and \`edges: [{from, to, via}]\` where \`via\` is the frontmatter key (\`capabilities\` / \`elements\` / \`dependencies\` / \`relates\` / \`contains\` / \`describes\`) that linked the pair** — so you see not just *that* A and B are connected but *why*.
+6. \`find_orphans\` — spot nodes that no other node points to (cleanup or deletion candidates).
+7. \`query_concepts(filter)\` — structured questions like \`kind=capability AND domain=auth AND NOT has(elements)\` (= "unfinished caps under auth").
+
+### B. Vault is empty / cold-start — bootstrap from code (R16 / R17)
+
+When the user says "이 codebase 분석해줘" or you find only the 5 starter nodes:
+
+1. \`analyze_repo_structure\` — walk \`package.json\` / \`README.md\` H2 / \`src/\` (FSD vs generic detect). Returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]). **side effect 0 — vault NOT modified.** You review & prune the list with the user.
+2. \`infer_imports\` — walk TS/JS source, collapse to module-level edges with import counts. **side effect 0.** You review \`moduleEdges\` with the user, then convert accepted ones into \`add_relation(..., type: 'depends_on')\` calls.
+3. Land accepted candidates with \`add_concept\` / \`add_relation\`. The user (via your subsequent calls) is the single source of truth — never auto-write the proposals.
 
 ## Write tools — safety patterns
 
-- **\`add_concept\`** throws on duplicate slug — use \`patch_concept\` to update an existing node, never delete-then-add.
-- **\`rename_concept\` / \`merge_concepts\`** are dry-run by default. The first call returns an \`updates\` preview (every affected file's before/after). To commit, repeat the call with \`confirm: true\`.
-- **\`delete_concept\`** refuses by default if any backlinks remain. Pass \`force: true\` only after confirming with the user.
+- **\`add_concept\`** throws on duplicate slug — use \`patch_concept\` to update an existing node, never delete-then-add (that loses backlinks).
+- **\`rename_concept\` / \`merge_concepts\`** are dry-run by default. The first call returns an \`updates\` preview (every affected file's before/after). To commit, repeat the call with \`confirm: true\`. Backlinks are redirected atomically — much safer than \`patch_concept\` + N find_backlinks loops.
+- **\`delete_concept\`** refuses by default if any backlinks remain. The error response captures the deleted frontmatter + body so a mistake is recoverable. Pass \`force: true\` only after confirming with the user.
 - **\`expected_mtime\` (all write tools)** — to guard against concurrent edits by the human or another agent: capture \`mtime\` from \`get_concept\`, pass it as \`expected_mtime\` on the next write. If the file changed in between, the call throws \`VaultConflictError\` instead of silently overwriting.
-- **Prefer graph-level writes** — to rename a slug or fold two nodes, use \`rename_concept\` / \`merge_concepts\` (atomic backlink redirect) rather than \`patch_concept\` + N find_backlinks loops.
+
+## When a tool throws — read the error suffix
+
+Every error message ends with the canonical fix tool. Examples:
+- \`Doc already exists at "X". To update fields, use **patch_concept**(...).\`
+- \`Doc not found: "Y". Use **list_concepts**() to see all slugs, or **find_evidence**(query) to search by title. Similar slugs in this vault: ...\`
+- \`Source slug does not exist in vault: "Z". Did you mean: ...?\`
+
+Don't retry blindly — parse the suffix and pivot to the suggested tool.
 
 ## What to write back
 
-When you discover a new capability/element/project from code, call \`add_concept\` so the human sees it appear in their workbench. When you fix or rename code, mirror the change in the graph with \`rename_concept\`. The vault is the shared mental model — keeping it in sync is the entire point.`;
+When code introduces a new capability / element / domain, mirror it in the vault with \`add_concept\` (and \`add_relation\` to wire it). When code is renamed / refactored, use \`rename_concept\` (one atomic call) instead of patch + manual backlink updates. The vault is the *shared* mental model — keeping it in sync is the point.`;
 
 const server = new Server(
   { name: 'oh-my-ontology-mcp', version: '0.7.1' },


### PR DESCRIPTION
## Summary

MCP `instructions` 필드 (MCP initialize 응답에 포함, 연결된 AI agent 가 항상 보는 system-prompt 수준 안내) 가 R16/R17 이후 stale.

| 항목 | Before | After |
|---|---|---|
| Tool count | 14 (read 8 + write 6) | 16 (read 10 + write 6) |
| analyze_repo_structure / infer_imports | 미언급 | 새 섹션 "Two starting workflows" 의 B (cold-start) |
| find_path 응답 형태 | hops 만 안내 | `edges: [{from, to, via}]` + `via` 의 의미 명시 |
| 에러 메시지 | 안내 없음 | "When a tool throws — read the error suffix" 섹션, 예시 3개 |

## 사용자 가치

AI agent 가 vault 에 처음 연결할 때 받는 first-message guidance — "지금 너는 어떤 vault 에 붙었고, 16 tool 중 어떤 걸 어떤 순서로 호출해야 하고, 에러 받으면 suffix 가 다음 tool 을 가리킨다" 를 한 번에 안다. 이전엔 시행착오로 학습 (잘못된 tool 호출 → 에러 → list_concepts 시도 → 다시 호출).

## 부수 정리
- `mcp/src/index.js` 헤더 코멘트 (도구 14종 → 16종) 동기화
- `cli/README.md` 의 "14 tools" / "14 MCP tools" 3 곳 → 16 tools

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors
- [x] mcp node-test 9/9
- [x] `mcp/CHANGELOG.md` Unreleased 항목 추가

## Out of scope
- AGENTS.md 본문의 "MCP server 15 tools" 언급 (그곳은 별도 PR — dogfood)
- agent 가 instructions 안 읽고 list_kinds 부터 호출하는 fallback (별도 cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)