### PR TITLE
feat(cli): validate --json — CI / 스크립트 / agent 가독 출력 (parity)

### DIFF
--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -17,8 +17,12 @@ const COLORS = {
  * vault 의 frontmatter integrity 검증. 5 issue codes (unclosed-frontmatter
  * / empty-kind / missing-kind / unknown-kind / parse-zero-keys). error 1+
  * 시 exit 1.
+ *
+ * R+ — \`--json\` 플래그 (cycle 40): 머신 가독 출력. CI / 스크립트 / agent
+ * 가 ANSI strip 없이 issue 행을 그대로 파싱.
  */
 export function runValidate(args) {
+  const json = args.includes('--json');
   const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
   const files = walkMd(vaultPath);
   const reports = [];
@@ -40,6 +44,45 @@ export function runValidate(args) {
     });
     if (report.issues.some((i) => i.severity === 'error')) errorFiles += 1;
     else warningFiles += 1;
+  }
+
+  // R+ — JSON 출력은 항상 같은 shape (clean vault 도 problems: [] 로). caller
+  // 가 .summary.errorFiles 만 보고 분기 가능 — text 모드의 분기 없는 단일
+  // structure.
+  if (json) {
+    const groups = groupIssuesByCode(reports);
+    const byCode = {};
+    for (const g of groups) {
+      byCode[g.code] = {
+        severity: g.severity,
+        count: g.count,
+        files: g.files,
+      };
+    }
+    process.stdout.write(
+      JSON.stringify(
+        {
+          scanned: files.length,
+          problems: reports.map(({ file, report }) => ({
+            file,
+            issues: report.issues.map((i) => ({
+              code: i.code,
+              severity: i.severity,
+              message: i.message,
+            })),
+          })),
+          summary: {
+            problemFiles: reports.length,
+            errorFiles,
+            warningFiles,
+            byCode,
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return errorFiles > 0 ? 1 : 0;
   }
 
   if (reports.length === 0) {

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -47,6 +47,7 @@ ${COLORS.bold}Usage:${COLORS.reset}
                                               ${COLORS.dim}--kind <kind>     filter by kind${COLORS.reset}
                                               ${COLORS.dim}--json            JSON output${COLORS.reset}
   npx oh-my-ontology validate [vault]         Frontmatter integrity check (exit 1 on errors)
+       --json                                 ${COLORS.dim}structured issue output for CI / scripts${COLORS.reset}
   npx oh-my-ontology add <kind> <slug>        Scaffold a new ontology node (.md)
        --title "..."                          ${COLORS.dim}required, non-empty${COLORS.reset}
        --domain X --body "..." --vault path   ${COLORS.dim}optional${COLORS.reset}

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -174,6 +174,46 @@ await test('validate — 1회짜리 code 는 grouped 섹션 안 보임 (per-file
   }
 });
 
+await test('validate --json — clean vault: scanned/problems[]/summary 노출, exit 0 (R+ cycle 40)', async () => {
+  // capability 는 domain 누락 시 missing-expected-field warning. project 로
+  // 정말 깨끗한 vault 만든다.
+  const root = withVault([
+    { slug: 'p', content: '---\nkind: project\ntitle: P\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(typeof data.scanned, 'number');
+    assert.deepEqual(data.problems, []);
+    assert.equal(data.summary.errorFiles, 0);
+    assert.equal(data.summary.warningFiles, 0);
+    assert.deepEqual(data.summary.byCode, {});
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --json — empty-kind error: problems[] / summary.byCode, exit 1 (R+ cycle 40)', async () => {
+  const root = withVault([
+    { slug: 'broken', content: '---\nkind:\ntitle: X\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--json']);
+    assert.equal(r.code, 1);
+    const data = JSON.parse(r.stdout);
+    assert.ok(data.problems.length >= 1);
+    const p = data.problems.find((x) => /broken\.md$/.test(x.file));
+    assert.ok(p, 'broken.md 가 problems 에 있어야');
+    assert.ok(p.issues.some((i) => i.code === 'empty-kind'));
+    assert.ok(data.summary.byCode['empty-kind']);
+    assert.equal(data.summary.byCode['empty-kind'].severity, 'error');
+    assert.ok(data.summary.errorFiles >= 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('add — 새 노드 + duplicate throws', async () => {
   const root = withVault([]);
   try {


### PR DESCRIPTION
## Summary

list / find / analyze / infer-imports / bootstrap 모두 \`--json\` 가 있는데 \`validate\` 만 누락이라 parity gap. CI 가 validate output 을 파싱하려면 ANSI strip 후 정규식 조립 — 비효율적이고 fragile. \`--json\` 으로 머신 가독 구조 노출.

## JSON 출력 shape

\`\`\`json
{
  "scanned": 26,
  "problems": [
    { "file": "broken.md", "issues": [{ "code": "empty-kind", "severity": "error", "message": "..." }] }
  ],
  "summary": {
    "problemFiles": 1,
    "errorFiles": 1,
    "warningFiles": 0,
    "byCode": {
      "empty-kind": { "severity": "error", "count": 1, "files": ["broken.md"] }
    }
  }
}
\`\`\`

clean vault 도 같은 shape (\`problems: [], summary.errorFiles: 0\`). caller 가 \`.summary.errorFiles > 0\` 만 보고 분기 가능 — text 모드의 분기 없는 단일 structure.

exit code 그대로: errors > 0 → 1, else 0. text 모드 동작 변경 0.

## Test plan

- [x] cli integration 63 → 65 (+2 — clean vault json shape / empty-kind error json + exit 1)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope

- \`--exit-on-warn\` (warning 도 exit 1) — 별 cycle. 현재는 errors 만 exit 1.
- \`--quiet\` (issue 0 시 silent) — text 모드 보조, 현재 한 줄 메시지로 충분.
- \`--fail-on=<code>\` (특정 code 만 fail) — CI 가 직접 \`.summary.byCode\` 파싱 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)