### PR TITLE
fix(topology): 드래그 후 마우스 release 가 노드 detail 로 들어가는 회귀

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -911,9 +911,11 @@ function SigmaTopologyImpl({
       if (containerRef.current) {
         containerRef.current.style.cursor = hoveredNode ? 'pointer' : '';
       }
-      queueMicrotask(() => {
-        dragMoved = false;
-      });
+      // dragMoved reset 은 *다음 downNode* 에서. queueMicrotask 로 즉시
+      // reset 하면 mouseup → microtask flush → clickNode 순서에서 click
+      // 가드 (if dragMoved return) 가 무력화 → 드래그 후 손 떼면 노드
+      // detail 로 들어가는 회귀. downNode 에서 dragMoved=false 로 다시
+      // 시작하므로 상태 leak 없음.
     };
     captor.on('mouseup', endDrag);
 


### PR DESCRIPTION
## Summary

**사용자 보고**: 토폴로지에서 *허브 노드 드래그 후 손 떼면 그 노드의 detail 드로어가 열림*. 의도는 drag=위치 이동만, plain click=detail 열기 분리.

### 원인

`endDrag` 의 `queueMicrotask(() => dragMoved = false)` 가 다음 순서에서 가드를 무력화:

```
mouseup (captor) → endDrag() → queueMicrotask flush → dragMoved=false
                                                    ↓
                                            clickNode (renderer)
                                            if (dragMoved) return; ← false 이라 skip
                                            → setSelectedSlug → drawer 열림
```

### 수정

`queueMicrotask` reset 제거. `dragMoved` reset 은 *다음 downNode* 시점에서 자연스럽게 진행 (이미 `dragMoved = false` 처리 중). 상태 leak 없음 — 새 드래그 시작 시 깨끗.

```diff
-      queueMicrotask(() => {
-        dragMoved = false;
-      });
+      // dragMoved reset 은 *다음 downNode* 에서. queueMicrotask 로 즉시
+      // reset 하면 mouseup → microtask flush → clickNode 순서에서 click
+      // 가드 (if dragMoved return) 가 무력화 → 드래그 후 손 떼면 노드
+      // detail 로 들어가는 회귀.
```

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — topology 91 통과
- [ ] **시각 smoke**: hub 노드 드래그 → 손 떼기 → drawer 안 열림 / plain click → drawer 열림

🤖 Generated with [Claude Code](https://claude.com/claude-code)