### PR TITLE
fix: INDEX 헤더 전체를 접기 토글로 + 레일 속도 진단

### DIFF
--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -103,6 +103,39 @@ describe("TopologyIndexPanel", () => {
     expect(screen.getByText("MCP Server")).toBeInTheDocument();
   });
 
+  it("collapses when any part of the header row is clicked, not just the chevron", () => {
+    // Regression: the chevron used to be the only hit area for collapsing
+    // INDEX. The whole header row is now the toggle (role=button via a real
+    // <button>), so a click anywhere in it — including the label text far
+    // from the chevron — must fire onCollapse.
+    const onCollapse = vi.fn();
+    const treeResult = buildFixtureTree();
+    render(
+      <TopologyIndexPanel
+        treeResult={treeResult}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={onCollapse}
+        labels={labels}
+      />,
+    );
+
+    const header = screen.getByTestId("topology-index-fold");
+    expect(header.tagName).toBe("BUTTON");
+    expect(header).toHaveAttribute("aria-expanded", "true");
+
+    // Click the label span, not the chevron — proves the whole row is live.
+    fireEvent.click(screen.getByText(labels.label));
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(header);
+    expect(onCollapse).toHaveBeenCalledTimes(2);
+  });
+
   it("calls onSelect with the node id when a row is clicked", () => {
     const onSelect = vi.fn();
     const treeResult = buildFixtureTree();

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -135,25 +135,36 @@ export function TopologyIndexPanel({
       />
       {/* v2.1 헤더 — 라벨 + 실측 총수 + 접기만. 에이전트 동기화 상태는
           푸터로 이관(아래) — 헤더는 "이 패널이 무엇인지", 푸터는 "언제
-          마지막으로 살아있었는지"를 말한다. */}
-      <div className="mb-2.5 flex items-center gap-1.5 border-b border-[color:var(--topology-v2-panel-divider)] px-0.5 pb-2.5">
+          마지막으로 살아있었는지"를 말한다.
+
+          헤더 행 전체가 접기 토글이다 (소유자 피드백 — 셰브론만 히트 영역이라
+          불편했다). INDEX 트리 행과 같은 hover 문법
+          (`--topology-v2-panel-row-hover` 배경, `transition-colors`) 을 그대로
+          재사용해 "이것도 클릭 가능한 행이다" 를 같은 언어로 말한다. 셰브론은
+          더 이상 별도 버튼이 아니라 상태 표시자(`aria-hidden`)로만 남는다 —
+          중첩 인터랙티브 엘리먼트를 피하기 위해 바깥 `<button>` 하나로 접는다. */}
+      <button
+        type="button"
+        onClick={onCollapse}
+        aria-expanded={true}
+        aria-label={labels.foldAria}
+        title={labels.fold}
+        data-testid="topology-index-fold"
+        className="group mb-2.5 flex w-full cursor-pointer items-center gap-1.5 rounded-[var(--chrome-radius-inner)] border-b border-[color:var(--topology-v2-panel-divider)] px-0.5 pb-2.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.46)] focus-visible:ring-inset"
+      >
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
           {labels.label}
         </span>
         <span className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">
           · {totalConcepts}
         </span>
-        <button
-          type="button"
-          onClick={onCollapse}
-          aria-label={labels.foldAria}
-          title={labels.fold}
-          data-testid="topology-index-fold"
-          className="ml-auto inline-flex size-[26px] shrink-0 items-center justify-center rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:border-[color:var(--topology-v2-panel-action-border)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+        <span
+          aria-hidden="true"
+          className="ml-auto inline-flex size-[26px] shrink-0 items-center justify-center rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors group-hover:border-[color:var(--topology-v2-panel-action-border)] group-hover:text-[color:var(--topology-v2-panel-text-secondary)]"
         >
           <ChevronUp size={13} aria-hidden="true" />
-        </button>
-      </div>
+        </span>
+      </button>
       <p data-testid="topology-index-census" className="sr-only">
         {totalConcepts} {labels.censusConcepts} · {totalRelations} {labels.censusRelations} ·{" "}
         {domainCount} {labels.censusDomains}


### PR DESCRIPTION
## Summary
- INDEX 접기: 작은 셰브론 → **헤더 행 전체가 네이티브 button**(hover=트리 행 동일 토큰, Enter/Space 기본 지원, aria-expanded, URL/localStorage 계약 무변). 접힘 탭은 이미 전체 버튼이라 무변.
- 레일 이동 속도: 실측 진단 — **프로덕션(정적)은 전 구간 37~183ms로 목표(<300ms) 충족**, prefetch(뷰포트 자동)·xyflow/sigma lazy 전부 이미 구현 확인. "2초"는 Next dev 모드의 온디맨드 컴파일 고유 특성(고치면 HMR 정확성 깨짐)으로 판명 — 코드 변경 불필요 결론.

## Test plan
vitest 6 pass(라벨 클릭 토글 회귀 테스트 신설) · tsc/eslint clean · pnpm build+정적 서빙 5목적지 왕복 타이밍 표.

🤖 Generated with [Claude Code](https://claude.com/claude-code)