### PR TITLE
docs: README 정체성 훅 — 인지 부채(사람 쪽) 문장 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 >
 > Your AI coding agent forgets your codebase between sessions. Give it a
 > local, git-backed mental model it can read, query, and maintain through MCP.
+>
+> And agents now ship faster than humans can read. The same graph pays down
+> that cognitive debt — you keep understanding what is being built, and stay
+> the arbiter of what it means.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)


### PR DESCRIPTION
## Summary
소유자 정리 프레이밍 반영: "바이브코딩 속도 > 사람의 읽기 속도 → 인지 부채"가 정체성의 사람 쪽 절반인데 README 훅이 에이전트 기억 쪽만 담고 있었음. 인용부에 사람 쪽 2문장 추가 (같은 그래프가 인지 부채를 상환하고, 사람이 의미의 중재자로 남는다). GitHub repo 설명·homepage 도 동일 프레이밍으로 갱신 완료 (gh repo edit).

## Test plan
- docs-only (README 인용부 3줄) · `pnpm docs-vault:build` current
🤖 Generated with [Claude Code](https://claude.com/claude-code)