### PR TITLE
fix: 유휴 게이트 휠 줌 교착 해소 (UX 라운드 Blocker M-1) + 헌장 현행화 M-13

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -6,7 +6,11 @@
 
 - **Linear 베이스**. 무채색 + 단일 인디고 (`#5e6ad2`) 라는 극단적 제약으로 AI 생성 UI 클리셰 차단.
 - 채색은 **인디고 하나**. **신호 톤은 3종이다: warning(amber) · error(red) · success(emerald)** — 각 신호는 solid dot + surface/border/text 알파 사다리를 대칭으로 갖는다 (Design Guardian verdict, `.qa-scratch/audit-2026-07/guardian-color-verdict.md` §①, 2026-07-20). success 는 "연결됨 / 쓰기 확인 / 완료" 같은 긍정 상태 신호에만 쓴다 — 확장 금지, 기존 리터럴 토큰화까지만. 장식적 green, 성공과 무관한 green 은 금지. 상세: `docs/DESIGN-SYSTEM.md` "Signal tones" 절.
-- Hub 노드와 Layer 0 컨테이너에만 보조 톤 (앰버 `#d4b478`) 허용. Hub 와 Container 는 같은 뷰에 동시에 나오지 않는다. (docs 표면의 장식적 gold 악센트는 별개의 `--color-amber-docs-*` **quarantine 토큰** — 헌장 승인 아님, 확장 금지, 후속 강등 검토 대기.)
+- Hub 노드와 Layer 0 컨테이너에만 보조 톤 (앰버 `#d4b478`) 허용. v2 스파인
+  뷰에서는 **단일 hub 링 + Layer 0 컨테이너 1개**의 공존까지가 승인 범위다
+  (2026-07 소유자 라이브 테스트 + Guardian 검증 통과 설계 — 구 "동시 금지"
+  문구는 v2 이전 뷰 기준이라 현행화). 그 외 노드/표면으로의 앰버 확장은
+  여전히 금지 — 앰버가 셋 이상 보이면 결함이다. (docs 표면의 장식적 gold 악센트는 별개의 `--color-amber-docs-*` **quarantine 토큰** — 헌장 승인 아님, 확장 금지, 후속 강등 검토 대기.)
 - ontology kind 색상은 예외적으로 허용하지만 data mark 로만 쓴다. graph fill 은 작은 점의 3:1 대비를 위해 선명할 수 있고, panel/card 에서는 neutral surface + compact marker/swatch + label/icon 으로 낮춘다. detail card 내부의 full-height colored rail 은 AI SaaS callout 처럼 읽히므로 금지한다.
 - 카테고리 구분은 **색이 아닌 보더 스타일** (작업중: 인디고 underline, 예정: dashed).
 

--- a/src/widgets/topology-map-v2/model/idle-gate.test.ts
+++ b/src/widgets/topology-map-v2/model/idle-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isCanvasActive, shouldSkipFrame, type CanvasActivityFlags } from "./idle-gate";
+import { isCameraUnsettled, isCanvasActive, shouldSkipFrame, type CanvasActivityFlags } from "./idle-gate";
 
 const IDLE: CanvasActivityFlags = {
   pointerActive: false,
@@ -33,5 +33,27 @@ describe("shouldSkipFrame", () => {
 
   it("grace 를 넘긴 유휴만 스킵한다", () => {
     expect(shouldSkipFrame(1701, 500, 1200)).toBe(true);
+  });
+});
+
+describe("isCameraUnsettled (M-1 — 유휴 중 휠 줌 사망 회귀)", () => {
+  const settled = { x: 100, y: 50, scale: 1.2 };
+
+  it("타깃과 값이 일치하면 정착", () => {
+    expect(isCameraUnsettled(settled, { tx: 100, ty: 50, tscale: 1.2 })).toBe(false);
+  });
+
+  it("휠이 스케일 타깃만 바꿔도 활동으로 판정한다 — 값 이동 없이도", () => {
+    // 유휴 스킵 중엔 물리 스텝이 안 돌아 value 는 그대로다. 이때 타깃만
+    // 바뀐 상태를 활동으로 못 치면 게이트가 영원히 안 깨어난다.
+    expect(isCameraUnsettled(settled, { tx: 100, ty: 50, tscale: 1.4 })).toBe(true);
+  });
+
+  it("팬 타깃 변화도 활동", () => {
+    expect(isCameraUnsettled(settled, { tx: 130, ty: 50, tscale: 1.2 })).toBe(true);
+  });
+
+  it("입실론 안 미세 차이는 정착으로 (재도색 헛깨움 방지)", () => {
+    expect(isCameraUnsettled(settled, { tx: 100.005, ty: 50, tscale: 1.20005 })).toBe(false);
   });
 });

--- a/src/widgets/topology-map-v2/model/idle-gate.ts
+++ b/src/widgets/topology-map-v2/model/idle-gate.ts
@@ -48,3 +48,23 @@ export function isCanvasActive(flags: CanvasActivityFlags): boolean {
 export function shouldSkipFrame(nowMs: number, lastActiveMs: number, graceMs: number): boolean {
   return nowMs - lastActiveMs > graceMs;
 }
+
+/**
+ * M-1 회귀 계약 — 카메라 스프링 "미정착(타깃≠값)"은 활동이다.
+ *
+ * 값 이동만 활동으로 치면: 유휴 스킵 중엔 물리 스텝이 안 돌아 값이 못
+ * 움직이고, 휠 줌은 타깃만 바꾸므로 게이트가 영원히 안 깨어나는 교착
+ * (유휴 1.2초 후 휠 줌 사망). 타깃과 값의 차이를 직접 본다.
+ */
+export function isCameraUnsettled(
+  camera: { x: number; y: number; scale: number },
+  target: { tx: number; ty: number; tscale: number },
+  positionEps = 0.01,
+  scaleEps = 0.0001,
+): boolean {
+  return (
+    Math.abs(camera.x - target.tx) > positionEps ||
+    Math.abs(camera.y - target.ty) > positionEps ||
+    Math.abs(camera.scale - target.tscale) > scaleEps
+  );
+}

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -13,7 +13,7 @@ import { useEffect, useRef, type RefObject } from "react";
 
 import type { CameraAxes, CameraTarget } from "../engine/camera";
 import { stepTugAxis, tugFactorForHop, tugFalloffForDistance } from "../interaction/drag-tug";
-import { isCanvasActive, shouldSkipFrame } from "../model/idle-gate";
+import { isCameraUnsettled, isCanvasActive, shouldSkipFrame } from "../model/idle-gate";
 import { relaxNodeSeparation, type SeparationNode } from "../model/separation";
 import { createForceSimulation, type ForceSimulation } from "../model/force-layout";
 import { INITIAL_POINTER_MACHINE_STATE, type PointerMachineState } from "../interaction/pointer-state-machine";
@@ -489,9 +489,17 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 변화든 다음 프레임에 자연 복귀, wake 배선/동결 실패 모드 없음).
       {
         const cam = cameraRef.current;
+        const target = cameraTargetRef.current;
         const prev = prevCameraSampleRef.current;
+        // M-1 회귀: 값 이동만 보면 유휴 스킵 중 휠(타깃만 변경)이 영원히
+        // 무시된다 — 스프링 미정착(타깃≠값)도 활동이다 (idle-gate 계약).
+        const cameraUnsettled = isCameraUnsettled(
+          { x: cam.x.value, y: cam.y.value, scale: cam.scale.value },
+          target,
+        );
         const cameraMoving =
           prev === null ||
+          cameraUnsettled ||
           Math.abs(cam.x.value - prev.x) > 0.01 ||
           Math.abs(cam.y.value - prev.y) > 0.01 ||
           Math.abs(cam.scale.value - prev.s) > 0.0001;


### PR DESCRIPTION
## Summary
- M-1 (Blocker): 유휴 1.2초 후 휠 줌 사망 — 게이트가 카메라 값 이동만 활동으로 쳐서, 타깃만 바꾸는 휠이 물리 스텝 스킵과 교착. `isCameraUnsettled`(타깃≠값) 활동 계약 추가
- M-13: hub 링·Layer0 컨테이너 공존을 승인 설계로 헌장 문구 현행화 (앰버 3개 이상은 여전히 결함)

## Test plan
- idle-gate 8 pass (신규 4: 타깃-only 변화 활동 판정 회귀) · topology-map-v2 377 pass · tsc · eslint

🤖 Generated with [Claude Code](https://claude.com/claude-code)