### PR TITLE
fix(ux): 404 / error surface 의 hardcoded white alpha → 디자인 토큰

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -47,9 +47,9 @@ export default function LocaleNotFound() {
       id="main"
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10"
     >
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:rgba(255,255,255,0.08)] bg-[color:var(--color-panel)] p-7 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
         <div className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:rgba(255,255,255,0.08)] text-[color:var(--color-text-tertiary)]">
+          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
             <Compass size={16} />
           </span>
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
@@ -73,7 +73,7 @@ export default function LocaleNotFound() {
           </button>
           <Link
             href="/"
-            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t("home")}
           </Link>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -21,7 +21,7 @@ export default function RouteError({ error, reset }: Props) {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10">
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:rgba(255,255,255,0.08)] bg-[color:var(--color-panel)] p-6">
+      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
         <div className="flex items-center gap-2">
           <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:rgba(244,183,49,0.35)] bg-[color:rgba(244,183,49,0.08)] text-[color:var(--color-status-warning)]">
             <AlertTriangle size={16} />
@@ -53,7 +53,7 @@ export default function RouteError({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(255,255,255,0.14)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(255,255,255,0.22)]"
+            className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
           >
             Topology home
           </Link>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -24,7 +24,7 @@ export default function GlobalError({ error, reset }: Props) {
     <html lang="en">
       <body className="bg-[color:var(--color-canvas)] text-[color:var(--color-text-primary)]">
         <main className="flex min-h-screen items-center justify-center px-6 py-10">
-          <div className="w-full max-w-[440px] rounded-[22px] border border-[color:rgba(255,255,255,0.08)] bg-[color:var(--color-panel)] p-6">
+          <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
             <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               Critical error
             </p>
@@ -50,7 +50,7 @@ export default function GlobalError({ error, reset }: Props) {
               </button>
               <Link
                 href="/"
-                className="inline-flex h-10 items-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(255,255,255,0.14)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(255,255,255,0.22)]"
+                className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
               >
                 Home
               </Link>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -72,9 +72,9 @@ export default function NotFound() {
       id="main"
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10"
     >
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:rgba(255,255,255,0.08)] bg-[color:var(--color-panel)] p-7 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
+      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[0_24px_48px_rgba(0,0,0,0.24)]">
         <div className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:rgba(255,255,255,0.08)] text-[color:var(--color-text-tertiary)]">
+          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
             <Compass size={16} />
           </span>
           <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
@@ -98,7 +98,7 @@ export default function NotFound() {
           </button>
           <Link
             href={`/${locale}/`}
-            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:rgba(255,255,255,0.08)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t.home}
           </Link>


### PR DESCRIPTION
## Summary

404 (`app/not-found.tsx` · `app/[locale]/not-found.tsx`), route error (`app/error.tsx`), root global error (`app/global-error.tsx`) 의 border 색이 `rgba(255,255,255,0.08)` / `0.14` / `0.22` 처럼 *흰 alpha* 로 하드코딩되어 있었음. 다크 모드 single-target 으로 만든 surface 라 light mode 토글 시 *흰 배경에 흰 alpha* 가 거의 안 보이는 회귀.

`app/globals.css` 에 이미 다크/light 양립 토큰이 정의 — 매핑:

| Before | After |
|---|---|
| `rgba(255,255,255,0.08)` | `var(--color-divider)` |
| `rgba(255,255,255,0.14)` | `var(--color-border-strong)` |
| `rgba(255,255,255,0.22)` (focus ring) | `rgba(94,106,210,0.5)` (인디고 ring — 다른 surface 와 일관) |

14 곳 hardcoded → 0. 다크 톤은 시각 동일 (토큰 정의가 동일 값). light 회귀만 차단.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: light mode 에서 잘못된 URL (`/foobar`) 진입 시 카드 border 가 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)