### PR TITLE
fix: UX 감사 막다른 길 3건 (문서 404·편집 진입로·크럼)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2714,7 +2714,8 @@
       "label": "Agent handoff",
       "copy": "Copy next action",
       "copied": "Copied the agent handoff call",
-      "openDocument": "Open document →"
+      "openDocument": "Open document →",
+      "openBuilder": "Edit in builder →"
     },
     "body": {
       "title": "Body",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2714,7 +2714,8 @@
       "label": "에이전트 핸드오프",
       "copy": "다음 액션 복사",
       "copied": "에이전트 핸드오프 호출을 복사했어요",
-      "openDocument": "문서 열기 →"
+      "openDocument": "문서 열기 →",
+      "openBuilder": "빌더에서 수정 →"
     },
     "body": {
       "title": "본문",

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -309,7 +309,9 @@ function DocsVaultContent() {
   const queryView = parseView(searchParams?.get('view'));
   const queryDogfood = searchParams?.get('dogfood') ?? null;
   const projectsListHref = '/projects/';
-  const workspaceHref = '/';
+  // UX 감사 (2026-07): '/' 는 하드 내비게이션 시 vault 복원 전이라 랜딩으로
+  // 떨어지는 막다른 길이었다 — 크럼은 항상 지도 허브로 직행.
+  const workspaceHref = '/topology';
   const getDocHref = useCallback(
     (slug: string, hash?: string) => buildDocsVaultHref({ slug, hash }),
     [],

--- a/src/widgets/full-detail-a1/ui/FullDetailA1.test.tsx
+++ b/src/widgets/full-detail-a1/ui/FullDetailA1.test.tsx
@@ -6,6 +6,14 @@ import { buildFullDetailReachModel } from "../lib/full-detail-reach";
 import { FullDetailA1 } from "./FullDetailA1";
 import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
 
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: React.ComponentProps<"a">) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),

--- a/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
+++ b/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Link2, X } from "lucide-react";
+import { Link } from "@/i18n/navigation";
 import ReactMarkdown from "react-markdown";
 import { buildOntologyNodeHref } from "@/entities/knowledge-graph";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
@@ -291,13 +292,20 @@ export function FullDetailA1({
           {t("handoff.copy")}
         </button>
         {documentHref ? (
-          <a
+          <Link
             href={documentHref}
             className="shrink-0 text-[12px] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
           >
             {t("handoff.openDocument")}
-          </a>
+          </Link>
         ) : null}
+        <Link
+          href={`/ontology/edit?node=${encodeURIComponent(node.slug)}`}
+          data-testid="full-detail-a1-open-builder"
+          className="shrink-0 text-[12px] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+        >
+          {t("handoff.openBuilder")}
+        </Link>
       </section>
 
       <section data-fulldetail-body className="mt-6.5">


### PR DESCRIPTION
## Summary
UX 전수 감사가 확정한 "뭘 해야 할지 모르겠다"의 물리적 원인 중 즉시 수정 가능한 3건: ① 전체 상세 → 문서 열기 404(locale 누락) ② 편집 진입로가 z-index에 깔려 사망 → 전체 상세에 "빌더에서 수정 →"(기존 ?node= 딥링크 수신부에 연결) ③ /docs 크럼 랜딩 막다른 길 → /topology 직행.

## Test plan
vitest full-detail-a1 29 + docs-vault 65 pass · tsc exit 0 (TS7 drift 우회 config, EXIT-CODE 검사) · i18n 그린 · eslint 0. 근본 IA 재설계(내비 레일·데이터시트 브리지)는 패널 종합 후 별도 웨이브.

🤖 Generated with [Claude Code](https://claude.com/claude-code)