### PR TITLE
docs: stale "14/15 tools" 표기 일괄 동기화 → 16 (read 10 + write 6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ src/                       FSD layers
   ├── features/            interaction units
   ├── entities/            business entities
   └── shared/              UI · lib · config primitives
-mcp/                       MCP server (the AI agent's surface) — npm pkg, 15 tools
+mcp/                       MCP server (the AI agent's surface) — npm pkg, 16 tools
 cli/                       CLI binary (developer's daily entry point) — npm pkg, R12 v0.2
                            init / list / validate / add / find / import
 docs/                      long-form docs
@@ -125,7 +125,7 @@ Long-form docs:
 - `@docs/FEATURES.md` — features users can use right now
 - `@docs/ARCHITECTURE.md` · `@docs/DESIGN-SYSTEM.md`
 - `@docs/CHANGELOG.md` — chronological user-visible changes
-- `@mcp/README.md` — AI agent partner (MCP 15 tools — read 9 + write 6) registration + usage
+- `@mcp/README.md` — AI agent partner (MCP 16 tools — read 10 + write 6) registration + usage
 - `@docs/archive/` — historical analysis docs (no longer normative)
 
 ## This project's own ontology
@@ -191,7 +191,7 @@ When an AI agent (`add_concept`) or a developer (`oh-my-ontology add` / `oh-my-o
 
 ### 프로젝트 개요
 
-`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (15 tools) 로 같은 `.md` 파일을 read/write.
+`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (16 tools) 로 같은 `.md` 파일을 read/write.
 
 핵심 원칙 한 줄 (v3, R11 fire #25):
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ cd my-vault
 ### 핵심 약속
 
 1. **vault frontmatter = 그래프** — 검수 큐 / 추출 워커 없음. frontmatter 자기-승인.
-2. **AI agent partner** — MCP 서버 (read 9 + write 6, R16 `analyze_repo_structure` 포함) 로 같은 vault read/write + 빈 vault bootstrap.
+2. **AI agent partner** — MCP 서버 (read 10 + write 6, R16 `analyze_repo_structure` · R17 `infer_imports` 포함) 로 같은 vault read/write + 빈 vault bootstrap.
 3. **Local-first single-source** — 사용자 디스크 vault 가 진실원. Firebase / 백엔드 / 인증 의존 0 (R10 — 2026-05).
 4. **Dogfooding** — `docs/ontology/` 가 프로젝트 자기 자신의 mental model.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ---
 
+## Unreleased — docs tool count sync
+
+- `AGENTS.md`, `README.md` (root), `docs/FEATURES.md`, `docs/PRODUCT-DIRECTION.md`, `mcp/README.md` 의 stale "14 / 15 tools" / "read 8" / "read 9" 표기를 **R17 후 실제 16 tools (read 10 + write 6)** 로 일괄 동기화. `mcp/scripts/verify.mjs` doc-comment 도 같이.
+- 문서를 처음 보는 개발자 / AI agent 가 *현재 surface* 를 정확히 보게 — round 별 진화 이력은 그대로 보존.
+
 ## 2026-05-06 — Round 17: `infer_imports` — TS/JS import graph → depends_on edges
 
 R16 의 `analyze_repo_structure` (heuristic 후보) 의 *강력한 짝*. 코드의 *진짜 import graph* 를 자동 추출해 `depends_on` 관계 후보로. mcp v0.8.0 → v0.9.0 (15 → 16 tools), cli v0.4.0 → v0.5.0 (12 → 13 명령).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -15,7 +15,7 @@
 | Surface | Entry | Audience |
 |---|---|---|
 | **CLI** (R12 / R14 / R15) | `oh-my-ontology init / list / validate / add / find / import` | developer terminal — vault scaffold, daily exploration, bulk import |
-| **MCP** (R5 / R7 / R11 / R14 / R16) | 15 tools (9 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings · bootstrap empty vault (R16 `analyze_repo_structure`) |
+| **MCP** (R5 / R7 / R11 / R14 / R16 / R17) | 16 tools (10 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings · bootstrap empty vault (R16 `analyze_repo_structure` · R17 `infer_imports`) |
 | **Web** (8 routes, R10 surface diet) | `pnpm dev` / static export | sigma topology · tree+ego · ERD builder · insights — graph visualization, mobile-friendly |
 
 ```
@@ -384,7 +384,7 @@ Used when a non-existent slug is hit in static export. Redirects or shows "not f
 
 ---
 
-## 3. MCP server (15 tools)
+## 3. MCP server (16 tools)
 
 Run via `pnpm exec node mcp/src/index.js` (registered in user's `.mcp.json`). AI agents read/write the same vault as humans.
 

--- a/docs/PRODUCT-DIRECTION.md
+++ b/docs/PRODUCT-DIRECTION.md
@@ -57,7 +57,7 @@ This is the differentiator. **Generic ontology workbench (Protégé etc.) → "w
 | Audience | Role | Primary surface |
 |---|---|---|
 | **Developer** | Author + maintain the ontology as part of normal coding | CLI (`oh-my-ontology init/list/validate/add/find/import`), web UI (`/ontology`, `/docs`) |
-| **AI agent** (Claude Code, Cursor, …) | Read for context · write back new findings | MCP server (14 tools — read 8 + write 6) |
+| **AI agent** (Claude Code, Cursor, …) | Read for context · write back new findings | MCP server (16 tools — read 10 + write 6) |
 | ~~PM / designer / ops~~ | ~~Build mental model without reading source~~ | dropped (R11 fire #25 — developer-primary 결정 후) |
 
 The two primary audiences are **the developer and their own AI agent**. Both work on the same `.md` files in the same git repo. PM-friendly side effects are bonus, not requirements.
@@ -233,7 +233,7 @@ When an agent enters the codebase, it sees this on the first page and picks up t
 ### ✅ Phase 3 — AI agent partner — merged
 
 1. ✅ `mcp/` package — MCP server v0.5.0 (`oh-my-ontology-mcp`)
-2. ✅ 14 tools (read 8 + write 6): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `query_concepts` (typed filter DSL) / `add_concept` / `add_relation` / `patch_concept` / `delete_concept` / `rename_concept` / `merge_concepts` (R11 — atomic graph-level write)
+2. ✅ 16 tools (read 10 + write 6): `list_concepts` / `get_concept` / `find_evidence` / `find_backlinks` / `find_path` / `list_kinds` / `find_orphans` / `query_concepts` (typed filter DSL) / `analyze_repo_structure` (R16) / `infer_imports` (R17) / `add_concept` / `add_relation` / `patch_concept` / `delete_concept` / `rename_concept` / `merge_concepts` (R11 — atomic graph-level write)
 3. ✅ CLI command (`oh-my-ontology`) — `npx oh-my-ontology init <folder>` scaffolds the vault. The web `/docs` "Create starter seed" button is the no-terminal alternative.
 4. ⏸ Auto-generated AGENTS.md — DEFERRED (manual updates + dogfood vault cover this)
 5. ✅ `docs/ontology/` dogfood vault — ~18 nodes describing our own mental model

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -129,7 +129,7 @@ A successful run looks like this:
 ✓ result: 7 passed, 0 failed
 · step 2 — server boot + tools/list + list_concepts
 ✓ initialize OK — server oh-my-ontology-mcp@0.7.1
-✓ tools/list 14/14 — add_concept · add_relation · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · list_concepts · list_kinds · merge_concepts · patch_concept · query_concepts · rename_concept
+✓ tools/list 16/16 — add_concept · add_relation · analyze_repo_structure · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · infer_imports · list_concepts · list_kinds · merge_concepts · patch_concept · query_concepts · rename_concept
 ✓ list_concepts — vault total 25 nodes
 
 All checks passed — register .mcp.json with Claude Code, restart, and the 16 tools are ready.

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -11,7 +11,7 @@
  * 검증 항목:
  *   1. parser smoke test (parser.test.mjs) 통과
  *   2. server boot — initialize JSON-RPC 응답
- *   3. tools/list — 14 도구 모두 노출
+ *   3. tools/list — 16 도구 모두 노출
  *   4. tools/call list_concepts — vault 노드 수 출력
  *
  * 모두 PASS → exit 0, 실패 → exit 1 + 진단 메시지.


### PR DESCRIPTION
## Summary

R16 (`analyze_repo_structure`) + R17 (`infer_imports`) 추가 후 canonical 가이드 문서들이 stale 표기로 머무르는 회귀. 처음 프로젝트를 여는 개발자 / AI agent 가 *현재 surface* 를 정확히 보게.

| 파일 | 변경 |
|---|---|
| `AGENTS.md` | folder map / SoT 목록 / 한국어 개요 — 3곳 |
| `README.md` (root) | "AI agent partner" 섹션 — read 9 → 10 + R17 명시 |
| `docs/FEATURES.md` | Surface 표 + section 3 헤더 — 2곳 |
| `docs/PRODUCT-DIRECTION.md` | audience 표 + Phase 3 ✅ — 2곳 |
| `mcp/README.md` | verify 출력 예시 (14/14 → 16/16, 두 신규 도구 포함) |
| `mcp/scripts/verify.mjs` | doc 코멘트 (14 도구 → 16) |
| `docs/CHANGELOG.md` | Unreleased 항목 (자기 추적) |

## 사용자 가치

처음 README / AGENTS.md 를 본 개발자가 "MCP 14 tools" 라 읽고 mental model 만든 다음 실제 etc tooling 이 16개라 confusion. AI agent 도 첫 round 에 "MCP 15 tools" 라 학습. 이 정정으로 두 audience 모두 첫 글에서 정확.

이력 (Round 17 / R16 / R11 / 0.7.0 entries 등) 은 그대로 보존 — *역사* 는 정확하게, *현재* 는 깔끔하게.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors
- 코드 변경 없음 (docs/comment only) — 회귀 risk 0

## Out of scope (다음 cycle 후보)
- `mcp/CHANGELOG.md` 의 0.7.1 entry 가 "16 tools" 라 적힌 doc-bug (실제로는 14 tools 이었다 — 별도 PR 에서 history rectify 검토)
- AGENTS.md 의 dogfood "25 nodes" 표기 (실제 26)
- `cli/README.md` 의 "14 tools" 3 곳 — PR #178 가 같이 fix 함, 충돌 회피

🤖 Generated with [Claude Code](https://claude.com/claude-code)