### PR TITLE
feat(mcp): 단일 도구 description 이 batch 짝 cross-reference (tool list 직접 노출)

### DIFF
--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -209,7 +209,7 @@ const TOOLS = [
   {
     name: 'get_concept',
     description:
-      'Fetch a single node by slug — its frontmatter, a body excerpt, and direct neighbors (dependencies / relates).',
+      'Fetch a single node by slug — its frontmatter, a body excerpt, and direct neighbors (dependencies / relates). **For K specific slugs in one call use `get_concepts({slugs: [...]})` (max 50) instead of K round-trips.**',
     inputSchema: {
       type: 'object',
       properties: {
@@ -261,7 +261,8 @@ const TOOLS = [
       'normalized per kind (project gets `domains/capabilities/elements` empty ' +
       'arrays; capability gets `elements: []`; capability/element should also ' +
       'set `domain:` so the tree has a parent — missing extras come back as ' +
-      '`warnings` in the response, not as an error.',
+      '`warnings` in the response, not as an error. ' +
+      '**For bulk creation (e.g. bootstrap flow with 5+ nodes) use `add_concepts({concepts: [...]})` (batch, max 50, partial result) — saves K-1 round-trips.**',
     inputSchema: {
       type: 'object',
       properties: {
@@ -340,7 +341,8 @@ const TOOLS = [
       'frontmatter array (dependencies / relates / contains / describes); the ' +
       'relation type picks which key receives the entry. **R11**: optional ' +
       '`expected_mtime` — pass the source-side `mtime` from a prior get_concept ' +
-      'so concurrent external edits throw VaultConflictError.',
+      'so concurrent external edits throw VaultConflictError. ' +
+      '**For multiple edges (e.g. all suggestedRelations from analyze, or all moduleEdges from infer_imports) use `add_relations({relations: [...]})` (batch, idempotent, max 50).**',
     inputSchema: {
       type: 'object',
       properties: {

--- a/mcp/src/integration.test.mjs
+++ b/mcp/src/integration.test.mjs
@@ -129,6 +129,33 @@ function isErrorResponse(responses, id) {
 
 console.log("integration");
 
+// R+ — cycle 39: 단일 도구 (get_concept · add_concept · add_relation) 의
+// description 이 batch 짝 (get_concepts · add_concepts · add_relations) 을
+// 명시 cross-reference. agent 가 tool list 만 보고도 K-round-trip 대안을
+// 인지. drift 시 즉시 회귀.
+await test("tools/list — 단일 도구 description 이 batch 짝을 cross-reference", async () => {
+  const root = makeVault([]);
+  try {
+    const { responses } = await rpc(root, [
+      ...INIT_REQUESTS,
+      { jsonrpc: "2.0", id: 99, method: "tools/list", params: {} },
+    ]);
+    const list = responses.find((r) => r.id === 99);
+    assert.ok(list, "tools/list 응답");
+    const tools = list.result?.tools;
+    assert.ok(Array.isArray(tools));
+    const findDesc = (name) => tools.find((t) => t.name === name)?.description;
+    const getC = findDesc("get_concept");
+    const addC = findDesc("add_concept");
+    const addR = findDesc("add_relation");
+    assert.ok(getC && /get_concepts/.test(getC), "get_concept → get_concepts hint");
+    assert.ok(addC && /add_concepts/.test(addC), "add_concept → add_concepts hint");
+    assert.ok(addR && /add_relations/.test(addR), "add_relation → add_relations hint");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test("initialize — instructions 필드 (#45) AI agent 안내 노출", async () => {
   // initialize 응답에 instructions 가 있어야 연결된 agent (Claude Code 등) 가
   // kind 계층 / 호출 순서 / write 도구 dry-run 패턴을 즉시 인지. 누락 시


### PR DESCRIPTION
## Summary

cycle 36 의 \`SERVER_INSTRUCTIONS\` 갱신은 *전체 instructions* 를 읽는 agent 에게만 도달. \`tools/list\` 만 훑는 agent 는 여전히 \`add_concept\` / \`add_relation\` / \`get_concept\` 만 보고 batch 짝의 존재를 모를 수 있음. 단일 도구 \`description\` 자체에 한 줄 cross-reference 추가 — agent 의 어느 inspection path 든 batch 대안을 즉시 인지.

## 변경

- **\`get_concept\`** description 에: *\"For K specific slugs in one call use \`get_concepts({slugs: [...]})\` (max 50) instead of K round-trips.\"*
- **\`add_concept\`** description 에: *\"For bulk creation (e.g. bootstrap flow with 5+ nodes) use \`add_concepts({concepts: [...]})\` (batch, max 50, partial result) — saves K-1 round-trips.\"*
- **\`add_relation\`** description 에: *\"For multiple edges (e.g. all suggestedRelations from analyze, or all moduleEdges from infer_imports) use \`add_relations({relations: [...]})\` (batch, idempotent, max 50).\"*

## 회귀 차단

신규 mcp integration test \"tools/list — 단일 도구 description 이 batch 짝을 cross-reference\" — \`tools/list\` 응답을 fetch 후 각 description 에 batch 짝 이름이 들어있는지 검사. 향후 누군가 cross-reference 를 잘못 빼면 즉시 fail.

## Test plan

- [x] mcp integration: 24 → 25 (+1 — tools/list cross-reference assertion)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope / backward compat

- description 텍스트 추가만 — 도구 시맨틱 변경 0.
- batch tools 자체 동작 변경 0.
- SERVER_INSTRUCTIONS (cycle 36) 와 description (이 PR) 두 path 모두에서 cross-reference — agent inspection 경로 무관하게 일관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)