### PR TITLE
feat: 문서함 웹 세션 로컬 vault 개방 (P1b — N1 모순 해소)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ---
 
+## 2026-07-21 — 문서함 웹 세션 로컬 vault 개방 (표면 간 모순 해소)
+
+같은 웹 브라우저 세션에서 빌더는 로컬 vault 에 쓰기까지 되는데
+문서함만 "macOS 앱에서 시작" 잠금이었다 (페르소나 실측 N1, High —
+표면 간 모순 계약). 게이트 3종(`shouldHonorLocalIntent` ·
+`isDocsVaultLocalSourceDisabled` · `shouldShowDesktopVaultWelcome`)을
+런타임(웹/데스크톱) 기준에서 **능력(FSA 지원) 기준**으로 전환 — FSA
+미지원 브라우저만 막는다. 샘플 안내 스트립의 macOS 다운로드 CTA 도
+능력 기준 "내 폴더 열기"로. 경로 pill 은 웹 핸들의 폴더 이름 폴백.
+실증: 웹 스텁 세션에서 intent=local → welcome → 폴더 열기 → 사용자
+vault 로드·편집 활성까지 완주.
+
 ## 2026-07-21 — census 단일 진실원 (표면 간 숫자 불일치 해소)
 
 같은 vault 를 두고 지도 294 · 인사이트 293 · 프로젝트 288 · 빌더 102 로

--- a/src/views/docs-vault/lib/persistence.test.ts
+++ b/src/views/docs-vault/lib/persistence.test.ts
@@ -144,10 +144,13 @@ describe("doc list collapse storage", () => {
   });
 });
 
-describe("desktop-only local vault source", () => {
-  it("honors ?intent=local only inside the installed desktop runtime", () => {
+// P1b (N1) 계약 변경: 게이트는 런타임이 아니라 능력(FSA 지원)만 본다 —
+// 같은 웹 세션에서 빌더는 vault 쓰기가 되는데 문서함만 macOS 잠금이던
+// 표면 간 모순 해소.
+describe("capability-gated local vault source", () => {
+  it("honors ?intent=local in every runtime (web included — builder parity)", () => {
     expect(shouldHonorLocalIntent("local", true)).toBe(true);
-    expect(shouldHonorLocalIntent("local", false)).toBe(false);
+    expect(shouldHonorLocalIntent("local", false)).toBe(true);
     expect(shouldHonorLocalIntent("server", true)).toBe(false);
     expect(shouldHonorLocalIntent(null, true)).toBe(false);
     expect(shouldHonorLocalIntent(undefined, true)).toBe(false);
@@ -248,11 +251,17 @@ describe("desktop-only local vault source", () => {
     ).toBe(false);
   });
 
-  it("disables local vault source in hosted browsers even when browser APIs exist", () => {
+  it("gates local vault source on capability, not runtime", () => {
     expect(
       isDocsVaultLocalSourceDisabled({
         isDesktopRuntime: false,
         localVaultStatus: "idle",
+      }),
+    ).toBe(false);
+    expect(
+      isDocsVaultLocalSourceDisabled({
+        isDesktopRuntime: false,
+        localVaultStatus: "unsupported",
       }),
     ).toBe(true);
     expect(
@@ -286,6 +295,7 @@ describe("desktop-only local vault source", () => {
         hasLocalManifest: true,
       }),
     ).toBe(false);
+    // P1b — 웹 세션도 welcome(열기 CTA)을 받는다 (능력 기준 계약).
     expect(
       shouldShowDesktopVaultWelcome({
         isDesktopRuntime: false,
@@ -293,7 +303,7 @@ describe("desktop-only local vault source", () => {
         localVaultStatus: "idle",
         hasLocalManifest: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldShowDesktopVaultWelcome({
         isDesktopRuntime: true,

--- a/src/views/docs-vault/lib/persistence.ts
+++ b/src/views/docs-vault/lib/persistence.ts
@@ -85,7 +85,12 @@ export function shouldHonorLocalIntent(
   intent: string | null | undefined,
   isDesktopRuntime: boolean,
 ): boolean {
-  return intent === "local" && isDesktopRuntime;
+  // P1b (N1) — 웹 세션도 local intent 를 존중한다. 같은 브라우저에서
+  // 빌더는 이미 vault 에 쓰기까지 허용하는데 문서함만 데스크톱 게이트로
+  // 막는 것은 표면 간 모순 계약이었다. FSA 미지원 브라우저는
+  // `localVaultStatus === 'unsupported'` 쪽 게이트가 막는다.
+  void isDesktopRuntime;
+  return intent === "local";
 }
 
 export function shouldShowDogfoodVaultHint({
@@ -137,7 +142,10 @@ export function isDocsVaultLocalSourceDisabled({
   isDesktopRuntime: boolean;
   localVaultStatus: string;
 }): boolean {
-  return !isDesktopRuntime || localVaultStatus === "unsupported";
+  // P1b (N1) — 게이트는 능력(FSA 지원 여부)만 본다. 런타임(웹/데스크톱)
+  // 은 더 이상 게이트가 아니다 — 빌더와 같은 계약.
+  void isDesktopRuntime;
+  return localVaultStatus === "unsupported";
 }
 
 export function shouldShowDesktopVaultWelcome({
@@ -151,8 +159,11 @@ export function shouldShowDesktopVaultWelcome({
   localVaultStatus: string;
   hasLocalManifest: boolean;
 }): boolean {
+  // P1b (N1) — welcome(폴더 열기 CTA 포함)도 능력 기준: 웹 FSA 세션에서도
+  // 로컬 소스에 진입하면 열기 표면이 있어야 한다. 데스크톱 전용 요소
+  // (dogfood 경로 힌트)는 shouldShowDogfoodVaultHint 가 따로 게이트한다.
+  void isDesktopRuntime;
   return (
-    isDesktopRuntime &&
     source === "local" &&
     !hasLocalManifest &&
     (localVaultStatus === "idle" ||

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -242,7 +242,7 @@ function DocsVaultContent() {
   const openLocalVault = localVault.open;
   const openRecentLocalVault = localVault.openRecent;
   const localVaultRootPath = localVault.handle
-    ? getTauriVaultRootPath(localVault.handle) ?? null
+    ? getTauriVaultRootPath(localVault.handle) ?? localVault.handle.name ?? null
     : null;
   const toast = useToast();
   const handleOpenDogfoodVault = useCallback(() => {
@@ -411,13 +411,14 @@ function DocsVaultContent() {
   // Hosted browser 에서는 local vault 작업을 열지 않는다. 기존 브라우저
   // 세션이 local source 를 저장해 둔 경우에도 promo/read-only surface 로 복귀.
   useEffect(() => {
-    if (source === 'local' && (!isDesktopRuntime || localVaultStatus === 'unsupported')) {
+    // P1b — FSA 미지원일 때만 server 로 복귀 (웹 세션 local 은 이제 유효).
+    if (source === 'local' && localVaultStatus === 'unsupported') {
       scheduleStateSync(() => {
         setSource('server');
         storeSource('server');
       });
     }
-  }, [isDesktopRuntime, source, localVaultStatus]);
+  }, [source, localVaultStatus]);
 
   useEffect(() => {
     if (
@@ -1744,9 +1745,7 @@ function DocsVaultContent() {
             </button>
             <Tooltip
               content={
-                !isDesktopRuntime
-                  ? t('vaultStatus.desktopOnlyTooltip')
-                  : localVault.status === 'unsupported'
+                localVault.status === 'unsupported'
                   ? t('vaultStatus.unsupportedTooltip')
                   : t('vaultStatus.localTooltip')
               }
@@ -1781,9 +1780,7 @@ function DocsVaultContent() {
                 id="docs-vault-local-unsupported-hint"
                 className="sr-only"
               >
-                {isDesktopRuntime
-                  ? t('vaultStatus.unsupportedTooltip')
-                  : t('vaultStatus.desktopOnlyTooltip')}
+                {t('vaultStatus.unsupportedTooltip')}
               </span>
             ) : null}
           </div>
@@ -2092,7 +2089,7 @@ function DocsVaultContent() {
                   설명 + 액션을 맡는다 (po-pass.md §1-3). */}
               {!editing && !isLocalSourceLoaded ? (
                 <SampleNotice
-                  isDesktopRuntime={isDesktopRuntime}
+                  canOpenLocalVault={!localSourceDisabled}
                   onOpenFolder={() => handleSourceChange('local')}
                 />
               ) : null}

--- a/src/views/docs-vault/ui/parts/SampleNotice.test.tsx
+++ b/src/views/docs-vault/ui/parts/SampleNotice.test.tsx
@@ -22,12 +22,12 @@ vi.mock("@/i18n/navigation", () => ({
   ),
 }));
 
-function renderNotice(isDesktopRuntime: boolean, onOpenFolder = vi.fn()) {
+function renderNotice(canOpenLocalVault: boolean, onOpenFolder = vi.fn()) {
   return {
     onOpenFolder,
     ...render(
       <NextIntlClientProvider locale="ko" messages={koMessages}>
-        <SampleNotice isDesktopRuntime={isDesktopRuntime} onOpenFolder={onOpenFolder} />
+        <SampleNotice canOpenLocalVault={canOpenLocalVault} onOpenFolder={onOpenFolder} />
       </NextIntlClientProvider>,
     ),
   };

--- a/src/views/docs-vault/ui/parts/SampleNotice.tsx
+++ b/src/views/docs-vault/ui/parts/SampleNotice.tsx
@@ -3,7 +3,8 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
 export interface SampleNoticeProps {
-  isDesktopRuntime: boolean;
+  /** P1b — 게이트는 런타임이 아니라 능력: FSA 지원이면 웹에서도 폴더 열기. */
+  canOpenLocalVault: boolean;
   onOpenFolder: () => void;
 }
 
@@ -16,11 +17,11 @@ export interface SampleNoticeProps {
  * 가 전달되지 않는다는 관찰(po-pass.md §1-3)을 해소한다.
  *
  * 표시 조건(`!isLocalSourceLoaded`)은 caller 가 판단 — 이 컴포넌트는 항상
- * 렌더된 것을 전제로 한 순수 표시. 데스크톱 런타임이면 기존 로컬 vault 선택
- * 흐름(`handleSourceChange('local')`)을 그대로 재사용, 웹이면 macOS 앱
- * 다운로드 페이지로 안내(신규 라우트/모달 없음).
+ * 렌더된 것을 전제로 한 순수 표시. P1b(N1): FSA 를 지원하면 런타임과
+ * 무관하게 폴더 열기 흐름을 재사용하고, 미지원 브라우저에서만 macOS 앱
+ * 다운로드로 안내한다 — 빌더와 같은 능력 기준 계약.
  */
-export function SampleNotice({ isDesktopRuntime, onOpenFolder }: SampleNoticeProps) {
+export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticeProps) {
   const t = useTranslations("docsVault");
   return (
     <div
@@ -33,7 +34,7 @@ export function SampleNotice({ isDesktopRuntime, onOpenFolder }: SampleNoticePro
         </span>{" "}
         — {t("sampleNotice.body")}
       </p>
-      {isDesktopRuntime ? (
+      {canOpenLocalVault ? (
         <button
           type="button"
           onClick={onOpenFolder}


### PR DESCRIPTION
## Summary
페르소나 실측 N1(High): 웹에서 빌더는 로컬 vault **쓰기**까지 허용되는데 문서함만 "macOS 앱에서 시작" 잠금 — 표면 간 모순 계약. 게이트 3종(`shouldHonorLocalIntent`/`isDocsVaultLocalSourceDisabled`/`shouldShowDesktopVaultWelcome`)을 **능력(FSA) 기준**으로 전환. 기술 검수가 지목한 깨질 지점 3개 처리(강제 리셋 effect · 경로 pill 폴백 · SampleNotice CTA 능력 분기). 데스크톱 전용 dogfood 힌트는 기존 게이트 유지.

## Test plan
- 계약 테스트 3건 신계약 갱신(사유 주석) — docs-vault **108 pass** · tsc 0 · eslint 0
- **FSA 스텁 실증(:3107 웹)**: `?intent=local` → welcome 렌더 → "기존 온톨로지 저장소 열기" → **사용자 vault(my-saas) 로드** — 문서 3개 트리 · "동기화됨 · 로컬" · 편집 활성 (`n1-web-local-7/8.png`)
- 샘플 상태 배너 CTA: macOS 다운로드 → **내 폴더 열기** (웹 FSA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)