### PR TITLE
feat(cli): node 명령 — 한 노드 deep dive + cli 0.9.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.9.0 — 2026-05-14
+
+### Added — `node` 명령 (23rd, query_ontology node_profile wrap)
+
+- `oh-my-ontology node <slug> [vault] [--json]` — 한 노드 전체 deep dive. MCP `query_ontology({operation: 'node_profile'})` thin wrapper.
+- 출력: header (kind · title · slug · domain · degree · aliases) + LINEAGE chain (project → domain → ... → 이 노드) + INCOMING/OUTGOING edges (relation 별 그룹, peer 노드 title 동봉, external 마크).
+- 기존 `backlinks` 가 incoming 만, `path` 가 두 노드 사이만 보여줬다면 `node` 는 *한 노드 둘레의 전부* — dev 가 모르는 노드 만났을 때 첫 호출.
+- 신규 integration test 3건 (counts / --json / slug 누락 usage).
+
 ## 0.8.0 — 2026-05-14
 
 ### Added — 5 graph commands (18–22, query_ontology operations)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 23-tool agent surface.",
   "type": "module",
   "bin": {

--- a/cli/src/commands/node-profile.mjs
+++ b/cli/src/commands/node-profile.mjs
@@ -1,0 +1,170 @@
+// `oh-my-ontology node <slug> [vault]` — 한 노드의 전체 deep dive.
+// MCP `query_ontology({operation: 'node_profile'})` thin wrapper.
+// header / 도메인 / containment lineage / incoming-outgoing edges (relation 별 그룹) 한 화면.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+  external: COLORS.dim,
+};
+
+export async function runNodeProfile(args) {
+  const { slug, vault, json, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', {
+      operation: 'node_profile',
+      slug,
+    });
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  render(result);
+  return 0;
+}
+
+function render(result) {
+  const n = result?.node;
+  if (!n) {
+    process.stdout.write(`${COLORS.dim}node not found${COLORS.reset}\n`);
+    return;
+  }
+  const kc = KIND_COLORS[n.kind] || COLORS.dim;
+  const deg = result?.degree ?? { in: 0, out: 0, total: 0 };
+
+  // Header
+  process.stdout.write(
+    `${kc}${(n.kind || '?').padEnd(11)}${COLORS.reset} ${COLORS.bold}${n.title || n.slug}${COLORS.reset}\n` +
+      `  ${COLORS.dim}slug${COLORS.reset}    ${n.slug}\n` +
+      (n.domain ? `  ${COLORS.dim}domain${COLORS.reset}  ${COLORS.blue}${n.domain}${COLORS.reset}\n` : '') +
+      `  ${COLORS.dim}degree${COLORS.reset}  ${COLORS.bold}${deg.total}${COLORS.reset}` +
+      ` ${COLORS.dim}(in ${deg.in} · out ${deg.out})${COLORS.reset}\n`,
+  );
+
+  // Aliases (slug 외 추가 alias)
+  const aliases = Array.isArray(result?.aliases) ? result.aliases : [];
+  const extraAliases = aliases.filter((a) => a !== n.slug);
+  if (extraAliases.length > 0) {
+    process.stdout.write(`  ${COLORS.dim}aliases${COLORS.reset} ${extraAliases.join(', ')}\n`);
+  }
+
+  // Lineage (ancestor chain — project ← domain ← capability 흐름)
+  const ancestors = result?.lineage?.ancestors?.nodes ?? [];
+  if (ancestors.length > 0) {
+    const chain = ancestors
+      .slice()
+      .sort((a, b) => b.distance - a.distance) // 멀리부터 (project → 가까이)
+      .map((a) => {
+        const ac = KIND_COLORS[a.node?.kind] || COLORS.dim;
+        return `${ac}${a.node?.title || a.slug}${COLORS.reset}`;
+      });
+    process.stdout.write(
+      `\n${COLORS.dim}LINEAGE${COLORS.reset}  ${chain.join(` ${COLORS.dim}→${COLORS.reset} `)} ${COLORS.dim}→${COLORS.reset} ${kc}${n.title || n.slug}${COLORS.reset}\n`,
+    );
+  }
+
+  // Incoming edges
+  const incoming = result?.edges?.incoming;
+  if (incoming?.total > 0) {
+    process.stdout.write(
+      `\n${COLORS.dim}INCOMING${COLORS.reset} ${COLORS.bold}${incoming.total}${COLORS.reset}` +
+        ` ${COLORS.dim}— 어디가 이 노드를 reference 하나${COLORS.reset}\n`,
+    );
+    renderEdgesByRelation(incoming.edges, 'from');
+  }
+
+  // Outgoing edges
+  const outgoing = result?.edges?.outgoing;
+  if (outgoing?.total > 0) {
+    process.stdout.write(
+      `\n${COLORS.dim}OUTGOING${COLORS.reset} ${COLORS.bold}${outgoing.total}${COLORS.reset}` +
+        ` ${COLORS.dim}— 이 노드가 무엇을 reference 하나${COLORS.reset}\n`,
+    );
+    renderEdgesByRelation(outgoing.edges, 'to');
+  }
+
+  if ((incoming?.total ?? 0) === 0 && (outgoing?.total ?? 0) === 0) {
+    process.stdout.write(`\n${COLORS.dim}isolated — 어떤 노드와도 연결 안 됨${COLORS.reset}\n`);
+  }
+}
+
+function renderEdgesByRelation(edges, peerField) {
+  // relation 별 그룹 (via 키)
+  const grouped = new Map();
+  for (const e of edges) {
+    const key = e.via || '?';
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(e);
+  }
+  // relation count 큰 순으로
+  const sorted = [...grouped.entries()].sort(([, a], [, b]) => b.length - a.length);
+  for (const [via, rows] of sorted) {
+    process.stdout.write(`  ${COLORS.yellow}${via}${COLORS.reset} ${COLORS.dim}× ${rows.length}${COLORS.reset}\n`);
+    for (const e of rows) {
+      const other = e[peerField];
+      const otherKind = e.otherKind || (e.external ? 'external' : '?');
+      const kc = KIND_COLORS[otherKind] || COLORS.dim;
+      const title = e.otherNode?.title ? ` ${COLORS.dim}— ${e.otherNode.title}${COLORS.reset}` : '';
+      const externalMark = e.external ? ` ${COLORS.dim}[external]${COLORS.reset}` : '';
+      process.stdout.write(`    ${kc}${other}${COLORS.reset}${title}${externalMark}\n`);
+    }
+  }
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0) {
+    return { error: 'slug is required (e.g. `node capabilities/foo`)' };
+  }
+  const [slug, vault] = positional;
+  if (vault && flags.vault === '.') flags.vault = vault;
+  return { slug, vault: flags.vault, json: flags.json };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology node <slug> [vault] [--json]\n\n` +
+      `한 노드의 전체 deep dive — header · 도메인 · lineage · incoming/outgoing edges (relation 별 그룹).\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -90,6 +90,8 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --json                                 ${COLORS.dim}exit 0 만 healthy${COLORS.reset}
   npx oh-my-ontology workspace-brief [vault]  Status + hotspots + project 요약 + next actions 한 화면
        --json
+  npx oh-my-ontology node <slug> [vault]      한 노드 deep dive — header · lineage · incoming/outgoing edges
+       --json                                 ${COLORS.dim}relation 별 그룹 + 노드 title 동봉${COLORS.reset}
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
        --confirm                              ${COLORS.dim}default dry-run (preview); --confirm to apply${COLORS.reset}
   npx oh-my-ontology merge <from> <into>      Atomic merge — redirect backlinks then delete fromSlug
@@ -404,6 +406,11 @@ if (SUBCOMMAND === 'health') {
 if (SUBCOMMAND === 'workspace-brief') {
   const { runWorkspaceBrief } = await import('./commands/workspace-brief.mjs');
   exit(await runWorkspaceBrief(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'node') {
+  const { runNodeProfile } = await import('./commands/node-profile.mjs');
+  exit(await runNodeProfile(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1130,6 +1130,48 @@ await test('overview --limit 3 — 허브 N 만 출력', async () => {
   }
 });
 
+await test('node — graph fixture 의 capabilities/foo deep dive', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['node', 'capabilities/foo', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    // header
+    assert.match(clean, /capability/);
+    assert.match(clean, /slug\s+capabilities\/foo/);
+    // foo 는 bar 가 relates 로 reference + auth domain 의 capabilities 로 reference
+    assert.match(clean, /INCOMING/);
+    assert.match(clean, /capabilities\/bar|domains\/auth/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('node --json — JSON 응답 node/edges/lineage 키 노출', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['node', 'capabilities/foo', root, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.operation, 'node_profile');
+    assert.equal(data.center, 'capabilities/foo');
+    assert.ok(data.node);
+    assert.equal(data.node.slug, 'capabilities/foo');
+    assert.ok(data.edges);
+    assert.ok(data.edges.incoming);
+    assert.ok(data.edges.outgoing);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('node — slug 누락 시 usage + exit 1', async () => {
+  const r = await run(['node']);
+  assert.equal(r.code, 1);
+  const clean = stripAnsi(r.stderr);
+  assert.match(clean, /slug is required/);
+});
+
 await test('rename — dry-run preview, no disk change', async () => {
   const root = await buildGraphFixture();
   try {


### PR DESCRIPTION
## Summary

\`oh-my-ontology node <slug> [vault] [--json]\` — 한 노드 둘레의 전부 한 호출에. 모르는 vault 의 임의 노드 만났을 때 dev 가 가장 먼저 누르는 명령.

기존 graph 명령 중 비슷한 것:
- \`backlinks <slug>\` → incoming 만
- \`path A B\` → 두 노드 사이만
- \`blast-radius\` → 영향 노드 (depth N)

\`node\` 는 그 사이 자리 — 한 노드 *전체 둘레*:

\`\`\`
capability  MCP Server (23 tools)
  slug    capabilities/mcp-server
  domain  ai-agent-partner
  degree  15 (in 5 · out 10)
  aliases mcp-server

LINEAGE  oh-my-ontology → AI Agent Partner → MCP Server (23 tools)

INCOMING 5 — 어디가 이 노드를 reference 하나
  relates × 3
    capabilities/cli-developer-entry — CLI Developer Entry (16 commands)
    capabilities/mcp-conflict-guard — MCP Conflict Guard
    elements/mcp-sdk — @modelcontextprotocol/sdk
  ...

OUTGOING 10 — 이 노드가 무엇을 reference 하나
  elements × 7
    mcp/src/analyze.mjs [external]
    ...
\`\`\`

CLI 18 → 23 번째 명령. MCP \`query_ontology({operation:'node_profile'})\` thin wrapper, 같은 권한이 dev 터미널에서도.

## Test plan

- [x] integration test 3건 신규 (deep dive / --json / usage)
- [x] tsc / lint clean
- [x] pnpm test:run 895 / 895 pass
- [x] 실 \`node cli/src/index.mjs node capabilities/mcp-server\` — header / lineage / incoming-outgoing relation 별 그룹 정확

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>