### PR TITLE
test: stop pinning infer_imports 'files scanned' to exact count

### DIFF
--- a/scripts/check-package-contracts.test.mjs
+++ b/scripts/check-package-contracts.test.mjs
@@ -1330,7 +1330,12 @@ describe('package contract helpers', () => {
     );
     assert.match(
       verifySection,
-      new RegExp(`✓ infer_imports — ${countLabel(inferredImports.filesScanned, 'file')} scanned, ${countLabel(inferredImports.moduleEdges.length, 'module edge')} \\(${topModuleEdgeSummary}`),
+      // infer_imports "files scanned" is intentionally NOT pinned to the exact
+      // live count: it changes on every source-file add/remove (incidental), so
+      // pinning it forced a README bump on unrelated PRs. The module-edge count
+      // and top-edge summary stay pinned — they reflect the actual dependency
+      // graph, which is the meaningful contract.
+      new RegExp(`✓ infer_imports — \\d+ files? scanned, ${countLabel(inferredImports.moduleEdges.length, 'module edge')} \\(${topModuleEdgeSummary}`),
     );
     assert.match(verifySection, new RegExp(`✓ find_neighbors — ${neighborSmokeLine}`));
     assert.match(verifySection, /✓ find_path — elements\/file-system-access-api → project \(2 hops, 2 edges\)/);


### PR DESCRIPTION
## Summary

README verify-snapshot 정렬 contract 테스트(`check-package-contracts.test.mjs`)가 `infer_imports` 의 **정확한 `filesScanned` 수**를 `mcp/README.md` 가 담고 있길 요구했다. 그 결과 소스 파일을 추가/삭제하는 *모든* PR 이 무관한 README 카운트 bump 를 강제당했다 (직전 PR #276 의 485→491 이 그 예 — 워커 소스 6개 추가).

`filesScanned` 는 가장 incidental 한 카운트(모든 소스 add/remove 에 변동)라, 정확-수 핀 대신 `\d+ files?` 형태만 검증하도록 완화했다. **module-edge 수 + top-edge summary 는 핀 유지** — 실제 의존성 그래프를 반영하는 의미있는 contract 이므로. node census(60)·graph hash 등 다른 의미있는 스냅샷도 그대로다.

## Test plan

- [x] `pnpm test:mcp:docs` — 52 pass / 0 fail (README=491)
- [x] 비고정 증명: `mcp/README` 의 "491 files scanned" 를 임의 수(999)로 바꿔도 52 pass / 0 fail → 더 이상 정확 수에 묶이지 않음. (README 는 491 로 복원)
- [x] 나머지 51개 contract 단언(module edges·census·hash·strict enums 등) 그대로 통과
- [x] `pnpm exec eslint scripts/check-package-contracts.test.mjs` — 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)