### PR TITLE
fix(seo): PWA manifest description 을 R12 mission 어휘로 갱신

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -19,7 +19,7 @@ export default function manifest(): MetadataRoute.Manifest {
     scope: '/',
     name: 'oh-my-ontology',
     short_name: 'oh-my-ontology',
-    description: '문서·프로젝트·허브·노드, 모든 컨텍스트를 하나의 지도로.',
+    description: '사람과 AI 에이전트가 같이 키우는 코드베이스 온톨로지 워크벤치.',
     start_url: '/',
     display: 'standalone',
     orientation: 'any',


### PR DESCRIPTION
## Summary

`app/manifest.ts` 의 description 이 "문서·프로젝트·허브·노드, 모든 컨텍스트를 하나의 지도로." 라는 R12 mission v3 이전 카피였음. *허브 · 노드* 같은 graph terminology 가 prominent 해서 R12 의 mission ("개발자와 그 AI agent 가 같이 키우는 codebase ontology") 과 맞지 않음.

PWA 설치 prompt (iOS Safari · Android Chrome · 데스크탑 PWA) 의 첫인상 카피라 mission 정합이 중요. README hero 와 동일 어휘로 통일:

> 사람과 AI 에이전트가 같이 키우는 코드베이스 온톨로지 워크벤치.

`lang: 'ko-KR'` 유지 (manifest spec 은 1 lang 만, ko 가 주력 locale).

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] iOS/Android 에서 PWA "홈 화면에 추가" 시 새 description 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)