### PR TITLE
fix: name + aria-label DependencyPicker search input

### DIFF
--- a/src/features/project-edit/ui/DependencyPicker.tsx
+++ b/src/features/project-edit/ui/DependencyPicker.tsx
@@ -243,9 +243,11 @@ export function DependencyPicker({
         <Search size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
         <input
           type="text"
+          name="dependency-search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t('searchPlaceholder')}
+          aria-label={t('searchPlaceholder')}
           className="flex-1 bg-transparent text-xs text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
         />
       </div>


### PR DESCRIPTION
## Summary

ProjectForm dependencies 필드의 `DependencyPicker` 검색 `<input>` 이 `name`/`id` 없이 렌더돼 브라우저 form-field 경고가 남아 있었다 (#283 이후 `/project/[slug]/edit` 잔여 1건). `name="dependency-search"` + `aria-label`(기존 `dependencyPicker.searchPlaceholder` 키 재사용 — 메시지 파일 변경 0) 부여.

## Test plan

- [x] `/project/[slug]/edit` 미명명 form 필드 **1→0** (chrome-devtools)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint DependencyPicker.tsx` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)