### PR TITLE
fix: v2 데이터시트 caps 라벨 대비 AA 넛지

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1060,7 +1060,10 @@
     --topology-v2-panel-power-off: #45454d;
     --topology-v2-panel-text-primary: #ececf0;
     --topology-v2-panel-text-secondary: #a3a3ac;
-    --topology-v2-panel-text-tertiary: #77777f;
+    /* tertiary = CONTAINS/DEPENDS caps 라벨 + kind 서브라벨. #77777f 는 다크
+       패널(#17171c) 위 4.02:1 로 10px AA(4.5) 미달 → #868690 으로 넛지(≈4.9:1),
+       primary 대비 여전히 recede. Guardian follow-up #2. */
+    --topology-v2-panel-text-tertiary: #868690;
     --topology-v2-panel-text-quaternary: #55555d;
     /* 연결 그룹 trace 미니라인 — 캔버스 엣지와 같은 계열(contains 실선/depends 점선) */
     --topology-v2-edge-contains-mark: #4a4a54;


### PR DESCRIPTION
## Summary

v2 데이터시트 패널 caps 라벨(CONTAINS/DEPENDS)·kind 서브라벨 대비를 AA 4.5 로 넛지 — tertiary `#77777f`(4.02:1) → `#868690`(실측 4.96:1). Guardian follow-up #2 의 ship 판정분.

**라이트 오버라이드는 보류** (Guardian 판정 b): v2 캔버스가 테마 무관 다크(rgb(6,6,9))라 지금 `data-theme=light` 에 바인딩하면 흰 패널이 검은 캔버스 위에 떠 "깨진 렌더"로 읽힘. `라이트 모드 작업은 한 사이클에 한 번에` 헌장대로 "v2 canvas light-mode" 패스에서 패널+캔버스 원자적 전환. 실측 라이트 값은 큐에 보관(재도출 0).

## Test plan

- CSS 토큰 1건 — 로직/테스트 무관
- 라이브 실측(:3106, flag on, MCP Server 허브): caps **4.96:1**(AA 통과), metric 8.88 · row 7.14 위계 유지(라벨 여전히 recede)
- Guardian: **Build and verify (ship)** — 다크 미학 무손상, flag/theme 무관 순수 접근성 개선

🤖 Generated with [Claude Code](https://claude.com/claude-code)