### PR TITLE
fix: 대형화면에서 내비 레일도 지도 크롬과 같은 비율로 확대

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -262,6 +262,23 @@
     );
     --topology-panel-overview-reserved-width: clamp(380px, calc(38vw - 170px), 420px);
     --topology-ui-scale-factor: 1;
+    /*
+     * App nav rail (`AppNavRail.tsx`, 좌측 64px 상시 chrome) 스케일 —
+     * feat/rail-scale. 레일은 캔버스와 나란한 full-height flex 형제라
+     * `.topology-ui-scale` 의 `zoom` 을 그대로 쓰면 100vh 컨테이너가
+     * 130vh 로 늘어나 세로 오버플로가 생긴다. 대신 같은
+     * `--topology-ui-scale-factor` (1 / 1.15 / 1.3) 를 레일 내부 치수에만
+     * calc() 곱셈으로 적용 — 폭은 커지고 높이는 flex 정렬 그대로라 오버플로
+     * 없음. ≥1920/2400px 에서 맵 크롬(zoom 기반)과 레일(calc 기반)이 같은
+     * 비율로 커져 좌측 레일만 상대적으로 작아 보이는 결함을 해소한다.
+     */
+    --app-nav-rail-width: calc(64px * var(--topology-ui-scale-factor));
+    --app-nav-rail-logo-size: calc(34px * var(--topology-ui-scale-factor));
+    --app-nav-rail-logo-icon-size: calc(20px * var(--topology-ui-scale-factor));
+    --app-nav-rail-icon-size: calc(18px * var(--topology-ui-scale-factor));
+    --app-nav-rail-label-size: calc(9.5px * var(--topology-ui-scale-factor));
+    --app-nav-rail-tile-width: calc(38px * var(--topology-ui-scale-factor));
+    --app-nav-rail-tile-height: calc(32px * var(--topology-ui-scale-factor));
     --topology-panel-path-rail-width: clamp(
       calc(320px / var(--topology-ui-scale-factor)),
       calc(23vw / var(--topology-ui-scale-factor)),

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -28,7 +28,7 @@ interface RailDestination {
   id: AppNavRailItemId;
   href: string;
   label: string;
-  Icon: ComponentType<{ size?: number; "aria-hidden"?: boolean }>;
+  Icon: ComponentType<{ size?: number; className?: string; "aria-hidden"?: boolean }>;
 }
 
 /**
@@ -81,7 +81,7 @@ export function AppNavRail({ settingsSlot, className }: AppNavRailProps) {
       aria-label={t("ariaLabel")}
       data-testid="app-nav-rail"
       className={cn(
-        "hidden w-16 shrink-0 flex-col items-center border-r border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] py-3 md:flex",
+        "hidden w-[var(--app-nav-rail-width)] shrink-0 flex-col items-center border-r border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] py-3 md:flex",
         className,
       )}
     >
@@ -90,9 +90,13 @@ export function AppNavRail({ settingsSlot, className }: AppNavRailProps) {
         title="Ontology Atlas"
         aria-label="Ontology Atlas"
         translate="no"
-        className="mb-3.5 flex h-[34px] w-[34px] shrink-0 items-center justify-center text-[color:var(--color-indigo-accent)] transition-colors hover:text-[color:var(--color-indigo-hover)]"
+        className="mb-3.5 flex h-[var(--app-nav-rail-logo-size)] w-[var(--app-nav-rail-logo-size)] shrink-0 items-center justify-center text-[color:var(--color-indigo-accent)] transition-colors hover:text-[color:var(--color-indigo-hover)]"
       >
-        <BrandMark size={20} detail="compact" />
+        <BrandMark
+          size={20}
+          detail="compact"
+          className="h-[var(--app-nav-rail-logo-icon-size)] w-[var(--app-nav-rail-logo-icon-size)]"
+        />
       </Link>
 
       <nav aria-label={t("ariaLabel")} className="flex w-full flex-1 flex-col gap-0.5">
@@ -117,17 +121,21 @@ export function AppNavRail({ settingsSlot, className }: AppNavRailProps) {
                   ) : null}
                   <span
                     className={cn(
-                      "flex h-8 w-[38px] items-center justify-center rounded-[8px] transition-colors",
+                      "flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-[8px] transition-colors",
                       isActive
                         ? "bg-[color:rgba(94,106,210,0.14)] text-[color:var(--color-indigo-accent)] shadow-[inset_0_0_0_1px_rgba(139,151,255,0.22)]"
                         : "text-[color:var(--color-text-tertiary)] group-hover:bg-[color:var(--color-overlay-2)] group-hover:text-[color:var(--color-text-primary)]",
                     )}
                   >
-                    <Icon size={18} aria-hidden />
+                    <Icon
+                      size={18}
+                      aria-hidden
+                      className="h-[var(--app-nav-rail-icon-size)] w-[var(--app-nav-rail-icon-size)]"
+                    />
                   </span>
                   <span
                     className={cn(
-                      "text-[9.5px]",
+                      "text-[length:var(--app-nav-rail-label-size)]",
                       isActive
                         ? "font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
                         : "text-[color:var(--color-text-quaternary)]",
@@ -147,9 +155,13 @@ export function AppNavRail({ settingsSlot, className }: AppNavRailProps) {
           title={agentTitle}
           aria-label={agentTitle}
           data-testid="app-nav-rail-agent-status"
-          className="relative flex h-8 w-[38px] items-center justify-center rounded-[8px] text-[color:var(--color-text-tertiary)]"
+          className="relative flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-[8px] text-[color:var(--color-text-tertiary)]"
         >
-          <Activity size={18} aria-hidden />
+          <Activity
+            size={18}
+            aria-hidden
+            className="h-[var(--app-nav-rail-icon-size)] w-[var(--app-nav-rail-icon-size)]"
+          />
           {hasFreshHeartbeat ? (
             <span
               aria-hidden="true"


### PR DESCRIPTION
## Summary
소유자 "화면 커지면 이상함"의 근본 원인(Guardian 진단) 수정 — 맵 크롬은 ≥1920/≥2400에서 1.15/1.3× 커지는데 레일만 고정이던 비율 어긋남. 기존 `--topology-ui-scale-factor`를 재사용해 레일 치수 6종을 calc 비례 확대(컨테이너 zoom 아님 — 세로 오버플로 없음).

## Test plan
vitest app-nav-rail 13 pass · tsc exit 0 · eslint 0 · 라이브 실측: 1440/1920/2560에서 레일 폭 64/73.59/83.2px(factor 정확 일치), scrollHeight==innerHeight(오버플로 0), 검증 서버 종료 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)