### PR TITLE
feat: topology-v2 노드 클릭 연결 하이라이트 — 전원 인가 은유

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -994,6 +994,11 @@
     --topology-v2-breathe-freq-rad: 1.15;
     --topology-v2-pulse-duration-ms: 420;
     --topology-v2-tip-fade-ms: 120;
+    /* depends 엣지 comet-tail 진행 속도(t += dt × speed). 기본은 ambient
+       흐름, ego(선택 노드에 물린 엣지)는 "전류가 더 흐른다"는 회로 은유로
+       가속 — B2+ 연결 하이라이트(lead spec §2). */
+    --topology-v2-edge-pulse-speed: 0.075;
+    --topology-v2-edge-pulse-speed-ego: 0.2;
 
     /* 2.5 안전 영역 (fixed chrome inset — px, canvas 2D 가 숫자로 소비)
        좌측 ReaderLens 분석 패널 + 우측 팝오버 레일 + 상단 유틸리티 레인 +

--- a/src/widgets/topology-map-v2/model/focus-state.test.ts
+++ b/src/widgets/topology-map-v2/model/focus-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isNodeEmphasisActive,
   resolveEdgeEgoState,
+  resolveEdgePulseSpeed,
   resolveNodeEgoState,
   scheduleRipple,
   stepEmphasis,
@@ -37,6 +39,41 @@ describe("resolveEdgeEgoState", () => {
 
   it("is dim when the edge does not touch the focused node", () => {
     expect(resolveEdgeEgoState(false, "a")).toBe("dim");
+  });
+});
+
+describe("resolveEdgePulseSpeed", () => {
+  const BASE = 0.075;
+  const EGO = 0.2;
+
+  it("keeps the ambient base speed when there is no focus", () => {
+    expect(resolveEdgePulseSpeed(true, null, BASE, EGO)).toBe(BASE);
+    expect(resolveEdgePulseSpeed(false, null, BASE, EGO)).toBe(BASE);
+  });
+
+  it("accelerates to the ego speed for an edge touching the focused node", () => {
+    expect(resolveEdgePulseSpeed(true, "a", BASE, EGO)).toBe(EGO);
+  });
+
+  it("keeps the base speed for an edge not touching the focused node", () => {
+    expect(resolveEdgePulseSpeed(false, "a", BASE, EGO)).toBe(BASE);
+  });
+});
+
+describe("isNodeEmphasisActive", () => {
+  it("follows the hover ego-set membership when there is no focus", () => {
+    expect(isNodeEmphasisActive("b", null, true, null)).toBe(true);
+    expect(isNodeEmphasisActive("z", null, false, null)).toBe(false);
+  });
+
+  it("suppresses hover emphasis while a focus is active", () => {
+    // b is a live hover ego-member, but focus owns attention -> suppressed
+    expect(isNodeEmphasisActive("b", "a", true, null)).toBe(false);
+  });
+
+  it("lets the panel-designated neighbor ramp under focus (panel↔map linkage)", () => {
+    expect(isNodeEmphasisActive("b", "a", false, "b")).toBe(true);
+    expect(isNodeEmphasisActive("c", "a", true, "b")).toBe(false);
   });
 });
 

--- a/src/widgets/topology-map-v2/model/focus-state.ts
+++ b/src/widgets/topology-map-v2/model/focus-state.ts
@@ -58,6 +58,48 @@ export function resolveEdgeEgoState(
   return edgeTouchesFocusedNode ? "ego" : "dim";
 }
 
+/**
+ * Ambient comet-tail advance speed for one `depends` edge (`world.edges[].t +=
+ * dt * speed`). When a node is clicked ("powered"), its own incident edges carry
+ * *more current* — the pulse advances at `egoSpeed` instead of the ambient
+ * `baseSpeed`, so the selected subgraph visibly reads as energized (B2+ circuit
+ * metaphor, lead spec §2). Every other edge keeps the ambient `baseSpeed`.
+ *
+ * Pure — the caller decides `edgeTouchesFocusedNode` from
+ * `edge.sourceId/targetId === focusedNodeId`. Speeds are tokens
+ * (`--topology-v2-edge-pulse-speed` / `-ego`).
+ */
+export function resolveEdgePulseSpeed(
+  edgeTouchesFocusedNode: boolean,
+  focusedNodeId: string | null,
+  baseSpeed: number,
+  egoSpeed: number,
+): number {
+  return focusedNodeId !== null && edgeTouchesFocusedNode ? egoSpeed : baseSpeed;
+}
+
+/**
+ * Whether a node may ramp its `emphasis` (hover-ripple) this frame.
+ *
+ * - **No focus:** hover owns the ripple — the hovered node and its 1-hop
+ *   neighbors (`isHoverEgoMember`) ramp.
+ * - **Focus active:** hover is suppressed (focus owns attention), EXCEPT the one
+ *   node the user is hovering in the detail panel's "연결된 노드" list
+ *   (`panelEmphasisNodeId`). That single neighbor still ramps so the panel row
+ *   and the on-canvas node/edge light up together ("emphasis ripple" linkage,
+ *   lead spec §4). `panelEmphasisNodeId` is null until the panel-hover API feeds
+ *   it in.
+ */
+export function isNodeEmphasisActive(
+  nodeId: string,
+  focusedNodeId: string | null,
+  isHoverEgoMember: boolean,
+  panelEmphasisNodeId: string | null,
+): boolean {
+  if (focusedNodeId !== null) return nodeId === panelEmphasisNodeId;
+  return isHoverEgoMember;
+}
+
 export interface RippleSchedule {
   nodeId: string;
   /** Absolute ms timestamp (same clock as `performance.now()`) when this node's ramp may begin. */

--- a/src/widgets/topology-map-v2/render/traces.ts
+++ b/src/widgets/topology-map-v2/render/traces.ts
@@ -81,6 +81,13 @@ export interface TraceDrawState {
   farT: number;
   /** 0..1 progress of the ambient comet-tail / pulse position along the curve, `depends` edges only. */
   t: number;
+  /**
+   * True for the single ego edge the user is hovering in the detail panel's
+   * "연결된 노드" list — an extra "emphasis ripple" over the ego brightening so
+   * the panel row and this edge read as one (lead spec §4). Ignored unless
+   * `egoState === "ego"`.
+   */
+  emphasized?: boolean;
 }
 
 export interface TraceTokens {
@@ -104,6 +111,7 @@ const COMET_TAIL_FAR_SIZES = [1.3, 0.9, 0.6];
 export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, tokens: TraceTokens): void {
   const { a, b, control, farT, egoState, t } = state;
   const isDepends = state.relationType === "depends";
+  const emphasized = egoState === "ego" && state.emphasized === true;
 
   let stroke: string;
   let width: number;
@@ -111,8 +119,10 @@ export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, token
     stroke = tokens.edgeDim;
     width = 1;
   } else if (egoState === "ego") {
-    stroke = isDepends ? tokens.indigoBright : tokens.indigo;
-    width = (isDepends ? 1.8 : 1.5) - farT * 0.5;
+    // Panel-linked ripple: brightest indigo + thicker; otherwise the standard
+    // ego brightening (depends bright, contains indigo).
+    stroke = emphasized || isDepends ? tokens.indigoBright : tokens.indigo;
+    width = (isDepends ? 1.8 : 1.5) - farT * 0.5 + (emphasized ? 0.9 : 0);
   } else {
     stroke = isDepends ? tokens.edgeDepends : tokens.edgeContains;
     width = (isDepends ? 1.3 : 1) + ((isDepends ? 0.6 : 0.45) - (isDepends ? 1.3 : 1)) * farT;
@@ -132,7 +142,7 @@ export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, token
   // ambient comet tail — three shrinking dots trailing the live pulse
   // position, thinning toward hairline dust as altitude rises rather than
   // fading via alpha (forbidden.md bans glow/alpha-based "signal" motifs).
-  const baseSizes = egoState === "ego" ? [2.9, 2.1, 1.3] : [2.1, 1.5, 0.9];
+  const baseSizes = emphasized ? [3.6, 2.7, 1.7] : egoState === "ego" ? [2.9, 2.1, 1.3] : [2.1, 1.5, 0.9];
   const tailColor = egoState === "ego" ? tokens.indigoBright : tokens.indigo;
   COMET_TAIL_STEPS.forEach((step, i) => {
     let tt = t - step;

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -84,6 +84,8 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-breathe-freq-rad": "1.15",
   "--topology-v2-pulse-duration-ms": "420",
   "--topology-v2-tip-fade-ms": "120",
+  "--topology-v2-edge-pulse-speed": "0.075",
+  "--topology-v2-edge-pulse-speed-ego": "0.2",
 
   "--topology-v2-safe-inset-left": "344",
   "--topology-v2-safe-inset-right": "120",
@@ -97,7 +99,7 @@ function fixtureReader(overrides: Record<string, string> = {}) {
 }
 
 describe("resolveTopologyV2Tokens", () => {
-  it("resolves all 74 §2 tokens to the exact prototype-sourced values", () => {
+  it("resolves all 77 §2 tokens to the exact prototype-sourced values", () => {
     const tokens = resolveTopologyV2Tokens(fixtureReader());
 
     expect(tokens.nodeFillProject).toBe("#1c1c22");
@@ -116,6 +118,8 @@ describe("resolveTopologyV2Tokens", () => {
     expect(tokens.starCount).toBe(4);
     expect(tokens.overviewEntryRatio).toBeCloseTo(0.95, 3);
     expect(tokens.tipFadeMs).toBe(120);
+    expect(tokens.edgePulseSpeed).toBeCloseTo(0.075, 4);
+    expect(tokens.edgePulseSpeedEgo).toBeCloseTo(0.2, 4);
   });
 
   it("parses declared numeric tokens as numbers, not strings", () => {

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -6,7 +6,7 @@
  * `skeletonInkRef` 해석-캐시 패턴 재사용). 값의 진실원은 여전히
  * `app/globals.css` 하나 — 이 파일은 읽기 전용 어댑터다.
  *
- * 토큰 drift 가드: §2 표에 있는 64개 토큰 중 하나라도 빈 문자열로 해석되면
+ * 토큰 drift 가드: §2 표에 있는 77개 토큰 중 하나라도 빈 문자열로 해석되면
  * (= `app/globals.css` 에서 삭제/오타) 조용히 기본값으로 폴백하지 않고
  * `TopologyV2TokenError` 를 던진다 — 누락을 "감"으로 흡수하지 않기 위해.
  */
@@ -89,6 +89,8 @@ export interface TopologyV2Tokens {
   breatheFreqRad: number;
   pulseDurationMs: number;
   tipFadeMs: number;
+  edgePulseSpeed: number;
+  edgePulseSpeedEgo: number;
 
   // 2.5 안전 영역 (fixed chrome inset, px — 라벨 컬링 + 카메라 fit)
   safeInsetLeft: number;
@@ -180,6 +182,8 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "breatheFreqRad", cssVar: "--topology-v2-breathe-freq-rad", kind: "number" },
   { key: "pulseDurationMs", cssVar: "--topology-v2-pulse-duration-ms", kind: "number" },
   { key: "tipFadeMs", cssVar: "--topology-v2-tip-fade-ms", kind: "number" },
+  { key: "edgePulseSpeed", cssVar: "--topology-v2-edge-pulse-speed", kind: "number" },
+  { key: "edgePulseSpeedEgo", cssVar: "--topology-v2-edge-pulse-speed-ego", kind: "number" },
 
   { key: "safeInsetLeft", cssVar: "--topology-v2-safe-inset-left", kind: "number" },
   { key: "safeInsetRight", cssVar: "--topology-v2-safe-inset-right", kind: "number" },
@@ -199,7 +203,7 @@ export class TopologyV2TokenError extends Error {
 }
 
 /**
- * `getComputedStyle` 결과(또는 테스트용 대체 함수)에서 64개 토큰 전부를
+ * `getComputedStyle` 결과(또는 테스트용 대체 함수)에서 77개 토큰 전부를
  * 해석한다. 하나라도 빈 문자열이면 `TopologyV2TokenError` 를 던진다 — 이게
  * §2.3 "누락 시 명시적 실패" 계약.
  */

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -78,6 +78,14 @@ export interface TopologyMapV2Props {
   fitViewToken: number;
   /** Increment to force a full relayout. */
   relayoutToken: number;
+  /**
+   * The connected-node slug the user is hovering in the detail panel's
+   * "연결된 노드" list. Under focus, that node + its connecting edge light up on
+   * the canvas so panel and map read as one (lead spec §4). Optional — the
+   * panel-hover wiring is a follow-up; omitting it keeps the map behavior
+   * identical.
+   */
+  emphasizedNeighborSlug?: string | null;
   onSelect?: (slug: string) => void;
   onOpen?: (slug: string) => void;
   onPaneClick?: () => void;
@@ -88,7 +96,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, fitViewToken, relayoutToken, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange } = props;
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
@@ -97,6 +105,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       nodes,
       edges,
       focusedSlug: focus.selectedSlug,
+      emphasizedNeighborSlug,
       fitViewToken,
       relayoutToken,
       onSelect,

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -73,6 +73,7 @@ function resolveNodeVisual(
   egoState: NodeEgoState,
   emphasis: number,
   focusedNodeId: string | null,
+  isEmphasizedNeighbor: boolean,
   tokens: TopologyV2Tokens,
   reducedMotion: boolean,
 ): NodeVisual {
@@ -90,6 +91,9 @@ function resolveNodeVisual(
   if (freshness.strokeIndigoLerp > 0) stroke = lerpColorHex(stroke, tokens.indigo, freshness.strokeIndigoLerp);
   if (!focusedNodeId && emphasis > 0.02) stroke = lerpColorHex(stroke, tokens.indigo, Math.min(1, emphasis));
   if (egoState === "neighbor") stroke = lerpColorHex(stroke, tokens.indigo, 0.5);
+  // Panel-linked ripple: the hovered detail-row's neighbor pushes past the flat
+  // 0.5 neighbor tint toward the brightest indigo, tracking its emphasis ramp.
+  if (isEmphasizedNeighbor && emphasis > 0.02) stroke = lerpColorHex(stroke, tokens.indigoBright, Math.min(1, emphasis));
   if (egoState === "center") stroke = tokens.indigoBright;
 
   return { fill: tierFill(node.kind, tokens), stroke, dash: freshness.dash, lineWidth, breatheEnabled: freshness.breatheEnabled };
@@ -111,6 +115,13 @@ export interface FrameDrawParams {
   tokens: TopologyV2Tokens;
   focusedNodeId: string | null;
   hoveredNodeId: string | null;
+  /**
+   * Under focus, the one neighbor whose detail-panel row the user is hovering.
+   * Its node + the ego edge that connects it to the focused node get an extra
+   * "emphasis ripple" brightening so panel and map read as one (lead spec §4).
+   * Null in the common case (no panel hover).
+   */
+  emphasizedNeighborId: string | null;
   emphasisById: ReadonlyMap<string, number>;
   reducedMotion: boolean;
 }
@@ -131,6 +142,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     tokens,
     focusedNodeId,
     hoveredNodeId,
+    emphasizedNeighborId,
     emphasisById,
     reducedMotion,
   } = params;
@@ -169,6 +181,10 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
       const edgeAlpha = edgeTierAlpha(tierAlphaById.get(edge.sourceId) ?? 1, tierAlphaById.get(edge.targetId) ?? 1);
       if (edgeAlpha <= 0.02) continue;
       const touches = focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
+      const emphasized =
+        emphasizedNeighborId !== null &&
+        touches &&
+        (edge.sourceId === emphasizedNeighborId || edge.targetId === emphasizedNeighborId);
       ctx.globalAlpha = edgeAlpha;
       tracesDraw(
         ctx,
@@ -180,6 +196,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
           egoState: resolveEdgeEgoState(touches, focusedNodeId),
           farT,
           t: edge.t,
+          emphasized,
         },
         {
           edgeContains: tokens.edgeContains,
@@ -198,7 +215,8 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     if (tierAlpha <= 0.02) continue;
     const egoState = resolveNodeEgoState(node.id, focusedNodeId, neighborsOfFocused);
     const emphasis = emphasisById.get(node.id) ?? 0;
-    const visual = resolveNodeVisual(node, egoState, emphasis, focusedNodeId, tokens, reducedMotion);
+    const isEmphasizedNeighbor = emphasizedNeighborId !== null && node.id === emphasizedNeighborId && egoState === "neighbor";
+    const visual = resolveNodeVisual(node, egoState, emphasis, focusedNodeId, isEmphasizedNeighbor, tokens, reducedMotion);
 
     const baseRadius = radiusForKind(node.kind, tokens);
     let breathe = 1;
@@ -209,6 +227,8 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     if (egoState === "center") effRadius *= 1.12;
     if (!focusedNodeId) {
       effRadius += emphasis * (node.id === hoveredNodeId ? baseRadius * 0.16 : baseRadius * 0.08);
+    } else if (isEmphasizedNeighbor) {
+      effRadius += emphasis * baseRadius * 0.12;
     }
 
     const screen = project(node.x, node.y);

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -10,7 +10,7 @@
 
 import { computePanBounds, stepCamera, type CameraAxes, type CameraTarget } from "../engine/camera";
 import { computeAltitudeBand, computeFarT } from "../model/altitude";
-import { stepEmphasis } from "../model/focus-state";
+import { isNodeEmphasisActive, resolveEdgePulseSpeed, stepEmphasis } from "../model/focus-state";
 import { computeZoomRatio } from "../model/tier-visibility";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import type { TopologyWorld } from "./topology-world";
@@ -26,6 +26,14 @@ export interface PhysicsStepInput {
   now: number;
   focusedNodeId: string | null;
   hoveredNodeId: string | null;
+  /**
+   * The one neighbor the user is hovering in the detail panel's "연결된 노드"
+   * list, or null. Under focus (hover suppressed) this node still ramps its
+   * emphasis so the panel row and the on-canvas node/edge light up together
+   * ("emphasis ripple" linkage, lead spec §4). Null until the panel-hover API
+   * feeds it in.
+   */
+  panelEmphasisNodeId: string | null;
   /** True while the pointer is actively dragging — suppresses the elastic pan-bounds clamp (see `engine/camera.ts`). */
   isDragging: boolean;
   /** Mutated in place — the hook owns this map's lifetime across frames. */
@@ -58,6 +66,7 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     now,
     focusedNodeId,
     hoveredNodeId,
+    panelEmphasisNodeId,
     isDragging,
     emphasisById,
     rippleStartById,
@@ -107,7 +116,9 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
 
   const activeEgoId = focusedNodeId ? null : hoveredNodeId;
   for (const node of world.nodes) {
-    const isInActiveEgoSet = !!activeEgoId && (node.id === activeEgoId || world.neighborMap.get(activeEgoId)?.has(node.id) === true);
+    const isHoverEgoMember =
+      !!activeEgoId && (node.id === activeEgoId || world.neighborMap.get(activeEgoId)?.has(node.id) === true);
+    const isInActiveEgoSet = isNodeEmphasisActive(node.id, focusedNodeId, isHoverEgoMember, panelEmphasisNodeId);
     const rippleHasStarted = now >= (rippleStartById.get(node.id) ?? 0);
     const previous = emphasisById.get(node.id) ?? 0;
     emphasisById.set(
@@ -116,8 +127,15 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     );
   }
 
+  // Powered subgraph carries more current: an edge incident to the focused node
+  // advances its comet-tail at the accelerated ego speed, everything else at the
+  // ambient base speed (`resolveEdgePulseSpeed`, lead spec §2).
   for (const edge of world.edges) {
-    if (edge.kind === "depends") edge.t = (edge.t + dt * 0.075) % 1;
+    if (edge.kind !== "depends") continue;
+    const touchesFocused =
+      focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
+    const speed = resolveEdgePulseSpeed(touchesFocused, focusedNodeId, tokens.edgePulseSpeed, tokens.edgePulseSpeedEgo);
+    edge.t = (edge.t + dt * speed) % 1;
   }
 
   return { camera: nextCamera, farT, zoomRatio };

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -40,6 +40,13 @@ export interface UseTopologyLoopArgs {
   nodes: TopologyMapV2Props["nodes"];
   edges: TopologyMapV2Props["edges"];
   focusedSlug: string | null;
+  /**
+   * The neighbor slug the user is hovering in the detail panel's "연결된 노드"
+   * list, or null. Under focus this one node (+ its connecting edge) lights up
+   * on the canvas so panel and map read as one ("emphasis ripple" linkage,
+   * lead spec §4). Null until the panel-hover wiring feeds it in.
+   */
+  emphasizedNeighborSlug?: string | null;
   fitViewToken: number;
   relayoutToken: number;
   onSelect?: (slug: string) => void;
@@ -54,7 +61,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, fitViewToken, relayoutToken, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -103,6 +110,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
 
   const focusedSlugRef = useRef<string | null>(focusedSlug);
   const lastFocusedSlugRef = useRef<string | null>(focusedSlug);
+  const panelEmphasisNodeIdRef = useRef<string | null>(emphasizedNeighborSlug);
   const hoveredNodeIdRef = useRef<string | null>(null);
   const emphasisRef = useRef<Map<string, number>>(new Map());
   const rippleStartRef = useRef<Map<string, number>>(new Map());
@@ -111,6 +119,10 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   useEffect(() => {
     focusedSlugRef.current = focusedSlug;
   }, [focusedSlug]);
+
+  useEffect(() => {
+    panelEmphasisNodeIdRef.current = emphasizedNeighborSlug;
+  }, [emphasizedNeighborSlug]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
@@ -292,6 +304,9 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
 
       const focusedNodeId = focusedSlugRef.current;
       const hoveredNodeId = focusedNodeId ? null : hoveredNodeIdRef.current;
+      // Panel-row emphasis only bites while a node is focused (that's the only
+      // time the "연결된 노드" list exists) — otherwise hover owns the ripple.
+      const panelEmphasisNodeId = focusedNodeId ? panelEmphasisNodeIdRef.current : null;
 
       const { camera, farT, zoomRatio } = stepTopologyPhysics({
         world,
@@ -304,6 +319,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         now,
         focusedNodeId,
         hoveredNodeId,
+        panelEmphasisNodeId,
         isDragging: pointerMachineRef.current.phase === "dragging",
         emphasisById: emphasisRef.current,
         rippleStartById: rippleStartRef.current,
@@ -326,6 +342,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         tokens,
         focusedNodeId,
         hoveredNodeId,
+        emphasizedNeighborId: panelEmphasisNodeId,
         emphasisById: emphasisRef.current,
         reducedMotion: reducedMotionRef.current,
       });


### PR DESCRIPTION
## Summary
노드 클릭 시 선택 노드+연결 엣지가 '전원 인가'되는 B2+ 회로 은유 (flag off).

- ego-focus dim(선택↔이웃 밝게, 비이웃 노드+엣지 불투명 dim)은 기존 확인. 추가분:
- **펄스 가속**: ego 엣지의 comet-tail이 ego 속도로 흐름 ('전류 증가' 신호, resolveEdgePulseSpeed 순수 헬퍼)
- **패널↔맵 canvas API**: emphasizedNeighborSlug prop → 지도 트레이스 emphasis ripple (popover-row hover 배선은 1834줄 공유 컴포넌트라 follow-up defer, 캔버스 측 API는 완료·단위테스트)
- 토큰: --topology-v2-edge-pulse-speed(0.075)/-ego(0.2). 저알파 금지 준수.

## Test plan
- v2 vitest 200 pass + 3 todo · tsc clean · scoped eslint clean · TDD 2 순수 헬퍼
- Chrome 실조작: views 클릭 → 이웃 엣지 인디고 점등+펄스 가속, 비이웃 노드/엣지 dim, bg클릭 복원. 콘솔 에러 0
- click-safe·결정론 격자·drag-only force·카메라 물리 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)