### PR TITLE
docs(scripts): dogfood-mcp-walk header comment off-by-one 정정

### DIFF
--- a/scripts/dogfood-mcp-walk.mjs
+++ b/scripts/dogfood-mcp-walk.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // R12 #38 — AI agent dogfood 시뮬. 사용자 .mcp.json 등록 후 시나리오와
-// 같은 흐름으로 mcp server 에 5 read tool 호출. *진짜 AI agent 입장* 에서
+// 같은 흐름으로 mcp server 에 6 read tool 호출. *진짜 AI agent 입장* 에서
 // 받는 정보 quality 측정.
 //
-// write 안 함 (dogfood vault 보존). list/get/find_evidence/find_path/
-// find_backlinks/list_kinds 만.
+// write 안 함 (dogfood vault 보존). list_kinds / list_concepts /
+// find_evidence / find_path / find_backlinks / find_orphans 만.
 
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## Summary

`scripts/dogfood-mcp-walk.mjs` 의 헤더 comment 가 "5 read tool" 인데 실제 호출 시퀀스는 6 개 (`list_kinds`/`list_concepts`/`find_evidence`/`find_path`/`find_backlinks`/`find_orphans`). 목록의 `get` 도 stale — 실제는 `list_concepts`.

코드 변경 X, comment 만 정정.

## Test plan

- 코드 변경 없음 — 기존 tsc/lint/test 그대로 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)