### PR TITLE
fix: associate ontology inspector field labels with inputs (a11y)

### DIFF
--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -623,11 +623,15 @@ function LiteralEditor({
     "w-full rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50";
   return (
     <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <label
+        htmlFor={`literal-${fieldKey}`}
+        className="block font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
+      >
         {literalLabel(t, fieldKey)}
-      </p>
+      </label>
       {multiline ? (
         <textarea
+          id={`literal-${fieldKey}`}
           name={`literal-${fieldKey}`}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -639,6 +643,7 @@ function LiteralEditor({
         />
       ) : (
         <input
+          id={`literal-${fieldKey}`}
           name={`literal-${fieldKey}`}
           type="text"
           value={draft}
@@ -720,9 +725,12 @@ function ArrayKeyEditor({
   };
   return (
     <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <label
+        htmlFor={`array-${fieldKey}`}
+        className="block font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
+      >
         {arrayLabel(t, fieldKey)}
-      </p>
+      </label>
       {values.length > 0 ? (
         <ul className="mt-2 flex flex-wrap gap-1">
           {values.map((slug) => {
@@ -752,6 +760,7 @@ function ArrayKeyEditor({
       ) : null}
       <div className="mt-2 flex gap-1">
         <input
+          id={`array-${fieldKey}`}
           name="array-item"
           type="text"
           value={input}


### PR DESCRIPTION
## Summary

`/ontology/edit` 인스펙터의 `LiteralEditor` / `ArrayKeyEditor` 필드 라벨이 `<p>` 로 렌더되고 input/textarea 와 프로그램적으로 연결돼 있지 않았다(`htmlFor`/`id` 누락). 결과적으로 접근성 트리에서 이 입력들의 **accessible name 이 visible 라벨이 아니라 placeholder** 로 떨어졌다 (`label-content-name-mismatch`). #295(ProjectForm)와 같은 결함류.

- `<p>` → `<label htmlFor={…}>` (block 유지) + input/textarea 에 `id` 부여.
- `id` 는 `fieldKey` 로 유니크(`literal-${fieldKey}` / `array-${fieldKey}`)해 인스펙터에 동시 렌더되는 여러 literal/array 필드 간 충돌 없음.
- node-title / vault-title 입력은 이미 wrapping `<label>` (암묵 연결) 이라 정상 — 손대지 않음. dependencies 의 `DependencyPicker` 도 자체 aria-label 보유.

## Test plan
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0 · `pnpm test:run src/views/ontology-edit` 118/118
- [ ] `LiteralEditor`/`ArrayKeyEditor` 는 vault 노드 선택 시 **vault 모드**에서만 렌더 — dev 브라우저(vault 미선택)에서 직접 실측 불가. 연결 메커니즘은 DOM 으로 검증된 #295 와 구조상 동일하므로 동일하게 동작. vault-mode 실측은 사람 몫.

## 참고 (이 PR 범위 아님)
`/ontology/edit` 에서 별개의 **hydration mismatch** 를 발견했다 — `OntologyKindPalette` `<aside>` 가 서버는 펼침(`w-[248px]`), 클라이언트는 접힘(`w-11`) 으로 렌더(collapsed 상태가 client-persisted). 다음 사이클 후보로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)