### PR TITLE
feat(cli): infer-imports --apply 플래그 — agent-less depends_on 일괄 land

### DIFF
--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -109,7 +109,11 @@ Show the kind census diff in the reply (e.g. *"Vault grew 5 → 18 nodes (+3 dom
 - **`missing-expected-field` warning on a per-row `warnings: [...]`** — a capability or element was added without `domain:`. Tolerable for bootstrap (vault still validates), but surface the warnings to the user so they can backfill.
 - **`add_relations` row returns `ok: false` with "does not exist"** — an endpoint was rejected in the `add_concepts` step. Confirm and either drop the relation or add the missing concept first.
 - **`add_relations` row returns `alreadyExists: true`** — that edge was already present (idempotent). Not an error; surface as informational only.
-- **MCP unavailable in this session** — fall back to the CLI: `oh-my-ontology analyze . --apply` lands every candidate via the same `add_concepts` + `add_relations` batch (R+). Or `oh-my-ontology analyze .` first to preview, then re-run with `--apply`. For per-row picking, drop `--apply` and call `oh-my-ontology add <kind> <slug> --title=...` for accepted ones (K round-trips, but only when curating).
+- **MCP unavailable in this session** — fall back to the CLI:
+  - `oh-my-ontology analyze . --apply` lands every node candidate via the same `add_concepts` + `add_relations` batch (R+).
+  - `oh-my-ontology infer-imports . --apply` then lands `depends_on` edges from the TS/JS import graph (50-row chunks).
+  - Together these two commands give agent-less full bootstrap (nodes + import edges) without K-round-trip CLI loops.
+  - For per-row picking, drop `--apply` and call `oh-my-ontology add <kind> <slug> --title=...` for accepted ones (K round-trips, but only when curating).
 - **Repo too deep / monorepo** — pass `rootPath` for the relevant subdirectory, or run `analyze` per package and merge results.
 
 ## Reply discipline

--- a/cli/src/commands/infer-imports.mjs
+++ b/cli/src/commands/infer-imports.mjs
@@ -16,7 +16,7 @@ const COLORS = {
 };
 
 export async function runInferImports(args) {
-  const { rootPath, vault, json, maxFiles, error } = parseArgs(args);
+  const { rootPath, vault, json, maxFiles, apply, error } = parseArgs(args);
   if (error) {
     process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
     printUsage();
@@ -37,6 +37,12 @@ export async function runInferImports(args) {
       `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return 2;
+  }
+
+  // R+ — --apply 분기. moduleEdges 를 depends_on 관계로 batch land.
+  // analyze --apply (cycle 29) 와 짝 — agent-less full bootstrap pair.
+  if (apply) {
+    return await runApply(vaultRoot, result, json);
   }
 
   if (json) {
@@ -79,13 +85,14 @@ export async function runInferImports(args) {
 }
 
 function parseArgs(args) {
-  const flags = { vault: '.', json: false };
+  const flags = { vault: '.', json: false, apply: false };
   const positional = [];
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     if (a === '--vault') flags.vault = args[++i] || '.';
     else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
     else if (a === '--json') flags.json = true;
+    else if (a === '--apply') flags.apply = true;
     else if (a === '--max-files')
       flags.maxFiles = Number(args[++i]) || undefined;
     else if (a.startsWith('--max-files='))
@@ -97,23 +104,114 @@ function parseArgs(args) {
     rootPath: positional[0] ?? '.',
     vault: flags.vault,
     json: flags.json,
+    apply: flags.apply,
     maxFiles: flags.maxFiles,
   };
+}
+
+// R+ — moduleEdges → depends_on 관계 batch land. analyze --apply 의 짝.
+// 50 cap 초과시 자동 chunk 분할 — moduleEdges 는 큰 codebase 면 100+ 도 쉽게.
+async function runApply(vaultRoot, result, json) {
+  const moduleEdges = result.moduleEdges ?? [];
+  const relations = moduleEdges.map((m) => ({
+    from: m.from,
+    to: m.to,
+    type: 'depends_on',
+  }));
+
+  // chunk in batches of 50 (add_relations cap).
+  const allRows = [];
+  for (let i = 0; i < relations.length; i += 50) {
+    const chunk = relations.slice(i, i + 50);
+    let res;
+    try {
+      res = await callMcpTool(vaultRoot, 'add_relations', { relations: chunk });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  add_relations chunk @${i}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+    for (const row of res.relations ?? []) allRows.push(row);
+  }
+
+  const summary = summarizeRelations(allRows);
+
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          rootPath: result.rootPath,
+          filesScanned: result.filesScanned,
+          applied: { relations: allRows },
+          summary,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return summary.errors === 0 ? 0 : 1;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}infer-imports --apply${COLORS.reset} ${COLORS.dim}vault=${vaultRoot}${COLORS.reset}\n\n`,
+  );
+  process.stdout.write(
+    `  ${COLORS.bold}depends_on relations${COLORS.reset}  ` +
+      `${COLORS.green}${summary.landed}${COLORS.reset} landed · ` +
+      `${COLORS.dim}${summary.existing}${COLORS.reset} already existed · ` +
+      `${summary.errors > 0 ? COLORS.red : COLORS.dim}${summary.errors}${COLORS.reset} errors ` +
+      `${COLORS.dim}(of ${allRows.length} edges)${COLORS.reset}\n\n`,
+  );
+  // 에러 행만 노출 (성공/idempotent 는 noise). 큰 codebase 면 모두 missing
+  // slug 일 수 있어 first 12 만 표시.
+  let errCount = 0;
+  for (const row of allRows) {
+    if (row.ok === false) {
+      if (errCount < 12) {
+        process.stdout.write(
+          `  ${COLORS.red}✗${COLORS.reset} ${row.from} —${row.type}→ ${row.to} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        );
+      }
+      errCount += 1;
+    }
+  }
+  if (errCount > 12) {
+    process.stdout.write(
+      `  ${COLORS.dim}… ${errCount - 12} more errors${COLORS.reset}\n`,
+    );
+  }
+  return summary.errors === 0 ? 0 : 1;
+}
+
+function summarizeRelations(rows) {
+  let landed = 0;
+  let existing = 0;
+  let errors = 0;
+  for (const r of rows) {
+    if (r.ok === true && r.alreadyExists) existing += 1;
+    else if (r.ok === true) landed += 1;
+    else errors += 1;
+  }
+  return { landed, existing, errors };
 }
 
 function printUsage() {
   process.stderr.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
-      `  oh-my-ontology infer-imports [rootPath] [--vault path] [--json] [--max-files N]\n\n` +
+      `  oh-my-ontology infer-imports [rootPath] [--vault path] [--apply] [--json] [--max-files N]\n\n` +
       `${COLORS.bold}What it does:${COLORS.reset}\n` +
       `  Walk TS/JS files (default: src,lib,app,packages → fallback rootPath),\n` +
       `  parse imports (static / dynamic / require / re-export / side-effect),\n` +
       `  resolve relative paths, classify external (npm) vs internal (relative),\n` +
       `  collapse to module edges (capability A → B with import count).\n\n` +
-      `  ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함. moduleEdges 가\n` +
-      `  AI agent 또는 사용자가 ${COLORS.bold}add_relation depends_on${COLORS.reset} 후보로 사용.\n\n` +
-      `${COLORS.bold}Example:${COLORS.reset}\n` +
-      `  oh-my-ontology infer-imports\n` +
-      `  oh-my-ontology infer-imports ~/my-app --json --max-files 10000\n`,
+      `  Default: ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함, moduleEdges 만 출력.\n` +
+      `  ${COLORS.bold}--apply${COLORS.reset}: moduleEdges 를 depends_on 관계로 batch land\n` +
+      `  (50 단위 chunk, partial — 없는 endpoint 는 row-level error).\n\n` +
+      `${COLORS.bold}Examples:${COLORS.reset}\n` +
+      `  oh-my-ontology infer-imports                    # preview only\n` +
+      `  oh-my-ontology infer-imports ~/my-app --json    # machine output\n` +
+      `  oh-my-ontology infer-imports --apply            # land depends_on edges\n`,
   );
 }

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1023,5 +1023,141 @@ await test('analyze --apply --json — applied / summary 필드 노출', async (
   }
 });
 
+// ── infer-imports --apply (R+ — agent-less depends_on landing) ──────────
+//
+// analyze --apply 의 짝. moduleEdges 를 depends_on 관계로 batch land.
+
+function makeImportRepo() {
+  // 두 capability (a, b) 가 a → b 로 import. moduleEdges 가 1 개 나옴.
+  const repo = mkdtempSync(join(tmpdir(), 'cli-imp-'));
+  mkdirSync(join(repo, 'src', 'a'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'b'), { recursive: true });
+  writeFileSync(
+    join(repo, 'src', 'a', 'index.ts'),
+    "import { x } from '../b';\nexport const z = x;\n",
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'b', 'index.ts'),
+    'export const x = 1;\n',
+    'utf-8',
+  );
+  return repo;
+}
+
+await test('infer-imports --apply — depends_on 관계 land (endpoints 존재 시)', async () => {
+  const vault = withVault([
+    {
+      slug: 'a',
+      content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n',
+    },
+    {
+      slug: 'b',
+      content: '---\nkind: capability\ntitle: B\ndomain: x\n---\n',
+    },
+  ]);
+  const repo = makeImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+    ]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /infer-imports --apply/);
+    assert.match(clean, /landed|already existed/);
+    // a.md 의 frontmatter 에 dependencies (inline 또는 list) 에 b 포함.
+    const aDoc = readFileSync(join(vault, 'a.md'), 'utf-8');
+    assert.match(aDoc, /dependencies:.*\bb\b/s);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports (default) — vault 변경 0', async () => {
+  const vault = withVault([
+    {
+      slug: 'a',
+      content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n',
+    },
+  ]);
+  const repo = makeImportRepo();
+  try {
+    const before = readFileSync(join(vault, 'a.md'), 'utf-8');
+    const r = await run(['infer-imports', repo, '--vault', vault]);
+    assert.equal(r.code, 0);
+    const after = readFileSync(join(vault, 'a.md'), 'utf-8');
+    assert.equal(after, before, 'a.md 내용 그대로 (default 모드)');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --apply — endpoint 없으면 row-level error, batch 살아남음', async () => {
+  // vault 에 a 만 있고 b 가 없음 — a → b edge 는 fail 행, batch 자체는 OK.
+  const vault = withVault([
+    {
+      slug: 'a',
+      content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n',
+    },
+  ]);
+  const repo = makeImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+    ]);
+    // 적어도 한 row 가 fail → exit 1.
+    assert.equal(r.code, 1, `expected exit 1; stdout: ${r.stdout}`);
+    const clean = stripAnsi(r.stdout);
+    // 에러 행 노출.
+    assert.match(clean, /✗|does not exist|errors/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --apply --json — applied / summary 필드 노출', async () => {
+  const vault = withVault([
+    {
+      slug: 'a',
+      content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n',
+    },
+    {
+      slug: 'b',
+      content: '---\nkind: capability\ntitle: B\ndomain: x\n---\n',
+    },
+  ]);
+  const repo = makeImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.applied, 'applied 필드');
+    assert.ok(Array.isArray(data.applied.relations), 'applied.relations 배열');
+    assert.ok(data.summary, 'summary 필드');
+    assert.equal(typeof data.summary.errors, 'number');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 console.log(`\ncli integration: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

cycle 29 의 \`analyze --apply\` 짝. \`moduleEdges\` 를 \`depends_on\` 관계로 batch land — \`analyze\` 가 노드를 채웠다면 \`infer-imports\` 는 import-graph 기반 edge 를 채움. 둘 합쳐 **agent-less full bootstrap (nodes + import edges)**.

## 흐름

\`\`\`bash
oh-my-ontology analyze . --apply           # 1) 노드 batch land
oh-my-ontology infer-imports . --apply     # 2) depends_on edges batch land
\`\`\`

## 설계

- \`--apply\` 미지정 default 는 read-only (현재 동작 유지).
- \`moduleEdges → relations[] = [{from, to, type: 'depends_on'}, ...]\`.
- 50-row chunk — 큰 codebase (100+ edges) 도 안전. 각 chunk 가 1 회의 \`add_relations\` 호출, partial result.
- partial result — endpoint 가 vault 에 없으면 row-level \"does not exist\" error. analyze 후 imports apply 하는 일반 흐름이면 자연 OK.
- 에러 행만 ✗ 노출, first 12 + \"… N more errors\" rest cap (큰 codebase noise 방지).
- exit 0 if errors === 0, else 1.

## Test plan

- [x] cli integration 45 → 49 (+4 — apply land · default read-only · missing endpoint partial · --json shape)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839 (vitest 변동 없음)
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] backward compat — \`--apply\` 없으면 기존 동작 그대로

## Out of scope

- \`--type\` 플래그 (다른 관계 타입 적용) — depends_on 이 import 의 자연 매핑이라 단일 type 으로 고정.
- \`--threshold\` (count 기반 필터, 약한 import 제외) — 다음 cycle 후보. 큰 codebase 의 noise 차단용.
- bidirectional dedup — moduleEdges 가 이미 from→to 단방향 collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)