### PR TITLE
fix: align project page titles to Context Atlas siteName

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1512,7 +1512,7 @@
       "workspaceMap": "Workspace map",
       "headerEyebrow": "Project list",
       "headerTitle": "Projects",
-      "documentTitle": "Projects · oh-my-ontology",
+      "documentTitle": "Projects · Context Atlas",
       "countTotal": "{count}",
       "countFiltered": "{filtered} / {total}",
       "searchPlaceholder": "Search by name, description, tag…",
@@ -1637,8 +1637,8 @@
       "linksRemoveAria": "Remove {label}"
     },
     "editor": {
-      "documentTitleEdit": "Edit project · oh-my-ontology",
-      "documentTitleNew": "New project · oh-my-ontology",
+      "documentTitleEdit": "Edit project · Context Atlas",
+      "documentTitleNew": "New project · Context Atlas",
       "confirmDiscardChanges": "You have unsaved changes. Leave anyway?",
       "loadErrorEdit": "Project not found.",
       "loadErrorDuplicate": "The project to duplicate could not be found.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1512,7 +1512,7 @@
       "workspaceMap": "워크스페이스 지도",
       "headerEyebrow": "프로젝트 목록",
       "headerTitle": "프로젝트",
-      "documentTitle": "프로젝트 · oh-my-ontology",
+      "documentTitle": "프로젝트 · Context Atlas",
       "countTotal": "{count}개",
       "countFiltered": "{filtered} / {total}",
       "searchPlaceholder": "이름, 설명, 태그로 검색…",
@@ -1637,8 +1637,8 @@
       "linksRemoveAria": "{label} 제거"
     },
     "editor": {
-      "documentTitleEdit": "프로젝트 편집 · oh-my-ontology",
-      "documentTitleNew": "새 프로젝트 · oh-my-ontology",
+      "documentTitleEdit": "프로젝트 편집 · Context Atlas",
+      "documentTitleNew": "새 프로젝트 · Context Atlas",
       "confirmDiscardChanges": "저장하지 않은 변경사항이 있습니다. 정말 나갈까요?",
       "loadErrorEdit": "프로젝트를 찾을 수 없습니다.",
       "loadErrorDuplicate": "복제할 프로젝트를 찾을 수 없습니다.",


### PR DESCRIPTION
## Summary

앱 표시명(`metadata.siteName`)은 metadata 제목 템플릿(`%s · Context Atlas`)·`og:title`·`manifest.ts`·landing H1·locale-redirect 전부에서 **"Context Atlas"** 로 통일돼 있는데, client-side `useDocumentTitle` 이 읽는 프로젝트 화면 3개 메시지만 이전 이름 **"oh-my-ontology"** 접미사로 남아 있었다:

- `projectPages.selector.documentTitle` — `/projects`
- `projectPages.editor.documentTitleEdit` — `/project/[slug]/edit`
- `projectPages.editor.documentTitleNew` — `/project/new`

결과적으로 해당 화면들은 `og:title="Context Atlas"` 인데 브라우저 `<title>` 은 `"… · oh-my-ontology"` 로 같은 페이지가 자기모순. `siteName → Context Atlas` 리네임 때 누락된 stale string (en+ko 6개) 을 정렬했다. (생성 archive 감사 문서가 *"title metadata template `'%s · oh-my-ontology'` 일관"* 이라 기록 — 리네임 이전 상태 확인됨.)

## Test plan
- [x] `/projects` `<title>`: `"프로젝트 · oh-my-ontology"` → `"프로젝트 · Context Atlas"` (playwright, og:title 과 정합 확인)
- [x] en↔ko 메시지 키 균형 2595=2595 유지, 제목 접미사 `· oh-my-ontology` 잔여 0
- [x] `pnpm exec tsc --noEmit` 0 · lint 0 · 해당 string 단언 테스트 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)