### PR TITLE
feat(cli): analyze/infer-imports 의 --apply 도 vault census — DRY shared helper

### DIFF
--- a/cli/src/commands/analyze.mjs
+++ b/cli/src/commands/analyze.mjs
@@ -5,6 +5,7 @@
 
 import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { getVaultCensus, writeVaultCensus } from '../lib/vault-census.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -222,6 +223,8 @@ async function runApply(vaultRoot, result, json) {
   const relationRows = relationsResult.relations ?? [];
 
   const summary = summarize(conceptRows, relationRows);
+  // R+ — apply 흐름 마무리 census (cycle 38, shared helper).
+  const vaultCensus = await getVaultCensus(vaultRoot);
 
   if (json) {
     process.stdout.write(
@@ -231,6 +234,7 @@ async function runApply(vaultRoot, result, json) {
           framework: result.framework,
           applied: { concepts: conceptRows, relations: relationRows },
           summary,
+          vaultCensus,
         },
         null,
         2,
@@ -267,6 +271,7 @@ async function runApply(vaultRoot, result, json) {
       );
     }
   }
+  writeVaultCensus(vaultCensus);
   return summary.errors === 0 ? 0 : 1;
 }
 

--- a/cli/src/commands/bootstrap.mjs
+++ b/cli/src/commands/bootstrap.mjs
@@ -21,6 +21,7 @@
 
 import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { getVaultCensus, writeVaultCensus } from '../lib/vault-census.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -122,13 +123,8 @@ export async function runBootstrap(args) {
   );
 
   // R+ — 마지막 census. 사용자가 \"방금 뭐 land 됐나?\" 를 1줄로 인지.
-  // 실패해도 bootstrap exit code 영향 안 줌 (informational only).
-  let vaultCensus = null;
-  try {
-    vaultCensus = await callMcpTool(vaultRoot, 'list_kinds', {});
-  } catch {
-    // census 못 받아도 bootstrap 자체 실패 아님 — silent.
-  }
+  // analyze --apply / infer-imports --apply 와 같은 helper 공유 (cycle 38).
+  const vaultCensus = await getVaultCensus(vaultRoot);
 
   if (parsed.json) {
     process.stdout.write(
@@ -229,19 +225,8 @@ export async function runBootstrap(args) {
     );
   }
 
-  // R+ — 마지막 census 한 줄. \"vault now has N nodes (project=A · domain=B · …)\"
-  if (vaultCensus && typeof vaultCensus.total === 'number') {
-    const byKind = vaultCensus.byKind || {};
-    const order = ['project', 'domain', 'capability', 'element', 'document', 'vault-readme'];
-    const parts = order
-      .filter((k) => byKind[k])
-      .map((k) => `${k}=${byKind[k]}`);
-    process.stdout.write(
-      `\n  ${COLORS.dim}→ vault now has ${COLORS.bold}${vaultCensus.total}${COLORS.reset}${COLORS.dim} nodes` +
-        (parts.length > 0 ? ` (${parts.join(' · ')})` : '') +
-        `${COLORS.reset}\n`,
-    );
-  }
+  // R+ — \"vault now has N nodes (...)\" 한 줄 (shared helper).
+  writeVaultCensus(vaultCensus);
 
   return summary.errors === 0 ? 0 : 1;
 }

--- a/cli/src/commands/infer-imports.mjs
+++ b/cli/src/commands/infer-imports.mjs
@@ -4,6 +4,7 @@
 
 import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { getVaultCensus, writeVaultCensus } from '../lib/vault-census.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -168,6 +169,8 @@ async function runApply(vaultRoot, result, json) {
   }
 
   const summary = summarizeRelations(allRows);
+  // R+ — apply 흐름 마무리 census (cycle 38, shared helper).
+  const vaultCensus = await getVaultCensus(vaultRoot);
 
   if (json) {
     process.stdout.write(
@@ -177,6 +180,7 @@ async function runApply(vaultRoot, result, json) {
           filesScanned: result.filesScanned,
           applied: { relations: allRows },
           summary,
+          vaultCensus,
         },
         null,
         2,
@@ -213,6 +217,7 @@ async function runApply(vaultRoot, result, json) {
       `  ${COLORS.dim}… ${errCount - 12} more errors${COLORS.reset}\n`,
     );
   }
+  writeVaultCensus(vaultCensus);
   return summary.errors === 0 ? 0 : 1;
 }
 

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -998,6 +998,44 @@ await test('analyze --apply 두 번째 실행 → "already existed" 카운트, e
   }
 });
 
+await test('analyze --apply — 마지막 vault census 라인 (R+ cycle 38)', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r = await run(['analyze', repo, '--vault', vault, '--apply']);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /vault now has \d+ nodes/);
+    assert.match(clean, /project=1/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('analyze --apply --json — vaultCensus 필드 (R+ cycle 38)', async () => {
+  const vault = withVault([]);
+  const repo = makeRepoFixture();
+  try {
+    const r = await run([
+      'analyze',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+      '--json',
+    ]);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.vaultCensus);
+    assert.equal(typeof data.vaultCensus.total, 'number');
+    assert.ok(data.vaultCensus.total >= 1);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 await test('analyze --apply --json — applied / summary 필드 노출', async () => {
   const vault = withVault([]);
   const repo = makeRepoFixture();
@@ -1120,6 +1158,30 @@ await test('infer-imports --apply — endpoint 없으면 row-level error, batch 
     const clean = stripAnsi(r.stdout);
     // 에러 행 노출.
     assert.match(clean, /✗|does not exist|errors/);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('infer-imports --apply — 마지막 vault census 라인 (R+ cycle 38)', async () => {
+  const vault = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\ndomain: x\n---\n' },
+    { slug: 'b', content: '---\nkind: capability\ntitle: B\ndomain: x\n---\n' },
+  ]);
+  const repo = makeImportRepo();
+  try {
+    const r = await run([
+      'infer-imports',
+      repo,
+      '--vault',
+      vault,
+      '--apply',
+    ]);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /vault now has \d+ nodes/);
+    assert.match(clean, /capability=2/);
   } finally {
     rmSync(vault, { recursive: true, force: true });
     rmSync(repo, { recursive: true, force: true });

--- a/cli/src/lib/vault-census.mjs
+++ b/cli/src/lib/vault-census.mjs
@@ -1,0 +1,63 @@
+// R+ — analyze --apply / infer-imports --apply / bootstrap 셋이 공유하는
+// vault census 출력 helper. 사용자가 명령 한 번 후 *방금 vault 에 뭐가
+// land 됐는지* 한 줄로 인지 — \"→ vault now has N nodes (...)\".
+//
+// 공유 이유: 세 명령이 모두 같은 \"after-write summary\" 형식을 원함 — DRY.
+// helper 하나가 list_kinds 호출 + 텍스트 포맷 + JSON 데이터 반환 모두 cover.
+//
+// 호출 실패 (e.g. mcp 시동 실패) 시 silent — caller 의 exit code 영향 0.
+
+import { callMcpTool } from './mcp-call.mjs';
+
+const COLORS = {
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  reset: '\x1b[0m',
+};
+
+/**
+ * mcp list_kinds 호출 → { total, byKind } | null.
+ * 에러 시 silent null — caller 가 census 누락도 허용.
+ */
+export async function getVaultCensus(vaultRoot) {
+  try {
+    const result = await callMcpTool(vaultRoot, 'list_kinds', {});
+    if (
+      result
+      && typeof result.total === 'number'
+      && result.byKind
+      && typeof result.byKind === 'object'
+    ) {
+      return result;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * stdout 에 \"→ vault now has N nodes (project=A · capability=B · ...)\"
+ * 한 줄 출력. census 가 null 이면 no-op.
+ *
+ * 출력 순서 = 하향식 hierarchy: project · domain · capability · element ·
+ * document · vault-readme. byKind 에 0 인 항목은 표시 생략.
+ */
+export function writeVaultCensus(census) {
+  if (!census || typeof census.total !== 'number') return;
+  const order = [
+    'project',
+    'domain',
+    'capability',
+    'element',
+    'document',
+    'vault-readme',
+  ];
+  const byKind = census.byKind || {};
+  const parts = order.filter((k) => byKind[k]).map((k) => `${k}=${byKind[k]}`);
+  process.stdout.write(
+    `\n  ${COLORS.dim}→ vault now has ${COLORS.bold}${census.total}${COLORS.reset}${COLORS.dim} nodes` +
+      (parts.length > 0 ? ` (${parts.join(' · ')})` : '') +
+      `${COLORS.reset}\n`,
+  );
+}


### PR DESCRIPTION
## Summary

cycle 37 의 \`bootstrap\` census 를 \`analyze --apply\` / \`infer-imports --apply\` 에도 동일 적용. 세 명령이 모두 \"vault now has N nodes (...)\" 한 줄로 사용자에게 결과 확인. 공통 helper (\`cli/src/lib/vault-census.mjs\`) 로 묶어 DRY.

## 설계

신규 \`cli/src/lib/vault-census.mjs\`:
- \`getVaultCensus(vaultRoot)\` → \`{ total, byKind } | null\`. 에러 silent.
- \`writeVaultCensus(census)\` → stdout 한 줄. census null 이면 no-op.

\`analyze.mjs\` / \`infer-imports.mjs\` / \`bootstrap.mjs\` 셋 다 helper import. \`bootstrap\` 의 기존 inline census 코드 (cycle 37) 도 helper 호출로 교체. \`--json\` 출력에 \`vaultCensus\` 필드 동일 shape 노출.

출력 순서: project · domain · capability · element · document · vault-readme (하향식 hierarchy). byKind 에 0 인 항목 생략.

## Test plan

- [x] cli integration 60 → 63 (+3 — analyze --apply census line / analyze --json vaultCensus / infer-imports --apply census line)
- [x] bootstrap census test (cycle 37) helper 경유라 의미 그대로 통과
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope / backward compat

- 추가 출력만, 기존 stdout 의미 보존.
- \`--json\` 의 새 \`vaultCensus\` 필드는 census 실패 시 \`null\` — caller 가 null-handle 가능.
- bootstrap 의 cycle 37 inline 코드를 helper 호출로 교체 — 동일 shape 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)