### PR TITLE
fix(topology): 노드에 별빛 halo + edge dust 톤 — "은하계 별자리" 시각

### DIFF
--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -80,7 +80,12 @@ export interface SigmaEdgeAttrs {
 }
 
 const HUB_COLOR = INDIGO_HUB;
-const NODE_OUTER_HALO = 'rgba(0, 0, 0, 0)'; // 비허브는 halo 없음 (투명)
+// R+ 사용자 비전: "은하계의 별처럼 / 별자리처럼". 비허브 노드에도 매우
+// 흐릿한 푸른 별빛 halo (alpha 0.06). 어두운 캔버스 위에서 작은 dot 가
+// *light bloom* 처럼 보여 stick 시각이 별 collection 으로 전환. hub 의
+// 강한 인디고 halo (palette.hubOuterHalo, alpha 0.08-0.32) 는 그대로 —
+// 별 vs 큰 별 (Sirius 급) 위계 보존.
+const NODE_OUTER_HALO = 'rgba(180, 195, 230, 0.06)';
 
 /**
  * ontology 노드가 forceLabel = true 로 승격되는 degree 기준.
@@ -345,8 +350,9 @@ export function buildGraph(
             : 'depends-on';
       graph.addEdge(edge.from, edge.to, {
         // ontology 엣지는 project↔project dependencies 보다 가늘게 — 메인
-        // 의존 골격이 시야에서 사라지지 않도록.
-        size: 0.35,
+        // 의존 골격이 시야에서 사라지지 않도록. R+ stick-bug 후속: 0.35 →
+        // 0.28 로 더 얇게.
+        size: 0.28,
         color: palette.edge,
         kind,
         // R+ 사용자 피드백: zoom out 시 거의 직선 (0.06) 이 "대벌레 다리"

--- a/src/widgets/topology-map-sigma/lib/topology-palette.ts
+++ b/src/widgets/topology-map-sigma/lib/topology-palette.ts
@@ -44,9 +44,13 @@ const DARK: TopologyPalette = {
   nodeBorder: 'rgba(200, 210, 230, 0.3)',
   hubBorder: 'rgba(139, 151, 255, 0.55)',
   hubOuterHalo: 'rgba(139, 151, 255, 0.08)',
-  edge: 'rgba(170, 185, 210, 0.08)',
-  edgeContains: 'rgba(170, 185, 210, 0.10)',
-  edgeDependsOn: 'rgba(139, 151, 255, 0.16)',
+  // R+ 사용자 피드백: zoom out 시 흰 stick 시각. edge 톤을 white-blue 에서
+  // 더 cool blue-dust 로 시프트 + alpha 살짝 낮춤. dark bg 위에서 "흰 가는
+  // 선" 이 아닌 "푸른 먼지" 느낌. RGB 170/185/210 (white-blue) → 130/150/195
+  // (vivid blue-grey). alpha 0.08 → 0.06.
+  edge: 'rgba(130, 150, 195, 0.06)',
+  edgeContains: 'rgba(130, 150, 195, 0.08)',
+  edgeDependsOn: 'rgba(139, 151, 255, 0.14)',
   edgeDim: 'rgba(255, 255, 255, 0.005)',
   labelText: 'rgba(235, 240, 250, 0.95)',
   leafFillSaturate: 1,


### PR DESCRIPTION
## Summary

사용자 비전: **"은하계의 별처럼 / 별자리처럼"**. 직접 화면 캡쳐 비교하며 3 가지 변경 — 단순 노드+선 → 작은 별 collection + 별자리 가는 dust 톤.

### 1. 비허브 노드 outer halo 활성

`NODE_OUTER_HALO`: `rgba(0,0,0,0)` (투명) → `rgba(180,195,230,0.06)` (흐릿한 푸른 별빛).

`borderNodeProgram` 의 outer ring 이 2.5px 픽셀 모드라 작은 dot 가 *light bloom* 처럼 빛남. hub 의 강한 인디고 halo (`palette.hubOuterHalo`, alpha 0.08–0.32) 는 그대로 — *큰 별 vs 작은 별* 위계 보존.

### 2. edge palette 톤 (다크 모드)

| Token | Before | After |
|---|---|---|
| `palette.edge` | `rgba(170, 185, 210, 0.08)` | **`rgba(130, 150, 195, 0.06)`** |
| `palette.edgeContains` | `…0.10)` | `…0.08)` |
| `palette.edgeDependsOn` | `…0.16)` | `…0.14)` |

흰-블루 → cool blue-grey + alpha 살짝 낮춤. "흰 가는 선" → "푸른 dust". 라이트 모드 palette 그대로 (이미 graphite 톤).

### 3. ontology edge size 0.35 → 0.28

zoom in 시도 살짝 더 얇게. PR #241 의 zoom-out 감쇠와 함께 *기본/멀리/가까이* 모든 zoom 에서 stick 회귀 차단.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] 시각 캡쳐 비교 — default zoom (ratio 1) + zoom out (ratio 1.5) 양쪽에서 별자리 톤 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)