### PR TITLE
fix: name OntologyInspector text inputs (a11y/autofill)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -292,6 +292,7 @@ function EphemeralDetail({
         </span>
         <input
           ref={nameInputRef}
+          name="node-title"
           type="text"
           value={node.title}
           onChange={(e) => onRename(node.id, e.target.value)}
@@ -417,6 +418,7 @@ function VaultDetail({
           {t("vaultTitleLabel")}
         </span>
         <input
+          name="vault-title"
           type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -748,6 +750,7 @@ function ArrayKeyEditor({
       ) : null}
       <div className="mt-2 flex gap-1">
         <input
+          name="array-item"
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}


### PR DESCRIPTION
## Summary

빌더 인스펙터(OntologyInspector)의 텍스트 input 3개가 `name` 없이 렌더돼 브라우저 form-field 경고가 떴다: 노드 이름(`node-title`), vault 제목(`vault-title`), 배열 항목 추가(`array-item`). 세 곳에 `name` 부여. node-title/vault-title 은 wrapping `<label>` 로 접근명은 이미 있고 `name` 만 누락이었음.

## Test plan

- [x] `/ontology/edit` 미명명 form 필드 **1→0** (chrome-devtools, 기본 렌더)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint OntologyInspector.tsx` 0

## Follow-up

같은 파일의 범용 `EditableField` input(:638)은 여러 필드에 재사용돼 정적 `name` 이 부적절 — `name` prop threading 필요(별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)