### PR TITLE
fix: topology-v2 카메라 팬/관성 물리 3종 (정지 릴리스·비례 flick·포커스 이탈방지)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -972,6 +972,12 @@
     --topology-v2-camera-flick-min-speed: 0.05;
     --topology-v2-camera-scale-min: 0.24;
     --topology-v2-camera-scale-max: 2.6;
+    /* 포커스(ego) 상태에서 빈 공간 팬 시 카메라 중심이 포커스 노드로부터 이
+       world-unit 이상 벗어나지 못한다 — "둘러볼 순 있어도 대상을 놓치진 않는다"
+       (옵시디언 촉각). 넘어서면 러버밴드로 복귀. 최대 포커스 스케일(1.9)에서도
+       180×1.9≈342px < 안전영역 반높이(354px) 라 대상이 화면 밖으로 안 나간다.
+       줌인 상태에서만 적용(fit view/포커스 해제 시엔 전체 bounds). */
+    --topology-v2-camera-focus-pan-margin: 180;
     --topology-v2-altitude-far-high-ratio: 0.92;
     --topology-v2-altitude-far-low-ratio: 0.62;
     /* Overview entry scale = tight-fit × this ratio. Kept above the far-high

--- a/app/globals.css
+++ b/app/globals.css
@@ -964,6 +964,12 @@
     --topology-v2-camera-damping-default: 1.0;
     --topology-v2-camera-damping-flick: 0.82;
     --topology-v2-camera-momentum-decay: 0.998;
+    /* 정지 릴리스 게이트 (iOS scroll rule) — 릴리스 직전 이 창(ms)에서 포인터
+       속도를 샘플한다. 이 창 안에 움직임이 없으면(=멈춘 뒤 릴리스) 모멘텀 0. */
+    --topology-v2-camera-release-velocity-window-ms: 80;
+    /* 이 임계(px/ms) 미만 속도는 정지로 간주 — 관성 글라이드 없이 제자리 정지.
+       실제 플릭(≈0.3~0.5px/ms)의 약 10% 지점. */
+    --topology-v2-camera-flick-min-speed: 0.05;
     --topology-v2-camera-scale-min: 0.24;
     --topology-v2-camera-scale-max: 2.6;
     --topology-v2-altitude-far-high-ratio: 0.92;

--- a/src/widgets/topology-map-v2/engine/momentum.test.ts
+++ b/src/widgets/topology-map-v2/engine/momentum.test.ts
@@ -10,11 +10,11 @@ import { projectFlickLanding, sampleReleaseVelocity } from "./momentum";
 const DECAY = 0.998; // --topology-v2-camera-momentum-decay
 
 describe("projectFlickLanding", () => {
-  it("matches the exact prototype formula for a rightward flick (vx=0.5px/ms, scale=1)", () => {
-    // d = 0.998; projMsX = (0.5*1000)*0.998/(1-0.998)/1000 = (500*0.998/0.002)/1000
-    //          = (500*499)/1000 = 249.5
-    // worldVX  = -0.5/1*1000 = -500
-    // landingX = 100 + (-249.5*60)/1 = 100 - 14970 = -14870
+  it("projects a proportional landing for a rightward flick (vx=0.5px/ms, scale=1)", () => {
+    // iOS UIScrollView deceleration projection — distance ∝ release velocity:
+    //   worldVelocity = -0.5/1 * 1000 = -500 (world units/sec)
+    //   landingOffset = -0.5/1 * decay/(1-decay) = -0.5 * (0.998/0.002) = -0.5*499 = -249.5
+    //   landingTarget = 100 - 249.5 = -149.5
     const result = projectFlickLanding({
       velocityPxPerMs: 0.5,
       cameraPosition: 100,
@@ -23,13 +23,13 @@ describe("projectFlickLanding", () => {
     });
 
     expect(result.worldVelocity).toBeCloseTo(-500, 6);
-    expect(result.landingTarget).toBeCloseTo(-14870, 3);
+    expect(result.landingTarget).toBeCloseTo(-149.5, 6);
   });
 
-  it("matches the exact prototype formula for a leftward flick (vy=-0.2px/ms, scale=1)", () => {
-    // projMsY = (-0.2*1000)*0.998/0.002/1000 = (-200*499)/1000 = -99.8
-    // worldVY = -(-0.2)/1*1000 = 200
-    // landingY = 50 + (-(-99.8)*60)/1 = 50 + 5988 = 6038
+  it("projects a proportional landing for a leftward flick (vy=-0.2px/ms, scale=1)", () => {
+    //   worldVelocity = -(-0.2)/1 * 1000 = 200
+    //   landingOffset = -(-0.2)/1 * 499 = +99.8
+    //   landingTarget = 50 + 99.8 = 149.8
     const result = projectFlickLanding({
       velocityPxPerMs: -0.2,
       cameraPosition: 50,
@@ -38,7 +38,16 @@ describe("projectFlickLanding", () => {
     });
 
     expect(result.worldVelocity).toBeCloseTo(200, 6);
-    expect(result.landingTarget).toBeCloseTo(6038, 2);
+    expect(result.landingTarget).toBeCloseTo(149.8, 6);
+  });
+
+  it("glides proportionally to velocity — half the flick, half the landing offset", () => {
+    // The headline of the QA fix: a small flick lands proportionally close, not
+    // slammed to the same pan-bounds edge as a big flick.
+    const small = projectFlickLanding({ velocityPxPerMs: 0.25, cameraPosition: 0, cameraScale: 1, decay: DECAY });
+    const big = projectFlickLanding({ velocityPxPerMs: 0.5, cameraPosition: 0, cameraScale: 1, decay: DECAY });
+    expect(small.landingTarget).toBeCloseTo(big.landingTarget / 2, 6);
+    expect(small.landingTarget).toBeCloseTo(-124.75, 6);
   });
 
   it("scales the landing projection inversely with camera scale", () => {

--- a/src/widgets/topology-map-v2/engine/momentum.test.ts
+++ b/src/widgets/topology-map-v2/engine/momentum.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { projectFlickLanding } from "./momentum";
+import { projectFlickLanding, sampleReleaseVelocity } from "./momentum";
 
 /**
  * Spec for `projectFlickLanding` — ported from the prototype's `releaseDrag()`
@@ -71,5 +71,107 @@ describe("projectFlickLanding", () => {
 
     expect(result.worldVelocity).toBe(0);
     expect(result.landingTarget).toBe(42);
+  });
+});
+
+const WINDOW_MS = 80; // --topology-v2-camera-release-velocity-window-ms
+const MIN_SPEED = 0.05; // --topology-v2-camera-flick-min-speed (px/ms)
+
+describe("sampleReleaseVelocity — 정지 릴리스 게이트 (iOS scroll rule)", () => {
+  it("registers a flick when the pointer was moving right up to release", () => {
+    // 5 samples ~16ms apart, moving +8px/frame → ~0.5px/ms, released at t=64.
+    const history = [
+      { x: 0, y: 0, t: 0 },
+      { x: 8, y: 0, t: 16 },
+      { x: 16, y: 0, t: 32 },
+      { x: 24, y: 0, t: 48 },
+      { x: 32, y: 0, t: 64 },
+    ];
+    const result = sampleReleaseVelocity({
+      history,
+      releaseTime: 64,
+      windowMs: WINDOW_MS,
+      minSpeedPxPerMs: MIN_SPEED,
+    });
+    expect(result.isFlick).toBe(true);
+    expect(result.vx).toBeCloseTo(0.5, 6);
+    expect(result.vy).toBe(0);
+  });
+
+  it("gates to zero when the pointer stopped and was held before release (owner spec)", () => {
+    // Same fast drag, but the last sample is 500ms before release — the user
+    // dragged, stopped, held, then lifted. No sample within the 80ms window.
+    const history = [
+      { x: 0, y: 0, t: 0 },
+      { x: 8, y: 0, t: 16 },
+      { x: 16, y: 0, t: 32 },
+      { x: 24, y: 0, t: 48 },
+      { x: 32, y: 0, t: 64 },
+    ];
+    const result = sampleReleaseVelocity({
+      history,
+      releaseTime: 564, // 500ms after the last move
+      windowMs: WINDOW_MS,
+      minSpeedPxPerMs: MIN_SPEED,
+    });
+    expect(result.isFlick).toBe(false);
+    expect(result.vx).toBe(0);
+    expect(result.vy).toBe(0);
+  });
+
+  it("gates to zero for a slow crawl below the min-speed threshold", () => {
+    // Moving 0.5px/frame ≈ 0.03px/ms — under the 0.05 threshold → hold in place.
+    const history = [
+      { x: 0, y: 0, t: 0 },
+      { x: 0.5, y: 0, t: 16 },
+      { x: 1, y: 0, t: 32 },
+      { x: 1.5, y: 0, t: 48 },
+      { x: 2, y: 0, t: 64 },
+    ];
+    const result = sampleReleaseVelocity({
+      history,
+      releaseTime: 64,
+      windowMs: WINDOW_MS,
+      minSpeedPxPerMs: MIN_SPEED,
+    });
+    expect(result.isFlick).toBe(false);
+    expect(result.vx).toBe(0);
+    expect(result.vy).toBe(0);
+  });
+
+  it("ignores an earlier fast segment once the pointer stops and holds (window excludes it)", () => {
+    // Fast drag (t=0..32), then held stationary for ~150ms with events still
+    // firing at the same coordinate, then released at t=180. The 80ms window
+    // (t≥100) contains only the stationary tail → hold, even though the whole
+    // gesture had a fast start. This is the "드래그 후 멈추면 그 자리에 정지" case
+    // on a device that keeps emitting pointermove while the finger is held.
+    const history = [
+      { x: 0, y: 0, t: 0 },
+      { x: 40, y: 0, t: 16 },
+      { x: 80, y: 0, t: 32 }, // fast — but >80ms before release
+      { x: 80, y: 0, t: 100 }, // stopped and held
+      { x: 80, y: 0, t: 140 },
+      { x: 80, y: 0, t: 180 },
+    ];
+    const result = sampleReleaseVelocity({
+      history,
+      releaseTime: 180,
+      windowMs: WINDOW_MS,
+      minSpeedPxPerMs: MIN_SPEED,
+    });
+    expect(result.isFlick).toBe(false);
+    expect(result.vx).toBe(0);
+  });
+
+  it("returns hold when there are fewer than two samples in the window", () => {
+    const result = sampleReleaseVelocity({
+      history: [{ x: 10, y: 10, t: 0 }],
+      releaseTime: 200,
+      windowMs: WINDOW_MS,
+      minSpeedPxPerMs: MIN_SPEED,
+    });
+    expect(result.isFlick).toBe(false);
+    expect(result.vx).toBe(0);
+    expect(result.vy).toBe(0);
   });
 });

--- a/src/widgets/topology-map-v2/engine/momentum.ts
+++ b/src/widgets/topology-map-v2/engine/momentum.ts
@@ -1,35 +1,38 @@
 /**
- * Flick-release momentum projection — ported 1:1 from the B2+ prototype's
- * `releaseDrag()` (`docs/prototypes/topology-b2plus.html` §9 "interaction state").
+ * Flick-release momentum projection — the iOS `UIScrollView` deceleration
+ * projection (`docs/INTERACTION-DESIGN.md` §1 "관성 투영 (v/1000)·d/(1−d)").
  *
- * Contract (`docs/TOPOLOGY-V2-DESIGN.md` §2.4, §4 P2 — "projection formula
- * (v/1000)·d/(1−d)"): when a pan drag is released with screen-space velocity
- * `v` (px/ms, sampled from the last ~6 pointermove history entries), the
- * camera does not stop instantly — it projects a landing target using a
- * geometric-decay series and hands that target + a residual world-space
- * velocity to the spring (`engine/spring.ts`, `damping = 0.82` — see
+ * When a pan drag is released with screen-space velocity `v` (px/ms, sampled
+ * from the release-velocity window by `sampleReleaseVelocity`), the camera does
+ * not stop instantly — it projects a landing target a distance PROPORTIONAL to
+ * the release velocity and hands that target + a residual world-space velocity
+ * to the spring (`engine/spring.ts`, `damping = 0.82` — see
  * `--topology-v2-camera-damping-flick`).
  *
- * Exact prototype steps (preserved 1:1 — do not "simplify" the algebra, the
- * intermediate `*1000`/`/1000` round-trip is the prototype's literal
- * computation even though it cancels to `v·d/(1−d)`):
+ * FIX (owner + QA — "flick snaps to the pan-bounds edge instead of gliding
+ * proportionately"): the prototype's port carried an extra `* 60` factor
+ * (`landing = pos + (-projMs * 60)/scale`) that inflated the projected distance
+ * ~60× — a modest 0.5px/ms flick projected ~14,900 world units, so EVERY flick
+ * (small or large) landed thousands of units past the graph and got hard-clamped
+ * to the exact same pan-bounds edge. That read as a snap, not a glide, and lost
+ * all proportionality. Corrected to the standard iOS projection, where the
+ * landing offset is the residual velocity integrated over the geometric decay:
  * ```
- * d          = decay                         // --topology-v2-camera-momentum-decay ≈ 0.998
- * projMs     = (v * 1000) * d / (1 - d) / 1000
- * worldV     = -v / cameraScale * 1000
- * landing    = cameraPosition + (-projMs * 60) / cameraScale
+ * d       = decay                         // --topology-v2-camera-momentum-decay ≈ 0.998
+ * worldV  = -v / cameraScale * 1000       // world units/sec, seeds the spring's velocity
+ * offset  = -v / cameraScale * d/(1 − d)  // = worldV/1000 · d/(1−d), world units
+ * landing = cameraPosition + offset
  * ```
- * Both x and y axes use the same formula independently. The `* 60` factor is
- * a prototype constant with no assigned `--topology-v2-*` token in the
- * design doc's §2.4 table — flagged as an open question for the lead/design
- * doc author (see this scaffold's handoff notes).
+ * Now a 0.5px/ms flick at scale 1 projects −249.5 world units (proportional),
+ * a 0.25px/ms flick exactly half that. Landings within the pan bounds glide
+ * freely; only a landing that would exceed the bounds is clamped by the caller
+ * (`topology-pointer-handlers.ts`) so the graph's own edge rubber-bands
+ * (`engine/camera.ts#clampAxisToPanBounds`) instead of stranding the camera.
+ * Both x and y axes use the same formula independently.
  *
- * This module is pure — the caller (`engine/camera.ts`) is responsible for
- * calling `stepSpring` afterward with the returned `worldVelocity` seeded in
- * and `landingTarget` as the new spring target.
- *
- * STUB: the lead implements the body. Exact expected values are pinned in
- * `momentum.test.ts` (hand-derived from the formula above).
+ * This module is pure — the caller is responsible for calling `stepSpring`
+ * afterward with the returned `worldVelocity` seeded in and `landingTarget` as
+ * the new spring target. Exact expected values are pinned in `momentum.test.ts`.
  */
 
 /** One recorded pointer position while dragging (screen px + `performance.now()`). */
@@ -116,13 +119,16 @@ export interface FlickReleaseResult {
  */
 export function projectFlickLanding(input: FlickReleaseInput): FlickReleaseResult {
   const { velocityPxPerMs, cameraPosition, cameraScale, decay } = input;
-  const projMs = ((velocityPxPerMs * 1000) * decay) / (1 - decay) / 1000;
+  // World-space residual velocity (seeds the spring). Screen px/ms → world/sec.
   const worldVelocity = (-velocityPxPerMs / cameraScale) * 1000;
-  const landingTarget = cameraPosition + (-projMs * 60) / cameraScale;
+  // iOS projection: landing offset = residual velocity integrated over the
+  // geometric decay = (worldVelocity/1000) · d/(1−d), proportional to velocity.
+  const landingOffset = (-velocityPxPerMs / cameraScale) * (decay / (1 - decay));
+  const landingTarget = cameraPosition + landingOffset;
   // -0 normalization: a zero-velocity release must yield +0, not IEEE -0
   // (spring seeding and Object.is-based equality both treat them differently).
   return {
-    landingTarget,
+    landingTarget: landingTarget === 0 ? 0 : landingTarget,
     worldVelocity: worldVelocity === 0 ? 0 : worldVelocity,
   };
 }

--- a/src/widgets/topology-map-v2/engine/momentum.ts
+++ b/src/widgets/topology-map-v2/engine/momentum.ts
@@ -32,6 +32,65 @@
  * `momentum.test.ts` (hand-derived from the formula above).
  */
 
+/** One recorded pointer position while dragging (screen px + `performance.now()`). */
+export interface DragSample {
+  x: number;
+  y: number;
+  t: number;
+}
+
+export interface ReleaseVelocityInput {
+  /** Recent drag samples (`dragHistoryRef`), oldest → newest. */
+  history: readonly DragSample[];
+  /** `performance.now()` at pointerup. */
+  releaseTime: number;
+  /** Trailing window sampled for release velocity, ms — `--topology-v2-camera-release-velocity-window-ms`. */
+  windowMs: number;
+  /** |velocity| below this (px/ms) counts as stationary → hold, no glide — `--topology-v2-camera-flick-min-speed`. */
+  minSpeedPxPerMs: number;
+}
+
+export interface ReleaseVelocity {
+  /** Screen-space release velocity, px/ms. Zeroed when the release was stationary. */
+  vx: number;
+  vy: number;
+  /** True only for a release WITH motion above the threshold — the sole momentum trigger. */
+  isFlick: boolean;
+}
+
+/**
+ * 정지 릴리스 게이트 (owner spec: "드래그 후 멈추면 그 자리에 정지") — the iOS
+ * scroll rule. Samples pointer velocity over the last `windowMs` before release
+ * and returns `isFlick: false` (zero velocity) when the pointer was stationary
+ * at release, so the caller holds the camera exactly where it is. Only a release
+ * WITH motion (a genuine flick) returns `isFlick: true` to trigger the momentum
+ * glide (`projectFlickLanding`).
+ *
+ * Why a trailing window and not first→last over the whole gesture: when the user
+ * pans, stops, and holds before lifting, the recent samples cluster at the rest
+ * position (or stop arriving entirely). Anchoring the measurement window at the
+ * release time means a held release has no fast samples in-window — a flat
+ * first→last over the entire history would keep reading the initial fling speed
+ * and glide anyway (the QA/owner-reported bug).
+ *
+ * Pure — no DOM/token knowledge; the caller passes the resolved token values.
+ */
+export function sampleReleaseVelocity(input: ReleaseVelocityInput): ReleaseVelocity {
+  const { history, releaseTime, windowMs, minSpeedPxPerMs } = input;
+  const windowStart = releaseTime - windowMs;
+  const inWindow = history.filter((sample) => sample.t >= windowStart);
+  if (inWindow.length < 2) return { vx: 0, vy: 0, isFlick: false };
+
+  const first = inWindow[0];
+  const last = inWindow[inWindow.length - 1];
+  const dtMs = Math.max(1, last.t - first.t);
+  const vx = (last.x - first.x) / dtMs;
+  const vy = (last.y - first.y) / dtMs;
+
+  if (Math.hypot(vx, vy) < minSpeedPxPerMs) return { vx: 0, vy: 0, isFlick: false };
+  return { vx, vy, isFlick: true };
+}
+
 export interface FlickReleaseInput {
   /** Screen-space release velocity, px/ms, one axis. */
   velocityPxPerMs: number;

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -70,6 +70,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-camera-flick-min-speed": "0.05",
   "--topology-v2-camera-scale-min": "0.24",
   "--topology-v2-camera-scale-max": "2.6",
+  "--topology-v2-camera-focus-pan-margin": "180",
   "--topology-v2-altitude-far-high-ratio": "0.92",
   "--topology-v2-altitude-far-low-ratio": "0.62",
   "--topology-v2-overview-entry-ratio": "0.95",
@@ -96,7 +97,7 @@ function fixtureReader(overrides: Record<string, string> = {}) {
 }
 
 describe("resolveTopologyV2Tokens", () => {
-  it("resolves all 73 §2 tokens to the exact prototype-sourced values", () => {
+  it("resolves all 74 §2 tokens to the exact prototype-sourced values", () => {
     const tokens = resolveTopologyV2Tokens(fixtureReader());
 
     expect(tokens.nodeFillProject).toBe("#1c1c22");

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -66,6 +66,8 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-camera-damping-default": "1.0",
   "--topology-v2-camera-damping-flick": "0.82",
   "--topology-v2-camera-momentum-decay": "0.998",
+  "--topology-v2-camera-release-velocity-window-ms": "80",
+  "--topology-v2-camera-flick-min-speed": "0.05",
   "--topology-v2-camera-scale-min": "0.24",
   "--topology-v2-camera-scale-max": "2.6",
   "--topology-v2-altitude-far-high-ratio": "0.92",
@@ -94,7 +96,7 @@ function fixtureReader(overrides: Record<string, string> = {}) {
 }
 
 describe("resolveTopologyV2Tokens", () => {
-  it("resolves all 71 §2 tokens to the exact prototype-sourced values", () => {
+  it("resolves all 73 §2 tokens to the exact prototype-sourced values", () => {
     const tokens = resolveTopologyV2Tokens(fixtureReader());
 
     expect(tokens.nodeFillProject).toBe("#1c1c22");

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -75,6 +75,7 @@ export interface TopologyV2Tokens {
   cameraFlickMinSpeed: number;
   cameraScaleMin: number;
   cameraScaleMax: number;
+  cameraFocusPanMargin: number;
   altitudeFarHighRatio: number;
   altitudeFarLowRatio: number;
   overviewEntryRatio: number;
@@ -165,6 +166,7 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "cameraFlickMinSpeed", cssVar: "--topology-v2-camera-flick-min-speed", kind: "number" },
   { key: "cameraScaleMin", cssVar: "--topology-v2-camera-scale-min", kind: "number" },
   { key: "cameraScaleMax", cssVar: "--topology-v2-camera-scale-max", kind: "number" },
+  { key: "cameraFocusPanMargin", cssVar: "--topology-v2-camera-focus-pan-margin", kind: "number" },
   { key: "altitudeFarHighRatio", cssVar: "--topology-v2-altitude-far-high-ratio", kind: "number" },
   { key: "altitudeFarLowRatio", cssVar: "--topology-v2-altitude-far-low-ratio", kind: "number" },
   { key: "overviewEntryRatio", cssVar: "--topology-v2-overview-entry-ratio", kind: "number" },

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -71,6 +71,8 @@ export interface TopologyV2Tokens {
   cameraDampingDefault: number;
   cameraDampingFlick: number;
   cameraMomentumDecay: number;
+  cameraReleaseVelocityWindowMs: number;
+  cameraFlickMinSpeed: number;
   cameraScaleMin: number;
   cameraScaleMax: number;
   altitudeFarHighRatio: number;
@@ -159,6 +161,8 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "cameraDampingDefault", cssVar: "--topology-v2-camera-damping-default", kind: "number" },
   { key: "cameraDampingFlick", cssVar: "--topology-v2-camera-damping-flick", kind: "number" },
   { key: "cameraMomentumDecay", cssVar: "--topology-v2-camera-momentum-decay", kind: "number" },
+  { key: "cameraReleaseVelocityWindowMs", cssVar: "--topology-v2-camera-release-velocity-window-ms", kind: "number" },
+  { key: "cameraFlickMinSpeed", cssVar: "--topology-v2-camera-flick-min-speed", kind: "number" },
   { key: "cameraScaleMin", cssVar: "--topology-v2-camera-scale-min", kind: "number" },
   { key: "cameraScaleMax", cssVar: "--topology-v2-camera-scale-max", kind: "number" },
   { key: "altitudeFarHighRatio", cssVar: "--topology-v2-altitude-far-high-ratio", kind: "number" },

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -15,7 +15,7 @@
 
 import type { CameraAxes, CameraTarget } from "../engine/camera";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
-import { radiusForKind, type TopologyWorld } from "./topology-world";
+import { computeEgoBounds, radiusForKind, type TopologyWorld } from "./topology-world";
 import type { WorldNode } from "./topology-world";
 
 interface Point {
@@ -194,30 +194,17 @@ export function computeFocusCameraTarget(
     // entry), not the full 295-node bounds; see `topology-world.ts#spineBounds`.
     return computeOverviewCameraTarget(world.spineBounds, viewportWidth, viewportHeight, tokens);
   }
-  const focusNode = world.nodeById.get(focusedSlug);
-  if (!focusNode) return null;
+  const egoBounds = computeEgoBounds(world, tokens, focusedSlug);
+  if (!egoBounds) return null;
 
-  const neighborIds = world.neighborMap.get(focusedSlug) ?? new Set<string>();
-  const egoNodes: WorldNode[] = [focusNode];
-  for (const id of neighborIds) {
-    const neighbor = world.nodeById.get(id);
-    if (neighbor) egoNodes.push(neighbor);
-  }
-
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const n of egoNodes) {
-    const r = radiusForKind(n.kind, tokens);
-    minX = Math.min(minX, n.x - r);
-    maxX = Math.max(maxX, n.x + r);
-    minY = Math.min(minY, n.y - r);
-    maxY = Math.max(maxY, n.y + r);
-  }
   const margin = tokens.focusBboxMargin;
   return fitWorldTarget(
-    { minX: minX - margin, minY: minY - margin, maxX: maxX + margin, maxY: maxY + margin },
+    {
+      minX: egoBounds.minX - margin,
+      minY: egoBounds.minY - margin,
+      maxX: egoBounds.maxX + margin,
+      maxY: egoBounds.maxY + margin,
+    },
     viewportWidth,
     viewportHeight,
     tokens.focusFitMaxScale,

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -63,6 +63,28 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     rippleStartById,
   } = input;
 
+  // Focus-aware pan clamp (drag-while-focused must not lose the subject): while
+  // a node is ego-focused AND the camera is zoomed IN past the overview scale,
+  // clamp the pan so the camera centre stays within `cameraFocusPanMargin` world
+  // units of the FOCUSED NODE — so an empty-space pan can look around the cluster
+  // but the subject can never leave the frame; overshooting rubber-bands back
+  // (Obsidian feel). Clamping to the focused node's own point (not the whole ego
+  // bbox) is what keeps the subject on screen: a wide ego bbox + margin would let
+  // the camera reach the cluster's far corner and slide the focused node off the
+  // opposite edge. The zoom gate is essential: "지도 전체 맞추기"/fit-view keeps the
+  // node selected (focusedNodeId stays set) while springing OUT to the overview;
+  // once the camera scale drops below the overview fit scale the clamp reverts to
+  // the full world bounds, so fit-view/close-focus recovery is never fought.
+  const focusNode = focusedNodeId !== null && camera.scale.value > overviewScale
+    ? world.nodeById.get(focusedNodeId)
+    : undefined;
+  const panBounds = focusNode
+    ? computePanBounds(
+        { minX: focusNode.x, minY: focusNode.y, maxX: focusNode.x, maxY: focusNode.y },
+        tokens.cameraFocusPanMargin,
+      )
+    : computePanBounds(world.bounds);
+
   const nextCamera = stepCamera({
     camera,
     target,
@@ -71,7 +93,7 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     angularFrequency: tokens.cameraSpringAngFreq,
     scaleMin: tokens.cameraScaleMin,
     scaleMax: tokens.cameraScaleMax,
-    panBounds: computePanBounds(world.bounds),
+    panBounds,
     isDragging,
   });
 

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -22,7 +22,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 
 import { clampPointToPanBounds, computePanBounds, type CameraAxes, type CameraTarget } from "../engine/camera";
-import { projectFlickLanding } from "../engine/momentum";
+import { projectFlickLanding, sampleReleaseVelocity } from "../engine/momentum";
 import { scheduleRipple } from "../model/focus-state";
 import type { ForceSimulation } from "../model/force-layout";
 import { computeZoomRatio, DEFAULT_TIER_REVEAL, nodeTierAlpha } from "../model/tier-visibility";
@@ -240,7 +240,11 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       cameraRef.current = { ...cameraRef.current, x: { value: nextX, velocity: 0 }, y: { value: nextY, velocity: 0 } };
       cameraTargetRef.current = { ...cameraTargetRef.current, tx: nextX, ty: nextY };
       dragHistoryRef.current.push({ x: point.x, y: point.y, t: performance.now() });
-      if (dragHistoryRef.current.length > 6) dragHistoryRef.current.shift();
+      // Keep ~10 samples (~160ms at 60fps) so the release-velocity window
+      // (`--topology-v2-camera-release-velocity-window-ms`) is always covered,
+      // even on lower-frame-rate devices. The sampler filters by timestamp, so
+      // extra old samples are harmless.
+      if (dragHistoryRef.current.length > 10) dragHistoryRef.current.shift();
       return;
     }
 
@@ -274,17 +278,31 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     }
 
     if (wasDragging) {
-      const history = dragHistoryRef.current;
-      const first = history[0];
-      const last = history[history.length - 1];
-      const dtMs = first && last ? Math.max(1, last.t - first.t) : 16;
-      const vx = first && last ? (last.x - first.x) / dtMs : 0;
-      const vy = first && last ? (last.y - first.y) / dtMs : 0;
+      // 정지 릴리스 게이트 (owner spec: "드래그 후 멈추면 그 자리에 정지") — sample
+      // the last ~80ms of pointer motion; a stationary release yields isFlick=false
+      // and the camera holds exactly here (no momentum glide). Only a release WITH
+      // motion (a flick) projects a landing target.
+      const release = sampleReleaseVelocity({
+        history: dragHistoryRef.current,
+        releaseTime: performance.now(),
+        windowMs: tokens.cameraReleaseVelocityWindowMs,
+        minSpeedPxPerMs: tokens.cameraFlickMinSpeed,
+      });
 
-      if (reducedMotionRef.current) {
+      if (reducedMotionRef.current || !release.isFlick) {
+        // Hold in place: pin the spring target to the current camera position and
+        // clear any residual velocity so it comes to rest exactly here.
         cameraTargetRef.current = { tx: cameraRef.current.x.value, ty: cameraRef.current.y.value, tscale: cameraTargetRef.current.tscale };
+        cameraRef.current = {
+          ...cameraRef.current,
+          x: { value: cameraRef.current.x.value, velocity: 0 },
+          y: { value: cameraRef.current.y.value, velocity: 0 },
+        };
+        dampingRef.current = tokens.cameraDampingDefault;
         return;
       }
+      const vx = release.vx;
+      const vy = release.vy;
       const px = projectFlickLanding({
         velocityPxPerMs: vx,
         cameraPosition: cameraRef.current.x.value,

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -6,17 +6,18 @@
  * files under the 300-line budget — `Ref<T>` here is any mutable box the
  * hook owns (`useRef`'s `.current`), not necessarily React's own ref type.
  *
- * FIX (QA first-light pass, blocker 1 — "drag makes everything vanish"):
- * `projectFlickLanding`'s landing target grows unboundedly with flick speed
- * (its own test pins -14870 world units for a routine 0.5px/ms flick at
- * scale=1) — `handlePointerUp` now clamps that target into the world's own
- * pan bounds (`engine/camera.ts#computePanBounds`) before handing it to the
- * spring, so a fast flick still glides but can never strand the camera
- * outside the graph's content. `stepCamera`'s own per-frame elastic clamp
- * (`clampAxisToPanBounds`) alone was not enough — the spring's restoring
- * force toward a fixed, far-away target outpaces a flat 14%/frame pull-back
- * (verified manually via chrome-devtools: the camera was still lost 5+
- * seconds after release without this).
+ * FIX (owner + QA — flick proportionality): `projectFlickLanding` now projects
+ * a landing PROPORTIONAL to release velocity (iOS deceleration, ~−249 world
+ * units for a 0.5px/ms flick at scale 1), so a small flick glides a small
+ * distance and a big flick a big distance. `handlePointerUp` still clamps the
+ * projected target into the world's pan bounds
+ * (`engine/camera.ts#computePanBounds`) — but now that only engages when the
+ * projection genuinely EXCEEDS the bounds, so within-bounds flicks glide freely
+ * and only edge-exceeding flicks rubber-band (the seeded velocity overshoots the
+ * clamped bound, then `stepCamera`'s per-frame `clampAxisToPanBounds` elastically
+ * returns it — INTERACTION-DESIGN §1 "경계는 러버밴드"). The old port inflated
+ * the projection ~60× so EVERY flick slammed to the same edge (the reported
+ * snap); see `engine/momentum.ts`.
  */
 
 import type { PointerEvent as ReactPointerEvent } from "react";
@@ -315,10 +316,10 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
         cameraScale: cameraRef.current.scale.value,
         decay: tokens.cameraMomentumDecay,
       });
-      // The raw landing target can be thousands of world units past the
-      // graph's own content (see file header) — clamp it into the world's
-      // pan bounds before handing it to the spring so a fast flick still
-      // glides but never strands the camera in blank canvas.
+      // The projected landing is proportional to velocity (see file header) and
+      // usually within the graph's pan bounds — clamp it only so a landing that
+      // WOULD exceed the bounds rubber-bands at the edge instead of overshooting
+      // into blank canvas. Within-bounds flicks are unaffected by this clamp.
       const world = worldRef.current;
       const clampedLanding = world
         ? clampPointToPanBounds(px.landingTarget, py.landingTarget, computePanBounds(world.bounds))

--- a/src/widgets/topology-map-v2/ui/topology-world.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
-import { computeSpineBounds, isSpineNode, type WorldNode } from "./topology-world";
+import { computeEgoBounds, computeSpineBounds, isSpineNode, type WorldNode } from "./topology-world";
 
 /**
  * Spine bounds (fit-fix): the overview camera must fit to the level-0 spine
@@ -87,5 +87,49 @@ describe("computeSpineBounds", () => {
     const bounds = computeSpineBounds([], tokens);
     expect(Number.isFinite(bounds.minX)).toBe(true);
     expect(bounds.maxX).toBeGreaterThan(bounds.minX);
+  });
+});
+
+/**
+ * Ego bounds — the radius-padded bbox of a focused node + its 1-hop neighbors.
+ * Feeds the focus-aware pan clamp (drag-while-focused must not lose the cluster)
+ * and the focus camera fit. Pure — derived from `nodeById` + `neighborMap`.
+ */
+describe("computeEgoBounds", () => {
+  function egoWorld(nodes: WorldNode[], neighbors: Record<string, string[]>) {
+    const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
+    const neighborMap = new Map<string, ReadonlySet<string>>(
+      Object.entries(neighbors).map(([id, ns]) => [id, new Set(ns)] as const),
+    );
+    return { nodeById, neighborMap };
+  }
+
+  it("returns the padded bbox of the focused node plus its 1-hop neighbors only", () => {
+    const nodes: WorldNode[] = [
+      node({ id: "f", kind: "domain", x: 0, y: 0 }), // r14
+      node({ id: "n1", kind: "capability", x: 100, y: 0 }), // r8 → maxX 108
+      node({ id: "n2", kind: "element", x: 0, y: -50 }), // r5 → minY -55
+      // Not a neighbor of f — must be excluded even though it's far out.
+      node({ id: "far", kind: "element", x: 900, y: 900 }),
+    ];
+    const world = egoWorld(nodes, { f: ["n1", "n2"], n1: ["f"], n2: ["f"], far: [] });
+    const bounds = computeEgoBounds(world, tokens, "f");
+    expect(bounds).not.toBeNull();
+    expect(bounds!.minX).toBe(-14); // focused domain r14 at 0
+    expect(bounds!.maxX).toBe(108); // n1 at 100 + r8
+    expect(bounds!.minY).toBe(-55); // n2 at -50 - r5
+    expect(bounds!.maxY).toBe(14); // focused domain r14
+  });
+
+  it("returns just the focused node's own bbox when it has no neighbors", () => {
+    const nodes: WorldNode[] = [node({ id: "lonely", kind: "capability", x: 10, y: 10 })];
+    const world = egoWorld(nodes, { lonely: [] });
+    const bounds = computeEgoBounds(world, tokens, "lonely");
+    expect(bounds).toEqual({ minX: 2, minY: 2, maxX: 18, maxY: 18 }); // r8 around (10,10)
+  });
+
+  it("returns null when the focused slug doesn't resolve to a node", () => {
+    const world = egoWorld([node({ id: "a", kind: "domain", x: 0, y: 0 })], { a: [] });
+    expect(computeEgoBounds(world, tokens, "missing")).toBeNull();
   });
 });

--- a/src/widgets/topology-map-v2/ui/topology-world.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.ts
@@ -128,6 +128,40 @@ export function computeSpineBounds(nodes: readonly WorldNode[], tokens: Topology
   return accumulateBounds(nodes, tokens, isSpineNode) ?? computeFullBounds(nodes, tokens);
 }
 
+/**
+ * Radius-padded bbox of a focused node + its 1-hop neighbors (the ego cluster).
+ * Returns `null` when `focusedSlug` doesn't resolve. Shared by the focus camera
+ * fit (`topology-camera-math.ts#computeFocusCameraTarget`, which adds its own
+ * fit margin) and the focus-aware pan clamp (`topology-physics-step.ts`, which
+ * adds `--topology-v2-camera-focus-pan-margin`) so the "ego cluster" is defined
+ * in exactly one place. Pure — derived from `nodeById` + `neighborMap`.
+ */
+export function computeEgoBounds(
+  world: Pick<TopologyWorld, "nodeById" | "neighborMap">,
+  tokens: TopologyV2Tokens,
+  focusedSlug: string,
+): Bounds | null {
+  const focusNode = world.nodeById.get(focusedSlug);
+  if (!focusNode) return null;
+  const egoIds = new Set<string>([focusedSlug]);
+  for (const id of world.neighborMap.get(focusedSlug) ?? []) egoIds.add(id);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const id of egoIds) {
+    const n = world.nodeById.get(id);
+    if (!n) continue;
+    const r = radiusForKind(n.kind, tokens);
+    minX = Math.min(minX, n.x - r);
+    maxX = Math.max(maxX, n.x + r);
+    minY = Math.min(minY, n.y - r);
+    maxY = Math.max(maxY, n.y + r);
+  }
+  if (!Number.isFinite(minX)) return null;
+  return { minX, minY, maxX, maxY };
+}
+
 export function buildTopologyWorld(
   nodes: readonly TopologyV2Node[],
   edges: readonly TopologyV2Edge[],


### PR DESCRIPTION
## Summary
topology-map-v2 카메라 팬/관성 물리 마무리 (node-drag/force 무변경, flag off).

- **정지 릴리스 게이트**: 릴리스 직전 80ms 윈도우 속도 샘플링 → 정지 시 관성 0 (그 자리 정지, iOS 스크롤 규칙). drift 0.00 실측.
- **비례 flick glide**: 관성 투영의 stray `*60` 제거 (모든 flick이 pan-bounds edge로 튕기던 근본 원인) → 속도 비례 glide + 경계 러버밴드. 2× 속도 = 2.06× glide 실측.
- **drag-while-focus 주제 유지**: 포커스+줌인 시 pan clamp를 포커스 노드 기준으로 rebase → 주제가 프레임 밖으로 사라지지 않음. fit-view 복구 무간섭.

## Test plan
- v2 vitest 311 pass + 3 todo · tsc clean · scoped eslint clean
- 실측: 정지 drift 0.00 / flick 비례 2.06× / 포커스 하드팬 주제 유지 (before=화면밖 이탈)
- node-drag 무변경 확인 (노드 195px 이동 시 카메라 1.9px)
- 튜닝값(release-window 80ms·flick-min 0.05·focus-margin 180) feel-pass는 flag-on 전 종합 Guardian 패스에 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)