### PR TITLE
feat(cli): path 명령 재도입 (회귀 fix) — find_path edges[] 의 CLI 노출 (16th 명령)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added — `path` command (16th, mcp find_path wrapper) — 회귀 fix
+
+- `oh-my-ontology path <from> <to> [vault]` — 두 slug 사이 최단 경로 (BFS, 무방향). MCP `find_path` thin wrapper.
+- 각 hop 사이에 `via` (frontmatter 키 = relation type) 를 ↓ 화살표와 함께 한 줄로 표시 — `capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`. AI agent 가 path 를 받아 *왜* A 와 B 가 연결됐는지 한 호출에 본다.
+- 옵션: `--max-hops N` (기본 5), `--json` (raw 응답).
+- trivial path (`from === to`) 는 0 hops 안내. 누락 인자 시 usage + exit 1.
+- 신규 integration test 4건.
+- *회귀 fix*: 과거 PR #177 가 머지 안 되고 닫혀 main 에 누락됐던 명령. find_path edges[] (PR #175) 의 CLI 노출 다시 도입.
+
 ### Added — `orphans` command (15th, mcp find_orphans wrapper)
 
 - `oh-my-ontology orphans [vault]` — vault 의 *고립 노드* (어디서도 frontmatter 로 reference 안 받는 doc) 한 줄 명령. mcp `find_orphans` thin spawn wrapper.

--- a/cli/README.md
+++ b/cli/README.md
@@ -30,6 +30,7 @@ These wrap the MCP server (`oh-my-ontology-mcp`) so the developer has the same a
 |---|---|
 | `oh-my-ontology backlinks <slug>` | Lists every node referencing the target (`matches[]` from MCP `find_backlinks`, `--json` for raw). |
 | `oh-my-ontology orphans [vault]` | Lists isolated nodes — docs no other node references in their frontmatter (MCP `find_orphans`). Options: `--kind X` (filter), `--exclude-kinds A,B` (skip; default `vault-readme`), `--json`. Quick "what should I clean up" surface for vault maintenance. |
+| `oh-my-ontology path <from> <to> [vault]` | Shortest path (BFS, undirected) between two slugs. Each hop is annotated with the frontmatter key (`capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`) that linked the pair, so you see *why* A and B are connected. (`--max-hops N --json`) |
 | `oh-my-ontology query "<filter>"` | Typed filter DSL — `kind=X AND has(Y) AND NOT domain=Z`, parens / OR / NOT supported. (`--limit N --json`) |
 | `oh-my-ontology rename <oldSlug> <newSlug>` | Atomic rename — moves the `.md`, updates `slug:`, rewrites every backlink (frontmatter array entries, inline strings, body links). Default dry-run preview; `--confirm` to apply. |
 | `oh-my-ontology merge <fromSlug> <intoSlug>` | Atomic merge — redirects every backlink `from → into`, then deletes `from.md`. Default dry-run; `--confirm` to apply. The `into` node's frontmatter / body are **not** auto-combined — edit by hand if needed. |

--- a/cli/src/commands/path.mjs
+++ b/cli/src/commands/path.mjs
@@ -1,0 +1,131 @@
+// `oh-my-ontology path <from> <to> [vault]`
+// Shortest path between two slugs (BFS, undirected). Thin wrapper over MCP
+// find_path — same authority as a coding AI agent. find_path 의 `edges[]`
+// (relation type per hop) 도 함께 사용자에게 노출해, 두 노드가 *왜* 연결됐는지
+// 한 줄로 본다.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runPath(args) {
+  const { from, to, vault, maxHops, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolve(process.cwd(), vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'find_path', {
+      from,
+      to,
+      ...(typeof maxHops === 'number' ? { maxHops } : {}),
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  if (!result || result.found === false || !Array.isArray(result.hops) || result.hops.length === 0) {
+    process.stdout.write(
+      `${COLORS.dim}no path${COLORS.reset} ${COLORS.bold}${from}${COLORS.reset} ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${to}${COLORS.reset}` +
+        ` ${COLORS.dim}(maxHops ${maxHops ?? 5} 초과 또는 vault 에 slug 없음)${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  const hops = result.hops;
+  const edges = Array.isArray(result.edges) ? result.edges : [];
+  const hopCount = typeof result.hopCount === 'number' ? result.hopCount : hops.length - 1;
+
+  // Trivial path (from === to).
+  if (hopCount === 0) {
+    process.stdout.write(
+      `${COLORS.bold}${hops[0]}${COLORS.reset} ${COLORS.dim}(same slug — 0 hops)${COLORS.reset}\n`,
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}${from}${COLORS.reset} ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${to}${COLORS.reset}` +
+      ` ${COLORS.dim}— ${hopCount} hop${hopCount === 1 ? '' : 's'}${COLORS.reset}\n\n`,
+  );
+
+  // Render: hop i  --(via)-->  hop i+1
+  for (let i = 0; i < hops.length; i += 1) {
+    process.stdout.write(`  ${COLORS.cyan}${hops[i]}${COLORS.reset}\n`);
+    if (i < hops.length - 1) {
+      const via = edges[i]?.via;
+      const viaLabel = via ? `${COLORS.yellow}${via}${COLORS.reset}` : `${COLORS.dim}(unknown)${COLORS.reset}`;
+      process.stdout.write(`    ${COLORS.dim}↓ via${COLORS.reset} ${viaLabel}\n`);
+    }
+  }
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, maxHops: undefined };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--max-hops') {
+      const next = args[++i];
+      const n = Number.parseInt(next, 10);
+      if (!Number.isFinite(n) || n < 1) {
+        return { error: `--max-hops requires a positive integer, got "${next}"` };
+      }
+      flags.maxHops = n;
+    } else if (a.startsWith('--max-hops=')) {
+      const n = Number.parseInt(a.slice('--max-hops='.length), 10);
+      if (!Number.isFinite(n) || n < 1) {
+        return { error: `--max-hops requires a positive integer` };
+      }
+      flags.maxHops = n;
+    } else if (a.startsWith('--')) {
+      return { error: `unknown flag: ${a}` };
+    } else {
+      positional.push(a);
+    }
+  }
+  if (positional.length < 2) {
+    return { error: 'both <from> and <to> are required' };
+  }
+  // 3rd positional = vault path (parity with list/find/validate/backlinks/orphans).
+  const [from, to, maybeVault] = positional;
+  if (maybeVault && flags.vault === '.') {
+    flags.vault = maybeVault;
+  }
+  return { from, to, vault: flags.vault, json: flags.json, maxHops: flags.maxHops };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology path <from> <to> [vault] [--max-hops N] [--vault path] [--json]\n\n` +
+      `${COLORS.bold}Example:${COLORS.reset}\n` +
+      `  oh-my-ontology path capabilities/cli-developer-entry capabilities/mcp-server\n` +
+      `  oh-my-ontology path project elements/sigma-graphology --max-hops 8 --json\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -68,6 +68,8 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
   npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
   npx oh-my-ontology orphans [vault]          Isolated nodes (어떤 다른 노드도 reference 안 함)
        --kind X --exclude-kinds A,B --json    ${COLORS.dim}filter / skip / machine output${COLORS.reset}
+  npx oh-my-ontology path <from> <to>         Shortest path (BFS) with relation type per hop
+       --max-hops N --json                    ${COLORS.dim}default 5${COLORS.reset}
   npx oh-my-ontology query "<filter>"         Typed filter DSL (kind=X AND has(elements))
        --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
@@ -284,6 +286,11 @@ if (SUBCOMMAND === 'backlinks') {
 if (SUBCOMMAND === 'orphans') {
   const { runOrphans } = await import('./commands/orphans.mjs');
   exit(await runOrphans(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'path') {
+  const { runPath } = await import('./commands/path.mjs');
+  exit(await runPath(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -679,6 +679,62 @@ await test('backlinks --json — JSON 응답 파싱', async () => {
   }
 });
 
+await test('path — capabilities/bar → capabilities/foo (1 hop, via relates)', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['path', 'capabilities/bar', 'capabilities/foo', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /1 hop/);
+    assert.match(clean, /capabilities\/bar/);
+    assert.match(clean, /capabilities\/foo/);
+    // bar.relates 가 foo 를 가리키므로 via=relates 로 노출
+    assert.match(clean, /relates/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path --json — edges[] 포함된 raw 응답 파싱', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run([
+      'path',
+      'capabilities/bar',
+      'capabilities/foo',
+      root,
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(data.hops), 'hops 배열');
+    assert.ok(Array.isArray(data.edges), 'edges 배열');
+    assert.equal(data.edges.length, data.hops.length - 1, 'edges 길이는 hops - 1');
+    assert.equal(data.found, true);
+    assert.equal(data.edges[0].via, 'relates');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path — same slug → 0 hops trivial', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['path', 'capabilities/foo', 'capabilities/foo', root]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /same slug|0 hops/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('path — 두 인자 누락 시 usage + exit 1', async () => {
+  const r = await run(['path', 'only-one']);
+  assert.equal(r.code, 1);
+  assert.match(stripAnsi(r.stderr), /from.*to.*required|both/);
+});
+
 await test('orphans — graph fixture 에서 referenced 노드 0건 보고', async () => {
   // buildGraphFixture: foo (referenced by bar.relates + auth.capabilities),
   // bar (referenced by 0 — orphan? but auth domain.capabilities 가 references bar),


### PR DESCRIPTION
## Summary

PR #177 (cycle 3 의 CLI path 명령) 이 머지 안 되고 닫혀 main 에 누락됐던 회귀 fix. find_path edges[] (PR #175) 의 CLI 노출이 빠진 상태였음.

```
$ oh-my-ontology path capabilities/bar capabilities/foo

capabilities/bar → capabilities/foo — 1 hop

  capabilities/bar
    ↓ via relates
  capabilities/foo
```

## 추가
- `oh-my-ontology path <from> <to> [vault]` — find_path BFS 의 thin wrapper (16th 명령, cycle 18 orphans 후 +1)
- 각 hop 사이 `via` (frontmatter 키) ↓ 화살표 표시
- `--max-hops N` · `--json` · `--vault path` 옵션
- trivial path / 누락 인자 처리

## Test plan
- [x] 4 신규 integration test (1-hop via relates / `--json` edges / trivial / arg validation)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test:run` 830/830
- [x] `pnpm lint` 0 errors

## Out of scope (다음 cycle)
- `path --confirm-add depends_on` (path 결과를 add_relation 후보로 자동 변환)
- 노드 metadata (kind/title) 도 hop 별 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)