### PR TITLE
chore(ci): bundle audit step 의 continue-on-error 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,7 @@ jobs:
         run: pnpm build
 
       - name: Bundle audit (firebase chunk leak guard)
+        # R10 (2026-05) 부터 firebase deps 자체가 package.json 에서 제거되어
+        # chunk 0 이 default 통과 조건. 더 이상 soft-warn 의미 없음 — chunk 가
+        # 검출되면 *진짜 회귀* 라 PR block 이 정상.
         run: pnpm bundle:check
-        continue-on-error: true


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` 의 `Bundle audit` 단계에 `continue-on-error: true` 가 R10 (2026-05, Firebase / cloud deps 영구 제거) 전 시절 잔재로 남아 있었음.

- firebase deps 자체가 `package.json` 에서 사라져 chunk 0 이 default 통과 조건
- `pnpm bundle:check` 가 항상 exit 0 → soft-warn 의미가 없는 dead flag
- 미래에 chunk 0 이 깨지면 *진짜 회귀 (다시 firebase 끌어옴)* 라 PR block 이 정상 동작

`continue-on-error: true` 제거 + 의도 comment 명시.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] `pnpm bundle:check` — exit 0 ("firebase SDK 청크 0 — 모든 라우트 자동 통과")
- [ ] CI 실행 시 bundle audit step 통과 (실제 chunk 0 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)