### PR TITLE
fix: topology-v2 데이터시트 연결 그룹을 전체 세트에서 파생

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -199,9 +199,9 @@ import { TopologyMapCanvas } from "@/widgets/topology-map-canvas";
 import {
   TopologyMapV2,
   TopologyV2DetailPanel,
+  buildV2Connections,
+  buildV2ConnectionGroups,
   formatV2HandoffText,
-  groupV2Connections,
-  type V2DatasheetConnection,
 } from "@/widgets/topology-map-v2";
 import { useTopologyMapV2Enabled } from "@/shared/lib/use-topology-map-v2-enabled";
 import { selectTopologyEngine } from "../lib/topology-engine-select";
@@ -958,18 +958,18 @@ export function HomePage() {
   // editing the shared TopologyNodePopover, so the Sigma path stays byte-
   // identical when the flag is off. See widgets/topology-map-v2/TopologyV2DetailPanel.
   const v2DatasheetModel = useMemo(() => {
-    if (!nodeFocus || !selectedOntologyNode) return null;
+    if (!nodeFocus || !selectedOntologyNode || !ontologyInsight) return null;
     const slug = nodeFocus.sourceSlug ?? selectedOntologyNode.id;
-    const connections: V2DatasheetConnection[] = nodeFocus.connections.map(
-      (connection) => ({
-        id: connection.id,
-        title: connection.title,
-        kind: connection.kind,
-        relationType: connection.relationType,
-        direction: connection.direction,
-      }),
+    // Group from the FULL connection set (not the shared 5-item outgoing-first
+    // preview) so a contains-hub's depends group renders its real total instead
+    // of collapsing into a generic overflow — and the handoff names never
+    // contradict the depends_on count.
+    const connections = buildV2Connections(
+      selectedOntologyNode.id,
+      ontologyInsight.nodes,
+      ontologyInsight.edges,
     );
-    const grouped = groupV2Connections(connections);
+    const groups = buildV2ConnectionGroups(connections);
     const metric = {
       usedBy: nodeFocus.usedByCount,
       dependsOn: nodeFocus.dependsOnCount,
@@ -982,8 +982,8 @@ export function HomePage() {
       usedBy: metric.usedBy,
       dependsOn: metric.dependsOn,
       evidence: metric.evidence,
-      containsNames: grouped.contains.map((connection) => connection.title),
-      dependsNames: grouped.depends.map((connection) => connection.title),
+      containsNames: groups.contains.rows.map((connection) => connection.title),
+      dependsNames: groups.depends.rows.map((connection) => connection.title),
     });
     return {
       slug,
@@ -991,11 +991,10 @@ export function HomePage() {
       kind: nodeFocus.kind,
       powered: changedSlugs.has(selectedOntologyNode.id),
       metric,
-      connections,
-      hiddenConnectionCount: nodeFocus.hiddenConnectionCount,
+      groups,
       handoffText,
     };
-  }, [nodeFocus, selectedOntologyNode, nodeFocusData, changedSlugs]);
+  }, [nodeFocus, selectedOntologyNode, ontologyInsight, nodeFocusData, changedSlugs]);
   const copyV2NodeHandoff = useCallback(
     async (text: string) => {
       const ok = await copyText(text);
@@ -2777,8 +2776,7 @@ export function HomePage() {
                 kind={v2DatasheetModel.kind}
                 powered={v2DatasheetModel.powered}
                 metric={v2DatasheetModel.metric}
-                connections={v2DatasheetModel.connections}
-                hiddenConnectionCount={v2DatasheetModel.hiddenConnectionCount}
+                groups={v2DatasheetModel.groups}
                 handoffText={v2DatasheetModel.handoffText}
                 labels={{
                   kindLabel: tKinds(normalizeKindLabelKey(v2DatasheetModel.kind)),

--- a/src/widgets/topology-map-v2/index.ts
+++ b/src/widgets/topology-map-v2/index.ts
@@ -13,11 +13,18 @@ export type {
   TopologyV2DetailPanelLabels,
 } from './ui/TopologyV2DetailPanel';
 export {
+  buildV2Connections,
+  buildV2ConnectionGroups,
   formatV2HandoffText,
   formatV2MetricLine,
   groupV2Connections,
+  V2_CONNECTION_ROW_CAP,
 } from './ui/topology-v2-datasheet';
 export type {
+  V2ConnectionGroupsView,
+  V2ConnectionGroupView,
+  V2ConnectionSourceEdge,
+  V2ConnectionSourceNode,
   V2DatasheetConnection,
   V2GroupedConnections,
   V2HandoffInput,

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -4,8 +4,8 @@ import { type KeyboardEvent as ReactKeyboardEvent, useCallback } from "react";
 import { X } from "lucide-react";
 import {
   formatV2MetricLine,
-  groupV2Connections,
-  type V2DatasheetConnection,
+  type V2ConnectionGroupsView,
+  type V2ConnectionGroupView,
   type V2MetricValues,
 } from "./topology-v2-datasheet";
 
@@ -46,8 +46,10 @@ export interface TopologyV2DetailPanelProps {
   /** "전원" — powered (recently updated / fresh) vs unpowered (quiet). */
   powered: boolean;
   metric: V2MetricValues;
-  connections: readonly V2DatasheetConnection[];
-  hiddenConnectionCount: number;
+  /** Connections grouped by relation type, each with a capped row preview + the
+   * group's true total — so a contains-hub's depends group renders its real
+   * count instead of collapsing into a generic overflow. */
+  groups: V2ConnectionGroupsView;
   /** Pre-built agent handoff payload; the view owns clipboard + toast. */
   handoffText: string;
   labels: TopologyV2DetailPanelLabels;
@@ -155,8 +157,7 @@ export function TopologyV2DetailPanel({
   kind,
   powered,
   metric,
-  connections,
-  hiddenConnectionCount,
+  groups,
   handoffText,
   labels,
   onSelectConnection,
@@ -164,13 +165,12 @@ export function TopologyV2DetailPanel({
   onClose,
   className,
 }: TopologyV2DetailPanelProps) {
-  const grouped = groupV2Connections(connections);
   const metricLine = formatV2MetricLine(metric, {
     usedBy: labels.metricUsedBy,
     dependsOn: labels.metricDependsOn,
     evidence: labels.metricEvidence,
   });
-  const hasConnections = grouped.contains.length > 0 || grouped.depends.length > 0;
+  const hasConnections = groups.contains.total > 0 || groups.depends.total > 0;
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -185,9 +185,10 @@ export function TopologyV2DetailPanel({
   const renderGroup = (
     group: "contains" | "depends",
     label: string,
-    rows: V2DatasheetConnection[],
+    view: V2ConnectionGroupView,
   ) => {
-    if (rows.length === 0) return null;
+    if (view.total === 0) return null;
+    const overflow = view.total - view.rows.length;
     return (
       <div className="flex flex-col gap-1" data-datasheet-group={group}>
         <div className="flex items-center gap-2">
@@ -195,12 +196,15 @@ export function TopologyV2DetailPanel({
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-tertiary)]">
             {label}
           </span>
-          <span className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-            {rows.length}
+          <span
+            data-datasheet-group-total={group}
+            className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+          >
+            {view.total}
           </span>
         </div>
         <ul className="flex flex-col">
-          {rows.map((row) => (
+          {view.rows.map((row) => (
             <li key={`${group}:${row.id}`}>
               <button
                 type="button"
@@ -215,6 +219,14 @@ export function TopologyV2DetailPanel({
             </li>
           ))}
         </ul>
+        {overflow > 0 ? (
+          <span
+            data-datasheet-group-overflow={group}
+            className="pl-[30px] font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+          >
+            +{overflow}
+          </span>
+        ) : null}
       </div>
     );
   };
@@ -290,13 +302,8 @@ export function TopologyV2DetailPanel({
       <div className="flex flex-col gap-2.5">
         {hasConnections ? (
           <>
-            {renderGroup("contains", labels.groupContains, grouped.contains)}
-            {renderGroup("depends", labels.groupDepends, grouped.depends)}
-            {hiddenConnectionCount > 0 ? (
-              <span className="pl-1.5 font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-                +{hiddenConnectionCount}
-              </span>
-            ) : null}
+            {renderGroup("contains", labels.groupContains, groups.contains)}
+            {renderGroup("depends", labels.groupDepends, groups.depends)}
           </>
         ) : (
           <span className="text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildV2Connections,
+  buildV2ConnectionGroups,
   formatV2HandoffText,
   formatV2MetricLine,
   groupV2Connections,
@@ -31,6 +33,69 @@ describe("groupV2Connections", () => {
 
   it("preserves input order within each group and handles an empty list", () => {
     expect(groupV2Connections([])).toEqual({ contains: [], depends: [] });
+  });
+});
+
+describe("buildV2Connections", () => {
+  const nodes = [
+    { id: "hub", title: "MCP Server", kind: "capability" },
+    { id: "file-a", title: "index.mjs", kind: "element" },
+    { id: "file-b", title: "verify.mjs", kind: "element" },
+    { id: "domain", title: "AI Agent Partner", kind: "domain" },
+    { id: "dep", title: "Relation Graph", kind: "capability" },
+  ];
+  const edges = [
+    { from: "hub", to: "file-a", type: "contains" },
+    { from: "hub", to: "file-b", type: "contains" },
+    { from: "hub", to: "dep", type: "depends_on" },
+    { from: "domain", to: "hub", type: "contains" },
+  ];
+
+  it("returns the FULL direct-connection set, outgoing first then incoming, neighbor-resolved", () => {
+    const connections = buildV2Connections("hub", nodes, edges);
+    expect(connections.map((c) => [c.id, c.direction, c.relationType])).toEqual([
+      ["file-a", "outgoing", "contains"],
+      ["file-b", "outgoing", "contains"],
+      ["dep", "outgoing", "depends_on"],
+      ["domain", "incoming", "contains"],
+    ]);
+    // carries the neighbor's own title/kind (not the source node's)
+    expect(connections[0]).toMatchObject({ title: "index.mjs", kind: "element" });
+  });
+
+  it("drops edges whose neighbor is missing and returns [] for an unconnected node", () => {
+    expect(buildV2Connections("ghost", nodes, edges)).toEqual([]);
+    const dangling = buildV2Connections("hub", nodes, [
+      { from: "hub", to: "not-in-nodes", type: "contains" },
+    ]);
+    expect(dangling).toEqual([]);
+  });
+});
+
+describe("buildV2ConnectionGroups", () => {
+  it("caps each group independently and keeps the TRUE total (contains-hub bug)", () => {
+    // 8 contains + 2 depends — the old 5-item outgoing-first slice starved
+    // depends to empty; per-group capping keeps both totals honest.
+    const connections: V2DatasheetConnection[] = [
+      ...Array.from({ length: 8 }, (_, i) =>
+        conn({ id: `c${i}`, relationType: "contains" }),
+      ),
+      conn({ id: "d0", relationType: "depends_on" }),
+      conn({ id: "d1", relationType: "uses" }),
+    ];
+    const groups = buildV2ConnectionGroups(connections, 6);
+    expect(groups.contains.total).toBe(8);
+    expect(groups.contains.rows).toHaveLength(6); // capped
+    expect(groups.depends.total).toBe(2);
+    expect(groups.depends.rows.map((r) => r.id)).toEqual(["d0", "d1"]); // never starved
+  });
+
+  it("handles an empty set with zero totals", () => {
+    const groups = buildV2ConnectionGroups([]);
+    expect(groups).toEqual({
+      contains: { rows: [], total: 0 },
+      depends: { rows: [], total: 0 },
+    });
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -47,6 +47,101 @@ export function groupV2Connections(
   return { contains, depends };
 }
 
+/** Minimal structural shapes — keeps this module pure + testable without
+ * importing the full KnowledgeGraph types (which are structurally compatible). */
+export interface V2ConnectionSourceNode {
+  id: string;
+  title: string;
+  kind: string;
+}
+export interface V2ConnectionSourceEdge {
+  from: string;
+  to: string;
+  type: string;
+}
+
+/**
+ * The FULL direct-connection list for a node — every incoming + outgoing edge,
+ * direction-tagged, resolved to the neighbor's title/kind. Outgoing first, then
+ * incoming (same order the shared drawer preview uses). Unlike the shared 5-item
+ * `previewRelations` slice, this is complete, so the datasheet can show each
+ * relation-type group's TRUE total instead of folding depends edges into a
+ * generic overflow on contains-dominated hubs.
+ */
+export function buildV2Connections(
+  nodeId: string,
+  nodes: readonly V2ConnectionSourceNode[],
+  edges: readonly V2ConnectionSourceEdge[],
+): V2DatasheetConnection[] {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const outgoing: V2DatasheetConnection[] = [];
+  const incoming: V2DatasheetConnection[] = [];
+  for (const edge of edges) {
+    if (edge.from === nodeId) {
+      const other = nodeById.get(edge.to);
+      if (other) {
+        outgoing.push({
+          id: other.id,
+          title: other.title,
+          kind: other.kind,
+          relationType: edge.type,
+          direction: "outgoing",
+        });
+      }
+    } else if (edge.to === nodeId) {
+      const other = nodeById.get(edge.from);
+      if (other) {
+        incoming.push({
+          id: other.id,
+          title: other.title,
+          kind: other.kind,
+          relationType: edge.type,
+          direction: "incoming",
+        });
+      }
+    }
+  }
+  return [...outgoing, ...incoming];
+}
+
+/** One relation-type group as the panel renders it: a capped preview of rows +
+ * the group's TRUE total (so the header can say "DEPENDS 23" while showing 6). */
+export interface V2ConnectionGroupView {
+  rows: V2DatasheetConnection[];
+  total: number;
+}
+export interface V2ConnectionGroupsView {
+  contains: V2ConnectionGroupView;
+  depends: V2ConnectionGroupView;
+}
+
+/** Default rows shown per group before the typed "+N" overflow. */
+export const V2_CONNECTION_ROW_CAP = 6;
+
+/**
+ * Group the full connection set by relation type and cap each group to
+ * `perGroupCap` rows, keeping the true total. This guarantees BOTH groups can
+ * render their real count independently — the contains-hub bug was that a single
+ * outgoing-first 5-item slice starved the depends group to empty.
+ */
+export function buildV2ConnectionGroups(
+  connections: readonly V2DatasheetConnection[],
+  perGroupCap: number = V2_CONNECTION_ROW_CAP,
+): V2ConnectionGroupsView {
+  const grouped = groupV2Connections(connections);
+  const cap = Math.max(0, perGroupCap);
+  return {
+    contains: {
+      rows: grouped.contains.slice(0, cap),
+      total: grouped.contains.length,
+    },
+    depends: {
+      rows: grouped.depends.slice(0, cap),
+      total: grouped.depends.length,
+    },
+  };
+}
+
 export interface V2MetricValues {
   /** Direct incoming — plain "쓰는 곳" (places that use this). */
   usedBy: number;


### PR DESCRIPTION
## Summary

topology-v2 데이터시트 패널의 연결 그룹을 **전체 직접연결 세트**에서 파생하도록 정정 (Guardian follow-up #1, PR #321).

**문제**: 허브(contains-지배) 노드에서 DEPENDS 그룹이 아예 안 뜨고 제네릭 `+29` 오버플로로 뭉텅여짐. 핸드오프 페이로드가 `depends: -` 를 내면서 같은 블록의 `depends_on: 23` 과 자기모순.

**원인**: 패널이 공유 5-item outgoing-first 프리뷰(`nodeFocus.connections`)를 그룹핑 → 허브에서는 5칸이 전부 contains 로 차 depends 그룹이 굶음.

**수정** (v2 전용, 공유 drawer/popover/Sigma 미변경):
- `buildV2Connections(nodeId, nodes, edges)` — 전체 직접연결을 방향태그로 (outgoing→incoming)
- `buildV2ConnectionGroups(connections, cap)` — 관계타입별 per-group cap + **진짜 total**
- 패널: 그룹 헤더에 `rows.length` 대신 진짜 `total`, 각 그룹에 타입별 typed overflow `+N`
- 핸드오프 `containsNames`/`dependsNames` 도 같은 전체 그룹에서 → `depends_on` 카운트와 모순 불가

## Test plan

- tsc(스톡 5.9.3, src 에러 0)* · vitest **210 pass / 3 todo**(신규 `buildV2Connections`/`buildV2ConnectionGroups` 테스트 = contains-hub 시나리오 커버) · scoped eslint 0
- 라이브(:3105, flag on) MCP Server 허브: CONTAINS **21**(6행+`+15`) / DEPENDS **13**(6행+`+7`) 양쪽 렌더, 핸드오프 `depends:` 실제 이름 6개(모순 소멸), 콘솔 에러 0
- flag-OFF: 레거시 `TopologyNodePopover` 렌더(v2 패널 부재) — 공유 경로 미변경 확인

*이 체크아웃 node_modules 는 TS7 alias 미설치(스톡 5.9.3)라 `tsconfig.stableTypeOrdering`(TS7 전용)에서 parse-abort — 환경 drift, 본 변경 무관. TS7 옵션 strip 한 임시 config 로 src 타입 0 확인.

flag OFF 기본이라 사용자 회귀 0. 남은 flag-on 전 MUST-FIX = #2(라이트모드 패널 토큰).

🤖 Generated with [Claude Code](https://claude.com/claude-code)