### PR TITLE
fix(seo): sitemap 에 /ontology/edit 빌더 surface 추가

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,7 +10,19 @@ import { routing } from '@/i18n/routing';
 // Static export — must resolve at build time.
 export const dynamic = 'force-static';
 
-const STATIC_ROUTES = ['', 'projects', 'topology', 'docs', 'ontology', 'ontology/insights'];
+// 사용자가 직접 진입 가능한 모든 정적 surface. /ontology/edit 빌더는
+// 이전엔 빠져 있어 SEO 에 안 잡혔는데, AGENTS.md 의 routes 표에 1급
+// surface 로 명시되어 있고 데모 모드에서도 read-only 로 로드 가능 → 색인
+// 가치 충분. /project/new 는 vault-mode 진입 후만 의미 있어 제외.
+const STATIC_ROUTES = [
+  '',
+  'projects',
+  'topology',
+  'docs',
+  'ontology',
+  'ontology/edit',
+  'ontology/insights',
+];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 빌드 타임 dogfood vault manifest 의 `kind: project` doc 만으로 sitemap


### PR DESCRIPTION
## Summary

`app/sitemap.ts` 의 `STATIC_ROUTES` 가 `/ontology` 와 `/ontology/insights` 는 포함하지만 같은 ontology 군의 1급 surface 인 `/ontology/edit` (빌더) 가 빠져 있었다. `AGENTS.md` 의 routes 표에 명시된 사용자 진입 가능 surface 인데 sitemap 미포함이라 검색엔진 색인 누락.

- `/ontology/edit` 는 데모 모드에서도 read-only 로 로드 가능 (vault 미선택 시 안내 + 캔버스), SEO 가치 충분
- `/project/new` 는 vault-mode 진입 후에만 의미 있어 의도적으로 제외 (정적 export 에서 빈 폼만 노출)
- priority 0.8 (다른 STATIC_ROUTES 와 동일), `routing.locales` 양쪽 등록

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 빌드 후 `out/sitemap.xml` 에 `/{locale}/ontology/edit/` 2 entry 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)