### PR TITLE
fix(tree): light 모드 capability/element kind chip 가독성 개선

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -69,13 +69,17 @@ const KIND_TONE: Record<
     text: "var(--color-text-secondary)",
     border: "var(--color-border-strong)",
   },
+  // capability / element 의 bg 가 한 단계 옅은 토큰 (overlay-1/-2) 이라
+  // light mode (alpha 2.5–5%) 에서 흰 배경 위 거의 invisible. dark 에선
+  // 차이 미세, light 에선 가독성 큰 개선 — 한 단계 진한 토큰으로 통일
+  // (border 도 같이).
   capability: {
-    bg: "var(--color-overlay-2)",
+    bg: "var(--color-overlay-3)",
     text: "var(--color-text-tertiary)",
-    border: "var(--color-overlay-3)",
+    border: "var(--color-border-soft)",
   },
   element: {
-    bg: "var(--color-overlay-1)",
+    bg: "var(--color-overlay-2)",
     text: "var(--color-text-quaternary)",
     border: "var(--color-divider)",
   },


### PR DESCRIPTION
## Summary

`KIND_TONE` 의 `capability` bg 가 `var(--color-overlay-2)`, `element` bg 가 `var(--color-overlay-1)` — light mode 에선 각각 alpha 5% / 2.5% black 이라 흰 배경 위 거의 invisible. dark 에선 영향 없지만 light 가독성 회귀.

### 변경 (한 단계 진한 토큰)

| Kind | Before bg / border | After bg / border |
|---|---|---|
| capability | `overlay-2` (5%) / `overlay-3` (10%) | `overlay-3` (10%) / `border-soft` (14%) |
| element | `overlay-1` (2.5%) / `divider` (16%) | `overlay-2` (5%) / `divider` (16%) |

dark 모드도 살짝 brighter chip — 미세 영향. light 가독성 큰 개선.

### 화면 캡쳐 비교 (light mode `/ontology` 트리)

- 이전: capability/element chip 의 fill 이 거의 흰색 → row 끝에 border 만 살짝 보임
- 이후: chip 의 fill/border 경계 명확, kind 식별 한눈에

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass (tree 42 통과)
- [x] 시각 캡쳐: light mode `/ontology` 트리 chip 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)