### PR TITLE
fix: 지형도 레이아웃 붕괴·클리핑·선 가림 수리 (design-guardian a1~a6)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -217,8 +217,12 @@
        존재 이유이므로 잉크를 한 단계 상향 (3:1 대비 목표). */
     --topology-relation-stroke-strong: rgba(139, 151, 255, 0.82);
     --topology-relation-stroke-strong-width: 2.2;
-    --topology-relation-stroke-supported: rgba(72, 184, 203, 0.68);
+    /* R+ 디자인 가디언 verdict a5: cyan(72,184,203) 은 인디고 외 제2 채색
+       시스템이었다(헌장 위반 — "카테고리 구분은 색이 아닌 보더 스타일"). 같은
+       인디고 잉크로 통일하고 dash 로 spine(실선/strong)과 구분한다. */
+    --topology-relation-stroke-supported: rgba(139, 151, 255, 0.5);
     --topology-relation-stroke-supported-width: 1.8;
+    --topology-relation-stroke-supported-dasharray: 5 3;
     --topology-relation-stroke-weak: rgba(217, 161, 65, 0.62);
     --topology-relation-stroke-weak-width: 1.5;
     --topology-relation-stroke-review: rgba(226, 105, 105, 0.66);
@@ -296,6 +300,18 @@
       calc(100vw - 520px)
     );
     --topology-path-endpoint-card-max-width: min(26rem, calc(100vw - 1rem));
+    /*
+     * 지도(TopologyMapCanvas) fit 안전영역 — fixed chrome(좌측 분석 패널 +
+     * 상단 HUD)이 차지하는 px. 디자인 가디언 verdict a4: 이전 하드코딩
+     * 480px 좌측 예약이 실측 패널 우측 엣지(24px 여백 + ~320px 폭 ≈ 344px)
+     * 보다 136px 과대해 카드 절반이 안전영역 밑에 숨었다. 이 네 토큰이
+     * 단일 진실원 — camera.ts 의 fit 수학은 이 값을 그대로 읽는다
+     * (TopologyMapCanvas.tsx readSafeInsetTokens).
+     */
+    --topology-map-safe-inset-top: 120px;
+    --topology-map-safe-inset-right: 120px;
+    --topology-map-safe-inset-bottom: 110px;
+    --topology-map-safe-inset-left: 344px;
     --topology-panel-radius: 12px;
     --topology-panel-padding: 16px;
     --topology-panel-border: rgba(255, 255, 255, 0.07);
@@ -1115,6 +1131,9 @@
     --topology-relation-direction-surface: rgba(77, 86, 200, 0.08);
     --topology-relation-direction-border: rgba(77, 86, 200, 0.18);
     --topology-relation-direction-text: rgba(40, 50, 175, 0.90);
+    /* verdict a5: cyan(72,184,203) 이 라이트 배경(#f3f5f9)에서 소멸했던
+       실측 대비 결함 — 인디고로 통일(다크와 동일 원칙, 라이트 팔레트 톤). */
+    --topology-relation-stroke-supported: rgba(77, 86, 200, 0.44);
     --topology-relation-spine-halo: rgba(77, 86, 200, 0.24);
     --topology-relation-spine-halo-opacity: 0.24;
     --topology-relation-spine-halo-width: 5.6;
@@ -1196,6 +1215,10 @@
     --topology-overview-handoff-primary-border: rgba(77, 86, 200, 0.22);
     --topology-overview-handoff-secondary-surface: rgba(15, 23, 42, 0.035);
     --topology-overview-handoff-secondary-border: rgba(15, 23, 42, 0.10);
+    /* verdict a5: 다크 전용 rgba(222,225,255,*) 라이트 오버라이드가 아예
+       없어 접힘 섹션("다음 단계") 헤더가 유령 텍스트 수준으로 소멸했다. */
+    --topology-overview-secondary-disclosure-text: rgba(15, 23, 42, 0.42);
+    --topology-overview-secondary-disclosure-hover-text: rgba(15, 23, 42, 0.68);
     --topology-overview-quality-surface: rgba(20, 148, 128, 0.055);
     --topology-overview-quality-border: rgba(20, 148, 128, 0.22);
     --topology-overview-quality-meter-surface: rgba(15, 23, 42, 0.045);

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -214,7 +214,14 @@ import { TopologyReviewLink } from "./TopologyReviewLink";
 import { TopologyNoMatchesState } from "./TopologyNoMatchesState";
 
 const LEFT_PANEL_COLLAPSED_KEY = "demo:left-panel-collapsed:v2";
-const TOPOLOGY_OVERVIEW_WIDE_CANVAS_ASPECT_X = 8;
+// aspectX 는 렌더 엔진에 종속된 상수다 — 옛 Sigma 경로는 `autoRescale` 이
+// bounds 를 뷰포트에 재정규화해주므로 늘려도 다시 맞춰졌지만, 신 지도 엔진
+// (TopologyMapCanvas) 은 진짜 metric 카메라라 8배 늘림이 그대로 노출되어
+// radial ring 이 수평 띠로 붕괴한다(디자인 가디언 verdict a1). 캔버스 엔진은
+// 늘리지 않는다(1) — ring 위치가 kind 위계의 1차 인코딩이라는 계약
+// (topology-skeleton-layout.ts) 을 지키는 값.
+const TOPOLOGY_OVERVIEW_MAP_CANVAS_ASPECT_X = 1;
+const TOPOLOGY_OVERVIEW_LEGACY_SIGMA_ASPECT_X = 8;
 
 export function HomePage() {
   const t = useTranslations('topology');
@@ -661,6 +668,14 @@ export function HomePage() {
           null
         : (selectedOntologyNode?.id ?? null);
 
+  // 어떤 렌더 엔진이 골격을 그리는지(verdict a1) — 캔버스 엔진
+  // (TopologyMapCanvas) 은 이 조건이 참일 때만 마운트된다(아래 JSX,
+  // `analysisMode !== "graph" && localGraphRoot === null` 과 동일 조건).
+  // useMemo 콜백 안에서 매번 `analysisMode === "graph"` 를 다시 비교하면
+  // 이른 return 이후 TS 가 리터럴 타입을 좁혀 "unintentional comparison"
+  // 오류가 나므로, 바깥 스코프에서 한 번만 계산해 boolean 으로 넘긴다.
+  const isTopologyMapCanvasEngine = localGraphRoot === null && analysisMode !== "graph";
+
   // 구조 골격 진입 — root /topology 에서만(local-graph ego 제외). ontology 노드를
   // 결정론적 radial 골격으로 배치할 precomputed 좌표(slug→{x,y,size}) + 진입에
   // 보일 slug 집합을 계산해 SigmaTopology 에 데이터로 넘긴다. 클릭-레벨 확장:
@@ -690,10 +705,15 @@ export function HomePage() {
     const layout = buildRevealRadialLayout(skel, ontologyInsight.nodes, reveal, {
       width: 1000,
       height: 1000,
-      // 와이드 뷰포트 — 정원은 autoRescale 후 좌우가 비고 세로 거리가 멀어
-      // 보인다. 캔버스를 다시 움직이는 대신, 결정론적 overview projection 을
-      // 넓게 잡아 시작 지형 자체가 desktop canvas 를 쓰게 한다.
-      aspectX: TOPOLOGY_OVERVIEW_WIDE_CANVAS_ASPECT_X,
+      // 엔진별 분기(verdict a1) — 이 시점에선 위의 이른 return 때문에
+      // isTopologyMapCanvasEngine 이 항상 참이라 실질적으로 캔버스 엔진(1)만
+      // 쓰이지만, Sigma 의 옛 skeleton 경로가 나중에 다시 켜질 때를 대비해
+      // 어떤 상수가 어떤 엔진 것인지 분기로 명시해 둔다. Sigma 는
+      // `autoRescale` 이 bounds 를 재정규화해줘 늘려도 다시 맞춰졌지만, 캔버스
+      // 엔진은 진짜 metric 카메라라 늘리면 radial ring 이 수평 띠로 붕괴한다.
+      aspectX: isTopologyMapCanvasEngine
+        ? TOPOLOGY_OVERVIEW_MAP_CANVAS_ASPECT_X
+        : TOPOLOGY_OVERVIEW_LEGACY_SIGMA_ASPECT_X,
     });
     const map = new Map<string, { x: number; y: number; size: number }>();
     const slugs = new Set<string>(reveal.visibleSlugs);
@@ -760,7 +780,14 @@ export function HomePage() {
         dock: true,
       }),
     };
-  }, [analysisMode, localGraphRoot, ontologyInsight, pathTargetSlug, topologyRevealFocusSlug]);
+  }, [
+    analysisMode,
+    isTopologyMapCanvasEngine,
+    localGraphRoot,
+    ontologyInsight,
+    pathTargetSlug,
+    topologyRevealFocusSlug,
+  ]);
 
   useEffect(() => {
     if (!localGraphRoot) return;

--- a/src/views/home/ui/TopologyAnalysisBar.test.tsx
+++ b/src/views/home/ui/TopologyAnalysisBar.test.tsx
@@ -915,7 +915,7 @@ describe("TopologyAnalysisBar", () => {
     expect(screen.queryByRole("button", { name: "Health" })).toBeNull();
   });
 
-  it("keeps the overview guidance readable instead of truncating first-screen relief instructions", () => {
+  it("keeps the overview guidance to a single line and defers concept/relation census to the workspace HUD (design guardian verdict a6)", () => {
     render(
       <TopologyAnalysisBar
         mode="overview"
@@ -945,7 +945,11 @@ describe("TopologyAnalysisBar", () => {
     const prompt = screen.getByText(
       "Start with the product/system map: domains, capabilities, and change paths stay visible for team inspection and sharing.",
     );
-    expect(prompt.className).toContain("line-clamp-3");
+    // 산문 1줄화(verdict a6) — overview 는 더 이상 2~3줄로 펼쳐지지 않는다.
+    // (문안 자체는 scripts/validate-messages.test.mjs 계약이 고정 — 시각
+    // 압축은 line-clamp-1 로, ellipsis 로 1줄에 자연스럽게 잘린다.)
+    expect(prompt.className).toContain("line-clamp-1");
+    expect(prompt.className).not.toContain("line-clamp-3");
     expect(prompt.className).not.toContain("truncate");
     expect(prompt).toHaveAttribute(
       "data-prompt-text-token",
@@ -956,26 +960,13 @@ describe("TopologyAnalysisBar", () => {
     );
     expect(prompt.className).not.toContain("--color-text-secondary");
 
-    const metrics = screen.getByTestId("topology-analysis-panel-metrics");
-    expect(metrics.className).toContain("grid-cols-2");
-    expect(metrics).toHaveAttribute(
-      "data-metric-label-text-token",
-      "--topology-analysis-panel-metric-label-text",
-    );
-    expect(metrics).toHaveAttribute(
-      "data-metric-value-text-token",
-      "--topology-analysis-panel-metric-value-text",
-    );
-    expect(metrics.className).toContain(
-      "text-[color:var(--topology-analysis-panel-metric-label-text)]",
-    );
-    expect(metrics.className).not.toContain("--color-text-quaternary");
-    expect(screen.getByText("292").className).toContain(
-      "text-[color:var(--topology-analysis-panel-metric-value-text)]",
-    );
-    expect(screen.getByText("498").className).toContain(
-      "text-[color:var(--topology-analysis-panel-metric-value-text)]",
-    );
+    // census 중복 삭제(verdict a6) — concepts/relations 숫자는 상단 워크스페이스
+    // HUD(HeroCollapsed subtitle) 가 이미 보여주므로 overview 패널은 반복하지
+    // 않는다. 값 자체는 렌더되지 않아야 한다(다른 모드 프롬프트에 우연히
+    // "292"/"498" 이 없다는 전제 — 이 테스트의 labels 는 기본 labels 를 씀).
+    expect(screen.queryByTestId("topology-analysis-panel-metrics")).toBeNull();
+    expect(screen.queryByText("292")).toBeNull();
+    expect(screen.queryByText("498")).toBeNull();
   });
 
   it("keeps the primary overview brief visible and tucks secondary agent commands into a compact rail", () => {

--- a/src/views/home/ui/TopologyAnalysisBar.tsx
+++ b/src/views/home/ui/TopologyAnalysisBar.tsx
@@ -1106,7 +1106,7 @@ export function TopologyAnalysisBar({
             data-prompt-text-token="--topology-analysis-panel-prompt-text"
             className={`break-keep text-[13.5px] text-[color:var(--topology-analysis-panel-prompt-text)] ${
               panelMode === "overview"
-                ? "line-clamp-3 leading-5 max-md:line-clamp-2"
+                ? "line-clamp-1 leading-5"
                 : panelMode === "focus"
                   ? "line-clamp-2 leading-5"
                   : "line-clamp-3 leading-6"
@@ -1114,27 +1114,33 @@ export function TopologyAnalysisBar({
           >
             {prompt}
           </p>
-          <div
-            data-testid="topology-analysis-panel-metrics"
-            data-metric-label-text-token="--topology-analysis-panel-metric-label-text"
-            data-metric-value-text-token="--topology-analysis-panel-metric-value-text"
-            className={`grid grid-cols-2 gap-1.5 font-mono text-[10.5px] uppercase tracking-[0.12em] text-[color:var(--topology-analysis-panel-metric-label-text)] ${
-              panelMode === "focus" ? "mt-2" : "mt-3"
-            }`}
-          >
-            <span>
-              <span className="text-[color:var(--topology-analysis-panel-metric-value-text)]">
-                {summary.primaryMetric}
-              </span>{" "}
-              {primaryLabel}
-            </span>
-            <span>
-              <span className="text-[color:var(--topology-analysis-panel-metric-value-text)]">
-                {summary.secondaryMetric}
-              </span>{" "}
-              {labels.metricRelations}
-            </span>
-          </div>
+          {/* overview 는 census(concepts/relations) 를 상단 워크스페이스 HUD
+              (HeroCollapsed subtitle) 가 이미 보여준다 — 같은 숫자를 패널에서
+              또 반복하면 "295·505 중복" 이 된다(디자인 가디언 verdict a6).
+              다른 모드(health/focus/path)는 그 모드 고유 지표라 유지한다. */}
+          {panelMode !== "overview" ? (
+            <div
+              data-testid="topology-analysis-panel-metrics"
+              data-metric-label-text-token="--topology-analysis-panel-metric-label-text"
+              data-metric-value-text-token="--topology-analysis-panel-metric-value-text"
+              className={`grid grid-cols-2 gap-1.5 font-mono text-[10.5px] uppercase tracking-[0.12em] text-[color:var(--topology-analysis-panel-metric-label-text)] ${
+                panelMode === "focus" ? "mt-2" : "mt-3"
+              }`}
+            >
+              <span>
+                <span className="text-[color:var(--topology-analysis-panel-metric-value-text)]">
+                  {summary.primaryMetric}
+                </span>{" "}
+                {primaryLabel}
+              </span>
+              <span>
+                <span className="text-[color:var(--topology-analysis-panel-metric-value-text)]">
+                  {summary.secondaryMetric}
+                </span>{" "}
+                {labels.metricRelations}
+              </span>
+            </div>
+          ) : null}
           {panelMode === "overview" ? (
             <div
               data-testid="topology-overview-reader-lens"

--- a/src/widgets/topology-map-canvas/lib/camera.test.ts
+++ b/src/widgets/topology-map-canvas/lib/camera.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampFitScale,
   clampScale,
   fitBounds,
   MAP_SCALE_MAX,
@@ -77,6 +78,61 @@ describe("fitBounds", () => {
     expect(cam.k).toBeGreaterThanOrEqual(MAP_SCALE_MIN);
     expect(10 * cam.k + cam.tx).toBeCloseTo(500, 3);
     expect(10 * cam.k + cam.ty).toBeCloseTo(400, 3);
+  });
+
+  /**
+   * 기획자 감사 ③ 회귀 재발 방지 (design-guardian verdict a2+a3):
+   * 카드가 px-고정 크기(scale(1/k) 역보정)라 fit 수학은 world bounds 만으로는
+   * 부족하다 — 카드의 화면-px overhang 을 safe rect 에서 미리 빼야 코너가
+   * 실제로 안 잘린다. 이 케이스는 옛 aspectX=8 layout 처럼 world 폭이 넓어
+   * 요구 k 가 MAP_SCALE_MIN(0.25) 미만으로 떨어지는 상황을 재현한다.
+   */
+  it("reserves px-fixed card overhang so no card clips even when the required scale falls below the legacy user-zoom floor", () => {
+    const bounds = { minX: -3680, minY: -460, maxX: 3680, maxY: 460 };
+    const viewport = { width: 1512, height: 982 };
+    const insets = { top: 120, right: 120, bottom: 110, left: 344 };
+    const overhang = { left: 148, right: 148, top: 22, bottom: 22 };
+
+    const cam = fitBounds(bounds, viewport, insets, { overhang });
+
+    // fit 은 사용자 줌 하한(MAP_SCALE_MIN)에 clamp 되지 않는다 — a3 계약.
+    expect(cam.k).toBeLessThan(MAP_SCALE_MIN);
+
+    // 카드 전체 화면 extent(월드 코너 × k + overhang)가 safe rect 안에 있어야
+    // "0 clipped cards" 가 성립한다.
+    const screenLeft = bounds.minX * cam.k + cam.tx - overhang.left;
+    const screenRight = bounds.maxX * cam.k + cam.tx + overhang.right;
+    const screenTop = bounds.minY * cam.k + cam.ty - overhang.top;
+    const screenBottom = bounds.maxY * cam.k + cam.ty + overhang.bottom;
+
+    expect(screenLeft).toBeGreaterThanOrEqual(insets.left - 1);
+    expect(screenRight).toBeLessThanOrEqual(viewport.width - insets.right + 1);
+    expect(screenTop).toBeGreaterThanOrEqual(insets.top - 1);
+    expect(screenBottom).toBeLessThanOrEqual(viewport.height - insets.bottom + 1);
+  });
+
+  it("falls back to zero overhang when the caller doesn't measure cards (backward compatible)", () => {
+    const cam = fitBounds(
+      { minX: -500, minY: -300, maxX: 500, maxY: 300 },
+      { width: 1200, height: 800 },
+      { top: 80, right: 40, bottom: 40, left: 360 },
+    );
+    expect(cam.k).toBeGreaterThan(0);
+  });
+});
+
+describe("clampFitScale (a3 — fit clamp domain is separate from user-zoom clamp)", () => {
+  it("has no MAP_SCALE_MIN floor — fit may legitimately need a scale below the user-zoom minimum", () => {
+    expect(clampFitScale(0.05)).toBeCloseTo(0.05, 6);
+    expect(clampFitScale(0.001)).toBeGreaterThan(0); // 여전히 0/음수는 방지
+  });
+
+  it("still enforces the shared MAP_SCALE_MAX ceiling", () => {
+    expect(clampFitScale(999)).toBe(MAP_SCALE_MAX);
+  });
+
+  it("user-zoom clampScale keeps its MAP_SCALE_MIN floor unchanged", () => {
+    expect(clampScale(0.05)).toBe(MAP_SCALE_MIN);
   });
 });
 

--- a/src/widgets/topology-map-canvas/lib/camera.ts
+++ b/src/widgets/topology-map-canvas/lib/camera.ts
@@ -27,11 +27,37 @@ export interface MapInsets {
   left: number;
 }
 
+/**
+ * 카드는 `scale(1/k)` 역보정으로 화면-px 크기 고정이다(TopologyMapCanvas.tsx
+ * `--map-inv-k`). fit 은 world bounds 만으로는 부족하고, 극단 카드가 화면에서
+ * 실제로 차지하는 px 여백(overhang)을 safe rect 예산에서 미리 빼야 한다 —
+ * 디자인 가디언 verdict a2.
+ */
+export interface CardOverhang {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+const ZERO_OVERHANG: CardOverhang = { left: 0, right: 0, top: 0, bottom: 0 };
+
 export const MAP_SCALE_MIN = 0.25;
 export const MAP_SCALE_MAX = 3;
+/** fit 전용 하한 — 0/음수 나눗셈만 막는 수학적 안전장치, 판독성 하한이 아니다. */
+const FIT_SCALE_EPSILON = 0.001;
 
 export function clampScale(k: number): number {
   return Math.min(MAP_SCALE_MAX, Math.max(MAP_SCALE_MIN, k));
+}
+
+/**
+ * fit 전용 clamp — verdict a3: 사용자 줌 하한(MAP_SCALE_MIN)과 다른 도메인.
+ * 넓은 콘텐츠는 정직하게 0.25 미만으로 축소돼야 코너가 잘리지 않는다. 사용자가
+ * 그 다음 휠 줌을 하면 `zoomAt`(clampScale) 이 판독 가능한 하한을 다시 강제한다.
+ */
+export function clampFitScale(k: number): number {
+  return Math.min(MAP_SCALE_MAX, Math.max(FIT_SCALE_EPSILON, k));
 }
 
 /** 커서 아래 world 지점이 고정된 채 스케일만 바뀌는 줌. */
@@ -62,18 +88,27 @@ export function fitBounds(
   bounds: MapBounds,
   viewport: { width: number; height: number },
   insets: MapInsets,
-  options?: { maxScale?: number },
+  options?: { maxScale?: number; overhang?: CardOverhang },
 ): MapCamera {
-  const safeW = Math.max(1, viewport.width - insets.left - insets.right);
-  const safeH = Math.max(1, viewport.height - insets.top - insets.bottom);
+  const overhang = options?.overhang ?? ZERO_OVERHANG;
+  const safeW = Math.max(
+    1,
+    viewport.width - insets.left - insets.right - overhang.left - overhang.right,
+  );
+  const safeH = Math.max(
+    1,
+    viewport.height - insets.top - insets.bottom - overhang.top - overhang.bottom,
+  );
   const bw = Math.max(1e-6, bounds.maxX - bounds.minX);
   const bh = Math.max(1e-6, bounds.maxY - bounds.minY);
-  const k = clampScale(
+  // fit 은 clampScale(사용자 줌 하한) 이 아니라 clampFitScale 로 도메인을
+  // 분리한다 — verdict a3: 넓은 콘텐츠는 0.25 미만이 정답일 수 있다.
+  const k = clampFitScale(
     Math.min(options?.maxScale ?? 1.4, (safeW / bw) * 0.92, (safeH / bh) * 0.92),
   );
   const cx = (bounds.minX + bounds.maxX) / 2;
   const cy = (bounds.minY + bounds.maxY) / 2;
-  const safeCx = insets.left + safeW / 2;
-  const safeCy = insets.top + safeH / 2;
+  const safeCx = insets.left + overhang.left + safeW / 2;
+  const safeCy = insets.top + overhang.top + safeH / 2;
   return { k, tx: safeCx - cx * k, ty: safeCy - cy * k };
 }

--- a/src/widgets/topology-map-canvas/ui/TopologyMapCanvas.tsx
+++ b/src/widgets/topology-map-canvas/ui/TopologyMapCanvas.tsx
@@ -16,6 +16,7 @@ import {
   fitBounds,
   panBy,
   zoomAt,
+  type CardOverhang,
   type MapCamera,
   type MapInsets,
 } from '../lib/camera';
@@ -58,12 +59,36 @@ export interface TopologyMapCanvasProps {
   fitInsets?: MapInsets;
 }
 
-// 좌측 분석 패널(최대 ~430px 스케일 포함) + 상단 HUD 를 피하는 안전 영역.
-// 카드가 fixed chrome 아래 깔리면 verify 의 fixed-surface overlap 계약 위반.
-const DEFAULT_INSETS: MapInsets = { top: 120, right: 120, bottom: 110, left: 480 };
+// 좌측 분석 패널 + 상단 HUD 를 피하는 안전 영역 — `--topology-map-safe-inset-*`
+// 토큰이 단일 진실원(app/globals.css). 패널 실측(344px 우측 엣지, 디자인
+// 가디언 verdict a4)과 어긋났던 하드코딩 480px 을 제거한다: 토큰 해석 실패
+// (SSR/구 브라우저) 시에만 이 리터럴이 안전망으로 쓰인다.
+const SAFE_INSET_FALLBACK: MapInsets = { top: 120, right: 120, bottom: 110, left: 344 };
+
+function readSafeInsetTokens(): MapInsets {
+  if (typeof window === 'undefined' || typeof getComputedStyle !== 'function') {
+    return SAFE_INSET_FALLBACK;
+  }
+  const style = getComputedStyle(document.documentElement);
+  const read = (name: string, fallback: number) => {
+    const parsed = parseFloat(style.getPropertyValue(name));
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+  return {
+    top: read('--topology-map-safe-inset-top', SAFE_INSET_FALLBACK.top),
+    right: read('--topology-map-safe-inset-right', SAFE_INSET_FALLBACK.right),
+    bottom: read('--topology-map-safe-inset-bottom', SAFE_INSET_FALLBACK.bottom),
+    left: read('--topology-map-safe-inset-left', SAFE_INSET_FALLBACK.left),
+  };
+}
+
+// 모듈 로드 시 1회만 해석 — 토큰 값은 런타임에 바뀌지 않는 레이아웃 상수라
+// per-render 재계산이 낭비다.
+const DEFAULT_INSETS: MapInsets = readSafeInsetTokens();
 const DOCK_COL_GAP = 56;
 const DOCK_ROW_PITCH = 44;
 const CARD_HALF_WIDTH_FALLBACK = 150;
+const CARD_HALF_HEIGHT_FALLBACK = 24;
 // 트랙패드 지터가 클릭을 팬으로 오인·취소하지 않는 하한 — 구 엔진과 동일
 // 계약 (verify: topologyStagePanClickCancelPx >= 12).
 const PAN_CLICK_CANCEL_PX = 12;
@@ -209,22 +234,55 @@ export function TopologyMapCanvas({
   const runFit = useCallback(() => {
     const viewport = viewportRef.current;
     if (!viewport || positions.size === 0) return;
+    // world bounds 는 카드 "중심" 좌표만 — 카드 자체의 화면-px 크기는
+    // overhang 으로 별도 예산 처리한다(px-고정 카드에 world-px 여백을 더하면
+    // 차원이 안 맞는다는 게 verdict a2 의 핵심 진단).
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
-    for (const pos of positions.values()) {
-      minX = Math.min(minX, pos.x - CARD_HALF_WIDTH_FALLBACK);
-      maxX = Math.max(maxX, pos.x + CARD_HALF_WIDTH_FALLBACK);
-      minY = Math.min(minY, pos.y - 24);
-      maxY = Math.max(maxY, pos.y + 24);
+    let minXId: string | null = null;
+    let maxXId: string | null = null;
+    let minYId: string | null = null;
+    let maxYId: string | null = null;
+    for (const [id, pos] of positions) {
+      if (pos.x < minX) {
+        minX = pos.x;
+        minXId = id;
+      }
+      if (pos.x > maxX) {
+        maxX = pos.x;
+        maxXId = id;
+      }
+      if (pos.y < minY) {
+        minY = pos.y;
+        minYId = id;
+      }
+      if (pos.y > maxY) {
+        maxY = pos.y;
+        maxYId = id;
+      }
     }
+    const halfExtentOf = (id: string | null) => {
+      const el = id ? cardElsRef.current.get(id) : null;
+      if (!el || el.offsetWidth === 0) {
+        return { halfWidth: CARD_HALF_WIDTH_FALLBACK, halfHeight: CARD_HALF_HEIGHT_FALLBACK };
+      }
+      return { halfWidth: el.offsetWidth / 2, halfHeight: el.offsetHeight / 2 };
+    };
+    const overhang: CardOverhang = {
+      left: halfExtentOf(minXId).halfWidth,
+      right: halfExtentOf(maxXId).halfWidth,
+      top: halfExtentOf(minYId).halfHeight,
+      bottom: halfExtentOf(maxYId).halfHeight,
+    };
     const rect = viewport.getBoundingClientRect();
     applyCamera(
       fitBounds(
         { minX, minY, maxX, maxY },
         { width: rect.width, height: rect.height },
         fitInsets,
+        { overhang },
       ),
     );
   }, [applyCamera, fitInsets, positions]);
@@ -434,6 +492,14 @@ export function TopologyMapCanvas({
                 strokeLinecap="round"
                 vectorEffect="non-scaling-stroke"
                 opacity={touchesSelected ? 0.95 : spine ? 0.8 : 0.6}
+                // 신뢰(branch) 선은 spine 과 같은 인디고 잉크 — 색이 아니라
+                // dash 로 구분한다(verdict a5: 카테고리 구분은 색이 아닌
+                // 보더/선 스타일이라는 헌장).
+                strokeDasharray={
+                  !touchesSelected && !spine
+                    ? 'var(--topology-relation-stroke-supported-dasharray)'
+                    : undefined
+                }
               />
             );
           })}


### PR DESCRIPTION
## Summary
소유자의 "완전 별로" 판정 → design-guardian 실측 검토 → 결함 3연쇄의 기계적 수리.

- **a1**: aspectX=8 (구 Sigma autoRescale 전제)이 신 캔버스 엔진에 노출돼 방사형 레이아웃을 띠로 붕괴시키던 근원 — 엔진별 분기 (map=1 / legacy sigma=8)
- **a2+a3**: fit이 카드의 실제 화면 px 크기를 반영하도록 수학 교정 + fit clamp와 사용자 줌 clamp 도메인 분리 (TDD — 실패 테스트 선작성, 카메라 회귀 테스트 4건 추가)
- **a4**: `--topology-map-safe-inset-*` 토큰 신설 (실측 344px — 기존 480 하드코딩 교정)
- **a5**: cyan 신뢰선 → 인디고+dash (단일 인디고 헌장 준수) + 라이트 모드 대비 결함 2건 동반 수리
- **a6**: 패널 census 중복 삭제 + 산문 1줄 압축

## 실측 게이트 (라이브, 22카드)
| | before | after |
|---|---|---|
| 카메라 스케일 | 0.250 (clamp 바닥) | 0.546 (정상 fit) |
| 잘린 카드 | 7/22 | **0/22** |
| 수직 점유 | 32.2% | **65.6%** |

## Test plan
- 카메라·패널·레이아웃 vitest 84/84 (신규 회귀 4건 포함) · tsc 클린 · i18n messages 클린
- 전체 스위트 2,228/2,230 — 실패 1건은 main 기존 census drift (PR #312가 해결)
- before/after 스크린샷 (dark/light, 14인치+와이드) 촬영 완료

잔여 (verdict layer-b, Slice 2 범위): 카드 충돌/anatomy, 요약 복사 CTA 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)