### PR TITLE
fix(seo): /[locale] 루트 canonical 을 locale 별로 분리

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,15 +2,28 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { RootEntryPage } from '@/views/root-entry';
 import { absoluteUrl } from "@/shared/config";
+import { routing } from "@/i18n/routing";
 
-// 공유 링크에 ?utm_* 같은 query 가 붙어도 SERP canonical 은 루트 하나로 고정.
-// metadataBase 가 SITE_URL 을 이미 쥐고 있지만 정적 export 환경에서 절대 URL
-// 로 명시적으로 박아 두는 게 안전.
-export const metadata: Metadata = {
-  alternates: {
-    canonical: absoluteUrl('/'),
-  },
-};
+// 각 locale page 의 canonical 은 *자기 자신 URL* 이어야 hreflang group 이
+// 정확히 동작. 이전엔 모든 locale 이 `/` 로 통일됐는데, 그러면 `/en/` 과
+// `/ko/` 가 같은 canonical → 검색엔진이 둘 중 하나만 색인 (한쪽 dedup).
+// hreflang map (layout.tsx) 의 trailing slash 정합 (PR #231) 과 같은 방향
+// 정정 — locale 별 명시 canonical.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const safeLocale = (routing.locales as readonly string[]).includes(locale)
+    ? locale
+    : routing.defaultLocale;
+  return {
+    alternates: {
+      canonical: absoluteUrl(`/${safeLocale}/`),
+    },
+  };
+}
 
 export default function Page() {
   return (


### PR DESCRIPTION
## Summary

`app/[locale]/page.tsx` 의 canonical 이 `absoluteUrl('/')` 로 *모든 locale* 에서 root URL 로 통일되어 있었음. `/en/` 과 `/ko/` 가 같은 canonical 을 가리키면 검색엔진이 둘 중 하나만 색인 → 한쪽 locale dedup 회귀.

표준 hreflang 가이드: **각 locale page 의 canonical 은 자기 자신 URL.** `/en/` → `canonical='/en/'`, `/ko/` → `canonical='/ko/'`. PR #231 의 hreflang group `{en, ko, x-default}` 과 정합.

- `metadata` (정적) → `generateMetadata` (비동기) 로 전환
- `params.locale` 받아 동적 canonical
- 알 수 없는 locale 은 `routing.defaultLocale` fallback (정적 export 의 `generateStaticParams` 가 막아주지만 safety)

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 빌드 후 `out/en/index.html` 의 `<link rel="canonical" href=".../en/">`, `out/ko/index.html` 도 자기 자신 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)