### PR TITLE
fix: 데이터시트 수치 단일 소스화(방향 그룹) + Esc 한 단계 닫기

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -621,7 +621,7 @@
     "globalSearch": {
       "dialogAriaLabel": "Global search",
       "dialogTitle": "Global search",
-      "dialogDescription": "Search concepts (ontology nodes), documents, and projects in one place. Use up/down arrows to move, Enter to select, ESC to close.",
+      "dialogDescription": "Search ontology concepts and projects in one place. Use up/down arrows to move, Enter to select, ESC to close.",
       "commandLabel": "Global search",
       "closeAriaLabel": "Close global search",
       "placeholderWithProjects": "Search concepts and projects — KR/EN mix OK",
@@ -2813,10 +2813,8 @@
       "poweredOn": "fresh",
       "poweredOff": "idle",
       "metricUsedBy": "used by",
-      "metricDependsOn": "depends on",
+      "metricDependsOn": "leans on",
       "metricEvidence": "evidence",
-      "groupContains": "contains",
-      "groupDepends": "depends",
       "noConnections": "no direct connections",
       "handoff": "Copy next action",
       "handoffCopied": "Agent handoff copied"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -621,7 +621,7 @@
     "globalSearch": {
       "dialogAriaLabel": "글로벌 검색",
       "dialogTitle": "글로벌 검색",
-      "dialogDescription": "개념 (ontology 노드) · 글 (문서) · 프로젝트를 한 번에 검색합니다. 위·아래 화살표로 이동, Enter 로 선택, ESC 로 닫기.",
+      "dialogDescription": "온톨로지 개념과 프로젝트를 한 번에 검색합니다. 위·아래 화살표로 이동, Enter 로 선택, ESC 로 닫기.",
       "commandLabel": "글로벌 검색",
       "closeAriaLabel": "글로벌 검색 닫기",
       "placeholderWithProjects": "개념 · 프로젝트 검색 — 한·영 혼합 OK",
@@ -2815,8 +2815,6 @@
       "metricUsedBy": "쓰는 곳",
       "metricDependsOn": "기대는 곳",
       "metricEvidence": "근거",
-      "groupContains": "포함",
-      "groupDepends": "의존",
       "noConnections": "직접 연결 없음",
       "handoff": "다음 액션 복사",
       "handoffCopied": "에이전트 인계를 복사했어요"

--- a/src/views/home/lib/topology-esc-ladder.test.ts
+++ b/src/views/home/lib/topology-esc-ladder.test.ts
@@ -6,6 +6,7 @@ import {
 
 const BASE: TopologyEscLadderInput = {
   createNodeOpen: false,
+  searchOpen: false,
   fullDetailOpen: false,
   selectedRelationActive: false,
   hasSelection: false,
@@ -28,6 +29,53 @@ describe("resolveTopologyEscLadderAction", () => {
         hasLocalGraphRoot: true,
       }),
     ).toBe("close-create-node");
+  });
+
+  it("returns none when the search/ontology palette is open, even with a selection and every other tier open — the palette's own Escape handler (Radix Dialog) owns this keypress, not the window ladder", () => {
+    // Regression: the palette is a Radix Dialog that already closes itself on
+    // Escape. Before this input existed, the window-level ladder had no idea
+    // the palette was open, so it ALSO deselected the node on the same
+    // keypress — one Escape closed both the palette AND the selection.
+    expect(
+      resolveTopologyEscLadderAction({
+        ...BASE,
+        searchOpen: true,
+        fullDetailOpen: true,
+        selectedRelationActive: true,
+        hasSelection: true,
+        hasLocalGraphRoot: true,
+      }),
+    ).toBe("none");
+  });
+
+  it("the create-node composer still wins over an open search palette", () => {
+    expect(
+      resolveTopologyEscLadderAction({
+        ...BASE,
+        createNodeOpen: true,
+        searchOpen: true,
+      }),
+    ).toBe("close-create-node");
+  });
+
+  it("a second Escape, after the palette has closed, deselects the surviving selection", () => {
+    // Step 1: palette open + node selected — ladder does nothing, palette's
+    // own handler closes it.
+    const step1 = resolveTopologyEscLadderAction({
+      ...BASE,
+      searchOpen: true,
+      hasSelection: true,
+    });
+    expect(step1).toBe("none");
+
+    // Step 2: palette is now closed — the SAME selection survived step 1 and
+    // deselects on this next keypress.
+    const step2 = resolveTopologyEscLadderAction({
+      ...BASE,
+      searchOpen: false,
+      hasSelection: true,
+    });
+    expect(step2).toBe("deselect");
   });
 
   it("closes the full-detail drawer before the relation lens or deselecting", () => {

--- a/src/views/home/lib/topology-esc-ladder.ts
+++ b/src/views/home/lib/topology-esc-ladder.ts
@@ -25,6 +25,14 @@ export interface TopologyEscLadderInput {
    *  closes itself on Escape while it holds focus; this covers the case
    *  where focus has moved outside it while it's still blocking the page). */
   createNodeOpen: boolean;
+  /** Global search / ontology palette open (`MountedGlobalSearch` → Radix
+   *  `Dialog`, which already closes itself on Escape). If this is true the
+   *  ladder must return "none" and let the palette's own handler own the
+   *  keypress — otherwise the window-level ladder ALSO acts on the same
+   *  Escape (e.g. deselecting the node underneath), so one keypress closes
+   *  two things at once. Regression: persona hit palette-open + node-selected
+   *  → Escape closed the palette AND cleared the selection in one press. */
+  searchOpen: boolean;
   /** "전체 상세" drawer — the popover/datasheet's opt-in full-detail overlay. */
   fullDetailOpen: boolean;
   /** Relation lens active — replaces the popover with a relation-focused view. */
@@ -45,16 +53,21 @@ export type TopologyEscLadderAction =
 
 /**
  * Resolves what a single Escape keypress should do, in priority order:
- * create-node composer → full-detail drawer → relation lens → deselect the
- * current node → pop one level of the local-graph breadcrumb → nothing.
- * Each tier closes exactly one thing; the caller re-evaluates on the next
- * keypress, which is what makes this "one step at a time" rather than
- * "close everything".
+ * create-node composer → search palette (deferred to its own handler) →
+ * full-detail drawer → relation lens → deselect the current node → pop one
+ * level of the local-graph breadcrumb → nothing. Each tier closes exactly
+ * one thing; the caller re-evaluates on the next keypress, which is what
+ * makes this "one step at a time" rather than "close everything".
  */
 export function resolveTopologyEscLadderAction(
   input: TopologyEscLadderInput,
 ): TopologyEscLadderAction {
   if (input.createNodeOpen) return "close-create-node";
+  // The palette (Radix Dialog) already closes itself on Escape — returning
+  // "none" here means the window ladder does nothing this keypress, so only
+  // the palette closes. Without this tier, the ladder would fall through to
+  // "deselect"/etc. on the SAME keypress the palette handles internally.
+  if (input.searchOpen) return "none";
   if (input.fullDetailOpen) return "close-full-detail";
   if (input.selectedRelationActive) return "close-relation-lens";
   if (input.hasSelection) return "deselect";

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -635,12 +635,21 @@ export function HomePage() {
   // topology-map-v2 "component datasheet" panel. Re-presents the
   // nodeFocus/significance facts — grouped connections + one engraved metric
   // line + an agent handoff payload. See widgets/topology-map-v2/TopologyV2DetailPanel.
+  //
+  // R+ 카운트 시맨틱 통일: the metric's usedBy/dependsOn now come from the
+  // SAME `groups` object the panel renders headers from (`groups.usedBy.total`
+  // / `groups.dependsOn.total`), not from `nodeFocus.usedByCount`/
+  // `dependsOnCount` (raw incoming/outgoing edge counts, not deduped by
+  // neighbor). Previously these were two independently-computed numbers that
+  // could diverge whenever a neighbor had a parallel edge — the persona bug
+  // ("used by 10 · depends on 73" vs groups "포함 71 / 의존 12"). One
+  // construction, one number, everywhere.
   const v2DatasheetModel = useMemo(() => {
     if (!nodeFocus || !selectedOntologyNode || !ontologyInsight) return null;
     const slug = nodeFocus.sourceSlug ?? selectedOntologyNode.id;
     // Group from the FULL connection set (not the shared 5-item outgoing-first
-    // preview) so a contains-hub's depends group renders its real total instead
-    // of collapsing into a generic overflow — and the handoff names never
+    // preview) so a hub's dependsOn group renders its real total instead of
+    // collapsing into a generic overflow — and the handoff names never
     // contradict the depends_on count.
     const connections = buildV2Connections(
       selectedOntologyNode.id,
@@ -649,8 +658,8 @@ export function HomePage() {
     );
     const groups = buildV2ConnectionGroups(connections);
     const metric = {
-      usedBy: nodeFocus.usedByCount,
-      dependsOn: nodeFocus.dependsOnCount,
+      usedBy: groups.usedBy.total,
+      dependsOn: groups.dependsOn.total,
       evidence: selectedOntologyNode.evidenceIds.length,
     };
     const handoffText = formatV2HandoffText({
@@ -660,8 +669,8 @@ export function HomePage() {
       usedBy: metric.usedBy,
       dependsOn: metric.dependsOn,
       evidence: metric.evidence,
-      containsNames: groups.contains.rows.map((connection) => connection.title),
-      dependsNames: groups.depends.rows.map((connection) => connection.title),
+      usedByNames: groups.usedBy.rows.map((connection) => connection.title),
+      dependsNames: groups.dependsOn.rows.map((connection) => connection.title),
     });
     return {
       slug,
@@ -760,17 +769,39 @@ export function HomePage() {
 
   // P0#3 — Esc staged-close ladder (docs/FEATURES.md / shortcut sheet's
   // `stepCloseOverlays` promise: "Close drawers and overlays one step at a
-  // time"). The composer/search/shortcuts/docs-drawer overlays already close
-  // themselves on Escape (see topology-esc-ladder.ts's doc comment); this
-  // effect covers what previously had no Escape binding at all — the
-  // full-detail drawer, the relation lens, the selected node itself, and the
-  // local-graph ego-drill breadcrumb (which used to pop unconditionally on
-  // every Escape, racing with whatever else was open).
+  // time"). The composer/shortcuts/docs-drawer overlays already close
+  // themselves on Escape; this effect covers what previously had no Escape
+  // binding at all — the full-detail drawer, the relation lens, the selected
+  // node itself, and the local-graph ego-drill breadcrumb (which used to pop
+  // unconditionally on every Escape, racing with whatever else was open).
+  //
+  // `searchOpen: ontologySearchOpen` is passed so the ladder returns "none"
+  // while the palette (a Radix `Dialog`) is open — otherwise this
+  // window-level handler ALSO fired on the same keypress (e.g. deselecting
+  // the node underneath), so one Escape closed both the palette AND the
+  // selection.
+  //
+  // `event.defaultPrevented` is checked FIRST and is what actually closes the
+  // race in the browser: Radix's `DismissableLayer` registers its own Escape
+  // handler on `document` with `{ capture: true }` (`useEscapeKeydown`) and
+  // calls `event.preventDefault()` + synchronously flushes
+  // `onOpenChange(false)` — verified live, this had ALREADY happened
+  // (`ontologySearchOpen` read back `false`, `event.defaultPrevented` already
+  // `true`) by the time this bubble-phase `window` listener ran on the SAME
+  // keypress. `searchOpen` stays as an explicit, testable input for the
+  // decision table (see `topology-esc-ladder.test.ts`) and covers any future
+  // dismissable surface that does the same without calling
+  // `preventDefault()`; `defaultPrevented` covers Radix's actual (capture +
+  // synchronous-flush) behavior. Kept on the bubble phase (not capture) so
+  // this doesn't reorder relative to unrelated local Escape handlers (e.g.
+  // inline-field-edit cancel) elsewhere on the page.
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
       const action = resolveTopologyEscLadderAction({
         createNodeOpen,
+        searchOpen: ontologySearchOpen,
         fullDetailOpen,
         selectedRelationActive,
         hasSelection: canvasSelectedSlug != null,
@@ -800,6 +831,7 @@ export function HomePage() {
     return () => window.removeEventListener("keydown", handler);
   }, [
     createNodeOpen,
+    ontologySearchOpen,
     fullDetailOpen,
     selectedRelationActive,
     canvasSelectedSlug,
@@ -2294,8 +2326,6 @@ export function HomePage() {
                   metricUsedBy: t("nodeDatasheet.metricUsedBy"),
                   metricDependsOn: t("nodeDatasheet.metricDependsOn"),
                   metricEvidence: t("nodeDatasheet.metricEvidence"),
-                  groupContains: t("nodeDatasheet.groupContains"),
-                  groupDepends: t("nodeDatasheet.groupDepends"),
                   noConnections: t("nodeDatasheet.noConnections"),
                   handoff: t("nodeDatasheet.handoff"),
                   close: t("controls.close"),

--- a/src/widgets/topology-map-v2/index.ts
+++ b/src/widgets/topology-map-v2/index.ts
@@ -17,7 +17,7 @@ export {
   buildV2ConnectionGroups,
   formatV2HandoffText,
   formatV2MetricLine,
-  groupV2Connections,
+  groupV2ConnectionsByDirection,
   V2_CONNECTION_ROW_CAP,
 } from './ui/topology-v2-datasheet';
 export type {

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -2,10 +2,12 @@
 
 import { type KeyboardEvent as ReactKeyboardEvent, useCallback } from "react";
 import { X } from "lucide-react";
+import { isContainmentRelation } from "@/shared/lib/ontology-tree";
 import {
   formatV2MetricLine,
   type V2ConnectionGroupsView,
   type V2ConnectionGroupView,
+  type V2DatasheetConnection,
   type V2MetricValues,
 } from "./topology-v2-datasheet";
 
@@ -23,6 +25,14 @@ import {
  * FSD: this widget owns its own prop shape — the view (`HomePage`) maps
  * `TopologyNodeFocusModel` into these props, so the import direction stays
  * view → widget. Colors/sizes come from `--topology-v2-panel-*` tokens.
+ *
+ * R+ 카운트 시맨틱 통일: connection groups are DIRECTION-based (usedBy /
+ * dependsOn) — the SAME axis the metric line counts — so the group header's
+ * number and the metric line's number are the same number by construction.
+ * Group headers reuse `labels.metricUsedBy`/`labels.metricDependsOn` (no
+ * separate group-label strings) so the words match too. Relation TYPE
+ * (containment vs depends) demotes to a per-row `TraceMark`, one per
+ * connection row instead of one per group header.
  */
 
 export interface TopologyV2DetailPanelLabels {
@@ -32,8 +42,6 @@ export interface TopologyV2DetailPanelLabels {
   metricUsedBy: string;
   metricDependsOn: string;
   metricEvidence: string;
-  groupContains: string;
-  groupDepends: string;
   noConnections: string;
   handoff: string;
   close: string;
@@ -127,24 +135,25 @@ function hexPoints(cx: number, cy: number, r: number): string {
 
 /**
  * Trace mini-line matching the canvas edge style: contains = solid hairline,
- * depends = dashed. One compact marker per group, drawn once in the group
- * header — never per row.
+ * depends = dashed. R+ moved this from the group header (one per group) to
+ * each row's leading position (one per row) — connection groups are now
+ * DIRECTION-based, so relation TYPE (containment vs depends) is no longer
+ * the grouping axis and needs a per-row marker to stay visible at all.
  */
-function TraceMark({ group }: { group: "contains" | "depends" }) {
-  const stroke =
-    group === "contains"
-      ? "var(--topology-v2-edge-contains-mark)"
-      : "var(--topology-v2-edge-depends-mark)";
+function TraceMark({ containment }: { containment: boolean }) {
+  const stroke = containment
+    ? "var(--topology-v2-edge-contains-mark)"
+    : "var(--topology-v2-edge-depends-mark)";
   return (
-    <svg width={22} height={6} viewBox="0 0 22 6" aria-hidden="true" className="shrink-0">
+    <svg width={14} height={6} viewBox="0 0 14 6" aria-hidden="true" className="shrink-0">
       <line
         x1={1}
         y1={3}
-        x2={21}
+        x2={13}
         y2={3}
         stroke={stroke}
         strokeWidth={1.4}
-        strokeDasharray={group === "depends" ? "3 3" : undefined}
+        strokeDasharray={containment ? undefined : "3 3"}
         strokeLinecap="round"
       />
     </svg>
@@ -170,7 +179,7 @@ export function TopologyV2DetailPanel({
     dependsOn: labels.metricDependsOn,
     evidence: labels.metricEvidence,
   });
-  const hasConnections = groups.contains.total > 0 || groups.depends.total > 0;
+  const hasConnections = groups.usedBy.total > 0 || groups.dependsOn.total > 0;
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -182,8 +191,13 @@ export function TopologyV2DetailPanel({
     [onClose],
   );
 
+  // Group headers reuse the SAME i18n stems as the metric line
+  // (`labels.metricUsedBy`/`labels.metricDependsOn`) — the header count and
+  // the metric count are the same number (§module doc), so the words must
+  // match too, or the reconciliation reads as a coincidence instead of a
+  // guarantee.
   const renderGroup = (
-    group: "contains" | "depends",
+    group: "usedBy" | "dependsOn",
     label: string,
     view: V2ConnectionGroupView,
   ) => {
@@ -192,7 +206,6 @@ export function TopologyV2DetailPanel({
     return (
       <div className="flex flex-col gap-1" data-datasheet-group={group}>
         <div className="flex items-center gap-2">
-          <TraceMark group={group} />
           <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-tertiary)]">
             {label}
           </span>
@@ -204,18 +217,19 @@ export function TopologyV2DetailPanel({
           </span>
         </div>
         <ul className="flex flex-col">
-          {view.rows.map((row) => (
-            // Direction is part of the key too — `groupV2Connections` only
-            // collapses same-direction duplicates; the same neighbor id can
-            // legitimately appear once outgoing and once incoming (a mutual
-            // dependency), which would otherwise collide on `group:id` alone.
-            <li key={`${group}:${row.direction}:${row.id}`}>
+          {view.rows.map((row: V2DatasheetConnection) => (
+            // Neighbor `id` is unique within a direction group post-dedup
+            // (`groupV2ConnectionsByDirection`) — the same neighbor can still
+            // appear once per group (mutual dependency, item 5 — no
+            // cross-group dedup), which is a different `group` prefix.
+            <li key={`${group}:${row.id}`}>
               <button
                 type="button"
                 onClick={() => onSelectConnection(row.id)}
                 data-datasheet-connection={row.id}
                 className="flex w-full items-center gap-2 rounded-[var(--topology-v2-panel-row-radius)] px-1.5 py-1 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
               >
+                <TraceMark containment={isContainmentRelation(row.relationType)} />
                 <span className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--topology-v2-panel-text-secondary)]">
                   {row.title}
                 </span>
@@ -226,7 +240,7 @@ export function TopologyV2DetailPanel({
         {overflow > 0 ? (
           <span
             data-datasheet-group-overflow={group}
-            className="pl-[30px] font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+            className="pl-[28px] font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]"
           >
             +{overflow}
           </span>
@@ -306,8 +320,8 @@ export function TopologyV2DetailPanel({
       <div className="flex flex-col gap-2.5">
         {hasConnections ? (
           <>
-            {renderGroup("contains", labels.groupContains, groups.contains)}
-            {renderGroup("depends", labels.groupDepends, groups.depends)}
+            {renderGroup("usedBy", labels.metricUsedBy, groups.usedBy)}
+            {renderGroup("dependsOn", labels.metricDependsOn, groups.dependsOn)}
           </>
         ) : (
           <span className="text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -5,7 +5,7 @@ import {
   buildV2ConnectionGroups,
   formatV2HandoffText,
   formatV2MetricLine,
-  groupV2Connections,
+  groupV2ConnectionsByDirection,
   type V2DatasheetConnection,
 } from "./topology-v2-datasheet";
 
@@ -18,45 +18,43 @@ const conn = (
   ...partial,
 });
 
-describe("groupV2Connections", () => {
-  it("splits containment relations (contains/belongs_to) from dependency relations", () => {
-    const grouped = groupV2Connections([
-      conn({ id: "child-a", relationType: "contains" }),
-      conn({ id: "parent", relationType: "belongs_to" }),
-      conn({ id: "dep-x", relationType: "depends_on" }),
-      conn({ id: "impl-y", relationType: "implements" }),
-      conn({ id: "use-z", relationType: "uses" }),
+describe("groupV2ConnectionsByDirection — DIRECTION is the grouping axis, not relation type", () => {
+  it("splits incoming (usedBy) from outgoing (dependsOn) regardless of relation type", () => {
+    const grouped = groupV2ConnectionsByDirection([
+      conn({ id: "child-a", relationType: "contains", direction: "outgoing" }),
+      conn({ id: "parent", relationType: "belongs_to", direction: "incoming" }),
+      conn({ id: "dep-x", relationType: "depends_on", direction: "outgoing" }),
+      conn({ id: "impl-y", relationType: "implements", direction: "incoming" }),
+      conn({ id: "use-z", relationType: "uses", direction: "outgoing" }),
     ]);
-    expect(grouped.contains.map((c) => c.id)).toEqual(["child-a", "parent"]);
-    expect(grouped.depends.map((c) => c.id)).toEqual(["dep-x", "impl-y", "use-z"]);
+    expect(grouped.usedBy.map((c) => c.id)).toEqual(["parent", "impl-y"]);
+    expect(grouped.dependsOn.map((c) => c.id)).toEqual(["child-a", "dep-x", "use-z"]);
   });
 
   it("preserves input order within each group and handles an empty list", () => {
-    expect(groupV2Connections([])).toEqual({ contains: [], depends: [] });
+    expect(groupV2ConnectionsByDirection([])).toEqual({ usedBy: [], dependsOn: [] });
   });
 
-  it("collapses the SAME neighbor+direction within a group even when relationType differs (mcp-server live bug: depends_on AND related_to to the same neighbor)", () => {
-    // The datasheet panel keys rows by (group, id) and shows only the title —
-    // it has no separate UI for "this is depends_on vs related_to" — so two
-    // rows for the SAME neighbor in the SAME direction read as one duplicated
-    // row and collide on the React list key. `buildV2Connections`'s own
-    // (id, relationType, direction) dedup can't catch this because the
-    // relationType genuinely differs; this is a SEPARATE, group-level collapse.
-    const grouped = groupV2Connections([
+  it("collapses the SAME neighbor id within a direction even when relationType differs (mcp-server live bug: depends_on AND related_to to the same neighbor)", () => {
+    // The datasheet panel keys rows by (direction, id) and shows only the
+    // title + a per-row type mark — two rows for the SAME neighbor in the
+    // SAME direction would otherwise read as one duplicated row and collide
+    // on the React list key.
+    const grouped = groupV2ConnectionsByDirection([
       conn({ id: "frontmatter-to-ontology", relationType: "depends_on", direction: "outgoing" }),
       conn({ id: "frontmatter-to-ontology", relationType: "related_to", direction: "outgoing" }),
     ]);
-    expect(grouped.depends).toHaveLength(1);
-    expect(grouped.depends[0]).toMatchObject({ id: "frontmatter-to-ontology", relationType: "depends_on" });
+    expect(grouped.dependsOn).toHaveLength(1);
+    expect(grouped.dependsOn[0]).toMatchObject({ id: "frontmatter-to-ontology", relationType: "depends_on" });
   });
 
   it("keeps the SAME neighbor id as two rows when it appears in OPPOSITE directions (a real mutual-dependency fact, not a duplicate)", () => {
-    const grouped = groupV2Connections([
+    const grouped = groupV2ConnectionsByDirection([
       conn({ id: "vault-local-first", relationType: "depends_on", direction: "outgoing" }),
       conn({ id: "vault-local-first", relationType: "depends_on", direction: "incoming" }),
     ]);
-    expect(grouped.depends).toHaveLength(2);
-    expect(grouped.depends.map((c) => c.direction)).toEqual(["outgoing", "incoming"]);
+    expect(grouped.usedBy.map((c) => c.id)).toEqual(["vault-local-first"]);
+    expect(grouped.dependsOn.map((c) => c.id)).toEqual(["vault-local-first"]);
   });
 });
 
@@ -100,7 +98,7 @@ describe("buildV2Connections", () => {
     // `depends_on` edges to `capability:frontmatter-to-ontology` (one direct,
     // one re-derived) — the datasheet rendered both as a React list keyed by
     // neighbor id, producing "Encountered two children with the same key"
-    // and a visibly duplicated DEPENDS row.
+    // and a visibly duplicated row.
     const parallelNodes = [
       { id: "mcp-server", title: "MCP Server", kind: "capability" },
       { id: "frontmatter-to-ontology", title: "Frontmatter → Ontology Stub", kind: "capability" },
@@ -130,30 +128,48 @@ describe("buildV2Connections", () => {
   });
 });
 
-describe("buildV2ConnectionGroups", () => {
-  it("caps each group independently and keeps the TRUE total (contains-hub bug)", () => {
-    // 8 contains + 2 depends — the old 5-item outgoing-first slice starved
-    // depends to empty; per-group capping keeps both totals honest.
+describe("buildV2ConnectionGroups — direction axis, single source for metric + header parity", () => {
+  it("caps each group independently and keeps the TRUE total (contains-heavy node bug analog)", () => {
+    // 8 outgoing + 2 incoming — a naive outgoing-first slice would starve
+    // the incoming (usedBy) group to empty; per-group capping keeps both
+    // totals honest regardless of relation type mix.
     const connections: V2DatasheetConnection[] = [
       ...Array.from({ length: 8 }, (_, i) =>
-        conn({ id: `c${i}`, relationType: "contains" }),
+        conn({ id: `d${i}`, relationType: "contains", direction: "outgoing" }),
       ),
-      conn({ id: "d0", relationType: "depends_on" }),
-      conn({ id: "d1", relationType: "uses" }),
+      conn({ id: "u0", relationType: "depends_on", direction: "incoming" }),
+      conn({ id: "u1", relationType: "uses", direction: "incoming" }),
     ];
     const groups = buildV2ConnectionGroups(connections, 6);
-    expect(groups.contains.total).toBe(8);
-    expect(groups.contains.rows).toHaveLength(6); // capped
-    expect(groups.depends.total).toBe(2);
-    expect(groups.depends.rows.map((r) => r.id)).toEqual(["d0", "d1"]); // never starved
+    expect(groups.dependsOn.total).toBe(8);
+    expect(groups.dependsOn.rows).toHaveLength(6); // capped
+    expect(groups.usedBy.total).toBe(2);
+    expect(groups.usedBy.rows.map((r) => r.id)).toEqual(["u0", "u1"]); // never starved
   });
 
   it("handles an empty set with zero totals", () => {
     const groups = buildV2ConnectionGroups([]);
     expect(groups).toEqual({
-      contains: { rows: [], total: 0 },
-      depends: { rows: [], total: 0 },
+      usedBy: { rows: [], total: 0 },
+      dependsOn: { rows: [], total: 0 },
     });
+  });
+
+  it("the group totals are the SAME numbers the metric line reports for the same connection set (the reconciliation guarantee)", () => {
+    // This is the actual persona bug: header said "used by 10 / depends on
+    // 73" while the groups below said "포함 71 / 의존 12" — two different
+    // axes computed independently. With direction as the ONLY axis, the
+    // group totals ARE the metric numbers by construction.
+    const connections: V2DatasheetConnection[] = [
+      conn({ id: "in-1", relationType: "contains", direction: "incoming" }),
+      conn({ id: "in-2", relationType: "depends_on", direction: "incoming" }),
+      conn({ id: "out-1", relationType: "depends_on", direction: "outgoing" }),
+    ];
+    const groups = buildV2ConnectionGroups(connections);
+    const metricUsedBy = groups.usedBy.total;
+    const metricDependsOn = groups.dependsOn.total;
+    expect(metricUsedBy).toBe(2);
+    expect(metricDependsOn).toBe(1);
   });
 });
 
@@ -174,7 +190,7 @@ describe("formatV2MetricLine", () => {
 });
 
 describe("formatV2HandoffText", () => {
-  it("emits a deterministic MCP/CLI-style payload with slug, typed facts, and a next action", () => {
+  it("emits a deterministic MCP/CLI-style payload with slug, typed facts, and direction-grouped name lists", () => {
     const text = formatV2HandoffText({
       slug: "mcp-server",
       kind: "capability",
@@ -182,7 +198,7 @@ describe("formatV2HandoffText", () => {
       usedBy: 5,
       dependsOn: 2,
       evidence: 3,
-      containsNames: ["mcp-tool-registry", "stdio-transport"],
+      usedByNames: ["frontmatter-to-ontology"],
       dependsNames: ["relation-graph"],
     });
     expect(text).toBe(
@@ -193,14 +209,14 @@ describe("formatV2HandoffText", () => {
         "used_by: 5",
         "depends_on: 2",
         "evidence: 3",
-        "contains: mcp-tool-registry, stdio-transport",
-        "depends: relation-graph",
+        "used_by_names: frontmatter-to-ontology",
+        "depends_names: relation-graph",
         'next: get_concept("mcp-server") → review context, then patch_concept / add_relation as needed',
       ].join("\n"),
     );
   });
 
-  it("falls back to '-' for a missing domain and for empty connection groups", () => {
+  it("falls back to '-' for a missing domain and for empty name lists", () => {
     const text = formatV2HandoffText({
       slug: "orphan",
       kind: "element",
@@ -208,11 +224,11 @@ describe("formatV2HandoffText", () => {
       usedBy: 0,
       dependsOn: 0,
       evidence: 0,
-      containsNames: [],
+      usedByNames: [],
       dependsNames: [],
     });
     expect(text).toContain("domain: -");
-    expect(text).toContain("contains: -");
-    expect(text).toContain("depends: -");
+    expect(text).toContain("used_by_names: -");
+    expect(text).toContain("depends_names: -");
   });
 });

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -7,12 +7,18 @@
  * The datasheet re-presents the SAME selection facts the shared popover already
  * derives (`TopologyNodeFocusModel`); the view maps that model into these
  * inputs. This module only groups + formats — it never recomputes counts.
+ *
+ * R+ 카운트 시맨틱 통일: groups used to split by relation TYPE (containment vs
+ * depends) while the metric line above counted by DIRECTION (incoming vs
+ * outgoing) — same words ("포함"/"의존" near "쓰는 곳"/"기대는 곳"), two
+ * different axes, so the numbers never reconciled (persona finding: header
+ * "used by 10 · depends on 73" vs groups "포함 71 / 의존 12"). Groups are now
+ * DIRECTION-based too, computed from the exact same connection set the metric
+ * line counts — the header count and the group total are the SAME number by
+ * construction, not just by convention. Relation TYPE (containment vs depends)
+ * demotes to a per-row trace mark (`TopologyV2DetailPanel.tsx`'s `TraceMark`),
+ * still visible, just no longer the grouping axis.
  */
-
-import { isContainmentRelation } from "@/shared/lib/ontology-tree";
-
-/** contains = structural containment (contains/belongs_to); depends = everything else. */
-export type V2ConnectionGroupKey = "contains" | "depends";
 
 export interface V2DatasheetConnection {
   id: string;
@@ -22,47 +28,49 @@ export interface V2DatasheetConnection {
   direction: "incoming" | "outgoing";
 }
 
+/** usedBy = incoming (places that use this node); dependsOn = outgoing
+ * (places this node leans on). The SAME axis the metric line counts. */
 export interface V2GroupedConnections {
-  contains: V2DatasheetConnection[];
-  depends: V2DatasheetConnection[];
+  usedBy: V2DatasheetConnection[];
+  dependsOn: V2DatasheetConnection[];
 }
 
 /**
- * Split direct connections into the two relation-type groups the datasheet
- * renders (one compact marker per group, not a per-row badge pile). Input
- * order is preserved inside each group so the panel stays deterministic.
+ * Split direct connections into the two DIRECTION groups the datasheet
+ * renders and the metric line counts — one axis, everywhere. Input order is
+ * preserved inside each group so the panel stays deterministic.
  *
- * Also collapses each group to one row per `(neighbor id, direction)` — the
- * live dogfood bug (`capability:mcp-server` had BOTH a `depends_on` AND a
- * `related_to` edge to the SAME neighbor, `capability:frontmatter-to-
- * ontology`) isn't caught by `buildV2Connections`'s own dedup (the
- * relationType genuinely differs there), but the panel shows only the
- * neighbor's title with no per-row relationType badge, so two rows for the
- * same neighbor in the same direction read as one duplicated row AND collide
- * on the React list key (`TopologyV2DetailPanel.tsx`'s `key={group:id}`).
+ * Also collapses each group to one row per neighbor `id` — the live dogfood
+ * bug (`capability:mcp-server` had BOTH a `depends_on` AND a `related_to`
+ * edge to the SAME neighbor, `capability:frontmatter-to-ontology`) isn't
+ * caught by `buildV2Connections`'s own dedup (the relationType genuinely
+ * differs there), but the panel shows only the neighbor's title with a
+ * per-row type mark, not a relationType-keyed row, so two rows for the same
+ * neighbor in the same direction read as one duplicated row AND collide on
+ * the React list key (`TopologyV2DetailPanel.tsx`'s `key={group:direction:id}`).
  * The SAME neighbor in the OPPOSITE direction (a real mutual-dependency fact)
- * is a different `(id, direction)` pair and stays as two rows.
+ * lands in the OTHER group and stays as two rows total — that's correct,
+ * not a duplicate (item 5 — no cross-group dedup).
  */
-export function groupV2Connections(
+export function groupV2ConnectionsByDirection(
   connections: readonly V2DatasheetConnection[],
 ): V2GroupedConnections {
-  const contains: V2DatasheetConnection[] = [];
-  const depends: V2DatasheetConnection[] = [];
-  const seenContains = new Set<string>();
-  const seenDepends = new Set<string>();
+  const usedBy: V2DatasheetConnection[] = [];
+  const dependsOn: V2DatasheetConnection[] = [];
+  const seenUsedBy = new Set<string>();
+  const seenDependsOn = new Set<string>();
   for (const connection of connections) {
-    const key = `${connection.id}|${connection.direction}`;
-    if (isContainmentRelation(connection.relationType)) {
-      if (seenContains.has(key)) continue;
-      seenContains.add(key);
-      contains.push(connection);
+    if (connection.direction === "incoming") {
+      if (seenUsedBy.has(connection.id)) continue;
+      seenUsedBy.add(connection.id);
+      usedBy.push(connection);
     } else {
-      if (seenDepends.has(key)) continue;
-      seenDepends.add(key);
-      depends.push(connection);
+      if (seenDependsOn.has(connection.id)) continue;
+      seenDependsOn.add(connection.id);
+      dependsOn.push(connection);
     }
   }
-  return { contains, depends };
+  return { usedBy, dependsOn };
 }
 
 /** Minimal structural shapes — keeps this module pure + testable without
@@ -135,40 +143,44 @@ export function buildV2Connections(
   return [...outgoing, ...incoming];
 }
 
-/** One relation-type group as the panel renders it: a capped preview of rows +
- * the group's TRUE total (so the header can say "DEPENDS 23" while showing 6). */
+/** One direction group as the panel renders it: a capped preview of rows +
+ * the group's TRUE total (so the header can say "쓰는 곳 23" while showing 6). */
 export interface V2ConnectionGroupView {
   rows: V2DatasheetConnection[];
   total: number;
 }
 export interface V2ConnectionGroupsView {
-  contains: V2ConnectionGroupView;
-  depends: V2ConnectionGroupView;
+  usedBy: V2ConnectionGroupView;
+  dependsOn: V2ConnectionGroupView;
 }
 
 /** Default rows shown per group before the typed "+N" overflow. */
 export const V2_CONNECTION_ROW_CAP = 6;
 
 /**
- * Group the full connection set by relation type and cap each group to
+ * Group the full connection set by DIRECTION and cap each group to
  * `perGroupCap` rows, keeping the true total. This guarantees BOTH groups can
- * render their real count independently — the contains-hub bug was that a single
- * outgoing-first 5-item slice starved the depends group to empty.
+ * render their real count independently — a hub node with many outgoing
+ * containment edges must not starve the (usually smaller) incoming group to
+ * empty. Because direction is the SAME axis the metric line counts, callers
+ * should source `metric.usedBy`/`metric.dependsOn` from `.usedBy.total`/
+ * `.dependsOn.total` here, not recompute them separately — that's what
+ * guarantees the metric line and the group headers can never diverge.
  */
 export function buildV2ConnectionGroups(
   connections: readonly V2DatasheetConnection[],
   perGroupCap: number = V2_CONNECTION_ROW_CAP,
 ): V2ConnectionGroupsView {
-  const grouped = groupV2Connections(connections);
+  const grouped = groupV2ConnectionsByDirection(connections);
   const cap = Math.max(0, perGroupCap);
   return {
-    contains: {
-      rows: grouped.contains.slice(0, cap),
-      total: grouped.contains.length,
+    usedBy: {
+      rows: grouped.usedBy.slice(0, cap),
+      total: grouped.usedBy.length,
     },
-    depends: {
-      rows: grouped.depends.slice(0, cap),
-      total: grouped.depends.length,
+    dependsOn: {
+      rows: grouped.dependsOn.slice(0, cap),
+      total: grouped.dependsOn.length,
     },
   };
 }
@@ -211,7 +223,10 @@ export interface V2HandoffInput {
   usedBy: number;
   dependsOn: number;
   evidence: number;
-  containsNames: readonly string[];
+  /** Names of the direct-incoming (usedBy) group's rows — same direction axis
+   * as `usedBy`, so the count and the list can never contradict. */
+  usedByNames: readonly string[];
+  /** Names of the direct-outgoing (dependsOn) group's rows. */
   dependsNames: readonly string[];
 }
 
@@ -220,6 +235,11 @@ export interface V2HandoffInput {
  * 액션 복사" differentiation. Stable English field keys + a suggested MCP call
  * so it pastes cleanly into a coding agent regardless of UI locale; the button
  * label is localized, this payload is intentionally not. Deterministic.
+ *
+ * R+ payload shape change: `contains`/`depends` name-list fields (relation
+ * TYPE axis) renamed to `used_by_names`/`depends_names` (relation DIRECTION
+ * axis) — matching the datasheet's groups now that direction is the single
+ * grouping axis everywhere. Agents parsing the old field names must update.
  */
 export function formatV2HandoffText(input: V2HandoffInput): string {
   const list = (names: readonly string[]) =>
@@ -231,8 +251,8 @@ export function formatV2HandoffText(input: V2HandoffInput): string {
     `used_by: ${input.usedBy}`,
     `depends_on: ${input.dependsOn}`,
     `evidence: ${input.evidence}`,
-    `contains: ${list(input.containsNames)}`,
-    `depends: ${list(input.dependsNames)}`,
+    `used_by_names: ${list(input.usedByNames)}`,
+    `depends_names: ${list(input.dependsNames)}`,
     `next: get_concept("${input.slug}") → review context, then patch_concept / add_relation as needed`,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

페르소나 발견 "카운트 계약 불일치"(3/5) 해소 — 리드 설계 / sonnet 구현 / opus 검증 SHIP.

- **그룹을 방향 기준으로 재편**: "쓰는 곳(used by)"/"기대는 곳(leans on)" — **수치가 그룹 총계에서 단일 파생**되어 헤더와 그룹이 구조적으로 어긋날 수 없음(실측: mcp-server 10·22 = 헤더 10·22, 전 kind·양 locale). 관계 타입은 행 내 실선/점선 트레이스 마커로 강등(frontmatter 교차검증 통과)
- 핸드오프 페이로드: `used_by_names`/`depends_names` 신설, 기계 계약 키(`used_by`/`depends_on`)는 불변(에이전트 호환 유지)
- **Esc 한 단계 닫기**: Radix capture-phase 레이스를 `defaultPrevented` 가드로 해결 + ladder에 searchOpen 티어 — 팔레트 열림+선택 상태에서 Esc 1회=팔레트만, 2회=선택 해제(실증)
- GlobalSearch aria 문구 정정(존재하지 않는 "documents" 약속 제거)

## Test plan

opus 검증 **SHIP**: tsc exit 0 · vitest ~507 · eslint 0 · i18n 26 · 잔존 구 API 소비자 0(그렙) · 라이브 DOM 판독으로 수치 일치·클립보드 페이로드·Esc 시퀀스·콘솔 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)