### PR TITLE
fix: label-in-name on /ontology hub action buttons (partial)

### DIFF
--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -296,7 +296,7 @@ export function OntologyViewPage() {
 	              >
 	                <Search size={13} aria-hidden />
 	                <span className="hidden sm:inline">{t('actions.search')}</span>
-	                <kbd className="hidden font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline">⌘K</kbd>
+	                <kbd className="hidden font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline" aria-hidden>⌘K</kbd>
 	              </button>
 	            </Tooltip>
             {/* 노드 + 프로젝트 통합 검색 — ⇧⌘K 단축키 (이전엔 단축키만
@@ -307,12 +307,12 @@ export function OntologyViewPage() {
               <button
                 type="button"
                 onClick={() => setGlobalSearchOpen(true)}
-                aria-label={t('actions.globalSearchAria')}
+                aria-label={`${t('actions.globalSearch')} — ${t('actions.globalSearchAria')}`}
 	                className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-primary)]"
 	              >
 	                <Network size={13} aria-hidden />
 	                <span className="hidden sm:inline">{t('actions.globalSearch')}</span>
-	                <kbd className="hidden font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline">⇧⌘K</kbd>
+	                <kbd className="hidden font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline" aria-hidden>⇧⌘K</kbd>
 	              </button>
 	            </Tooltip>
 	            <Tooltip content={t('actions.queryTooltip')} withProvider={false}>
@@ -329,7 +329,7 @@ export function OntologyViewPage() {
               <Link
                 href={builderHref}
                 className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-brand)] px-4 text-xs font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90"
-                aria-label={t('actions.builderAria')}
+                aria-label={`${t('actions.builder')} — ${t('actions.builderAria')}`}
               >
                 <PencilLine size={13} aria-hidden />
                 {t('actions.builder')}


### PR DESCRIPTION
## Summary

`/ontology` 허브 액션 버튼(검색·전체·빌더)이 visible 텍스트를 accessible name 에 포함하지 않아 WCAG **label-in-name** 위반(Lighthouse `label-content-name-mismatch`):
- 검색·전체: 단축키 `<kbd>`(⌘K·⇧⌘K)를 `aria-hidden` → name 계산 제외.
- 전체·빌더: `aria-label` 을 `${visible} — ${descriptiveAria}` 로 조합해 visible 텍스트("전체"/"빌더 열기") 포함. **i18n 값 변경 0.**

## Test plan
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint OntologyViewPage.tsx` 0
- [x] 대상 3개 요소의 accessible name 이 visible 텍스트 포함(논리 검증)

## ⚠️ Known systemic remainder (이 PR 범위 밖 — Lighthouse 감사는 여전히 red)

동일 label-in-name 위반이 **ontology 트리 행 버튼 전체**(visible KindChip 라벨이 row aria-label 에 미포함, ~50개)·워크플로 카드·경고 버튼에도 존재. `KindChip` 이 트리 밖(orphan 카드·ego graph)에서도 쓰여 단순 aria-hidden 불가 — **컨텍스트별 처리 + 라벨 관계 판단이 필요한 전용 a11y 패스**가 별도로 필요. (이 PR 은 허브 3버튼만 부분 해소.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)