### PR TITLE
fix(cli): vault 인자 미지정 시 cwd/docs/ontology 자동 감지

### DIFF
--- a/cli/src/commands/backlinks.mjs
+++ b/cli/src/commands/backlinks.mjs
@@ -1,8 +1,8 @@
 // R15 follow-up — `oh-my-ontology backlinks <slug> [vault]`
 // Lists every node referencing the target. Thin wrapper over MCP find_backlinks.
 
-import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -21,7 +21,7 @@ export async function runBacklinks(args) {
     return 1;
   }
 
-  const vaultRoot = resolve(process.cwd(), vault);
+  const vaultRoot = resolveVaultRoot(vault);
   let result;
   try {
     result = await callMcpTool(vaultRoot, 'find_backlinks', { slug });

--- a/cli/src/commands/find.mjs
+++ b/cli/src/commands/find.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { parseFrontmatter } from '../lib/parse-frontmatter.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 import { walkMd, pathToSlug } from '../lib/walk-vault.mjs';
 
 const COLORS = {
@@ -129,7 +129,7 @@ function parseArgs(args) {
   const [query, vault] = positional;
   return {
     query,
-    vaultPath: resolve(vault || flags.vaultPath),
+    vaultPath: resolveVaultRoot(vault || flags.vaultPath),
     kindFilter: flags.kindFilter,
     asJson: flags.asJson,
   };

--- a/cli/src/commands/list.mjs
+++ b/cli/src/commands/list.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { parseFrontmatter } from '../lib/parse-frontmatter.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 import { walkMd, pathToSlug } from '../lib/walk-vault.mjs';
 
 const COLORS = {
@@ -26,7 +26,7 @@ const KIND_COLORS = {
  * --kind <kind> 필터, --json 머신 가독 출력.
  */
 export function runList(args) {
-  const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
+  const vaultPath = resolveVaultRoot(args.find((a) => !a.startsWith('--')));
   const kindFilter = pickFlag(args, '--kind');
   const asJson = args.includes('--json');
 

--- a/cli/src/commands/orphans.mjs
+++ b/cli/src/commands/orphans.mjs
@@ -2,8 +2,8 @@
 // Lists isolated nodes — docs that no other node references in their
 // frontmatter. Thin wrapper over MCP find_orphans.
 
-import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -31,7 +31,7 @@ export async function runOrphans(args) {
     return 1;
   }
 
-  const vaultRoot = resolve(process.cwd(), vault);
+  const vaultRoot = resolveVaultRoot(vault);
   const toolArgs = {};
   if (kind) toolArgs.kind = kind;
   if (excludeKinds.length > 0) toolArgs.excludeKinds = excludeKinds;

--- a/cli/src/commands/path.mjs
+++ b/cli/src/commands/path.mjs
@@ -4,8 +4,8 @@
 // (relation type per hop) 도 함께 사용자에게 노출해, 두 노드가 *왜* 연결됐는지
 // 한 줄로 본다.
 
-import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -25,7 +25,7 @@ export async function runPath(args) {
     return 1;
   }
 
-  const vaultRoot = resolve(process.cwd(), vault);
+  const vaultRoot = resolveVaultRoot(vault);
   let result;
   try {
     result = await callMcpTool(vaultRoot, 'find_path', {

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -2,8 +2,8 @@
 // Typed filter DSL: kind=X AND has(elements) AND NOT domain=auth.
 // Thin wrapper over MCP query_concepts.
 
-import { resolve } from 'node:path';
 import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 
 const COLORS = {
   green: '\x1b[32m',
@@ -32,7 +32,7 @@ export async function runQuery(args) {
     return 1;
   }
 
-  const vaultRoot = resolve(process.cwd(), vault);
+  const vaultRoot = resolveVaultRoot(vault);
   let result;
   try {
     result = await callMcpTool(vaultRoot, 'query_concepts', { filter, limit });

--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
-import { resolve, relative } from 'node:path';
+import { relative } from 'node:path';
 import { walkMd } from '../lib/walk-vault.mjs';
 import { parseFrontmatter } from '../lib/parse-frontmatter.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 import { validateVaultDocument } from '../lib/validate.mjs';
 
 const COLORS = {
@@ -101,7 +102,7 @@ export function runValidate(args) {
       );
     }
   }
-  const vaultPath = resolve(args.find((a) => !a.startsWith('--')) || '.');
+  const vaultPath = resolveVaultRoot(args.find((a) => !a.startsWith('--')));
   const files = walkMd(vaultPath);
   const entries = [];
   const reportByFile = new Map();

--- a/cli/src/lib/resolve-vault.mjs
+++ b/cli/src/lib/resolve-vault.mjs
@@ -1,0 +1,44 @@
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Vault root 결정 우선순위 — graph-level read 명령 (list / query / path /
+ * orphans / backlinks / find / validate) 공유.
+ *
+ *  1. 호출자가 명시한 `explicit` (positional 인자 또는 `--vault path`) 가 있고
+ *     기본값 (`.` 또는 빈 문자열) 이 아니면 → 그대로 사용
+ *  2. 환경 변수 `OMOT_VAULT` 설정되어 있으면 → 그 경로
+ *  3. cwd 에 `docs/ontology/` 디렉토리 있으면 → 그쪽 (자기 repo dogfood 대응
+ *     — 빌드 미러 `public/docs-vault/` 나 `cli/templates/` 가 cwd 안에 있어도
+ *     의도된 canonical vault 가 우선)
+ *  4. 마지막 fallback: cwd
+ *
+ * 항상 절대 경로 반환.
+ */
+export function resolveVaultRoot(explicit) {
+  // 1) 명시적 사용자 지정 — 우선
+  if (typeof explicit === 'string' && explicit && explicit !== '.') {
+    return resolve(process.cwd(), explicit);
+  }
+
+  // 2) OMOT_VAULT env (MCP 서버 규약과 동일)
+  const env = process.env.OMOT_VAULT;
+  if (typeof env === 'string' && env.length > 0) {
+    return resolve(process.cwd(), env);
+  }
+
+  // 3) cwd 의 docs/ontology 디렉토리 — repo dogfood 자동 감지
+  const candidate = resolve(process.cwd(), 'docs/ontology');
+  if (isDirectory(candidate)) return candidate;
+
+  // 4) fallback — cwd
+  return process.cwd();
+}
+
+function isDirectory(path) {
+  try {
+    return existsSync(path) && statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/lib/resolve-vault.test.mjs
+++ b/cli/src/lib/resolve-vault.test.mjs
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { resolveVaultRoot } from './resolve-vault.mjs';
+
+test('resolveVaultRoot — explicit 인자가 1순위 (env 보다 강함)', () => {
+  process.env.OMOT_VAULT = '/tmp/env-vault';
+  try {
+    const got = resolveVaultRoot('./my-vault');
+    assert.equal(got, resolve(process.cwd(), 'my-vault'));
+  } finally {
+    delete process.env.OMOT_VAULT;
+  }
+});
+
+test("resolveVaultRoot — explicit 이 '.' 면 default 로 취급 (env 가 다음 차례)", () => {
+  process.env.OMOT_VAULT = '/tmp/env-vault';
+  try {
+    const got = resolveVaultRoot('.');
+    assert.equal(got, resolve(process.cwd(), '/tmp/env-vault'));
+  } finally {
+    delete process.env.OMOT_VAULT;
+  }
+});
+
+test('resolveVaultRoot — env 가 2순위', () => {
+  delete process.env.OMOT_VAULT;
+  process.env.OMOT_VAULT = '/tmp/foo';
+  try {
+    const got = resolveVaultRoot();
+    assert.equal(got, resolve(process.cwd(), '/tmp/foo'));
+  } finally {
+    delete process.env.OMOT_VAULT;
+  }
+});
+
+test('resolveVaultRoot — cwd/docs/ontology 자동 감지 (3 순위)', () => {
+  // 임시 cwd 에 docs/ontology 디렉토리 만들고 chdir. macOS 의 tmp 는 symlink
+  // (`/var/folders` → `/private/var/folders`) 라 realpathSync 로 정규화 후 비교.
+  const tmp = realpathSync(mkdtempSync(resolve(tmpdir(), 'omot-vault-test-')));
+  const vaultDir = resolve(tmp, 'docs/ontology');
+  mkdirSync(vaultDir, { recursive: true });
+  const prevCwd = process.cwd();
+  process.chdir(tmp);
+  try {
+    delete process.env.OMOT_VAULT;
+    const got = resolveVaultRoot();
+    assert.equal(got, vaultDir);
+  } finally {
+    process.chdir(prevCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolveVaultRoot — fallback 은 cwd (4 순위, 아무것도 없을 때)', () => {
+  // cwd 에 docs/ontology 없는 임시 디렉토리 — realpathSync 로 정규화.
+  const tmp = realpathSync(mkdtempSync(resolve(tmpdir(), 'omot-vault-test-')));
+  const prevCwd = process.cwd();
+  process.chdir(tmp);
+  try {
+    delete process.env.OMOT_VAULT;
+    const got = resolveVaultRoot();
+    assert.equal(got, tmp);
+  } finally {
+    process.chdir(prevCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('resolveVaultRoot — 빈 문자열 explicit 은 default 로 취급', () => {
+  process.env.OMOT_VAULT = '/tmp/from-env';
+  try {
+    const got = resolveVaultRoot('');
+    assert.equal(got, resolve(process.cwd(), '/tmp/from-env'));
+  } finally {
+    delete process.env.OMOT_VAULT;
+  }
+});


### PR DESCRIPTION
## Summary

self-dogfood (이 repo 안에서 CLI 사용) 시 vault 인자 없는 graph-level 명령이 cwd 전체를 walk 해서 build 미러 (`public/docs-vault/`) 와 starter 템플릿 (`cli/templates/vault/`) 까지 잡아 노드 수가 2 배로 보이던 paper cut 정정.

- 신규 `resolveVaultRoot(explicit?)` 헬퍼 — 우선순위: explicit 인자 → `OMOT_VAULT` env → cwd 의 `docs/ontology/` 자동 감지 → cwd fallback
- 영향 받는 명령 7: list / query / path / orphans / backlinks / find / validate
- add / import / init 등 *생성* 명령은 그대로 (명시 destination 필요)

## Test plan

- [x] 신규 단위 테스트 6 (`cli/src/lib/resolve-vault.test.mjs`) — explicit 우선 / env / 자동 감지 / cwd fallback / 빈 문자열 default / macOS realpath symlink
- [x] `pnpm exec tsc --noEmit` clean / `pnpm lint` clean
- [x] `pnpm test:run` — 895 / 895 pass (변경 없음, CLI 명령은 별도 node --test)
- [x] 실 검증:
  - `node cli/src/index.mjs list` → docs/ontology **27 노드** (이전 57)
  - `node cli/src/index.mjs query "kind=capability AND has(elements)"` → 공식 capability slug 만 (이전 `public/docs-vault/*` prefix)
  - `node cli/src/index.mjs path domains/ai-agent-partner capabilities/mcp-server` → 1 hop, slug 도 정식

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>