### PR TITLE
test: guard ProjectForm label-input association (#295)

### DIFF
--- a/src/features/project-edit/ui/ProjectForm.labels.test.tsx
+++ b/src/features/project-edit/ui/ProjectForm.labels.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { render as rtlRender, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import koMessages from "../../../../messages/ko.json";
+import { TaxonomyProvider } from "@/features/taxonomy";
+import { ProjectForm } from "./ProjectForm";
+
+/**
+ * 폼 라벨-입력 연결 회귀 가드 (#295).
+ *
+ * FieldRow 라벨이 `htmlFor` 로, 입력이 같은 `id` 로 연결돼야 접근성 트리에서
+ * 입력의 accessible name 이 visible 라벨이 된다. #295 이전엔 태그/스택/링크
+ * 필드가 연결이 없어 accessible name 이 placeholder 로 떨어졌고, 그 상태에선
+ * `getByLabelText(라벨)` 이 입력을 찾지 못한다. 라벨 문자열은 메시지에서
+ * 파생해 라벨 텍스트가 바뀌어도 가드가 따라가게 한다.
+ */
+
+const fields = koMessages.settings.projectForm.fields;
+
+function renderForm() {
+  return rtlRender(
+    <NextIntlClientProvider locale="ko" messages={koMessages}>
+      <TaxonomyProvider>
+        <ProjectForm
+          mode="create"
+          allProjects={[]}
+          onSubmit={async () => {}}
+          onCancel={() => {}}
+        />
+      </TaxonomyProvider>
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("ProjectForm 라벨-입력 연결 (a11y, #295)", () => {
+  // 기본 열린 섹션(기본정보 · 소개와 문서)의 필드만 — 접힌 섹션
+  // (연결과 미디어 · 운영 정보) 은 DOM 에 없어 펼침 없이는 못 찾는다.
+  it.each([
+    fields.name,
+    fields.description,
+    fields.tagsCsv,
+    fields.stackCsv,
+    fields.linksText,
+  ])("'%s' 라벨이 입력과 연결돼 있다", (label) => {
+    renderForm();
+    expect(screen.getByLabelText(label)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

#295(프로젝트 폼 8개 필드의 라벨이 input 과 미연결이라 accessible name 이 placeholder 로 떨어지던 a11y 결함) 의 회귀 차단 테스트.

- `FieldRow` 라벨이 `htmlFor` 로, 입력이 같은 `id` 로 연결돼야 `getByLabelText(라벨)` 이 입력을 찾는다 — 연결이 빠지면 실패.
- 기본 열린 섹션(기본정보 · 소개와 문서)의 `name`/`description`/`tagsCsv`/`stackCsv`/`linksText` 필드를 단언. (접힌 섹션의 owner/icon/progress/날짜는 DOM 부재로 제외 — 동일 FieldRow 패턴이라 위 5개가 대표 커버.)
- 라벨 문자열은 `messages/ko.json` 에서 파생 — 라벨 텍스트가 바뀌어도 가드가 따라간다.
- `TaxonomyProvider`(children-only, build-time 기본값) + `NextIntlClientProvider` 로만 렌더 — mock 데이터 불필요.

## Test plan
- [x] `pnpm test:run src/features/project-edit/ui/ProjectForm.labels.test.tsx` — 5/5 통과
- [x] negative: `tagsCsv` 의 `fieldId` 연결 제거 시 해당 케이스가 정확히 실패(`no form control was found associated to that label`) 후 복구
- [x] `pnpm exec tsc --noEmit` 0 · `pnpm exec eslint` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)