### PR TITLE
fix: Guardian 최종 총괄 교정 — R-1·C-1·C-2·C-3

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1241,6 +1241,9 @@
        답하게 한다. 로그 압축이라 103짜리 도메인이 9짜리의 ~1.2배 — 순위
        단서이지 막대그래프가 아니다. */
     --topology-v2-radius-magnitude-k: 0.45;
+    /* B3 잔여 — dust 시차 깊이 범위 (그리드 1.0 대비 느린 흐름). */
+    --topology-v2-dust-parallax-min: 0.15;
+    --topology-v2-dust-parallax-max: 0.45;
     --topology-v2-edge-depends: #4c4c63;
     --topology-v2-edge-dim: #1e1e22;
     --topology-v2-hull-stroke: #3a3a42;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ---
 
+## 2026-07-21 — Guardian 최종 총괄 교정 (R-1 · C-1~C-3)
+
+라운드 총괄 판정(조건부 승인)의 반려·조건부 4건 즉시 교정:
+- **R-1 엣지 팝오버**: raw `<a>` 2개가 locale prefix 없이 404/500 —
+  `@/i18n/navigation` `Link` 로 교체(실측 200/200) + Esc 1단이 팝오버를
+  닫도록 사다리 최상단 소비 추가.
+- **C-1 dust 결정론**: depth 만 `Math.random()` 이던 자기 계약 위반 —
+  seed rng 로 복원 + 시차 깊이 토큰 승격(`--topology-v2-dust-parallax-min/max`)
+  + 결정론 테스트.
+- **C-2**: 연결 시트 agentLabel ko 하드코딩 → i18n.
+- **C-3 최근 변경 렌즈**: 세션 스냅샷 + 미래-제외가 결합해 "방금 만든
+  노드 직후 최근 변경 0" 자기모순 — 24h 미래 허용 창("오늘"로 포함),
+  진짜 skew 만 제외. 계약 테스트 갱신.
+
+잔여(다음 라운드): I-1 도메인 수준 census 3원 장부 · B5/연결시트
+데스크톱 분기의 설치 앱 proof(Tauri 전용) · 부트스트랩 토스트 4연발
+단일 요약화 · 샘플 mtime git-date 화.
+
 ## 2026-07-21 — 판정·입력 표면: 문서함 절삭 3건 · frontmatter 판정 액션 · kind-first 새 문서 · 빌더 입력기 3종 (P5)
 
 근거: `.qa-scratch/docs-identity-2026-07/verdict.md` (문서함 = 의미 편집실

--- a/messages/en.json
+++ b/messages/en.json
@@ -2700,6 +2700,7 @@
     "previewLabel": "Once connected, the agent reads it like this",
     "previewSentence": "\"This project is made of {domains}, and each document is its evidence.\"",
     "copyHandoff": "Copy handoff text",
-    "handoffCopied": "Copied"
+    "handoffCopied": "Copied",
+    "defaultAgentLabel": "the agent"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2700,6 +2700,7 @@
     "previewLabel": "연결되면 에이전트는 이렇게 읽어요",
     "previewSentence": "\"이 프로젝트는 {domains} 영역으로 이루어져 있고, 각 문서가 그 근거입니다.\"",
     "copyHandoff": "인계 텍스트 복사",
-    "handoffCopied": "복사됨"
+    "handoffCopied": "복사됨",
+    "defaultAgentLabel": "에이전트"
   }
 }

--- a/src/shared/lib/ontology-tree/recent-changes.test.ts
+++ b/src/shared/lib/ontology-tree/recent-changes.test.ts
@@ -40,8 +40,11 @@ describe("isWithinRecentWindow", () => {
     expect(isWithinRecentWindow("not-a-date", NOW, 7)).toBe(false);
   });
 
-  it("is false for a future-dated (clock skew) value", () => {
-    expect(isWithinRecentWindow("2026-07-22T00:00:00.000Z", NOW, 7)).toBe(false);
+  it("허용 창(24h) 밖의 미래만 제외한다 — C-3 계약 갱신", () => {
+    // NOW = 2026-07-21T12:00Z. +12h 는 세션 중 생성으로 간주 → 포함.
+    expect(isWithinRecentWindow("2026-07-22T00:00:00.000Z", NOW, 7)).toBe(true);
+    // +25h 는 진짜 skew → 제외.
+    expect(isWithinRecentWindow("2026-07-22T13:00:00.000Z", NOW, 7)).toBe(false);
   });
 
   it("defaults to a 7-day window", () => {
@@ -150,3 +153,17 @@ describe("selectRecentVaultDocs", () => {
     expect(selectRecentVaultDocs([doc("old", "2025-01-01T00:00:00.000Z")], NOW)).toEqual([]);
   });
 });
+/** C-3 (Guardian 실증) — 세션 중 생성된 문서(스냅샷보다 미래 mtime)는 "오늘". */
+describe("future-tolerance (session-created docs)", () => {
+  const NOW = Date.parse("2026-07-21T12:00:00Z");
+  it("스냅샷 이후 1시간 뒤 생성 문서도 최근에 포함된다", () => {
+    const iso = new Date(NOW + 60 * 60 * 1000).toISOString();
+    expect(isWithinRecentWindow(iso, NOW, 7)).toBe(true);
+    expect(daysAgoFromIso(iso, NOW)).toBe(0);
+  });
+  it("24h 를 넘는 미래(진짜 skew)는 여전히 제외", () => {
+    const iso = new Date(NOW + 25 * 60 * 60 * 1000).toISOString();
+    expect(isWithinRecentWindow(iso, NOW, 7)).toBe(false);
+  });
+});
+

--- a/src/shared/lib/ontology-tree/recent-changes.ts
+++ b/src/shared/lib/ontology-tree/recent-changes.ts
@@ -19,9 +19,17 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 export const RECENT_CHANGES_DEFAULT_WINDOW_DAYS = 7;
 
 /**
+ * C-3 (Guardian 총괄) — "약간 미래" 허용 창. `nowMs` 는 세션 첫-렌더
+ * 스냅샷이라, 세션 도중 만들어진 문서(첫 지도 부트스트랩 등)는 mtime 이
+ * 스냅샷보다 미래다. 이걸 전부 제외하면 "방금 만든 노드 6개 직후 최근
+ * 변경 0"이라는 자기모순이 실증됐다. 24h 안의 미래는 "지금(오늘)"으로
+ * 포함하고, 그 밖(진짜 clock skew/데이터 이상)만 제외한다.
+ */
+const FUTURE_TOLERANCE_MS = 24 * 60 * 60 * 1000;
+
+/**
  * `updatedAtIso` 가 `nowMs` 기준 `windowDays` 안(과거)에 들어오는지. 파싱 불가
- * 값은 false(모른다≠최근). 미래 날짜(clock skew)도 false로 취급 — "방금"이
- * 아니라 데이터 이상이므로 렌즈에 끼워 넣지 않는다.
+ * 값은 false(모른다≠최근). 미래는 24h 허용 창 안이면 "오늘"로 포함.
  */
 export function isWithinRecentWindow(
   updatedAtIso: string,
@@ -31,7 +39,7 @@ export function isWithinRecentWindow(
   const updatedMs = Date.parse(updatedAtIso);
   if (!Number.isFinite(updatedMs)) return false;
   const ageMs = nowMs - updatedMs;
-  if (ageMs < 0) return false;
+  if (ageMs < -FUTURE_TOLERANCE_MS) return false;
   return ageMs <= windowDays * DAY_MS;
 }
 
@@ -39,7 +47,8 @@ export function isWithinRecentWindow(
 export function daysAgoFromIso(updatedAtIso: string, nowMs: number): number {
   const updatedMs = Date.parse(updatedAtIso);
   if (!Number.isFinite(updatedMs)) return Number.POSITIVE_INFINITY;
-  return Math.floor((nowMs - updatedMs) / DAY_MS);
+  // 허용 창 안의 미래(세션 중 생성)는 0일 = "오늘" (음수 일수 방지).
+  return Math.max(0, Math.floor((nowMs - updatedMs) / DAY_MS));
 }
 
 export interface RecentChangeRow {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -581,8 +581,8 @@ export function HomePage() {
     const focusTitle = focusSlug
       ? (ontologyInsight?.nodes.find((n) => n.evidenceIds[0] === focusSlug || n.id === focusSlug)?.title ?? focusSlug)
       : null;
-    return { kind: "connected", agentLabel: hb.agent ?? "에이전트", agoLabel: ago, focusTitle };
-  }, [agentActivityStatus, ontologyInsight, agentConnectNowMs]);
+    return { kind: "connected", agentLabel: hb.agent ?? t("agentConnect.defaultAgentLabel"), agoLabel: ago, focusTitle };
+  }, [agentActivityStatus, ontologyInsight, agentConnectNowMs, t]);
   const agentConnectSnippets = useMemo(() => {
     const vaultName = vault.handle?.name ?? "my-vault";
     const desktopPath = vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null;
@@ -1249,6 +1249,12 @@ export function HomePage() {
     const handler = (event: globalThis.KeyboardEvent) => {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
+      // R-1 (Guardian 총괄) — 엣지 팝오버가 열려 있으면 Esc 1단은 그것부터
+      // 닫는다 (사다리 최상단 소비 — 노드 팝오버와 같은 계약).
+      if (selectedEdge !== null) {
+        setSelectedEdge(null);
+        return;
+      }
       const action = resolveTopologyEscLadderAction({
         contextMenuOpen: contextMenuNode !== null,
         createNodeOpen,
@@ -1293,8 +1299,7 @@ export function HomePage() {
     localGraphRoot,
     closeContextMenu,
     closeCreateNode,
-    handleClose,
-  ]);
+    handleClose,, selectedEdge]);
 
   const handleSelectImpactMode = useCallback(
     (nextMode: ProjectImpactMode) => {

--- a/src/widgets/topology-map-v2/render/starfield.test.ts
+++ b/src/widgets/topology-map-v2/render/starfield.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeStarDustCount } from "./starfield";
+import { computeStarDustCount, buildDustPoints } from "./starfield";
 
 const AREA_PER_POINT = 5200; // --topology-v2-dust-area-per-point
 
@@ -23,5 +23,18 @@ describe("computeStarDustCount", () => {
 
   it("returns 0 for a degenerate zero-area viewport", () => {
     expect(computeStarDustCount(0, 900, AREA_PER_POINT)).toBe(0);
+  });
+});
+
+/** C-1 (Guardian 총괄) — depth 도 seed 결정론: 같은 입력 = 같은 dust. */
+describe("buildDustPoints depth determinism", () => {
+  it("두 번 생성해도 depth 까지 동일하고 범위 안이다", () => {
+    const a = buildDustPoints(800, 600, 24, 0.15, 0.45);
+    const b = buildDustPoints(800, 600, 24, 0.15, 0.45);
+    expect(a.map((pt) => pt.depth)).toEqual(b.map((pt) => pt.depth));
+    for (const p of a) {
+      expect(p.depth).toBeGreaterThanOrEqual(0.15);
+      expect(p.depth).toBeLessThanOrEqual(0.45);
+    }
   });
 });

--- a/src/widgets/topology-map-v2/render/starfield.ts
+++ b/src/widgets/topology-map-v2/render/starfield.ts
@@ -67,8 +67,13 @@ export function buildDustPoints(
   const rng = mulberry32(7);
   const points: DustPoint[] = [];
   for (let i = 0; i < count; i += 1) {
-    points.push({ x: rng() * viewportWidth, y: rng() * viewportHeight, r: 0.4 + rng() * 0.7, alpha: 0.02 + rng() * 0.04,
-      depth: depthMin + Math.random() * (depthMax - depthMin),
+    points.push({
+      x: rng() * viewportWidth,
+      y: rng() * viewportHeight,
+      r: 0.4 + rng() * 0.7,
+      alpha: 0.02 + rng() * 0.04,
+      // C-1 (Guardian) — depth 도 같은 seed rng: 이 함수의 결정론 계약 유지.
+      depth: depthMin + rng() * (depthMax - depthMin),
     });
   }
   return points;

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -110,6 +110,8 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-edge-passthrough-alpha": "0.3",
   "--topology-v2-node-min-separation-ratio": "1.35",
   "--topology-v2-radius-magnitude-k": "0.45",
+  "--topology-v2-dust-parallax-min": "0.15",
+  "--topology-v2-dust-parallax-max": "0.45",
 
   "--topology-v2-safe-inset-left": "344",
   "--topology-v2-safe-inset-right": "120",

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -160,6 +160,9 @@ export interface TopologyV2Tokens {
   nodeMinSeparationRatio: number;
   /** `--topology-v2-radius-magnitude-k` — log-compressed magnitude encoding strength for domain/capability radii (B4). */
   radiusMagnitudeK: number;
+  /** `--topology-v2-dust-parallax-min/max` — dust 시차 깊이 범위 (B3 잔여). */
+  dustParallaxMin: number;
+  dustParallaxMax: number;
 
   // 2.5 안전 영역 (fixed chrome inset, px — 라벨 컬링 + 카메라 fit)
   safeInsetLeft: number;
@@ -276,6 +279,8 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "edgePassthroughAlpha", cssVar: "--topology-v2-edge-passthrough-alpha", kind: "number" },
   { key: "nodeMinSeparationRatio", cssVar: "--topology-v2-node-min-separation-ratio", kind: "number" },
   { key: "radiusMagnitudeK", cssVar: "--topology-v2-radius-magnitude-k", kind: "number" },
+  { key: "dustParallaxMin", cssVar: "--topology-v2-dust-parallax-min", kind: "number" },
+  { key: "dustParallaxMax", cssVar: "--topology-v2-dust-parallax-max", kind: "number" },
 
   { key: "safeInsetLeft", cssVar: "--topology-v2-safe-inset-left", kind: "number" },
   { key: "safeInsetRight", cssVar: "--topology-v2-safe-inset-right", kind: "number" },

--- a/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
+import { Link } from "@/i18n/navigation";
 
 /**
  * P3b — 엣지 팝오버. 노드 데이터시트와 같은 재질(panel 토큰)로, 관계
@@ -117,23 +118,23 @@ export function TopologyV2EdgePanel({
             {labels.declaredByLabel}
             {updatedAtLabel ? ` · ${updatedAtLabel}` : ""}
           </span>
-          <a
+          <Link
             href={declaredBy.href}
             data-testid="topology-v2-edge-declared-by"
             className="truncate font-mono text-[11px] text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)]"
           >
             {declaredBy.slug}.md → {labels.openDoc}
-          </a>
+          </Link>
         </div>
       ) : null}
 
-      <a
+      <Link
         href={builderEditHref}
         data-testid="topology-v2-edge-edit"
         className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--topology-v2-panel-action-border)] bg-[color:var(--topology-v2-panel-action-surface)] text-[11.5px] text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
       >
         {labels.editRelation}
-      </a>
+      </Link>
     </aside>
   );
 }

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -320,7 +320,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           baseColor: tokens.canvasBgNear,
         });
       }
-      dustPointsRef.current = buildDustPoints(rect.width, rect.height, computeStarDustCount(rect.width, rect.height, tokens.dustAreaPerPoint));
+      dustPointsRef.current = buildDustPoints(rect.width, rect.height, computeStarDustCount(rect.width, rect.height, tokens.dustAreaPerPoint), tokens.dustParallaxMin, tokens.dustParallaxMax);
       trySnapInitialCamera(tokens);
     };
 


### PR DESCRIPTION
## Summary
총괄 판정(`.qa-scratch/final-guardian-2026-07/verdict.md`)의 반려 1 + 조건부 3 전건 교정:
- **R-1**: 엣지 팝오버 `<a>`→i18n `Link`(실측 **200/200**, 이전 404/500) + Esc 사다리 최상단 소비(실측 닫힘)
- **C-1**: dust depth seed 결정론 복원 + `--topology-v2-dust-parallax-min/max` 토큰 승격 + 결정론 테스트
- **C-2**: agentLabel i18n
- **C-3**: 렌즈 24h 미래 허용 창(세션 중 생성 문서="오늘") — Guardian 실증 자기모순 해소, 계약 테스트 갱신

## Test plan
- 관련 3영역 **759 pass** · tsc 0 · eslint 에러 0 · i18n 게이트 · 토큰 픽스처 102
- **실화면**: 엣지 팝오버 href `/ko/` prefix + 200/200 + Esc 닫힘 확인
- 잔여(I-1 도메인 census·설치앱 proof·토스트 정리) CHANGELOG 에 다음 라운드 등재

🤖 Generated with [Claude Code](https://claude.com/claude-code)