### PR TITLE
fix: locale toggle accessible name includes visible text

### DIFF
--- a/src/features/locale-switch/ui/LocaleSwitch.tsx
+++ b/src/features/locale-switch/ui/LocaleSwitch.tsx
@@ -56,7 +56,7 @@ export function LocaleSwitch() {
             onClick={() => switchTo(code)}
             disabled={isPending}
             aria-pressed={active}
-            aria-label={t(nameKey)}
+            aria-label={`${label} ${t(nameKey)}`}
             className={
               'rounded-[4px] px-2 py-1 font-medium transition-colors ' +
               (active


### PR DESCRIPTION
## Summary

`LocaleSwitch` 토글 버튼의 visible 텍스트("EN"/"KO")가 `aria-label`(전체 언어명 "English"/"한국어")에 포함되지 않아 WCAG **label-in-name** 위반 — Lighthouse a11y `label-content-name-mismatch` 실패. `aria-label` 을 `${label} ${t(nameKey)}`(예: "KO 한국어")로 바꿔 visible 텍스트를 포함시키면서 전체 언어명도 유지.

## Test plan

- [x] Lighthouse(landing `/ko/`, desktop) a11y 감사 **통과 52→53 / 실패 2→1** (label-content-name-mismatch 해소)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint LocaleSwitch.tsx` 0

## Known remaining (범위 밖)

landing 의 GitHub releases 링크 `color-contrast` 부족(a11y 잔여 1) — 색 변경은 디자인 시스템(단일 인디고/토큰) 민감이라 디자인 판단 필요, 자율 수정 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)