### PR TITLE
feat: 토폴로지 검색↔지도 통합 — 검색 결과가 지도를 떠나지 않는다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -702,7 +702,7 @@
         "docsActions": "Ontology workspace · document actions"
       },
       "rows": {
-        "openProjectPalette": "Open the project search palette",
+        "openProjectPalette": "Open the search palette",
         "openGlobalPalette": "Search ontology, docs, and projects together",
         "toggleDocsDrawer": "Toggle the ontology workspace preview drawer (with edit access)",
         "showShortcuts": "Show or hide keyboard shortcuts",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -702,7 +702,7 @@
         "docsActions": "문서함 · 문서 액션"
       },
       "rows": {
-        "openProjectPalette": "프로젝트 검색 팔레트 열기",
+        "openProjectPalette": "검색 팔레트 열기",
         "openGlobalPalette": "ontology / 문서 / 프로젝트 통합 검색",
         "toggleDocsDrawer": "문서함 빠른 보기 드로어 토글 (편집 권한 시)",
         "showShortcuts": "키보드 단축키 보기·닫기",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -43,10 +43,6 @@ const TopologyEmptyState = dynamic(
   () => import("@/widgets/topology-map-sigma").then((m) => m.TopologyEmptyState),
   { ssr: false },
 );
-const SearchPalette = dynamic(
-  () => import("@/widgets/search-palette").then((m) => m.SearchPalette),
-  { ssr: false },
-);
 const ShortcutSheet = dynamic(
   () => import("@/widgets/shortcut-sheet").then((m) => m.ShortcutSheet),
   { ssr: false },
@@ -175,12 +171,18 @@ export function HomePage() {
   const projects = projectsQuery.projects;
   const projectsError = projectsQuery.error;
   const [routeState, setRouteState] = useHomeRouteState();
-  // 상세 화면에서 Cmd+K를 누르면 홈으로 이동하며 sessionStorage 플래그를
-  // 남긴다. 여기서 그 플래그가 있으면 첫 렌더부터 검색 팔레트를 열어 hydration
-  // mismatch 없이 한 번에 보이게 한다. lazy initializer는 클라이언트에서만 실제
-  // 실행되므로 SSR은 항상 false, 클라이언트 hydration도 sessionStorage 없는
-  // 서버 프리렌더 기준 false → 불일치 없음.
-  const [searchOpen, setSearchOpen] = useState(() => {
+  // 헤더 "Concept search" 버튼 · ⌘K · ⇧⌘K 모두 이 팔레트(MountedGlobalSearch,
+  // ontology 노드 + 프로젝트 통합 검색)를 연다 — persona-P1 fix: 예전에는
+  // ⌘K 가 프로젝트 전용 SearchPalette 를 열어 ontology 노드가 검색 결과에
+  // 전혀 없었고(project/doc 만), 그 팔레트의 ALL/HUB/NODE 레이어 칩도 프로젝트
+  // 허브 여부만 가르는 축이라 "NODE" 를 눌러도 체감상 no-op 이었다. 세 진입점
+  // 모두 이미 kind 필터가 동작하는 단일 통합 팔레트로 합쳐 새 팔레트를 만들지
+  // 않는다. 상세 화면(ProjectDetailPage)에서 Cmd+K를 누르면 홈으로 이동하며
+  // sessionStorage 플래그를 남긴다 — 여기서 그 플래그가 있으면 첫 렌더부터
+  // 이 팔레트를 열어 hydration mismatch 없이 한 번에 보이게 한다. lazy
+  // initializer는 클라이언트에서만 실제 실행되므로 SSR은 항상 false, 클라이언트
+  // hydration도 sessionStorage 없는 서버 프리렌더 기준 false → 불일치 없음.
+  const [ontologySearchOpen, setOntologySearchOpen] = useState(() => {
     if (typeof window === "undefined") return false;
     try {
       if (window.sessionStorage.getItem("demo:open-search") === "1") {
@@ -192,10 +194,6 @@ export function HomePage() {
     }
     return false;
   });
-  // ⇧⌘K — ontology / 문서 / 프로젝트 통합 검색 (project 전용
-  // SearchPalette 와 별 슬롯). MountedGlobalSearch 가 controlled mode 로
-  // 이 open state 를 받아 동작.
-  const [ontologySearchOpen, setOntologySearchOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(() => {
     if (typeof window === "undefined") return false;
     try {
@@ -581,8 +579,6 @@ export function HomePage() {
     ? "create-node"
     : createNodePending
       ? "create-node-pending-vault"
-    : searchOpen
-      ? "project-search"
       : ontologySearchOpen
         ? "global-search"
         : shortcutsOpen
@@ -590,7 +586,6 @@ export function HomePage() {
           : "none";
   const topologyBlockingOverlayActive = topologyBlockingOverlayState !== "none";
   const openCreateNode = useCallback(() => {
-    setSearchOpen(false);
     setOntologySearchOpen(false);
     setShortcutsOpen(false);
     setDocsDrawerOpen(false);
@@ -846,9 +841,12 @@ export function HomePage() {
   }, [docsDrawerOpen]);
 
   // 공용 useTypingShortcuts로 글로벌 키 단축키 통합.
+  // ⌘K 와 ⇧⌘K 는 이제 동일한 팔레트(ontology 노드 + 프로젝트 통합 검색)를
+  // 연다 — persona-P1: 예전엔 ⌘K 만 프로젝트 전용 SearchPalette 를 열어
+  // ontology 노드를 절대 찾을 수 없었다. useTypingShortcuts 는 첫 일치 후
+  // return 하므로 순서 자체는 유지(둘 다 같은 setter 를 호출해 순서 무관하지만
+  // 관례상 shift 조합을 먼저 둔다).
   useTypingShortcuts([
-    // ⇧⌘K (ontology / 문서 통합 검색) — useTypingShortcuts 는 첫 일치 후
-    // return 하므로 ⌘K 보다 먼저 정의해야 한다.
     {
       combo: { key: "k", meta: true, shift: true },
       onFire: () => {
@@ -860,7 +858,7 @@ export function HomePage() {
       combo: { key: "k", meta: true },
       onFire: () => {
         if (createNodeOpen) return;
-        setSearchOpen((v) => !v);
+        setOntologySearchOpen((v) => !v);
       },
     },
     {
@@ -1356,7 +1354,7 @@ export function HomePage() {
                     density={topologyUtilityChromeCompact ? "compact-focus" : "default"}
                     phoneFocusSuppressed={selectedNodeFocusActive}
                     onOpenSearch={() => {
-                      setSearchOpen(true);
+                      setOntologySearchOpen(true);
                     }}
                     onRelayout={() => {
                       setTopologyRelayoutToken((current) => current + 1);
@@ -2624,25 +2622,19 @@ export function HomePage() {
             }
           />
         ) : null}
-        <SearchPalette
-          open={!createNodeOpen && searchOpen}
-          onClose={() => setSearchOpen(false)}
-          projects={renderProjects}
-          onSelect={(slug) => {
-            handleSelect(slug);
-          }}
-          containerLabel={null}
-        />
-        {/* ⇧⌘K — ontology / 문서 통합 검색. project 전용 SearchPalette 와
-            별 슬롯이라 SearchPalette 의 layer filter / 최근 검색 같은 고유
-            기능 보존. controlled (open/onOpenChange) — hotkey 는 위
-            useTypingShortcuts 가 관리. */}
+        {/* 헤더 "Concept search" 버튼 · ⌘K · ⇧⌘K 공용 단일 팔레트 —
+            ontology 노드 + 프로젝트 통합 검색 (persona-P1). 노드 선택도
+            프로젝트 선택도 handleSelect 로 흘려 지도 위 선택 상태만 바꾼다 —
+            기본값(onSelectNode 미제공 시 `/ontology/?node=` 로 push)을 쓰면
+            지도를 벗어나므로 반드시 override. controlled (open/onOpenChange)
+            — hotkey 는 위 useTypingShortcuts 가 관리. */}
         <MountedGlobalSearch
           open={!createNodeOpen && ontologySearchOpen}
           onOpenChange={(next) => {
             if (createNodeOpen && next) return;
             setOntologySearchOpen(next);
           }}
+          onSelectNode={(node) => handleSelect(node.id)}
           onSelectProject={(project) => handleSelect(project.slug)}
         />
         <ShortcutSheet

--- a/src/widgets/global-search/ui/GlobalSearch.test.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render as rtlRender, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import type { Project } from "@/entities/project";
+import enMessages from "../../../../messages/en.json";
+import { GlobalSearch } from "./GlobalSearch";
+
+// cmdk (Command) + @tanstack/react-virtual 의 project chip row 가
+// ResizeObserver 를 요구 — jsdom 엔 없어 최소 stub 필요.
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only jsdom polyfill
+  (globalThis as any).ResizeObserver = ResizeObserverStub;
+  // cmdk 가 활성 항목을 스크롤시키는 데 사용 — jsdom 엔 미구현.
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+function render(ui: React.ReactElement) {
+  return rtlRender(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+const APPROVED_AT = new Date("2026-04-27T00:00:00Z");
+
+function node(input: Partial<KnowledgeGraphNode> & { id: string; title: string }): KnowledgeGraphNode {
+  return {
+    kind: "capability",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: APPROVED_AT,
+    lastApprovedBy: "test",
+    ...input,
+  };
+}
+
+function project(input: Partial<Project> & { slug: string; name: string }): Project {
+  return {
+    category: "frontend",
+    status: "active",
+    description: "",
+    tags: [],
+    stack: [],
+    links: [],
+    dependencies: [],
+    isHub: false,
+    screenshots: [],
+    timeline: { start: undefined, end: undefined } as Project["timeline"],
+    position: { x: 0, y: 0 } as Project["position"],
+    createdAt: new Date(),
+    updatedAt: new Date("2026-04-20T00:00:00Z"),
+    ...input,
+  } as Project;
+}
+
+/** cmdk 옵션은 `data-value="ontology:<id>"` 로 마킹 — 매치 하이라이트(<mark>)가
+ * title 텍스트를 여러 element 로 쪼개 getByText 매칭이 깨지므로, RTL 텍스트
+ * 매칭 대신 이 안정적인 data 속성으로 옵션을 찾는다. */
+function findOntologyOption(nodeId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    `[cmdk-item][data-value="ontology:${nodeId}"]`,
+  );
+}
+
+/**
+ * persona-P1 회귀 방지 — "MCP Server" 를 찾고, 골라서 지도를 벗어나지 않는
+ * 흐름의 근본이 되는 두 계약을 이 컴포넌트 레벨에서 고정한다:
+ *
+ * 1. onSelectNode 콜백 — HomePage 는 이 콜백을 handleSelect(node.id) 로
+ *    override 해서 지도 위에 머문다. 콜백 자체가 올바른 node 로 불리는지가
+ *    그 override 가 의미를 가지는 전제조건.
+ * 2. kind 필터 칩 — 예전 헤더 검색(SearchPalette)의 ALL/HUB/NODE 칩은
+ *    ontology 노드를 전혀 다루지 않는 축이라 체감상 no-op 이었다. 이
+ *    통합 팔레트(GlobalSearch)의 kind 칩이 실제로 결과를 좁히는지 고정.
+ */
+describe("GlobalSearch", () => {
+  const nodes: KnowledgeGraphNode[] = [
+    node({ id: "capability:mcp-server", title: "MCP Server (24 tools)", kind: "capability" }),
+    node({ id: "capability:mcp-conflict-guard", title: "MCP Conflict Guard", kind: "capability" }),
+    node({ id: "element:mcp-index", title: "mcp/src/index.js", kind: "element" }),
+    node({ id: "domain:ai-agent-partner", title: "AI Agent Partner", kind: "domain" }),
+  ];
+  const projects: Project[] = [project({ slug: "ontology-atlas", name: "ontology-atlas" })];
+
+  it("검색 결과에 ontology 노드가 포함된다 (project/doc 만 있던 이전 헤더 팔레트와의 차이)", () => {
+    render(
+      <GlobalSearch
+        open
+        onOpenChange={() => {}}
+        nodes={nodes}
+        onSelectNode={() => {}}
+        projects={projects}
+        onSelectProject={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Global search" }), {
+      target: { value: "mcp server" },
+    });
+
+    expect(findOntologyOption("capability:mcp-server")).not.toBeNull();
+  });
+
+  it("ontology 노드 결과를 고르면 onSelectNode 가 정확한 노드로 호출된다", () => {
+    const onSelectNode = vi.fn();
+    render(
+      <GlobalSearch
+        open
+        onOpenChange={() => {}}
+        nodes={nodes}
+        onSelectNode={onSelectNode}
+        projects={projects}
+        onSelectProject={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Global search" }), {
+      target: { value: "mcp server" },
+    });
+    const option = findOntologyOption("capability:mcp-server");
+    expect(option).not.toBeNull();
+    fireEvent.click(option!);
+
+    expect(onSelectNode).toHaveBeenCalledTimes(1);
+    expect(onSelectNode.mock.calls[0][0]).toMatchObject({ id: "capability:mcp-server" });
+  });
+
+  it("kind 필터 칩이 실제로 결과를 좁힌다 (no-op 회귀 방지)", () => {
+    render(
+      <GlobalSearch
+        open
+        onOpenChange={() => {}}
+        nodes={nodes}
+        onSelectNode={() => {}}
+        projects={projects}
+        onSelectProject={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Global search" }), {
+      target: { value: "mcp" },
+    });
+    // 필터 없이는 capability 2건 + element 1건 모두 노출.
+    expect(findOntologyOption("capability:mcp-server")).not.toBeNull();
+    expect(findOntologyOption("capability:mcp-conflict-guard")).not.toBeNull();
+    expect(findOntologyOption("element:mcp-index")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Element" }));
+
+    // ELEMENT 칩 활성화 후 — capability 결과는 사라지고 element 만 남는다.
+    expect(findOntologyOption("capability:mcp-server")).toBeNull();
+    expect(findOntologyOption("capability:mcp-conflict-guard")).toBeNull();
+    expect(findOntologyOption("element:mcp-index")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

페르소나 P1(4/5 충돌) 해소 — 테크리드의 #1 플로우("X가 뭘 물고 있나")가 검색 경로로 완주 가능.

- **진단**: 팔레트가 2개였음 — ⌘K `SearchPalette`(레거시 프로젝트/문서 전용, NODE 칩은 온톨로지와 무관한 축이라 무동작으로 체감) vs ⇧⌘K `GlobalSearch`(노드 검색·kind 칩 정상이나 HomePage가 `onSelectNode` 미전달 → `/ontology`로 이탈)
- **최소 통합**: 헤더 버튼·⌘K·⇧⌘K 전부 GlobalSearch 로 일원화, `onSelectNode → handleSelect` — 기존 `?p=` 포커스 딥링크 재사용(라우트 유지·카메라 플라이·데이터시트). 티어-숨김 element 선택도 ego 면제로 정상 포커스(opus 실증). ProjectDetailPage 팔레트는 무변경, 레거시 마운트/상태 제거
- 신규 GlobalSearch 테스트 3(TDD): 노드 결과·onSelectNode·kind 칩 실동작(무동작 회귀 가드)

## Test plan

opus 검증 **SHIP**: tsc exit 0 · vitest 259(+main 합류 후 283) · eslint 0 · 라이브(capability/domain/element 포커스·composer·Auto-arrange·콘솔 0). 문서 퀵검색 트레이드오프는 "지도 표면은 노드 우선"으로 수용(vault docs는 /docs 팔레트 유지).

## Follow-ups

- Esc 이중 닫힘(팔레트+선택 해제 동시 — **main에도 있는 pre-existing**, ⇧⌘K로 실증): esc-ladder에 search-open 플래그 전달. 카운트 시맨틱 슬라이스에 번들
- 팔레트 aria-description "documents" 문구 조정

🤖 Generated with [Claude Code](https://claude.com/claude-code)