### PR TITLE
feat(cli): bootstrap 명령 — analyze --apply + infer-imports --apply 합본 (1줄 full bootstrap)

### DIFF
--- a/cli/src/commands/bootstrap.mjs
+++ b/cli/src/commands/bootstrap.mjs
@@ -1,0 +1,381 @@
+// R+ — `oh-my-ontology bootstrap [rootPath]`
+//
+// 1줄 full bootstrap. analyze --apply (노드) → infer-imports --apply (depends_on
+// 엣지) 를 한 명령으로 묶는다. agent-less 환경 (CI · plain shell) 또는 새 repo
+// 진입 직후 가장 자주 쓰는 흐름이라 명령으로 승격.
+//
+// 흐름:
+//   1. analyze_repo_structure → add_concepts + add_relations (cycle 29)
+//   2. infer_imports → add_relations (depends_on, cycle 30)
+//   3. 통합 summary 출력 (concepts landed/existing/errors + relations)
+//
+// 옵션:
+//   --vault path             vault 위치 (default cwd)
+//   --max-depth N            analyze folder depth
+//   --max-files N            infer-imports file cap
+//   --threshold N            infer-imports 약한 edge 차단 (cycle 33, default 없음)
+//   --skip-imports           1단계 (analyze) 만 — import graph 안 건드림
+//   --json                   머신 가독 출력 (모든 단계 결과 합쳐 한 JSON)
+//
+// exit: 0 if 모든 단계 errors 0, 1 if 어느 단계 errors > 0, 2 if mcp 실패.
+
+import { resolve } from 'node:path';
+import { callMcpTool } from '../lib/mcp-call.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runBootstrap(args) {
+  const parsed = parseArgs(args);
+  if (parsed.error) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${parsed.error}\n`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  const target = resolve(process.cwd(), parsed.rootPath);
+  const vaultRoot = resolve(process.cwd(), parsed.vault);
+
+  // Stage 1 — analyze + apply.
+  let analyzeResult;
+  try {
+    analyzeResult = await callMcpTool(vaultRoot, 'analyze_repo_structure', {
+      rootPath: target,
+      maxDepth: parsed.maxDepth,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  analyze: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  const concepts = collectConcepts(analyzeResult);
+  let conceptsRows = [];
+  if (concepts.length > 0) {
+    try {
+      const r = await callMcpTool(vaultRoot, 'add_concepts', { concepts });
+      conceptsRows = r.concepts ?? [];
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  add_concepts: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+  }
+
+  const suggested = analyzeResult.suggestedRelations ?? [];
+  const analyzeRelationsRows = await applyRelations(vaultRoot, suggested);
+  if (analyzeRelationsRows === null) return 2;
+
+  // Stage 2 — infer-imports + apply (--skip-imports 면 생략).
+  let importsResult = null;
+  let importsRows = [];
+  if (!parsed.skipImports) {
+    try {
+      importsResult = await callMcpTool(vaultRoot, 'infer_imports', {
+        rootPath: target,
+        maxFiles: parsed.maxFiles,
+      });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  infer_imports: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return 2;
+    }
+    let edges = Array.isArray(importsResult.moduleEdges)
+      ? importsResult.moduleEdges
+      : [];
+    let filteredOut = 0;
+    if (parsed.threshold && parsed.threshold > 1) {
+      const before = edges.length;
+      edges = edges.filter((m) => Number(m.count) >= parsed.threshold);
+      filteredOut = before - edges.length;
+      importsResult.thresholdApplied = {
+        threshold: parsed.threshold,
+        filteredOut,
+      };
+    }
+    const importRelations = edges.map((e) => ({
+      from: e.from,
+      to: e.to,
+      type: 'depends_on',
+    }));
+    const rows = await applyRelations(vaultRoot, importRelations);
+    if (rows === null) return 2;
+    importsRows = rows;
+  }
+
+  const summary = combineSummary(
+    conceptsRows,
+    analyzeRelationsRows,
+    importsRows,
+  );
+
+  if (parsed.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          rootPath: analyzeResult.rootPath,
+          framework: analyzeResult.framework,
+          analyze: {
+            concepts: conceptsRows,
+            relations: analyzeRelationsRows,
+          },
+          imports: parsed.skipImports
+            ? null
+            : {
+                filesScanned: importsResult?.filesScanned,
+                thresholdApplied: importsResult?.thresholdApplied,
+                relations: importsRows,
+              },
+          summary,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return summary.errors === 0 ? 0 : 1;
+  }
+
+  process.stdout.write(
+    `${COLORS.bold}bootstrap${COLORS.reset} ${COLORS.dim}repo=${target}\n           vault=${vaultRoot}${COLORS.reset}\n\n`,
+  );
+  process.stdout.write(
+    `  ${COLORS.bold}1) analyze${COLORS.reset}    concepts: ` +
+      `${COLORS.green}${summary.conceptsLanded}${COLORS.reset} landed · ` +
+      `${COLORS.dim}${summary.conceptsExisting}${COLORS.reset} already existed · ` +
+      `${summary.conceptsErrors > 0 ? COLORS.red : COLORS.dim}${summary.conceptsErrors}${COLORS.reset} errors\n`,
+  );
+  process.stdout.write(
+    `                relations (suggested): ` +
+      `${COLORS.green}${summary.analyzeRelationsLanded}${COLORS.reset} landed · ` +
+      `${COLORS.dim}${summary.analyzeRelationsExisting}${COLORS.reset} already existed · ` +
+      `${summary.analyzeRelationsErrors > 0 ? COLORS.red : COLORS.dim}${summary.analyzeRelationsErrors}${COLORS.reset} errors\n`,
+  );
+  if (parsed.skipImports) {
+    process.stdout.write(
+      `  ${COLORS.dim}2) imports     skipped (--skip-imports)${COLORS.reset}\n`,
+    );
+  } else {
+    const thr = importsResult?.thresholdApplied;
+    process.stdout.write(
+      `  ${COLORS.bold}2) imports${COLORS.reset}    depends_on: ` +
+        `${COLORS.green}${summary.importsLanded}${COLORS.reset} landed · ` +
+        `${COLORS.dim}${summary.importsExisting}${COLORS.reset} already existed · ` +
+        `${summary.importsErrors > 0 ? COLORS.red : COLORS.dim}${summary.importsErrors}${COLORS.reset} errors` +
+        (thr
+          ? ` ${COLORS.dim}(--threshold ${thr.threshold} filtered ${thr.filteredOut})${COLORS.reset}`
+          : '') +
+        '\n',
+    );
+  }
+  process.stdout.write('\n');
+
+  // 에러 행만 노출 — first 12 + summary.
+  let errCount = 0;
+  for (const row of conceptsRows) {
+    if (row.ok === false) {
+      if (errCount < 12) {
+        process.stdout.write(
+          `  ${COLORS.red}✗${COLORS.reset} concept ${row.slug} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        );
+      }
+      errCount += 1;
+    }
+  }
+  for (const row of analyzeRelationsRows) {
+    if (row.ok === false) {
+      if (errCount < 12) {
+        process.stdout.write(
+          `  ${COLORS.red}✗${COLORS.reset} suggested ${row.from} —${row.type}→ ${row.to} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        );
+      }
+      errCount += 1;
+    }
+  }
+  for (const row of importsRows) {
+    if (row.ok === false) {
+      if (errCount < 12) {
+        process.stdout.write(
+          `  ${COLORS.red}✗${COLORS.reset} import ${row.from} —${row.type}→ ${row.to} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        );
+      }
+      errCount += 1;
+    }
+  }
+  if (errCount > 12) {
+    process.stdout.write(
+      `  ${COLORS.dim}… ${errCount - 12} more errors${COLORS.reset}\n`,
+    );
+  }
+
+  return summary.errors === 0 ? 0 : 1;
+}
+
+function collectConcepts(analyzeResult) {
+  const out = [];
+  if (analyzeResult.project) {
+    out.push({
+      slug: analyzeResult.project.slug,
+      kind: 'project',
+      title: analyzeResult.project.title,
+    });
+  }
+  for (const d of analyzeResult.domains ?? []) {
+    out.push({ slug: d.slug, kind: 'domain', title: d.title });
+  }
+  for (const c of analyzeResult.capabilities ?? []) {
+    out.push({
+      slug: c.slug,
+      kind: 'capability',
+      title: c.title,
+      ...(c.domain ? { domain: c.domain } : {}),
+    });
+  }
+  for (const e of analyzeResult.elements ?? []) {
+    out.push({
+      slug: e.slug,
+      kind: 'element',
+      title: e.title,
+      ...(e.domain ? { domain: e.domain } : {}),
+    });
+  }
+  return out;
+}
+
+// add_relations 의 50-row chunk 분할. 호출 실패 (mcp throw) 시 null 리턴.
+async function applyRelations(vaultRoot, relations) {
+  if (!Array.isArray(relations) || relations.length === 0) return [];
+  const all = [];
+  for (let i = 0; i < relations.length; i += 50) {
+    const chunk = relations.slice(i, i + 50);
+    let res;
+    try {
+      res = await callMcpTool(vaultRoot, 'add_relations', { relations: chunk });
+    } catch (err) {
+      process.stderr.write(
+        `${COLORS.red}error${COLORS.reset}  add_relations chunk @${i}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return null;
+    }
+    for (const r of res.relations ?? []) all.push(r);
+  }
+  return all;
+}
+
+function combineSummary(conceptsRows, analyzeRelRows, importsRows) {
+  const conceptStats = countConcepts(conceptsRows);
+  const analyzeRelStats = countRelations(analyzeRelRows);
+  const importStats = countRelations(importsRows);
+  return {
+    conceptsLanded: conceptStats.landed,
+    conceptsExisting: conceptStats.existing,
+    conceptsErrors: conceptStats.errors,
+    analyzeRelationsLanded: analyzeRelStats.landed,
+    analyzeRelationsExisting: analyzeRelStats.existing,
+    analyzeRelationsErrors: analyzeRelStats.errors,
+    importsLanded: importStats.landed,
+    importsExisting: importStats.existing,
+    importsErrors: importStats.errors,
+    errors:
+      conceptStats.errors + analyzeRelStats.errors + importStats.errors,
+  };
+}
+
+function countConcepts(rows) {
+  let landed = 0;
+  let existing = 0;
+  let errors = 0;
+  for (const r of rows) {
+    if (r.ok === true) landed += 1;
+    else if (/already exists/i.test(r.error || '')) existing += 1;
+    else errors += 1;
+  }
+  return { landed, existing, errors };
+}
+
+function countRelations(rows) {
+  let landed = 0;
+  let existing = 0;
+  let errors = 0;
+  for (const r of rows) {
+    if (r.ok === true && r.alreadyExists) existing += 1;
+    else if (r.ok === true) landed += 1;
+    else errors += 1;
+  }
+  return { landed, existing, errors };
+}
+
+function parseArgs(args) {
+  const flags = {
+    vault: '.',
+    json: false,
+    skipImports: false,
+  };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--skip-imports') flags.skipImports = true;
+    else if (a === '--max-depth')
+      flags.maxDepth = Number(args[++i]) || undefined;
+    else if (a.startsWith('--max-depth='))
+      flags.maxDepth = Number(a.slice('--max-depth='.length)) || undefined;
+    else if (a === '--max-files')
+      flags.maxFiles = Number(args[++i]) || undefined;
+    else if (a.startsWith('--max-files='))
+      flags.maxFiles = Number(a.slice('--max-files='.length)) || undefined;
+    else if (a === '--threshold') {
+      const v = Number(args[++i]);
+      if (!Number.isFinite(v) || v < 1)
+        return { error: '--threshold must be a positive integer' };
+      flags.threshold = v;
+    } else if (a.startsWith('--threshold=')) {
+      const v = Number(a.slice('--threshold='.length));
+      if (!Number.isFinite(v) || v < 1)
+        return { error: '--threshold must be a positive integer' };
+      flags.threshold = v;
+    } else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  return {
+    rootPath: positional[0] ?? '.',
+    vault: flags.vault,
+    json: flags.json,
+    skipImports: flags.skipImports,
+    maxDepth: flags.maxDepth,
+    maxFiles: flags.maxFiles,
+    threshold: flags.threshold,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology bootstrap [rootPath] [--vault path] [--threshold N]\n` +
+      `                           [--skip-imports] [--json]\n` +
+      `                           [--max-depth N] [--max-files N]\n\n` +
+      `${COLORS.bold}What it does:${COLORS.reset}\n` +
+      `  1줄 full bootstrap. analyze --apply (노드 + suggested relations) +\n` +
+      `  infer-imports --apply (depends_on edges) 를 합친 단일 명령.\n` +
+      `  agent-less 환경 (CI · plain shell) 또는 새 repo 진입 직후 흐름.\n\n` +
+      `${COLORS.bold}Examples:${COLORS.reset}\n` +
+      `  oh-my-ontology bootstrap                       # cwd → cwd vault\n` +
+      `  oh-my-ontology bootstrap ~/my-app --vault .    # 다른 repo 분석\n` +
+      `  oh-my-ontology bootstrap --threshold 3         # 약한 import 차단\n` +
+      `  oh-my-ontology bootstrap --skip-imports        # 노드만 (1단계)\n` +
+      `  oh-my-ontology bootstrap --json                # 머신 가독\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -59,10 +59,12 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --auto-prefix --rename --dry-run       ${COLORS.dim}folder prefix · slug rename · plan-only${COLORS.reset}
 
 ${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous ingest base)${COLORS.reset}
+  npx oh-my-ontology bootstrap [rootPath]     ${COLORS.green}1줄 full bootstrap${COLORS.reset} — analyze --apply + infer-imports --apply
+       --threshold N --skip-imports --json    ${COLORS.dim}weak edge 차단 · 노드만 · machine output${COLORS.reset}
   npx oh-my-ontology analyze [rootPath]       Walk a repo, propose ontology node candidates (side effect 0)
-       --max-depth N --json                   ${COLORS.dim}folder walk depth · machine output${COLORS.reset}
+       --apply --max-depth N --json           ${COLORS.dim}or land via batch · folder walk depth · machine output${COLORS.reset}
   npx oh-my-ontology infer-imports [rootPath] TS/JS import graph → depends_on edge candidates (side effect 0)
-       --max-files N --json                   ${COLORS.dim}default 5000 max · machine output${COLORS.reset}
+       --apply --threshold N --max-files N    ${COLORS.dim}or land · weak filter · default 5000 max${COLORS.reset}
 
 ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   npx oh-my-ontology backlinks <slug>         Every node referencing the slug (--json)
@@ -321,6 +323,11 @@ if (SUBCOMMAND === 'analyze') {
 if (SUBCOMMAND === 'infer-imports') {
   const { runInferImports } = await import('./commands/infer-imports.mjs');
   exit(await runInferImports(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'bootstrap') {
+  const { runBootstrap } = await import('./commands/bootstrap.mjs');
+  exit(await runBootstrap(ARGS.slice(1)));
 }
 
 fail(`unknown command: ${SUBCOMMAND}`);

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1322,5 +1322,136 @@ await test('infer-imports --threshold abc — 잘못된 입력 거부', async ()
   }
 });
 
+// ── bootstrap (R+ — analyze --apply + infer-imports --apply 합본) ───────
+
+function makeFullRepo() {
+  // Generic (non-FSD) layout — analyze 와 infer_imports 의 slug derivation 이
+  // 일치 (둘 다 src/auth → "auth"). FSD layout 은 두 도구의 slug 가 어긋나
+  // import edges 가 "does not exist" 로 fail (다음 cycle 의 known issue).
+  const repo = mkdtempSync(join(tmpdir(), 'cli-bs-'));
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify({ name: 'bs-app', description: 'BS app' }, null, 2),
+    'utf-8',
+  );
+  mkdirSync(join(repo, 'src', 'auth'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'billing'), { recursive: true });
+  writeFileSync(
+    join(repo, 'src', 'auth', 'index.ts'),
+    "import { x } from '../billing';\nexport const a = x;\n",
+    'utf-8',
+  );
+  writeFileSync(
+    join(repo, 'src', 'billing', 'index.ts'),
+    'export const x = 1;\n',
+    'utf-8',
+  );
+  return repo;
+}
+
+await test('bootstrap — analyze + infer-imports 한 명령으로 land', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run(['bootstrap', repo, '--vault', vault]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /1\) analyze/);
+    assert.match(clean, /2\) imports/);
+    // project 노드 + capability 들 land 되어야.
+    assert.equal(existsSyncTest(join(vault, 'bs-app.md')), true, 'project');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('bootstrap --skip-imports — 1단계 (analyze) 만, imports 영역 skipped 표시', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run([
+      'bootstrap',
+      repo,
+      '--vault',
+      vault,
+      '--skip-imports',
+    ]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /1\) analyze/);
+    assert.match(clean, /skipped \(--skip-imports\)/);
+    assert.equal(existsSyncTest(join(vault, 'bs-app.md')), true);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('bootstrap --json — analyze / imports / summary 모두 단일 JSON', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run(['bootstrap', repo, '--vault', vault, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.analyze, 'analyze 필드');
+    assert.ok(Array.isArray(data.analyze.concepts));
+    assert.ok(Array.isArray(data.analyze.relations));
+    assert.ok(data.imports, 'imports 필드');
+    assert.ok(Array.isArray(data.imports.relations));
+    assert.ok(data.summary, 'summary 필드');
+    assert.equal(typeof data.summary.errors, 'number');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('bootstrap --threshold 3 — 약한 import (count<3) 안 land', async () => {
+  // billing 는 1번만 import 됨 → threshold 3 면 import edge 안 land.
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run([
+      'bootstrap',
+      repo,
+      '--vault',
+      vault,
+      '--threshold',
+      '3',
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    // imports 의 thresholdApplied 메타데이터.
+    assert.ok(data.imports.thresholdApplied);
+    assert.equal(data.imports.thresholdApplied.threshold, 3);
+    // import relations 거의 0 (모두 약함).
+    assert.equal(data.imports.relations.length, 0);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('bootstrap 두번째 실행 — idempotent (errors 0)', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r1 = await run(['bootstrap', repo, '--vault', vault]);
+    assert.equal(r1.code, 0);
+    const r2 = await run(['bootstrap', repo, '--vault', vault]);
+    assert.equal(r2.code, 0, `2nd run failed: ${r2.stdout}`);
+    const clean = stripAnsi(r2.stdout);
+    assert.match(clean, /already existed/);
+    // errors 0 — 모든 행이 already exists / alreadyExists.
+    assert.match(clean, /0 errors/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 console.log(`\ncli integration: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/docs/ontology/capabilities/cli-developer-entry.md
+++ b/docs/ontology/capabilities/cli-developer-entry.md
@@ -1,15 +1,15 @@
 ---
 slug: capabilities/cli-developer-entry
 kind: capability
-title: CLI Developer Entry (15 commands incl. analyze/infer-imports --apply)
+title: CLI Developer Entry (16 commands incl. bootstrap)
 domain: onboarding-ux
-elements: [cli/src/index.mjs, cli/src/commands/list.mjs, cli/src/commands/validate.mjs, cli/src/commands/add.mjs, cli/src/commands/find.mjs, cli/src/commands/import.mjs, cli/src/commands/analyze.mjs, cli/src/commands/infer-imports.mjs, cli/src/commands/backlinks.mjs, cli/src/commands/query.mjs, cli/src/commands/rename.mjs, cli/src/commands/merge.mjs, cli/src/commands/delete.mjs, cli/src/commands/path.mjs, cli/src/commands/orphans.mjs, cli/src/lib/mcp-call.mjs]
+elements: [cli/src/index.mjs, cli/src/commands/list.mjs, cli/src/commands/validate.mjs, cli/src/commands/add.mjs, cli/src/commands/find.mjs, cli/src/commands/import.mjs, cli/src/commands/analyze.mjs, cli/src/commands/infer-imports.mjs, cli/src/commands/bootstrap.mjs, cli/src/commands/backlinks.mjs, cli/src/commands/query.mjs, cli/src/commands/rename.mjs, cli/src/commands/merge.mjs, cli/src/commands/delete.mjs, cli/src/commands/path.mjs, cli/src/commands/orphans.mjs, cli/src/lib/mcp-call.mjs]
 relates: [capabilities/mcp-server, capabilities/vault-validator, domains/onboarding-ux]
 ---
 
 # CLI Developer Entry
 
-R12 (2026-05-04) 에 도입된 *developer-primary* 진입점. R14 에서 `import`, R15 follow-up 에서 graph-level 5 명령, R16-R17 에서 `analyze` / `infer-imports`, R+ cycle 에서 `path` / `orphans` + 두 `--apply` 플래그 추가 — **총 15 명령**. 사용자가 vault 만든 후 *터미널 즉시* ontology 작업 가능 — 웹 UI / MCP 등록 불필요.
+R12 (2026-05-04) 에 도입된 *developer-primary* 진입점. R14 에서 `import`, R15 follow-up 에서 graph-level 5 명령, R16-R17 에서 `analyze` / `infer-imports`, R+ cycle 에서 `path` / `orphans` + 두 `--apply` 플래그 + `bootstrap` 합본 명령 추가 — **총 16 명령**. 사용자가 vault 만든 후 *터미널 즉시* ontology 작업 가능 — 웹 UI / MCP 등록 불필요.
 
 ## Local commands (R12 + R14 — vault scaffold + frontmatter)
 
@@ -22,12 +22,13 @@ R12 (2026-05-04) 에 도입된 *developer-primary* 진입점. R14 에서 `import
 | `oh-my-ontology find <query> [vault]` | Search slug + title with yellow highlight (`--kind --json`) |
 | `oh-my-ontology import <path...>` | **R14** Import external `.md` (frontmatter normalize + `--auto-prefix` / `--rename` / `--dry-run`) |
 
-## Repo analysis commands (R16-R17 — codebase → ontology)
+## Repo analysis commands (R16-R17 + R+ — codebase → ontology)
 
 | Command | What it does |
 |---|---|
-| `oh-my-ontology analyze [rootPath]` | **R16** Walk `package.json` / `README.md` H2 / `src/` → ontology 노드 후보. side effect 0 (default). **R+ `--apply`**: 후보를 `add_concepts` + `add_relations` 배치로 land — agent-less full bootstrap. |
-| `oh-my-ontology infer-imports [rootPath]` | **R17** TS/JS import graph → moduleEdges (capability A → B). side effect 0 (default). **R+ `--apply`**: moduleEdges 를 `depends_on` 관계로 batch land (50-row chunk). analyze 의 짝. |
+| `oh-my-ontology bootstrap [rootPath]` | **R+** 1줄 full bootstrap. analyze --apply (노드 + suggested relations) + infer-imports --apply (depends_on edges) 합본. `--threshold N` (약한 import 차단), `--skip-imports` (1단계만), `--json`. agent-less 흐름의 가장 짧은 path. |
+| `oh-my-ontology analyze [rootPath]` | **R16** Walk `package.json` / `README.md` H2 / `src/` → ontology 노드 후보. side effect 0 (default). **R+ `--apply`**: 후보를 `add_concepts` + `add_relations` 배치로 land. |
+| `oh-my-ontology infer-imports [rootPath]` | **R17** TS/JS import graph → moduleEdges. side effect 0 (default). **R+ `--apply`**: moduleEdges 를 `depends_on` 관계로 batch land (50-row chunk). **R+ `--threshold N`**: count < N 약한 edge 필터. |
 
 ## Graph-level commands (R15 follow-up — Concern 4 fix + R+ extras)
 
@@ -45,10 +46,10 @@ post-publish architectural audit 발견 — *위험한-그러나-필수* 작업 
 
 ## 구현 단일 진실원
 
-local commands 는 *cli 안* 구현 (4-way parser/3-way validator contract). graph-level + analyze/infer-imports + `--apply` 흐름은 *MCP server child_process spawn + JSON-RPC* — `cli/src/lib/mcp-call.mjs` 의 thin wrapper. drift surface 0 (logic 복제 안 함). spawn ~50-100ms per call — 한 번씩 호출이라 acceptable.
+local commands 는 *cli 안* 구현 (4-way parser/3-way validator contract). graph-level + analyze/infer-imports + bootstrap + `--apply` 흐름은 *MCP server child_process spawn + JSON-RPC* — `cli/src/lib/mcp-call.mjs` 의 thin wrapper. drift surface 0 (logic 복제 안 함). spawn ~50-100ms per call — bootstrap 은 3-4 회 호출이라 ~200-400ms 정도.
 
-cli 가 별도 npm package — `oh-my-ontology` binary. cli/package.json 의 `dependencies: oh-my-ontology-mcp` 가 graph-level + apply 흐름 자동 활성.
+cli 가 별도 npm package — `oh-my-ontology` binary. cli/package.json 의 `dependencies: oh-my-ontology-mcp` 가 graph-level + apply + bootstrap 흐름 자동 활성.
 
 ## 회귀 차단
 
-cli/src/integration.test.mjs — **49 spawn-based** integration test (R12 #40 11 + R14 add/import 9 + R15 follow-up 8 + R15 hint 4 + R+ analyze/infer-imports apply 4×2). 매 PR 마다 graph-level 명령의 dry-run/confirm 경로 + backlink redirect 검증.
+cli/src/integration.test.mjs — **58 spawn-based** integration test (R12 #40 11 + R14 add/import 9 + R15 follow-up 8 + R15 hint 4 + R+ analyze/infer-imports apply 4×2 + R+ threshold 4 + R+ bootstrap 5). 매 PR 마다 graph-level 명령의 dry-run/confirm 경로 + backlink redirect 검증.


### PR DESCRIPTION
## Summary

cycle 29 (\`analyze --apply\`) + cycle 30 (\`infer-imports --apply\`) + cycle 33 (\`--threshold\`) 의 자연스러운 합본. agent-less 환경 (CI · plain shell · 새 repo 진입) 에서 가장 자주 쓰는 흐름이라 단일 명령으로 승격. 16번째 CLI 명령.

## 흐름

\`\`\`bash
oh-my-ontology bootstrap [rootPath]
├─ 1) analyze_repo_structure → add_concepts (노드) + add_relations (suggested)
└─ 2) infer_imports → add_relations (depends_on, 50-row chunk)
\`\`\`

## 옵션

- \`--vault path\` — vault 위치 (default cwd)
- \`--max-depth / --max-files\` — 하위 명령 cap 그대로
- \`--threshold N\` — 약한 import edge 차단 (cycle 33 의 짝)
- \`--skip-imports\` — 1단계 (analyze) 만 — import graph 안 건드림
- \`--json\` — 머신 가독, analyze / imports / summary 단일 JSON

## 설계

- bootstrap.mjs 가 thin orchestrator — logic 복제 없이 mcp 도구 직접 호출.
- 통합 summary: \"1) analyze\" + \"2) imports\" 두 단계 별도 화면 표시.
- 에러 행만 ✗ 노출 (first 12 + cap), 두번째 실행 idempotent.
- \`exit 0\` if \`summary.errors === 0\`, else 1.

## Test plan

- [x] cli integration 53 → 58 (+5 — bootstrap land · --skip-imports · --json shape · --threshold · idempotent 두번째 실행)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Known issue (다음 cycle)

- **analyze 의 capability slug (FSD: \"auth\") 와 infer_imports 의 module slug (FSD: \"features/auth\") 불일치.** bootstrap 테스트는 generic layout 으로 우회. 양 도구 한 쪽이 통일되어야 FSD repo 의 imports edge 들이 자연 land. 다음 cycle 권장.

## Docs

- dogfood \`capabilities/cli-developer-entry\` — 15→16 명령, bootstrap.mjs 추가, Repo analysis commands 섹션에 항목 추가 (\`patch_concept\` + mtime guard)
- \`cli/src/index.mjs\` help — bootstrap 행 추가, analyze/infer-imports 의 --apply 플래그 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)