### PR TITLE
docs(agents): PR #253 의 contains BFS 동작 명시

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,15 @@ When an AI agent (`add_concept`) or a developer (`oh-my-ontology add` / `oh-my-o
 
 `oh-my-ontology import <path...>` is the bulk path: hand it your own `.md` (single file, directory, or many) and each file is run through the same schema before landing in the vault. Frontmatter `kind`/`slug`/`title` win when present; `--kind` is the fallback, the first `# H1` is the title fallback, `--auto-prefix` / `--rename` / `--dry-run` cover the typical conflict cases. Same shape as `add_concept` / `add` — one schema, three entry points.
 
+### Project containment is implicit (no `project:` key needed)
+
+Frontmatter does **not** require an explicit `project:` key. The runtime (`derivationToInsight`) walks the `contains` / `belongs_to` graph from each `kind: project` root and stamps every descendant (domain / capability / element) with that project's slug as a `projectIds` entry. So:
+
+- write `kind: capability` with `domain: foo` and the project containment falls out automatically (capability → domain → project, all wired via `contains`)
+- `/projects` card fact strips, `/ontology/insights` per-project bars, and cross-project edge counts all derive from this BFS — no manual stamping
+
+A vault with no `kind: project` doc still works (no containment, all nodes orphans in project terms). When you eventually add the project doc, all existing descendants pick up `projectIds` on the next derive — no migration.
+
 ## CLAUDE.md / AGENTS.md sync
 
 - **AGENTS.md** (this file) is canonical — the cross-tool standard.


### PR DESCRIPTION
## Summary

PR #253 가 `derivationToInsight` 에 contains/belongs_to BFS 추가로 모든 project 후손 노드가 자동 projectIds 매달림. AGENTS.md 의 "Frontmatter shape per kind (R14)" 섹션 끝에 새 sub-section 추가:

> ### Project containment is implicit (no `project:` key needed)

- project containment 가 implicit (contains chain 따라 자동)
- `/projects` 카드 / insights 분포 / cross-project edge count 모두 이 BFS 기반
- 미래에 project doc 추가하면 기존 descendants 자동 픽업 (migration 0)

문서만 변경, 코드 영향 0.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)