### PR TITLE
style: 크롬 마감 — 우측 컨트롤 재스킨·census 각인·44px 통일

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -616,7 +616,12 @@
       100dvh - var(--topology-floating-panel-phone-bottom) - 64px
     );
     --topology-floating-control-desktop-top: 140px;
-    --topology-floating-panel-desktop-top: 184px;
+    /* Fit 타일(--chrome-tile-size 44px) 바닥 + 8px gap — SigmaControls
+       크롬 재스킨(feat/chrome-finish) 이후 값. 이전엔 h-9(36px) 버튼 기준
+       184px 였다 — 타일이 44px 로 커져 8px gap 을 유지하려면 192px. */
+    --topology-floating-panel-desktop-top: calc(
+      var(--topology-floating-control-desktop-top) + var(--chrome-tile-size) + 8px
+    );
     --topology-floating-panel-desktop-max-height: calc(100vh - 260px);
     /*
      * Relief/Topology chrome DENSITY tokens (feat/topology-chrome-density).
@@ -738,7 +743,12 @@
     --topology-analysis-panel-path-collapsed-scroll-end-reserve: 12px;
     --topology-shortcuts-help-phone-top: 188px;
     --topology-shortcuts-help-focus-phone-top: 208px;
-    --topology-shortcuts-help-desktop-top: 228px;
+    /* 우측 세로 레일 3타일(전체보기/조절/단축키, chrome-rail-combined.html)
+       리듬 — Fit + Controls 트리거 타일(각 44px) + 그 사이 8px gap + 단축키
+       타일 앞 8px gap = control-desktop-top + 2×타일 + 2×8px gap. */
+    --topology-shortcuts-help-desktop-top: calc(
+      var(--topology-floating-control-desktop-top) + (var(--chrome-tile-size) * 2) + 16px
+    );
     /* 설정 기어 (`TopologyV2SettingsGear`, chrome-datasheet-final.html 시안) —
        우측 유틸리티 레일의 "?" 버튼 바로 아래 한 칸. fit/필터 스택과 같은
        hide 조건(createNodeOpen/selectedRelationActive/blocking-overlay/

--- a/messages/en.json
+++ b/messages/en.json
@@ -2253,7 +2253,7 @@
     },
     "workspace": {
       "growthThisWeek": " · +{count} this week",
-      "subtitle": "{concepts} concepts · {relations} relations{growth}",
+      "subtitle": "<b>{concepts}</b> concepts · <b>{relations}</b> relations{growth}",
       "eyebrow": "{concepts} concepts",
       "fallbackTitle": "Relief",
       "selectedEyebrow": "Selected concept",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2253,7 +2253,7 @@
     },
     "workspace": {
       "growthThisWeek": " · 이번 주 +{count}",
-      "subtitle": "개념 {concepts}개 · 관계 {relations}개{growth}",
+      "subtitle": "개념 <b>{concepts}</b>개 · 관계 <b>{relations}</b>개{growth}",
       "eyebrow": "개념 {concepts}개",
       "fallbackTitle": "지형도",
       "selectedEyebrow": "선택한 개념",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1769,9 +1769,13 @@ export function HomePage() {
                           data-utility-action-border-token="--topology-utility-lane-accent-border"
                           data-utility-action-shadow-token="--topology-utility-lane-shadow"
                           data-utility-action-focus-ring-token="--topology-utility-lane-focus-ring"
-                          className={`inline-flex h-[var(--topology-utility-lane-height)] items-center justify-center gap-2 rounded-[var(--topology-utility-lane-radius)] border border-[color:var(--topology-utility-lane-accent-border)] bg-[color:var(--topology-utility-lane-accent-surface)] text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] shadow-[var(--topology-utility-lane-shadow)] transition-[background-color,border-color] duration-180 ease-out hover:bg-[color:var(--topology-utility-lane-accent-hover-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-utility-lane-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none ${
+                          // 높이/radius/compact 폭은 ChromeChip 기준(44px·10px)으로
+                          // 수렴 — 같은 열의 "작업공간" 칩과 나란히 있어
+                          // --topology-utility-lane-height(32~36px clamp) 를
+                          // 쓰면 과도기 높이 불일치가 났다(feat/chrome-finish).
+                          className={`inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--topology-utility-lane-accent-border)] bg-[color:var(--topology-utility-lane-accent-surface)] text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] shadow-[var(--topology-utility-lane-shadow)] transition-[background-color,border-color] duration-180 ease-out hover:bg-[color:var(--topology-utility-lane-accent-hover-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-utility-lane-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none ${
                             topologyUtilityChromeCompact
-                              ? "w-[var(--topology-utility-lane-compact-width)] px-0"
+                              ? "w-[var(--chrome-tile-size)] px-0"
                               : "px-3.5"
                           }`}
                         >

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1544,10 +1544,23 @@ export function HomePage() {
               // growth 는 별도 prop(censusGrowthText)으로 넘겨 HeroCollapsed 가
               // 인디고로 강조 표시(feat/chrome-system §5 census 각인)할 수
               // 있게 한다 — 여기서 한 문자열로 합치면 세그먼트별 스타일이 안 됨.
-              const workspaceSubtitle = t('workspace.subtitle', {
+              // 개념/관계 숫자 두 세그먼트는 t.rich 의 <b> 태그(messages/*.json
+              // — feat/chrome-finish 세그먼트 각인)로 감싸 engraved-numeral
+              // 토큰(다른 census 표면 — ProjectDetailPage/DocsVaultPage — 와
+              // 동일 문법)으로 볼드 처리한다. subtitle prop 이 문자열이 아니라
+              // ReactNode 를 받아야 해서 HeroCollapsed 타입도 함께 넓혔다.
+              const workspaceSubtitle = t.rich('workspace.subtitle', {
                 concepts: topologyTotalNodes,
                 relations: topologyTotalRelations,
                 growth: '',
+                b: (chunks) => (
+                  <b
+                    data-token="engraved-numeral"
+                    className="font-semibold not-italic text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+                  >
+                    {chunks}
+                  </b>
+                ),
               });
               const workspaceEyebrow = t('workspace.eyebrow', {
                 concepts: topologyTotalNodes,

--- a/src/views/home/ui/TopologyReviewLink.tsx
+++ b/src/views/home/ui/TopologyReviewLink.tsx
@@ -38,7 +38,10 @@ export function TopologyReviewLink({
       data-utility-action-focus-ring-token="--topology-utility-lane-focus-ring"
       aria-label={ariaLabel(count)}
       title={ariaLabel(count)}
-      className="inline-flex h-[var(--topology-utility-lane-height)] items-center gap-2 rounded-[var(--topology-utility-lane-radius)] border border-[color:var(--topology-utility-lane-accent-border)] bg-[color:var(--topology-utility-lane-accent-surface)] px-3.5 text-[length:var(--topology-chrome-title-size)] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] shadow-[var(--topology-utility-lane-shadow)] transition-[background-color,border-color] duration-180 ease-out hover:bg-[color:var(--topology-utility-lane-accent-hover-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-utility-lane-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none"
+      // 높이/radius 는 ChromeChip 기준(44px·10px)으로 수렴 — 같은 우상단
+      // 열의 "작업공간" 칩과 나란히 있어 --topology-utility-lane-height
+      // (32~36px clamp) 를 쓰면 과도기 높이 불일치가 났다(feat/chrome-finish).
+      className="inline-flex h-[var(--chrome-tile-size)] items-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--topology-utility-lane-accent-border)] bg-[color:var(--topology-utility-lane-accent-surface)] px-3.5 text-[length:var(--topology-chrome-title-size)] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] shadow-[var(--topology-utility-lane-shadow)] transition-[background-color,border-color] duration-180 ease-out hover:bg-[color:var(--topology-utility-lane-accent-hover-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-utility-lane-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none"
     >
       <GitCompare className="size-[var(--topology-chrome-icon-size)]" aria-hidden />
       <span>{label(count)}</span>

--- a/src/widgets/hero-header/ui/HeroCollapsed.test.tsx
+++ b/src/widgets/hero-header/ui/HeroCollapsed.test.tsx
@@ -1,10 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import { describe, expect, it, vi } from 'vitest';
+import enMessages from '../../../../messages/en.json';
+import koMessages from '../../../../messages/ko.json';
 import { HeroCollapsed } from './HeroCollapsed';
-
-vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key,
-}));
 
 vi.mock('@/i18n/navigation', () => ({
   Link: ({
@@ -18,19 +17,67 @@ vi.mock('@/i18n/navigation', () => ({
   ),
 }));
 
+function renderWithLocale(locale: 'ko' | 'en', ui: React.ReactElement) {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  return render(
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
 describe('HeroCollapsed', () => {
   it('does not show a SAMPLE badge by default', () => {
-    render(<HeroCollapsed />);
+    renderWithLocale('ko', <HeroCollapsed />);
     expect(screen.queryByTestId('hero-sample-badge')).not.toBeInTheDocument();
   });
 
   it('shows a SAMPLE badge when sampleBadge is set (static/no-vault mode)', () => {
-    render(<HeroCollapsed sampleBadge />);
+    renderWithLocale('ko', <HeroCollapsed sampleBadge />);
     expect(screen.getByTestId('hero-sample-badge')).toBeInTheDocument();
   });
 
   it('hides the SAMPLE badge in compact mode (no room for it)', () => {
-    render(<HeroCollapsed sampleBadge compact />);
+    renderWithLocale('ko', <HeroCollapsed sampleBadge compact />);
     expect(screen.queryByTestId('hero-sample-badge')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * HomePage 의 실제 census 조립(`workspace.subtitle` t.rich + engraved-numeral
+ * <b>)을 재현하는 얇은 harness — HeroCollapsed 자체는 t.rich 를 호출하지
+ * 않고 이미 렌더된 ReactNode 를 subtitle prop 으로 받기만 하므로, 실제
+ * 소비 지점(HomePage)과 같은 조립 방식으로 렌더해야 카피 정합을 검증한다.
+ */
+function CensusSubtitleHarness({ concepts, relations }: { concepts: number; relations: number }) {
+  const t = useTranslations('topology');
+  const subtitle = t.rich('workspace.subtitle', {
+    concepts,
+    relations,
+    growth: '',
+    b: (chunks) => <b data-testid="census-numeral">{chunks}</b>,
+  });
+  return <HeroCollapsed subtitle={subtitle} subtitleVariant="census" title="ontology-atlas" />;
+}
+
+describe('HeroCollapsed — census 세그먼트 각인 (feat/chrome-finish)', () => {
+  it('ko: 개념/관계 숫자 두 세그먼트가 각각 <b> 로 감싸진다', () => {
+    renderWithLocale('ko', <CensusSubtitleHarness concepts={289} relations={483} />);
+    const numerals = screen.getAllByTestId('census-numeral');
+    expect(numerals).toHaveLength(2);
+    expect(numerals[0]).toHaveTextContent('289');
+    expect(numerals[1]).toHaveTextContent('483');
+    expect(screen.getByText(/개념/)).toBeInTheDocument();
+    expect(screen.getByText(/관계/)).toBeInTheDocument();
+  });
+
+  it('en: 개념/관계 숫자 두 세그먼트가 각각 <b> 로 감싸진다', () => {
+    renderWithLocale('en', <CensusSubtitleHarness concepts={289} relations={483} />);
+    const numerals = screen.getAllByTestId('census-numeral');
+    expect(numerals).toHaveLength(2);
+    expect(numerals[0]).toHaveTextContent('289');
+    expect(numerals[1]).toHaveTextContent('483');
+    expect(screen.getByText(/concepts/)).toBeInTheDocument();
+    expect(screen.getByText(/relations/)).toBeInTheDocument();
   });
 });

--- a/src/widgets/hero-header/ui/HeroCollapsed.tsx
+++ b/src/widgets/hero-header/ui/HeroCollapsed.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { Link } from "@/i18n/navigation";
 import { motion } from "framer-motion";
 import { useTranslations } from "next-intl";
@@ -13,7 +14,10 @@ interface Props {
   /** 없으면 pill 이 클릭 불가(확장 상태가 없는 surface) — chevron 도 숨김. */
   onExpand?: () => void;
   title?: string;
-  subtitle?: string;
+  /** 'eyebrow' 상태는 보통 순문자열, 'census' 상태는 개념/관계 숫자
+   *  세그먼트가 <b> 각인(engraved-numeral 토큰)으로 볼드 처리된 ReactNode
+   *  (next-intl `t.rich` 결과) — feat/chrome-finish 세그먼트 각인. */
+  subtitle?: ReactNode;
   /** subtitle 뒤에 붙는 "성장 신호" 조각(예: " · 이번 주 +1") — census 상태에서만
    *  넘긴다. amber 는 허브 노드 전용(design.md)이라 여기선 인디고로 강조. */
   censusGrowthText?: string;

--- a/src/widgets/search-hint/ui/SearchHint.tsx
+++ b/src/widgets/search-hint/ui/SearchHint.tsx
@@ -27,10 +27,11 @@ const ARRANGE_FEEDBACK_MS = 950;
  * 상단 중앙 툴바. 자동 정렬 · 검색 2버튼.
  * glassmorphism(backdrop-blur) 금지 룰 준수 — solid panel bg만 사용.
  *
- * feat/chrome-system §6 — ChromeChip(44px·10px radius) 재스킨. 우측 문서함
- * 버튼은 이번 슬라이스 스코프 밖이라 여전히 `--topology-utility-lane-*`
- * 문법 — 같은 상단 열에 두 표면 높이가 과도기적으로 공존한다(합본 시안
- * 확정 후 다음 슬라이스에서 수렴).
+ * feat/chrome-system §6 — ChromeChip(44px·10px radius) 재스킨. 우상단
+ * "작업공간" 칩(`HomePage`)도 이후 슬라이스에서 같은 ChromeChip 으로
+ * 이관되어 상단 열 전체가 44px 로 수렴했다(feat/chrome-finish — 남은
+ * TopologyReviewLink/Create-Node 버튼의 --topology-utility-lane-height
+ * 잔재도 같은 슬라이스에서 --chrome-tile-size 로 정리).
  */
 export function SearchHint({
   onOpenSearch,

--- a/src/widgets/topology-map-sigma/ui/SigmaControls.tsx
+++ b/src/widgets/topology-map-sigma/ui/SigmaControls.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ChevronDown, ChevronUp, Maximize2, Search, Sliders, SlidersHorizontal, X } from 'lucide-react';
-import { Tooltip } from '@/shared/ui';
+import { ChromeTile, Tooltip } from '@/shared/ui';
 import type {
   SigmaControlsState,
   SigmaForces,
@@ -111,17 +111,19 @@ export function SigmaControls({
     setHelpOpen(true);
   };
 
-  // 기본 접힘 상태 — Fit + Controls 아이콘을 한 pill에 수직 스택으로 합친다.
-  // 우측 상단 두 번째 행 (account menu 아래, Hub Rail과 수평)
+  // 기본 접힘 상태 — Fit + Controls 트리거를 ChromeTile 문법(44px 정사각 ·
+  // --chrome-* 토큰)으로 8px gap 스택. 우측 상단 두 번째 행 (account menu
+  // 아래, Hub Rail과 수평). 합본 시안(chrome-rail-combined.html)의 우측
+  // 세로 레일 3타일(전체보기/조절/단축키) 중 앞 2개 — 세 번째 "?" 타일은
+  // HomePage 가 별도 렌더(같은 --chrome-* 토큰, top 오프셋만 globals.css
+  // 에서 이 스택 높이 기준으로 8px gap 유지하도록 계산).
   if (!expanded) {
     return (
       <>
         <div
-          className="topology-ui-scale pointer-events-auto absolute bottom-[var(--topology-floating-control-phone-bottom)] right-4 z-20 flex flex-col overflow-hidden rounded-md border border-[color:var(--topology-floating-control-border)] bg-[color:var(--topology-floating-control-surface)] shadow-[var(--topology-floating-control-shadow)] md:bottom-auto md:right-6 md:top-[var(--topology-floating-control-desktop-top)] xl:right-8"
+          className="topology-ui-scale pointer-events-auto absolute bottom-[var(--topology-floating-control-phone-bottom)] right-4 z-20 flex flex-col gap-2 md:bottom-auto md:right-6 md:top-[var(--topology-floating-control-desktop-top)] xl:right-8"
           data-testid="topology-sigma-controls-stack"
           data-controls-density={density}
-          data-control-surface-token="--topology-floating-control-surface"
-          data-control-border-token="--topology-floating-control-border"
           data-control-phone-bottom-token="--topology-floating-control-phone-bottom"
           data-control-desktop-top-token="--topology-floating-control-desktop-top"
           data-controls-contract={
@@ -130,34 +132,31 @@ export function SigmaControls({
         >
           {/* Fit · 도움말은 데스크톱에서만 노출 — 모바일은 pinch-zoom 으로
               fit 가능하고 키보드 단축키도 의미 없음. sliders 만 모바일에 남겨
-              우측 floating 무게를 줄인다. */}
+              우측 floating 무게를 줄인다. wrapper 의 hidden/md:block 이 표시
+              여부를 맡아 ChromeTile 자체 display 유틸과 안 부딪힌다
+              (SearchHint 의 동일 패턴 — feat/chrome-system §6). */}
           {onFitView ? (
-            <>
+            <div className="hidden md:block">
               <Tooltip content={t('fitViewTooltip')} side="left" withProvider={false}>
-                <button
-                  type="button"
-                  onClick={onFitView}
+                <ChromeTile
+                  icon={<Maximize2 />}
+                  title={t('fitViewTooltip')}
                   aria-label={t('fitViewAriaLabel')}
-                  className="hidden h-9 w-9 items-center justify-center text-[color:var(--topology-floating-control-icon)] transition-colors hover:bg-[color:var(--topology-floating-control-hover-surface)] hover:text-[color:var(--topology-floating-control-icon-hover)] active:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-inset md:flex"
-                >
-                  <Maximize2 className="h-4 w-4" />
-                </button>
+                  onClick={onFitView}
+                />
               </Tooltip>
-              <div className="hidden h-px bg-[color:var(--color-border-soft)] md:block" />
-            </>
+            </div>
           ) : null}
           <Tooltip content={t('openTooltip')} side="left" withProvider={false}>
-            <button
-              type="button"
+            <ChromeTile
+              icon={<SlidersHorizontal />}
+              title={t('openTooltip')}
+              aria-label={t('openAriaLabel')}
               onClick={() => {
                 setExpanded(true);
                 setHelpOpen(false);
               }}
-              aria-label={t('openAriaLabel')}
-              className="flex h-9 w-9 items-center justify-center text-[color:var(--topology-floating-control-icon)] transition-colors hover:bg-[color:var(--topology-floating-control-hover-surface)] hover:text-[color:var(--topology-floating-control-icon-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-inset"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-            </button>
+            />
           </Tooltip>
         </div>
         {helpOpen ? <HelpOverlay onClose={() => setHelpOpen(false)} /> : null}
@@ -177,23 +176,22 @@ export function SigmaControls({
 
   return (
     <>
-      {/* 펼친 상태에서도 Fit 버튼은 같은 우측 컬럼에 남겨둔다.
-          모바일은 분석 바를 가리지 않도록 하단 그래프 영역에 고정하고,
-          데스크톱 panel은 그 아래 top-[184px]부터. */}
+      {/* 펼친 상태에서도 Fit 버튼은 같은 우측 컬럼에 남겨둔다(ChromeTile
+          문법). 모바일은 분석 바를 가리지 않도록 하단 그래프 영역에
+          고정하고, 데스크톱 panel은 그 아래
+          --topology-floating-panel-desktop-top (Fit 타일 44px + 8px gap)
+          부터 이어진다. */}
       {onFitView ? (
         <Tooltip content={t('fitViewTooltip')} side="left" withProvider={false}>
-          <button
-            type="button"
-            onClick={onFitView}
+          <ChromeTile
+            icon={<Maximize2 />}
+            title={t('fitViewTooltip')}
             aria-label={t('fitViewAriaLabel')}
-            data-control-surface-token="--topology-floating-control-surface"
-            data-control-border-token="--topology-floating-control-border"
+            onClick={onFitView}
             data-control-phone-bottom-token="--topology-floating-control-phone-bottom"
             data-control-desktop-top-token="--topology-floating-control-desktop-top"
-            className="topology-ui-scale pointer-events-auto absolute bottom-[var(--topology-floating-control-phone-bottom)] right-4 z-20 flex h-9 w-9 items-center justify-center rounded-md border border-[color:var(--topology-floating-control-border)] bg-[color:var(--topology-floating-control-surface)] text-[color:var(--topology-floating-control-icon)] shadow-[var(--topology-floating-control-shadow)] transition-colors hover:bg-[color:var(--topology-floating-control-hover-surface)] hover:text-[color:var(--topology-floating-control-icon-hover)] active:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-inset md:bottom-auto md:right-6 md:top-[var(--topology-floating-control-desktop-top)] xl:right-8"
-          >
-            <Maximize2 className="h-4 w-4" />
-          </button>
+            className="topology-ui-scale pointer-events-auto absolute bottom-[var(--topology-floating-control-phone-bottom)] right-4 z-20 md:bottom-auto md:right-6 md:top-[var(--topology-floating-control-desktop-top)] xl:right-8"
+          />
         </Tooltip>
       ) : null}
       <div


### PR DESCRIPTION
## Summary
Guardian 보류분 3건 마감: ① 우측 전체보기/조절 트리거 ChromeTile 재스킨(44px, 파생 top 오프셋 calc화) ② 브랜드 필 census 숫자 세그먼트 engraved 각인(t.rich 재편, ko/en) ③ 우상단 리뷰링크·생성토글의 구 32~36px 높이를 44px 크롬 문법으로 수렴 — 전 크롬 44px 통일 실측 완료.

## Test plan
전체 vitest 282파일 2,214 pass · tsc 0 · eslint 0 · i18n 18 pass · 라이브 1920/2560 실측(타일 44/50.6/57.2px 스케일 정합·간격 8px·각인 확인). 스코프 밖 미접근 diff 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)