### PR TITLE
fix: name LiteralEditor inputs via fieldKey (a11y)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -628,6 +628,7 @@ function LiteralEditor({
       </p>
       {multiline ? (
         <textarea
+          name={`literal-${fieldKey}`}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
@@ -638,6 +639,7 @@ function LiteralEditor({
         />
       ) : (
         <input
+          name={`literal-${fieldKey}`}
           type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}


### PR DESCRIPTION
## Summary

인스펙터 재사용 inline 에디터 `LiteralEditor` 의 `<input>`/`<textarea>` 가 `name` 없이 렌더돼 form-field 경고가 남았다 (#285 follow-up). 컴포넌트가 이미 받는 `fieldKey`("domain"/"description")로 `name={\`literal-${fieldKey}\`}` 부여 — 새 prop·call-site 변경 0, 인스턴스별 distinct name. 라벨은 `<p>{literalLabel}` 로 이미 존재.

## Test plan

- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint OntologyInspector.tsx` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)