### PR TITLE
feat(cli): validate --list-codes + unknown-code 경고 — --fail-on 발견 UX 보강

### DIFF
--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -8,8 +8,46 @@ const COLORS = {
   yellow: '\x1b[33m',
   green: '\x1b[32m',
   dim: '\x1b[2m',
+  bold: '\x1b[1m',
   reset: '\x1b[0m',
 };
+
+// R+ — cycle 44: validateVaultDocument 가 surface 하는 6 issue codes 의
+// canonical list. --list-codes 출력 + --fail-on 의 unknown code 감지에
+// 사용. cli/src/lib/validate.mjs (3-way contract) 의 코드와 일관 — drift
+// 시 contract test 가 실패하도록 곧 추가 권장.
+const KNOWN_CODES = [
+  {
+    code: 'unclosed-frontmatter',
+    severity: 'error',
+    description: '`---` 가 닫히지 않음 — 파일 머리에 frontmatter 가 끝나지 않았습니다.',
+  },
+  {
+    code: 'parse-zero-keys',
+    severity: 'warning',
+    description: 'frontmatter 가 0 keys 로 파싱됨 — YAML syntax 깨짐 가능.',
+  },
+  {
+    code: 'missing-kind',
+    severity: 'warning',
+    description: '`kind:` 키 자체가 없음 — 그래프에서 빠짐.',
+  },
+  {
+    code: 'empty-kind',
+    severity: 'error',
+    description: '`kind:` 값이 비어있음 — 그래프에서 빠지고 invalid.',
+  },
+  {
+    code: 'unknown-kind',
+    severity: 'warning',
+    description: 'project / domain / capability / element / document 외 값.',
+  },
+  {
+    code: 'missing-expected-field',
+    severity: 'warning',
+    description: 'kind 별 강하게 기대되는 필드 누락 (예: capability/element 의 `domain:`).',
+  },
+];
 
 /**
  * R11 #32 — \`oh-my-ontology validate [vault]\`
@@ -30,9 +68,26 @@ const COLORS = {
  * 나머지는 무시. CI 가 점진적으로 특정 violation 만 hard-gate 하려 할 때.
  */
 export function runValidate(args) {
+  // --list-codes 는 vault 안 보고 즉시 출력. 다른 옵션이 같이 와도 무시.
+  if (args.includes('--list-codes')) {
+    return printKnownCodes(args.includes('--json'));
+  }
+
   const json = args.includes('--json');
   const strict = args.includes('--strict');
   const failOn = parseFailOn(args);
+  // R+ — cycle 44: --fail-on 에 unknown code 가 들어오면 stderr 경고.
+  // 실행은 진행 (silently no-match 로 빠지는 것보다 *명시 경고* 가 나음).
+  if (failOn) {
+    const known = new Set(KNOWN_CODES.map((c) => c.code));
+    const unknown = failOn.filter((c) => !known.has(c));
+    if (unknown.length > 0) {
+      process.stderr.write(
+        `${COLORS.yellow}warning${COLORS.reset}  --fail-on 에 알려지지 않은 code: ${unknown.join(', ')}. ` +
+          `사용 가능한 code 목록: ${COLORS.bold}oh-my-ontology validate --list-codes${COLORS.reset}\n`,
+      );
+    }
+  }
   const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
   const files = walkMd(vaultPath);
   const reports = [];
@@ -182,6 +237,27 @@ function splitCsv(value) {
     .map((s) => s.trim())
     .filter(Boolean);
   return out.length > 0 ? out : null;
+}
+
+// R+ — cycle 44: --list-codes 출력. text 모드는 사람이 읽기 좋은 표,
+// --json 모드는 머신 가독 (CI 가 어떤 code 가 있는지 동적으로 알 수 있게).
+function printKnownCodes(asJson) {
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ codes: KNOWN_CODES }, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(
+    `${COLORS.bold}validate issue codes${COLORS.reset} ${COLORS.dim}(--fail-on=<code> 로 특정 code 만 fail)${COLORS.reset}\n\n`,
+  );
+  for (const c of KNOWN_CODES) {
+    const severityColor = c.severity === 'error' ? COLORS.red : COLORS.yellow;
+    const severityTag = c.severity === 'error' ? '✗ error  ' : '▲ warning';
+    process.stdout.write(
+      `  ${severityColor}${severityTag}${COLORS.reset}  ${COLORS.bold}${c.code.padEnd(24)}${COLORS.reset}  ${COLORS.dim}${c.description}${COLORS.reset}\n`,
+    );
+  }
+  process.stdout.write('\n');
+  return 0;
 }
 
 /**

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -48,6 +48,7 @@ ${COLORS.bold}Usage:${COLORS.reset}
                                               ${COLORS.dim}--json            JSON output${COLORS.reset}
   npx oh-my-ontology validate [vault]         Frontmatter integrity check (exit 1 on errors)
        --json --strict --fail-on=code,...     ${COLORS.dim}structured · warning 도 fail · 특정 code 만 fail${COLORS.reset}
+       --list-codes                           ${COLORS.dim}사용 가능한 issue code 목록 (--fail-on 발견용)${COLORS.reset}
   npx oh-my-ontology add <kind> <slug>        Scaffold a new ontology node (.md)
        --title "..."                          ${COLORS.dim}required, non-empty${COLORS.reset}
        --domain X --body "..." --vault path   ${COLORS.dim}optional${COLORS.reset}

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -174,6 +174,52 @@ await test('validate — 1회짜리 code 는 grouped 섹션 안 보임 (per-file
   }
 });
 
+await test('validate --list-codes — 6 issue code 목록 출력 (R+ cycle 44)', async () => {
+  const r = await run(['validate', '--list-codes']);
+  assert.equal(r.code, 0);
+  const clean = stripAnsi(r.stdout);
+  for (const code of [
+    'unclosed-frontmatter',
+    'parse-zero-keys',
+    'missing-kind',
+    'empty-kind',
+    'unknown-kind',
+    'missing-expected-field',
+  ]) {
+    assert.match(clean, new RegExp(code), `${code} 가 출력에 있어야`);
+  }
+  // severity 표시
+  assert.match(clean, /error/i);
+  assert.match(clean, /warning/i);
+});
+
+await test('validate --list-codes --json — codes 배열 머신 가독', async () => {
+  const r = await run(['validate', '--list-codes', '--json']);
+  assert.equal(r.code, 0);
+  const data = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(data.codes));
+  assert.ok(data.codes.length >= 6);
+  for (const c of data.codes) {
+    assert.equal(typeof c.code, 'string');
+    assert.ok(c.severity === 'error' || c.severity === 'warning');
+    assert.equal(typeof c.description, 'string');
+  }
+});
+
+await test('validate --fail-on=does-not-exist — stderr 에 unknown code 경고 (R+ cycle 44)', async () => {
+  const root = withVault([
+    { slug: 'p', content: '---\nkind: project\ntitle: P\n---\n' },
+  ]);
+  try {
+    const r = await run(['validate', root, '--fail-on=does-not-exist']);
+    // unknown code 경고가 stderr 에 보여야 (실행은 그대로 — 매치 없으니 exit 0).
+    assert.equal(r.code, 0);
+    assert.match(r.stderr, /알려지지 않은 code|--list-codes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('validate --fail-on=empty-kind — empty-kind 있으면 exit 1 (R+ cycle 43)', async () => {
   const root = withVault([
     { slug: 'broken', content: '---\nkind:\ntitle: X\n---\n' },


### PR DESCRIPTION
## Summary

cycle 43 의 \`--fail-on\` 후속 두 부분 묶음 PR:

1. **\`--list-codes\` 플래그** — 사용 가능한 6 issue codes 목록 + severity + 설명을 표로 출력 (또는 \`--json\` 으로 머신 가독). CI 가 \`--fail-on\` 에 어떤 code 를 넣어야 할지 발견.
2. **unknown code 경고** — \`--fail-on=does-not-exist\` 처럼 알려지지 않은 code 가 들어오면 stderr 에 경고 + \`--list-codes\` 안내. 실행은 진행 (silently no-match 로 빠지는 것보다 *명시 경고* 가 typo 발견에 도움).

\`KNOWN_CODES\` 정적 list 가 진실원 — 6 codes (unclosed-frontmatter · parse-zero-keys · missing-kind · empty-kind · unknown-kind · missing-expected-field). \`validate.mjs\` (3-way contract) 의 코드와 일관 유지 책임 (drift 감지 contract test 다음 cycle 후보).

## 활용

\`\`\`bash
$ oh-my-ontology validate --list-codes
validate issue codes (--fail-on=<code> 로 특정 code 만 fail)

  ✗ error    unclosed-frontmatter      \`---\` 가 닫히지 않음 — ...
  ▲ warning  parse-zero-keys           frontmatter 가 0 keys 로 ...
  ...

$ oh-my-ontology validate . --fail-on=typo
warning  --fail-on 에 알려지지 않은 code: typo. 사용 가능한 code 목록: oh-my-ontology validate --list-codes
\`\`\`

## Test plan

- [x] cli integration 73 → 76 (+3 — text list-codes / json codes / unknown code stderr 경고)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 839/839
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean

## Out of scope

- \`KNOWN_CODES\` ↔ \`cli/src/lib/validate.mjs\` drift 감지 contract test — 다음 cycle 후보.
- \`mcp/src/validate.mjs\` 측의 비대칭 (mcp warnings 응답 shape) — read-only 라 영향 없음, 별 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)