### PR TITLE
fix(ux): /[locale]/not-found router 를 locale-aware 로 정정

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { ArrowLeft, Compass, Search } from "lucide-react";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 
 /**
  * 로케일 segment 안에서 404. NextIntlClientProvider 가 layout.tsx 에 마운트되어
  * 있으므로 useTranslations 사용 가능. root not-found.tsx 는 [locale] 외부 라우트
  * 진입 시 last-resort 영어 fallback 으로 남겨둔다.
+ *
+ * router 는 `@/i18n/navigation` 의 locale-aware 버전을 사용 — `router.push('/')`
+ * 가 자동으로 현재 locale prefix 를 보존해 ko 사용자가 `/` 가 아닌 `/ko/` 로
+ * 라우팅. `next/navigation` 의 raw router 는 cross-locale 이동 (locale-switch)
+ * 처럼 의도적으로 prefix 를 무시할 때만 사용 (`.claude/rules/architecture.md`).
  */
 export default function LocaleNotFound() {
   const router = useRouter();


### PR DESCRIPTION
## Summary

`app/[locale]/not-found.tsx` 가 raw `next/navigation` 의 `useRouter` 를 사용해 `router.push("/")` / `router.back()` 호출 시 현재 locale prefix 가 누락될 위험. `/ko/foobar` 에서 404 발생 시 "홈" 버튼이 `/` (영문 home) 으로 cross-locale 점프하는 회귀.

`.claude/rules/architecture.md` 의 i18n 라우팅 가드 ("인-앱 라우트 이동은 `@/i18n/navigation` 사용") 위반이라 그대로 정정.

- `useRouter` import 를 `@/i18n/navigation` 으로 교체
- `app/not-found.tsx` (root) 와 `LocaleSwitch` 는 의도적 raw 유지 (NextIntlClientProvider 미마운트 / cross-locale 이동 자체가 목적)

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: `/ko/foobar` 진입 후 "홈" 버튼이 `/ko/` 로 보내는지 (이전엔 `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)