### PR TITLE
fix: 설치 앱 WebView 검증 v2 캔버스 계약 복구 + relief 마커 현행화

### DIFF
--- a/scripts/lib/verify-macos/payload-contract.mjs
+++ b/scripts/lib/verify-macos/payload-contract.mjs
@@ -86,8 +86,12 @@ export function validateWebviewVerifyPayload(payload, {
   const webviewPath = webviewUrl.pathname;
   // 지도 재구성 엔진 (docs/TOPOLOGY-MAP-REBUILD.md) — Sigma/skeleton 계약
   // 대신 map-canvas 계약을 검증한다. 함수 전역에서 게이트로 쓰인다.
+  const topologyMapEngine = payload?.markers?.topologyMapEngine ?? "";
+  // "canvas" = 구 map-canvas 엔진, "v2" = topology-map-v2 (현행 기본 지도).
+  // 둘 다 Sigma/skeleton 계약 대신 canvas 계약을 탄다.
   const topologyMapCanvasActive =
-    payload?.markers?.topologyMapEngine === "canvas";
+    topologyMapEngine === "canvas" || topologyMapEngine === "v2";
+  const topologyMapV2Active = topologyMapEngine === "v2";
   const topologyAnalysisMode =
     typeof payload.markers.topologyAnalysisPanelMode === "string"
       ? payload.markers.topologyAnalysisPanelMode.trim() || webviewUrl.searchParams.get("mode") || ""
@@ -1955,8 +1959,11 @@ export function validateWebviewVerifyPayload(payload, {
     if (!topologyMapCanvasActive && payload.markers.topologySigmaReady === false) {
       return "WebView reported Relief before the Sigma renderer was ready";
     }
-    if (!(Number(payload.markers.topologyStagePanClickCancelPx) >= 12)) {
-      return `WebView reported an over-sensitive Relief stage pan threshold (${payload.markers.topologyStagePanClickCancelPx ?? "missing"}px)`;
+    // v2 캔버스의 클릭-취소 임계는 `--topology-v2-hysteresis-px` = 7 (B2+
+    // 프로토타입 승인값) — 구 Relief 의 12px 하한은 v2 에는 사전 부패다.
+    const stagePanFloor = topologyMapV2Active ? 6 : 12;
+    if (!(Number(payload.markers.topologyStagePanClickCancelPx) >= stagePanFloor)) {
+      return `WebView reported an over-sensitive stage pan threshold (${payload.markers.topologyStagePanClickCancelPx ?? "missing"}px, floor ${stagePanFloor}px)`;
     }
     if (
       payload.markers.topologySigmaReady === true &&
@@ -1975,7 +1982,9 @@ export function validateWebviewVerifyPayload(payload, {
     // 계약 — 골격 카드 검사를 건너뛴다. Sigma 캔버스/뷰포트 검사는 그대로.
     const topologyGraphModeActive =
       webviewUrl.searchParams.get("mode") === "graph";
-    if (topologyMapCanvasActive) {
+    if (topologyMapEngine === "canvas") {
+      // 카드 수는 구 map-canvas(DOM 카드) 전용 — v2 는 순수 캔버스 드로잉이라
+      // DOM 카드가 0 인 것이 정상이다.
       if (!(Number(payload.markers.topologyMapCanvasCardCount) >= 8)) {
         return `WebView map canvas rendered too few cards (${payload.markers.topologyMapCanvasCardCount ?? "unknown"})`;
       }
@@ -2332,6 +2341,8 @@ export function validateWebviewVerifyPayload(payload, {
       payload.markers.topologyAnalysisPanelSelectedContext !== true &&
       payload.markers.topologyAnalysisPanelSelectedFocusRail !== true;
     if (
+      // v2 크롬은 분석 패널(W3)을 INDEX 로 대체했다 — 은퇴 표면 게이트 제외.
+      !topologyMapV2Active &&
       Object.hasOwn(payload.markers, "topologyAnalysisPanelVisible") &&
       !selectedRelationContextVisible &&
       payload.markers.topologyCreateNodeOpen !== true &&

--- a/scripts/verify-macos-app-launch.payload-contract.test.mjs
+++ b/scripts/verify-macos-app-launch.payload-contract.test.mjs
@@ -6531,7 +6531,7 @@ test("WebView verification payload parses nested JSON and checks loaded DOM", ()
         topologyUiScale: 1.12,
       },
     }),
-    /over-sensitive Relief stage pan threshold/,
+    /over-sensitive stage pan threshold .*floor 12px/,
   );
   assert.match(
     validateWebviewVerifyPayload({

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3253,7 +3253,7 @@ pub fn run() {
                                   readerDecisionLens: hasReaderDecisionLens,
                                   topologyRelief:
                                     location.pathname.includes("/topology") &&
-                                    /Relief|Ontology relief map|concept cards|온톨로지 지형도|대표 카드|카드 골격|후보 \d+\/\d+개 표시/.test(bodyText),
+                                    /Relief|Ontology relief map|concept cards|온톨로지 지형도|대표 카드|카드 골격|후보 \d+\/\d+개 표시|개념 \d+개 · 관계 \d+개|CONCEPTS/.test(bodyText),
                                   topologyAttentionWinner,
                                   topologyRootAttentionWinner,
                                   topologyAgentCurrentSurface,
@@ -5801,6 +5801,8 @@ mod tests {
 
         assert!(source.contains("온톨로지 지형도"));
         assert!(source.contains("후보 \\d+\\/\\d+개 표시"));
+        // v2 캔버스 카피 — 정본 census 문구가 relief 마커에 포함돼야 한다.
+        assert!(source.contains("개념 \\d+개 · 관계 \\d+개"));
         assert!(source.contains("data-focus-cluster-size"));
         assert!(source.contains("data-drag-cluster-hull-dom-policy"));
         assert!(source.contains("dragHandleSlug"));

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -266,6 +266,12 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   useEffect(() => {
     const tokens = readTopologyV2TokensOrNull();
     if (!tokens) return;
+    // 설치 앱 proof — 데스크톱 WebView 검증이 클릭-취소 임계(hysteresis)를
+    // 읽는 계약 지점. 토큰 값 그대로 노출한다 (v2 = 7px).
+    containerRef.current?.setAttribute(
+      "data-stage-pan-click-cancel-px",
+      String(tokens.hysteresisPx),
+    );
     const world = buildTopologyWorld(nodes, edges, tokens);
     worldRef.current = world;
     // Seed the force sim off the concentric layout (spatial memory) and warm it


### PR DESCRIPTION
## Summary
- 데스크톱 WebView 검증(payload-contract)이 은퇴한 Sigma/Relief 계약을 요구해 v2 지형도에서 항상 실패 → v2 엔진 인정, 엔진별 클릭-취소 임계(7px 토큰), 은퇴 표면(W3 분석 패널·DOM 카드) 게이트 제외
- topologyRelief 마커 regex 에 v2 정본 census 카피 추가 (Rust 소스 계약 테스트 포함)
- 설치 앱 proof 완주: Tauri 재빌드 → /Applications 설치 → verify green (창·크기·라우트·census 렌더)

## Test plan
- verify-macos node --test 23 pass · cargo test 11 pass · topology-map-v2 vitest 373 pass · tsc
- installed-app: `verify-macos-app-launch` green, evidence `.tmp/backlog-sweep-installed-proof.webview.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)