### PR TITLE
fix(vault): derivationToInsight 가 contains BFS 로 projectIds 채움

### DIFF
--- a/src/features/vault-ontology/model/use-ontology-insight.ts
+++ b/src/features/vault-ontology/model/use-ontology-insight.ts
@@ -55,6 +55,48 @@ function derivationToInsight(
     lastApprovedAt: VAULT_SENTINEL_DATE,
     lastApprovedBy: VAULT_SENTINEL_AUTHOR,
   }));
+
+  // R+ projectIds 채우기 — vault frontmatter 에 `project:` 키가 없어도
+  // contains 관계를 BFS 로 transitive closure 잡아 각 project 노드의 후손
+  // 에 그 project slug 매달기. dogfood 처럼 single-project vault 에서
+  // ProjectSelector 카드의 도메인/역량/요소 fact strip 이 빈 map 으로
+  // 빠져 hide 되던 회귀 차단. UI fallback (PR #252) 도 유지 — 정확한 fix
+  // 가 데이터 보강 끝나면 조건 false 가 되어 자동 skip.
+  const projectNodes = nodes.filter((n) => n.kind === 'project');
+  if (projectNodes.length > 0) {
+    const containsAdj = new Map<string, string[]>();
+    for (const e of edges) {
+      const isContains = e.type === 'contains' || e.type === 'belongs_to';
+      if (!isContains) continue;
+      // belongs_to 는 contains 의 역방향 — 일관되게 container → contained
+      // 로 정규화.
+      const [from, to] = e.type === 'contains' ? [e.from, e.to] : [e.to, e.from];
+      const arr = containsAdj.get(from);
+      if (arr) arr.push(to);
+      else containsAdj.set(from, [to]);
+    }
+    const nodeById = new Map(nodes.map((n) => [n.id, n]));
+    for (const p of projectNodes) {
+      const projectSlug = p.id.replace(/^project:/, '');
+      const visited = new Set<string>([p.id]);
+      const queue: string[] = [p.id];
+      while (queue.length > 0) {
+        const cur = queue.shift()!;
+        const children = containsAdj.get(cur);
+        if (!children) continue;
+        for (const c of children) {
+          if (visited.has(c)) continue;
+          visited.add(c);
+          queue.push(c);
+          const cnode = nodeById.get(c);
+          if (cnode && !cnode.projectIds.includes(projectSlug)) {
+            cnode.projectIds.push(projectSlug);
+          }
+        }
+      }
+    }
+  }
+
   return { nodes, edges };
 }
 


### PR DESCRIPTION
## Summary

PR #252 의 fallback 후 **진짜 fix** — vault 의 contains 관계를 transitive closure 로 잡아 각 project 노드의 모든 후손 (도메인/역량/요소) 에 그 project slug 를 `projectIds` 로 매달기.

### Before

`derivationToInsight` 가 모든 노드의 `projectIds: []` hardcoded → `buildProjectOntologyCounts` 가 항상 empty map → dogfood single-project vault 에서 `/projects` 카드 fact strip hide 회귀.

### After (BFS)

```
contains adjacency 구성:
  contains:    container → contained
  belongs_to:  reversed   container → contained (정규화)

each project p:
  visited = { p.id }
  BFS from p.id via containsAdj
  for each descendant: descendant.projectIds.push(p.slug)
```

dogfood (project 1 + domain 6 + cap 14 + element 62) → BFS 후 모든 ontology 노드 `projectIds: ['oh-my-ontology']` 보유. PR #252 fallback 조건 (`map.size === 0`) false 가 되어 자동 skip. 다중 project vault 에서도 contains chain 따라 정확히 분배.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] **시각 smoke**: `/projects` 카드의 도메인 6 / 역량 14 / 요소 62 fact strip 노출
- [ ] `/projects` 페이지 헤더 `WorkspaceOntologyStrip` 의 도메인/역량/요소 칩도 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)