### PR TITLE
fix(topology): hub 0 vault 의 recenter fallback → bbox center

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -1355,6 +1355,31 @@ function SigmaTopologyImpl({
       );
       return;
     }
+    // hub 가 0 인 vault (예: dogfood 처럼 single-project 인 경우 isHub
+    // 노드 0) 에선 hubCount-centroid 분기 fall-through 후 canvas (0.5, 0.5)
+    // 로 가버려 settle 결과 graph 가 한쪽으로 쏠려 보임. 그 케이스에
+    // *모든 노드의 bounding-box center* 로 fallback — 평균은 isolated
+    // outlier 에 끌리지만 bbox center 는 outlier 양쪽 분포만 잡으면 안정.
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    graph.forEachNode((id) => {
+      const display = renderer.getNodeDisplayData(id);
+      if (!display) return;
+      if (display.x < minX) minX = display.x;
+      if (display.x > maxX) maxX = display.x;
+      if (display.y < minY) minY = display.y;
+      if (display.y > maxY) maxY = display.y;
+    });
+    if (Number.isFinite(minX)) {
+      camera.animate(
+        {
+          x: (minX + maxX) / 2,
+          y: (minY + maxY) / 2,
+          ratio: minimal ? 1.1 : 1,
+        },
+        { duration: 420, easing: CAMERA_EASING },
+      );
+      return;
+    }
     camera.animate(
       { x: 0.5, y: 0.5, ratio: 1 },
       { duration: 420, easing: CAMERA_EASING },


### PR DESCRIPTION
## Summary

`SigmaTopology.recenter` 가 hub centroid 분기 후 *canvas (0.5, 0.5)* 로 떨어져 settle 결과 graph 가 한쪽으로 쏠려 보이는 회귀. dogfood 처럼 single-project (모든 노드 `isHub=false`) vault 에서 항상 발생.

### 새 fallback

모든 노드의 **bounding-box center** 로 카메라 이동:
- 평균 (centroid) 은 isolated outlier 에 한쪽으로 끌림 (시험: y centroid 가 상단으로 30% 끌렸음)
- bbox center 는 양쪽 outlier 분포만 잡으면 안정 — single-cluster + 멀리 떨어진 orphan 패턴에서도 main cluster 중앙 캡쳐

### 화면 캡쳐 (1440×900) 비교

| | cluster 위치 |
|---|---|
| Before (canvas 0.5, 0.5) | 우상단 쏠림, viewport 왼쪽 60% 비어 있음 |
| Centroid 평균 (시도 1) | y=0.302 — 상단 30% 쏠림 (outlier 끌림) |
| **Bbox center (적용)** | vertical center, 양쪽 여백 균형 |

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] 시각 캡쳐: `/topology` 첫 진입 → graph cluster 가 viewport center 부근

🤖 Generated with [Claude Code](https://claude.com/claude-code)