### PR TITLE
feat(ontology-tree): ←/→ 키로 row collapse/expand — ARIA 접근성

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
@@ -154,6 +154,72 @@ describe("OntologyTreeView — keyboard nav (R+)", () => {
     fireEvent.keyDown(buttons[0]!, { key: "ArrowUp" });
     expect(document.activeElement).toBe(buttons[0]);
   });
+
+  it("ArrowLeft on expanded parent → collapse (자식 hide)", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    expect(screen.queryByText("인증")).toBeInTheDocument();
+    expect(screen.queryByText("로그인")).toBeInTheDocument();
+    const projectBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "p1",
+      )!;
+    projectBtn.focus();
+    fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("인증")).not.toBeInTheDocument();
+    expect(screen.queryByText("로그인")).not.toBeInTheDocument();
+  });
+
+  it("ArrowRight on collapsed parent → expand (자식 show)", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    const projectBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "p1",
+      )!;
+    projectBtn.focus();
+    fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("인증")).not.toBeInTheDocument();
+    fireEvent.keyDown(projectBtn, { key: "ArrowRight" });
+    expect(screen.queryByText("인증")).toBeInTheDocument();
+  });
+
+  it("ArrowLeft on already-collapsed → no-op", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    const projectBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "p1",
+      )!;
+    projectBtn.focus();
+    fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("인증")).not.toBeInTheDocument();
+    fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("인증")).not.toBeInTheDocument();
+  });
+
+  it("ArrowLeft / ArrowRight on leaf row → no-op", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    const leafBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "c1",
+      )!;
+    expect(leafBtn.getAttribute("data-row-has-children")).toBe("false");
+    leafBtn.focus();
+    fireEvent.keyDown(leafBtn, { key: "ArrowRight" });
+    fireEvent.keyDown(leafBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("인증")).toBeInTheDocument();
+    expect(screen.queryByText("로그인")).toBeInTheDocument();
+  });
 });
 
 describe("OntologyTreeView — UX-11 element kind dim", () => {

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -151,6 +151,9 @@ function TreeRow({
         onClick={() => onSelect?.(treeNode.node)}
         title={treeNode.node.title}
         data-tree-select-button="true"
+        data-row-slug={treeNode.node.id}
+        data-row-has-children={hasChildren ? "true" : "false"}
+        data-row-expanded={hasChildren ? (expanded ? "true" : "false") : ""}
         className="flex min-w-0 flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[color:rgba(94,106,210,0.5)] focus-visible:rounded-sm"
       >
         <KindChip kind={treeNode.node.kind} />
@@ -278,24 +281,43 @@ export function OntologyTreeView({
     setCollapsed(defaultExpanded ? new Set(collapsibleIds) : new Set());
   };
 
-  // R+ — 트리 키보드 nav. Tab 으로 트리 진입 후 ↑/↓ 로 visible row 사이 이동.
-  // Enter 는 button 자체가 처리 (browser default), ArrowUp/Down 만 가로챔.
+  // R+ — 트리 키보드 nav. Tab 으로 트리 진입 후 ↑/↓ 로 visible row 사이 이동
+  // (focus only). ←/→ 로 collapse/expand. Enter 는 button 자체가 처리.
   // 기존 Tab 흐름은 그대로 — power user 용 추가 layer.
+  //
+  //   ↓/↑    → 다음/이전 visible row 의 select button 으로 focus 이동.
+  //   →     → focused row 가 children 있고 접혀 있으면 펼침.
+  //   ←     → focused row 가 children 있고 펼쳐져 있으면 접음.
+  //   (parent focus / Home / End 는 미래 확장 — 현재 minimal 셋만.)
   const handleTreeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
     const target = event.target as HTMLElement;
     if (!target?.matches?.('[data-tree-select-button="true"]')) return;
-    const buttons = Array.from(
-      event.currentTarget.querySelectorAll<HTMLButtonElement>(
-        '[data-tree-select-button="true"]',
-      ),
-    );
-    const idx = buttons.indexOf(target as HTMLButtonElement);
-    if (idx < 0) return;
-    event.preventDefault();
-    const next = event.key === "ArrowDown" ? idx + 1 : idx - 1;
-    if (next < 0 || next >= buttons.length) return;
-    buttons[next]?.focus();
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      const buttons = Array.from(
+        event.currentTarget.querySelectorAll<HTMLButtonElement>(
+          '[data-tree-select-button="true"]',
+        ),
+      );
+      const idx = buttons.indexOf(target as HTMLButtonElement);
+      if (idx < 0) return;
+      event.preventDefault();
+      const next = event.key === "ArrowDown" ? idx + 1 : idx - 1;
+      if (next < 0 || next >= buttons.length) return;
+      buttons[next]?.focus();
+      return;
+    }
+    if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+      const hasChildren = target.dataset.rowHasChildren === "true";
+      if (!hasChildren) return; // leaf → no-op
+      const slug = target.dataset.rowSlug;
+      if (!slug) return;
+      const expanded = target.dataset.rowExpanded === "true";
+      const wantExpand = event.key === "ArrowRight";
+      // 이미 원하는 상태면 no-op (toggle 호출하면 반대 방향으로 가버림).
+      if (wantExpand === expanded) return;
+      event.preventDefault();
+      toggle(slug);
+    }
   };
 
   if (


### PR DESCRIPTION
## Summary

PR #188 의 ↑/↓ row 이동에 이어 ←/→ 로 collapse/expand. ARIA tree 표준 키셋의 일부.

```
↑/↓   row 사이 focus 이동 (PR #188)
←     focused row collapse (이번)
→     focused row expand (이번)
Enter row 선택 (button default)
```

## Why

트리 노드 펼침/접음은 chevron 토글 button 마우스 클릭 또는 Tab → Enter 가 유일했다. 키보드만 쓰는 power user / 스크린리더 사용자에게 마찰.

## 동작
- → focused row 가 children 있고 접혀 있으면 펼침
- ← focused row 가 children 있고 펼쳐져 있으면 접음
- leaf row 또는 이미 원하는 상태 → no-op
- parent focus / Home / End / type-to-search 는 미래 확장

## 구현
- select button 에 `data-row-slug` / `data-row-has-children` / `data-row-expanded` 부착 → onKeyDown 가 DOM 한 번만 읽어 `toggle(slug)` 호출
- focus / Tab 흐름 무변동 (추가 layer)

## Test plan
- [x] 4 신규 unit test (← 접기 / → 펼치기 / 이미 접힘 no-op / leaf no-op)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 830/830
- [x] `pnpm lint` 0 errors

## Out of scope (다음 cycle)
- parent focus (← on collapsed row → 부모 row 로 focus)
- Home/End (트리 첫/끝)
- type-to-search (글자 입력 시 prefix 매칭 row 로 jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)