### PR TITLE
fix(vault): project kind node 의 id 를 frontmatter.slug 로 — Project.slug 정합

### DIFF
--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
@@ -135,7 +135,19 @@ function deriveDocNode(doc: VaultDoc): OntologyStubNode | null {
   const rawKind = typeof fm.kind === 'string' ? fm.kind.trim() : '';
   if (!rawKind) return null;
   const title = doc.title?.trim() || doc.slug.split('/').pop() || doc.slug;
-  const id = `${rawKind}:${doc.slug.split('/').pop() || doc.slug}`;
+  // project kind 는 *user-facing slug* (frontmatter.slug 우선) 로 id 형성 —
+  // computeProjectSlug 와 정합. 그래서 PR #253 의 BFS 가 매다는 projectIds
+  // 값이 Project.slug 와 match → /projects 카드 fact strip / /ontology/
+  // insights projectRows 모두 정확한 매핑. 다른 kind 는 file slug 그대로
+  // (relates/depends_on 의 외부 ref 호환).
+  let idSlug: string;
+  const fmSlug = typeof fm.slug === 'string' ? fm.slug.trim() : '';
+  if (rawKind === 'project' && fmSlug) {
+    idSlug = fmSlug;
+  } else {
+    idSlug = doc.slug.split('/').pop() || doc.slug;
+  }
+  const id = `${rawKind}:${idSlug}`;
   return {
     id,
     title,


### PR DESCRIPTION
## Summary

PR #253 의 BFS 가 project 노드의 id (`project:project`, file slug 기반) 끝부분을 떼어 `'project'` 를 projectIds 에 매달았는데, `ProjectSelector` 의 `project.slug` 는 `computeProjectSlug` 결과 (`'oh-my-ontology'`, frontmatter.slug 기반) — **두 layer 불일치** → `/projects` 카드 fact strip 및 `/ontology/insights` projectRows 가 사용자에게 의미 없는 `'project'` label 로 노출.

### 수정

`derive-ontology-from-vault.ts` 의 `deriveDocNode` 가 `kind === 'project'` 일 때 frontmatter.slug 우선 사용해 id 형성:

```
id = `project:${frontmatter.slug ?? fileSlug}` = `project:oh-my-ontology`
```

다른 kind 는 file slug 그대로 (relates / depends_on 의 외부 ref 호환).

### 화면 캡쳐 비교

| | Before | After |
|---|---|---|
| `/ontology/insights` projectRows | `project — 82` | **`oh-my-ontology — 82`** |
| `/projects` 카드 fact strip | hide (mismatch → fallback empty) | **도메인 6 / 역량 14 / 요소 62** |

사용자 첫 점검 보고서의 **P4** (`/projects 카드 stale 필드 정리`) → 완전 fix. PR 라인: #223 (initial) → #252 (UI fallback) → #253 (BFS) → **#255 (id 정합)**.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [x] 시각 캡쳐: `/projects` 카드 + `/ontology/insights` projectRows 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)