### PR TITLE
docs: document /download route in route lists

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -34,7 +34,8 @@ src/
 - 새 라우트는 `app/[locale]/` 아래에만. `src/views/` 의 페이지 컴포넌트가 1:1 대응.
 - 살아있는 라우트: `/`, `/topology/`, `/docs/`, `/ontology/`, `/ontology/edit/`,
   `/ontology/insights/`, `/projects/`, `/project/[slug]/`,
-  `/project/[slug]/edit/`, `/project/new/`, `/project/fallback/`. R10 (auth +
+  `/project/[slug]/edit/`, `/project/new/`, `/project/fallback/`, `/download/`
+  (macOS 데스크톱 앱 배포). R10 (auth +
   cloud surface 영구 제거) 이후 외 namespace (`/login`, `/signup`, `/account`,
   `/reset-password`, `/settings/*`, `/admin/*`, `/review/*`, `/diagnostics/*`,
   `/knowledge/*`) 부활 금지. `/ontology/relations` 도 R12 에서 제거되어 그

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ scripts/                   vault tooling (R11) + perf baseline (R11) + dogfood w
 /ontology                  tree + ego graph hub
 /ontology/edit             ERD canvas builder (xyflow → vault md export)
 /ontology/insights         graph insights (kind census · hubs · relation breakdown)
+/download                  macOS desktop app download (DMG)
 ```
 
 > Round 10 (2026-05) permanently removed: `/login`, `/signup`, `/account`, `/reset-password`, `/settings/*`, and earlier rounds had already removed `/admin/*`, `/review/*`, `/diagnostics/*`, `/knowledge/*`. Cloud entity API, Firestore subscribers, manual node/edge cloud modals, screenshot uploader (Firebase Storage) are all gone. Future cloud collab features will be re-designed when sponsorship / collaboration requests come.


### PR DESCRIPTION
## Summary

`/download` (macOS 데스크톱 앱 배포 페이지, #274 에서 추가) 가 실제 라우트로 존재하고 `docs/ARCHITECTURE.md` · `docs/FEATURES.md` · `README.md` 엔 문서화돼 있으나, **canonical route 목록** 두 곳에서 누락돼 있었다:

- `AGENTS.md` Routes 코드블록
- `.claude/rules/architecture.md` "살아있는 라우트" 리스트

라우트 추가 시 일부 문서만 갱신된 drift. 두 목록에 `/download` 를 추가해 실제 12개 라우트(`app/[locale]/**/page.tsx`)와 정합시켰다. (`/project/fallback` 은 정적 export 내부 fallback 이라 AGENTS.md 의 user-facing 목록에선 기존대로 제외, architecture.md 엔 이미 포함.)

## Test plan
- [x] 실제 라우트 전수(`find app/[locale] -name page.tsx`)와 문서 목록 대조 — `/download` 외 누락 없음 확인
- [x] 문서 전용 변경 (코드/테스트 영향 없음). CI tsc·lint·test·build 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)