### PR TITLE
chore(test): vitest alias 에 @/i18n 추가

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
       '@/features': path.resolve(__dirname, './src/features'),
       '@/entities': path.resolve(__dirname, './src/entities'),
       '@/shared': path.resolve(__dirname, './src/shared'),
+      // tsconfig paths 의 `@/i18n/*` 와 정합 — vitest 의 fallback `@/*` →
+      // `./*` 가 `@/i18n/foo` 를 `./i18n/foo` (존재 X) 로 잘못 resolve 하지
+      // 않도록 명시. 현재 .test.{ts,tsx} 에 i18n alias import 가 없어 latent
+      // 회귀였음.
+      '@/i18n': path.resolve(__dirname, './src/i18n'),
       '@': path.resolve(__dirname, './'),
     },
   },


### PR DESCRIPTION
## Summary

`vitest.config.ts` 의 alias 에 `@/i18n` 가 누락되어 있어 tsconfig paths (`@/i18n/*` → `./src/i18n/*`) 와 불일치. vitest 는 fallback `@/*` → `./*` 로 떨어져 `@/i18n/foo` 를 존재하지 않는 `./i18n/foo` 로 silent misresolve 위험.

현재 `.test.{ts,tsx}` 에 `@/i18n` 사용한 import 가 없어 latent 회귀라 즉시 영향 0 이지만, 미래에 i18n 코드의 unit test 추가 시 silent fail 가능. preventive 등록.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)