### PR TITLE
feat(ontology-tree): ← 키 parent focus — ARIA tree 표준 패턴 마무리

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
@@ -188,7 +188,7 @@ describe("OntologyTreeView — keyboard nav (R+)", () => {
     expect(screen.queryByText("인증")).toBeInTheDocument();
   });
 
-  it("ArrowLeft on already-collapsed → no-op", () => {
+  it("ArrowLeft on already-collapsed root → no-op (parent 없음)", () => {
     render(<OntologyTreeView result={makeResult()} />);
     const projectBtn = screen
       .getAllByRole("button")
@@ -198,10 +198,60 @@ describe("OntologyTreeView — keyboard nav (R+)", () => {
           && b.getAttribute("data-row-slug") === "p1",
       )!;
     projectBtn.focus();
+    // 첫 ArrowLeft — 펼쳐진 root 를 접음.
     fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
     expect(screen.queryByText("인증")).not.toBeInTheDocument();
+    // 두번째 ArrowLeft — 이미 접힌 root → parent 가 없어 no-op (focus 유지).
     fireEvent.keyDown(projectBtn, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(projectBtn);
     expect(screen.queryByText("인증")).not.toBeInTheDocument();
+  });
+
+  it("ArrowLeft on leaf → 부모 행 focus (R+ 표준 ARIA)", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    const leafBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "c1",
+      )!;
+    const domainBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "d1",
+      )!;
+    leafBtn.focus();
+    fireEvent.keyDown(leafBtn, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(domainBtn);
+  });
+
+  it("ArrowLeft on collapsed non-root → 부모 행 focus", () => {
+    render(<OntologyTreeView result={makeResult()} />);
+    // domain 행 (d1) 을 먼저 접고, 그 상태에서 ArrowLeft → project (p1) 로 이동.
+    const domainBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "d1",
+      )!;
+    const projectBtn = screen
+      .getAllByRole("button")
+      .find(
+        (b) =>
+          b.getAttribute("data-tree-select-button") === "true"
+          && b.getAttribute("data-row-slug") === "p1",
+      )!;
+    domainBtn.focus();
+    // d1 의 ←: 펼쳐진 → 접음
+    fireEvent.keyDown(domainBtn, { key: "ArrowLeft" });
+    expect(screen.queryByText("로그인")).not.toBeInTheDocument();
+    // 다시 ←: 이제 접힌 d1 에서 부모 p1 로 focus.
+    fireEvent.keyDown(domainBtn, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(projectBtn);
   });
 
   it("Home → 첫 행 focus", () => {
@@ -314,7 +364,8 @@ describe("OntologyTreeView — keyboard nav (R+)", () => {
     expect(document.activeElement).toBe(buttons[0]);
   });
 
-  it("ArrowLeft / ArrowRight on leaf row → no-op", () => {
+  it("ArrowRight on leaf row → no-op (collapse/expand 변동 없음)", () => {
+    // ArrowLeft 의 leaf 동작은 별도 test (parent focus) — 여기는 ArrowRight 만.
     render(<OntologyTreeView result={makeResult()} />);
     const leafBtn = screen
       .getAllByRole("button")
@@ -326,7 +377,7 @@ describe("OntologyTreeView — keyboard nav (R+)", () => {
     expect(leafBtn.getAttribute("data-row-has-children")).toBe("false");
     leafBtn.focus();
     fireEvent.keyDown(leafBtn, { key: "ArrowRight" });
-    fireEvent.keyDown(leafBtn, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(leafBtn);
     expect(screen.queryByText("인증")).toBeInTheDocument();
     expect(screen.queryByText("로그인")).toBeInTheDocument();
   });

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -152,6 +152,7 @@ function TreeRow({
         title={treeNode.node.title}
         data-tree-select-button="true"
         data-row-slug={treeNode.node.id}
+        data-row-depth={treeNode.depth}
         data-row-has-children={hasChildren ? "true" : "false"}
         data-row-expanded={hasChildren ? (expanded ? "true" : "false") : ""}
         className="flex min-w-0 flex-1 items-center gap-2 break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[color:rgba(94,106,210,0.5)] focus-visible:rounded-sm"
@@ -285,7 +286,8 @@ export function OntologyTreeView({
   //
   //   ↓/↑       → 다음/이전 visible row.
   //   →         → focused row children 있고 접혀 있으면 펼침.
-  //   ←         → focused row children 있고 펼쳐져 있으면 접음.
+  //   ←         → focused row children 있고 펼쳐져 있으면 접음. 그 외
+  //              (leaf · 이미 접힌 parent) → parent 행 focus (표준 ARIA).
   //   Home/End  → 첫/마지막 visible row.
   //   a-z, 한글 → type-to-search. 600ms 안에 누적된 chars 로 첫 일치 row
   //              focus (현재 focus 다음부터 wrap-around). 같은 char 반복 시
@@ -320,15 +322,40 @@ export function OntologyTreeView({
     }
     if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
       const hasChildren = target.dataset.rowHasChildren === "true";
-      if (!hasChildren) return; // leaf → no-op
       const slug = target.dataset.rowSlug;
-      if (!slug) return;
       const expanded = target.dataset.rowExpanded === "true";
       const wantExpand = event.key === "ArrowRight";
-      // 이미 원하는 상태면 no-op (toggle 호출하면 반대 방향으로 가버림).
-      if (wantExpand === expanded) return;
-      event.preventDefault();
-      toggle(slug);
+
+      if (wantExpand) {
+        // ArrowRight — 접힌 parent 만 펼침. 이외 (leaf · 이미 펼쳐진 parent)
+        // 는 표준 ARIA 면 첫 자식 focus 인데 ↓ 로 동일 효과 → 단순 no-op.
+        if (!hasChildren || !slug || expanded) return;
+        event.preventDefault();
+        toggle(slug);
+        return;
+      }
+      // ArrowLeft — 두 분기:
+      //   ① 펼쳐진 parent → 접음
+      //   ② 그 외 (leaf · 이미 접힌 parent) → parent 행 focus (R+ 표준 ARIA)
+      if (hasChildren && expanded && slug) {
+        event.preventDefault();
+        toggle(slug);
+        return;
+      }
+      // parent focus — depth 기준 직전 더 얕은 깊이 button 찾기.
+      const ownDepth = Number(target.dataset.rowDepth);
+      if (!Number.isFinite(ownDepth) || ownDepth <= 0) return; // root → no-op
+      const buttons = collectButtons();
+      const idx = buttons.indexOf(target as HTMLButtonElement);
+      if (idx <= 0) return;
+      for (let i = idx - 1; i >= 0; i -= 1) {
+        const d = Number(buttons[i]?.dataset.rowDepth);
+        if (Number.isFinite(d) && d < ownDepth) {
+          event.preventDefault();
+          buttons[i]?.focus();
+          return;
+        }
+      }
       return;
     }
     if (event.key === "Home" || event.key === "End") {


### PR DESCRIPTION
## Summary

cycle 27 (Home/End/type-to-search) 후 ARIA tree 키 셋의 마지막 한 가지. leaf 또는 이미 접힌 row 에서 ← 누르면 부모 행 focus — W3C WAI tree role 표준 패턴.

이전 ↔ 지금:
- 이전 ←: 펼쳐진 parent 만 접음. leaf · 이미 접힌 parent → no-op.
- 지금 ←: 첫 누름 (펼쳐진 parent) → 접음 → 두번째 누름 (이제 접힘) → 부모 focus. leaf 면 첫 ← 부터 부모 focus. → 의 동작은 변경 없음.

표준 ARIA 따라 \"누를수록 위로 올라간다\" 흐름 — 키보드만으로 트리를 자연스럽게 탈출/축약.

## 구현

- button 에 \`data-row-depth\` 추가 (부모 탐색 기준).
- 직전 visible row 들 중 더 얕은 깊이 button 으로 walk-back. collapsed 행은 DOM 에 없으므로 자동 제외.
- root-level (depth 0) 이미 접힌 row → 부모 없음 → no-op.

## Test plan

- [x] vitest tree-view: 31 → 33 (+2 — leaf parent focus / collapsed non-root parent focus)
- [x] 기존 \"ArrowLeft on already-collapsed → no-op\" → parent 없는 root 케이스로 의미 유지 + 이름 갱신
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 837 → 839
- [x] \`pnpm lint\` — 0 errors
- [x] backward compat — 펼쳐진 parent 의 ← 첫 누름은 \"접음\" 그대로

## Out of scope

- 한 번에 root-most parent 까지 (Shift+←) — 표준 ARIA 에 없음.
- /topology 키보드 nav — 별도 component.
- 트리 가로 scroll / 가상화 — large vault 의 별 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)