### PR TITLE
WIP: /ontology/insights mobile responsiveness (needs review)

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -1559,7 +1559,7 @@ function InsightsCollaboratorBriefPanel({
           </div>
         ))}
       </div>
-      <div className="mt-3 grid gap-2 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+      <div className="mt-3 grid grid-cols-1 gap-2 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
         <div className="rounded-md border border-[color:rgba(139,151,255,0.14)] bg-[color:rgba(255,255,255,0.035)] px-3 py-2.5">
           <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
             {t("collaboratorTopHubs")}


### PR DESCRIPTION
> **DRAFT — 리뷰/방향 필요.** 자가개선 루프가 ③ insights 워크스트림에서 발견·진단한 모바일 반응형 이슈. 표시 방식이 UX 결정을 포함해 단독 머지하지 않고 제안으로 올림.

## 발견 (객관적 버그)

`/ontology/insights` 는 모바일(390px)에서 콘텐츠가 우측으로 잘려 읽히지 않음 — `bodyScrollWidth` 1052 @ 390px, `body` 의 `overflow-x-hidden` 이 클리핑해 스크롤도 안 됨. (직전 #281 이 `<main>` 폭은 고쳤으나 내부 요소가 잔존.)

**두 원인:**
1. **그리드 base 누락** — 일부 그리드가 `grid gap-2 lg:grid-cols-[…]` 처럼 lg 에서만 멀티컬럼을 지정하고 모바일 base(`grid-cols-1`)가 없어, 모바일에서 content-sized 단일 컬럼(~499px)으로 커짐. → 이 PR 에서 brief 2-그리드(`:1562`)에 `grid-cols-1` 추가로 정정.
2. **(주범, 미해결)** graph-db pack / CLI fallback **명령 리스트의 긴 mono 문자열** — `<li>` ~888px ("oh-my-ontology blast-radius capability:cli-developer-entry [vault] --plan --depth 2" 등)이 줄바꿈/스크롤 없이 오버플로. 이게 잔여 오버플로의 대부분.

## 결정 필요 (이래서 draft)

CLI 명령의 모바일 표시 방식 — 둘 중 선호?
- **(A) 줄바꿈** — 명령 컨테이너에 `break-words`/`break-all`. 한 화면에 다 보이나 긴 slug 가 중간에 끊김.
- **(B) 코드블록 가로 스크롤** — 각 명령 블록 `overflow-x-auto`. 명령이 한 줄로 유지되고 좌우 스와이프(코드 표준). 권장.

방향 주면 명령 리스트 컴포넌트들(여러 곳)에 일괄 적용해 insights 모바일을 마저 고치고 normal PR 로 전환할게.

## 현재 포함

- `:1562` brief 그리드 `grid-cols-1` base 추가 (tsc 0, lint 0). 데스크톱 거동 불변(lg+ 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)