### PR TITLE
fix: ego 그래프 스케일 정직화 + 딥링크 전 형태 해석

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -613,7 +613,9 @@
       "neighborTitleAria": "{title} ({kind}, {direction})",
       "directionOutgoing": "from this concept",
       "directionIncoming": "to this concept",
-      "centerAria": "Center: {title}"
+      "centerAria": "Center: {title}",
+      "overflowChip": "{kind} +{count}",
+      "overflowChipAria": "{count} more {kind} neighbors not drawn here — open the list below"
     },
     "manualSourceChipTitle": "Node authored directly by a person or AI agent (vault frontmatter / save/edit / MCP)"
   },
@@ -3298,6 +3300,7 @@
       "footer": "Document nodes act as reference evidence and are kept separate from the tree. <strong>Use Edit relations for writes and Verify graph for graph DB-style scans.</strong>"
     },
     "titleTooltipAria": "Explain what the ontology workbench is",
+    "deeplinkNotFound": "Node not found: {query}",
     "actions": {
       "workbenchOverview": "Work overview",
       "workbenchOverviewTooltip": "Show the Concept map · Edit relations · Verify graph flow",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -613,7 +613,9 @@
       "neighborTitleAria": "{title} ({kind}, {direction})",
       "directionOutgoing": "이 개념에서",
       "directionIncoming": "이 개념으로",
-      "centerAria": "중심: {title}"
+      "centerAria": "중심: {title}",
+      "overflowChip": "{kind} +{count}",
+      "overflowChipAria": "표시 안 된 {kind} {count}개 — 아래 목록에서 전체 보기"
     },
     "manualSourceChipTitle": "사람 / AI agent 가 vault frontmatter · 저장·편집 · MCP 로 직접 작성한 노드"
   },
@@ -3298,6 +3300,7 @@
       "footer": "문서 노드는 참고 근거로 별도 보관하고, 여기서는 개념만 보여줍니다. <strong>관계를 고치려면 관계 편집, 검증 쿼리는 그래프 검증에서 이어가세요.</strong>"
     },
     "titleTooltipAria": "온톨로지 워크벤치가 무엇인지 설명",
+    "deeplinkNotFound": "노드를 찾을 수 없음: {query}",
     "actions": {
       "workbenchOverview": "이 화면 안내",
       "workbenchOverviewTooltip": "개념 지도 · 관계 편집 · 그래프 검증 흐름 보기",

--- a/src/views/ontology-view/lib/resolve-deeplink-node.test.ts
+++ b/src/views/ontology-view/lib/resolve-deeplink-node.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
-import { resolveOntologyDeeplinkNode } from "./resolve-deeplink-node";
+import {
+  computeDeeplinkNotFoundNotice,
+  resolveOntologyDeeplinkNode,
+} from "./resolve-deeplink-node";
 
 function node(overrides: Partial<KnowledgeGraphNode>): KnowledgeGraphNode {
   return {
@@ -55,5 +58,149 @@ describe("resolveOntologyDeeplinkNode", () => {
         node({ evidenceIds: ["capabilities/mcp-server"] }),
       ]),
     ).toBeNull();
+  });
+
+  it("matches a bare slug (post-colon segment of the node id) — agent-handoff deeplinks", () => {
+    const selected = node({ id: "capability:mcp-server" });
+
+    expect(resolveOntologyDeeplinkNode("mcp-server", [selected])).toBe(selected);
+  });
+
+  it("prefers capability over domain/element/document on bare-slug ambiguity", () => {
+    const capability = node({
+      id: "capability:reporting",
+      kind: "capability",
+    });
+    const domain = node({
+      id: "domain:reporting",
+      kind: "domain",
+    });
+    const element = node({
+      id: "element:reporting",
+      kind: "element",
+    });
+
+    expect(
+      resolveOntologyDeeplinkNode("reporting", [element, domain, capability]),
+    ).toBe(capability);
+  });
+
+  it("prefers domain over element/document when no capability shares the slug", () => {
+    const domain = node({ id: "domain:reporting", kind: "domain" });
+    const element = node({ id: "element:reporting", kind: "element" });
+    const doc = node({ id: "document:reporting", kind: "document" });
+
+    expect(
+      resolveOntologyDeeplinkNode("reporting", [doc, element, domain]),
+    ).toBe(domain);
+  });
+
+  it("falls back to element over document, and is order-independent (deterministic)", () => {
+    const element = node({ id: "element:reporting", kind: "element" });
+    const doc = node({ id: "document:reporting", kind: "document" });
+
+    expect(resolveOntologyDeeplinkNode("reporting", [doc, element])).toBe(element);
+    expect(resolveOntologyDeeplinkNode("reporting", [element, doc])).toBe(element);
+  });
+
+  // ADDITIONAL REPRO (owner screenshot, real vault) — the id format the
+  // producer emits and the id format the vault node actually carries can
+  // disagree on singular-vs-plural `kind` (colon OR folder-slash form), not
+  // just on "kind prefix present or absent" (already covered above). A
+  // resolver that only checks `node.id === normalized` verbatim silently
+  // no-ops here even though the node clearly exists.
+  it("resolves 'kind:slug' singular form even when the query's tail doesn't literally equal node.id (real repro string)", () => {
+    // vault node's own id happens to already equal this exact string —
+    // guards the trivial case (branch 1 direct match) does not regress.
+    const target = node({
+      id: "element:agent-activity-cli-command",
+      kind: "element",
+      title: "Agent Activity CLI Command",
+    });
+
+    expect(
+      resolveOntologyDeeplinkNode("element:agent-activity-cli-command", [target]),
+    ).toBe(target);
+  });
+
+  it("resolves a 'kinds/slug' plural path-style deeplink against a singular-kind node with the same tail", () => {
+    const target = node({
+      id: "element:agent-activity-cli-command",
+      kind: "element",
+      title: "Agent Activity CLI Command",
+    });
+
+    expect(
+      resolveOntologyDeeplinkNode("elements/agent-activity-cli-command", [target]),
+    ).toBe(target);
+  });
+
+  it("resolves a 'kind:slug' query even when the vault node's own id carries a plural kind prefix (authoring drift)", () => {
+    // Some producer/authoring path stored the node id with a plural kind
+    // segment (`elements:` instead of canonical `element:`) — a real id
+    // format mismatch, not just a missing kind prefix. The deeplink still
+    // names the right tail + a normalizable kind hint, so it should resolve
+    // instead of silently no-opping into the default empty state.
+    const target = node({
+      id: "elements:agent-activity-cli-command",
+      kind: "element",
+      title: "Agent Activity CLI Command",
+    });
+
+    expect(
+      resolveOntologyDeeplinkNode("element:agent-activity-cli-command", [target]),
+    ).toBe(target);
+    expect(
+      resolveOntologyDeeplinkNode("elements/agent-activity-cli-command", [target]),
+    ).toBe(target);
+  });
+
+  it("prefers the kind hint in 'kind:slug' / 'kinds/slug' queries to disambiguate a shared tail", () => {
+    const capability = node({ id: "capability:agent-activity-cli-command", kind: "capability" });
+    const element = node({ id: "element:agent-activity-cli-command", kind: "element" });
+
+    expect(
+      resolveOntologyDeeplinkNode("element:agent-activity-cli-command", [capability, element]),
+    ).toBe(element);
+    expect(
+      resolveOntologyDeeplinkNode("capabilities/agent-activity-cli-command", [capability, element]),
+    ).toBe(capability);
+  });
+
+  it("prefers the canonical id / builder-slug / evidence match over a bare-slug match", () => {
+    const exact = node({ id: "element:mcp-server", kind: "element" });
+    const decoy = node({ id: "capability:mcp-server-legacy", kind: "capability" });
+
+    // "mcp-server" bare-slug would only match `decoy` if we stripped
+    // "-legacy" — it doesn't, so this just guards that an exact id match
+    // short-circuits before bare-slug logic runs at all.
+    expect(resolveOntologyDeeplinkNode("element:mcp-server", [exact, decoy])).toBe(
+      exact,
+    );
+  });
+});
+
+describe("computeDeeplinkNotFoundNotice", () => {
+  it("returns null when there is no deeplink node id", () => {
+    expect(computeDeeplinkNotFoundNotice(null, null, null)).toBeNull();
+  });
+
+  it("returns null once the selected node already matches the deeplink id", () => {
+    expect(
+      computeDeeplinkNotFoundNotice("capability:mcp-server", "capability:mcp-server", null),
+    ).toBeNull();
+  });
+
+  it("returns null when the deeplink id resolved to a node", () => {
+    const resolved = node({ id: "capability:mcp-server" });
+    expect(
+      computeDeeplinkNotFoundNotice("mcp-server", null, resolved),
+    ).toBeNull();
+  });
+
+  it("returns the raw query when the deeplink id did not resolve — visible notice, no silent no-op", () => {
+    expect(
+      computeDeeplinkNotFoundNotice("nonexistent-xyz", null, null),
+    ).toBe("nonexistent-xyz");
   });
 });

--- a/src/views/ontology-view/lib/resolve-deeplink-node.ts
+++ b/src/views/ontology-view/lib/resolve-deeplink-node.ts
@@ -3,6 +3,89 @@ import {
   type KnowledgeGraphNode,
 } from "@/entities/knowledge-graph";
 
+/**
+ * bare-slug ambiguity 우선순위 — 같은 slug 를 여러 kind 가 공유할 때
+ * (드묾, 예: `domain:reporting` + `element:reporting`) 어느 kind 를 먼저
+ * 보여줄지 결정론적으로 고정. capability 가 "사람이 논의하는 제품 행동"
+ * 이라 가장 먼저, 그다음 domain(업무 경계) → element(구현 근거) →
+ * document(참고 문서) 순.
+ */
+const BARE_SLUG_KIND_PRIORITY = ["capability", "domain", "element", "document"];
+
+/**
+ * kind(singular) → vault 폴더(plural) 매핑의 로컬 미러. 원본은
+ * `src/entities/knowledge-graph/lib/ontology-node-href.ts` 의
+ * `KIND_TO_VAULT_FOLDER` (모듈 비공개 — 이 작업 scope 가 entities 를
+ * 건드릴 수 없어 3-entry 매핑만 로컬 복제. `document`/`project` 는 폴더
+ * 접두 딥링크 형태로 안 옴 — 매핑 대상 아님).
+ */
+const VAULT_FOLDER_TO_KIND: Record<string, string> = {
+  domains: "domain",
+  capabilities: "capability",
+  elements: "element",
+};
+
+function bareSlugOf(id: string): string {
+  const separatorIndex = id.indexOf(":");
+  return separatorIndex === -1 ? id : id.slice(separatorIndex + 1);
+}
+
+function kindPriorityRank(kind: string): number {
+  const rank = BARE_SLUG_KIND_PRIORITY.indexOf(kind);
+  return rank === -1 ? BARE_SLUG_KIND_PRIORITY.length : rank;
+}
+
+/**
+ * 딥링크 문자열에서 (있다면) kind 힌트와 매칭에 쓸 tail 을 뽑아낸다.
+ * agent/사람이 kind 접두사를 singular colon (`element:foo`) 으로 붙이든
+ * plural slash (`elements/foo`) 로 붙이든 붙이지 않든 (`foo`) 같은 노드를
+ * 가리키려는 의도는 같다 — 접두사 스타일과 무관하게 tail 만 비교하고,
+ * kind 힌트는 동일 tail 이 여러 kind 에 걸칠 때만 우선순위로 쓴다.
+ *
+ * plural 접두사가 알려진 vault 폴더가 아니면 (예: 중첩 소스 경로
+ * `cli/src/commands/foo.mjs`) kind 힌트 없이 전체 문자열을 그대로 tail 로
+ * 둔다 — evidence-path 매칭(위 direct 단계)이 이미 그 형태를 담당.
+ */
+function splitDeeplinkKindHintAndTail(normalized: string): {
+  kindHint: string | null;
+  tail: string;
+} {
+  const colonIndex = normalized.indexOf(":");
+  if (colonIndex > 0 && colonIndex < normalized.length - 1) {
+    const prefix = normalized.slice(0, colonIndex);
+    const tail = normalized.slice(colonIndex + 1);
+    return { kindHint: VAULT_FOLDER_TO_KIND[prefix] ?? prefix, tail };
+  }
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex > 0 && slashIndex < normalized.length - 1) {
+    const prefix = normalized.slice(0, slashIndex);
+    const mappedKind = VAULT_FOLDER_TO_KIND[prefix];
+    if (mappedKind) {
+      return { kindHint: mappedKind, tail: normalized.slice(slashIndex + 1) };
+    }
+  }
+  return { kindHint: null, tail: normalized };
+}
+
+/**
+ * `?node=<id>` 딥링크를 실제 노드로 해석.
+ *
+ * 매칭 우선순위:
+ * 1. canonical ontology id (`capability:mcp-server`) — 정확 일치.
+ * 2. builder 가 쓰는 vault slug (`capabilities/mcp-server`).
+ * 3. `ontology/` 접두 evidence id.
+ * 4. tail 매칭 — id 의 콜론 뒤 segment 만 비교, 딥링크 쪽 kind 접두사는
+ *    singular colon(`element:foo`) / plural slash(`elements/foo`) / 없음
+ *    (`foo`) 어느 형태든 정규화해서 뗀다. agent 가 kind 를 안 붙이거나,
+ *    실제 vault 노드의 id 가 kind 를 plural 로 잘못 저장한 authoring
+ *    drift(`elements:foo`) 여도 tail 이 같으면 찾는다. 여러 kind 가 같은
+ *    tail 을 공유하면 딥링크의 kind 힌트로 먼저 좁히고, 힌트가 없거나
+ *    안 맞으면 `BARE_SLUG_KIND_PRIORITY` 로 결정론적으로 하나를 고른다
+ *    (입력 배열 순서에 의존하지 않음).
+ *
+ * 1~3 이 하나라도 맞으면 4 는 시도하지 않는다 — canonical/evidence 매칭이
+ * 항상 tail 폴백보다 우선.
+ */
 export function resolveOntologyDeeplinkNode(
   nodeId: string,
   nodes: readonly KnowledgeGraphNode[],
@@ -10,13 +93,58 @@ export function resolveOntologyDeeplinkNode(
   const normalized = nodeId.trim();
   if (!normalized) return null;
 
-  return (
-    nodes.find((node) => {
-      if (node.id === normalized) return true;
-      if (resolveOntologyBuilderNodeSlug(node) === normalized) return true;
-      return node.evidenceIds.some(
-        (evidenceId) => evidenceId.replace(/^ontology\//, "") === normalized,
+  const direct = nodes.find((node) => {
+    if (node.id === normalized) return true;
+    if (resolveOntologyBuilderNodeSlug(node) === normalized) return true;
+    return node.evidenceIds.some(
+      (evidenceId) => evidenceId.replace(/^ontology\//, "") === normalized,
+    );
+  });
+  if (direct) return direct;
+
+  const { kindHint, tail } = splitDeeplinkKindHintAndTail(normalized);
+  if (!tail) return null;
+
+  const tailMatches = nodes.filter((node) => bareSlugOf(node.id) === tail);
+  if (tailMatches.length === 0) return null;
+  if (tailMatches.length === 1) return tailMatches[0]!;
+
+  if (kindHint) {
+    const withinHintedKind = tailMatches.filter((node) => node.kind === kindHint);
+    if (withinHintedKind.length > 0) {
+      const [bestOfHinted] = [...withinHintedKind].sort((a, b) =>
+        a.id.localeCompare(b.id),
       );
-    }) ?? null
-  );
+      return bestOfHinted!;
+    }
+    // kind 힌트가 이 tail 의 실제 kind 와 안 맞으면 (드묾) 아래 일반
+    // 우선순위로 폴백 — hint 를 무시하고 조용히 실패시키지 않는다.
+  }
+
+  const [best] = [...tailMatches].sort((a, b) => {
+    const rankDiff = kindPriorityRank(a.kind) - kindPriorityRank(b.kind);
+    if (rankDiff !== 0) return rankDiff;
+    return a.id.localeCompare(b.id);
+  });
+  return best!;
+}
+
+/**
+ * `?node=<id>` 가 있는데 해석이 안 됐을 때 보여줄 notice 문구용 query.
+ * null 이면 notice 를 숨긴다 (정상 — 딥링크 없음 / 이미 선택됨 / 해석 성공).
+ *
+ * 순수 함수로 분리 — effect 타이밍과 무관하게 "지금 notice 를 보여줘야
+ * 하는가" 를 독립적으로 테스트하기 위함. 회귀 실패 모드: 딥링크가 안 풀려도
+ * 아무 신호 없이 기본 empty state 만 보여 agent-handoff 흐름이 조용히
+ * 끊기는 것 (silent no-op).
+ */
+export function computeDeeplinkNotFoundNotice(
+  deeplinkNodeId: string | null,
+  selectedNodeId: string | null,
+  resolvedNode: KnowledgeGraphNode | null,
+): string | null {
+  if (!deeplinkNodeId) return null;
+  if (selectedNodeId === deeplinkNodeId) return null;
+  if (resolvedNode) return null;
+  return deeplinkNodeId;
 }

--- a/src/views/ontology-view/ui/NodeDetailPanel.layout.test.tsx
+++ b/src/views/ontology-view/ui/NodeDetailPanel.layout.test.tsx
@@ -6,6 +6,7 @@ import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
 import type { OntologyEgoSubgraph, OntologyReachability } from "@/shared/lib/ontology-tree";
 import { TooltipProvider } from "@/shared/ui";
 import {
+  DeeplinkNotFoundNotice,
   NodeDetailPanel,
   OntologyCommandBarHeader,
   OntologyMetaFooter,
@@ -20,6 +21,12 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => "/ko/ontology/",
 }));
+
+// jsdom 은 scrollIntoView 를 구현하지 않는다 — overflow 칩 클릭 핸들러가
+// 이걸 호출하므로 없으면 throw. 다른 위젯 테스트와 같은 폴리필 패턴.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
 
 vi.mock("@/i18n/navigation", () => ({
   Link: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
@@ -623,7 +630,12 @@ describe("NodeDetailPanel layout", () => {
     expect(
       screen.getByRole("button", { name: "Views에서 ontology-atlas로 연관 관계 연결" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "ontology-atlas 의 관계 그래프 (2단계)" })).toBeInTheDocument();
+    const egoGraphImg = screen.getByRole("img", { name: "ontology-atlas 의 관계 그래프 (2단계)" });
+    expect(egoGraphImg).toBeInTheDocument();
+    // fable sigma-surfaces 리뷰 #1 — 컨테이너가 svg 를 제약 없이 늘리면
+    // (예: ~990px) 320×200 viewBox 기준 라벨/화살표가 실제 노드보다 커지는
+    // 3배 이상 과확대 회귀가 생긴다. max-width 캡으로 방지.
+    expect(egoGraphImg.closest('[style]')).toHaveStyle({ maxWidth: "384px" });
     expect(relationGraphSection).not.toHaveTextContent("Reachability");
     expect(relationGraphSection).not.toHaveTextContent("3-hop");
     expect(relationGraphSection).not.toHaveTextContent("1-hop");
@@ -854,6 +866,78 @@ describe("NodeDetailPanel layout", () => {
     expect(screen.getByTestId("ontology-node-detail-section-relations")).not.toHaveAttribute(
       "hidden",
     );
+  });
+
+  it("caps a dense single-kind ego ring to a kind-grouped '+N' chip, and clicking it expands and scrolls the neighbor list below instead of dead-ending", () => {
+    const selected = node();
+    const neighbors = Array.from({ length: 14 }, (_, i) => {
+      const target = node({
+        id: `element:e-${i}`,
+        title: `Element ${i}`,
+        kind: "element",
+      });
+      return {
+        node: target,
+        neighborId: target.id,
+        edge: edge({
+          id: `edge:e-${i}`,
+          from: selected.id,
+          to: target.id,
+          type: "related_to",
+        }),
+        direction: "outgoing" as const,
+        hop: 1 as const,
+      };
+    });
+
+    renderPanel(selected, { ego: { centerId: selected.id, neighbors } });
+    fireEvent.click(screen.getByRole("tab", { name: "연결" }));
+
+    // dense (14 > 12 threshold): ego SVG draws a capped, kind-grouped subset
+    // (per-kind cap 8) and folds the rest into a "+N" chip instead of a
+    // 14-dot ring. "요소" = element's ko kind label.
+    const overflowChip = screen.getByRole("button", { name: "요소 +6" });
+    // preview-collapsed neighbor list below starts folded ("+8개 더").
+    expect(screen.getByRole("button", { name: "+8개 더" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    fireEvent.click(overflowChip);
+
+    // clicking overflow expands the same list the review calls out as
+    // "already there" — it must not be a dead end.
+    expect(screen.getByRole("button", { name: "접기" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(
+      screen.getAllByRole("button", { name: /Element \d+로 연관 관계 연결/ }),
+    ).toHaveLength(14);
+  });
+});
+
+describe("DeeplinkNotFoundNotice", () => {
+  it("renders nothing when there is no unresolved deeplink query", () => {
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DeeplinkNotFoundNotice query={null} />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.queryByTestId("ontology-deeplink-not-found")).not.toBeInTheDocument();
+  });
+
+  it("shows a visible notice naming the unresolved query instead of a silent no-op", () => {
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DeeplinkNotFoundNotice query="nonexistent-xyz" />
+      </NextIntlClientProvider>,
+    );
+
+    const notice = screen.getByTestId("ontology-deeplink-not-found");
+    expect(notice).toHaveTextContent("노드를 찾을 수 없음: nonexistent-xyz");
+    expect(notice).toHaveAttribute("role", "status");
   });
 });
 

--- a/src/views/ontology-view/ui/OntologyViewPage.tsx
+++ b/src/views/ontology-view/ui/OntologyViewPage.tsx
@@ -67,7 +67,10 @@ import {
   resolveReachabilityQuerySlug,
 } from "../lib/reachability-copy";
 import { formatQueryOntologyCall as mcpCall } from "@/shared/lib/ontology-query-call";
-import { resolveOntologyDeeplinkNode } from "../lib/resolve-deeplink-node";
+import {
+  computeDeeplinkNotFoundNotice,
+  resolveOntologyDeeplinkNode,
+} from "../lib/resolve-deeplink-node";
 import {
   buildOntologyReviewBrief,
   buildOntologyReviewTopologyHref,
@@ -160,27 +163,40 @@ export function OntologyViewPage() {
   // of truth: 외부 surface (검색 / 문서 / 직접 입력) 에서 URL 만 바뀌어도
   // 패널이 자동 열림. selectNode() 자체가 URL 도 갱신하므로 cycle 회피는
   // ID 비교로 (이미 같은 노드면 setState 호출 안 함).
+  //
+  // agent-handoff 딥링크가 안 풀리면 (bare slug 오타 / 삭제된 노드) 예전엔
+  // 아무 신호 없이 기본 empty state 만 보여 조용히 끊겼다 (silent no-op).
+  // deeplinkNotFoundId 가 그 실패를 눈에 보이는 notice 로 바꾼다.
   const deeplinkNodeId = searchParams.get("node");
+  const [deeplinkNotFoundId, setDeeplinkNotFoundId] = useState<string | null>(null);
   useEffect(() => {
     if (!insight) return;
     let cancelled = false;
     if (!deeplinkNodeId) {
-      if (selectedNode) {
-        window.queueMicrotask(() => {
-          if (!cancelled) setSelectedNode(null);
-        });
-      }
+      window.queueMicrotask(() => {
+        if (cancelled) return;
+        setDeeplinkNotFoundId(null);
+        if (selectedNode) setSelectedNode(null);
+      });
       return () => {
         cancelled = true;
       };
     }
-    if (selectedNode?.id === deeplinkNodeId) return;
-    const found = resolveOntologyDeeplinkNode(deeplinkNodeId, insight.nodes);
-    if (found) {
+    if (selectedNode?.id === deeplinkNodeId) {
       window.queueMicrotask(() => {
-        if (!cancelled) setSelectedNode(found);
+        if (!cancelled) setDeeplinkNotFoundId(null);
       });
+      return () => {
+        cancelled = true;
+      };
     }
+    const found = resolveOntologyDeeplinkNode(deeplinkNodeId, insight.nodes);
+    const notice = computeDeeplinkNotFoundNotice(deeplinkNodeId, selectedNode?.id ?? null, found);
+    window.queueMicrotask(() => {
+      if (cancelled) return;
+      setDeeplinkNotFoundId(notice);
+      if (found) setSelectedNode(found);
+    });
     return () => {
       cancelled = true;
     };
@@ -437,6 +453,8 @@ export function OntologyViewPage() {
           </div>
         </div>
       </section>
+
+      <DeeplinkNotFoundNotice query={deeplinkNotFoundId} />
 
       {showChangeReviewPanel ? (
         <div className="mb-3">
@@ -754,6 +772,26 @@ what this capability does.
       />
       </main>
     </>
+  );
+}
+
+/**
+ * `?node=<id>` 딥링크가 해석 안 됐을 때의 visible notice — 예전엔 이 경우
+ * 아무 신호 없이 기본 empty state 만 보여 agent-handoff 딥링크가 조용히
+ * 끊겼다 (fable sigma-surfaces 리뷰 #3). `query` 가 null 이면 아무것도
+ * 그리지 않는다 (정상 상태 — 딥링크 없음 / 이미 풀림).
+ */
+export function DeeplinkNotFoundNotice({ query }: { query: string | null }) {
+  const t = useTranslations('ontologyView');
+  if (!query) return null;
+  return (
+    <div
+      role="status"
+      data-testid="ontology-deeplink-not-found"
+      className="mb-3 rounded-md border border-[color:rgba(255,179,71,0.28)] bg-[color:rgba(255,179,71,0.06)] px-3 py-2 text-[12px] text-[color:var(--color-text-secondary)]"
+    >
+      {t('deeplinkNotFound', { query })}
+    </div>
   );
 }
 
@@ -1492,6 +1530,14 @@ export function NodeDetailPanel({
   };
   const NEIGHBOR_PREVIEW = 6;
   const EVIDENCE_PREVIEW = 6;
+  // ego SVG 의 dense-ring "+N" 칩 클릭 시 — 이미 렌더 중인 neighbor 목록을
+  // 펼치고 그쪽으로 스크롤. "숨긴 나머지"가 항상 도달 가능한 곳으로 이어진다
+  // (fable sigma-surfaces 리뷰 #2 — overflow 는 막다른 길이면 안 됨).
+  const neighborListRef = useRef<HTMLUListElement | null>(null);
+  const handleEgoOverflowClick = () => {
+    setShowAllNeighbors(() => true);
+    neighborListRef.current?.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+  };
   const shouldClampSummary = (node.summary?.length ?? 0) > 180;
   const summaryText = node.summary && shouldClampSummary && !showFullSummary
     ? buildCollapsedSummaryPreview(node.summary)
@@ -2782,17 +2828,25 @@ export function NodeDetailPanel({
               </Tooltip>
             </div>
           </div>
-          {/* ego SVG — 데스크톱·모바일 모두 노출. 큰 ego (>12) 도 작동
-              하지만 라벨 겹침 가능 — 그 경우는 트리·검색 surface 가 보조.
-              2-hop 토글 시 동심원 (1-hop inner / 2-hop outer) 으로 분리. */}
-          <div className="mt-2 overflow-hidden rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)]">
+          {/* ego SVG — 데스크톱·모바일 모두 노출. dense ego (>12) 는 위젯이
+              kind 별로 그룹핑해 "+N" 칩으로 접는다 (194개 점 ring 방지).
+              2-hop 토글 시 동심원 (1-hop inner / 2-hop outer) 으로 분리.
+              max-width 는 svg 의 320×200 viewBox 디자인 의도(라벨 10px,
+              화살표 markerWidth 6)를 넘어 과확대되지 않게 캡 — 컨테이너
+              폭에 그대로 늘리면 라벨/화살표가 실제 노드보다 커지는 회귀
+              (fable sigma-surfaces 리뷰 #1). 캡 아래로는 그대로 반응형. */}
+          <div
+            className="mx-auto mt-2 w-full overflow-hidden rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)]"
+            style={{ maxWidth: 384 }}
+          >
             <OntologyEgoGraph
               ego={ego}
               centerNode={node}
               onSelectNeighbor={onSelectNeighbor}
+              onOverflowClick={handleEgoOverflowClick}
             />
           </div>
-          <ul className="mt-2 space-y-1">
+          <ul ref={neighborListRef} className="mt-2 space-y-1">
             {(showAllNeighbors ? ego.neighbors : ego.neighbors.slice(0, NEIGHBOR_PREVIEW)).map((neighbor) => {
               const isOutgoing = neighbor.direction === "outgoing";
               const directionLabel = isOutgoing

--- a/src/widgets/ontology-ego-graph/lib/dense-grouping.test.ts
+++ b/src/widgets/ontology-ego-graph/lib/dense-grouping.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import type { OntologyEgoNeighbor } from "@/shared/lib/ontology-tree";
+import { EGO_LABEL_DENSE_THRESHOLD } from "./label-visibility";
+import {
+  EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP,
+  groupEgoNeighborsForDenseRing,
+} from "./dense-grouping";
+
+function node(overrides: Partial<KnowledgeGraphNode> = {}): KnowledgeGraphNode {
+  return {
+    id: "element:x",
+    title: "x",
+    kind: "element",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date(0),
+    lastApprovedBy: "test",
+    ...overrides,
+  };
+}
+
+function neighbor(
+  overrides: Partial<OntologyEgoNeighbor> & { hop: 1 | 2 },
+): OntologyEgoNeighbor {
+  const id = overrides.neighborId ?? `n${Math.random()}`;
+  return {
+    node: node({ id }),
+    neighborId: id,
+    edge: {
+      id: `edge:${id}`,
+      from: "center",
+      to: id,
+      type: "related_to",
+      projectIds: [],
+      evidenceIds: [],
+      lastApprovedAt: new Date(0),
+      lastApprovedBy: "test",
+    },
+    direction: "outgoing",
+    ...overrides,
+  };
+}
+
+function ringOfKind(count: number, hop: 1 | 2, kind: string, idPrefix: string) {
+  return Array.from({ length: count }, (_, i) => {
+    const id = `${kind}:${idPrefix}-${i}`;
+    return neighbor({ hop, neighborId: id, node: node({ id, kind }) });
+  });
+}
+
+describe("groupEgoNeighborsForDenseRing", () => {
+  it("passes small rings through unchanged (regression — <12 neighbors unaffected)", () => {
+    const neighbors = [
+      ...ringOfKind(5, 1, "element", "e"),
+      ...ringOfKind(3, 2, "capability", "c"),
+    ];
+
+    const result = groupEgoNeighborsForDenseRing(neighbors);
+
+    expect(result.visible).toHaveLength(8);
+    expect(result.visible).toEqual(neighbors);
+    expect(result.overflow).toEqual([]);
+  });
+
+  it("passes a ring through unchanged at exactly the dense threshold", () => {
+    const neighbors = ringOfKind(EGO_LABEL_DENSE_THRESHOLD, 1, "element", "e");
+
+    const result = groupEgoNeighborsForDenseRing(neighbors);
+
+    expect(result.visible).toHaveLength(EGO_LABEL_DENSE_THRESHOLD);
+    expect(result.overflow).toEqual([]);
+  });
+
+  it("caps a single-kind dense ring to the per-kind cap and reports the remainder as one overflow group", () => {
+    const neighbors = ringOfKind(34, 1, "element", "e");
+
+    const result = groupEgoNeighborsForDenseRing(neighbors);
+
+    expect(result.visible).toHaveLength(EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP);
+    expect(result.visible).toEqual(
+      neighbors.slice(0, EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP),
+    );
+    expect(result.overflow).toEqual([
+      { hop: 1, kind: "element", count: 34 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP },
+    ]);
+  });
+
+  it("never draws a 194-dot ring — 2-hop dense breakdown caps drawn nodes per kind", () => {
+    // dogfood-shaped case: capability:mcp-server has 34 1-hop, 194 2-hop.
+    const hop1 = ringOfKind(34, 1, "element", "e1");
+    const hop2 = [
+      ...ringOfKind(120, 2, "element", "e2"),
+      ...ringOfKind(74, 2, "capability", "c2"),
+    ];
+
+    const result = groupEgoNeighborsForDenseRing([...hop1, ...hop2]);
+
+    const drawnHop2 = result.visible.filter((n) => n.hop === 2);
+    expect(drawnHop2.length).toBeLessThan(30);
+    expect(drawnHop2.length).toBe(EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP * 2);
+    const overflowHop2 = result.overflow.filter((g) => g.hop === 2);
+    expect(overflowHop2).toEqual(
+      expect.arrayContaining([
+        { hop: 2, kind: "element", count: 120 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP },
+        { hop: 2, kind: "capability", count: 74 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP },
+      ]),
+    );
+  });
+
+  it("treats hop=1 and hop=2 rings independently — one ring can be dense while the other is not", () => {
+    const hop1 = ringOfKind(5, 1, "element", "e"); // not dense
+    const hop2 = ringOfKind(40, 2, "capability", "c"); // dense
+
+    const result = groupEgoNeighborsForDenseRing([...hop1, ...hop2]);
+
+    expect(result.visible.filter((n) => n.hop === 1)).toHaveLength(5);
+    expect(result.visible.filter((n) => n.hop === 2)).toHaveLength(
+      EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP,
+    );
+    expect(result.overflow).toEqual([
+      { hop: 2, kind: "capability", count: 40 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP },
+    ]);
+  });
+
+  it("groups missing (node === null) neighbors under an 'unknown' kind bucket", () => {
+    const neighbors = Array.from({ length: 20 }, (_, i) =>
+      neighbor({ hop: 1, neighborId: `missing-${i}`, node: null }),
+    );
+
+    const result = groupEgoNeighborsForDenseRing(neighbors);
+
+    expect(result.visible).toHaveLength(EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP);
+    expect(result.overflow).toEqual([
+      { hop: 1, kind: "unknown", count: 20 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP },
+    ]);
+  });
+
+  it("supports a custom per-kind cap", () => {
+    const neighbors = ringOfKind(20, 1, "element", "e");
+
+    const result = groupEgoNeighborsForDenseRing(neighbors, 3);
+
+    expect(result.visible).toHaveLength(3);
+    expect(result.overflow).toEqual([{ hop: 1, kind: "element", count: 17 }]);
+  });
+});

--- a/src/widgets/ontology-ego-graph/lib/dense-grouping.ts
+++ b/src/widgets/ontology-ego-graph/lib/dense-grouping.ts
@@ -1,0 +1,97 @@
+import type { OntologyEgoNeighbor } from "@/shared/lib/ontology-tree";
+import { EGO_LABEL_DENSE_THRESHOLD } from "./label-visibility";
+
+/**
+ * dense ego 대응 — kind 별 overflow 요약. 개별 dot 으로 안 그리고 남은
+ * 개수만 들고 있다가 UI 가 "{kind} +{count}" 칩으로 렌더.
+ */
+export interface EgoOverflowGroup {
+  hop: 1 | 2;
+  kind: string;
+  count: number;
+}
+
+export interface DenseEgoGrouping {
+  /** 실제로 ring 에 그릴 (제한된) neighbor 목록 — hop=1 먼저, hop=2 다음. */
+  visible: OntologyEgoNeighbor[];
+  /** kind 별로 접힌 나머지. 빈 배열 = dense 아님 (원본 그대로 통과). */
+  overflow: EgoOverflowGroup[];
+}
+
+/**
+ * ring 하나(같은 hop)당 kind 별로 남기는 최대 개수. 8~10 권장 범위의
+ * 중간값 — 라벨이 겹치지 않을 만큼 작으면서 "이 kind 에 뭐가 있는지"
+ * 감 잡기엔 충분한 수.
+ */
+export const EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP = 8;
+
+function neighborKind(neighbor: OntologyEgoNeighbor): string {
+  return neighbor.node?.kind ?? "unknown";
+}
+
+/**
+ * ring 하나(hop 고정) 를 kind 별로 그룹 짓고 그룹당 `perKindCap` 개만
+ * 남긴다. threshold(`EGO_LABEL_DENSE_THRESHOLD`) 이하면 원본 그대로 통과
+ * — 회귀 없음 (기존 <12 ego 는 지금과 똑같이 보인다).
+ *
+ * kind 순서는 입력에서 처음 등장한 순서 그대로 유지 (build-ego 의 안정적인
+ * outgoing→incoming→hop2 정렬을 그대로 반영, 임의 재정렬 없음).
+ */
+function capRing(
+  ring: OntologyEgoNeighbor[],
+  hop: 1 | 2,
+  perKindCap: number,
+): { visible: OntologyEgoNeighbor[]; overflow: EgoOverflowGroup[] } {
+  if (ring.length <= EGO_LABEL_DENSE_THRESHOLD) {
+    return { visible: ring, overflow: [] };
+  }
+
+  const kindOrder: string[] = [];
+  const byKind = new Map<string, OntologyEgoNeighbor[]>();
+  for (const item of ring) {
+    const kind = neighborKind(item);
+    if (!byKind.has(kind)) {
+      byKind.set(kind, []);
+      kindOrder.push(kind);
+    }
+    byKind.get(kind)!.push(item);
+  }
+
+  const visible: OntologyEgoNeighbor[] = [];
+  const overflow: EgoOverflowGroup[] = [];
+  for (const kind of kindOrder) {
+    const group = byKind.get(kind)!;
+    const kept = group.slice(0, perKindCap);
+    visible.push(...kept);
+    const remainder = group.length - kept.length;
+    if (remainder > 0) {
+      overflow.push({ hop, kind, count: remainder });
+    }
+  }
+  return { visible, overflow };
+}
+
+/**
+ * ego neighbor 전체를 dense-scale 대응 kind-grouped 형태로 축소.
+ *
+ * 1-hop / 2-hop 링을 독립적으로 취급한다 — dogfood 의 `capability:mcp-server`
+ * 처럼 1-hop(34) 은 dense 이고 2-hop(194) 은 훨씬 더 dense 인 비대칭 케이스가
+ * 흔하다. 194개 점을 다 그리는 moiré ring 은 절대 만들지 않는다: 한 kind 당
+ * `perKindCap` 개만 그리고, 나머지는 kind 별 overflow 카운트로 접는다.
+ *
+ * Shneiderman 의 overview-first — 세부는 필요할 때(neighbor 리스트 / "+N"
+ * 클릭)만 연다.
+ */
+export function groupEgoNeighborsForDenseRing(
+  neighbors: OntologyEgoNeighbor[],
+  perKindCap: number = EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP,
+): DenseEgoGrouping {
+  const hop1 = neighbors.filter((n) => n.hop === 1);
+  const hop2 = neighbors.filter((n) => n.hop === 2);
+  const cappedHop1 = capRing(hop1, 1, perKindCap);
+  const cappedHop2 = capRing(hop2, 2, perKindCap);
+  return {
+    visible: [...cappedHop1.visible, ...cappedHop2.visible],
+    overflow: [...cappedHop1.overflow, ...cappedHop2.overflow],
+  };
+}

--- a/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.test.tsx
+++ b/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.test.tsx
@@ -1,0 +1,150 @@
+import { NextIntlClientProvider } from "next-intl";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { vi } from "vitest";
+import enMessages from "../../../../messages/en.json";
+import type { KnowledgeGraphNode, KnowledgeGraphEdge } from "@/entities/knowledge-graph";
+import type { OntologyEgoNeighbor, OntologyEgoSubgraph } from "@/shared/lib/ontology-tree";
+import { EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP } from "../lib/dense-grouping";
+import { OntologyEgoGraph } from "./OntologyEgoGraph";
+
+function node(overrides: Partial<KnowledgeGraphNode> = {}): KnowledgeGraphNode {
+  return {
+    id: "element:x",
+    title: "X",
+    kind: "element",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date(0),
+    lastApprovedBy: "test",
+    ...overrides,
+  };
+}
+
+function edge(overrides: Partial<KnowledgeGraphEdge> & { id: string }): KnowledgeGraphEdge {
+  return {
+    from: "center",
+    to: "neighbor",
+    type: "related_to",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date(0),
+    lastApprovedBy: "test",
+    ...overrides,
+  };
+}
+
+function neighbor(
+  overrides: Partial<OntologyEgoNeighbor> & { hop: 1 | 2; neighborId: string },
+): OntologyEgoNeighbor {
+  return {
+    node: node({ id: overrides.neighborId }),
+    edge: edge({ id: `edge:${overrides.neighborId}`, to: overrides.neighborId }),
+    direction: "outgoing",
+    ...overrides,
+  };
+}
+
+function ringOfKind(count: number, hop: 1 | 2, kind: string, idPrefix: string) {
+  return Array.from({ length: count }, (_, i) => {
+    const id = `${kind}:${idPrefix}-${i}`;
+    return neighbor({ hop, neighborId: id, node: node({ id, kind, title: id }) });
+  });
+}
+
+function renderEgoGraph(
+  neighbors: OntologyEgoNeighbor[],
+  props: Partial<Parameters<typeof OntologyEgoGraph>[0]> = {},
+) {
+  const ego: OntologyEgoSubgraph = { centerId: "center", neighbors };
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <OntologyEgoGraph
+        ego={ego}
+        centerNode={node({ id: "center", title: "Center" })}
+        {...props}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("OntologyEgoGraph — dense-scale rendering", () => {
+  it("regression: a small ego (<12 neighbors) draws and labels every neighbor as before", () => {
+    const neighbors = [
+      ...ringOfKind(4, 1, "element", "e"),
+      ...ringOfKind(2, 2, "capability", "c"),
+    ];
+    renderEgoGraph(neighbors);
+
+    const shownNodes = document.querySelectorAll('[data-neighbor-index]');
+    expect(shownNodes).toHaveLength(6);
+    for (const el of Array.from(shownNodes)) {
+      expect(el.getAttribute("data-label-shown")).toBe("true");
+    }
+    expect(screen.queryByRole("button", { name: /\+/ })).not.toBeInTheDocument();
+  });
+
+  it("caps a dense single-kind ring to the per-kind cap and shows a '+N' overflow chip instead of a giant dot ring", () => {
+    const neighbors = ringOfKind(34, 1, "element", "e");
+    renderEgoGraph(neighbors);
+
+    const shownNodes = document.querySelectorAll('[data-neighbor-index]');
+    expect(shownNodes).toHaveLength(EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP);
+
+    const remainder = 34 - EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP;
+    expect(
+      screen.getByRole("button", { name: `Element +${remainder}` }),
+    ).toBeInTheDocument();
+  });
+
+  it("never draws a 194-dot ring — 2-hop dense breakdown caps drawn nodes across kinds", () => {
+    const hop1 = ringOfKind(34, 1, "element", "e1");
+    const hop2 = [
+      ...ringOfKind(120, 2, "element", "e2"),
+      ...ringOfKind(74, 2, "capability", "c2"),
+    ];
+    renderEgoGraph([...hop1, ...hop2]);
+
+    const shownNodes = document.querySelectorAll('[data-neighbor-index]');
+    // capped: 8 (hop1 element) + 8 (hop2 element) + 8 (hop2 capability) = 24, never 34+194=228.
+    expect(shownNodes.length).toBe(EGO_DENSE_GROUPING_DEFAULT_PER_KIND_CAP * 3);
+    expect(shownNodes.length).toBeLessThan(30);
+  });
+
+  it("invokes onOverflowClick when an overflow chip is activated", () => {
+    const onOverflowClick = vi.fn();
+    const neighbors = ringOfKind(20, 1, "element", "e");
+    renderEgoGraph(neighbors, { onOverflowClick });
+
+    const chip = screen.getByRole("button", { name: "Element +12" });
+    fireEvent.click(chip);
+    expect(onOverflowClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OntologyEgoGraph — preserved strengths", () => {
+  it("keeps neighbors keyboard-operable (Tab focus + Enter selects)", () => {
+    const onSelectNeighbor = vi.fn();
+    const target = node({ id: "element:target", title: "Target" });
+    renderEgoGraph(
+      [neighbor({ hop: 1, neighborId: "element:target", node: target })],
+      { onSelectNeighbor },
+    );
+
+    const button = screen.getByRole("button", { name: /Target/ });
+    fireEvent.keyDown(button, { key: "Enter" });
+    expect(onSelectNeighbor).toHaveBeenCalledWith(target);
+  });
+
+  it("keeps a native <title> tooltip on every neighbor for hover/focus identification", () => {
+    const target = node({ id: "element:target", title: "Target" });
+    renderEgoGraph([neighbor({ hop: 1, neighborId: "element:target", node: target })]);
+
+    const group = document.querySelector('[data-neighbor-index="0"]')!;
+    expect(within(group as HTMLElement).getByText(/Target \(/)).toBeInTheDocument();
+  });
+
+  it("keeps the ego graph as an accessible <svg role=img>", () => {
+    renderEgoGraph(ringOfKind(2, 1, "element", "e"));
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.tsx
+++ b/src/widgets/ontology-ego-graph/ui/OntologyEgoGraph.tsx
@@ -13,6 +13,7 @@ import {
   computeEgoLabelDensity,
   shouldShowEgoLabel,
 } from "../lib/label-visibility";
+import { groupEgoNeighborsForDenseRing } from "../lib/dense-grouping";
 
 export interface OntologyEgoGraphProps {
   ego: OntologyEgoSubgraph;
@@ -20,6 +21,12 @@ export interface OntologyEgoGraphProps {
   centerNode: KnowledgeGraphNode;
   /** neighbor 클릭 시 호출 — 미존재 (node === null) 노드는 클릭 불가. */
   onSelectNeighbor?: (node: KnowledgeGraphNode) => void;
+  /**
+   * dense ring 의 "{kind} +N" overflow 칩 클릭 시 호출. 보통 호출자가 이미
+   * 렌더하고 있는 neighbor 목록(패널 하단)을 펼치고 그쪽으로 스크롤 —
+   * "숨긴 나머지"가 어디로 가는지 항상 도달 가능해야 하기 때문.
+   */
+  onOverflowClick?: () => void;
   /** 기본 320 — 패널 폭에 맞게 조정 가능. */
   width?: number;
   /** 기본 200 — 노드 라벨 안 잘리게 200 권장. */
@@ -43,19 +50,36 @@ export function OntologyEgoGraph({
   ego,
   centerNode,
   onSelectNeighbor,
+  onOverflowClick,
   width = 320,
   height = 200,
 }: OntologyEgoGraphProps) {
   const t = useTranslations('ontologyWidgets');
   const kindLabel = useOntologyKindLabel();
+
+  // dense-scale 대응 (fable sigma-surfaces 리뷰 #2) — 194개 점을 다 그리는
+  // moiré ring 을 만들지 않는다. kind 별로 최대 개수만 남기고 나머지는
+  // "{kind} +N" overflow 칩으로 접는다. <12 ego 는 그대로 통과 (회귀 없음).
+  const grouped = useMemo(
+    () => groupEgoNeighborsForDenseRing(ego.neighbors),
+    [ego.neighbors],
+  );
+  const cappedEgo: OntologyEgoSubgraph = useMemo(
+    () => ({ centerId: ego.centerId, neighbors: grouped.visible }),
+    [ego.centerId, grouped.visible],
+  );
   const layout = useMemo(
-    () => buildRadialEgoLayout(ego, width, height, { padding: 36 }),
-    [ego, width, height],
+    () => buildRadialEgoLayout(cappedEgo, width, height, { padding: 36 }),
+    [cappedEgo, width, height],
   );
 
   // dense ring 일 때만 hover 한 라벨만 노출 — 다른 라벨은 native <title>
-  // 툴팁으로 폴백. dense 가 아니면 hover 상태와 무관하게 모두 보임.
-  const density = useMemo(() => computeEgoLabelDensity(ego.neighbors), [ego.neighbors]);
+  // 툴팁으로 폴백. dense 가 아니면 hover 상태와 무관하게 모두 보임. capping
+  // 이후의 목록 기준 — 그룹핑으로 threshold 아래로 줄었으면 항상 라벨 노출.
+  const density = useMemo(
+    () => computeEgoLabelDensity(grouped.visible),
+    [grouped.visible],
+  );
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   if (ego.neighbors.length === 0) {
@@ -63,6 +87,7 @@ export function OntologyEgoGraph({
   }
 
   return (
+    <div className="w-full">
     <svg
       viewBox={`0 0 ${width} ${height}`}
       width="100%"
@@ -74,6 +99,12 @@ export function OntologyEgoGraph({
       }
       className="block max-w-full"
     >
+      {/* fable sigma-surfaces 리뷰 #4 — 아래 rgba(94,106,210,*) / rgba(159,170,235,*) /
+          rgba(180,186,200,*) / rgba(140,148,168,*) 는 각 hop·direction 조합마다
+          다른 alpha 가 필요해 1:1 매칭되는 --color-* 토큰이 없다 (94,106,210 자체는
+          --color-indigo-brand 와 채널이 같지만 alpha 변형을 var() 로 표현할 토큰이
+          없음). 이번 패스는 신규 토큰을 만들지 않기로 해 하드코딩 유지 — 다음 토큰
+          정리 패스의 대상으로 남겨둔다. */}
       <defs>
         {/* 화살표 마커 — outgoing 인디고, incoming 무채색 */}
         <marker id="ego-arrow-out" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -112,9 +143,9 @@ export function OntologyEgoGraph({
         );
       })}
 
-      {/* neighbors */}
+      {/* neighbors — capped/grouped 목록 기준 (raw ego.neighbors 아님). */}
       {layout.neighbors.map((point, i) => {
-        const neighbor = ego.neighbors[i]!;
+        const neighbor = grouped.visible[i]!;
         const node = neighbor.node;
         const title = node?.title ?? neighbor.neighborId;
         const neighborKindLabel = node ? kindLabel(node.kind) : t('egoGraph.neighborMissingKind');
@@ -194,7 +225,7 @@ export function OntologyEgoGraph({
                 y={point.y + labelDy}
                 textAnchor={labelAnchor}
                 fontSize={10}
-                fill="rgba(220,226,240,0.80)"
+                fill="var(--color-text-secondary)"
                 fontFamily="Inter, system-ui, sans-serif"
               >
                 {truncated}
@@ -216,5 +247,30 @@ export function OntologyEgoGraph({
         />
       </g>
     </svg>
+    {grouped.overflow.length > 0 ? (
+      <div className="mt-1.5 flex flex-wrap gap-1 px-1 pb-1">
+        {grouped.overflow.map((group) => {
+          const overflowKindLabel =
+            group.kind === "unknown"
+              ? t('egoGraph.neighborMissingKind')
+              : kindLabel(group.kind);
+          return (
+            <button
+              key={`${group.hop}-${group.kind}`}
+              type="button"
+              onClick={onOverflowClick}
+              title={t('egoGraph.overflowChipAria', {
+                count: group.count,
+                kind: overflowKindLabel,
+              })}
+              className="rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:rgba(94,106,210,0.32)] hover:text-[color:var(--color-text-secondary)]"
+            >
+              {t('egoGraph.overflowChip', { kind: overflowKindLabel, count: group.count })}
+            </button>
+          );
+        })}
+      </div>
+    ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Sigma 표면 검수 P1 + 소유자 스크린샷 실버그 — fable 처방 / sonnet 구현(TDD 전면).

- **3.1× 업스케일 해소**: 컨테이너 384px 캡 — 화살표가 노드보다 크던 장식 잉크 역전 제거
- **밀집 스케일 전략**: 링당 >12 이웃이면 kind 그룹 8개 캡 + "{kind} +N" 오버플로 칩(클릭=이웃 목록 스크롤 — 막다른 길 없음). 실측: 1-hop 34→16+칩, 2-hop 194→유계 링+칩 5(194점 기어링 소멸)
- **딥링크 전 형태 해석**: 소유자 재현 `element:agent-activity-cli-command` 의 진짜 원인 = 폴백이 콜론 접두어를 미제거 + 복수형 id drift(`elements:`) 미대응 — `splitDeeplinkKindHintAndTail` 로 콜론형·복수 경로형·bare 전부 정규화, kind 힌트 결정론 타이브레이크, 미존재 시 가시 알림(en/ko). 해당 문자열 정확히 테스트 케이스로 고정
- 키보드/aria/툴팁 강점 보존(회귀 테스트), 라벨 잉크 1건 토큰화(잔여는 주석 플래그)

## Test plan

vitest 94/94 · i18n 26 · tsc exit 0 · eslint clean · 라이브 DOM 검증(mcp-server 밀집 링·bare slug 해석·미존재 알림 en/ko/light·콘솔 0). 스크린샷 재캡처는 머지 후 main에서 리드가 수행(브라우저 단일 창 계약으로 이번 세션 파일 저장 실패).

🤖 Generated with [Claude Code](https://claude.com/claude-code)