### PR TITLE
feat(cli): validate --fail-on=<code,...> — 특정 issue code 만 fail (점진적 CI hardening)

### DIFF
--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -24,10 +24,15 @@ const COLORS = {
  * R+ — \`--strict\` 플래그 (cycle 42): warning 도 exit 1. CI 가 missing-
  * expected-field (capability/element 의 domain 누락 등) 도 차단하려 할 때.
  * default 는 errors 만 fail.
+ *
+ * R+ — \`--fail-on=<code1,code2,...>\` (cycle 43): 특정 issue code 만 fail.
+ * \`--strict\` 보다 우선 — listed code 들에 해당하는 issue 1+ 시 exit 1,
+ * 나머지는 무시. CI 가 점진적으로 특정 violation 만 hard-gate 하려 할 때.
  */
 export function runValidate(args) {
   const json = args.includes('--json');
   const strict = args.includes('--strict');
+  const failOn = parseFailOn(args);
   const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
   const files = walkMd(vaultPath);
   const reports = [];
@@ -54,8 +59,8 @@ export function runValidate(args) {
   // R+ — JSON 출력은 항상 같은 shape (clean vault 도 problems: [] 로). caller
   // 가 .summary.errorFiles 만 보고 분기 가능 — text 모드의 분기 없는 단일
   // structure.
+  const groups = groupIssuesByCode(reports);
   if (json) {
-    const groups = groupIssuesByCode(reports);
     const byCode = {};
     for (const g of groups) {
       byCode[g.code] = {
@@ -82,13 +87,14 @@ export function runValidate(args) {
             warningFiles,
             byCode,
             strict,
+            failOn,
           },
         },
         null,
         2,
       ) + '\n',
     );
-    return decideExit(errorFiles, warningFiles, strict);
+    return decideExit(errorFiles, warningFiles, strict, failOn, groups);
   }
 
   if (reports.length === 0) {
@@ -113,7 +119,7 @@ export function runValidate(args) {
   // R+ — issue code 별 그룹 요약. 큰 vault 에서 같은 종류 경고가 30+ 줄 흐를
   // 때 *어느 코드가 얼마나 많은지* 한눈에. 2+ 회 등장한 code 만 노출 — 1
   // 회짜리는 위 per-file 출력으로 충분.
-  const groups = groupIssuesByCode(reports);
+  // (groups 는 위에서 한 번 빌드해놨음 — JSON / fail-on / 텍스트 모두 공유.)
   const repeatedCodes = groups.filter((g) => g.count >= 2);
   if (repeatedCodes.length > 0) {
     console.log(`\n${COLORS.dim}── grouped by code ──${COLORS.reset}`);
@@ -129,23 +135,53 @@ export function runValidate(args) {
     }
   }
 
-  const strictTag =
-    strict && warningFiles > 0
-      ? ` ${COLORS.dim}[--strict: warning 도 exit 1]${COLORS.reset}`
-      : '';
+  let modeTag = '';
+  if (failOn && failOn.length > 0) {
+    const matched = failOn.filter((code) => groups.some((g) => g.code === code));
+    if (matched.length > 0) {
+      modeTag = ` ${COLORS.dim}[--fail-on=${failOn.join(',')}: matched ${matched.join(',')}]${COLORS.reset}`;
+    } else {
+      modeTag = ` ${COLORS.dim}[--fail-on=${failOn.join(',')}: no match → exit 0]${COLORS.reset}`;
+    }
+  } else if (strict && warningFiles > 0) {
+    modeTag = ` ${COLORS.dim}[--strict: warning 도 exit 1]${COLORS.reset}`;
+  }
   console.log(
     `\n[validate] ${files.length} 파일 / ${reports.length} 문제 ` +
       `(${COLORS.red}error ${errorFiles}${COLORS.reset} · ` +
-      `${COLORS.yellow}warning ${warningFiles}${COLORS.reset})${strictTag}`,
+      `${COLORS.yellow}warning ${warningFiles}${COLORS.reset})${modeTag}`,
   );
-  return decideExit(errorFiles, warningFiles, strict);
+  return decideExit(errorFiles, warningFiles, strict, failOn, groups);
 }
 
-// strict 모드면 warning 도 fail. default 는 errors 만 fail.
-function decideExit(errorFiles, warningFiles, strict) {
+// 우선순위: --fail-on (있으면 그것만) > --strict > default (errors only).
+function decideExit(errorFiles, warningFiles, strict, failOn, groups) {
+  if (failOn && failOn.length > 0) {
+    return groups.some((g) => failOn.includes(g.code)) ? 1 : 0;
+  }
   if (errorFiles > 0) return 1;
   if (strict && warningFiles > 0) return 1;
   return 0;
+}
+
+function parseFailOn(args) {
+  // \`--fail-on=code1,code2\` 또는 \`--fail-on code1,code2\`. 비어 있거나
+  // 지정 안 됐으면 null.
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--fail-on') return splitCsv(args[i + 1]);
+    if (a.startsWith('--fail-on=')) return splitCsv(a.slice('--fail-on='.length));
+  }
+  return null;
+}
+
+function splitCsv(value) {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const out = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return out.length > 0 ? out : null;
 }
 
 /**

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -47,7 +47,7 @@ ${COLORS.bold}Usage:${COLORS.reset}
                                               ${COLORS.dim}--kind <kind>     filter by kind${COLORS.reset}
                                               ${COLORS.dim}--json            JSON output${COLORS.reset}
   npx oh-my-ontology validate [vault]         Frontmatter integrity check (exit 1 on errors)
-       --json --strict                        ${COLORS.dim}structured output · warning 도 exit 1 (CI)${COLORS.reset}
+       --json --strict --fail-on=code,...     ${COLORS.dim}structured · warning 도 fail · 특정 code 만 fail${COLORS.reset}
   npx oh-my-ontology add <kind> <slug>        Scaffold a new ontology node (.md)
        --title "..."                          ${COLORS.dim}required, non-empty${COLORS.reset}
        --domain X --body "..." --vault path   ${COLORS.dim}optional${COLORS.reset}

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -174,6 +174,94 @@ await test('validate — 1회짜리 code 는 grouped 섹션 안 보임 (per-file
   }
 });
 
+await test('validate --fail-on=empty-kind — empty-kind 있으면 exit 1 (R+ cycle 43)', async () => {
+  const root = withVault([
+    { slug: 'broken', content: '---\nkind:\ntitle: X\n---\n' },
+    { slug: 'capWithoutDomain', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--fail-on=empty-kind']);
+    assert.equal(r.code, 1);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /--fail-on=empty-kind: matched empty-kind/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --fail-on=empty-kind — empty-kind 없으면 exit 0 (warning 무관)', async () => {
+  // 다른 warning (missing-expected-field) 만 있는 vault. --fail-on 이 그
+  // code 가 아니므로 exit 0.
+  const root = withVault([
+    { slug: 'capWithoutDomain', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--fail-on=empty-kind']);
+    assert.equal(r.code, 0, 'empty-kind 없으니 exit 0 (warning 무시)');
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /--fail-on=empty-kind: no match → exit 0/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --fail-on=code1,code2 — 다중 code (CSV) 중 하나라도 매치되면 exit 1', async () => {
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    // missing-expected-field warning 만 있음. CSV 에 그 code 포함.
+    const r = await run([
+      'validate',
+      root,
+      '--fail-on=empty-kind,missing-expected-field',
+    ]);
+    assert.equal(r.code, 1);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /matched missing-expected-field/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --fail-on 이 --strict 보다 우선 — 다른 warning 은 fail 안 함', async () => {
+  // --strict 면 missing-expected-field warning → exit 1.
+  // --strict --fail-on=empty-kind 면 → empty-kind 만 보고 exit 0.
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+  ]);
+  try {
+    const r = await run([
+      'validate',
+      root,
+      '--strict',
+      '--fail-on=empty-kind',
+    ]);
+    assert.equal(r.code, 0, '--fail-on 이 --strict 무력화');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('validate --json --fail-on — summary.failOn 노출', async () => {
+  const root = withVault([
+    { slug: 'broken', content: '---\nkind:\ntitle: X\n---\n' },
+  ]);
+  try {
+    const r = await run([
+      'validate',
+      root,
+      '--json',
+      '--fail-on=empty-kind',
+    ]);
+    assert.equal(r.code, 1);
+    const data = JSON.parse(r.stdout);
+    assert.deepEqual(data.summary.failOn, ['empty-kind']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('validate --strict — warning 만 있어도 exit 1 (R+ cycle 42)', async () => {
   // capability 의 domain 누락 → missing-expected-field warning. default 면
   // exit 0 (errors 만 fail), --strict 면 exit 1.


### PR DESCRIPTION
## Summary

cycle 40 (\`--json\`) + cycle 42 (\`--strict\`) 의 자연스러운 마무리. CI 가 *전체* warning 차단 (\`--strict\`) 도, *errors only* (default) 도 아닌, 특정 issue code (예: \`empty-kind\`) 만 점진적으로 hard-gate 하려 할 때 사용.

## 설계

- 입력: \`--fail-on=code1,code2\` (CSV) 또는 \`--fail-on code1,code2\`.
- **우선순위**: \`--fail-on\` > \`--strict\` > default (errors only). \`--fail-on\` 지정 시 listed code 들 중 하나라도 매치되면 exit 1, 나머지 무시. \`--strict\` 도 같이 줘도 fail-on 이 우선.
- text 모드: \`[--fail-on=X: matched X]\` 또는 \`[--fail-on=X: no match → exit 0]\` 으로 사유 노출.
- \`--json\`: \`summary.failOn\` 필드 (string[]) 노출 — CI 가 어느 code list 로 돌렸는지 머신 가독.

## 활용

\`\`\`bash
# 점진적 hardening: 처음엔 empty-kind 만, 이후 더 추가.
oh-my-ontology validate . --fail-on=empty-kind
oh-my-ontology validate . --fail-on=empty-kind,unknown-kind
\`\`\`

## Test plan

- [x] cli integration 68 → 73 (+5 — fail-on match exit 1 / no match exit 0 / CSV 다중 / strict overridden / --json summary.failOn)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## 회귀 fix (incidental)

\`groups\` 변수 중복 const 선언이 모든 validate text 경로를 깨뜨렸음. JSON / fail-on / text 가 같은 \`groups\` 객체 공유하도록 선언 위치 단일화.

## Out of scope / backward compat

- \`--fail-on\` 미지정 시 기존 동작 그대로.
- 알려지지 않은 code 입력 시 silently \"no match → exit 0\" — typo 경고 X (다음 cycle 후보).
- Negation (\`--fail-on-not=code\`) — 별 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)