### PR TITLE
fix(ux): /docs 첫 진입 default slug 을 FEATURES 우선으로

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -837,10 +837,17 @@ function DocsVaultContent() {
   useEffect(() => {
     if (selectedSlug && docsBySlug.has(selectedSlug)) return;
 
+    // 첫 진입 default — `docs/README.md` 가 vault 에 없는 경우가 default
+    // (`AGENTS.md` 자체가 canonical 가이드). 그래서 ARCHITECTURE 가 fallback
+    // 으로 잡혀왔는데, 처음 들어온 사용자에게 *지금 쓸 수 있는 기능 목록*
+    // (FEATURES) 이 ARCHITECTURE 보다 첫인상 가치가 크다. AGENTS.md 가
+    // "features users can use right now, see docs/FEATURES.md" 로 직접 지목.
     const candidates = [
       ...pinnedSlugs,
       ...recentSlugs,
       'README',
+      'FEATURES',
+      'PRODUCT-DIRECTION',
       'ARCHITECTURE',
       manifest.docs[0]?.slug,
     ];


### PR DESCRIPTION
## Summary

`/docs/` 첫 진입 시 fallback chain 의 `README` slug 이 `docs/README.md` 부재로 매치 안 돼 `ARCHITECTURE` 가 항상 default 였다. ARCHITECTURE 는 codebase 구조 다이어그램이라 처음 들어온 사용자가 *지금 무엇을 쓸 수 있는지* 인지하기 어려움.

`AGENTS.md` 자체가 "features users can use right now, see docs/FEATURES.md" 로 FEATURES 를 명시 지목 — UI default 에도 반영. 새 fallback chain: pinned → recent → **README → FEATURES → PRODUCT-DIRECTION → ARCHITECTURE → manifest.docs[0]**.

## 영향

- 이미 README 가 있는 vault → 변화 X (README 1순위 유지)
- pinnedSlugs / recentSlugs 있는 사용자 → 변화 X (사용자 선택 보존)
- 첫 방문 사용자 (dogfood vault 포함) → FEATURES 가 default 노출

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: `/docs/` 진입 후 URL 이 `?slug=FEATURES` 로 자동 정착하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)