### PR TITLE
fix(topology): ontology 노드 클릭이 자동 /ontology 로 redirect 되던 회귀

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -319,17 +319,16 @@ export function HomePage() {
       slug: string,
       options?: { preserveImpact?: boolean },
     ) => {
-      // R+ — 토폴로지에서 ontology 노드 (frontmatter `kind:` 가 만든
-      // capability/domain/element id, 형식 `kind:tail`) 클릭은 빈 project
-      // drawer 대신 /ontology 의 ego-graph + detail 패널로 라우팅. project
-      // 가 아닌 노드는 projectBySlug 에 없어 drawer 가 빈 상태로 떴던 회귀.
-      // graph-build.ts 의 long-standing TODO ("ontology 노드 클릭 시 vault md
-      // 열기") 해소 — 같은 vault frontmatter 가 두 surface 에서 일관되게
-      // 보이게 한다.
+      // R+ 사용자 보고: ontology 노드 클릭이 *자동으로* /ontology/?node=...
+      // 로 redirect 되어 우측 drawer 가 안 뜬다. 원래 의도는 "drawer 안에
+      // detail + 트리 이동 버튼". auto-redirect 제거 — selectedSlug 만 set
+      // 해서 drawer 자체는 띄움 (ontology 노드는 projectBySlug 에 없어
+      // drawer 의 project section 은 비지만 적어도 자동 jump 는 차단).
+      // 트리로의 명시 이동은 컨텍스트 메뉴 (rightClickNode) 의 "포커스" /
+      // "이웃만 보기" 또는 별도 nav 로. drawer 의 ontology mode 풀 fledged
+      // 는 follow-up PR scope.
       if (isOntologyNodeId(slug)) {
-        router.push(`/ontology/?node=${encodeURIComponent(slug)}`);
-        dismissSigmaHint();
-        return;
+        // dismissSigmaHint 만 호출 — drawer 는 setRouteState 분기로 뜸.
       }
       // 노드 선택 = drawer 열기. 허브를 선택하면 포커스 모드 자동 활성,
       // 일반 노드는 포커스 해제.
@@ -344,7 +343,7 @@ export function HomePage() {
       }));
       dismissSigmaHint();
     },
-    [projectBySlug, router, setRouteState, dismissSigmaHint],
+    [projectBySlug, setRouteState, dismissSigmaHint],
   );
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Summary

**사용자 보고**: 토폴로지에서 노드 클릭하면 *원래 우측 drawer 가 떠야* 하는데 *바로 `/ontology` 트리로 이동* 됨.

### 원인

`HomePage.handleSelect` 의 `isOntologyNodeId(slug)` 분기가 `router.push('/ontology/?node=...')` 로 강제 이동. 이전 의도: ontology 노드는 `projectBySlug` 에 없어 drawer 가 빈 채로 떠서 어색 → 자동 트리로 jump.

### 수정

auto-redirect 제거. `selectedSlug` 만 set 되어 drawer 자체는 뜸. ontology 노드는 `projectBySlug` 에 없으니 drawer 의 project-specific section 은 빈 채지만 **자동 jump 회귀** 는 차단.

트리로의 명시 이동은 **컨텍스트 메뉴 (rightClickNode)** 또는 별도 nav 로. drawer 의 ontology mode (title + summary + 트리 이동 버튼) 풀 fledged 는 follow-up PR scope.

`router` dep 도 `useCallback` 에서 제거 (더 이상 안 씀).

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:run` — 861 tests pass
- [ ] **시각 smoke**: 토폴로지 ontology 노드 (domain/capability/element) 클릭 → drawer 뜸 (빈 부분 있음) / 트리로 자동 jump 안 함

### Follow-up scope (out of this PR)

drawer 안에 ontology kind 분기 추가 — title + summary + "트리에서 보기" 버튼 + 1-hop ego graph. 별도 PR 에서 ProjectDrawer 의 mode 확장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)