### PR TITLE
fix(docs): ?intent=local + vault 미선택 첫 진입 에러 회귀

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -289,10 +289,15 @@ function DocsVaultContent() {
   );
 
   // Viewer content resolver — 로컬은 파일 핸들로 읽기, 서버는 기본 fetch.
+  // R+ 사용자 보고: `?intent=local` 진입 시 source='local' 강제 set 후
+  // vault 미선택 (handles 0) 단계에서 viewer 가 fh 없는 slug 를 요청해
+  // "no file handle for 'FEATURES'" 에러 노출. handles 가 empty 면 server
+  // fetch fallback — 사용자가 picker 클릭 전까지 demo content 노출.
   const getDocContent = useMemo<
     ((slug: string) => Promise<string>) | undefined
   >(() => {
     if (source !== 'local') return undefined;
+    if (localVault.fileHandles.size === 0) return undefined;
     const handles = localVault.fileHandles;
     return async (slug: string) => {
       const fh = handles.get(slug);


### PR DESCRIPTION
## Summary

사용자가 landing CTA "내 마크다운 폴더 열기" 클릭 → `/docs/?intent=local` 진입 시 `source='local'` 강제 set 되지만 vault picker 미선택 (`fileHandles.size === 0`). PR #225 의 default slug auto-set (FEATURES) 가 trigger 되어 viewer 가 FEATURES.md fetch 시도 → `getDocContent` 가 local 분기로 들어가 `no file handle for "FEATURES"` 영문 에러 노출.

본문 영역이 *영문 에러* 로 막혀 사용자가 picker 안내도 못 봄.

### 수정

`getDocContent`: `source === 'local'` 이지만 `fileHandles.size === 0` 이면 `undefined` 반환 → viewer 가 server fetch (manifest.docs[slug]) fallback. 사용자가 picker 클릭 전까지 demo content 노출, picker 클릭 후 handles populated 되면 자동 local 모드 전환.

`editResolver` 는 그대로 (handle 없으면 edit 불가 = 의도된 동작).

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] 화면 캡쳐: `/docs/?intent=local` 진입 → FEATURES.md demo content 정상 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)