### PR TITLE
fix: ego 라벨 safe-rect 클램프 + element 라벨 대비 넛지

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -791,7 +791,7 @@
     --topology-v2-label-project: #ececf0;
     --topology-v2-label-domain: #b8b8c1;
     --topology-v2-label-capability: #84848c;
-    --topology-v2-label-element: #57575f;
+    --topology-v2-label-element: #6a6a73; /* Guardian follow-up B: 2.76:1 → 3.16:1 (AA-large) — element 라벨은 최심 줌에서만 뜨지만 대비 하한은 지킨다 */
     /* Max on-screen label width (px) before word-boundary ellipsis — keeps a
        long element title (file path) from clipping the right edge / colliding
        with its horizontal neighbor (Design Guardian 가독성 반려). */

--- a/src/widgets/topology-map-v2/render/label-layout.test.ts
+++ b/src/widgets/topology-map-v2/render/label-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampAnchorIntoSafeRect,
   bboxesOverlap,
   ellipsizeToWidth,
   greedyPlaceLabels,
@@ -143,5 +144,26 @@ describe("resolveLabelPriority", () => {
     expect(project).toBeLessThan(domain);
     expect(domain).toBeLessThan(capability);
     expect(capability).toBeLessThan(element);
+  });
+});
+
+describe("clampAnchorIntoSafeRect (Guardian follow-up A)", () => {
+  const rect = { left: 344, right: 1500, top: 0, bottom: 900 };
+
+  it("clamps an anchor under the left chrome inset to the inset edge (+margins)", () => {
+    const c = clampAnchorIntoSafeRect(200, 450, rect, 40, 12);
+    expect(c).toEqual({ x: 344 + 40, y: 450 });
+  });
+
+  it("leaves an in-rect anchor untouched", () => {
+    expect(clampAnchorIntoSafeRect(800, 450, rect, 40, 12)).toEqual({ x: 800, y: 450 });
+  });
+
+  it("clamps both axes at a corner and never inverts on degenerate rects", () => {
+    expect(clampAnchorIntoSafeRect(0, 2000, rect, 40, 12)).toEqual({ x: 384, y: 888 });
+    const tiny = { left: 0, right: 10, top: 0, bottom: 10 };
+    const c = clampAnchorIntoSafeRect(-5, -5, tiny, 40, 12);
+    expect(Number.isFinite(c.x)).toBe(true);
+    expect(Number.isFinite(c.y)).toBe(true);
   });
 });

--- a/src/widgets/topology-map-v2/render/label-layout.ts
+++ b/src/widgets/topology-map-v2/render/label-layout.ts
@@ -38,6 +38,30 @@ export function isWithinSafeRect(x: number, y: number, rect: SafeRect): boolean 
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
 }
 
+/**
+ * Clamp a label anchor INTO the safe rect instead of dropping it — for
+ * ego-protected labels (selected/hovered/ego member) whose node sits under a
+ * chrome inset. Guardian follow-up A (label-clarity): the safe-rect cull ran
+ * BEFORE the selected/hovered alpha floor, so a focused domain's fan children
+ * under the left panel lost their labels — recreating the "이름 없는 도형"
+ * symptom the slice existed to fix. A clamped label sits at the inset edge
+ * nearest its node ("이 패널 밑에 이 노드가 있다"), which beats silence.
+ * `marginX`/`marginY` keep the text box itself inside the rect (width/2, font).
+ */
+export function clampAnchorIntoSafeRect(
+  x: number,
+  y: number,
+  rect: SafeRect,
+  marginX: number,
+  marginY: number,
+): { x: number; y: number } {
+  const lo = Math.min(rect.left + marginX, rect.right - marginX);
+  const hi = Math.max(rect.left + marginX, rect.right - marginX);
+  const top = Math.min(rect.top + marginY, rect.bottom - marginY);
+  const bottom = Math.max(rect.top + marginY, rect.bottom - marginY);
+  return { x: Math.min(hi, Math.max(lo, x)), y: Math.min(bottom, Math.max(top, y)) };
+}
+
 /** Standard AABB overlap (touching edges do NOT count as overlap). */
 export function bboxesOverlap(a: LabelBBox, b: LabelBBox): boolean {
   return a.minX < b.maxX && a.maxX > b.minX && a.minY < b.maxY && a.maxY > b.minY;

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -39,7 +39,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-label-project": "#ececf0",
   "--topology-v2-label-domain": "#b8b8c1",
   "--topology-v2-label-capability": "#84848c",
-  "--topology-v2-label-element": "#57575f",
+  "--topology-v2-label-element": "#6a6a73",
   "--topology-v2-label-max-width": "168",
   "--topology-v2-canvas-bg-near": "#0a0a0d",
   "--topology-v2-canvas-bg-far": "#050507",

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -21,6 +21,7 @@ import {
 import {
   ellipsizeToWidth,
   greedyPlaceLabels,
+  clampAnchorIntoSafeRect,
   isWithinSafeRect,
   resolveLabelPriority,
   type LabelCandidate,
@@ -339,13 +340,26 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     const screen = project(node.x, node.y);
     const screenRadius = radiusForKind(node.kind, tokens) * camera.scale.value;
     const anchorY = screen.y + screenRadius + LABEL_OFFSET[node.kind];
-    if (!isWithinSafeRect(screen.x, anchorY, safeRect)) return;
-
     const text = ellipsizeToWidth(node.label, tokens.labelMaxWidth, (candidate) =>
       measureLabelWidth(ctx, node.kind, candidate),
     );
     const width = measureLabelWidth(ctx, node.kind, text);
     const fontSize = LABEL_FONT_SIZE[node.kind];
+    // Safe-rect gate — but selected/hovered/ego labels are PROTECTED: instead
+    // of dropping (which defeated the "selected → alpha 1" guarantee under the
+    // left chrome inset, Guardian follow-up A) their anchor clamps to the
+    // nearest safe edge. Everything else culls as before.
+    let anchorX = screen.x;
+    let clampedAnchorY = anchorY;
+    if (!isWithinSafeRect(anchorX, anchorY, safeRect)) {
+      const isProtected = egoState !== "none" || isHovered;
+      if (!isProtected) return;
+      const clamped = clampAnchorIntoSafeRect(anchorX, anchorY, safeRect, width / 2 + 4, fontSize + 4);
+      anchorX = clamped.x;
+      clampedAnchorY = clamped.y;
+    }
+    const shiftX = anchorX - screen.x;
+    const shiftY = clampedAnchorY - anchorY;
     labelCandidates.push({
       priority: resolveLabelPriority({
         kind: node.kind,
@@ -354,8 +368,17 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
         isHub: node.isHub,
       }),
       order: index,
-      bbox: { minX: screen.x - width / 2, maxX: screen.x + width / 2, minY: anchorY - fontSize, maxY: anchorY + 2 },
-      payload: { kind: node.kind, text, screenX: screen.x, screenY: screen.y, screenRadius, egoState, isHovered, revealAlpha },
+      bbox: { minX: anchorX - width / 2, maxX: anchorX + width / 2, minY: clampedAnchorY - fontSize, maxY: clampedAnchorY + 2 },
+      payload: {
+        kind: node.kind,
+        text,
+        screenX: screen.x + shiftX,
+        screenY: screen.y + shiftY,
+        screenRadius,
+        egoState,
+        isHovered,
+        revealAlpha,
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

라벨 명료성(#336) Guardian follow-up A·B — 리드 직접 구현.

- **A**: 보호 라벨(selected/hovered/ego)은 safe-rect 밖에서 드롭 대신 **가장자리 클램프** — 포커스 시 좌측 인셋 밑 자식들의 "이름 없는 도형" 재발 해소. 순수 헬퍼 `clampAnchorIntoSafeRect` + 3 tests, 실화면 확인(포커스 뷰 좌측 자식 전원 라벨)
- **B**: element 라벨 토큰 2.76:1 → **3.16:1**(AA-large) + 토큰 가드 테스트 동반

## Test plan

v2 vitest **261 pass**(+3) · tsc clean · eslint 0 · 라이브 스크린샷(focus-left-inset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)