### PR TITLE
feat(mcp): get_concepts 배치 reader — 17번째 MCP 도구, K round-trip → 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Project overview
 
-`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (16 tools).
+`oh-my-ontology` is **a local-first codebase ontology workbench for the developer + their AI agent**. The `.md` frontmatter inside the vault *is* the nodes and edges — frontmatter is self-approving, no separate review step. Developer edits via CLI (`oh-my-ontology init/list/validate/add/find/import`) or web UI (`/ontology`, `/docs`); AI agent (Claude Code, Codex, Cursor) reads/writes the same `.md` files via the `mcp/` MCP server (17 tools).
 
 For direction, see `docs/PRODUCT-DIRECTION.md`. For features users can use right now, see `docs/FEATURES.md`.
 
@@ -60,7 +60,7 @@ src/                       FSD layers
   ├── features/            interaction units
   ├── entities/            business entities
   └── shared/              UI · lib · config primitives
-mcp/                       MCP server (the AI agent's surface) — npm pkg, 16 tools
+mcp/                       MCP server (the AI agent's surface) — npm pkg, 17 tools
 cli/                       CLI binary (developer's daily entry point) — npm pkg, R12 v0.2
                            init / list / validate / add / find / import
 docs/                      long-form docs
@@ -191,7 +191,7 @@ When an AI agent (`add_concept`) or a developer (`oh-my-ontology add` / `oh-my-o
 
 ### 프로젝트 개요
 
-`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (16 tools) 로 같은 `.md` 파일을 read/write.
+`oh-my-ontology` 는 **개발자와 그 AI agent 가 같이 키우는 local-first codebase ontology workbench** 다. vault 의 `.md` frontmatter 가 *그대로* 노드와 관계 — 자기-승인이라 별도 검수 단계 없음. 개발자는 CLI (`oh-my-ontology init/list/validate/add/find/import`) 또는 웹 UI (`/ontology`, `/docs`) 로 편집, AI agent (Claude Code, Codex, Cursor) 는 `mcp/` MCP 서버 (17 tools) 로 같은 `.md` 파일을 read/write.
 
 핵심 원칙 한 줄 (v3, R11 fire #25):
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **One codebase, one ontology, that the developer and their AI agent grow together.**
 >
 > Local-first markdown vault. Developer authors via CLI / web UI.
-> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 16 tools.
+> AI agent (Claude Code, Codex, Cursor) reads + writes the same `.md` files via MCP — 17 tools.
 > No backend. No login. The git repo is the source of truth.
 
 [![CI](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml/badge.svg)](https://github.com/wlsdks/oh-my-ontology/actions/workflows/ci.yml)
@@ -44,7 +44,7 @@ Three claims:
 2. **Developer + AI agent share one source of truth** — both edit the same
    `.md` files. The developer authors via CLI / web UI; the AI agent reads
    + writes via MCP (Claude Code, Codex, Cursor). Same git repo, same diff.
-3. **MCP server gives the AI its only interface** — **16 tools** (10 read +
+3. **MCP server gives the AI its only interface** — **17 tools** (11 read +
    6 write) over JSON-RPC. The agent doesn't need to "ingest your codebase";
    it reads the ontology the developer already curates. R16 / R17 added
    `analyze_repo_structure` and `infer_imports` so the agent can also
@@ -74,7 +74,7 @@ The same frontmatter graph rendered three ways:
 - **Topology** (`/topology`) — Sigma WebGL spatial network of projects
 - **Tree** (`/`, `/ontology`) — hierarchical drill-down (project → domain → capability → element)
 - **ERD builder** (`/ontology/edit`) — xyflow canvas to add nodes and relations visually
-- **MCP** (separate package) — JSON-RPC over stdio, 16 tools
+- **MCP** (separate package) — JSON-RPC over stdio, 17 tools
 
 All four read and write the same `.md` files. Pick whichever view fits
 the moment.
@@ -128,7 +128,7 @@ becoming graph nodes.
 | Promise | Verification |
 |---|---|
 | **vault frontmatter = the graph** (no review queue, no LLM extraction) | `grep -r "extractionJob" src/ → 0` |
-| **AI agent partner via MCP** | `mcp/` package, 16 tools, `mcp/scripts/verify.mjs` smoke |
+| **AI agent partner via MCP** | `mcp/` package, 17 tools, `mcp/scripts/verify.mjs` smoke |
 | **No backend** (Firebase / DB / auth) | `pnpm bundle:check` — firebase SDK chunk 0 (deps removed in R10) |
 | **Dogfooding** | `docs/ontology/` is this project's own curated mental model — **26 nodes** (capabilities 14 · domains 6 · elements 4 · project 1 · vault-readme 1). The MCP server you'd run is the one we use to write *this README*. |
 | **Vault scale** | `node scripts/perf-vault.mjs` measures walk + read + parse on synthetic vaults. **2,000 .md files in 33 ms** (linear, ~17 µs/file). Sub-second up to 1,000 nodes — the ontology will not become the bottleneck. |
@@ -140,7 +140,7 @@ becoming graph nodes.
 - **i18n**: next-intl 4.11 with `/[locale]/` URL prefix (en / ko)
 - **Visualization**: Sigma.js (WebGL) + Graphology + ForceAtlas2 + xyflow + dagre
 - **Local-first**: File System Access API + IndexedDB
-- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 16 tools
+- **AI agent surface**: `mcp/` MCP server, stdio JSON-RPC, 17 tools
 - **Architecture**: Feature-Sliced Design (ESLint boundaries enforced)
 - **Tests**: Vitest unit + Playwright e2e
 
@@ -156,7 +156,7 @@ src/            Feature-Sliced Design layers
   ├── features/ user interactions
   ├── entities/ domain entities (project, ontology-class, knowledge-graph, …)
   └── shared/   ui primitives, lib, config
-mcp/            MCP server (`oh-my-ontology-mcp`, 16 tools) — AI agent surface
+mcp/            MCP server (`oh-my-ontology-mcp`, 17 tools) — AI agent surface
 cli/            `npx oh-my-ontology` (vault scaffold + 6 commands) — developer terminal surface
 docs/           Long-form docs + dogfood vault (docs/ontology/) + benchmark results
 docs/archive/   Historical analysis docs
@@ -202,7 +202,7 @@ cd my-vault
 ### 핵심 약속
 
 1. **vault frontmatter = 그래프** — 검수 큐 / 추출 워커 없음. frontmatter 자기-승인.
-2. **AI agent partner** — MCP 서버 (read 10 + write 6, R16 `analyze_repo_structure` · R17 `infer_imports` 포함) 로 같은 vault read/write + 빈 vault bootstrap.
+2. **AI agent partner** — MCP 서버 (read 11 + write 6, R16 `analyze_repo_structure` · R17 `infer_imports` 포함) 로 같은 vault read/write + 빈 vault bootstrap.
 3. **Local-first single-source** — 사용자 디스크 vault 가 진실원. Firebase / 백엔드 / 인증 의존 0 (R10 — 2026-05).
 4. **Dogfooding** — `docs/ontology/` 가 프로젝트 자기 자신의 mental model.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -15,7 +15,7 @@
 | Surface | Entry | Audience |
 |---|---|---|
 | **CLI** (R12 / R14 / R15) | `oh-my-ontology init / list / validate / add / find / import` | developer terminal — vault scaffold, daily exploration, bulk import |
-| **MCP** (R5 / R7 / R11 / R14 / R16 / R17) | 16 tools (10 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings · bootstrap empty vault (R16 `analyze_repo_structure` · R17 `infer_imports`) |
+| **MCP** (R5 / R7 / R11 / R14 / R16 / R17) | 17 tools (11 read · 6 write) over JSON-RPC | AI agent (Claude Code, Codex, Cursor) — read for context · write back findings · bootstrap empty vault (R16 `analyze_repo_structure` · R17 `infer_imports`) |
 | **Web** (8 routes, R10 surface diet) | `pnpm dev` / static export | sigma topology · tree+ego · ERD builder · insights — graph visualization, mobile-friendly |
 
 ```
@@ -384,7 +384,7 @@ Used when a non-existent slug is hit in static export. Redirects or shows "not f
 
 ---
 
-## 3. MCP server (16 tools)
+## 3. MCP server (17 tools)
 
 Run via `pnpm exec node mcp/src/index.js` (registered in user's `.mcp.json`). AI agents read/write the same vault as humans.
 

--- a/docs/ontology/capabilities/mcp-server.md
+++ b/docs/ontology/capabilities/mcp-server.md
@@ -1,20 +1,21 @@
 ---
 slug: capabilities/mcp-server
 kind: capability
-title: MCP Server (16 tools)
+title: MCP Server (17 tools)
 domain: ai-agent-partner
 elements: [mcp/src/index.js, mcp/src/parser.mjs, mcp/src/vault.mjs, mcp/src/analyze.mjs, mcp/src/infer-imports.mjs]
 relates: [capabilities/frontmatter-to-ontology, domains/ai-agent-partner]
 ---
 
-# MCP Server (16 tools)
+# MCP Server (17 tools)
 
-`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 16 도구 노출 (read 10 + write 6):
+`@modelcontextprotocol/sdk` 기반 stdio JSON-RPC 서버. 17 도구 노출 (read 11 + write 6):
 
 | 도구 | 동작 |
 |---|---|
 | `list_concepts` | vault 의 모든 노드 (kind 필터) |
 | `get_concept` | 단일 slug 의 frontmatter + body excerpt + 이웃 |
+| `get_concepts` | **R+** 배치 reader — 여러 slug 한 호출에 (max 50, 입력 순서 보존, missing 은 partial result) |
 | `find_evidence` | title 부분매칭으로 vault 문서 검색 |
 | `find_backlinks` | 특정 slug 를 가리키는 다른 노드들 (frontmatter array 키 + body wikilink/mdlink) |
 | `find_path` | 두 slug 사이 그래프 최단 경로 (BFS, 무방향, default maxHops 5) |

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **`get_concepts` (17번째 MCP 도구) — 배치 reader.** 입력 `{slugs: string[]}` (max 50), 출력 `{concepts: [{slug, ok: true, frontmatter, excerpt, neighbors, mtime, warnings?} | {slug, ok: false, error}, ...]}`. 입력 순서 보존. agent 가 `list_concepts` / `find_path` / `find_orphans` 결과의 K 개 slug 에 대해 full body+neighbors 가 필요할 때 K round-trip → 1 round-trip. partial result — missing slug 이 있어도 batch 가 abort 되지 않고 그 행만 `ok:false` 로. read tool 11 종 = list_concepts · get_concept · **get_concepts** · find_evidence · find_backlinks · find_path · list_kinds · find_orphans · query_concepts · analyze_repo_structure · infer_imports. write 6 = 변동 없음. 신규 integration test 2 건 (배치 read + partial / 빈 + cap).
 - **`find_evidence` 매치 row 에 `domain` + `mtime` 추가.** 기존 row 는 `slug, kind, title, matchedIn, excerpt` 만 — domain/mtime 누락이라 read tool 5종 중 유일하게 일관성 갭. 추가하여 list_concepts · find_backlinks · find_orphans · query_concepts · find_evidence 모두 동일 shape (`slug, kind, title, domain, mtime, ...specific`). 기존 find_evidence 테스트에 mtime > 0 assertion 추가.
 - **`query_concepts` 매치 row 에 `mtime` 추가.** 기존 row 는 `slug, kind, title, domain, capabilities, elements` 만 — `mtime` 누락이라 read tool 4종 중 유일하게 staleness 정보 없음. 추가하여 list_concepts · find_backlinks · find_orphans · query_concepts 모두 일관 shape. 신규 integration test 1건.
 - **`find_orphans` orphan row 에 `domain` + `mtime` 포함.** `list_concepts` / `find_backlinks` 와 동일 shape — read tool 응답 일관성 완성. agent 가 orphans 받자마자 "old orphans in domain X" sort/filter 가능, 후속 `get_concept` 없이. 신규 integration test 1건.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,7 +44,7 @@ If `OMOT_VAULT` is not set, the current working directory is used as the vault r
 
 ### 2. Restart Claude Code
 
-The server connects over stdio. You should now see 16 tools under the `oh-my-ontology` namespace.
+The server connects over stdio. You should now see 17 tools under the `oh-my-ontology` namespace.
 
 ### 3. Call the tools
 
@@ -56,12 +56,13 @@ The server connects over stdio. You should now see 16 tools under the `oh-my-ont
 → mcp__oh-my-ontology__get_concept({ slug: 'capabilities/mcp-server' })
 ```
 
-## The 16 tools (v0.7.1)
+## The 17 tools (v0.7.1)
 
 | Tool | What it does |
 |---|---|
 | `list_concepts` | Lists every node in the vault (any `.md` with a `kind:` frontmatter). Options: `kind`, `domain` (filter by frontmatter `domain:` slug — combine with `kind` for "all capabilities under auth" in one call), `since` (mtime-based incremental sync — only nodes with `mtime > since` ms; pair with the `mtime` returned in earlier responses for "what changed since I last looked"; strict `>` so re-passing the prior max does not double-fetch), `summary` (opt-in — when true, each row includes a prose `summary` (max 200 chars, heading/표/코드/리스트/인용 skip — same `extractSummaryExcerpt` helper as `get_concept` / `find_evidence`) so agents get list + previews in one call instead of N follow-up `get_concept` calls; default off to keep payload small), `limit`. Each node row includes `mtime` (ms) — agents can sort/filter "what changed recently" without a follow-up `get_concept` call. **R11**: when the vault has frontmatter corruption, response includes `vaultWarnings: { errorCount, warningCount }` so AI agents can flag it to the user. |
 | `get_concept` | Fetches a single node by `slug` (no extension): frontmatter + body excerpt (R+ — *prose-only*: heading / 표 / 코드블록 / 리스트 / 인용 skip 후 첫 단락만 — agent 가 markdown table syntax 대신 사람이 의도한 설명문을 받음, max 800 chars) + neighbors (dependencies / relates) + `mtime` (ms — pass to subsequent `patch_concept` / `delete_concept` as `expected_mtime` to detect concurrent external edits). **R11**: response includes `warnings: [...]` when this doc has frontmatter issues (unclosed-frontmatter / empty-kind / missing-kind / unknown-kind / parse-zero-keys). |
+| `get_concepts` | **R+** Batch reader — accepts an array of slugs (max 50), returns `concepts[]` with the same per-row shape as `get_concept` (frontmatter + excerpt + neighbors + mtime + warnings?). Order of `concepts[]` matches input `slugs[]`. Missing slugs return `{ slug, ok: false, error }` rather than aborting the batch. Replaces N×`get_concept` round-trips when an agent already has K specific slugs (e.g. from `list_concepts` / `find_path` / `find_orphans`) and needs full bodies for all of them. |
 | `find_evidence` | Partial-match search by `title` — scans frontmatter title/capabilities/elements as well as body content. Each match row includes `slug, kind, title, domain, mtime, matchedIn, excerpt` (same shape as `list_concepts` / `find_backlinks` / `find_orphans` / `query_concepts` plus the `excerpt` is a prose preview, max 200 chars, heading/표/코드/리스트/인용 skip — same `extractSummaryExcerpt` helper as `get_concept`) so agents see *what the matching doc says* without a follow-up get_concept call. |
 | `find_backlinks` | Finds every node that points to a given `slug`. Inspects all frontmatter array keys (capabilities / elements / dependencies / relates / …) plus body wikilinks/markdown links. Each match row includes `kind`, `title`, `domain`, `mtime` (same shape as `list_concepts`) — agents can sort/filter "which referrer is in domain X" or "which referrer was touched recently" without follow-up `get_concept` calls. |
 | `find_path` | Shortest path between two slugs (BFS, undirected). Returns `{ from, to, hops, edges, hopCount, found }` where `edges[i] = { from, to, via }` and `via` is the frontmatter key (`capabilities` / `elements` / `dependencies` / `relates` / `contains` / `describes`) that linked the pair — so the agent sees not just *that* A and B are connected but *why*. Option: `maxHops` (default 5). |
@@ -132,7 +133,7 @@ A successful run looks like this:
 ✓ tools/list 16/16 — add_concept · add_relation · analyze_repo_structure · delete_concept · find_backlinks · find_evidence · find_orphans · find_path · get_concept · infer_imports · list_concepts · list_kinds · merge_concepts · patch_concept · query_concepts · rename_concept
 ✓ list_concepts — vault total 25 nodes
 
-All checks passed — register .mcp.json with Claude Code, restart, and the 16 tools are ready.
+All checks passed — register .mcp.json with Claude Code, restart, and the 17 tools are ready.
 ```
 
 On failure, it tells you which step blocked progress and prints a diagnostic message.
@@ -161,7 +162,7 @@ After you add `.mcp.json` and restart Claude Code, try the following with your L
 > 3. Call `find_backlinks({ slug: "capabilities/mcp-server" })` to find what depends on that capability.
 > 4. (Optional) Call `add_concept` to create a new capability node — `slug`, `kind`, and `title` are required.
 
-If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 16 tools (10 read + 6 write), the human + AI co-authoring loop is officially open.
+If those four tools respond cleanly, your read/write round-trip against the vault is working. Once an agent starts *committing* its analysis of your codebase to the ontology through these 17 tools (11 read + 6 write), the human + AI co-authoring loop is officially open.
 
 ## Design principles
 

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -7,6 +7,7 @@
  * read 10:
  *   - list_concepts          — vault 의 노드 목록 (kind / project_filter)
  *   - get_concept            — 단일 노드 + 이웃 (dependencies / relates) + mtime
+ *   - get_concepts           — 배치 read (slugs[] → concepts[], partial 허용)
  *   - find_evidence          — title / capabilities / elements / body 부분매칭
  *   - find_backlinks         — 특정 slug 를 가리키는 다른 노드들
  *   - find_path              — 두 slug 사이 BFS 최단 경로 + edges[via] (R+)
@@ -97,9 +98,9 @@ try {
 // 매번 시행착오로 학습되는 문제를 단번에 해소.
 const SERVER_INSTRUCTIONS = `oh-my-ontology — vault of markdown files where each \`.md\` with a frontmatter \`kind:\` is an ontology node. The graph encodes the codebase's mental model and is shared with the human via plain markdown.
 
-## Tool inventory (16 tools = read 10 + write 6)
+## Tool inventory (17 tools = read 11 + write 6)
 
-**read** — \`list_concepts\` · \`get_concept\` · \`find_evidence\` · \`find_backlinks\` · \`find_path\` · \`list_kinds\` · \`find_orphans\` · \`query_concepts\` · \`analyze_repo_structure\` · \`infer_imports\`.
+**read** — \`list_concepts\` · \`get_concept\` · \`get_concepts\` · \`find_evidence\` · \`find_backlinks\` · \`find_path\` · \`list_kinds\` · \`find_orphans\` · \`query_concepts\` · \`analyze_repo_structure\` · \`infer_imports\`.
 **write** — \`add_concept\` · \`add_relation\` · \`patch_concept\` · \`delete_concept\` · \`rename_concept\` · \`merge_concepts\`.
 
 ## Kind hierarchy (top → leaf)
@@ -211,6 +212,22 @@ const TOOLS = [
         },
       },
       required: ['slug'],
+    },
+  },
+  {
+    name: 'get_concepts',
+    description:
+      'Fetch *multiple* nodes in one call — same per-row shape as `get_concept` (frontmatter + excerpt + neighbors + mtime + warnings?), but accepts an array of slugs. Use when you have K specific slugs from `list_concepts` / `find_path` / `find_orphans` etc. and need their full details — saves K-1 round-trips. Order of `concepts[]` matches input `slugs[]`. Missing slugs return `{ slug, ok: false, error }` rather than aborting the batch — agents handle partial results gracefully.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        slugs: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Vault-relative slugs (e.g. ["capabilities/x", "elements/y"]). Omit the .md extension. Max 50 per call.',
+        },
+      },
+      required: ['slugs'],
     },
   },
   {
@@ -644,6 +661,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok(listConcepts(args));
       case 'get_concept':
         return ok(getConcept(args));
+      case 'get_concepts':
+        return ok(getConceptsBatch(args));
       case 'find_evidence':
         return ok(findEvidence(args));
       case 'add_concept':
@@ -781,6 +800,39 @@ function getConcept({ slug }) {
     warnings:
       validation && validation.issues.length > 0 ? validation.issues : undefined,
   };
+}
+
+// R+ — get_concept 의 batch 변종. 입력 slugs[] 순서를 보존하고 missing slug 는
+// 배치를 abort 하지 않고 { ok: false, error } 행으로 surface — agent 가
+// partial result 받아 핸들링 (예: list_concepts 결과를 재검증 없이 그대로
+// 사용하다 stale slug 한두 개 있어도 배치 전체가 죽지 않음). 50 cap 은
+// payload 폭주 방지 (vault 가 더 큰 경우 청크 분할).
+function getConceptsBatch({ slugs }) {
+  if (!Array.isArray(slugs)) {
+    throw new Error('slugs must be an array of strings');
+  }
+  if (slugs.length === 0) {
+    return { concepts: [] };
+  }
+  if (slugs.length > 50) {
+    throw new Error(
+      `Too many slugs: ${slugs.length}. Max 50 per call — split into multiple get_concepts batches.`
+    );
+  }
+  const concepts = slugs.map((slug) => {
+    if (typeof slug !== 'string' || !slug) {
+      return { slug: String(slug), ok: false, error: 'invalid-slug' };
+    }
+    try {
+      const result = getConcept({ slug });
+      return { ok: true, ...result };
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      // Doc not found 같은 친화 메시지를 그대로 surface — 절대 경로 leak 방지.
+      return { slug, ok: false, error: msg };
+    }
+  });
+  return { concepts };
 }
 
 function findEvidence({ title }) {

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -490,6 +490,68 @@ await test("get_concept 응답에 mtime (R11 #8) 포함", async () => {
   }
 });
 
+// R+ — get_concepts 배치 reader. K개 slug → 1 round trip. 입력 순서 보존,
+// missing slug 는 batch 를 abort 하지 않고 { ok: false, error } 행으로 surface.
+await test("get_concepts — 배치 read, 입력 순서 보존 + partial result", async () => {
+  const root = makeVault([
+    { slug: "alpha", content: "---\nkind: capability\ntitle: Alpha\n---\nbody A" },
+    { slug: "beta", content: "---\nkind: element\ntitle: Beta\n---\nbody B" },
+    { slug: "gamma", content: "---\nkind: capability\ntitle: Gamma\n---\nbody G" },
+  ]);
+  try {
+    const { responses } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "get_concepts", { slugs: ["beta", "missing-slug", "alpha"] }),
+    ]);
+    const result = getCallParsed(responses, 2);
+    assert.equal(result.concepts.length, 3, "concepts row 수 = 입력 slugs 수");
+    // 순서 보존: 입력 [beta, missing, alpha] → 출력 같은 순서.
+    assert.equal(result.concepts[0].slug, "beta");
+    assert.equal(result.concepts[0].ok, true);
+    assert.equal(result.concepts[0].frontmatter.title, "Beta");
+    assert.equal(typeof result.concepts[0].mtime, "number");
+    assert.ok(result.concepts[0].mtime > 0);
+    // missing slug → ok:false, error message, batch 살아남음.
+    assert.equal(result.concepts[1].slug, "missing-slug");
+    assert.equal(result.concepts[1].ok, false);
+    assert.match(result.concepts[1].error, /not found/i);
+    // 그 다음 valid 한 slug 는 정상 처리.
+    assert.equal(result.concepts[2].slug, "alpha");
+    assert.equal(result.concepts[2].ok, true);
+    assert.equal(result.concepts[2].frontmatter.title, "Alpha");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// R+ — get_concepts 빈 배열 / cap (50) 가드. 정상 빈 응답 vs error.
+await test("get_concepts — 빈 slugs[] → 빈 concepts[], 51개 → error", async () => {
+  const root = makeVault([
+    { slug: "foo", content: "---\nkind: capability\ntitle: Foo\n---\n" },
+  ]);
+  try {
+    const { responses: r1 } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "get_concepts", { slugs: [] }),
+    ]);
+    const empty = getCallParsed(r1, 2);
+    assert.deepEqual(empty.concepts, []);
+
+    // 51개 → error response (batch 호출 자체가 throw, MCP 가 error 직렬화).
+    const tooMany = Array.from({ length: 51 }, (_, i) => `s${i}`);
+    const { responses: r2 } = await rpc(root, [
+      ...INIT_REQUESTS,
+      callTool(2, "get_concepts", { slugs: tooMany }),
+    ]);
+    // server 는 throw → MCP 응답에 isError content 또는 error 필드. text 안에
+    // 우리 cap 메시지 ("Too many slugs") 가 있는지로만 검증.
+    const text = JSON.stringify(r2.find((r) => r.id === 2));
+    assert.match(text, /Too many slugs|50/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test("patch_concept — expected_mtime stale 면 conflict error response", async () => {
   const root = makeVault([
     { slug: "foo", content: "---\nkind: capability\ntitle: Foo\n---\n" },


### PR DESCRIPTION
## Summary

agent 가 \`list_concepts\` / \`find_path\` / \`find_orphans\` 결과의 K 개 slug 에 대해 full body+neighbors 가 필요할 때 현재 K 번의 \`get_concept\` 호출 → 1 번의 \`get_concepts\` 호출로 단축.

설계:
- 입력 \`{ slugs: string[] }\` (max 50, 초과 시 throw)
- 출력 \`{ concepts: [...] }\` — 입력 순서 보존
- per-row shape: \`{slug, ok: true, frontmatter, excerpt, neighbors, mtime, warnings?}\` 또는 \`{slug, ok: false, error}\`
- partial result — missing slug 이 있어도 batch abort 안 함, 그 행만 \`ok:false\` 로 surface

도구 카운트 16 → 17 (read 10 → 11, write 6 unchanged).
read 11: \`list_concepts · get_concept · get_concepts · find_evidence · find_backlinks · find_path · list_kinds · find_orphans · query_concepts · analyze_repo_structure · infer_imports\`

## Test plan

- [x] mcp integration 18 → 20 — 배치 read + 입력순서 + partial result + 빈/cap 가드 2 신규
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 830/830
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] backward compat — 신규 도구만, 기존 도구 변경 0

## Out of scope

- \`get_concept\` 의 deprecation — 남겨둠. 단일 호출 빠른 path + 명료성.
- frontend (web UI) 노출 — MCP-only 도구. 필요 시 cycle 별도.
- write 측 \`add_concepts\` 배치 — 다음 cycle 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)