### PR TITLE
feat(cli): overview 명령 추가 + cli 0.7.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.7.0 — 2026-05-14
+
+### Added — `overview` command (17th, query_ontology wrap)
+
+- `oh-my-ontology overview [vault] [--limit N] [--json]` — vault first-contact dashboard. MCP `query_ontology({operation: 'overview'})` thin wrapper.
+- 출력 4 섹션: header 한 줄 (총 노드/관계 카운트 + resolved/external/unresolved 분해), **KIND 분포** (kind 별 count + 색깔 막대 그래프), **관계 종류 분포** (frontmatter key 별 비율), **도메인 분포** (도메인 별 노드 수), **허브 노드 top N** (degree 상위, document/project 제외).
+- 신규 사용자가 모르는 vault 를 처음 열었을 때 — `oh-my-ontology overview` 한 줄로 *어떤 vault 인지* 즉시 파악. AI agent 의 MCP overview 호출과 같은 권한.
+- 옵션: `--limit N` (허브 N 개, 기본 10), `--json` (raw query_ontology 응답 pass-through), `--vault path` (auto-detect override).
+- 신규 integration test 3건 (counts / --json / --limit).
+
 ## 0.6.0 — 2026-05-14
 
 ### Fixed — graph-level 명령 vault 자동 감지

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 23-tool agent surface.",
   "type": "module",
   "bin": {

--- a/cli/src/commands/overview.mjs
+++ b/cli/src/commands/overview.mjs
@@ -1,0 +1,168 @@
+// `oh-my-ontology overview [vault]`
+// Vault 의 first-contact dashboard — counts + relation distribution + 허브 노드.
+// MCP `query_ontology({operation: 'overview'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+};
+
+export async function runOverview(args) {
+  const { vault, json, hubsLimit, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', { operation: 'overview' });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+
+  renderOverview(result, hubsLimit);
+  return 0;
+}
+
+function renderOverview(result, hubsLimit) {
+  const graph = result?.graph ?? {};
+  const byKind = result?.byKind ?? {};
+  const byDomain = result?.byDomain ?? {};
+  const byRelation = result?.byRelation ?? {};
+  const hubs = Array.isArray(result?.hubs) ? result.hubs : [];
+
+  // Header — 그래프 한 줄 요약.
+  const nodes = graph.nodes ?? 0;
+  const edges = graph.edges ?? 0;
+  const resolved = graph.resolvedEdges ?? 0;
+  const external = graph.externalEdges ?? 0;
+  const unresolved = graph.unresolvedEdges ?? 0;
+  process.stdout.write(
+    `${COLORS.bold}vault overview${COLORS.reset}` +
+      ` ${COLORS.dim}— ${nodes} 노드 · ${edges} 관계 (resolved ${resolved} · external ${external}${unresolved ? ` · unresolved ${unresolved}` : ''})${COLORS.reset}\n\n`,
+  );
+
+  // Kind 분포 — kind 별 count + 색깔 bar.
+  if (Object.keys(byKind).length > 0) {
+    process.stdout.write(`${COLORS.dim}KIND 분포${COLORS.reset}\n`);
+    const total = Object.values(byKind).reduce((sum, n) => sum + n, 0) || 1;
+    for (const [kind, count] of sortByCount(byKind)) {
+      const pct = Math.round((count / total) * 100);
+      const bar = '█'.repeat(Math.max(1, Math.round((count / total) * 20)));
+      const kc = KIND_COLORS[kind] || COLORS.dim;
+      process.stdout.write(
+        `  ${kc}${kind.padEnd(14)}${COLORS.reset} ${String(count).padStart(3)} ${COLORS.dim}${pct}%${COLORS.reset}  ${kc}${bar}${COLORS.reset}\n`,
+      );
+    }
+    process.stdout.write('\n');
+  }
+
+  // 관계 종류 분포.
+  if (Object.keys(byRelation).length > 0) {
+    process.stdout.write(`${COLORS.dim}관계 종류 분포${COLORS.reset}\n`);
+    const total = Object.values(byRelation).reduce((sum, n) => sum + n, 0) || 1;
+    for (const [rel, count] of sortByCount(byRelation)) {
+      const pct = Math.round((count / total) * 100);
+      const bar = '─'.repeat(Math.max(1, Math.round((count / total) * 20)));
+      process.stdout.write(
+        `  ${COLORS.yellow}${rel.padEnd(14)}${COLORS.reset} ${String(count).padStart(3)} ${COLORS.dim}${pct}%${COLORS.reset}  ${COLORS.dim}${bar}${COLORS.reset}\n`,
+      );
+    }
+    process.stdout.write('\n');
+  }
+
+  // 도메인 분포 (있을 때만).
+  if (Object.keys(byDomain).length > 0) {
+    process.stdout.write(`${COLORS.dim}도메인 분포${COLORS.reset}\n`);
+    for (const [dom, count] of sortByCount(byDomain)) {
+      process.stdout.write(
+        `  ${COLORS.blue}${dom.padEnd(28)}${COLORS.reset} ${String(count).padStart(3)} 노드\n`,
+      );
+    }
+    process.stdout.write('\n');
+  }
+
+  // 허브 노드 — degree 상위. document / vault-readme 제외.
+  if (hubs.length > 0) {
+    const cap = Math.min(hubs.length, hubsLimit);
+    process.stdout.write(`${COLORS.dim}허브 노드${COLORS.reset} ${COLORS.dim}(degree 상위 ${cap}, document/project 제외)${COLORS.reset}\n`);
+    for (let i = 0; i < cap; i += 1) {
+      const h = hubs[i];
+      const kc = KIND_COLORS[h.kind] || COLORS.dim;
+      const rank = String(i + 1).padStart(2);
+      const slug = h.slug.padEnd(50);
+      const deg = `${COLORS.dim}deg ${h.degree}${COLORS.reset}` +
+        ` ${COLORS.dim}(in ${h.inDegree} · out ${h.outDegree})${COLORS.reset}`;
+      process.stdout.write(`  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${slug}${COLORS.reset} ${deg}\n`);
+    }
+  }
+}
+
+function sortByCount(obj) {
+  return Object.entries(obj).sort(([, a], [, b]) => b - a);
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, hubsLimit: 10 };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--limit') flags.hubsLimit = Number(args[++i]) || 10;
+    else if (a.startsWith('--limit='))
+      flags.hubsLimit = Number(a.slice('--limit='.length)) || 10;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  // first positional = vault (optional, overrides default).
+  if (positional.length > 0 && flags.vault === '.') flags.vault = positional[0];
+  return {
+    vault: flags.vault,
+    json: flags.json,
+    hubsLimit: flags.hubsLimit,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology overview [vault] [--vault path] [--limit N] [--json]\n\n` +
+      `${COLORS.bold}Examples:${COLORS.reset}\n` +
+      `  oh-my-ontology overview\n` +
+      `  oh-my-ontology overview ./docs/ontology\n` +
+      `  oh-my-ontology overview --limit 20\n` +
+      `  oh-my-ontology overview --json\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -78,6 +78,8 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --max-hops N --json                    ${COLORS.dim}default 5${COLORS.reset}
   npx oh-my-ontology query "<filter>"         Typed filter DSL (kind=X AND has(elements))
        --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
+  npx oh-my-ontology overview [vault]         Vault first-contact dashboard (counts + 분포 + 허브)
+       --limit N --json                       ${COLORS.dim}허브 N 개 (default 10) · machine output${COLORS.reset}
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
        --confirm                              ${COLORS.dim}default dry-run (preview); --confirm to apply${COLORS.reset}
   npx oh-my-ontology merge <from> <into>      Atomic merge — redirect backlinks then delete fromSlug
@@ -362,6 +364,11 @@ if (SUBCOMMAND === 'orphans') {
 if (SUBCOMMAND === 'path') {
   const { runPath } = await import('./commands/path.mjs');
   exit(await runPath(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'overview') {
+  const { runOverview } = await import('./commands/overview.mjs');
+  exit(await runOverview(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1078,6 +1078,58 @@ await test('query — kind=capability AND has(elements)', async () => {
   }
 });
 
+await test('overview — graph fixture 의 counts + 허브 정확', async () => {
+  // buildGraphFixture: 3 노드 (capabilities/foo, capabilities/bar, domains/auth)
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['overview', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    // header — 3 노드 (vault-readme 없음)
+    assert.match(clean, /3 노드/);
+    // KIND 분포 — capability 2 / domain 1
+    assert.match(clean, /capability\s+2/);
+    assert.match(clean, /domain\s+1/);
+    // 허브 — degree 가 가장 큰 domains/auth 가 top
+    assert.match(clean, /domains\/auth/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('overview --json — JSON 응답 graph/byKind/hubs 키 노출', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['overview', root, '--json']);
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.operation, 'overview');
+    assert.ok(data.graph);
+    assert.equal(data.graph.nodes, 3);
+    assert.ok(data.byKind);
+    assert.equal(data.byKind.capability, 2);
+    assert.equal(data.byKind.domain, 1);
+    assert.ok(Array.isArray(data.hubs));
+    // domains/auth 가 hubs 안에 있어야 함 (degree 가장 큼)
+    assert.ok(data.hubs.some((h) => h.slug === 'domains/auth'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('overview --limit 3 — 허브 N 만 출력', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['overview', root, '--limit', '3']);
+    assert.equal(r.code, 0);
+    const clean = stripAnsi(r.stdout);
+    // 허브 라인 (rank prefix 1-3 만) — 4+ 가 없어야
+    assert.match(clean, /허브 노드.*상위 3/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('rename — dry-run preview, no disk change', async () => {
   const root = await buildGraphFixture();
   try {


### PR DESCRIPTION
## Summary

CLI 가 graph operations 를 직접 노출 안 해서 dev 가 MCP 도구 호출 없이 vault first-contact dashboard 받을 길 없던 paper cut 정정. mission v3 의 dev primary surface (CLI) 와 AI agent primary surface (MCP) 의 권한 격차 한 단계 좁힘.

- 새 명령 \`oh-my-ontology overview [vault] [--limit N] [--json]\` — MCP \`query_ontology({operation:'overview'})\` 의 thin wrapper. 17 번째 CLI 명령
- 출력 4 섹션: header (총 노드/관계 + resolved/external/unresolved) · KIND 분포 (색깔 bar) · 관계 종류 분포 · 도메인 분포 · 허브 top N (document/project 제외)
- 신규 사용자가 모르는 vault 를 처음 열 때 한 줄로 \"어떤 vault 인지\" 즉시 파악
- CLI 0.6.0 (publish prep 직전, npm 미발행) → 0.7.0 으로 bump

## 실 검증 (이 repo 의 27 노드 dogfood vault)

\`\`\`
vault overview — 27 노드 · 170 관계 (resolved 90 · external 80)

KIND 분포 — capability 15 (56%) · domain 6 (22%) · element 4 (15%) · project 1 · vault-readme 1
관계 종류 — elements 84 (49%) · relates 43 (25%) · domain 19 (11%) · capabilities 16 (9%) · domains 6 · dependencies 2
도메인 — ai-agent-partner 6 · views 5 · vault-local-first 4 · mode-aware-adapters 2 · onboarding-ux 1 · ontology-core 1
허브 top 10 — domains/vault-local-first deg 24 · domains/views deg 24 · capabilities/cli-developer-entry deg 23 · ...
\`\`\`

## Test plan

- [x] integration test 3건 신규 (counts / --json / --limit) — buildGraphFixture 의 3 노드 (foo/bar/auth) 에 대해 byKind / hubs / paging 정확 검증
- [x] cli/src/integration.test.mjs 전체 통과
- [x] pnpm exec tsc --noEmit clean / pnpm lint clean / pnpm test:run 895 / 895 pass
- [x] 실제 \`node cli/src/index.mjs overview\` 시각 검증 (위 출력)

## 다음 단계 후보 (follow-up)

\`query_ontology\` 의 다른 power op 들도 CLI 노출:
- \`hubs --limit N\` (centrality)
- \`blast-radius <slug> [--depth N]\` (refactor safety)
- \`cycles\` (dependency cycle detection)
- \`health\` (graph integrity dashboard)
- \`workspace-brief\` (first-contact + next actions)

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>