### PR TITLE
feat(cli): similar 명령 — 비슷한 노드 검색 + cli 0.10.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — oh-my-ontology (CLI)
 
+## 0.10.0 — 2026-05-14
+
+### Added — `similar` 명령 (24th, query_ontology similar_nodes wrap)
+
+- `oh-my-ontology similar "<title>" [vault] [--slug X] [--kind K] [--limit N] [--json]` — vault 에서 비슷한 노드 찾기. MCP `query_ontology({operation: 'similar_nodes'})` thin wrapper.
+- 두 입력 모드: 자연어 title 또는 `--slug` (둘 다도 가능 — slug-similarity + title-similarity 둘 다 계산).
+- 출력: score (red ≥ 0.5 / yellow 0.25-0.5 / dim < 0.25) + signal breakdown (slug / title / kind / domain / neighbors 어디서 매치) + shared neighbors + 행동 가이드 한 줄 (top score 별 patch vs add 권장).
+- `/ontology-extract` skill 의 핵심 cross-check (duplicate 회피) 가 CLI 에서도 1 줄. dev 가 "내 머리 속 개념이 vault 에 이미 있나" 즉시 확인.
+- 신규 integration test 3건 (title 매치 / --json / usage).
+
 ## 0.9.0 — 2026-05-14
 
 ### Added — `node` 명령 (23rd, query_ontology node_profile wrap)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ontology",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI-native codebase ontology workbench — vault scaffold + graph-level/CRUD commands + MCP 23-tool agent surface.",
   "type": "module",
   "bin": {

--- a/cli/src/commands/similar.mjs
+++ b/cli/src/commands/similar.mjs
@@ -1,0 +1,155 @@
+// `oh-my-ontology similar "<query>" [vault]` — 비슷한 노드 검색.
+// MCP `query_ontology({operation: 'similar_nodes'})` thin wrapper. 새 노드
+// 만들기 전 *duplicate 회피* 와 `/ontology-extract` skill 의 핵심 cross-check.
+
+import { callMcpTool } from '../lib/mcp-call.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  yellow: '\x1b[33m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+const KIND_COLORS = {
+  project: COLORS.magenta,
+  domain: COLORS.blue,
+  capability: COLORS.cyan,
+  element: COLORS.green,
+  document: COLORS.dim,
+  'vault-readme': COLORS.dim,
+};
+
+export async function runSimilar(args) {
+  const { title, slug, vault, json, limit, kind, error } = parseArgs(args);
+  if (error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${error}\n`);
+    printUsage();
+    return 1;
+  }
+  const vaultRoot = resolveVaultRoot(vault);
+  // candidateSlug 우선 (slug-similarity), title 도 같이 (title-similarity).
+  // 둘 다 없으면 안 됨 (parseArgs 가 보장).
+  const toolArgs = { operation: 'similar_nodes', limit };
+  if (slug) toolArgs.candidateSlug = slug;
+  if (title) toolArgs.title = title;
+  if (kind) toolArgs.kind = kind;
+  let result;
+  try {
+    result = await callMcpTool(vaultRoot, 'query_ontology', toolArgs);
+  } catch (err) {
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  }
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return 0;
+  }
+  render(result, title || slug);
+  return 0;
+}
+
+function render(result, query) {
+  const matches = Array.isArray(result?.matches) ? result.matches : [];
+  const total = result?.totalMatches ?? matches.length;
+  process.stdout.write(
+    `${COLORS.bold}similar to:${COLORS.reset} ${COLORS.bold}${query}${COLORS.reset}` +
+      ` ${COLORS.dim}— ${total} match${total === 1 ? '' : 'es'}${result?.limited ? ' (limited)' : ''}${COLORS.reset}\n\n`,
+  );
+  if (matches.length === 0) {
+    process.stdout.write(`${COLORS.green}no similar node — safe to create new${COLORS.reset}\n`);
+    return;
+  }
+  for (let i = 0; i < matches.length; i += 1) {
+    const m = matches[i];
+    const n = m.node ?? {};
+    const kc = KIND_COLORS[n.kind] || COLORS.dim;
+    const score = (m.score ?? 0).toFixed(3);
+    const scoreColor = m.score >= 0.5 ? COLORS.red : m.score >= 0.25 ? COLORS.yellow : COLORS.dim;
+    const rank = String(i + 1).padStart(2);
+    const title = n.title ? ` ${COLORS.dim}— ${n.title}${COLORS.reset}` : '';
+    process.stdout.write(
+      `  ${COLORS.bold}${rank}${COLORS.reset} ${scoreColor}${score}${COLORS.reset}` +
+        ` ${kc}${(n.kind || '?').padEnd(11)}${COLORS.reset} ${kc}${n.slug || '?'}${COLORS.reset}${title}\n`,
+    );
+    // signals — score 가 어디서 왔는지 한 줄 (0 아닌 신호만)
+    const signals = m.signals ?? {};
+    const active = Object.entries(signals)
+      .filter(([, v]) => typeof v === 'number' && v > 0)
+      .sort(([, a], [, b]) => b - a)
+      .map(([k, v]) => `${k} ${v.toFixed(2)}`);
+    if (active.length > 0) {
+      process.stdout.write(`       ${COLORS.dim}signals: ${active.join(' · ')}${COLORS.reset}\n`);
+    }
+    if (Array.isArray(m.sharedNeighbors) && m.sharedNeighbors.length > 0) {
+      process.stdout.write(
+        `       ${COLORS.dim}shared: ${m.sharedNeighbors.slice(0, 3).join(', ')}${m.sharedNeighbors.length > 3 ? ` +${m.sharedNeighbors.length - 3}` : ''}${COLORS.reset}\n`,
+      );
+    }
+  }
+  // 행동 가이드 (한 줄)
+  const top = matches[0];
+  if (top && top.score >= 0.5) {
+    process.stdout.write(
+      `\n${COLORS.red}⚠${COLORS.reset} ${COLORS.dim}top score ≥ 0.5 — \`patch_concept\` 가 \`add_concept\` 보다 안전${COLORS.reset}\n`,
+    );
+  } else if (top && top.score >= 0.25) {
+    process.stdout.write(
+      `\n${COLORS.yellow}~${COLORS.reset} ${COLORS.dim}top score 0.25-0.5 — 새 노드 + \`relates\` edge 가 보통 더 깨끗${COLORS.reset}\n`,
+    );
+  }
+}
+
+function parseArgs(args) {
+  const flags = { vault: '.', json: false, limit: 10, kind: null, slug: null };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i] || '.';
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--limit') flags.limit = Number(args[++i]) || 10;
+    else if (a.startsWith('--limit=')) flags.limit = Number(a.slice('--limit='.length)) || 10;
+    else if (a === '--kind') flags.kind = args[++i] || null;
+    else if (a.startsWith('--kind=')) flags.kind = a.slice('--kind='.length);
+    else if (a === '--slug') flags.slug = args[++i] || null;
+    else if (a.startsWith('--slug=')) flags.slug = a.slice('--slug='.length);
+    else if (a.startsWith('--')) return { error: `unknown flag: ${a}` };
+    else positional.push(a);
+  }
+  if (positional.length === 0 && !flags.slug) {
+    return { error: 'query is required (e.g. `similar "사용자 로그인"` or `similar --slug capabilities/foo`)' };
+  }
+  const [title, vault] = positional;
+  if (vault && flags.vault === '.') flags.vault = vault;
+  return {
+    title: title || null,
+    slug: flags.slug,
+    vault: flags.vault,
+    json: flags.json,
+    limit: flags.limit,
+    kind: flags.kind,
+  };
+}
+
+function printUsage() {
+  process.stderr.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  oh-my-ontology similar "<title>" [vault] [--slug X] [--kind K] [--limit N] [--json]\n\n` +
+      `${COLORS.bold}Examples:${COLORS.reset}\n` +
+      `  oh-my-ontology similar "사용자 로그인"\n` +
+      `  oh-my-ontology similar "auth flow" --kind capability\n` +
+      `  oh-my-ontology similar --slug capabilities/auth-login\n\n` +
+      `${COLORS.bold}Score 가이드:${COLORS.reset}\n` +
+      `  ≥ 0.5  — 같은 노드 가능성 높음 → \`patch_concept\` 권장\n` +
+      `  0.25-0.5 — 인접 개념 → 새 노드 + \`relates\` edge 깨끗\n` +
+      `  < 0.25 — 무관 → 새 노드 안전\n`,
+  );
+}

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -92,6 +92,8 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --json
   npx oh-my-ontology node <slug> [vault]      한 노드 deep dive — header · lineage · incoming/outgoing edges
        --json                                 ${COLORS.dim}relation 별 그룹 + 노드 title 동봉${COLORS.reset}
+  npx oh-my-ontology similar "<title>" [vault] vault 에서 비슷한 노드 찾기 (duplicate 회피, /ontology-extract 짝)
+       --slug X --kind K --limit N --json    ${COLORS.dim}slug 기반 / kind 필터 / 결과 N / machine${COLORS.reset}
   npx oh-my-ontology rename <old> <new>       Atomic rename — moves .md, redirects every backlink
        --confirm                              ${COLORS.dim}default dry-run (preview); --confirm to apply${COLORS.reset}
   npx oh-my-ontology merge <from> <into>      Atomic merge — redirect backlinks then delete fromSlug
@@ -411,6 +413,11 @@ if (SUBCOMMAND === 'workspace-brief') {
 if (SUBCOMMAND === 'node') {
   const { runNodeProfile } = await import('./commands/node-profile.mjs');
   exit(await runNodeProfile(ARGS.slice(1)));
+}
+
+if (SUBCOMMAND === 'similar') {
+  const { runSimilar } = await import('./commands/similar.mjs');
+  exit(await runSimilar(ARGS.slice(1)));
 }
 
 if (SUBCOMMAND === 'query') {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -1172,6 +1172,44 @@ await test('node — slug 누락 시 usage + exit 1', async () => {
   assert.match(clean, /slug is required/);
 });
 
+await test('similar — title 매치로 graph fixture 의 비슷한 노드 발견', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['similar', 'foo capability', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+    assert.match(clean, /similar to:.*foo capability/);
+    // fixture 의 capabilities/foo 가 매치되어야 (title 'Foo' 에 매치)
+    assert.match(clean, /capabilities\/(foo|bar)/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('similar --json — JSON 응답 matches/score/signals 키 노출', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const r = await run(['similar', 'foo', root, '--json']);
+    assert.equal(r.code, 0);
+    const data = JSON.parse(r.stdout);
+    assert.equal(data.operation, 'similar_nodes');
+    assert.ok(Array.isArray(data.matches));
+    if (data.matches.length > 0) {
+      assert.ok(typeof data.matches[0].score === 'number');
+      assert.ok(data.matches[0].signals);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('similar — query / --slug 둘 다 없으면 usage + exit 1', async () => {
+  const r = await run(['similar']);
+  assert.equal(r.code, 1);
+  const clean = stripAnsi(r.stderr);
+  assert.match(clean, /query is required/);
+});
+
 await test('rename — dry-run preview, no disk change', async () => {
   const root = await buildGraphFixture();
   try {


### PR DESCRIPTION
## Summary

\`oh-my-ontology similar "<title>" [vault]\` — 새 노드 만들기 전 *duplicate 회피*. \`/ontology-extract\` skill 의 핵심 cross-check 가 CLI 에서도 한 줄. CLI 24 번째 명령.

기존 \`find\` 가 substring 매치였다면 \`similar\` 는 MCP \`similar_nodes\` 의 multi-signal score (slug / title / kind / domain / neighbors) 사용. dev 가 "내 머릿속 개념이 vault 에 이미 있나" 즉시 확인.

## 출력 예 (이 repo dogfood)

\`\`\`
\$ oh-my-ontology similar "ontology agent skill" --limit 5
similar to: ontology agent skill — 10 matches (limited)

   1 0.315 capability  capabilities/ontology-sync-skill — Ontology-Sync Agent Skill
            signals: title 0.17 · slug 0.14
   2 0.257 capability  capabilities/ontology-bootstrap-skill — Ontology-Bootstrap Skill
            signals: slug 0.14 · title 0.12
   3 0.257 capability  capabilities/ontology-extract-skill — Ontology-Extract Skill
            signals: slug 0.14 · title 0.12
   ...
~ top score 0.25-0.5 — 새 노드 + \`relates\` edge 가 보통 더 깨끗
\`\`\`

## 입력 모드

- positional title — \`similar "사용자 로그인"\`
- \`--slug\` — \`similar --slug capabilities/auth-login\`
- 둘 다 — slug-similarity + title-similarity 합산

## Score 가이드 (CLI 가이드 line 도 출력)

- ≥ 0.5 (red) — 같은 노드 가능성 높음 → \`patch_concept\`
- 0.25-0.5 (yellow) — 인접 개념 → 새 노드 + \`relates\` edge 깨끗
- < 0.25 (dim) — 무관 → 새 노드 안전

## Test plan

- [x] integration test 3건 신규 (title 매치 / --json / usage)
- [x] tsc / lint clean / pnpm test:run 895 / 895 pass
- [x] 실 \`node cli/src/index.mjs similar "ontology agent skill"\` — 3 skill 노드가 top 3 으로 정확

## Co-Authored-By
Claude Opus 4.7 (1M context) <noreply@anthropic.com>