### PR TITLE
fix: skip-link target coverage (remaining routed mains)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -1286,6 +1286,7 @@ export function OntologyEditPage() {
         }}
       />
       <main
+        id="main"
         className={
           fullscreen
             ? "flex h-dvh w-full flex-col px-2 py-2"

--- a/src/views/root-entry/ui/RootEntryPage.tsx
+++ b/src/views/root-entry/ui/RootEntryPage.tsx
@@ -55,6 +55,7 @@ function DesktopVaultRedirect() {
 
   return (
     <main
+      id="main"
       aria-busy="true"
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6"
     >


### PR DESCRIPTION
## Summary

공통 `layout.tsx` 의 스킵 링크 `<a href="#main">` 는 모든 라우트에 렌더되지만 `/ontology/edit`(OntologyEditPage)와 루트 진입 로딩 화면(RootEntryPage)의 `<main>` 에만 `id="main"` 이 없어 타깃이 비어 있었다 — Lighthouse `skip-link` 실패. 나머지 routed `<main>` 은 모두 `id="main"` 보유. #290(/project editor)·#291(/docs)에 이은 마지막 커버리지 보완.

## Test plan
- [x] Lighthouse(/ontology/edit, desktop) `skip-link` score **0→1**, a11y 97
- [x] RootEntryPage 는 transient 로딩 화면이라 audit 어렵지만 동일 패턴의 1줄 속성 추가 (다른 모든 routed main 과 일치)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)