### PR TITLE
fix: 전 페이지 반응형 스윕 — 모바일 잔여 6건 + e2e 매트릭스 가드

### DIFF
--- a/src/shared/ui/tab-bar.tsx
+++ b/src/shared/ui/tab-bar.tsx
@@ -33,7 +33,11 @@ export function TabBar({
     <div
       role="tablist"
       aria-label={ariaLabel}
-      className="flex gap-7 border-b border-[color:var(--color-divider)]"
+      // overflow-x-auto — 좁은 폰(<=360px)에서 3-tab(개요·관계·신선도) 라벨+
+      // 카운트 합이 뷰포트를 근소하게 넘을 수 있다. 탭을 줄바꿈하면 언더라인
+      // 탭바 자체 정체성이 깨지므로 AppSettingsMenu 의 tablist 와 같은
+      // 패턴(내부 가로 스크롤)으로 페이지 레벨 overflow 를 막는다.
+      className="flex gap-7 overflow-x-auto border-b border-[color:var(--color-divider)]"
     >
       {items.map((item) => {
         const active = item.key === activeKey;

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -103,7 +103,7 @@ export function DownloadPage({ showFirstReleaseChecklist = true }: Props) {
                 {t('subtitle')}
               </p>
             </div>
-            <div className="ml-auto flex shrink-0 flex-wrap items-center gap-3">
+            <div className="ml-auto flex max-w-full shrink-0 flex-wrap items-center gap-3">
               <MacosDownloadLink
                 className={cn(buttonVariants({ size: 'lg' }), 'rounded-full min-w-[13rem]')}
               >

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1630,14 +1630,23 @@ export function HomePage() {
                   priority
                   className="h-[26px] w-[26px] shrink-0 rounded-[7px] border border-[color:var(--color-border-soft)] object-cover"
                 />
-                <div>
+                <div
+                  className="min-w-0 overflow-hidden"
+                  // 우측 topology-utility-action-lane(Graph/Workspace pill,
+                  // absolute right-4 + 콘텐츠 폭 ~236px)과 이 브랜드 라벨은
+                  // 서로 다른 absolute 오버레이라 flex-wrap 으로 자연스럽게
+                  // 밀어낼 수 없다 — 뷰포트가 좁을수록(<390px) 레인의 왼쪽
+                  // 시작점도 함께 왼쪽으로 밀리므로 고정 px 대신 vw 기반
+                  // calc 로 항상 여유 간격을 확보한다(criterion ② 겹침 0).
+                  style={{ maxWidth: "max(0px, calc(100vw - 310px))" }}
+                >
                   <span
                     translate="no"
-                    className="break-keep text-[11px] text-[color:var(--color-text-quaternary)]"
+                    className="block truncate text-[11px] text-[color:var(--color-text-quaternary)]"
                   >
                     ontology-atlas
                   </span>
-                  <p className="mt-0.5 max-w-[180px] text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-0.5 truncate text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('mobileTagline')}
                   </p>
                 </div>

--- a/src/views/ontology-insights/ui/parts/InsightsHeroCensus.tsx
+++ b/src/views/ontology-insights/ui/parts/InsightsHeroCensus.tsx
@@ -34,7 +34,7 @@ export function InsightsHeroCensus({
   labels: InsightsHeroCensusLabels;
 }) {
   return (
-    <div className="flex items-stretch gap-0 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-4">
+    <div className="flex flex-col items-stretch gap-3 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-4 sm:flex-row sm:gap-0">
       <HeroSegment label={labels.concepts} gcap="concepts">
         <BigNum value={totalNodes} />
         <SubStrip items={kindsSummary} />
@@ -58,7 +58,7 @@ export function InsightsHeroCensus({
 
 function HeroSegment({ label, gcap, children }: { label: string; gcap: string; children: ReactNode }) {
   return (
-    <div className="flex min-w-0 flex-1 flex-col gap-2.5 border-l border-[color:var(--color-divider)] px-6 py-0.5 first:border-l-0">
+    <div className="flex min-w-0 flex-1 flex-col gap-2.5 border-t border-[color:var(--color-divider)] px-6 py-0.5 pt-3 first:border-t-0 first:pt-0.5 sm:border-t-0 sm:border-l sm:pt-0.5 sm:first:border-l-0">
       <div className="flex items-baseline gap-2 text-[13px] font-medium text-[color:var(--color-text-secondary)]">
         {label}
         <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">

--- a/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
@@ -103,12 +103,12 @@ export function OverviewTab({
                 const width = domainMax > 0 ? Math.max(2, Math.round((row.total / domainMax) * 100)) : 0;
                 const hot = row.total === domainMax && domainMax > 0;
                 return (
-                  <div key={row.id} className="flex items-center gap-3 py-0.5">
-                    <span className="flex w-[220px] flex-none items-center gap-2 truncate text-[14px] text-[color:var(--color-text-secondary)]">
+                  <div key={row.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-0.5">
+                    <span className="flex w-full shrink-0 items-center gap-2 truncate text-[14px] text-[color:var(--color-text-secondary)] sm:w-[220px]">
                       <TopologyV2KindGlyph kind="domain" size={15} />
                       <span className="truncate">{row.title}</span>
                     </span>
-                    <span className="h-2 flex-1 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
+                    <span className="h-2 min-w-[48px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
                       <span
                         className="block h-full rounded-full"
                         style={{

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -156,7 +156,7 @@ export function ProjectSelectorPage() {
                   }`}
                 >
                   <TopologyV2KindGlyph kind={row.kind} size={14} />
-                  <span className="font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
+                  <span className="min-w-0 shrink truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
                     {row.slug}
                   </span>
                   {row.what ? (
@@ -218,7 +218,7 @@ export function ProjectSelectorPage() {
             <code className="font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
               {t("nextSlotCliCommand")}
             </code>
-            <span className="ml-auto whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="ml-auto hidden whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotCliCaption")}
             </span>
           </div>
@@ -229,7 +229,7 @@ export function ProjectSelectorPage() {
             <code className="font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
               {t("nextSlotAgentCommand")}
             </code>
-            <span className="ml-auto whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="ml-auto hidden whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotAgentCaption")}
             </span>
           </div>
@@ -288,12 +288,12 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
       {domainRows.length > 0 ? (
         <div className="mt-4 flex flex-col gap-2">
           {domainRows.map((row, index) => (
-            <div key={row.domainId} className="flex items-center gap-4">
-              <span className="flex w-[280px] shrink-0 items-center gap-2 truncate text-[12.5px] text-[color:var(--color-text-secondary)]">
+            <div key={row.domainId} className="flex flex-wrap items-center gap-x-4 gap-y-1">
+              <span className="flex w-full shrink-0 items-center gap-2 truncate text-[12.5px] text-[color:var(--color-text-secondary)] sm:w-[280px]">
                 <TopologyV2KindGlyph kind="domain" size={14} />
                 {row.title}
               </span>
-              <span className="h-1 max-w-[640px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-border-soft)]">
+              <span className="h-1 max-w-[640px] min-w-[64px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-border-soft)]">
                 <span
                   className="block h-full rounded-full"
                   style={{

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -137,6 +137,14 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
           {t('settingsLabel')}
         </span>
       </summary>
+      {/* details 의 UA 기본 "닫힘 시 non-summary 자식 display:none" 규칙은
+          author stylesheet(Tailwind 의 `flex` 유틸 등)가 더 높은 cascade
+          우선순위로 덮어써 무력화될 수 있다 — 그 경우 닫힌 상태에서도 이
+          오버레이가 실제 레이아웃 박스를 차지해 `document.body.scrollWidth`
+          를 부풀린다(모바일에서 `body{overflow-x:hidden}` 가 시각적으로만
+          가려줌, tests/e2e/overflow-sweep.spec.ts 회귀 발견). `open` 상태로
+          직접 마운트를 걷어내 브라우저 구현에 기대지 않는다. */}
+      {open ? (
       <div
         className="fixed inset-0 z-40 flex items-center justify-center overflow-hidden p-3 sm:p-6"
         data-testid="app-settings-overlay"
@@ -647,6 +655,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
         </div>
       </div>
       </div>
+      ) : null}
     </details>
   );
 }

--- a/tests/e2e/overflow-sweep.spec.ts
+++ b/tests/e2e/overflow-sweep.spec.ts
@@ -3,6 +3,14 @@ import { test, expect } from "@playwright/test";
 /**
  * 주요 라우트를 여러 뷰포트에서 열어 document scrollWidth가 viewport를 넘지
  * 않는지 일괄 확인한다. 가로 스크롤이 생기면 즉시 실패.
+ *
+ * 뷰포트 목록은 소유자 반응형 스윕 매트릭스(fix/responsive-sweep)를 따른다 —
+ * 1280·1440·1512(MBP14 실제 해상도)·1920·2560 데스크톱 + 모바일 스모크
+ * 390·360(파손 방지 수준, 데스크톱 우선 제품이라 최적화 대상 아님) + 기존
+ * tablet-768 회귀 유지. 1920/2560 은 `.topology-ui-scale`(app/globals.css)의
+ * 실제 zoom 1.15/1.3 브레이크포인트와 일치해 크롬 스케일 정합도 같이 덮는다 —
+ * 별도 zoom 시뮬레이션 뷰포트가 필요 없다(실제 min-width 미디어쿼리라 진짜
+ * 값으로 통과해야 의미 있다).
  */
 
 const VIEWPORTS = [
@@ -10,6 +18,8 @@ const VIEWPORTS = [
   { label: "mobile-360", w: 360, h: 780 },
   { label: "tablet-768", w: 768, h: 1024 },
   { label: "desktop-1280", w: 1280, h: 800 },
+  { label: "desktop-1440", w: 1440, h: 900 },
+  { label: "desktop-1512", w: 1512, h: 949 },
   { label: "desktop-1920", w: 1920, h: 1080 },
   { label: "desktop-2560", w: 2560, h: 1440 },
 ];
@@ -18,12 +28,23 @@ const ROUTES = [
   "/en/",
   "/en/projects/",
   "/en/project/ontology-atlas/",
+  "/en/project/new/",
   // R10 (auth + cloud surface 영구 제거) 이후 살아있는 user-facing surface 만.
   "/en/topology/",
   "/en/ontology/",
   "/en/ontology/edit/",
+  "/en/ontology/insights/",
   "/en/docs/",
+  "/en/download/",
 ];
+
+async function measureOverflow(page: import("@playwright/test").Page) {
+  return page.evaluate(() => ({
+    scroll: document.documentElement.scrollWidth,
+    bodyScroll: document.body.scrollWidth,
+    client: document.documentElement.clientWidth,
+  }));
+}
 
 for (const vp of VIEWPORTS) {
   test(`overflow sweep — ${vp.label}`, async ({ page }) => {
@@ -38,11 +59,7 @@ for (const vp of VIEWPORTS) {
     for (const url of ROUTES) {
       await page.goto(url, { waitUntil: "domcontentloaded" });
       await page.waitForTimeout(800);
-      const { scroll, bodyScroll, client } = await page.evaluate(() => ({
-        scroll: document.documentElement.scrollWidth,
-        bodyScroll: document.body.scrollWidth,
-        client: document.documentElement.clientWidth,
-      }));
+      const { scroll, bodyScroll, client } = await measureOverflow(page);
       if (scroll > client || bodyScroll > client) {
         violations.push({ route: url, scroll, bodyScroll, client });
       }
@@ -57,3 +74,36 @@ for (const vp of VIEWPORTS) {
     ).toHaveLength(0);
   });
 }
+
+// 리사이즈 전환 1920↔2560 — reload 없이 뷰포트만 바꿔 `.topology-ui-scale`
+// zoom(1.15→1.3) 미디어쿼리가 다시 계산되는 순간에도 overflow가 생기지
+// 않는지 확인한다. SPA 라우트 전환 후 리사이즈하는 실사용 패턴(외부 모니터
+// 연결/분리, 창 드래그)과 가장 가깝다.
+test("overflow sweep — resize transition 1920↔2560", async ({ page }) => {
+  const violations: Array<{ step: string; route: string; scroll: number; client: number }> = [];
+
+  for (const url of ROUTES) {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(800);
+
+    await page.setViewportSize({ width: 2560, height: 1440 });
+    await page.waitForTimeout(300);
+    const afterGrow = await measureOverflow(page);
+    if (afterGrow.scroll > afterGrow.client) {
+      violations.push({ step: "1920→2560", route: url, ...afterGrow });
+    }
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.waitForTimeout(300);
+    const afterShrink = await measureOverflow(page);
+    if (afterShrink.scroll > afterShrink.client) {
+      violations.push({ step: "2560→1920", route: url, ...afterShrink });
+    }
+  }
+
+  if (violations.length > 0) {
+    console.log("[OVF] resize-transition violations:", JSON.stringify(violations));
+  }
+  expect(violations, `resize-transition overflow: ${JSON.stringify(violations)}`).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
9라우트 × 8뷰포트(360~2560)+리사이즈 전환 전수 스윕. **데스크톱 1280~2560 전 구간 결함 0**(zoom 1.15/1.3 스케일 정합·1600 컬럼 캡 확인 — 소유자 원 지적 해소 확정). 모바일 잔여 수정 6건: 지형도 브랜드 라벨 겹침·insights 히어로 3분할/용량 행/탭바·다운로드 CTA·projects slug truncate (#391 수정과 수렴, 중복 회피). overflow-sweep e2e를 전 매트릭스 회귀 가드로 확장(9/9 그린).

## Test plan
확장 e2e 9/9 그린 · tsc/eslint clean · 관련 unit 18 pass · before/after 스크린샷 81장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)