### PR TITLE
feat: topology-v2 노드 패널을 컴포넌트 데이터시트로 재구성

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1010,6 +1010,37 @@
     --topology-v2-safe-inset-right: 120;
     --topology-v2-safe-inset-top: 96;
     --topology-v2-safe-inset-bottom: 96;
+
+    /* 2.6 컴포넌트 데이터시트 패널 (`TopologyV2DetailPanel`, DOM 소비)
+       노드 클릭 시 우측에 뜨는 계측기 밀도(instrument) 상세 패널 —
+       구 `TopologyNodePopover` 보다 촘촘하다(소유자 "아이콘 너무 큼" +
+       "정보가 세 번 나온다" 반려). 색은 중립 5단계 + 인디고 신호만,
+       kind 미니어처는 캔버스와 공유하는 `--topology-v2-node-*` 토큰 재사용.
+       P6 에서 구엔진 삭제 시 `--topology-v2-` grep 으로 함께 제거된다. */
+    --topology-v2-panel-width: 288px;
+    --topology-v2-panel-radius: 9px;
+    --topology-v2-panel-row-radius: 5px;
+    --topology-v2-panel-pad: 11px;
+    --topology-v2-panel-gap: 10px;
+    --topology-v2-panel-surface: #17171c;
+    --topology-v2-panel-border: #2a2a30;
+    --topology-v2-panel-divider: #23232a;
+    --topology-v2-panel-shadow: 0 16px 40px rgba(0, 0, 0, 0.42);
+    --topology-v2-panel-row-hover: rgba(255, 255, 255, 0.045);
+    --topology-v2-panel-metric-surface: rgba(255, 255, 255, 0.028);
+    --topology-v2-panel-metric-text: #b6b6c0;
+    --topology-v2-panel-action-surface: rgba(255, 255, 255, 0.03);
+    --topology-v2-panel-action-border: #2f2f37;
+    /* "전원" 표시 — powered(최근 갱신)=인디고 신호, unpowered=중립 저채도 */
+    --topology-v2-panel-power-on: var(--color-indigo-brand);
+    --topology-v2-panel-power-off: #45454d;
+    --topology-v2-panel-text-primary: #ececf0;
+    --topology-v2-panel-text-secondary: #a3a3ac;
+    --topology-v2-panel-text-tertiary: #77777f;
+    --topology-v2-panel-text-quaternary: #55555d;
+    /* 연결 그룹 trace 미니라인 — 캔버스 엣지와 같은 계열(contains 실선/depends 점선) */
+    --topology-v2-edge-contains-mark: #4a4a54;
+    --topology-v2-edge-depends-mark: #5c5c72;
   }
 
   html {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2788,6 +2788,18 @@
       "relationPayloadCopyShort": "copy",
       "relationEvidenceShort": "proof"
     },
+    "nodeDatasheet": {
+      "poweredOn": "fresh",
+      "poweredOff": "idle",
+      "metricUsedBy": "used by",
+      "metricDependsOn": "depends on",
+      "metricEvidence": "evidence",
+      "groupContains": "contains",
+      "groupDepends": "depends",
+      "noConnections": "no direct connections",
+      "handoff": "Copy next action",
+      "handoffCopied": "Agent handoff copied"
+    },
     "ontologyDrawer": {
       "caption": "Concept profile",
       "source": "Document",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2788,6 +2788,18 @@
       "relationPayloadCopyShort": "복사",
       "relationEvidenceShort": "근거"
     },
+    "nodeDatasheet": {
+      "poweredOn": "최근 갱신",
+      "poweredOff": "정체",
+      "metricUsedBy": "쓰는 곳",
+      "metricDependsOn": "기대는 곳",
+      "metricEvidence": "근거",
+      "groupContains": "포함",
+      "groupDepends": "의존",
+      "noConnections": "직접 연결 없음",
+      "handoff": "다음 액션 복사",
+      "handoffCopied": "에이전트 인계를 복사했어요"
+    },
     "ontologyDrawer": {
       "caption": "개념 정보",
       "source": "문서",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -196,7 +196,13 @@ import { replaceVaultBody } from "@/shared/lib/replace-vault-body";
 import { TopologyOntologyDrawer } from "./TopologyOntologyDrawer";
 import { TopologyNodePopover } from "./TopologyNodePopover";
 import { TopologyMapCanvas } from "@/widgets/topology-map-canvas";
-import { TopologyMapV2 } from "@/widgets/topology-map-v2";
+import {
+  TopologyMapV2,
+  TopologyV2DetailPanel,
+  formatV2HandoffText,
+  groupV2Connections,
+  type V2DatasheetConnection,
+} from "@/widgets/topology-map-v2";
 import { useTopologyMapV2Enabled } from "@/shared/lib/use-topology-map-v2-enabled";
 import { selectTopologyEngine } from "../lib/topology-engine-select";
 import { buildTopologyV2Graph } from "../lib/topology-v2-adapter";
@@ -946,6 +952,57 @@ export function HomePage() {
       level: significance.importance.level,
     };
   }, [nodeFocusData, t, tKinds]);
+  // topology-map-v2 "component datasheet" panel (flag ON only). Re-presents the
+  // SAME nodeFocus/significance facts the shared popover consumes — grouped
+  // connections + one engraved metric line + an agent handoff payload — without
+  // editing the shared TopologyNodePopover, so the Sigma path stays byte-
+  // identical when the flag is off. See widgets/topology-map-v2/TopologyV2DetailPanel.
+  const v2DatasheetModel = useMemo(() => {
+    if (!nodeFocus || !selectedOntologyNode) return null;
+    const slug = nodeFocus.sourceSlug ?? selectedOntologyNode.id;
+    const connections: V2DatasheetConnection[] = nodeFocus.connections.map(
+      (connection) => ({
+        id: connection.id,
+        title: connection.title,
+        kind: connection.kind,
+        relationType: connection.relationType,
+        direction: connection.direction,
+      }),
+    );
+    const grouped = groupV2Connections(connections);
+    const metric = {
+      usedBy: nodeFocus.usedByCount,
+      dependsOn: nodeFocus.dependsOnCount,
+      evidence: selectedOntologyNode.evidenceIds.length,
+    };
+    const handoffText = formatV2HandoffText({
+      slug,
+      kind: nodeFocus.kind,
+      domainTitle: nodeFocusData?.significance.ownerDomainTitle ?? null,
+      usedBy: metric.usedBy,
+      dependsOn: metric.dependsOn,
+      evidence: metric.evidence,
+      containsNames: grouped.contains.map((connection) => connection.title),
+      dependsNames: grouped.depends.map((connection) => connection.title),
+    });
+    return {
+      slug,
+      title: nodeFocus.title,
+      kind: nodeFocus.kind,
+      powered: changedSlugs.has(selectedOntologyNode.id),
+      metric,
+      connections,
+      hiddenConnectionCount: nodeFocus.hiddenConnectionCount,
+      handoffText,
+    };
+  }, [nodeFocus, selectedOntologyNode, nodeFocusData, changedSlugs]);
+  const copyV2NodeHandoff = useCallback(
+    async (text: string) => {
+      const ok = await copyText(text);
+      if (ok) toast.show(t("nodeDatasheet.handoffCopied"), "success");
+    },
+    [t, toast],
+  );
   const selectedNodeFocusActive =
     Boolean(
       selectedOntologyNode &&
@@ -2713,6 +2770,35 @@ export function HomePage() {
             data-position-right-inset-token="--topology-node-popover-right-inset"
             className="fixed inset-x-3 top-[72px] z-50 flex justify-center lg:inset-x-auto lg:right-[var(--topology-node-popover-right-inset)] lg:top-[var(--topology-node-popover-top)] lg:block"
           >
+            {topologyMapV2Enabled && v2DatasheetModel ? (
+              <TopologyV2DetailPanel
+                slug={v2DatasheetModel.slug}
+                title={v2DatasheetModel.title}
+                kind={v2DatasheetModel.kind}
+                powered={v2DatasheetModel.powered}
+                metric={v2DatasheetModel.metric}
+                connections={v2DatasheetModel.connections}
+                hiddenConnectionCount={v2DatasheetModel.hiddenConnectionCount}
+                handoffText={v2DatasheetModel.handoffText}
+                labels={{
+                  kindLabel: tKinds(normalizeKindLabelKey(v2DatasheetModel.kind)),
+                  poweredOn: t("nodeDatasheet.poweredOn"),
+                  poweredOff: t("nodeDatasheet.poweredOff"),
+                  metricUsedBy: t("nodeDatasheet.metricUsedBy"),
+                  metricDependsOn: t("nodeDatasheet.metricDependsOn"),
+                  metricEvidence: t("nodeDatasheet.metricEvidence"),
+                  groupContains: t("nodeDatasheet.groupContains"),
+                  groupDepends: t("nodeDatasheet.groupDepends"),
+                  noConnections: t("nodeDatasheet.noConnections"),
+                  handoff: t("nodeDatasheet.handoff"),
+                  close: t("controls.close"),
+                }}
+                onSelectConnection={(id) => handleSelect(id)}
+                onCopyHandoff={copyV2NodeHandoff}
+                onClose={handleClose}
+                className="max-lg:w-[min(520px,calc(100vw-1.5rem))]"
+              />
+            ) : (
             <TopologyNodePopover
               focus={nodeFocus}
               significance={nodeSignificancePresentation}
@@ -2803,6 +2889,7 @@ export function HomePage() {
                   : "max-lg:max-h-[var(--topology-node-popover-mobile-expanded-max-height)] max-lg:w-[min(520px,calc(100vw-1.5rem))]"
               }
             />
+            )}
           </div>
         ) : null}
         {selectedOntologyNode && ontologyInsight && fullDetailOpen && !createNodeOpen ? (

--- a/src/widgets/topology-map-v2/index.ts
+++ b/src/widgets/topology-map-v2/index.ts
@@ -7,3 +7,19 @@ export type {
   TopologyV2Overlays,
   TopologyV2Forces,
 } from './ui/TopologyMapV2';
+export { TopologyV2DetailPanel } from './ui/TopologyV2DetailPanel';
+export type {
+  TopologyV2DetailPanelProps,
+  TopologyV2DetailPanelLabels,
+} from './ui/TopologyV2DetailPanel';
+export {
+  formatV2HandoffText,
+  formatV2MetricLine,
+  groupV2Connections,
+} from './ui/topology-v2-datasheet';
+export type {
+  V2DatasheetConnection,
+  V2GroupedConnections,
+  V2HandoffInput,
+  V2MetricValues,
+} from './ui/topology-v2-datasheet';

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { type KeyboardEvent as ReactKeyboardEvent, useCallback } from "react";
+import { X } from "lucide-react";
+import {
+  formatV2MetricLine,
+  groupV2Connections,
+  type V2DatasheetConnection,
+  type V2MetricValues,
+} from "./topology-v2-datasheet";
+
+/**
+ * topology-map-v2 "component datasheet" node panel
+ * (`docs/TOPOLOGY-V2-DESIGN.md` §5). Rendered ONLY when the
+ * `atlas:feature:topology-map-v2` flag is on — the flag-off path keeps the
+ * shared `TopologyNodePopover` byte-identical, so the Sigma engine is
+ * untouched (lead design decision). Re-presents the SAME selection facts the
+ * shared popover derives, at instrument density: a kind-shape miniature +
+ * power dot header, ONE engraved metric line (no triplication), connections
+ * grouped by relation type with a canvas-matching trace mini-line (no badge
+ * pile), and an agent-handoff copy row.
+ *
+ * FSD: this widget owns its own prop shape — the view (`HomePage`) maps
+ * `TopologyNodeFocusModel` into these props, so the import direction stays
+ * view → widget. Colors/sizes come from `--topology-v2-panel-*` tokens.
+ */
+
+export interface TopologyV2DetailPanelLabels {
+  kindLabel: string;
+  poweredOn: string;
+  poweredOff: string;
+  metricUsedBy: string;
+  metricDependsOn: string;
+  metricEvidence: string;
+  groupContains: string;
+  groupDepends: string;
+  noConnections: string;
+  handoff: string;
+  close: string;
+}
+
+export interface TopologyV2DetailPanelProps {
+  slug: string;
+  title: string;
+  kind: string;
+  /** "전원" — powered (recently updated / fresh) vs unpowered (quiet). */
+  powered: boolean;
+  metric: V2MetricValues;
+  connections: readonly V2DatasheetConnection[];
+  hiddenConnectionCount: number;
+  /** Pre-built agent handoff payload; the view owns clipboard + toast. */
+  handoffText: string;
+  labels: TopologyV2DetailPanelLabels;
+  onSelectConnection: (id: string) => void;
+  onCopyHandoff: (text: string) => void;
+  onClose: () => void;
+  className?: string;
+}
+
+type RenderableKind = "project" | "domain" | "capability" | "element";
+
+function isRenderableKind(kind: string): kind is RenderableKind {
+  return (
+    kind === "project" ||
+    kind === "domain" ||
+    kind === "capability" ||
+    kind === "element"
+  );
+}
+
+/**
+ * The kind-shape miniature — the same silhouette family the v2 canvas draws
+ * (hex = project, chip = domain, circle = capability, via-pad = element),
+ * stroked/filled with the shared `--topology-v2-node-*` kind tokens so the
+ * header reads as a shrunk copy of the node on the map.
+ */
+function KindGlyph({ kind }: { kind: string }) {
+  const resolved: RenderableKind = isRenderableKind(kind) ? kind : "element";
+  const fill = `var(--topology-v2-node-fill-${resolved})`;
+  const stroke = `var(--topology-v2-node-stroke-${resolved})`;
+  const s = 15;
+  const c = s / 2;
+  const common = {
+    fill,
+    stroke,
+    strokeWidth: 1.25,
+    vectorEffect: "non-scaling-stroke" as const,
+  };
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox={`0 0 ${s} ${s}`}
+      aria-hidden="true"
+      data-kind-glyph={resolved}
+      className="shrink-0"
+    >
+      {resolved === "project" ? (
+        // hexagon (flat-top-ish, matching canvas hexPoints)
+        <polygon points={hexPoints(c, c, c - 1.2)} {...common} />
+      ) : resolved === "domain" ? (
+        // chip — wider rounded rectangle
+        <rect x={1} y={3.4} width={s - 2} height={s - 6.8} rx={1.6} {...common} />
+      ) : resolved === "capability" ? (
+        <circle cx={c} cy={c} r={c - 1.6} {...common} />
+      ) : (
+        // via-pad — square with a drilled hole
+        <g>
+          <rect x={2.4} y={2.4} width={s - 4.8} height={s - 4.8} rx={1.4} {...common} />
+          <circle cx={c} cy={c} r={1.5} fill="var(--topology-v2-node-hole-fill)" stroke="none" />
+        </g>
+      )}
+    </svg>
+  );
+}
+
+function hexPoints(cx: number, cy: number, r: number): string {
+  const pts: string[] = [];
+  for (let i = 0; i < 6; i += 1) {
+    const a = ((i * 60 - 90) * Math.PI) / 180;
+    pts.push(`${(cx + r * Math.cos(a)).toFixed(2)},${(cy + r * Math.sin(a)).toFixed(2)}`);
+  }
+  return pts.join(" ");
+}
+
+/**
+ * Trace mini-line matching the canvas edge style: contains = solid hairline,
+ * depends = dashed. One compact marker per group, drawn once in the group
+ * header — never per row.
+ */
+function TraceMark({ group }: { group: "contains" | "depends" }) {
+  const stroke =
+    group === "contains"
+      ? "var(--topology-v2-edge-contains-mark)"
+      : "var(--topology-v2-edge-depends-mark)";
+  return (
+    <svg width={22} height={6} viewBox="0 0 22 6" aria-hidden="true" className="shrink-0">
+      <line
+        x1={1}
+        y1={3}
+        x2={21}
+        y2={3}
+        stroke={stroke}
+        strokeWidth={1.4}
+        strokeDasharray={group === "depends" ? "3 3" : undefined}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function TopologyV2DetailPanel({
+  slug,
+  title,
+  kind,
+  powered,
+  metric,
+  connections,
+  hiddenConnectionCount,
+  handoffText,
+  labels,
+  onSelectConnection,
+  onCopyHandoff,
+  onClose,
+  className,
+}: TopologyV2DetailPanelProps) {
+  const grouped = groupV2Connections(connections);
+  const metricLine = formatV2MetricLine(metric, {
+    usedBy: labels.metricUsedBy,
+    dependsOn: labels.metricDependsOn,
+    evidence: labels.metricEvidence,
+  });
+  const hasConnections = grouped.contains.length > 0 || grouped.depends.length > 0;
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const renderGroup = (
+    group: "contains" | "depends",
+    label: string,
+    rows: V2DatasheetConnection[],
+  ) => {
+    if (rows.length === 0) return null;
+    return (
+      <div className="flex flex-col gap-1" data-datasheet-group={group}>
+        <div className="flex items-center gap-2">
+          <TraceMark group={group} />
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-tertiary)]">
+            {label}
+          </span>
+          <span className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+            {rows.length}
+          </span>
+        </div>
+        <ul className="flex flex-col">
+          {rows.map((row) => (
+            <li key={`${group}:${row.id}`}>
+              <button
+                type="button"
+                onClick={() => onSelectConnection(row.id)}
+                data-datasheet-connection={row.id}
+                className="flex w-full items-center gap-2 rounded-[var(--topology-v2-panel-row-radius)] px-1.5 py-1 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+              >
+                <span className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--topology-v2-panel-text-secondary)]">
+                  {row.title}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label={title}
+      data-testid="topology-v2-detail-panel"
+      data-datasheet-density="instrument"
+      onKeyDown={handleKeyDown}
+      className={[
+        "flex w-[var(--topology-v2-panel-width)] flex-col gap-[var(--topology-v2-panel-gap)]",
+        "rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)]",
+        "bg-[color:var(--topology-v2-panel-surface)] p-[var(--topology-v2-panel-pad)]",
+        "shadow-[var(--topology-v2-panel-shadow)]",
+        className ?? "",
+      ].join(" ")}
+    >
+      {/* Header — kind miniature + name + power dot + close */}
+      <div className="flex items-start gap-2">
+        <div className="mt-[1px]">
+          <KindGlyph kind={kind} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-center gap-1.5">
+            <span
+              data-power-state={powered ? "on" : "off"}
+              aria-hidden="true"
+              className="inline-block h-[6px] w-[6px] shrink-0 rounded-full"
+              style={{
+                backgroundColor: powered
+                  ? "var(--topology-v2-panel-power-on)"
+                  : "var(--topology-v2-panel-power-off)",
+              }}
+            />
+            <h2 className="min-w-0 flex-1 truncate text-[13.5px] font-semibold tracking-[-0.01em] text-[color:var(--topology-v2-panel-text-primary)]">
+              {title}
+            </h2>
+          </div>
+          <div className="flex items-center gap-1.5 pl-[13.5px]">
+            <span className="text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+              {labels.kindLabel}
+            </span>
+            <span className="text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">·</span>
+            <span className="text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+              {powered ? labels.poweredOn : labels.poweredOff}
+            </span>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={labels.close}
+          data-testid="topology-v2-detail-panel-close"
+          className="-mr-1 -mt-1 shrink-0 rounded-[var(--topology-v2-panel-row-radius)] p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* One engraved metric line — no subtitle + boxes triplication */}
+      <div
+        data-datasheet-metric="engraved"
+        className="rounded-[var(--topology-v2-panel-row-radius)] bg-[color:var(--topology-v2-panel-metric-surface)] px-2 py-1.5"
+      >
+        <span className="font-mono text-[11.5px] tracking-[0.01em] text-[color:var(--topology-v2-panel-metric-text)]">
+          {metricLine}
+        </span>
+      </div>
+
+      {/* Connections grouped by relation type */}
+      <div className="flex flex-col gap-2.5">
+        {hasConnections ? (
+          <>
+            {renderGroup("contains", labels.groupContains, grouped.contains)}
+            {renderGroup("depends", labels.groupDepends, grouped.depends)}
+            {hiddenConnectionCount > 0 ? (
+              <span className="pl-1.5 font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+                +{hiddenConnectionCount}
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <span className="text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+            {labels.noConnections}
+          </span>
+        )}
+      </div>
+
+      {/* Agent-handoff row */}
+      <div className="flex items-center gap-2 border-t border-[color:var(--topology-v2-panel-divider)] pt-2">
+        <button
+          type="button"
+          onClick={() => onCopyHandoff(handoffText)}
+          data-testid="topology-v2-detail-panel-handoff"
+          className="flex items-center gap-1.5 rounded-[var(--topology-v2-panel-row-radius)] border border-[color:var(--topology-v2-panel-action-border)] bg-[color:var(--topology-v2-panel-action-surface)] px-2 py-1 text-[11px] font-medium text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+        >
+          {labels.handoff}
+        </button>
+        <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+          {slug}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatV2HandoffText,
+  formatV2MetricLine,
+  groupV2Connections,
+  type V2DatasheetConnection,
+} from "./topology-v2-datasheet";
+
+const conn = (
+  partial: Partial<V2DatasheetConnection> & { id: string; relationType: string },
+): V2DatasheetConnection => ({
+  title: partial.id,
+  kind: "capability",
+  direction: "outgoing",
+  ...partial,
+});
+
+describe("groupV2Connections", () => {
+  it("splits containment relations (contains/belongs_to) from dependency relations", () => {
+    const grouped = groupV2Connections([
+      conn({ id: "child-a", relationType: "contains" }),
+      conn({ id: "parent", relationType: "belongs_to" }),
+      conn({ id: "dep-x", relationType: "depends_on" }),
+      conn({ id: "impl-y", relationType: "implements" }),
+      conn({ id: "use-z", relationType: "uses" }),
+    ]);
+    expect(grouped.contains.map((c) => c.id)).toEqual(["child-a", "parent"]);
+    expect(grouped.depends.map((c) => c.id)).toEqual(["dep-x", "impl-y", "use-z"]);
+  });
+
+  it("preserves input order within each group and handles an empty list", () => {
+    expect(groupV2Connections([])).toEqual({ contains: [], depends: [] });
+  });
+});
+
+describe("formatV2MetricLine", () => {
+  const labels = { usedBy: "쓰는 곳", dependsOn: "기대는 곳", evidence: "근거" };
+
+  it("joins the three plain-language facts as ONE engraved line (no triplication)", () => {
+    expect(
+      formatV2MetricLine({ usedBy: 3, dependsOn: 5, evidence: 2 }, labels),
+    ).toBe("쓰는 곳 3 · 기대는 곳 5 · 근거 2");
+  });
+
+  it("keeps zeros explicit so the line always has three segments", () => {
+    expect(
+      formatV2MetricLine({ usedBy: 0, dependsOn: 0, evidence: 0 }, labels),
+    ).toBe("쓰는 곳 0 · 기대는 곳 0 · 근거 0");
+  });
+});
+
+describe("formatV2HandoffText", () => {
+  it("emits a deterministic MCP/CLI-style payload with slug, typed facts, and a next action", () => {
+    const text = formatV2HandoffText({
+      slug: "mcp-server",
+      kind: "capability",
+      domainTitle: "AI Agent Partner",
+      usedBy: 5,
+      dependsOn: 2,
+      evidence: 3,
+      containsNames: ["mcp-tool-registry", "stdio-transport"],
+      dependsNames: ["relation-graph"],
+    });
+    expect(text).toBe(
+      [
+        "node: mcp-server",
+        "kind: capability",
+        "domain: AI Agent Partner",
+        "used_by: 5",
+        "depends_on: 2",
+        "evidence: 3",
+        "contains: mcp-tool-registry, stdio-transport",
+        "depends: relation-graph",
+        'next: get_concept("mcp-server") → review context, then patch_concept / add_relation as needed',
+      ].join("\n"),
+    );
+  });
+
+  it("falls back to '-' for a missing domain and for empty connection groups", () => {
+    const text = formatV2HandoffText({
+      slug: "orphan",
+      kind: "element",
+      domainTitle: null,
+      usedBy: 0,
+      dependsOn: 0,
+      evidence: 0,
+      containsNames: [],
+      dependsNames: [],
+    });
+    expect(text).toContain("domain: -");
+    expect(text).toContain("contains: -");
+    expect(text).toContain("depends: -");
+  });
+});

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure view-model helpers for the topology-map-v2 "component datasheet" panel
+ * (`docs/TOPOLOGY-V2-DESIGN.md` §5 — agent-handoff differentiation). No React,
+ * no i18n, no DOM — so the grouping / metric line / handoff payload are
+ * unit-testable on structure alone and stay locale-agnostic.
+ *
+ * The datasheet re-presents the SAME selection facts the shared popover already
+ * derives (`TopologyNodeFocusModel`); the view maps that model into these
+ * inputs. This module only groups + formats — it never recomputes counts.
+ */
+
+import { isContainmentRelation } from "@/shared/lib/ontology-tree";
+
+/** contains = structural containment (contains/belongs_to); depends = everything else. */
+export type V2ConnectionGroupKey = "contains" | "depends";
+
+export interface V2DatasheetConnection {
+  id: string;
+  title: string;
+  kind: string;
+  relationType: string;
+  direction: "incoming" | "outgoing";
+}
+
+export interface V2GroupedConnections {
+  contains: V2DatasheetConnection[];
+  depends: V2DatasheetConnection[];
+}
+
+/**
+ * Split direct connections into the two relation-type groups the datasheet
+ * renders (one compact marker per group, not a per-row badge pile). Input
+ * order is preserved inside each group so the panel stays deterministic.
+ */
+export function groupV2Connections(
+  connections: readonly V2DatasheetConnection[],
+): V2GroupedConnections {
+  const contains: V2DatasheetConnection[] = [];
+  const depends: V2DatasheetConnection[] = [];
+  for (const connection of connections) {
+    if (isContainmentRelation(connection.relationType)) {
+      contains.push(connection);
+    } else {
+      depends.push(connection);
+    }
+  }
+  return { contains, depends };
+}
+
+export interface V2MetricValues {
+  /** Direct incoming — plain "쓰는 곳" (places that use this). */
+  usedBy: number;
+  /** Direct outgoing — plain "기대는 곳" (places this leans on). */
+  dependsOn: number;
+  /** Node-level evidence references — plain "근거". */
+  evidence: number;
+}
+
+export interface V2MetricLabels {
+  usedBy: string;
+  dependsOn: string;
+  evidence: string;
+}
+
+/**
+ * The ONE engraved metric line — "쓰는 곳 3 · 기대는 곳 5 · 근거 2". Replaces the
+ * old subtitle + two big count boxes (the owner's "정보가 세 번 나온다" complaint);
+ * every fact appears exactly once. Always three segments, zeros explicit.
+ */
+export function formatV2MetricLine(
+  values: V2MetricValues,
+  labels: V2MetricLabels,
+): string {
+  return [
+    `${labels.usedBy} ${values.usedBy}`,
+    `${labels.dependsOn} ${values.dependsOn}`,
+    `${labels.evidence} ${values.evidence}`,
+  ].join(" · ");
+}
+
+export interface V2HandoffInput {
+  slug: string;
+  kind: string;
+  domainTitle: string | null;
+  usedBy: number;
+  dependsOn: number;
+  evidence: number;
+  containsNames: readonly string[];
+  dependsNames: readonly string[];
+}
+
+/**
+ * Agent-ready handoff payload (MCP/CLI-style) for a single node — the "다음
+ * 액션 복사" differentiation. Stable English field keys + a suggested MCP call
+ * so it pastes cleanly into a coding agent regardless of UI locale; the button
+ * label is localized, this payload is intentionally not. Deterministic.
+ */
+export function formatV2HandoffText(input: V2HandoffInput): string {
+  const list = (names: readonly string[]) =>
+    names.length > 0 ? names.join(", ") : "-";
+  return [
+    `node: ${input.slug}`,
+    `kind: ${input.kind}`,
+    `domain: ${input.domainTitle ?? "-"}`,
+    `used_by: ${input.usedBy}`,
+    `depends_on: ${input.dependsOn}`,
+    `evidence: ${input.evidence}`,
+    `contains: ${list(input.containsNames)}`,
+    `depends: ${list(input.dependsNames)}`,
+    `next: get_concept("${input.slug}") → review context, then patch_concept / add_relation as needed`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

topology-map-v2 노드 상세 패널을 B2+ **컴포넌트 데이터시트**로 재구성. `atlas:feature:topology-map-v2` flag ON 일 때만 렌더되는 v2 전용 위젯(`TopologyV2DetailPanel`)을 신설했고, 공유 `TopologyNodePopover`/`NodeDetailPanel`(Sigma 경로)은 미변경 — flag OFF 는 레거시 팝오버를 바이트-동일하게 유지.

**왜**: 기존 우측 패널이 (1) 같은 수치를 3중 표기(부제 + 큰 박스 2개), (2) `Contains·Element·proof1·explain` 배지 수프, (3) 터치 크기 — 계기판 밀도 아님. 소유자가 "안 예쁨"으로 반려.

**데이터시트 구조**:
- 헤더 = kind 형태 미니어처(hex 프로젝트 / chip 도메인 / circle capability / drilled-pad element) + 이름 + 전원/신선도 dot
- 각인 수치 **1줄** (`used by N · depends on M · evidence K`) — 중복 제거
- 연결 = 관계 타입별 그룹(CONTAINS 실선 / DEPENDS 점선 트레이스 마커), 배지 수프 대체
- 에이전트 인계 행 (`Copy next action`) — MCP/CLI 핸드오프 페이로드
- 288px 계기판 밀도 (1920 아이콘 과대 교정 겸함)
- 신규 토큰 `--topology-v2-panel-*`, i18n `topology.nodeDatasheet` (ko/en)

## Test plan

- `tsc --noEmit` clean · v2 widget vitest 213 pass / 3 todo (신규 datasheet formatter 6 tests) · scoped eslint clean · 콘솔 무에러
- 라이브 검증(:3103, flag on): project·capability(MCP hub)·element 클릭 → 데이터시트 정상. flag OFF → 레거시 팝오버 바이트-동일
- Design Guardian: **approve-with-followups** — 헌장 전 PASS(토큰만·단일 인디고·글래스모피즘/글로우/스케일-호버 없음), 대비 metric 8.88:1

## Follow-ups (flag-on 전 MUST-FIX, 별도 커밋)

1. 허브 노드(contains-지배)에서 DEPENDS 그룹 미표시 + 핸드오프 페이로드 `depends: -` vs `depends_on: N` 자기모순 — 공유 5-item outgoing-first 프리뷰 재사용 탓. 관계타입 인지 selection 으로 교체 필요
2. 라이트모드 `--topology-v2-panel-*` 오버라이드 블록 + caps 라벨 대비 넛지(4.02→AA 4.5)

flag OFF 기본이라 사용자 회귀 0 — followup 은 flag-on(P6) 전 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)