### PR TITLE
feat: 엣지 히트테스트 + 의미 배관 (P3b 1단계)

### DIFF
--- a/src/views/home/lib/topology-v2-adapter.ts
+++ b/src/views/home/lib/topology-v2-adapter.ts
@@ -121,6 +121,8 @@ export function buildTopologyV2Graph(
       relationQuality: quality === "strong" ? "strong" : quality === "weak" ? "weak" : null,
       evidenceCount: edge.evidenceIds.length,
       kind: isContainmentRelation(edge.type) ? "contains" : "depends",
+      // P3b — 선언 출처: derive 가 evidenceIds[0] 에 선언 doc slug 를 싣는다.
+      declaredBySlug: edge.evidenceIds[0] ?? null,
     };
   });
 

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -39,6 +39,8 @@ export interface TopologyV2Edge {
   relationQuality: "strong" | "weak" | null;
   evidenceCount: number;
   kind: "contains" | "depends";
+  /** P3b — 이 관계를 선언한 vault 문서 slug (frontmatter 가 곧 그래프이므로 출처 표시 비용 0). */
+  declaredBySlug: string | null;
 }
 
 export interface TopologyV2Focus {

--- a/src/widgets/topology-map-v2/ui/topology-edge-hit.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-edge-hit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { hitTestEdges, type EdgeHitCandidate } from "./topology-edge-hit";
+import type { WorldEdge } from "./topology-world";
+
+const edge = (id: string): WorldEdge => ({
+  sourceId: `${id}-a`,
+  targetId: `${id}-b`,
+  kind: "contains",
+  ax: 0, ay: 0, bx: 0, by: 0, controlX: 0, controlY: 0,
+  t: 0,
+  level: 1,
+  relationType: "contains",
+  declaredBySlug: null,
+});
+
+const straight = (id: string, y: number): EdgeHitCandidate => ({
+  edge: edge(id),
+  a: { x: 100, y },
+  b: { x: 500, y },
+  control: { x: 300, y },
+});
+
+describe("hitTestEdges", () => {
+  it("임계 안의 가장 가까운 엣지를 고른다", () => {
+    const hit = hitTestEdges([straight("far", 100), straight("near", 200)], 300, 204, 8);
+    expect(hit?.sourceId).toBe("near-a");
+  });
+
+  it("임계 밖이면 null — 빈 공간 클릭이 엣지를 잡으면 안 된다", () => {
+    expect(hitTestEdges([straight("e", 100)], 300, 130, 8)).toBeNull();
+  });
+
+  it("곡선(제어점 오프셋) 위의 점도 잡는다 — 직선 근사가 아니라 베지어 샘플링", () => {
+    const bowed: EdgeHitCandidate = {
+      edge: edge("bow"),
+      a: { x: 100, y: 300 },
+      b: { x: 500, y: 300 },
+      control: { x: 300, y: 100 }, // 위로 휜 활
+    };
+    // 베지어 t=0.5 지점 = (300, 200) — 직선(현) 위가 아니다
+    expect(hitTestEdges([bowed], 300, 200, 6)?.sourceId).toBe("bow-a");
+    // 현(y=300) 중앙은 곡선에서 멀다 — 잡히면 직선 근사를 하고 있다는 뜻
+    expect(hitTestEdges([bowed], 300, 296, 6)).toBeNull();
+  });
+
+  it("AABB 밖 후보는 스킵돼도 결과가 같다 (프리패스 무손실)", () => {
+    const many = Array.from({ length: 400 }, (_, i) => straight(`e${i}`, 1000 + i * 10));
+    many.push(straight("target", 200));
+    expect(hitTestEdges(many, 300, 203, 8)?.sourceId).toBe("target-a");
+  });
+});

--- a/src/widgets/topology-map-v2/ui/topology-edge-hit.ts
+++ b/src/widgets/topology-map-v2/ui/topology-edge-hit.ts
@@ -1,0 +1,88 @@
+/**
+ * P3b — 엣지 히트테스트 (순수 수학, DOM/캔버스 무접촉).
+ *
+ * 레퍼런스 연구 판정(edge-meaning-refs): "엣지 = 선택 가능한 1급 객체 +
+ * 패널 상세"가 업계 표준형(Kumu/Bloom/Foundry) — 그 첫 단추가 이 모듈이다.
+ * 노드 히트가 항상 우선한다(호출자 규약): 노드가 잡히지 않은 지점에서만
+ * 엣지 근접을 판정한다.
+ *
+ * 성능: AABB 프리패스(껍질 bbox + 임계) 후 통과한 엣지만 2차 베지어를
+ * 균등 샘플링해 세그먼트 체인 거리로 판정 — 기술 검수 실측 기준
+ * ~500 엣지에 수십 µs/이벤트, 프레임 예산 <1ms 여유 (공간 분할 불필요).
+ */
+
+import type { WorldEdge } from "./topology-world";
+
+export interface EdgeHitPoint {
+  x: number;
+  y: number;
+}
+
+const SAMPLE_STEPS = 16;
+
+function distSqToSegment(px: number, py: number, ax: number, ay: number, bx: number, by: number): number {
+  const vx = bx - ax;
+  const vy = by - ay;
+  const wx = px - ax;
+  const wy = py - ay;
+  const len2 = vx * vx + vy * vy;
+  const t = len2 > 0 ? Math.min(1, Math.max(0, (wx * vx + wy * vy) / len2)) : 0;
+  const cx = ax + vx * t;
+  const cy = ay + vy * t;
+  const dx = px - cx;
+  const dy = py - cy;
+  return dx * dx + dy * dy;
+}
+
+/** 2차 베지어(끝점 a/b + 제어점 c) 위 점 — 스크린 좌표. */
+function bezier(ax: number, ay: number, cx: number, cy: number, bx: number, by: number, t: number): EdgeHitPoint {
+  const u = 1 - t;
+  return {
+    x: u * u * ax + 2 * u * t * cx + t * t * bx,
+    y: u * u * ay + 2 * u * t * cy + t * t * by,
+  };
+}
+
+export interface EdgeHitCandidate {
+  edge: WorldEdge;
+  /** 스크린 공간 투영 결과 — 호출자(포인터 핸들러)가 world→screen 변환을 소유. */
+  a: EdgeHitPoint;
+  b: EdgeHitPoint;
+  control: EdgeHitPoint;
+}
+
+/**
+ * `(screenX, screenY)` 에서 `thresholdPx` 안의 가장 가까운 엣지.
+ * 없으면 null. 후보는 화면에 그려진(컬링 통과) 엣지만 넘기는 것이 호출자
+ * 책임 — 안 보이는 엣지가 클릭되는 것은 계약 위반이다.
+ */
+export function hitTestEdges(
+  candidates: readonly EdgeHitCandidate[],
+  screenX: number,
+  screenY: number,
+  thresholdPx: number,
+): WorldEdge | null {
+  const threshold2 = thresholdPx * thresholdPx;
+  let best: WorldEdge | null = null;
+  let bestD2 = threshold2;
+  for (const { edge, a, b, control } of candidates) {
+    // AABB 프리패스 — 껍질 bbox 가 임계 밖이면 샘플링 생략.
+    const minX = Math.min(a.x, b.x, control.x) - thresholdPx;
+    const maxX = Math.max(a.x, b.x, control.x) + thresholdPx;
+    const minY = Math.min(a.y, b.y, control.y) - thresholdPx;
+    const maxY = Math.max(a.y, b.y, control.y) + thresholdPx;
+    if (screenX < minX || screenX > maxX || screenY < minY || screenY > maxY) continue;
+
+    let prev = bezier(a.x, a.y, control.x, control.y, b.x, b.y, 0);
+    for (let i = 1; i <= SAMPLE_STEPS; i += 1) {
+      const cur = bezier(a.x, a.y, control.x, control.y, b.x, b.y, i / SAMPLE_STEPS);
+      const d2 = distSqToSegment(screenX, screenY, prev.x, prev.y, cur.x, cur.y);
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        best = edge;
+      }
+      prev = cur;
+    }
+  }
+  return best;
+}

--- a/src/widgets/topology-map-v2/ui/topology-world.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.test.ts
@@ -81,7 +81,7 @@ describe("buildTopologyWorld — homeX/homeY", () => {
       inputNode({ id: "p", kind: "project" }),
       inputNode({ id: "d", kind: "domain" }),
     ];
-    const edges: TopologyV2Edge[] = [{ source: "p", target: "d", relationType: "contains", relationQuality: null, evidenceCount: 0, kind: "contains" }];
+    const edges: TopologyV2Edge[] = [{ source: "p", target: "d", relationType: "contains", relationQuality: null, evidenceCount: 0, kind: "contains", declaredBySlug: null }];
     const world = buildTopologyWorld(nodes, edges, fullTokens);
     for (const node of world.nodes) {
       expect(node.homeX).toBe(node.x);

--- a/src/widgets/topology-map-v2/ui/topology-world.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.ts
@@ -56,6 +56,10 @@ export interface WorldEdge {
    * `depends` 엣지는 타입 채널(파선) 소속이라 이 값을 쓰지 않는다.
    */
   level: 0 | 1 | 2;
+  /** P3b — 원 관계 타입 (contains/depends 2치로 뭉개기 전의 의미). */
+  relationType: string;
+  /** P3b — 이 관계를 선언한 vault 문서 slug (엣지 팝오버의 출처 표시). */
+  declaredBySlug: string | null;
 }
 
 /** P3a — 두 엔드포인트 kind 에서 containment 잉크 레벨을 유도한다. */
@@ -266,6 +270,8 @@ export function buildTopologyWorld(
       controlY: control.y,
       t: 0,
       level: containmentLevelFor(a.kind, b.kind),
+      relationType: edge.relationType,
+      declaredBySlug: edge.declaredBySlug ?? null,
     });
   }
 


### PR DESCRIPTION
## Summary
엣지 클릭 팝오버의 기반 2종 (UI 는 P1a 어휘 사전 머지 후 2단계):
- **`hitTestEdges`** (순수): AABB 프리패스 + 베지어 16-샘플. 곡선 위 클릭 잡고 현은 안 잡음(직선 근사 방지 테스트). 성능: 기술 검수 실측 근거로 공간 분할 불필요.
- **의미 배관**: `TopologyV2Edge`/`WorldEdge` 에 `relationType`(원 타입) + `declaredBySlug`(선언 출처 — `evidenceIds[0]`) 스레딩.

## Test plan
- 신규 hit 테스트 4 (최근접·임계 밖 null·베지어 vs 현·프리패스 무손실) — topology-map-v2+home **524 pass** · tsc 0 · eslint 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)