### PR TITLE
fix: update release advice after PR merge

### DIFF
--- a/scripts/check-macos-release-status.mjs
+++ b/scripts/check-macos-release-status.mjs
@@ -375,6 +375,13 @@ function releasePublishCommands({ repo, tag, prNumber }) {
   return commands;
 }
 
+function releaseMissingNext({ prMerged: merged, tag }) {
+  if (merged) {
+    return `Add Apple release secrets, then push ${tag} so .github/workflows/release-macos.yml can publish signed DMGs.`;
+  }
+  return `Merge the desktop PR, add Apple release secrets, then push ${tag} so .github/workflows/release-macos.yml can publish signed DMGs.`;
+}
+
 function isNotFound(message) {
   return /\b404\b|not found|release not found/i.test(message);
 }
@@ -394,6 +401,7 @@ function hostedWorkflowUnavailableMessage(repo) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const checks = [];
+  let selectedPr = null;
 
   const auth = runGh(["auth", "status"]);
   if (!auth.ok) {
@@ -432,6 +440,7 @@ async function main() {
       checks.push(blocked("pull_request", "Pull request", pr.message, `Open https://github.com/${options.repo}/pull/${options.pr} and verify it manually.`));
     } else {
       const value = pr.value;
+      selectedPr = value;
       const checksOk = prChecksPassed(value);
       const reviewOk = prReviewSatisfied(value);
       const mergeOk = value.mergeStateStatus === "CLEAN";
@@ -587,7 +596,10 @@ async function main() {
   ], { parseJson: true });
   if (!release.ok) {
     const next = isNotFound(release.message)
-      ? `Merge the desktop PR, add Apple release secrets, then push ${options.tag} so .github/workflows/release-macos.yml can publish signed DMGs.`
+      ? releaseMissingNext({
+          prMerged: prMerged(selectedPr),
+          tag: options.tag,
+        })
       : `Run gh release view ${options.tag} --repo ${options.repo}.`;
     const commands = isNotFound(release.message)
       ? releasePublishCommands({

--- a/scripts/check-macos-release-status.test.mjs
+++ b/scripts/check-macos-release-status.test.mjs
@@ -909,6 +909,31 @@ test("desktop release status accepts an already merged PR", () => {
   );
 });
 
+test("desktop release status skips merge advice for missing releases after PR merge", () => {
+  withFakeGh(
+    {
+      prState: "MERGED",
+      prMergeState: "UNKNOWN",
+      prMergedAt: "2026-05-26T00:00:00Z",
+      secretNames: [],
+      releaseMissing: true,
+    },
+    (fakeGhPath) => {
+      const result = runStatus(fakeGhPath, ["--tag=v0.1.0", "--pr=274", "--json"]);
+
+      assert.equal(result.status, 1);
+      const payload = JSON.parse(result.stdout);
+      const blocker = payload.checks.find((check) => check.id === "github_release");
+      assert.match(blocker.next, /^Add Apple release secrets, then push v0\.1\.0/);
+      assert.doesNotMatch(blocker.next, /Merge the desktop PR/);
+      assert.equal(
+        blocker.commands[0],
+        "gh pr view 274 --repo wlsdks/ontology-atlas --json state,mergedAt,reviewDecision,mergeStateStatus,statusCheckRollup,url",
+      );
+    },
+  );
+});
+
 test("desktop release status blocks version-mismatched tags before completion", () => {
   withFakeGh({}, (fakeGhPath) => {
     const result = runStatus(fakeGhPath, ["--tag=v9.9.9", "--pr=274"]);


### PR DESCRIPTION
## Summary
- make desktop:release-status remove stale PR merge advice once a PR is already merged
- keep the GitHub Release next action focused on Apple secrets and v0.1.0 tag publishing after merge

## Verification
- node --test scripts/check-macos-release-status.test.mjs
- pnpm desktop:check
- pnpm desktop:release-status -- --pr=301
- git diff --check
- pre-push tsc --noEmit