### PR TITLE
fix: v2 드래그 캔버스 소실·스터터 — 포인터 캡처 + 가시 티어 클램프

### DIFF
--- a/src/widgets/topology-map-v2/model/tier-visibility.test.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.test.ts
@@ -4,6 +4,7 @@ import {
   computeZoomRatio,
   DEFAULT_TIER_REVEAL,
   edgeTierAlpha,
+  isSpineOnlyZoom,
   nodeTierAlpha,
 } from "./tier-visibility";
 
@@ -81,5 +82,28 @@ describe("edgeTierAlpha", () => {
     expect(edgeTierAlpha(1, 0)).toBe(0);
     expect(edgeTierAlpha(0.8, 0.4)).toBe(0.4);
     expect(edgeTierAlpha(1, 1)).toBe(1);
+  });
+});
+
+describe("isSpineOnlyZoom (QA 소실 A — clamp-bounds source)", () => {
+  it("is true at the overview entry and while zoomed out (only the spine draws)", () => {
+    expect(isSpineOnlyZoom(ENTRY, DEFAULT_TIER_REVEAL)).toBe(true);
+    expect(isSpineOnlyZoom(0.5, DEFAULT_TIER_REVEAL)).toBe(true);
+    // Just below the capability enter ratio: still spine-only.
+    expect(isSpineOnlyZoom(DEFAULT_TIER_REVEAL.capability.enterRatio - 1e-6, DEFAULT_TIER_REVEAL)).toBe(true);
+  });
+
+  it("flips false exactly when the capability tier begins revealing (full bounds become honest)", () => {
+    expect(isSpineOnlyZoom(DEFAULT_TIER_REVEAL.capability.enterRatio, DEFAULT_TIER_REVEAL)).toBe(false);
+    expect(isSpineOnlyZoom(ZOOMED_IN, DEFAULT_TIER_REVEAL)).toBe(false);
+  });
+
+  it("agrees with nodeTierAlpha: spine-only zoom ⇔ capabilities are fully hidden", () => {
+    for (let ratio = 0.4; ratio <= 4.0001; ratio += 0.05) {
+      const spineOnly = isSpineOnlyZoom(ratio, DEFAULT_TIER_REVEAL);
+      const capAlpha = nodeTierAlpha("capability", false, ratio, DEFAULT_TIER_REVEAL);
+      if (spineOnly) expect(capAlpha).toBe(0);
+      else expect(capAlpha).toBeGreaterThanOrEqual(0);
+    }
   });
 });

--- a/src/widgets/topology-map-v2/model/tier-visibility.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.ts
@@ -92,3 +92,18 @@ export function nodeTierAlpha(
 export function edgeTierAlpha(sourceAlpha: number, targetAlpha: number): number {
   return Math.min(sourceAlpha, targetAlpha);
 }
+
+/**
+ * True while the semantic zoom still shows ONLY the project/domain/hub spine
+ * (the capability tier has not begun to reveal). Pan/flick clamps must then use
+ * the SPINE bounds, not the full-graph bounds: the de-pileup layout spreads all
+ * 295 nodes over a far larger area than the ~8 spine nodes actually drawn at
+ * the overview, so clamping to the full bounds leaves a vast legal-but-EMPTY
+ * region the camera can strand in — the owner's "드래그하면 캔버스가
+ * 사라져버림" (QA 소실 A). One strong flick projected thousands of world units
+ * and landed inside the invisible fan; every pixel was "in bounds", nothing was
+ * drawn.
+ */
+export function isSpineOnlyZoom(zoomRatio: number, config: TierRevealConfig): boolean {
+  return zoomRatio < config.capability.enterRatio;
+}

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -11,7 +11,7 @@
 import { computePanBounds, stepCamera, type CameraAxes, type CameraTarget } from "../engine/camera";
 import { computeAltitudeBand, computeFarT } from "../model/altitude";
 import { isNodeEmphasisActive, resolveEdgePulseSpeed, stepEmphasis } from "../model/focus-state";
-import { computeZoomRatio } from "../model/tier-visibility";
+import { computeZoomRatio, DEFAULT_TIER_REVEAL, isSpineOnlyZoom } from "../model/tier-visibility";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import type { TopologyWorld } from "./topology-world";
 
@@ -87,12 +87,20 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
   const focusNode = focusedNodeId !== null && camera.scale.value > overviewScale
     ? world.nodeById.get(focusedNodeId)
     : undefined;
+  // Unfocused clamp source = the VISIBLE tier's bounds. At spine-only zoom the
+  // full-graph bounds cover the vast legal-but-empty de-pileup fan (only the
+  // ~8-node spine draws), so the elastic clamp would happily leave the camera
+  // stranded over nothing (owner's "캔버스가 사라져버림", QA 소실 A). Uses the
+  // pre-step camera scale — one frame of lag is imperceptible at spring speeds.
+  const preStepZoomRatio = computeZoomRatio(camera.scale.value, overviewScale * tokens.overviewEntryRatio);
   const panBounds = focusNode
     ? computePanBounds(
         { minX: focusNode.x, minY: focusNode.y, maxX: focusNode.x, maxY: focusNode.y },
         tokens.cameraFocusPanMargin,
       )
-    : computePanBounds(world.bounds);
+    : computePanBounds(
+        isSpineOnlyZoom(preStepZoomRatio, DEFAULT_TIER_REVEAL) ? world.spineBounds : world.bounds,
+      );
 
   const nextCamera = stepCamera({
     camera,

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -26,7 +26,7 @@ import { clampPointToPanBounds, computePanBounds, type CameraAxes, type CameraTa
 import { projectFlickLanding, sampleReleaseVelocity } from "../engine/momentum";
 import { scheduleRipple } from "../model/focus-state";
 import type { ForceSimulation } from "../model/force-layout";
-import { computeZoomRatio, DEFAULT_TIER_REVEAL, nodeTierAlpha } from "../model/tier-visibility";
+import { computeZoomRatio, DEFAULT_TIER_REVEAL, isSpineOnlyZoom, nodeTierAlpha } from "../model/tier-visibility";
 import { computeGrabOffsetWorld, computePinWorld, type WorldOffset } from "../interaction/node-drag";
 import {
   INITIAL_POINTER_MACHINE_STATE,
@@ -177,6 +177,18 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     const tokens = readTopologyV2TokensOrNull();
     const world = worldRef.current;
     if (!tokens || !world) return;
+    // Capture the pointer for the whole gesture — without this, releasing over
+    // the analysis rail / outside the window never delivers `pointerup` to the
+    // canvas, the state machine sticks in `dragging`, and the camera then
+    // follows a button-less mouse until it strands off-graph (owner's
+    // "드래그하면 캔버스가 사라져버림", QA 소실 B). Implicit release on
+    // pointerup/cancel is per-spec automatic.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // jsdom / test envs may not implement pointer capture — the buttons===0
+      // guard in `handlePointerMove` covers the fallback.
+    }
     // Snapshot the rect once per gesture (see `canvasRectRef` JSDoc).
     const domRect = e.currentTarget.getBoundingClientRect();
     canvasRectRef.current = { left: domRect.left, top: domRect.top };
@@ -195,6 +207,16 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     if (!tokens || !world) return;
     const rect = currentRect(e.currentTarget);
     const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+
+    // Stuck-drag guard (QA 소실 B fallback): a button-less move during an
+    // active gesture means we missed the real `pointerup` (capture unsupported
+    // or interrupted). Treat it as that pointerup — the stationary-release path
+    // holds the camera exactly where it is — and let the NEXT move resume as a
+    // plain hover on the now-idle machine.
+    if (pointerMachineRef.current.phase !== "idle" && e.buttons === 0) {
+      handlePointerUp();
+      return;
+    }
 
     // Capture the pressed node BEFORE the transition — the pressed→dragging
     // transition clears `pressedNodeId`, but we need it to know whether this
@@ -320,10 +342,19 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       // usually within the graph's pan bounds — clamp it only so a landing that
       // WOULD exceed the bounds rubber-bands at the edge instead of overshooting
       // into blank canvas. Within-bounds flicks are unaffected by this clamp.
+      // The clamp source is the VISIBLE tier's bounds: at spine-only zoom the
+      // full 295-node bounds cover a huge legal-but-empty fan region (only ~8
+      // spine nodes draw), so a strong flick could land the camera on nothing
+      // (owner's "캔버스가 사라져버림", QA 소실 A). Once capabilities start
+      // revealing, the full bounds become honest again.
       const world = worldRef.current;
-      const clampedLanding = world
-        ? clampPointToPanBounds(px.landingTarget, py.landingTarget, computePanBounds(world.bounds))
-        : { x: px.landingTarget, y: py.landingTarget };
+      let clampedLanding = { x: px.landingTarget, y: py.landingTarget };
+      if (world) {
+        const overviewEntryScale = overviewScaleRef.current * tokens.overviewEntryRatio;
+        const zoomRatio = computeZoomRatio(cameraRef.current.scale.value, overviewEntryScale);
+        const boundsSource = isSpineOnlyZoom(zoomRatio, DEFAULT_TIER_REVEAL) ? world.spineBounds : world.bounds;
+        clampedLanding = clampPointToPanBounds(px.landingTarget, py.landingTarget, computePanBounds(boundsSource));
+      }
       cameraTargetRef.current = { tx: clampedLanding.x, ty: clampedLanding.y, tscale: cameraTargetRef.current.tscale };
       cameraRef.current = {
         ...cameraRef.current,


### PR DESCRIPTION
## Summary

소유자 신고 2건("드래그하면 캔버스 화면이 사라져버림" · "드드드득 끊기는 드래그")의 근본 수정 — QA 정밀 감사가 현 main에서 재현·file:line 특정한 flag-on 블로커 #1·#2.

- **소실 A**: 플릭 착지/탄성 클램프가 full 295-node bounds 기준 ↔ 오버뷰는 스파인 ~8개만 그림 → 카메라가 "합법적 빈 공간"에 좌초. `isSpineOnlyZoom`(신규 순수 헬퍼)으로 클램프 소스를 가시 티어 bounds(spineBounds↔full)로 전환
- **소실 B + 스터터**: `setPointerCapture` 부재 → 패널 위 릴리스 시 pointerup 미수신(고착·버튼 없는 견인) + 드래그 중 덮인 DOM 통과 시 move 단절(드드득). 캡처 + `buttons===0` 폴백 가드

## Test plan

- vitest v2 **203 pass**(신규 isSpineOnlyZoom 3케이스) · tsc(TS7 strip) clean · eslint 0
- Chrome 실측(:3110): 강플릭 콘텐츠 0.0000→**0.0023**(러버밴드 복귀, 스크린샷), 버튼리스 스윕 0.0006 붕괴→**불변**, 저속 팬·클릭 무회귀, 콘솔 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)