### PR TITLE
fix(topology): edge curvature 0.06–0.08 → 0.14 — 직선 격자 완화

### DIFF
--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -275,7 +275,9 @@ export function buildGraph(
           size: hubToHub ? 0.9 : 0.5,
           color: palette.edge,
           kind: isContainsRelation ? 'contains' : 'depends-on',
-          curvature: hubToHub ? 0.28 : 0.08,
+          // R+ stick-bug fix: non-hub 의 0.08 도 거의 직선 → 0.14. hub-hub
+          // 의 0.28 은 그대로 (메인 의존 골격 강조).
+          curvature: hubToHub ? 0.28 : 0.14,
         });
       }
     }
@@ -347,7 +349,11 @@ export function buildGraph(
         size: 0.35,
         color: palette.edge,
         kind,
-        curvature: 0.06,
+        // R+ 사용자 피드백: zoom out 시 거의 직선 (0.06) 이 "대벌레 다리"
+        // 격자 시각의 한 원인. 살짝 더 휘게 (0.14) — 노드 클러스터 사이가
+        // organic 한 흐름. project hub-hub 의 0.28 보다 약함 (메인 의존
+        // 골격이 여전히 두드러지게).
+        curvature: 0.14,
       });
     }
   }


### PR DESCRIPTION
## Summary

PR #241 의 후속 — zoom out 시 "대벌레" 시각의 또 다른 원인은 edge 가 *거의 직선* 으로 그려진 점.

| Edge | Before | After |
|---|---|---|
| ontology (domain/cap/element) | 0.06 | **0.14** |
| project non-hub | 0.08 | **0.14** |
| project hub-hub | 0.28 | 0.28 (그대로 — 메인 의존 골격 강조) |

`0.14` 는 곡선이 명확히 보이지만 얽힘이 과도하지 않은 균형 — 노드 클러스터 사이에 organic 한 흐름 회복.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass (topology 91 통과)
- [ ] 시각: `/topology` zoom out 해서 edge 가 격자 stick 이 아닌 organic curve 로 보이는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)