### PR TITLE
feat(ontology-tree): ↑/↓ 키보드 nav 추가 — 선택 행 사이 이동

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
@@ -110,6 +110,52 @@ describe("OntologyTreeView — onSelect", () => {
   });
 });
 
+describe("OntologyTreeView — keyboard nav (R+)", () => {
+  it("ArrowDown on focused select button → focus next row", () => {
+    const { container } = render(<OntologyTreeView result={makeResult()} />);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-tree-select-button="true"]',
+    );
+    expect(buttons.length).toBe(3); // p1 / d1 / c1
+    buttons[0]!.focus();
+    expect(document.activeElement).toBe(buttons[0]);
+    fireEvent.keyDown(buttons[0]!, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(buttons[1]);
+    fireEvent.keyDown(buttons[1]!, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  it("ArrowUp on focused select button → focus previous row", () => {
+    const { container } = render(<OntologyTreeView result={makeResult()} />);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-tree-select-button="true"]',
+    );
+    buttons[2]!.focus();
+    fireEvent.keyDown(buttons[2]!, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(buttons[1]);
+  });
+
+  it("ArrowDown at last row — focus 유지 (out-of-bound 무시)", () => {
+    const { container } = render(<OntologyTreeView result={makeResult()} />);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-tree-select-button="true"]',
+    );
+    buttons[2]!.focus();
+    fireEvent.keyDown(buttons[2]!, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  it("ArrowUp at first row — focus 유지 (out-of-bound 무시)", () => {
+    const { container } = render(<OntologyTreeView result={makeResult()} />);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-tree-select-button="true"]',
+    );
+    buttons[0]!.focus();
+    fireEvent.keyDown(buttons[0]!, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+});
+
 describe("OntologyTreeView — UX-11 element kind dim", () => {
   function withElement(): OntologyTreeBuildResult {
     return {

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -150,7 +150,8 @@ function TreeRow({
         type="button"
         onClick={() => onSelect?.(treeNode.node)}
         title={treeNode.node.title}
-        className="flex min-w-0 flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
+        data-tree-select-button="true"
+        className="flex min-w-0 flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[color:rgba(94,106,210,0.5)] focus-visible:rounded-sm"
       >
         <KindChip kind={treeNode.node.kind} />
         <span className="min-w-0 flex-1 truncate">{treeNode.node.title}</span>
@@ -277,6 +278,26 @@ export function OntologyTreeView({
     setCollapsed(defaultExpanded ? new Set(collapsibleIds) : new Set());
   };
 
+  // R+ — 트리 키보드 nav. Tab 으로 트리 진입 후 ↑/↓ 로 visible row 사이 이동.
+  // Enter 는 button 자체가 처리 (browser default), ArrowUp/Down 만 가로챔.
+  // 기존 Tab 흐름은 그대로 — power user 용 추가 layer.
+  const handleTreeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    const target = event.target as HTMLElement;
+    if (!target?.matches?.('[data-tree-select-button="true"]')) return;
+    const buttons = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+        '[data-tree-select-button="true"]',
+      ),
+    );
+    const idx = buttons.indexOf(target as HTMLButtonElement);
+    if (idx < 0) return;
+    event.preventDefault();
+    const next = event.key === "ArrowDown" ? idx + 1 : idx - 1;
+    if (next < 0 || next >= buttons.length) return;
+    buttons[next]?.focus();
+  };
+
   if (
     result.roots.length === 0
     && result.orphans.length === 0
@@ -387,7 +408,12 @@ export function OntologyTreeView({
           </div>
         </div>
       ) : null}
-      <div role="tree" data-testid="ontology-tree" className="space-y-0.5">
+      <div
+        role="tree"
+        data-testid="ontology-tree"
+        className="space-y-0.5"
+        onKeyDown={handleTreeKeyDown}
+      >
         {filteredRoots.map((root) => renderSubtree(root))}
       </div>
       {isFiltering && filteredRoots.length === 0 && filteredOrphans.length === 0 ? (


### PR DESCRIPTION
## Summary

`/ontology` 트리는 mouse-only — Tab 으로 button 별 진입만 가능하고 "다음 row 로" 가 없음. 큰 트리 (dogfood 79 노드) 에서 power user / vim 사용자 마찰.

추가 layer 로 ArrowDown/Up 가로채 select button 사이 이동. 기존 Tab / Enter / Space 흐름 무변동.

## 설계

- 트리 select button 에 `data-tree-select-button="true"` 속성
- 컨테이너 (role=tree) onKeyDown 리스너: target 이 select button 이고 ↑/↓ 면 buttons 배열의 prev/next 로 focus 이동
- ArrowDown/Up 외 모든 키 browser default
- visible row 만 — collapsed 자식은 DOM 에 없어 자동 skip
- out-of-bound (첫/끝) → focus 유지 (wrap 안 함)
- `focus-visible:ring` (인디고 α 0.5) — 디자인 헌장 단일 인디고 보존

## Test plan
- [x] 4 신규 unit test (`OntologyTreeView.test.tsx`):
  - ArrowDown 1→2→3 step
  - ArrowUp 3→2 step
  - 끝행 ArrowDown: focus 유지
  - 첫행 ArrowUp: focus 유지
- [x] 브라우저 검증 (dogfood 79 노드): "프로젝트 oh-my-ontology" → ArrowDown → "도메인 AI Agent Partner" 이동
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 818/818
- [x] `pnpm lint` 0 errors

## Out of scope (다음 cycle 후보)
- ←/→ collapse/expand (full ARIA tree spec)
- Home/End (트리 첫/끝 row)
- Type-to-search (focused 상태에서 글자 입력 시 prefix 매칭 row 로)
- vim j/k binding (현재는 ↑/↓ 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)