### PR TITLE
fix(topology): zoom out 시 edge 두께 점진 감쇠

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -792,6 +792,20 @@ function SigmaTopologyImpl({
 
       const focus = activeNode();
       if (!focus) {
+        // R+ 사용자 피드백: zoom out 시 hub-hub edge 가 *대벌레 다리* 처럼
+        // 가늘게 stick 으로 박힌 시각. sigma 가 edge 두께를 camera ratio
+        // 와 별개로 그대로 그려 멀어질수록 노드 대비 line 비중이 커짐.
+        // ratio > 1.0 (zoom out) 부터 size 점진 감쇠 — node 가 시각 우위
+        // 회복. zoom in (ratio ≤ 1.0) 은 그대로 유지해 가까이서의 두꺼운
+        // 선 (1-hop pulse 등) 영향 X.
+        const ratio = cameraRatioRef.current;
+        if (ratio > 1.0) {
+          const fade = Math.max(0.35, 1.0 - (ratio - 1.0) * 0.55);
+          return {
+            ...attrs,
+            size: (attrs.size ?? 0.5) * fade,
+          };
+        }
         return attrs;
       }
       if (src === focus || tgt === focus) {


### PR DESCRIPTION
## Summary

사용자 피드백: 토폴로지 멀리 (zoom out) 보면 hub-hub edge 가 가는 stick 으로 박혀 **"대벌레 다리"** 처럼 보임. sigma 가 edge 두께를 camera ratio 와 별개로 그대로 그려 멀어질수록 *얇지만 살아있는 선들* 이 노드 대비 비중이 커지는 시각 회귀.

## 변경

`edgeReducer` 의 base return 분기에 `cameraRatioRef` 기반 size 감쇠 추가:

| Camera ratio | Size factor |
|---|---|
| ≤ 1.0 (zoom in / default) | 1.0 (그대로) |
| 1.2 | 0.89 |
| 1.5 | 0.725 |
| 1.8 (= LOD_HIDE_RATIO) | 0.56 |
| 2.0+ | 0.45–0.35 (clamped) |

즉 멀리 갈수록 edge 가 점진 fade — 노드 시각 우위 회복.

### 보존되는 분기 (영향 X)

- `hover` edge 부스트 (size ≥ 1.8)
- focus 1-hop pulse breathing
- depth / category / search dim → DIM_EDGE
- `pathEdgeSet` 강조
- hubsOnly / audit overlay

zoom in (ratio ≤ 1.0) 상태는 그대로 — 가까이서의 두꺼운 1-hop pulse 시각 그대로 동작.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass (topology suite 91 통과)
- [ ] 시각: `/topology` zoom out 해서 edge 가 stick 으로 안 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)