### PR TITLE
feat: filter narrative/language README H2s from analyze domain candidates

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -525,7 +525,7 @@ A successful run looks like this:
 ✓ find_backlinks — project (1 backlink)
 ✓ query_concepts — 1 query result / 1 total query result
 ✓ query_concepts limited — 1 query result / 59 total query results (limited true)
-✓ analyze_repo_structure — fsd (9 domain candidates, 20 capability candidates, 29 element candidates)
+✓ analyze_repo_structure — fsd (4 domain candidates, 20 capability candidates, 29 element candidates)
 ✓ infer_imports — 491 files scanned, 399 module edges (elements/src/views/docs-vault->elements/src/widgets/docs-vault x14 (static:13/dynamic:1), elements/src/views/ontology-edit->capabilities/docs-vault x11 (static:10/dynamic:1), +397 more)
 ✓ find_neighbors — elements/file-system-access-api (3/3 edges, limited false)
 ✓ find_path — elements/file-system-access-api → project (2 hops, 2 edges)

--- a/mcp/src/analyze.mjs
+++ b/mcp/src/analyze.mjs
@@ -272,11 +272,24 @@ function detectDomainsFromReadme(rootPath) {
         const m = lines[i].match(/^##\s+(.+?)\s*$/);
         if (!m) continue;
         const title = m[1].trim();
-        // skip generic README sections
+        // README H2 is a heuristic domain source. Skip headers that are almost
+        // never real codebase domains and only add bootstrap noise: generic doc
+        // sections, narrative / question-style headers ("Why It Exists"),
+        // language-guide headers ("한국어 가이드"), and sentence-like headers
+        // ("Three views plus MCP, one vault").
+        const wordCount = title.split(/\s+/).filter(Boolean).length;
         if (
-          /^(usage|installation|getting started|quick start|license|contributing|requirements|features|setup|status|tech stack|architecture|folder map|routes|tests?|documentation)$/i.test(
+          // generic doc sections (exact match)
+          /^(usage|installation|getting started|quick start|license|contributing|requirements|features|setup|status|tech stack|architecture|folder map|routes|tests?|documentation|overview|development|deployment|changelog|roadmap|faq|demo|examples?|guides?|table of contents|toc|acknowledge?ments?)$/i.test(
             title,
-          )
+          ) ||
+          // narrative / question-style headers
+          /^(why|what|how|when|where|who)\b/i.test(title) ||
+          // language-guide / translation section headers
+          /가이드|\bguide\b/i.test(title) ||
+          // sentence-like headers (clause separator or long phrase)
+          title.includes(',') ||
+          wordCount > 5
         ) {
           continue;
         }

--- a/mcp/src/analyze.test.mjs
+++ b/mcp/src/analyze.test.mjs
@@ -125,6 +125,35 @@ test('Generic README sections (Usage / Installation / Tests) skipped from domain
   }
 });
 
+test('Narrative / language-guide / sentence README H2s skipped from domains', () => {
+  const root = withRepo((r) => {
+    writeFileSync(
+      join(r, 'README.md'),
+      [
+        '# X',
+        '',
+        '## Why It Exists', // question/narrative prefix
+        '## What It Does', // narrative prefix
+        '## How The Memory Works', // narrative prefix
+        '## Three views plus MCP, one vault', // sentence (comma)
+        '## 한국어 가이드', // language guide
+        '## English Guide', // language guide
+        '## Billing', // real domain — kept
+        '',
+      ].join('\n'),
+    );
+  });
+  try {
+    const r = analyzeRepoStructure(root);
+    assert.deepEqual(
+      r.domains.map((d) => d.slug),
+      ['domains/billing'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('Ignored folders skip — node_modules / .git / dist', () => {
   const root = withRepo((r) => {
     mkdirSync(join(r, 'src/real'), { recursive: true });


### PR DESCRIPTION
## Summary

`analyze_repo_structure`(자동 ontology 구축의 cold-start 후보 생성기)의 **README-H2 → domain 휴리스틱이 서술형/문서 헤더를 domain 으로 오인**했다. dogfood repo 에서 domain 후보 9개 중 다음이 섞여 나와 bootstrap 후보 목록을 오염시켰다:

- `Why It Exists`, `What It Does`, `How The Memory Works` (질문/서술형)
- `Three views plus MCP, one vault` (문장)
- **`한국어 가이드`** (언어 가이드 섹션 헤더 — 명백히 domain 아님)

기존 exact-match skip-list(Usage/Installation/…)에 더해 다음을 skip 하도록 확장:
- 질문/서술형 prefix: `why|what|how|when|where|who`
- 언어 가이드 / 번역 마커: `가이드 | guide`
- 문장형 헤더: 콤마 포함 또는 5단어 초과
- 추가 doc 섹션: overview/development/deployment/changelog/roadmap/faq/demo/examples/guides/toc/…

**결과:** dogfood domain 후보 **9 → 4** (`agent-workflow`/`web-routes`/`verifiable-promises`/`local-development` 만 유지). FSD 기반 capability(20)/element(29) 후보는 영향 없음. 휴리스틱은 보수적 — 코드 구조(FSD)는 그대로 신뢰하고 README 서술 헤더 노이즈만 제거.

## Test plan

- [x] `node --test mcp/src/analyze.test.mjs` — 11/11 (신규 narrative/language/sentence skip 케이스 + 기존 Usage/Installation 케이스 호환)
- [x] `pnpm test:mcp:docs` — 52/0 (fresh MCP 서버가 라이브 4 domains 산출 → mcp/README "4 domain candidates" 정합 확인)
- [x] `pnpm integration:mcp:repo-analysis` — 1/1
- [x] `pnpm exec eslint mcp/src/analyze.mjs mcp/src/analyze.test.mjs` — 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)