### PR TITLE
feat(cli): 5 graph commands + cli 0.8.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.8.0 — 2026-05-14
+
+### Added — 5 graph commands (18–22, query_ontology operations)
+
+mission v3 의 *dev primary surface* (CLI) 와 *AI agent primary surface* (MCP) 의 권한 격차 추가 축소. `overview` (0.7.0) 에 이어 `query_ontology` 의 5 operation 직접 노출.
+
+- `oh-my-ontology hubs [vault] [--limit N]` — centrality 4 rankings (PageRank / Bridges / Authorities / Hubs)
+- `oh-my-ontology blast-radius <slug> [--depth N] [--direction incoming|outgoing|both]` — 이 노드 변경 시 영향받는 노드/관계 (refactor safety). risk low/medium/high + byKind/byDomain breakdown
+- `oh-my-ontology cycles [vault] [--max-hops N]` — depends_on dependency cycle 검출. 0 cycle 시 그린 "graph clean ✓", 그 외 cycle 별 슬러그 chain 출력
+- `oh-my-ontology health [vault]` — 5 graph 무결성 check (compile / unresolved / cycles / relation recommendations / components). exit 0 만 healthy
+- `oh-my-ontology workspace-brief [vault]` — status + hotspots top 5 + project 별 노드 수 + next actions 한 화면
+
+전부 `--json` 옵션으로 raw query_ontology 응답 pass-through.
+
 ## 0.7.0 — 2026-05-14
 
 ### Added — `overview` command (17th, query_ontology wrap)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 23-tool agent surface.",
   "type": "module",
   "bin": {

--- a/cli/src/commands/blast-radius.mjs
+++ b/cli/src/commands/blast-radius.mjs
@@ -1,0 +1,144 @@
+// `oh-my-ontology blast-radius <slug> [vault] [--depth N] [--direction]`
+// 이 노드를 바꾸면 무엇이 깨지나 — refactor safety 도구.
+// MCP `query_ontology({operation: 'blast_radius'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+};
+const RISK_COLORS = {
+  low: COLORS.green,
+  medium: COLORS.yellow,
+  high: COLORS.red,
+};
+
+export async function runBlastRadius(args) {
+  const { slug, vault, json, depth, direction, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', {
+      operation: 'blast_radius',
+      slug,
+      depth,
+      direction,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  render(result, slug);
+  return 0;
+}
+
+function render(result, requestedSlug) {
+  const sum = result?.summary ?? {};
+  const risk = result?.risk ?? 'unknown';
+  const rc = RISK_COLORS[risk] || COLORS.dim;
+  process.stdout.write(
+    `${COLORS.bold}${requestedSlug}${COLORS.reset} ${COLORS.dim}— blast radius${COLORS.reset}` +
+      ` ${COLORS.dim}(depth ${result?.depth ?? 2}, ${result?.direction ?? 'incoming'})${COLORS.reset}\n` +
+      `  risk ${rc}${risk}${COLORS.reset}` +
+      ` · ${sum.affectedNodes ?? 0} 노드 · ${sum.affectedEdges ?? 0} 관계` +
+      ` · ${sum.crossDomainEdges ?? 0} cross-domain\n\n`,
+  );
+  const byKind = result?.byKind ?? {};
+  if (Object.keys(byKind).length > 0) {
+    process.stdout.write(`${COLORS.dim}affected by kind${COLORS.reset}\n`);
+    for (const [kind, count] of Object.entries(byKind).sort(([, a], [, b]) => b - a)) {
+      const kc = KIND_COLORS[kind] || COLORS.dim;
+      process.stdout.write(`  ${kc}${kind.padEnd(14)}${COLORS.reset} ${count}\n`);
+    }
+    process.stdout.write('\n');
+  }
+  const byDomain = result?.byDomain ?? {};
+  if (Object.keys(byDomain).length > 0) {
+    process.stdout.write(`${COLORS.dim}affected by domain${COLORS.reset}\n`);
+    for (const [dom, count] of Object.entries(byDomain).sort(([, a], [, b]) => b - a)) {
+      process.stdout.write(`  ${COLORS.blue}${dom.padEnd(40)}${COLORS.reset} ${count}\n`);
+    }
+    process.stdout.write('\n');
+  }
+  const rows = result?.nodes?.rows ?? [];
+  if (rows.length > 0) {
+    process.stdout.write(`${COLORS.dim}affected nodes (distance 별)${COLORS.reset}\n`);
+    for (const r of rows) {
+      const kind = r.node?.kind ?? '?';
+      const kc = KIND_COLORS[kind] || COLORS.dim;
+      const dist = `${COLORS.dim}d${r.distance}${COLORS.reset}`;
+      process.stdout.write(`  ${dist} ${kc}${r.slug}${COLORS.reset}\n`);
+    }
+  }
+}
+
+function parseArgs(args) {
+  const flags = {
+    vault: '.',
+    json: false,
+    depth: undefined,
+    direction: 'incoming',
+  };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--depth') flags.depth = Number(args[++i]) || undefined;
+    else if (a.startsWith('--depth=')) flags.depth = Number(a.slice('--depth='.length)) || undefined;
+    else if (a === '--direction') flags.direction = args[++i] || 'incoming';
+    else if (a.startsWith('--direction='))
+      flags.direction = a.slice('--direction='.length) || 'incoming';
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0) {
+    return { error: 'slug is required (e.g. `blast-radius capabilities/foo`)' };
+  }
+  const [slug, vault] = positional;
+  if (vault && flags.vault === '.') flags.vault = vault;
+  return {
+    slug,
+    vault: flags.vault,
+    json: flags.json,
+    depth: flags.depth,
+    direction: flags.direction,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology blast-radius <slug> [vault] [--depth N] [--direction incoming|outgoing|both] [--json]\n\n` +
+      `default depth 2, direction incoming (이 노드를 의존하는 무엇).\n`,
+  );
+}

--- a/cli/src/commands/cycles.mjs
+++ b/cli/src/commands/cycles.mjs
@@ -1,0 +1,88 @@
+// `oh-my-ontology cycles [vault]` — dependency cycle 검출.
+// MCP `query_ontology({operation: 'cycles'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+export async function runCycles(args) {
+  const { vault, json, maxHops, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', {
+      operation: 'cycles',
+      maxHops,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  const cycles = Array.isArray(result?.cycles) ? result.cycles : [];
+  const total = result?.totalCycles ?? cycles.length;
+  if (total === 0) {
+    process.stdout.write(`${COLORS.green}cycles 0 — dependency graph clean ✓${COLORS.reset}\n`);
+    return 0;
+  }
+  process.stdout.write(
+    `${COLORS.red}${total} cycle${total === 1 ? '' : 's'} found${COLORS.reset}` +
+      ` ${COLORS.dim}(relation: ${(result?.relationTypes || []).join(', ') || 'dependencies'}, maxDepth ${result?.maxDepth ?? 8})${COLORS.reset}\n\n`,
+  );
+  for (let i = 0; i < cycles.length; i += 1) {
+    const c = cycles[i];
+    process.stdout.write(`${COLORS.bold}cycle ${i + 1}${COLORS.reset}\n`);
+    const slugs = Array.isArray(c?.slugs) ? c.slugs : [];
+    for (let j = 0; j < slugs.length; j += 1) {
+      process.stdout.write(`  ${COLORS.yellow}${slugs[j]}${COLORS.reset}\n`);
+      if (j < slugs.length - 1) process.stdout.write(`    ${COLORS.dim}↓ depends_on${COLORS.reset}\n`);
+    }
+    if (slugs.length > 0) process.stdout.write(`    ${COLORS.dim}↩ back to ${slugs[0]}${COLORS.reset}\n\n`);
+  }
+  return 0;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, maxHops: undefined };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--max-hops') flags.maxHops = Number(args[++i]) || undefined;
+    else if (a.startsWith('--max-hops='))
+      flags.maxHops = Number(a.slice('--max-hops='.length)) || undefined;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length > 0 && flags.vault === '.') flags.vault = positional[0];
+  return { vault: flags.vault, json: flags.json, maxHops: flags.maxHops };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology cycles [vault] [--max-hops N] [--json]\n\n` +
+      `directed depends_on cycle detection (default maxDepth 8).\n`,
+  );
+}

--- a/cli/src/commands/health.mjs
+++ b/cli/src/commands/health.mjs
@@ -1,0 +1,93 @@
+// `oh-my-ontology health [vault]` — graph 무결성 dashboard.
+// MCP `query_ontology({operation: 'health'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const STATUS_COLORS = {
+  pass: COLORS.green,
+  fail: COLORS.red,
+  warn: COLORS.yellow,
+  info: COLORS.dim,
+};
+const STATUS_ICONS = {
+  pass: '✓',
+  fail: '✗',
+  warn: '⚠',
+  info: 'ℹ',
+};
+
+export async function runHealth(args) {
+  const { vault, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', { operation: 'health' });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  const status = result?.status ?? 'unknown';
+  const sc = STATUS_COLORS[status] || COLORS.dim;
+  const sum = result?.summary ?? {};
+  process.stdout.write(
+    `${COLORS.bold}vault health${COLORS.reset} ${sc}${status}${COLORS.reset}` +
+      ` ${COLORS.dim}— ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계${COLORS.reset}\n\n`,
+  );
+  const checks = Array.isArray(result?.checks) ? result.checks : [];
+  for (const c of checks) {
+    const cc = STATUS_COLORS[c.status] || COLORS.dim;
+    const icon = STATUS_ICONS[c.status] || '·';
+    process.stdout.write(
+      `  ${cc}${icon}${COLORS.reset} ${cc}${(c.id || '').padEnd(28)}${COLORS.reset}` +
+        ` ${COLORS.dim}${c.message ?? ''}${COLORS.reset}\n`,
+    );
+  }
+  // dependency cycle / components count 강조
+  if (sum.dependencyCycles) {
+    process.stdout.write(`\n${COLORS.red}cycles ${sum.dependencyCycles}${COLORS.reset} — \`cycles\` 명령으로 자세히\n`);
+  }
+  return status === 'healthy' || status === 'pass' ? 0 : 1;
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length > 0 && flags.vault === '.') flags.vault = positional[0];
+  return { vault: flags.vault, json: flags.json };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology health [vault] [--json]\n\n` +
+      `pass=healthy / warn=info-only / fail=blocking. exit 0 만 healthy.\n`,
+  );
+}

--- a/cli/src/commands/hubs.mjs
+++ b/cli/src/commands/hubs.mjs
@@ -1,0 +1,103 @@
+// `oh-my-ontology hubs [vault]` — centrality 기반 hub 노드 ranking.
+// MCP `query_ontology({operation: 'centrality'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+};
+
+export async function runHubs(args) {
+  const { vault, json, limit, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', {
+      operation: 'centrality',
+      limit,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  render(result);
+  return 0;
+}
+
+function render(result) {
+  const r = result?.rankings ?? {};
+  const sections = [
+    ['PageRank (영향력)', r.pageRank, 'pageRank'],
+    ['Bridges (도메인 사이 잇는 노드)', r.bridges, 'bridgeScore'],
+    ['Authorities (많이 referenced)', r.authorities, 'inDegree'],
+    ['Hubs (많이 reference)', r.hubs, 'outDegree'],
+  ];
+  for (const [title, rows, scoreKey] of sections) {
+    if (!Array.isArray(rows) || rows.length === 0) continue;
+    process.stdout.write(`${COLORS.dim}${title}${COLORS.reset}\n`);
+    for (let i = 0; i < rows.length; i += 1) {
+      const h = rows[i];
+      const kc = KIND_COLORS[h.kind] || COLORS.dim;
+      const rank = String(i + 1).padStart(2);
+      const slug = h.slug.padEnd(50);
+      const score =
+        typeof h[scoreKey] === 'number' ? h[scoreKey].toFixed(scoreKey === 'pageRank' ? 4 : 0) : '-';
+      const deg = `${COLORS.dim}${scoreKey} ${score}${COLORS.reset} ${COLORS.dim}(deg ${h.degree})${COLORS.reset}`;
+      process.stdout.write(`  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${slug}${COLORS.reset} ${deg}\n`);
+    }
+    process.stdout.write('\n');
+  }
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, limit: 10 };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--limit') flags.limit = Number(args[++i]) || 10;
+    else if (a.startsWith('--limit=')) flags.limit = Number(a.slice('--limit='.length)) || 10;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length > 0 && flags.vault === '.') flags.vault = positional[0];
+  return { vault: flags.vault, json: flags.json, limit: flags.limit };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology hubs [vault] [--limit N] [--json]\n\n` +
+      `4 rankings: PageRank (영향력) · Bridges (도메인 잇는) · Authorities (referenced) · Hubs (referencing).\n`,
+  );
+}

--- a/cli/src/commands/workspace-brief.mjs
+++ b/cli/src/commands/workspace-brief.mjs
@@ -1,0 +1,135 @@
+// `oh-my-ontology workspace-brief [vault]` — first-contact + next actions.
+// MCP `query_ontology({operation: 'workspace_brief'})` thin wrapper.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+};
+const SEVERITY_COLORS = {
+  fail: COLORS.red,
+  warn: COLORS.yellow,
+  info: COLORS.dim,
+};
+
+export async function runWorkspaceBrief(args) {
+  const { vault, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', { operation: 'workspace_brief' });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  render(result);
+  return 0;
+}
+
+function render(result) {
+  const status = result?.status ?? 'unknown';
+  const sum = result?.summary ?? {};
+  const sc = status === 'healthy' ? COLORS.green : status === 'unhealthy' ? COLORS.red : COLORS.yellow;
+  process.stdout.write(
+    `${COLORS.bold}workspace brief${COLORS.reset} ${sc}${status}${COLORS.reset}` +
+      ` ${COLORS.dim}— ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계` +
+      ` · ${sum.projects ?? 0} 프로젝트 · ${sum.domains ?? 0} 도메인${COLORS.reset}\n\n`,
+  );
+
+  // Hotspots (degree 상위)
+  const hotspots = Array.isArray(result?.hotspots) ? result.hotspots : [];
+  if (hotspots.length > 0) {
+    process.stdout.write(`${COLORS.dim}HOTSPOTS${COLORS.reset} ${COLORS.dim}(degree 상위)${COLORS.reset}\n`);
+    for (let i = 0; i < Math.min(hotspots.length, 5); i += 1) {
+      const h = hotspots[i];
+      const kc = KIND_COLORS[h.kind] || COLORS.dim;
+      const rank = String(i + 1).padStart(2);
+      process.stdout.write(
+        `  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${h.slug.padEnd(50)}${COLORS.reset}` +
+          ` ${COLORS.dim}deg ${h.degree}${COLORS.reset}\n`,
+      );
+    }
+    process.stdout.write('\n');
+  }
+
+  // Projects 요약
+  const projects = result?.projects?.maps ?? [];
+  if (projects.length > 0) {
+    process.stdout.write(`${COLORS.dim}PROJECT 별 노드 수${COLORS.reset}\n`);
+    for (const p of projects) {
+      const pn = p.node?.title || p.project;
+      const ps = p.summary ?? {};
+      process.stdout.write(
+        `  ${COLORS.magenta}${pn.padEnd(30)}${COLORS.reset}` +
+          ` ${COLORS.dim}${ps.nodes ?? 0} 노드 · ${ps.domains ?? 0} 도메인 · ${ps.capabilities ?? 0} 역량 · ${ps.elements ?? 0} 요소${COLORS.reset}\n`,
+      );
+    }
+    process.stdout.write('\n');
+  }
+
+  // Next actions
+  const next = Array.isArray(result?.nextActions) ? result.nextActions : [];
+  if (next.length > 0) {
+    process.stdout.write(`${COLORS.dim}NEXT ACTIONS${COLORS.reset}\n`);
+    for (const a of next) {
+      const sev = SEVERITY_COLORS[a.severity] || COLORS.dim;
+      process.stdout.write(
+        `  ${sev}[${(a.severity || 'info').padEnd(4)}]${COLORS.reset}` +
+          ` ${COLORS.bold}${a.kind}${COLORS.reset}` +
+          ` ${COLORS.dim}× ${a.count ?? '?'}${COLORS.reset}\n`,
+      );
+      if (a.message) process.stdout.write(`         ${COLORS.dim}${a.message}${COLORS.reset}\n`);
+    }
+  }
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length > 0 && flags.vault === '.') flags.vault = positional[0];
+  return { vault: flags.vault, json: flags.json };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology workspace-brief [vault] [--json]\n\n` +
+      `first-contact dashboard: status + hotspots + project 요약 + next actions.\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -80,6 +80,16 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
   npx oh-my-ontology overview [vault]         Vault first-contact dashboard (counts + 분포 + 허브)
        --limit N --json                       ${COLORS.dim}허브 N 개 (default 10) · machine output${COLORS.reset}
+  npx oh-my-ontology hubs [vault]             Centrality 4 rankings — PageRank / Bridges / Authorities / Hubs
+       --limit N --json                       ${COLORS.dim}각 랭킹 N rows (default 10)${COLORS.reset}
+  npx oh-my-ontology blast-radius <slug>      이 노드 변경 시 영향받는 노드/관계 (refactor safety)
+       --depth N --direction incoming|outgoing|both --json
+  npx oh-my-ontology cycles [vault]           depends_on dependency cycle 검출
+       --max-hops N --json                    ${COLORS.dim}default maxDepth 8${COLORS.reset}
+  npx oh-my-ontology health [vault]           Graph 무결성 dashboard (5 checks)
+       --json                                 ${COLORS.dim}exit 0 만 healthy${COLORS.reset}
+  npx oh-my-ontology workspace-brief [vault]  Status + hotspots + project 요약 + next actions 한 화면
+       --json
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
        --confirm                              ${COLORS.dim}default dry-run (preview); --confirm to apply${COLORS.reset}
   npx oh-my-ontology merge <from> <into>      Atomic merge — redirect backlinks then delete fromSlug
@@ -369,6 +379,31 @@ if (SUBCOMMAND === 'path') {
 if (SUBCOMMAND === 'overview') {
   const { runOverview } = await import('./commands/overview.mjs');
   exit(await runOverview(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'hubs') {
+  const { runHubs } = await import('./commands/hubs.mjs');
+  exit(await runHubs(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'blast-radius') {
+  const { runBlastRadius } = await import('./commands/blast-radius.mjs');
+  exit(await runBlastRadius(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'cycles') {
+  const { runCycles } = await import('./commands/cycles.mjs');
+  exit(await runCycles(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'health') {
+  const { runHealth } = await import('./commands/health.mjs');
+  exit(await runHealth(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'workspace-brief') {
+  const { runWorkspaceBrief } = await import('./commands/workspace-brief.mjs');
+  exit(await runWorkspaceBrief(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {


### PR DESCRIPTION
## Summary

PR #266 (`overview`) 에 이어 `query_ontology` 의 5 더 많은 operation 을 CLI 로 노출 — dev primary surface 와 AI agent primary surface 의 권한 격차 추가 축소.

5 신규 명령 (CLI 18–22):

- `hubs [vault] [--limit N]` — centrality 4 rankings (PageRank / Bridges / Authorities / Hubs)
- `blast-radius <slug> [--depth N] [--direction]` — refactor safety (영향 노드/관계 + risk + byKind/byDomain)
- `cycles [vault] [--max-hops N]` — depends_on dependency cycle 검출
- `health [vault]` — 5 graph 무결성 check, exit 0 만 healthy
- `workspace-brief [vault]` — status + hotspots + project 요약 + next actions 한 화면

전부 `--json` opt 로 raw query_ontology 응답 pass-through.

## 실 검증 (이 repo 27 노드 dogfood)

```
$ oh-my-ontology hubs --limit 3
PageRank 1위 domains/views deg 17 · 2위 domains/vault-local-first · 3위 domains/ontology-core
Bridges  1위 domains/views bridgeScore 72 · 2위 vault-local-first 60 · 3위 ai-agent-partner 56
...

$ oh-my-ontology blast-radius capabilities/mcp-server
risk high · 10 노드 · 22 관계 · 3 cross-domain
affected: cli-developer-entry (d1) · mcp-conflict-guard (d1) · ontology-sync-skill (d1) · ai-agent-partner (d1) · mcp-sdk (d1) · ontology-bootstrap-skill (d2) · session-start-ontology-context (d2) · vault-live-updates (d2) · onboarding-ux (d2) · project (d2)

$ oh-my-ontology cycles
cycles 0 — dependency graph clean ✓

$ oh-my-ontology health
healthy · 5/5 checks pass

$ oh-my-ontology workspace-brief
healthy · 27 노드 · 170 관계 · 1 프로젝트 · 6 도메인
HOTSPOTS 1위 vault-local-first · 2위 views · 3위 cli-developer-entry · ...
NEXT ACTIONS 80 materialize_external_elements (info)
```

## Test plan

- [x] 5 명령 실 검증 (위 출력)
- [x] tsc / lint clean / 895 test pass (CLI 신규 명령은 thin wrapper, query_ontology 자체 테스트가 mcp 패키지에 이미 있음)
- [x] CLI 0.7.0 → 0.8.0 (minor) — npm 미발행 상태

## 다음

- E: maintenance_plan / growth_plan 의 80 external ref noise 줄이기 (`.omotignore`)
- I: `/ontology/insights` UI 폴리시 (빌더와 같은 design system)
- D: 빌더 ROI 결정 (사용자 input 필요)

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>
