### PR TITLE
feat(mcp): list_concepts 에 domain 필터 — "auth 도메인 모든 capability" 한 호출로

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **`list_concepts` 에 `domain` 필터.** 기존엔 `kind` 만 지원해 "auth 도메인 모든 capability" 같은 흔한 query 를 위해 `query_concepts("kind=capability AND domain=auth")` DSL 로 fallback 해야 했다. `domain` 옵션 추가로 한 호출 — `list_concepts({ kind: "capability", domain: "auth" })`. capability/element kind 만 의미 있지만 모든 kind 에 일관 적용 (매칭 없으면 자연스럽게 빈 결과). schema description + tool description 갱신, 신규 integration test 1건 (3 assertion: domain only / domain + kind / 매칭 없음 빈 결과). `mcp/src/integration.test.mjs` 의 `makeVault` helper 도 subdir slug 자동 mkdir 보강.
+
 ### Changed
 
 - **에러 메시지를 actionable 하게.** AI agent 가 다음 액션을 한 호출에 결정 가능:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -60,7 +60,7 @@ The server connects over stdio. You should now see 16 tools under the `oh-my-ont
 
 | Tool | What it does |
 |---|---|
-| `list_concepts` | Lists every node in the vault (any `.md` with a `kind:` frontmatter). Options: `kind`, `limit`. **R11**: when the vault has frontmatter corruption, response includes `vaultWarnings: { errorCount, warningCount }` so AI agents can flag it to the user. |
+| `list_concepts` | Lists every node in the vault (any `.md` with a `kind:` frontmatter). Options: `kind`, `domain` (filter by frontmatter `domain:` slug — combine with `kind` for "all capabilities under auth" in one call), `limit`. **R11**: when the vault has frontmatter corruption, response includes `vaultWarnings: { errorCount, warningCount }` so AI agents can flag it to the user. |
 | `get_concept` | Fetches a single node by `slug` (no extension): frontmatter + body excerpt + neighbors (dependencies / relates) + `mtime` (ms — pass to subsequent `patch_concept` / `delete_concept` as `expected_mtime` to detect concurrent external edits). **R11**: response includes `warnings: [...]` when this doc has frontmatter issues (unclosed-frontmatter / empty-kind / missing-kind / unknown-kind / parse-zero-keys). |
 | `find_evidence` | Partial-match search by `title` — scans frontmatter title/capabilities/elements as well as body content. |
 | `find_backlinks` | Finds every node that points to a given `slug`. Inspects all frontmatter array keys (capabilities / elements / dependencies / relates / …) plus body wikilinks/markdown links. |

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -165,7 +165,7 @@ const TOOLS = [
     name: 'list_concepts',
     description:
       'List every ontology node in the vault (each .md file with a frontmatter `kind:`). ' +
-      'Filter by kind / project_filter. AI agents call this first to grasp the ' +
+      'Filter by `kind` and/or `domain`. AI agents call this first to grasp the ' +
       "codebase's mental model.",
     inputSchema: {
       type: 'object',
@@ -174,6 +174,11 @@ const TOOLS = [
           type: 'string',
           description:
             'Filter to one kind (e.g. project, domain, capability, element). Omit to return all.',
+        },
+        domain: {
+          type: 'string',
+          description:
+            'Filter to nodes whose frontmatter `domain:` matches this slug (e.g. "auth"). Combine with `kind` for "all capabilities under auth" in one call. Use the domain *slug*, not the title.',
         },
         limit: {
           type: 'number',
@@ -675,7 +680,7 @@ function ok(result) {
 
 // ── 도구 구현 ─────────────────────────────────────────────────────────────
 
-function listConcepts({ kind, limit = 100 }) {
+function listConcepts({ kind, domain, limit = 100 }) {
   const docs = loadVaultDocs(VAULT_ROOT);
 
   // R11 #23 — vault-wide validation 카운트. raw 모두 검증해 silent corruption
@@ -694,6 +699,11 @@ function listConcepts({ kind, limit = 100 }) {
   const filtered = docs.filter((doc) => {
     const docKind = doc.frontmatter.kind;
     if (kind && docKind !== kind) return false;
+    // domain 필터 — frontmatter `domain:` 매칭. "auth 도메인 모든 capability"
+    // 처럼 흔한 query 를 query_concepts DSL 없이 한 호출로. capability /
+    // element kind 만 의미 있지만 (project / domain 자체는 domain 키 없음)
+    // 필터는 모든 kind 에 일관 적용 — 매칭 없으면 자연스럽게 빈 결과.
+    if (domain && doc.frontmatter.domain !== domain) return false;
     return Boolean(docKind); // frontmatter `kind:` 가 있어야 ontology 노드.
   });
   return {

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,6 +37,8 @@ function makeVault(seed = []) {
   const root = mkdtempSync(join(tmpdir(), "omot-int-"));
   for (const { slug, content } of seed) {
     const fullPath = join(root, `${slug}.md`);
+    // subdir 가 있는 slug ("capabilities/foo") 는 부모 디렉토리 자동 생성.
+    mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, content, "utf-8");
   }
   return root;
@@ -163,6 +165,61 @@ await test("list_concepts — tmp vault 의 노드 수 정확히 보고", async 
     ]);
     const result = getCallParsed(responses, 2);
     assert.equal(result.total, 2, "kind 있는 노드 2 개만 카운트");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test("list_concepts — domain 필터 (R+)", async () => {
+  // "all capabilities under auth" 같은 흔한 query 를 query_concepts DSL 없이
+  // 한 호출로. capability/element kind 만 의미 있지만 모든 kind 에 일관 적용.
+  const root = makeVault([
+    {
+      slug: "domains/auth",
+      content: "---\nkind: domain\ntitle: Auth\n---\n",
+    },
+    {
+      slug: "capabilities/login",
+      content: "---\nkind: capability\ntitle: Login\ndomain: auth\n---\n",
+    },
+    {
+      slug: "capabilities/logout",
+      content: "---\nkind: capability\ntitle: Logout\ndomain: auth\n---\n",
+    },
+    {
+      slug: "capabilities/billing-charge",
+      content: "---\nkind: capability\ntitle: Charge\ndomain: billing\n---\n",
+    },
+    {
+      slug: "elements/auth-token",
+      content: "---\nkind: element\ntitle: Token\ndomain: auth\n---\n",
+    },
+  ]);
+  try {
+    // domain=auth 만 — capability 2 + element 1 = 3 (domain 자체는 domain: 없음)
+    const { responses: r1 } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "list_concepts", { domain: "auth" }),
+    ]);
+    const out1 = getCallParsed(r1, 2);
+    assert.equal(out1.total, 3, "domain=auth → 3");
+    assert.ok(out1.nodes.every((n) => n.domain === "auth"));
+
+    // domain=auth + kind=capability → 2 (login, logout)
+    const { responses: r2 } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "list_concepts", { domain: "auth", kind: "capability" }),
+    ]);
+    const out2 = getCallParsed(r2, 2);
+    assert.equal(out2.total, 2, "domain=auth + kind=capability → 2");
+
+    // 매칭 없는 domain → 빈 결과 (throw 없이)
+    const { responses: r3 } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "list_concepts", { domain: "totally-unknown" }),
+    ]);
+    const out3 = getCallParsed(r3, 2);
+    assert.equal(out3.total, 0);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

AI agent UX — 흔한 lookup ("auth 도메인 capability 다 줘") 가 query_concepts DSL fallback 없이 한 호출로.

```js
// Before
mcp__oh-my-ontology__query_concepts({ filter: 'kind=capability AND domain=auth' })

// After
mcp__oh-my-ontology__list_concepts({ kind: 'capability', domain: 'auth' })
```

## Why

`list_concepts` 가 `kind` 필터만 지원해 사용자/agent 가 "이 도메인의 모든 X" 같은 매우 흔한 query 를 해야 할 때:
1. `query_concepts` DSL 로 fallback (heavier · 학습 필요)
2. 또는 `list_concepts({ kind: 'capability' })` 후 client-side 필터 (페이로드 낭비)

`domain` 옵션 추가로 한 호출에 답.

## 변경
- `list_concepts({ kind?, domain?, limit? })` — frontmatter `domain:` slug 매칭. 모든 kind 에 일관 적용 (매칭 없으면 빈 결과).
- 신규 integration test 1건 (3 assertion: domain only / domain+kind / 빈 결과).
- `mcp/src/integration.test.mjs` 의 `makeVault` helper — subdir slug 자동 `mkdirSync`. 기존 호출 호환.
- `mcp/README.md` (`list_concepts` row) + `mcp/CHANGELOG.md` (Unreleased) 갱신.

## Test plan
- [x] 신규 integration test 통과 (domain only=3, domain+kind=2, 매칭 없음=0)
- [x] mcp 전체 integration 11/11 통과
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors

## Out of scope (다음 cycle 후보)
- `list_concepts` 에 `project` 필터 (project 별 scope 좁히기)
- `list_concepts` 응답에 `summary` (body 첫 paragraph) 옵션 — agent 가 추가 get_concept 없이 overview 잡기
- AGENTS.md "25 nodes" → 26 (cycle 5 메모)

🤖 Generated with [Claude Code](https://claude.com/claude-code)