### PR TITLE
test: next-intl 인라인 — 테스트 15파일 로드 실패 복구

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,15 @@ export default defineConfig({
       'tests/contract/**/*.test.ts',
     ],
     exclude: ['tests/e2e/**'],
+    // next-intl 을 Node ESM 으로 externalize 하면 `next/navigation` 서브패스가
+    // pnpm 가상 스토어 realpath 기준으로 resolve 되지 못해 테스트 파일 로드
+    // 자체가 깨진다 (2026-07 재구성 중 15개 파일 동시 실패로 표면화). vite
+    // 인라인 처리로 vite 리졸버가 서브패스를 해석하게 한다.
+    server: {
+      deps: {
+        inline: ['next-intl'],
+      },
+    },
   },
   resolve: {
     // @rollup/plugin-alias 는 등록 순서대로 prefix 매칭해 첫 매칭을 채택한다.


### PR DESCRIPTION
## Summary
next-intl ESM externalize가 pnpm 가상 스토어에서 next/navigation 해석에 실패해 테스트 파일 15개(140 테스트)가 로드조차 안 되던 환경 회귀 — vitest server.deps.inline으로 복구.

## Test plan
전체 vitest 282파일 2,209 pass (이전 267파일 2,069 → +15파일 +140). 부수: pnpm install로 TS7 alias 복원되어 `pnpm exec tsc --noEmit`가 우회 없이 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)