### PR TITLE
docs: UX 개편 라운드 시안 8종 보존

### DIFF
--- a/docs/prototypes/app-icon-concepts.html
+++ b/docs/prototypes/app-icon-concepts.html
@@ -1,0 +1,153 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  app-icon-concepts — 서비스 마크 리디자인 후보 4종 (소유자: "지금거 안예뻐").
+  용처: ① 내비 레일 로고(20px) ② 브랜드 필 pip(15px) ③ macOS 앱 아이콘(스쿼클)
+  ④ 파비콘. 각 후보를 대/중/소 + 실제 용처 컨텍스트로 제시.
+  공통 언어: 헥사곤(프로젝트 노드) × 별자리(그래프) × 회로(신호), 인디고+앰버.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>앱 아이콘 후보 4종</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#101118; --elevated:#16171d;
+    --divider:rgba(255,255,255,.08); --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#63656e;
+    --indigo:#5e6ad2; --indigo-line:rgba(139,151,255,.9); --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;padding:44px 0 60px}
+  .wrap{max-width:1600px;margin:0 auto;padding:0 24px}
+  h1{font-size:20px;font-weight:650;margin-bottom:6px}
+  .lede{font-size:12.5px;color:var(--t3);margin-bottom:30px}
+  .grid{display:grid;grid-template-columns:repeat(4,1fr);gap:20px}
+  .card{border:1px solid var(--border-soft);border-radius:12px;background:var(--panel);padding:20px;display:flex;flex-direction:column;gap:16px}
+  .card h2{font-size:13.5px;font-weight:650}
+  .card h2 .tag{font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.16em;color:var(--t4);margin-right:8px;text-transform:uppercase}
+  .card p{font-size:11.5px;color:var(--t3);line-height:1.55;word-break:keep-all;min-height:52px}
+  .hero{display:grid;place-items:center;padding:22px 0;border:1px solid var(--divider);border-radius:10px;
+    background:radial-gradient(circle at 50% 42%, rgba(94,106,210,.06), transparent 70%), var(--elevated)}
+  .sizes{display:flex;align-items:flex-end;justify-content:center;gap:26px;padding:14px 0;border:1px solid var(--divider);border-radius:10px;background:var(--elevated)}
+  .sizes .s{display:flex;flex-direction:column;align-items:center;gap:7px}
+  .sizes .s em{font-style:normal;font-family:ui-monospace,monospace;font-size:8.5px;color:var(--t4)}
+  .ctx{display:flex;gap:12px;align-items:center;justify-content:center;padding:14px 0;border:1px solid var(--divider);border-radius:10px;background:var(--elevated)}
+  .railctx{width:64px;height:110px;background:#0a0b0f;border:1px solid var(--divider);border-radius:8px;display:flex;flex-direction:column;align-items:center;padding-top:10px;gap:8px}
+  .railctx .below{width:38px;height:32px;border-radius:8px;background:rgba(94,106,210,.14);box-shadow:inset 0 0 0 1px rgba(139,151,255,.22)}
+  .squircle{width:96px;height:96px;border-radius:22px;background:linear-gradient(165deg,#14151c,#0a0b10);border:1px solid rgba(255,255,255,.14);display:grid;place-items:center;box-shadow:0 10px 24px rgba(0,0,0,.5)}
+  svg{display:block}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>앱 아이콘 후보 4종</h1>
+  <p class="lede">공통 언어: 헥사곤(프로젝트) × 별자리(그래프) × 회로(신호). 각 후보 = 대형 / 사이즈 스케일(48·32·20px) / 실제 용처(레일 로고·macOS 스쿼클).</p>
+
+  <div class="grid">
+
+    <!-- A. 헥사 별자리 -->
+    <div class="card">
+      <h2><span class="tag">A</span>헥사 별자리</h2>
+      <p>꼭짓점 6개가 노드, 중심이 앰버 허브. 도형이자 그래프 — 제품 그 자체. 소형에서는 헥사곤으로, 대형에서는 별자리로 읽힘.</p>
+      <div class="hero">
+        <svg width="160" height="160" viewBox="0 0 48 48">
+          <g stroke="rgba(139,151,255,.55)" stroke-width="1.1">
+            <path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/>
+            <line x1="24" y1="7" x2="24" y2="24"/><line x1="38.7" y1="15.5" x2="24" y2="24"/>
+            <line x1="38.7" y1="32.5" x2="24" y2="24"/><line x1="24" y1="41" x2="24" y2="24"/>
+            <line x1="9.3" y1="32.5" x2="24" y2="24"/><line x1="9.3" y1="15.5" x2="24" y2="24"/>
+          </g>
+          <g fill="#ececf0"><circle cx="24" cy="7" r="2"/><circle cx="38.7" cy="15.5" r="2"/><circle cx="38.7" cy="32.5" r="2"/><circle cx="24" cy="41" r="2"/><circle cx="9.3" cy="32.5" r="2"/><circle cx="9.3" cy="15.5" r="2"/></g>
+          <circle cx="24" cy="24" r="3.2" fill="#d4b478"/>
+        </svg>
+      </div>
+      <div class="sizes">
+        <span class="s"><svg width="48" height="48" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.6)" stroke-width="1.4"><path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/><line x1="24" y1="7" x2="24" y2="24"/><line x1="38.7" y1="15.5" x2="24" y2="24"/><line x1="38.7" y1="32.5" x2="24" y2="24"/><line x1="24" y1="41" x2="24" y2="24"/><line x1="9.3" y1="32.5" x2="24" y2="24"/><line x1="9.3" y1="15.5" x2="24" y2="24"/></g><g fill="#ececf0"><circle cx="24" cy="7" r="2.4"/><circle cx="38.7" cy="15.5" r="2.4"/><circle cx="38.7" cy="32.5" r="2.4"/><circle cx="24" cy="41" r="2.4"/><circle cx="9.3" cy="32.5" r="2.4"/><circle cx="9.3" cy="15.5" r="2.4"/></g><circle cx="24" cy="24" r="3.6" fill="#d4b478"/></svg><em>48</em></span>
+        <span class="s"><svg width="32" height="32" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.65)" stroke-width="1.8"><path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/><line x1="24" y1="7" x2="24" y2="24"/><line x1="38.7" y1="15.5" x2="24" y2="24"/><line x1="38.7" y1="32.5" x2="24" y2="24"/><line x1="24" y1="41" x2="24" y2="24"/><line x1="9.3" y1="32.5" x2="24" y2="24"/><line x1="9.3" y1="15.5" x2="24" y2="24"/></g><g fill="#ececf0"><circle cx="24" cy="7" r="2.8"/><circle cx="38.7" cy="15.5" r="2.8"/><circle cx="38.7" cy="32.5" r="2.8"/><circle cx="24" cy="41" r="2.8"/><circle cx="9.3" cy="32.5" r="2.8"/><circle cx="9.3" cy="15.5" r="2.8"/></g><circle cx="24" cy="24" r="4" fill="#d4b478"/></svg><em>32</em></span>
+        <span class="s"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.75)" stroke-width="2.6"><path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/></g><circle cx="24" cy="24" r="5.5" fill="#d4b478"/></svg><em>20</em></span>
+      </div>
+      <div class="ctx">
+        <span class="railctx"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.75)" stroke-width="2.6"><path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/></g><circle cx="24" cy="24" r="5.5" fill="#d4b478"/></svg><span class="below"></span></span>
+        <span class="squircle"><svg width="60" height="60" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.6)" stroke-width="1.3"><path d="M24 7 L38.7 15.5 L38.7 32.5 L24 41 L9.3 32.5 L9.3 15.5 Z" fill="none"/><line x1="24" y1="7" x2="24" y2="24"/><line x1="38.7" y1="15.5" x2="24" y2="24"/><line x1="38.7" y1="32.5" x2="24" y2="24"/><line x1="24" y1="41" x2="24" y2="24"/><line x1="9.3" y1="32.5" x2="24" y2="24"/><line x1="9.3" y1="15.5" x2="24" y2="24"/></g><g fill="#ececf0"><circle cx="24" cy="7" r="2.2"/><circle cx="38.7" cy="15.5" r="2.2"/><circle cx="38.7" cy="32.5" r="2.2"/><circle cx="24" cy="41" r="2.2"/><circle cx="9.3" cy="32.5" r="2.2"/><circle cx="9.3" cy="15.5" r="2.2"/></g><circle cx="24" cy="24" r="3.4" fill="#d4b478"/></svg></span>
+      </div>
+    </div>
+
+    <!-- B. 궤도 헥사 -->
+    <div class="card">
+      <h2><span class="tag">B</span>궤도 헥사</h2>
+      <p>이중 헤어라인 헥사곤(가공 부품) + 한 변을 타고 도는 신호 펄스. 절제된 기계식 — 현재 마크의 정통 진화형.</p>
+      <div class="hero">
+        <svg width="160" height="160" viewBox="0 0 48 48">
+          <path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.85)" stroke-width="1.4"/>
+          <path d="M24 11 L35.3 17.5 L35.3 30.5 L24 37 L12.7 30.5 L12.7 17.5 Z" fill="none" stroke="rgba(139,151,255,.35)" stroke-width="1"/>
+          <path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="1.6"/>
+          <circle cx="39.6" cy="15" r="2.6" fill="#d4b478"/>
+          <circle cx="24" cy="24" r="2" fill="rgba(139,151,255,.9)"/>
+        </svg>
+      </div>
+      <div class="sizes">
+        <span class="s"><svg width="48" height="48" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.85)" stroke-width="1.7"/><path d="M24 11 L35.3 17.5 L35.3 30.5 L24 37 L12.7 30.5 L12.7 17.5 Z" fill="none" stroke="rgba(139,151,255,.35)" stroke-width="1.2"/><path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="2"/><circle cx="39.6" cy="15" r="3" fill="#d4b478"/><circle cx="24" cy="24" r="2.3" fill="rgba(139,151,255,.9)"/></svg><em>48</em></span>
+        <span class="s"><svg width="32" height="32" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.9)" stroke-width="2.2"/><path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="2.6"/><circle cx="39.6" cy="15" r="3.6" fill="#d4b478"/><circle cx="24" cy="24" r="2.8" fill="rgba(139,151,255,.9)"/></svg><em>32</em></span>
+        <span class="s"><svg width="20" height="20" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.95)" stroke-width="3"/><path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="3.6"/><circle cx="39.6" cy="15" r="4.6" fill="#d4b478"/></svg><em>20</em></span>
+      </div>
+      <div class="ctx">
+        <span class="railctx"><svg width="20" height="20" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.95)" stroke-width="3"/><path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="3.6"/><circle cx="39.6" cy="15" r="4.6" fill="#d4b478"/></svg><span class="below"></span></span>
+        <span class="squircle"><svg width="60" height="60" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(236,236,240,.85)" stroke-width="1.5"/><path d="M24 11 L35.3 17.5 L35.3 30.5 L24 37 L12.7 30.5 L12.7 17.5 Z" fill="none" stroke="rgba(139,151,255,.35)" stroke-width="1"/><path d="M24 6 L39.6 15" stroke="#d4b478" stroke-width="1.8"/><circle cx="39.6" cy="15" r="2.8" fill="#d4b478"/><circle cx="24" cy="24" r="2.1" fill="rgba(139,151,255,.9)"/></svg></span>
+      </div>
+    </div>
+
+    <!-- C. 아틀라스 A -->
+    <div class="card">
+      <h2><span class="tag">C</span>아틀라스 A</h2>
+      <p>헥사곤 안에 트레이스로 그린 "A" — 두 갈래 경로가 정점(허브)에서 만나는 모노그램. 브랜드 문자성이 가장 강함.</p>
+      <div class="hero">
+        <svg width="160" height="160" viewBox="0 0 48 48">
+          <path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(139,151,255,.5)" stroke-width="1.2"/>
+          <g stroke="rgba(236,236,240,.9)" stroke-width="1.6" fill="none">
+            <path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/>
+          </g>
+          <circle cx="24" cy="13" r="2.6" fill="#d4b478"/>
+          <g fill="rgba(139,151,255,.9)"><circle cx="15" cy="34" r="2"/><circle cx="33" cy="34" r="2"/></g>
+        </svg>
+      </div>
+      <div class="sizes">
+        <span class="s"><svg width="48" height="48" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(139,151,255,.5)" stroke-width="1.4"/><g stroke="rgba(236,236,240,.9)" stroke-width="2" fill="none"><path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/></g><circle cx="24" cy="13" r="3" fill="#d4b478"/><g fill="rgba(139,151,255,.9)"><circle cx="15" cy="34" r="2.3"/><circle cx="33" cy="34" r="2.3"/></g></svg><em>48</em></span>
+        <span class="s"><svg width="32" height="32" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(139,151,255,.45)" stroke-width="1.8"/><g stroke="rgba(236,236,240,.95)" stroke-width="2.6" fill="none"><path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/></g><circle cx="24" cy="13" r="3.4" fill="#d4b478"/></svg><em>32</em></span>
+        <span class="s"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(236,236,240,1)" stroke-width="3.4" fill="none"><path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/></g><circle cx="24" cy="13" r="4.4" fill="#d4b478"/></svg><em>20</em></span>
+      </div>
+      <div class="ctx">
+        <span class="railctx"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(236,236,240,1)" stroke-width="3.4" fill="none"><path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/></g><circle cx="24" cy="13" r="4.4" fill="#d4b478"/></svg><span class="below"></span></span>
+        <span class="squircle"><svg width="60" height="60" viewBox="0 0 48 48"><path d="M24 6 L39.6 15 L39.6 33 L24 42 L8.4 33 L8.4 15 Z" fill="none" stroke="rgba(139,151,255,.5)" stroke-width="1.3"/><g stroke="rgba(236,236,240,.9)" stroke-width="1.8" fill="none"><path d="M15 34 L24 13 L33 34"/><line x1="18.4" y1="26" x2="29.6" y2="26"/></g><circle cx="24" cy="13" r="2.8" fill="#d4b478"/><g fill="rgba(139,151,255,.9)"><circle cx="15" cy="34" r="2.1"/><circle cx="33" cy="34" r="2.1"/></g></svg></span>
+      </div>
+    </div>
+
+    <!-- D. 분기 노드 -->
+    <div class="card">
+      <h2><span class="tag">D</span>분기 노드</h2>
+      <p>헥사곤을 버리고 그래프만 — 허브에서 세 갈래로 뻗는 최소 별자리. 가장 가볍고 현대적, 단 소형에서 정체성이 약해질 수 있음.</p>
+      <div class="hero">
+        <svg width="160" height="160" viewBox="0 0 48 48">
+          <g stroke="rgba(139,151,255,.6)" stroke-width="1.4" fill="none">
+            <path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/>
+          </g>
+          <circle cx="24" cy="26" r="4.2" fill="none" stroke="#d4b478" stroke-width="1.6"/>
+          <circle cx="24" cy="26" r="1.6" fill="#d4b478"/>
+          <g fill="#ececf0"><circle cx="31" cy="10" r="2.4"/><circle cx="10" cy="33" r="2.4"/><circle cx="38" cy="28" r="2.4"/></g>
+        </svg>
+      </div>
+      <div class="sizes">
+        <span class="s"><svg width="48" height="48" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.65)" stroke-width="1.7" fill="none"><path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/></g><circle cx="24" cy="26" r="4.6" fill="none" stroke="#d4b478" stroke-width="1.9"/><circle cx="24" cy="26" r="1.8" fill="#d4b478"/><g fill="#ececf0"><circle cx="31" cy="10" r="2.7"/><circle cx="10" cy="33" r="2.7"/><circle cx="38" cy="28" r="2.7"/></g></svg><em>48</em></span>
+        <span class="s"><svg width="32" height="32" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.7)" stroke-width="2.2" fill="none"><path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/></g><circle cx="24" cy="26" r="5" fill="none" stroke="#d4b478" stroke-width="2.3"/><g fill="#ececf0"><circle cx="31" cy="10" r="3.1"/><circle cx="10" cy="33" r="3.1"/><circle cx="38" cy="28" r="3.1"/></g></svg><em>32</em></span>
+        <span class="s"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.8)" stroke-width="3" fill="none"><path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/></g><circle cx="24" cy="26" r="6" fill="none" stroke="#d4b478" stroke-width="3"/><g fill="#ececf0"><circle cx="31" cy="10" r="4"/><circle cx="10" cy="33" r="4"/><circle cx="38" cy="28" r="4"/></g></svg><em>20</em></span>
+      </div>
+      <div class="ctx">
+        <span class="railctx"><svg width="20" height="20" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.8)" stroke-width="3" fill="none"><path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/></g><circle cx="24" cy="26" r="6" fill="none" stroke="#d4b478" stroke-width="3"/><g fill="#ececf0"><circle cx="31" cy="10" r="4"/><circle cx="10" cy="33" r="4"/><circle cx="38" cy="28" r="4"/></g></svg><span class="below"></span></span>
+        <span class="squircle"><svg width="60" height="60" viewBox="0 0 48 48"><g stroke="rgba(139,151,255,.62)" stroke-width="1.5" fill="none"><path d="M24 26 Q24 16 31 10"/><path d="M24 26 Q16 26 10 33"/><path d="M24 26 Q32 30 38 28"/></g><circle cx="24" cy="26" r="4.4" fill="none" stroke="#d4b478" stroke-width="1.7"/><circle cx="24" cy="26" r="1.7" fill="#d4b478"/><g fill="#ececf0"><circle cx="31" cy="10" r="2.5"/><circle cx="10" cy="33" r="2.5"/><circle cx="38" cy="28" r="2.5"/></g></svg></span>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/docs/prototypes/app-rail-unified-nav.html
+++ b/docs/prototypes/app-rail-unified-nav.html
@@ -1,0 +1,132 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  app-rail-unified-nav v3 — 합성 시안: 좌측 레일(목업) + 실제 지형도 화면 캡처.\n  보여주는 페이지 = / (지도 허브, /topology 동일). 캔버스·INDEX·크롬은 실화면 그대로.
+  변경: ① 이모지 폐기 → Lucide(프로젝트 표준 오픈소스 아이콘셋) 실SVG 인라인
+  ② 크롬을 실제 앱 렌더 기반으로 재현(브랜드 필 census 포맷·INDEX 구조·
+  데이터시트) ③ 레일 리듬 재설계 — 아이템 타일 40px + 라벨, 활성=인디고
+  타일+좌측 2px 바, 비활성 라벨 대비 상향.
+  구현 계약: 아이콘 = lucide-react { Map, BookOpen, GitBranch, ChartColumn,
+  FolderKanban, Bot, Settings, Search, Plus, CircleHelp }. 레일 64px 고정,
+  전 화면 공통, 하단 = LiveActivity(Bot+앰버 점) · 설정.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>통합 내비 레일 v2 — 실적용 형태</title>
+<style>
+  :root{
+    --canvas:#060609; --rail:#0a0b0f; --panel:#101118; --elevated:#16171d;
+    --divider:rgba(255,255,255,.08); --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#63656e;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.14); --indigo-line:rgba(139,151,255,.85);
+    --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  html,body{height:100%}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;overflow:hidden}
+  .frame{width:100%;height:100vh;display:flex;overflow:hidden}
+  svg.lucide{width:18px;height:18px;fill:none;stroke:currentColor;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round}
+  /* ══ 통합 레일 ══ */
+  .rail{width:64px;flex:none;display:flex;flex-direction:column;align-items:center;padding:12px 0 14px;
+    background:var(--rail);border-right:1px solid var(--divider);z-index:10}
+  .rail .logo{width:34px;height:34px;display:grid;place-items:center;color:var(--t2);margin-bottom:14px}
+  .rail .logo svg{width:20px;height:20px}
+  .rail nav{display:flex;flex-direction:column;gap:2px;width:100%}
+  .rail .it{position:relative;display:flex;flex-direction:column;align-items:center;gap:4px;padding:7px 0 8px;cursor:pointer;color:var(--t3)}
+  .rail .it .tile{width:38px;height:32px;border-radius:8px;display:grid;place-items:center;transition:background .15s,color .15s}
+  .rail .it span{font-size:9.5px;letter-spacing:.01em;color:var(--t4)}
+  .rail .it:hover .tile{background:rgba(255,255,255,.05);color:var(--t1)}
+  .rail .it:hover span{color:var(--t2)}
+  .rail .it.on{color:var(--indigo-line)}
+  .rail .it.on .tile{background:var(--indigo-soft);box-shadow:inset 0 0 0 1px rgba(139,151,255,.22)}
+  .rail .it.on span{color:var(--t1);font-weight:600}
+  .rail .it.on::before{content:"";position:absolute;left:0;top:9px;height:30px;width:2px;background:var(--indigo);border-radius:0 2px 2px 0}
+  .rail .foot{margin-top:auto;display:flex;flex-direction:column;align-items:center;gap:4px;width:100%}
+  .rail .foot .it{padding:6px 0}
+  .rail .agentdot{position:absolute;top:8px;right:14px;width:6px;height:6px;border-radius:50%;background:var(--amber);outline:2px solid var(--rail)}
+  /* ══ 본문 ══ */
+  .stage{position:relative;flex:1;min-width:0}
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  text{font-family:ui-monospace,monospace}
+  .wm{fill:rgba(255,255,255,.045);font-size:44px;letter-spacing:.34em}
+  /* 상단 크롬 — 실제 브랜드 필 포맷 재현 */
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:flex-start;justify-content:space-between;padding:14px 24px;z-index:5}
+  .pill{display:flex;align-items:center;gap:12px;border:1px solid var(--border-soft);background:rgba(16,17,24,.95);border-radius:10px;padding:9px 14px;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .pill .pip{width:24px;height:24px;border:1px solid var(--border-strong);border-radius:7px;display:grid;place-items:center;color:var(--indigo-line)}
+  .pill .pip svg{width:13px;height:13px}
+  .pill .tx b{display:block;font-size:13px;font-weight:650;line-height:1.2}
+  .pill .tx span{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4)}
+  .pill .tx span b{display:inline;font-size:10.5px;color:var(--t2);font-weight:600;text-shadow:0 1px 0 rgba(0,0,0,.6)}
+  .util{display:flex;gap:8px}
+  .util .btn{width:32px;height:32px;border:1px solid var(--border-soft);background:rgba(16,17,24,.95);border-radius:8px;display:grid;place-items:center;color:var(--t3);cursor:pointer}
+  .util .btn:hover{color:var(--t1);border-color:var(--border-strong)}
+  .util .btn svg{width:15px;height:15px}
+  /* INDEX — 실제 구조 재현 (역량·요소 서브카운트 + 미터) */
+  .index{position:absolute;top:78px;left:24px;bottom:24px;width:302px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);border-radius:12px;z-index:4;padding:15px;display:flex;flex-direction:column;gap:11px;box-shadow:0 18px 48px rgba(0,0,0,.4)}
+  .index .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.2em;color:var(--t3);text-transform:uppercase;display:flex;align-items:center;gap:7px}
+  .index .cap .dot{width:5px;height:5px;border-radius:50%;background:var(--indigo)}
+  .index .cap .fold{margin-left:auto;color:var(--t4);letter-spacing:.1em;font-size:9px;border:1px solid var(--divider);border-radius:5px;padding:2px 7px}
+  .index .search{display:flex;align-items:center;gap:8px;border:1px solid var(--divider);border-radius:8px;background:var(--elevated);color:var(--t4);font-size:12px;padding:8px 11px;box-shadow:inset 0 1px 2px rgba(0,0,0,.3)}
+  .index .search svg{width:13px;height:13px}
+  .row{display:grid;grid-template-columns:16px 1fr auto;align-items:center;column-gap:9px;padding:7px 9px;border-radius:7px;cursor:pointer}
+  .row:hover{background:rgba(255,255,255,.035)}
+  .row .g{width:10px;height:10px;justify-self:center}
+  .row .g.hex{border:1.2px solid var(--amber);clip-path:polygon(50% 0,100% 27%,100% 73%,50% 100%,0 73%,0 27%)}
+  .row .g.sq{width:9px;height:9px;border:1.2px solid rgba(139,151,255,.7);border-radius:2px}
+  .row .lbl{font-size:12.5px;color:var(--t2);min-width:0}
+  .row.proj .lbl{color:var(--amber);font-weight:600}
+  .row .lbl .sub{display:block;font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);margin-top:1px}
+  .row .lbl .meter{display:block;height:1px;margin-top:4px;background:rgba(255,255,255,.06)}
+  .row .lbl .meter i{display:block;height:100%;background:rgba(139,151,255,.42)}
+  .row .n{font-family:ui-monospace,monospace;font-size:10.5px;color:var(--t3);text-shadow:0 1px 0 rgba(0,0,0,.6);align-self:start;margin-top:2px}
+  .index .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:10px;font-size:11px;color:var(--t4);display:flex;align-items:center;gap:7px}
+  .index .foot .dot{width:5px;height:5px;border-radius:50%;background:var(--amber)}
+  /* 데이터시트 (선택 상태) + 행동 행 */
+  .sheet{position:absolute;top:78px;right:24px;width:352px;border:1px solid var(--border-soft);background:rgba(16,17,24,.97);border-radius:12px;z-index:4;padding:16px;box-shadow:0 18px 48px rgba(0,0,0,.4)}
+  .sheet .hd{display:flex;align-items:center;gap:10px;margin-bottom:9px}
+  .sheet .hd .g{width:13px;height:13px;border:1.4px solid rgba(236,236,240,.85);border-radius:50%;flex:none}
+  .sheet .hd b{font-size:15px;font-weight:650}
+  .sheet .hd .k{margin-left:auto;font-family:ui-monospace,monospace;font-size:8.5px;letter-spacing:.14em;color:var(--t4);text-transform:uppercase;border:1px solid var(--divider);border-radius:5px;padding:2px 7px}
+  .sheet .metric{font-family:ui-monospace,monospace;font-size:11px;color:var(--t3);padding-bottom:11px;border-bottom:1px solid var(--divider)}
+  .sheet .metric b{font-size:12.5px;color:var(--t1);text-shadow:0 1px 0 rgba(0,0,0,.6)}
+  .sheet .acts{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;padding:11px 0;border-bottom:1px solid var(--divider)}
+  .sheet .acts .a{display:flex;flex-direction:column;align-items:center;gap:5px;padding:9px 0 8px;border:1px solid var(--divider);border-radius:8px;color:var(--t3);font-size:10.5px;cursor:pointer;transition:border-color .15s,color .15s}
+  .sheet .acts .a:hover{border-color:rgba(139,151,255,.4);color:var(--t1)}
+  .sheet .acts .a svg{width:15px;height:15px}
+  .sheet .grp{padding:11px 0 4px;font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.16em;color:var(--t4);text-transform:uppercase}
+  .sheet .rowc{display:flex;align-items:center;gap:8px;font-size:12.5px;color:var(--t2);padding:5px 2px}
+  .sheet .rowc .tm{width:14px;border-top:1.5px solid rgba(184,186,194,.6);flex:none}
+  .sheet .rowc .tm.dash{border-top-style:dashed}
+  .sheet .rowc span:last-child{margin-left:auto;color:var(--t4);font-family:ui-monospace,monospace;font-size:9.5px}
+  .sheet .more{font-size:11.5px;color:var(--t4);padding:4px 2px}
+</style>
+</head>
+<body>
+<div class="frame">
+  <aside class="rail">
+    <div class="logo" title="Ontology Atlas">
+      <svg class="lucide" viewBox="0 0 24 24"><path d="M12 2l8.66 5v10L12 22l-8.66-5V7z"/></svg>
+    </div>
+    <nav>
+      <div class="it on"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z"/><path d="M15 5.764v15"/><path d="M9 3.236v15"/></svg></span><span>지도</span></div>
+      <div class="it"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span><span>문서함</span></div>
+      <div class="it"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></span><span>빌더</span></div>
+      <div class="it"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg></span><span>인사이트</span></div>
+      <div class="it"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/><path d="M8 10v4"/><path d="M12 10v2"/><path d="M16 10v6"/></svg></span><span>프로젝트</span></div>
+    </nav>
+    <div class="foot">
+      <div class="it" title="에이전트 활동 — 방금 mcp-server 갱신" style="position:relative">
+        <span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg><span class="agentdot"></span></span>
+      </div>
+      <div class="it"><span class="tile"><svg class="lucide" viewBox="0 0 24 24"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></span></div>
+    </div>
+  </aside>
+
+  <main class="stage">
+    <img src="shots/rail-real-topology.png" alt="실제 지형도 화면 (localhost:3107/ko/topology 캡처)"
+         style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:left top"/>
+  </main>
+</div>
+</body>
+</html>

--- a/docs/prototypes/chrome-rail-combined.html
+++ b/docs/prototypes/chrome-rail-combined.html
@@ -1,0 +1,261 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  chrome-rail-combined — 최종 합본: 좌측 64px 내비 레일 + 통일 크롬 + INDEX v2.1.
+  (소유자 지적: index-panel-v2-full 에 app-rail-unified-nav 의 레일이 빠져 있었음)
+  합본 규칙: 레일이 전역 목적지(지도/문서함/빌더/인사이트/프로젝트) + 하단
+  에이전트 상태·설정을 전담 → 구 좌상단 유틸 타일(문서함/빌더) 제거,
+  우측 세로 레일은 지도 전용 3타일(전체보기/조절/단축키)만, 설정은 내비 레일로.
+  이하 원본 주석 (v2.1 다듬기):
+  실제 지형도 캡처(shots/rail-real-topology.png) 위에 구 좌측 컬럼을 덮고
+  새 브랜드 필 + INDEX 패널 v2.1 을 실척으로 합성. "분석 보기" 칩은 은퇴
+  예정이라 덮인 상태가 곧 실적용 모습.
+  v2 → v2.1 다듬기: 텍스트 캐럿(▶) 폐기 → Lucide chevron SVG · 행 세로 정렬
+  (카운트 센터) · 미터 트랙 인셋 · pip 인디고 틴트 · 유틸 타일 아이콘 16px ·
+  푸터/헤더 리듬 정리 · 캐럿 회전 상태.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>최종 합본 — 레일 + 통일 크롬 + INDEX v2.1</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#101118; --elevated:#16171d;
+    --divider:rgba(255,255,255,.08); --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#63656e;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.14); --indigo-line:rgba(139,151,255,.8);
+    --indigo-ink:rgba(139,151,255,.45);
+    --amber:#d4b478;
+    --engrave:0 1px 0 rgba(0,0,0,.65);
+  }
+  *{margin:0;box-sizing:border-box}
+  html,body{height:100%}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;overflow:hidden}
+  .frame{width:100%;height:100vh;display:flex;overflow:hidden}
+  .stage{position:relative;flex:1;min-width:0;height:100vh;overflow:hidden}
+  /* ══ 좌측 내비 레일 (app-rail-unified-nav v2 문법) ══ */
+  .navrail{width:64px;flex:none;display:flex;flex-direction:column;align-items:center;padding:12px 0 14px;
+    background:#0a0b0f;border-right:1px solid var(--divider);z-index:10}
+  .navrail .logo{width:34px;height:34px;display:grid;place-items:center;color:var(--t2);margin-bottom:14px}
+  .navrail .logo svg{width:20px;height:20px}
+  .navrail nav{display:flex;flex-direction:column;gap:2px;width:100%}
+  .navrail .it{position:relative;display:flex;flex-direction:column;align-items:center;gap:4px;padding:7px 0 8px;cursor:pointer;color:var(--t3)}
+  .navrail .it .ntile{width:38px;height:32px;border-radius:8px;display:grid;place-items:center}
+  .navrail .it .ntile svg{width:18px;height:18px}
+  .navrail .it span{font-size:9.5px;color:var(--t4)}
+  .navrail .it:hover .ntile{background:rgba(255,255,255,.05);color:var(--t1)}
+  .navrail .it.on{color:var(--indigo-line)}
+  .navrail .it.on .ntile{background:var(--indigo-soft);box-shadow:inset 0 0 0 1px rgba(139,151,255,.22)}
+  .navrail .it.on span{color:var(--t1);font-weight:600}
+  .navrail .it.on::before{content:"";position:absolute;left:0;top:9px;height:30px;width:2px;background:var(--indigo);border-radius:0 2px 2px 0}
+  .navrail .foot{margin-top:auto;display:flex;flex-direction:column;align-items:center;gap:4px;width:100%}
+  .navrail .agentdot{position:absolute;top:4px;right:7px;width:6px;height:6px;border-radius:50%;background:var(--amber);outline:2px solid #0a0b0f}
+  .stage>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:left top}
+  /* 구 크롬 커버 — 좌측 컬럼 + 상단 스트립 + 우측 레일을 캔버스색으로 덮음 */
+  .cover{position:absolute;top:0;left:0;bottom:0;width:412px;
+    background:linear-gradient(90deg, var(--canvas) 0%, var(--canvas) 92%, rgba(6,6,9,0) 100%)}
+  .cover-top{position:absolute;top:0;left:0;right:0;height:82px;
+    background:linear-gradient(180deg, var(--canvas) 0%, var(--canvas) 86%, rgba(6,6,9,0) 100%)}
+  .cover-right{position:absolute;top:0;right:0;bottom:0;width:96px;
+    background:linear-gradient(270deg, var(--canvas) 0%, var(--canvas) 82%, rgba(6,6,9,0) 100%)}
+  svg.lucide{fill:none;stroke:currentColor;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round}
+  /* ── 브랜드 필 + 유틸 타일 ── */
+  .toprow{position:absolute;top:14px;left:24px;display:flex;align-items:stretch;gap:8px;z-index:3}
+  .pill{display:flex;align-items:center;gap:11px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);
+    border-radius:10px;padding:8px 14px 8px 9px;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .pill .pip{width:28px;height:28px;border:1px solid rgba(139,151,255,.3);background:var(--indigo-soft);border-radius:8px;display:grid;place-items:center;color:var(--indigo-line);flex:none}
+  .pill .pip svg{width:15px;height:15px}
+  .pill .tx b{display:block;font-size:13px;font-weight:650;line-height:1.25;letter-spacing:-.005em}
+  .pill .tx .census{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);display:flex;gap:4px;align-items:baseline;margin-top:1.5px}
+  .pill .tx .census b{display:inline;font-size:11px;color:var(--t2);font-weight:600;text-shadow:var(--engrave)}
+  .pill .tx .census .up{color:var(--amber)}
+  .tile{width:44px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);border-radius:10px;
+    display:grid;place-items:center;color:var(--t3);cursor:pointer;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .tile:hover{color:var(--t1);border-color:var(--border-strong)}
+  .tile svg{width:16px;height:16px}
+  /* ── 상단 중앙/우상단/우측 레일 — 동일 문법 ── */
+  .midrow{position:absolute;top:14px;left:50%;transform:translateX(-50%);display:flex;align-items:stretch;gap:8px;z-index:3}
+  .chip{display:flex;align-items:center;gap:8px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);
+    border-radius:10px;padding:0 14px;height:44px;font-size:12.5px;color:var(--t2);cursor:pointer;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .chip:hover{color:var(--t1);border-color:var(--border-strong)}
+  .chip svg{width:14px;height:14px;color:var(--t3)}
+  .chip .kbd{font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px;color:var(--t4)}
+  .searchbar{display:flex;align-items:center;gap:8px;width:220px;border:1px solid var(--divider);border-radius:10px;
+    background:rgba(16,17,24,.96);color:var(--t4);font-size:12.5px;padding:0 12px;height:44px;
+    box-shadow:0 6px 20px rgba(0,0,0,.35), inset 0 1px 2px rgba(0,0,0,.35)}
+  .searchbar svg{width:14px;height:14px;flex:none}
+  .searchbar .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px}
+  .toprt{position:absolute;top:14px;right:24px;z-index:3}
+  .rightrail{position:absolute;right:24px;top:50%;transform:translateY(-60%);display:flex;flex-direction:column;gap:8px;z-index:3}
+  .rightrail .tile{height:44px}
+  /* ── INDEX 패널 v2.1 ── */
+  .index{position:absolute;top:76px;left:24px;bottom:24px;width:302px;z-index:3;
+    border:1px solid var(--border-soft);background:rgba(15,16,22,.97);border-radius:12px;
+    display:flex;flex-direction:column;overflow:hidden;box-shadow:0 18px 48px rgba(0,0,0,.45)}
+  .index .hd{display:flex;align-items:center;gap:7px;padding:12px 12px 11px 16px;border-bottom:1px solid var(--divider)}
+  .index .hd .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.2em;color:var(--t3);text-transform:uppercase}
+  .index .hd .n{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4)}
+  .index .hd .fold{margin-left:auto;width:26px;height:26px;border:1px solid var(--divider);border-radius:7px;display:grid;place-items:center;color:var(--t4);cursor:pointer}
+  .index .hd .fold:hover{color:var(--t2);border-color:var(--border-strong)}
+  .index .hd .fold svg{width:13px;height:13px}
+  .index .bd{padding:12px 10px 8px;display:flex;flex-direction:column;gap:10px;flex:1;min-height:0}
+  .search{display:flex;align-items:center;gap:8px;margin:0 5px;border:1px solid var(--divider);border-radius:8px;
+    background:var(--elevated);color:var(--t4);font-size:12px;padding:8px 11px;box-shadow:inset 0 1px 2px rgba(0,0,0,.35)}
+  .search svg{width:13px;height:13px;flex:none}
+  .search .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px;color:var(--t4)}
+  .tree{display:flex;flex-direction:column;gap:1px;overflow-y:auto}
+  .row{display:grid;grid-template-columns:14px 15px 1fr auto;align-items:center;column-gap:8px;padding:7px 9px;border-radius:8px;cursor:pointer;min-height:34px}
+  .row:hover{background:rgba(255,255,255,.035)}
+  .row.sel{background:var(--indigo-soft);box-shadow:inset 0 0 0 1px rgba(139,151,255,.18)}
+  .row .caret{justify-self:center;color:var(--t4);display:grid;place-items:center}
+  .row .caret svg{width:11px;height:11px}
+  .row .caret.open svg{transform:rotate(90deg)}
+  .row .g{justify-self:center}
+  .row .g.hex{width:11px;height:11px;border:1.3px solid var(--amber);clip-path:polygon(50% 0,100% 27%,100% 73%,50% 100%,0 73%,0 27%)}
+  .row .g.sq{width:9px;height:9px;border:1.3px solid var(--indigo-line);border-radius:2.5px}
+  .row .g.doc{width:9px;height:9px;border:1.3px solid var(--t3);border-radius:50%}
+  .row .lbl{min-width:0;font-size:12.5px;color:var(--t2);line-height:1.35}
+  .row.proj .lbl{color:var(--amber);font-weight:600;font-size:13px}
+  .row .lbl .nm{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row .lbl .sub{display:flex;align-items:center;gap:7px;margin-top:3.5px}
+  .row .lbl .sub em{font-style:normal;font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);flex:none;letter-spacing:.01em}
+  .row .lbl .meter{flex:1;height:2px;border-radius:1px;background:rgba(0,0,0,.45);box-shadow:inset 0 1px 1px rgba(0,0,0,.5);overflow:hidden}
+  .row .lbl .meter i{display:block;height:100%;background:var(--indigo-ink)}
+  .row.sel .lbl .meter i{background:var(--indigo-line)}
+  .row .n{font-family:ui-monospace,monospace;font-size:11px;color:var(--t3);font-weight:600;text-shadow:var(--engrave)}
+  .row.proj .n{color:var(--t2);font-size:11.5px}
+  .row.doc .lbl{color:var(--t3);font-size:12px}
+  .index .ft{border-top:1px solid var(--divider);padding:10px 16px;display:flex;align-items:center;gap:8px;font-size:11px;color:var(--t4)}
+  .index .ft .dot{width:5px;height:5px;border-radius:50%;background:var(--amber);flex:none}
+  .index .ft b{color:var(--t3);font-weight:500}
+  .index .ft .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px}
+</style>
+</head>
+<body>
+<div class="frame">
+  <aside class="navrail">
+    <div class="logo" title="Ontology Atlas"><svg class="lucide" viewBox="0 0 24 24"><path d="M12 2l8.66 5v10L12 22l-8.66-5V7z"/></svg></div>
+    <nav>
+      <div class="it on"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><path d="M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z"/><path d="M15 5.764v15"/><path d="M9 3.236v15"/></svg></span><span>지도</span></div>
+      <div class="it"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span><span>문서함</span></div>
+      <div class="it"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></span><span>빌더</span></div>
+      <div class="it"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg></span><span>인사이트</span></div>
+      <div class="it"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/><path d="M8 10v4"/><path d="M12 10v2"/><path d="M16 10v6"/></svg></span><span>프로젝트</span></div>
+    </nav>
+    <div class="foot">
+      <div class="it" title="에이전트 활동 — 방금 mcp-server 갱신"><span class="ntile" style="position:relative"><svg class="lucide" viewBox="0 0 24 24"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg><span class="agentdot"></span></span></div>
+      <div class="it" title="설정"><span class="ntile"><svg class="lucide" viewBox="0 0 24 24"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></span></div>
+    </div>
+  </aside>
+<div class="stage">
+  <img src="shots/rail-real-topology.png" alt="실제 지형도 화면"/>
+  <div class="cover-top"></div>
+  <div class="cover-right"></div>
+  <div class="cover"></div>
+
+  <!-- 상단 중앙 — 같은 문법의 정렬/검색 클러스터 -->
+  <div class="midrow">
+    <span class="chip"><svg class="lucide" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>자동 정렬</span>
+    <div class="searchbar">
+      <svg class="lucide" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+      검색<span class="kbd">⌘K</span>
+    </div>
+  </div>
+
+  <!-- 우상단 — 작업공간 (같은 pill 문법) -->
+  <div class="toprt">
+    <span class="chip"><svg class="lucide" viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/></svg>작업공간<span class="kbd">D</span></span>
+  </div>
+
+  <!-- 우측 세로 레일 — 좌측 유틸과 동일한 44px 타일 -->
+  <div class="rightrail">
+    <span class="tile" title="전체 보기"><svg class="lucide" viewBox="0 0 24 24"><path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg></span>
+    <span class="tile" title="지도 조절"><svg class="lucide" viewBox="0 0 24 24"><line x1="21" x2="14" y1="4" y2="4"/><line x1="10" x2="3" y1="4" y2="4"/><line x1="21" x2="12" y1="12" y2="12"/><line x1="8" x2="3" y1="12" y2="12"/><line x1="21" x2="16" y1="20" y2="20"/><line x1="12" x2="3" y1="20" y2="20"/><line x1="14" x2="14" y1="2" y2="6"/><line x1="8" x2="8" y1="10" y2="14"/><line x1="16" x2="16" y1="18" y2="22"/></svg></span>
+    <span class="tile" title="단축키"><svg class="lucide" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+  </div>
+
+  <div class="toprow">
+    <div class="pill">
+      <span class="pip"><svg class="lucide" viewBox="0 0 24 24"><path d="M12 2l8.66 5v10L12 22l-8.66-5V7z"/></svg></span>
+      <span class="tx"><b>지형도</b>
+        <span class="census">개념 <b>289</b> · 관계 <b>483</b> · <span class="up">이번 주 +1</span></span></span>
+    </div>
+
+  </div>
+
+  <aside class="index">
+    <div class="hd">
+      <span class="cap">INDEX</span><span class="n">· 103</span>
+      <span class="fold" title="접기"><svg class="lucide" viewBox="0 0 24 24"><path d="m18 15-6-6-6 6"/></svg></span>
+    </div>
+    <div class="bd">
+      <div class="search">
+        <svg class="lucide" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        개념 검색<span class="kbd">⌘K</span>
+      </div>
+      <div class="tree">
+        <div class="row proj">
+          <span class="caret open"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g hex"></span>
+          <span class="lbl"><span class="nm">ontology-atlas</span></span>
+          <span class="n">6</span>
+        </div>
+        <div class="row sel">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">AI Agent Partner</span>
+            <span class="sub"><em>역량 10 · 요소 32</em><span class="meter"><i style="width:44%"></i></span></span></span>
+          <span class="n">42</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Mode-Aware Adapters</span>
+            <span class="sub"><em>역량 2 · 요소 8</em><span class="meter"><i style="width:10%"></i></span></span></span>
+          <span class="n">10</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Onboarding &amp; UX</span>
+            <span class="sub"><em>역량 2 · 요소 94</em><span class="meter"><i style="width:100%"></i></span></span></span>
+          <span class="n">96</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Ontology Core</span>
+            <span class="sub"><em>역량 1 · 요소 7</em><span class="meter"><i style="width:8%"></i></span></span></span>
+          <span class="n">8</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Vault — Local-First</span>
+            <span class="sub"><em>역량 4 · 요소 27</em><span class="meter"><i style="width:32%"></i></span></span></span>
+          <span class="n">31</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Views — Topology · Browse</span>
+            <span class="sub"><em>역량 17 · 요소 73</em><span class="meter"><i style="width:94%"></i></span></span></span>
+          <span class="n">90</span>
+        </div>
+        <div class="row doc">
+          <span class="caret"></span>
+          <span class="g doc"></span>
+          <span class="lbl"><span class="nm">자기 ontology vault 안내</span></span>
+          <span class="n"></span>
+        </div>
+      </div>
+    </div>
+    <div class="ft">
+      <span class="dot"></span><b>에이전트 동기화</b> · 이번 주 +1
+      <span class="kbd">⇧⌘K</span>
+    </div>
+  </aside>
+</div>
+</div>
+</body>
+</html>

--- a/docs/prototypes/first-run-chooser-v2a-dock.html
+++ b/docs/prototypes/first-run-chooser-v2a-dock.html
@@ -1,0 +1,136 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  first-run chooser 재설계 v2a — "하단 커맨드 독"
+  소유자 반려(중앙 카드 "디자인 별로") 후 재설계. 중앙 플로팅 박스 폐기 —
+  지도(주인공, 특히 중앙 hexagon)를 가리지 않는다. 하단 중앙에 얇은 기계식
+  독 하나: 맥락 한 줄 + 액션 2 + 닫기. Figma 하단 툴바 포지션.
+  동작 계약: 재방문(복원된 vault 존재) 시 이 독은 아예 렌더되지 않는다 —
+  본인 vault 허브 직행. 독은 "저장된 vault 없음" 상태 전용.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>시작하기 v2a — 하단 커맨드 독</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#111217; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.16);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.55);
+    --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif}
+  .frame{width:1920px;height:1080px;margin:0 auto;position:relative;overflow:hidden}
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:13px 22px;z-index:5}
+  .pill{display:flex;align-items:center;gap:10px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:9px;padding:8px 13px}
+  .pill .pip{width:20px;height:20px;border:1px solid var(--border-strong);border-radius:6px;display:grid;place-items:center;color:var(--indigo-line);font-size:10px}
+  .pill b{font-size:12.5px;font-weight:600}
+  .pill .census{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border-left:1px solid var(--divider);padding-left:10px}
+  .pill .census b{font-size:11px;color:var(--t2);font-weight:600}
+  .pill .sample{font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.14em;color:var(--amber);border:1px solid rgba(212,180,120,.4);border-radius:5px;padding:2px 7px;text-transform:uppercase}
+  .util{display:flex;gap:8px}
+  .util .btn{width:30px;height:30px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:7px;display:grid;place-items:center;color:var(--t3);font-size:12px}
+  .index{position:absolute;top:76px;left:22px;bottom:96px;width:300px;border:1px solid var(--border-soft);background:rgba(17,18,23,.94);border-radius:11px;z-index:4;padding:14px;display:flex;flex-direction:column;gap:10px}
+  .index .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase;display:flex;justify-content:space-between}
+  .index .cap .s{color:var(--amber)}
+  .index .search{border:1px solid var(--divider);border-radius:7px;background:var(--elevated);color:var(--t4);font-size:12px;padding:7px 10px}
+  .index .tree{font-size:12.5px;color:var(--t2);display:grid;gap:2px}
+  .index .tree .d{display:flex;justify-content:space-between;padding:6px 8px;border-radius:6px}
+  .index .tree .d:hover{background:rgba(255,255,255,.04)}
+  .index .tree .d .n{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4)}
+  .index .tree .proj{color:var(--amber);font-weight:600}
+  .index .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:10px;font-size:11px;color:var(--t4);word-break:keep-all}
+  .index .foot b{color:var(--t3);font-weight:500}
+  /* ★ 하단 커맨드 독 — 유일한 신규 표면 */
+  .dock{position:absolute;left:50%;bottom:26px;transform:translateX(-50%);z-index:6;
+    display:flex;align-items:center;gap:18px;height:58px;padding:0 10px 0 20px;
+    border:1px solid var(--border-strong);border-radius:12px;background:rgba(17,18,23,.97);
+    box-shadow:0 14px 40px rgba(0,0,0,.5)}
+  .dock .sig{display:flex;align-items:center;gap:9px}
+  .dock .sig .dot{width:6px;height:6px;border-radius:50%;background:var(--amber)}
+  .dock .sig .tx b{font-size:13px;font-weight:600;display:block;line-height:1.3}
+  .dock .sig .tx span{font-size:11px;color:var(--t4)}
+  .dock .sep{width:1px;height:30px;background:var(--divider)}
+  .dock .cta{display:flex;align-items:center;gap:8px}
+  .dock .open{display:flex;align-items:center;gap:8px;border:0;border-radius:8px;background:var(--indigo);color:#fff;font-size:13px;font-weight:600;padding:9px 16px}
+  .dock .open .kbd{font-family:ui-monospace,monospace;font-size:9.5px;opacity:.65;border:1px solid rgba(255,255,255,.3);border-radius:4px;padding:1px 5px}
+  .dock .new{border:1px solid var(--border-strong);border-radius:8px;background:transparent;color:var(--t2);font-size:13px;padding:9px 14px}
+  .dock .close{width:30px;height:30px;display:grid;place-items:center;color:var(--t4);font-size:13px;border-radius:7px}
+  .dock .close:hover{background:rgba(255,255,255,.05)}
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  .wm{font-family:ui-monospace,monospace;fill:rgba(255,255,255,.045);font-size:44px;letter-spacing:.3em}
+  text{font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+<div class="frame">
+  <svg class="map" viewBox="0 0 1920 1080">
+    <text class="wm" x="1210" y="330">VIEWS</text>
+    <text class="wm" x="520" y="820">CORE</text>
+    <g stroke="rgba(255,255,255,.09)" stroke-width="1">
+      <line x1="1010" y1="540" x2="1010" y2="320"/><line x1="1010" y1="540" x2="1330" y2="400"/>
+      <line x1="1010" y1="540" x2="1370" y2="680"/><line x1="1010" y1="540" x2="1010" y2="790"/>
+      <line x1="1010" y1="540" x2="680" y2="720"/><line x1="1010" y1="540" x2="640" y2="380"/>
+    </g>
+    <g stroke="rgba(139,151,255,.32)" stroke-width="1" stroke-dasharray="3 4">
+      <line x1="1330" y1="400" x2="1370" y2="680"/><line x1="640" y1="380" x2="1010" y2="320"/>
+      <line x1="680" y1="720" x2="1010" y2="790"/>
+    </g>
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="1010" y1="320" x2="1120" y2="230"/><line x1="1010" y1="320" x2="905" y2="225"/>
+      <line x1="1330" y1="400" x2="1470" y2="330"/><line x1="1370" y1="680" x2="1520" y2="750"/>
+      <line x1="640" y1="380" x2="520" y2="300"/><line x1="680" y1="720" x2="560" y2="640"/>
+    </g>
+    <polygon points="1010,518 1030,529 1030,551 1010,562 990,551 990,529" fill="#101118" stroke="#d4b478" stroke-width="1.4"/>
+    <g fill="#101118" stroke="rgba(139,151,255,.75)" stroke-width="1.1">
+      <rect x="1001" y="311" width="18" height="18" rx="2.5"/><rect x="1321" y="391" width="18" height="18" rx="2.5"/>
+      <rect x="1361" y="671" width="18" height="18" rx="2.5"/><rect x="1001" y="781" width="18" height="18" rx="2.5"/>
+      <rect x="671" y="711" width="18" height="18" rx="2.5"/><rect x="631" y="371" width="18" height="18" rx="2.5"/>
+    </g>
+    <g fill="rgba(184,186,194,.8)">
+      <circle cx="1120" cy="230" r="3.4"/><circle cx="905" cy="225" r="3.4"/><circle cx="1470" cy="330" r="3.4"/>
+      <circle cx="1520" cy="750" r="3.4"/><circle cx="520" cy="300" r="3.4"/><circle cx="560" cy="640" r="3.4"/>
+    </g>
+    <g fill="#84868f" font-size="11">
+      <text x="1010" y="298" text-anchor="middle">mcp-server</text>
+      <text x="1348" y="384">ai-agent-partner</text><text x="1388" y="706">mode-aware-adapters</text>
+      <text x="1010" y="820" text-anchor="middle">ontology-core</text>
+      <text x="655" y="748" text-anchor="middle">vault-local-first</text><text x="622" y="364" text-anchor="middle">views</text>
+    </g>
+    <text x="1010" y="582" text-anchor="middle" fill="#d4b478" font-size="11">ontology-atlas</text>
+  </svg>
+
+  <div class="chrome">
+    <div class="pill"><span class="pip">◈</span><b>Ontology Atlas</b><span class="census"><b>102</b> concepts · <b>478</b> relations</span><span class="sample">Sample</span></div>
+    <div class="util"><span class="btn">🔍</span><span class="btn">?</span><span class="btn">⚙</span></div>
+  </div>
+
+  <aside class="index">
+    <p class="cap">INDEX <span class="s">· Sample</span><span>⌘K 검색</span></p>
+    <div class="search">노드 검색…</div>
+    <div class="tree">
+      <div class="d proj"><span>◇ ontology-atlas</span><span class="n">102</span></div>
+      <div class="d"><span>▸ ontology-core</span><span class="n">24</span></div>
+      <div class="d"><span>▸ views</span><span class="n">31</span></div>
+      <div class="d"><span>▸ vault-local-first</span><span class="n">14</span></div>
+      <div class="d"><span>▸ ai-agent-partner</span><span class="n">17</span></div>
+      <div class="d"><span>▸ mode-aware-adapters</span><span class="n">9</span></div>
+      <div class="d"><span>▸ onboarding-ux</span><span class="n">6</span></div>
+    </div>
+    <p class="foot"><b>샘플 vault</b> — 이 프로젝트 자신의 frontmatter. 목업 데이터 없음.</p>
+  </aside>
+
+  <div class="dock">
+    <span class="sig"><span class="dot"></span><span class="tx"><b>샘플 온톨로지를 둘러보는 중</b><span>frontmatter 가 곧 그래프 · 폴더를 고르면 내 데이터로 · 읽기 전용</span></span></span>
+    <span class="sep"></span>
+    <span class="cta">
+      <button class="open">내 마크다운 폴더 열기 <span class="kbd">⌘O</span></button>
+      <button class="new">새 vault 만들기</button>
+    </span>
+    <span class="close">✕</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/prototypes/first-run-chooser-v2b-index.html
+++ b/docs/prototypes/first-run-chooser-v2b-index.html
@@ -1,0 +1,131 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  first-run chooser 재설계 v2b — "INDEX 패널 통합" (플로팅 표면 0개)
+  소유자 반려(중앙 카드) 후 재설계. 신규 플로팅 surface 를 아예 만들지 않는다 —
+  첫 방문 상태의 INDEX 패널(B3 계기 패널, 첫 방문 기본 = 펼침) 맨 위가
+  "시작하기" 모듈로 시작한다: 폴더 열기 primary + 새 vault, 그 아래 hairline
+  건너 샘플 트리. 지도는 완전 무차폐. 시작하기 모듈은 vault 를 열면 사라지고
+  그 자리가 원래 INDEX 검색으로 돌아온다.
+  동작 계약: 재방문(복원된 vault)엔 이 모듈·SAMPLE 배지 없이 본인 vault 직행.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>시작하기 v2b — INDEX 통합</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#111217; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.16);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.55);
+    --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif}
+  .frame{width:1920px;height:1080px;margin:0 auto;position:relative;overflow:hidden}
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:13px 22px;z-index:5}
+  .pill{display:flex;align-items:center;gap:10px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:9px;padding:8px 13px}
+  .pill .pip{width:20px;height:20px;border:1px solid var(--border-strong);border-radius:6px;display:grid;place-items:center;color:var(--indigo-line);font-size:10px}
+  .pill b{font-size:12.5px;font-weight:600}
+  .pill .census{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border-left:1px solid var(--divider);padding-left:10px}
+  .pill .census b{font-size:11px;color:var(--t2);font-weight:600}
+  .pill .sample{font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.14em;color:var(--amber);border:1px solid rgba(212,180,120,.4);border-radius:5px;padding:2px 7px;text-transform:uppercase}
+  .util{display:flex;gap:8px}
+  .util .btn{width:30px;height:30px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:7px;display:grid;place-items:center;color:var(--t3);font-size:12px}
+  .index{position:absolute;top:76px;left:22px;bottom:22px;width:320px;border:1px solid var(--border-soft);background:rgba(17,18,23,.95);border-radius:11px;z-index:4;display:flex;flex-direction:column;overflow:hidden}
+  /* ★ 시작하기 모듈 — 패널 상단, 별도 플로팅 없음 */
+  .starter{padding:16px 16px 14px;border-bottom:1px solid var(--divider);background:linear-gradient(180deg,rgba(94,106,210,.07),transparent)}
+  .starter .cap{display:flex;align-items:center;gap:8px;font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t3);text-transform:uppercase;margin-bottom:9px}
+  .starter .cap .dot{width:5px;height:5px;border-radius:50%;background:var(--amber)}
+  .starter .cap .s{color:var(--amber);margin-left:auto;letter-spacing:.14em}
+  .starter p{font-size:12px;line-height:1.55;color:var(--t3);word-break:keep-all;margin-bottom:12px}
+  .starter p b{color:var(--t2);font-weight:500}
+  .starter .open{display:flex;width:100%;align-items:center;justify-content:center;gap:8px;border:0;border-radius:8px;background:var(--indigo);color:#fff;font-size:13px;font-weight:600;padding:10px 0}
+  .starter .open .kbd{font-family:ui-monospace,monospace;font-size:9.5px;opacity:.65;border:1px solid rgba(255,255,255,.3);border-radius:4px;padding:1px 5px}
+  .starter .sub{display:flex;justify-content:space-between;margin-top:9px;font-size:11.5px}
+  .starter .sub a{color:var(--t3);text-decoration:none;border-bottom:1px solid var(--divider);padding-bottom:1px}
+  .starter .sub a:hover{color:var(--t2)}
+  .body{padding:14px 16px;display:flex;flex-direction:column;gap:10px;flex:1;min-height:0}
+  .index .cap2{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase;display:flex;justify-content:space-between}
+  .index .search{border:1px solid var(--divider);border-radius:7px;background:var(--elevated);color:var(--t4);font-size:12px;padding:7px 10px}
+  .index .tree{font-size:12.5px;color:var(--t2);display:grid;gap:2px}
+  .index .tree .d{display:flex;justify-content:space-between;padding:6px 8px;border-radius:6px}
+  .index .tree .d:hover{background:rgba(255,255,255,.04)}
+  .index .tree .d .n{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4)}
+  .index .tree .proj{color:var(--amber);font-weight:600}
+  .index .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:10px;font-size:11px;color:var(--t4);word-break:keep-all}
+  .index .foot b{color:var(--t3);font-weight:500}
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  .wm{font-family:ui-monospace,monospace;fill:rgba(255,255,255,.045);font-size:44px;letter-spacing:.3em}
+  text{font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+<div class="frame">
+  <svg class="map" viewBox="0 0 1920 1080">
+    <text class="wm" x="1210" y="330">VIEWS</text>
+    <text class="wm" x="560" y="840">CORE</text>
+    <g stroke="rgba(255,255,255,.09)" stroke-width="1">
+      <line x1="1060" y1="560" x2="1060" y2="330"/><line x1="1060" y1="560" x2="1390" y2="420"/>
+      <line x1="1060" y1="560" x2="1430" y2="700"/><line x1="1060" y1="560" x2="1060" y2="810"/>
+      <line x1="1060" y1="560" x2="730" y2="740"/><line x1="1060" y1="560" x2="690" y2="400"/>
+    </g>
+    <g stroke="rgba(139,151,255,.32)" stroke-width="1" stroke-dasharray="3 4">
+      <line x1="1390" y1="420" x2="1430" y2="700"/><line x1="690" y1="400" x2="1060" y2="330"/>
+      <line x1="730" y1="740" x2="1060" y2="810"/>
+    </g>
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="1060" y1="330" x2="1170" y2="240"/><line x1="1060" y1="330" x2="955" y2="235"/>
+      <line x1="1390" y1="420" x2="1530" y2="350"/><line x1="1430" y1="700" x2="1580" y2="770"/>
+      <line x1="690" y1="400" x2="570" y2="320"/><line x1="730" y1="740" x2="610" y2="660"/>
+    </g>
+    <polygon points="1060,538 1080,549 1080,571 1060,582 1040,571 1040,549" fill="#101118" stroke="#d4b478" stroke-width="1.4"/>
+    <g fill="#101118" stroke="rgba(139,151,255,.75)" stroke-width="1.1">
+      <rect x="1051" y="321" width="18" height="18" rx="2.5"/><rect x="1381" y="411" width="18" height="18" rx="2.5"/>
+      <rect x="1421" y="691" width="18" height="18" rx="2.5"/><rect x="1051" y="801" width="18" height="18" rx="2.5"/>
+      <rect x="721" y="731" width="18" height="18" rx="2.5"/><rect x="681" y="391" width="18" height="18" rx="2.5"/>
+    </g>
+    <g fill="rgba(184,186,194,.8)">
+      <circle cx="1170" cy="240" r="3.4"/><circle cx="955" cy="235" r="3.4"/><circle cx="1530" cy="350" r="3.4"/>
+      <circle cx="1580" cy="770" r="3.4"/><circle cx="570" cy="320" r="3.4"/><circle cx="610" cy="660" r="3.4"/>
+    </g>
+    <g fill="#84868f" font-size="11">
+      <text x="1060" y="308" text-anchor="middle">mcp-server</text>
+      <text x="1408" y="404">ai-agent-partner</text><text x="1448" y="726">mode-aware-adapters</text>
+      <text x="1060" y="840" text-anchor="middle">ontology-core</text>
+      <text x="705" y="768" text-anchor="middle">vault-local-first</text><text x="672" y="384" text-anchor="middle">views</text>
+    </g>
+    <text x="1060" y="602" text-anchor="middle" fill="#d4b478" font-size="11">ontology-atlas</text>
+  </svg>
+
+  <div class="chrome">
+    <div class="pill"><span class="pip">◈</span><b>Ontology Atlas</b><span class="census"><b>102</b> concepts · <b>478</b> relations</span><span class="sample">Sample</span></div>
+    <div class="util"><span class="btn">🔍</span><span class="btn">?</span><span class="btn">⚙</span></div>
+  </div>
+
+  <aside class="index">
+    <div class="starter">
+      <p class="cap"><span class="dot"></span>시작하기<span class="s">지금은 샘플</span></p>
+      <p><b>마크다운 frontmatter 가 곧 그래프입니다.</b> 지금 지도는 이 프로젝트 자신의 온톨로지(읽기 전용) — 폴더를 고르면 내 데이터로 그려집니다.</p>
+      <button class="open">내 마크다운 폴더 열기 <span class="kbd">⌘O</span></button>
+      <p class="sub"><a>새 vault 만들기</a><a>그냥 둘러볼게요</a></p>
+    </div>
+    <div class="body">
+      <p class="cap2">INDEX <span>⌘K 검색</span></p>
+      <div class="search">노드 검색…</div>
+      <div class="tree">
+        <div class="d proj"><span>◇ ontology-atlas</span><span class="n">102</span></div>
+        <div class="d"><span>▸ ontology-core</span><span class="n">24</span></div>
+        <div class="d"><span>▸ views</span><span class="n">31</span></div>
+        <div class="d"><span>▸ vault-local-first</span><span class="n">14</span></div>
+        <div class="d"><span>▸ ai-agent-partner</span><span class="n">17</span></div>
+        <div class="d"><span>▸ mode-aware-adapters</span><span class="n">9</span></div>
+        <div class="d"><span>▸ onboarding-ux</span><span class="n">6</span></div>
+      </div>
+      <p class="foot"><b>샘플 vault</b> — 이 프로젝트 자신의 frontmatter. 목업 데이터 없음.</p>
+    </div>
+  </aside>
+</div>
+</body>
+</html>

--- a/docs/prototypes/first-run-v3-flagship.html
+++ b/docs/prototypes/first-run-v3-flagship.html
@@ -1,0 +1,270 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  first-run v3 FLAGSHIP — "관제탑 첫 기동" (소유자 "더 멋지고 예쁘게" 라운드)
+  베이스 = v2b INDEX 통합(플로팅 표면 0) + B2+ 렌더 언어 풀 밀도:
+  · 캔버스: 결정론 도트 격자 · 곡선 회로 트레이스(PCB 곡률) · 별먼지 ·
+    회절 스파이크(밝은 별) · 신호 펄스(hex→mcp-server 전원 인가) ·
+    가공 헥사곤(이중 헤어라인+핀틱) · 도메인 칩(IC 핀틱) · 정적 비네트
+  · 시작하기 모듈: 가공 베젤 코너 틱 · 각인 census 계기 3구 · sheen 버튼
+    (inset 1px 하이라이트 — glow 아님) · 키캡 ⌘O
+  · INDEX 트리: kind 글리프 + 도메인별 1px capacity meter(실카운트 비례)
+  동작 계약(불변): 재방문·복원 vault 시 이 모듈/SAMPLE 배지 미렌더, 본인
+  vault 직행. "그냥 둘러볼게요" = sessionStorage 닫힘.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>첫 기동 v3 — 관제탑</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#101118; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.6);
+    --amber:#d4b478; --amber-soft:rgba(212,180,120,.42);
+  }
+  *{margin:0;box-sizing:border-box}
+  html,body{height:100%}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;overflow:hidden}
+  .frame{width:100%;height:100vh;position:relative;overflow:hidden;background:var(--canvas)}
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  text{font-family:ui-monospace,monospace}
+  /* ── 상단 크롬 ── */
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:14px 24px;z-index:5}
+  .pill{display:flex;align-items:center;gap:11px;border:1px solid var(--border-soft);background:rgba(16,17,24,.94);border-radius:10px;padding:9px 14px;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .pill .pip{width:22px;height:22px;border:1px solid var(--border-strong);border-radius:6px;display:grid;place-items:center;color:var(--indigo-line);font-size:10px}
+  .pill b.nm{font-size:12.5px;font-weight:600;letter-spacing:.01em}
+  .pill .census{display:flex;align-items:baseline;gap:5px;font-family:ui-monospace,monospace;border-left:1px solid var(--divider);padding-left:11px}
+  .pill .census b{font-size:12px;color:var(--t1);font-weight:600;text-shadow:0 1px 0 rgba(0,0,0,.65)}
+  .pill .census span{font-size:8.5px;letter-spacing:.14em;color:var(--t4);text-transform:uppercase}
+  .pill .census i{font-style:normal;color:var(--t4);font-size:10px;margin:0 2px}
+  .pill .sample{font-family:ui-monospace,monospace;font-size:8.5px;letter-spacing:.16em;color:var(--amber);border:1px solid var(--amber-soft);border-radius:5px;padding:2.5px 8px;text-transform:uppercase}
+  .util{display:flex;gap:8px}
+  .util .btn{width:31px;height:31px;border:1px solid var(--border-soft);background:rgba(16,17,24,.94);border-radius:8px;display:grid;place-items:center;color:var(--t3);font-size:12px}
+  /* ── INDEX 패널 ── */
+  .index{position:absolute;top:78px;left:24px;bottom:24px;width:326px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);border-radius:12px;z-index:4;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 18px 48px rgba(0,0,0,.45)}
+  /* 시작하기 모듈 — 가공 베젤 */
+  .starter{position:relative;padding:18px 18px 16px;border-bottom:1px solid var(--divider);background:linear-gradient(180deg,rgba(94,106,210,.08),rgba(94,106,210,.015) 70%,transparent)}
+  .starter .tick{position:absolute;width:9px;height:9px;border-color:rgba(139,151,255,.5);border-style:solid;border-width:0}
+  .starter .tick.tl{top:7px;left:7px;border-top-width:1px;border-left-width:1px}
+  .starter .tick.tr{top:7px;right:7px;border-top-width:1px;border-right-width:1px}
+  .starter .tick.bl{bottom:7px;left:7px;border-bottom-width:1px;border-left-width:1px}
+  .starter .tick.br{bottom:7px;right:7px;border-bottom-width:1px;border-right-width:1px}
+  .starter .cap{display:flex;align-items:center;gap:9px;font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.22em;color:var(--t2);text-transform:uppercase;margin-bottom:11px}
+  .starter .cap .pw{position:relative;width:8px;height:8px;flex:none}
+  .starter .cap .pw::before{content:"";position:absolute;inset:0;border-radius:50%;background:var(--amber)}
+  .starter .cap .pw::after{content:"";position:absolute;inset:-3px;border-radius:50%;border:1px solid var(--amber-soft)}
+  .starter .cap .s{color:var(--amber);margin-left:auto;letter-spacing:.16em;font-size:8.5px}
+  .starter p.ctx{font-size:12px;line-height:1.6;color:var(--t3);word-break:keep-all;margin-bottom:13px}
+  .starter p.ctx b{color:var(--t1);font-weight:600}
+  /* census 계기 3구 */
+  .meterrow{display:grid;grid-template-columns:1fr 1fr 1fr;border:1px solid var(--divider);border-radius:9px;background:rgba(6,6,9,.55);box-shadow:inset 0 1px 2px rgba(0,0,0,.4);margin-bottom:14px;overflow:hidden}
+  .meterrow .m{padding:9px 0 8px;text-align:center;font-family:ui-monospace,monospace}
+  .meterrow .m+.m{border-left:1px solid var(--divider)}
+  .meterrow .m b{display:block;font-size:19px;font-weight:600;color:var(--t1);text-shadow:0 1px 0 rgba(0,0,0,.7);letter-spacing:.02em}
+  .meterrow .m span{font-size:8px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase}
+  .starter .open{position:relative;display:flex;width:100%;align-items:center;justify-content:center;gap:9px;border:1px solid rgba(139,151,255,.45);border-radius:9px;background:var(--indigo);color:#fff;font-size:13.5px;font-weight:600;padding:11px 0;box-shadow:inset 0 1px 0 rgba(255,255,255,.22),0 8px 20px rgba(0,0,0,.35);cursor:pointer}
+  .starter .open .kbd{font-family:ui-monospace,monospace;font-size:9.5px;font-weight:500;opacity:.8;border:1px solid rgba(255,255,255,.35);border-bottom-width:2px;border-radius:4px;padding:1px 6px}
+  .starter .sub{display:flex;justify-content:space-between;margin-top:11px;font-size:11.5px}
+  .starter .sub a{color:var(--t3);text-decoration:none;border-bottom:1px solid var(--divider);padding-bottom:1px;cursor:pointer}
+  .starter .sub a:hover{color:var(--t2)}
+  /* INDEX 본문 */
+  .body{padding:15px 18px;display:flex;flex-direction:column;gap:11px;flex:1;min-height:0}
+  .cap2{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.2em;color:var(--t4);text-transform:uppercase;display:flex;justify-content:space-between}
+  .search{display:flex;align-items:center;gap:8px;border:1px solid var(--divider);border-radius:8px;background:var(--elevated);color:var(--t4);font-size:12px;padding:8px 11px;box-shadow:inset 0 1px 2px rgba(0,0,0,.3)}
+  .tree{display:grid;gap:1px}
+  .row{display:grid;grid-template-columns:16px 1fr auto;align-items:center;gap:9px;padding:7px 9px;border-radius:7px}
+  .row:hover{background:rgba(255,255,255,.035)}
+  .row .g{width:9px;height:9px;justify-self:center}
+  .row .g.hex{background:none;border:1.2px solid var(--amber);width:10px;height:10px;clip-path:polygon(50% 0,100% 27%,100% 73%,50% 100%,0 73%,0 27%)}
+  .row .g.sq{border:1.2px solid var(--indigo-line);border-radius:2px}
+  .row .lbl{font-size:12.5px;color:var(--t2);min-width:0}
+  .row.proj .lbl{color:var(--amber);font-weight:600}
+  .row .lbl .meter{display:block;height:1px;margin-top:4px;background:rgba(255,255,255,.06);border-radius:1px;overflow:hidden}
+  .row .lbl .meter i{display:block;height:100%;background:rgba(139,151,255,.4)}
+  .row .n{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);text-shadow:0 1px 0 rgba(0,0,0,.6)}
+  .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:11px;font-size:11px;line-height:1.55;color:var(--t4);word-break:keep-all}
+  .foot b{color:var(--t3);font-weight:500}
+  /* 우하단 계기 판독 */
+  .readout{position:absolute;right:24px;bottom:24px;z-index:5;font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.2em;color:var(--t4);text-transform:uppercase;display:flex;gap:14px;align-items:center}
+  .readout .k{color:var(--t3)}
+  .readout .d{width:3px;height:3px;border-radius:50%;background:var(--t4)}
+</style>
+</head>
+<body>
+<div class="frame">
+  <svg class="map" viewBox="0 0 1920 1080" preserveAspectRatio="xMidYMid slice">
+    <defs>
+      <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+        <circle cx="1" cy="1" r="0.8" fill="rgba(255,255,255,.03)"/>
+      </pattern>
+      <radialGradient id="vig" cx="56%" cy="50%" r="72%">
+        <stop offset="58%" stop-color="rgba(6,6,9,0)"/>
+        <stop offset="100%" stop-color="rgba(6,6,9,.75)"/>
+      </radialGradient>
+      <radialGradient id="halo" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stop-color="rgba(94,106,210,.06)"/>
+        <stop offset="100%" stop-color="rgba(94,106,210,0)"/>
+      </radialGradient>
+    </defs>
+    <rect width="1920" height="1080" fill="url(#grid)"/>
+    <circle cx="1080" cy="565" r="520" fill="url(#halo)"/>
+
+    <text x="1330" y="330" fill="rgba(255,255,255,.042)" font-size="46" letter-spacing=".34em">VIEWS</text>
+    <text x="600" y="880" fill="rgba(255,255,255,.042)" font-size="46" letter-spacing=".34em">CORE</text>
+    <text x="1490" y="640" fill="rgba(255,255,255,.032)" font-size="30" letter-spacing=".3em">AGENT</text>
+
+    <!-- 별먼지 -->
+    <g fill="rgba(236,236,240,.16)">
+      <circle cx="520" cy="200" r="1.1"/><circle cx="640" cy="150" r="1.4"/><circle cx="880" cy="180" r="1"/>
+      <circle cx="1240" cy="140" r="1.3"/><circle cx="1560" cy="210" r="1.1"/><circle cx="1720" cy="330" r="1.4"/>
+      <circle cx="1800" cy="540" r="1"/><circle cx="1760" cy="820" r="1.3"/><circle cx="1560" cy="950" r="1.1"/>
+      <circle cx="1240" cy="990" r="1.4"/><circle cx="900" cy="960" r="1"/><circle cx="640" cy="990" r="1.2"/>
+      <circle cx="470" cy="620" r="1.2"/><circle cx="560" cy="450" r="1"/><circle cx="1660" cy="470" r="1.2"/>
+      <circle cx="1350" cy="870" r="1"/><circle cx="760" cy="250" r="1.1"/><circle cx="1450" cy="180" r="1"/>
+      <circle cx="1840" cy="700" r="1.1"/><circle cx="420" cy="820" r="1.3"/>
+    </g>
+
+    <!-- 곡선 회로 트레이스 (hex→domain) -->
+    <g fill="none" stroke="rgba(255,255,255,.10)" stroke-width="1.1">
+      <path d="M1080,530 Q1070,420 1080,362"/>
+      <path d="M1112,548 Q1280,470 1388,442"/>
+      <path d="M1112,585 Q1310,650 1442,706"/>
+      <path d="M1080,606 Q1088,720 1080,800"/>
+      <path d="M1048,588 Q900,680 800,738"/>
+      <path d="M1048,548 Q880,470 762,404"/>
+    </g>
+    <!-- 도메인 상호 관계 (점선) -->
+    <g fill="none" stroke="rgba(139,151,255,.28)" stroke-width="1" stroke-dasharray="2.5 5">
+      <path d="M1400,458 Q1450,580 1448,692"/>
+      <path d="M776,418 Q920,360 1062,352"/>
+      <path d="M812,742 Q950,800 1064,812"/>
+    </g>
+    <!-- 전원 인가 트레이스: hex→mcp-server + 신호 펄스 3점 -->
+    <path d="M1080,530 Q1070,420 1080,362" fill="none" stroke="rgba(139,151,255,.55)" stroke-width="1.3"/>
+    <g>
+      <circle cx="1076" cy="484" r="2.6" fill="rgba(139,151,255,.9)"/>
+      <circle cx="1074" cy="452" r="2" fill="rgba(139,151,255,.55)"/>
+      <circle cx="1075" cy="424" r="1.5" fill="rgba(139,151,255,.3)"/>
+    </g>
+
+    <!-- element pads (도메인 주변 위성) -->
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="1400" y1="432" x2="1520" y2="368"/><line x1="1400" y1="432" x2="1540" y2="452"/>
+      <line x1="1456" y1="716" x2="1590" y2="690"/><line x1="1456" y1="716" x2="1570" y2="800"/>
+      <line x1="1080" y1="814" x2="1210" y2="880"/><line x1="1080" y1="814" x2="960" y2="892"/>
+      <line x1="786" y1="748" x2="670" y2="700"/><line x1="750" y1="392" x2="640" y2="320"/>
+      <line x1="1080" y1="348" x2="1190" y2="272"/><line x1="1080" y1="348" x2="964" y2="264"/>
+    </g>
+    <g fill="rgba(184,186,194,.85)">
+      <circle cx="1520" cy="368" r="3.2"/><circle cx="1540" cy="452" r="3.2"/><circle cx="1590" cy="690" r="3.2"/>
+      <circle cx="1570" cy="800" r="3.2"/><circle cx="1210" cy="880" r="3.2"/><circle cx="960" cy="892" r="3.2"/>
+      <circle cx="670" cy="700" r="3.2"/><circle cx="640" cy="320" r="3.2"/>
+    </g>
+    <g fill="none" stroke="rgba(184,186,194,.3)" stroke-width="1">
+      <circle cx="1520" cy="368" r="6"/><circle cx="1590" cy="690" r="6"/><circle cx="960" cy="892" r="6"/><circle cx="640" cy="320" r="6"/>
+    </g>
+
+    <!-- 회절 스파이크: mcp-server(허브 별) + 외곽 밝은 별 2 -->
+    <g stroke="rgba(236,236,240,.35)" stroke-width="1">
+      <line x1="1080" y1="322" x2="1080" y2="298"/><line x1="1080" y1="374" x2="1080" y2="398"/>
+      <line x1="1054" y1="348" x2="1030" y2="348"/><line x1="1106" y1="348" x2="1130" y2="348"/>
+    </g>
+    <g stroke="rgba(236,236,240,.22)" stroke-width="1">
+      <line x1="1190" y1="258" x2="1190" y2="286"/><line x1="1176" y1="272" x2="1204" y2="272"/>
+      <line x1="670" y1="686" x2="670" y2="714"/><line x1="656" y1="700" x2="684" y2="700"/>
+    </g>
+
+    <!-- mcp-server 허브 노드 (밝은 별 + 링) -->
+    <circle cx="1080" cy="348" r="7" fill="#101118" stroke="rgba(236,236,240,.8)" stroke-width="1.3"/>
+    <circle cx="1080" cy="348" r="12" fill="none" stroke="rgba(212,180,120,.4)" stroke-width="1"/>
+    <text x="1080" y="286" text-anchor="middle" fill="#b8bac2" font-size="11.5">mcp-server</text>
+
+    <!-- 도메인 칩 (IC 핀틱) -->
+    <g>
+      <g fill="#101118" stroke="rgba(139,151,255,.8)" stroke-width="1.1">
+        <rect x="1388" y="420" width="24" height="24" rx="3"/><rect x="1444" y="704" width="24" height="24" rx="3"/>
+        <rect x="1068" y="802" width="24" height="24" rx="3"/><rect x="774" y="736" width="24" height="24" rx="3"/>
+        <rect x="738" y="380" width="24" height="24" rx="3"/>
+      </g>
+      <g stroke="rgba(139,151,255,.35)" stroke-width="1">
+        <line x1="1394" y1="416" x2="1394" y2="410"/><line x1="1400" y1="416" x2="1400" y2="410"/><line x1="1406" y1="416" x2="1406" y2="410"/>
+        <line x1="1450" y1="700" x2="1450" y2="694"/><line x1="1456" y1="700" x2="1456" y2="694"/><line x1="1462" y1="700" x2="1462" y2="694"/>
+        <line x1="1074" y1="798" x2="1074" y2="792"/><line x1="1080" y1="798" x2="1080" y2="792"/><line x1="1086" y1="798" x2="1086" y2="792"/>
+        <line x1="780" y1="732" x2="780" y2="726"/><line x1="786" y1="732" x2="786" y2="726"/><line x1="792" y1="732" x2="792" y2="726"/>
+        <line x1="744" y1="376" x2="744" y2="370"/><line x1="750" y1="376" x2="750" y2="370"/><line x1="756" y1="376" x2="756" y2="370"/>
+      </g>
+      <g fill="rgba(139,151,255,.55)" font-size="8">
+        <text x="1400" y="437" text-anchor="middle">17</text><text x="1456" y="721" text-anchor="middle">9</text>
+        <text x="1080" y="819" text-anchor="middle">24</text><text x="786" y="753" text-anchor="middle">14</text>
+        <text x="750" y="397" text-anchor="middle">31</text>
+      </g>
+    </g>
+    <g fill="#84868f" font-size="11.5">
+      <text x="1432" y="428">ai-agent-partner</text>
+      <text x="1488" y="740">mode-aware-adapters</text>
+      <text x="1080" y="856" text-anchor="middle">ontology-core</text>
+      <text x="786" y="782" text-anchor="middle">vault-local-first</text>
+      <text x="750" y="366" text-anchor="middle">views</text>
+    </g>
+
+    <!-- 프로젝트 헥사곤 (이중 헤어라인 + 핀틱 + 각인) -->
+    <polygon points="1080,522 1116,542 1116,584 1080,604 1044,584 1044,542" fill="#101118" stroke="#d4b478" stroke-width="1.5"/>
+    <polygon points="1080,532 1107,547 1107,579 1080,594 1053,579 1053,547" fill="none" stroke="rgba(212,180,120,.35)" stroke-width="1"/>
+    <g stroke="rgba(212,180,120,.5)" stroke-width="1">
+      <line x1="1080" y1="516" x2="1080" y2="510"/><line x1="1080" y1="610" x2="1080" y2="616"/>
+      <line x1="1038" y1="563" x2="1032" y2="563"/><line x1="1122" y1="563" x2="1128" y2="563"/>
+    </g>
+    <text x="1080" y="568" text-anchor="middle" fill="rgba(212,180,120,.9)" font-size="8" letter-spacing=".2em">PRJ</text>
+    <text x="1080" y="640" text-anchor="middle" fill="#d4b478" font-size="12">ontology-atlas</text>
+
+    <rect width="1920" height="1080" fill="url(#vig)" pointer-events="none"/>
+  </svg>
+
+  <div class="chrome">
+    <div class="pill">
+      <span class="pip">◈</span><b class="nm">Ontology Atlas</b>
+      <span class="census"><b>102</b><span>concepts</span><i>·</i><b>478</b><span>relations</span></span>
+      <span class="sample">Sample</span>
+    </div>
+    <div class="util"><span class="btn">🔍</span><span class="btn">?</span><span class="btn">⚙</span></div>
+  </div>
+
+  <aside class="index">
+    <div class="starter">
+      <i class="tick tl"></i><i class="tick tr"></i><i class="tick bl"></i><i class="tick br"></i>
+      <p class="cap"><span class="pw"></span>First Run<span class="s">지금은 샘플</span></p>
+      <p class="ctx"><b>마크다운 frontmatter 가 곧 그래프입니다.</b> 지금 지도는 이 프로젝트 자신의 온톨로지(읽기 전용) — 폴더를 고르면 같은 지도가 내 데이터로 켜집니다.</p>
+      <div class="meterrow">
+        <div class="m"><b>102</b><span>concepts</span></div>
+        <div class="m"><b>478</b><span>relations</span></div>
+        <div class="m"><b>6</b><span>domains</span></div>
+      </div>
+      <button class="open">내 마크다운 폴더 열기 <span class="kbd">⌘O</span></button>
+      <p class="sub"><a>✚ 새 vault 만들기</a><a>그냥 둘러볼게요 →</a></p>
+    </div>
+    <div class="body">
+      <p class="cap2">INDEX <span>⌘K 검색</span></p>
+      <div class="search">⌕ 노드 검색…</div>
+      <div class="tree">
+        <div class="row proj"><span class="g hex"></span><span class="lbl">ontology-atlas</span><span class="n">102</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">views<span class="meter"><i style="width:100%"></i></span></span><span class="n">31</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">ontology-core<span class="meter"><i style="width:77%"></i></span></span><span class="n">24</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">ai-agent-partner<span class="meter"><i style="width:55%"></i></span></span><span class="n">17</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">vault-local-first<span class="meter"><i style="width:45%"></i></span></span><span class="n">14</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">mode-aware-adapters<span class="meter"><i style="width:29%"></i></span></span><span class="n">9</span></div>
+        <div class="row"><span class="g sq"></span><span class="lbl">onboarding-ux<span class="meter"><i style="width:19%"></i></span></span><span class="n">6</span></div>
+      </div>
+      <p class="foot"><b>샘플 vault</b> — 이 프로젝트 자신의 frontmatter 를 빌드 시점 그대로. 목업 데이터 없음.</p>
+    </div>
+  </aside>
+
+  <div class="readout">
+    <span><span class="k">1</span> project</span><span class="d"></span>
+    <span><span class="k">6</span> domains</span><span class="d"></span>
+    <span>Spine view · 줌인하면 요소가 나타납니다</span>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/prototypes/index-panel-v2-full.html
+++ b/docs/prototypes/index-panel-v2-full.html
@@ -1,0 +1,224 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  index-panel-v2-full — 전체 실적용 합성 시안 (라운드 3, 다듬기).
+  실제 지형도 캡처(shots/rail-real-topology.png) 위에 구 좌측 컬럼을 덮고
+  새 브랜드 필 + INDEX 패널 v2.1 을 실척으로 합성. "분석 보기" 칩은 은퇴
+  예정이라 덮인 상태가 곧 실적용 모습.
+  v2 → v2.1 다듬기: 텍스트 캐럿(▶) 폐기 → Lucide chevron SVG · 행 세로 정렬
+  (카운트 센터) · 미터 트랙 인셋 · pip 인디고 틴트 · 유틸 타일 아이콘 16px ·
+  푸터/헤더 리듬 정리 · 캐럿 회전 상태.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>INDEX 패널 v2.1 — 전체 실적용 합성</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#101118; --elevated:#16171d;
+    --divider:rgba(255,255,255,.08); --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#63656e;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.14); --indigo-line:rgba(139,151,255,.8);
+    --indigo-ink:rgba(139,151,255,.45);
+    --amber:#d4b478;
+    --engrave:0 1px 0 rgba(0,0,0,.65);
+  }
+  *{margin:0;box-sizing:border-box}
+  html,body{height:100%}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;overflow:hidden}
+  .stage{position:relative;width:100%;height:100vh;overflow:hidden}
+  .stage>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:left top}
+  /* 구 크롬 커버 — 좌측 컬럼 + 상단 스트립 + 우측 레일을 캔버스색으로 덮음 */
+  .cover{position:absolute;top:0;left:0;bottom:0;width:412px;
+    background:linear-gradient(90deg, var(--canvas) 0%, var(--canvas) 92%, rgba(6,6,9,0) 100%)}
+  .cover-top{position:absolute;top:0;left:0;right:0;height:82px;
+    background:linear-gradient(180deg, var(--canvas) 0%, var(--canvas) 86%, rgba(6,6,9,0) 100%)}
+  .cover-right{position:absolute;top:0;right:0;bottom:0;width:96px;
+    background:linear-gradient(270deg, var(--canvas) 0%, var(--canvas) 82%, rgba(6,6,9,0) 100%)}
+  svg.lucide{fill:none;stroke:currentColor;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round}
+  /* ── 브랜드 필 + 유틸 타일 ── */
+  .toprow{position:absolute;top:14px;left:24px;display:flex;align-items:stretch;gap:8px;z-index:3}
+  .pill{display:flex;align-items:center;gap:11px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);
+    border-radius:10px;padding:8px 14px 8px 9px;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .pill .pip{width:28px;height:28px;border:1px solid rgba(139,151,255,.3);background:var(--indigo-soft);border-radius:8px;display:grid;place-items:center;color:var(--indigo-line);flex:none}
+  .pill .pip svg{width:15px;height:15px}
+  .pill .tx b{display:block;font-size:13px;font-weight:650;line-height:1.25;letter-spacing:-.005em}
+  .pill .tx .census{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);display:flex;gap:4px;align-items:baseline;margin-top:1.5px}
+  .pill .tx .census b{display:inline;font-size:11px;color:var(--t2);font-weight:600;text-shadow:var(--engrave)}
+  .pill .tx .census .up{color:var(--amber)}
+  .tile{width:44px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);border-radius:10px;
+    display:grid;place-items:center;color:var(--t3);cursor:pointer;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .tile:hover{color:var(--t1);border-color:var(--border-strong)}
+  .tile svg{width:16px;height:16px}
+  /* ── 상단 중앙/우상단/우측 레일 — 동일 문법 ── */
+  .midrow{position:absolute;top:14px;left:50%;transform:translateX(-50%);display:flex;align-items:stretch;gap:8px;z-index:3}
+  .chip{display:flex;align-items:center;gap:8px;border:1px solid var(--border-soft);background:rgba(16,17,24,.96);
+    border-radius:10px;padding:0 14px;height:44px;font-size:12.5px;color:var(--t2);cursor:pointer;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .chip:hover{color:var(--t1);border-color:var(--border-strong)}
+  .chip svg{width:14px;height:14px;color:var(--t3)}
+  .chip .kbd{font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px;color:var(--t4)}
+  .searchbar{display:flex;align-items:center;gap:8px;width:220px;border:1px solid var(--divider);border-radius:10px;
+    background:rgba(16,17,24,.96);color:var(--t4);font-size:12.5px;padding:0 12px;height:44px;
+    box-shadow:0 6px 20px rgba(0,0,0,.35), inset 0 1px 2px rgba(0,0,0,.35)}
+  .searchbar svg{width:14px;height:14px;flex:none}
+  .searchbar .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px}
+  .toprt{position:absolute;top:14px;right:24px;z-index:3}
+  .rightrail{position:absolute;right:24px;top:50%;transform:translateY(-60%);display:flex;flex-direction:column;gap:8px;z-index:3}
+  .rightrail .tile{height:44px}
+  /* ── INDEX 패널 v2.1 ── */
+  .index{position:absolute;top:76px;left:24px;bottom:24px;width:302px;z-index:3;
+    border:1px solid var(--border-soft);background:rgba(15,16,22,.97);border-radius:12px;
+    display:flex;flex-direction:column;overflow:hidden;box-shadow:0 18px 48px rgba(0,0,0,.45)}
+  .index .hd{display:flex;align-items:center;gap:7px;padding:12px 12px 11px 16px;border-bottom:1px solid var(--divider)}
+  .index .hd .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.2em;color:var(--t3);text-transform:uppercase}
+  .index .hd .n{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4)}
+  .index .hd .fold{margin-left:auto;width:26px;height:26px;border:1px solid var(--divider);border-radius:7px;display:grid;place-items:center;color:var(--t4);cursor:pointer}
+  .index .hd .fold:hover{color:var(--t2);border-color:var(--border-strong)}
+  .index .hd .fold svg{width:13px;height:13px}
+  .index .bd{padding:12px 10px 8px;display:flex;flex-direction:column;gap:10px;flex:1;min-height:0}
+  .search{display:flex;align-items:center;gap:8px;margin:0 5px;border:1px solid var(--divider);border-radius:8px;
+    background:var(--elevated);color:var(--t4);font-size:12px;padding:8px 11px;box-shadow:inset 0 1px 2px rgba(0,0,0,.35)}
+  .search svg{width:13px;height:13px;flex:none}
+  .search .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px;color:var(--t4)}
+  .tree{display:flex;flex-direction:column;gap:1px;overflow-y:auto}
+  .row{display:grid;grid-template-columns:14px 15px 1fr auto;align-items:center;column-gap:8px;padding:7px 9px;border-radius:8px;cursor:pointer;min-height:34px}
+  .row:hover{background:rgba(255,255,255,.035)}
+  .row.sel{background:var(--indigo-soft);box-shadow:inset 0 0 0 1px rgba(139,151,255,.18)}
+  .row .caret{justify-self:center;color:var(--t4);display:grid;place-items:center}
+  .row .caret svg{width:11px;height:11px}
+  .row .caret.open svg{transform:rotate(90deg)}
+  .row .g{justify-self:center}
+  .row .g.hex{width:11px;height:11px;border:1.3px solid var(--amber);clip-path:polygon(50% 0,100% 27%,100% 73%,50% 100%,0 73%,0 27%)}
+  .row .g.sq{width:9px;height:9px;border:1.3px solid var(--indigo-line);border-radius:2.5px}
+  .row .g.doc{width:9px;height:9px;border:1.3px solid var(--t3);border-radius:50%}
+  .row .lbl{min-width:0;font-size:12.5px;color:var(--t2);line-height:1.35}
+  .row.proj .lbl{color:var(--amber);font-weight:600;font-size:13px}
+  .row .lbl .nm{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row .lbl .sub{display:flex;align-items:center;gap:7px;margin-top:3.5px}
+  .row .lbl .sub em{font-style:normal;font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);flex:none;letter-spacing:.01em}
+  .row .lbl .meter{flex:1;height:2px;border-radius:1px;background:rgba(0,0,0,.45);box-shadow:inset 0 1px 1px rgba(0,0,0,.5);overflow:hidden}
+  .row .lbl .meter i{display:block;height:100%;background:var(--indigo-ink)}
+  .row.sel .lbl .meter i{background:var(--indigo-line)}
+  .row .n{font-family:ui-monospace,monospace;font-size:11px;color:var(--t3);font-weight:600;text-shadow:var(--engrave)}
+  .row.proj .n{color:var(--t2);font-size:11.5px}
+  .row.doc .lbl{color:var(--t3);font-size:12px}
+  .index .ft{border-top:1px solid var(--divider);padding:10px 16px;display:flex;align-items:center;gap:8px;font-size:11px;color:var(--t4)}
+  .index .ft .dot{width:5px;height:5px;border-radius:50%;background:var(--amber);flex:none}
+  .index .ft b{color:var(--t3);font-weight:500}
+  .index .ft .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px}
+</style>
+</head>
+<body>
+<div class="stage">
+  <img src="shots/rail-real-topology.png" alt="실제 지형도 화면"/>
+  <div class="cover-top"></div>
+  <div class="cover-right"></div>
+  <div class="cover"></div>
+
+  <!-- 상단 중앙 — 같은 문법의 정렬/검색 클러스터 -->
+  <div class="midrow">
+    <span class="chip"><svg class="lucide" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>자동 정렬</span>
+    <div class="searchbar">
+      <svg class="lucide" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+      검색<span class="kbd">⌘K</span>
+    </div>
+  </div>
+
+  <!-- 우상단 — 작업공간 (같은 pill 문법) -->
+  <div class="toprt">
+    <span class="chip"><svg class="lucide" viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/></svg>작업공간<span class="kbd">D</span></span>
+  </div>
+
+  <!-- 우측 세로 레일 — 좌측 유틸과 동일한 44px 타일 -->
+  <div class="rightrail">
+    <span class="tile" title="전체 보기"><svg class="lucide" viewBox="0 0 24 24"><path d="M15 3h6v6"/><path d="M9 21H3v-6"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg></span>
+    <span class="tile" title="지도 조절"><svg class="lucide" viewBox="0 0 24 24"><line x1="21" x2="14" y1="4" y2="4"/><line x1="10" x2="3" y1="4" y2="4"/><line x1="21" x2="12" y1="12" y2="12"/><line x1="8" x2="3" y1="12" y2="12"/><line x1="21" x2="16" y1="20" y2="20"/><line x1="12" x2="3" y1="20" y2="20"/><line x1="14" x2="14" y1="2" y2="6"/><line x1="8" x2="8" y1="10" y2="14"/><line x1="16" x2="16" y1="18" y2="22"/></svg></span>
+    <span class="tile" title="단축키"><svg class="lucide" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg></span>
+    <span class="tile" title="설정"><svg class="lucide" viewBox="0 0 24 24"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></span>
+  </div>
+
+  <div class="toprow">
+    <div class="pill">
+      <span class="pip"><svg class="lucide" viewBox="0 0 24 24"><path d="M12 2l8.66 5v10L12 22l-8.66-5V7z"/></svg></span>
+      <span class="tx"><b>지형도</b>
+        <span class="census">개념 <b>289</b> · 관계 <b>483</b> · <span class="up">이번 주 +1</span></span></span>
+    </div>
+    <span class="tile" title="문서함"><svg class="lucide" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span>
+    <span class="tile" title="빌더"><svg class="lucide" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></span>
+  </div>
+
+  <aside class="index">
+    <div class="hd">
+      <span class="cap">INDEX</span><span class="n">· 103</span>
+      <span class="fold" title="접기"><svg class="lucide" viewBox="0 0 24 24"><path d="m18 15-6-6-6 6"/></svg></span>
+    </div>
+    <div class="bd">
+      <div class="search">
+        <svg class="lucide" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        개념 검색<span class="kbd">⌘K</span>
+      </div>
+      <div class="tree">
+        <div class="row proj">
+          <span class="caret open"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g hex"></span>
+          <span class="lbl"><span class="nm">ontology-atlas</span></span>
+          <span class="n">6</span>
+        </div>
+        <div class="row sel">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">AI Agent Partner</span>
+            <span class="sub"><em>역량 10 · 요소 32</em><span class="meter"><i style="width:44%"></i></span></span></span>
+          <span class="n">42</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Mode-Aware Adapters</span>
+            <span class="sub"><em>역량 2 · 요소 8</em><span class="meter"><i style="width:10%"></i></span></span></span>
+          <span class="n">10</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Onboarding &amp; UX</span>
+            <span class="sub"><em>역량 2 · 요소 94</em><span class="meter"><i style="width:100%"></i></span></span></span>
+          <span class="n">96</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Ontology Core</span>
+            <span class="sub"><em>역량 1 · 요소 7</em><span class="meter"><i style="width:8%"></i></span></span></span>
+          <span class="n">8</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Vault — Local-First</span>
+            <span class="sub"><em>역량 4 · 요소 27</em><span class="meter"><i style="width:32%"></i></span></span></span>
+          <span class="n">31</span>
+        </div>
+        <div class="row">
+          <span class="caret"><svg class="lucide" viewBox="0 0 24 24"><path d="m9 18 6-6-6-6"/></svg></span>
+          <span class="g sq"></span>
+          <span class="lbl"><span class="nm">Views — Topology · Browse</span>
+            <span class="sub"><em>역량 17 · 요소 73</em><span class="meter"><i style="width:94%"></i></span></span></span>
+          <span class="n">90</span>
+        </div>
+        <div class="row doc">
+          <span class="caret"></span>
+          <span class="g doc"></span>
+          <span class="lbl"><span class="nm">자기 ontology vault 안내</span></span>
+          <span class="n"></span>
+        </div>
+      </div>
+    </div>
+    <div class="ft">
+      <span class="dot"></span><b>에이전트 동기화</b> · 이번 주 +1
+      <span class="kbd">⇧⌘K</span>
+    </div>
+  </aside>
+</div>
+</body>
+</html>

--- a/docs/prototypes/index-panel-v2.html
+++ b/docs/prototypes/index-panel-v2.html
@@ -1,0 +1,176 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min (이 파일은 좌측 컬럼 확대 시안 — 실척) -->
+<!--
+  index-panel-v2 — 지형도 좌측 컬럼(브랜드 필 + INDEX 패널) 리디자인.
+  소유자 반려("디자인 별로") + Guardian 실측 처방 반영:
+  · 단일 24px 좌측 레일 정렬 (필 32 / 패널 18px 어긋남 해소), radius 패밀리 10/12
+  · 필 = 직사각(999px 원형 폐기), 헥스 pip + 타이틀 + 각인 census 한 줄
+  · 원형 아이콘 버튼 2개 → 8px 정사각 타일 (Lucide)
+  · INDEX 헤더 평문화: "INDEX · 에이전트 동기화" → 패널 정체(트리)와 상태 분리
+    — 상태는 푸터로, 헤더는 INDEX + 접기 정사각 버튼
+  · 트리 행 = grid(캐럿+글리프 / 라벨+서브+미터 / 각인 카운트):
+    - kind 글리프: 프로젝트=앰버 헥스, 도메인=인디고 스퀘어, 문서=서클
+    - 역량·요소 서브카운트 mono
+    - capacity meter = 라벨 폭 안 1px 인라인, 상시 인디고 잉크 (회색 3px 별도 줄 폐기)
+    - 카운트 = 각인(letterpress) 적용 (--topology-v2-numeral-shadow 실적용)
+  · 실데이터 그대로 (스크린샷 기준): 289/483, 도메인 6 + 문서 1
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>INDEX 패널 v2 — 좌측 컬럼 실척</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#101118; --elevated:#16171d;
+    --divider:rgba(255,255,255,.08); --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.17);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#63656e;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.14); --indigo-line:rgba(139,151,255,.8);
+    --indigo-ink:rgba(139,151,255,.45);
+    --amber:#d4b478;
+    --engrave:0 1px 0 rgba(0,0,0,.65);
+  }
+  *{margin:0;box-sizing:border-box}
+  html,body{height:100%}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif;overflow:hidden}
+  .stage{position:relative;width:100%;height:100vh;
+    background:
+      radial-gradient(ellipse 60% 50% at 70% 40%, rgba(94,106,210,.04), transparent 70%),
+      var(--canvas)}
+  .stage::before{content:"";position:absolute;inset:0;
+    background-image:radial-gradient(rgba(255,255,255,.025) .8px, transparent .8px);
+    background-size:30px 30px}
+  svg.lucide{width:15px;height:15px;fill:none;stroke:currentColor;stroke-width:1.75;stroke-linecap:round;stroke-linejoin:round}
+  /* ── 상단: 브랜드 필 + 유틸 타일 — 24px 레일 정렬 ── */
+  .toprow{position:absolute;top:14px;left:24px;display:flex;align-items:stretch;gap:8px}
+  .pill{display:flex;align-items:center;gap:11px;border:1px solid var(--border-soft);background:rgba(16,17,24,.95);
+    border-radius:10px;padding:8px 14px;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .pill .pip{width:26px;height:26px;border:1px solid var(--border-strong);border-radius:7px;display:grid;place-items:center;color:var(--indigo-line);flex:none}
+  .pill .pip svg{width:14px;height:14px}
+  .pill .tx b{display:block;font-size:13px;font-weight:650;line-height:1.25;letter-spacing:-.005em}
+  .pill .tx .census{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);display:flex;gap:4px;align-items:baseline;margin-top:1px}
+  .pill .tx .census b{display:inline;font-size:11px;color:var(--t2);font-weight:600;text-shadow:var(--engrave)}
+  .pill .tx .census .up{color:var(--amber);font-size:10px}
+  .tile{width:42px;border:1px solid var(--border-soft);background:rgba(16,17,24,.95);border-radius:10px;
+    display:grid;place-items:center;color:var(--t3);cursor:pointer;box-shadow:0 6px 20px rgba(0,0,0,.35)}
+  .tile:hover{color:var(--t1);border-color:var(--border-strong)}
+  /* ── INDEX 패널 — 같은 24px 레일, radius 12 ── */
+  .index{position:absolute;top:76px;left:24px;bottom:24px;width:302px;
+    border:1px solid var(--border-soft);background:rgba(16,17,24,.96);border-radius:12px;
+    display:flex;flex-direction:column;overflow:hidden;box-shadow:0 18px 48px rgba(0,0,0,.45)}
+  .index .hd{display:flex;align-items:center;gap:8px;padding:13px 15px 11px;border-bottom:1px solid var(--divider)}
+  .index .hd .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.22em;color:var(--t3);text-transform:uppercase}
+  .index .hd .n{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);margin-left:2px}
+  .index .hd .fold{margin-left:auto;width:26px;height:26px;border:1px solid var(--divider);border-radius:7px;display:grid;place-items:center;color:var(--t4);cursor:pointer}
+  .index .hd .fold:hover{color:var(--t2);border-color:var(--border-strong)}
+  .index .hd .fold svg{width:13px;height:13px}
+  .index .bd{padding:12px 10px 10px;display:flex;flex-direction:column;gap:10px;flex:1;min-height:0}
+  .search{display:flex;align-items:center;gap:8px;margin:0 5px;border:1px solid var(--divider);border-radius:8px;
+    background:var(--elevated);color:var(--t4);font-size:12px;padding:8px 11px;box-shadow:inset 0 1px 2px rgba(0,0,0,.35)}
+  .search svg{width:13px;height:13px;flex:none}
+  .search .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px;color:var(--t4)}
+  .tree{display:flex;flex-direction:column;gap:1px;overflow-y:auto}
+  .row{display:grid;grid-template-columns:14px 14px 1fr auto;align-items:center;column-gap:8px;padding:7px 9px 8px;border-radius:8px;cursor:pointer}
+  .row:hover{background:rgba(255,255,255,.035)}
+  .row.sel{background:var(--indigo-soft);box-shadow:inset 0 0 0 1px rgba(139,151,255,.18)}
+  .row .caret{color:var(--t4);font-size:8px;justify-self:center;transition:transform .12s}
+  .row .g{justify-self:center}
+  .row .g.hex{width:11px;height:11px;border:1.3px solid var(--amber);clip-path:polygon(50% 0,100% 27%,100% 73%,50% 100%,0 73%,0 27%)}
+  .row .g.sq{width:9px;height:9px;border:1.3px solid var(--indigo-line);border-radius:2.5px}
+  .row .g.doc{width:9px;height:9px;border:1.3px solid var(--t3);border-radius:50%}
+  .row .lbl{min-width:0;font-size:12.5px;color:var(--t2);line-height:1.35}
+  .row.proj .lbl{color:var(--amber);font-weight:600;font-size:13px}
+  .row .lbl .nm{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .row .lbl .sub{display:flex;align-items:center;gap:6px;margin-top:3px}
+  .row .lbl .sub em{font-style:normal;font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);flex:none}
+  .row .lbl .meter{flex:1;height:1px;background:rgba(255,255,255,.06);border-radius:1px;overflow:hidden}
+  .row .lbl .meter i{display:block;height:100%;background:var(--indigo-ink)}
+  .row.sel .lbl .meter i{background:var(--indigo-line)}
+  .row .n{font-family:ui-monospace,monospace;font-size:11px;color:var(--t3);font-weight:600;text-shadow:var(--engrave);align-self:start;margin-top:1px}
+  .row.proj .n{color:var(--t2);font-size:11.5px}
+  .row.doc .lbl{color:var(--t3);font-size:12px}
+  .index .ft{border-top:1px solid var(--divider);padding:10px 15px;display:flex;align-items:center;gap:8px;
+    font-size:11px;color:var(--t4)}
+  .index .ft .dot{width:5px;height:5px;border-radius:50%;background:var(--amber);flex:none}
+  .index .ft b{color:var(--t3);font-weight:500}
+  .index .ft .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9px;border:1px solid var(--divider);border-radius:4px;padding:1px 5px}
+</style>
+</head>
+<body>
+<div class="stage">
+  <div class="toprow">
+    <div class="pill">
+      <span class="pip"><svg class="lucide" viewBox="0 0 24 24"><path d="M12 2l8.66 5v10L12 22l-8.66-5V7z"/></svg></span>
+      <span class="tx"><b>지형도</b>
+        <span class="census">개념 <b>289</b> · 관계 <b>483</b> · <span class="up">이번 주 +1</span></span></span>
+    </div>
+    <span class="tile" title="문서함"><svg class="lucide" viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span>
+    <span class="tile" title="빌더"><svg class="lucide" viewBox="0 0 24 24"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></span>
+  </div>
+
+  <aside class="index">
+    <div class="hd">
+      <span class="cap">INDEX</span><span class="n">· 103</span>
+      <span class="fold" title="접기"><svg class="lucide" viewBox="0 0 24 24"><path d="m18 15-6-6-6 6"/></svg></span>
+    </div>
+    <div class="bd">
+      <div class="search">
+        <svg class="lucide" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        개념 검색<span class="kbd">⌘K</span>
+      </div>
+      <div class="tree">
+        <div class="row proj">
+          <span class="caret">▼</span><span class="g hex"></span>
+          <span class="lbl"><span class="nm">ontology-atlas</span></span>
+          <span class="n">6</span>
+        </div>
+        <div class="row sel">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">AI Agent Partner</span>
+            <span class="sub"><em>역량 10 · 요소 32</em><span class="meter"><i style="width:44%"></i></span></span></span>
+          <span class="n">42</span>
+        </div>
+        <div class="row">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">Mode-Aware Adapters</span>
+            <span class="sub"><em>역량 2 · 요소 8</em><span class="meter"><i style="width:10%"></i></span></span></span>
+          <span class="n">10</span>
+        </div>
+        <div class="row">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">Onboarding &amp; UX</span>
+            <span class="sub"><em>역량 2 · 요소 94</em><span class="meter"><i style="width:100%"></i></span></span></span>
+          <span class="n">96</span>
+        </div>
+        <div class="row">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">Ontology Core</span>
+            <span class="sub"><em>역량 1 · 요소 7</em><span class="meter"><i style="width:8%"></i></span></span></span>
+          <span class="n">8</span>
+        </div>
+        <div class="row">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">Vault — Local-First</span>
+            <span class="sub"><em>역량 4 · 요소 27</em><span class="meter"><i style="width:32%"></i></span></span></span>
+          <span class="n">31</span>
+        </div>
+        <div class="row">
+          <span class="caret">▶</span><span class="g sq"></span>
+          <span class="lbl"><span class="nm">Views — Topology · Browse</span>
+            <span class="sub"><em>역량 17 · 요소 73</em><span class="meter"><i style="width:94%"></i></span></span></span>
+          <span class="n">90</span>
+        </div>
+        <div class="row doc">
+          <span class="caret"></span><span class="g doc"></span>
+          <span class="lbl"><span class="nm">자기 ontology vault 안내</span></span>
+          <span class="n"></span>
+        </div>
+      </div>
+    </div>
+    <div class="ft">
+      <span class="dot"></span><b>에이전트 동기화</b> · 이번 주 +1
+      <span class="kbd">⇧⌘K</span>
+    </div>
+  </aside>
+</div>
+</body>
+</html>

--- a/docs/prototypes/root-first-open-a-workbench.html
+++ b/docs/prototypes/root-first-open-a-workbench.html
@@ -1,0 +1,143 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  root-first-open A — "워크벤치 첫 화면" (웹·데스크톱 진입 통일)
+  관찰 현상: OSS 셀프호스트 첫 오픈이 "macOS 다운로드" 마케팅 랜딩 — 모순.
+  안 A: 웹의 vault-미선택 `/` 를 데스크톱 FirstRun 과 같은 "작업 시작" 화면으로
+  통일. 열기/새로 만들기/샘플 3택 + 에이전트 셋업 행. 마케팅은 하단 한 줄로 강등.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>첫 화면 A — 워크벤치 진입</title>
+<style>
+  :root{
+    --canvas:#0a0b0e; --panel:#111217; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.16);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.55);
+    --amber:#d4b478;
+    --page-max:1600px; --section-gap:28px; --card-gap:20px; --card-pad:16px;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.55 -apple-system,"Pretendard",sans-serif;}
+  .frame{width:1920px;height:1080px;margin:0 auto;display:flex;flex-direction:column;overflow:hidden}
+  .chrome{display:flex;align-items:center;justify-content:space-between;padding:14px 26px;border-bottom:1px solid var(--divider)}
+  .brand{display:flex;align-items:center;gap:12px}
+  .brand .pip{width:26px;height:26px;border:1px solid var(--border-strong);border-radius:7px;display:grid;place-items:center;color:var(--indigo-line);font-size:12px}
+  .brand b{font-size:13.5px;font-weight:600}
+  .brand .sub{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase;margin-left:6px}
+  .loc{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border:1px solid var(--divider);border-radius:6px;padding:4px 8px}
+  .loc b{color:var(--t2)}
+  main{flex:1;display:grid;grid-template-columns:1fr 620px;gap:56px;max-width:var(--page-max);width:100%;margin:0 auto;padding:64px 26px 40px;align-content:start}
+  .eyebrow{font-family:ui-monospace,monospace;font-size:10px;letter-spacing:.2em;color:var(--t4);text-transform:uppercase;display:flex;align-items:center;gap:8px}
+  .eyebrow .dot{width:5px;height:5px;border-radius:50%;background:var(--indigo)}
+  h1{font-size:34px;line-height:1.25;font-weight:650;margin:14px 0 10px;letter-spacing:-.01em;word-break:keep-all}
+  h1 .accent{color:var(--indigo-line)}
+  .lede{font-size:14.5px;color:var(--t3);max-width:560px;word-break:keep-all}
+  .actions{display:grid;gap:var(--card-gap);margin-top:var(--section-gap)}
+  .act{display:flex;align-items:center;gap:16px;border:1px solid var(--border-soft);border-radius:10px;background:var(--panel);padding:18px var(--card-pad);cursor:pointer}
+  .act:hover{border-color:var(--border-strong)}
+  .act.primary{border-color:var(--indigo);background:linear-gradient(0deg,var(--indigo-soft),var(--indigo-soft)),var(--panel)}
+  .act .glyph{width:38px;height:38px;border:1px solid var(--border-strong);border-radius:9px;display:grid;place-items:center;font-size:15px;color:var(--t2);flex:none}
+  .act.primary .glyph{border-color:var(--indigo-line);color:var(--indigo-line)}
+  .act .tx b{display:block;font-size:14.5px;font-weight:600}
+  .act .tx span{font-size:12px;color:var(--t3)}
+  .act .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border:1px solid var(--divider);border-radius:5px;padding:3px 7px;flex:none}
+  .agent{margin-top:var(--section-gap);border:1px dashed var(--border-soft);border-radius:10px;padding:14px var(--card-pad)}
+  .agent .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.16em;color:var(--t4);text-transform:uppercase;margin-bottom:10px}
+  .row{display:flex;align-items:center;gap:10px;padding:7px 0;border-top:1px solid var(--divider);font-size:12px;color:var(--t3)}
+  .row:first-of-type{border-top:0}
+  .row code{font-family:ui-monospace,monospace;font-size:11px;color:var(--t2);background:var(--elevated);border:1px solid var(--divider);border-radius:5px;padding:2px 8px}
+  .row .who{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.12em;color:var(--t4);width:44px;flex:none;text-transform:uppercase}
+  /* 우측 — 샘플 지도 계기 */
+  .inst{border:1px solid var(--border-soft);border-radius:12px;background:var(--panel);overflow:hidden;align-self:start}
+  .inst .hd{display:flex;justify-content:space-between;align-items:center;padding:11px 16px;border-bottom:1px solid var(--divider)}
+  .inst .hd .l{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t3);text-transform:uppercase;display:flex;gap:8px;align-items:center}
+  .inst .hd .l .dot{width:5px;height:5px;border-radius:50%;background:var(--indigo)}
+  .inst .hd .r{font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4)}
+  .inst svg{display:block;width:100%;height:400px;background:radial-gradient(ellipse at 50% 42%,rgba(94,106,210,.05),transparent 65%)}
+  .inst .census{display:flex;gap:22px;align-items:baseline;padding:13px 16px;border-top:1px solid var(--divider);font-family:ui-monospace,monospace}
+  .inst .census b{font-size:19px;font-weight:600;color:var(--t1);text-shadow:0 1px 0 rgba(0,0,0,.6)}
+  .inst .census span{font-size:9.5px;letter-spacing:.14em;color:var(--t4);text-transform:uppercase}
+  .inst .note{padding:11px 16px;border-top:1px solid var(--divider);font-size:11.5px;color:var(--t4);word-break:keep-all}
+  .inst .note b{color:var(--t3);font-weight:500}
+  footer{display:flex;justify-content:space-between;align-items:center;max-width:var(--page-max);width:100%;margin:0 auto;padding:16px 26px 22px;border-top:1px solid var(--divider)}
+  footer .l{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase}
+  footer .r{font-size:12px;color:var(--t3)}
+  footer .r a{color:var(--t2);text-decoration:none;border-bottom:1px solid var(--divider);margin-left:14px}
+  text{font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+<div class="frame">
+  <div class="chrome">
+    <div class="brand"><span class="pip">◈</span><b>Ontology Atlas</b><span class="sub">Local-first ontology workbench</span></div>
+    <span class="loc">EN <b>KO</b></span>
+  </div>
+
+  <main>
+    <section>
+      <p class="eyebrow"><span class="dot"></span>시작하기 · 설치 완료</p>
+      <h1>마크다운 폴더 하나가<br><span class="accent">살아있는 온톨로지</span>가 됩니다</h1>
+      <p class="lede">폴더를 고르면 그 안의 frontmatter 가 곧 그래프입니다. 로그인도 백엔드도 없습니다 — 데이터는 당신의 디스크에만 있습니다.</p>
+
+      <div class="actions">
+        <div class="act primary">
+          <span class="glyph">⬚</span>
+          <span class="tx"><b>내 마크다운 폴더 열기</b><span>기존 vault 나 문서 폴더를 선택해 바로 지도로</span></span>
+          <span class="kbd">⌘O</span>
+        </div>
+        <div class="act">
+          <span class="glyph">✚</span>
+          <span class="tx"><b>새 vault 만들기</b><span>빈 폴더에 스타터 노드 5개로 시작</span></span>
+        </div>
+        <div class="act">
+          <span class="glyph">◉</span>
+          <span class="tx"><b>샘플로 둘러보기</b><span>이 프로젝트 자신의 온톨로지 102개 노드를 읽기 전용으로</span></span>
+        </div>
+      </div>
+
+      <div class="agent">
+        <p class="cap">터미널·AI 에이전트로 시작할 수도 있어요</p>
+        <div class="row"><span class="who">CLI</span><code>npx ontology-atlas init</code><span>vault 스캐폴드 + 에이전트 설정</span></div>
+        <div class="row"><span class="who">MCP</span><code>.mcp.json 자동 등록</code><span>Claude Code · Codex · Cursor 가 같은 파일을 읽고 씁니다</span></div>
+      </div>
+    </section>
+
+    <aside class="inst">
+      <div class="hd"><span class="l"><span class="dot"></span>Sample · Dogfood vault</span><span class="r">docs/ontology</span></div>
+      <svg viewBox="0 0 620 400">
+        <g stroke="rgba(255,255,255,.10)" stroke-width="1">
+          <line x1="310" y1="200" x2="310" y2="86"/><line x1="310" y1="200" x2="452" y2="128"/>
+          <line x1="310" y1="200" x2="470" y2="252"/><line x1="310" y1="200" x2="310" y2="322"/>
+          <line x1="310" y1="200" x2="158" y2="262"/><line x1="310" y1="200" x2="150" y2="132"/>
+        </g>
+        <g stroke="rgba(139,151,255,.35)" stroke-width="1" stroke-dasharray="3 4">
+          <line x1="452" y1="128" x2="470" y2="252"/><line x1="150" y1="132" x2="310" y2="86"/>
+        </g>
+        <polygon points="310,182 326,191 326,209 310,218 294,209 294,191" fill="#101118" stroke="#d4b478" stroke-width="1.2"/>
+        <g fill="#101118" stroke="rgba(139,151,255,.7)" stroke-width="1">
+          <rect x="303" y="79" width="14" height="14" rx="2"/><rect x="445" y="121" width="14" height="14" rx="2"/>
+          <rect x="463" y="245" width="14" height="14" rx="2"/><rect x="303" y="315" width="14" height="14" rx="2"/>
+          <rect x="151" y="255" width="14" height="14" rx="2"/><rect x="143" y="125" width="14" height="14" rx="2"/>
+        </g>
+        <g fill="#84868f" font-size="9.5">
+          <text x="310" y="70" text-anchor="middle">mcp-server</text><text x="468" y="114">ai-agent-partner</text>
+          <text x="486" y="256">mode-aware-adapters</text><text x="310" y="344" text-anchor="middle">ontology-core</text>
+          <text x="120" y="282">vault-local-first</text><text x="118" y="118">views</text>
+        </g>
+        <text x="310" y="238" text-anchor="middle" fill="#d4b478" font-size="9.5">ontology-atlas</text>
+      </svg>
+      <div class="census"><span><b>102</b> <span>concepts</span></span><span><b>478</b> <span>relations</span></span><span><b>6</b> <span>domains</span></span></div>
+      <p class="note"><b>목업 데이터 없음</b> — 빌드 시점의 실제 frontmatter 를 그대로 그립니다. "샘플로 둘러보기"가 이 그래프를 엽니다.</p>
+    </aside>
+  </main>
+
+  <footer>
+    <span class="l">오픈소스 · Local-first · MCP</span>
+    <span class="r">처음이신가요? <a>제품 소개</a><a>macOS 앱</a><a>GitHub</a></span>
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/prototypes/root-first-open-b-live-demo.html
+++ b/docs/prototypes/root-first-open-b-live-demo.html
@@ -1,0 +1,128 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  root-first-open B — "지도가 곧 첫 화면" (제품이 곧 랜딩)
+  안 B: vault 미선택 `/` 가 곧바로 토폴로지 허브를 dogfood 샘플로 렌더
+  (정적 모드 fallback — 이미 코드가 지원). 상단에 얇은 first-run 배너 하나만
+  얹는다: "샘플을 보는 중 — 내 폴더 열기". 별도 첫 화면 surface 자체가 없음.
+  기존 허브 크롬(INDEX·데이터시트·기어)을 그대로 쓰므로 신규 UI = 배너 1개.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>첫 화면 B — 라이브 데모 지도</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#111217; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.16);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.55);
+    --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif}
+  .frame{width:1920px;height:1080px;margin:0 auto;position:relative;overflow:hidden}
+  /* 상단 크롬 (기존 허브 그대로) */
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:13px 22px;z-index:5}
+  .pill{display:flex;align-items:center;gap:10px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:9px;padding:8px 13px}
+  .pill .pip{width:20px;height:20px;border:1px solid var(--border-strong);border-radius:6px;display:grid;place-items:center;color:var(--indigo-line);font-size:10px}
+  .pill b{font-size:12.5px;font-weight:600}
+  .pill .census{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border-left:1px solid var(--divider);padding-left:10px}
+  .pill .census b{font-size:11px;color:var(--t2);font-weight:600}
+  .util{display:flex;gap:8px}
+  .util .btn{width:30px;height:30px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:7px;display:grid;place-items:center;color:var(--t3);font-size:12px}
+  /* ★ first-run 배너 — 이 시안의 유일한 신규 surface */
+  .firstrun{position:absolute;top:64px;left:50%;transform:translateX(-50%);z-index:6;
+    display:flex;align-items:center;gap:14px;border:1px solid var(--indigo);border-radius:10px;
+    background:linear-gradient(0deg,var(--indigo-soft),var(--indigo-soft)),rgba(17,18,23,.96);padding:11px 16px;box-shadow:0 12px 32px rgba(0,0,0,.5)}
+  .firstrun .dot{width:6px;height:6px;border-radius:50%;background:var(--indigo);flex:none}
+  .firstrun .tx b{font-size:13px;font-weight:600;display:block}
+  .firstrun .tx span{font-size:11.5px;color:var(--t3)}
+  .firstrun .cta{display:flex;align-items:center;gap:8px;margin-left:8px}
+  .firstrun .cta .open{border:0;border-radius:7px;background:var(--indigo);color:#fff;font-size:12.5px;font-weight:600;padding:8px 14px}
+  .firstrun .cta .new{border:1px solid var(--border-strong);border-radius:7px;background:transparent;color:var(--t2);font-size:12.5px;padding:8px 12px}
+  .firstrun .close{color:var(--t4);font-size:12px;margin-left:2px}
+  /* INDEX 패널 (기존) */
+  .index{position:absolute;top:76px;left:22px;bottom:22px;width:300px;border:1px solid var(--border-soft);background:rgba(17,18,23,.94);border-radius:11px;z-index:4;padding:14px;display:flex;flex-direction:column;gap:10px}
+  .index .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase;display:flex;justify-content:space-between}
+  .index .search{border:1px solid var(--divider);border-radius:7px;background:var(--elevated);color:var(--t4);font-size:12px;padding:7px 10px}
+  .index .tree{font-size:12.5px;color:var(--t2);display:grid;gap:2px}
+  .index .tree .d{display:flex;justify-content:space-between;padding:6px 8px;border-radius:6px}
+  .index .tree .d:hover{background:rgba(255,255,255,.04)}
+  .index .tree .d .n{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4)}
+  .index .tree .proj{color:var(--amber);font-weight:600}
+  .index .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:10px;font-size:11px;color:var(--t4);word-break:keep-all}
+  .index .foot b{color:var(--t3);font-weight:500}
+  /* 캔버스 별자리 */
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  .wm{font-family:ui-monospace,monospace;fill:rgba(255,255,255,.045);font-size:44px;letter-spacing:.3em}
+  text{font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+<div class="frame">
+  <svg class="map" viewBox="0 0 1920 1080">
+    <text class="wm" x="1210" y="330">VIEWS</text>
+    <text class="wm" x="520" y="820">CORE</text>
+    <g stroke="rgba(255,255,255,.09)" stroke-width="1">
+      <line x1="1010" y1="560" x2="1010" y2="330"/><line x1="1010" y1="560" x2="1330" y2="420"/>
+      <line x1="1010" y1="560" x2="1370" y2="700"/><line x1="1010" y1="560" x2="1010" y2="810"/>
+      <line x1="1010" y1="560" x2="680" y2="740"/><line x1="1010" y1="560" x2="640" y2="400"/>
+    </g>
+    <g stroke="rgba(139,151,255,.32)" stroke-width="1" stroke-dasharray="3 4">
+      <line x1="1330" y1="420" x2="1370" y2="700"/><line x1="640" y1="400" x2="1010" y2="330"/>
+      <line x1="680" y1="740" x2="1010" y2="810"/>
+    </g>
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="1010" y1="330" x2="1120" y2="240"/><line x1="1010" y1="330" x2="905" y2="235"/>
+      <line x1="1330" y1="420" x2="1470" y2="350"/><line x1="1370" y1="700" x2="1520" y2="770"/>
+      <line x1="640" y1="400" x2="520" y2="320"/><line x1="680" y1="740" x2="560" y2="660"/>
+    </g>
+    <polygon points="1010,538 1030,549 1030,571 1010,582 990,571 990,549" fill="#101118" stroke="#d4b478" stroke-width="1.4"/>
+    <g fill="#101118" stroke="rgba(139,151,255,.75)" stroke-width="1.1">
+      <rect x="1001" y="321" width="18" height="18" rx="2.5"/><rect x="1321" y="411" width="18" height="18" rx="2.5"/>
+      <rect x="1361" y="691" width="18" height="18" rx="2.5"/><rect x="1001" y="801" width="18" height="18" rx="2.5"/>
+      <rect x="671" y="731" width="18" height="18" rx="2.5"/><rect x="631" y="391" width="18" height="18" rx="2.5"/>
+    </g>
+    <g fill="rgba(184,186,194,.8)">
+      <circle cx="1120" cy="240" r="3.4"/><circle cx="905" cy="235" r="3.4"/><circle cx="1470" cy="350" r="3.4"/>
+      <circle cx="1520" cy="770" r="3.4"/><circle cx="520" cy="320" r="3.4"/><circle cx="560" cy="660" r="3.4"/>
+    </g>
+    <g fill="#84868f" font-size="11">
+      <text x="1010" y="308" text-anchor="middle">mcp-server</text>
+      <text x="1348" y="404">ai-agent-partner</text><text x="1388" y="726">mode-aware-adapters</text>
+      <text x="1010" y="840" text-anchor="middle">ontology-core</text>
+      <text x="655" y="768" text-anchor="middle">vault-local-first</text><text x="622" y="384" text-anchor="middle">views</text>
+    </g>
+    <text x="1010" y="602" text-anchor="middle" fill="#d4b478" font-size="11">ontology-atlas</text>
+  </svg>
+
+  <div class="chrome">
+    <div class="pill"><span class="pip">◈</span><b>Ontology Atlas</b><span class="census"><b>102</b> concepts · <b>478</b> relations · 샘플</span></div>
+    <div class="util"><span class="btn">🔍</span><span class="btn">?</span><span class="btn">⚙</span></div>
+  </div>
+
+  <div class="firstrun">
+    <span class="dot"></span>
+    <span class="tx"><b>지금 보는 건 이 프로젝트 자신의 샘플 온톨로지예요</b><span>내 폴더를 고르면 같은 지도가 내 데이터로 그려집니다 · 읽기 전용</span></span>
+    <span class="cta"><button class="open">내 마크다운 폴더 열기</button><button class="new">새 vault 만들기</button></span>
+    <span class="close">✕</span>
+  </div>
+
+  <aside class="index">
+    <p class="cap">INDEX<span>⌘K 검색</span></p>
+    <div class="search">노드 검색…</div>
+    <div class="tree">
+      <div class="d proj"><span>◇ ontology-atlas</span><span class="n">102</span></div>
+      <div class="d"><span>▸ ontology-core</span><span class="n">24</span></div>
+      <div class="d"><span>▸ views</span><span class="n">31</span></div>
+      <div class="d"><span>▸ vault-local-first</span><span class="n">14</span></div>
+      <div class="d"><span>▸ ai-agent-partner</span><span class="n">17</span></div>
+      <div class="d"><span>▸ mode-aware-adapters</span><span class="n">9</span></div>
+      <div class="d"><span>▸ onboarding-ux</span><span class="n">6</span></div>
+    </div>
+    <p class="foot"><b>샘플 vault</b> — docs/ontology 의 실제 frontmatter. 목업 데이터 없음.</p>
+  </aside>
+</div>
+</body>
+</html>

--- a/docs/prototypes/root-first-open-final.html
+++ b/docs/prototypes/root-first-open-final.html
@@ -1,0 +1,152 @@
+<!-- 시안 표준: 1920×1080 primary · 1440 fluid min -->
+<!--
+  root-first-open FINAL — 페르소나 판정(2026-07-18) 반영 확정안.
+  판정: B(지도가 곧 첫 화면) + 강화 배너. 3인 페르소나 보완 요구 흡수:
+  · [김도현] 배너 → 선택 카드급 강화(3택 명시), SAMPLE 시각 명시(필+INDEX)
+  · [박세린] 맥락 한 줄("frontmatter가 곧 그래프…") + 하단 오픈소스 스트립
+  · [이유진] 배너 persistent + ✕ 닫기 = sessionStorage(새 세션 재노출),
+    "읽기 전용" 명시, 지도는 배너 뒤에서도 즉시 탐색 가능(스크림 없음 — 0클릭 aha)
+  구현 계약: vault-미선택 웹 `/` = HomePage(정적 dogfood) + FirstRunChooser 1개.
+  스크림/모달 아님 — 지도 인터랙션 차단 금지. 데스크톱 FirstRun 통일은 후속 결정.
+-->
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>첫 화면 확정안 — 샘플 지도 + 시작 카드</title>
+<style>
+  :root{
+    --canvas:#060609; --panel:#111217; --elevated:#16171d; --divider:rgba(255,255,255,.08);
+    --border-soft:rgba(255,255,255,.10); --border-strong:rgba(255,255,255,.16);
+    --t1:#ececf0; --t2:#b8bac2; --t3:#84868f; --t4:#5c5e66;
+    --indigo:#5e6ad2; --indigo-soft:rgba(94,106,210,.16); --indigo-line:rgba(139,151,255,.55);
+    --amber:#d4b478;
+  }
+  *{margin:0;box-sizing:border-box}
+  body{background:var(--canvas);color:var(--t1);font:14px/1.5 -apple-system,"Pretendard",sans-serif}
+  .frame{width:1920px;height:1080px;margin:0 auto;position:relative;overflow:hidden}
+  .chrome{position:absolute;top:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:13px 22px;z-index:5}
+  .pill{display:flex;align-items:center;gap:10px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:9px;padding:8px 13px}
+  .pill .pip{width:20px;height:20px;border:1px solid var(--border-strong);border-radius:6px;display:grid;place-items:center;color:var(--indigo-line);font-size:10px}
+  .pill b{font-size:12.5px;font-weight:600}
+  .pill .census{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4);border-left:1px solid var(--divider);padding-left:10px}
+  .pill .census b{font-size:11px;color:var(--t2);font-weight:600}
+  .pill .sample{font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.14em;color:var(--amber);border:1px solid rgba(212,180,120,.4);border-radius:5px;padding:2px 7px;text-transform:uppercase}
+  .util{display:flex;gap:8px}
+  .util .btn{width:30px;height:30px;border:1px solid var(--border-soft);background:rgba(17,18,23,.92);border-radius:7px;display:grid;place-items:center;color:var(--t3);font-size:12px}
+  /* ★ FirstRunChooser — 선택 카드급 배너 (스크림 없음, 지도는 뒤에서 인터랙티브) */
+  .chooser{position:absolute;top:70px;left:50%;transform:translateX(-50%);z-index:6;width:560px;
+    border:1px solid var(--indigo);border-radius:12px;background:rgba(17,18,23,.97);
+    box-shadow:0 18px 48px rgba(0,0,0,.55);overflow:hidden}
+  .chooser .hd{display:flex;align-items:center;gap:9px;padding:13px 16px 11px;border-bottom:1px solid var(--divider)}
+  .chooser .hd .dot{width:6px;height:6px;border-radius:50%;background:var(--amber)}
+  .chooser .hd b{font-size:13.5px;font-weight:600}
+  .chooser .hd span{font-family:ui-monospace,monospace;font-size:9px;letter-spacing:.14em;color:var(--amber);margin-left:auto;text-transform:uppercase}
+  .chooser .ctx{padding:10px 16px;font-size:12px;color:var(--t3);border-bottom:1px solid var(--divider);word-break:keep-all}
+  .chooser .ctx b{color:var(--t2);font-weight:500}
+  .chooser .opts{display:grid;padding:10px;gap:6px}
+  .opt{display:flex;align-items:center;gap:12px;border:1px solid transparent;border-radius:8px;padding:10px 12px;cursor:pointer}
+  .opt:hover{background:rgba(255,255,255,.03)}
+  .opt.primary{border-color:var(--indigo);background:linear-gradient(0deg,var(--indigo-soft),var(--indigo-soft))}
+  .opt .g{width:30px;height:30px;border:1px solid var(--border-strong);border-radius:7px;display:grid;place-items:center;font-size:12.5px;color:var(--t2);flex:none}
+  .opt.primary .g{border-color:var(--indigo-line);color:var(--indigo-line)}
+  .opt .tx b{display:block;font-size:13px;font-weight:600}
+  .opt .tx span{font-size:11.5px;color:var(--t3)}
+  .opt .kbd{margin-left:auto;font-family:ui-monospace,monospace;font-size:9.5px;color:var(--t4);border:1px solid var(--divider);border-radius:4px;padding:2px 6px}
+  .opt.ghost .tx b{font-weight:500;color:var(--t2)}
+  /* INDEX — SAMPLE 명시 */
+  .index{position:absolute;top:76px;left:22px;bottom:52px;width:300px;border:1px solid var(--border-soft);background:rgba(17,18,23,.94);border-radius:11px;z-index:4;padding:14px;display:flex;flex-direction:column;gap:10px}
+  .index .cap{font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.18em;color:var(--t4);text-transform:uppercase;display:flex;justify-content:space-between}
+  .index .cap .s{color:var(--amber)}
+  .index .search{border:1px solid var(--divider);border-radius:7px;background:var(--elevated);color:var(--t4);font-size:12px;padding:7px 10px}
+  .index .tree{font-size:12.5px;color:var(--t2);display:grid;gap:2px}
+  .index .tree .d{display:flex;justify-content:space-between;padding:6px 8px;border-radius:6px}
+  .index .tree .d:hover{background:rgba(255,255,255,.04)}
+  .index .tree .d .n{font-family:ui-monospace,monospace;font-size:10px;color:var(--t4)}
+  .index .tree .proj{color:var(--amber);font-weight:600}
+  .index .foot{margin-top:auto;border-top:1px solid var(--divider);padding-top:10px;font-size:11px;color:var(--t4);word-break:keep-all}
+  .index .foot b{color:var(--t3);font-weight:500}
+  /* 하단 오픈소스 스트립 */
+  .strip{position:absolute;left:0;right:0;bottom:0;display:flex;justify-content:space-between;align-items:center;padding:9px 22px;z-index:5;
+    background:linear-gradient(0deg,rgba(6,6,9,.9),transparent);font-family:ui-monospace,monospace;font-size:9.5px;letter-spacing:.16em;color:var(--t4);text-transform:uppercase}
+  .strip a{color:var(--t3);text-decoration:none;border-bottom:1px solid var(--divider);margin-left:16px;letter-spacing:.08em}
+  svg.map{position:absolute;inset:0;width:100%;height:100%}
+  .wm{font-family:ui-monospace,monospace;fill:rgba(255,255,255,.045);font-size:44px;letter-spacing:.3em}
+  text{font-family:ui-monospace,monospace}
+</style>
+</head>
+<body>
+<div class="frame">
+  <svg class="map" viewBox="0 0 1920 1080">
+    <text class="wm" x="1210" y="360">VIEWS</text>
+    <text class="wm" x="520" y="840">CORE</text>
+    <g stroke="rgba(255,255,255,.09)" stroke-width="1">
+      <line x1="1010" y1="600" x2="1010" y2="380"/><line x1="1010" y1="600" x2="1330" y2="460"/>
+      <line x1="1010" y1="600" x2="1370" y2="740"/><line x1="1010" y1="600" x2="1010" y2="850"/>
+      <line x1="1010" y1="600" x2="680" y2="780"/><line x1="1010" y1="600" x2="640" y2="440"/>
+    </g>
+    <g stroke="rgba(139,151,255,.32)" stroke-width="1" stroke-dasharray="3 4">
+      <line x1="1330" y1="460" x2="1370" y2="740"/><line x1="640" y1="440" x2="1010" y2="380"/>
+      <line x1="680" y1="780" x2="1010" y2="850"/>
+    </g>
+    <g stroke="rgba(255,255,255,.05)" stroke-width="1">
+      <line x1="1010" y1="380" x2="1120" y2="290"/><line x1="1010" y1="380" x2="905" y2="285"/>
+      <line x1="1330" y1="460" x2="1470" y2="390"/><line x1="1370" y1="740" x2="1520" y2="810"/>
+      <line x1="640" y1="440" x2="520" y2="360"/><line x1="680" y1="780" x2="560" y2="700"/>
+    </g>
+    <polygon points="1010,578 1030,589 1030,611 1010,622 990,611 990,589" fill="#101118" stroke="#d4b478" stroke-width="1.4"/>
+    <g fill="#101118" stroke="rgba(139,151,255,.75)" stroke-width="1.1">
+      <rect x="1001" y="371" width="18" height="18" rx="2.5"/><rect x="1321" y="451" width="18" height="18" rx="2.5"/>
+      <rect x="1361" y="731" width="18" height="18" rx="2.5"/><rect x="1001" y="841" width="18" height="18" rx="2.5"/>
+      <rect x="671" y="771" width="18" height="18" rx="2.5"/><rect x="631" y="431" width="18" height="18" rx="2.5"/>
+    </g>
+    <g fill="rgba(184,186,194,.8)">
+      <circle cx="1120" cy="290" r="3.4"/><circle cx="905" cy="285" r="3.4"/><circle cx="1470" cy="390" r="3.4"/>
+      <circle cx="1520" cy="810" r="3.4"/><circle cx="520" cy="360" r="3.4"/><circle cx="560" cy="700" r="3.4"/>
+    </g>
+    <g fill="#84868f" font-size="11">
+      <text x="1010" y="358" text-anchor="middle">mcp-server</text>
+      <text x="1348" y="444">ai-agent-partner</text><text x="1388" y="766">mode-aware-adapters</text>
+      <text x="1010" y="880" text-anchor="middle">ontology-core</text>
+      <text x="655" y="808" text-anchor="middle">vault-local-first</text><text x="622" y="424" text-anchor="middle">views</text>
+    </g>
+    <text x="1010" y="642" text-anchor="middle" fill="#d4b478" font-size="11">ontology-atlas</text>
+  </svg>
+
+  <div class="chrome">
+    <div class="pill"><span class="pip">◈</span><b>Ontology Atlas</b><span class="census"><b>102</b> concepts · <b>478</b> relations</span><span class="sample">Sample</span></div>
+    <div class="util"><span class="btn">🔍</span><span class="btn">?</span><span class="btn">⚙</span></div>
+  </div>
+
+  <div class="chooser">
+    <div class="hd"><span class="dot"></span><b>시작하기</b><span>지금은 샘플</span></div>
+    <p class="ctx"><b>마크다운 frontmatter 가 곧 그래프입니다.</b> 지금 보는 지도는 이 프로젝트 자신의 온톨로지(읽기 전용) — 폴더를 고르면 같은 지도가 내 데이터로 그려집니다. 데이터는 내 디스크에만 있습니다.</p>
+    <div class="opts">
+      <div class="opt primary"><span class="g">⬚</span><span class="tx"><b>내 마크다운 폴더 열기</b><span>기존 vault 나 문서 폴더 선택 → 바로 내 지도</span></span><span class="kbd">⌘O</span></div>
+      <div class="opt"><span class="g">✚</span><span class="tx"><b>새 vault 만들기</b><span>빈 폴더에 스타터 노드 5개로 시작</span></span></div>
+      <div class="opt ghost"><span class="g">◉</span><span class="tx"><b>샘플 계속 둘러보기</b><span>카드를 닫고 지도 탐색 — 이번 세션에는 다시 뜨지 않아요</span></span></div>
+    </div>
+  </div>
+
+  <aside class="index">
+    <p class="cap">INDEX <span class="s">· Sample</span><span>⌘K 검색</span></p>
+    <div class="search">노드 검색…</div>
+    <div class="tree">
+      <div class="d proj"><span>◇ ontology-atlas</span><span class="n">102</span></div>
+      <div class="d"><span>▸ ontology-core</span><span class="n">24</span></div>
+      <div class="d"><span>▸ views</span><span class="n">31</span></div>
+      <div class="d"><span>▸ vault-local-first</span><span class="n">14</span></div>
+      <div class="d"><span>▸ ai-agent-partner</span><span class="n">17</span></div>
+      <div class="d"><span>▸ mode-aware-adapters</span><span class="n">9</span></div>
+      <div class="d"><span>▸ onboarding-ux</span><span class="n">6</span></div>
+    </div>
+    <p class="foot"><b>샘플 vault</b> — docs/ontology 의 실제 frontmatter. 목업 데이터 없음.</p>
+  </aside>
+
+  <div class="strip">
+    <span>오픈소스 · Local-first · MCP</span>
+    <span><a>소개 · macOS 앱</a><a>GitHub</a></span>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
이번 UX 개편 라운드의 시안 계약 8종을 main에 보존 — 확정본: first-run-v3-flagship(첫 화면), chrome-rail-combined(레일+크롬 합본), app-icon-concepts(A 헥사 별자리).

## Test plan
정적 HTML 시안 — 코드 영향 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)