### PR TITLE
fix: project editor skip-link target (add id=main)

### DIFF
--- a/src/views/project-editor/ui/ProjectEditorPage.tsx
+++ b/src/views/project-editor/ui/ProjectEditorPage.tsx
@@ -223,7 +223,7 @@ function EditorContent({
   }
 
   return (
-    <main className="min-h-screen bg-[color:var(--color-canvas)] px-4 py-8 md:px-12 md:py-10">
+    <main id="main" className="min-h-screen bg-[color:var(--color-canvas)] px-4 py-8 md:px-12 md:py-10">
       <div className="mx-auto max-w-4xl">
         <Link
           href={safeReturnTo}


### PR DESCRIPTION
## Summary

공유 헤더의 스킵 링크 `<a href="#main">` 가 `ProjectEditorPage`(/project/new · /project/[slug]/edit)에서 타깃을 못 찾았다 — 이 페이지의 `<main>` 만 `id="main"` 이 없어 Lighthouse `skip-link`("Skip links are not focusable") 실패. 다른 페이지는 `<main id="main">` 이라 정상. `id="main"` 부여로 정합.

## Test plan
- [x] Lighthouse(/project/new, desktop) a11y **95→96, skip-link 통과**(Passed 53→54)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0
- [x] `/project/[slug]/edit` 도 동일 컴포넌트라 함께 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)