### PR TITLE
fix(ux): ontology surface UX pass 1 — 8 가독성 개선

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -109,7 +109,7 @@
       "pathPickSecondNode": "Shift+click another node",
       "statsNodes": "nodes",
       "statsHubs": "hubs",
-      "statsEdges": "edges",
+      "statsEdges": "relations",
       "auditLegendTitle": "Things to look at",
       "auditLegendStale": "Stale · {threshold} day+ untouched ({count})",
       "auditLegendOrphan": "Orphan · 0 connections ({count})",
@@ -377,6 +377,8 @@
     },
     "workspaceStrip": {
       "openOntologyAriaLabel": "Open ontology tree",
+      "ontologyLabel": "Domains+Capabilities+Elements",
+      "ontologyTitle": "Sum of ontology nodes owned by this project — excludes project / vault-readme nodes. May differ from the 'N nodes' count on /ontology.",
       "domain": "Domain",
       "capability": "Capability",
       "element": "Element",
@@ -850,6 +852,9 @@
       "factStatus": "Status",
       "factConnections": "Links",
       "factCount": "{count}",
+      "factDomain": "Domains",
+      "factCapability": "Capabilities",
+      "factElement": "Elements",
       "categoryUncategorized": "Uncategorized",
       "ontologyBadgeTitle": "{count} ontology nodes for this project",
       "ontologyBadgeLabel": "Ontology {count}"
@@ -1128,9 +1133,9 @@
       "ctaOpenVault": "Open my markdown folder"
     },
     "hint": {
-      "title": "Project terrain map",
+      "title": "Ontology terrain map",
       "dismissAriaLabel": "Close hint",
-      "body": "Nodes are projects, lines are dependencies. Click to open details, search to narrow.",
+      "body": "Nodes are projects · domains · capabilities · elements. Lines are depends-on / related / contains. Click to open details, search to narrow.",
       "click": "Click",
       "clickDescription": " · open the detail panel",
       "drag": "Drag",
@@ -1165,7 +1170,10 @@
     "stat": {
       "treeNodes": "Tree nodes",
       "totalRelations": "Total relations",
-      "documents": "Evidence docs"
+      "documents": "Evidence docs",
+      "warnings": "Data warnings",
+      "warningsHint": "Relations dropped from the tree (multi-parent etc.)",
+      "warningsAria": "Data warnings {count} — click for details"
     },
     "error": "Something went wrong while loading ontology data. {message}",
     "loading": "Loading…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -109,7 +109,7 @@
       "pathPickSecondNode": "다른 노드를 Shift+클릭",
       "statsNodes": "노드",
       "statsHubs": "허브",
-      "statsEdges": "엣지",
+      "statsEdges": "관계",
       "auditLegendTitle": "챙길 곳 표시",
       "auditLegendStale": "오래된 · {threshold}일+ 안 건드림 ({count})",
       "auditLegendOrphan": "외톨이 · 연결 0 ({count})",
@@ -377,6 +377,8 @@
     },
     "workspaceStrip": {
       "openOntologyAriaLabel": "온톨로지 트리 열기",
+      "ontologyLabel": "도메인+역량+요소",
+      "ontologyTitle": "프로젝트가 가진 ontology 노드 합 — project / vault-readme 노드는 제외. /ontology 의 '노드 N' 카운트와 다를 수 있음.",
       "domain": "도메인",
       "capability": "역량",
       "element": "요소",
@@ -850,6 +852,9 @@
       "factStatus": "상태",
       "factConnections": "연결",
       "factCount": "{count}개",
+      "factDomain": "도메인",
+      "factCapability": "역량",
+      "factElement": "요소",
       "categoryUncategorized": "미분류",
       "ontologyBadgeTitle": "이 프로젝트의 ontology 노드 {count}개",
       "ontologyBadgeLabel": "Ontology {count}"
@@ -1128,9 +1133,9 @@
       "ctaOpenVault": "마크다운 폴더 열기"
     },
     "hint": {
-      "title": "프로젝트 지형도",
+      "title": "온톨로지 지형도",
       "dismissAriaLabel": "안내 닫기",
-      "body": "노드는 프로젝트, 선은 의존 관계입니다. 클릭해서 상세를 열고 검색으로 좁혀보세요.",
+      "body": "노드는 프로젝트 · 도메인 · 역량 · 요소. 선은 의존 · 관련 · 포함 관계입니다. 클릭해서 상세를 열고 검색으로 좁혀보세요.",
       "click": "클릭",
       "clickDescription": " · 상세 패널 열기",
       "drag": "드래그",
@@ -1165,7 +1170,10 @@
     "stat": {
       "treeNodes": "트리 노드",
       "totalRelations": "총 관계",
-      "documents": "근거 문서"
+      "documents": "근거 문서",
+      "warnings": "데이터 경고",
+      "warningsHint": "다중 부모 등으로 트리에서 누락된 관계",
+      "warningsAria": "데이터 경고 {count}건 — 클릭해서 자세히 보기"
     },
     "error": "ontology 데이터를 불러오는 중 오류가 났어요. {message}",
     "loading": "불러오는 중…",

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -256,10 +256,12 @@ function computeDagreLayout(
   if (docs.length === 0) return map;
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
-  // rankdir LR — 좌→우 계층 흐름. nodesep / ranksep 축소 — 빽빽하게 배치해
-  // viewport fitView 시 노드 글자가 너무 작아지지 않게 (이전엔 18 노드가
-  // 가로로 너무 펼쳐져 화면 fit 시 노드 가독성 떨어짐).
-  g.setGraph({ rankdir: "LR", nodesep: 24, ranksep: 56, marginx: 16, marginy: 16 });
+  // rankdir LR — 좌→우 계층 흐름. R12 — capability 가 14+ 같은 rank 에 쌓이는
+  // 케이스에서 nodesep=24 면 NODE_HEIGHT 와 비교해 라벨 영역이 겹침. 60 으로
+  // 늘려 행간 라벨 충돌 완화. ranksep 은 70 으로 확장 — 화살표 라벨 (포함/관련)
+  // 가 column 사이에 들어갈 공간 확보. fitView 가 자동 줌-아웃해서 너무
+  // 작아지지 않게 비율 유지.
+  g.setGraph({ rankdir: "LR", nodesep: 60, ranksep: 70, marginx: 16, marginy: 16 });
   for (const doc of docs) {
     g.setNode(doc.slug, { width: NODE_WIDTH, height: NODE_HEIGHT });
   }

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -264,18 +264,38 @@ export function OntologyViewPage() {
       </section>
 
       {/* tree node + relation stat strip. 사용자가 vault 에 document kind
-          노드를 만들면 추가 카운트만 surface (docCount > 0 일 때만). */}
+          노드를 만들면 추가 카운트만 surface (docCount > 0 일 때만).
+          treeResult.warnings 가 있으면 (multi-parent silent drop 등) amber
+          액션 칸을 추가 — 페이지 끝의 details disclosure 로 스크롤. */}
       <section
         className={
-          docCount > 0
-            ? "mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3"
-            : "mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2"
+          (() => {
+            const cols = 2 + (docCount > 0 ? 1 : 0) + ((treeResult?.warnings.length ?? 0) > 0 ? 1 : 0);
+            if (cols >= 4) return "mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4";
+            if (cols === 3) return "mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3";
+            return "mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2";
+          })()
         }
       >
         <Stat label={t('stat.treeNodes')} value={String(totalNodes)} />
         <Stat label={t('stat.totalRelations')} value={insight ? String(insight.edges.length) : "—"} />
         {docCount > 0 ? (
           <Stat label={t('stat.documents')} value={String(docCount)} />
+        ) : null}
+        {treeResult && treeResult.warnings.length > 0 ? (
+          <Stat
+            label={t('stat.warnings')}
+            value={`⚠ ${treeResult.warnings.length}`}
+            accent="amber"
+            hint={t('stat.warningsHint')}
+            ariaLabel={t('stat.warningsAria', { count: treeResult.warnings.length })}
+            onClick={() => {
+              const el = document.getElementById('tree-data-warnings');
+              if (!el) return;
+              if (el instanceof HTMLDetailsElement) el.open = true;
+              el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }}
+          />
         ) : null}
       </section>
 
@@ -860,9 +880,11 @@ function Stat({
   value,
   accent,
   href,
+  onClick,
   hint,
   hintFull,
   className,
+  ariaLabel,
 }: {
   label: string;
   value: string;
@@ -870,12 +892,15 @@ function Stat({
   accent?: "amber" | "indigo";
   /** truthy 면 카드 자체가 Link 로 렌더 — 사용자 행동 유도. */
   href?: string;
+  /** href 없이 in-page 점프 / 토글 등 액션이 필요할 때. */
+  onClick?: () => void;
   /** 라벨이 입문자에게 외계어인 경우 카드 내부에 1 줄 풀설명 (짧게 유지). */
   hint?: string;
   /** hint 가 길면 별도 풀설명을 호버 title 로 — 좁은 카드 wrap 회피. */
   hintFull?: string;
   /** grid 안에서 col-span 등 layout 변형. */
   className?: string;
+  ariaLabel?: string;
 }) {
   const accentClass =
     accent === "amber"
@@ -914,6 +939,18 @@ function Stat({
       >
         {body}
       </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className={`${wrapperClass} block w-full text-left transition-colors hover:border-[color:rgba(94,106,210,0.32)]`}
+      >
+        {body}
+      </button>
     );
   }
   return <div className={wrapperClass}>{body}</div>;

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -15,7 +15,10 @@ import { ProjectQuickCreatePanel } from "@/features/project-quick-create";
 import { useProjectMutations, useProjects } from "@/features/project-data-source";
 import { downloadProjectsCsv } from "@/features/project-export";
 import { useOntologyInsight } from "@/features/vault-ontology";
-import { buildProjectOntologyCounts } from "@/shared/lib/ontology-tree";
+import {
+  buildProjectOntologyCounts,
+  type OntologyCountsForProject,
+} from "@/shared/lib/ontology-tree";
 import { OperationsNav } from "@/widgets/operations-nav";
 import { WorkspaceOntologyStrip } from "@/widgets/workspace-ontology-strip";
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/shared/ui";
@@ -89,13 +92,13 @@ export function ProjectSelectorPage() {
   // 로 집계해 카드 우상단에 "ontology 4" 같은 chip 표시. project / document
   // 메타 kind 제외 (domain / capability / element / unknown 합).
   const { insight } = useOntologyInsight();
-  const ontologyCountBySlug = useMemo(() => {
-    if (!insight) return new Map<string, number>();
-    const counts = buildProjectOntologyCounts(insight.nodes);
-    const map = new Map<string, number>();
-    for (const [slug, c] of counts) map.set(slug, c.total);
-    return map;
-  }, [insight]);
+  // 카드 fact 영역이 stale 한 단계/상태/연결 (cloud-mode 잔재) 대신 ontology
+  // breakdown 으로 fallback 할 수 있도록 byKind 까지 보존. badge chip 은
+  // .total 만 쓰는데, 같은 데이터 흐름에서 카드 본문도 같이 활용.
+  const ontologyCountsBySlug = useMemo<Map<string, OntologyCountsForProject>>(
+    () => (insight ? buildProjectOntologyCounts(insight.nodes) : new Map()),
+    [insight],
+  );
 
   const filteredProjects = useMemo(
     () =>
@@ -419,22 +422,43 @@ export function ProjectSelectorPage() {
                       </div>
                     </CardHeader>
                     <CardContent className="flex flex-1 flex-col justify-between space-y-4">
-                      {/* 카드 내 요약 3 fact. "구분" 은 category (lifecycle
-                          phase: 작업중/예정), "상태" 는 status (구체 단계:
-                          개발중/운영중/기획/아이디어). 두 축이 서로 겹쳐 보여
-                          label 을 "단계 / 상태" 로 명확히 분리. */}
-                      <div className="grid grid-cols-3 gap-2 rounded-[18px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-3">
-                        <QuickFact label={t("factPhase")} value={categoryLabel(project.category)} />
-                        <QuickFact label={t("factStatus")} value={statusLabel(project.status)} />
-                        <QuickFact label={t("factConnections")} value={t("factCount", { count: project.dependencies.length })} />
-                      </div>
+                      {/* 카드 내 요약 fact strip. R12 — cloud-mode 의
+                          단계/상태/연결 3축은 dogfood 같은 local-first
+                          프로젝트에서 모두 "—"/0 으로 비어 회귀.
+                          ontology breakdown (도메인/역량/요소) 이 있으면
+                          그걸 우선 — 없으면 기존 3 fact 가 fallback. */}
+                      {(() => {
+                        const counts = ontologyCountsBySlug.get(project.slug);
+                        const hasOntology = (counts?.total ?? 0) > 0;
+                        if (hasOntology) {
+                          return (
+                            <div className="grid grid-cols-3 gap-2 rounded-[18px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-3">
+                              <QuickFact label={t("factDomain")} value={String(counts!.byKind.domain)} />
+                              <QuickFact label={t("factCapability")} value={String(counts!.byKind.capability)} />
+                              <QuickFact label={t("factElement")} value={String(counts!.byKind.element)} />
+                            </div>
+                          );
+                        }
+                        const phase = categoryLabel(project.category);
+                        const status = statusLabel(project.status);
+                        const conn = project.dependencies.length;
+                        const allEmpty = phase === "—" && status === "—" && conn === 0;
+                        if (allEmpty) return null;
+                        return (
+                          <div className="grid grid-cols-3 gap-2 rounded-[18px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-3">
+                            <QuickFact label={t("factPhase")} value={phase} />
+                            <QuickFact label={t("factStatus")} value={status} />
+                            <QuickFact label={t("factConnections")} value={t("factCount", { count: conn })} />
+                          </div>
+                        );
+                      })()}
                       <div className="space-y-3">
                         <div className="flex items-center justify-between gap-2 text-sm text-[color:var(--color-text-secondary)]">
                           <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                             {project.slug}
                           </span>
                           {(() => {
-                            const ontologyCount = ontologyCountBySlug.get(project.slug) ?? 0;
+                            const ontologyCount = ontologyCountsBySlug.get(project.slug)?.total ?? 0;
                             if (ontologyCount === 0) return null;
                             return (
                               <span

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.test.tsx
@@ -417,7 +417,9 @@ describe("OntologyTreeView — UX-11 element kind dim", () => {
   }
 
   it("element kind row 에 data-dim=true + opacity-60 클래스", () => {
-    render(<OntologyTreeView result={withElement()} />);
+    // R12 — capability default-collapsed 라 element 가 안 보임. 이 케이스는
+    // *element row dim 자체* 의 단위 테스트라 capability 펼친 상태를 명시적으로 요청.
+    render(<OntologyTreeView result={withElement()} collapseCapabilitiesByDefault={false} />);
     const rows = screen.getAllByTestId("ontology-tree-row");
     const elementRow = rows.find((r) => r.getAttribute("data-kind") === "element");
     expect(elementRow).toBeDefined();
@@ -428,7 +430,7 @@ describe("OntologyTreeView — UX-11 element kind dim", () => {
   });
 
   it("non-element kind row (project/domain/capability) 에 data-dim=false + opacity 클래스 없음", () => {
-    render(<OntologyTreeView result={withElement()} />);
+    render(<OntologyTreeView result={withElement()} collapseCapabilitiesByDefault={false} />);
     const rows = screen.getAllByTestId("ontology-tree-row");
     const projectRow = rows.find((r) => r.getAttribute("data-kind") === "project");
     const domainRow = rows.find((r) => r.getAttribute("data-kind") === "domain");

--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -27,6 +27,11 @@ export interface OntologyTreeViewProps {
   emptyHint?: string;
   /** 시작 시 모든 노드 펼침 여부. 기본 true. */
   defaultExpanded?: boolean;
+  /** R12 — first-impression UX: capability 노드는 default 접힘. element
+   *  file path leaf 가 capability 마다 길게 펼쳐져 첫 화면 정보 과다.
+   *  capability 한 줄만 보이고, 클릭하면 elements 펼침. domain 까지는
+   *  default 펼침 유지 — 위계 자체를 한눈에. */
+  collapseCapabilitiesByDefault?: boolean;
   /** 행 클릭 콜백 — 상세 패널로 라우팅 등에 사용. */
   onSelect?: (node: OntologyTreeNode["node"]) => void;
   /** 외부에서 선택된 노드 id (deeplink ?node=..., panel 클릭 등). 트리 행
@@ -160,7 +165,29 @@ function TreeRow({
         className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden break-keep text-left text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[color:rgba(94,106,210,0.5)] focus-visible:rounded-sm"
       >
         <KindChip kind={treeNode.node.kind} />
-        <span className="min-w-0 flex-1 truncate">{treeNode.node.title}</span>
+        {(() => {
+          // R12 — element 의 file path 라벨은 모바일에서 ellipsis 가 *파일명*
+          // 을 먹어 식별 불가 ("src/features/.../use-projec…"). prefix 만
+          // 잘리고 basename 은 항상 보이게 split. path 아닌 element 는 일반
+          // truncate. element 외 kind 도 그대로.
+          const title = treeNode.node.title;
+          const isElementPath =
+            treeNode.node.kind === "element" && title.includes("/") && !title.includes(" ");
+          if (!isElementPath) {
+            return <span className="min-w-0 flex-1 truncate">{title}</span>;
+          }
+          const lastSlash = title.lastIndexOf("/");
+          const prefix = title.slice(0, lastSlash + 1);
+          const basename = title.slice(lastSlash + 1);
+          return (
+            <span className="flex min-w-0 flex-1 items-center">
+              <span className="min-w-0 truncate text-[color:var(--color-text-quaternary)]">
+                {prefix}
+              </span>
+              <span className="flex-none">{basename}</span>
+            </span>
+          );
+        })()}
         {/* EvidenceCountChip / ProjectIdChip 모두 R10 후 vault 모드에서
             evidenceCount / projectIds 가 영구 빈 값이라 미렌더되어 cycle
             15 / 24 에서 제거. 미래에 vault 측에서 해당 값을 derive 해
@@ -184,6 +211,7 @@ export function OntologyTreeView({
   result,
   emptyHint,
   defaultExpanded = true,
+  collapseCapabilitiesByDefault = true,
   onSelect,
   selectedId,
 }: OntologyTreeViewProps) {
@@ -251,6 +279,9 @@ export function OntologyTreeView({
   const isCollapsed = (id: string) => {
     // selectedId 의 조상은 항상 펼친 상태로 보이도록 override.
     if (forceOpenAncestors.has(id)) return false;
+    // capability default-collapsed: collapsed Set 의미가 *반전* — Set 에
+    // 있으면 "사용자가 펼친" 것, 없으면 "default 접힌" 그대로.
+    if (defaultCollapsedIds.has(id)) return !collapsed.has(id);
     if (defaultExpanded) return collapsed.has(id);
     // collapsed 가 default → 토글된 것만 펼침.
     return !collapsed.has(id);
@@ -265,23 +296,52 @@ export function OntologyTreeView({
     return ids;
   }, [result.roots]);
 
-  // \`collapsed\` Set 의미가 \`defaultExpanded\` 에 따라 뒤집힌다:
-  // - true (default): collapsed Set = 접힌 노드 → expanded = total - collapsed
-  // - false: collapsed Set = 펼친 노드 → expanded = collapsed.size
-  // 둘 다 동일 변수 이름을 쓰는 v0 구현 단순화에 따른 quirk.
-  const expandedCount = defaultExpanded
-    ? collapsibleIds.size - collapsed.size
-    : collapsed.size;
+  // R12 — first-impression UX: capability 노드는 default 접힘.
+  // capability 가 children (element) 을 가질 때만 의미. element/domain/project 는 영향 X.
+  // 작은 트리 (수십 노드) 라 매 렌더 O(N) 계산 — useMemo 는 lint 의 manual
+  // memoization 보존 룰과 충돌해서 인라인.
+  const defaultCollapsedIds = new Set<string>();
+  if (collapseCapabilitiesByDefault) {
+    for (const flat of flattenTree(result.roots)) {
+      if (flat.node.kind === "capability" && flat.children.length > 0) {
+        defaultCollapsedIds.add(flat.node.id);
+      }
+    }
+  }
+
+  // \`collapsed\` Set 의미가 \`defaultExpanded\` 와 노드별 \`defaultCollapsedIds\`
+  // 에 따라 뒤집힌다. 매 렌더 O(N) 단순 계산 — 작은 트리 (수십 노드) 라
+  // useMemo 비용보다 인라인이 가독성 우위.
+  let expandedCount = 0;
+  for (const id of collapsibleIds) {
+    let isCol: boolean;
+    if (forceOpenAncestors.has(id)) {
+      isCol = false;
+    } else if (defaultCollapsedIds.has(id)) {
+      isCol = !collapsed.has(id);
+    } else if (defaultExpanded) {
+      isCol = collapsed.has(id);
+    } else {
+      isCol = !collapsed.has(id);
+    }
+    if (!isCol) expandedCount += 1;
+  }
   const canExpandMore = expandedCount < collapsibleIds.size;
   const canCollapseMore = expandedCount > 0;
 
   const expandAll = () => {
-    setCollapsed(new Set());
+    // capability default-collapsed 가 있으면 그것들을 set 에 채워야 펼쳐짐
+    // (반전 의미). 그 외 ID 는 비워 둠.
+    setCollapsed(new Set(defaultCollapsedIds));
   };
   const collapseAll = () => {
-    // defaultExpanded 가 true 면 collapsed Set 에 모든 ID 가 들어가야 모두 접힘.
-    // false 면 빈 Set 이 모두 접힘.
-    setCollapsed(defaultExpanded ? new Set(collapsibleIds) : new Set());
+    // defaultExpanded 노드: set 에 추가 → 접힘.
+    // capability default-collapsed: set 에서 제외 → default 접힘 유지.
+    const next = new Set<string>();
+    for (const id of collapsibleIds) {
+      if (!defaultCollapsedIds.has(id)) next.add(id);
+    }
+    setCollapsed(next);
   };
 
   // R+ — 트리 키보드 nav. Tab 으로 트리 진입 후 다음 키로 power-user 이동:
@@ -568,7 +628,10 @@ export function OntologyTreeView({
         </div>
       ) : null}
       {result.warnings.length > 0 ? (
-        <details className="group rounded-xl border border-[color:rgba(229,72,77,0.24)] bg-[color:rgba(229,72,77,0.06)] px-4 py-3 text-xs text-[color:var(--color-status-danger)] open:bg-[color:rgba(229,72,77,0.09)]">
+        <details
+          id="tree-data-warnings"
+          className="group scroll-mt-24 rounded-xl border border-[color:rgba(229,72,77,0.24)] bg-[color:rgba(229,72,77,0.06)] px-4 py-3 text-xs text-[color:var(--color-status-danger)] open:bg-[color:rgba(229,72,77,0.09)]"
+        >
           <summary className="flex cursor-pointer list-none items-center gap-2 font-[var(--font-weight-signature)] [&::-webkit-details-marker]:hidden">
             <ChevronRight className="h-3 w-3 flex-none transition-transform duration-150 group-open:rotate-90" />
             <span className="flex-1">{t('tree.warningsSummary', { count: result.warnings.length })}</span>

--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -16,7 +16,7 @@ import {
   type MeaningfulOntologyKind,
   type OntologyCountsForProject,
 } from '@/shared/lib/ontology-tree';
-import { ontologyBorderTone } from './ontology-tone';
+import { ontologyBorderTone, ONTOLOGY_NODE_SIZE_BY_KIND } from './ontology-tone';
 import { resolveTopologyPalette, applyLeafFillSaturate } from './topology-palette';
 
 export interface SigmaNodeAttrs {
@@ -303,8 +303,10 @@ export function buildGraph(
       graph.addNode(node.id, {
         x: Math.cos(theta) * r,
         y: Math.sin(theta) * r,
-        // ontology 노드는 project leaf (4.5) 보다 작게 — 시각적 위계 보존.
-        size: 3.5,
+        // R12 — kind 별 size 차등. domain (5.5) > capability (4) > element
+        // (2.8). 위계가 *크기* 로 한눈에 — color 단일 제약 보존하면서 시각
+        // 정보량 증가.
+        size: ONTOLOGY_NODE_SIZE_BY_KIND[kind],
         label: node.title,
         forceLabel: false,
         recentlyUpdated: false,
@@ -368,10 +370,17 @@ export function buildGraph(
         10 + Math.min(3, Math.log2(Math.max(1, degree)) * 0.8),
       );
     } else if (attrs.isOntology) {
+      // R12 — kind 별 base size (ONTOLOGY_NODE_SIZE_BY_KIND) + degree 가중.
+      // 이전 단일 3.5 → domain 5.5 / capability 4 / element 2.8 로 첫인상
+      // 위계 강화. degree 영향은 약하게 유지.
+      const kind = attrs.ontologyTopKind;
+      const base = kind && ONTOLOGY_NODE_SIZE_BY_KIND[kind] !== undefined
+        ? ONTOLOGY_NODE_SIZE_BY_KIND[kind]
+        : 3.5;
       graph.setNodeAttribute(
         id,
         'size',
-        3.5 + Math.min(2, Math.log2(Math.max(1, degree)) * 0.4),
+        base + Math.min(2, Math.log2(Math.max(1, degree)) * 0.4),
       );
       const isDomain = attrs.ontologyTopKind === 'domain';
       const isHighDegree = degree >= ONTOLOGY_LABEL_DEGREE;

--- a/src/widgets/topology-map-sigma/lib/ontology-tone.ts
+++ b/src/widgets/topology-map-sigma/lib/ontology-tone.ts
@@ -26,6 +26,19 @@ const ONTOLOGY_BORDER_BY_KIND: Record<MeaningfulOntologyKind, string> = {
 /** 모든 ontology border 의 단일 두께 — 헌장의 "size 변동 최소" 정책. */
 export const ONTOLOGY_BORDER_WIDTH = 1.5;
 
+/**
+ * R12 — kind 별 노드 size. domain (큰 분류) > capability (관심 단위) >
+ * element (구현체). 사용자가 그래프 첫인상에서 위계를 색이 아닌 *크기* 로
+ * 인지하게. project leaf (4.5) 보다 작고 hub (10+) 와 차이 보존 — 헌장의
+ * "허브만 유일한 채색" 약속과 충돌 X (인디고 fill 은 hub 만).
+ */
+export const ONTOLOGY_NODE_SIZE_BY_KIND: Record<MeaningfulOntologyKind, number> = {
+  domain: 5.5,
+  capability: 4,
+  element: 2.8,
+  unknown: 3.2,
+};
+
 export interface OntologyBorderTone {
   borderColor: string;
   borderWidth: number;

--- a/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
@@ -177,7 +177,7 @@ export function SigmaMinimap({ sigma, graph }: SigmaMinimapProps) {
           Map
         </span>
         <span className="font-mono text-[9px] tracking-[0.08em] text-[color:var(--color-text-tertiary)]">
-          {totalNodes} · {primaryCount} {primaryLabel}
+          {primaryCount > 0 ? `${totalNodes} · ${primaryCount} ${primaryLabel}` : `${totalNodes} nodes`}
         </span>
       </div>
       <svg

--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -1408,12 +1408,18 @@ function SigmaTopologyImpl({
     graph.forEachNode((_, attrs) => {
       if (attrs.isHub) hubs += 1;
     });
+    // ontology extension 이 켜진 surface 에선 edge 카운트를 vault 의 원본
+    // 관계 (insight.edges.length) 와 정렬 — graphology 의 graph.size 는
+    // 같은 (from,to) 쌍을 1개로 dedup 해서 /ontology 의 "총 관계" 와
+    // 카운트가 어긋났다 (141 vs 135).
+    const originalRelationCount =
+      showOntologyNodes && ontologyInsight ? ontologyInsight.edges.length : graph.size;
     return {
       nodes: graph.order,
       hubs,
-      edges: graph.size,
+      edges: originalRelationCount,
     };
-  }, [graph]);
+  }, [graph, showOntologyNodes, ontologyInsight]);
 
   return (
     <div className={`relative h-full w-full overflow-hidden ${className ?? ''}`}>
@@ -1588,10 +1594,14 @@ function SigmaTopologyImpl({
         <span>
           <span className="text-[color:var(--color-text-secondary)]">{stats.nodes}</span> {t('statsNodes')}
         </span>
-        <span className="h-2 w-px bg-[color:var(--color-overlay-3)]" />
-        <span>
-          <span className="text-[color:var(--color-indigo-accent)]">{stats.hubs}</span> {t('statsHubs')}
-        </span>
+        {stats.hubs > 0 ? (
+          <>
+            <span className="h-2 w-px bg-[color:var(--color-overlay-3)]" />
+            <span>
+              <span className="text-[color:var(--color-indigo-accent)]">{stats.hubs}</span> {t('statsHubs')}
+            </span>
+          </>
+        ) : null}
         <span className="h-2 w-px bg-[color:var(--color-overlay-3)]" />
         <span>
           <span className="text-[color:var(--color-text-secondary)]">{stats.edges}</span> {t('statsEdges')}

--- a/src/widgets/workspace-ontology-strip/ui/WorkspaceOntologyStrip.tsx
+++ b/src/widgets/workspace-ontology-strip/ui/WorkspaceOntologyStrip.tsx
@@ -46,8 +46,9 @@ export function WorkspaceOntologyStrip() {
         href={ontologyHref}
         className="inline-flex items-center gap-1.5 rounded-full border border-[color:rgba(94,106,210,0.32)] bg-[color:rgba(94,106,210,0.08)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:rgba(159,170,235,0.95)] transition-colors hover:bg-[color:rgba(94,106,210,0.16)]"
         aria-label={t("openOntologyAriaLabel")}
+        title={t("ontologyTitle")}
       >
-        Ontology {counts.total}
+        {t("ontologyLabel")} {counts.total}
         <span aria-hidden>→</span>
       </Link>
       {counts.domain > 0 ? <CountChip label={t("domain")} value={counts.domain} /> : null}


### PR DESCRIPTION
## Summary

`/ontology`, `/topology`, `/projects`, `/ontology/edit` 의 UX 점검 보고서에서 식별된 우선순위 8 항목 일괄 적용. 첫인상 정보 과다 / 카운트 불일치 / silent drop / stale 잔재 정리가 핵심.

### 적용 항목

| # | 영역 | 변경 |
|---|---|---|
| 🔴 1 | `/ontology` warning | multi-parent silent drop 을 stat strip 의 amber `⚠ N` 칸으로 표면화. 클릭 시 details 자동 열림 + scrollIntoView. |
| 🔴 2 | `/topology` 안내 카피 | "프로젝트 지형도, 노드는 프로젝트" → "온톨로지 지형도, 노드는 프로젝트/도메인/역량/요소". 카피 stale 회귀. |
| 🟡 3 | 카운트 통일 | 토폴로지 edge 카운트를 graphology dedup (135) → vault 원본 (141). "0 허브" 칸 자체 숨김. 라벨 "엣지" → "관계". `/projects` 의 "Ontology 82" → "도메인+역량+요소 82" + title 정의. |
| 🟡 4 | `/projects` 카드 | R10 cloud-mode 잔재 "단계/상태/연결" 3 fact 가 모두 비는 dogfood 같은 케이스에서 ontology breakdown (도메인/역량/요소) 으로 fallback. 셋 다 비면 strip hide. |
| 🟡 5 | 트리 default 접힘 | capability 노드만 default collapsed. domain 위계는 펼침 유지. 21/21 펼침 → 일반 vault 에서 ~5/21 첫 화면. `collapseCapabilitiesByDefault` prop 추가. |
| 🟢 6 | Sigma kind 시각 | 노드 size 단일 3.5 → kind 별 (domain 5.5 / capability 4 / element 2.8). 색 단일 인디고 약속 유지, 위계가 크기로 한눈에. |
| 🟢 7 | 빌더 dagre | nodesep 24→60, ranksep 56→70. 14+ capability 가 같은 rank 에 쌓이는 라벨 충돌 완화. |
| 🟢 8 | 모바일 element 라벨 | path-like element 라벨의 prefix 만 truncate, basename 항상 보이게 split. `src/features/.../use-projec…` 문제 해결. |

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm vault:validate` — 26 files clean
- [x] `pnpm test:run` — **106 files / 861 tests pass**
- [ ] 시각 검수 — `pnpm dev` 후:
  - `/ontology` — capability 기본 접힘 + ⚠ pill 상단 노출
  - `/topology` — 안내 카피 갱신 + 노드 크기 위계 + 0 허브 칸 사라짐
  - `/projects` — 카드 fact 가 도메인/역량/요소 로 교체
  - `/ontology/edit` — capability column 라벨 충돌 완화

## 영향 범위

- i18n: ko/en `topology.hint.*`, `topology.statsEdges`, `ontologyView.stat.warnings*`, `projectSelector.factDomain/Capability/Element`, `searchWidgets.workspaceStrip.ontologyLabel/Title` 추가/갱신
- 단일 contract 영향 X (vault parser / validator drift 없음)
- 빌드 출력물 (`docs-vault/data/manifest.json`) 은 의도적으로 제외 — predev 가 매번 regenerate 하는 timestamp drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)