### PR TITLE
feat(cli): infer-imports --threshold N — 약한 module edge 필터 (큰 codebase noise 차단)

### DIFF
--- a/cli/src/commands/infer-imports.mjs
+++ b/cli/src/commands/infer-imports.mjs
@@ -16,7 +16,8 @@ const COLORS = {
 };
 
 export async function runInferImports(args) {
-  const { rootPath, vault, json, maxFiles, apply, error } = parseArgs(args);
+  const { rootPath, vault, json, maxFiles, apply, threshold, error } =
+    parseArgs(args);
   if (error) {
     process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
     printUsage();
@@ -39,6 +40,19 @@ export async function runInferImports(args) {
     return 2;
   }
 
+  // R+ — --threshold N 필터 (count >= N). 큰 codebase 의 약한 import (count=1
+  // accidental) 가 ontology 에 노이즈 들어가는 걸 차단. moduleEdges 만 적용
+  // (file-level edges/external/unresolved 는 그대로 — agent diagnostic 용).
+  let filteredOut = 0;
+  if (threshold && threshold > 1 && Array.isArray(result.moduleEdges)) {
+    const before = result.moduleEdges.length;
+    result.moduleEdges = result.moduleEdges.filter(
+      (m) => Number(m.count) >= threshold,
+    );
+    filteredOut = before - result.moduleEdges.length;
+    result.thresholdApplied = { threshold, filteredOut };
+  }
+
   // R+ — --apply 분기. moduleEdges 를 depends_on 관계로 batch land.
   // analyze --apply (cycle 29) 와 짝 — agent-less full bootstrap pair.
   if (apply) {
@@ -59,6 +73,12 @@ export async function runInferImports(args) {
     `${COLORS.bold}infer-imports${COLORS.reset} ${COLORS.dim}${target}${COLORS.reset} ` +
       `${COLORS.dim}— ${result.filesScanned} files / ${fileEdges} edges / ${ext} external / ${unres} unresolved${COLORS.reset}\n\n`,
   );
+
+  if (filteredOut > 0) {
+    process.stdout.write(
+      `  ${COLORS.dim}--threshold ${threshold} filtered ${filteredOut} weak edges (count < ${threshold})${COLORS.reset}\n\n`,
+    );
+  }
 
   if (modEdges.length > 0) {
     process.stdout.write(
@@ -97,7 +117,17 @@ function parseArgs(args) {
       flags.maxFiles = Number(args[++i]) || undefined;
     else if (a.startsWith('--max-files='))
       flags.maxFiles = Number(a.slice('--max-files='.length)) || undefined;
-    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else if (a === '--threshold') {
+      const v = Number(args[++i]);
+      if (!Number.isFinite(v) || v < 1)
+        return { error: '--threshold must be a positive integer' };
+      flags.threshold = v;
+    } else if (a.startsWith('--threshold=')) {
+      const v = Number(a.slice('--threshold='.length));
+      if (!Number.isFinite(v) || v < 1)
+        return { error: '--threshold must be a positive integer' };
+      flags.threshold = v;
+    } else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
     else positional.push(a);
   }
   return {
@@ -106,6 +136,7 @@ function parseArgs(args) {
     json: flags.json,
     apply: flags.apply,
     maxFiles: flags.maxFiles,
+    threshold: flags.threshold,
   };
 }
 
@@ -200,7 +231,8 @@ function summarizeRelations(rows) {
 function printUsage() {
   process.stderr.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
-      `  oh-my-ontology infer-imports [rootPath] [--vault path] [--apply] [--json] [--max-files N]\n\n` +
+      `  oh-my-ontology infer-imports [rootPath] [--vault path] [--apply] [--json]\n` +
+      `                              [--max-files N] [--threshold N]\n\n` +
       `${COLORS.bold}What it does:${COLORS.reset}\n` +
       `  Walk TS/JS files (default: src,lib,app,packages → fallback rootPath),\n` +
       `  parse imports (static / dynamic / require / re-export / side-effect),\n` +
@@ -208,10 +240,14 @@ function printUsage() {
       `  collapse to module edges (capability A → B with import count).\n\n` +
       `  Default: ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함, moduleEdges 만 출력.\n` +
       `  ${COLORS.bold}--apply${COLORS.reset}: moduleEdges 를 depends_on 관계로 batch land\n` +
-      `  (50 단위 chunk, partial — 없는 endpoint 는 row-level error).\n\n` +
+      `  (50 단위 chunk, partial — 없는 endpoint 는 row-level error).\n` +
+      `  ${COLORS.bold}--threshold N${COLORS.reset}: count < N 인 약한 module edge 를 필터.\n` +
+      `  큰 codebase 의 accidental cross-feature import 가 ontology 에\n` +
+      `  들어가는 걸 차단. preview / --apply / --json 모두 적용.\n\n` +
       `${COLORS.bold}Examples:${COLORS.reset}\n` +
-      `  oh-my-ontology infer-imports                    # preview only\n` +
-      `  oh-my-ontology infer-imports ~/my-app --json    # machine output\n` +
-      `  oh-my-ontology infer-imports --apply            # land depends_on edges\n`,
+      `  oh-my-ontology infer-imports                       # preview only\n` +
+      `  oh-my-ontology infer-imports ~/my-app --json       # machine output\n` +
+      `  oh-my-ontology infer-imports --apply               # land depends_on edges\n` +
+      `  oh-my-ontology infer-imports --apply --threshold 3 # only count ≥ 3 edges\n`,
   );
 }

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1159,5 +1159,168 @@ await test('infer-imports --apply --json — applied / summary 필드 노출', a
   }
 });
 
+// ── infer-imports --threshold N (R+ — weak edge 차단) ────────────────────
+
+function makeStrongImportRepo() {
+  // a 가 b 를 3번 import (count 3), c 를 1번 import (count 1).
+  const repo = mkdtempSync(join(tmpdir(), 'cli-thr-'));
+  mkdirSync(join(repo, 'src', 'a'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'b'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'c'), { recursive: true });
+  // a 안 3개 파일이 b 를 import → b 는 count=3
+  writeFileSync(
+    join(repo, 'src', 'a', 'one.ts'),
+    "import { x } from '../b';\nexport const a1 = x;\n",
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'a', 'two.ts'),
+    "import { x } from '../b';\nexport const a2 = x;\n",
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'a', 'three.ts'),
+    "import { x } from '../b';\nexport const a3 = x;\n",
+    'utf-8',
+  );
+  // a/four 만 c 를 import → c 는 count=1 (weak)
+  writeFileSync(
+    join(repo, 'src', 'a', 'four.ts'),
+    "import { y } from '../c';\nexport const a4 = y;\n",
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'b', 'index.ts'),
+    'export const x = 1;\n',
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'c', 'index.ts'),
+    'export const y = 1;\n',
+    'utf-8',
+  );
+  return repo;
+}
+
+await test('infer-imports --threshold 3 — count < 3 edges 필터 (preview 모드)', async () => {
+  const vault = withVault([]);
+  const repo = makeStrongImportRepo();
+  try {
+    // 사전 — threshold 없이는 a→b · a→c 두 edge 모두 보여야 함.
+    const noThr = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--json',
+    ]);
+    assert.equal(noThr.code, 0);
+    const noThrData = JSON.parse(noThr.stdout);
+    assert.ok(
+      noThrData.moduleEdges.length >= 2,
+      `expected 2+ edges, got ${noThrData.moduleEdges.length}`,
+    );
+
+    // threshold 3 — count < 3 인 a→c 는 제외.
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--threshold',
+      '3',
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.moduleEdges.length < noThrData.moduleEdges.length);
+    for (const m of data.moduleEdges) {
+      assert.ok(m.count >= 3, `${m.from}→${m.to} count=${m.count} should be ≥3`);
+    }
+    // thresholdApplied 메타데이터.
+    assert.ok(data.thresholdApplied);
+    assert.equal(data.thresholdApplied.threshold, 3);
+    assert.ok(data.thresholdApplied.filteredOut >= 1);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --threshold 3 --apply — 약한 edge 는 land 안 됨', async () => {
+  // vault 에 a, b, c 모두 존재 — threshold 없으면 a→b, a→c 둘 다 land.
+  // threshold 3 면 a→b 만 land, a→c 는 filtered out (depend on c 안 생김).
+  const vault = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n' },
+    { slug: 'b', content: '---\nkind: capability\ntitle: B\ndomain: x\n---\n' },
+    { slug: 'c', content: '---\nkind: capability\ntitle: C\ndomain: x\n---\n' },
+  ]);
+  const repo = makeStrongImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+      '--threshold',
+      '3',
+    ]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const aDoc = readFileSync(join(vault, 'a.md'), 'utf-8');
+    // a 는 b 의존 (count=3, ≥ threshold).
+    assert.match(aDoc, /dependencies:.*\bb\b/s);
+    // a 는 c 의존 *없음* (count=1, < threshold) — filter out.
+    assert.doesNotMatch(aDoc, /\bc\b/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --threshold 0 (또는 미지정) — 변경 없음', async () => {
+  const vault = withVault([]);
+  const repo = makeStrongImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--threshold',
+      '1',
+      '--json',
+    ]);
+    // threshold=1 이면 count >= 1 — 사실상 모든 edge. 필터 메타데이터도 안 붙음
+    // (코드가 threshold > 1 일 때만 필터).
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.thresholdApplied, undefined);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --threshold abc — 잘못된 입력 거부', async () => {
+  const vault = withVault([]);
+  const repo = makeStrongImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--threshold',
+      'abc',
+    ]);
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, /threshold/i);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 console.log(`\ncli integration: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

cycle 30 의 \`--apply\` 후속. 큰 codebase 에서 accidental cross-feature import (count=1) 가 ontology 에 \`depends_on\` 으로 들어가면 그래프 노이즈. \`--threshold N\` 으로 \`count >= N\` 만 통과시켜 *의도된* 의존만 반영.

## 활용

\`\`\`bash
oh-my-ontology infer-imports --apply --threshold 3
# 3+ import 만 depends_on 관계로 land. monorepo / 큰 codebase 에서
# 의미있는 의존만 ontology 에 반영.
\`\`\`

## 설계

- preview / \`--apply\` / \`--json\` 모두 적용 (한 곳에서 \`result.moduleEdges\` 필터).
- threshold ≤ 1 이면 효과 없음 (모든 count ≥ 1, no-op). ≥ 2 일 때만 실제 필터 + \`result.thresholdApplied\` 메타데이터 부착 (json 노출).
- 잘못된 입력 (\`--threshold abc\` / \`0\` / 음수) 거부 — 양수 정수만.
- file-level edges / external / unresolved 는 *그대로* — agent diagnostic 용 (모듈 단위 ontology edge 만 noise 차단).

## Test plan

- [x] cli integration 49 → 53 (+4 — preview 필터 / --apply 약한 edge skip / threshold=1 no-op / abc 거부)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] backward compat — \`--threshold\` 미지정 / =1 시 기존 동작 그대로

## Out of scope

- MCP \`infer_imports\` 도구 자체에 \`threshold\` 파라미터 — CLI-level 후처리로 충분 (mcp 응답은 변경 없음, agent 가 직접 필터링도 가능).
- \`--exclude-pattern\` (글로벌 패턴 기반 필터) — 다음 cycle 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)