### PR TITLE
fix(docs): README/AGENTS 의 잔존 stale tool count + dogfood 노드 수 정정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ mcp/                       MCP server (the AI agent's surface) — npm pkg, 15 t
 cli/                       CLI binary (developer's daily entry point) — npm pkg, R12 v0.2
                            init / list / validate / add / find / import
 docs/                      long-form docs
-docs/ontology/             this project's own ontology vault (dogfood — 25 nodes)
+docs/ontology/             this project's own ontology vault (dogfood — 26 nodes)
 tests/                     Vitest unit + Playwright E2E
   └── contract/            cross-package contract tests (parser 4-way, validator 3-way)
 scripts/                   vault tooling (R11) + perf baseline (R11) + dogfood walk (R12)
@@ -133,7 +133,7 @@ Long-form docs:
 This project describes its own mental model in `docs/ontology/` as frontmatter markdown (dogfooding — we describe ourselves in our own data format).
 
 - Entry points: `docs/ontology/README.md` · `docs/ontology/project.md`
-- ~25 nodes (domains / capabilities / elements / project / vault-readme)
+- ~26 nodes (capability 14 · domain 6 · element 4 · project 1 · vault-readme 1)
 - AI agents query it via the `mcp/` MCP server — registration guide in `mcp/README.md`, example in `.mcp.json.example`
 - When you discover a new domain / capability / element, add it to the same directory (with the MCP `add_concept` tool, or by hand)
 
@@ -238,7 +238,7 @@ pnpm vault:migrate --list         # 등록된 schema 마이그레이션 (R11)
 이 프로젝트 자신의 mental model 은 `docs/ontology/` 에 frontmatter md 로 표현되어 있다 (dogfooding — 우리 데이터 형식으로 우리 자신을 기술).
 
 - 진입점: `docs/ontology/README.md` · `docs/ontology/project.md`
-- 25 노드 (capability 12 · domain 6 · element 4 · project 1 · vault-readme 1) — 이 repo 의 `.mcp.json` 자동 등록 후 `mcp__oh-my-ontology__list_concepts` 로 즉시 조회
+- 26 노드 (capability 14 · domain 6 · element 4 · project 1 · vault-readme 1) — 이 repo 의 `.mcp.json` 자동 등록 후 `mcp__oh-my-ontology__list_concepts` 로 즉시 조회
 - AI agent 는 `mcp/` MCP 서버로 query/write — 등록 가이드 `mcp/README.md`. **R14 부터** `add_concept` / `add` / `import` 세 진입점이 같은 schema 모듈로 양식 정규화 (`mcp/src/schema.mjs` ↔ `cli/src/lib/schema.mjs`)
 - 새 도메인/capability/element 가 생기면 같은 디렉토리에 추가 (`add_concept` 도구로 또는 직접 작성). **R14 의 `/ontology-sync` skill** 또는 SessionStart hook 으로 자동 sync 가능
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml/badge.svg)](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Built with Next.js](https://img.shields.io/badge/Built_with-Next.js-000?logo=next.js)](https://nextjs.org)
-[![MCP server](https://img.shields.io/badge/MCP-14_tools-5e6ad2)](mcp/README.md)
+[![MCP server](https://img.shields.io/badge/MCP-16_tools-5e6ad2)](mcp/README.md)
 
 ```bash
 npx oh-my-ontology init my-vault                # scaffold
@@ -44,11 +44,12 @@ Three claims:
 2. **Developer + AI agent share one source of truth** — both edit the same
    `.md` files. The developer authors via CLI / web UI; the AI agent reads
    + writes via MCP (Claude Code, Codex, Cursor). Same git repo, same diff.
-3. **MCP server gives the AI its only interface** — **16 tools** (9 read +
+3. **MCP server gives the AI its only interface** — **16 tools** (10 read +
    6 write) over JSON-RPC. The agent doesn't need to "ingest your codebase";
-   it reads the ontology the developer already curates. R16 added
-   `analyze_repo_structure` so the agent can also bootstrap a fresh repo
-   into the vault with one call (side effect 0, candidates only).
+   it reads the ontology the developer already curates. R16 / R17 added
+   `analyze_repo_structure` and `infer_imports` so the agent can also
+   bootstrap a fresh repo into the vault from heuristics + real import
+   graph (side effect 0, candidates only).
 
 ## Why we built this
 
@@ -62,7 +63,7 @@ to git, and the AI agent reads via a tiny MCP server.
 The primary audience is the **developer + their AI agent** (R12, 2026-05).
 The developer is already in the codebase — the cost of authoring frontmatter
 is low. Their AI agent (Claude Code, Cursor) is the *real* daily user of
-the 14 MCP tools — it needs ground-truth structure to give better answers,
+the 16 MCP tools — it needs ground-truth structure to give better answers,
 and without a developer maintaining it, the ontology rots. PM/designer
 friendliness is a side effect of plain markdown, not a target.
 
@@ -129,7 +130,7 @@ becoming graph nodes.
 | **vault frontmatter = the graph** (no review queue, no LLM extraction) | `grep -r "extractionJob" src/ → 0` |
 | **AI agent partner via MCP** | `mcp/` package, 16 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
-| **Dogfooding** | `docs/ontology/` is this project's own curated mental model — **25 nodes** (capabilities 12 · domains 6 · elements 4 · project 1 · vault-readme 1). The MCP server you'd run is the one we use to write *this README*. |
+| **Dogfooding** | `docs/ontology/` is this project's own curated mental model — **26 nodes** (capabilities 14 · domains 6 · elements 4 · project 1 · vault-readme 1). The MCP server you'd run is the one we use to write *this README*. |
 | **Vault scale** | `node scripts/perf-vault.mjs` measures walk + read + parse on synthetic vaults. **2,000 .md files in 33 ms** (linear, ~17 µs/file). Sub-second up to 1,000 nodes — the ontology will not become the bottleneck. |
 | **AI agent quality measurement** *(cross-agent, n=2)* | [`docs/benchmark/`](docs/benchmark/) — 7 tasks × 3 categories × 2 agents (Claude Code + Codex). [Claude Code results](docs/benchmark/results/2026-05-04-claude-code.md): hallucinations 9 → 0, Cat A correctness +1.0. [Codex results](docs/benchmark/results/2026-05-04-codex.md): Cat A tool calls 7.0 → 1.67. Negative control (Cat C, file-read tasks) passes for both — agents correctly defer to Read/Grep, no over-reach. |
 


### PR DESCRIPTION
## Summary

PR #179 (cycle 5 docs sync) 에서 missed 한 4 곳 (README) + 3 곳 (AGENTS — 한국어 섹션 추가) 추가 정정. github landing badge + audience 섹션 + 한국어 가이드 dogfood 진입처라 첫 인상에 영향 큼.

## 변경
- **README.md**
  - badge: `MCP-14_tools` → `MCP-16_tools` (landing 첫 줄)
  - `**16 tools** (9 read + 6 write)` → `(10 read + 6 write)` + R17 infer_imports 명시
  - `the 14 MCP tools` → `the 16 MCP tools`
  - dogfooding row: **25 nodes / capabilities 12** → **26 nodes / capabilities 14**
- **AGENTS.md**
  - folder map "(dogfood — 25 nodes)" → 26
  - 한국어 진입 "~25 nodes" → "~26 nodes (capability 14 · domain 6 · ...)"
  - 한국어 dogfood "25 노드 (capability 12 ...)" → "26 노드 (capability 14 ...)"

vault 실제 분포 (`list_kinds`: 26 = capability 14 + domain 6 + element 4 + project 1 + vault-readme 1) 일치.

## PR #179 와 비-중복

같은 파일이지만 다른 line. AGENTS.md line 128 / README.md line 205 (한국어 "AI agent partner" 섹션) 은 PR #179 의 territory — 이 PR 은 거기 안 건드림.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors
- [x] docs only — 코드 변경 0, 회귀 risk 0

## Out of scope (다음 cycle 후보)
- mcp/CHANGELOG.md 의 0.7.1 entry 가 history-bug ("16 tools" 라 적혔지만 v0.7.1 은 14 tools 였음)
- list_concepts 에 `project` 필터 (cycle 6 메모)
- list_concepts 응답에 옵션 `summary` (body 첫 단락)
- CLI `validate` 출력 그루핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)