### PR TITLE
docs(coc): enforcement 채널을 GitHub Security Advisory 로 정정

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opening a private issue at https://github.com/wlsdks/oh-my-ontology/issues/new (mark it private) or contacting the maintainer via the email listed on the GitHub profile. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening a private Security Advisory at https://github.com/wlsdks/oh-my-ontology/security/advisories/new, or by contacting the maintainer via the email listed on the GitHub profile. (Note: regular GitHub issues are public and cannot be made private — use the Security Advisory channel for confidential reports.) All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary

`CODE_OF_CONDUCT.md` 의 Enforcement 섹션이 "opening a private issue at github.com/.../issues/new (mark it private)" 안내였는데, **public repo 의 일반 GitHub issue 는 private 으로 표시 불가능** — 항상 public. "mark it private" 는 misleading.

GitHub 에서 confidential 보고용 채널은 **Security Advisory** (private vulnerability reporting):
- 변경: `https://github.com/wlsdks/oh-my-ontology/security/advisories/new`
- inline note 추가 (일반 issue 가 private 안 되는 이유)

기존 email 채널 (maintainer GitHub profile) 그대로 유지.

## Test plan

- docs only — 코드 영향 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)