### PR TITLE
fix: mobile content clipping on /ontology (add w-full to main)

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -346,7 +346,7 @@ export function OntologyInsightsPage() {
   return (
     <div>
       <OperationsNav />
-      <main id="main" className="mx-auto max-w-5xl px-5 py-8 md:px-8 md:py-12">
+      <main id="main" className="mx-auto w-full max-w-5xl px-5 py-8 md:px-8 md:py-12">
       <MountedGlobalSearch />
 
       <section className="mb-8 space-y-3">

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -244,7 +244,7 @@ export function OntologyViewPage() {
           가운데 몰려 보이는 회귀 회피). 'ontology surface' 인 / 와 /ontology*
           에선 OperationsNav 가 SubNav 행을 inline 으로 함께 렌더. */}
       <OperationsNav />
-      <main id="main" className="mx-auto max-w-5xl overflow-hidden px-5 py-8 md:px-8 md:py-12">
+      <main id="main" className="mx-auto w-full max-w-5xl overflow-hidden px-5 py-8 md:px-8 md:py-12">
       <section className="mb-8 space-y-3">
         {/* eyebrow 는 SubNav 의 'ONTOLOGY' caption 과 중복 → 제거. */}
         <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">


### PR DESCRIPTION
## Summary

`/ontology` · `/ontology/insights` 의 `<main>` 이 `mx-auto max-w-5xl` 인데 **`w-full` 이 빠져** 모바일에서 콘텐츠가 잘렸다. `body` 가 `flex flex-col` 이라 main 의 `mx-auto`(auto 좌우 마진)가 flex stretch 를 꺼서 main 이 콘텐츠 max-content(~1024px)로 커지고, `body` 의 `overflow-x-hidden` 이 우측을 잘라 **390px 뷰포트에서 카드 텍스트가 잘려 읽히지 않고 스크롤도 안 됐다.**

캐노니컬 중앙정렬 컨테이너 패턴 `mx-auto w-full max-w-5xl` 로 정정. landing/docs/download main 은 이미 `w-full` 을 써서 정상 reflow 됐고, 이 두 ontology main 만 누락돼 있었다. 데스크톱 거동 불변(>1024px 에서 `w-full`=100% 가 `max-w-5xl` 로 cap + `mx-auto` 중앙정렬).

## Test plan

- [x] 모바일 390px (chrome-devtools): `/ontology` `bodyScrollWidth` 1024→390, `main` 1024→390, 가로 오버플로 0, 카드 전부 reflow·텍스트 줄바꿈(before/after 스크린샷 확인)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint <두 파일>` 0
- [x] 데스크톱 거동 불변 (w-full + max-w-5xl + mx-auto = 기존과 동일 렌더)

## Known follow-up (이 PR 범위 밖)

`/ontology/insights` 는 main 폭은 교정됐으나 **내부에 별도 오버플로**가 남음 — CLI 명령 리스트 `<li>`(~888px, 긴 명령 문자열 비줄바꿈)와 collaborator/review brief 카드 2-그리드가 모바일에서 안 쌓임. 별도 반응형 작업(코드블록 wrap/scroll + 카드 그리드 stack)으로 후속 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)