### PR TITLE
fix: /docs 폴더 토폴로지 재스타일 — 라이트모드·라벨·불투명색·결정론

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1015,6 +1015,11 @@
       "expand": "Show context",
       "collapse": "Hide context"
     },
+    "folderTopology": {
+      "hudCount": "folder topology · {count} projects",
+      "danglingHeading": "Dangling dependencies · {count}",
+      "danglingMore": "… {count} more"
+    },
     "parts": {
       "meta": {
         "recordProofAria": "Ontology evidence",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1015,6 +1015,11 @@
       "expand": "컨텍스트 보기",
       "collapse": "컨텍스트 숨기기"
     },
+    "folderTopology": {
+      "hudCount": "프로젝트 지형도 · {count}개",
+      "danglingHeading": "깨진 의존 · {count}",
+      "danglingMore": "… 외 {count}"
+    },
     "parts": {
       "meta": {
         "recordProofAria": "온톨로지 근거",

--- a/src/widgets/docs-vault/lib/folder-topology-theme.test.ts
+++ b/src/widgets/docs-vault/lib/folder-topology-theme.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetFolderTopologyColorCache,
+  blendOverBackground,
+  hashJitter,
+  resolveFolderTopologyColors,
+} from './folder-topology-theme';
+
+describe('hashJitter', () => {
+  it('is deterministic for the same seed', () => {
+    expect(hashJitter('atlas-core', 20)).toBe(hashJitter('atlas-core', 20));
+    expect(hashJitter('mcp-server', 20)).toBe(hashJitter('mcp-server', 20));
+  });
+
+  it('spreads different seeds to different values', () => {
+    const a = hashJitter('atlas-core', 20);
+    const b = hashJitter('mcp-server', 20);
+    const c = hashJitter('cli-tooling', 20);
+    // 세 값이 전부 같을 확률은 무시할 만큼 낮다 — 진짜 해시라면 갈라진다.
+    expect(new Set([a, b, c]).size).toBeGreaterThan(1);
+  });
+
+  it('stays within [-spread/2, spread/2)', () => {
+    const seeds = ['a', 'b', 'c', 'd', 'e', 'atlas', 'ontology-atlas', 'x'.repeat(40)];
+    for (const seed of seeds) {
+      const v = hashJitter(seed, 20);
+      expect(v).toBeGreaterThanOrEqual(-10);
+      expect(v).toBeLessThan(10);
+    }
+  });
+
+  it('scales with the requested spread', () => {
+    const seed = 'scale-check';
+    const narrow = hashJitter(seed, 4);
+    const wide = hashJitter(seed, 40);
+    expect(Math.abs(narrow)).toBeLessThanOrEqual(2);
+    expect(Math.abs(wide)).toBeLessThanOrEqual(20);
+  });
+});
+
+describe('blendOverBackground', () => {
+  it('returns the background untouched for a fully-opaque overlay', () => {
+    expect(blendOverBackground('rgba(139, 151, 255, 1)', '#000000')).toBe(
+      'rgb(139, 151, 255)',
+    );
+  });
+
+  it('returns the background untouched for a fully-transparent overlay', () => {
+    expect(blendOverBackground('rgba(139, 151, 255, 0)', '#08090a')).toBe(
+      'rgb(8, 9, 10)',
+    );
+  });
+
+  it('alpha-composites a half-opacity overlay over an opaque background', () => {
+    // rgba(255,255,255,0.5) over #000000 → rgb(128,128,128) (rounded)
+    expect(blendOverBackground('rgba(255, 255, 255, 0.5)', '#000000')).toBe(
+      'rgb(128, 128, 128)',
+    );
+  });
+
+  it('accepts hex overlay colors', () => {
+    expect(blendOverBackground('#ffffff', '#000000')).toBe('rgb(255, 255, 255)');
+  });
+
+  it('falls back to the background string when the overlay is unparseable', () => {
+    expect(blendOverBackground('not-a-color', '#08090a')).toBe('#08090a');
+  });
+});
+
+describe('resolveFolderTopologyColors', () => {
+  beforeEach(() => {
+    __resetFolderTopologyColorCache();
+    document.documentElement.removeAttribute('style');
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  function setTokens(tokens: Record<string, string>) {
+    for (const [name, value] of Object.entries(tokens)) {
+      document.documentElement.style.setProperty(name, value);
+    }
+  }
+
+  it('resolves opaque colors from dark-theme tokens', () => {
+    setTokens({
+      '--color-canvas': '#08090a',
+      '--color-text-secondary': '#d0d6e0',
+      '--color-text-quaternary': '#787c84',
+    });
+    const colors = resolveFolderTopologyColors();
+    for (const value of Object.values(colors)) {
+      expect(value).not.toMatch(/rgba?\([^)]*,\s*0(\.\d+)?\s*\)/);
+    }
+    expect(colors.label).toBe('#d0d6e0');
+  });
+
+  it('re-resolves to different opaque tones for light-theme tokens', () => {
+    setTokens({
+      '--color-canvas': '#08090a',
+      '--color-text-secondary': '#d0d6e0',
+      '--color-text-quaternary': '#787c84',
+    });
+    const dark = resolveFolderTopologyColors();
+
+    setTokens({
+      '--color-canvas': '#f3f5f9',
+      '--color-text-secondary': '#1f2329',
+      '--color-text-quaternary': '#6f7480',
+    });
+    const light = resolveFolderTopologyColors();
+
+    expect(light.label).toBe('#1f2329');
+    expect(light.edgeDefault).not.toBe(dark.edgeDefault);
+    expect(light.nodeDim).not.toBe(dark.nodeDim);
+  });
+
+  it('caches the result until the underlying tokens change', () => {
+    setTokens({
+      '--color-canvas': '#08090a',
+      '--color-text-secondary': '#d0d6e0',
+      '--color-text-quaternary': '#787c84',
+    });
+    const first = resolveFolderTopologyColors();
+    const second = resolveFolderTopologyColors();
+    expect(second).toBe(first); // 동일 참조 — 재계산 안 함
+  });
+});

--- a/src/widgets/docs-vault/lib/folder-topology-theme.ts
+++ b/src/widgets/docs-vault/lib/folder-topology-theme.ts
@@ -1,0 +1,149 @@
+import { INDIGO_HIGHLIGHT, indigoRgba } from '@/shared/config/indigo-tokens';
+
+/**
+ * DocsVaultFolderTopology 전용 테마 대응 색 계산.
+ *
+ * Sigma 는 WebGL 캔버스라 alpha 합성이 브라우저/webview 조합에 따라 신뢰할
+ * 수 없다 — 저-알파 rgba 를 그대로 넘기면 사실상 안 보이거나 렌더러마다
+ * 다르게 보인다 (memory: "WebGL 알파 결함" — dim 은 hidden 또는 불투명 톤만).
+ * 그래서 Sigma settings / node·edge attrs 로 넘기는 모든 색은 **불투명**
+ * 이어야 한다. 이 모듈은 `--color-*` 토큰(테마별로 이미 값이 다름)을 실제
+ * 캔버스 배경 위에 alpha-composite 해서 불투명 `rgb()` 문자열로 만든다.
+ */
+
+export interface FolderTopologyColors {
+  /** Sigma label 색 — 다크/라이트 모두 텍스트로서 읽혀야 하므로 이미 불투명인
+   *  `--color-text-secondary` 를 그대로 쓴다 (블렌딩 불필요). */
+  label: string;
+  /** 기본 엣지 톤 — 인디고 틴트, 캔버스 위에서 뚜렷이 보이는 불투명 회색. */
+  edgeDefault: string;
+  /** hover 로 다른 노드가 강조될 때 나머지 엣지의 dim 톤 — 여전히 보여야 함. */
+  edgeDim: string;
+  /** hover/selected 엣지 강조 톤. */
+  edgeHighlight: string;
+  /** hover 로 다른 노드가 강조될 때 나머지 노드의 dim 톤. */
+  nodeDim: string;
+  /** hover 노드의 border 강조 색 (인디고, 테마 무관 — 브랜드 색은 원래 불투명). */
+  hoverBorder: string;
+}
+
+interface ParsedColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+function parseColor(input: string): ParsedColor | null {
+  const s = input.trim();
+  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(s);
+  if (hexMatch) {
+    let hex = hexMatch[1];
+    if (hex.length === 3) {
+      hex = hex
+        .split('')
+        .map((c) => c + c)
+        .join('');
+    }
+    const num = parseInt(hex, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255, a: 1 };
+  }
+  const rgbMatch =
+    /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(
+      s,
+    );
+  if (rgbMatch) {
+    return {
+      r: Number(rgbMatch[1]),
+      g: Number(rgbMatch[2]),
+      b: Number(rgbMatch[3]),
+      a: rgbMatch[4] !== undefined ? Number(rgbMatch[4]) : 1,
+    };
+  }
+  return null;
+}
+
+/**
+ * `overlay` (alpha 있을 수 있음) 를 불투명 `background` 위에 합성해 불투명
+ * `rgb()` 문자열로 반환. 파싱 실패 시 background(있으면) 로 안전하게 폴백.
+ */
+export function blendOverBackground(overlay: string, background: string): string {
+  const fg = parseColor(overlay);
+  const bg = parseColor(background);
+  if (!fg || !bg) return background || overlay;
+  const a = Math.max(0, Math.min(1, fg.a));
+  const r = Math.round(fg.r * a + bg.r * (1 - a));
+  const g = Math.round(fg.g * a + bg.g * (1 - a));
+  const b = Math.round(fg.b * a + bg.b * (1 - a));
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+function readVar(
+  styles: Pick<CSSStyleDeclaration, 'getPropertyValue'>,
+  name: string,
+  fallback: string,
+): string {
+  const value = styles.getPropertyValue(name).trim();
+  return value || fallback;
+}
+
+let cacheKey: string | null = null;
+let cachedColors: FolderTopologyColors | null = null;
+
+/** 테스트 전용 — 모듈 레벨 resolve-cache 리셋. */
+export function __resetFolderTopologyColorCache(): void {
+  cacheKey = null;
+  cachedColors = null;
+}
+
+/**
+ * 현재 `data-theme` 기준 Sigma 색 팔레트를 계산. `getComputedStyle` 로 읽은
+ * 토큰 조합이 이전 호출과 같으면 캐시된 참조를 그대로 반환 — 매 reducer
+ * 호출마다 다시 계산하지 않도록 (호출부는 MutationObserver 로 `data-theme`
+ * 변경 시에만 다시 부르면 된다).
+ */
+export function resolveFolderTopologyColors(
+  root: HTMLElement = document.documentElement,
+): FolderTopologyColors {
+  const styles = getComputedStyle(root);
+  const canvas = readVar(styles, '--color-canvas', '#08090a');
+  const textSecondary = readVar(styles, '--color-text-secondary', '#d0d6e0');
+  const quaternaryHex = readVar(styles, '--color-text-quaternary', '#787c84');
+
+  const key = `${canvas}|${textSecondary}|${quaternaryHex}`;
+  if (cachedColors && cacheKey === key) return cachedColors;
+
+  const quaternary = parseColor(quaternaryHex) ?? { r: 120, g: 124, b: 132, a: 1 };
+  const neutralInkRgb = `${quaternary.r}, ${quaternary.g}, ${quaternary.b}`;
+
+  const colors: FolderTopologyColors = {
+    label: textSecondary,
+    edgeDefault: blendOverBackground(indigoRgba('highlight', 0.42), canvas),
+    edgeDim: blendOverBackground(`rgba(${neutralInkRgb}, 0.2)`, canvas),
+    edgeHighlight: blendOverBackground(indigoRgba('highlight', 0.94), canvas),
+    nodeDim: blendOverBackground(`rgba(${neutralInkRgb}, 0.42)`, canvas),
+    // 브랜드 인디고는 이미 불투명 hex — 블렌딩 불필요, 테마 무관 단일 색.
+    hoverBorder: INDIGO_HIGHLIGHT,
+  };
+
+  cacheKey = key;
+  cachedColors = colors;
+  return colors;
+}
+
+/**
+ * `slug` 로부터 결정론적 pseudo-random jitter 를 만든다. `Math.random()` 을
+ * 대체 — 같은 vault 는 매 마운트마다 같은 배치로 렌더돼야 재현 가능
+ * (B2+ deterministic-skeleton 원칙). djb2 계열 해시 → [0,1) 정규화 → 요청
+ * spread 로 스케일.
+ *
+ * @returns `[-spread/2, spread/2)` 범위의 값.
+ */
+export function hashJitter(seed: string, spread: number): number {
+  let h = 5381;
+  for (let i = 0; i < seed.length; i++) {
+    h = (h * 33) ^ seed.charCodeAt(i);
+  }
+  const normalized = (h >>> 0) / 4294967296; // uint32 → [0, 1)
+  return (normalized - 0.5) * spread;
+}

--- a/src/widgets/docs-vault/ui/DocsVaultFolderTopology.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultFolderTopology.tsx
@@ -4,7 +4,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import Graph from 'graphology';
 import forceAtlas2 from 'graphology-layout-forceatlas2';
 import Sigma from 'sigma';
+import { createNodeBorderProgram } from '@sigma/node-border';
+import { useTranslations } from 'next-intl';
 import { INDIGO_HIGHLIGHT } from '@/shared/config/indigo-tokens';
+import {
+  hashJitter,
+  resolveFolderTopologyColors,
+  type FolderTopologyColors,
+} from '../lib/folder-topology-theme';
 import type {
   FolderTopologyBuild,
   FolderTopologyCategory,
@@ -21,15 +28,26 @@ interface Props {
   onPositionChange?: (slug: string, position: { x: number; y: number }) => void;
 }
 
+// 카테고리 톤 — 그래프 fill 은 작은 점의 대비를 위해 선명해도 되지만
+// (DESIGN-SYSTEM.md), 여기로 넘어가는 모든 색은 Sigma(WebGL) 로 직접
+// 전달되므로 불투명이어야 한다 (memory: WebGL 알파 결함 — 저-알파 rgba 는
+// 렌더러마다 다르게/안 보이게 합성된다). neutral 톤도 불투명 hex 로.
 const TONE_COLOR: Record<string, string> = {
   indigo: INDIGO_HIGHLIGHT,
   amber: '#d4b478',
-  neutral: 'rgba(180, 190, 210, 0.88)',
+  neutral: '#b4bed2',
 };
-const EDGE_COLOR = 'rgba(139, 151, 255, 0.22)';
-const EDGE_DIM = 'rgba(100, 108, 125, 0.08)';
-const EDGE_HIGHLIGHT = 'rgba(139, 151, 255, 0.85)';
-const DIM_NODE = 'rgba(100, 108, 125, 0.22)';
+
+// 초기 원형 배치용 지터 폭 (px, 그래프 좌표계).
+const JITTER_SPREAD = 20;
+// hover 노드 강조 배율 — 이전 1.5x 는 순간적으로 튀는 느낌(스프링 없이 즉시
+// 커짐)이라 1.15 로 완화. 대신 border 강조로 시선을 보완.
+const HOVER_SIZE_FACTOR = 1.15;
+const SELECTED_SIZE_FACTOR = 1.25;
+// 카메라 초기 fit 여백 — Sigma 는 그래프 bounding box 를 뷰포트에 꽉 채워
+// 정규화하므로 여백 없이 그리면 가장자리 노드가 캔버스 경계에서 잘린다.
+// ratio 를 살짝 키워(zoom out) 사방에 여백을 준다.
+const CAMERA_FIT_PADDING_RATIO = 1.18;
 
 function toneForCategory(
   cat: string,
@@ -38,6 +56,20 @@ function toneForCategory(
   const found = categories.find((c) => c.slug === cat);
   const tone = found?.tone ?? 'neutral';
   return TONE_COLOR[tone] ?? TONE_COLOR.neutral;
+}
+
+function safeResolveColors(): FolderTopologyColors {
+  if (typeof document === 'undefined') {
+    return {
+      label: '#d0d6e0',
+      edgeDefault: 'rgb(64, 68, 96)',
+      edgeDim: 'rgb(28, 29, 32)',
+      edgeHighlight: 'rgb(132, 143, 231)',
+      nodeDim: 'rgb(56, 58, 64)',
+      hoverBorder: INDIGO_HIGHLIGHT,
+    };
+  }
+  return resolveFolderTopologyColors();
 }
 
 /**
@@ -51,11 +83,15 @@ export function DocsVaultFolderTopology({
   onSelect,
   onPositionChange,
 }: Props) {
+  const t = useTranslations('vaultWidgets.folderTopology');
   const containerRef = useRef<HTMLDivElement | null>(null);
   const sigmaRef = useRef<Sigma | null>(null);
   const graphRef = useRef<Graph | null>(null);
   const onSelectRef = useRef(onSelect);
   const onPositionChangeRef = useRef(onPositionChange);
+  // 다크/라이트 색 팔레트 resolve-cache — mount 시 1회, data-theme 변경 시
+  // MutationObserver 가 갱신. reducer 는 매번 이 ref 를 읽어 계산 안 함.
+  const colorsRef = useRef<FolderTopologyColors>(safeResolveColors());
   useEffect(() => {
     onSelectRef.current = onSelect;
   }, [onSelect]);
@@ -85,17 +121,20 @@ export function DocsVaultFolderTopology({
       // 으로 잘못 인식돼 모든 노드가 원점에 겹쳤음).
       const hasPosition =
         p.position && (p.position.x !== 0 || p.position.y !== 0);
+      // slug 기반 결정론적 해시 지터 — Math.random() 은 매 마운트마다 배치가
+      // 달라져 재현 불가능했다 (B2+ deterministic-skeleton 원칙 위반).
+      const jitterX = hashJitter(`${p.slug}:x`, JITTER_SPREAD);
+      const jitterY = hashJitter(`${p.slug}:y`, JITTER_SPREAD);
       graph.addNode(p.slug, {
-        x: hasPosition
-          ? p.position!.x
-          : Math.cos(angle) * radius + (Math.random() - 0.5) * 20,
-        y: hasPosition
-          ? p.position!.y
-          : Math.sin(angle) * radius + (Math.random() - 0.5) * 20,
+        x: hasPosition ? p.position!.x : Math.cos(angle) * radius + jitterX,
+        y: hasPosition ? p.position!.y : Math.sin(angle) * radius + jitterY,
         size: p.isHub ? 8 : 4.5,
         label: p.name,
         color: toneForCategory(p.category ?? '', build.categories),
         originalColor: toneForCategory(p.category ?? '', build.categories),
+        // 기본 투명 — hover 시에만 인디고 링으로 강조 (finding #7: 순간적으로
+        // 1.5x 커지는 대신 border 로 시선 보완).
+        borderColor: 'rgba(0, 0, 0, 0)',
         isHub: Boolean(p.isHub),
       });
     });
@@ -103,7 +142,7 @@ export function DocsVaultFolderTopology({
       for (const dep of p.dependencies) {
         if (!graph.hasNode(dep)) continue;
         if (graph.hasEdge(p.slug, dep)) continue;
-        graph.addEdge(p.slug, dep, { color: EDGE_COLOR, size: 1 });
+        graph.addEdge(p.slug, dep, { size: 1 });
       }
     }
     // in-degree 기반 크기 조정
@@ -132,18 +171,38 @@ export function DocsVaultFolderTopology({
       });
     }
 
+    // border 프로그램 — 기본은 투명 링(안 보임), hover 시 nodeReducer 가
+    // borderColor 를 인디고로 바꿔 강조. finding #7 — 즉시 1.5x 커지는 대신
+    // 모던한 배율(1.15) + border 강조 조합.
+    const borderNodeProgram = createNodeBorderProgram({
+      borders: [
+        { size: { value: 2, mode: 'pixels' }, color: { attribute: 'borderColor' } },
+        { size: { fill: true }, color: { attribute: 'color' } },
+      ],
+    });
+
     const renderer = new Sigma(graph, containerRef.current, {
       renderLabels: true,
       renderEdgeLabels: false,
       labelFont: 'Inter, system-ui, sans-serif',
       labelSize: 12,
-      labelColor: { color: 'rgba(220, 226, 240, 0.92)' },
-      labelRenderedSizeThreshold: 5,
+      labelColor: { color: colorsRef.current.label },
+      // finding #2 — 5 는 non-hub 기본 size(4.5) 보다 커서 leaf 노드가
+      // 영원히 라벨 후보에서 제외됐다. 0 으로 모든 노드를 후보로 둔다.
+      labelRenderedSizeThreshold: 0,
       defaultEdgeType: 'arrow',
+      defaultNodeType: 'bordered',
+      nodeProgramClasses: { bordered: borderNodeProgram },
       minEdgeThickness: 0.6,
       zIndex: true,
     });
     sigmaRef.current = renderer;
+
+    // finding #5 — Sigma 는 그래프 bounding box 를 뷰포트에 꽉 채워
+    // 정규화해서 가장자리 노드가 캔버스 경계에서 잘린다. 초기 카메라 ratio 를
+    // 살짝 키워(zoom out) 사방에 안전 여백을 준다.
+    const camera = renderer.getCamera();
+    camera.setState({ ...camera.getState(), ratio: camera.getState().ratio * CAMERA_FIT_PADDING_RATIO });
 
     renderer.on('enterNode', ({ node }) => {
       setHovered(node);
@@ -213,23 +272,42 @@ export function DocsVaultFolderTopology({
     };
   }, [build.projects, build.categories]);
 
+  // finding #1 — labelColor / edge / dim 톤이 다크 전용으로 하드코딩돼
+  // 라이트 모드에서 안 읽혔다. data-theme 변경을 관찰해 팔레트를 다시
+  // 계산하고 Sigma settings 를 갱신 (SigmaTopology 의 기존 패턴과 동일).
+  useEffect(() => {
+    const target = document.documentElement;
+    const refresh = () => {
+      colorsRef.current = resolveFolderTopologyColors();
+      const renderer = sigmaRef.current;
+      if (!renderer) return;
+      renderer.setSetting('labelColor', { color: colorsRef.current.label });
+      renderer.refresh();
+    };
+    const observer = new MutationObserver(refresh);
+    observer.observe(target, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+
   // hover / selection 반영
   useEffect(() => {
     const renderer = sigmaRef.current;
     const graph = graphRef.current;
     if (!renderer || !graph) return;
     renderer.setSetting('nodeReducer', (node, attrs) => {
+      const colors = colorsRef.current;
       const isHovered = node === hovered;
       const isNeighbor = neighbors.has(node);
       const isSelected = node === selectedSlug;
       if (hovered && !isHovered && !isNeighbor) {
-        return { ...attrs, color: DIM_NODE, label: '' };
+        return { ...attrs, color: colors.nodeDim, label: '' };
       }
       if (isHovered) {
         return {
           ...attrs,
           color: attrs.originalColor ?? attrs.color,
-          size: (attrs.originalSize ?? attrs.size) * 1.5,
+          size: (attrs.originalSize ?? attrs.size) * HOVER_SIZE_FACTOR,
+          borderColor: colors.hoverBorder,
           zIndex: 3,
           forceLabel: true,
         };
@@ -245,7 +323,7 @@ export function DocsVaultFolderTopology({
       if (isSelected) {
         return {
           ...attrs,
-          size: (attrs.originalSize ?? attrs.size) * 1.25,
+          size: (attrs.originalSize ?? attrs.size) * SELECTED_SIZE_FACTOR,
           zIndex: 2,
           forceLabel: true,
         };
@@ -253,17 +331,18 @@ export function DocsVaultFolderTopology({
       return { ...attrs };
     });
     renderer.setSetting('edgeReducer', (edge, attrs) => {
+      const colors = colorsRef.current;
       const [src, tgt] = graph.extremities(edge);
       if (hovered) {
         if (src === hovered || tgt === hovered) {
-          return { ...attrs, color: EDGE_HIGHLIGHT, size: 1.8 };
+          return { ...attrs, color: colors.edgeHighlight, size: 1.8 };
         }
-        return { ...attrs, color: EDGE_DIM };
+        return { ...attrs, color: colors.edgeDim };
       }
       if (selectedSlug && (src === selectedSlug || tgt === selectedSlug)) {
-        return { ...attrs, color: EDGE_HIGHLIGHT, size: 1.4 };
+        return { ...attrs, color: colors.edgeHighlight, size: 1.4 };
       }
-      return { ...attrs };
+      return { ...attrs, color: colors.edgeDefault };
     });
     renderer.refresh();
   }, [hovered, neighbors, selectedSlug]);
@@ -274,12 +353,12 @@ export function DocsVaultFolderTopology({
     <div className="relative h-full w-full">
       <div ref={containerRef} className="absolute inset-0" />
       <div className="pointer-events-none absolute left-3 top-3 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
-        folder topology · {build.projects.length} projects
+        {t('hudCount', { count: build.projects.length })}
       </div>
       {build.danglingRefs.length > 0 ? (
         <div className="pointer-events-none absolute right-3 top-3 max-w-[280px] rounded-md border border-[color:rgba(239,180,120,0.35)] bg-[color:rgba(239,180,120,0.06)] px-3 py-2 text-[11px] text-[color:rgba(239,200,150,0.95)]">
           <div className="font-mono text-[9.5px] uppercase tracking-[0.14em]">
-            깨진 의존 · {build.danglingRefs.length}
+            {t('danglingHeading', { count: build.danglingRefs.length })}
           </div>
           <ul className="mt-1 space-y-0.5 font-mono text-[10.5px]">
             {build.danglingRefs.slice(0, 3).map((r) => (
@@ -288,13 +367,15 @@ export function DocsVaultFolderTopology({
               </li>
             ))}
             {build.danglingRefs.length > 3 ? (
-              <li className="opacity-60">… 외 {build.danglingRefs.length - 3}</li>
+              <li className="opacity-60">
+                {t('danglingMore', { count: build.danglingRefs.length - 3 })}
+              </li>
             ) : null}
           </ul>
         </div>
       ) : null}
       {hoveredProject ? (
-        <div className="pointer-events-none absolute bottom-3 left-3 max-w-[320px] rounded-md border border-[color:rgba(139,151,255,0.28)] bg-[color:rgba(12,14,20,0.98)] px-3 py-2 shadow-[0_10px_26px_rgba(0,0,0,0.45)]">
+        <div className="pointer-events-none absolute bottom-3 left-3 max-w-[320px] rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3 py-2 shadow-[0_10px_26px_rgba(0,0,0,0.45)]">
           <div className="flex items-center gap-2 text-[13px] font-medium text-[color:var(--color-text-primary)]">
             {hoveredProject.name}
           </div>


### PR DESCRIPTION
## Summary

Sigma 표면 검수 P1 — /docs 폴더 토폴로지(데스크톱 전용) 7개 지적 전부 수정 (fable 처방 / sonnet 구현 / 리드 스팟체크).

- 라이트모드 불가독 → 토큰 resolve-cache + `data-theme` MutationObserver(SigmaTopology 패턴), 호버 카드 토큰화 — 양 테마 실화면 검증
- 리프 영구 무라벨(threshold 5>base 4.5) → 0, 전 노드 라벨
- 저알파 WebGL 색 → 캔버스 배경에 사전 합성한 불투명 rgb (defect 클래스 제거)
- `Math.random` 지터 → slug 해시 결정론(12 TDD) · 카메라 fit 패딩 1.18 · 호버 ×1.5→×1.15+인디고 보더 링(@sigma/node-border) · HUD 어휘 i18n 통일(ko/en)

## Test plan

tsc exit 0 · docs-vault 66 tests(+12 신규) · i18n 26 · lint 0 err · 라이브(모킹 Tauri, 7프로젝트+깨진 의존 1): 다크/라이트 스크린샷·팔레트 진입·hover 카드·콘솔 0

## 부채 (명시)

- **설치앱(Tauri WebView) 증명 미실행** — 다음 DMG 전 `desktop:verify-app` 확인 목록에 포함
- 드래그→frontmatter 영속은 본 diff 미변경 경로라 라이브 재검 생략(회귀 위험 낮음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)