### PR TITLE
feat(cli): bootstrap 마지막에 vault census — "vault now has N nodes (...)"

### DIFF
--- a/cli/src/commands/bootstrap.mjs
+++ b/cli/src/commands/bootstrap.mjs
@@ -121,6 +121,15 @@ export async function runBootstrap(args) {
     importsRows,
   );
 
+  // R+ — 마지막 census. 사용자가 \"방금 뭐 land 됐나?\" 를 1줄로 인지.
+  // 실패해도 bootstrap exit code 영향 안 줌 (informational only).
+  let vaultCensus = null;
+  try {
+    vaultCensus = await callMcpTool(vaultRoot, 'list_kinds', {});
+  } catch {
+    // census 못 받아도 bootstrap 자체 실패 아님 — silent.
+  }
+
   if (parsed.json) {
     process.stdout.write(
       JSON.stringify(
@@ -139,6 +148,7 @@ export async function runBootstrap(args) {
                 relations: importsRows,
               },
           summary,
+          vaultCensus,
         },
         null,
         2,
@@ -216,6 +226,20 @@ export async function runBootstrap(args) {
   if (errCount > 12) {
     process.stdout.write(
       `  ${COLORS.dim}… ${errCount - 12} more errors${COLORS.reset}\n`,
+    );
+  }
+
+  // R+ — 마지막 census 한 줄. \"vault now has N nodes (project=A · domain=B · …)\"
+  if (vaultCensus && typeof vaultCensus.total === 'number') {
+    const byKind = vaultCensus.byKind || {};
+    const order = ['project', 'domain', 'capability', 'element', 'document', 'vault-readme'];
+    const parts = order
+      .filter((k) => byKind[k])
+      .map((k) => `${k}=${byKind[k]}`);
+    process.stdout.write(
+      `\n  ${COLORS.dim}→ vault now has ${COLORS.bold}${vaultCensus.total}${COLORS.reset}${COLORS.dim} nodes` +
+        (parts.length > 0 ? ` (${parts.join(' · ')})` : '') +
+        `${COLORS.reset}\n`,
     );
   }
 

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1450,6 +1450,41 @@ await test('bootstrap --threshold 3 — 약한 import (count<3) 안 land', async
   }
 });
 
+await test('bootstrap — 마지막에 vault census 한 줄 (R+ cycle 37)', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run(['bootstrap', repo, '--vault', vault]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    // census 라인 — \"vault now has N nodes (project=1 · capability=2 · ...)\"
+    assert.match(clean, /vault now has \d+ nodes/);
+    // 적어도 project + capability 카운트 표시.
+    assert.match(clean, /project=1/);
+    assert.match(clean, /capability=/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('bootstrap --json — vaultCensus 필드 노출 (R+ cycle 37)', async () => {
+  const vault = withVault([]);
+  const repo = makeFullRepo();
+  try {
+    const r = await run(['bootstrap', repo, '--vault', vault, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.vaultCensus, 'vaultCensus 필드');
+    assert.equal(typeof data.vaultCensus.total, 'number');
+    assert.ok(data.vaultCensus.byKind, 'byKind 객체');
+    assert.ok(data.vaultCensus.total >= 3, 'project + 2 capability 최소');
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 await test('bootstrap 두번째 실행 — idempotent (errors 0)', async () => {
   const vault = withVault([]);
   const repo = makeFullRepo();


### PR DESCRIPTION
## Summary

cycle 34 의 \`bootstrap\` 흐름 마무리. 명령 한 줄 후 사용자가 *방금 vault 에 뭐가 land 됐는지* 즉시 인지할 수 있도록 마지막에 census 한 줄 추가.

## 흐름

\`\`\`bash
$ oh-my-ontology bootstrap . --apply
bootstrap repo=/path/to/repo
           vault=/path/to/vault

  1) analyze    concepts: 4 landed · 0 already existed · 0 errors
                relations (suggested): 4 landed · 0 already existed · 0 errors
  2) imports    depends_on: 2 landed · 0 already existed · 0 errors

  → vault now has 7 nodes (project=1 · capability=4 · element=2)
\`\`\`

## 설계

- \`list_kinds\` MCP 호출 — 추가 round-trip 1 회 (~50ms). bootstrap 의 3-4 round-trip 흐름에 미미한 비용.
- census 호출이 fail 해도 bootstrap exit code 영향 없음 (informational only, silent fallback).
- \`--json\` 출력에는 \`vaultCensus: { total, byKind }\` 필드로 노출.
- 출력 순서 — project · domain · capability · element · document · vault-readme (하향식 hierarchy).

## Test plan

- [x] cli integration: 58 → 60 (+2 — text census line / json vaultCensus shape)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope

- \`analyze --apply\` / \`infer-imports --apply\` 의 같은 census — 다음 cycle 후보 (DRY helper 로 묶을 수 있음).
- census 카운트의 색상 차별화 — \`bold\` 강조 만으로 충분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)