### PR TITLE
feat: init --quick-start + 매직 모먼트 계측 + absorb 검증 편입 (Slice 0 완결)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontology-atlas",
   "version": "0.11.0",
-  "description": "AI-native codebase ontology workbench — 46-command vault scaffold + graph-level/CRUD CLI + MCP 25-tool agent surface.",
+  "description": "AI-native codebase ontology workbench — 47-command vault scaffold + graph-level/CRUD CLI + MCP 25-tool agent surface.",
   "type": "module",
   "bin": {
     "ontology-atlas": "src/index.mjs"

--- a/cli/src/commands/absorb.mjs
+++ b/cli/src/commands/absorb.mjs
@@ -32,6 +32,7 @@ import { writeDoc, slugToPath } from '../lib/write-vault.mjs';
 import { buildFrontmatter } from '../lib/schema.mjs';
 import { buildAbsorptionPlan, buildSlimPointer } from '../lib/absorb.mjs';
 import { formatUnknownFlagError, parseVaultFlag } from '../lib/cli-args.mjs';
+import { stampAbsorbWriteCompleted } from '../lib/telemetry.mjs';
 
 const ALLOWED_FLAGS = ['--vault', '--write'];
 const BACKUP_SUFFIX = '.pre-absorb.bak';
@@ -112,6 +113,10 @@ export function runAbsorb(args) {
     copyFileSync(filePath, backupPath);
     const pointer = buildSlimPointer(plan);
     writeFileSync(filePath, pointer, 'utf-8');
+
+    // Slice 0 magic-moment instrumentation (PRODUCT-PLAN-2026-07.md §4/§9) —
+    // local-only baseline for "vault worth asking" (see lib/telemetry.mjs).
+    stampAbsorbWriteCompleted(vaultPath);
 
     process.stdout.write(
       `${COLORS.green}written${COLORS.reset}  ${plan.summary.absorbed} node(s) · ` +

--- a/cli/src/commands/absorb.test.mjs
+++ b/cli/src/commands/absorb.test.mjs
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runAbsorb } from './absorb.mjs';
+import { readTelemetry, TELEMETRY_RELATIVE_PATH } from '../lib/telemetry.mjs';
 
 // `ontology-atlas absorb` — dry-run default, --write lands the plan,
 // backup + slim-pointer rewrite, injection-suspect exclusion. See
@@ -93,6 +94,11 @@ describe('runAbsorb — dry-run (default)', () => {
     assert.match(out, /Git workflow/);
     assert.match(out, /Folder map/);
     assert.match(out, /dry-run/);
+    assert.equal(
+      existsSync(join(vault, TELEMETRY_RELATIVE_PATH)),
+      false,
+      'dry-run must not stamp Slice 0 moment telemetry',
+    );
   });
 
   it('reports confidence and action per section', () => {
@@ -136,6 +142,14 @@ describe('runAbsorb --write', () => {
     assert.match(nodeContent, /kind: document/);
     assert.match(nodeContent, /role: policy/);
     assert.match(nodeContent, /Commit messages must follow conventional prefixes\./);
+  });
+
+  it('stamps the Slice 0 magic-moment telemetry baseline (absorbWriteCompletedAt)', () => {
+    const file = writeSource('AGENTS.md', SAMPLE);
+    const code = runAbsorb([file, '--vault', vault, '--write']);
+    assert.equal(code, 0);
+    const telemetry = readTelemetry(vault);
+    assert.ok(typeof telemetry.absorbWriteCompletedAt === 'string' && telemetry.absorbWriteCompletedAt.length > 0);
   });
 
   it('never writes a node for a suggested (architecture) section', () => {

--- a/cli/src/commands/agent-brief.mjs
+++ b/cli/src/commands/agent-brief.mjs
@@ -10,6 +10,7 @@ import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
 import { formatUnknownFlagError, parsePositiveIntegerFlag, parseVaultFlag, resolveExclusiveVaultArg } from '../lib/cli-args.mjs';
 import { DIAGNOSIS_OPTION_FLAGS, parseDiagnosisOption } from '../lib/diagnosis-options.mjs';
 import { diagnosisStatusColor } from '../lib/diagnosis-colors.mjs';
+import { stampMomentIfFirst } from '../lib/telemetry.mjs';
 
 const CLI_ENTRYPOINT = fileURLToPath(new URL('../index.mjs', import.meta.url));
 const ALLOWED_FLAGS = ['--vault', '--json', '--prompt', '--graph-db-pack', '--verify-fallbacks', '--fallback-timeout-ms', '--fallback-slow-ms', '--fallback-concurrency', ...DIAGNOSIS_OPTION_FLAGS];
@@ -48,6 +49,16 @@ export async function runAgentBrief(args) {
       `${COLORS.red}error${COLORS.reset}  ${err instanceof Error ? err.message : String(err)}\n`,
     );
     return 2;
+  }
+  // Slice 0 magic-moment instrumentation (PRODUCT-PLAN-2026-07.md §4/§9) —
+  // this CLI command is the cheapest safe proxy for "an agent read the vault
+  // and answered" (see lib/telemetry.mjs for why the MCP-side read tools
+  // themselves are intentionally NOT instrumented). Best-effort only — a
+  // telemetry write failure must never break the actual agent-brief output.
+  try {
+    stampMomentIfFirst(vaultRoot, { source: 'agent-brief' });
+  } catch {
+    // local-only instrumentation is advisory; ignore write failures.
   }
   if (verifyFallbacks) {
     const effectiveFallbackTimeoutMs = fallbackTimeoutMs ?? agentFallbackTimeoutMs();

--- a/cli/src/commands/moment.mjs
+++ b/cli/src/commands/moment.mjs
@@ -1,0 +1,136 @@
+// `ontology-atlas moment [vault]` — Slice 0 magic-moment instrumentation
+// readout (docs/PRODUCT-PLAN-2026-07.md §4/§9 북극성: "흡수/init 직후
+// 에이전트가 vault 노드를 인용하며 답하는 첫 순간" ≤5분 도달).
+//
+// Reads `.ontology-atlas/telemetry.local.json` (written by `init`, `absorb
+// --write`, and `agent-brief` — see ../lib/telemetry.mjs) and prints the
+// elapsed init/absorb → first-agent-read time, if it has been recorded yet.
+//
+// --mark manually records the moment right now. This is the fallback for
+// workflows where an AI agent calls the MCP tools (query_ontology
+// operation:'agent_brief' / get_concept) directly instead of going through
+// this CLI: both are declared read-only (readOnlyHint: true) in the MCP
+// tool inventory, so adding a disk write as a side effect there would
+// quietly break that contract — they are intentionally NOT instrumented.
+
+import { COLORS } from '../lib/colors.mjs';
+import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
+import { MOMENT_TARGET_MS, momentSummary, stampMomentIfFirst } from '../lib/telemetry.mjs';
+import { formatUnknownFlagError, resolveExclusiveVaultArg } from '../lib/cli-args.mjs';
+
+const ALLOWED_FLAGS = ['--vault', '--json', '--mark'];
+
+export function runMoment(args) {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    printUsage(process.stdout);
+    return 0;
+  }
+  if (parsed.error) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  ${parsed.error}\n`);
+    printUsage();
+    return 1;
+  }
+
+  const vaultRoot = resolveVaultRoot(parsed.vault);
+  if (parsed.mark) {
+    stampMomentIfFirst(vaultRoot, { source: 'manual' });
+  }
+  const summary = momentSummary(vaultRoot);
+
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return 0;
+  }
+  render(summary);
+  return 0;
+}
+
+function render(summary) {
+  process.stdout.write(`${COLORS.bold}moment${COLORS.reset} ${COLORS.dim}Slice 0 magic-moment readout${COLORS.reset}\n\n`);
+
+  if (!summary.hasBaseline) {
+    process.stdout.write(
+      `${COLORS.yellow}no init/absorb baseline yet${COLORS.reset} — run ` +
+        `${COLORS.cyan}ontology-atlas init --quick-start${COLORS.reset} or ` +
+        `${COLORS.cyan}ontology-atlas absorb <file> --write${COLORS.reset} first.\n`,
+    );
+    return;
+  }
+
+  if (summary.initCompletedAt) {
+    process.stdout.write(`init completed        ${summary.initCompletedAt}\n`);
+  }
+  if (summary.absorbWriteCompletedAt) {
+    process.stdout.write(`absorb --write        ${summary.absorbWriteCompletedAt}\n`);
+  }
+
+  if (!summary.moment) {
+    process.stdout.write(
+      `\n${COLORS.yellow}moment not reached yet${COLORS.reset} — run ` +
+        `${COLORS.cyan}ontology-atlas agent-brief${COLORS.reset} once your agent answers citing a vault\n` +
+        `node, or ${COLORS.cyan}ontology-atlas moment --mark${COLORS.reset} by hand if your agent calls the\n` +
+        `MCP tools directly (agent_brief/get_concept are read-only and are not auto-stamped).\n`,
+    );
+    return;
+  }
+
+  const elapsedLabel = formatElapsed(summary.moment.elapsedMs);
+  const withinLabel =
+    summary.withinTarget === true
+      ? `${COLORS.green}within the ≤5min target${COLORS.reset}`
+      : summary.withinTarget === false
+        ? `${COLORS.red}past the ≤5min target${COLORS.reset}`
+        : `${COLORS.dim}target unknown (no baseline)${COLORS.reset}`;
+  process.stdout.write(
+    `\n${COLORS.green}moment reached${COLORS.reset}        ${summary.moment.at} via ${summary.moment.source}\n` +
+      `elapsed               ${elapsedLabel} — ${withinLabel}\n`,
+  );
+}
+
+function formatElapsed(elapsedMs) {
+  if (typeof elapsedMs !== 'number' || !Number.isFinite(elapsedMs)) return 'unknown';
+  const totalSeconds = Math.round(elapsedMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+}
+
+function parseArgs(args) {
+  if (args.includes('--help') || args.includes('-h')) return { help: true };
+  const flags = { vault: null, json: false, mark: false };
+  const positional = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === '--vault') flags.vault = args[++i];
+    else if (a.startsWith('--vault=')) flags.vault = a.slice('--vault='.length);
+    else if (a === '--json') flags.json = true;
+    else if (a === '--mark') flags.mark = true;
+    else if (a.startsWith('-')) return { error: formatUnknownFlagError(a, ALLOWED_FLAGS) };
+    else positional.push(a);
+  }
+  const vaultResult = resolveExclusiveVaultArg({ vault: flags.vault, positional });
+  if (vaultResult.error) return vaultResult;
+  return { vault: vaultResult.vault, json: flags.json, mark: flags.mark };
+}
+
+function printUsage(stream = process.stderr) {
+  stream.write(
+    `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
+      `  ontology-atlas moment [vault] [--mark] [--json]\n\n` +
+      `  Prints the Slice 0 magic-moment north star (PRODUCT-PLAN-2026-07.md §4/§9):\n` +
+      `  the elapsed time from ${COLORS.bold}init${COLORS.reset}/${COLORS.bold}absorb --write${COLORS.reset} to the first ` +
+      `${COLORS.bold}agent-brief${COLORS.reset} run afterward,\n` +
+      `  target ≤5 minutes. All data lives in ${COLORS.dim}.ontology-atlas/telemetry.local.json${COLORS.reset} — local\n` +
+      `  only, never transmitted.\n\n` +
+      `${COLORS.bold}options:${COLORS.reset}\n` +
+      `  --mark   manually stamp the moment now — fallback for agents that call the\n` +
+      `           MCP tools (agent_brief/get_concept) directly instead of this CLI;\n` +
+      `           those two are read-only and are not auto-stamped\n` +
+      `  --json   machine-readable momentSummary output\n` +
+      `  --vault path   target vault (default: cwd)\n\n` +
+      `${COLORS.bold}examples:${COLORS.reset}\n` +
+      `  ontology-atlas moment\n` +
+      `  ontology-atlas moment --mark\n`,
+  );
+}

--- a/cli/src/commands/moment.test.mjs
+++ b/cli/src/commands/moment.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMoment } from './moment.mjs';
+import { stampInitCompleted, stampMomentIfFirst } from '../lib/telemetry.mjs';
+
+// `ontology-atlas moment [vault]` — Slice 0 magic-moment instrumentation
+// readout (docs/PRODUCT-PLAN-2026-07.md §4/§9). See lib/telemetry.mjs for
+// why only init / absorb --write / agent-brief are auto-stamped.
+
+let tmp;
+let vault;
+let stdout;
+let stderr;
+let restoreWrite;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'ontology-atlas-moment-test-'));
+  vault = join(tmp, 'vault');
+  mkdirSync(vault, { recursive: true });
+  stdout = [];
+  stderr = [];
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = (chunk) => {
+    stdout.push(String(chunk));
+    return true;
+  };
+  process.stderr.write = (chunk) => {
+    stderr.push(String(chunk));
+    return true;
+  };
+  restoreWrite = () => {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  };
+});
+
+afterEach(() => {
+  restoreWrite();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+function stripAnsi(text) {
+  return text.replace(ANSI_RE, '');
+}
+
+describe('runMoment', () => {
+  it('reports no baseline yet when init/absorb never stamped', () => {
+    const code = runMoment(['--vault', vault]);
+    assert.equal(code, 0);
+    const out = stripAnsi(stdout.join(''));
+    assert.match(out, /no init\/absorb baseline yet/);
+  });
+
+  it('reports the init baseline and that the moment has not been reached yet', () => {
+    stampInitCompleted(vault, '2026-07-17T12:00:00.000Z');
+    const code = runMoment(['--vault', vault]);
+    assert.equal(code, 0);
+    const out = stripAnsi(stdout.join(''));
+    assert.match(out, /2026-07-17T12:00:00\.000Z/);
+    assert.match(out, /moment not reached yet/);
+    assert.match(out, /agent-brief/);
+    assert.match(out, /--mark/);
+  });
+
+  it('reports the elapsed time and within-target verdict once the moment is stamped', () => {
+    stampInitCompleted(vault, '2026-07-17T12:00:00.000Z');
+    stampMomentIfFirst(vault, { source: 'agent-brief', at: '2026-07-17T12:02:00.000Z' });
+    const code = runMoment(['--vault', vault]);
+    assert.equal(code, 0);
+    const out = stripAnsi(stdout.join(''));
+    assert.match(out, /agent-brief/);
+    assert.match(out, /2m/);
+    assert.match(out, /within.*5.?min|≤5min|target/i);
+  });
+
+  it('--mark stamps the moment now when it has not fired yet', () => {
+    stampInitCompleted(vault, '2026-07-17T12:00:00.000Z');
+    const code = runMoment(['--vault', vault, '--mark']);
+    assert.equal(code, 0);
+    const out = stripAnsi(stdout.join(''));
+    assert.match(out, /manual/);
+  });
+
+  it('--mark is a no-op once a moment already exists', () => {
+    stampInitCompleted(vault, '2026-07-17T12:00:00.000Z');
+    stampMomentIfFirst(vault, { source: 'agent-brief', at: '2026-07-17T12:02:00.000Z' });
+    runMoment(['--vault', vault, '--mark']);
+    const out = stripAnsi(stdout.join(''));
+    assert.match(out, /agent-brief/);
+    assert.doesNotMatch(out, /manual/);
+  });
+
+  it('--json prints the momentSummary shape', () => {
+    stampInitCompleted(vault, '2026-07-17T12:00:00.000Z');
+    const code = runMoment(['--vault', vault, '--json']);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout.join(''));
+    assert.equal(data.hasBaseline, true);
+    assert.equal(data.initCompletedAt, '2026-07-17T12:00:00.000Z');
+    assert.equal(data.moment, null);
+  });
+
+  it('exits 1 and errors on an unknown flag', () => {
+    const code = runMoment(['--vault', vault, '--bogus']);
+    assert.equal(code, 1);
+    assert.match(stderr.join(''), /error/);
+  });
+
+  it('--help prints usage and exits 0 without touching anything', () => {
+    const code = runMoment(['--help']);
+    assert.equal(code, 0);
+    assert.match(stdout.join(''), /Usage:/);
+  });
+});

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -22,6 +22,8 @@ import { stdout, stderr, argv, cwd } from 'node:process';
 import { CLI_COMMAND_COUNT, CLI_COMMAND_RUNNERS, CLI_COMMANDS } from './lib/cli-commands.mjs';
 import { closestAllowedValue, formatUnknownFlagError } from './lib/cli-args.mjs';
 import { readMcpPackageMetadata } from './lib/mcp-metadata.mjs';
+import { runBootstrap } from './commands/bootstrap.mjs';
+import { stampInitCompleted } from './lib/telemetry.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_ROOT = resolve(__dirname, '..', 'templates', 'vault');
@@ -32,7 +34,7 @@ const require_ = createRequire(import.meta.url);
 const MCP_METADATA = readMcpPackageMetadata();
 const MCP_TOOL_COUNT = MCP_METADATA.toolCount ?? 'current';
 const MCP_TOOL_SPLIT = MCP_METADATA.splitText ?? 'read/write';
-const INIT_ALLOWED_FLAGS = ['--help'];
+const INIT_ALLOWED_FLAGS = ['--help', '--quick-start'];
 const TOP_LEVEL_COMMAND_VALUES = ['--help', '-h', 'help', '--version', '-v', ...CLI_COMMANDS];
 
 
@@ -46,6 +48,7 @@ AI-native codebase ontology workbench — ${CLI_COMMAND_COUNT} commands + MCP se
 
 ${COLORS.bold}Usage:${COLORS.reset}
   npx ontology-atlas init [folder]            Scaffold a new ontology vault (default: ./vault)
+       --quick-start                          ${COLORS.dim}Slice 0 one-liner: + bootstrap + absorb suggestion + compact next steps${COLORS.reset}
   npx ontology-atlas list [vault]             List ontology nodes in a vault
                                               ${COLORS.dim}--kind <kind>     filter by kind${COLORS.reset}
                                               ${COLORS.dim}--json            JSON output${COLORS.reset}
@@ -70,6 +73,8 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --raw-slug --rename --dry-run          ${COLORS.dim}no folder prefix · slug rename · plan-only${COLORS.reset}
   npx ontology-atlas absorb <file...>         ${COLORS.green}Absorb CLAUDE.md/AGENTS.md into typed vault nodes${COLORS.reset} (Slice 0)
        --vault path --write                   ${COLORS.dim}default dry-run plan · --write lands + rewrites source as slim pointer${COLORS.reset}
+  npx ontology-atlas moment [vault]            ${COLORS.green}Slice 0 magic-moment readout${COLORS.reset} — init/absorb → first agent-brief elapsed
+       --mark --json                           ${COLORS.dim}manual stamp fallback · machine output${COLORS.reset}
 
 ${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous ingest base)${COLORS.reset}
   npx ontology-atlas index [rootPath]         ${COLORS.green}project ontology index${COLORS.reset} — analyze + imports + validate plan
@@ -187,21 +192,30 @@ function parseInitArgs(args) {
     return { help: true };
   }
   const positional = [];
+  let quickStart = false;
   for (const arg of args) {
+    if (arg === '--quick-start') {
+      quickStart = true;
+      continue;
+    }
     if (arg.startsWith('-')) return { error: formatUnknownFlagError(arg, INIT_ALLOWED_FLAGS) };
     positional.push(arg);
   }
   if (positional.length > 1) {
     return { error: `too many arguments: ${positional.slice(1).join(' ')}` };
   }
-  return { target: positional[0] };
+  return { target: positional[0], quickStart };
 }
 
 function printInitUsage(stream = stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
-      `  ontology-atlas init [folder]\n\n` +
-      `Scaffold a local ontology vault. Default folder: ./vault\n`,
+      `  ontology-atlas init [folder]\n` +
+      `  ontology-atlas init [folder] --quick-start\n\n` +
+      `Scaffold a local ontology vault. Default folder: ./vault\n\n` +
+      `${COLORS.bold}--quick-start${COLORS.reset}  no-prompt one-liner (Slice 0): scaffold + bootstrap from\n` +
+      `  this repo + .mcp.json (already unconditional) + an absorb suggestion when\n` +
+      `  CLAUDE.md/AGENTS.md exists (never auto-absorbed) + a compact next-steps block.\n`,
   );
 }
 
@@ -275,7 +289,8 @@ function copyTree(srcRoot, destRoot) {
   return { created, skipped };
 }
 
-function runInit(targetArg) {
+async function runInit(targetArg, opts = {}) {
+  const quickStart = Boolean(opts.quickStart);
   const target = resolve(cwd(), targetArg ?? 'vault');
   let serverCommand;
   try {
@@ -407,6 +422,15 @@ function runInit(targetArg) {
     cwdVaultArg,
   ].map(shellQuote).join(' ');
 
+  // Slice 0 magic-moment instrumentation (PRODUCT-PLAN-2026-07.md §4/§9) —
+  // local-only baseline for "vault worth asking" (see lib/telemetry.mjs).
+  // Applies to every init, quick-start or not.
+  stampInitCompleted(target);
+
+  if (quickStart) {
+    return runQuickStart({ target, cwdVaultArg });
+  }
+
   stdout.write(`
 ${COLORS.green}${COLORS.bold}done${COLORS.reset} — vault scaffolded.
 
@@ -454,6 +478,46 @@ ${COLORS.bold}Next steps:${COLORS.reset}
 ${COLORS.dim}AI agents and humans now share the same vault. Have fun.${COLORS.reset}
 `);
   return 0;
+}
+
+// `init --quick-start` (Slice 0 — docs/PRODUCT-PLAN-2026-07.md §9): one
+// command = scaffold (already done by the time this runs, no prompts either
+// way) + bootstrap from the repo (reuses the existing analyze/infer-imports
+// pipeline via `runBootstrap` — no reimplementation) + .mcp.json (already
+// unconditional above) + an absorb suggestion when CLAUDE.md/AGENTS.md
+// exists (approval-tier principle: never auto-absorbed, human opt-in only)
+// + a compact next-steps block (3 lines max).
+async function runQuickStart({ target, cwdVaultArg }) {
+  stdout.write(`\n${COLORS.bold}quick start${COLORS.reset} — bootstrapping from your repo...\n`);
+  const bootstrapCode = await runBootstrap(['.', '--vault', cwdVaultArg]);
+
+  const repoRoot = cwd();
+  const foundGuides = ['AGENTS.md', 'CLAUDE.md'].filter((name) => existsSync(join(repoRoot, name)));
+  if (foundGuides.length > 0) {
+    stdout.write(
+      `\n${COLORS.yellow}note${COLORS.reset}  found ${foundGuides.join(', ')} — consider absorbing ` +
+        `${foundGuides.length > 1 ? 'them' : 'it'} into the vault (never automatic — your call):\n`,
+    );
+    for (const guide of foundGuides) {
+      const absorbCommand = ['ontology-atlas', 'absorb', guide, '--vault', cwdVaultArg]
+        .map(shellQuote)
+        .join(' ');
+      stdout.write(`       ${COLORS.cyan}${absorbCommand}${COLORS.reset}\n`);
+    }
+    stdout.write(
+      `       ${COLORS.dim}dry-run by default — review the plan, then land it yourself by adding --write${COLORS.reset}\n`,
+    );
+  }
+
+  stdout.write(`
+${COLORS.green}${COLORS.bold}quick start done${COLORS.reset} — vault scaffolded + bootstrapped from your repo.
+
+${COLORS.bold}Next:${COLORS.reset}
+  ${COLORS.dim}1.${COLORS.reset} Open the vault        ${COLORS.cyan}cd ${target} && ontology-atlas list${COLORS.reset}
+  ${COLORS.dim}2.${COLORS.reset} MCP already wired      restart Claude Code / Cursor / Codex from this folder
+  ${COLORS.dim}3.${COLORS.reset} Try asking your agent  e.g. "what does the auth capability depend on?"
+`);
+  return bootstrapCode;
 }
 
 async function runCommandHelp(command) {
@@ -523,7 +587,7 @@ async function main() {
       printInitUsage();
       return 1;
     }
-    return runInit(parsed.target);
+    return runInit(parsed.target, { quickStart: parsed.quickStart });
   }
 
   const runner = CLI_COMMAND_RUNNERS[SUBCOMMAND];

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -262,6 +262,124 @@ await test('init — generated MCP config points at a runnable local server in s
   }
 });
 
+// ── init --quick-start (Slice 0 — docs/PRODUCT-PLAN-2026-07.md §9) ──────
+//
+// One command = scaffold (no prompts, already the default) + bootstrap from
+// the repo (reuses the existing analyze/infer-imports pipeline, no
+// reimplementation) + .mcp.json (already unconditional) + an absorb
+// suggestion when CLAUDE.md/AGENTS.md exists (never auto-absorbed — human
+// opt-in) + a compact 3-line next-steps block.
+
+function makeQuickStartRepoFixture() {
+  const repo = mkdtempSync(join(tmpdir(), 'cli-quick-start-'));
+  writeFileSync(
+    join(repo, 'package.json'),
+    JSON.stringify({ name: 'quick-start-app', description: 'Quick start fixture app' }, null, 2),
+    'utf-8',
+  );
+  mkdirSync(join(repo, 'src', 'features', 'auth'), { recursive: true });
+  return repo;
+}
+
+await test('init --quick-start — scaffolds, bootstraps from the repo, and ends with a compact next-steps block', async () => {
+  const repo = makeQuickStartRepoFixture();
+  try {
+    const r = await run(['init', 'ontology', '--quick-start'], { cwd: repo });
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+
+    const vault = join(repo, 'ontology');
+    // bootstrap actually ran — same evidence the analyze --apply tests use
+    // (untouched starter project.md is pruned and replaced by <slug>.md).
+    const projectDoc = readFileSync(join(vault, 'quick-start-app.md'), 'utf-8');
+    assert.match(projectDoc, /title: Quick start fixture app/);
+    assert.equal(existsSyncTest(join(vault, 'capabilities', 'auth.md')), true);
+
+    // .mcp.json still generated (already unconditional, verify quick-start keeps it).
+    assert.equal(existsSyncTest(join(repo, '.mcp.json')), true);
+    assert.equal(existsSyncTest(join(vault, '.mcp.json')), true);
+
+    // compact next-steps block, not the long 6-step default block.
+    assert.match(clean, /quick start done/);
+    assert.equal((clean.match(/^\s*\d\.\s/gm) || []).length, 3, `expected exactly 3 next-step lines:\n${clean}`);
+    assert.doesNotMatch(clean, /Open this folder in an AI agent/);
+    assert.doesNotMatch(clean, /See the graph/);
+
+    // Slice 0 magic-moment baseline stamped (local only, never transmitted).
+    const telemetry = JSON.parse(
+      readFileSync(join(vault, '.ontology-atlas', 'telemetry.local.json'), 'utf-8'),
+    );
+    assert.ok(typeof telemetry.initCompletedAt === 'string' && telemetry.initCompletedAt.length > 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('init --quick-start — suggests absorbing an existing AGENTS.md without auto-absorbing it', async () => {
+  const repo = makeQuickStartRepoFixture();
+  try {
+    const agentsBefore = '# Team guide\n\n## Rules\n\nNever skip tests.\n';
+    writeFileSync(join(repo, 'AGENTS.md'), agentsBefore, 'utf-8');
+
+    const r = await run(['init', 'ontology', '--quick-start'], { cwd: repo });
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const clean = stripAnsi(r.stdout);
+
+    assert.match(clean, /found AGENTS\.md/);
+    assert.match(clean, /ontology-atlas absorb AGENTS\.md --vault \.\/ontology/);
+    const absorbLine = clean.split('\n').find((line) => line.includes('ontology-atlas absorb AGENTS.md'));
+    assert.ok(absorbLine, `expected an absorb suggestion line in:\n${clean}`);
+    assert.doesNotMatch(absorbLine, /--write/);
+
+    // never auto-absorbed — human opt-in only (approval-tier principle).
+    assert.equal(readFileSync(join(repo, 'AGENTS.md'), 'utf-8'), agentsBefore);
+    assert.equal(existsSyncTest(join(repo, 'AGENTS.md.pre-absorb.bak')), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('init --quick-start — no CLAUDE.md/AGENTS.md present skips the absorb suggestion', async () => {
+  const repo = makeQuickStartRepoFixture();
+  try {
+    const r = await run(['init', 'ontology', '--quick-start'], { cwd: repo });
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.doesNotMatch(stripAnsi(r.stdout), /ontology-atlas absorb/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+await test('init --quick-start — unaffected plain init keeps the original verbose next-steps block', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'cli-init-plain-'));
+  try {
+    const r = await run(['init', 'ontology'], { cwd: root });
+    assert.equal(r.code, 0);
+    assert.doesNotMatch(stripAnsi(r.stdout), /quick start done/);
+    assert.match(stripAnsi(r.stdout), /Open this folder in an AI agent/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('init --quick-start — --help documents the flag', async () => {
+  const help = await run(['init', '--help']);
+  assert.equal(help.code, 0);
+  assert.match(stripAnsi(help.stdout), /--quick-start/);
+});
+
+await test('init — starter .gitignore keeps the local-only Slice 0 telemetry file out of git', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'cli-init-gitignore-'));
+  try {
+    const r = await run(['init', 'ontology'], { cwd: root });
+    assert.equal(r.code, 0);
+    const gitignore = readFileSync(join(root, 'ontology', '.gitignore'), 'utf-8');
+    assert.match(gitignore, /\.ontology-atlas\//);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('agent-setup — writes agent configs for an existing vault without starter files', async () => {
   const root = mkdtempSync(join(tmpdir(), 'cli-agent-setup-'));
   try {
@@ -361,6 +479,42 @@ await test('agent-setup — terminal output points humans to the workflow guide'
     assert.match(stripAnsi(r.stdout), /sync docs\/ontology before finishing/);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('moment — end-to-end via init --quick-start then agent-brief', async () => {
+  const repo = mkdtempSync(join(tmpdir(), 'cli-moment-e2e-'));
+  try {
+    writeFileSync(
+      join(repo, 'package.json'),
+      JSON.stringify({ name: 'moment-e2e-app', description: 'Moment e2e fixture' }, null, 2),
+      'utf-8',
+    );
+    mkdirSync(join(repo, 'src', 'features', 'auth'), { recursive: true });
+
+    const init = await run(['init', 'ontology', '--quick-start'], { cwd: repo });
+    assert.equal(init.code, 0, `init failed: ${init.stdout}\n${init.stderr}`);
+
+    const vault = join(repo, 'ontology');
+    const before = await run(['moment', vault, '--json']);
+    assert.equal(before.code, 0, before.stderr);
+    const beforeData = JSON.parse(before.stdout);
+    assert.equal(beforeData.hasBaseline, true);
+    assert.equal(beforeData.moment, null);
+
+    // agent-brief's exit code reflects vault readiness (not telemetry) — a
+    // freshly bootstrapped fixture vault can be `needs_shape`. Only the
+    // telemetry side effect matters here.
+    const brief = await run(['agent-brief', vault]);
+    assert.equal(brief.stderr, '', `agent-brief errored: ${brief.stderr}`);
+
+    const after = await run(['moment', vault, '--json']);
+    assert.equal(after.code, 0, after.stderr);
+    const afterData = JSON.parse(after.stdout);
+    assert.equal(afterData.moment.source, 'agent-brief');
+    assert.equal(typeof afterData.moment.elapsedMs, 'number');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
   }
 });
 
@@ -4978,6 +5132,36 @@ await test('agent-brief — prints agent handoff entrypoints and playbooks', asy
     assert.match(clean, /all_paths\s+report limit, searchBudget, expandedStates, exhaustive, truncatedByBudget, totalPathsExact, evidence\.status, evidence\.reason, evidence\.pathsComplete/);
     assert.match(clean, /partial evidence/);
     assert.match(clean, /WRITE POLICY/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('agent-brief — stamps the Slice 0 magic-moment telemetry the first time it runs after init', async () => {
+  const root = await buildGraphFixture();
+  try {
+    const initTelemetryPath = join(root, '.ontology-atlas', 'telemetry.local.json');
+    mkdirSync(dirname(initTelemetryPath), { recursive: true });
+    writeFileSync(
+      initTelemetryPath,
+      JSON.stringify({ initCompletedAt: '2020-01-01T00:00:00.000Z', absorbWriteCompletedAt: null, moment: null }, null, 2),
+      'utf-8',
+    );
+
+    const r = await run(['agent-brief', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+
+    const telemetry = JSON.parse(readFileSync(initTelemetryPath, 'utf-8'));
+    assert.equal(telemetry.moment.source, 'agent-brief');
+    assert.equal(typeof telemetry.moment.elapsedMs, 'number');
+    assert.ok(telemetry.moment.elapsedMs >= 0);
+
+    // a second run must not overwrite the first recorded moment.
+    const before = telemetry.moment.at;
+    const r2 = await run(['agent-brief', root]);
+    assert.equal(r2.code, 0);
+    const telemetryAfter = JSON.parse(readFileSync(initTelemetryPath, 'utf-8'));
+    assert.equal(telemetryAfter.moment.at, before);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/cli/src/lib/cli-commands.mjs
+++ b/cli/src/lib/cli-commands.mjs
@@ -16,6 +16,7 @@ export const CLI_COMMAND_RUNNERS = Object.freeze({
   find: runner('find.mjs', 'runFind'),
   import: runner('import.mjs', 'runImport'),
   absorb: runner('absorb.mjs', 'runAbsorb'),
+  moment: runner('moment.mjs', 'runMoment'),
   backlinks: runner('backlinks.mjs', 'runBacklinks'),
   orphans: runner('orphans.mjs', 'runOrphans'),
   path: runner('path.mjs', 'runPath'),

--- a/cli/src/lib/telemetry.mjs
+++ b/cli/src/lib/telemetry.mjs
@@ -1,0 +1,111 @@
+// Slice 0 — magic-moment instrumentation (PRODUCT-PLAN-2026-07.md §4/§9 북극성:
+// "흡수/init 직후 에이전트가 vault 노드를 인용하며 답하는 첫 순간" ≤5분 도달).
+//
+// LOCAL ONLY — this file never leaves the user's disk and is never
+// transmitted anywhere (PRODUCT-PLAN-2026-07.md §7 신뢰 헌장 ② "조용한 수집
+// 0"). It records two kinds of timestamp:
+//   - a baseline: `init`'s completion time, or `absorb --write`'s completion
+//     time if that ran more recently (either counts as "the moment the vault
+//     became worth asking").
+//   - `moment`: the first time an agent-facing read happened afterward. This
+//     is stamped from the CLI's own `agent-brief` command (the cheapest safe
+//     proxy for "an agent read the vault and answered") — NOT from the MCP
+//     `query_ontology(operation:'agent_brief')` / `get_concept` tools. Those
+//     two are declared read-only (`readOnlyHint: true`) in the MCP tool
+//     inventory; adding a disk write as a side effect of a "read" tool would
+//     quietly break that contract. If you drive the vault through an AI
+//     agent's direct MCP calls instead of the CLI, run
+//     `ontology-atlas moment --mark` by hand right after it answers citing a
+//     node to record the same moment.
+//
+// `cli/src/commands/moment.mjs` is the human-facing surface for this file.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const TELEMETRY_RELATIVE_PATH = '.ontology-atlas/telemetry.local.json';
+// North star (PRODUCT-PLAN-2026-07.md §4): moment reached within 5 minutes.
+export const MOMENT_TARGET_MS = 5 * 60 * 1000;
+
+function telemetryPath(vaultRoot) {
+  return join(vaultRoot, TELEMETRY_RELATIVE_PATH);
+}
+
+function defaultTelemetry() {
+  return {
+    '//': 'local only, never transmitted — see AGENTS.md trust charter (PRODUCT-PLAN-2026-07.md §7)',
+    initCompletedAt: null,
+    absorbWriteCompletedAt: null,
+    moment: null,
+  };
+}
+
+export function readTelemetry(vaultRoot) {
+  const filePath = telemetryPath(vaultRoot);
+  if (!existsSync(filePath)) return defaultTelemetry();
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return defaultTelemetry();
+    return { ...defaultTelemetry(), ...parsed };
+  } catch {
+    return defaultTelemetry();
+  }
+}
+
+function writeTelemetry(vaultRoot, telemetry) {
+  const filePath = telemetryPath(vaultRoot);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(telemetry, null, 2)}\n`, 'utf-8');
+  return telemetry;
+}
+
+export function stampInitCompleted(vaultRoot, at = new Date().toISOString()) {
+  const telemetry = readTelemetry(vaultRoot);
+  telemetry.initCompletedAt = at;
+  return writeTelemetry(vaultRoot, telemetry);
+}
+
+export function stampAbsorbWriteCompleted(vaultRoot, at = new Date().toISOString()) {
+  const telemetry = readTelemetry(vaultRoot);
+  telemetry.absorbWriteCompletedAt = at;
+  return writeTelemetry(vaultRoot, telemetry);
+}
+
+function baselineMsFromTelemetry(telemetry) {
+  const candidates = [telemetry.initCompletedAt, telemetry.absorbWriteCompletedAt]
+    .filter((value) => typeof value === 'string' && value.length > 0)
+    .map((value) => Date.parse(value))
+    .filter((value) => Number.isFinite(value));
+  if (candidates.length === 0) return null;
+  return Math.max(...candidates);
+}
+
+// Stamps `moment` only the first time it is called for a given vault —
+// re-running an agent-facing read after the moment has already fired never
+// overwrites the original measurement.
+export function stampMomentIfFirst(vaultRoot, { source, at = new Date().toISOString() } = {}) {
+  const telemetry = readTelemetry(vaultRoot);
+  if (telemetry.moment) return telemetry;
+  const baselineMs = baselineMsFromTelemetry(telemetry);
+  const momentMs = Date.parse(at);
+  const elapsedMs =
+    baselineMs !== null && Number.isFinite(momentMs) ? Math.max(0, momentMs - baselineMs) : null;
+  telemetry.moment = { at, source: source || 'unknown', elapsedMs };
+  return writeTelemetry(vaultRoot, telemetry);
+}
+
+export function momentSummary(vaultRoot) {
+  const telemetry = readTelemetry(vaultRoot);
+  const baselineMs = baselineMsFromTelemetry(telemetry);
+  const elapsedMs = telemetry.moment && typeof telemetry.moment.elapsedMs === 'number'
+    ? telemetry.moment.elapsedMs
+    : null;
+  return {
+    hasBaseline: baselineMs !== null,
+    initCompletedAt: telemetry.initCompletedAt,
+    absorbWriteCompletedAt: telemetry.absorbWriteCompletedAt,
+    moment: telemetry.moment,
+    targetMs: MOMENT_TARGET_MS,
+    withinTarget: elapsedMs === null ? null : elapsedMs <= MOMENT_TARGET_MS,
+  };
+}

--- a/cli/src/lib/telemetry.test.mjs
+++ b/cli/src/lib/telemetry.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  MOMENT_TARGET_MS,
+  TELEMETRY_RELATIVE_PATH,
+  momentSummary,
+  readTelemetry,
+  stampAbsorbWriteCompleted,
+  stampInitCompleted,
+  stampMomentIfFirst,
+} from './telemetry.mjs';
+
+function withTempVault(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'oatlas-telemetry-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('telemetry (Slice 0 magic-moment instrumentation)', () => {
+  it('returns an empty-but-shaped record when no telemetry file exists yet', () => {
+    withTempVault((vaultRoot) => {
+      const telemetry = readTelemetry(vaultRoot);
+      assert.equal(telemetry.initCompletedAt, null);
+      assert.equal(telemetry.absorbWriteCompletedAt, null);
+      assert.equal(telemetry.moment, null);
+    });
+  });
+
+  it('stamps initCompletedAt into .ontology-atlas/telemetry.local.json (local only)', () => {
+    withTempVault((vaultRoot) => {
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      const filePath = join(vaultRoot, TELEMETRY_RELATIVE_PATH);
+      const onDisk = JSON.parse(readFileSync(filePath, 'utf-8'));
+      assert.equal(onDisk.initCompletedAt, '2026-07-17T12:00:00.000Z');
+      assert.match(onDisk['//'], /local only, never transmitted/);
+
+      const telemetry = readTelemetry(vaultRoot);
+      assert.equal(telemetry.initCompletedAt, '2026-07-17T12:00:00.000Z');
+    });
+  });
+
+  it('stamps absorbWriteCompletedAt without clobbering an existing initCompletedAt', () => {
+    withTempVault((vaultRoot) => {
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      stampAbsorbWriteCompleted(vaultRoot, '2026-07-17T12:01:00.000Z');
+      const telemetry = readTelemetry(vaultRoot);
+      assert.equal(telemetry.initCompletedAt, '2026-07-17T12:00:00.000Z');
+      assert.equal(telemetry.absorbWriteCompletedAt, '2026-07-17T12:01:00.000Z');
+    });
+  });
+
+  it('recovers from a corrupt telemetry file instead of throwing', () => {
+    withTempVault((vaultRoot) => {
+      const filePath = join(vaultRoot, TELEMETRY_RELATIVE_PATH);
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      // corrupt it
+      writeFileSync(filePath, '{ not json', 'utf-8');
+      const telemetry = readTelemetry(vaultRoot);
+      assert.equal(telemetry.initCompletedAt, null);
+    });
+  });
+
+  it('stampMomentIfFirst records elapsed time from the init baseline and only fires once', () => {
+    withTempVault((vaultRoot) => {
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      const first = stampMomentIfFirst(vaultRoot, {
+        source: 'agent-brief',
+        at: '2026-07-17T12:03:00.000Z',
+      });
+      assert.equal(first.moment.source, 'agent-brief');
+      assert.equal(first.moment.elapsedMs, 180000);
+
+      // second call must not overwrite the first moment
+      const second = stampMomentIfFirst(vaultRoot, {
+        source: 'manual',
+        at: '2026-07-17T12:10:00.000Z',
+      });
+      assert.equal(second.moment.source, 'agent-brief');
+      assert.equal(second.moment.elapsedMs, 180000);
+    });
+  });
+
+  it('stampMomentIfFirst prefers the later of init/absorb as the baseline', () => {
+    withTempVault((vaultRoot) => {
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      stampAbsorbWriteCompleted(vaultRoot, '2026-07-17T12:05:00.000Z');
+      const stamped = stampMomentIfFirst(vaultRoot, {
+        source: 'agent-brief',
+        at: '2026-07-17T12:06:00.000Z',
+      });
+      assert.equal(stamped.moment.elapsedMs, 60000);
+    });
+  });
+
+  it('stampMomentIfFirst records a null elapsedMs when there is no baseline yet', () => {
+    withTempVault((vaultRoot) => {
+      const stamped = stampMomentIfFirst(vaultRoot, { source: 'agent-brief' });
+      assert.equal(stamped.moment.elapsedMs, null);
+    });
+  });
+
+  it('momentSummary reports whether the north-star ≤5min target was met', () => {
+    withTempVault((vaultRoot) => {
+      assert.deepEqual(momentSummary(vaultRoot), {
+        hasBaseline: false,
+        initCompletedAt: null,
+        absorbWriteCompletedAt: null,
+        moment: null,
+        targetMs: MOMENT_TARGET_MS,
+        withinTarget: null,
+      });
+
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      stampMomentIfFirst(vaultRoot, { source: 'agent-brief', at: '2026-07-17T12:01:00.000Z' });
+      const within = momentSummary(vaultRoot);
+      assert.equal(within.hasBaseline, true);
+      assert.equal(within.withinTarget, true);
+    });
+  });
+
+  it('momentSummary reports withinTarget:false past the 5-minute north star', () => {
+    withTempVault((vaultRoot) => {
+      stampInitCompleted(vaultRoot, '2026-07-17T12:00:00.000Z');
+      stampMomentIfFirst(vaultRoot, { source: 'agent-brief', at: '2026-07-17T12:06:00.000Z' });
+      const summary = momentSummary(vaultRoot);
+      assert.equal(summary.withinTarget, false);
+    });
+  });
+});

--- a/cli/templates/vault/.gitignore
+++ b/cli/templates/vault/.gitignore
@@ -1,0 +1,6 @@
+# ontology-atlas local-only data — never commit.
+#
+# .ontology-atlas/ holds machine-local state only: the live agent-activity
+# heartbeat and the Slice 0 magic-moment telemetry.local.json (init/absorb
+# timing, local only, never transmitted — see AGENTS.md trust charter).
+.ontology-atlas/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -523,6 +523,7 @@ A successful run looks like this:
 
 ```
 [ontology-atlas-mcp verify]
+
 · step 1 — parser smoke test
 ✓ result: 7 passed, 0 failed
 · step 2 — server boot + tools/list + list_concepts/project probe/get_concept/get_concepts/find_evidence/find_backlinks/query_concepts/limited query_concepts/analyze_repo_structure/infer_imports/index_project/find_neighbors/find_path/find_orphans/list_kinds/destructive dry-runs (vault=../docs/ontology, timeout=15000ms)
@@ -538,14 +539,15 @@ A successful run looks like this:
 ✓ add_relations — non-object, single/multi unknown-field repair, Received fields, invalid-type rows isolated with input indexes and closest-value hints, and invalid-only batches return no write metadata
 ✓ batch caps — get_concepts/add_concepts/add_relations reject 51 rows with invalid_arguments
 ✓ destructive dry-runs — rename_concept · merge_concepts · delete_concept preview without write-maintenance
+✓ absorb_document dry-run — temp fixture classified (policy + architecture sections) without writing
 ✓ patch_concept conflict guard — stale expected_mtime rejected with vault_conflict
 ✓ strict enums — invalid query operation rejected with closest-value hint
 ✓ strict maintenance filters — invalid phase/severity/kind rejected at runtime (phases=validate/repair/link/materialize/review; severities=fail/warn/info; kinds=inspect_compile_issue/break_dependency_cycle/canonicalize_graph_arrays/resolve_dangling_reference/add_missing_relation/materialize_external_element/unassigned_node/empty_domain)
 ✓ strict relation filters — invalid dependencyTypes rejected with closest-value hint
-✓ strict list_concepts filters — invalid kind rejected with closest-value hint
-✓ strict query_concepts filters — invalid kind/has-key rejected with closest-value hints
 ✓ strict find_neighbors filters — invalid relation types rejected before slug resolution with closest-value hint
 ✓ strict find_orphans filters — invalid kind/excludeKinds rejected with closest-value hints
+✓ strict list_concepts filters — invalid kind rejected with closest-value hint
+✓ strict query_concepts filters — invalid kind/has-key rejected with closest-value hints
 ✓ strict relation_check — invalid type rejected before endpoint resolution with closest-value hint and structured repair
 ✓ strict add_relation — invalid type rejected before endpoint resolution with structured repair and no write metadata
 ✓ strict graph filters — invalid match_nodes.kind/sort, match_edges.type, and recommend_relations.kind rejected with narrowed diagnostics
@@ -553,41 +555,41 @@ A successful run looks like this:
 ✓ maintenance cursor — missing afterActionId reported (afterActionId not found in filtered maintenance actions; phase none; severity none; kind none; executable none; review none)
 ✓ maintenance cursor — ready page stable (1 remaining action; phase materialize:1; severity info:1; kind materialize_external_element:1; executable maint_198312e5:materialize/materialize_external_element:info->add_concept; review none)
 ✓ maintenance cursor — resume afterActionId advanced (maint_198312e5; 0 remaining actions; phase none; severity none; kind none; executable none; review none)
-✓ list_concepts — vault total 106 nodes (vaultRoot /path/to/docs/ontology)
+✓ list_concepts — vault total 107 nodes (vaultRoot /path/to/docs/ontology)
 ✓ get_concept — project (6 outgoing edges)
 ✓ get_concepts — 2 ok rows, 1 partial row
-✓ find_evidence — 60 evidence results for "project"
+✓ find_evidence — 58 evidence results for "project"
 ✓ find_backlinks — project (1 backlink)
 ✓ query_concepts — 1 query result / 1 total query result
-✓ query_concepts limited — 1 query result / 105 total query results (limited true)
-✓ analyze_repo_structure — fsd (4 domain candidates, 20 capability candidates, 29 element candidates)
-✓ infer_imports — 659 files scanned, 484 module edges (elements/src/views/home->capabilities/knowledge-graph x24 (static:24), elements/src/widgets/docs-vault->capabilities/docs-vault x14 (static:14), +482 more)
-✓ index_project — 54 concept candidates, 484 import relations, validation 0 problem files
+✓ query_concepts limited — 1 query result / 106 total query results (limited true)
+✓ analyze_repo_structure — fsd (4 domain candidates, 20 capability candidates, 30 element candidates)
+✓ infer_imports — 679 files scanned, 487 module edges (elements/src/views/home->capabilities/knowledge-graph x24 (static:24), elements/src/widgets/docs-vault->capabilities/docs-vault x14 (static:14), +485 more)
+✓ index_project — 55 concept candidates, 487 import relations, validation 0 problem files
 ✓ find_neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)
 ✓ find_path — src/widgets/bottom-tab-bar → project (2 hops, 2 edges)
 ✓ find_orphans — 0 orphans (root/sentinel defaults excluded)
-✓ list_kinds — 106 nodes (capability:36, document:3, domain:6, element:59, project:1, vault-readme:1)
-✓ validate_vault — 106 files, 0 problem files
+✓ list_kinds — 107 nodes (capability:36, document:3, domain:6, element:60, project:1, vault-readme:1)
+✓ validate_vault — 107 files, 0 problem files
 ✓ project probe — 1 project node
-✓ workspace_brief — healthy (106 nodes, 1 next action, 5 health checks, growth actions:1 external:1 ignoredExternal:203)
+✓ workspace_brief — healthy (107 nodes, 1 next action, 5 health checks, growth actions:1 external:1 ignoredExternal:203)
 · workspace_brief non-blocking advisory nextActions — materialize_external_elements:info:1 - Materialize frequently referenced external files as element nodes when they should be first-class.
 ✓ agent_brief — healthy (ready 100/100, 3 entrypoints, 5 first calls, 6 graph DB pack items, 4 playbooks, 3 write guardrails, 3 result contracts)
-✓ workspace_brief_tuned — healthy (106 nodes, 2 next actions, 5 health checks, growth actions:1 external:1 ignoredExternal:203; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies; nodeLimit=3)
+✓ workspace_brief_tuned — healthy (107 nodes, 2 next actions, 5 health checks, growth actions:1 external:1 ignoredExternal:203; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies; nodeLimit=3)
 · workspace_brief_tuned non-blocking advisory nextActions — components/health_check:info:4 - The scoped ontology graph has disconnected actionable islands., materialize_external_elements:info:1 - Materialize frequently referenced external files as element nodes when they should be first-class.
 ✓ health — healthy (issues:0, unresolved:0, cycles:0, 5 checks: compile_issues:pass:0, unresolved_edges:pass:0, dependency_cycles:pass:0, relation_recommendations:pass:0, components:pass:1)
 ✓ health_tuned — healthy (issues:0, unresolved:0, cycles:0, 5 checks: compile_issues:pass:0, unresolved_edges:pass:0, dependency_cycles:pass:0, relation_recommendations:pass:0, components:info:4; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies)
 · health_tuned non-blocking advisory checks — components:info:4 - The scoped ontology graph has disconnected actionable islands.
-✓ compile_ontology — graph 4eaa32583fa9 (106 nodes, 595 edges, issues 0)
-✓ compile_ontology page — 1/106 nodes, 1/595 edges
-✓ compile_ontology indexes — out 106, in 105, edgeById 595, aliases 211, edges 391/204/0
-✓ overview — graph 4eaa32583fa9 (106 nodes, 595 edges, hubs 5)
-✓ overview query_plan — aggregate_scan (medium, nodes 106, edges 595)
-✓ project_map query_plan — aggregate_scan (medium, nodes 106, edges 595)
+✓ compile_ontology — graph cc6d014dac81 (107 nodes, 597 edges, issues 0)
+✓ compile_ontology page — 1/107 nodes, 1/597 edges
+✓ compile_ontology indexes — out 107, in 106, edgeById 597, aliases 213, edges 393/204/0
+✓ overview — graph cc6d014dac81 (107 nodes, 597 edges, hubs 5)
+✓ overview query_plan — aggregate_scan (medium, nodes 107, edges 597)
+✓ project_map query_plan — aggregate_scan (medium, nodes 107, edges 597)
 ✓ neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)
 ✓ path — src/widgets/bottom-tab-bar → project (2 hops, 2 edges)
 ✓ all_paths — src/widgets/bottom-tab-bar → project (5/16 paths, budget 1000, expanded 1000, exhaustive false, evidence partial)
-✓ project_scope — project (102 nodes, internalEdges 372)
-✓ read census consistency — 106 nodes across list_kinds/list_concepts/compile_ontology/overview, 6 kinds
+✓ project_scope — project (103 nodes, internalEdges 374)
+✓ read census consistency — 107 nodes across list_kinds/list_concepts/compile_ontology/overview, 6 kinds
 ✓ structuredContent — direct 16/16, write 5/5 (batch row-isolation 2/2, batch no-write metadata 2/2, destructive dry-run 3/3), maintenance 3/3, graph 13/13
 
 All passed — register .mcp.json with your MCP client and restart to use the 25 tools.

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -32,12 +32,14 @@
  *   17. tools/call query_ontology overview + query_plan(overview/project_map) — graph-query smoke contract
  *   18. tools/call query_ontology neighbors/node-to-project path/all_paths/project_scope — core graph query smoke contract
  *   19. tools/call query_ontology relation_check + graph kind typo rejection — write/query preflight fail-closed smoke
+ *   20. tools/call absorb_document dry-run against a temp fixture (Slice 0) — CLAUDE.md/AGENTS.md absorption tool smoke, never touches the vault under test
  *
  * 모두 PASS → exit 0, 실패 → exit 1 + 진단 메시지.
  */
 
 import { spawn } from 'node:child_process';
-import { statSync } from 'node:fs';
+import { mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve, join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
@@ -100,6 +102,43 @@ export const VERIFY_TUNED_HEALTH_ARGS = {
   componentTypes: ['domains', 'domain', 'capabilities', 'dependencies'],
 };
 export const VERIFY_TUNED_WORKSPACE_BRIEF_NODE_LIMIT = 3;
+
+// Slice 0 (PRODUCT-PLAN-2026-07.md §9) — absorb_document dry-run smoke.
+// A fixed, per-verify-process temp file so the live walk exercises the tool
+// end-to-end without touching the vault under test (dry-run only — never
+// confirm:true here). One heading matches the policy vocabulary (→ absorb
+// candidate) and one matches the architecture vocabulary (→ suggest
+// candidate, never auto-written) so both classification branches are
+// covered; neither is injection-suspect.
+const ABSORB_FIXTURE_DIR = join(tmpdir(), `ontology-atlas-verify-absorb-${process.pid}`);
+export const ABSORB_FIXTURE_PATH = join(ABSORB_FIXTURE_DIR, 'CLAUDE.md');
+const ABSORB_FIXTURE_CONTENT = [
+  '# Sample Team Agent Guide',
+  '',
+  '## Testing rules',
+  '',
+  '- Always write a failing test before implementing a fix.',
+  '- Never skip the pre-commit hook.',
+  '',
+  '## Architecture',
+  '',
+  'The billing service calls the ledger service through gRPC.',
+  '',
+].join('\n');
+
+export function ensureAbsorbFixture() {
+  mkdirSync(ABSORB_FIXTURE_DIR, { recursive: true });
+  writeFileSync(ABSORB_FIXTURE_PATH, ABSORB_FIXTURE_CONTENT, 'utf-8');
+  return ABSORB_FIXTURE_PATH;
+}
+
+export function cleanupAbsorbFixture() {
+  try {
+    rmSync(ABSORB_FIXTURE_DIR, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup only — a leftover temp file is harmless.
+  }
+}
 
 export const EXPECTED_READ_TOOLS = [
   'list_concepts',
@@ -3291,6 +3330,7 @@ export const FIRST_CONTACT_RESPONSE_LABELS = new Map([
   [66, 'agent_brief'],
   [67, 'all_paths'],
   [68, 'index_project'],
+  [69, 'absorb_document_dry_run'],
 ]);
 
 export const OPTIONAL_FIRST_CONTACT_RESPONSE_IDS = [
@@ -3603,6 +3643,7 @@ export function verifyUsage() {
     'tools/list inventory names, initialize-instruction tool inventory, schema strictness, and annotation coverage (title/read/write/destructive/idempotent/local-only),\n' +
     'batch reader/writer row isolation for non-object rows and unknown row fields with concepts[n]/relations[n] error labels, invalid add_relations type closest-value hints, and 50-row batch cap rejection,\n' +
     'destructive writer dry-runs for rename_concept/merge_concepts/delete_concept with every planned response present and no changed/postWriteMaintenance,\n' +
+    'an absorb_document dry-run against a temp fixture file (Slice 0 — never the vault under test) covering both the policy-absorb and architecture-suggest classification branches,\n' +
     'structuredContent coverage summary splits direct reads, batch row-isolation writes with no write metadata, destructive dry-runs, maintenance cursor checks, and graph queries,\n' +
     'and maintenance_plan cursor handling: ready page (cursor.found=true, cursor.reason=null)\n' +
     'plus missing afterActionId (cursor.found=false, reason, empty page, nextAfterActionId=null, hasMore=false).\n' +
@@ -3757,6 +3798,16 @@ export function buildFirstContactRequests() {
       id: 68,
       method: 'tools/call',
       params: { name: 'index_project', arguments: { rootPath: REPO_ROOT, maxFiles: 5000 } },
+    },
+    {
+      jsonrpc: '2.0',
+      id: 69,
+      method: 'tools/call',
+      // Slice 0 — absorb_document dry-run against a temp fixture (never the
+      // vault under test). Unconditional: no vault dependency, so this is
+      // part of the initial batch rather than a reactive follow-up like the
+      // rename/merge/delete dry-run smokes.
+      params: { name: 'absorb_document', arguments: { filePath: ABSORB_FIXTURE_PATH } },
     },
     {
       jsonrpc: '2.0',
@@ -4408,6 +4459,76 @@ export function destructiveDryRunFailure(response, toolName) {
     }
     const backlinkRowsFailure = destructiveBacklinkRowsFailure(parsed.backlinks, toolName, 'backlinks');
     if (backlinkRowsFailure) return backlinkRowsFailure;
+  }
+  return null;
+}
+
+// Slice 0 — absorb_document dry-run smoke (separate from
+// destructiveDryRunFailure/destructiveDryRunSmokeFailure: it targets a temp
+// fixture file rather than a vault node, so it is checked and logged as its
+// own line instead of joining the rename/merge/delete dry-run count).
+export function absorbDocumentDryRunFailure(response) {
+  if (!response || !response.result) {
+    return 'no absorb_document dry-run response';
+  }
+  if (response.result.isError === true) {
+    return 'absorb_document dry-run returned top-level tool error';
+  }
+  let parsed = null;
+  try {
+    parsed = JSON.parse(response.result.content?.[0]?.text || '{}');
+  } catch (err) {
+    return `failed to parse absorb_document dry-run response: ${err.message}`;
+  }
+  const structuredFailure = structuredContentFailure(response, parsed, 'absorb_document dry-run');
+  if (structuredFailure) return structuredFailure;
+  if (parsed.ok !== false || parsed.dryRun !== true) {
+    return 'absorb_document dry-run response must be ok:false with dryRun:true';
+  }
+  if (Object.prototype.hasOwnProperty.call(parsed, 'changed')) {
+    return 'absorb_document dry-run response unexpectedly included changed';
+  }
+  if (Object.prototype.hasOwnProperty.call(parsed, 'postWriteMaintenance')) {
+    return 'absorb_document dry-run response unexpectedly included postWriteMaintenance';
+  }
+  if (typeof parsed.message !== 'string' || !/confirm:\s*true/.test(parsed.message)) {
+    return 'absorb_document dry-run response missing follow-up safety hint';
+  }
+  if (!isCleanNonBlankString(parsed.filePath) || !isCleanNonBlankString(parsed.sourceLabel)) {
+    return 'absorb_document dry-run response missing file identity fields';
+  }
+  const summary = parsed.summary;
+  if (
+    !summary ||
+    !Number.isInteger(summary.total) ||
+    !Number.isInteger(summary.absorbed) ||
+    !Number.isInteger(summary.suggested) ||
+    !Number.isInteger(summary.injectionSuspect) ||
+    !Number.isInteger(summary.unclassified)
+  ) {
+    return 'absorb_document dry-run response missing summary counts';
+  }
+  if (!Array.isArray(parsed.sections) || parsed.sections.length !== summary.total) {
+    return 'absorb_document dry-run response sections/summary.total mismatch';
+  }
+  for (let index = 0; index < parsed.sections.length; index += 1) {
+    const section = parsed.sections[index];
+    if (
+      !section ||
+      !isCleanNonBlankString(section.heading) ||
+      !isCleanNonBlankString(section.category) ||
+      !isCleanNonBlankString(section.action) ||
+      typeof section.injectionSuspect !== 'boolean' ||
+      !Array.isArray(section.injectionMatches)
+    ) {
+      return `absorb_document dry-run response sections[${index}] shape drift`;
+    }
+  }
+  // The verify fixture (ensureAbsorbFixture) is crafted with one policy
+  // heading and one architecture heading so both branches are exercised —
+  // guard against a classifier regression silently collapsing that.
+  if (summary.absorbed < 1 || summary.suggested < 1) {
+    return 'absorb_document dry-run response did not classify the fixture as expected (need >=1 absorb and >=1 suggest section)';
   }
   return null;
 }
@@ -7278,9 +7399,15 @@ async function step2BootAndCall() {
   }
   log('info', `step 2 — server boot + tools/list + list_concepts/project probe/get_concept/get_concepts/find_evidence/find_backlinks/query_concepts/limited query_concepts/analyze_repo_structure/infer_imports/index_project/find_neighbors/find_path/find_orphans/list_kinds/destructive dry-runs (vault=${VAULT}, timeout=${timeoutMs}ms)`);
 
+  // Slice 0 — the absorb_document dry-run request (id 69, part of the
+  // initial batch above) targets this temp fixture. Must exist before the
+  // server can process it; cleaned up in the finally below regardless of
+  // outcome.
+  ensureAbsorbFixture();
   const lines = buildFirstContactRequests().map((request) => JSON.stringify(request));
 
-  return new Promise((res) => {
+  try {
+    return await new Promise((res) => {
     const proc = spawn(process.execPath, [SERVER_ENTRY], {
       env: { ...process.env, OATLAS_VAULT: VAULT },
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -7522,6 +7649,7 @@ async function step2BootAndCall() {
       const strictQueryConceptsHasKeyFilterRes = responses.find((r) => r.id === 59);
       const strictListConceptsKindFilterRes = responses.find((r) => r.id === 60);
       const patchConflictGuardRes = responses.find((r) => r.id === 61);
+      const absorbDocumentDryRunRes = responses.find((r) => r.id === 69);
       const strictGraphFromKindFilterRes = responses.find((r) => r.id === 48);
       const strictGraphToKindFilterRes = responses.find((r) => r.id === 49);
       const maintenanceMissingCursorRes = responses.find((r) => r.id === 25);
@@ -7652,6 +7780,12 @@ async function step2BootAndCall() {
         destructiveDryRunCount = destructiveDryRunResponses.length;
         log('ok', `destructive dry-runs — ${destructiveDryRunResponses.map(([toolName]) => toolName).join(' · ')} preview without write-maintenance`);
       }
+      const absorbDocumentDryRunFailureMessage = absorbDocumentDryRunFailure(absorbDocumentDryRunRes);
+      if (absorbDocumentDryRunFailureMessage) {
+        log('fail', absorbDocumentDryRunFailureMessage);
+        return res(false);
+      }
+      log('ok', 'absorb_document dry-run — temp fixture classified (policy + architecture sections) without writing');
       if (patchConflictGuardRes) {
         const patchConflictFailure = patchConflictGuardFailure(patchConflictGuardRes);
         if (patchConflictFailure) {
@@ -8713,7 +8847,10 @@ async function step2BootAndCall() {
       log('fail', `server spawn failed: ${err.message}`);
       res(false);
     });
-  });
+    });
+  } finally {
+    cleanupAbsorbFixture();
+  }
 }
 
 async function main() {

--- a/mcp/src/verify-script.test.mjs
+++ b/mcp/src/verify-script.test.mjs
@@ -19,6 +19,7 @@ import {
 } from './ontology-engine.mjs';
 
 import {
+  absorbDocumentDryRunFailure,
   advisoryHealthChecksSummary,
   advisoryNextActionsSummary,
   agentBriefFailure,
@@ -27,6 +28,8 @@ import {
   batchCapFailure,
   batchRowIsolationFailure,
   buildFirstContactRequests,
+  cleanupAbsorbFixture,
+  ensureAbsorbFixture,
   buildGetConceptSmokeSlug,
   buildGetConceptsSmokeSlugs,
   buildDestructiveDryRunSmokeRequests,
@@ -149,6 +152,7 @@ import {
 import { expectedResponseIds, missingResponseLabels } from '../scripts/json-rpc-lines.mjs';
 import { GRAPH_ARRAY_KEYS } from './vault.mjs';
 import { assertPnpmScriptsExist } from '../../scripts/lib/pnpm-script-refs.mjs';
+import { buildAbsorptionPlan } from './absorb.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MCP_PKG = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
@@ -7061,6 +7065,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(FIRST_CONTACT_RESPONSE_LABELS.get(65), 'strict_unknown_tool');
     assert.equal(FIRST_CONTACT_RESPONSE_LABELS.get(67), 'all_paths');
     assert.equal(FIRST_CONTACT_RESPONSE_LABELS.get(68), 'index_project');
+    assert.equal(FIRST_CONTACT_RESPONSE_LABELS.get(69), 'absorb_document_dry_run');
     assert.deepEqual(
       [...expectedResponseIds(buildFirstContactRequests()), ...DYNAMIC_FIRST_CONTACT_RESPONSE_IDS].sort((a, b) => a - b),
       [...FIRST_CONTACT_RESPONSE_LABELS.keys()].sort((a, b) => a - b),
@@ -7173,6 +7178,113 @@ describe('verify.mjs first-contact gates', () => {
         expectedTotal: 2,
       },
     );
+  });
+
+  it('sends an absorb_document dry-run request against the temp fixture at boot (unconditional — no vault dependency)', () => {
+    const requests = buildFirstContactRequests();
+    const request = requests.find((r) => r.id === 69);
+    assert.ok(request, 'expected an id:69 absorb_document request in the first-contact batch');
+    assert.equal(request.method, 'tools/call');
+    assert.equal(request.params.name, 'absorb_document');
+    assert.equal(typeof request.params.arguments.filePath, 'string');
+    assert.ok(request.params.arguments.filePath.length > 0);
+    // dry-run — confirm must be omitted/false so the live walk never writes.
+    assert.equal(request.params.arguments.confirm, undefined);
+  });
+
+  it('the absorb_document fixture classifies to at least one absorb and one suggest section', () => {
+    const fixturePath = ensureAbsorbFixture();
+    try {
+      const raw = readFileSync(fixturePath, 'utf-8');
+      const plan = buildAbsorptionPlan(raw, { sourceLabel: 'CLAUDE', isSlugTaken: () => false });
+      assert.ok(plan.summary.absorbed >= 1, `expected >=1 absorbed section, got ${plan.summary.absorbed}`);
+      assert.ok(plan.summary.suggested >= 1, `expected >=1 suggested section, got ${plan.summary.suggested}`);
+      assert.equal(plan.summary.injectionSuspect, 0);
+    } finally {
+      cleanupAbsorbFixture();
+    }
+  });
+
+  function wrapAbsorbResponse(parsed) {
+    return {
+      result: {
+        content: [{ type: 'text', text: JSON.stringify(parsed) }],
+        structuredContent: parsed,
+      },
+    };
+  }
+
+  it('accepts a clean absorb_document dry-run response', () => {
+    assert.equal(
+      absorbDocumentDryRunFailure(
+        wrapAbsorbResponse({
+          ok: false,
+          dryRun: true,
+          filePath: '/tmp/CLAUDE.md',
+          sourceLabel: 'CLAUDE',
+          title: 'Sample Team Agent Guide',
+          summary: { total: 2, absorbed: 1, suggested: 1, injectionSuspect: 0, unclassified: 0 },
+          sections: [
+            {
+              heading: 'Testing rules',
+              category: 'policy',
+              kind: 'document',
+              role: 'policy',
+              confidence: 0.7,
+              action: 'absorb',
+              targetSlug: 'claude-testing-rules',
+              injectionSuspect: false,
+              injectionMatches: [],
+            },
+            {
+              heading: 'Architecture',
+              category: 'architecture',
+              kind: 'capability',
+              role: null,
+              confidence: 0.6,
+              action: 'suggest',
+              targetSlug: 'capabilities/architecture',
+              injectionSuspect: false,
+              injectionMatches: [],
+            },
+          ],
+          message: 'dry-run — 1 section(s) would be absorbed as document/policy nodes, 1 suggested (not written), 0 injection-suspect (excluded from absorption). Pass confirm:true to write.',
+        }),
+      ),
+      null,
+    );
+  });
+
+  it('rejects a malformed absorb_document dry-run response', () => {
+    const base = {
+      ok: false,
+      dryRun: true,
+      filePath: '/tmp/CLAUDE.md',
+      sourceLabel: 'CLAUDE',
+      summary: { total: 1, absorbed: 1, suggested: 0, injectionSuspect: 0, unclassified: 0 },
+      sections: [{
+        heading: 'Testing rules',
+        category: 'policy',
+        confidence: 0.7,
+        action: 'absorb',
+        injectionSuspect: false,
+        injectionMatches: [],
+      }],
+      message: 'dry-run — pass confirm:true to write.',
+    };
+    const wrap = wrapAbsorbResponse;
+
+    assert.match(absorbDocumentDryRunFailure(wrap({ ...base, ok: true })), /ok:false with dryRun:true/);
+    assert.match(absorbDocumentDryRunFailure(wrap({ ...base, changed: true })), /unexpectedly included changed/);
+    assert.match(absorbDocumentDryRunFailure(wrap({ ...base, postWriteMaintenance: {} })), /unexpectedly included postWriteMaintenance/);
+    assert.match(absorbDocumentDryRunFailure(wrap({ ...base, message: 'no safety hint here' })), /missing follow-up safety hint/);
+    assert.match(absorbDocumentDryRunFailure(wrap({ ...base, summary: { total: 2, absorbed: 1, suggested: 0, injectionSuspect: 0, unclassified: 0 } })), /sections\/summary\.total mismatch/);
+    assert.match(
+      absorbDocumentDryRunFailure(wrap({ ...base, summary: { total: 1, absorbed: 0, suggested: 0, injectionSuspect: 0, unclassified: 1 } })),
+      /did not classify the fixture as expected/,
+    );
+    assert.match(absorbDocumentDryRunFailure({ result: { isError: true } }), /top-level tool error/);
+    assert.match(absorbDocumentDryRunFailure(null), /no absorb_document dry-run response/);
   });
 
   it('builds destructive writer dry-run smoke requests from listed nodes', () => {

--- a/scripts/check-package-contracts.test.mjs
+++ b/scripts/check-package-contracts.test.mjs
@@ -70,13 +70,17 @@ function regexEscape(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Mirrors mcp/src/index.js findEvidence()'s scoreEvidence() inclusion rule
+// (mcp/src/evidence-rank.mjs): title / frontmatter capabilities+elements /
+// body substring match. Deliberately does NOT match on slug — scoreEvidence
+// never checks the slug, so including it here over-counts relative to the
+// live find_evidence tool (this drifted the README-alignment assertion by
+// one doc whose slug, but not title/frontmatter/body, contained the query).
 function findEvidenceCount(docs, query) {
   const needle = query.toLowerCase();
   return docs.filter((doc) => {
-    const docSlug = String(doc.slug || doc.frontmatter.slug || '').toLowerCase();
     const docTitle = String(doc.frontmatter.title || doc.frontmatter.name || '').toLowerCase();
     const inFrontmatter =
-      docSlug.includes(needle) ||
       docTitle.includes(needle) ||
       String(doc.frontmatter.capabilities || '').toLowerCase().includes(needle) ||
       String(doc.frontmatter.elements || '').toLowerCase().includes(needle);

--- a/scripts/dogfood-mcp-walk.test.mjs
+++ b/scripts/dogfood-mcp-walk.test.mjs
@@ -85,6 +85,7 @@ const WRITE_TOOL_NAMES = new Set([
   "delete_concept",
   "rename_concept",
   "merge_concepts",
+  "absorb_document",
 ]);
 const ROOT_PKG = JSON.parse(readFileSync("package.json", "utf-8"));
 
@@ -122,7 +123,7 @@ function makeDogfoodInitialize() {
       "maintenance_plan afterActionId cursor misses return cursor.found=false and cursor.reason.",
       "maintenance_plan missing cursors return cursor.nextAfterActionId=null and cursor.hasMore=false.",
       "query_ontology agent_brief returns relationDecisionGuide for relation_check outcomes skip_existing, review_inverse, safe_to_add, and review_new_schema.",
-      "query_ontology agent_brief returns graphDbQueryPack for match_nodes, match_edges, domain_matrix, centrality, all_paths, and explain_relation.",
+      "query_ontology agent_brief returns graphDbQueryPack for facets, schema, match_nodes, match_edges, domain_matrix, centrality, all_paths, and explain_relation.",
       "query_ontology agent_brief returns traversalStrategy plan_before_enumeration, bounded_path_evidence, and containment_cross_check.",
       "query_ontology agent_brief resultContracts describe all_paths limit, searchBudget, expandedStates, exhaustive, truncatedByBudget, totalPathsExact, evidence.status, evidence.reason, and evidence.pathsComplete.",
     ].join("\n"),
@@ -487,7 +488,7 @@ function makeDogfoodToolsList() {
         },
       };
       if (name === "query_ontology") {
-        tool.description = "Graph query tool with current-page `nextExecutableAction` / `nextReviewAction` pointers and cursor `nextAfterActionId`/`hasMore` pagination metadata. `agent_brief` includes graphDbQueryPack for match_nodes, match_edges, domain_matrix, centrality, all_paths, and explain_relation, traversalStrategy plan_before_enumeration, bounded_path_evidence, and containment_cross_check guidance plus resultContracts for all_paths completeness. `all_paths` responses include limit/searchBudget/exhaustive/truncatedByBudget/totalPathsExact metadata and evidence guidance.";
+        tool.description = "Graph query tool with current-page `nextExecutableAction` / `nextReviewAction` pointers and cursor `nextAfterActionId`/`hasMore` pagination metadata. `agent_brief` includes graphDbQueryPack for facets, schema, match_nodes, match_edges, domain_matrix, centrality, all_paths, and explain_relation, traversalStrategy plan_before_enumeration, bounded_path_evidence, and containment_cross_check guidance plus resultContracts for all_paths completeness. `all_paths` responses include limit/searchBudget/exhaustive/truncatedByBudget/totalPathsExact metadata and evidence guidance.";
         tool.inputSchema.required = ["operation"];
         tool.inputSchema.properties = {
           operation: { enum: QUERY_ONTOLOGY_OPERATIONS },
@@ -1205,7 +1206,7 @@ function makeDogfoodToolsList() {
         };
         tool.outputSchema = {
           type: "object",
-          required: ["rootPath", "framework", "domains", "capabilities", "elements", "suggestedRelations", "skipped"],
+          required: ["rootPath", "framework", "domains", "capabilities", "elements", "meaningGate", "suggestedRelations", "skipped"],
           properties: {
             rootPath: { type: "string" },
             project: {
@@ -1271,6 +1272,64 @@ function makeDogfoodToolsList() {
                 },
                 additionalProperties: false,
               },
+            },
+            meaningGate: {
+              type: "object",
+              required: ["policy", "sourceStructureRole", "businessOntology", "implementationEvidence", "reviewQuestions"],
+              properties: {
+                policy: { type: "string" },
+                sourceStructureRole: { type: "string" },
+                businessOntology: {
+                  type: "object",
+                  required: ["domains", "capabilities", "evidence"],
+                  properties: {
+                    domains: { type: "array", items: { type: "string" } },
+                    capabilities: { type: "array", items: { type: "string" } },
+                    evidence: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        required: ["slug", "kind", "source"],
+                        properties: {
+                          slug: { type: "string" },
+                          kind: { type: "string", enum: ["domain", "capability"] },
+                          source: { type: "string" },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                implementationEvidence: {
+                  type: "object",
+                  required: ["elements", "reviewRequiredCapabilities"],
+                  properties: {
+                    elements: { type: "array", items: { type: "string" } },
+                    reviewRequiredCapabilities: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        required: ["slug", "reason", "evidence"],
+                        properties: {
+                          slug: { type: "string" },
+                          reason: { type: "string" },
+                          evidence: {
+                            type: "object",
+                            required: ["source"],
+                            properties: { source: { type: "string" } },
+                            additionalProperties: false,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                reviewQuestions: { type: "array", items: { type: "string" } },
+              },
+              additionalProperties: false,
             },
             suggestedRelations: {
               type: "array",
@@ -3805,7 +3864,7 @@ describe("rpc response completion helpers", () => {
     drifted.find((tool) => tool.name === "list_concepts").annotations.openWorldHint = true;
     assert.equal(
       toolsListAnnotationSummary(drifted),
-      "23/23 titled; 15/15 read; 8/8 write; 3/3 destructive; 2/2 idempotent; 22/23 local-only",
+      "25/25 titled; 16/16 read; 9/9 write; 4/4 destructive; 2/2 idempotent; 24/25 local-only",
     );
     assert.equal(toolsListAnnotationSummary(null), "missing tools/list");
   });


### PR DESCRIPTION
## Summary
Slice 0의 잔여 3종 (PR #310 스택 — base: feat/slice0-absorb).

- **`init --quick-start`**: 프롬프트 없는 원라이너 — scaffold → 기존 bootstrap 재사용 → `.mcp.json` 자동 → CLAUDE.md/AGENTS.md 감지 시 absorb 제안 출력 (자동 실행 안 함 — 승인 계층 원칙) → 3줄 next-steps. 일반 `init` 동작 무변경 (회귀 테스트로 보증).
- **매직 모먼트 계측**: `.ontology-atlas/telemetry.local.json` (로컬 전용, 절대 전송 안 함 — 신뢰 헌장, scaffold .gitignore에 자동 제외) + `ontology-atlas moment` 명령(47번째). MCP 읽기 도구에는 의도적으로 미배선 — `readOnlyHint` 계약 보호 (한계 문서화 + `--mark` 수동 폴백).
- **mcp-verify 편입**: `absorb_document` dry-run이 스모크 워크에 포함 — 임시 fixture 생성·검증·정리까지 라이브 e2e 확인.
- **absorb발 drift 청소**: mcp/README 예제 트랜스크립트 실측 재생성 (107노드 census 포함) + dogfood-walk fixture 4겹 stale 동기화 + evidence 카운트 테스트 헬퍼의 실제 버그 수정 (slug를 evidence로 오집계).

## Test plan
- verify-script 122/122 · dogfood-mcp-walk 124/124 · contracts 187/187 · mcp:maintenance 10/10 ✅
- 잔여 실패는 main의 census drift 기존 건 — PR #312가 해결 (머지 순서: #312 → #310 → 본 PR 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)