### PR TITLE
fix: add name attrs to ProjectForm fields (a11y/autofill)

### DIFF
--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1022,6 +1022,7 @@ export function ProjectForm({
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <FieldRow label={t("fields.tagsCsv")}>
               <Input
+                name="tagsCsv"
                 value={values.tagsCsv ?? ""}
                 onChange={(v) => setValue("tagsCsv", v)}
                 placeholder={t("fields.tagsPlaceholder")}
@@ -1030,6 +1031,7 @@ export function ProjectForm({
 
             <FieldRow label={t("fields.stackCsv")}>
               <Input
+                name="stackCsv"
                 value={values.stackCsv ?? ""}
                 onChange={(v) => setValue("stackCsv", v)}
                 placeholder={t("fields.stackPlaceholder")}
@@ -1044,6 +1046,7 @@ export function ProjectForm({
             errorTestId="project-error-links"
           >
             <Textarea
+              name="linksText"
               data-testid="project-input-links"
               value={values.linksText ?? ""}
               onChange={(v) => setValue("linksText", v)}
@@ -1111,6 +1114,7 @@ export function ProjectForm({
               errorTestId="project-error-startedAt"
             >
               <Input
+                name="startedAt"
                 data-testid="project-input-started-at"
                 type="date"
                 value={values.startedAt ?? ""}
@@ -1124,6 +1128,7 @@ export function ProjectForm({
               errorTestId="project-error-launchedAt"
             >
               <Input
+                name="launchedAt"
                 data-testid="project-input-launched-at"
                 type="date"
                 value={values.launchedAt ?? ""}
@@ -1135,6 +1140,7 @@ export function ProjectForm({
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
             <FieldRow label={t("fields.owner")}>
               <Input
+                name="owner"
                 value={values.owner ?? ""}
                 onChange={(v) => setValue("owner", v)}
                 placeholder={t("fields.ownerPlaceholder")}
@@ -1143,6 +1149,7 @@ export function ProjectForm({
 
             <FieldRow label={t("fields.icon")}>
               <Input
+                name="icon"
                 value={values.icon ?? ""}
                 onChange={(v) => setValue("icon", v)}
                 placeholder={t("fields.iconPlaceholder")}
@@ -1151,6 +1158,7 @@ export function ProjectForm({
 
             <FieldRow label={t("fields.progress")}>
               <Input
+                name="progress"
                 type="number"
                 value={
                   values.progress !== undefined ? String(values.progress) : ""
@@ -1166,6 +1174,7 @@ export function ProjectForm({
           <label className="flex items-center gap-2 text-sm text-[color:var(--color-text-secondary)]">
             <input
               type="checkbox"
+              name="isHub"
               checked={values.isHub}
               onChange={(e) => setValue("isHub", e.target.checked)}
               className="h-4 w-4 accent-[color:var(--color-indigo-brand)]"


### PR DESCRIPTION
## Summary

`/project/[slug]/edit` (ProjectForm) 의 controlled 입력 9개가 `name`/`id` 없이 렌더돼 브라우저 "form field should have an id or name" 경고 + autofill 연관이 누락됐다 (mobile 점검에서 미명명 필드 10개 발견). 공유 `Input`/`Textarea`/`Select` 가 이미 `...props` 를 spread 하므로 call-site 에 `name` 만 부여:

`tagsCsv` · `stackCsv` · `linksText` · `startedAt` · `launchedAt` · `owner` · `icon` · `progress` · `isHub`

기존에 명시돼 있던 `slug`/`name`/`category`/`status`/`description` 과 일관.

## Test plan

- [x] `/project/[slug]/edit` 미명명 form 필드 10→1 (chrome-devtools; 남은 1개는 별도 검색 위젯, follow-up)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint ProjectForm.tsx` 0

## Follow-up (범위 밖)

편집 페이지의 검색 input 1개(별도 위젯, i18n placeholder)가 아직 미명명 — 다음 사이클.

🤖 Generated with [Claude Code](https://claude.com/claude-code)