### PR TITLE
fix: 스타터 템플릿 MCP 도구 카운트 24→25 동기화

### DIFF
--- a/cli/templates/vault/README.md
+++ b/cli/templates/vault/README.md
@@ -135,7 +135,7 @@ For an agent opened at your codebase root instead of this vault folder, replace
 
 ## What an AI agent can do for you
 
-Once you register the `ontology-atlas-mcp` server, the agent gets 24
+Once you register the `ontology-atlas-mcp` server, the agent gets 25
 tools to read/write this vault:
 
 - **read 16**: list_concepts / get_concept / get_concepts / find_evidence /

--- a/src/features/docs-vault-local/lib/ontology-starter.ts
+++ b/src/features/docs-vault-local/lib/ontology-starter.ts
@@ -148,7 +148,7 @@ For an agent opened at your codebase root instead of this vault folder, replace
 
 ## What an AI agent can do for you
 
-Once you register the \`ontology-atlas-mcp\` server, the agent gets 24
+Once you register the \`ontology-atlas-mcp\` server, the agent gets 25
 tools to read/write this vault:
 
 - **read 16**: list_concepts / get_concept / get_concepts / find_evidence /


### PR DESCRIPTION
main에서 실패하던 유일한 테스트(`ontology-starter.test.ts` — 'agent gets 25' 기대) 정정. absorb_document 추가(PR #310) 이후 스타터 템플릿 2곳이 24로 잔존. 전체 suite 이제 완전 그린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)