### PR TITLE
docs: 외향 슬라이스 — 시장 언어 브릿지·드리프트 케이스스터디·유산 선언 (P2d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ ontology-atlas workspace-brief ./ontology
 ontology-atlas health ./ontology
 ```
 
-No backend. No login. No cloud account. Your repo is the source of truth.
+No backend. No login. No cloud account. Your repo is the source of truth —
+this map is markdown files on your disk, so it still opens in a text editor,
+in Obsidian, in `cat`, even if `ontology-atlas` itself is long gone.
 
 ---
 
@@ -57,6 +59,26 @@ and design decisions.
 
 `ontology-atlas` gives agents a durable local memory they can query before
 touching code and update after real changes.
+
+If you've been searching for a **codebase map** for AI agents, an **agent
+memory** layer, or a **context layer** that survives
+[context rot](https://www.producttalk.org/context-rot/) — this is the same
+shape of tool, purpose-built for the layer above source code: domains,
+capabilities, and the elements that prove them, not another symbol index.
+See [`docs/CASE-STUDY-AGENTS-MD-DRIFT.md`](docs/CASE-STUDY-AGENTS-MD-DRIFT.md)
+for how this repo uses that same "permanent reference file" idea to keep its
+own `AGENTS.md`/`CLAUDE.md` instructions from drifting apart, and extends it
+into the vault for facts that change faster than instructions do.
+
+The same shape of tool has already found organic demand as a **plain
+markdown vault an agent reads and writes**: Andrej Karpathy's 2026 note
+framed it as *"Obsidian is the IDE; the LLM is the programmer; the wiki is
+the codebase"*
+([gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)),
+and the pattern spread quickly through general-purpose note-taking tools.
+`ontology-atlas` is the same mechanism specialized one layer down — not a
+wiki over your notes, but a graph over your business domains, capabilities,
+and the code that proves them.
 
 The minimum useful setup is just Atlas plus a normal agent. If Claude Code,
 Codex, Cursor, or another MCP-capable agent can connect to the Atlas MCP server
@@ -396,6 +418,7 @@ app -> views -> widgets -> features -> entities -> shared
 |---|---|
 | [`docs/PRODUCT-DIRECTION.md`](docs/PRODUCT-DIRECTION.md) | Product strategy and launch framing |
 | [`docs/AGENT-MEMORY-POSITIONING.md`](docs/AGENT-MEMORY-POSITIONING.md) | Why this is agent memory, not an ontology editor |
+| [`docs/CASE-STUDY-AGENTS-MD-DRIFT.md`](docs/CASE-STUDY-AGENTS-MD-DRIFT.md) | How this repo avoids AGENTS.md/CLAUDE.md drift, and why the vault extends the same pattern |
 | [`docs/AGENT-GRAPH-WORKFLOW.md`](docs/AGENT-GRAPH-WORKFLOW.md) | CLI-only vs MCP-connected graph workflows, graph DB differences, and verification evidence |
 | [`docs/FEATURES.md`](docs/FEATURES.md) | Current CLI, MCP, and web feature inventory |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Local-first architecture and data flow |

--- a/docs/CASE-STUDY-AGENTS-MD-DRIFT.md
+++ b/docs/CASE-STUDY-AGENTS-MD-DRIFT.md
@@ -1,0 +1,98 @@
+# Case Study: Avoiding AGENTS.md / CLAUDE.md Drift
+
+> How this repo keeps its own instruction files in sync, and why the same
+> pattern extends into the vault for facts that change faster than
+> instructions do. Written from this repo's own history, not a hypothetical.
+
+## The problem, as the community describes it
+
+Multiple coding-agent instruction files (`AGENTS.md`, `CLAUDE.md`,
+`GEMINI.md`, `.github/copilot-instructions.md`, …) are now a common setup for
+any repo touched by more than one AI tool. Community reporting on the result
+is consistent:
+
+- **Hacker News, "A good AGENTS.md is a model upgrade"**
+  ([discussion](https://news.ycombinator.com/item?id=47938417)) — one
+  commenter (`forgotusername6`) reported that VS Code Copilot "often" misses
+  nested `AGENTS.md` files, a discovery mismatch between tools. Another
+  (`kajman`) noted that "every attempt I've made to quickly get an LLM to
+  one-shot an AGENTS file has been too verbose in all the wrong areas."
+- **Lobsters, "AGENTS.md as a dark signal"**
+  ([discussion](https://lobste.rs/s/x0qrlm/agents_md_as_dark_signal)) —
+  `ChaelCodes` asked the pointed question directly: "Why do the robots need
+  extra hints that human collaborators don't get?" — a proxy for the real
+  cost, which is that someone has to keep those hints correct.
+- **kau.sh, "Keep your AGENTS.md in sync"**
+  ([post](https://kau.sh/blog/agents-md/)) — names the failure mode plainly:
+  "When developers use more than one tool, things drift fast... The same
+  setup steps and style rules get duplicated in different formats, and the
+  moment your project changes, those files drift out of sync." The post goes
+  on to describe a small ecosystem of third-party sync tools that exists
+  specifically to patch this gap.
+
+The shape of the problem is always the same: two or more files claim to
+describe the same working rules, nobody owns keeping them equal, and they
+silently disagree.
+
+## What this repo actually does about it
+
+This repo has carried both `AGENTS.md` and `CLAUDE.md` since before this case
+study was written, and the fix is deliberately boring:
+
+- `AGENTS.md` is the single canonical source. Every rule — architecture,
+  product gates, testing, git workflow, forbidden patterns — is written there
+  once.
+- `CLAUDE.md` is a thin wrapper. Its entire body is one import line,
+  `@AGENTS.md`, plus a short "Claude Code only" section for things that
+  genuinely don't apply to other tools (skills, hooks, the design-guardian
+  subagent). See the current file: [`CLAUDE.md`](../CLAUDE.md).
+- The sync rule is written down as policy, not left to memory —
+  `AGENTS.md`'s own "CLAUDE.md / AGENTS.md sync" section states it directly:
+  *"AGENTS.md 가 single source of truth... 이 파일은 thin wrapper... AGENTS.md
+  를 수정해도 이 파일은 그대로 일관성을 유지한다"* (AGENTS.md is the single
+  source of truth; this file is a thin wrapper; editing AGENTS.md keeps this
+  file consistent without a second edit).
+- Drift between the two is listed as a named forbidden pattern in
+  [`.claude/rules/forbidden.md`](../.claude/rules/forbidden.md), under
+  "문서" (documentation): *"AGENTS.md 와 CLAUDE.md 가 비동기"* — AGENTS.md and
+  CLAUDE.md being out of sync is treated the same as a shipped bug, not a
+  documentation nice-to-have.
+
+The mechanism is not clever — it is import-instead-of-duplicate. But it means
+there is structurally only one place to edit, so the "which file is
+current?" question the community reports never comes up in this repo. This
+document is itself the evidence: it points at real files in this repo, not a
+description of a technique used somewhere else.
+
+## The vault extends the same pattern to facts that change
+
+`AGENTS.md`/`CLAUDE.md` solves drift for **static instructions** — the rules
+an agent should follow regardless of what it is working on this week. It does
+not solve the harder problem: a codebase's domains, capabilities, and
+implementation evidence change *with every feature*, and a single
+instruction file can't stay both current and short.
+
+That is a close match for what the community calls **context rot** — the
+term (coined on Hacker News by user `Workaccount2`, since adopted broadly)
+for an agent that starts "forgetting the function it wrote an hour ago,
+reintroducing a bug you already fixed" as a session grows
+([braingrid.ai](https://www.braingrid.ai/blog/context-rot),
+[producttalk.org](https://www.producttalk.org/context-rot/)). The mitigation
+those write-ups converge on is exactly this shape: *"Moving persistent
+information out of the conversation and into reference files that the agent
+can consult rather than carry. Instead of restating your project rules,
+conventions, and constraints in every session, you write them once into a
+permanent reference file."*
+
+`AGENTS.md` is one permanent reference file, for instructions. The vault
+(`docs/ontology/` in this repo, or any vault folder pointed at by
+`ontology-atlas init`) is the same pattern applied to the part instructions
+can't cover: which domain a piece of code belongs to, which capability it
+proves, what it depends on, and what changed recently. An agent calls
+`get_concept` or `workspace-brief` instead of re-deriving that mental model
+from source files and chat history every session — the same "consult a
+reference file instead of restating it" move, aimed at facts instead of
+rules. See [`mcp/README.md`](../mcp/README.md) for the tool surface an agent
+uses to read and write that reference file, and
+[`AGENTS.md`](../AGENTS.md#working-with-the-ontology-while-you-code) for how
+this repo's own agents are told to use it.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ---
 
+## 2026-07-21 — 외향 문서 슬라이스 (시장 언어 연결, 계획 구조 결함 해소)
+
+제품 검수가 "계획 전체에 외향(시장에 말하는) 슬라이스 0개"를 구조 결함으로
+판정 — 니즈 조사(`.qa-scratch/community-research-2026-07/needs.md`)가 확인한
+수요와 실제 카피 사이에 다리가 없었다. README에 "codebase map / agent
+memory / context layer" 시장 어휘를 잇는 브릿지 문단과 유산 선언 문장("이
+지도는 당신 디스크의 마크다운") 추가. 신규
+[`docs/CASE-STUDY-AGENTS-MD-DRIFT.md`](CASE-STUDY-AGENTS-MD-DRIFT.md) —
+AGENTS.md/CLAUDE.md drift 커뮤니티 고통 → 이 저장소가 실제로 쓰는 해법(단일
+진실원 + thin wrapper) → context rot 완화책으로서의 vault, 세 단계 케이스
+스터디. README에 Karpathy "Obsidian is the IDE; the LLM is the programmer;
+the wiki is the codebase" LLM-wiki 패턴과의 위치 관계 1문단 추가. 코드 변경
+없음 — 문서만.
+
 ## 2026-07-21 — 문서함 웹 세션 로컬 vault 개방 (표면 간 모순 해소)
 
 같은 웹 브라우저 세션에서 빌더는 로컬 vault 에 쓰기까지 되는데


### PR DESCRIPTION
## Summary
제품 검수의 구조 결함("외향 슬라이스 0개") 해소. 커뮤니티 실측 니즈 3건 응답: #2 context rot(README 브릿지+영구 참조 파일 절) · #3 AGENTS.md 드리프트(신규 케이스스터디 — HN/Lobsters/kau.sh 인용 + 이 저장소의 실제 해법) · #10 Karpathy LLM-wiki(어휘 연결+gist 인용). 유산 선언 한 문장 포함.

## Test plan
- 내부 링크 실재 확인 + **외부 링크 6개 HTTP 200 리드 검증**
- 코드/vault 무접촉 · CHANGELOG 동반 (병합 충돌 수동 해소 — 두 항목 모두 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)