### PR TITLE
fix: 페르소나 QA 발견 결함 — 경로 확정·backlinks·빌더 상세 안전망

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1819,7 +1819,8 @@
       "ariaLabel": "Frontmatter graph fields"
     },
     "backlinksStrip": {
-      "openInOntology": "Open in ontology →"
+      "openInOntology": "Open in ontology →",
+      "empty": "No documents link here yet"
     },
     "vaultStatus": {
       "localTooltip": "Pick a folder on your disk as the workspace",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1819,7 +1819,8 @@
       "ariaLabel": "프론트매터 그래프 필드"
     },
     "backlinksStrip": {
-      "openInOntology": "온톨로지에서 열기 →"
+      "openInOntology": "온톨로지에서 열기 →",
+      "empty": "아직 이 문서를 참조한 문서가 없습니다"
     },
     "vaultStatus": {
       "localTooltip": "내 디스크의 폴더를 vault 로 선택",

--- a/scripts/build-docs-vault.mjs
+++ b/scripts/build-docs-vault.mjs
@@ -158,9 +158,26 @@ function buildExcerpt(body) {
   return stripped.slice(0, 320);
 }
 
+// 위키링크 target 을 문서가 속한 vault 기준으로 정규화 — mirror of
+// src/shared/lib/parse-frontmatter.ts#resolveWikilinkTargetSlug (동일 로직
+// 두 곳에 물리적으로 중복돼 있음 — parser 3-way contract 처럼 별도 계약
+// 테스트는 아직 없지만, 여기 고치면 저기도 같이 고쳐야 drift 안 남).
+// docs/ontology/ 는 이 프로젝트가 dogfood 하는 중첩 MCP vault — 그 안의
+// 위키링크는 MCP 툴/사람이 쓰는 `capabilities/x` 같은 ontology-vault-루트
+// 기준 slug 를 그대로 쓰지만, `/docs` 통합 트리에서 실제 slug 는
+// `ontology/` 접두사가 붙어 접두사 보정 없이는 backlinksDetail 키가
+// 어긋나 실제 역참조가 있어도 조회에서 누락된다 (persona QA
+// fix/persona-findings ③).
+export function resolveWikilinkTargetSlug(targetSlug, fromSlug) {
+  if (fromSlug.startsWith('ontology/') && !targetSlug.startsWith('ontology/')) {
+    return `ontology/${targetSlug}`;
+  }
+  return targetSlug;
+}
+
 // 링크 추출 — 상대 경로 md 참조 + 옵시디언 wikilinks. 외부 URL·이미지·
 // 앵커 only 는 무시. 각 링크마다 targetSlug + 주변 context (120자) 반환.
-function extractOutLinksWithContext(body, fromSlug) {
+export function extractOutLinksWithContext(body, fromSlug) {
   const slugs = new Set();
   const contexts = [];
   const re = /\[([^\]]+)\]\(([^)]+)\)/g;
@@ -188,14 +205,18 @@ function extractOutLinksWithContext(body, fromSlug) {
     const context = raw.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
     contexts.push({ target: targetSlug, context, linkText });
   }
-  // Wikilinks [[slug]] / [[slug|text]] / [[slug#anchor]] — vault root slug.
+  // Wikilinks [[slug]] / [[slug|text]] / [[slug#anchor]] — vault root slug
+  // (중첩된 ontology/ vault 안에서는 그 vault 의 루트 기준 — 위
+  // resolveWikilinkTargetSlug 참고).
   const wre = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
   while ((m = wre.exec(body))) {
     const targetSpec = m[1].trim();
-    const [targetSlug] = targetSpec.split('#');
+    const [rawTargetSlug] = targetSpec.split('#');
+    if (!rawTargetSlug) continue;
+    const targetSlug = resolveWikilinkTargetSlug(rawTargetSlug, fromSlug);
     if (!targetSlug || targetSlug === fromSlug) continue;
     slugs.add(targetSlug);
-    const linkText = (m[2] ?? targetSlug).trim();
+    const linkText = (m[2] ?? rawTargetSlug).trim();
     const matchStart = m.index;
     const matchEnd = m.index + m[0].length;
     const before = body.slice(Math.max(0, matchStart - 120), matchStart);

--- a/scripts/build-docs-vault.test.mjs
+++ b/scripts/build-docs-vault.test.mjs
@@ -4,7 +4,9 @@ import { describe, it } from 'node:test';
 import {
   comparableDoc,
   comparableManifest,
+  extractOutLinksWithContext,
   parseArgs,
+  resolveWikilinkTargetSlug,
   usage,
 } from './build-docs-vault.mjs';
 
@@ -62,5 +64,35 @@ describe('build-docs-vault script helpers', () => {
         docs: [{ ...nextDoc, title: 'Changed' }],
       }),
     );
+  });
+});
+
+describe('resolveWikilinkTargetSlug / extractOutLinksWithContext — nested ontology/ vault', () => {
+  // persona QA (fix/persona-findings ③) — mirror of the shared TS test in
+  // src/shared/lib/parse-frontmatter.test.ts. This .mjs copy is the one that
+  // actually builds the static dogfood manifest (`docs-vault:build`), so it
+  // needs its own regression guard against the same drift.
+  it('ontology/ 문서 안의 위키링크는 ontology/ 접두사를 붙여 정규화한다', () => {
+    assert.equal(
+      resolveWikilinkTargetSlug('capabilities/topology-canvas-render', 'ontology/elements/sigma-graphology'),
+      'ontology/capabilities/topology-canvas-render',
+    );
+    const { contexts } = extractOutLinksWithContext(
+      '같은 캔버스 엔진 얘기는 [[capabilities/topology-canvas-render]] 참고.',
+      'ontology/elements/sigma-graphology',
+    );
+    assert.equal(contexts.length, 1);
+    assert.equal(contexts[0].target, 'ontology/capabilities/topology-canvas-render');
+  });
+
+  it('이미 ontology/ 접두사가 붙은 위키링크는 이중으로 접두사를 붙이지 않는다', () => {
+    assert.equal(
+      resolveWikilinkTargetSlug('ontology/project', 'ontology/domains/views'),
+      'ontology/project',
+    );
+  });
+
+  it('ontology/ 바깥(최상위) 문서의 위키링크는 그대로 vault 루트 기준을 유지한다', () => {
+    assert.equal(resolveWikilinkTargetSlug('FEATURES', 'CHANGELOG'), 'FEATURES');
   });
 });

--- a/src/shared/lib/parse-frontmatter.test.ts
+++ b/src/shared/lib/parse-frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildExcerpt, parseFrontmatter } from './parse-frontmatter';
+import { buildExcerpt, extractOutLinksWithContext, parseFrontmatter } from './parse-frontmatter';
 
 describe('parseFrontmatter — basics', () => {
   it('returns empty frontmatter when no leading ---', () => {
@@ -153,5 +153,49 @@ describe('buildExcerpt — markdown is flattened to readable prose', () => {
   it('respects the max length', () => {
     expect(buildExcerpt('x'.repeat(500)).length).toBe(320);
     expect(buildExcerpt('x'.repeat(500), 50).length).toBe(50);
+  });
+});
+
+describe('extractOutLinksWithContext — wikilinks inside the nested ontology/ vault', () => {
+  // persona QA (fix/persona-findings ③): docs/ontology/ 는 이 프로젝트가
+  // dogfood 하는 중첩 MCP vault — 그 안의 위키링크(`[[capabilities/x]]`)는
+  // ontology-vault-루트 기준 slug 를 쓰지만, 실제 문서 slug 는
+  // `ontology/` 접두사가 붙는다. 접두사 보정 없이는 실제 역참조가 있어도
+  // backlinksDetail 조회가 항상 빗나가 `/docs` 하단 backlinks strip 이
+  // 절대 렌더되지 않았다 (예: docs/ontology/elements/sigma-graphology.md
+  // 의 `[[capabilities/topology-canvas-render]]`).
+  it('ontology/ 문서 안의 위키링크는 ontology/ 접두사를 붙여 정규화한다', () => {
+    const body = '같은 캔버스 엔진 얘기는 [[capabilities/topology-canvas-render]] 참고.';
+    const { contexts } = extractOutLinksWithContext(
+      body,
+      'ontology/elements/sigma-graphology',
+    );
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].target).toBe('ontology/capabilities/topology-canvas-render');
+    expect(contexts[0].linkText).toBe('capabilities/topology-canvas-render');
+  });
+
+  it('이미 ontology/ 접두사가 붙은 위키링크는 이중으로 접두사를 붙이지 않는다', () => {
+    const body = '전체 문맥은 [[ontology/project]] 문서 참고.';
+    const { contexts } = extractOutLinksWithContext(
+      body,
+      'ontology/domains/views',
+    );
+    expect(contexts[0].target).toBe('ontology/project');
+  });
+
+  it('ontology/ 바깥(최상위) 문서의 위키링크는 그대로 vault 루트 기준을 유지한다', () => {
+    const body = '자세한 기능은 [[FEATURES]] 참고.';
+    const { contexts } = extractOutLinksWithContext(body, 'CHANGELOG');
+    expect(contexts[0].target).toBe('FEATURES');
+  });
+
+  it('표준 markdown 상대경로 링크는 (이미 정확했던) fromDir 기준 정규화를 그대로 유지한다', () => {
+    const body = '관련 element 는 [여기](../domains/ai-agent-partner.md) 참고.';
+    const { contexts } = extractOutLinksWithContext(
+      body,
+      'ontology/capabilities/mcp-server',
+    );
+    expect(contexts[0].target).toBe('ontology/domains/ai-agent-partner');
   });
 });

--- a/src/shared/lib/parse-frontmatter.ts
+++ b/src/shared/lib/parse-frontmatter.ts
@@ -201,6 +201,28 @@ export interface LinkContext {
 }
 
 /**
+ * 위키링크 `[[slug]]` 의 target 을 문서가 속한 vault 기준으로 정규화한다.
+ *
+ * `docs/ontology/` 는 이 프로젝트가 dogfood 하는 **중첩 MCP vault** —
+ * 그 안의 위키링크는 MCP 툴/사람이 쓰는 `capabilities/x`, `domains/y` 같은
+ * ontology-vault-루트 기준 slug 를 그대로 쓴다(예:
+ * `docs/ontology/elements/sigma-graphology.md` 의
+ * `[[capabilities/topology-canvas-render]]`). 하지만 `/docs` 페이지가
+ * 만드는 통합 트리에서 그 문서의 실제 slug 는 `ontology/` 접두사가 붙은
+ * `ontology/capabilities/topology-canvas-render` 라, 접두사 보정 없이는
+ * `backlinksDetail` 키가 서로 어긋나 실제 역참조가 있어도 조회에서
+ * 누락된다 (persona QA fix/persona-findings ③). `ontology/` 바깥의
+ * 최상위 문서가 쓰는 위키링크(예: `docs/CHANGELOG.md` 의 `[[FEATURES]]`)
+ * 는 이미 루트 기준이라 그대로 둔다.
+ */
+function resolveWikilinkTargetSlug(targetSlug: string, fromSlug: string): string {
+  if (fromSlug.startsWith('ontology/') && !targetSlug.startsWith('ontology/')) {
+    return `ontology/${targetSlug}`;
+  }
+  return targetSlug;
+}
+
+/**
  * 마크다운 본문에서 상대 경로 md 참조를 추출해 target slug + 주변 context
  * 로 반환. http(s)/앵커/이미지는 무시. fromSlug 는 현재 문서의 vault slug
  * (디렉터리 포함, 확장자 제외).
@@ -247,14 +269,18 @@ export function extractOutLinksWithContext(
     const context = raw.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
     contexts.push({ target: targetSlug, context, linkText });
   }
-  // Wikilinks [[slug]] / [[slug|text]] / [[slug#anchor]] — vault 루트 기준 slug.
+  // Wikilinks [[slug]] / [[slug|text]] / [[slug#anchor]] — vault 루트 기준 slug
+  // (중첩된 ontology/ vault 안에서는 그 vault 의 루트 기준 — 위
+  // resolveWikilinkTargetSlug 참고).
   const wre = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
   while ((m = wre.exec(body)) !== null) {
     const targetSpec = m[1].trim();
-    const [targetSlug] = targetSpec.split('#');
+    const [rawTargetSlug] = targetSpec.split('#');
+    if (!rawTargetSlug) continue;
+    const targetSlug = resolveWikilinkTargetSlug(rawTargetSlug, fromSlug);
     if (!targetSlug || targetSlug === fromSlug) continue;
     slugs.add(targetSlug);
-    const linkText = (m[2] ?? targetSlug).trim();
+    const linkText = (m[2] ?? rawTargetSlug).trim();
     const matchStart = m.index;
     const matchEnd = m.index + m[0].length;
     const before = body.slice(Math.max(0, matchStart - 120), matchStart);

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -2218,15 +2218,26 @@ function DocsVaultContent() {
               </div>
 
               {/* 하단 backlinks 스트립 — pane 전체 폭에 앵커, 항상 보임
-                  (docs-vault-final spec §하단 백링크 스트립). */}
-              {!editing && backlinksDetail.length > 0 ? (
+                  (docs-vault-final spec §하단 백링크 스트립). persona QA
+                  (fix/persona-findings ③): "항상 보임" 스펙과 달리
+                  backlinksDetail.length > 0 조건으로 실제 역참조가 없는
+                  문서에서는 스트립 자체가 사라져 기능 발견성이 없었다 —
+                  역참조 0 개도 빈 상태 문구로 보여 "여긴 아직 없다" 를
+                  알 수 있게 한다. */}
+              {!editing ? (
                 <div className="flex flex-none items-center gap-2 border-t border-[color:var(--color-border-soft)] px-4 py-2.5">
-                  <DocsVaultBacklinks
-                    entries={backlinksDetail}
-                    docsBySlug={docsBySlug}
-                    onNavigate={handleSelect}
-                    layout="strip"
-                  />
+                  {backlinksDetail.length > 0 ? (
+                    <DocsVaultBacklinks
+                      entries={backlinksDetail}
+                      docsBySlug={docsBySlug}
+                      onNavigate={handleSelect}
+                      layout="strip"
+                    />
+                  ) : (
+                    <p className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--color-text-quaternary)]">
+                      {t('backlinksStrip.empty')}
+                    </p>
+                  )}
                   <Link
                     href={buildOntologyDeeplinkForDoc(selectedDoc) ?? '/ontology/'}
                     className="flex-none text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"

--- a/src/views/home/model/url-state.test.ts
+++ b/src/views/home/model/url-state.test.ts
@@ -3,6 +3,7 @@ import {
   applyHomeRouteState,
   DEFAULT_HOME_ROUTE_STATE,
   parseHomeRouteState,
+  resolveTopologyNodeClickRouteState,
   selectTopologyNodeRouteState,
   selectTopologyPathRouteState,
 } from "./url-state";
@@ -352,5 +353,74 @@ describe("selectTopologyPathRouteState", () => {
     ).toBe(
       "mode=path&pathFrom=project%3Aontology-atlas&pathTo=domain%3Aai-agent-partner",
     );
+  });
+});
+
+describe("resolveTopologyNodeClickRouteState", () => {
+  // persona QA (fix/persona-findings ②): 두 번째 노드 클릭으로 캔버스는
+  // A→B 를 그리지만 칩 문구가 "대상 선택" 에 고정되고 경로 패킷 복사
+  // 버튼도 나타나지 않던 회귀 — `HomePage.tsx` 의 클릭 핸들러가
+  // analysisMode 를 보지 않고 항상 일반 선택 경로로만 흘렀던 게 원인.
+  it("일반 모드에서는 selectTopologyNodeRouteState 와 동일하게 동작한다", () => {
+    for (const mode of ["overview", "focus", "health"] as const) {
+      const state = { ...DEFAULT_HOME_ROUTE_STATE, analysisMode: mode };
+      expect(resolveTopologyNodeClickRouteState(state, "domain:views")).toEqual(
+        selectTopologyNodeRouteState(state, "domain:views"),
+      );
+    }
+  });
+
+  it("path 모드 + 소스 미확정 상태에서 첫 클릭은 소스를 확정한다", () => {
+    const state = { ...DEFAULT_HOME_ROUTE_STATE, analysisMode: "path" as const };
+    expect(
+      resolveTopologyNodeClickRouteState(state, "project:ontology-atlas"),
+    ).toMatchObject({
+      analysisMode: "path",
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: null,
+    });
+  });
+
+  it("path 모드 + 소스 확정 상태에서 두 번째 클릭은 대상을 확정한다 (회귀 fix)", () => {
+    const state = {
+      ...DEFAULT_HOME_ROUTE_STATE,
+      analysisMode: "path" as const,
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: null,
+    };
+    expect(
+      resolveTopologyNodeClickRouteState(state, "domain:ai-agent-partner"),
+    ).toMatchObject({
+      analysisMode: "path",
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: "domain:ai-agent-partner",
+    });
+  });
+
+  it("path 모드에서 이미 확정된 대상과 다른 세 번째 노드를 클릭하면 대상을 갈아끼운다", () => {
+    const state = {
+      ...DEFAULT_HOME_ROUTE_STATE,
+      analysisMode: "path" as const,
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: "domain:ai-agent-partner",
+    };
+    expect(
+      resolveTopologyNodeClickRouteState(state, "domain:ontology-core"),
+    ).toMatchObject({
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: "domain:ontology-core",
+    });
+  });
+
+  it("path 모드에서 소스 노드 자체를 다시 클릭해도 상태를 그대로 둔다", () => {
+    const state = {
+      ...DEFAULT_HOME_ROUTE_STATE,
+      analysisMode: "path" as const,
+      pathSourceSlug: "project:ontology-atlas",
+      pathTargetSlug: null,
+    };
+    expect(
+      resolveTopologyNodeClickRouteState(state, "project:ontology-atlas"),
+    ).toBe(state);
   });
 });

--- a/src/views/home/model/url-state.ts
+++ b/src/views/home/model/url-state.ts
@@ -165,6 +165,47 @@ export function selectTopologyPathRouteState(
   };
 }
 
+/**
+ * 캔버스 노드 클릭의 단일 진입점 — path 모드인지 여부로
+ * `selectTopologyNodeRouteState` (일반 선택) 과 `selectTopologyPathRouteState`
+ * (경로 소스/대상 확정) 사이를 분기한다.
+ *
+ * persona QA 발견 (fix/persona-findings ②): 이전엔 `HomePage.tsx` 의
+ * `handleSelect` 가 analysisMode 를 전혀 보지 않고 항상
+ * `selectTopologyNodeRouteState` 로만 흘렀다 — path 모드에서 소스 노드를
+ * 고른 뒤 두 번째 노드를 클릭해도 `pathTargetSlug` 가 절대 채워지지 않아,
+ * 캔버스는 새로 선택된 노드의 ego 이웃을 그려 "경로가 확정된 것처럼"
+ * 보였지만 `TopologyPathChip` 은 `pathTargetSlug` 를 엄격히 요구해 "대상
+ * 선택" 문구에 고정되고 경로 패킷 복사 버튼도 끝내 나타나지 않았다.
+ *
+ * 판정: path 모드 + 소스 미확정 → 클릭한 노드를 소스로. path 모드 + 소스
+ * 확정 + 클릭한 노드가 소스와 다름 → 그 노드를 대상으로 확정(다시 클릭해
+ * 대상을 갈아끼우는 재선택 흐름 유지). 그 외(overview/focus/health 등,
+ * 또는 소스 노드 자체를 다시 클릭) → 기존 일반 선택 그대로.
+ */
+export function resolveTopologyNodeClickRouteState(
+  current: HomeRouteState,
+  slug: string,
+  options?: { isHub?: boolean; preserveImpact?: boolean },
+): HomeRouteState {
+  if (current.analysisMode === "path") {
+    if (!current.pathSourceSlug) {
+      return selectTopologyPathRouteState(current, {
+        sourceSlug: slug,
+        targetSlug: null,
+      });
+    }
+    if (slug !== current.pathSourceSlug) {
+      return selectTopologyPathRouteState(current, {
+        sourceSlug: current.pathSourceSlug,
+        targetSlug: slug,
+      });
+    }
+    return current;
+  }
+  return selectTopologyNodeRouteState(current, slug, options);
+}
+
 export function applyHomeRouteState(
   searchParams: URLSearchParams,
   state: HomeRouteState,

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -85,6 +85,7 @@ import { useHomeRouteState } from "../model/use-home-route-state";
 import {
   selectTopologyNodeRouteState,
   selectTopologyPathRouteState,
+  resolveTopologyNodeClickRouteState,
   type TopologyAnalysisMode,
 } from "../model/url-state";
 import {
@@ -975,8 +976,11 @@ export function HomePage() {
       setFullDetailSlug(null);
       setSelectedRelationActive(false);
       const project = projectBySlug.get(slug);
+      // path 모드/일반 선택 분기는 `resolveTopologyNodeClickRouteState` 가
+      // 담당 — persona QA fix/persona-findings ②, 자세한 배경은 그 함수의
+      // 주석 참고 (`../model/url-state.ts`).
       setRouteState((current) =>
-        selectTopologyNodeRouteState(current, slug, {
+        resolveTopologyNodeClickRouteState(current, slug, {
           isHub: Boolean(project?.isHub),
           preserveImpact: options?.preserveImpact,
         }),

--- a/src/views/ontology-edit/lib/builder-command-strip-state.ts
+++ b/src/views/ontology-edit/lib/builder-command-strip-state.ts
@@ -46,3 +46,21 @@ export function isSelectedBuilderCommandState(state: BuilderCommandStripState): 
     state === "selectedCapability"
   );
 }
+
+/**
+ * 헤더 ⋯ 오버플로 메뉴의 "상세 열기" 항목 노출 판정 — persona QA 발견
+ * (fix/persona-findings ①): 이전엔 `commandStripState !== "selected"` 로
+ * 게이팅되어 있어, 방금 만든 draft 를 닫은 뒤 다시 이름을 채우려 할 때 상태에
+ * 따라 이 유일한 명시적 "상세 보기" 진입점이 숨어버릴 수 있었다. 상세
+ * sheet 가 이미 열려 있지 않고 선택된 개념(ephemeral 또는 vault)이 있으면
+ * 항상 노출 — 상태 조합과 무관한 단순하고 예측 가능한 안전망.
+ */
+export function shouldShowBuilderOpenDetailsMenuItem({
+  hasSelection,
+  detailsOpen,
+}: {
+  hasSelection: boolean;
+  detailsOpen: boolean;
+}): boolean {
+  return hasSelection && !detailsOpen;
+}

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.node-open.test.ts
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.node-open.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "OntologyEditCanvas.tsx"), "utf8");
+
+// persona QA (fix/persona-findings ①): "캔버스 ghost 노드 단일/더블클릭
+// 무반응" 신고 — ReactFlow 는 노드 더블클릭을 별도 처리하지 않고, 이
+// 컴포넌트는 이전엔 onNodeClick 만 연결해 더블클릭 전용 계약이 코드에
+// 없었다. 단일 클릭과 동일하게 onNodeOpen 을 호출하는 명시적 핸들러를
+// 추가해 회귀를 막는다 (ReactFlow 는 dynamic import 로 마운트되어 RTL
+// 렌더 대신 소스 계약을 문자열로 검증하는 이 파일의 기존 패턴을 따른다,
+// c.f. OntologyEditCanvas.edge-layer.test.ts).
+describe("OntologyEditCanvas node-open wiring", () => {
+  it("연결된 onNodeClick 이 onNodeOpen 을 호출한다", () => {
+    expect(source).toContain("onNodeClick={(_, node) => onNodeOpen?.(node.id)}");
+  });
+
+  it("더블클릭도 명시적으로 같은 onNodeOpen 을 호출한다", () => {
+    expect(source).toContain("onNodeDoubleClick={(_, node) => onNodeOpen?.(node.id)}");
+  });
+
+  it("더블클릭이 캔버스 확대(zoomOnDoubleClick)와 충돌하지 않는다", () => {
+    // zoomOnDoubleClick=false 가 없으면 pane 확대와 상세 열기가 동시에
+    // 발동해 사용자가 "아무 반응 없다"고 느낄 수 있다 (뷰가 확대되며
+    // 다이얼로그 위치가 어긋나 보이는 혼란).
+    expect(source).toContain("zoomOnDoubleClick={false}");
+  });
+});

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -665,6 +665,10 @@ export function OntologyEditCanvas({
         onSelectionChange={handleSelectionChange}
         onPaneClick={() => onSelectionChange?.(null)}
         onNodeClick={(_, node) => onNodeOpen?.(node.id)}
+        // 단일 클릭과 동일한 의도 — ReactFlow 는 더블클릭을 별도로 처리하지
+        // 않으므로 명시적으로 같은 핸들러를 연결해 "더블클릭도 상세를 연다"는
+        // 계약을 코드로 보장한다 (persona QA: 더블클릭 무반응 신고 방어).
+        onNodeDoubleClick={(_, node) => onNodeOpen?.(node.id)}
         onNodeDragStop={handleNodeDragStop}
         onEdgesDelete={(deleted) => {
           // 위 ephemeral edge 의 deletable: true / vault edge 의 deletable: false

--- a/src/views/ontology-edit/ui/OntologyEditPage.anchor-rail.test.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.anchor-rail.test.tsx
@@ -13,7 +13,10 @@ import {
   formatBuilderAnchorDegreeBadge,
 } from "../lib/format-builder-anchor-labels";
 import { resolveBuilderHeaderActionLabel } from "../lib/builder-header-action-label";
-import { resolveBuilderCommandStripState } from "../lib/builder-command-strip-state";
+import {
+  resolveBuilderCommandStripState,
+  shouldShowBuilderOpenDetailsMenuItem,
+} from "../lib/builder-command-strip-state";
 
 vi.mock("@/i18n/navigation", () => ({
   Link: ({ href, children, ...props }: React.ComponentProps<"a">) => (
@@ -288,6 +291,31 @@ describe("BuilderCommandStrip", () => {
       "href",
       "/ontology/insights/?node=capabilities%2Fbuilder-canvas-polish",
     );
+  });
+});
+
+describe("shouldShowBuilderOpenDetailsMenuItem", () => {
+  // persona QA (fix/persona-findings ①): draft 를 만들고 상세를 닫은 뒤
+  // 다시 이름을 채우려 할 때, 헤더 ⋯ 메뉴의 "상세 열기" 항목이 캔버스
+  // 상태 조합(state)에 따라 숨어버려 진입로가 막힌 사례가 있었다 — 이제
+  // 선택 여부 + 상세 열림 여부만으로 판정해 상태 조합과 무관하게 항상
+  // 안전망으로 노출한다.
+  it("선택된 개념이 있고 상세가 닫혀 있으면 항상 노출한다", () => {
+    expect(
+      shouldShowBuilderOpenDetailsMenuItem({ hasSelection: true, detailsOpen: false }),
+    ).toBe(true);
+  });
+
+  it("이미 상세가 열려 있으면 중복 진입점을 숨긴다", () => {
+    expect(
+      shouldShowBuilderOpenDetailsMenuItem({ hasSelection: true, detailsOpen: true }),
+    ).toBe(false);
+  });
+
+  it("선택된 개념이 없으면 숨긴다", () => {
+    expect(
+      shouldShowBuilderOpenDetailsMenuItem({ hasSelection: false, detailsOpen: false }),
+    ).toBe(false);
   });
 });
 

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -68,6 +68,7 @@ import {
 import {
   resolveBuilderCommandStripState,
   isSelectedBuilderCommandState,
+  shouldShowBuilderOpenDetailsMenuItem,
 } from "../lib/builder-command-strip-state";
 import { resolveBuilderHeaderActionLabel } from "../lib/builder-header-action-label";
 import { formatBuilderAnchorDegreeBadge } from "../lib/format-builder-anchor-labels";
@@ -1241,7 +1242,10 @@ export function OntologyEditPage() {
                   <ShieldCheck size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                   <span className="min-w-0 flex-1 truncate">{t("writeSummaryCollapsedLabel")}</span>
                 </button>
-                {(ephemeralSelected || vaultSelected) && commandStripState !== "selected" ? (
+                {shouldShowBuilderOpenDetailsMenuItem({
+                  hasSelection: Boolean(ephemeralSelected || vaultSelected),
+                  detailsOpen,
+                }) ? (
                   <button
                     type="button"
                     role="menuitem"


### PR DESCRIPTION
## Summary
페르소나 사용성 검증 발견 3건:
- **(확실 버그) path 모드 대상 미확정**: handleSelect가 analysisMode를 무시하고 항상 노드 선택으로만 흘러 두 번째 클릭이 pathTarget을 절대 못 채우던 분기 누락 → 순수 함수 분기 신설, "A → B · 2 hops + 복사" 실증
- **(확실 버그 2건) /docs backlinks**: 중첩 dogfood vault의 위키링크 slug가 통합 트리 접두사와 안 맞아 조회가 항상 빗나감(파서 2벌 모두 정규화 추가) + 역참조 0일 때 기능이 통째로 숨던 것을 빈 상태 표시로
- **(재현 불가 정직 보고 + 인접 결함 수정) 빌더 이름 입력**: main에서 정상 작동 확인 — 대신 ⋯ 메뉴 "상세 열기"의 예측 불가 조건을 순수 함수 안전망으로 교체 + 캔버스 더블클릭 핸들러 부재 보완. 회귀 테스트 13개 추가

## Test plan
전체 vitest 2,225 pass · contracts 187 · tsc/lint/i18n clean · 라이브 실증 스크린샷 5장(경로 확정·복사, backlinks 양 상태, 이름 입력 재진입).

🤖 Generated with [Claude Code](https://claude.com/claude-code)