### PR TITLE
fix(seo): hreflang map 에 trailing slash + x-default 추가

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -31,9 +31,13 @@ export async function generateMetadata({
     },
     description: t('siteTagline'),
     alternates: {
+      // hreflang map — `next.config.ts` 의 `trailingSlash: true` 와 정합되게
+      // 모든 path 에 trailing slash. `x-default` 는 언어 미지정 사용자에게
+      // 어느 locale 을 기본 노출할지 Google 에 hint (en).
       languages: {
-        en: '/en',
-        ko: '/ko',
+        en: '/en/',
+        ko: '/ko/',
+        'x-default': '/en/',
       },
     },
   };


### PR DESCRIPTION
## Summary

`app/[locale]/layout.tsx` 의 `metadata.alternates.languages` 가 `/en` / `/ko` 처럼 trailing slash 없는 path 였는데, `next.config.ts` 가 `trailingSlash: true` 라 모든 실제 route 가 `/en/`, `/ko/` 형식. 검색엔진이 canonical 비교 시 redirect 한 단계 (`/en` → `/en/`) 추가 — 작은 SEO friction.

또 `x-default` 가 누락 — 언어 미지정 사용자에게 어떤 locale 을 기본 노출할지 Google 에 줄 hint 부재.

| Before | After |
|---|---|
| `en: '/en'` | `en: '/en/'` |
| `ko: '/ko'` | `ko: '/ko/'` |
| — | `x-default: '/en/'` |

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 빌드 후 `out/{locale}/.../index.html` 의 `<link rel="alternate" hreflang="…">` 가 trailing slash 형식인지

🤖 Generated with [Claude Code](https://claude.com/claude-code)