### PR TITLE
fix: associate project form labels with inputs (a11y)

### DIFF
--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1020,8 +1020,9 @@ export function ProjectForm({
           </FieldRow>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <FieldRow label={t("fields.tagsCsv")}>
+            <FieldRow label={t("fields.tagsCsv")} fieldId={PROJECT_FIELD_IDS.tagsCsv}>
               <Input
+                id={PROJECT_FIELD_IDS.tagsCsv}
                 name="tagsCsv"
                 value={values.tagsCsv ?? ""}
                 onChange={(v) => setValue("tagsCsv", v)}
@@ -1029,8 +1030,9 @@ export function ProjectForm({
               />
             </FieldRow>
 
-            <FieldRow label={t("fields.stackCsv")}>
+            <FieldRow label={t("fields.stackCsv")} fieldId={PROJECT_FIELD_IDS.stackCsv}>
               <Input
+                id={PROJECT_FIELD_IDS.stackCsv}
                 name="stackCsv"
                 value={values.stackCsv ?? ""}
                 onChange={(v) => setValue("stackCsv", v)}
@@ -1044,8 +1046,10 @@ export function ProjectForm({
             label={t("fields.linksText")}
             error={errors.linksText}
             errorTestId="project-error-links"
+            fieldId={PROJECT_FIELD_IDS.linksText}
           >
             <Textarea
+              id={PROJECT_FIELD_IDS.linksText}
               name="linksText"
               data-testid="project-input-links"
               value={values.linksText ?? ""}
@@ -1112,8 +1116,10 @@ export function ProjectForm({
               label={t("fields.startedAt")}
               error={errors.startedAt}
               errorTestId="project-error-startedAt"
+              fieldId={PROJECT_FIELD_IDS.startedAt}
             >
               <Input
+                id={PROJECT_FIELD_IDS.startedAt}
                 name="startedAt"
                 data-testid="project-input-started-at"
                 type="date"
@@ -1126,8 +1132,10 @@ export function ProjectForm({
               label={t("fields.launchedAt")}
               error={errors.launchedAt}
               errorTestId="project-error-launchedAt"
+              fieldId={PROJECT_FIELD_IDS.launchedAt}
             >
               <Input
+                id={PROJECT_FIELD_IDS.launchedAt}
                 name="launchedAt"
                 data-testid="project-input-launched-at"
                 type="date"
@@ -1138,8 +1146,9 @@ export function ProjectForm({
           </div>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            <FieldRow label={t("fields.owner")}>
+            <FieldRow label={t("fields.owner")} fieldId={PROJECT_FIELD_IDS.owner}>
               <Input
+                id={PROJECT_FIELD_IDS.owner}
                 name="owner"
                 value={values.owner ?? ""}
                 onChange={(v) => setValue("owner", v)}
@@ -1147,8 +1156,9 @@ export function ProjectForm({
               />
             </FieldRow>
 
-            <FieldRow label={t("fields.icon")}>
+            <FieldRow label={t("fields.icon")} fieldId={PROJECT_FIELD_IDS.icon}>
               <Input
+                id={PROJECT_FIELD_IDS.icon}
                 name="icon"
                 value={values.icon ?? ""}
                 onChange={(v) => setValue("icon", v)}
@@ -1156,8 +1166,9 @@ export function ProjectForm({
               />
             </FieldRow>
 
-            <FieldRow label={t("fields.progress")}>
+            <FieldRow label={t("fields.progress")} fieldId={PROJECT_FIELD_IDS.progress}>
               <Input
+                id={PROJECT_FIELD_IDS.progress}
                 name="progress"
                 type="number"
                 value={


### PR DESCRIPTION
## Summary

`ProjectForm` 의 8개 필드 — 태그(CSV)·스택(CSV)·링크·시작일·출시일·담당자·아이콘·진행도 — 의 `FieldRow` 라벨이 입력과 프로그램적으로 연결돼 있지 않았다(`htmlFor`/`id` 누락). 결과적으로 접근성 트리에서 이 입력들의 **accessible name 이 visible 라벨이 아니라 placeholder** 로 떨어졌다 (`label-content-name-mismatch`). 예: "태그 (CSV)" 라벨인데 accessible name 은 "AI, MCP, Portfolio".

`PROJECT_FIELD_IDS` 에 해당 id 들은 **이미 정의돼 있었으나 미배선** 상태였다. slug/name/category/description 등 정상 필드와 동일하게 `FieldRow fieldId={…}` + `Input/Textarea id={…}` 를 연결했다. `/project/new` 와 `/project/[slug]/edit` 양쪽이 같은 폼을 쓰므로 둘 다 개선된다. (`dependencies` 는 `DependencyPicker` 복합 컴포넌트라 자체 aria-label 보유 — 제외.)

## Test plan
- [x] playwright: 8개 필드 모두 라이브 DOM 에서 `label[for]=id` 연결 + `labelText` 가 visible 라벨과 일치 확인 (tags→"태그 (CSV)", owner→"담당자", progress→"진행도 %" 등)
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0 · `pnpm test:run src/features/project-edit` 22/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)