### PR TITLE
fix: design 게이트 빌더 마커 경로 — main 그린 복원

### DIFF
--- a/scripts/check-ontology-design-surface.mjs
+++ b/scripts/check-ontology-design-surface.mjs
@@ -87,7 +87,14 @@ export const ONTOLOGY_DESIGN_REQUIRED_SURFACE_MARKERS = [
   },
   {
     id: "builder-write-verify-loop",
-    files: ["src/views/ontology-edit/ui/OntologyEditPage.tsx"],
+    // A4 파일 분해(2026-07-19)로 마커들이 개별 컴포넌트/lib 로 이동 —
+    // 체크는 파일 묶음 전체에서 마커 존재를 본다.
+    files: [
+      "src/views/ontology-edit/ui/OntologyEditPage.tsx",
+      "src/views/ontology-edit/ui/BuilderWriteSummary.tsx",
+      "src/views/ontology-edit/ui/BuilderCanvasEntryRail.tsx",
+      "src/views/ontology-edit/lib/builder-proof-packet.ts",
+    ],
     markers: [
       "function BuilderWriteSummary",
       "function BuilderCanvasEntryRail",


### PR DESCRIPTION
## Summary
A4 파일 분해가 옮긴 마커 12개 때문에 design:ontology가 main에서 빨강이던 것(대청소 2차가 발견) — 체크 파일 목록을 분해 후 위치로 확장.

## Test plan
pnpm design:ontology — clean (137파일 9표면).

🤖 Generated with [Claude Code](https://claude.com/claude-code)