### PR TITLE
fix: 프로젝트 상세 본문이 절대 표시되지 않던 버그

### DIFF
--- a/src/entities/docs-vault/index.ts
+++ b/src/entities/docs-vault/index.ts
@@ -28,6 +28,12 @@ export {
 } from './lib/build-vault-markdown';
 export { deriveOntologyFromVault } from './lib/derive-ontology-from-vault';
 export { deriveProjectsFromVault } from './lib/derive-projects-from-vault';
+export {
+  computeProjectSlug,
+  isProjectVaultDoc,
+  findProjectVaultDoc,
+} from './lib/project-slug';
+export { extractProjectBody } from './lib/resolve-project-body';
 export type {
   OntologyStubEdge,
   OntologyStubNode,

--- a/src/entities/docs-vault/lib/derive-projects-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-projects-from-vault.ts
@@ -1,6 +1,6 @@
 import type { Project } from '@/entities/project';
 import type { VaultDoc, VaultManifest } from '../model/types';
-import { computeProjectSlug } from './project-slug';
+import { computeProjectSlug, isProjectVaultDoc } from './project-slug';
 
 /**
  * vault manifest 에서 *project 노드* 를 Project 도메인 모델로 매핑.
@@ -19,9 +19,7 @@ import { computeProjectSlug } from './project-slug';
 export function deriveProjectsFromVault(manifest: VaultManifest): Project[] {
   const projects: Project[] = [];
   for (const doc of manifest.docs) {
-    const isProjectKind = doc.frontmatter?.kind === 'project';
-    const isLegacyPath = doc.slug.startsWith('projects/');
-    if (!isProjectKind && !isLegacyPath) continue;
+    if (!isProjectVaultDoc(doc)) continue;
     const project = mapVaultDocToProject(doc);
     if (project) projects.push(project);
   }

--- a/src/entities/docs-vault/lib/project-slug.test.ts
+++ b/src/entities/docs-vault/lib/project-slug.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { VaultDoc } from "../model/types";
-import { computeProjectSlug } from "./project-slug";
+import type { VaultDoc, VaultManifest } from "../model/types";
+import {
+  computeProjectSlug,
+  findProjectVaultDoc,
+  isProjectVaultDoc,
+} from "./project-slug";
 
 function makeDoc(partial: Partial<VaultDoc>): VaultDoc {
   return {
@@ -15,6 +19,17 @@ function makeDoc(partial: Partial<VaultDoc>): VaultDoc {
     wordCount: partial.wordCount ?? 0,
     updatedAt: partial.updatedAt ?? new Date(0).toISOString(),
     linksOut: partial.linksOut ?? [],
+  };
+}
+
+function makeManifest(docs: VaultDoc[]): VaultManifest {
+  return {
+    version: "1",
+    generatedAt: new Date(0).toISOString(),
+    docs,
+    backlinksDetail: {},
+    tags: {},
+    tree: { name: "vault", path: "", type: "dir" },
   };
 }
 
@@ -58,5 +73,58 @@ describe("computeProjectSlug", () => {
         makeDoc({ slug: "projects/foo", frontmatter: { slug: 42 } }),
       ),
     ).toBe("foo");
+  });
+});
+
+describe("isProjectVaultDoc", () => {
+  it("frontmatter.kind === 'project' 는 path 무관하게 인식", () => {
+    expect(
+      isProjectVaultDoc(
+        makeDoc({ slug: "ontology/project", frontmatter: { kind: "project" } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("legacy 'projects/' prefix 는 frontmatter 없어도 인식", () => {
+    expect(isProjectVaultDoc(makeDoc({ slug: "projects/legacy-app" }))).toBe(true);
+  });
+
+  it("kind 도 'projects/' prefix 도 없으면 false", () => {
+    expect(
+      isProjectVaultDoc(makeDoc({ slug: "domains/foo", frontmatter: { kind: "domain" } })),
+    ).toBe(false);
+  });
+});
+
+describe("findProjectVaultDoc", () => {
+  it("Project.slug (fm.slug 산정값) 으로 원본 VaultDoc 을 역참조한다", () => {
+    const doc = makeDoc({
+      slug: "ontology/project",
+      frontmatter: { kind: "project", slug: "ontology-atlas" },
+    });
+    const manifest = makeManifest([
+      doc,
+      makeDoc({ slug: "domains/foo", frontmatter: { kind: "domain" } }),
+    ]);
+
+    expect(findProjectVaultDoc(manifest, "ontology-atlas")).toBe(doc);
+  });
+
+  it("일치하는 project doc 이 없으면 null", () => {
+    const manifest = makeManifest([
+      makeDoc({ slug: "domains/foo", frontmatter: { kind: "domain" } }),
+    ]);
+
+    expect(findProjectVaultDoc(manifest, "missing")).toBeNull();
+  });
+
+  it("project 가 아닌 doc 의 slug 우연 일치는 무시한다", () => {
+    // frontmatter.slug 가 우연히 같아도 kind !== project / projects/ path
+    // 아니면 project doc 으로 취급하지 않는다.
+    const manifest = makeManifest([
+      makeDoc({ slug: "domains/foo", frontmatter: { kind: "domain", slug: "foo" } }),
+    ]);
+
+    expect(findProjectVaultDoc(manifest, "foo")).toBeNull();
   });
 });

--- a/src/entities/docs-vault/lib/project-slug.ts
+++ b/src/entities/docs-vault/lib/project-slug.ts
@@ -1,4 +1,4 @@
-import type { VaultDoc } from "../model/types";
+import type { VaultDoc, VaultManifest } from "../model/types";
 
 /**
  * vault doc → Project.slug 산정 — `fm.slug` 가 truthy 면 그것을 (앞뒤 공백
@@ -20,4 +20,29 @@ export function computeProjectSlug(doc: VaultDoc): string | null {
     ? doc.slug.replace(/^projects\//, "")
     : doc.slug.split("/").pop() || doc.slug;
   return fmSlug ?? (fileSlug || null);
+}
+
+/**
+ * deriveProjectsFromVault 과 동일한 project-doc 인식 기준 (frontmatter.kind
+ * === 'project' 우선, 'projects/' path 는 legacy 호환). 두 곳에서 각자
+ * 다시 적어 drift 나던 걸 단일화 — findProjectVaultDoc 도 이 helper 위에.
+ */
+export function isProjectVaultDoc(doc: VaultDoc): boolean {
+  return doc.frontmatter?.kind === "project" || doc.slug.startsWith("projects/");
+}
+
+/**
+ * Project.slug (frontmatter `slug:` 우선 산정값) 로 원본 VaultDoc 을 역참조.
+ * 본문(raw markdown) 은 manifest 에 없고 content.json(static) / fileHandle
+ * (local) 에 doc.slug(파일 경로) 키로 별도 존재 — 본문 lazy-load 의 첫 hop.
+ */
+export function findProjectVaultDoc(
+  manifest: VaultManifest,
+  slug: string,
+): VaultDoc | null {
+  for (const doc of manifest.docs) {
+    if (!isProjectVaultDoc(doc)) continue;
+    if (computeProjectSlug(doc) === slug) return doc;
+  }
+  return null;
 }

--- a/src/entities/docs-vault/lib/resolve-project-body.test.ts
+++ b/src/entities/docs-vault/lib/resolve-project-body.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractProjectBody } from "./resolve-project-body";
+
+describe("extractProjectBody", () => {
+  it("frontmatter 를 스트립하고 본문만 반환한다", () => {
+    const raw = [
+      "---",
+      "kind: project",
+      "title: demo",
+      "---",
+      "",
+      "# demo",
+      "",
+      "실제 본문 내용입니다.",
+    ].join("\n");
+
+    expect(extractProjectBody(raw)).toBe("# demo\n\n실제 본문 내용입니다.");
+  });
+
+  it("frontmatter 가 없어도 본문 그대로 반환한다 (legacy 파일 호환)", () => {
+    expect(extractProjectBody("그냥 본문")).toBe("그냥 본문");
+  });
+
+  it("본문이 공백뿐이면 undefined (본문 없음 UI 분기와 일치)", () => {
+    const raw = ["---", "kind: project", "---", "", "   \n\n  "].join("\n");
+    expect(extractProjectBody(raw)).toBeUndefined();
+  });
+
+  it("null / undefined / 빈 문자열 입력은 undefined", () => {
+    expect(extractProjectBody(null)).toBeUndefined();
+    expect(extractProjectBody(undefined)).toBeUndefined();
+    expect(extractProjectBody("")).toBeUndefined();
+  });
+});

--- a/src/entities/docs-vault/lib/resolve-project-body.ts
+++ b/src/entities/docs-vault/lib/resolve-project-body.ts
@@ -1,0 +1,21 @@
+import { parseFrontmatter } from '@/shared/lib/parse-frontmatter';
+
+/**
+ * project.md 의 raw 파일 전체(frontmatter 포함)에서 본문만 추출.
+ *
+ * 왜 필요한가 — /project/[slug] 상세의 "본문" 카드는 실제로 project.md 의
+ * 마크다운 본문을 보여줘야 하는데, Project.detail 은 frontmatter 의 명시적
+ * `detail:` 키(에디터 폼의 별도 필드, project-frontmatter.ts 가 그대로
+ * round-trip 저장)만 읽는다. 실제 vault 문서는 대부분 `detail:` 없이 body
+ * 에 내용을 쓰므로 본문 카드가 항상 비어 보였다 (본 파일이 그 gap 을 메움).
+ *
+ * 이 함수는 표시 전용 — 반환값을 Project.detail 에 대입하면 에디터 폼이
+ * 본문 전체를 "detail" 필드로 오인해 저장 시 frontmatter 에 중복 기록하는
+ * 회귀가 생긴다. 호출자는 반드시 별도 필드로 유지 (project-data-source 의
+ * useProjectBody 참고).
+ */
+export function extractProjectBody(raw: string | undefined | null): string | undefined {
+  if (!raw) return undefined;
+  const body = parseFrontmatter(raw).body.trim();
+  return body.length > 0 ? body : undefined;
+}

--- a/src/features/project-data-source/index.ts
+++ b/src/features/project-data-source/index.ts
@@ -2,3 +2,5 @@ export { useProjectMutations } from './model/use-project-mutations';
 export type { ProjectMutations } from './model/use-project-mutations';
 export { useProjects } from './model/use-projects';
 export type { UseProjectsState } from './model/use-projects';
+export { useProjectBody } from './model/use-project-body';
+export type { UseProjectBodyState } from './model/use-project-body';

--- a/src/features/project-data-source/model/use-project-body.ts
+++ b/src/features/project-data-source/model/use-project-body.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useDataSourceMode } from '@/features/data-source-mode';
+import { useLocalVault } from '@/features/docs-vault-local';
+import {
+  extractProjectBody,
+  findProjectVaultDoc,
+  vaultContent as staticVaultContentRaw,
+  vaultManifest as staticVaultManifestRaw,
+  type VaultManifest,
+} from '@/entities/docs-vault';
+
+const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
+const staticVaultContent = staticVaultContentRaw as Record<string, string>;
+
+export interface UseProjectBodyState {
+  /** project.md 의 실제 마크다운 본문. 없거나 아직 못 읽었으면 null. */
+  body: string | null;
+}
+
+/**
+ * /project/[slug] 상세 "본문" 카드 전용 lazy 본문 로더.
+ *
+ * `useProjects` (list 화면도 쓰는 공유 파생) 는 excerpt 까지만 필요해
+ * 절대 본문 전체를 미리 읽지 않는다 — 이 hook 은 ProjectDetailPage 가
+ * mount 된 시점, 그 슬러그에 대해서만 I/O 를 발생시킨다.
+ *
+ * - static: content.json 이 이미 번들에 있어 동기 lookup (추가 I/O 없음).
+ * - local: FileSystemFileHandle.getFile() 로 실제 파일을 비동기 read —
+ *   S4 노드 설명 편집(HomePage nodeBody)과 같은 기제 재사용.
+ */
+export function useProjectBody(slug: string | null): UseProjectBodyState {
+  const mode = useDataSourceMode();
+  const vault = useLocalVault();
+  const [resolved, setResolved] = useState<{ slug: string; body: string | null } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!slug) {
+      window.queueMicrotask(() => {
+        if (!cancelled) setResolved(null);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (mode === 'static') {
+      const doc = findProjectVaultDoc(staticVaultManifest, slug);
+      const body = doc ? extractProjectBody(staticVaultContent[doc.slug]) ?? null : null;
+      window.queueMicrotask(() => {
+        if (!cancelled) setResolved({ slug, body });
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    // local
+    const doc = vault.manifest ? findProjectVaultDoc(vault.manifest, slug) : null;
+    const fh = doc ? vault.fileHandles.get(doc.slug) : null;
+    if (!fh) {
+      window.queueMicrotask(() => {
+        if (!cancelled) setResolved({ slug, body: null });
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    fh.getFile()
+      .then((file) => file.text())
+      .then((raw) => {
+        if (!cancelled) setResolved({ slug, body: extractProjectBody(raw) ?? null });
+      })
+      .catch(() => {
+        if (!cancelled) setResolved({ slug, body: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, mode, vault.manifest, vault.fileHandles]);
+
+  return { body: resolved && resolved.slug === slug ? resolved.body : null };
+}

--- a/src/views/project-detail/ui/ProjectDetailPage.test.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { NextIntlClientProvider } from "next-intl";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import enMessages from "../../../../messages/en.json";
 import { ProjectDetailPage } from "./ProjectDetailPage";
 
@@ -84,6 +84,7 @@ const mocks = vi.hoisted(() => ({
   insightNodes: [] as unknown[],
   insightEdges: [] as unknown[],
   canEdit: false,
+  vaultBody: null as string | null,
 }));
 
 vi.mock("@/features/vault-ontology", () => ({
@@ -102,6 +103,7 @@ vi.mock("@/features/project-data-source", () => ({
     mode: "static",
     updateProject: vi.fn(),
   }),
+  useProjectBody: () => ({ body: mocks.vaultBody }),
 }));
 
 function baseProject() {
@@ -132,6 +134,10 @@ function renderPage(overrides: { related?: ReturnType<typeof baseProject>[] } = 
 }
 
 describe("ProjectDetailPage", () => {
+  beforeEach(() => {
+    mocks.vaultBody = null;
+  });
+
   it("renders the hero metric strip with real projectIds-derived counts", () => {
     mocks.insightNodes = BASE_NODES;
     mocks.insightEdges = BASE_EDGES;
@@ -229,5 +235,49 @@ describe("ProjectDetailPage", () => {
     renderPage();
 
     expect(screen.queryByTestId("project-detail-domain-card")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty-body hint when neither project.detail nor the vault body is available (pre-fix behavior preserved)", () => {
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    mocks.vaultBody = null;
+    renderPage();
+
+    expect(screen.getByTestId("project-detail-body-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("project-detail-body-content")).not.toBeInTheDocument();
+  });
+
+  it("renders the real project.md body as a fallback when project.detail (the frontmatter field) is unset — the bug this fix closes", () => {
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    mocks.vaultBody = "## Real project.md content\n\nThis is the actual markdown body.";
+    renderPage();
+
+    const content = screen.getByTestId("project-detail-body-content");
+    expect(content).toHaveTextContent("Real project.md content");
+    expect(content).toHaveTextContent("This is the actual markdown body.");
+    expect(screen.queryByTestId("project-detail-body-empty")).not.toBeInTheDocument();
+  });
+
+  it("prefers the explicit frontmatter detail field over the vault body fallback when both exist", () => {
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    mocks.vaultBody = "Vault body text that should be shadowed.";
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <ProjectDetailPage
+          slug={SLUG}
+          initialProject={{ ...baseProject(), detail: "Explicit detail field wins." }}
+          initialRelated={[]}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    const content = screen.getByTestId("project-detail-body-content");
+    expect(content).toHaveTextContent("Explicit detail field wins.");
+    expect(content).not.toHaveTextContent("Vault body text that should be shadowed.");
   });
 });

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -28,7 +28,7 @@ import {
   resolveFallbackProjects,
   type Project,
 } from "@/entities/project";
-import { useProjects, useProjectMutations } from "@/features/project-data-source";
+import { useProjects, useProjectMutations, useProjectBody } from "@/features/project-data-source";
 import { VaultConflictError } from "@/features/docs-vault-local";
 import { useOntologyInsight } from "@/features/vault-ontology";
 import { CopyProjectLinkButton } from "@/features/project-share";
@@ -243,6 +243,12 @@ export function ProjectDetailPage({
   // 단일 hook 이 항상 최신 snapshot 을 들고 있어 list/subscribe race 없음.
   const projectsQuery = useProjects();
   const projectMutations = useProjectMutations();
+  // 본문(project.md) lazy load — R+ "본문이 절대 표시되지 않음" 정정.
+  // project.detail 은 에디터 폼의 별도 frontmatter `detail:` 필드라 대부분의
+  // 실제 vault 문서엔 없다 — 진짜 본문은 vault 파일에서 별도로 읽어야 한다.
+  // fallback 순서: 명시적 detail 필드 > 실제 project.md 본문.
+  const { body: vaultBody } = useProjectBody(project?.slug ?? null);
+  const bodyContent = project?.detail ?? vaultBody ?? null;
   useEffect(() => {
     if (!slug) return;
     let cancelled = false;
@@ -521,12 +527,15 @@ export function ProjectDetailPage({
               {t("bodyCardGcap")}
             </span>
           </div>
-          {project.detail ? (
-            <div className={storyMarkdownClassName}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{project.detail}</ReactMarkdown>
+          {bodyContent ? (
+            <div className={storyMarkdownClassName} data-testid="project-detail-body-content">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{bodyContent}</ReactMarkdown>
             </div>
           ) : (
-            <p className="text-[13.5px] leading-[1.75] text-[color:var(--color-text-tertiary)]">
+            <p
+              data-testid="project-detail-body-empty"
+              className="text-[13.5px] leading-[1.75] text-[color:var(--color-text-tertiary)]"
+            >
               {t("bodyEmptyHint")}
             </p>
           )}


### PR DESCRIPTION
## Summary
시안 정합 감사 발견 High — 상세 페이지 본문 카드가 존재하지 않는 frontmatter `detail:` 키만 읽어 실제 project.md 본문이 항상 "본문 없음"이던 버그. 설계 판단: 파생 로직에 body를 합치면 편집 폼 round-trip에서 본문이 detail 필드로 중복 기록되는 새 회귀 → **상세 페이지 전용 lazy 훅**(`useProjectBody` — 정적=content.json, 로컬=파일핸들 read, 기존 nodeBody 패턴 재사용)으로 렌더 시점 fallback 병합(`detail 우선 → body`). project doc 인식 로직 단일화 리팩터 동봉.

## Test plan
전체 vitest 290파일 2,210 pass · tsc/lint clean · 라이브 before("본문 없음")/after(실본문 렌더) stash 대조 스크린샷. 잔여: 로컬 FS 모드 실폴더 검증은 피커 자동화 제약으로 구조 재사용 근거만(위험 낮음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)