### PR TITLE
fix(topology+light): "벌레같은" 토폴로지 정정 — Obsidian/Logseq 톤 적용

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -359,3 +359,33 @@ html[data-theme="light"] a[class*="transition-colors"]:hover:not([class*="hover:
 html[data-theme="light"] button[class*="transition-colors"]:hover:not([class*="hover:bg-"]):not([class*="bg-[color"]):not(:disabled) {
   background-color: rgba(0, 0, 0, 0.04);
 }
+
+/*
+ * 라이트 모드 — 트리의 element kind 행 dim 보정 (cycle 47).
+ *
+ * OntologyTreeView 의 element 행은 다크 모드 70% element 점유를 시각적
+ * 평탄화하려고 \`opacity-60\` 적용. 다크 캔버스에선 회색-on-검정 으로 자연
+ * 스럽지만 라이트 캔버스에서는 회색-on-흰 → \"읽기 전 거의 사라짐\" 단계
+ * 까지 fade. 라이트 한정 80% 로 끌어올려 readable 유지하되 여전히 다른
+ * kind (project/domain/capability) 보다 한 단계 dim 인 시그널 보존.
+ */
+html[data-theme="light"] [data-tree-row][data-dim="true"],
+html[data-theme="light"] [data-testid="ontology-tree-row"][data-dim="true"] {
+  opacity: 0.82;
+}
+
+/*
+ * 라이트 모드 — uppercase 모노 라벨 (kind chips, section headers,
+ * outline labels) 가독성 보정 (cycle 47).
+ *
+ * 라이트 모드의 \`--color-text-quaternary\` 는 #6f7480. 흰 캔버스 위에서
+ * 0.10em letter-spacing + 9-11px font-size 의 uppercase 모노 텍스트가
+ * 시각적으로 \"공기처럼\" 사라짐 (anti-aliasing 위약 효과). font-weight
+ * 를 한 단계 올려 (var --font-weight-signature ≈ 540) 가독성 회복.
+ *
+ * 다크 모드는 어두운 캔버스 위에서 같은 색이 충분히 떠오르므로 영향
+ * 없음. 라이트 전용 셀렉터.
+ */
+html[data-theme="light"] .font-mono[class*="uppercase"][class*="tracking"] {
+  font-weight: 520;
+}

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-05-06T07:40:22.486Z",
+  "generatedAt": "2026-05-07T08:38:50.697Z",
   "docs": [
     {
       "slug": "ARCHITECTURE",
@@ -1675,7 +1675,7 @@
       ],
       "excerpt": "작업 순번 만. user 가 \"T?? 진행해\" 하면 그것만 분해해서 실행. 완료된 항목은 ✅ 표시 후 별도 batch 정리 시 일괄 삭제. 갱신 (20260506): R12/R13/R14 wave 묶음 정리 후 전면 재정렬. 4 surface 완성, dogfood 25 노드, AI agent ↔ vault 자동 sync 도달. | PR | 항목 | 결과 | |||| | 155 | vault polling 5s | ✅ visibleonly setInterval, fingerprint diff | | 156 | graph diff pulse | ✅ 새 노드 amber s",
       "wordCount": 1361,
-      "updatedAt": "2026-05-06T02:02:33.369Z",
+      "updatedAt": "2026-05-07T08:01:36.195Z",
       "linksOut": []
     },
     {
@@ -2289,6 +2289,121 @@
         },
         {
           "depth": 2,
+          "text": "2026-05-07 — Round 18: AI agent UX 강화 루프 — read shape · batch tools · ARIA tree · CLI --apply",
+          "slug": "2026-05-07-round-18-ai-agent-ux-강화-루프-read-shape-batch-tools-aria-tree-cli---apply"
+        },
+        {
+          "depth": 3,
+          "text": "MCP — read tool 응답 shape 완전 일관 (#176 #180 #183 #186 #189 #191 #194 #195 #196)",
+          "slug": "mcp-read-tool-응답-shape-완전-일관-176-180-183-186-189-191-194-195-196"
+        },
+        {
+          "depth": 3,
+          "text": "MCP — 배치 도구 3개 신규 (R+, 16→19 tools, #197 #198 #199)",
+          "slug": "mcp-배치-도구-3개-신규-r-1619-tools-197-198-199"
+        },
+        {
+          "depth": 3,
+          "text": "Tree — full ARIA tree 키보드 패턴 (#188 #190 #201 #202)",
+          "slug": "tree-full-aria-tree-키보드-패턴-188-190-201-202"
+        },
+        {
+          "depth": 3,
+          "text": "CLI — agent-less full bootstrap (#203 #204)",
+          "slug": "cli-agent-less-full-bootstrap-203-204"
+        },
+        {
+          "depth": 3,
+          "text": "CLI — graph-level 명령 보강 (#182 #192 #193)",
+          "slug": "cli-graph-level-명령-보강-182-192-193"
+        },
+        {
+          "depth": 3,
+          "text": "/topology 사용성 (#173 #174 #185)",
+          "slug": "topology-사용성-173-174-185"
+        },
+        {
+          "depth": 3,
+          "text": "Skill / Docs / Dogfood (#178 #179 #181 #200 #205)",
+          "slug": "skill-docs-dogfood-178-179-181-200-205"
+        },
+        {
+          "depth": 3,
+          "text": "측정",
+          "slug": "측정"
+        },
+        {
+          "depth": 2,
+          "text": "2026-05-06 — Round 17: `infer_imports` — TS/JS import graph → depends_on edges",
+          "slug": "2026-05-06-round-17-infer_imports-tsjs-import-graph-depends_on-edges"
+        },
+        {
+          "depth": 3,
+          "text": "MCP `infer_imports` (16번째 tool)",
+          "slug": "mcp-infer_imports-16번째-tool"
+        },
+        {
+          "depth": 3,
+          "text": "Validated — Paravel real-codebase",
+          "slug": "validated-paravel-real-codebase"
+        },
+        {
+          "depth": 3,
+          "text": "CLI `infer-imports` 명령 (13번째)",
+          "slug": "cli-infer-imports-명령-13번째"
+        },
+        {
+          "depth": 3,
+          "text": "단일 source of truth 보존",
+          "slug": "단일-source-of-truth-보존"
+        },
+        {
+          "depth": 3,
+          "text": "Tests",
+          "slug": "tests"
+        },
+        {
+          "depth": 3,
+          "text": "Mission align",
+          "slug": "mission-align"
+        },
+        {
+          "depth": 2,
+          "text": "2026-05-06 — Round 16: 자율 ingest base — `analyze_repo_structure` 첫 도구",
+          "slug": "2026-05-06-round-16-자율-ingest-base-analyze_repo_structure-첫-도구"
+        },
+        {
+          "depth": 3,
+          "text": "MCP `analyze_repo_structure` (15번째 tool, mcp v0.7.1 → v0.8.0)",
+          "slug": "mcp-analyze_repo_structure-15번째-tool-mcp-v071-v080"
+        },
+        {
+          "depth": 3,
+          "text": "CLI `analyze` 명령 (cli v0.3.0 → v0.4.0, 11 → 12 명령)",
+          "slug": "cli-analyze-명령-cli-v030-v040-11-12-명령"
+        },
+        {
+          "depth": 3,
+          "text": "Tests + dogfood",
+          "slug": "tests-dogfood"
+        },
+        {
+          "depth": 3,
+          "text": "Mission align",
+          "slug": "mission-align-2"
+        },
+        {
+          "depth": 3,
+          "text": "R16 follow-up — `/ontology-bootstrap` skill",
+          "slug": "r16-follow-up-ontology-bootstrap-skill"
+        },
+        {
+          "depth": 3,
+          "text": "다음 step (R18 후보)",
+          "slug": "다음-step-r18-후보"
+        },
+        {
+          "depth": 2,
           "text": "2026-05-06 — Round 15 follow-up #2: Project type honest (Concern 1 fix)",
           "slug": "2026-05-06-round-15-follow-up-2-project-type-honest-concern-1-fix"
         },
@@ -2320,7 +2435,7 @@
         {
           "depth": 3,
           "text": "Mission align",
-          "slug": "mission-align"
+          "slug": "mission-align-3"
         },
         {
           "depth": 2,
@@ -2340,12 +2455,12 @@
         {
           "depth": 3,
           "text": "Mission align",
-          "slug": "mission-align-2"
+          "slug": "mission-align-4"
         },
         {
           "depth": 3,
           "text": "Tests",
-          "slug": "tests"
+          "slug": "tests-2"
         },
         {
           "depth": 3,
@@ -3123,9 +3238,9 @@
           "slug": "before-2026-04-30"
         }
       ],
-      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. postpublish architectural audit (Plan agent advisor) 의 blocking Concern 1 fix. Project 18 ",
-      "wordCount": 12425,
-      "updatedAt": "2026-05-06T06:48:12.698Z",
+      "excerpt": "Major change history. Code commit messages answer why; this file answers when / which surface changed. Focused on uservisible changes, not PRlevel granularity. Newest at the top. Datebased since we're presemver in the v0.x stage. 자율 개선 루프 ~30 PR. mcp 16→19 tools (read 10→11, write 6→8), cli 13→15 commands, /ontologyboo",
+      "wordCount": 13963,
+      "updatedAt": "2026-05-07T07:09:56.710Z",
       "linksOut": [
         "slug"
       ]
@@ -3986,8 +4101,8 @@
         },
         {
           "depth": 2,
-          "text": "3. MCP server (14 tools)",
-          "slug": "3-mcp-server-14-tools"
+          "text": "3. MCP server (20 tools)",
+          "slug": "3-mcp-server-20-tools"
         },
         {
           "depth": 4,
@@ -4056,8 +4171,8 @@
         }
       ],
       "excerpt": "Complete inventory of features users can actually use right now. Last updated: 20260506 (postRound15 — VSCode plugin 제거, 3 surface 회복 + R14 자동화/live updates 추가 반영). Routes section UI 디테일은 R10 시점 snapshot — surface 자체와 mode branching 은 R15 까지 정확. routes UI microdetail 은 R10 후 변화 작아 별도 sweep 보다 대부분 정확 가정. Update trigger:",
-      "wordCount": 4485,
-      "updatedAt": "2026-05-06T02:02:33.370Z",
+      "wordCount": 4498,
+      "updatedAt": "2026-05-07T08:29:28.849Z",
       "linksOut": [
         "slug",
         "project:slug",
@@ -4349,12 +4464,12 @@
     {
       "slug": "ontology/capabilities/cli-developer-entry",
       "path": "docs/ontology/capabilities/cli-developer-entry.md",
-      "title": "CLI Developer Entry (init / list / validate / add / find / import + graph-level)",
+      "title": "CLI Developer Entry (16 commands incl. bootstrap)",
       "tags": [],
       "frontmatter": {
         "slug": "capabilities/cli-developer-entry",
         "kind": "capability",
-        "title": "CLI Developer Entry (init / list / validate / add / find / import + graph-level)",
+        "title": "CLI Developer Entry (16 commands incl. bootstrap)",
         "domain": "onboarding-ux",
         "elements": [
           "cli/src/index.mjs",
@@ -4363,11 +4478,16 @@
           "cli/src/commands/add.mjs",
           "cli/src/commands/find.mjs",
           "cli/src/commands/import.mjs",
+          "cli/src/commands/analyze.mjs",
+          "cli/src/commands/infer-imports.mjs",
+          "cli/src/commands/bootstrap.mjs",
           "cli/src/commands/backlinks.mjs",
           "cli/src/commands/query.mjs",
           "cli/src/commands/rename.mjs",
           "cli/src/commands/merge.mjs",
           "cli/src/commands/delete.mjs",
+          "cli/src/commands/path.mjs",
+          "cli/src/commands/orphans.mjs",
           "cli/src/lib/mcp-call.mjs"
         ],
         "relates": [
@@ -4389,8 +4509,13 @@
         },
         {
           "depth": 2,
-          "text": "Graph-level commands (R15 follow-up — Concern 4 fix)",
-          "slug": "graph-level-commands-r15-follow-up-concern-4-fix"
+          "text": "Repo analysis commands (R16-R17 + R+ — codebase → ontology)",
+          "slug": "repo-analysis-commands-r16-r17-r-codebase-ontology"
+        },
+        {
+          "depth": 2,
+          "text": "Graph-level commands (R15 follow-up — Concern 4 fix + R+ extras)",
+          "slug": "graph-level-commands-r15-follow-up-concern-4-fix-r-extras"
         },
         {
           "depth": 2,
@@ -4403,9 +4528,9 @@
           "slug": "회귀-차단"
         }
       ],
-      "excerpt": "R12 (20260504) 에 도입된 developerprimary 진입점. R14 에서 import (6 명령), R15 followup 에서 graphlevel 5 명령 추가 — 총 11 명령. 사용자가 vault 만든 후 터미널 즉시 ontology 작업 가능 — 웹 UI / MCP 등록 불필요. | Command | What it does | ||| | ohmyontology init [folder] | Scaffold vault (5 starter .md + .mcp.json cwd + vault) | | ohmyontology list [vault] | L",
-      "wordCount": 374,
-      "updatedAt": "2026-05-06T06:32:01.996Z",
+      "excerpt": "R12 (20260504) 에 도입된 developerprimary 진입점. R14 에서 import, R15 followup 에서 graphlevel 5 명령, R16R17 에서 analyze / inferimports, R+ cycle 에서 path / orphans + 두 apply 플래그 + bootstrap 합본 명령 추가 — 총 16 명령. 사용자가 vault 만든 후 터미널 즉시 ontology 작업 가능 — 웹 UI / MCP 등록 불필요. | Command | What it does | ||| | ohmyontology init [folder] | S",
+      "wordCount": 583,
+      "updatedAt": "2026-05-07T07:25:33.027Z",
       "linksOut": []
     },
     {
@@ -4488,17 +4613,19 @@
     {
       "slug": "ontology/capabilities/mcp-server",
       "path": "docs/ontology/capabilities/mcp-server.md",
-      "title": "MCP Server (14 tools)",
+      "title": "MCP Server (20 tools)",
       "tags": [],
       "frontmatter": {
         "slug": "capabilities/mcp-server",
         "kind": "capability",
-        "title": "MCP Server (14 tools)",
+        "title": "MCP Server (20 tools)",
         "domain": "ai-agent-partner",
         "elements": [
           "mcp/src/index.js",
           "mcp/src/parser.mjs",
-          "mcp/src/vault.mjs"
+          "mcp/src/vault.mjs",
+          "mcp/src/analyze.mjs",
+          "mcp/src/infer-imports.mjs"
         ],
         "relates": [
           "capabilities/frontmatter-to-ontology",
@@ -4508,13 +4635,13 @@
       "headings": [
         {
           "depth": 1,
-          "text": "MCP Server (14 tools)",
-          "slug": "mcp-server-14-tools"
+          "text": "MCP Server (20 tools)",
+          "slug": "mcp-server-20-tools"
         }
       ],
-      "excerpt": "@modelcontextprotocol/sdk 기반 stdio JSONRPC 서버. 14 도구 노출 (read 8 + write 6): | 도구 | 동작 | ||| | listconcepts | vault 의 모든 노드 (kind 필터) | | getconcept | 단일 slug 의 frontmatter + body excerpt + 이웃 | | findevidence | title 부분매칭으로 vault 문서 검색 | | findbacklinks | 특정 slug 를 가리키는 다른 노드들 (frontmatter array 키 + body wikilink/mdlin",
-      "wordCount": 283,
-      "updatedAt": "2026-05-04T02:11:27.044Z",
+      "excerpt": "@modelcontextprotocol/sdk 기반 stdio JSONRPC 서버. 20 도구 노출 (read 12 + write 8): | 도구 | 동작 | ||| | listconcepts | vault 의 모든 노드 (kind 필터) | | getconcept | 단일 slug 의 frontmatter + body excerpt + 이웃 | | getconcepts | R+ 배치 reader — 여러 slug 한 호출에 (max 50, 입력 순서 보존, missing 은 partial result) | | findevidence | title 부분매칭으로 vau",
+      "wordCount": 458,
+      "updatedAt": "2026-05-07T08:29:28.849Z",
       "linksOut": []
     },
     {
@@ -4548,6 +4675,47 @@
       "excerpt": "R10 (auth + cloud surface 영구 제거) 이후 2 mode: local — useLocalVault().status === 'loaded' (사용자 디스크 vault) static — vault 미선택. 빌드타임 dogfood 매니페스트 (docs/ontology/) 가 fallback. useDataSourceMode() 가 두 mode 를 분기. 같은 hook 호출이 mode 별로 다른 source 를 본다 — 호출자 코드는 단일. 적용 surface: useProjects — local: vault manifest 의 kind: project ",
       "wordCount": 107,
       "updatedAt": "2026-05-04T01:27:35.686Z",
+      "linksOut": []
+    },
+    {
+      "slug": "ontology/capabilities/ontology-bootstrap-skill",
+      "path": "docs/ontology/capabilities/ontology-bootstrap-skill.md",
+      "title": "Ontology-Bootstrap Skill (.claude/skills/ontology-bootstrap)",
+      "tags": [],
+      "frontmatter": {
+        "slug": "capabilities/ontology-bootstrap-skill",
+        "kind": "capability",
+        "title": "Ontology-Bootstrap Skill (.claude/skills/ontology-bootstrap)",
+        "domain": "ai-agent-partner",
+        "elements": [
+          ".claude/skills/ontology-bootstrap/SKILL.md"
+        ]
+      },
+      "headings": [
+        {
+          "depth": 2,
+          "text": "흐름 (R+, 3 round-trips)",
+          "slug": "흐름-r-3-round-trips"
+        },
+        {
+          "depth": 2,
+          "text": "단일 source of truth",
+          "slug": "단일-source-of-truth"
+        },
+        {
+          "depth": 2,
+          "text": "Mission align",
+          "slug": "mission-align"
+        },
+        {
+          "depth": 2,
+          "text": "참조",
+          "slug": "참조"
+        }
+      ],
+      "excerpt": "R16 followup — /ontologybootstrap slash skill 의 coldstart counterpart. /ontologysync 가 이미 자란 vault 의 incremental sync 라면, 이 skill 은 fresh init 직후 빈 vault 를 codebase 에서 한 번에 채우는 흐름. 1. listkinds — vault 가 진짜 coldstart 인지 (≤ 5 nodes) 확인 2. analyzerepostructure 1 회 호출 (mcp 도구, R16 v0.8.0) — package.json / README.md H2 / s",
+      "wordCount": 241,
+      "updatedAt": "2026-05-07T06:25:25.011Z",
       "linksOut": []
     },
     {
@@ -4849,7 +5017,8 @@
           "mcp-server",
           "mcp-conflict-guard",
           "ontology-sync-skill",
-          "session-start-ontology-context"
+          "session-start-ontology-context",
+          "ontology-bootstrap-skill"
         ],
         "elements": [
           "mcp-sdk",
@@ -4872,7 +5041,7 @@
       ],
       "excerpt": "Claude Code 같은 LLM agent 가 같은 ontology 를 read/write 하는 surface. MCP 서버 (mcp/) 가 14 도구 (read 8 + write 6) 를 stdin/stdout JSONRPC 로 노출. 등록 가이드: mcp/README.md. 사용자 LLM 비용을 cloud 로 옮기지 않음 — agent 가 자기 LLM 으로 호출.",
       "wordCount": 49,
-      "updatedAt": "2026-05-05T15:29:33.665Z",
+      "updatedAt": "2026-05-06T08:16:21.710Z",
       "linksOut": []
     },
     {
@@ -5241,9 +5410,9 @@
           "slug": "갱신"
         }
       ],
-      "excerpt": "이 디렉토리는 이 프로젝트 자신의 ontology 다. dogfooding — 이 서비스를 만드는 데 필요한 mental model 을 이 서비스의 데이터 형식 (frontmatter md) 으로 표현. 파일을 직접 열거나, pnpm dev 후 /docs/ 에서 vault picker 로 이 디렉토리 선택. MCP 서버 등록 — mcp/README.md 의 .mcp.json 예시 참고. 14 도구 (read 8 + write 6): listconcepts · getconcept · findevidence · findbacklinks · findpath · listki",
-      "wordCount": 188,
-      "updatedAt": "2026-05-04T02:11:33.286Z",
+      "excerpt": "이 디렉토리는 이 프로젝트 자신의 ontology 다. dogfooding — 이 서비스를 만드는 데 필요한 mental model 을 이 서비스의 데이터 형식 (frontmatter md) 으로 표현. 총 26 노드. 정확한 census 는 ohmyontology list 또는 mcp listkinds 호출. 파일을 직접 열거나, pnpm dev 후 /docs/ 에서 vault picker 로 이 디렉토리 선택. MCP 서버 등록 — mcp/README.md 의 .mcp.json 예시 참고. 19 도구 (read 11 + write 8): read — listcon",
+      "wordCount": 262,
+      "updatedAt": "2026-05-07T08:01:36.196Z",
       "linksOut": []
     },
     {
@@ -5415,8 +5584,8 @@
         }
       ],
       "excerpt": "Written (v2): 20260501 Decisions captured: the user confirmed Direction A (ontologyfirst) and added dogfooding + AIagent partnership as a new direction. This file overlays v2 on top of v1's strategic diagnosis (left in place); the decisions and the new direction below are what's current. One codebase, one ontology, tha",
-      "wordCount": 1788,
-      "updatedAt": "2026-05-06T02:02:33.370Z",
+      "wordCount": 1794,
+      "updatedAt": "2026-05-07T08:01:36.196Z",
       "linksOut": []
     },
     {
@@ -6084,7 +6253,7 @@
                 "path": "ontology/capabilities/cli-developer-entry",
                 "type": "doc",
                 "slug": "ontology/capabilities/cli-developer-entry",
-                "title": "CLI Developer Entry (init / list / validate / add / find / import + graph-level)"
+                "title": "CLI Developer Entry (16 commands incl. bootstrap)"
               },
               {
                 "name": "frontmatter-to-ontology",
@@ -6105,7 +6274,7 @@
                 "path": "ontology/capabilities/mcp-server",
                 "type": "doc",
                 "slug": "ontology/capabilities/mcp-server",
-                "title": "MCP Server (14 tools)"
+                "title": "MCP Server (20 tools)"
               },
               {
                 "name": "mode-aware-adapter",
@@ -6113,6 +6282,13 @@
                 "type": "doc",
                 "slug": "ontology/capabilities/mode-aware-adapter",
                 "title": "Mode-Aware Data Source Adapter"
+              },
+              {
+                "name": "ontology-bootstrap-skill",
+                "path": "ontology/capabilities/ontology-bootstrap-skill",
+                "type": "doc",
+                "slug": "ontology/capabilities/ontology-bootstrap-skill",
+                "title": "Ontology-Bootstrap Skill (.claude/skills/ontology-bootstrap)"
               },
               {
                 "name": "ontology-hub-mode-aware",

--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -17,7 +17,7 @@ import {
   type OntologyCountsForProject,
 } from '@/shared/lib/ontology-tree';
 import { ontologyBorderTone } from './ontology-tone';
-import { resolveTopologyPalette } from './topology-palette';
+import { resolveTopologyPalette, applyLeafFillSaturate } from './topology-palette';
 
 export interface SigmaNodeAttrs {
   x: number;
@@ -232,14 +232,18 @@ export function buildGraph(
     graph.addNode(project.slug, {
       x: Math.cos(theta) * r,
       y: Math.sin(theta) * r,
-      // 크기 위계: Hub 10 → Node 5.5. 2nd pass 에서 degree 스케일 미세 조정.
-      size: project.isHub ? 10 : 5.5,
+      // 크기 위계: Hub 13 → Node 5.5 (cycle 47 — Obsidian/Logseq 스타일,
+      // hub vs leaf 명확한 시각 차이로 \"별 + 위성\" 메타포 강화). 2nd pass
+      // 에서 degree 스케일 미세 조정.
+      size: project.isHub ? 13 : 5.5,
       label: shortenName(project.name),
       // Hub 는 forceLabel — 토폴로지 상시 노출 anchor. Node 는 threshold 로
       // 점진 노출.
       forceLabel: project.isHub,
       recentlyUpdated: recent,
-      color: project.isHub ? HUB_COLOR : toneForSlug(project.slug),
+      color: project.isHub
+        ? HUB_COLOR
+        : applyLeafFillSaturate(toneForSlug(project.slug), palette.leafFillSaturate),
       borderColor: project.isHub
         ? palette.hubBorder
         : ontologyTone?.borderColor ?? palette.nodeBorder,
@@ -305,7 +309,7 @@ export function buildGraph(
         forceLabel: false,
         recentlyUpdated: false,
         // 흐린 무채색 fill — 헌장의 "허브만 유일한 채색" 과 충돌 안 함.
-        color: 'rgba(160, 168, 184, 0.55)',
+        color: palette.ontologyFill,
         borderColor: tone?.borderColor ?? palette.nodeBorder,
         outerBorderColor: NODE_OUTER_HALO,
         // SigmaTopology 의 click handler 가 projectSlug 를 키로 drawer 를

--- a/src/widgets/topology-map-sigma/lib/topology-palette.test.ts
+++ b/src/widgets/topology-map-sigma/lib/topology-palette.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { applyLeafFillSaturate } from './topology-palette';
+
+/**
+ * R+ (cycle 47) — DOMAIN_TONE 의 pale rgba 를 light 모드 graphite 으로 시프트
+ * 하는 helper. saturate 1 은 no-op, > 1 은 base lightness 감산.
+ */
+describe('applyLeafFillSaturate', () => {
+  it('saturate=1 → 입력 그대로 (no-op)', () => {
+    expect(applyLeafFillSaturate('rgba(160, 168, 184, 0.82)', 1)).toBe(
+      'rgba(160, 168, 184, 0.82)',
+    );
+  });
+
+  it('saturate=1.7 → rgb 채널을 1.7 로 나눠 graphite shift', () => {
+    // 160/1.7 = 94.1 → 94, 168/1.7 = 98.8 → 99, 184/1.7 = 108.2 → 108
+    expect(applyLeafFillSaturate('rgba(160, 168, 184, 0.82)', 1.7)).toBe(
+      'rgba(94, 99, 108, 0.82)',
+    );
+  });
+
+  it('saturate 적용 시 alpha 는 보존', () => {
+    const out = applyLeafFillSaturate('rgba(200, 200, 200, 0.5)', 2);
+    expect(out).toMatch(/0.5\)$/);
+  });
+
+  it('rgb 형식 (alpha 없음) 도 처리 — alpha 1 으로 채워짐', () => {
+    expect(applyLeafFillSaturate('rgb(200, 200, 200)', 2)).toBe(
+      'rgba(100, 100, 100, 1)',
+    );
+  });
+
+  it('잘못된 입력은 그대로 반환 (best effort)', () => {
+    expect(applyLeafFillSaturate('not-a-color', 2)).toBe('not-a-color');
+    expect(applyLeafFillSaturate('', 1.5)).toBe('');
+  });
+});

--- a/src/widgets/topology-map-sigma/lib/topology-palette.ts
+++ b/src/widgets/topology-map-sigma/lib/topology-palette.ts
@@ -13,9 +13,9 @@
  */
 
 export interface TopologyPalette {
-  /** 비-허브 노드 테두리. 다크: 회청 30%, 라이트: 진회 28% */
+  /** 비-허브 노드 테두리. 다크: 회청 30%, 라이트: 진회 50% (cycle 47) */
   nodeBorder: string;
-  /** 허브 노드 테두리. 다크: 인디고 55%, 라이트: 인디고 70% */
+  /** 허브 노드 테두리. 다크: 인디고 55%, 라이트: 인디고 92% */
   hubBorder: string;
   /** 허브 노드 외곽 halo. 선택 / hover 시 reducer 가 강화. */
   hubOuterHalo: string;
@@ -29,6 +29,15 @@ export interface TopologyPalette {
   edgeDim: string;
   /** 카드/툴팁 배경 톤 (텍스트 라벨이 sigma label 영역과 어울리게). */
   labelText: string;
+  /**
+   * R+ (cycle 47) — DOMAIN_TONE 의 fill 알파 multiplier 와 base shift.
+   * 다크에선 1 (변경 없음). 라이트에선 흰 캔버스 위에서 pale 한 watercolor
+   * 톤이 \"먼지\" 처럼 보이는 문제 해결 — base lightness 를 감산해 graphite
+   * 톤으로 시프트. resolveLeafFill() 가 DOMAIN_TONE rgba 를 받아 변환.
+   */
+  leafFillSaturate: number;
+  /** R+ ontology 노드 (capability/element) 의 default fill. */
+  ontologyFill: string;
 }
 
 const DARK: TopologyPalette = {
@@ -40,22 +49,59 @@ const DARK: TopologyPalette = {
   edgeDependsOn: 'rgba(139, 151, 255, 0.16)',
   edgeDim: 'rgba(255, 255, 255, 0.005)',
   labelText: 'rgba(235, 240, 250, 0.95)',
+  leafFillSaturate: 1,
+  ontologyFill: 'rgba(160, 168, 184, 0.55)',
 };
 
 const LIGHT: TopologyPalette = {
-  // off-white(#f7f8fa) 배경 위에서 의미 있게 보이게 한참 진한 톤 + 충분한 알파.
-  nodeBorder: 'rgba(60, 72, 96, 0.6)',
-  hubBorder: 'rgba(70, 86, 200, 0.85)',
-  hubOuterHalo: 'rgba(70, 86, 200, 0.18)',
-  // 다크는 0.08 인데 그건 검은 배경에서 작동. 라이트 흰 배경엔 0.55+ 필요.
-  edge: 'rgba(60, 72, 96, 0.55)',
-  edgeContains: 'rgba(60, 72, 96, 0.6)',
-  edgeDependsOn: 'rgba(70, 86, 200, 0.7)',
-  // dim 은 "거의 안 보임" 의미를 유지하되 흰 배경에서 노이즈 없게 어두운 톤 +
-  // 낮은 알파.
+  // R+ (cycle 47): 사용자 피드백 \"화이트모드 토폴로지가 징그럽고 벌레같다\".
+  // 원인 분석 — 이전 nodeBorder 0.78 알파가 leaf 노드의 옅은 fill 을 압도해
+  // 모든 leaf 가 \"링/구멍\" 으로 읽혀 spider-web 효과. Obsidian/Logseq
+  // 패턴: solid filled circle 우세 + 매우 가는 hairline border + edge 알파
+  // 낮춤 으로 깔끔한 \"성좌\" 느낌. 흰 캔버스 한정으로 dramatic 하향:
+  //   nodeBorder 0.78 → 0.28 (border 는 hairline 만, fill 이 dominant)
+  //   edge 0.70 → 0.42 (dense graph 에서 spider-web 노이즈 제거)
+  //   edgeContains 0.72 → 0.32 (계층 edge 는 더 배경으로 — 시각 hierarchy)
+  //   hubOuterHalo 0.22 → 0.34 (hub 는 \"별\" 처럼 더 강한 글로우)
+  // 1st 시도: nodeBorder 0.28 → 노드 자체가 사라짐. 2nd 시도: 균형 — border
+  // 는 hairline-but-visible (0.5), fill 은 saturate (DOMAIN_TONE 자체는
+  // 그대로 두고 default leaf 만 진한 graphite 톤). 결과: 흰 배경 위에서
+  // \"solid filled circle with subtle outline\" — Obsidian/Logseq 톤.
+  nodeBorder: 'rgba(40, 50, 72, 0.5)',
+  hubBorder: 'rgba(60, 76, 200, 0.92)',
+  hubOuterHalo: 'rgba(70, 86, 200, 0.32)',
+  edge: 'rgba(40, 50, 72, 0.38)',
+  edgeContains: 'rgba(40, 50, 72, 0.28)',
+  edgeDependsOn: 'rgba(60, 76, 200, 0.58)',
+  // dim 은 \"거의 안 보임\" 의미 유지.
   edgeDim: 'rgba(20, 30, 50, 0.06)',
   labelText: 'rgba(20, 22, 26, 0.95)',
+  // saturate=1.7: DOMAIN_TONE 의 pale rgb (160-200) 를 60-90 graphite 까지
+  // 끌어내려 흰 배경에서 \"실재하는 dot\" 으로 읽힘. ontology 노드도 동일.
+  leafFillSaturate: 1.7,
+  ontologyFill: 'rgba(70, 84, 110, 0.85)',
 };
+
+/**
+ * DOMAIN_TONE 의 pale rgba 를 light 모드 graphite 으로 시프트.
+ * \`rgba(R, G, B, A)\` 입력. saturate factor 만큼 base lightness 를 감산.
+ */
+export function applyLeafFillSaturate(rgba: string, saturate: number): string {
+  if (saturate === 1) return rgba;
+  const m = rgba.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)/);
+  if (!m) return rgba;
+  const r = Number(m[1]);
+  const g = Number(m[2]);
+  const b = Number(m[3]);
+  const a = m[4] !== undefined ? Number(m[4]) : 1;
+  // saturate > 1 이면 darker shift. 단순 multiplicative 로 luminance 감소.
+  // 채도 보존을 위해 rgb 를 같은 factor 로 나눔. clamp 0~255.
+  const f = saturate;
+  const dr = Math.max(0, Math.round(r / f));
+  const dg = Math.max(0, Math.round(g / f));
+  const db = Math.max(0, Math.round(b / f));
+  return `rgba(${dr}, ${dg}, ${db}, ${a})`;
+}
 
 export function resolveTopologyPalette(): TopologyPalette {
   if (typeof document === 'undefined') return DARK;


### PR DESCRIPTION
## Summary

사용자 피드백: 라이트 모드 토폴로지가 \"징그럽고 벌레같다\". 직접 점검 결과 — \`nodeBorder\` 알파 0.78 이 leaf 의 옅은 fill 을 압도해 모든 leaf 가 \"링/구멍\" 으로 읽혀 bug-eye 효과. edge 0.7 + 작은 hub size 도 spider-web 톤에 기여.

## 참고 (Obsidian / Logseq 그래프 뷰)

- **solid filled circle** 우세 + hairline border (border 가 dominant 아님)
- **hub 가 명확히 더 큼** (3-4×)
- **edge 매우 가는 hairline + 낮은 알파**
- **hub 만 soft halo** (\"별 + 위성\" 메타포)

## 변경

1. **topology-palette LIGHT**: alpha 균형 재조정
   - nodeBorder 0.78 → 0.5 (hairline visible, dominant 아님)
   - edge 0.7 → 0.38 (spider-web 제거)
   - edgeContains 0.72 → 0.28 (계층 edge 더 배경)
   - hubOuterHalo 0.22 → 0.32 (hub \"별\" 글로우 강화)
2. **hub size 10 → 13** (다크/라이트 공통, 시각 hierarchy 강화)
3. **\`leafFillSaturate\` (LIGHT 1.7) + \`applyLeafFillSaturate\` helper**: DOMAIN_TONE 의 pale rgb (160-204) 를 라이트에선 1.7 로 나눠 graphite 톤 (~94-120) 으로 shift. \"먼지 dot\" → \"실재하는 graphite circle\". 다크 multiplier=1 → 영향 0.
4. **ontologyFill 토큰화**: 다크 기존 유지, 라이트는 진한 graphite (\`rgba(70,84,110,0.85)\`).
5. **globals.css 라이트 보정**:
   - 트리 element row opacity 60% → 82% (\"읽기 전 사라짐\" 방지)
   - uppercase 모노 라벨 font-weight 520 (anti-aliasing 위약 효과 보정)

## Test plan

- [x] vitest 843 → 848 (+5 — \`applyLeafFillSaturate\` 단위 테스트)
- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] dark mode 직접 확인 — 변경 없음 (hub size 13 만 더 또렷)
- [x] light mode 직접 확인 — bug-eye → graphite constellation 톤

## Out of scope

- \`bordered\` node program 의 ring layer 자체 제거 — Sigma 공통 program 이라 dark 영향 우려, 다음 cycle.
- 더 dramatic Obsidian-style (label hidden until zoom-in 등) — 별 cycle.
- ForceAtlas2 layout 강도 / repulsion 튜닝 — 별 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)