### PR TITLE
fix(topology): 노드 inner border 1.5 → 1.2px, outer halo 2 → 2.5px

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -112,14 +112,16 @@ function createSigma(
   minimal = false,
 ) {
   // 3-layer 노드 렌더링: outer halo → crisp border → fill.
-  //  · outer (2px): 허브는 인디고 α 0.18 로 정적 "중력감", 선택 시 nodeReducer 가
-  //    α 를 올려 선택 halo 역할 겸용. 비허브는 transparent.
-  //  · border (1.5px): 배경 대비 분리감.
+  //  · outer (2.5px): 허브는 인디고 α 글로우 — 정적 "중력감", 선택 시 nodeReducer
+  //    가 α 를 올려 선택 halo 역할 겸용. 비허브는 transparent.
+  //  · border (1.2px): 배경 대비 분리감. cycle 48 — 1.5 → 1.2 로 살짝
+  //    줄여 leaf 가 \"링\" 보다 \"solid disc with hairline\" 으로 읽히도록
+  //    조정 (0.8 까지 줄였더니 leaf 가 사라짐 — 1.2 가 균형점).
   //  · fill: 본체 색.
   const borderNodeProgram = createNodeBorderProgram<SigmaNodeAttrs, SigmaEdgeAttrs>({
     borders: [
-      { size: { value: 2, mode: 'pixels' }, color: { attribute: 'outerBorderColor' } },
-      { size: { value: 1.5, mode: 'pixels' }, color: { attribute: 'borderColor' } },
+      { size: { value: 2.5, mode: 'pixels' }, color: { attribute: 'outerBorderColor' } },
+      { size: { value: 1.2, mode: 'pixels' }, color: { attribute: 'borderColor' } },
       { size: { fill: true }, color: { attribute: 'color' } },
     ],
   });


### PR DESCRIPTION
## Summary

cycle 47 \"벌레같은\" 정정 후 추가 미세 조정. \`createNodeBorderProgram\` 의 3-layer 배치를 hub halo 우선 + inner rim hairline 쪽으로 한 단계 이동.

## 변경

- **inner border 1.5 → 1.2px** (양 모드 공통). leaf 가 \"링/구멍\" 보다 \"solid disc with hairline outline\" 으로 살짝 더 읽힘.
  - 0.8 까지 줄였더니 leaf 가 사라짐 — 1.2 가 시각 확인 균형점.
- **outer halo 2 → 2.5px**. hub 글로우 살짝 더 강조 (\"별과 위성\" 메타포). 비허브는 transparent 라 영향 0.

Sigma 의 \`createNodeBorderProgram\` options 는 mode-aware 가 아니라 양 모드 공통 적용. 다크 모드 직접 확인 — 변경 미미 (이미 깨끗했음).

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — 0 errors
- [x] \`pnpm test:run\` — 848/848
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm vault:validate\` — 26 파일 clean
- [x] light + dark 직접 확인 (Playwright screenshot)

## Out of scope

- mode-aware border thickness — Sigma program 인스턴스 1 개 공유 라 별 cycle 의 architectural 작업.
- ForceAtlas2 repulsion 튜닝 — 다음 cycle 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)