### PR TITLE
feat: INDEX 크롬 수렴 스펙 시공 (P0a)

### DIFF
--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -229,4 +229,24 @@ describe("TopologyIndexPanel", () => {
       domains: 6,
     });
   });
+
+  it("수렴 스펙 ①: 헤더는 시각 카운트를 렌더하지 않는다 (지형도 HUD 와 3중 중복 해소, sr-only census 만 존치)", () => {
+    render(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+      />,
+    );
+    const fold = screen.getByTestId("topology-index-fold");
+    expect(fold.textContent).not.toMatch(/\d/);
+    // sr-only census 는 남아 있다
+    expect(screen.getByTestId("topology-index-census")).toBeInTheDocument();
+  });
 });

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronUp, Search } from "lucide-react";
+import { ChevronLeft, Search } from "lucide-react";
 import {
   filterTreeByQuery,
   type OntologyTreeBuildResult,
@@ -150,19 +150,20 @@ export function TopologyIndexPanel({
         aria-label={labels.foldAria}
         title={labels.fold}
         data-testid="topology-index-fold"
-        className="group mb-2.5 flex w-full cursor-pointer items-center gap-1.5 rounded-[var(--chrome-radius-inner)] border-b border-[color:var(--topology-v2-panel-divider)] px-0.5 pb-2.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+        className="group mb-3 flex w-full cursor-pointer items-center gap-1.5 rounded-[var(--chrome-radius-inner)] px-0.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
       >
         <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
           {labels.label}
         </span>
-        <span className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-          · {totalConcepts}
-        </span>
+        {/* 수렴 판정 ①: 시각 카운트 "· N" 삭제 — 지형도 HUD 가 이미 라벨과
+            함께 총수를 상시 노출해 3중 중복이었다 (sr-only census 는 존치).
+            판정 ②/③: 셰브론은 보더 박스가 아니라 quiet glyph — 히트영역은
+            행 전체(소유자 피드백 보존), 방향은 접힘 결과와 일치하는 ‹. */}
         <span
           aria-hidden="true"
-          className="ml-auto inline-flex size-[26px] shrink-0 items-center justify-center rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors group-hover:border-[color:var(--topology-v2-panel-action-border)] group-hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+          className="ml-auto inline-flex size-[26px] shrink-0 items-center justify-center text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors group-hover:text-[color:var(--topology-v2-panel-text-secondary)]"
         >
-          <ChevronUp size={13} aria-hidden="true" />
+          <ChevronLeft size={13} aria-hidden="true" />
         </span>
       </button>
       <p data-testid="topology-index-census" className="sr-only">
@@ -170,7 +171,7 @@ export function TopologyIndexPanel({
         {domainCount} {labels.censusDomains}
       </p>
 
-      <div className="relative mb-2 shrink-0">
+      <div className="relative mb-3 shrink-0">
         <Search
           size={11}
           aria-hidden
@@ -220,7 +221,7 @@ export function TopologyIndexPanel({
           hotkey — 여기선 재확인용 표기, 별도 바인딩 아님). */}
       <div
         data-testid="topology-index-footer"
-        className="mt-2 flex shrink-0 items-center gap-1.5 border-t border-[color:var(--topology-v2-panel-divider)] px-1 pt-2.5 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+        className="mt-2.5 flex shrink-0 items-center gap-1.5 border-t border-[color:var(--topology-v2-panel-divider)] px-1 pt-2.5 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]"
       >
         <span
           aria-hidden="true"

--- a/src/widgets/topology-index-panel/ui/TopologyIndexTab.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexTab.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ChevronRight } from "lucide-react";
+
 export interface TopologyIndexTabLabels {
   expandAria: string;
   agentSyncTitle: string;
@@ -37,8 +39,9 @@ export function TopologyIndexTab({ onExpand, labels, className }: TopologyIndexT
       >
         Index
       </span>
-      <span aria-hidden="true" className="text-[9px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-        ›
+      {/* 수렴 판정 ④: 9px 텍스트 › → ChevronRight 13 — 펼침 ‹ 와 대칭쌍. */}
+      <span aria-hidden="true" className="inline-flex text-[color:var(--topology-v2-panel-text-quaternary)]">
+        <ChevronRight size={13} aria-hidden="true" />
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary
디자이너 듀얼 → Guardian 심판 수렴 판정(`.qa-scratch/design-duel-2026-07/converged-spec.md`)의 시공. 쟁점 5개 판정 그대로: 헤더 행 존치(A) · 시각 카운트 삭제(B — HUD 3중 중복) · 구획선 1개 원칙(B논리×A시공) · quiet ‹ / 탭 › 대칭(만장일치) · 신규 토큰 0(B). 그라디언트 강등은 심판 이연대로 무접촉.

## Test plan
- `topology-index-panel` **25 pass** (신규 assert: 헤더 시각 카운트 미렌더 + sr-only census 존치) · tsc 0 · eslint 0
- 실화면(:3107): 첫실행/호버/접힘 캡처 — 고아선 0 · quiet ‹ · 탭 ChevronRight (`built-1~3*.png`)
- 결정 기록·가드 2건은 FINAL-PLAN v2 에 등재 (HUD census 의존 · 구획 소유권 규칙)

🤖 Generated with [Claude Code](https://claude.com/claude-code)