### PR TITLE
feat: 빌더 캔버스 untangle + 정렬 도구 + 도메인 그룹 + n8n 스타일 폴리시

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -705,6 +705,19 @@
           "contains": "contains",
           "describes": "describes",
           "domains": "domain"
+        },
+        "alignToolbar": {
+          "ariaLabel": "Align selected nodes",
+          "selectedCount": "{count} selected",
+          "left": "Align left",
+          "centerX": "Align center (horizontal)",
+          "right": "Align right",
+          "top": "Align top",
+          "centerY": "Align center (vertical)",
+          "bottom": "Align bottom",
+          "distributeH": "Distribute horizontally",
+          "distributeV": "Distribute vertically",
+          "distributeHint": "Distribute requires 3+ selected"
         }
       },
       "inspector": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -703,7 +703,8 @@
           "dependencies": "depends",
           "relates": "relates",
           "contains": "contains",
-          "describes": "describes"
+          "describes": "describes",
+          "domains": "domain"
         }
       },
       "inspector": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -705,6 +705,19 @@
           "contains": "포함",
           "describes": "설명",
           "domains": "도메인"
+        },
+        "alignToolbar": {
+          "ariaLabel": "선택한 노드 정렬",
+          "selectedCount": "{count} 개 선택됨",
+          "left": "왼쪽 정렬",
+          "centerX": "가로 가운데 정렬",
+          "right": "오른쪽 정렬",
+          "top": "위쪽 정렬",
+          "centerY": "세로 가운데 정렬",
+          "bottom": "아래쪽 정렬",
+          "distributeH": "가로 균등 분포",
+          "distributeV": "세로 균등 분포",
+          "distributeHint": "분포는 3 개 이상 선택 필요"
         }
       },
       "inspector": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -703,7 +703,8 @@
           "dependencies": "의존",
           "relates": "관련",
           "contains": "포함",
-          "describes": "설명"
+          "describes": "설명",
+          "domains": "도메인"
         }
       },
       "inspector": {

--- a/src/views/ontology-edit/lib/align-nodes.test.ts
+++ b/src/views/ontology-edit/lib/align-nodes.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeAlignedPositions,
+  type AlignableNode,
+} from "./align-nodes";
+
+const n = (
+  id: string,
+  x: number,
+  y: number,
+  width = 220,
+  height = 60,
+): AlignableNode => ({ id, position: { x, y }, width, height });
+
+describe("computeAlignedPositions", () => {
+  it("노드 1 개 이하 → 빈 Map", () => {
+    expect(computeAlignedPositions([], "left").size).toBe(0);
+    expect(computeAlignedPositions([n("a", 0, 0)], "left").size).toBe(0);
+  });
+
+  it("left — 최소 x 로 세 노드 모두 정렬", () => {
+    const result = computeAlignedPositions(
+      [n("a", 10, 0), n("b", 50, 100), n("c", 200, 200)],
+      "left",
+    );
+    expect(result.get("b")).toEqual({ x: 10, y: 100 });
+    expect(result.get("c")).toEqual({ x: 10, y: 200 });
+    // a 는 이미 minX 라 skip (변경 없음)
+    expect(result.has("a")).toBe(false);
+  });
+
+  it("right — 최대 right edge 로 정렬 (width 보정)", () => {
+    const result = computeAlignedPositions(
+      [n("a", 0, 0, 100), n("b", 50, 0, 100), n("c", 80, 0, 100)],
+      "right",
+    );
+    // maxRight = 80 + 100 = 180
+    expect(result.get("a")).toEqual({ x: 80, y: 0 });
+    expect(result.get("b")).toEqual({ x: 80, y: 0 });
+    expect(result.has("c")).toBe(false);
+  });
+
+  it("center-x — 평균 center 로 정렬", () => {
+    // 노드 모두 width 100. center 들이 50, 100, 150 → 평균 100. target x = 100-50 = 50
+    const result = computeAlignedPositions(
+      [n("a", 0, 0, 100), n("b", 50, 0, 100), n("c", 100, 0, 100)],
+      "center-x",
+    );
+    expect(result.get("a")).toEqual({ x: 50, y: 0 });
+    expect(result.has("b")).toBe(false);
+    expect(result.get("c")).toEqual({ x: 50, y: 0 });
+  });
+
+  it("top — 최소 y 로 정렬", () => {
+    const result = computeAlignedPositions(
+      [n("a", 0, 10), n("b", 0, 50), n("c", 0, 200)],
+      "top",
+    );
+    expect(result.get("b")).toEqual({ x: 0, y: 10 });
+    expect(result.get("c")).toEqual({ x: 0, y: 10 });
+  });
+
+  it("distribute-h — 3 개 노드는 첫·마지막 고정, 가운데 균등", () => {
+    // x 0, 30, 100 → sort same. spacing = 50. mid 는 50 으로 이동
+    const result = computeAlignedPositions(
+      [n("a", 0, 0), n("b", 30, 0), n("c", 100, 0)],
+      "distribute-h",
+    );
+    expect(result.get("a")).toBeUndefined(); // first 고정 (skip)
+    expect(result.get("b")).toEqual({ x: 50, y: 0 });
+    expect(result.get("c")).toBeUndefined(); // last 고정 (skip)
+  });
+
+  it("distribute-h — 2 개 이하면 빈 Map (분포 불가)", () => {
+    expect(
+      computeAlignedPositions(
+        [n("a", 0, 0), n("b", 100, 0)],
+        "distribute-h",
+      ).size,
+    ).toBe(0);
+  });
+
+  it("distribute-v — y 축 균등", () => {
+    const result = computeAlignedPositions(
+      [n("a", 0, 0), n("b", 0, 100), n("c", 0, 60)],
+      "distribute-v",
+    );
+    // sort by y: a(0), c(60), b(100). spacing 50 → c 가 50 으로 이동
+    expect(result.get("c")).toEqual({ x: 0, y: 50 });
+  });
+});

--- a/src/views/ontology-edit/lib/align-nodes.ts
+++ b/src/views/ontology-edit/lib/align-nodes.ts
@@ -1,0 +1,134 @@
+/**
+ * 다중 선택 노드 정렬 — pure compute. UI / store 의존 0 → unit test 쉬움.
+ *
+ * 각 함수는 *현재* 노드 위치를 받아 *목표* 위치를 반환. 호출자가 ReactFlow
+ * setNodes 와 vault.updateFrontmatter 둘 다 트리거해서 in-memory 와 frontmatter
+ * 진실원을 동시에 갱신.
+ *
+ * Align: 같은 축에 줄세움 (좌/우/상/하/가운데).
+ * Distribute: 첫·마지막 노드는 고정, 그 사이를 균등 간격.
+ */
+
+export interface AlignableNode {
+  id: string;
+  position: { x: number; y: number };
+  width: number;
+  height: number;
+}
+
+export type AlignAction =
+  | "left"
+  | "center-x"
+  | "right"
+  | "top"
+  | "center-y"
+  | "bottom"
+  | "distribute-h"
+  | "distribute-v";
+
+/**
+ * 액션을 적용. 변경된 노드만 결과 Map 에 담는다 (이미 align 위치인 노드는
+ * skip — 불필요한 setNodes / vault patch 회피).
+ *
+ * distribute-h/v 는 노드 ≥ 3 필요. 2 개면 빈 Map (UI 가 알아서 disabled).
+ */
+export function computeAlignedPositions(
+  nodes: AlignableNode[],
+  action: AlignAction,
+): Map<string, { x: number; y: number }> {
+  if (nodes.length < 2) return new Map();
+  const result = new Map<string, { x: number; y: number }>();
+
+  switch (action) {
+    case "left": {
+      const minX = Math.min(...nodes.map((n) => n.position.x));
+      for (const n of nodes) {
+        if (n.position.x !== minX) {
+          result.set(n.id, { x: minX, y: n.position.y });
+        }
+      }
+      return result;
+    }
+    case "right": {
+      const maxRight = Math.max(...nodes.map((n) => n.position.x + n.width));
+      for (const n of nodes) {
+        const targetX = maxRight - n.width;
+        if (n.position.x !== targetX) {
+          result.set(n.id, { x: targetX, y: n.position.y });
+        }
+      }
+      return result;
+    }
+    case "center-x": {
+      const centerX =
+        nodes.reduce((s, n) => s + n.position.x + n.width / 2, 0) / nodes.length;
+      for (const n of nodes) {
+        const targetX = centerX - n.width / 2;
+        if (n.position.x !== targetX) {
+          result.set(n.id, { x: targetX, y: n.position.y });
+        }
+      }
+      return result;
+    }
+    case "top": {
+      const minY = Math.min(...nodes.map((n) => n.position.y));
+      for (const n of nodes) {
+        if (n.position.y !== minY) {
+          result.set(n.id, { x: n.position.x, y: minY });
+        }
+      }
+      return result;
+    }
+    case "bottom": {
+      const maxBottom = Math.max(...nodes.map((n) => n.position.y + n.height));
+      for (const n of nodes) {
+        const targetY = maxBottom - n.height;
+        if (n.position.y !== targetY) {
+          result.set(n.id, { x: n.position.x, y: targetY });
+        }
+      }
+      return result;
+    }
+    case "center-y": {
+      const centerY =
+        nodes.reduce((s, n) => s + n.position.y + n.height / 2, 0) / nodes.length;
+      for (const n of nodes) {
+        const targetY = centerY - n.height / 2;
+        if (n.position.y !== targetY) {
+          result.set(n.id, { x: n.position.x, y: targetY });
+        }
+      }
+      return result;
+    }
+    case "distribute-h": {
+      if (nodes.length < 3) return result;
+      const sorted = [...nodes].sort((a, b) => a.position.x - b.position.x);
+      const first = sorted[0];
+      const last = sorted[sorted.length - 1];
+      const spacing =
+        (last.position.x - first.position.x) / (sorted.length - 1);
+      sorted.forEach((n, i) => {
+        const targetX = first.position.x + spacing * i;
+        if (n.position.x !== targetX) {
+          result.set(n.id, { x: targetX, y: n.position.y });
+        }
+      });
+      return result;
+    }
+    case "distribute-v": {
+      if (nodes.length < 3) return result;
+      const sorted = [...nodes].sort((a, b) => a.position.y - b.position.y);
+      const first = sorted[0];
+      const last = sorted[sorted.length - 1];
+      const spacing =
+        (last.position.y - first.position.y) / (sorted.length - 1);
+      sorted.forEach((n, i) => {
+        const targetY = first.position.y + spacing * i;
+        if (n.position.y !== targetY) {
+          result.set(n.id, { x: n.position.x, y: targetY });
+        }
+      });
+      return result;
+    }
+  }
+}

--- a/src/views/ontology-edit/lib/domain-color.test.ts
+++ b/src/views/ontology-edit/lib/domain-color.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveDomainTint } from "./domain-color";
+
+describe("resolveDomainTint", () => {
+  it("같은 slug 는 항상 같은 색 (deterministic)", () => {
+    expect(resolveDomainTint("ai-agent-partner")).toEqual(
+      resolveDomainTint("ai-agent-partner"),
+    );
+  });
+
+  it("다른 slug 는 다른 hue (8 hue palette 안에서)", () => {
+    const a = resolveDomainTint("ai-agent-partner");
+    const b = resolveDomainTint("views");
+    // 같은 hue 가 collision 으로 동일할 수도 있지만 두 slug 의 hash 가 다른 index
+    // 가져야 정상. accent 또는 bg 둘 중 하나는 달라야 함.
+    expect(a.accent === b.accent && a.bg === b.bg).toBe(false);
+  });
+
+  it("null / undefined → neutral tint (배경 transparent)", () => {
+    expect(resolveDomainTint(null).bg).toBe("transparent");
+    expect(resolveDomainTint(undefined).bg).toBe("transparent");
+    expect(resolveDomainTint("").bg).toBe("transparent");
+  });
+
+  it("indigo family 만 사용 (hue 218 ~ 258 사이)", () => {
+    for (const slug of [
+      "ai-agent-partner",
+      "vault-local-first",
+      "views",
+      "onboarding-ux",
+      "ontology-core",
+      "mode-aware-adapters",
+      "anything-else",
+      "x",
+    ]) {
+      const { accent } = resolveDomainTint(slug);
+      const match = accent.match(/hsla\((\d+),/);
+      expect(match).not.toBeNull();
+      const hue = Number(match![1]);
+      expect(hue).toBeGreaterThanOrEqual(218);
+      expect(hue).toBeLessThanOrEqual(258);
+    }
+  });
+});

--- a/src/views/ontology-edit/lib/domain-color.ts
+++ b/src/views/ontology-edit/lib/domain-color.ts
@@ -1,0 +1,52 @@
+/**
+ * 도메인 slug → tint color resolver. 같은 도메인 노드는 같은 hue 의 옅은 좌측
+ * accent + background tint 으로 묶여 *시각 그룹* 을 형성. 디자인 헌장 §11 의
+ * "단일 인디고" 약속 유지 — 모든 색이 indigo family (hue 220-260) 안에서만
+ * saturation / lightness 미세 차이로 구분.
+ *
+ *  - 결정적 (deterministic): 같은 slug 는 항상 같은 색 (hash 기반)
+ *  - 8 hue 사이클 — 8 도메인까지 시각 분리, 9 번째부터 collision OK (인접 hue)
+ *  - dark canvas 가독: lightness 60-72, saturation 28-44 — pop 되되 노드 본문 안 가림
+ */
+
+/**
+ * Indigo family 안에서 8 hue/light 변주.
+ * hue 220 (cool blue) ~ 258 (purple-ish indigo) — 디자인 헌장 §11 단일 인디고 약속
+ * 안에서 도메인 분간 가능한 최소 폭.
+ */
+const DOMAIN_HUES = [228, 240, 222, 250, 234, 258, 218, 246];
+
+export interface DomainTint {
+  /** 노드 좌측 accent bar 색 (4px). */
+  accent: string;
+  /** 노드 배경 옅은 tint. */
+  bg: string;
+}
+
+/**
+ * 단순 djb2-ish 문자열 hash. Math.random / Date 의존 X — 결정적.
+ */
+function hashSlug(slug: string): number {
+  let h = 5381;
+  for (let i = 0; i < slug.length; i += 1) {
+    h = ((h << 5) + h + slug.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+/**
+ * 도메인 slug 가 null 이면 neutral tint (project / vault-readme 용 — 그룹화 안 함).
+ */
+export function resolveDomainTint(slug: string | null | undefined): DomainTint {
+  if (!slug) {
+    return {
+      accent: "rgba(94, 106, 210, 0.32)",
+      bg: "transparent",
+    };
+  }
+  const hue = DOMAIN_HUES[hashSlug(slug) % DOMAIN_HUES.length];
+  return {
+    accent: `hsla(${hue}, 62%, 70%, 0.85)`,
+    bg: `hsla(${hue}, 38%, 58%, 0.08)`,
+  };
+}

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { VaultManifest, VaultDoc } from "@/entities/docs-vault";
-import { buildVaultGraphFlow } from "./use-vault-graph-flow";
+import {
+  buildVaultGraphFlow,
+  stripTrailingParenthetical,
+} from "./use-vault-graph-flow";
 
 function makeDoc(partial: Partial<VaultDoc> & { slug: string }): VaultDoc {
   return {
@@ -104,6 +107,34 @@ describe("buildVaultGraphFlow", () => {
       ]),
     );
     expect(result.edges).toEqual([]);
+  });
+
+  it("노드 카드 라벨은 트레일링 괄호 메타 strip (fullTitle 은 원본 유지)", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "capabilities/cli",
+          title: "CLI Developer Entry (16 commands incl. bootstrap)",
+          frontmatter: {
+            kind: "capability",
+            title: "CLI Developer Entry (16 commands incl. bootstrap)",
+          },
+        }),
+        makeDoc({
+          slug: "capabilities/no-parens",
+          title: "Plain Title",
+          frontmatter: { kind: "capability", title: "Plain Title" },
+        }),
+      ]),
+      { kindLabelOf: () => "역량" },
+    );
+    const cli = result.nodes.find((n) => n.id === "capabilities/cli");
+    const plain = result.nodes.find((n) => n.id === "capabilities/no-parens");
+    expect(cli?.data.label).toBe("역량 · CLI Developer Entry");
+    expect(cli?.data.fullTitle).toBe(
+      "CLI Developer Entry (16 commands incl. bootstrap)",
+    );
+    expect(plain?.data.label).toBe("역량 · Plain Title");
   });
 
   it("self-edge 는 추가 안 함", () => {
@@ -233,5 +264,29 @@ describe("buildVaultGraphFlow", () => {
     expect(byKey["capabilities/bar->capabilities/qux"]?.data).toMatchObject({
       semanticType: "relation",
     });
+  });
+});
+
+describe("stripTrailingParenthetical", () => {
+  it("트레일링 괄호 메타 strip", () => {
+    expect(
+      stripTrailingParenthetical("CLI Developer Entry (16 commands incl. bootstrap)"),
+    ).toBe("CLI Developer Entry");
+  });
+  it("중첩 괄호도 trailing 그룹이면 전체 strip", () => {
+    expect(
+      stripTrailingParenthetical("Ontology Hub — Mode-Aware (Q1=(a))"),
+    ).toBe("Ontology Hub — Mode-Aware");
+  });
+  it("괄호 없으면 그대로", () => {
+    expect(stripTrailingParenthetical("Mode-Aware Adapter")).toBe(
+      "Mode-Aware Adapter",
+    );
+  });
+  it("중간 괄호 + 뒤 텍스트는 strip 안 함", () => {
+    expect(stripTrailingParenthetical("Foo (bar) baz")).toBe("Foo (bar) baz");
+  });
+  it("괄호로 시작하는 타이틀은 그대로", () => {
+    expect(stripTrailingParenthetical("(Internal)")).toBe("(Internal)");
   });
 });

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
@@ -117,4 +117,121 @@ describe("buildVaultGraphFlow", () => {
     );
     expect(result.edges).toEqual([]);
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Layout contract — 선 꼬임 회귀 차단. Containment (capabilities /
+  // elements / contains / domains) 만 dagre rank 에 들어가야 계층이
+  // 클리어해진다. relates / dependencies / describes 가 rank 에 끼면 같은
+  // kind 의 두 노드가 다른 column 으로 흩어져 사선 엣지가 폭증.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("containment chain 으로 LR 계층이 형성된다 (project → domain → capability → element)", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "project",
+          frontmatter: {
+            kind: "project",
+            domains: ["foo"],
+          },
+        }),
+        makeDoc({
+          slug: "domains/foo",
+          frontmatter: {
+            kind: "domain",
+            title: "Foo",
+            capabilities: ["bar"],
+          },
+        }),
+        makeDoc({
+          slug: "capabilities/bar",
+          frontmatter: {
+            kind: "capability",
+            title: "Bar",
+            elements: ["baz"],
+          },
+        }),
+        makeDoc({
+          slug: "elements/baz",
+          frontmatter: { kind: "element", title: "Baz" },
+        }),
+      ]),
+      { layoutMode: "dagre" },
+    );
+    const xOf = (id: string) =>
+      result.nodes.find((n) => n.id === id)?.position.x ?? NaN;
+    // LR 계층 — 좌→우 단조 증가.
+    expect(xOf("project")).toBeLessThan(xOf("domains/foo"));
+    expect(xOf("domains/foo")).toBeLessThan(xOf("capabilities/bar"));
+    expect(xOf("capabilities/bar")).toBeLessThan(xOf("elements/baz"));
+  });
+
+  it("relates 엣지는 rank 에 영향 주지 않는다 — 같은 kind 끼리는 같은 column", () => {
+    // 두 capability 가 서로 relates. 옛 버전은 rank 에 들어가서 b 가
+    // a 보다 한 단계 우측. fix 후엔 둘 다 같은 rank (x 동일).
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "capabilities/a",
+          frontmatter: {
+            kind: "capability",
+            title: "A",
+            relates: ["capabilities/b"],
+          },
+        }),
+        makeDoc({
+          slug: "capabilities/b",
+          frontmatter: { kind: "capability", title: "B" },
+        }),
+      ]),
+      { layoutMode: "dagre" },
+    );
+    const xA = result.nodes.find((n) => n.id === "capabilities/a")?.position.x;
+    const xB = result.nodes.find((n) => n.id === "capabilities/b")?.position.x;
+    expect(xA).toBe(xB);
+  });
+
+  it("엣지 data 에 semanticType 이 표시된다 (containment | relation)", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "domains/foo",
+          frontmatter: {
+            kind: "domain",
+            title: "Foo",
+            capabilities: ["bar"],
+          },
+        }),
+        makeDoc({
+          slug: "capabilities/bar",
+          frontmatter: {
+            kind: "capability",
+            title: "Bar",
+            relates: ["baz"],
+            dependencies: ["qux"],
+          },
+        }),
+        makeDoc({
+          slug: "capabilities/baz",
+          frontmatter: { kind: "capability", title: "Baz" },
+        }),
+        makeDoc({
+          slug: "capabilities/qux",
+          frontmatter: { kind: "capability", title: "Qux" },
+        }),
+      ]),
+    );
+    const byKey = Object.fromEntries(
+      result.edges.map((e) => [`${e.source}->${e.target}`, e]),
+    );
+    expect(byKey["domains/foo->capabilities/bar"]?.data).toMatchObject({
+      semanticType: "containment",
+    });
+    expect(byKey["capabilities/bar->capabilities/baz"]?.data).toMatchObject({
+      semanticType: "relation",
+    });
+    expect(byKey["capabilities/bar->capabilities/qux"]?.data).toMatchObject({
+      semanticType: "relation",
+    });
+  });
 });

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { VaultManifest, VaultDoc } from "@/entities/docs-vault";
 import {
   buildVaultGraphFlow,
+  resolveNodeDomainSlug,
   stripTrailingParenthetical,
 } from "./use-vault-graph-flow";
 
@@ -135,6 +136,34 @@ describe("buildVaultGraphFlow", () => {
       "CLI Developer Entry (16 commands incl. bootstrap)",
     );
     expect(plain?.data.label).toBe("역량 · Plain Title");
+  });
+
+  it("노드 data 에 domainSlug 가 들어간다 (capability/element=frontmatter.domain, domain=자기 tail)", () => {
+    const result = buildVaultGraphFlow(
+      makeManifest([
+        makeDoc({
+          slug: "domains/foo",
+          frontmatter: { kind: "domain", title: "Foo" },
+        }),
+        makeDoc({
+          slug: "capabilities/bar",
+          frontmatter: { kind: "capability", title: "Bar", domain: "foo" },
+        }),
+        makeDoc({
+          slug: "elements/baz",
+          frontmatter: { kind: "element", title: "Baz", domain: "foo" },
+        }),
+        makeDoc({
+          slug: "project",
+          frontmatter: { kind: "project", title: "P" },
+        }),
+      ]),
+    );
+    const byId = Object.fromEntries(result.nodes.map((n) => [n.id, n]));
+    expect(byId["domains/foo"]?.data.domainSlug).toBe("foo");
+    expect(byId["capabilities/bar"]?.data.domainSlug).toBe("foo");
+    expect(byId["elements/baz"]?.data.domainSlug).toBe("foo");
+    expect(byId["project"]?.data.domainSlug).toBeNull();
   });
 
   it("self-edge 는 추가 안 함", () => {
@@ -288,5 +317,54 @@ describe("stripTrailingParenthetical", () => {
   });
   it("괄호로 시작하는 타이틀은 그대로", () => {
     expect(stripTrailingParenthetical("(Internal)")).toBe("(Internal)");
+  });
+});
+
+describe("resolveNodeDomainSlug", () => {
+  const make = (slug: string, kind: string, fm: Record<string, unknown> = {}) =>
+    ({
+      slug,
+      path: `${slug}.md`,
+      title: slug,
+      tags: [],
+      frontmatter: { kind, title: slug, ...fm },
+      headings: [],
+      excerpt: "",
+      wordCount: 0,
+      updatedAt: "2026-05-14T00:00:00Z",
+      linksOut: [],
+    }) as VaultDoc;
+
+  it("domain → 자기 tail slug", () => {
+    expect(
+      resolveNodeDomainSlug(make("domains/ai-agent-partner", "domain"), "domain"),
+    ).toBe("ai-agent-partner");
+  });
+  it("capability → frontmatter.domain", () => {
+    expect(
+      resolveNodeDomainSlug(
+        make("capabilities/x", "capability", { domain: "foo" }),
+        "capability",
+      ),
+    ).toBe("foo");
+  });
+  it("element → frontmatter.domain", () => {
+    expect(
+      resolveNodeDomainSlug(
+        make("elements/y", "element", { domain: "bar" }),
+        "element",
+      ),
+    ).toBe("bar");
+  });
+  it("project → null", () => {
+    expect(resolveNodeDomainSlug(make("project", "project"), "project")).toBeNull();
+  });
+  it("frontmatter.domain 없으면 null", () => {
+    expect(
+      resolveNodeDomainSlug(
+        make("capabilities/z", "capability"),
+        "capability",
+      ),
+    ).toBeNull();
   });
 });

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -126,6 +126,27 @@ export function stripTrailingParenthetical(title: string): string {
 }
 
 /**
+ * 노드의 domain grouping 키 결정. UI tint / swimlane 분기용.
+ *  - domain 자체 → tail slug ("domains/ai-agent-partner" → "ai-agent-partner")
+ *  - capability / element → frontmatter.domain (inline 단일 string)
+ *  - project / vault-readme / 기타 → null (그룹화 안 함)
+ */
+export function resolveNodeDomainSlug(
+  doc: VaultDoc,
+  kind: string,
+): string | null {
+  if (kind === "domain") {
+    const tail = doc.slug.split("/").pop() ?? doc.slug;
+    return tail || null;
+  }
+  if (kind === "capability" || kind === "element") {
+    const dom = doc.frontmatter.domain;
+    return typeof dom === "string" && dom ? dom : null;
+  }
+  return null;
+}
+
+/**
  * 순수 함수 — manifest → xyflow Node[] / Edge[]. 테스트용 export.
  *
  * options:
@@ -240,6 +261,10 @@ export function buildVaultGraphFlow(
       typeof doc.frontmatter.description === "string"
         ? doc.frontmatter.description
         : "";
+    // 도메인 grouping 용 — capability / element 의 frontmatter.domain (inline
+    // 단일 string), domain 자체는 자기 slug 의 tail. project / vault-readme 는
+    // null (그룹화 없음).
+    const domainSlug = resolveNodeDomainSlug(doc, kind);
     return {
       id: doc.slug,
       type: "atlas",
@@ -252,6 +277,7 @@ export function buildVaultGraphFlow(
         ephemeral: false,
         vault: true,
         description,
+        domainSlug,
       },
       width: NODE_WIDTH,
       height: NODE_HEIGHT,

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { type CSSProperties, useMemo } from "react";
-import type { Edge, Node } from "@xyflow/react";
+import { MarkerType, type Edge, type Node } from "@xyflow/react";
 import dagre from "@dagrejs/dagre";
 import Graph from "graphology";
 import forceAtlas2 from "graphology-layout-forceatlas2";
@@ -74,14 +74,37 @@ export function useVaultGraphFlow(
 const NODE_WIDTH = 220;
 const NODE_HEIGHT = 60;
 
-const NEIGHBOR_KEYS = [
+// 의미상 부모→자식 hierarchy 를 만드는 keys. 이들 엣지가 dagre rank 계산을
+// 주도해서 project → domain → capability → element 의 LR 골격을 형성한다.
+// `domains` 가 R14 schema 에서 project 의 array 키 — 빠지면 골격이 안 그려져
+// 사선 relates 가 화면을 잡아먹는다.
+const CONTAINMENT_KEYS = [
+  "domains",
   "capabilities",
   "elements",
+  "contains",
+] as const;
+
+// 횡단 관계 — rank 에 영향 주지 않고 overlay 로만 그려진다. 같은 kind 두
+// 노드가 서로 relates 라도 같은 column 에 머물러야 사선이 폭증하지 않음.
+const RELATION_KEYS = [
   "dependencies",
   "relates",
-  "contains",
   "describes",
 ] as const;
+
+const NEIGHBOR_KEYS = [
+  ...CONTAINMENT_KEYS,
+  ...RELATION_KEYS,
+] as const;
+
+const CONTAINMENT_KEY_SET: ReadonlySet<string> = new Set(CONTAINMENT_KEYS);
+
+type SemanticType = "containment" | "relation";
+
+function semanticTypeOf(key: string): SemanticType {
+  return CONTAINMENT_KEY_SET.has(key) ? "containment" : "relation";
+}
 
 /**
  * 순수 함수 — manifest → xyflow Node[] / Edge[]. 테스트용 export.
@@ -123,9 +146,17 @@ export function buildVaultGraphFlow(
     return null;
   }
 
-  // Edge 페어 (sourceSlug → targetSlug) 를 layout 전에 한 번 모은다.
-  // dagre / 미래의 다른 layout 알고리즘 모두 이 raw 페어 list 가 필요.
-  const rawEdgePairs: Array<[string, string]> = [];
+  // Edge 페어를 한 번에 수집 — frontmatter key 와 semanticType 까지 같이
+  // tag. layout 은 containment 만 사용 (rank skeleton), 렌더는 전체 사용.
+  // 같은 (source, target) 페어는 *처음 본 key* 만 유지 (containment 가
+  // 먼저 등장하도록 NEIGHBOR_KEYS 순서가 containment 우선).
+  interface EdgeRecord {
+    source: string;
+    target: string;
+    key: string;
+    semanticType: SemanticType;
+  }
+  const edgeRecords: EdgeRecord[] = [];
   const seenPair = new Set<string>();
   for (const doc of ontologyDocs) {
     for (const key of NEIGHBOR_KEYS) {
@@ -138,20 +169,30 @@ export function buildVaultGraphFlow(
         const pairKey = `${doc.slug}->${resolved}`;
         if (seenPair.has(pairKey)) continue;
         seenPair.add(pairKey);
-        rawEdgePairs.push([doc.slug, resolved]);
+        edgeRecords.push({
+          source: doc.slug,
+          target: resolved,
+          key,
+          semanticType: semanticTypeOf(key),
+        });
       }
     }
   }
 
-  // 자동 layout — 사용자 선호에 따라 dagre (default, kind 계층 LR) 또는
-  // force (FA2 organic 분포) 두 가지. dagre 는 ontology 의 project → domain
-  // → capability → element 흐름이 자연스럽게 좌→우 계층, force 는 토폴로지
-  // 와 같이 노드 사이 인력/척력 시뮬레이션. 사용자가 drag 한 노드는 그대로
-  // 우선 (수동 배치 보존).
+  // 자동 layout — dagre 는 containment 엣지만 받는다. relates / dependencies
+  // / describes 가 rank 에 끼면 같은 kind 끼리 column 이 갈라져 사선 폭증.
+  // force 는 모든 엣지로 자연스럽게 인력/척력 분포.
+  const containmentPairs: Array<[string, string]> = edgeRecords
+    .filter((e) => e.semanticType === "containment")
+    .map((e) => [e.source, e.target]);
+  const allPairs: Array<[string, string]> = edgeRecords.map((e) => [
+    e.source,
+    e.target,
+  ]);
   const fallbackPositions =
     layoutMode === "force"
-      ? computeForceLayout(ontologyDocs, rawEdgePairs)
-      : computeDagreLayout(ontologyDocs, rawEdgePairs);
+      ? computeForceLayout(ontologyDocs, allPairs)
+      : computeDagreLayout(ontologyDocs, containmentPairs);
   const nodes: Node[] = ontologyDocs.map((doc) => {
     // frontmatter.canvasPosition: { x, y } 가 있으면 우선. 없으면 dagre fallback.
     // 사용자가 빌더에서 drag-stop 시 canvasPosition patch — 다음 mount 부터
@@ -204,41 +245,58 @@ export function buildVaultGraphFlow(
     };
   });
 
-  // edge style / label 풍부 결정 — frontmatter array 키별 톤. raw pair 는
-  // 이미 위에서 dedup 됐고, 여기서 같은 (source,target) 에 대해 처음 매칭된
-  // key 의 style 적용. 같은 페어가 두 키에 있으면 첫 번째만.
-  const seenEdges = new Set<string>();
-  const edges: Edge[] = [];
-  for (const doc of ontologyDocs) {
-    for (const key of NEIGHBOR_KEYS) {
-      const value = doc.frontmatter[key];
-      if (!Array.isArray(value)) continue;
-      for (const ref of value) {
-        if (typeof ref !== "string") continue;
-        const resolved = resolveRef(ref);
-        if (!resolved || resolved === doc.slug) continue;
-        const edgeId = `${doc.slug}--${key}-->${resolved}`;
-        if (seenEdges.has(edgeId)) continue;
-        seenEdges.add(edgeId);
-        edges.push({
-          id: edgeId,
-          source: doc.slug,
-          target: resolved,
-          type: "default",
-          label: resolveEdgeLabel(key),
-          labelStyle: edgeLabelStyle,
-          labelBgStyle: edgeLabelBgStyle,
-          labelBgPadding: [6, 4] as [number, number],
-          labelBgBorderRadius: 4,
-          style: edgeStrokeStyleByKey(key),
-          animated: false,
-          // vault edge 는 frontmatter 진실원이라 캔버스 Del 로 삭제 금지.
-          // 인스펙터의 array editor (-) 버튼만 patch 권한.
-          deletable: false,
-        });
-      }
-    }
-  }
+  // edge 렌더 — 위에서 모은 edgeRecords 를 xyflow Edge[] 로 변환. n8n 스타일:
+  //  - containment → smoothstep + 둥근 모서리 (borderRadius 12) + 화살표 marker
+  //  - dependencies → bezier 곡선 + 화살표 marker (방향성 의존 강조)
+  //  - relates / describes → 양방향 약한 overlay, marker 없음
+  // **라벨은 기본 비표시** — 시각 노이즈 주범, hover/inspector 가 담당.
+  // 라벨 텍스트는 data.frontmatterKey 로만 노출, edgeLabelOf 는 향후 hover
+  // 단계에서 호출. 지금은 미사용 분기 회피용으로 호출하지 않음.
+  void resolveEdgeLabel;
+  const edges: Edge[] = edgeRecords.map((rec) => {
+    const id = `${rec.source}--${rec.key}-->${rec.target}`;
+    const isContainment = rec.semanticType === "containment";
+    const isDirectional =
+      isContainment || rec.key === "dependencies";
+    const stroke = edgeStrokeStyleByKey(rec.key);
+    return {
+      id,
+      source: rec.source,
+      target: rec.target,
+      type: isContainment ? "smoothstep" : "default",
+      // smoothstep 모서리를 n8n 처럼 둥글게. 5(default) 는 거의 직각으로
+      // 보임, 12 면 부드러운 곡선 인상.
+      ...(isContainment
+        ? { pathOptions: { borderRadius: 12, offset: 18 } }
+        : {}),
+      style: stroke,
+      animated: false,
+      // 방향성 있는 엣지 (containment / depends_on) 에 화살표 marker. 색은
+      // stroke 와 매칭해서 시각 일관성. relates / describes 는 대칭 관계라
+      // marker 생략.
+      ...(isDirectional
+        ? {
+            markerEnd: {
+              type: MarkerType.ArrowClosed,
+              width: 16,
+              height: 16,
+              color: typeof stroke.stroke === "string"
+                ? stroke.stroke
+                : "rgba(139, 151, 255, 0.78)",
+            },
+          }
+        : {}),
+      // Inspector / 디버그 / 향후 hover UI 에서 의미를 알 수 있게 metadata
+      // 노출. semanticType 으로 스타일/필터 분기.
+      data: {
+        semanticType: rec.semanticType,
+        frontmatterKey: rec.key,
+      },
+      // vault edge 는 frontmatter 진실원이라 캔버스 Del 로 삭제 금지.
+      // 인스펙터의 array editor (-) 버튼만 patch 권한.
+      deletable: false,
+    };
+  });
 
   return { nodes, edges };
 }
@@ -356,34 +414,36 @@ function computeForceLayout(
   return map;
 }
 
-const edgeLabelStyle = {
-  fontSize: 10,
-  fill: "rgba(220, 226, 240, 0.96)",
-  fontWeight: 600,
-};
-const edgeLabelBgStyle = {
-  fill: "rgba(14, 16, 22, 0.92)",
-  stroke: "rgba(94, 106, 210, 0.32)",
-  strokeWidth: 1,
-};
-
 function edgeStrokeStyleByKey(key: string): CSSProperties {
-  if (key === "contains" || key === "capabilities" || key === "elements") {
-    return { stroke: "rgba(139, 151, 255, 0.66)", strokeWidth: 1.5 };
+  // n8n 스타일 — 굵은 indigo cable 이 골격. solid 선 + 화살표 marker (caller).
+  if (
+    key === "contains" ||
+    key === "capabilities" ||
+    key === "elements" ||
+    key === "domains"
+  ) {
+    return { stroke: "rgba(139, 151, 255, 0.85)", strokeWidth: 1.9 };
   }
+  // Dependencies — 방향성 있는 의존, dashed indigo + 화살표 marker (caller).
   if (key === "dependencies") {
-    return { stroke: "rgba(94, 106, 210, 0.46)", strokeWidth: 1.25 };
+    return {
+      stroke: "rgba(139, 151, 255, 0.62)",
+      strokeWidth: 1.45,
+      strokeDasharray: "6 4",
+    };
   }
+  // relates / describes — 양방향 overlay, marker 없음. 골격을 가리지 않으면서
+  // *읽힐 만큼* 가시 (이전 0.18 회귀 후 0.5 로).
   if (key === "describes") {
     return {
-      stroke: "rgba(180, 188, 220, 0.4)",
-      strokeWidth: 1,
+      stroke: "rgba(180, 188, 220, 0.5)",
+      strokeWidth: 1.1,
       strokeDasharray: "2 3",
     };
   }
   return {
-    stroke: "rgba(180, 188, 220, 0.32)",
-    strokeWidth: 1,
+    stroke: "rgba(180, 188, 220, 0.5)",
+    strokeWidth: 1.1,
     strokeDasharray: "4 4",
   };
 }

--- a/src/views/ontology-edit/lib/use-vault-graph-flow.ts
+++ b/src/views/ontology-edit/lib/use-vault-graph-flow.ts
@@ -107,6 +107,25 @@ function semanticTypeOf(key: string): SemanticType {
 }
 
 /**
+ * 노드 카드 라벨용 — 트레일링 괄호 메타데이터 strip.
+ *
+ *   "CLI Developer Entry (16 commands incl. bootstrap)"
+ *     → "CLI Developer Entry"
+ *   "Ontology Hub — Mode-Aware (Q1=(a))"
+ *     → "Ontology Hub — Mode-Aware"
+ *   "Mode-Aware Adapter"        // 괄호 없음 → 그대로
+ *
+ * 조건: 마지막 `)` 가 문자열 끝, 그 이전에 매칭되는 `(`, 그리고 그 앞에 본문
+ * 텍스트가 있을 때만. 중간 괄호 (예: "Foo (bar) baz") 는 건드리지 않음.
+ * Inspector / hover tooltip 은 원본 title 그대로 사용 — 카드 라벨만 짧아짐.
+ */
+export function stripTrailingParenthetical(title: string): string {
+  const trimmed = title.trim();
+  const match = trimmed.match(/^(.+?)\s+\(.+\)\s*$/);
+  return match ? match[1].trim() : trimmed;
+}
+
+/**
  * 순수 함수 — manifest → xyflow Node[] / Edge[]. 테스트용 export.
  *
  * options:
@@ -214,6 +233,9 @@ export function buildVaultGraphFlow(
     const pos = persistedPos ?? fallbackPositions.get(doc.slug) ?? { x: 0, y: 0 };
     const kind = String(doc.frontmatter.kind);
     const title = doc.title || doc.slug;
+    // 카드 라벨은 짧게 (트레일링 괄호 strip), inspector / hover tooltip 은
+    // 원본 title 그대로 (description 으로 노출).
+    const labelTitle = stripTrailingParenthetical(title);
     const description =
       typeof doc.frontmatter.description === "string"
         ? doc.frontmatter.description
@@ -223,7 +245,9 @@ export function buildVaultGraphFlow(
       type: "atlas",
       position: pos,
       data: {
-        label: `${resolveKindLabel(kind)} · ${title}`,
+        label: `${resolveKindLabel(kind)} · ${labelTitle}`,
+        // 원본 title — inspector / tooltip 이 짧은 라벨 아닌 풀 텍스트 필요할 때.
+        fullTitle: title,
         kind,
         ephemeral: false,
         vault: true,

--- a/src/views/ontology-edit/ui/AlignToolbar.tsx
+++ b/src/views/ontology-edit/ui/AlignToolbar.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  AlignStartHorizontal,
+  AlignCenterHorizontal,
+  AlignEndHorizontal,
+  AlignStartVertical,
+  AlignCenterVertical,
+  AlignEndVertical,
+  AlignHorizontalDistributeCenter,
+  AlignVerticalDistributeCenter,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { AlignAction, AlignableNode } from "../lib/align-nodes";
+
+type IconComponent = typeof AlignStartHorizontal;
+
+function AlignBtn({
+  action,
+  label,
+  Icon,
+  disabled,
+  onApply,
+}: {
+  action: AlignAction;
+  label: string;
+  Icon: IconComponent;
+  disabled?: boolean;
+  onApply: (action: AlignAction) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onApply(action)}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className="flex h-8 w-8 items-center justify-center rounded-md border border-[var(--color-overlay-3)] bg-[var(--color-panel)] text-[var(--color-text-secondary)] transition-colors hover:border-[rgba(139,151,255,0.6)] hover:text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[rgba(139,151,255,0.55)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-[var(--color-overlay-3)] disabled:hover:text-[var(--color-text-secondary)]"
+    >
+      <Icon className="h-4 w-4" strokeWidth={1.8} />
+    </button>
+  );
+}
+
+/**
+ * 다중 선택 시 캔버스 상단에 떠오르는 정렬 툴바.
+ *  - 2 개 이상 선택 시 표시
+ *  - L/R/T/B/center-x/center-y 6 정렬 + 가로/세로 분포 2 = 8 버튼
+ *  - 분포는 3 개 이상 선택일 때만 활성 (그 외 disabled)
+ *
+ * 디자인 헌장 §11: 단일 인디고, glow / 보라 / scale hover 없음. panel
+ * background + subtle border + 인디고 accent.
+ */
+export function AlignToolbar({
+  selected,
+  onApply,
+}: {
+  selected: AlignableNode[];
+  onApply: (action: AlignAction) => void;
+}) {
+  const t = useTranslations("ontologyPages.edit.canvas.alignToolbar");
+  if (selected.length < 2) return null;
+  const canDistribute = selected.length >= 3;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label={t("ariaLabel")}
+      className="pointer-events-auto absolute top-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1.5 rounded-lg border border-[var(--color-overlay-3)] bg-[var(--color-elevated)] px-2.5 py-1.5 shadow-[0_6px_16px_rgba(0,0,0,0.32)]"
+    >
+      <span className="px-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[var(--color-text-quaternary)]">
+        {t("selectedCount", { count: selected.length })}
+      </span>
+      <span aria-hidden className="mx-1 h-4 w-px bg-[var(--color-overlay-3)]" />
+      <AlignBtn action="left" label={t("left")} Icon={AlignStartVertical} onApply={onApply} />
+      <AlignBtn action="center-x" label={t("centerX")} Icon={AlignCenterVertical} onApply={onApply} />
+      <AlignBtn action="right" label={t("right")} Icon={AlignEndVertical} onApply={onApply} />
+      <span aria-hidden className="mx-1 h-4 w-px bg-[var(--color-overlay-3)]" />
+      <AlignBtn action="top" label={t("top")} Icon={AlignStartHorizontal} onApply={onApply} />
+      <AlignBtn action="center-y" label={t("centerY")} Icon={AlignCenterHorizontal} onApply={onApply} />
+      <AlignBtn action="bottom" label={t("bottom")} Icon={AlignEndHorizontal} onApply={onApply} />
+      <span aria-hidden className="mx-1 h-4 w-px bg-[var(--color-overlay-3)]" />
+      <AlignBtn
+        action="distribute-h"
+        label={canDistribute ? t("distributeH") : t("distributeHint")}
+        Icon={AlignHorizontalDistributeCenter}
+        disabled={!canDistribute}
+        onApply={onApply}
+      />
+      <AlignBtn
+        action="distribute-v"
+        label={canDistribute ? t("distributeV") : t("distributeHint")}
+        Icon={AlignVerticalDistributeCenter}
+        disabled={!canDistribute}
+        onApply={onApply}
+      />
+    </div>
+  );
+}

--- a/src/views/ontology-edit/ui/AtlasNode.tsx
+++ b/src/views/ontology-edit/ui/AtlasNode.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { resolveDomainTint } from "../lib/domain-color";
 
 /**
  * Atlas custom node — kind 별 디자인 폴리시.
@@ -11,6 +12,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
  * - glow / 보라핑크 / scale hover X
  * - rounded + soft shadow (정적, 무채색 alpha)
  * - vault (실선 border) vs ephemeral (dashed border) 시각 구분
+ * - 같은 도메인 노드는 같은 hue 좌측 accent bar (4px) — 그룹 시각화
  */
 export interface AtlasNodeData {
   label: string;
@@ -18,7 +20,10 @@ export interface AtlasNodeData {
   ephemeral?: boolean;
   /** vault 노드 frontmatter.description — hover 시 native title tooltip 으로 노출. */
   description?: string;
-  /** kindLabel 별도 (예: '프로젝트' / '도메인'). label 안에 이미 prefix 로 들어감. */
+  /** 원본 title (트레일링 괄호 strip 전) — tooltip / inspector 가 풀 텍스트 노출. */
+  fullTitle?: string;
+  /** 도메인 grouping 키. capability/element 의 frontmatter.domain, domain 자기 tail. */
+  domainSlug?: string | null;
   [key: string]: unknown;
 }
 
@@ -65,11 +70,23 @@ export function AtlasNode({ data, selected }: NodeProps) {
   const borderWidth = isEphemeral ? 2 : 1;
   const borderColor = isEphemeral ? "rgba(255, 179, 71, 0.55)" : tone.border;
   const ephemeralBadgeColor = "rgba(255, 179, 71, 0.95)";
-  // hover 시 native browser tooltip — description 있으면 frontmatter 미리보기,
-  // 없으면 label 만. 사용자가 클릭 안 해도 노드 정체 빠르게 확인.
+  // hover 시 native browser tooltip — description / fullTitle 노출.
+  // fullTitle 이 있으면 카드 짧은 라벨 대신 풀 텍스트 + description.
+  const hoverHeader =
+    typeof nodeData.fullTitle === "string" && nodeData.fullTitle
+      ? nodeData.fullTitle
+      : nodeData.label;
   const hoverTitle = nodeData.description
-    ? `${nodeData.label}\n\n${nodeData.description}`
-    : nodeData.label;
+    ? `${hoverHeader}\n\n${nodeData.description}`
+    : hoverHeader;
+  // 도메인 tint — 같은 도메인 노드끼리 시각 그룹화. domain 자체 노드 + capability /
+  // element 가 도메인 일치하면 같은 hue. project / vault-readme 는 null tint.
+  const domainTint = resolveDomainTint(
+    typeof nodeData.domainSlug === "string" ? nodeData.domainSlug : null,
+  );
+  // ephemeral 은 amber 신호색이 강해서 도메인 tint 적용 안 함 (혼동 방지).
+  // domain 노드 자기 카드도 자기 색으로 hue 진하게 (좌측 4px bar, bg tint).
+  const showDomainTint = !isEphemeral && nodeData.domainSlug;
   return (
     <div
       title={hoverTitle}
@@ -77,11 +94,19 @@ export function AtlasNode({ data, selected }: NodeProps) {
         minWidth: 220,
         minHeight: 60,
         padding: "12px 16px",
+        paddingLeft: showDomainTint ? 18 : 16,
         borderRadius: 12,
         border: `${borderWidth}px ${borderStyle} ${borderColor}`,
+        // 좌측 4px accent bar 가 domain 시각 그룹의 anchor. ephemeral 은
+        // amber 강조라 적용 X (잘못된 신호 혼합 회피).
+        borderLeft: showDomainTint
+          ? `4px solid ${domainTint.accent}`
+          : `${borderWidth}px ${borderStyle} ${borderColor}`,
         background: isEphemeral
           ? "rgba(255, 179, 71, 0.06)"
-          : tone.bg,
+          : showDomainTint
+            ? `linear-gradient(to right, ${domainTint.bg}, ${tone.bg})`
+            : tone.bg,
         color: "var(--color-text-primary)",
         boxShadow: selected
           ? `0 0 0 2px ${isEphemeral ? "rgba(255, 179, 71, 0.6)" : tone.accent}, 0 10px 22px rgba(0, 0, 0, 0.36)`

--- a/src/views/ontology-edit/ui/AtlasNode.tsx
+++ b/src/views/ontology-edit/ui/AtlasNode.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { resolveDomainTint } from "../lib/domain-color";
@@ -61,6 +62,10 @@ const KIND_TONE: Record<
 export function AtlasNode({ data, selected }: NodeProps) {
   const t = useTranslations("ontologyPages.edit.atlasNode");
   const nodeData = data as AtlasNodeData;
+  // 호버 elevation — 디자인 헌장 §11 의 'scale hover 금지' 약속 안에서 box-shadow
+  // 만 강화 (translateY 도 안 씀). React state 로 hover 분기 — 인라인 스타일이
+  // CSS hover 보다 우선이라 state 가 가장 깔끔.
+  const [hovered, setHovered] = useState(false);
   const tone = KIND_TONE[nodeData.kind] ?? KIND_TONE.element;
   const isEphemeral = Boolean(nodeData.ephemeral);
   // ephemeral 은 *저장 필요* 신호 — 디자인 헌장 §11 의 warning amber
@@ -87,9 +92,23 @@ export function AtlasNode({ data, selected }: NodeProps) {
   // ephemeral 은 amber 신호색이 강해서 도메인 tint 적용 안 함 (혼동 방지).
   // domain 노드 자기 카드도 자기 색으로 hue 진하게 (좌측 4px bar, bg tint).
   const showDomainTint = !isEphemeral && nodeData.domainSlug;
+  // 선택 / hover / 기본 시각 위계 — 디자인 헌장 §11 의 단일 인디고 약속 안에서
+  // box-shadow elevation 으로만 차별. scale / translate 금지.
+  //  - selected: indigo halo + ring (또는 ephemeral 의 amber halo)
+  //  - hovered: 그림자 한 단계 강화 (rest 보다 또렷, selected 보단 약함)
+  //  - rest: 살짝 떠있는 default shadow
+  const selectedShadow = selected
+    ? `0 0 0 2px ${isEphemeral ? "rgba(255, 179, 71, 0.62)" : tone.accent}, 0 0 22px ${isEphemeral ? "rgba(255, 179, 71, 0.32)" : "rgba(139, 151, 255, 0.32)"}, 0 12px 28px rgba(0, 0, 0, 0.42)`
+    : null;
+  const hoveredShadow = hovered
+    ? "0 8px 22px rgba(0, 0, 0, 0.36), 0 0 0 1px rgba(139, 151, 255, 0.22)"
+    : null;
+  const restShadow = "0 4px 12px rgba(0, 0, 0, 0.22)";
   return (
     <div
       title={hoverTitle}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       style={{
         minWidth: 220,
         minHeight: 60,
@@ -108,10 +127,9 @@ export function AtlasNode({ data, selected }: NodeProps) {
             ? `linear-gradient(to right, ${domainTint.bg}, ${tone.bg})`
             : tone.bg,
         color: "var(--color-text-primary)",
-        boxShadow: selected
-          ? `0 0 0 2px ${isEphemeral ? "rgba(255, 179, 71, 0.6)" : tone.accent}, 0 10px 22px rgba(0, 0, 0, 0.36)`
-          : "0 4px 12px rgba(0, 0, 0, 0.22)",
-        transition: "box-shadow 180ms ease-out, border-color 180ms ease-out",
+        boxShadow: selectedShadow ?? hoveredShadow ?? restShadow,
+        transition:
+          "box-shadow 200ms ease-out, border-color 200ms ease-out",
         fontSize: 13,
         lineHeight: 1.4,
         wordBreak: "keep-all",

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -26,6 +26,12 @@ import type { EphemeralNode } from "../lib/use-ephemeral-nodes";
 import type { EphemeralEdge } from "../lib/use-ephemeral-edges";
 import { ATLAS_NODE_TYPES } from "./AtlasNode";
 import { EphemeralEdge as EphemeralEdgeComponent } from "./EphemeralEdge";
+import { AlignToolbar } from "./AlignToolbar";
+import {
+  computeAlignedPositions,
+  type AlignAction,
+  type AlignableNode,
+} from "../lib/align-nodes";
 
 const EDGE_TYPES = { ephemeral: EphemeralEdgeComponent };
 
@@ -372,6 +378,50 @@ export function OntologyEditCanvas({
     [onVaultNodeDragStop, hasLiveVault],
   );
 
+  // 다중 선택 정렬 — selected 노드 (vault + ephemeral 모두 후보) 의 새 좌표를
+  // pure 함수로 계산 후 in-memory state 갱신. vault 노드에 한해 frontmatter
+  // canvasPosition 도 patch (drag-stop 과 동일 정신).
+  const selectedAlignable: AlignableNode[] = useMemo(() => {
+    return allNodes
+      .filter((n) => n.selected)
+      .map((n) => ({
+        id: n.id,
+        position: { x: n.position.x, y: n.position.y },
+        // n.width / n.height 가 undefined 일 수도 있어 default fallback. vault
+        // 노드는 220/60 으로 명시. ephemeral 도 220/64 라 비슷.
+        width: typeof n.width === "number" ? n.width : 220,
+        height: typeof n.height === "number" ? n.height : 60,
+      }));
+  }, [allNodes]);
+
+  const handleAlign = useCallback(
+    (action: AlignAction) => {
+      const updates = computeAlignedPositions(selectedAlignable, action);
+      if (updates.size === 0) return;
+      // in-memory: setLocalNodes 가 ReactFlow 캔버스에 즉시 반영.
+      setLocalNodes((current) =>
+        current.map((n) => {
+          const next = updates.get(n.id);
+          return next ? { ...n, position: next } : n;
+        }),
+      );
+      // vault 노드는 frontmatter.canvasPosition 도 patch — 다음 mount 부터
+      // 정렬 결과 유지. dogfood 매니페스트일 땐 skip (disk 권한 없음).
+      if (!hasLiveVault) return;
+      for (const [id, pos] of updates) {
+        const node = allNodes.find((n) => n.id === id);
+        const data = node?.data as { vault?: boolean } | undefined;
+        if (data?.vault) {
+          onVaultNodeDragStop?.(id, {
+            x: Math.round(pos.x),
+            y: Math.round(pos.y),
+          });
+        }
+      }
+    },
+    [selectedAlignable, allNodes, onVaultNodeDragStop, hasLiveVault],
+  );
+
   return (
     <div
       className={`relative h-full w-full ${isLayoutAnimating ? "rf-layout-animating" : ""}`}
@@ -390,6 +440,7 @@ export function OntologyEditCanvas({
         } as React.CSSProperties
       }
     >
+      <AlignToolbar selected={selectedAlignable} onApply={handleAlign} />
       <ReactFlow
         nodes={allNodes}
         edges={allEdges}
@@ -399,6 +450,10 @@ export function OntologyEditCanvas({
         proOptions={{ hideAttribution: true }}
         nodesConnectable
         nodesDraggable
+        // 16px 그리드 snap — drag 시 항상 정수 그리드 정렬. 사용자가
+        // 손으로도 깔끔하게 배치할 수 있도록.
+        snapToGrid
+        snapGrid={[16, 16]}
         // 사용자가 핸들에서 끌어 connection 그릴 때 미리보기 line — 인디고
         // alpha bezier 로 테마 일관 + 곡선이라 부드러움.
         connectionLineType={ConnectionLineType.Bezier}

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -32,6 +32,7 @@ import {
   type AlignAction,
   type AlignableNode,
 } from "../lib/align-nodes";
+import { resolveDomainTint } from "../lib/domain-color";
 
 const EDGE_TYPES = { ephemeral: EphemeralEdgeComponent };
 
@@ -495,7 +496,16 @@ export function OntologyEditCanvas({
             (220) 안에 9 줄 의 dot 가 깔려 시각 노이즈 강함. 36 은 ~6 줄로
             여유 — 노드와 dot 의 시각 위계가 더 자연 (캔버스 = 빈 종이,
             dot = 약한 그리드 hint). */}
-        <Background variant={BackgroundVariant.Dots} gap={36} size={1} />
+        {/* gap 36 + size 1.2 + 인디고 hint 색 — 너무 강하면 캔버스가 종이 →
+            방안지 느낌으로 변해 노드를 가린다. 약하게 깔린 'snap-able' 시각
+            힌트가 목표. snapGrid (16px) 의 배수 (gap 32) 와 정확히 일치시키면
+            점 밀도 1.5× → 시각 노이즈. 36 이 그래픽적으로 더 자연. */}
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={36}
+          size={1.2}
+          color="rgba(139, 151, 255, 0.22)"
+        />
         {/* xyflow Controls (zoom +/- / fitView) 는 우하단 MiniMap 과 겹침 +
             기본 스타일이 light theme 이라 dark canvas 와 어색 (Fit View
             아이콘 흰색 등). 사용자 navigation 은 MiniMap (점프) + 자동정렬
@@ -519,11 +529,18 @@ export function OntologyEditCanvas({
             marginBottom: 56,
           }}
           nodeColor={(node) => {
-            const data = node.data as { ephemeral?: boolean } | undefined;
-            return data?.ephemeral
-              ? "rgba(255, 179, 71, 0.78)"
-              : "rgba(139, 151, 255, 0.78)";
+            const data = node.data as
+              | { ephemeral?: boolean; domainSlug?: string | null }
+              | undefined;
+            if (data?.ephemeral) return "rgba(255, 179, 71, 0.78)";
+            // 도메인 tint 가 미니맵 노드에도 반영되어, 같은 hue 끼리 모여
+            // 있는 게 미니맵 한눈 navigation 의 단서가 됨.
+            if (typeof data?.domainSlug === "string" && data.domainSlug) {
+              return resolveDomainTint(data.domainSlug).accent;
+            }
+            return "rgba(139, 151, 255, 0.78)";
           }}
+          nodeStrokeColor="rgba(14, 16, 22, 0.85)"
           nodeStrokeWidth={2}
         />
       </ReactFlow>

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -511,13 +511,20 @@ export function OntologyEditCanvas({
           box-shadow: 0 0 0 4px rgba(94, 106, 210, 0.28);
         }
         .react-flow__edge-path {
-          transition: stroke-width 180ms ease-out;
+          transition: stroke-width 180ms ease-out, filter 180ms ease-out;
         }
         .react-flow__edge {
           animation: rfEdgeAppear 240ms ease-out;
         }
+        /* n8n 스타일 hover — 굵기 + soft indigo halo. drop-shadow 가 SVG
+           stroke 둘레로 부드러운 후광. relation overlay 도 hover 시엔 강조. */
         .react-flow__edge:hover .react-flow__edge-path {
-          stroke-width: 2.5px;
+          stroke-width: 2.6px;
+          filter: drop-shadow(0 0 4px rgba(139, 151, 255, 0.55));
+        }
+        /* 화살표 marker 도 hover 시 같이 또렷하게. */
+        .react-flow__edge:hover .react-flow__arrowhead {
+          filter: drop-shadow(0 0 3px rgba(139, 151, 255, 0.55));
         }
         /* 새 노드 / edge mount 시 부드러운 fade-in — 역동성 + 사용자가
            '추가됐다' 인지 빠름. id 새로 생긴 노드만 적용 (layout

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -564,24 +564,27 @@ export function OntologyEditCanvas({
         .react-flow__node-atlas:hover {
           filter: brightness(1.06);
         }
-        /* Handle (connection point) — 기본 9x9. 노드 hover 시 12x12 + glow,
-           핸들 직접 hover 시 14x14 + 더 강한 glow → 'drag here' 신호 강화. */
+        /* Handle (connection point) — n8n 스타일 항상 visible port. 기본 10x10
+           + 옅은 인디고 ring 으로 '여기서 끌어서 연결' 항상 인지 가능. 노드/
+           핸들 hover 시 단계적 enlarge + 짙은 ring. crosshair 커서가 'drag' 신호. */
         .react-flow__handle {
-          width: 9px;
-          height: 9px;
+          width: 10px;
+          height: 10px;
+          cursor: crosshair;
+          box-shadow: 0 0 0 2px rgba(94, 106, 210, 0.14);
           transition: width 160ms ease-out, height 160ms ease-out,
                       box-shadow 160ms ease-out, opacity 160ms ease-out;
         }
         .react-flow__node-atlas:hover .react-flow__handle {
           width: 12px;
           height: 12px;
-          box-shadow: 0 0 0 3px rgba(94, 106, 210, 0.18);
+          box-shadow: 0 0 0 3px rgba(94, 106, 210, 0.24);
         }
         .react-flow__handle.connectingto,
         .react-flow__handle:hover {
           width: 14px;
           height: 14px;
-          box-shadow: 0 0 0 4px rgba(94, 106, 210, 0.28);
+          box-shadow: 0 0 0 4px rgba(94, 106, 210, 0.36);
         }
         .react-flow__edge-path {
           transition: stroke-width 180ms ease-out, filter 180ms ease-out;

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -302,10 +302,11 @@ export function OntologyEditCanvas({
       });
     });
     // 자동정렬 / layoutMode 변경 시 transition 활성화 — 노드들이 새 위치로
-    // 부드럽게 슬라이드. fitView duration (400ms) 와 매칭되게 500ms 유지.
+    // 부드럽게 슬라이드. fitView duration (400ms) + transition duration (550ms)
+    // 후에도 안정화 시간 여유 둬 750ms 까지 클래스 유지.
     if (isAutoLayoutTrigger || isLayoutModeChange) {
       setIsLayoutAnimating(true);
-      const timer = setTimeout(() => setIsLayoutAnimating(false), 500);
+      const timer = setTimeout(() => setIsLayoutAnimating(false), 750);
       return () => clearTimeout(timer);
     }
   }, [baseNodes, autoLayoutToken, layoutMode]);
@@ -609,13 +610,19 @@ export function OntologyEditCanvas({
           from { opacity: 0; }
           to { opacity: 1; }
         }
-        /* layout 변경 시 일시적 슬라이드 애니메이션 — fitView duration
-           (400ms) 와 매칭. 드래그 중엔 클래스 비활성이라 즉각 반응. */
+        /* layout 변경 시 일시적 슬라이드 애니메이션 — 550ms 부드러운
+           ease-out-quint 으로 노드가 새 좌표로 흘러감. 드래그 중엔 클래스
+           비활성이라 즉각 반응. edge 의 SVG path 도 같이 슬라이드 — opacity
+           만이 아니라 d 도 부드럽게 보간되도록 transition 추가. */
         .rf-layout-animating .react-flow__node {
-          transition: transform 400ms cubic-bezier(0.4, 0, 0.2, 1);
+          transition: transform 550ms cubic-bezier(0.22, 1, 0.36, 1);
         }
         .rf-layout-animating .react-flow__edge {
-          transition: opacity 400ms ease-out;
+          transition: opacity 550ms ease-out;
+        }
+        .rf-layout-animating .react-flow__edge-path,
+        .rf-layout-animating .react-flow__connection-path {
+          transition: d 550ms cubic-bezier(0.22, 1, 0.36, 1);
         }
         @media (prefers-reduced-motion: reduce) {
           .react-flow__node-atlas,


### PR DESCRIPTION
## Summary

빌더 (`/ontology/edit`) 캔버스의 *선이 사선으로 꼬여 보기 어려움* 회귀 정정과 n8n 류 빌더 수준의 시각/인터랙션 정리. 한 PR 안에 7 commit (각 commit 이 독립적으로 검토 가능).

- **선 꼬임 해소** — dagre rank 계산에 containment 엣지 (`domains` / `capabilities` / `elements` / `contains`) 만 투입. relates / depends / describes 가 같은 kind 두 노드를 다른 column 으로 흩어 사선 폭증하던 회귀 정정. R14 schema 의 `domains` 키가 NEIGHBOR_KEYS 에 빠져 있어 project→domain 골격 자체가 안 그려지던 버그도 같이 정정.
- **n8n 스타일 엣지** — containment 는 smoothstep + 둥근 모서리 (`borderRadius: 12`) + `ArrowClosed` marker, dependencies 는 dashed bezier + marker, relates/describes 는 marker 없이 흐릿한 overlay. 엣지 라벨 일괄 비표시 (시각 노이즈 주범) → `data.semanticType` / `data.frontmatterKey` 만 남김. hover 시 stroke 굵기 + indigo drop-shadow halo.
- **라벨 정리** — 노드 카드 라벨에서 트레일링 괄호 메타 strip (`"CLI Developer Entry (16 commands incl. bootstrap)"` → `"CLI Developer Entry"`). 원본 title 은 `data.fullTitle` 로 보존, hover tooltip / inspector 가 풀 텍스트 노출.
- **도메인 그룹화** — slug djb2 hash → 8 hue indigo palette (218°~258°, 디자인 헌장 §11 단일 인디고 약속 안). 노드 좌측 4px accent bar + 옅은 가로 gradient 배경, 미니맵 노드 색도 같은 hue 반영.
- **수동 정렬 도구** — 16px snap-to-grid (드래그 시 항상 그리드 정렬) + 다중 선택 (Cmd+클릭, 2+) 시 캔버스 상단에 8-버튼 정렬 toolbar (L/R/T/B/center-X/center-Y/distribute-H/V). drag-stop 과 같은 방식으로 `frontmatter.canvasPosition` 영구화.
- **시각 elevation 3 단계** — rest / hover / selected box-shadow 차별 (scale 금지 약속 유지). selected 는 indigo halo + ring, hover 는 한 단계 강화, dot grid 옅은 인디고 hint.
- **부드러운 transition** — Hierarchy ↔ Force 토글 시 노드 transform + 엣지 path `d` 가 550ms ease-out-quint 으로 슬라이드 (이전 400ms cubic-bezier).
- **항상 visible port** — 연결 핸들이 10px indigo ring 항상 노출, hover 시 단계적 enlarge + crosshair cursor. 첫 사용자도 "끌어서 연결" affordance 즉시 발견.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0 error
- [x] `pnpm lint` — 0 error / 0 warning
- [x] `pnpm test:run` — 895 / 895 pass (이전 871 → +24 신규 단위 테스트)
  - layout contract 3 (LR 골격 / relates rank 영향 없음 / semanticType metadata)
  - title strip 6
  - resolveNodeDomainSlug 5
  - resolveDomainTint 4 (deterministic / hue range / null neutral)
  - computeAlignedPositions 8 (6 align + 2 distribute + edge cases)
- [x] dev server `/ko/ontology/edit/` 시각 검증: 계층 모드에서 4 column LR 흐름, 도메인 hue accent bar, 둥근 cable + 화살표, 짧은 라벨, 미니맵 grouping, dot grid
- [ ] **live vault 모드** 종단 검증 — `canvasPosition` 영구화는 기존 drag-stop hook 재사용이라 패턴 동일. 추가 검증은 PR 머지 후 일반 사용에서 회귀 모니터링

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>