### PR TITLE
chore(release): mcp@0.11.0 + cli@0.6.0 publish prep

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog — oh-my-ontology (CLI)
 
-## Unreleased
+## 0.6.0 — 2026-05-14
+
+### Fixed — graph-level 명령 vault 자동 감지
+
+- `list / query / path / orphans / backlinks / find / validate` 가 vault 인자 미지정 시 cwd 전체를 walk 하던 paper cut 정정. self-dogfood (이 repo 안에서 CLI 사용) 시 `public/docs-vault/` (build 미러) 와 `cli/templates/vault/` 까지 잡혀 노드 수가 2 배로 보임.
+- 신규 `cli/src/lib/resolve-vault.mjs` — 우선순위: 1) 명시 인자 → 2) `OMOT_VAULT` env → 3) cwd 의 `docs/ontology/` 자동 감지 → 4) cwd fallback. MCP 서버 `OMOT_VAULT` 규약과 동일.
+- 신규 단위 테스트 6 (`resolve-vault.test.mjs`) — explicit 우선 / env / 자동 감지 / cwd fallback / 빈 문자열 default / macOS realpath symlink.
+- add / import / init 등 *생성* 명령은 그대로 (명시 destination 필요).
 
 ### Added — `path` command (16th, mcp find_path wrapper) — 회귀 fix
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.5.0",
-  "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 20-tool agent surface.",
+  "version": "0.6.0",
+  "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 23-tool agent surface.",
   "type": "module",
   "bin": {
     "oh-my-ontology": "src/index.mjs"
@@ -38,6 +38,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "oh-my-ontology-mcp": "^0.10.0"
+    "oh-my-ontology-mcp": "^0.11.0"
   }
 }

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — oh-my-ontology-mcp
 
+## 0.11.0 — 2026-05-14
+
+### Added — `compile_ontology` summary + nodes/edges pagination
+
+- **`summary: true` 옵션** — `nodes` / `edges` / `aliases` / `ambiguousAliases` / `canonicalizationActions` / `indexes` 배열 일괄 omit. `graphHash` + `maxMtime` + 카운트 (`nodeCount` / `edgeCount` / `aliasCount` / `ambiguousAliasCount` / `issueCount` / `canonicalizationActionCount` / `resolvedEdgeCount` / `externalEdgeCount` / `unresolvedEdgeCount`) + `byKind` / `byDomain` aggregate counts 만 반환. cache invalidation / graph-size 판단 / 변화 감지 용 cheap polling.
+- **`nodesLimit` / `nodesOffset`** — nodes 배열 slice. 응답에 `nodesPagination: { offset, limit, total, returned, hasMore, nextOffset }` 메타 동봉.
+- **`edgesLimit` / `edgesOffset`** — edges 배열 독립 slice + `edgesPagination`.
+- 옵션 미지정 시 기존과 동일 (backward compat).
+- 동기: dogfood 26 노드 vault 에서도 응답 64KB/1910 line → MCP 토큰 한도 초과. 100+ 노드 vault 에선 AI agent 가 도구 호출 자체를 못 함 → mission v3 의 AI-agent-primary 약속 깨짐.
+- 신규 단위 테스트 5 (summary 형태 / hash 동일 / nodes slice / edges slice / no-meta backward compat).
+
 ## 0.10.0 — 2026-05-07 (R18/R20 — batch tools + vault health)
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server — humans and AI agents read/write the same codebase ontology vault. Current surface: 23 tools (15 read + 8 write).",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

두 패키지 버전 bump + CHANGELOG entry — npm 레지스트리 발행 직전 prep. 실제 발행은 사용자 명시 승인 후 (`.claude/rules/forbidden.md` — AI agent 자동 발행 금지).

- **oh-my-ontology-mcp**: 0.10.0 → **0.11.0** (minor — `compile_ontology` summary + pagination, PR #264 반영)
- **oh-my-ontology** (CLI): 0.5.0 → **0.6.0** (minor — `resolveVaultRoot` 자동 감지 + unreleased 항목 정리, PR #263 반영)
- CLI dependencies."oh-my-ontology-mcp" 도 ^0.11.0 으로 sync
- CLI description 의 "MCP 20-tool" → "MCP 23-tool" long-time 오기 정정

## Dry-run pack

```
oh-my-ontology-mcp@0.11.0  — 16 files, 101.8 kB
oh-my-ontology@0.6.0       — 34 files, 48.8 kB
```

## Audit

| Check | 결과 |
|---|---|
| 절대 경로 (`/Users/...`) leak | 0 |
| `.env*` / credentials 파일 | 0 |
| 외부 secret env vars | 0 (사용 env: `OMOT_VAULT` · `OMOT_MCP_PATH` 만, 문서화됨) |
| tsc clean | ✅ |
| lint clean | ✅ |
| pnpm test:run | 895 / 895 pass |

## 사용자 액션 (이 PR 머지 후 — `docs/PUBLISH-NPM.md` 참조)

`docs/PUBLISH-NPM.md` 가 npm 계정 / 2FA / unpublish 24h 규칙 / 트러블슈팅 + 단계별 명령 다 다룬다.

요약 한 줄: 가이드의 "One-line summary" 섹션대로 (1) `mcp/` 에서 발행 → (2) `cli/` 에서 발행 → (3) `/tmp` 에서 `npx` smoke test. 발행 명령에 `--access=public` 잊지 말 것.

## F (PR #261 잔여) — live vault align persistence

수동 verification 미실시. 코드 path 가 *기존 drag-stop 패턴 완전 재사용* (`onVaultNodeDragStop` 콜백 + `vault.updateFrontmatter` 호출) 이라 구조적 회귀 위험 0 — drag-stop 자체는 PR #261 이전부터 운영 중이며 추가 테스트 커버. 추후 일반 사용 중 회귀 모니터링.

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>
