### PR TITLE
fix(ux): /ontology/insights bar 옆 share% inline 노출

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -169,6 +169,12 @@ export function OntologyInsightsPage() {
             <ul className="space-y-2">
               {kindRows.map(({ kind, count }) => {
                 const pct = kindMax > 0 ? Math.round((count / kindMax) * 100) : 0;
+                // share-of-total — bar 의 시각 정보가 *kindMax 대비* 라 사용자
+                // 가 "전체 중 비중" 을 따로 인지 못 함. raw count 옆에 share
+                // (`{count} · {share}%`) 를 monospace 로 같이 노출 — 디자인
+                // 헌장의 무채색 quaternary 톤 유지.
+                const share =
+                  totalNodes > 0 ? Math.round((count / totalNodes) * 100) : 0;
                 return (
                   <li key={kind} className="text-[12px]">
                     <div className="flex items-baseline justify-between gap-2">
@@ -176,7 +182,7 @@ export function OntologyInsightsPage() {
                         {kindLabel(kind)}
                       </span>
                       <span className="font-mono text-[10px] tabular-nums text-[color:var(--color-text-quaternary)]">
-                        {count}
+                        {count} · {share}%
                       </span>
                     </div>
                     <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
@@ -227,6 +233,8 @@ export function OntologyInsightsPage() {
               <ul className="space-y-1.5" data-testid="insights-edge-type-rows">
                 {edgeTypeRows.map(({ type, count }) => {
                   const pct = edgeTypeMax > 0 ? Math.round((count / edgeTypeMax) * 100) : 0;
+                  const share =
+                    totalEdges > 0 ? Math.round((count / totalEdges) * 100) : 0;
                   return (
                     <li
                       key={type}
@@ -241,7 +249,7 @@ export function OntologyInsightsPage() {
                           {edgeTypeLabel(type)}
                         </span>
                         <span className="font-mono text-[10px] tabular-nums text-[color:var(--color-text-quaternary)]">
-                          {count}
+                          {count} · {share}%
                         </span>
                       </div>
                       <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">


### PR DESCRIPTION
## Summary

`/ontology/insights` 의 kind 분포 / edge type 분포 row 가 raw count 만 보여줘서 사용자가 "전체 중 비중" 을 따로 인지하기 어려웠다. 막대 그래프는 *max 대비* 정규화라 가장 큰 그룹과의 비교만 보이고, 작은 그룹의 절대 비중은 따로 계산해야 인지됨.

- kind 분포 — `{count} · {share}%` (분모 = `totalNodes`)
- edge type 분포 — `{count} · {share}%` (분모 = `totalEdges`)
- 프로젝트별 분포 — 의도적으로 share% 추가 X (분모 모호)

디자인 토큰 변경 없음 — quaternary 텍스트 톤 그대로.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: `/ontology/insights` 진입 시 kind/edge type bar 옆에 `62 · 74%` 같은 monospace inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)