### PR TITLE
fix(topology): light 모드 별자리 톤 회귀 정정

### DIFF
--- a/src/widgets/topology-map-sigma/lib/graph-build.ts
+++ b/src/widgets/topology-map-sigma/lib/graph-build.ts
@@ -80,12 +80,10 @@ export interface SigmaEdgeAttrs {
 }
 
 const HUB_COLOR = INDIGO_HUB;
-// R+ 사용자 비전: "은하계의 별처럼 / 별자리처럼". 비허브 노드에도 매우
-// 흐릿한 푸른 별빛 halo (alpha 0.06). 어두운 캔버스 위에서 작은 dot 가
-// *light bloom* 처럼 보여 stick 시각이 별 collection 으로 전환. hub 의
-// 강한 인디고 halo (palette.hubOuterHalo, alpha 0.08-0.32) 는 그대로 —
-// 별 vs 큰 별 (Sirius 급) 위계 보존.
-const NODE_OUTER_HALO = 'rgba(180, 195, 230, 0.06)';
+// R+ 사용자 비전: "은하계의 별처럼 / 별자리처럼". 비허브 노드에도 outer
+// halo 로 light bloom 효과 → 작은 dot 가 별처럼 빛남. 톤은 light/dark
+// 분기 — palette.nodeOuterHalo. dark: 흐릿한 푸른 dust, light: 어두운
+// graphite (흰 배경 회귀 차단).
 
 /**
  * ontology 노드가 forceLabel = true 로 승격되는 degree 기준.
@@ -252,7 +250,7 @@ export function buildGraph(
       borderColor: project.isHub
         ? palette.hubBorder
         : ontologyTone?.borderColor ?? palette.nodeBorder,
-      outerBorderColor: project.isHub ? palette.hubOuterHalo : NODE_OUTER_HALO,
+      outerBorderColor: project.isHub ? palette.hubOuterHalo : palette.nodeOuterHalo,
       projectSlug: project.slug,
       categoryId: project.category ?? '',
       isHub: Boolean(project.isHub),
@@ -320,7 +318,7 @@ export function buildGraph(
         // 흐린 무채색 fill — 헌장의 "허브만 유일한 채색" 과 충돌 안 함.
         color: palette.ontologyFill,
         borderColor: tone?.borderColor ?? palette.nodeBorder,
-        outerBorderColor: NODE_OUTER_HALO,
+        outerBorderColor: palette.nodeOuterHalo,
         // SigmaTopology 의 click handler 가 projectSlug 를 키로 drawer 를
         // 여는데, ontology 노드는 project 가 아니므로 drawer 가 빈 상태가
         // 된다 — 일단 id 를 그대로 박아두고 후속 단계에서 ontology 전용

--- a/src/widgets/topology-map-sigma/lib/topology-palette.ts
+++ b/src/widgets/topology-map-sigma/lib/topology-palette.ts
@@ -38,6 +38,12 @@ export interface TopologyPalette {
   leafFillSaturate: number;
   /** R+ ontology 노드 (capability/element) 의 default fill. */
   ontologyFill: string;
+  /**
+   * 비허브 노드의 outer halo — "별빛 bloom" 효과. dark 에선 푸른 dust,
+   * light 에선 어두운 graphite 톤이라 *흰 배경에서 dot 가 또렷*. graph-build
+   * 의 NODE_OUTER_HALO 상수를 대체해 light/dark 분기.
+   */
+  nodeOuterHalo: string;
 }
 
 const DARK: TopologyPalette = {
@@ -55,6 +61,8 @@ const DARK: TopologyPalette = {
   labelText: 'rgba(235, 240, 250, 0.95)',
   leafFillSaturate: 1,
   ontologyFill: 'rgba(160, 168, 184, 0.55)',
+  // dark: 흐릿한 푸른 별빛 halo — 어두운 캔버스 위에서 dot 의 light bloom.
+  nodeOuterHalo: 'rgba(180, 195, 230, 0.06)',
 };
 
 const LIGHT: TopologyPalette = {
@@ -83,7 +91,14 @@ const LIGHT: TopologyPalette = {
   // saturate=1.7: DOMAIN_TONE 의 pale rgb (160-200) 를 60-90 graphite 까지
   // 끌어내려 흰 배경에서 \"실재하는 dot\" 으로 읽힘. ontology 노드도 동일.
   leafFillSaturate: 1.7,
-  ontologyFill: 'rgba(70, 84, 110, 0.85)',
+  // ontology 노드 fill — 흰 배경 contrast 위해 RGB 50/60/90 graphite +
+  // alpha 0.95 (이전 70/84/110, 0.85 는 작은 dot 가 흐려 invisible 회귀).
+  ontologyFill: 'rgba(50, 60, 90, 0.95)',
+  // light: 어두운 graphite 별빛 halo — 흰 배경 위에서 dot 가 또렷한 *별*
+  // 으로 읽힘. dark 의 푸른 dust 톤 (180/195/230) 그대로 쓰면 흰 배경에
+  // 묻혀 invisible 회귀. alpha 0.18 — fill 보다 약하지만 dot 외곽에
+  // 흐릿한 *light bloom* 으로 시각.
+  nodeOuterHalo: 'rgba(40, 50, 72, 0.18)',
 };
 
 /**

--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -1104,6 +1104,15 @@ function SigmaTopologyImpl({
           graph.setNodeAttribute(id, 'outerBorderColor', palette.hubOuterHalo);
         } else {
           graph.setNodeAttribute(id, 'borderColor', palette.nodeBorder);
+          // 비허브 노드의 outer halo (별빛 bloom) — light/dark 분기. 누락
+          // 시 dark→light 토글 후 노드가 흰 배경에 묻혀 invisible 회귀.
+          graph.setNodeAttribute(id, 'outerBorderColor', palette.nodeOuterHalo);
+          // ontology 노드 fill 도 theme 의존 — light 는 dark graphite,
+          // dark 는 회색-블루. theme switch 시 fill 갱신 안 하면 light
+          // 모드에서 ontology 노드가 흐릿한 푸른 점으로 invisible.
+          if (attrs.isOntology) {
+            graph.setNodeAttribute(id, 'color', palette.ontologyFill);
+          }
         }
       });
       graph.forEachEdge((edge, attrs) => {


### PR DESCRIPTION
## Summary

PR #243 (별빛 halo + dust edge) 가 *DARK palette 만* 정합 → light 모드에서 invisible 회귀.

### 3 가지 원인 + fix

| # | 회귀 | fix |
|---|---|---|
| 1 | `NODE_OUTER_HALO` 가 hardcoded 푸른 dust (180/195/230) — 흰 배경 묻힘 | `palette.nodeOuterHalo` 토큰 분기 (DARK: 푸른 dust 0.06 / LIGHT: graphite 0.18) |
| 2 | LIGHT `ontologyFill` alpha 0.85 + 옅은 graphite — 작은 dot 흐릿 | RGB 50/60/90 + alpha 0.95 로 강화 |
| 3 | theme switch repaint 가 비허브 노드의 `outerBorderColor` / `color` 갱신 누락 | repaint loop 에 둘 다 추가 |

### 화면 캡쳐 (1440×900, light mode)

- Before: 그래프가 흰 배경에 거의 invisible (흐릿한 푸른 dust 만)
- After: 진한 navy 노드 + 흐릿한 light blue 연결선 — 별자리 톤 유지

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] 시각: light mode `/topology` 진입 + dark→light 토글 양쪽에서 노드 또렷

🤖 Generated with [Claude Code](https://claude.com/claude-code)