### PR TITLE
fix(mcp+cli): FSD slug parity — analyze ↔ infer_imports 일치, bootstrap silent fail 차단

### DIFF
--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1325,31 +1325,31 @@ await test('infer-imports --threshold abc — 잘못된 입력 거부', async ()
 // ── bootstrap (R+ — analyze --apply + infer-imports --apply 합본) ───────
 
 function makeFullRepo() {
-  // Generic (non-FSD) layout — analyze 와 infer_imports 의 slug derivation 이
-  // 일치 (둘 다 src/auth → "auth"). FSD layout 은 두 도구의 slug 가 어긋나
-  // import edges 가 "does not exist" 로 fail (다음 cycle 의 known issue).
+  // FSD-ish layout — cycle 35 fix 후 analyze 와 infer_imports 가 같은 slug
+  // ("auth" / "billing") 을 만들어 bootstrap 의 imports 단계가 endpoint 매치
+  // 가능. 이전 cycle 34 에선 생성된 generic layout 으로 우회했음.
   const repo = mkdtempSync(join(tmpdir(), 'cli-bs-'));
   writeFileSync(
     join(repo, 'package.json'),
     JSON.stringify({ name: 'bs-app', description: 'BS app' }, null, 2),
     'utf-8',
   );
-  mkdirSync(join(repo, 'src', 'auth'), { recursive: true });
-  mkdirSync(join(repo, 'src', 'billing'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'features', 'auth'), { recursive: true });
+  mkdirSync(join(repo, 'src', 'features', 'billing'), { recursive: true });
   writeFileSync(
-    join(repo, 'src', 'auth', 'index.ts'),
+    join(repo, 'src', 'features', 'auth', 'index.ts'),
     "import { x } from '../billing';\nexport const a = x;\n",
     'utf-8',
   );
   writeFileSync(
-    join(repo, 'src', 'billing', 'index.ts'),
+    join(repo, 'src', 'features', 'billing', 'index.ts'),
     'export const x = 1;\n',
     'utf-8',
   );
   return repo;
 }
 
-await test('bootstrap — analyze + infer-imports 한 명령으로 land', async () => {
+await test('bootstrap — analyze + infer-imports 한 명령으로 land (FSD slug parity, cycle 35)', async () => {
   const vault = withVault([]);
   const repo = makeFullRepo();
   try {
@@ -1358,8 +1358,23 @@ await test('bootstrap — analyze + infer-imports 한 명령으로 land', async 
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /1\) analyze/);
     assert.match(clean, /2\) imports/);
-    // project 노드 + capability 들 land 되어야.
+    // project + capability 노드 land
     assert.equal(existsSyncTest(join(vault, 'bs-app.md')), true, 'project');
+    assert.equal(existsSyncTest(join(vault, 'auth.md')), true, 'auth capability');
+    assert.equal(
+      existsSyncTest(join(vault, 'billing.md')),
+      true,
+      'billing capability',
+    );
+    // R+ — FSD slug parity 확인. analyze 가 "auth" / "billing" 으로 capability
+    // 만들고, infer_imports 의 module slug 도 "auth" → "billing" 으로 일치해야
+    // depends_on 에지가 진짜 land 됨. cycle 34 known issue 의 회귀 차단.
+    const authDoc = readFileSync(join(vault, 'auth.md'), 'utf-8');
+    assert.match(
+      authDoc,
+      /dependencies:.*\bbilling\b/s,
+      `auth.md should depend_on billing — got: ${authDoc}`,
+    );
   } finally {
     rmSync(vault, { recursive: true, force: true });
     rmSync(repo, { recursive: true, force: true });

--- a/mcp/src/infer-imports.mjs
+++ b/mcp/src/infer-imports.mjs
@@ -280,17 +280,29 @@ function resolveRelativeImport(spec, fromDir) {
 function moduleOf(filePath, sourceFolders) {
   // filePath is relative to rootPath. Find first segment that's a source
   // folder, then take the next segment as the "module" id.
+  //
+  // R+ — slug parity with analyze_repo_structure (cycle 35 fix). analyze
+  // 의 FSD 분기는 features/X · entities/X 의 X 만 capability slug 으로
+  // (bucket 접두 제거) 쓰고, widgets/X · views/X 는 path-style 그대로 유지
+  // (element slug). bootstrap 흐름이 두 도구의 결과를 짝지을 수 있도록
+  // 같은 규칙을 여기서도 적용 — 그래야 add_relations 에서 endpoint 가
+  // 실재 vault 노드로 매치된다.
   const parts = filePath.split(/[\\/]/);
   for (let i = 0; i < parts.length - 1; i += 1) {
     if (sourceFolders.includes(parts[i])) {
-      // for FSD: src/features/auth/x.ts → module = features/auth
-      // generic: src/api/x.ts → module = api
-      // Heuristic: skip 'src/', take first sub-folder unless it's an FSD bucket
       const next = parts[i + 1];
-      const fsdBuckets = new Set(['features', 'entities', 'widgets', 'views']);
-      if (fsdBuckets.has(next) && parts[i + 2]) {
+      // capability 류 bucket — analyze 가 inner name 만 slug 으로 쓰므로
+      // 동일하게 inner name 만.
+      const capabilityBuckets = new Set(['features', 'entities']);
+      if (capabilityBuckets.has(next) && parts[i + 2]) {
+        return parts[i + 2];
+      }
+      // element 류 bucket — analyze 가 path-style 유지하므로 동일하게.
+      const elementBuckets = new Set(['widgets', 'views']);
+      if (elementBuckets.has(next) && parts[i + 2]) {
         return `${next}/${parts[i + 2]}`;
       }
+      // generic — sourceFolder 다음 첫 segment 가 module.
       return next;
     }
   }

--- a/mcp/src/infer-imports.test.mjs
+++ b/mcp/src/infer-imports.test.mjs
@@ -101,7 +101,10 @@ test('dynamic import + require + reexport detected', () => {
   }
 });
 
-test('module-level edge collapse (FSD: features/ 안 module 합산)', () => {
+test('module-level edge collapse (FSD features/ — bucket 접두 stripped, analyze 와 일관)', () => {
+  // R+ — cycle 35: features/X · entities/X 는 inner 이름만 slug.
+  // analyze_repo_structure 가 capability 후보 slug 을 같은 식으로 만들어
+  // bootstrap 의 add_relations 가 endpoint 매치 가능.
   const root = withRepo((r) => {
     mkdirSync(join(r, 'src/features/auth'), { recursive: true });
     mkdirSync(join(r, 'src/features/billing'), { recursive: true });
@@ -115,10 +118,33 @@ test('module-level edge collapse (FSD: features/ 안 module 합산)', () => {
   try {
     const r = inferImports(root);
     const e = r.moduleEdges.find(
-      (x) => x.from === 'features/auth' && x.to === 'features/billing',
+      (x) => x.from === 'auth' && x.to === 'billing',
     );
-    assert.ok(e, `expected module edge features/auth → features/billing, got: ${JSON.stringify(r.moduleEdges)}`);
+    assert.ok(e, `expected module edge auth → billing, got: ${JSON.stringify(r.moduleEdges)}`);
     assert.equal(e.count, 2, '두 import 합산');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('module-level edge collapse (FSD widgets/ — path-style 유지, element slug 와 일관)', () => {
+  // R+ — cycle 35: widgets/X · views/X 는 path-style 유지 (analyze 가 element
+  // 후보 slug 으로 같은 식 — relative path).
+  const root = withRepo((r) => {
+    mkdirSync(join(r, 'src/widgets/header'), { recursive: true });
+    mkdirSync(join(r, 'src/widgets/footer'), { recursive: true });
+    writeFileSync(
+      join(r, 'src/widgets/header/index.ts'),
+      'import { x } from "../footer";\nexport const h = x;\n',
+    );
+    writeFileSync(join(r, 'src/widgets/footer/index.ts'), 'export const x = 1;');
+  });
+  try {
+    const r = inferImports(root);
+    const e = r.moduleEdges.find(
+      (x) => x.from === 'widgets/header' && x.to === 'widgets/footer',
+    );
+    assert.ok(e, `expected module edge widgets/header → widgets/footer, got: ${JSON.stringify(r.moduleEdges)}`);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

cycle 34 의 known issue 해결. \`analyze_repo_structure\` 가 \`features/auth\` → \"auth\" (capability slug — bucket 접두 제거) 로 노드를 만드는데, \`infer_imports\` 는 같은 코드 위치에서 \"features/auth\" (path-style 유지) 를 moduleEdge slug 으로 만들어 두 도구의 출력이 어긋났다.

**영향**: bootstrap (cycle 34) 의 imports 단계가 FSD repo 에서 \`add_relations\` 호출 시 endpoint 가 vault 에 \"features/auth\" 가 없어 row-level \"does not exist\" — 모든 import edge silent fail. cycle 34 의 bootstrap test 는 이를 회피하려고 generic layout (\`src/auth/\`) 으로 fixture 짰음.

## Fix

\`mcp/src/infer-imports.mjs\` \`moduleOf()\` 가 analyze 의 capability/element 분류 규칙을 따라가도록:

- **capability bucket** (\`features/X\` · \`entities/X\`) → inner name 만 (\`\"auth\"\`). analyze 의 capability slug 와 일치.
- **element bucket** (\`widgets/X\` · \`views/X\`) → path-style 유지 (\`\"widgets/header\"\`). analyze 의 element slug 와 일치.
- **generic** — sourceFolder 다음 첫 segment 그대로.

## 회귀 차단

cycle 34 bootstrap fixture 를 generic 우회 → FSD layout (\`src/features/auth · src/features/billing\`) 으로 교체. \"bootstrap — FSD slug parity\" 테스트가 \`auth.md\` 의 dependencies 에 billing 이 포함됐는지 확인.

## Test plan

- [x] mcp infer-imports unit: 8 → 9 (widgets/ path-style 유지 회귀 차단 신규)
- [x] cli integration: 58 (FSD layout 으로 재배치 — slug parity 회귀 검증)
- [x] mcp integration: 24/24
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope / backward compat

- generic layout 사용자는 동작 변경 없음.
- FSD layout 사용자는 (silent fail 됐던) edge 가 진짜 land — 명시적 fix.
- `analyze` 측은 변경 없음 (이미 inner-name slug 사용 중).

🤖 Generated with [Claude Code](https://claude.com/claude-code)