### PR TITLE
fix(ux): /ontology 트리 데이터 경고 disclosure 를 amber 톤으로 통일

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -630,7 +630,11 @@ export function OntologyTreeView({
       {result.warnings.length > 0 ? (
         <details
           id="tree-data-warnings"
-          className="group scroll-mt-24 rounded-xl border border-[color:rgba(229,72,77,0.24)] bg-[color:rgba(229,72,77,0.06)] px-4 py-3 text-xs text-[color:var(--color-status-danger)] open:bg-[color:rgba(229,72,77,0.09)]"
+          // R+ PR #223 의 stat strip amber pill 과 톤 통일 — red (status-danger)
+          // 은 *error* 신호, multi-parent drop 은 *warning* 신호. 디자인
+          // 헌장도 amber 가 stub/warning, red 가 error. 같은 신호인데 두 톤
+          // 이 어긋나면 사용자 시각 헷갈림.
+          className="group scroll-mt-24 rounded-xl border border-[color:rgba(255,179,71,0.30)] bg-[color:rgba(255,179,71,0.06)] px-4 py-3 text-xs text-[color:rgba(238,198,128,0.95)] open:bg-[color:rgba(255,179,71,0.09)]"
         >
           <summary className="flex cursor-pointer list-none items-center gap-2 font-[var(--font-weight-signature)] [&::-webkit-details-marker]:hidden">
             <ChevronRight className="h-3 w-3 flex-none transition-transform duration-150 group-open:rotate-90" />


### PR DESCRIPTION
## Summary

`OntologyTreeView` 페이지 끝의 "데이터 경고 N 건" disclosure 가 **red (status-danger)** 톤. 그러나 같은 multi-parent drop 신호를 *stat strip* 에서는 **amber** (PR #223) 로 표시 → 한 페이지 안에서 같은 신호가 두 톤으로 갈려 시각 일관성 깨짐.

### 디자인 헌장 톤 의미

| Tone | 의미 |
|---|---|
| **amber** (rgba 255,179,71) | warning / stub — 검수 필요, 작업 가능 |
| **red** (rgba 229,72,77) | error / 위반 — 즉시 fix |

multi-parent drop 은 *데이터 모델 vs 트리 표현* trade-off — warning 이지 error 아님. amber 가 의미 정확.

### 변경

- border `rgba(229,72,77,0.24)` → `rgba(255,179,71,0.30)`
- bg `rgba(229,72,77,0.06)` → `rgba(255,179,71,0.06)`
- text `var(--color-status-danger)` → `rgba(238,198,128,0.95)`
- open bg `rgba(229,72,77,0.09)` → `rgba(255,179,71,0.09)`

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] 시각: `/ontology` 페이지 끝 disclosure 가 stat strip pill 과 같은 amber 톤

🤖 Generated with [Claude Code](https://claude.com/claude-code)