### PR TITLE
chore(topology): clickStage 의 multiple handler 통합

### DIFF
--- a/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaTopology.tsx
@@ -984,7 +984,6 @@ function SigmaTopologyImpl({
       setContextMenu({ slug: node, name: attrs.label, x: event.x, y: event.y });
     });
     renderer.on('rightClickStage', () => setContextMenu(null));
-    renderer.on('clickStage', () => setContextMenu(null));
     renderer.on('doubleClickNode', ({ node, event }) => {
       // 옵시디언의 "이 노드로 포커스" 동작 — Local graph 모드 트리거.
       event.preventSigmaDefault();
@@ -994,7 +993,11 @@ function SigmaTopologyImpl({
         onFirstInteractionRef.current?.();
       }
     });
+    // clickStage 한 군데에서 두 가지 사이드 이펙트 처리 — 이전엔
+    // `setContextMenu(null)` 과 `onPaneClickRef` 가 별도 .on() 두 호출로
+    // 등록되어 같은 이벤트 multiple handler. 같은 effect 묶음으로 통합.
     renderer.on('clickStage', () => {
+      setContextMenu(null);
       onPaneClickRef.current?.();
     });
     renderer.on('enterNode', ({ node, event }) => {


### PR DESCRIPTION
## Summary

`renderer.on('clickStage', ...)` 가 두 곳에서 등록되어 있었음:

- line 987: `setContextMenu(null)`
- line 997: `onPaneClickRef.current?.()`

sigma 가 같은 이벤트의 multiple handler 호출은 지원하지만 동일 effect 묶음을 두 `.on()` 으로 나누어 cognitive overhead. 한 콜백으로 통합 — 행동 변화 없음, registration 만 1 회로 정리.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)