### PR TITLE
test: guard document-title messages against brand drift

### DIFF
--- a/src/shared/lib/document-title-brand.test.ts
+++ b/src/shared/lib/document-title-brand.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * i18n 제목 메시지의 브랜드 일관성 가드.
+ *
+ * 앱 표시명은 `metadata.siteName` 단일 출처이고, metadata 제목 템플릿은
+ * `%s · {siteName}` 이다. client-side `useDocumentTitle` 이 소비하는 정적
+ * `documentTitle*` 메시지도 같은 브랜드 접미사를 써야 한다. 구분자(' · ')를
+ * 포함한 제목 값이 siteName 으로 끝나지 않으면 brand drift 회귀다 (#293 —
+ * siteName 을 "Context Atlas" 로 리네임할 때 3개 메시지가 "oh-my-ontology"
+ * 접미사로 남아 같은 페이지의 og:title 과 <title> 이 어긋났던 사건).
+ */
+
+const LOCALES = ["en", "ko"] as const;
+const TITLE_SEPARATOR = " · ";
+
+type MessageTree = { [key: string]: string | MessageTree };
+
+function loadMessages(locale: string): MessageTree {
+  const file = path.join(process.cwd(), "messages", `${locale}.json`);
+  return JSON.parse(readFileSync(file, "utf8")) as MessageTree;
+}
+
+function flatten(
+  tree: MessageTree,
+  prefix = "",
+  acc: Record<string, string> = {},
+): Record<string, string> {
+  for (const [key, value] of Object.entries(tree)) {
+    const keyPath = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object") {
+      flatten(value, keyPath, acc);
+    } else if (typeof value === "string") {
+      acc[keyPath] = value;
+    }
+  }
+  return acc;
+}
+
+describe("i18n document-title brand consistency", () => {
+  for (const locale of LOCALES) {
+    const flat = flatten(loadMessages(locale));
+    const siteName = flat["metadata.siteName"];
+
+    const titleSuffixEntries = Object.entries(flat).filter(
+      ([key, value]) =>
+        /documentTitle/i.test(key) && value.includes(TITLE_SEPARATOR),
+    );
+
+    it(`[${locale}] defines metadata.siteName`, () => {
+      expect(siteName).toBeTruthy();
+    });
+
+    it(`[${locale}] has separator-bearing document-title messages to guard`, () => {
+      // 가드 대상이 사라지면 테스트가 무의미해지므로 최소 1개는 존재해야 한다.
+      expect(titleSuffixEntries.length).toBeGreaterThan(0);
+    });
+
+    it.each(titleSuffixEntries)(
+      `[${locale}] "%s" ends with siteName`,
+      (key, value) => {
+        expect(
+          value.endsWith(`${TITLE_SEPARATOR}${siteName}`),
+          `${key} = ${JSON.stringify(value)} should end with "${TITLE_SEPARATOR}${siteName}"`,
+        ).toBe(true);
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary

#293 (project 화면 제목이 옛 "oh-my-ontology" 접미사로 남아 같은 페이지의 `og:title` 과 `<title>` 이 어긋났던 brand drift) 의 회귀 차단 테스트.

- 앱 표시명은 `metadata.siteName` 단일 출처, metadata 제목 템플릿은 `%s · {siteName}`.
- client-side `useDocumentTitle` 이 읽는 정적 `documentTitle*` 메시지도 같은 브랜드 접미사를 써야 한다.
- 구분자(`' · '`)를 포함한 `documentTitle*` 값이 **해당 locale 의 siteName** 으로 끝나는지 en/ko 양쪽에서 단언. siteName 은 하드코딩하지 않고 메시지에서 파생 — 다음에 siteName 이 바뀌면 테스트가 자동으로 따라간다.
- 가드 대상이 0개로 사라지는 회귀(키 삭제·이름 변경)도 `length > 0` 으로 차단.
- `documentTitleSuffix`("Demo") · `topology.documentTitle`("Topology") 처럼 구분자 없는 값은 자연히 면제.

## Test plan
- [x] `pnpm test:run src/shared/lib/document-title-brand.test.ts` — 10/10 통과
- [x] negative: en 메시지를 옛 `"Projects · oh-my-ontology"` 로 되돌리면 정확히 1 fail (해당 키 지목) 후 복구
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)