### PR TITLE
fix(projects): single-project vault 의 ontology fact strip 회귀

### DIFF
--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -16,6 +16,7 @@ import { useProjectMutations, useProjects } from "@/features/project-data-source
 import { downloadProjectsCsv } from "@/features/project-export";
 import { useOntologyInsight } from "@/features/vault-ontology";
 import {
+  buildMeaningfulOntologyStats,
   buildProjectOntologyCounts,
   type OntologyCountsForProject,
 } from "@/shared/lib/ontology-tree";
@@ -95,8 +96,28 @@ export function ProjectSelectorPage() {
   // 카드 fact 영역이 stale 한 단계/상태/연결 (cloud-mode 잔재) 대신 ontology
   // breakdown 으로 fallback 할 수 있도록 byKind 까지 보존. badge chip 은
   // .total 만 쓰는데, 같은 데이터 흐름에서 카드 본문도 같이 활용.
+  // R+ 회귀 fix: dogfood 처럼 *single-project vault* 의 ontology 노드들이
+  // frontmatter 에 `project:` 없는 경우 projectIds 빈 array → counts map
+  // 에 entry 0 → 카드 fact strip 안 보임. project 가 정확히 1 개면 모든
+  // ontology 노드를 그 project 에 매달기 fallback.
   const ontologyCountsBySlug = useMemo<Map<string, OntologyCountsForProject>>(
-    () => (insight ? buildProjectOntologyCounts(insight.nodes) : new Map()),
+    () => {
+      if (!insight) return new Map();
+      const map = buildProjectOntologyCounts(insight.nodes);
+      // single-project vault 인데 어떤 노드도 그 project 에 매달리지 않은
+      // 케이스 — 모든 ontology 노드의 합을 그 project 카드에 노출.
+      const projectKindCount = insight.nodes.filter((n) => n.kind === "project").length;
+      if (projectKindCount === 1 && map.size === 0) {
+        const onlyProject = insight.nodes.find((n) => n.kind === "project");
+        if (onlyProject) {
+          const stats = buildMeaningfulOntologyStats(insight.nodes);
+          if (stats.total > 0) {
+            map.set(onlyProject.id.replace(/^project:/, ""), stats);
+          }
+        }
+      }
+      return map;
+    },
     [insight],
   );
 


### PR DESCRIPTION
## Summary

PR #223 의 ontology breakdown 분기 (도메인/역량/요소 3 칸) 가 dogfood 처럼 **single-project vault** 에서 작동 안 함.

### 원인

`derivationToInsight` 가 모든 node 의 `projectIds: []` 로 hardcoded — vault frontmatter 에 `project:` 키 없으면 ontology 노드가 어떤 project 에도 매달리지 않음. `buildProjectOntologyCounts` 가 빈 map 반환 → 카드 fact 분기 fallback path → category/status/connections 도 비어 `return null` → fact strip 통째로 hide.

### 수정

ontology nodes 에 project kind 1 개 + `map.size === 0` 인 single-project 케이스에 **모든 meaningful ontology node 합** 을 그 project 에 매달기 fallback.

```ts
const projectKindCount = insight.nodes.filter((n) => n.kind === "project").length;
if (projectKindCount === 1 && map.size === 0) {
  const onlyProject = insight.nodes.find((n) => n.kind === "project");
  if (onlyProject) {
    const stats = buildMeaningfulOntologyStats(insight.nodes);
    if (stats.total > 0) {
      map.set(onlyProject.id.replace(/^project:/, ""), stats);
    }
  }
}
```

다중 project vault 는 영향 X (조건 false). 이상적 fix 는 `derive-ontology-from-vault` 에서 contains 관계 추적해 projectIds 채우는 것 — 데이터 보강이라 별도 PR scope.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] **시각 smoke**: dogfood 모드에서 `/projects` 카드의 도메인/역량/요소 fact 3 칸 노출 — dev hot reload 가 hook 변경 reflect 안 해 자동 검증 X, 사용자 직접 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)