### PR TITLE
fix: 시안 정합 감사 — 최근 활동 도메인 태그·모바일 오버플로 수정

### DIFF
--- a/src/views/project-selector/lib/recent-activity.test.ts
+++ b/src/views/project-selector/lib/recent-activity.test.ts
@@ -55,15 +55,18 @@ describe("resolveRecentActivityAgo", () => {
 
 describe("buildRecentActivityRows", () => {
   it("sorts vault docs by real mtime desc, resolves kind + nearest domain title, skips project/readme noise", () => {
+    // doc.slug 는 vault-relative 전체 경로(deriveDocNode 의 doc.slug 규약과 동일하게
+    // "ontology/" 루트 접두를 포함) — 실제 node id 는 file tail 만 쓴다는 점이
+    // 이 테스트의 핵심 회귀 포인트다.
     const docs: VaultDoc[] = [
       doc({
-        slug: "elements/topology-map-canvas",
+        slug: "ontology/elements/topology-map-canvas",
         updatedAt: "2026-07-18T09:00:00.000Z",
         description: "지도 뷰 단일 컨테이너 변환 엔진",
         frontmatter: { kind: "element" },
       }),
       doc({
-        slug: "capabilities/mcp-server",
+        slug: "ontology/capabilities/mcp-server",
         updatedAt: "2026-07-17T09:00:00.000Z",
         description: "write 도구 9종으로 확장",
         frontmatter: { kind: "capability" },
@@ -80,14 +83,14 @@ describe("buildRecentActivityRows", () => {
       }),
     ];
     const nodes = [
-      node("element:elements/topology-map-canvas", "element", "topology-map-canvas"),
-      node("capability:capabilities/mcp-server", "capability", "MCP Server"),
-      node("domain:domains/views", "domain", "Views"),
-      node("domain:domains/ai-agent-partner", "domain", "AI Agent Partner"),
+      node("element:topology-map-canvas", "element", "topology-map-canvas"),
+      node("capability:mcp-server", "capability", "MCP Server"),
+      node("domain:views", "domain", "Views"),
+      node("domain:ai-agent-partner", "domain", "AI Agent Partner"),
     ];
     const parentOf = new Map<string, string>([
-      ["element:elements/topology-map-canvas", "domain:domains/views"],
-      ["capability:capabilities/mcp-server", "domain:domains/ai-agent-partner"],
+      ["element:topology-map-canvas", "domain:views"],
+      ["capability:mcp-server", "domain:ai-agent-partner"],
     ]);
     const nodeById = new Map(nodes.map((n) => [n.id, n]));
 
@@ -95,14 +98,14 @@ describe("buildRecentActivityRows", () => {
 
     expect(rows).toEqual([
       {
-        slug: "elements/topology-map-canvas",
+        slug: "ontology/elements/topology-map-canvas",
         kind: "element",
         domainTitle: "Views",
         what: "지도 뷰 단일 컨테이너 변환 엔진",
         updatedAt: new Date("2026-07-18T09:00:00.000Z"),
       },
       {
-        slug: "capabilities/mcp-server",
+        slug: "ontology/capabilities/mcp-server",
         kind: "capability",
         domainTitle: "AI Agent Partner",
         what: "write 도구 9종으로 확장",
@@ -114,13 +117,13 @@ describe("buildRecentActivityRows", () => {
   it("falls back to the node summary, then the doc excerpt, when description is missing", () => {
     const docs: VaultDoc[] = [
       doc({
-        slug: "elements/a",
+        slug: "ontology/elements/a",
         updatedAt: "2026-07-18T09:00:00.000Z",
         excerpt: "excerpt text",
         frontmatter: { kind: "element" },
       }),
     ];
-    const nodes = [node("element:elements/a", "element", "a", "summary text")];
+    const nodes = [node("element:a", "element", "a", "summary text")];
     const nodeById = new Map(nodes.map((n) => [n.id, n]));
 
     const rows = buildRecentActivityRows(docs, nodeById, new Map(), 4);

--- a/src/views/project-selector/lib/recent-activity.ts
+++ b/src/views/project-selector/lib/recent-activity.ts
@@ -51,7 +51,11 @@ export function buildRecentActivityRows(
     const updatedAt = new Date(doc.updatedAt);
     if (Number.isNaN(updatedAt.getTime())) continue;
 
-    const node = nodeById.get(`${kind}:${doc.slug}`);
+    // Node id 는 file tail slug 로 형성된다 (deriveDocNode 참고) — doc.slug 는
+    // vault-relative 전체 경로("ontology/capabilities/x")라 tail 없이 그대로
+    // 조회하면 항상 miss 해서 domainTitle 이 늘 fallback 이었다 (mockup 감사 회귀).
+    const tailSlug = doc.slug.split("/").pop() || doc.slug;
+    const node = nodeById.get(`${kind}:${tailSlug}`);
     const domainId = node ? nearestDomainId(node, parentOf, nodeById) : null;
     const domainTitle = domainId ? (nodeById.get(domainId)?.title ?? null) : null;
     const what = doc.description || node?.summary || doc.excerpt || "";

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -166,10 +166,10 @@ export function ProjectSelectorPage() {
                   ) : (
                     <span className="min-w-0 flex-1" />
                   )}
-                  <span className="whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                  <span className="max-w-[150px] shrink truncate font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] sm:max-w-[220px]">
                     {row.domainTitle ?? t("activityNoDomain")}
                   </span>
-                  <span className={`whitespace-nowrap text-[11px] ${numeralClass}`}>
+                  <span className={`shrink-0 whitespace-nowrap text-[11px] ${numeralClass}`}>
                     {formatAgo(resolveRecentActivityAgo(row.updatedAt, new Date()), t)}
                   </span>
                 </div>
@@ -215,10 +215,10 @@ export function ProjectSelectorPage() {
             <span className="w-[108px] shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("nextSlotCliLabel")}
             </span>
-            <code className="font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
+            <code className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
               {t("nextSlotCliCommand")}
             </code>
-            <span className="ml-auto whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotCliCaption")}
             </span>
           </div>
@@ -226,10 +226,10 @@ export function ProjectSelectorPage() {
             <span className="w-[108px] shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("nextSlotAgentLabel")}
             </span>
-            <code className="font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
+            <code className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
               {t("nextSlotAgentCommand")}
             </code>
-            <span className="ml-auto whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotAgentCaption")}
             </span>
           </div>
@@ -288,12 +288,12 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
       {domainRows.length > 0 ? (
         <div className="mt-4 flex flex-col gap-2">
           {domainRows.map((row, index) => (
-            <div key={row.domainId} className="flex items-center gap-4">
-              <span className="flex w-[280px] shrink-0 items-center gap-2 truncate text-[12.5px] text-[color:var(--color-text-secondary)]">
+            <div key={row.domainId} className="flex items-center gap-3 sm:gap-4">
+              <span className="flex w-[84px] min-w-0 shrink-0 items-center gap-2 truncate text-[12.5px] text-[color:var(--color-text-secondary)] sm:w-[200px] md:w-[280px]">
                 <TopologyV2KindGlyph kind="domain" size={14} />
                 {row.title}
               </span>
-              <span className="h-1 max-w-[640px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-border-soft)]">
+              <span className="h-1 min-w-0 max-w-[640px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-border-soft)]">
                 <span
                   className="block h-full rounded-full"
                   style={{
@@ -302,7 +302,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
                   }}
                 />
               </span>
-              <span className={`whitespace-nowrap text-[10.5px] ${numeralClass}`}>
+              <span className={`max-w-[120px] shrink text-right text-[10.5px] sm:max-w-none sm:shrink-0 sm:whitespace-nowrap ${numeralClass}`}>
                 {t("domainRowSummary", {
                   total: row.total,
                   cap: row.capabilityCount,

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -138,7 +138,13 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
         </span>
       </summary>
       <div
-        className="fixed inset-0 z-40 flex items-center justify-center overflow-hidden p-3 sm:p-6"
+        // 닫힌 native <details> 콘텐츠는 스펙상 렌더링만 스킵할 뿐 항상
+        // display:none 이 되는 건 아니다(content-visibility 계열 구현) — 그
+        // 결과 desktop 폭의 내부 tab strip 이 실제 layout box 를 유지해 모바일
+        // 뷰포트에서 document.body.scrollWidth 를 밀어 올렸다(overflow-sweep
+        // mobile-390/360 회귀). `hidden` + `group-open:flex` 로 열림 상태를
+        // 명시적 display 값에 묶어 확정적으로 닫는다.
+        className="fixed inset-0 z-40 hidden items-center justify-center overflow-hidden p-3 group-open:flex sm:p-6"
         data-testid="app-settings-overlay"
         onMouseDown={(event) => {
           if (event.target !== event.currentTarget) return;


### PR DESCRIPTION
## Summary
승인 시안 10종 × 구현 전수 감사(격리 브라우저 캡처 대조). 종합 정합도 매우 높음 — 4개 표면(인사이트·데이터시트·전체상세·허브)은 문구 단위 일치. 실버그 2건 수정:
- `/projects` 최근 활동 도메인 태그가 tail/full slug 키 불일치로 항상 "—" fallback → tail 조회 수정(+우연 통과하던 잘못된 fixture 정정)
- `/en/projects` 모바일 가로 스크롤(선재 e2e 실패) — 닫힌 details의 layout box 잔존 + 고정폭 nowrap 다수 → 명시 display 게이팅+반응형 보정 (데스크톱 무변)

구조 처방 보고 2건: (High) project.md 본문 미표시 — frontmatter `detail:` 키만 읽고 body 마크다운 미조회 (별도 수정 투입) / (Low) 전체상세 섹션 헤더 마커 장식.

## Test plan
overflow-sweep e2e 6/6 뷰포트 그린(모바일 포함) · 스코프 vitest 25·tsc·eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)