### PR TITLE
fix(topology): minimap node fill 을 별자리 톤 (PR #243) 으로 정합

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaMinimap.tsx
@@ -208,7 +208,10 @@ export function SigmaMinimap({ sigma, graph }: SigmaMinimapProps) {
             cx={n.x}
             cy={n.y}
             r={n.size}
-            fill={n.isHub ? INDIGO_HUB : 'rgba(168,178,198,0.45)'}
+            // R+ 별자리 톤 (PR #243) 정합 — main graph 의 NODE_OUTER_HALO
+            // 와 같은 푸른 별빛 hue (180/195/230). 이전 회색-블루 168/178/198
+            // 보다 main 의 dust edge 와 자연스럽게 어울림.
+            fill={n.isHub ? INDIGO_HUB : 'rgba(190,205,235,0.5)'}
           />
         ))}
         {showViewportRect ? (


### PR DESCRIPTION
## Summary

`SigmaMinimap` 의 비허브 노드 fill 이 `rgba(168,178,198,0.45)` (회색-블루) 인데 main graph 는 PR #243 에서 별빛 톤 (`NODE_OUTER_HALO` = `rgba(180,195,230,0.06)`) 으로 전환됨. minimap 만 옛 tone → 두 시각 분리감.

minimap fill → **`rgba(190,205,235,0.5)`** — main graph 와 같은 푸른 별빛 family (180/195/230), alpha 0.5 로 minimap 축약 지도 가독성 보존.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: `/topology` 우하단 minimap 의 node dot 색이 main graph 와 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)