### PR TITLE
chore(tsconfig): exclude 의 stale 디렉토리 제거

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,5 +38,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "packages", "functions"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

`tsconfig.json` 의 `exclude` 에 남아 있던 `packages` 와 `functions` 둘 다 *존재하지 않는* 디렉토리.

- `functions/` — R10 (2026-05, Firebase / cloud surface 영구 제거) 직후 삭제된 Cloud Functions 디렉토리
- `packages/` — monorepo 전환 적 없음, 한번도 만들어진 적 없는 dead reference

`exclude` 를 `["node_modules"]` 으로 정리. `mcp/` `cli/` 는 별도 npm package 지만 내부 `.ts/.tsx/.mts` 파일이 0 (모두 `.mjs/.js`) 이라 root tsc 가 이미 자연스럽게 ignore — 명시 제외 불필요.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)