### PR TITLE
feat(mcp): SERVER_INSTRUCTIONS 가 batch tools / 3-round-trip bootstrap 안내

### DIFF
--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -119,20 +119,25 @@ const SERVER_INSTRUCTIONS = `oh-my-ontology — vault of markdown files where ea
 ### A. Vault already has nodes (typical) — orient first
 
 1. \`list_kinds\` — see the kind census (how many projects/domains/capabilities/…).
-2. \`list_concepts\` — full node table. Watch \`vaultWarnings\` — if non-zero, surface it to the user before making decisions on stale data.
-3. \`get_concept(slug)\` — frontmatter + body excerpt + neighbors (dependencies / relates) + \`mtime\`. **Capture the \`mtime\`** if you plan to write later.
-4. \`find_backlinks(slug)\` — understand how a node is referenced (run *before* rename / merge).
+2. \`list_concepts\` — full node table. Pass \`summary: true\` for prose previews per row (avoid N follow-up \`get_concept\` calls). Pass \`since: <prevMaxMtime>\` for incremental sync. Watch \`vaultWarnings\` — if non-zero, surface it to the user before making decisions on stale data.
+3. \`get_concept(slug)\` — frontmatter + body excerpt + neighbors (dependencies / relates) + \`mtime\`. **Capture the \`mtime\`** if you plan to write later. **For K specific slugs use \`get_concepts({slugs: [...]})\` (max 50) to fetch all in one call instead of K round-trips.**
+4. \`find_backlinks(slug)\` — understand how a node is referenced (run *before* rename / merge). Each row already includes \`domain\` + \`mtime\` — no follow-up \`get_concept\` needed for sort/filter.
 5. \`find_path(from, to)\` — "how does A relate to B?" (BFS, undirected). Returns \`hops: [slug...]\` **and \`edges: [{from, to, via}]\` where \`via\` is the frontmatter key (\`capabilities\` / \`elements\` / \`dependencies\` / \`relates\` / \`contains\` / \`describes\`) that linked the pair** — so you see not just *that* A and B are connected but *why*.
 6. \`find_orphans\` — spot nodes that no other node points to (cleanup or deletion candidates).
 7. \`query_concepts(filter)\` — structured questions like \`kind=capability AND domain=auth AND NOT has(elements)\` (= "unfinished caps under auth").
 
-### B. Vault is empty / cold-start — bootstrap from code (R16 / R17)
+All read-tool match rows share the same shape \`{slug, kind, title, domain, mtime, ...}\` — same sort/filter logic works across every read tool.
 
-When the user says "이 codebase 분석해줘" or you find only the 5 starter nodes:
+### B. Vault is empty / cold-start — bootstrap from code (R16 / R17 / R+)
 
-1. \`analyze_repo_structure\` — walk \`package.json\` / \`README.md\` H2 / \`src/\` (FSD vs generic detect). Returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]). **side effect 0 — vault NOT modified.** You review & prune the list with the user.
-2. \`infer_imports\` — walk TS/JS source, collapse to module-level edges with import counts. **side effect 0.** You review \`moduleEdges\` with the user, then convert accepted ones into \`add_relation(..., type: 'depends_on')\` calls.
-3. Land accepted candidates with \`add_concept\` / \`add_relation\`. The user (via your subsequent calls) is the single source of truth — never auto-write the proposals.
+When the user says "이 codebase 분석해줘" or you find only the 5 starter nodes. **Modern path is 3 round-trips total — analyze + add_concepts + add_relations** (down from per-row K calls):
+
+1. \`analyze_repo_structure\` — walk \`package.json\` / \`README.md\` H2 / \`src/\` (FSD vs generic detect). Returns deterministic candidates (project + domains[] + capabilities[] + elements[] + suggestedRelations[]). **side effect 0 — vault NOT modified.** Show the candidates compactly, let the user prune / refine.
+2. \`add_concepts({concepts: [...]})\` — assemble the accepted project + domains + capabilities + elements into one array (max 50) and land them in **one batch call**. Each row processed independently: existing-slug / invalid-kind / missing-required surface as \`{ok: false, error}\`; the rest still land. Pre-checks duplicate slugs *within input batch*. Use single \`add_concept\` only when you need atomic per-call semantics.
+3. \`add_relations({relations: [...]})\` — convert \`suggestedRelations\` into the same shape and land all edges in **one batch call**. Idempotent (\`alreadyExists: true\` on second run); 50-row chunk if you have more.
+4. (Optional, R17) \`infer_imports\` for TS/JS \`depends_on\` edges from the actual import graph. Then another \`add_relations\` batch with \`type: 'depends_on'\`. The CLI \`oh-my-ontology bootstrap\` packages all 4 steps into one command.
+
+Throughout: the user (via your add_concepts / add_relations calls) is the single source of truth — never auto-write proposals without their confirmation.
 
 ## Write tools — safety patterns
 

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -148,6 +148,12 @@ await test("initialize — instructions 필드 (#45) AI agent 안내 노출", as
     assert.match(instructions, /kind hierarchy/i);
     assert.match(instructions, /dry-run|confirm/i);
     assert.match(instructions, /expected_mtime/i);
+    // R+ — cycle 36: batch tools 가 기본 path 임을 instructions 가 안내해야.
+    // agent 가 per-row K-round-trip 패턴 대신 batch 1-call 을 default 로
+    // 사용하도록 stale 안내 회귀 차단.
+    assert.match(instructions, /add_concepts/);
+    assert.match(instructions, /add_relations/);
+    assert.match(instructions, /get_concepts/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

cycle 23-25 의 \`add_concepts\` / \`add_relations\` / \`get_concepts\` 와 cycle 34 의 bootstrap (3 round-trip) 흐름이 \`SERVER_INSTRUCTIONS\` 의 \"Two starting workflows\" 섹션에 반영 안 됐다 — agent 가 매 연결 시 지침을 읽고도 stale 한 per-row \"add_concept N 회 + add_relation N 회\" 패턴 그대로 따라가게 됨. **priority (a) AI agent UX 회귀**.

## 변경

**Workflow A (orient first)** 에 batch reader 안내 추가:
- \`list_concepts\` 의 \`summary: true\` / \`since\` 옵션
- \`get_concepts({slugs: [...]})\` 로 K → 1 round-trip
- read-tool match rows 가 같은 shape \`{slug, kind, title, domain, mtime, ...}\` — 일관성 강조

**Workflow B (cold-start bootstrap)** 를 3-round-trip path 로 갱신:
1. \`analyze_repo_structure\` (preview)
2. \`add_concepts\` (한 batch)
3. \`add_relations\` (한 batch — suggestedRelations)
4. (optional) \`infer_imports\` + 두번째 \`add_relations\` (depends_on)

CLI \`oh-my-ontology bootstrap\` 가 이 4 단계를 한 줄로 packaging 한다는 cross-reference 도 명시.

## 회귀 차단

initialize instructions integration test 에 \`add_concepts\` / \`add_relations\` / \`get_concepts\` 키워드 assertion 추가. 향후 누군가 batch language 를 잘못 빼면 즉시 fail.

## Test plan

- [x] mcp integration: 24/24 (instructions test 에 batch 키워드 assertion 3 추가)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope / backward compat

- 단일 \`add_concept\` / \`add_relation\` 시맨틱 변경 0 — instructions 만 batch-first 권장.
- 기존 instructions 의 \"safety patterns\" / \"error suffix\" / \"what to write back\" 섹션 그대로.
- mcp 도구 자체 동작 변경 0 — 지침만 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)