### PR TITLE
docs(contributing): Mission v2 alignment → v3 갱신

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,18 +88,21 @@ so first-paint chunks of local-first routes don't pull them in. See
 [`.claude/rules/architecture.md`](.claude/rules/architecture.md) for the
 full rule.
 
-## Mission v2 alignment
+## Mission v3 alignment
 
-If a feature/route/widget would conflict with mission v2 ("vault
-frontmatter = the graph, AI agent partner via MCP, local-first"), please
-flag it in your PR. We've spent significant effort cleaning up v1 LLM
-extraction / TBox / cloud-only patterns; we want to avoid quietly
-re-introducing them.
+If a feature/route/widget would conflict with mission v3 — **"one
+codebase, one ontology, that the developer and their AI agent grow
+together"** (R12, 2026-05) — please flag it in your PR. We've spent
+significant effort cleaning up v1 LLM extraction / TBox / cloud-only
+patterns; we want to avoid quietly re-introducing them. Earlier mission
+v2 wording ("vault frontmatter = graph, MCP partner, local-first") still
+holds — v3 sharpens *who* the partner is (developer + their AI agent;
+PM/designer surface is bonus, not target).
 
 The 1-line gate question:
-*"Does X contradict the spine (vault frontmatter), partner (MCP), or
-self-approval (no review queue) flow?"* — if yes, please open a discussion
-before code.
+*"Does X contradict the spine (vault frontmatter), partner (developer +
+AI agent via MCP), or self-approval (no review queue) flow?"* — if yes,
+please open a discussion before code.
 
 ## Working with AI agents in this repo
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` 의 mission-gate 섹션 표제가 "Mission v2 alignment" 로 R12 (2026-05-04) 이전 어휘. mission v3 은 *who* 가 partner 인지 sharpen — **"developer + their AI agent"** (PM-primary 결정 R11 reverted, 비개발자 surface 는 bonus 가 target 아님).

### 변경

- 표제 `v2` → `v3`
- mission 한 줄 갱신 (R12 의 single guiding principle)
- v2 → v3 차이 1-2 줄 추가 — v2 의 "spine·MCP·local-first" 는 그대로 유지
- gate 질문에 partner 정의 inline (`developer + AI agent via MCP`)

docs only 변경, 코드 영향 0.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)