### PR TITLE
fix: docs vault skip-link target (add id=main)

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -309,7 +309,7 @@ function DesktopVaultWelcome({
   ] as const;
 
   return (
-    <main className="flex min-h-0 flex-1 overflow-auto bg-[color:var(--color-canvas)]">
+    <main id="main" className="flex min-h-0 flex-1 overflow-auto bg-[color:var(--color-canvas)]">
       <div className="mx-auto grid w-full max-w-5xl content-start gap-8 px-5 py-8 md:px-8 md:py-12">
         <section className="grid gap-3">
           <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
@@ -1855,7 +1855,7 @@ function DocsVaultContent() {
         ) : null}
 
         {/* 본문 + 우측 사이드 */}
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <main id="main" className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {view === 'folder-topology' ? (
             <div className="relative flex min-h-0 flex-1">
               {canEditCurrent && folderTopo && folderTopo.projects.length > 0 ? (


### PR DESCRIPTION
## Summary

`/docs` 의 두 상태별 `<main>`(welcome/empty-state + 로드된 doc-view) 모두 `id="main"` 이 없어 공유 스킵 링크 `<a href="#main">` 의 타깃이 없었다 — Lighthouse `skip-link` 실패. 두 main 은 배타적 render 분기(동시 렌더 X)라 둘 다 `id="main"` 부여해도 DOM 중복 없음.

## Test plan
- [x] Lighthouse(/docs, desktop) a11y **94→96, skip-link 통과**(Passed 53→54)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)