### PR TITLE
fix(topology): ontology 노드 클릭 시 빈 drawer 대신 /ontology ego graph 로 라우팅

### DIFF
--- a/src/shared/lib/ontology-node-id.test.ts
+++ b/src/shared/lib/ontology-node-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isOntologyNodeId } from "./ontology-node-id";
+
+describe("isOntologyNodeId", () => {
+  it("정확한 kind: prefix + tail → true", () => {
+    expect(isOntologyNodeId("capability:mcp-server")).toBe(true);
+    expect(isOntologyNodeId("domain:auth")).toBe(true);
+    expect(isOntologyNodeId("element:src/features/auth")).toBe(true);
+    expect(isOntologyNodeId("project:oh-my-ontology")).toBe(true);
+    expect(isOntologyNodeId("document:setup")).toBe(true);
+    expect(isOntologyNodeId("unknown:legacy-thing")).toBe(true);
+  });
+
+  it("project slug (`:` 없음) → false", () => {
+    expect(isOntologyNodeId("oh-my-ontology")).toBe(false);
+    expect(isOntologyNodeId("auth-platform")).toBe(false);
+  });
+
+  it("modern colon 포함 슬러그지만 알려진 kind 아님 → false", () => {
+    expect(isOntologyNodeId("oh-my:something")).toBe(false);
+    expect(isOntologyNodeId("foo:bar")).toBe(false);
+    expect(isOntologyNodeId("hub:platform")).toBe(false);
+  });
+
+  it("tail 비어있음 (`capability:`) → false (의미 있는 id 아님)", () => {
+    expect(isOntologyNodeId("capability:")).toBe(false);
+    expect(isOntologyNodeId("domain:")).toBe(false);
+  });
+
+  it("빈 / null / non-string → false (throw 안 함)", () => {
+    expect(isOntologyNodeId("")).toBe(false);
+    // @ts-expect-error — runtime 가드
+    expect(isOntologyNodeId(null)).toBe(false);
+    // @ts-expect-error — runtime 가드
+    expect(isOntologyNodeId(undefined)).toBe(false);
+    // @ts-expect-error — runtime 가드
+    expect(isOntologyNodeId(123)).toBe(false);
+  });
+});

--- a/src/shared/lib/ontology-node-id.ts
+++ b/src/shared/lib/ontology-node-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Ontology 노드 id 형식 가드 — `<kind>:<tail>` (e.g. `capability:mcp-server`,
+ * `domain:auth`, `element:src/features/auth`).
+ *
+ * `derive-ontology-from-vault.ts` 가 vault frontmatter `kind:` 가 있는 모든
+ * doc 에 이 형식의 id 를 붙인다. 토폴로지 / 트리 / ego graph 가 같은 id 공간을
+ * 공유. project slug (`oh-my-ontology` 같이 `:` 없는 plain slug) 와 구분 시
+ * 필요.
+ *
+ * 정의: 첫 segment 가 알려진 ontology kind 이고 그 뒤에 `:` 가 와야 한다.
+ * 단순 substring 검사가 아니라 정확 prefix — `oh-my:something` 같은 false
+ * positive 차단.
+ */
+
+const KIND_PREFIXES = [
+  'project:',
+  'domain:',
+  'capability:',
+  'element:',
+  'document:',
+  'unknown:',
+] as const;
+
+export function isOntologyNodeId(id: string): boolean {
+  if (typeof id !== 'string' || id.length === 0) return false;
+  return KIND_PREFIXES.some((p) => id.startsWith(p) && id.length > p.length);
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 import { BookOpen, X } from "lucide-react";
 import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
+import { isOntologyNodeId } from "@/shared/lib/ontology-node-id";
 import { useProjects } from "@/features/project-data-source";
 // 타입/기본값은 Sigma(WebGL) 의존성 없는 별도 모듈에서 직접 import해서
 // SSR 평가 경로에 WebGL 참조가 끼지 않도록 한다.
@@ -323,6 +324,18 @@ export function HomePage() {
       slug: string,
       options?: { preserveImpact?: boolean },
     ) => {
+      // R+ — 토폴로지에서 ontology 노드 (frontmatter `kind:` 가 만든
+      // capability/domain/element id, 형식 `kind:tail`) 클릭은 빈 project
+      // drawer 대신 /ontology 의 ego-graph + detail 패널로 라우팅. project
+      // 가 아닌 노드는 projectBySlug 에 없어 drawer 가 빈 상태로 떴던 회귀.
+      // graph-build.ts 의 long-standing TODO ("ontology 노드 클릭 시 vault md
+      // 열기") 해소 — 같은 vault frontmatter 가 두 surface 에서 일관되게
+      // 보이게 한다.
+      if (isOntologyNodeId(slug)) {
+        router.push(`/ontology/?node=${encodeURIComponent(slug)}`);
+        dismissSigmaHint();
+        return;
+      }
       // 노드 선택 = drawer 열기. 허브를 선택하면 포커스 모드 자동 활성,
       // 일반 노드는 포커스 해제.
       // projectBySlug Map 으로 O(1) lookup — 이전엔 매 클릭마다
@@ -336,7 +349,7 @@ export function HomePage() {
       }));
       dismissSigmaHint();
     },
-    [projectBySlug, setRouteState, dismissSigmaHint],
+    [projectBySlug, router, setRouteState, dismissSigmaHint],
   );
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Summary

`graph-build.ts` 의 long-standing TODO 해소 — *"ontology 노드 클릭 시 vault md 열기"*.

### 회귀
- `/topology` 에서 R14 ontology 확장 노드 (`capability:`, `domain:`, `element:` 등 `kind:tail` id) 클릭 시 `handleSelect` 가 `projectBySlug.get(slug)` 조회 → undefined.
- selectedSlug 만 set 되어 `ProjectDrawer` 가 *빈 상태* 로 열림. 사용자는 "왜 클릭해도 안 보이지?" 혼란.
- vault 에는 풍부한 정보가 있는데 surface 가 못 따라감.

### 수정
- 새 helper `isOntologyNodeId(id)` (`src/shared/lib/ontology-node-id.ts`) — 정확 prefix 매칭으로 6 kind (`project` / `domain` / `capability` / `element` / `document` / `unknown`) 인식. `foo:bar` false positive 차단.
- `handleSelect` 가 ontology node id 면 `router.push('/ontology/?node=<id>')` 로 ego-graph + detail 패널 라우팅. 일반 project slug 는 기존 drawer 흐름 유지.

같은 vault frontmatter 가 두 surface (`/topology` · `/ontology`) 에서 *일관되게* 동일 detail 노출 → 사용자가 "더 알고 싶으면 클릭" 신뢰 회복.

## Test plan
- [x] 신규 unit test 5건 (`src/shared/lib/ontology-node-id.test.ts`):
  - 정확 prefix → true
  - project slug (`:` 없음) → false
  - 알려지지 않은 prefix → false
  - empty tail (`capability:`) → false
  - null/undefined/non-string guard
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 819/819 (+5 신규)
- [x] `pnpm lint` 0 errors

## Out of scope (다음 cycle)
- /topology 안에서 ontology 노드를 *그 자리* 에서 보여주는 drawer (별도 ProjectDrawer 와 동등한 OntologyDrawer)
- 컨텍스트 메뉴에서 "vault md 직접 열기" 옵션 (지금은 /ontology ego 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)