### PR TITLE
fix: add name attrs to ontology tree search/sort form fields

### DIFF
--- a/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
+++ b/src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx
@@ -625,6 +625,7 @@ export function OntologyTreeView({
         <Search size={12} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
         <input
           type="search"
+          name="ontology-tree-search"
           value={searchQuery}
           onChange={(event) => setSearchQuery(event.target.value)}
           placeholder={t('tree.searchPlaceholder')}
@@ -655,6 +656,7 @@ export function OntologyTreeView({
                 {t('tree.sortLabel')}
               </span>
               <select
+                name="ontology-tree-sort"
                 value={sortKey}
                 onChange={(event) =>
                   setSortKey(event.target.value as OntologyRootSortKey)


### PR DESCRIPTION
## Summary

`/ontology` 트리 뷰의 검색 `<input type=search>` 와 정렬 `<select>` 에 `name` 속성이 없어 브라우저가 "A form field element should have an id or name attribute" 경고를 냈다 (콘솔 count 2). 둘 다 `aria-label` 은 있어 스크린리더엔 명명돼 있지만, `id`/`name` 부재로 폼 필드 연관/자동완성 경고가 발생. 안정적 `name`(`ontology-tree-search` / `ontology-tree-sort`) 부여.

## Test plan

- [x] `pnpm exec tsc --noEmit` — 0
- [x] `pnpm exec eslint src/widgets/ontology-tree-view/ui/OntologyTreeView.tsx` — 0
- [x] 브라우저: `/ko/ontology` 리로드 후 콘솔 폼-필드 경고 0 (이전 count 2 → 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)