### PR TITLE
feat(mcp): find_evidence 각 match 에 prose excerpt 동봉

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **`get_concept` excerpt 가 prose-aware.** 기존 `body.slice(0, 800)` 은 dogfood `capabilities/mcp-server.md` 같이 H1+표 위주 문서에선 800자 모두 markdown table syntax 만 채워져 agent token budget 낭비. 새 `extractSummaryExcerpt` helper 가 heading / 표 / 코드블록 / 리스트 / 인용을 skip 후 첫 prose 단락만 추출. 측정: dogfood `capabilities/mcp-server.md` excerpt **800 chars (table syntax) → 78 chars (clear prose summary)** — agent 가 받는 의미 밀도 ~10x ↑. block-only body 는 fallback 으로 원본 trim. 9 신규 unit test (prose / H1 skip / 표 skip / 코드블록 skip / multi-line / 빈 body / block-only / maxLen cap / 리스트).
+- **`find_evidence` 응답 each match 에 `excerpt` (max 200 chars).** `get_concept` 의 `extractSummaryExcerpt` 와 같은 prose-aware 추출. agent 가 find_evidence 한 호출로 *어느 doc 이 reference 하는지* + *그 doc 자체 무슨 내용인지* 둘 다 받음 — 추가 get_concept 호출 없이. tool description 도 갱신. 1 신규 integration test (subdir fixture 도 함께 — `makeVault` helper 가 subdir slug 자동 mkdir 하도록 보강).
 
 ## 0.9.0 — 2026-05-06 (R17 — import graph → depends_on edges)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -62,7 +62,7 @@ The server connects over stdio. You should now see 16 tools under the `oh-my-ont
 |---|---|
 | `list_concepts` | Lists every node in the vault (any `.md` with a `kind:` frontmatter). Options: `kind`, `limit`. **R11**: when the vault has frontmatter corruption, response includes `vaultWarnings: { errorCount, warningCount }` so AI agents can flag it to the user. |
 | `get_concept` | Fetches a single node by `slug` (no extension): frontmatter + body excerpt (R+ — *prose-only*: heading / 표 / 코드블록 / 리스트 / 인용 skip 후 첫 단락만 — agent 가 markdown table syntax 대신 사람이 의도한 설명문을 받음, max 800 chars) + neighbors (dependencies / relates) + `mtime` (ms — pass to subsequent `patch_concept` / `delete_concept` as `expected_mtime` to detect concurrent external edits). **R11**: response includes `warnings: [...]` when this doc has frontmatter issues (unclosed-frontmatter / empty-kind / missing-kind / unknown-kind / parse-zero-keys). |
-| `find_evidence` | Partial-match search by `title` — scans frontmatter title/capabilities/elements as well as body content. |
+| `find_evidence` | Partial-match search by `title` — scans frontmatter title/capabilities/elements as well as body content. Each match includes a prose `excerpt` (max 200 chars, heading/표/코드/리스트/인용 skip — same `extractSummaryExcerpt` helper as `get_concept`) so agents see *what the matching doc says* without a follow-up get_concept call. |
 | `find_backlinks` | Finds every node that points to a given `slug`. Inspects all frontmatter array keys (capabilities / elements / dependencies / relates / …) plus body wikilinks/markdown links. |
 | `find_path` | Shortest path between two slugs (BFS, undirected). Option: `maxHops` (default 5). |
 | `list_kinds` | Vault kind census: `{ total, byKind: { capability: N, ... } }`. |

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -174,7 +174,7 @@ const TOOLS = [
   {
     name: 'find_evidence',
     description:
-      "Find vault docs that mention a given concept by title. Useful when an AI agent asks where a capability is realized in code or docs.",
+      "Find vault docs that mention a given concept by title. Useful when an AI agent asks where a capability is realized in code or docs. Each match includes a prose `excerpt` (max 200 chars, heading/표/코드 skip) so agents see *what the matching doc says* without an extra get_concept call.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -735,6 +735,10 @@ function findEvidence({ title }) {
       kind: doc.frontmatter.kind,
       title: doc.frontmatter.title || doc.frontmatter.name || doc.slug,
       matchedIn: inFrontmatter ? 'frontmatter' : 'body',
+      // R+ — 매치된 doc 의 prose 한 줄 요약 (max 200 chars). agent 가 매치를
+      // 받자마자 "이 doc 이 무슨 내용인가?" 추가 get_concept 없이 파악.
+      // get_concept 의 800자 helper 와 같은 prose-aware 추출 + 더 짧은 cap.
+      excerpt: extractSummaryExcerpt(doc.body, 200),
     });
   }
   return { query: title, matches };

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,6 +37,9 @@ function makeVault(seed = []) {
   const root = mkdtempSync(join(tmpdir(), "omot-int-"));
   for (const { slug, content } of seed) {
     const fullPath = join(root, `${slug}.md`);
+    // subdir slug ("capabilities/foo") 도 자동 mkdir — fixture writer 가
+    // top-level 외에도 자유롭게 디렉터리 구조 표현 가능.
+    mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, content, "utf-8");
   }
   return root;
@@ -163,6 +166,45 @@ await test("list_concepts — tmp vault 의 노드 수 정확히 보고", async 
     ]);
     const result = getCallParsed(responses, 2);
     assert.equal(result.total, 2, "kind 있는 노드 2 개만 카운트");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test("find_evidence — 각 match 에 prose excerpt 동봉 (R+)", async () => {
+  // agent 가 find_evidence 한 호출로 *어떤 doc 이 reference 하는지* + *그 doc
+  // 이 무슨 내용인지* 둘 다 받음. 추가 get_concept 없이.
+  const root = makeVault([
+    {
+      slug: "capabilities/auth",
+      content:
+        "---\nkind: capability\ntitle: Auth\n---\n\n# Auth\n\n인증 흐름의 핵심 capability — 로그인/로그아웃 일원화.\n",
+    },
+    {
+      slug: "domains/billing",
+      content:
+        "---\nkind: domain\ntitle: Billing\ncapabilities: [auth]\n---\n\n# Billing\n\n결제 도메인 — auth 와 함께 사용자 세션 검증.\n",
+    },
+  ]);
+  try {
+    const { responses } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "find_evidence", { title: "auth" }),
+    ]);
+    const result = getCallParsed(responses, 2);
+    assert.ok(Array.isArray(result.matches));
+    assert.ok(result.matches.length >= 1);
+    for (const m of result.matches) {
+      assert.equal(typeof m.excerpt, "string");
+      // markdown table syntax / # heading 은 안 들어가야
+      assert.doesNotMatch(m.excerpt, /^#/);
+      assert.doesNotMatch(m.excerpt, /^\|/);
+    }
+    // domains/billing 매치는 첫 prose 단락 ("결제 도메인 — auth 와 함께...")
+    const billing = result.matches.find((m) => m.slug === "domains/billing");
+    if (billing) {
+      assert.match(billing.excerpt, /결제 도메인/);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

PR #183 의 `extractSummaryExcerpt` helper 위에 stack — 같은 prose-aware 추출 로직을 `find_evidence` 응답 each match 에도 적용.

```js
// Before
{ slug, kind, title, matchedIn }

// After
{ slug, kind, title, matchedIn, excerpt: "이 도메인의 결제 흐름 — auth 와 함께 사용자 세션 검증." }
```

## Why

`find_evidence` 가 매치만 알려주고 *내용* 은 안 줘서 agent 는 매치마다 후속 `get_concept` 호출 필요. n 매치 → n+1 spawn. excerpt (max 200 chars) 동봉으로 한 호출에 끝.

## 200자 cap 이유
- `get_concept` 는 800자 — agent 가 1 doc 깊이 들여다볼 때.
- `find_evidence` 는 매치 N개 — 응답 부풀림 방지 + 스캔 용도라 핵심만.
- block-only body 는 fallback 으로 원본 trim (현 helper 동작 그대로).

## 부수 정리
- `mcp/src/integration.test.mjs` 의 `makeVault` helper — subdir slug 자동 mkdir. 신규 테스트가 `capabilities/foo` 같은 subdir fixture 사용해서 ENOENT 회귀 방지. 기존 호출 호환.
- tool description + `mcp/README.md` + `mcp/CHANGELOG.md` 갱신.

## Test plan
- [x] 신규 integration test 1건 — 매치마다 excerpt string · heading/표 syntax 안 들어감 · 실 prose 매치 검증
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 814/814
- [x] `pnpm lint` 0 errors

## Depends on
**PR #183** (`feat: get_concept excerpt 를 prose-aware`) — `extractSummaryExcerpt` helper. base 가 그 브랜치.

## Out of scope
- `list_concepts` 응답에도 excerpt 옵션 (별도 cycle)
- 매치 위치 주변 텍스트 (지금은 doc 의 첫 prose, 매치 spot 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)