### PR TITLE
test: 토폴로지 토큰 개수 계약 고정

### DIFF
--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolveTopologyV2Tokens,
+  TOPOLOGY_V2_TOKEN_COUNT,
   TopologyV2TokenError,
 } from "./read-topology-v2-tokens";
 
@@ -117,7 +118,11 @@ function fixtureReader(overrides: Record<string, string> = {}) {
 }
 
 describe("resolveTopologyV2Tokens", () => {
-  it("resolves all 95 §2 tokens to the exact prototype-sourced values", () => {
+  it("TOKEN_SPECS count contract — the fixture covers every spec exactly (Guardian 2026-07-20: the old '88 tokens' header comment had silently drifted from reality with no assert)", () => {
+    expect(Object.keys(FIXTURE_VALUES).length).toBe(TOPOLOGY_V2_TOKEN_COUNT);
+  });
+
+  it("resolves all §2 tokens to the exact prototype-sourced values", () => {
     const tokens = resolveTopologyV2Tokens(fixtureReader());
 
     expect(tokens.nodeFillProject).toBe("#1c1c22");

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -6,7 +6,7 @@
  * `skeletonInkRef` 해석-캐시 패턴 재사용). 값의 진실원은 여전히
  * `app/globals.css` 하나 — 이 파일은 읽기 전용 어댑터다.
  *
- * 토큰 drift 가드: §2 표에 있는 88개 토큰(C1 — camera-max/min-zoom-ratio +
+ * 토큰 drift 가드: §2 표의 토큰 전부(정확한 개수는 TOKEN_SPECS.length 가 진실원 — 테스트가 계약으로 고정)(C1 — camera-max/min-zoom-ratio +
  * drag-tug-1hop/2hop 4종 추가, dive-zoom fix — camera-spring-angfreq 를
  * -interactive/-transition 둘로 분리해 순증 1; canvas-emphasis 슬라이스 — 프로젝트
  * 헥사곤 이중 헤어라인/핀틱 2종 + 선택 링/선택 헤어라인/호버 링 3종 + 선택
@@ -268,6 +268,9 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "safeInsetBottom", cssVar: "--topology-v2-safe-inset-bottom", kind: "number" },
 ];
 
+/** 토큰 개수 계약 — 주석 속 숫자가 아니라 이 값이 진실원 (테스트가 픽스처 커버리지를 이 값에 고정). */
+export const TOPOLOGY_V2_TOKEN_COUNT = TOKEN_SPECS.length;
+
 export class TopologyV2TokenError extends Error {
   constructor(public readonly missing: readonly string[]) {
     super(
@@ -280,7 +283,7 @@ export class TopologyV2TokenError extends Error {
 }
 
 /**
- * `getComputedStyle` 결과(또는 테스트용 대체 함수)에서 88개 토큰 전부를
+ * `getComputedStyle` 결과(또는 테스트용 대체 함수)에서 TOKEN_SPECS 의 토큰 전부를
  * 해석한다. 하나라도 빈 문자열이면 `TopologyV2TokenError` 를 던진다 — 이게
  * §2.3 "누락 시 명시적 실패" 계약.
  */


### PR DESCRIPTION
## Summary
Guardian 사후 검증(캔버스 3건 전 항목 승인) 중 발견된 가드 구멍: 토큰 헤더 주석 "88개"가 실제(95)와 drift + 카운트 assert 부재. 주석의 하드코딩 숫자 제거, `TOPOLOGY_V2_TOKEN_COUNT` export, 테스트 픽스처 커버리지를 카운트 계약으로 고정.

## Test plan
- tokens 스위트 6 pass (신규 카운트 계약 1) · tsc 0 · eslint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)