### PR TITLE
chore(gitignore): R10 Firebase section 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,14 +28,6 @@ next-env.d.ts
 .env.test.local
 .env.production.local
 
-# Firebase
-.firebase/
-firebase-debug.log
-firestore-debug.log
-ui-debug.log
-serviceAccountKey.json
-*-firebase-adminsdk-*.json
-
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

R10 (2026-05) 에서 Firebase / Firestore / Cloud Functions / Auth surface 가 영구 제거되어 `.gitignore` 의 Firebase section 8 줄이 dead pattern. 해당 파일들 (`.firebase/`, `firebase-debug.log`, `firestore-debug.log`, `ui-debug.log`, `serviceAccountKey.json`, `*-firebase-adminsdk-*.json`) 이 더 이상 생성되지 않음.

`.claude/rules/forbidden.md` 가 Firebase 재도입을 명시 금지 + 미래 cloud-collab 단계는 새로 디자인하기로 결정 — PR 단계 code review 가 가드 역할이라 gitignore 의 stale section 은 cleanup 안전.

R10 cleanup 의 마무리 (PR #234 `tsconfig.exclude` + PR #235 `bundle:check continue-on-error` 와 같은 R10 stale sweep 흐름).

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)