### PR TITLE
fix(ux): gradient 의 rgba(255,255,255,0) → transparent

### DIFF
--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -519,7 +519,7 @@ export function ProjectDetailPage({
 
 
       <section className="mt-8">
-        <div className="relative overflow-hidden rounded-[30px] border border-[color:var(--color-divider)] bg-[linear-gradient(180deg,var(--color-overlay-1)_0%,rgba(255,255,255,0)_100%)] px-5 py-5 md:px-7 md:py-6 xl:px-8 xl:py-7">
+        <div className="relative overflow-hidden rounded-[30px] border border-[color:var(--color-divider)] bg-[linear-gradient(180deg,var(--color-overlay-1)_0%,transparent_100%)] px-5 py-5 md:px-7 md:py-6 xl:px-8 xl:py-7">
           <div
             aria-hidden
             className={cn(

--- a/src/widgets/project-drawer/ui/ProjectDrawer.tsx
+++ b/src/widgets/project-drawer/ui/ProjectDrawer.tsx
@@ -426,7 +426,7 @@ export function ProjectDrawer({
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={MOTION.medium}
-                className="overflow-hidden rounded-[20px] border border-[color:var(--color-divider)] bg-[linear-gradient(180deg,var(--color-overlay-1)_0%,rgba(255,255,255,0)_100%)]"
+                className="overflow-hidden rounded-[20px] border border-[color:var(--color-divider)] bg-[linear-gradient(180deg,var(--color-overlay-1)_0%,transparent_100%)]"
               >
               <div className="relative px-5 py-5">
                 <div


### PR DESCRIPTION
## Summary

`ProjectDetailPage` / `ProjectDrawer` 의 배경 gradient bottom stop 이 `rgba(255,255,255,0)` 로 표기되어 있었음. 의도는 *완전 투명* 인데 흰 alpha 0 형식이라 색 의미가 모호하고, 직전 PR #227 의 hardcoded white sweep 의 남은 흔적.

`transparent` 키워드로 교체:
- alpha 0 이므로 시각 결과 동일 (다크/light 양쪽 보이지 않음)
- 의도 명확화 + hardcoded white sweep 완결

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] `grep -rn "rgba(255,255,255,0)" src/ app/` — 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)