### PR TITLE
docs(skill): /ontology-bootstrap 본문을 add_concepts/add_relations 배치로 갱신

### DIFF
--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ontology-bootstrap
-description: Bootstrap an empty (or near-empty) oh-my-ontology vault from the surrounding codebase — call analyze_repo_structure once, show the proposed candidates, and selectively land the accepted ones via add_concept / add_relation. Use when the user says "이 codebase 분석해줘" / "bootstrap the ontology" / "fill the vault from the code", or when you notice the vault has only the 5 starter nodes and the user has asked you to do anything ontology-related. Skip when the vault already has 20+ user-curated nodes — bootstrap is for the cold-start case only.
+description: Bootstrap an empty (or near-empty) oh-my-ontology vault from the surrounding codebase — call analyze_repo_structure once, show the proposed candidates, and selectively land the accepted ones via add_concepts / add_relations (batch writers). Use when the user says "이 codebase 분석해줘" / "bootstrap the ontology" / "fill the vault from the code", or when you notice the vault has only the 5 starter nodes and the user has asked you to do anything ontology-related. Skip when the vault already has 20+ user-curated nodes — bootstrap is for the cold-start case only.
 ---
 
 # /ontology-bootstrap — fill an empty vault from the code
@@ -13,8 +13,10 @@ Two facts make a fresh `oh-my-ontology` vault feel empty:
    onboarding path (measured: ~25 cli `add` calls in the Paravel real-codebase
    dogfood — `docs/dogfood-paravel-2026-05-06.md`).
 
-This skill closes that gap with **one MCP call + selective writes**.
-It is the *cold-start* counterpart to `/ontology-sync` (which keeps an
+This skill closes that gap with **3 MCP calls total** — one read
+(`analyze_repo_structure`) plus two batch writes (`add_concepts` for the
+nodes, `add_relations` for the edges). Down from ~25 round-trips. It is
+the *cold-start* counterpart to `/ontology-sync` (which keeps an
 already-grown vault in step with new code).
 
 ## When to run
@@ -81,13 +83,13 @@ Land all of these as the ontology bootstrap? (yes / pick / refine)
 
 ### 4. Hand control to the user
 
-Three branches:
+Three branches — all use the **batch writers** (R+: `add_concepts` cap 50, `add_relations` cap 50). Each batch is one round-trip; rows fail independently with `{ok: false, error}` so a stale slug or missing target doesn't abort the rest.
 
-- **yes** — call `add_concept` for project, then each domain, capability, element in that order. Each call is 1 line of args. Then call `add_relation` for each suggested relation (`from → to`, `type: 'contains'` for project→capability). Skip relations whose endpoints didn't make it in.
-- **pick** — list the candidates one kind at a time, let the user accept/reject per item, then call `add_concept` only for the accepted ones.
-- **refine** — let the user rename slugs / titles inline before any write. Pass the refined version to `add_concept`.
+- **yes** — assemble one `concepts[]` array containing the project + every domain + every capability + every element. Call `add_concepts({ concepts })` once. Then build `relations[]` from `suggestedRelations` and call `add_relations({ relations })` once. 2 writes total.
+- **pick** — list the candidates one kind at a time, let the user accept/reject per item, then build the filtered `concepts[]` / `relations[]` and run the same two batch calls. Drop relations whose endpoints didn't make the cut.
+- **refine** — let the user rename slugs / titles inline before any write. Apply the rename to the candidate arrays *and* to the relations (`from` / `to`) so they still match. Then 2 batch calls as above.
 
-Whatever path is chosen, **the user (via your `add_concept` / `add_relation` calls) is the only writer**. Single source of truth preserved.
+If a batch exceeds 50 rows (rare but possible in monorepos), split into chunks of 50 — each chunk is still one round-trip. Whatever path is chosen, **the user (via your `add_concepts` / `add_relations` calls) is the only writer**. Single source of truth preserved.
 
 ### 5. Land + verify
 
@@ -102,9 +104,12 @@ Show the kind census diff in the reply (e.g. *"Vault grew 5 → 18 nodes (+3 dom
 
 ## Failure modes
 
-- **`add_concept` throws on existing slug** — the starter `example` nodes (or a previous bootstrap) collided. Use `patch_concept` to overwrite, or pick a different slug.
-- **`missing-expected-field` warning** — a capability or element was added without `domain:`. Tolerable for bootstrap (vault still validates), but flag the warnings to the user so they can backfill.
-- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze .` to get the same JSON, then `oh-my-ontology add <kind> <slug> --title=...` for each accepted candidate.
+- **`add_concepts` row returns `ok: false` with "already exists"** — the starter `example` nodes (or a previous bootstrap) collided. Other rows still land (the batch is partial-success, not all-or-nothing). Inspect the failed rows; for each, either skip (already present is fine) or follow up with `patch_concept` to overwrite the body. Do *not* retry the whole batch — that just re-fails the same rows.
+- **`add_concepts` row returns `ok: false` with "duplicate slug in input batch"** — your candidate array had the same slug twice. Pick one occurrence and re-submit only that row.
+- **`missing-expected-field` warning on a per-row `warnings: [...]`** — a capability or element was added without `domain:`. Tolerable for bootstrap (vault still validates), but surface the warnings to the user so they can backfill.
+- **`add_relations` row returns `ok: false` with "does not exist"** — an endpoint was rejected in the `add_concepts` step. Confirm and either drop the relation or add the missing concept first.
+- **`add_relations` row returns `alreadyExists: true`** — that edge was already present (idempotent). Not an error; surface as informational only.
+- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze .` to get the same JSON, then `oh-my-ontology add <kind> <slug> --title=...` for each accepted candidate (CLI does not yet have a batch wrapper, so this path is K round-trips).
 - **Repo too deep / monorepo** — pass `rootPath` for the relevant subdirectory, or run `analyze` per package and merge results.
 
 ## Reply discipline

--- a/docs/ontology/capabilities/ontology-bootstrap-skill.md
+++ b/docs/ontology/capabilities/ontology-bootstrap-skill.md
@@ -8,24 +8,24 @@ elements: [.claude/skills/ontology-bootstrap/SKILL.md]
 
 R16 follow-up — `/ontology-bootstrap` slash skill 의 cold-start counterpart. `/ontology-sync` 가 *이미 자란 vault* 의 incremental sync 라면, 이 skill 은 *fresh init 직후 빈 vault* 를 codebase 에서 *한 번에* 채우는 흐름.
 
-## 흐름
+## 흐름 (R+, 3 round-trips)
 
 1. `list_kinds` — vault 가 진짜 cold-start 인지 (≤ 5 nodes) 확인
-2. `analyze_repo_structure` 1 회 호출 (mcp 15번째 도구, R16 v0.8.0)
+2. `analyze_repo_structure` 1 회 호출 (mcp 도구, R16 v0.8.0)
    — `package.json` / `README.md` H2 / `src/` 폴더 → deterministic 후보. side effect 0.
 3. 후보를 사용자에게 *5 줄 max* 요약 (kind 별 count + 상위 3 + evidence)
 4. 사용자 분기 — yes / pick / refine
-5. 채택된 것만 `add_concept` 다발 + `add_relation` 다발 (project contains capability)
+5. **`add_concepts`** (R+ batch writer, max 50) 1 회 — project + domains + capabilities + elements 일괄 land. 그 다음 **`add_relations`** (R+ batch edge writer, max 50) 1 회 — suggestedRelations 일괄 land. 두 호출 모두 partial result · idempotent.
 6. 마무리 — `list_kinds` + 사용자에게 census diff 보여주기 ("vault 5 → 18 nodes")
 
 ## 단일 source of truth
 
-skill 자체는 *agent prompt instruction*. 진입은 `add_concept` / `add_relation` 만 — vault frontmatter 가 유일 진실원. analyze 는 read only.
+skill 자체는 *agent prompt instruction*. 진입은 `add_concepts` / `add_relations` 만 — vault frontmatter 가 유일 진실원. analyze 는 read only.
 
 ## Mission align
 
 이전: 사용자 init 후 *수동 add 25 회* (Paravel real-codebase 측정 친구션).
-이후: agent 가 한 번 분석 → 30+ 후보 → 1-click confirm → 다발 add. 첫 user *Aha moment*.
+이후 (R+): agent 가 한 번 분석 → 30+ 후보 → 1-click confirm → **batch 2 호출 (add_concepts + add_relations) → 총 3 round-trip 으로 vault 채워짐**. 첫 user *Aha moment*.
 
 ## 참조
 


### PR DESCRIPTION
## Summary

cycle 24-25 에서 \`add_concepts\` / \`add_relations\` 배치 도구가 land 됐지만 \`/ontology-bootstrap\` skill 본문은 여전히 단건 \`add_concept\` / \`add_relation\` 직렬 호출을 지시하고 있었음. agent 가 새 도구를 인지·활용하도록 skill 본문 + 관련 dogfood 노드 갱신.

본문 변경:
- 첫 줄 요약 — \"one MCP call + selective writes\" → \"3 MCP calls total (analyze_repo_structure → add_concepts → add_relations)\"
- frontmatter description — add_concept / add_relation → add_concepts / add_relations 배치 writer 명시
- step 4 (Hand control to user) — yes / pick / refine 세 분기 모두 1×add_concepts + 1×add_relations 로 land. 50 초과 시 chunk 분할 안내.
- failure modes — \`{ok: false}\` row · \`alreadyExists: true\` · \"duplicate slug in input batch\" 등 batch 도구의 row-level 에러 시그널 명시. 전체 batch 재시도 금지.
- CLI fallback — CLI 는 아직 batch 미지원이라 K round-trip 임을 명시.

dogfood:
- \`docs/ontology/capabilities/ontology-bootstrap-skill.md\` — 흐름 단계에 batch 호출 + \"총 3 round-trip\" 명시 (patch_concept + mtime guard).

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors (코드 변경 없음, 형식 검증)
- [x] \`pnpm test:run\` — 830/830 (변동 없음)
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] skill 본문 자체 - 5-line discipline / 단일 source of truth / partial result 흐름 일관성 직접 확인

## Out of scope

- CLI batch wrapper (\`oh-my-ontology add-many\`) — 다음 cycle 후보. CLI 가 spawn 후 한 번의 mcp-call 로 add_concepts 호출만 하면 OK.
- skill 내 \"5 lines max\" 디스플레이 룰 변경 없음 — 기존 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)