### PR TITLE
feat(cli): analyze --apply 플래그 — agent-less vault bootstrap (CLI batch parity)

### DIFF
--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -109,7 +109,7 @@ Show the kind census diff in the reply (e.g. *"Vault grew 5 → 18 nodes (+3 dom
 - **`missing-expected-field` warning on a per-row `warnings: [...]`** — a capability or element was added without `domain:`. Tolerable for bootstrap (vault still validates), but surface the warnings to the user so they can backfill.
 - **`add_relations` row returns `ok: false` with "does not exist"** — an endpoint was rejected in the `add_concepts` step. Confirm and either drop the relation or add the missing concept first.
 - **`add_relations` row returns `alreadyExists: true`** — that edge was already present (idempotent). Not an error; surface as informational only.
-- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze .` to get the same JSON, then `oh-my-ontology add <kind> <slug> --title=...` for each accepted candidate (CLI does not yet have a batch wrapper, so this path is K round-trips).
+- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze . --apply` lands every candidate via the same `add_concepts` + `add_relations` batch (R+). Or `oh-my-ontology analyze .` first to preview, then re-run with `--apply`. For per-row picking, drop `--apply` and call `oh-my-ontology add <kind> <slug> --title=...` for accepted ones (K round-trips, but only when curating).
 - **Repo too deep / monorepo** — pass `rootPath` for the relevant subdirectory, or run `analyze` per package and merge results.
 
 ## Reply discipline

--- a/cli/src/commands/analyze.mjs
+++ b/cli/src/commands/analyze.mjs
@@ -26,7 +26,7 @@ const KIND_COLOR = {
 };
 
 export async function runAnalyze(args) {
-  const { rootPath, vault, json, maxDepth, error } = parseArgs(args);
+  const { rootPath, vault, json, maxDepth, apply, error } = parseArgs(args);
   if (error) {
     process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
     printUsage();
@@ -36,7 +36,8 @@ export async function runAnalyze(args) {
   const target = resolve(process.cwd(), rootPath);
   // analyze 는 *vault 와 무관* 한 도구지만 mcp 통과 시 OMOT_VAULT 가 필요해서
   // 그냥 cwd 또는 사용자 지정. mcp 의 analyze 도 vault 안 만지지만
-  // initialization 흐름에 vault path 가 필요.
+  // initialization 흐름에 vault path 가 필요. --apply 모드는 vault 에
+  // 실제로 쓰므로 vault 위치 정확히 지정 필요.
   const vaultRoot = resolve(process.cwd(), vault);
   let result;
   try {
@@ -49,6 +50,14 @@ export async function runAnalyze(args) {
       `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return 2;
+  }
+
+  // --apply 분기 — 후보를 vault 에 batch land. mcp 의 add_concepts +
+  // add_relations 호출. partial result OK (이미 존재하는 노드는 ok:false 로
+  // skip). agent-less 워크플로 (CI · plain CLI) 가 /ontology-bootstrap skill
+  // 의 K round-trip 을 우회.
+  if (apply) {
+    return await runApply(vaultRoot, result, json);
   }
 
   if (json) {
@@ -122,13 +131,14 @@ function printSection(label, items, colors, kindColor) {
 }
 
 function parseArgs(args) {
-  const flags = { vault: '.', json: false };
+  const flags = { vault: '.', json: false, apply: false };
   const positional = [];
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     if (a === '--vault') flags.vault = args[++i] || '.';
     else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
     else if (a === '--json') flags.json = true;
+    else if (a === '--apply') flags.apply = true;
     else if (a === '--max-depth')
       flags.maxDepth = Number(args[++i]) || undefined;
     else if (a.startsWith('--max-depth='))
@@ -140,21 +150,173 @@ function parseArgs(args) {
     rootPath: positional[0] ?? '.',
     vault: flags.vault,
     json: flags.json,
+    apply: flags.apply,
     maxDepth: flags.maxDepth,
   };
+}
+
+// R+ — analyze 결과를 vault 에 land. add_concepts + add_relations 배치 호출.
+// /ontology-bootstrap skill 의 CLI 짝 — agent-less 흐름 (CI / plain shell)
+// 도 1줄로 vault 부트스트랩.
+async function runApply(vaultRoot, result, json) {
+  // concepts[] 조립 — project 먼저 (capability 의 domain reference 가 의미
+  // 가 있으려면 domain 이 먼저 와야 하고, 그 전에 project 가). add_concepts
+  // 는 cap 50 이라 여기 한 번에 land 가능한 수준이 아니면 chunk 가 필요
+  // 하지만 analyze 의 current heuristic 은 보통 30 이하라 하나로 충분.
+  const concepts = [];
+  if (result.project) {
+    concepts.push({
+      slug: result.project.slug,
+      kind: 'project',
+      title: result.project.title,
+    });
+  }
+  for (const d of result.domains ?? []) {
+    concepts.push({ slug: d.slug, kind: 'domain', title: d.title });
+  }
+  for (const c of result.capabilities ?? []) {
+    concepts.push({
+      slug: c.slug,
+      kind: 'capability',
+      title: c.title,
+      ...(c.domain ? { domain: c.domain } : {}),
+    });
+  }
+  for (const e of result.elements ?? []) {
+    concepts.push({
+      slug: e.slug,
+      kind: 'element',
+      title: e.title,
+      ...(e.domain ? { domain: e.domain } : {}),
+    });
+  }
+
+  let conceptsResult;
+  try {
+    conceptsResult = await callBatch(vaultRoot, 'add_concepts', { concepts });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  add_concepts: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  const relations = result.suggestedRelations ?? [];
+  let relationsResult = { concepts: [] };
+  if (relations.length > 0) {
+    try {
+      relationsResult = await callBatch(vaultRoot, 'add_relations', {
+        relations,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  add_relations: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+  }
+
+  // mcp 응답 shape — add_concepts 는 { concepts: [...] }, add_relations 는
+  // { relations: [...] }. 두 도구가 다른 키.
+  const conceptRows = conceptsResult.concepts ?? [];
+  const relationRows = relationsResult.relations ?? [];
+
+  const summary = summarize(conceptRows, relationRows);
+
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          rootPath: result.rootPath,
+          framework: result.framework,
+          applied: { concepts: conceptRows, relations: relationRows },
+          summary,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return summary.errors === 0 ? 0 : 1;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}analyze --apply${COLORS.reset} ${COLORS.dim}vault=${vaultRoot}${COLORS.reset}\n\n`,
+  );
+  process.stdout.write(
+    `  ${COLORS.bold}concepts${COLORS.reset}   ${COLORS.green}${summary.conceptsLanded}${COLORS.reset} landed · ` +
+      `${COLORS.dim}${summary.conceptsExisting}${COLORS.reset} already existed · ` +
+      `${summary.conceptsErrors > 0 ? COLORS.red : COLORS.dim}${summary.conceptsErrors}${COLORS.reset} errors\n`,
+  );
+  process.stdout.write(
+    `  ${COLORS.bold}relations${COLORS.reset}  ${COLORS.green}${summary.relationsLanded}${COLORS.reset} landed · ` +
+      `${COLORS.dim}${summary.relationsExisting}${COLORS.reset} already existed · ` +
+      `${summary.relationsErrors > 0 ? COLORS.red : COLORS.dim}${summary.relationsErrors}${COLORS.reset} errors\n\n`,
+  );
+  // 에러 행만 사용자에게 노출 (성공/idempotent 는 noise).
+  for (const row of conceptRows) {
+    if (row.ok === false) {
+      process.stdout.write(
+        `  ${COLORS.red}✗${COLORS.reset} ${row.slug} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+      );
+    }
+  }
+  for (const row of relationRows) {
+    if (row.ok === false) {
+      process.stdout.write(
+        `  ${COLORS.red}✗${COLORS.reset} ${row.from} —${row.type}→ ${row.to} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+      );
+    }
+  }
+  return summary.errors === 0 ? 0 : 1;
+}
+
+function summarize(conceptRows, relationRows) {
+  let conceptsLanded = 0;
+  let conceptsExisting = 0;
+  let conceptsErrors = 0;
+  for (const r of conceptRows) {
+    if (r.ok === true) conceptsLanded += 1;
+    else if (/already exists/i.test(r.error || '')) conceptsExisting += 1;
+    else conceptsErrors += 1;
+  }
+  let relationsLanded = 0;
+  let relationsExisting = 0;
+  let relationsErrors = 0;
+  for (const r of relationRows) {
+    if (r.ok === true && r.alreadyExists) relationsExisting += 1;
+    else if (r.ok === true) relationsLanded += 1;
+    else relationsErrors += 1;
+  }
+  return {
+    conceptsLanded,
+    conceptsExisting,
+    conceptsErrors,
+    relationsLanded,
+    relationsExisting,
+    relationsErrors,
+    errors: conceptsErrors + relationsErrors,
+  };
+}
+
+// callMcpTool 의 1차 wrapper 가 mcp 호출의 result.content[0].text 를 JSON.parse
+// 해서 그대로 반환 — 우리도 그 shape 가정.
+async function callBatch(vaultRoot, name, args) {
+  return callMcpTool(vaultRoot, name, args);
 }
 
 function printUsage() {
   process.stderr.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
-      `  oh-my-ontology analyze [rootPath] [--vault path] [--json] [--max-depth N]\n\n` +
+      `  oh-my-ontology analyze [rootPath] [--vault path] [--apply] [--json] [--max-depth N]\n\n` +
       `${COLORS.bold}What it does:${COLORS.reset}\n` +
       `  Walk a code repository (default: cwd), detect package.json / README\n` +
       `  H2 sections / src/ folders, propose ontology node candidates.\n` +
-      `  ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함. 사용자가 후보 검토 후\n` +
-      `  ${COLORS.bold}oh-my-ontology add${COLORS.reset} 또는 AI agent 의 add_concept 로 명시 작성.\n\n` +
-      `${COLORS.bold}Example:${COLORS.reset}\n` +
-      `  oh-my-ontology analyze\n` +
-      `  oh-my-ontology analyze ~/my-app --json\n`,
+      `  Default: ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함, 후보만 출력.\n` +
+      `  ${COLORS.bold}--apply${COLORS.reset}: 후보를 vault 에 batch land (add_concepts + add_relations).\n` +
+      `  partial result — 이미 존재하는 노드는 skip, 새 노드만 land.\n\n` +
+      `${COLORS.bold}Examples:${COLORS.reset}\n` +
+      `  oh-my-ontology analyze                 # preview only (no writes)\n` +
+      `  oh-my-ontology analyze ~/my-app --json # machine output\n` +
+      `  oh-my-ontology analyze --apply         # bootstrap vault from cwd\n`,
   );
 }

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -911,5 +911,117 @@ await test('merge — dry-run preview', async () => {
   }
 });
 
+// ── analyze --apply (R+ — agent-less bootstrap) ─────────────────────────
+//
+// CLI 가 analyze_repo_structure 결과를 add_concepts + add_relations 배치로
+// land. /ontology-bootstrap skill 의 CLI 짝.
+
+function makeRepoFixture() {
+  const repo = mkdtempSync(join(tmpdir(), 'cli-repo-'));
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify(
+      { name: 'test-app', description: 'Test app for analyze --apply' },
+      null,
+      2,
+    ),
+    'utf-8',
+  );
+  // FSD-ish layout — features 한 두개 만들어 capability 후보 생성.
+  mkdirSync(join(repo, 'src', 'features', 'auth'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'features', 'billing'), { recursive: true });
+  return repo;
+}
+
+await test('analyze --apply — concepts/relations vault 에 land', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r = await run([
+      'analyze',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+    ]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /analyze --apply/);
+    assert.match(clean, /concepts/);
+    // project (test-app) 노드가 vault 에 land 됐어야.
+    const projectFile = join(vault, 'test-app.md');
+    assert.equal(existsSyncTest(projectFile), true, 'project file landed');
+    const fm = readFileSync(projectFile, 'utf-8');
+    assert.match(fm, /kind: project/);
+    // analyze 가 pkg.description 을 title 로 사용 (혹은 fallback humanize).
+    assert.match(fm, /title: Test app for analyze --apply/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('analyze (default, no --apply) — vault 변경 0', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r = await run(['analyze', repo, '--vault', vault]);
+    assert.equal(r.code, 0);
+    // vault 에 새 .md 파일이 *없어야* 함 (default 는 read-only).
+    assert.equal(
+      existsSyncTest(join(vault, 'test-app.md')),
+      false,
+      'project file 안 만들어짐 (default mode)',
+    );
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('analyze --apply 두 번째 실행 → "already existed" 카운트, errors 0', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r1 = await run(['analyze', repo, '--vault', vault, '--apply']);
+    assert.equal(r1.code, 0);
+    const r2 = await run(['analyze', repo, '--vault', vault, '--apply']);
+    assert.equal(r2.code, 0, `2번째 실행 실패: ${r2.stdout}\n${r2.stderr}`);
+    const clean = stripAnsi(r2.stdout);
+    // 모두 already existed (concept side) + 모두 already existed (relation side, idempotent).
+    assert.match(clean, /already existed/);
+    // errors 0
+    assert.match(clean, /0 errors/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('analyze --apply --json — applied / summary 필드 노출', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r = await run([
+      'analyze',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.applied, 'applied 필드 있음');
+    assert.ok(Array.isArray(data.applied.concepts), 'applied.concepts 배열');
+    assert.ok(Array.isArray(data.applied.relations), 'applied.relations 배열');
+    assert.ok(data.summary, 'summary 필드 있음');
+    assert.equal(typeof data.summary.errors, 'number');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 console.log(`\ncli integration: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

cycle 26 의 \`/ontology-bootstrap\` skill update 가 \"CLI 는 batch 미지원이라 K round-trip\" 으로 명시했던 마찰을 제거. CLI 자체로 \`analyze_repo_structure\` 결과를 \`add_concepts\` + \`add_relations\` 배치로 land — agent (Claude Code, Cursor) 가 없는 환경 (CI · plain shell · agent-less 흐름) 도 1줄로 vault 부트스트랩.

## 흐름

\`\`\`bash
oh-my-ontology analyze .             # preview only (default, side-effect 0)
oh-my-ontology analyze . --apply     # land 모든 후보 (concepts + relations)
oh-my-ontology analyze . --apply --json  # 머신 가독 출력
\`\`\`

## 설계

- \`--apply\` 미지정 default 는 read-only (현재 동작 유지). 사용자 명시 opt-in 으로만 vault 쓰기 → \"git push --force\" UX.
- \`concepts[] = [project, ...domains, ...capabilities, ...elements]\` — \`add_concepts\` 1 회. \`add_relations\` 는 \`suggestedRelations\` 그대로.
- partial result 노출 — \"N landed · M already existed · K errors\" 형식. 에러 행만 ✗ 로 surface.
- 두번째 실행 idempotent — 모두 already exists / alreadyExists, errors 0.
- exit 0 if errors === 0, else 1.
- \`--json\` 시 \`{ applied: { concepts, relations }, summary }\` 머신 가독.

## Test plan

- [x] cli integration 41 → 45 (+4 — apply land · default read-only · idempotent 두번째 실행 · --json shape)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839 (vitest, 변동 없음 — CLI integration 은 별도 runner)
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] backward compat — \`--apply\` 없으면 기존 동작 그대로

## Out of scope

- \`--pick\` interactive (per-row accept/reject) — TUI 가 필요해 별 cycle. agent flow 가 이미 그 케이스 cover.
- \`--apply\` confirmation prompt — 명시적 \`--apply\` 입력 자체가 의도. CI-friendly.
- 모노레포 chunk 분할 (50 cap 초과) — 일반적 monorepo 도 30 후보 이하라 deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)