### PR TITLE
fix: 페르소나 재검 신규 마찰 교정 — 승격 병합·로그 dedupe·relate --why

### DIFF
--- a/cli/src/commands/relate.mjs
+++ b/cli/src/commands/relate.mjs
@@ -21,14 +21,14 @@ import { COLORS } from '../lib/colors.mjs';
 import { runRelationCheckQuery, renderRelationCheckResult } from '../lib/relation-preflight.mjs';
 import { validateRelationTypeList } from '../lib/relation-types.mjs';
 import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
-import { normalizeRelationRefs, readDocFrontmatter, writeFrontmatterKey } from '../lib/write-vault.mjs';
+import { normalizeRelationRefs, readDocFrontmatter, writeFrontmatterKey, writeFrontmatterKeys } from '../lib/write-vault.mjs';
 import {
   formatUnknownFlagError,
   parseVaultFlag,
   resolveTrailingVaultArg,
 } from '../lib/cli-args.mjs';
 
-const ALLOWED_FLAGS = ['--vault', '--json', '--dry-run'];
+const ALLOWED_FLAGS = ['--vault', '--json', '--dry-run', '--why'];
 
 // type (public, what relation-check/add_relation accept) → frontmatter array
 // key. Mirrors mcp/src/index.js's RELATION_KEY — CLI keeps its own copy
@@ -46,7 +46,7 @@ const RELATION_KEY = Object.freeze({
 });
 
 export async function runRelate(args) {
-  const { from, to, type, vault, json, dryRun, error, help } = parseArgs(args);
+  const { from, to, type, vault, json, dryRun, why, error, help } = parseArgs(args);
   if (help) {
     printUsage(process.stdout);
     return 0;
@@ -94,7 +94,7 @@ export async function runRelate(args) {
   }
 
   try {
-    const filePath = writeRelation(vaultRoot, { from: check.from, to: check.to, relation: check.relation });
+    const filePath = writeRelation(vaultRoot, { from: check.from, to: check.to, relation: check.relation, why });
     if (json) {
       process.stdout.write(JSON.stringify({ ...check, written: true, dryRun: false, alreadyExists: false, filePath }, null, 2) + '\n');
     } else {
@@ -117,8 +117,10 @@ export async function runRelate(args) {
  *    (add_relation 과 동일하게) 거부 — patch_concept/직접 편집으로 유도.
  *  - 그 외 → 배열에 append + normalizeRelationRefs (정렬 + 중복 제거).
  */
-function writeRelation(rootPath, { from, to, relation }) {
-  const key = RELATION_KEY[relation];
+function writeRelation(rootPath, { from, to, relation, why = null }) {
+  // preflight 는 이미 frontmatter 키('dependencies' 등)를 relation 으로
+  // 돌려주기도 한다 — 타입/키 양쪽 표기를 수용한다.
+  const key = RELATION_KEY[relation] ?? relation;
   const { frontmatter } = readDocFrontmatter(rootPath, from);
   if (key === 'domain') {
     const existingDomain = frontmatter.domain;
@@ -131,12 +133,20 @@ function writeRelation(rootPath, { from, to, relation }) {
   }
   const existing = Array.isArray(frontmatter[key]) ? frontmatter[key] : [];
   const next = normalizeRelationRefs([...existing, to]);
+  // P6 — --why: 관계와 근거를 같은 쓰기로 (MCP add_relation why 미러).
+  if (typeof why === 'string' && why.trim()) {
+    const notes = frontmatter.relation_notes && typeof frontmatter.relation_notes === 'object'
+      ? { ...frontmatter.relation_notes }
+      : {};
+    notes[to] = why.trim();
+    return writeFrontmatterKeys(rootPath, from, { [key]: next, relation_notes: notes });
+  }
   return writeFrontmatterKey(rootPath, from, key, next);
 }
 
 function parseArgs(args) {
   if (args.includes('--help') || args.includes('-h')) return { help: true };
-  const flags = { vault: null, json: false, dryRun: false };
+  const flags = { vault: null, json: false, dryRun: false, why: null };
   const positional = [];
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
@@ -144,6 +154,8 @@ function parseArgs(args) {
     else if (a.startsWith('--vault=')) flags.vault = parseVaultFlag(a.slice('--vault='.length));
     else if (a === '--json') flags.json = true;
     else if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--why') flags.why = args[++i] ?? null;
+    else if (a.startsWith('--why=')) flags.why = a.slice('--why='.length);
     else if (a.startsWith('-')) return { error: formatUnknownFlagError(a, ALLOWED_FLAGS) };
     else positional.push(a);
   }
@@ -164,6 +176,7 @@ function parseArgs(args) {
     vault: vaultResult.vault,
     json: flags.json,
     dryRun: flags.dryRun,
+    why: flags.why,
   };
 }
 

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -3127,6 +3127,40 @@ await test('explain --json — unrelated verdict exits non-zero with evidence pa
   }
 });
 
+await test('relate — depends_on 관계를 from 문서 frontmatter 에 쓴다', async () => {
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+    { slug: 'b', content: '---\nkind: capability\ntitle: B\n---\n' },
+  ]);
+  try {
+    const r = await run(['relate', 'a', 'b', 'depends_on', root]);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const doc = readFileSync(join(root, 'a.md'), 'utf-8');
+    assert.match(doc, /dependencies: \[b\]/);
+    assert.doesNotMatch(doc, /relation_notes/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test('relate --why — 관계와 relation_notes 근거를 같은 쓰기로 남긴다 (P6)', async () => {
+  const root = withVault([
+    { slug: 'a', content: '---\nkind: capability\ntitle: A\n---\n' },
+    { slug: 'b', content: '---\nkind: capability\ntitle: B\n---\n' },
+  ]);
+  try {
+    // parseArgs 가 why 를 반환 계약에서 빠뜨리면 관계만 쓰이고 근거가
+    // 조용히 증발한다 — 그 회귀를 파일 내용으로 잡는다.
+    const r = await run(['relate', 'a', 'b', 'depends_on', root, '--why', 'A 의 쓰기 경로가 B 를 지난다']);
+    assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    const doc = readFileSync(join(root, 'a.md'), 'utf-8');
+    assert.match(doc, /dependencies: \[b\]/);
+    assert.match(doc, /relation_notes: \{ b: A 의 쓰기 경로가 B 를 지난다 \}/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test('explain --json — fails closed on malformed explain_relation payloads before output', async () => {
   const root = withVault();
   const fakeMcp = join(root, 'fake-mcp-explain-malformed.mjs');
@@ -5523,7 +5557,9 @@ await test('agent-brief --help — documents handoff and exit gates', async () =
   assert.match(clean, /--fallback-slow-ms N/);
   assert.match(clean, /OATLAS_AGENT_FALLBACK_TIMEOUT_MS=N/);
   assert.match(clean, /OATLAS_AGENT_FALLBACK_SLOW_MS=N/);
-  assert.match(clean, /Exits non-zero when readiness is not ready/);
+  // #453 이 exit 의미를 0/1/2 서술로 확장 — 옛 한 줄 문구 대신 새 계약을 단언.
+  assert.match(clean, /0 = ready and healthy/);
+  assert.match(clean, /pass --exit-zero to always exit 0/);
   assert.match(clean, /Tuning flags forward to query_ontology agent_brief/);
 });
 

--- a/cli/src/lib/write-vault.mjs
+++ b/cli/src/lib/write-vault.mjs
@@ -62,8 +62,13 @@ export function readDocFrontmatter(rootPath, slug) {
  * `add`/`import` 커맨드와 같은 관례). R+ `relate` 커맨드가 사용.
  */
 export function writeFrontmatterKey(rootPath, slug, key, value) {
+  return writeFrontmatterKeys(rootPath, slug, { [key]: value });
+}
+
+/** 복수 키를 한 번의 파일 쓰기로 — 관계+relation_notes 원자성 (P6 게이트 ③ CLI 측). */
+export function writeFrontmatterKeys(rootPath, slug, patch) {
   const { filePath, frontmatter, body } = readDocFrontmatter(rootPath, slug);
-  const next = { ...frontmatter, [key]: value };
+  const next = { ...frontmatter, ...patch };
   const md = buildMarkdown({ frontmatter: next, body });
   writeFileSync(filePath, md, 'utf-8');
   return filePath;

--- a/messages/en.json
+++ b/messages/en.json
@@ -2326,7 +2326,8 @@
       "confirm": "Build the map",
       "cancel": "Close",
       "errorPrefix": "Could not save:",
-      "toastDone": "Built your first map from {count} documents"
+      "toastDone": "Built your first map from {count} documents",
+      "toastAdded": "Added {count} documents to your map"
     },
     "edgePanel": {
       "kicker": "Relation",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2326,7 +2326,8 @@
       "confirm": "지도 만들기",
       "cancel": "닫기",
       "errorPrefix": "저장하지 못했어요:",
-      "toastDone": "문서 {count}개로 첫 지도를 만들었어요"
+      "toastDone": "문서 {count}개로 첫 지도를 만들었어요",
+      "toastAdded": "문서 {count}개를 지도에 더했어요"
     },
     "edgePanel": {
       "kicker": "관계",

--- a/src/features/docs-vault-local/lib/bootstrap-candidates.ts
+++ b/src/features/docs-vault-local/lib/bootstrap-candidates.ts
@@ -46,6 +46,12 @@ export interface BootstrapPlan {
   projectTitle: string;
   /** 생성할 project 문서의 slug — 기존 파일과 충돌하면 대체 slug. */
   projectSlug: string;
+  /**
+   * 재검 마찰 A — vault 에 이미 `kind: project` 문서가 있으면 그 slug.
+   * 이때 새 project 파일을 만들지 않고(이중 프로젝트 방지) 기존 문서의
+   * `domains:` 에 승인 도메인을 덧붙인다.
+   */
+  existingProjectSlug: string | null;
   domains: BootstrapDomainCandidate[];
   elements: BootstrapElementCandidate[];
   /** 이미 kind: 를 가진 문서 수 — "부분 구축" vault 안내용. */
@@ -70,6 +76,9 @@ export function deriveBootstrapPlan(
   vaultName: string,
 ): BootstrapPlan {
   const existingSlugs = new Set(docs.map((d) => d.slug));
+  const existingProject = docs.find(
+    (d) => typeof d.frontmatter.kind === 'string' && d.frontmatter.kind.trim() === 'project',
+  );
   let projectTitle = vaultName.trim() || 'my-project';
   let alreadyTypedCount = 0;
   const domainCounts = new Map<string, number>();
@@ -99,8 +108,11 @@ export function deriveBootstrapPlan(
     .sort((a, b) => b.docCount - a.docCount || a.name.localeCompare(b.name));
 
   return {
-    projectTitle,
+    projectTitle: existingProject
+      ? String(existingProject.frontmatter.title ?? projectTitle) || projectTitle
+      : projectTitle,
     projectSlug: existingSlugs.has('project') ? 'ontology-project' : 'project',
+    existingProjectSlug: existingProject?.slug ?? null,
     domains,
     elements,
     alreadyTypedCount,

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -617,11 +617,26 @@ export function HomePage() {
           { skipRefresh: true },
         );
       }
-      await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains));
+      if (plan.existingProjectSlug) {
+        // 재검 마찰 A — 이미 프로젝트가 있는 vault: 두 번째 프로젝트를
+        // 만들지 않고 기존 프로젝트의 domains 에 승인분을 덧붙인다.
+        const existing = vault.manifest.docs.find((d) => d.slug === plan.existingProjectSlug);
+        const prevDomains = Array.isArray(existing?.frontmatter.domains)
+          ? (existing.frontmatter.domains as string[])
+          : [];
+        const accepted = plan.domains.filter((d) => input.acceptedDomains.has(d.name)).map((d) => d.name);
+        const mergedDomains = [...new Set([...prevDomains, ...accepted])];
+        await vault.updateFrontmatter(plan.existingProjectSlug, { domains: mergedDomains });
+      } else {
+        await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains));
+      }
       setBootstrapOpen(false);
       // E1 — 리로드된 그래프가 "내 문서들이 모이는" 연출로 등장한다.
       setMapRevealToken((n) => n + 1);
-      toast.show(t("bootstrap.toastDone", { count: elements.length }), "success");
+      toast.show(
+        t(plan.existingProjectSlug ? "bootstrap.toastAdded" : "bootstrap.toastDone", { count: elements.length }),
+        "success",
+      );
     },
     [bootstrapPlan, vault, toast, t],
   );

--- a/src/widgets/topology-map-v2/ui/topology-read-tokens.ts
+++ b/src/widgets/topology-map-v2/ui/topology-read-tokens.ts
@@ -6,11 +6,19 @@
 
 import { getTopologyV2Tokens, TopologyV2TokenError, type TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 
+// 재검 마찰 E — 같은 drift 메시지를 프레임마다 반복 출력하지 않는다
+// (재마운트 직후 CSS 적용 전의 조기 읽기가 세션당 1,200+회 스팸을 만들던
+// 실증). 메시지 단위 1회 로그 — 새 종류의 drift 는 여전히 보인다.
+const loggedDriftMessages = new Set<string>();
+
 export function readTopologyV2TokensOrNull(): TopologyV2Tokens | null {
   try {
     return getTopologyV2Tokens();
   } catch (err) {
-    if (err instanceof TopologyV2TokenError) console.error("[topology-map-v2] token drift:", err.message);
+    if (err instanceof TopologyV2TokenError && !loggedDriftMessages.has(err.message)) {
+      loggedDriftMessages.add(err.message);
+      console.error("[topology-map-v2] token drift:", err.message);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- 재검 마찰 A/C: 부분 구축 vault 승격 시 기존 `kind: project` 를 존중 — 두 번째 프로젝트 문서 생성 대신 domains 병합 + "지도에 더했어요" 카피
- 재검 마찰 E: 토큰 드리프트 console.error 메시지 단위 dedupe (리마운트 스팸 1,244회 → 1회)
- ④ `relate --why`: 관계+`relation_notes` 근거를 원자 쓰기. parseArgs 반환 계약 why 누락 회귀를 파일 내용 단언 통합 테스트로 고정
- `agent-brief --help` 썩은 단언을 #453 의 0/1/2 exit 서술로 갱신

## Test plan
- `node cli/src/integration.test.mjs` — 266/266 (relate 2건 신규 포함)
- `pnpm exec vitest run src/features/docs-vault-local src/views/home src/widgets/topology-map-v2` — 670 pass
- `pnpm exec tsc --noEmit` · eslint(기존 main 경고 1 외 clean) · i18n messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)