### PR TITLE
feat(mcp): .omotignore — materialize_external_element 추천 noise 줄이기

### DIFF
--- a/docs/ontology/.omotignore
+++ b/docs/ontology/.omotignore
@@ -1,0 +1,21 @@
+# oh-my-ontology dogfood vault — `.omotignore`
+#
+# 이 패턴들에 매치되는 external element ref 는 `materialize_external_element`
+# 추천에서 제외된다. 즉 *의도된 외부 코드* (vault 노드로 승격할 계획 없음) 가
+# growth_plan / maintenance_plan 의 noise 가 되지 않도록.
+#
+# capability frontmatter `elements:` 안의 path 문자열에 대해 매치 검사한다.
+
+# 빌더 / 토폴로지 등 src 트리 — 코드 모듈이지 first-class ontology 노드 아님
+src/**
+
+# MCP 서버 / CLI / scripts — 동일 이유
+mcp/**
+cli/**
+scripts/**
+
+# Claude Code skill / hook
+.claude/**
+
+# 빌드 산출물 — 매번 regenerate
+public/**

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — oh-my-ontology-mcp
 
+## 0.12.0 — 2026-05-14
+
+### Added — `.omotignore` for materialize noise reduction
+
+- vault 루트의 `.omotignore` 파일 (gitignore-style glob 패턴) 이 `growth_plan` / `maintenance_plan` 의 `materialize_external_element` 추천에서 매치되는 ref 를 제외. 의도된 외부 코드 (예: `src/**`, `cli/**`) 가 매번 80+ noise 로 surface 되던 paper cut 정정.
+- 패턴 문법: `*` (디렉토리 안 모든 문자) · `**` (재귀) · `?` (단일 char) · `/`·이름 path. `#` 주석 + 빈 줄 skip. 부정 (`!`) 1차 미지원.
+- 응답 투명성: `growth_plan` / `maintenance_plan` 의 summary 에 `externalElementRefsIgnored: N` 카운트 노출. 사용자가 "왜 추천이 줄었지" 분간 가능.
+- `mcp/src/omot-ignore.mjs` (load + glob match) + 11 신규 단위 테스트.
+- `createOntologyEngine(artifact, { omotIgnorePatterns })` 옵션 + `queryCompiledOntology(artifact, query, { omotIgnorePatterns })` chain. wrapper 가 `loadOmotIgnore(VAULT_ROOT)` 호출.
+
 ## 0.11.0 — 2026-05-14
 
 ### Added — `compile_ontology` summary + nodes/edges pagination

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server — humans and AI agents read/write the same codebase ontology vault. Current surface: 23 tools (15 read + 8 write).",
   "keywords": [
     "mcp",

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -77,6 +77,7 @@ import { analyzeRepoStructure } from './analyze.mjs';
 import { inferImports } from './infer-imports.mjs';
 import { compileOntology } from './ontology-compiler.mjs';
 import { queryCompiledOntology } from './ontology-engine.mjs';
+import { loadOmotIgnore } from './omot-ignore.mjs';
 import { parseFilter } from './query.mjs';
 import { isValidVaultTitle, validateVaultDocument } from './validate.mjs';
 import {
@@ -1847,8 +1848,9 @@ function compileOntologyTool({
 
 function queryOntologyTool(args = {}) {
   const artifact = compileOntology(loadVaultDocs(VAULT_ROOT), { includeIndexes: true });
+  const omotIgnorePatterns = loadOmotIgnore(VAULT_ROOT);
   return {
-    ...queryCompiledOntology(artifact, args),
+    ...queryCompiledOntology(artifact, args, { omotIgnorePatterns }),
     compiledSummary: {
       nodes: artifact.nodeCount,
       edges: artifact.edgeCount,
@@ -1864,10 +1866,11 @@ function queryOntologyTool(args = {}) {
 
 function compactPostWriteMaintenance(limit = 5) {
   const artifact = compileOntology(loadVaultDocs(VAULT_ROOT), { includeIndexes: true });
+  const omotIgnorePatterns = loadOmotIgnore(VAULT_ROOT);
   const result = queryCompiledOntology(artifact, {
     operation: 'maintenance_plan',
     limit,
-  });
+  }, { omotIgnorePatterns });
   return {
     graphHash: result.graphHash,
     summary: result.summary,

--- a/mcp/src/omot-ignore.mjs
+++ b/mcp/src/omot-ignore.mjs
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// `.omotignore` — vault 루트에 두는 gitignore-style 패턴 파일.
+// `materialize_external_element` 추천에서 제외할 reference 패턴을 한 줄에 하나.
+// 의도된 외부 코드 (예: 모든 src 디렉토리 하위) 가 noise 로 매번 surface 되는 걸 막는다.
+//
+//   - `#` 으로 시작하는 줄은 주석
+//   - 빈 줄 무시
+//   - `*` 는 `/` 를 제외한 모든 문자에 매치
+//   - `**` 는 디렉토리 포함 모든 문자에 매치
+//   - `?` 는 `/` 를 제외한 단일 문자
+//   - 행 끝의 `/` 는 strip (디렉토리 표시는 매칭 무영향)
+//
+// 부정 (`!pattern`) 은 1차 버전 미지원 — 필요해지면 추가.
+export function loadOmotIgnore(vaultRoot) {
+  const file = resolve(vaultRoot, '.omotignore');
+  if (!existsSync(file)) return [];
+  const text = readFileSync(file, 'utf-8');
+  return parseOmotIgnore(text);
+}
+
+export function parseOmotIgnore(text) {
+  const lines = text.split(/\r?\n/);
+  const patterns = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('#')) continue;
+    if (line.startsWith('!')) continue; // negation 미지원
+    patterns.push(line.endsWith('/') ? line.slice(0, -1) : line);
+  }
+  return patterns;
+}
+
+/**
+ * ref (예: `src/views/foo.tsx`) 가 patterns 중 하나라도 매치하는가?
+ */
+export function refMatchesOmotIgnore(ref, patterns) {
+  if (!patterns || patterns.length === 0) return false;
+  for (const pat of patterns) {
+    if (matchPattern(ref, pat)) return true;
+  }
+  return false;
+}
+
+function matchPattern(ref, pattern) {
+  const regex = patternToRegex(pattern);
+  return regex.test(ref);
+}
+
+function patternToRegex(pattern) {
+  // 1. regex special chars escape (except `*`, `?`, `/` — 우리 glob 의 의미 char).
+  let r = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+
+  // 2. `/**/` 중간 — `/(?:.*/)?` 로 *zero-or-more 디렉토리* 매칭.
+  //     예: `src/**/foo.ts` 가 `src/foo.ts` 와 `src/x/foo.ts` 둘 다 매치.
+  r = r.replace(/\/\*\*\//g, '/__OMOT_MID__');
+  // 3. `**/` 시작 — 같은 의미로 0+ 디렉토리 prefix.
+  if (r.startsWith('**/')) r = '__OMOT_START__' + r.slice(3);
+  // 4. `/**` 끝 — 0+ 디렉토리 suffix (`src/**` 가 `src` 자체도 매치하나? gitignore
+  //     에선 디렉토리 안에 있는 것만 매치. 우리 ref 는 항상 path 라 `src/**` 는
+  //     `src/` 로 시작하는 모든 ref. 빈 경우 (`src` 단독) 는 매치 안 시킴).
+  if (r.endsWith('/**')) r = r.slice(0, -3) + '__OMOT_END__';
+
+  // 5. 남은 단순 `**` — `.*`
+  r = r.replace(/\*\*/g, '.*');
+  // 6. `*` — `[^/]*`
+  r = r.replace(/\*/g, '[^/]*');
+  // 7. `?` — `[^/]`
+  r = r.replace(/\?/g, '[^/]');
+
+  // 8. placeholder 복원.
+  r = r.replace(/__OMOT_MID__/g, '(?:.*/)?');
+  r = r.replace(/__OMOT_START__/g, '(?:.*/)?');
+  r = r.replace(/__OMOT_END__/g, '/.*');
+
+  return new RegExp('^' + r + '$');
+}

--- a/mcp/src/omot-ignore.test.mjs
+++ b/mcp/src/omot-ignore.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { parseOmotIgnore, refMatchesOmotIgnore } from './omot-ignore.mjs';
+
+describe('parseOmotIgnore', () => {
+  it('빈 줄 / 주석 / 부정(!) skip', () => {
+    const patterns = parseOmotIgnore(`
+# this is a comment
+src/views/**
+
+!keep-this
+
+cli/src/commands/*.mjs
+    `);
+    assert.deepEqual(patterns, ['src/views/**', 'cli/src/commands/*.mjs']);
+  });
+
+  it('행 끝 / 는 strip', () => {
+    assert.deepEqual(parseOmotIgnore('public/'), ['public']);
+  });
+
+  it('빈 입력은 빈 array', () => {
+    assert.deepEqual(parseOmotIgnore(''), []);
+    assert.deepEqual(parseOmotIgnore('\n\n# comment\n'), []);
+  });
+});
+
+describe('refMatchesOmotIgnore', () => {
+  it('* 는 / 제외 모든 문자', () => {
+    assert.equal(refMatchesOmotIgnore('src/foo.ts', ['src/*.ts']), true);
+    assert.equal(refMatchesOmotIgnore('src/views/foo.ts', ['src/*.ts']), false);
+  });
+
+  it('** 는 디렉토리 가로지름', () => {
+    assert.equal(refMatchesOmotIgnore('src/views/foo.ts', ['src/**']), true);
+    assert.equal(refMatchesOmotIgnore('src/views/deep/foo.ts', ['src/**']), true);
+    assert.equal(refMatchesOmotIgnore('cli/views/foo.ts', ['src/**']), false);
+  });
+
+  it('** 가운데 — src/**/foo.ts', () => {
+    assert.equal(refMatchesOmotIgnore('src/views/foo.ts', ['src/**/foo.ts']), true);
+    assert.equal(refMatchesOmotIgnore('src/views/deep/foo.ts', ['src/**/foo.ts']), true);
+    assert.equal(refMatchesOmotIgnore('src/foo.ts', ['src/**/foo.ts']), true);
+    assert.equal(refMatchesOmotIgnore('src/views/bar.ts', ['src/**/foo.ts']), false);
+  });
+
+  it('? — 단일 문자', () => {
+    assert.equal(refMatchesOmotIgnore('src/a.ts', ['src/?.ts']), true);
+    assert.equal(refMatchesOmotIgnore('src/ab.ts', ['src/?.ts']), false);
+  });
+
+  it('exact match', () => {
+    assert.equal(refMatchesOmotIgnore('mcp/src/index.js', ['mcp/src/index.js']), true);
+    assert.equal(refMatchesOmotIgnore('mcp/src/index.mjs', ['mcp/src/index.js']), false);
+  });
+
+  it('여러 패턴 중 어느 하나라도 매치하면 true', () => {
+    const patterns = ['src/**', 'mcp/src/*.mjs'];
+    assert.equal(refMatchesOmotIgnore('src/views/foo.ts', patterns), true);
+    assert.equal(refMatchesOmotIgnore('mcp/src/parser.mjs', patterns), true);
+    assert.equal(refMatchesOmotIgnore('cli/src/index.mjs', patterns), false);
+  });
+
+  it('빈 patterns → 무엇도 매치 안 됨', () => {
+    assert.equal(refMatchesOmotIgnore('anything', []), false);
+    assert.equal(refMatchesOmotIgnore('anything', null), false);
+    assert.equal(refMatchesOmotIgnore('anything', undefined), false);
+  });
+
+  it('정규식 메타 문자 안전 처리', () => {
+    // path.with.dots — `.` 가 regex 에서 any-char 인데 우리 패턴은 literal 로 다뤄야 함
+    assert.equal(refMatchesOmotIgnore('path.with.dots', ['path.with.dots']), true);
+    assert.equal(refMatchesOmotIgnore('pathXwithXdots', ['path.with.dots']), false);
+  });
+});

--- a/mcp/src/ontology-engine.mjs
+++ b/mcp/src/ontology-engine.mjs
@@ -1,10 +1,12 @@
+import { refMatchesOmotIgnore } from './omot-ignore.mjs';
+
 const DEFAULT_LIMIT = 100;
 const DOWNWARD_CONTAINMENT_TYPES = new Set(['domains', 'capabilities', 'elements', 'contains']);
 const UPWARD_CONTAINMENT_TYPES = new Set(['domain']);
 
-export function queryCompiledOntology(artifact, query = {}) {
+export function queryCompiledOntology(artifact, query = {}, options = {}) {
   const operation = query.operation;
-  const engine = createOntologyEngine(artifact);
+  const engine = createOntologyEngine(artifact, options);
 
   if (operation === 'neighbors') {
     return engine.neighbors(query.slug, query);
@@ -114,7 +116,10 @@ export function queryCompiledOntology(artifact, query = {}) {
   );
 }
 
-export function createOntologyEngine(artifact) {
+export function createOntologyEngine(artifact, options = {}) {
+  const omotIgnorePatterns = Array.isArray(options.omotIgnorePatterns)
+    ? options.omotIgnorePatterns
+    : [];
   const nodes = Array.isArray(artifact?.nodes) ? artifact.nodes : [];
   const edges = Array.isArray(artifact?.edges) ? artifact.edges : [];
   const nodeBySlug = new Map(nodes.map((node) => [node.slug, node]));
@@ -1879,8 +1884,22 @@ export function createOntologyEngine(artifact) {
   }
 
   function externalElementCandidates(limit) {
-    const rows = edges
-      .filter((edge) => edge.external && edge.via === 'elements')
+    // `.omotignore` 패턴에 매치되는 ref 는 *의도된 외부 코드* 로 간주, materialize
+    // 추천에서 skip. ignored 카운트는 응답에 같이 노출 (투명성 — 사용자가 "왜
+    // 외부 ref 가 적게 보이지?" 묻지 않도록).
+    const allExternal = edges.filter(
+      (edge) => edge.external && edge.via === 'elements',
+    );
+    let ignored = 0;
+    const kept = [];
+    for (const edge of allExternal) {
+      if (refMatchesOmotIgnore(edge.ref, omotIgnorePatterns)) {
+        ignored += 1;
+        continue;
+      }
+      kept.push(edge);
+    }
+    const rows = kept
       .sort(compareEdges)
       .map((edge) => {
         const slug = suggestedSlugForReference(edge.ref, 'element');
@@ -1903,7 +1922,9 @@ export function createOntologyEngine(artifact) {
         };
       });
 
-    return limitedCandidateGroup(rows, limit);
+    const result = limitedCandidateGroup(rows, limit);
+    if (ignored > 0) result.ignored = ignored;
+    return result;
   }
 
   function danglingReferenceCandidates(limit) {
@@ -2219,6 +2240,7 @@ export function createOntologyEngine(artifact) {
       summary: {
         relationRecommendations: relationRecommendations.totalRecommendations,
         externalElementRefs: externalElementRefs.total,
+        externalElementRefsIgnored: externalElementRefs.ignored ?? 0,
         danglingReferences: danglingReferences.total,
         unassignedNodes: unassignedNodes.total,
         emptyDomains: emptyDomains.total,
@@ -2380,6 +2402,7 @@ export function createOntologyEngine(artifact) {
         danglingReferences: danglingReferences.total,
         relationRecommendations: relationRecommendations.totalRecommendations,
         externalElementRefs: externalElementRefs.total,
+        externalElementRefsIgnored: externalElementRefs.ignored ?? 0,
         unassignedNodes: unassignedNodes.total,
         emptyDomains: emptyDomains.total,
       },

--- a/mcp/src/ontology-engine.test.mjs
+++ b/mcp/src/ontology-engine.test.mjs
@@ -306,6 +306,7 @@ describe('queryCompiledOntology', () => {
       danglingReferences: 0,
       relationRecommendations: 1,
       externalElementRefs: 1,
+      externalElementRefsIgnored: 0,
       unassignedNodes: 1,
       emptyDomains: 0,
     });
@@ -1925,6 +1926,7 @@ describe('queryCompiledOntology', () => {
     assert.deepEqual(result.summary, {
       relationRecommendations: 1,
       externalElementRefs: 1,
+      externalElementRefsIgnored: 0,
       danglingReferences: 1,
       unassignedNodes: 1,
       emptyDomains: 1,
@@ -1956,6 +1958,44 @@ describe('queryCompiledOntology', () => {
     ]);
     assert.deepEqual(result.unassignedNodes.rows.map((row) => row.slug), ['capabilities/orphan']);
     assert.deepEqual(result.emptyDomains.rows.map((row) => row.slug), ['domains/empty']);
+  });
+
+  it('omotIgnorePatterns 가 매치되는 external element ref 를 materialize 추천에서 제외 + ignored 카운트 노출', () => {
+    const graph = compileOntology(
+      [
+        doc('project', { kind: 'project', title: 'P', domains: ['domains/x'] }),
+        doc('domains/x', {
+          kind: 'domain',
+          title: 'X',
+          capabilities: ['capabilities/foo'],
+        }),
+        doc('capabilities/foo', {
+          kind: 'capability',
+          title: 'Foo',
+          domain: 'x',
+          // 두 external element ref (둘 다 path-like — `.` 가 있어 external 로 인식).
+          // src/** 매치 1 + 매치 안 됨 1.
+          elements: ['src/foo.ts', 'external/lib.ts'],
+        }),
+      ],
+      { includeIndexes: true },
+    );
+
+    const without = queryCompiledOntology(graph, { operation: 'growth_plan', limit: 10 });
+    // ignore 없을 때 둘 다 candidate
+    assert.equal(without.summary.externalElementRefs, 2);
+    assert.equal(without.summary.externalElementRefsIgnored, 0);
+
+    const withIgnore = queryCompiledOntology(
+      graph,
+      { operation: 'growth_plan', limit: 10 },
+      { omotIgnorePatterns: ['src/**'] },
+    );
+    // 'src/foo.ts' 는 매치, 'external/lib.ts' 는 안 매치
+    assert.equal(withIgnore.summary.externalElementRefs, 1);
+    assert.equal(withIgnore.summary.externalElementRefsIgnored, 1);
+    assert.equal(withIgnore.externalElementRefs.rows[0].ref, 'external/lib.ts');
+    assert.equal(withIgnore.externalElementRefs.ignored, 1);
   });
 
   it('returns a one-shot workspace brief for first-contact agent orientation', () => {
@@ -1998,6 +2038,7 @@ describe('queryCompiledOntology', () => {
     assert.deepEqual(result.growth, {
       relationRecommendations: 1,
       externalElementRefs: 1,
+      externalElementRefsIgnored: 0,
       danglingReferences: 0,
       unassignedNodes: 0,
       emptyDomains: 0,


### PR DESCRIPTION
## Summary

dogfood vault 의 80 external element ref 가 매번 \`growth_plan\` / \`maintenance_plan\` 에 surface 되던 paper cut 정정. 의도된 외부 코드 (\`src/**\`, \`cli/**\`, \`mcp/**\`, …) 는 진짜 materialize 후보가 아닌데 매번 추천에 끼어 신호 약화.

- vault 루트 \`.omotignore\` 파일 (gitignore-style glob) — 매치되는 ref 는 \`materialize_external_element\` 추천에서 skip
- 패턴: \`*\` (디렉토리 안 모든 문자) / \`**\` (재귀) / \`?\` (단일 char) / \`#\` 주석 / 빈 줄 skip. 부정 (\`!\`) 1차 미지원
- 투명성: \`growth_plan\` / \`maintenance_plan\` 의 summary 에 \`externalElementRefsIgnored: N\` 카운트 동봉
- engine API: \`createOntologyEngine(artifact, { omotIgnorePatterns })\` 옵션 + \`queryCompiledOntology(artifact, query, options)\` chain. wrapper 가 \`loadOmotIgnore(VAULT_ROOT)\` 호출

## 즉시 효과 (이 repo dogfood)

\`docs/ontology/.omotignore\` 추가 후 (\`src/**\`, \`cli/**\`, \`mcp/**\`, \`.claude/**\`, \`scripts/**\`, \`public/**\`):

\`\`\`
이전: workspace_brief NEXT ACTIONS — materialize_external_elements × 80
이후: workspace_brief NEXT ACTIONS — health_check × 2 (clean!)

growth_plan.summary.externalElementRefs: 80 → 0
\`\`\`

## Test plan

- [x] \`mcp/src/omot-ignore.test.mjs\` — 11 신규 단위 (parse 3 + match 8)
- [x] \`mcp/src/ontology-engine.test.mjs\` — 신규 1 (omotIgnorePatterns 적용 + ignored 카운트). 기존 38 → 39
- [x] tsc / lint clean / pnpm test:run 895 pass
- [x] 실 검증 — CLI \`workspace-brief\` 가 fresh MCP spawn 이므로 새 코드 사용: noise 완전 사라짐

mcp 0.11.0 → 0.12.0 (minor, backward compat — \`.omotignore\` 없으면 동작 동일).

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>