### PR TITLE
fix: ego 라벨 보호 가드 타입 오류 정정

### DIFF
--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -352,7 +352,10 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     let anchorX = screen.x;
     let clampedAnchorY = anchorY;
     if (!isWithinSafeRect(anchorX, anchorY, safeRect)) {
-      const isProtected = egoState !== "none" || isHovered;
+      // Protected = the focused node, its ego neighbors, or the hovered node —
+      // NOT "dim"/"normal" bystanders, or every off-rect label would clamp to
+      // the inset edge and pile up there.
+      const isProtected = egoState === "center" || egoState === "neighbor" || isHovered;
       if (!isProtected) return;
       const clamped = clampAnchorIntoSafeRect(anchorX, anchorY, safeRect, width / 2 + 4, fontSize + 4);
       anchorX = clamped.x;


### PR DESCRIPTION
#337 핫픽스 — `egoState !== "none"` 은 NodeEgoState에 없는 값 비교(TS2367, 항상 참 → 컬링 무력화 + 방관자 라벨 가장자리 적층 위험). 보호 조건을 `center|neighbor|hovered` 로 정정.

리드 게이트 실수 고백: tsc 출력 뒤 무조건 "ok" echo 라 에러가 머지를 통과 — 이후 exit-code 검사로 실행. tsc CLEAN · vitest 261 pass · eslint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)