### PR TITLE
docs: add CodeGraph code-intelligence guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,34 @@ The detailed rules live in `.claude/rules/*.md` and Claude Code auto-loads them.
 - **Forbidden patterns / Do-Not list** — `@.claude/rules/forbidden.md`
 - **Documentation discipline** — `@.claude/rules/documentation.md`
 
+## Code intelligence — CodeGraph
+
+CodeGraph builds a semantic knowledge graph of codebases for faster, smarter code exploration. This is tool-agnostic — any agent with the `codegraph` MCP server configured should follow it. The local index lives in `.codegraph/` (gitignored — it is a SQLite db + a live daemon socket, never committed).
+
+### If `.codegraph/` exists in the project
+
+**Answer directly with CodeGraph — don't delegate exploration to a file-reading sub-agent or a grep/read loop.** CodeGraph *is* the pre-built search index; re-deriving its answers with grep + Read repeats work it already did and costs more for the same result. For "how does X work?", architecture, trace, or where-is-X questions, answer in a handful of CodeGraph calls and stop — typically with **zero file reads**. The returned source is complete and authoritative: treat it as already read and do not re-open those files. Reach for raw Read/Grep only to confirm a specific detail CodeGraph didn't cover.
+
+**Tool selection by intent:**
+
+| Tool | Use For |
+|------|---------|
+| `codegraph_context` | Map a task / feature / area first — composes search + node + callers + callees in one call |
+| `codegraph_trace` | "How does X reach Y" — the call path, each hop's body inline (follows dynamic-dispatch hops grep can't) |
+| `codegraph_explore` | Survey several related symbols' source in ONE budget-capped call |
+| `codegraph_search` | Find a symbol by name |
+| `codegraph_callers` / `codegraph_callees` | Walk call flow one hop at a time |
+| `codegraph_impact` | Check what's affected before editing |
+| `codegraph_node` | Get a single symbol's source / signature |
+
+A direct CodeGraph answer is a handful of calls; a grep/read exploration is dozens.
+
+### If `.codegraph/` does NOT exist
+
+At the start of a session, ask the user if they'd like to initialize CodeGraph:
+
+"I notice this project doesn't have CodeGraph initialized. Would you like me to run `codegraph init -i` to build a code knowledge graph?"
+
 ## 🚫 npm publish guard
 
 `npm publish` / `pnpm publish` / `yarn publish` is **never** run automatically. PreToolUse hooks in `.claude/settings.json` / `.codex/hooks.json` block it; `.claude/rules/forbidden.md` documents why. Only execute publish commands when the user explicitly asks. Even then, run `npm pack --dry-run` first to audit the tarball.


### PR DESCRIPTION
## Summary

CodeGraph(`codegraph` MCP) 사용 공식 지침을 **canonical `AGENTS.md`** 에 추가. CLAUDE.md 는 `@AGENTS.md` import 로 본문을 자동 상속하므로 (Claude Code 는 CLAUDE.md 만 네이티브로 읽지만 import 가 AGENTS.md 를 펼쳐 로드) 두 파일에 중복 작성할 필요가 없다.

- `.codegraph/` 존재 시: grep/read 루프나 file-reading sub-agent 에 위임하지 말고 codegraph 로 직접 답한다 (보통 zero file reads). intent 별 도구 선택 표 포함.
- `.codegraph/` 미존재 시: 세션 시작에 `codegraph init -i` 초기화 제안.
- 위치: `## Working principles` 다음의 새 `## Code intelligence — CodeGraph` 섹션.

## Test plan

- [x] `pnpm test:mcp:docs` — 52 pass / 0 fail (docs/package contract 게이트, "CLAUDE.md a thin AGENTS wrapper" 포함 — CLAUDE.md 미수정으로 유지)
- [x] pre-push `tsc --noEmit` 통과 (AGENTS.md 는 코드가 import 하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)