### PR TITLE
feat: 시간·성장 표면 — 최근 변경 렌즈·귀속 배지·성장 행 (P4)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,28 @@
 
 ---
 
+## 2026-07-21 — 최근 변경 렌즈 · 에이전트 귀속 배지 · 성장 진입점 (P4a·P4b·P4c)
+
+- **최근 변경 렌즈** (mtime 7일 창, `computeRecentChanges`/`selectRecentVaultDocs`
+  — `shared/lib/ontology-tree/recent-changes.ts` 단일 진실원): INDEX 검색
+  아래 "전체 | 최근 변경 N" 2-세그먼트가 트리를 최근 노드 + 조상 경로로
+  좁힌다(`filterTreeByNodeIds` 재사용). 문서함(`/docs`) 사이드바에도 같은
+  창 계산으로 "최근 바뀐 문서 N" 접이식 스트립. 지도 자체의 dim 은
+  미구현 — 캔버스 엔진의 ego-dim 채널(`focus-state.ts`)이 클릭 기반
+  단일 focus 전제라, 렌즈 dim 을 얹으려면 `WorldNode`/`topology-world.ts`/
+  `resolveNodeVisual` 을 함께 건드려야 해 이번 슬라이스에서는 INDEX
+  필터 + 행 강조까지로 범위를 좁혔다.
+- **에이전트 귀속 배지**: heartbeat 가 fresh 하고 focus 가 렌즈 안의
+  노드와 일치하면 그 INDEX 행에 "에이전트가 방금" 표시(새 색 없이 평문
+  텍스트). 신뢰 투명성 조건 복원 — Live 팝오버에 heartbeat 상태 무관
+  항상 "이 신호 지우기" 안내 + `agent-activity --clear` 명령 복사.
+- **성장 진입점**: `bootstrapPlan`(기존 파생, "내 문서로 지도 만들기"와
+  동일 소스)의 카운트를 INDEX 푸터 위 "지도에 없는 문서 N개 · 올리기"
+  행으로 노출 — 지도가 이미 채워진 상태에서도 클릭 한 번으로 승격
+  다이얼로그가 열린다(이전엔 빈 지도 empty-state 에서만 열렸다).
+  성장/유지보수 큐는 `/ontology/insights` "수리 큐"(`buildOntologyHealthActionTarget`)
+  가 이미 인앱 노출 중이라 새 표면을 만들지 않았다.
+
 ## 2026-07-21 — "AI 에이전트 연결" 시트 (P2a — 웨지 표면)
 
 INDEX 푸터의 에이전트 상태를 누르면 연결 시트가 열린다: ① 연결 상태 —

--- a/messages/en.json
+++ b/messages/en.json
@@ -183,7 +183,11 @@
     "stateEditing": "editing",
     "stateVerifying": "verifying",
     "stateBlocked": "blocked",
-    "stateComplete": "complete"
+    "stateComplete": "complete",
+    "clearSignalHint": "To clear this activity signal, run the command below in your terminal.",
+    "clearSignalCopy": "Copy clear command",
+    "clearSignalCopied": "Copied",
+    "clearSignalCopyFailed": "Copy failed"
   },
   "locale": {
     "switcher": "Language",
@@ -852,7 +856,9 @@
         "tagsHeader": "Tags · {count}",
         "activeTagSummary": "#{tag}",
         "tagTitle": "#{tag} · {count} items",
-        "unpinTooltip": "Unpin"
+        "unpinTooltip": "Unpin",
+        "recentlyChangedHeader": "Recently changed · {count}",
+        "recentlyChangedWindowHint": "Docs edited in the last 7 days."
       },
       "empty": {
         "eyebrow": "{count} documents",
@@ -2313,7 +2319,14 @@
       "freshTitle": "Recently updated",
       "emptyHint": "No concepts match",
       "agentHandoff": "Handoff",
-      "agentHandoffAria": "Copy notes for your AI agent (summary, re-check request, update check)"
+      "agentHandoffAria": "Copy notes for your AI agent (summary, re-check request, update check)",
+      "segmentAll": "All",
+      "segmentRecent": "Recent {count}",
+      "segmentRecentAria": "Narrow the map to recently changed nodes",
+      "recentEmptyHint": "Nothing changed in the last 7 days",
+      "agentBadge": "Agent just now",
+      "uncatalogedDocsLabel": "{count} docs not on the map",
+      "uncatalogedDocsAction": "Promote"
     },
     "deeplinkNotFound": "Node not found: {query}",
     "bootstrap": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -183,7 +183,11 @@
     "stateEditing": "수정",
     "stateVerifying": "검증",
     "stateBlocked": "막힘",
-    "stateComplete": "완료"
+    "stateComplete": "완료",
+    "clearSignalHint": "이 작업 상태를 지우려면 터미널에서 아래 명령을 실행하세요.",
+    "clearSignalCopy": "지우기 명령 복사",
+    "clearSignalCopied": "복사됨",
+    "clearSignalCopyFailed": "복사 실패"
   },
   "locale": {
     "switcher": "언어",
@@ -852,7 +856,9 @@
         "tagsHeader": "태그 · {count}",
         "activeTagSummary": "#{tag}",
         "tagTitle": "#{tag} · {count}건",
-        "unpinTooltip": "고정 해제"
+        "unpinTooltip": "고정 해제",
+        "recentlyChangedHeader": "최근 바뀐 문서 · {count}",
+        "recentlyChangedWindowHint": "최근 7일 안에 수정된 문서입니다."
       },
       "empty": {
         "eyebrow": "문서 {count}개",
@@ -2313,7 +2319,14 @@
       "freshTitle": "최근 갱신",
       "emptyHint": "일치하는 개념이 없습니다",
       "agentHandoff": "인계",
-      "agentHandoffAria": "AI에게 넘길 메모 복사 (요약 · 다시 분석 요청 · 최신 상태 확인)"
+      "agentHandoffAria": "AI에게 넘길 메모 복사 (요약 · 다시 분석 요청 · 최신 상태 확인)",
+      "segmentAll": "전체",
+      "segmentRecent": "최근 변경 {count}",
+      "segmentRecentAria": "최근 변경 노드로 지도 좁히기",
+      "recentEmptyHint": "최근 7일 안에 바뀐 노드가 없습니다",
+      "agentBadge": "에이전트가 방금",
+      "uncatalogedDocsLabel": "지도에 없는 문서 {count}개",
+      "uncatalogedDocsAction": "올리기"
     },
     "deeplinkNotFound": "노드를 찾을 수 없습니다: {query}",
     "bootstrap": {

--- a/src/features/vault-ontology/index.ts
+++ b/src/features/vault-ontology/index.ts
@@ -1,6 +1,7 @@
 export { useVaultOntology } from './model/use-vault-ontology';
 export { useOntologyInsight } from './model/use-ontology-insight';
 export { useVaultDocFreshnessIndex } from './model/use-vault-doc-freshness';
+export { useRecentChanges } from './model/use-recent-changes';
 export { OntologyLiveBaselineInit } from './ui/OntologyLiveBaselineInit';
 export { LiveActivityIndicator } from './ui/LiveActivityIndicator';
 export { formatActivityAge } from './lib/format-activity-age';

--- a/src/features/vault-ontology/model/use-recent-changes.ts
+++ b/src/features/vault-ontology/model/use-recent-changes.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  computeRecentChanges,
+  RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+  type RecentChangesResult,
+} from '@/shared/lib/ontology-tree';
+import { useOntologyInsight } from './use-ontology-insight';
+import { useVaultDocFreshnessIndex } from './use-vault-doc-freshness';
+
+const EMPTY_RESULT: RecentChangesResult = { recentNodeIds: new Set(), rows: [] };
+
+/**
+ * P4a — "최근 변경" 렌즈의 mode-aware 어댑터. `useVaultDocFreshnessIndex()`
+ * (slug → 실제 updatedAt) 와 `useOntologyInsight()` (현재 그래프 노드) 를
+ * `computeRecentChanges` 순수 함수(`@/shared/lib/ontology-tree`)에 그대로
+ * 넘긴다 — mode 분기·시간 산수는 그 두 의존 hook/순수 함수가 이미 소유하므로
+ * 여기서 새로 만들지 않는다(`use-ontology-insight.ts`/`use-vault-doc-freshness.ts`
+ * 와 같은 얇은 조합 패턴).
+ *
+ * 기준 시각은 훅이 처음 호출된 순간의 스냅샷(`useState(() => Date.now())`) —
+ * 렌더 중 `Date.now()` 를 직접 읽지 않는다(렌더 purity, 이 저장소의 기존
+ * 관례 — `LiveActivityBadge`/`agentConnectNowMs` 등과 동일).
+ */
+export function useRecentChanges(
+  windowDays: number = RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+): RecentChangesResult {
+  const freshnessIndex = useVaultDocFreshnessIndex();
+  const { insight } = useOntologyInsight();
+  const [nowMs] = useState(() => Date.now());
+
+  return useMemo(() => {
+    if (!insight) return EMPTY_RESULT;
+    return computeRecentChanges(insight.nodes, freshnessIndex, nowMs, windowDays);
+  }, [insight, freshnessIndex, nowMs, windowDays]);
+}

--- a/src/features/vault-ontology/ui/LiveActivityIndicator.test.tsx
+++ b/src/features/vault-ontology/ui/LiveActivityIndicator.test.tsx
@@ -50,6 +50,10 @@ const labels = {
   agentCodegraph: "Source",
   agentVerification: "Verify",
   agentProofTrail: "Proof trail",
+  clearSignalHint: "Run this command in your terminal to clear this activity signal.",
+  clearSignalCopy: "Copy clear command",
+  clearSignalCopied: "Copied",
+  clearSignalCopyFailed: "Copy failed",
   close: "Close live activity popover",
   statePlanning: "planning",
   stateEditing: "editing",
@@ -264,6 +268,50 @@ describe("LiveActivityBadge", () => {
     expect(proofTrail).toHaveTextContent("validate_vault +1");
     expect(proofTrail).toHaveTextContent("serena symbols LiveActivityIndicator");
     expect(proofTrail).toHaveTextContent("pnpm exec vitest run ... +1");
+  });
+
+  it("P4b: 신선한 heartbeat 에도 '신호 지우기' 안내 + 복사 가능한 --clear 명령이 항상 노출된다", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <LiveActivityBadge
+        changedCount={0}
+        labels={labels}
+        trackingChanges={false}
+        agentActivityStatus={{
+          sourcePath: ".ontology-atlas/agent-activity.json",
+          exists: true,
+          valid: true,
+          stale: false,
+          reviewMode: "ontology-focus",
+          ageMs: 90_000,
+          errorMessage: null,
+          heartbeat: {
+            agent: "codex",
+            state: "editing",
+            focus: {
+              summary: "Wire heartbeat into Live popover",
+              ontologySlug: "capabilities/agent-live-activity-contract",
+              files: [],
+            },
+            plan: [],
+            evidence: { mcp: [], codegraph: [], verification: [] },
+            updatedAt: "2026-06-06T10:00:00.000Z",
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Agent heartbeat current/ }));
+    expect(screen.getByTestId("live-agent-activity")).toHaveTextContent(labels.clearSignalHint);
+
+    fireEvent.click(screen.getByTestId("live-agent-clear-signal-copy"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toBe("ontology-atlas agent-activity <vault> --clear");
   });
 
   it("focus summary가 없어도 닫힌 Live trigger는 ontology slug를 focus fallback으로 보여준다", () => {

--- a/src/features/vault-ontology/ui/LiveActivityIndicator.tsx
+++ b/src/features/vault-ontology/ui/LiveActivityIndicator.tsx
@@ -16,6 +16,11 @@ import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
 import { formatActivityAge } from "../lib/format-activity-age";
 import { useOntologyInsight } from "../model/use-ontology-insight";
 
+// P4b — heartbeat 신호를 지우는 CLI 명령. `<vault>` 는 `agent-activity-status.ts`
+// 의 `formatRefreshCommand` 와 같은 관례로 실제 경로가 아니라 자리표시자 —
+// 값이 정적이라 shellArg 이스케이프가 필요 없다(동적 인자 없음).
+const CLEAR_SIGNAL_COMMAND = "ontology-atlas agent-activity <vault> --clear";
+
 type LiveAgentActivityState =
   | "planning"
   | "editing"
@@ -145,6 +150,11 @@ export function LiveActivityBadge({
     agentCodegraph: string;
     agentVerification: string;
     agentProofTrail: string;
+    /** P4b — heartbeat 상시 노출 "이 신호 지우기" 투명성 카피(전략 메모 조건). */
+    clearSignalHint: string;
+    clearSignalCopy: string;
+    clearSignalCopied: string;
+    clearSignalCopyFailed: string;
     close: string;
     statePlanning: string;
     stateEditing: string;
@@ -219,6 +229,12 @@ export function LiveActivityBadge({
       : focusCopyState === "failed"
         ? labels.agentExtractCopyFailed
         : labels.agentExtractCopy;
+  const clearSignalCopyLabel =
+    focusCopyState === "copied"
+      ? labels.clearSignalCopied
+      : focusCopyState === "failed"
+        ? labels.clearSignalCopyFailed
+        : labels.clearSignalCopy;
   const evidenceCounts = heartbeat
     ? [
         [labels.agentMcp, heartbeat.evidence.mcp.length],
@@ -520,6 +536,24 @@ export function LiveActivityBadge({
                   </div>
                 </>
               ) : null}
+              {/* P4b — 전략 메모 투명성 조건: heartbeat 가 있는 한 상태(fresh/stale
+                  무관) 항상 "이 신호 지우기" 안내 + 복사 가능한 CLI 명령을 노출한다
+                  — 얕게(안내 카피만)도 허용되는 조건이라 실제 파일 삭제는 하지
+                  않는다(로컬 쓰기는 CLI/에이전트의 역할). */}
+              <div className="grid gap-1 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1.5">
+                <p className="break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  {labels.clearSignalHint}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void copyFocusCheck(CLEAR_SIGNAL_COMMAND)}
+                  data-testid="live-agent-clear-signal-copy"
+                  className="inline-flex w-fit items-center gap-1 rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+                >
+                  <Clipboard size={10} aria-hidden />
+                  {clearSignalCopyLabel}
+                </button>
+              </div>
             </div>
           ) : null}
         </div>
@@ -812,6 +846,10 @@ export function LiveActivityIndicator({
         agentCodegraph: t("agentCodegraph"),
         agentVerification: t("agentVerification"),
         agentProofTrail: t("agentProofTrail"),
+        clearSignalHint: t("clearSignalHint"),
+        clearSignalCopy: t("clearSignalCopy"),
+        clearSignalCopied: t("clearSignalCopied"),
+        clearSignalCopyFailed: t("clearSignalCopyFailed"),
         close: t("close"),
         statePlanning: t("statePlanning"),
         stateEditing: t("stateEditing"),

--- a/src/shared/lib/ontology-tree/index.ts
+++ b/src/shared/lib/ontology-tree/index.ts
@@ -136,3 +136,11 @@ export {
   buildProjectOntologyCounts,
   pickDominantOntologyKind,
 } from "./project-ontology-counts";
+export type { RecentChangeRow, RecentChangesResult } from "./recent-changes";
+export {
+  RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+  computeRecentChanges,
+  daysAgoFromIso,
+  isWithinRecentWindow,
+  selectRecentVaultDocs,
+} from "./recent-changes";

--- a/src/shared/lib/ontology-tree/recent-changes.test.ts
+++ b/src/shared/lib/ontology-tree/recent-changes.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import {
+  computeRecentChanges,
+  daysAgoFromIso,
+  isWithinRecentWindow,
+  RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+  selectRecentVaultDocs,
+} from "./recent-changes";
+
+function node(id: string, opts: Partial<KnowledgeGraphNode> = {}): KnowledgeGraphNode {
+  return {
+    id,
+    title: id,
+    kind: "capability",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date(0),
+    lastApprovedBy: "vault-frontmatter",
+    ...opts,
+  };
+}
+
+const NOW = Date.parse("2026-07-21T12:00:00.000Z");
+
+describe("isWithinRecentWindow", () => {
+  it("is true for a date inside the window", () => {
+    expect(isWithinRecentWindow("2026-07-19T12:00:00.000Z", NOW, 7)).toBe(true);
+  });
+
+  it("is true exactly at the window boundary", () => {
+    expect(isWithinRecentWindow("2026-07-14T12:00:00.000Z", NOW, 7)).toBe(true);
+  });
+
+  it("is false just past the window boundary", () => {
+    expect(isWithinRecentWindow("2026-07-14T11:59:00.000Z", NOW, 7)).toBe(false);
+  });
+
+  it("is false for an unparseable date", () => {
+    expect(isWithinRecentWindow("not-a-date", NOW, 7)).toBe(false);
+  });
+
+  it("is false for a future-dated (clock skew) value", () => {
+    expect(isWithinRecentWindow("2026-07-22T00:00:00.000Z", NOW, 7)).toBe(false);
+  });
+
+  it("defaults to a 7-day window", () => {
+    expect(isWithinRecentWindow("2026-07-15T12:00:00.000Z", NOW)).toBe(true);
+    expect(isWithinRecentWindow("2026-07-13T00:00:00.000Z", NOW)).toBe(false);
+  });
+});
+
+describe("daysAgoFromIso", () => {
+  it("floors to whole days", () => {
+    expect(daysAgoFromIso("2026-07-20T13:00:00.000Z", NOW)).toBe(0);
+    expect(daysAgoFromIso("2026-07-20T11:00:00.000Z", NOW)).toBe(1);
+  });
+
+  it("returns +Infinity for an unparseable date", () => {
+    expect(daysAgoFromIso("nope", NOW)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("computeRecentChanges", () => {
+  it("includes a node whose evidence doc updated inside the window", () => {
+    const nodes = [node("capability:a", { evidenceIds: ["docs/a"], title: "A" })];
+    const freshness = new Map([["docs/a", "2026-07-19T00:00:00.000Z"]]);
+
+    const result = computeRecentChanges(nodes, freshness, NOW);
+
+    expect(result.recentNodeIds.has("capability:a")).toBe(true);
+    expect(result.rows).toEqual([{ id: "capability:a", title: "A", kind: "capability", agoDays: 2 }]);
+  });
+
+  it("excludes a node whose evidence doc updated outside the window", () => {
+    const nodes = [node("capability:old", { evidenceIds: ["docs/old"] })];
+    const freshness = new Map([["docs/old", "2026-06-01T00:00:00.000Z"]]);
+
+    const result = computeRecentChanges(nodes, freshness, NOW);
+
+    expect(result.recentNodeIds.size).toBe(0);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("excludes a node with no evidenceIds (nothing to look up)", () => {
+    const nodes = [node("capability:no-evidence", { evidenceIds: [] })];
+    const freshness = new Map([["docs/whatever", "2026-07-20T00:00:00.000Z"]]);
+
+    const result = computeRecentChanges(nodes, freshness, NOW);
+
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("excludes a node whose evidence slug is not in the freshness index (unknown, not assumed recent)", () => {
+    const nodes = [node("capability:unknown", { evidenceIds: ["docs/missing"] })];
+    const result = computeRecentChanges(nodes, new Map(), NOW);
+
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("sorts rows newest-first", () => {
+    const nodes = [
+      node("capability:a", { evidenceIds: ["docs/a"], title: "A" }),
+      node("capability:b", { evidenceIds: ["docs/b"], title: "B" }),
+    ];
+    const freshness = new Map([
+      ["docs/a", "2026-07-18T00:00:00.000Z"],
+      ["docs/b", "2026-07-20T00:00:00.000Z"],
+    ]);
+
+    const result = computeRecentChanges(nodes, freshness, NOW);
+
+    expect(result.rows.map((r) => r.id)).toEqual(["capability:b", "capability:a"]);
+  });
+
+  it("respects a custom windowDays", () => {
+    const nodes = [node("capability:a", { evidenceIds: ["docs/a"] })];
+    const freshness = new Map([["docs/a", "2026-07-10T00:00:00.000Z"]]); // 11 days ago
+
+    expect(computeRecentChanges(nodes, freshness, NOW, 7).rows).toHaveLength(0);
+    expect(computeRecentChanges(nodes, freshness, NOW, 14).rows).toHaveLength(1);
+  });
+
+  it("uses RECENT_CHANGES_DEFAULT_WINDOW_DAYS (7) when omitted", () => {
+    expect(RECENT_CHANGES_DEFAULT_WINDOW_DAYS).toBe(7);
+  });
+
+  it("returns empty results for no nodes", () => {
+    const result = computeRecentChanges([], new Map(), NOW);
+    expect(result).toEqual({ recentNodeIds: new Set(), rows: [] });
+  });
+});
+
+describe("selectRecentVaultDocs", () => {
+  function doc(slug: string, updatedAt: string) {
+    return { slug, updatedAt };
+  }
+
+  it("keeps only docs inside the window, newest-first", () => {
+    const docs = [
+      doc("a", "2026-07-01T00:00:00.000Z"),
+      doc("b", "2026-07-19T00:00:00.000Z"),
+      doc("c", "2026-07-20T00:00:00.000Z"),
+    ];
+    const result = selectRecentVaultDocs(docs, NOW);
+    expect(result.map((d) => d.slug)).toEqual(["c", "b"]);
+  });
+
+  it("returns an empty array when nothing is recent", () => {
+    expect(selectRecentVaultDocs([doc("old", "2025-01-01T00:00:00.000Z")], NOW)).toEqual([]);
+  });
+});

--- a/src/shared/lib/ontology-tree/recent-changes.ts
+++ b/src/shared/lib/ontology-tree/recent-changes.ts
@@ -1,0 +1,120 @@
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+
+/**
+ * P4a — "최근 변경" 렌즈의 단일 진실원. 의미론은 **mtime 7일 창**(세션
+ * changeset 이 아니다 — `ontology-changeset.ts` 의 "마지막 기준 이후 변경"과는
+ * 다른 질문. 이 모듈은 "지난 N일 안에 실제로 수정된 문서가 뭔가"에 답한다).
+ *
+ * 두 표면이 이 창 계산을 공유한다 — INDEX 지도 렌즈(`computeRecentChanges`,
+ * 온톨로지 노드 → `evidenceIds[0]` → vault 문서 실제 갱신일 간접 조회)와
+ * 문서함 사이드바 스트립(`selectRecentVaultDocs`, `VaultDoc.updatedAt` 직접
+ * 조회 — 문서 자체가 이미 실제 날짜를 들고 있어 간접 조회가 필요 없다). 두
+ * 함수 모두 `isWithinRecentWindow`/`daysAgoFromIso` 라는 같은 날짜 산수를
+ * 호출해 "최근"의 기준이 표면마다 갈라지는 걸(N2 census drift 교훈) 막는다.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** 렌즈의 기본 창 — 7일. 페르소나 재검 문구("지난 7일 뭐가 바뀌었나")와 동일. */
+export const RECENT_CHANGES_DEFAULT_WINDOW_DAYS = 7;
+
+/**
+ * `updatedAtIso` 가 `nowMs` 기준 `windowDays` 안(과거)에 들어오는지. 파싱 불가
+ * 값은 false(모른다≠최근). 미래 날짜(clock skew)도 false로 취급 — "방금"이
+ * 아니라 데이터 이상이므로 렌즈에 끼워 넣지 않는다.
+ */
+export function isWithinRecentWindow(
+  updatedAtIso: string,
+  nowMs: number,
+  windowDays: number = RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+): boolean {
+  const updatedMs = Date.parse(updatedAtIso);
+  if (!Number.isFinite(updatedMs)) return false;
+  const ageMs = nowMs - updatedMs;
+  if (ageMs < 0) return false;
+  return ageMs <= windowDays * DAY_MS;
+}
+
+/** `updatedAtIso` 가 `nowMs` 로부터 며칠 전인지 — 내림(정수일). 파싱 불가면 +Infinity. */
+export function daysAgoFromIso(updatedAtIso: string, nowMs: number): number {
+  const updatedMs = Date.parse(updatedAtIso);
+  if (!Number.isFinite(updatedMs)) return Number.POSITIVE_INFINITY;
+  return Math.floor((nowMs - updatedMs) / DAY_MS);
+}
+
+export interface RecentChangeRow {
+  id: string;
+  title: string;
+  kind: string;
+  /** `daysAgoFromIso` — 0 = 오늘. */
+  agoDays: number;
+}
+
+export interface RecentChangesResult {
+  recentNodeIds: Set<string>;
+  /** 최신순(agoDays 오름차순) 정렬. */
+  rows: RecentChangeRow[];
+}
+
+/**
+ * 온톨로지 노드 → "최근 변경" 렌즈. 노드 자체엔 시간 정보가 없다(vault
+ * frontmatter 는 시간을 안 가짐) — `node.evidenceIds[0]` 이 곧 그 노드가
+ * 유래한 vault 문서 slug(`derivationToInsight` 계약, `use-vault-doc-freshness.ts`
+ * 와 동일 관례)이므로 `freshnessIndex`(slug → 실제 updatedAt ISO)로 간접
+ * 조회한다. evidenceIds 가 없거나 freshnessIndex 에 없는 노드는 "모른다"로
+ * 취급해 렌즈에서 제외(있다고 단정하지 않는다).
+ */
+export function computeRecentChanges(
+  nodes: readonly KnowledgeGraphNode[],
+  freshnessIndex: ReadonlyMap<string, string>,
+  nowMs: number,
+  windowDays: number = RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+): RecentChangesResult {
+  const recentNodeIds = new Set<string>();
+  const rows: RecentChangeRow[] = [];
+
+  for (const node of nodes) {
+    const slug = node.evidenceIds[0];
+    if (!slug) continue;
+    const updatedAt = freshnessIndex.get(slug);
+    if (!updatedAt) continue;
+    if (!isWithinRecentWindow(updatedAt, nowMs, windowDays)) continue;
+
+    recentNodeIds.add(node.id);
+    rows.push({
+      id: node.id,
+      title: node.title,
+      kind: node.kind,
+      agoDays: daysAgoFromIso(updatedAt, nowMs),
+    });
+  }
+
+  rows.sort((a, b) => a.agoDays - b.agoDays || a.title.localeCompare(b.title));
+  return { recentNodeIds, rows };
+}
+
+/**
+ * vault 문서(`VaultDoc` 호환 최소 shape) → "최근 변경" 목록. 문서 자체가 이미
+ * 실제 `updatedAt` 을 들고 있으므로(local 모드 = `file.lastModified`,
+ * static/dogfood = 빌드타임 값) `computeRecentChanges` 의 freshnessIndex 간접
+ * 조회가 필요 없다 — 대신 같은 `isWithinRecentWindow` 산수를 공유해 두 표면의
+ * "최근"이 갈라지지 않는다. 최신순 정렬.
+ */
+export function selectRecentVaultDocs<T extends { updatedAt: string }>(
+  docs: readonly T[],
+  nowMs: number,
+  windowDays: number = RECENT_CHANGES_DEFAULT_WINDOW_DAYS,
+): T[] {
+  return docs
+    .filter((doc) => isWithinRecentWindow(doc.updatedAt, nowMs, windowDays))
+    .slice()
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+}
+
+// P4b — "에이전트가 방금" 배지의 대상 노드 id 는 이 모듈에서 새로 만들지
+// 않는다. `HomePage.tsx` 가 이미 W6(agent visibility)용으로
+// `resolveAgentFocusNodeId`(`views/home/lib/resolve-agent-focus-node.ts`) 로
+// heartbeat focus → 그래프 노드 id 를 정규화해 두므로, 배지는 그 결과가
+// `recentNodeIds` 에 속하는지 집합 조회 한 줄로 판정한다(HomePage 참고) — 두
+// 번째 매치 휴리스틱을 만들면 두 표면의 "에이전트가 지금 보는 노드" 판정이
+// 갈라질 수 있어 피한다.

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import koMessages from "../../../../../messages/ko.json";
+import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
+import { DocsSidebarBody } from "./DocsSidebarBody";
+
+function makeDoc(slug: string, title: string, updatedAt: string): VaultDoc {
+  return {
+    slug,
+    path: `${slug}.md`,
+    title,
+    tags: [],
+    frontmatter: {},
+    headings: [],
+    excerpt: "",
+    wordCount: 0,
+    updatedAt,
+    linksOut: [],
+  };
+}
+
+function makeManifest(docs: VaultDoc[]): VaultManifest {
+  return {
+    version: "1",
+    generatedAt: new Date().toISOString(),
+    docs,
+    backlinksDetail: {},
+    tags: {},
+    tree: { name: "root", path: "", type: "dir" },
+  };
+}
+
+function renderSidebar(docs: VaultDoc[]) {
+  const manifest = makeManifest(docs);
+  const onSelect = vi.fn();
+  render(
+    <NextIntlClientProvider locale="ko" messages={koMessages}>
+      <DocsSidebarBody
+        pinnedSlugs={[]}
+        recentSlugs={[]}
+        selectedSlug={null}
+        docsBySlug={new Map(docs.map((d) => [d.slug, d]))}
+        activeTag={null}
+        manifest={manifest}
+        collection="guides"
+        collectionCounts={{ guides: docs.length, ontology: 0 }}
+        visibleDocSlugs={new Set(docs.map((d) => d.slug))}
+        onSelect={onSelect}
+        onCollectionChange={() => {}}
+        onTogglePin={() => {}}
+        onTagSelect={() => {}}
+      />
+    </NextIntlClientProvider>,
+  );
+  return { onSelect };
+}
+
+describe("DocsSidebarBody — P4a 최근 바뀐 문서 스트립", () => {
+  const now = Date.now();
+  const recentIso = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString(); // 2일 전
+  const oldIso = new Date(now - 90 * 24 * 60 * 60 * 1000).toISOString(); // 90일 전
+
+  it("renders the strip with only recently changed docs when at least one exists", () => {
+    renderSidebar([makeDoc("a", "Recent Doc", recentIso), makeDoc("b", "Old Doc", oldIso)]);
+
+    expect(screen.getByTestId("docs-sidebar-recently-changed-list")).toBeInTheDocument();
+    expect(screen.getByText("Recent Doc")).toBeInTheDocument();
+    expect(screen.queryByText("Old Doc")).not.toBeInTheDocument();
+  });
+
+  it("hides the strip entirely when nothing changed in the last 7 days", () => {
+    renderSidebar([makeDoc("b", "Old Doc", oldIso)]);
+    expect(screen.queryByTestId("docs-sidebar-recently-changed-toggle")).not.toBeInTheDocument();
+  });
+
+  it("toggling the header collapses and re-expands the list", () => {
+    renderSidebar([makeDoc("a", "Recent Doc", recentIso)]);
+    const toggle = screen.getByTestId("docs-sidebar-recently-changed-toggle");
+    expect(screen.getByTestId("docs-sidebar-recently-changed-list")).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId("docs-sidebar-recently-changed-list")).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("docs-sidebar-recently-changed-list")).toBeInTheDocument();
+  });
+
+  it("clicking a doc in the strip calls onSelect with its slug", () => {
+    const { onSelect } = renderSidebar([makeDoc("a", "Recent Doc", recentIso)]);
+    fireEvent.click(screen.getByText("Recent Doc"));
+    expect(onSelect).toHaveBeenCalledWith("a");
+  });
+});

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import {
   ChevronDown,
+  Clock,
   FileText,
   Hash,
   PinOff,
@@ -10,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { VaultDoc, VaultManifest } from "@/entities/docs-vault";
+import { selectRecentVaultDocs } from "@/shared/lib/ontology-tree";
 import type { DocsVaultCollection } from "../../lib/docs-vault-collection";
 import { DocsVaultTree } from "@/widgets/docs-vault/ui/DocsVaultTree";
 import { Tooltip } from "@/shared/ui";
@@ -70,6 +72,17 @@ export function DocsSidebarBody({
 }: DocsSidebarBodyProps) {
   const t = useTranslations("vaultWidgets.parts.sidebar");
   const [treeQuery, setTreeQuery] = useState("");
+  // P4a — "최근 바뀐 문서" 진입점. `selectRecentVaultDocs` 는 INDEX 지도 렌즈
+  // (`useRecentChanges`)와 같은 mtime 7일 창 산수(`recent-changes.ts`)를
+  // 공유한다 — 문서함은 `VaultDoc.updatedAt` 을 직접 갖고 있어 온톨로지
+  // 노드처럼 evidenceIds 간접 조회가 필요 없다. 세션 스냅샷 시각 —
+  // `updatedAgoNowMs`(HomePage)와 같은 렌더-purity 이유로 mount 시 1회.
+  const [recentNowMs] = useState(() => Date.now());
+  const recentlyChangedDocs = useMemo(
+    () => selectRecentVaultDocs(manifest.docs, recentNowMs),
+    [manifest.docs, recentNowMs],
+  );
+  const [recentlyChangedOpen, setRecentlyChangedOpen] = useState(true);
   const normalizedTreeQuery = treeQuery.trim().toLowerCase();
   // 활성 태그가 매치하는 slug 집합 — DocsVaultTree 가 매 노드 재귀 시 .has()
   // 로 조회. 매 render 새 Set 만들면 트리 내부 useMemo 들이 활성/해제 무관
@@ -202,6 +215,58 @@ export function DocsSidebarBody({
             {t("clearFilter")}
           </button>
         </div>
+      ) : null}
+
+      {/* P4a — "최근 바뀐 문서" 접이식 스트립. `recentSlugs`(아래, 세션 중
+          방문한 문서)와는 다른 개념 — 이건 실제 mtime 이 최근 7일 안인
+          문서다. 새로 열 때마다 "지난 7일 뭐가 바뀌었나"에 클릭 0회로
+          답하도록 기본 펼침. */}
+      {recentlyChangedDocs.length > 0 ? (
+        <section className="flex-none border-b border-[color:var(--color-overlay-2)] pb-1">
+          <button
+            type="button"
+            onClick={() => setRecentlyChangedOpen((open) => !open)}
+            aria-expanded={recentlyChangedOpen}
+            data-testid="docs-sidebar-recently-changed-toggle"
+            className="flex w-full items-center gap-1.5 px-3 pb-1.5 pt-3 text-left transition-colors hover:text-[color:var(--color-text-secondary)]"
+          >
+            <Clock size={10} className="flex-none text-[color:var(--color-text-quaternary)]" aria-hidden />
+            <span className="flex-1 font-mono text-[9.5px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+              {t("recentlyChangedHeader", { count: recentlyChangedDocs.length })}
+            </span>
+            <ChevronDown
+              size={11}
+              aria-hidden
+              className={`flex-none text-[color:var(--color-text-quaternary)] transition-transform ${recentlyChangedOpen ? "rotate-180" : ""}`}
+            />
+          </button>
+          {recentlyChangedOpen ? (
+            <ul
+              data-testid="docs-sidebar-recently-changed-list"
+              className="flex max-h-[22vh] flex-col gap-0.5 overflow-auto px-2"
+            >
+              {recentlyChangedDocs.map((doc) => {
+                const active = selectedSlug === doc.slug;
+                return (
+                  <li key={doc.slug}>
+                    <button
+                      type="button"
+                      onClick={() => onSelect(doc.slug)}
+                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-[12px] transition-colors ${
+                        active
+                          ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
+                          : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+                      }`}
+                    >
+                      <FileText size={11} className="flex-none opacity-60" aria-hidden />
+                      <span className="min-w-0 flex-1 truncate">{doc.title}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </section>
       ) : null}
 
       {/* 항상 보이는 3 섹션 — Pinned / Vault / Recent. 트리(Vault)만 남는 공간을

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -14,7 +14,7 @@ import { useTranslations } from "next-intl";
 import { BookOpen, HelpCircle, Plus, Waypoints, X } from "lucide-react";
 import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
 import { useProjects } from "@/features/project-data-source";
-import { useOntologyInsight, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
+import { useOntologyInsight, useRecentChanges, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
 import {
   buildProjectMarkdown,
   deriveBootstrapPlan,
@@ -389,6 +389,9 @@ export function HomePage() {
   const { insight: ontologyInsight } = useOntologyInsight();
   // S-C1 — 노드 데이터시트 "언제 바뀌었나" (mode-aware manifest updatedAt).
   const docFreshnessIndex = useVaultDocFreshnessIndex();
+  // P4a — "최근 변경" 렌즈(mtime 7일 창). `computeRecentChanges` 순수 함수 +
+  // 이 훅과 같은 session-snapshot 시각 규율(`use-recent-changes.ts`).
+  const recentChanges = useRecentChanges();
   // "N일 전" 계산의 기준 시각 — 일 단위 해상도라 세션 시작 스냅샷이면 충분
   // (render 중 Date.now() 는 react-hooks/purity 위반; 세션 동안 라벨이
   // 흔들리지 않는 것도 changeBaseline 과 같은 이유로 오히려 바람직하다).
@@ -486,6 +489,13 @@ export function HomePage() {
       ontologyInsight?.nodes,
     );
   }, [hasFreshAgentHeartbeat, agentActivityStatus, ontologyInsight]);
+  // P4b — "에이전트가 방금" INDEX 배지. 이미 fresh-게이트를 통과한
+  // `agentFocusNodeId`(W6 지도 링과 같은 소스)가 최근-변경 렌즈 안에도 있을
+  // 때만 — 두 번째 매치 휴리스틱을 새로 만들지 않고 기존 신호를 그대로 재사용.
+  const agentAttributedRecentNodeId = useMemo(
+    () => (agentFocusNodeId && recentChanges.recentNodeIds.has(agentFocusNodeId) ? agentFocusNodeId : null),
+    [agentFocusNodeId, recentChanges],
+  );
   // S2 — 토폴로지에서 새 노드를 직접 생성. writable 로컬 vault 일 때만.
   const [createNodeOpen, setCreateNodeOpen] = useState(false);
   const createNodeToggleRef = useRef<HTMLButtonElement | null>(null);
@@ -2288,6 +2298,23 @@ export function HomePage() {
                       setAgentConnectNowMs(Date.now());
                       setAgentConnectOpen(true);
                     }}
+                    // P4a — 렌즈 필터용 id 집합 + P4b 배지 대상.
+                    recentChanges={{
+                      ids: recentChanges.recentNodeIds,
+                      agentAttributedNodeId: agentAttributedRecentNodeId,
+                    }}
+                    // P4c — "지도에 없는 문서 N개 · 올리기". `bootstrapPlan` 은
+                    // vault 가 로드되기만 하면(빈 지도든 아니든) 항상 계산돼
+                    // 있으므로 새 파생 없이 그 카운트를 그대로 노출한다 —
+                    // 클릭은 기존 "내 문서로 지도 만들기" 다이얼로그를 연다
+                    // (이전에는 지도가 완전히 빈 상태의 empty-state 에서만
+                    // 열렸다; 이 행은 지도가 이미 채워진 상태에서도 연다).
+                    uncatalogedDocCount={bootstrapPlan?.elements.length ?? 0}
+                    onPromoteUncatalogedDocs={
+                      bootstrapPlan && bootstrapPlan.elements.length > 0
+                        ? () => setBootstrapOpen(true)
+                        : undefined
+                    }
                     // 브랜드 필의 censusGrowthText 와 같은 출처(recentlyUpdatedCount)
                     // — feat/chrome-system §9, 헤더→푸터 이관.
                     footerGrowthText={
@@ -2329,6 +2356,15 @@ export function HomePage() {
                       elementsShort: t("index.elementsShort"),
                       freshTitle: t("index.freshTitle"),
                       emptyHint: t("index.emptyHint"),
+                      segmentAll: t("index.segmentAll"),
+                      segmentRecent: t("index.segmentRecent", { count: recentChanges.recentNodeIds.size }),
+                      segmentRecentAria: t("index.segmentRecentAria"),
+                      recentEmptyHint: t("index.recentEmptyHint"),
+                      agentBadge: t("index.agentBadge"),
+                      uncatalogedDocsLabel: t("index.uncatalogedDocsLabel", {
+                        count: bootstrapPlan?.elements.length ?? 0,
+                      }),
+                      uncatalogedDocsAction: t("index.uncatalogedDocsAction"),
                     }}
                   />
                 ) : (

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -57,6 +57,13 @@ const labels = {
   elementsShort: "elems",
   freshTitle: "recently updated",
   emptyHint: "No matches",
+  segmentAll: "All",
+  segmentRecent: "Recent changes 0",
+  segmentRecentAria: "Filter by recent changes",
+  recentEmptyHint: "Nothing changed in the last 7 days",
+  agentBadge: "Agent just now",
+  uncatalogedDocsLabel: "0 docs not on the map",
+  uncatalogedDocsAction: "Promote",
 };
 
 function buildFixtureTree() {
@@ -228,6 +235,154 @@ describe("TopologyIndexPanel", () => {
       relations: 478,
       domains: 6,
     });
+  });
+
+  it("P4a: omitting recentChanges skips the segment control entirely", () => {
+    render(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+      />,
+    );
+    expect(screen.queryByTestId("topology-index-segment-recent")).not.toBeInTheDocument();
+  });
+
+  it("P4a: the recent-changes segment filters the tree to the given ids and keeps ancestor chains", () => {
+    const treeResult = buildFixtureTree();
+    render(
+      <TopologyIndexPanel
+        treeResult={treeResult}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        recentChanges={{ ids: new Set(["element:agent-brief"]), agentAttributedNodeId: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("topology-index-segment-recent"));
+
+    expect(screen.getByText("Agent Brief")).toBeInTheDocument();
+    expect(screen.getByText("MCP Server")).toBeInTheDocument(); // ancestor chain preserved
+    expect(screen.queryByText("CLI Developer Entry")).not.toBeInTheDocument(); // unrelated sibling pruned
+  });
+
+  it("P4a: switching back to 'all' restores the full tree", () => {
+    const treeResult = buildFixtureTree();
+    render(
+      <TopologyIndexPanel
+        treeResult={treeResult}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        recentChanges={{ ids: new Set(["element:agent-brief"]), agentAttributedNodeId: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("topology-index-segment-recent"));
+    fireEvent.click(screen.getByTestId("topology-index-segment-all"));
+
+    expect(screen.queryByText("CLI Developer Entry")).not.toBeInTheDocument(); // still collapsed by default
+    const domainRow = screen.getByText("Onboarding & UX").closest('[data-index-row]')!;
+    fireEvent.click(domainRow.querySelector("button")!);
+    expect(screen.getByText("CLI Developer Entry")).toBeInTheDocument();
+  });
+
+  it("P4a: an empty recent-changes lens shows the dedicated empty hint, not the search one", () => {
+    render(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        recentChanges={{ ids: new Set(), agentAttributedNodeId: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("topology-index-segment-recent"));
+    expect(screen.getByText(labels.recentEmptyHint)).toBeInTheDocument();
+  });
+
+  it("P4b: renders the agent-attribution badge only on the matching row", () => {
+    render(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        recentChanges={{
+          ids: new Set(["capability:mcp-server"]),
+          agentAttributedNodeId: "capability:mcp-server",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("topology-index-segment-recent"));
+    expect(screen.getAllByTestId("topology-index-agent-badge")).toHaveLength(1);
+  });
+
+  it("P4c: renders the uncataloged-docs row only when count > 0 and a handler is given", () => {
+    const onPromote = vi.fn();
+    const { rerender } = render(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        uncatalogedDocCount={0}
+        onPromoteUncatalogedDocs={onPromote}
+      />,
+    );
+    expect(screen.queryByTestId("topology-index-uncataloged-docs")).not.toBeInTheDocument();
+
+    rerender(
+      <TopologyIndexPanel
+        treeResult={buildFixtureTree()}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+        uncatalogedDocCount={3}
+        onPromoteUncatalogedDocs={onPromote}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("topology-index-uncataloged-docs"));
+    expect(onPromote).toHaveBeenCalledTimes(1);
   });
 
   it("수렴 스펙 ①: 헤더는 시각 카운트를 렌더하지 않는다 (지형도 HUD 와 3중 중복 해소, sr-only census 만 존치)", () => {

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { ChevronLeft, Search } from "lucide-react";
 import {
+  filterTreeByNodeIds,
   filterTreeByQuery,
   type OntologyTreeBuildResult,
 } from "@/shared/lib/ontology-tree";
@@ -27,6 +28,18 @@ export interface TopologyIndexPanelLabels {
   elementsShort: string;
   freshTitle: string;
   emptyHint: string;
+  /** P4a — 렌즈 세그먼트 "전체". */
+  segmentAll: string;
+  /** P4a — 렌즈 세그먼트 "최근 변경 N"(호출자가 count 를 이미 포맷). */
+  segmentRecent: string;
+  segmentRecentAria: string;
+  /** P4a — "최근 변경" 렌즈가 활성인데 결과가 0일 때. */
+  recentEmptyHint: string;
+  /** P4b — heartbeat 귀속 배지. */
+  agentBadge: string;
+  /** P4c — "지도에 없는 문서 N개"(호출자가 count 를 이미 포맷). */
+  uncatalogedDocsLabel: string;
+  uncatalogedDocsAction: string;
 }
 
 export interface TopologyIndexPanelProps {
@@ -57,6 +70,21 @@ export interface TopologyIndexPanelProps {
     syncText: string;
     labels: TopologyIndexAgentHandoffLabels;
   };
+  /**
+   * P4a — "최근 변경" 렌즈(mtime 7일 창, `useRecentChanges`). 생략하면 세그먼트
+   * 컨트롤 자체를 렌더하지 않는다(기존 검색-only 동작 그대로). 활성화하면
+   * `filterTreeByNodeIds` 로 트리를 이 id 집합 + 조상 경로만으로 좁힌다 —
+   * `filterTreeByQuery` 와 같은 "부모 chain 보존" 필터 메커니즘 재사용.
+   */
+  recentChanges?: {
+    ids: ReadonlySet<string>;
+    /** P4b — fresh heartbeat 의 focus 와 일치하는 노드(있다면) 하나. */
+    agentAttributedNodeId: string | null;
+  } | null;
+  /** P4c — vault 에 있지만 아직 kind 없는(=지도에 없는) 문서 수. */
+  uncatalogedDocCount?: number;
+  /** P4c — 위 행 클릭 → "내 문서로 지도 만들기" 다이얼로그(`bootstrapOpen`). */
+  onPromoteUncatalogedDocs?: (() => void) | null;
 }
 
 /**
@@ -89,18 +117,27 @@ export function TopologyIndexPanel({
   className,
   footerGrowthText,
   agentHandoff,
+  recentChanges = null,
+  uncatalogedDocCount,
+  onPromoteUncatalogedDocs = null,
   onOpenAgentConnect = null,}: TopologyIndexPanelProps) {
   const [query, setQuery] = useState("");
   const [openIds, setOpenIds] = useState<Set<string>>(
     () => new Set(treeResult.roots.map((root) => root.node.id)),
   );
+  // P4a — "최근 변경" 렌즈. 검색이 활성이면 검색이 우선한다(둘을 동시에 좁히면
+  // "왜 안 보이지"가 두 원인으로 갈라져 헷갈린다) — 렌즈는 검색이 비어 있을
+  // 때만 트리를 좁힌다.
+  const [lens, setLens] = useState<"all" | "recent">("all");
   const trimmedQuery = query.trim();
   const isFiltering = trimmedQuery.length > 0;
+  const lensActive = !isFiltering && lens === "recent" && recentChanges !== null;
 
-  const visibleRoots = useMemo(
-    () => (isFiltering ? filterTreeByQuery(treeResult.roots, trimmedQuery) : treeResult.roots),
-    [treeResult.roots, isFiltering, trimmedQuery],
-  );
+  const visibleRoots = useMemo(() => {
+    if (isFiltering) return filterTreeByQuery(treeResult.roots, trimmedQuery);
+    if (lensActive && recentChanges) return filterTreeByNodeIds(treeResult.roots, recentChanges.ids);
+    return treeResult.roots;
+  }, [treeResult.roots, isFiltering, trimmedQuery, lensActive, recentChanges]);
   const maxDomainDescendantCount = useMemo(() => {
     const domains = treeResult.roots.flatMap((root) =>
       root.children.filter((child) => child.node.kind === "domain"),
@@ -116,7 +153,10 @@ export function TopologyIndexPanel({
       return next;
     });
   };
-  const isOpen = (nodeId: string) => isFiltering || openIds.has(nodeId);
+  // 검색과 마찬가지로 렌즈 활성 시에도 자동 펼침 — 좁혀진 조상 경로를 사용자가
+  // 일일이 캐럿으로 열지 않게 한다(filterTreeByQuery 의 "auto-reveal matches"
+  // 와 같은 UX 계약, filterTreeByNodeIds 결과에도 그대로 적용).
+  const isOpen = (nodeId: string) => isFiltering || lensActive || openIds.has(nodeId);
 
   return (
     <aside
@@ -190,6 +230,46 @@ export function TopologyIndexPanel({
         />
       </div>
 
+      {/* P4a — "전체 | 최근 변경 N" 렌즈 세그먼트. `recentChanges` 를 안 받으면
+          (mode 가 아직 못 계산했거나 호출자가 생략) 렌더 자체를 skip —
+          기존 검색-only 동작 그대로 유지된다. */}
+      {recentChanges ? (
+        <div
+          role="tablist"
+          aria-label={labels.segmentRecentAria}
+          className="mb-3 grid shrink-0 grid-cols-2 gap-1 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-overlay-1)] p-1"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={!lensActive}
+            data-testid="topology-index-segment-all"
+            onClick={() => setLens("all")}
+            className={`min-w-0 rounded-[var(--chrome-radius-inner)] px-2 py-1 text-[11px] transition-colors ${
+              !lensActive
+                ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--topology-v2-panel-text-primary)]"
+                : "text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+            }`}
+          >
+            {labels.segmentAll}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={lensActive}
+            data-testid="topology-index-segment-recent"
+            onClick={() => setLens("recent")}
+            className={`min-w-0 truncate rounded-[var(--chrome-radius-inner)] px-2 py-1 text-[11px] transition-colors ${
+              lensActive
+                ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--topology-v2-panel-text-primary)]"
+                : "text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+            }`}
+          >
+            {labels.segmentRecent}
+          </button>
+        </div>
+      ) : null}
+
       <nav
         role="tree"
         aria-label={labels.label}
@@ -198,7 +278,7 @@ export function TopologyIndexPanel({
       >
         {visibleRoots.length === 0 ? (
           <p className="px-1 py-2 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-            {labels.emptyHint}
+            {lensActive ? labels.recentEmptyHint : labels.emptyHint}
           </p>
         ) : (
           visibleRoots.map((root) => (
@@ -211,12 +291,33 @@ export function TopologyIndexPanel({
               onSelect={onSelect}
               selectedId={selectedId}
               changedSlugs={changedSlugs}
+              agentAttributedNodeId={recentChanges?.agentAttributedNodeId ?? null}
               maxDomainDescendantCount={maxDomainDescendantCount}
               labels={labels}
             />
           ))
         )}
       </nav>
+
+      {/* P4c — "지도에 없는 문서 N개" 조용한 행. `bootstrapPlan.elements.length`
+          (HomePage, `deriveBootstrapPlan` — 이미 kind 있는 문서는 제외된
+          카운트) 를 그대로 받는다 — 새 파생 없음. 0 이거나 승격 핸들러가
+          없으면 행 자체를 숨긴다. */}
+      {uncatalogedDocCount && uncatalogedDocCount > 0 && onPromoteUncatalogedDocs ? (
+        <button
+          type="button"
+          onClick={onPromoteUncatalogedDocs}
+          data-testid="topology-index-uncataloged-docs"
+          className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+        >
+          <span className="min-w-0 flex-1 truncate text-[color:var(--topology-v2-panel-text-tertiary)]">
+            {labels.uncatalogedDocsLabel}
+          </span>
+          <span className="shrink-0 text-[color:var(--color-indigo-accent)]">
+            {labels.uncatalogedDocsAction}
+          </span>
+        </button>
+      ) : null}
 
       {/* v2.1 푸터 — 구 헤더의 "● 에이전트 동기화" 문구 + 성장 신호가
           여기로 이관. 단축키 캡은 장식(⇧⌘K 는 전역 팔레트가 이미 쓰는

--- a/src/widgets/topology-index-panel/ui/TopologyIndexTreeRow.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexTreeRow.tsx
@@ -13,6 +13,8 @@ export interface TopologyIndexTreeRowLabels {
   capabilitiesShort: string;
   elementsShort: string;
   freshTitle: string;
+  /** P4b — "에이전트가 방금" 귀속 배지. */
+  agentBadge?: string;
 }
 
 export interface TopologyIndexTreeRowProps {
@@ -23,6 +25,8 @@ export interface TopologyIndexTreeRowProps {
   onSelect: (nodeId: string) => void;
   selectedId: string | null;
   changedSlugs: ReadonlySet<string>;
+  /** P4b — fresh heartbeat 의 focus 와 일치하는 노드 하나(있다면). */
+  agentAttributedNodeId?: string | null;
   maxDomainDescendantCount: number;
   labels: TopologyIndexTreeRowLabels;
 }
@@ -54,6 +58,7 @@ export function TopologyIndexTreeRow({
   onSelect,
   selectedId,
   changedSlugs,
+  agentAttributedNodeId = null,
   maxDomainDescendantCount,
   labels,
 }: TopologyIndexTreeRowProps) {
@@ -62,6 +67,7 @@ export function TopologyIndexTreeRow({
   const open = isOpen(node.id);
   const selected = selectedId === node.id;
   const fresh = changedSlugs.has(node.id);
+  const agentAttributed = agentAttributedNodeId !== null && agentAttributedNodeId === node.id;
   const isDomain = node.kind === "domain";
   const subcounts = isDomain ? computeDomainSubcounts(entry) : null;
   const capacityRatio = subcounts
@@ -128,6 +134,14 @@ export function TopologyIndexTreeRow({
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-1.5">
             <span className="min-w-0 flex-1 truncate">{node.title}</span>
+            {agentAttributed && labels.agentBadge ? (
+              <span
+                data-testid="topology-index-agent-badge"
+                className="shrink-0 font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--topology-v2-panel-text-tertiary)]"
+              >
+                {labels.agentBadge}
+              </span>
+            ) : null}
             {fresh ? (
               <span
                 title={labels.freshTitle}
@@ -171,6 +185,7 @@ export function TopologyIndexTreeRow({
               onSelect={onSelect}
               selectedId={selectedId}
               changedSlugs={changedSlugs}
+              agentAttributedNodeId={agentAttributedNodeId}
               maxDomainDescendantCount={maxDomainDescendantCount}
               labels={labels}
             />


### PR DESCRIPTION
## Summary
- **4a**: 순수 `recent-changes.ts`(mtime 7일 창, 18 fixture — 지도/문서함이 같은 창 함수 공유로 N2 재생산 차단) + mode-aware 훅 + INDEX "전체 | 최근 변경 N" 세그먼트(기존 조상 보존 필터 재사용) + 문서함 "최근 바뀐 문서 N" 스트립. **지도 dim 미구현** — ego 채널이 단일 focusedNodeId 설계라 얕은 경로 없음(계획 허용 조항, 사유 기록).
- **4b**: "에이전트가 방금" 배지(기존 `resolveAgentFocusNodeId` 재사용, 새 휴리스틱 0) + LiveActivity 에 `--clear` 안내(전략 메모 투명성 조건).
- **4c**: INDEX 푸터 "지도에 없는 문서 N개 · 올리기" — 기존 bootstrapPlan 재사용, 부분 구축 vault 에서도 부트스트랩 도달(discovery Slice 2/3).

## Test plan
- 신규 18+13+4 테스트 — 관련 5영역 **556 pass** · tsc 0 · eslint 에러 0 · i18n 17 · check-no-raw-color clean
- **실화면**: 세그먼트 "최근 변경 228" 클릭 → 필터 작동 · 문서함 스트립 "최근 바뀐 문서 · 22" (`p4-recent-lens.png`). 3클릭 경로 충족(지도 2클릭).
- 미구현·사유: 지도 dim(엔진 수술) — 로드맵 후보로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)