### PR TITLE
fix: /projects heading order (card titles → h2)

### DIFF
--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -22,18 +22,19 @@ export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivEleme
 );
 CardHeader.displayName = 'CardHeader';
 
-export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3
-      ref={ref}
-      className={cn(
-        'text-lg tracking-[var(--tracking-card)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]',
-        className,
-      )}
-      {...props}
-    />
-  ),
-);
+export const CardTitle = forwardRef<
+  HTMLHeadingElement,
+  HTMLAttributes<HTMLHeadingElement> & { as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' }
+>(({ className, as: Tag = 'h3', ...props }, ref) => (
+  <Tag
+    ref={ref}
+    className={cn(
+      'text-lg tracking-[var(--tracking-card)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]',
+      className,
+    )}
+    {...props}
+  />
+));
 CardTitle.displayName = 'CardTitle';
 
 export const CardDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -336,7 +336,7 @@ export function ProjectSelectorPage() {
           {filteredProjects.length === 0 ? (
             <Card className="rounded-[24px]">
               <CardHeader>
-                <CardTitle>
+                <CardTitle as="h2">
                   {projects.length === 0
                     ? t("emptyTitleNoProjects")
                     : t("emptyTitleNoResults")}
@@ -430,7 +430,7 @@ export function ProjectSelectorPage() {
                           aria-label={t("cardDetailAriaLabel", { name: project.name })}
                           className="min-w-0 rounded-md after:absolute after:inset-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
                         >
-                          <CardTitle className="truncate break-keep">{project.name}</CardTitle>
+                          <CardTitle as="h2" className="truncate break-keep">{project.name}</CardTitle>
                           <CardDescription className="mt-2 line-clamp-2 break-keep">
                             {project.description || t("cardDescriptionFallback")}
                           </CardDescription>


### PR DESCRIPTION
## Summary

`/projects` 는 `h1`("프로젝트") 다음 카드 제목이 곧장 `h3`(공유 `CardTitle` 이 `<h3>` 하드코딩)이라 `h2` 를 건너뛰어 WCAG **heading-order** 위반(Lighthouse `heading-order`). `CardTitle` 에 optional `as` prop 추가(기본 `h3` — 기존 사용처 무변경)하고 ProjectSelectorPage 의 top-level 카드 제목(empty-state + 프로젝트 카드)에 `as="h2"` 부여.

## Test plan
- [x] Lighthouse(/projects, desktop) a11y **95→96**, heading-order 통과(Passed 53→54)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0 · `card.test` 7/7(기본 h3 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)