### PR TITLE
feat(cli): validate --strict — warning 도 exit 1 (CI 친화 옵션)

### DIFF
--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -20,9 +20,14 @@ const COLORS = {
  *
  * R+ — \`--json\` 플래그 (cycle 40): 머신 가독 출력. CI / 스크립트 / agent
  * 가 ANSI strip 없이 issue 행을 그대로 파싱.
+ *
+ * R+ — \`--strict\` 플래그 (cycle 42): warning 도 exit 1. CI 가 missing-
+ * expected-field (capability/element 의 domain 누락 등) 도 차단하려 할 때.
+ * default 는 errors 만 fail.
  */
 export function runValidate(args) {
   const json = args.includes('--json');
+  const strict = args.includes('--strict');
   const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
   const files = walkMd(vaultPath);
   const reports = [];
@@ -76,13 +81,14 @@ export function runValidate(args) {
             errorFiles,
             warningFiles,
             byCode,
+            strict,
           },
         },
         null,
         2,
       ) + '\n',
     );
-    return errorFiles > 0 ? 1 : 0;
+    return decideExit(errorFiles, warningFiles, strict);
   }
 
   if (reports.length === 0) {
@@ -91,6 +97,8 @@ export function runValidate(args) {
     );
     return 0;
   }
+
+  // strict 모드 안내는 마지막 summary 줄에서 처리.
 
   for (const { file, report } of reports) {
     console.log(`\n${file}`);
@@ -121,12 +129,23 @@ export function runValidate(args) {
     }
   }
 
+  const strictTag =
+    strict && warningFiles > 0
+      ? ` ${COLORS.dim}[--strict: warning 도 exit 1]${COLORS.reset}`
+      : '';
   console.log(
     `\n[validate] ${files.length} 파일 / ${reports.length} 문제 ` +
       `(${COLORS.red}error ${errorFiles}${COLORS.reset} · ` +
-      `${COLORS.yellow}warning ${warningFiles}${COLORS.reset})`,
+      `${COLORS.yellow}warning ${warningFiles}${COLORS.reset})${strictTag}`,
   );
-  return errorFiles > 0 ? 1 : 0;
+  return decideExit(errorFiles, warningFiles, strict);
+}
+
+// strict 모드면 warning 도 fail. default 는 errors 만 fail.
+function decideExit(errorFiles, warningFiles, strict) {
+  if (errorFiles > 0) return 1;
+  if (strict && warningFiles > 0) return 1;
+  return 0;
 }
 
 /**

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -47,7 +47,7 @@ ${COLORS.bold}Usage:${COLORS.reset}
                                               ${COLORS.dim}--kind <kind>     filter by kind${COLORS.reset}
                                               ${COLORS.dim}--json            JSON output${COLORS.reset}
   npx oh-my-ontology validate [vault]         Frontmatter integrity check (exit 1 on errors)
-       --json                                 ${COLORS.dim}structured issue output for CI / scripts${COLORS.reset}
+       --json --strict                        ${COLORS.dim}structured output · warning 도 exit 1 (CI)${COLORS.reset}
   npx oh-my-ontology add <kind> <slug>        Scaffold a new ontology node (.md)
        --title "..."                          ${COLORS.dim}required, non-empty${COLORS.reset}
        --domain X --body "..." --vault path   ${COLORS.dim}optional${COLORS.reset}

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -174,6 +174,54 @@ await test('validate — 1회짜리 code 는 grouped 섹션 안 보임 (per-file
   }
 });
 
+await test('validate --strict — warning 만 있어도 exit 1 (R+ cycle 42)', async () => {
+  // capability 의 domain 누락 → missing-expected-field warning. default 면
+  // exit 0 (errors 만 fail), --strict 면 exit 1.
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    const noStrict = await run(['validate', root]);
+    assert.equal(noStrict.code, 0, 'default: warning only → exit 0');
+    const strict = await run(['validate', root, '--strict']);
+    assert.equal(strict.code, 1, '--strict: warning → exit 1');
+    const clean = stripAnsi(strict.stdout);
+    assert.match(clean, /missing-expected-field|warning/);
+    // strict 모드 표시.
+    assert.match(clean, /--strict/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --strict — clean vault 면 strict 여도 exit 0', async () => {
+  const root = withVault([
+    { slug: 'p', content: '---\nkind: project\ntitle: P\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--strict']);
+    assert.equal(r.code, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --json --strict — summary.strict=true, warning 시 exit 1', async () => {
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--json', '--strict']);
+    assert.equal(r.code, 1);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.summary.strict, true);
+    assert.equal(data.summary.errorFiles, 0);
+    assert.ok(data.summary.warningFiles >= 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('validate --json — clean vault: scanned/problems[]/summary 노출, exit 0 (R+ cycle 40)', async () => {
   // capability 는 domain 누락 시 missing-expected-field warning. project 로
   // 정말 깨끗한 vault 만든다.


### PR DESCRIPTION
## Summary

cycle 40 의 \`--json\` 후속 — 그 PR 의 \"Out of scope\" 였던 \`--strict (warning 도 exit 1)\`. CI 가 missing-expected-field (capability/element 의 domain 누락 등) warning 도 차단하려 할 때 사용.

## 설계

- **default**: errors 만 exit 1, warnings 는 exit 0 (현재 동작 유지).
- **\`--strict\`**: errors OR warnings → exit 1. clean vault 는 그대로 exit 0.
- text 모드: errors 0 / warnings 1+ + \`--strict\` 일 때 \"[--strict: warning 도 exit 1]\" 표시 — 사용자가 왜 exit 1 인지 즉시 인지.
- \`--json\`: \`summary.strict\` 필드 (true/false) 노출 — CI 가 어느 모드로 돌렸는지 머신 가독.

## Test plan

- [x] cli integration 65 → 68 (+3 — text strict warning exit 1 / clean strict exit 0 / --json --strict shape)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope / backward compat

- \`--strict\` 미지정 시 기존 동작 그대로 — exit code semantic 변경 0.
- CI 가 점진적으로 \`--strict\` 도입 가능.
- \`--fail-on=<code>\` (특정 issue code 만 fail) — 별 cycle. 현재는 binary error/warning gate 만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)