### PR TITLE
fix: 빌더 UX 확정 결함 4건 — 엣지 선택·스폰 겹침·캔버스 카운트·dry-run 라벨

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -923,8 +923,8 @@
         "writeConfirmBar": {
           "ariaLabel": "Write-confirm bar",
           "label": "Write confirm",
-          "dryRunButton": "Preview dry-run",
-          "dryRunAriaLabel": "Open a dry-run preview of pending changes",
+          "dryRunButton": "Open save review",
+          "dryRunAriaLabel": "Open the save-status panel — pending files and the dry-run command",
           "writeButton": "Write to vault",
           "writeAriaLabelRelation": "Write {source} → {target} relation to vault",
           "writeAriaLabelDraft": "Save {title} to vault",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -923,8 +923,8 @@
         "writeConfirmBar": {
           "ariaLabel": "쓰기 확인 바",
           "label": "쓰기 확인",
-          "dryRunButton": "dry-run 미리보기",
-          "dryRunAriaLabel": "쓰기 전 변경 사항 dry-run 미리보기 열기",
+          "dryRunButton": "저장 점검 열기",
+          "dryRunAriaLabel": "저장 상태 패널 열기 — 변경 예정 파일과 dry-run 명령 확인",
           "writeButton": "vault 에 쓰기",
           "writeAriaLabelRelation": "{source} → {target} 관계를 vault 에 쓰기",
           "writeAriaLabelDraft": "{title} 을 vault 에 저장",

--- a/src/views/ontology-edit/lib/builder-census-label.test.ts
+++ b/src/views/ontology-edit/lib/builder-census-label.test.ts
@@ -4,25 +4,26 @@ import { shouldShowFocusedCensus } from "./builder-census-label";
 describe("shouldShowFocusedCensus", () => {
   it("shows the focused variant when the canvas draws fewer nodes than the vault total", () => {
     expect(
-      shouldShowFocusedCensus({ isFocused: true, shownCount: 12, totalCount: 128 }),
+      shouldShowFocusedCensus({ shownCount: 12, totalCount: 128 }),
     ).toBe(true);
   });
 
-  it("stays on the plain total label when there is no focus (whole graph drawn)", () => {
+  it("stays on the plain total label when the whole graph is drawn (shown === total)", () => {
     expect(
-      shouldShowFocusedCensus({ isFocused: false, shownCount: 128, totalCount: 128 }),
+      shouldShowFocusedCensus({ shownCount: 128, totalCount: 128 }),
     ).toBe(false);
   });
 
-  it("stays on the plain total label when the focused subset happens to equal the total (no noisy '128 of 128')", () => {
+  it("shows the canvas count when a draft (unsaved) node pushes the render count above the saved total", () => {
+    // B-1: 8 saved + 1 draft on canvas → 9 drawn, must not read as a flat "8".
     expect(
-      shouldShowFocusedCensus({ isFocused: true, shownCount: 128, totalCount: 128 }),
-    ).toBe(false);
+      shouldShowFocusedCensus({ shownCount: 9, totalCount: 8 }),
+    ).toBe(true);
   });
 
   it("stays on the plain total label for an empty vault", () => {
     expect(
-      shouldShowFocusedCensus({ isFocused: false, shownCount: 0, totalCount: 0 }),
+      shouldShowFocusedCensus({ shownCount: 0, totalCount: 0 }),
     ).toBe(false);
   });
 });

--- a/src/views/ontology-edit/lib/builder-census-label.ts
+++ b/src/views/ontology-edit/lib/builder-census-label.ts
@@ -6,19 +6,23 @@
  * 전체 총계만 보여줘 "128개 저장" 인데 캔버스엔 12개만 보이는 게 버그처럼
  * 읽혔다(페르소나 N11).
  *
- * 이 순수 함수는 "총계 라벨 그대로 둘지, 축소분을 병기할지"만 판정한다 —
- * focus 로직 자체(Canvas 의 성능 축소)는 건드리지 않는다. shown < total
- * 일 때만 병기 — 포커스가 없거나(isFocused=false, 전체 표시) 우연히 shown
- * === total 이면 불필요한 "128개 중 128개 표시" 잡음을 피한다.
+ * B-1 (2026-07-21 UX 라운드) — 같은 라벨이 이번엔 반대로 거짓말을 했다:
+ * "도메인 추가" 로 미저장(임시) 노드를 캔버스에 올려도 "캔버스 8개 표시"
+ * 가 8 로 고정돼, 한 헤더 안에서 "임시 개념 1" 배지와 숫자가 모순됐다.
+ * 해결: `shownCount` 는 caller 가 임시 노드까지 더한 "실제 캔버스 렌더 수"
+ * 로 넘기고, 이 함수는 그 값이 정본 저장 총계와 다를 때만 병기를 켠다.
+ *
+ * 이 순수 함수는 "총계 라벨 그대로 둘지, 캔버스 실제 표시 수를 병기할지"만
+ * 판정한다 — focus 로직 자체(Canvas 의 성능 축소)는 건드리지 않는다.
+ * shownCount !== totalCount 일 때만 병기 — 우연히 같으면(포커스 없이 전체
+ * 표시 + 임시 0) 불필요한 "128개 중 128개 표시" 잡음을 피한다.
  */
 export function shouldShowFocusedCensus({
-  isFocused,
   shownCount,
   totalCount,
 }: {
-  isFocused: boolean;
   shownCount: number;
   totalCount: number;
 }): boolean {
-  return isFocused && shownCount < totalCount;
+  return shownCount !== totalCount;
 }

--- a/src/views/ontology-edit/lib/find-free-spawn-position.test.ts
+++ b/src/views/ontology-edit/lib/find-free-spawn-position.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { findFreeSpawnPosition, type SpawnBox } from "./find-free-spawn-position";
+
+const SIZE = { width: 196, height: 56 };
+
+function overlaps(a: SpawnBox, b: SpawnBox, padding = 0): boolean {
+  return (
+    a.x < b.x + b.width + padding &&
+    a.x + a.width + padding > b.x &&
+    a.y < b.y + b.height + padding &&
+    a.y + a.height + padding > b.y
+  );
+}
+
+describe("findFreeSpawnPosition", () => {
+  it("returns the center itself when nothing occupies it", () => {
+    const pos = findFreeSpawnPosition({ boxes: [], center: { x: 240, y: 160 } });
+    expect(pos).toEqual({ x: 240, y: 160 });
+  });
+
+  it("does not overlap an existing node sitting exactly at the center (B-2 regression)", () => {
+    // "Vault — Local-First" occupies the spawn center; new node must dodge it.
+    const occupied: SpawnBox = { x: 240, y: 160, width: 220, height: 64 };
+    const pos = findFreeSpawnPosition({
+      boxes: [occupied],
+      center: { x: 240, y: 160 },
+      size: SIZE,
+    });
+    expect(
+      overlaps({ ...pos, ...SIZE }, occupied, 24),
+    ).toBe(false);
+  });
+
+  it("finds a free spot amid a cluster of nodes without overlapping any", () => {
+    const boxes: SpawnBox[] = [];
+    for (let gx = 0; gx < 3; gx += 1) {
+      for (let gy = 0; gy < 3; gy += 1) {
+        boxes.push({ x: 100 + gx * 120, y: 100 + gy * 90, width: 100, height: 60 });
+      }
+    }
+    const pos = findFreeSpawnPosition({
+      boxes,
+      center: { x: 220, y: 190 },
+      size: SIZE,
+    });
+    const placed: SpawnBox = { ...pos, ...SIZE };
+    expect(boxes.every((b) => !overlaps(placed, b, 8))).toBe(true);
+  });
+});

--- a/src/views/ontology-edit/lib/find-free-spawn-position.ts
+++ b/src/views/ontology-edit/lib/find-free-spawn-position.ts
@@ -1,0 +1,85 @@
+/**
+ * B-2 (2026-07-21 UX 라운드) — 팔레트에서 "도메인 추가" 를 누르면 새(임시)
+ * 노드가 항상 고정 좌표 (240,160) 에 태어나 기존 vault 노드를 그대로 덮어,
+ * 사용자가 매번 드래그로 겹침을 풀어야 했다(스크린샷: "결제" 가 "Vault —
+ * Local-First" 를 가림). 디자인 게이트의 14-inch 충돌 규칙과 동류의 표면
+ * 충돌이다.
+ *
+ * 이 순수 함수는 기존 노드 bbox 목록과 중심점을 받아, 중심에서 바깥으로
+ * 링(ring)을 돌며 어느 기존 노드와도 겹치지 않는 첫 자리를 찾는다. 단순
+ * 사각 나선 — 중심 → 8방위 링 → 반경 2배 링 … 순으로 확장하다 빈칸을 만나면
+ * 반환. 모든 링이 막혀도(빽빽한 그래프) 마지막 후보를 반환해 최소한 중심
+ * 스택보다는 흩뿌린다. 레이아웃/뷰포트 로직은 건드리지 않는다 — 좌표 계산만.
+ */
+export interface SpawnBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface FindFreeSpawnOptions {
+  /** 이미 캔버스에 있는 노드들의 bbox (좌상단 x,y + 크기). */
+  boxes: SpawnBox[];
+  /** 탐색 중심 (보통 뷰포트/그래프 중심). 새 노드의 좌상단 기준점. */
+  center: { x: number; y: number };
+  /** 새 노드의 예상 크기 — 겹침 판정에 사용. */
+  size?: { width: number; height: number };
+  /** 링 간격 (px). 노드가 안 겹칠 만큼 넉넉히. */
+  step?: number;
+  /** 최대 링 수 — 이 링까지 다 막히면 마지막 후보 반환. */
+  maxRings?: number;
+  /** 겹침 여유 (px) — 이 값만큼 부풀린 bbox 로 판정해 딱 붙는 것도 피함. */
+  padding?: number;
+}
+
+function overlaps(a: SpawnBox, b: SpawnBox, padding: number): boolean {
+  return (
+    a.x < b.x + b.width + padding &&
+    a.x + a.width + padding > b.x &&
+    a.y < b.y + b.height + padding &&
+    a.y + a.height + padding > b.y
+  );
+}
+
+export function findFreeSpawnPosition({
+  boxes,
+  center,
+  size = { width: 196, height: 56 },
+  step = 48,
+  maxRings = 6,
+  padding = 24,
+}: FindFreeSpawnOptions): { x: number; y: number } {
+  const isFree = (x: number, y: number): boolean => {
+    const candidate: SpawnBox = { x, y, width: size.width, height: size.height };
+    return !boxes.some((box) => overlaps(candidate, box, padding));
+  };
+
+  // 링 0 — 중심 그 자리.
+  if (isFree(center.x, center.y)) return { x: center.x, y: center.y };
+
+  // 링 1..maxRings — 각 링의 둘레를 정사각으로 훑는다. 오프셋은 step 배수.
+  for (let ring = 1; ring <= maxRings; ring += 1) {
+    const r = ring * step;
+    // 정사각 둘레의 격자점 (모서리 + 변 중앙 포함) — 촘촘하지 않아도 충분.
+    const offsets: Array<[number, number]> = [];
+    for (let dx = -ring; dx <= ring; dx += 1) {
+      for (let dy = -ring; dy <= ring; dy += 1) {
+        // 둘레(현재 링)만 — 내부는 이전 링에서 이미 검사됨.
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== ring) continue;
+        offsets.push([dx, dy]);
+      }
+    }
+    // 중심에서 가까운(작은 유클리드 거리) 순으로 — 위/아래 편향 없이 균형.
+    offsets.sort((a, b) => a[0] * a[0] + a[1] * a[1] - (b[0] * b[0] + b[1] * b[1]));
+    for (const [dxUnit, dyUnit] of offsets) {
+      const x = center.x + (dxUnit / ring) * r;
+      const y = center.y + (dyUnit / ring) * r;
+      if (isFree(x, y)) return { x, y };
+    }
+  }
+
+  // 전부 막힘 — 최소한 겹침을 줄이려 마지막 링 바깥 대각선으로 밀어낸다.
+  const r = (maxRings + 1) * step;
+  return { x: center.x + r, y: center.y + r };
+}

--- a/src/views/ontology-edit/ui/BuilderWriteConfirmBar.test.tsx
+++ b/src/views/ontology-edit/ui/BuilderWriteConfirmBar.test.tsx
@@ -37,7 +37,7 @@ describe("BuilderWriteConfirmBar", () => {
     renderBar();
 
     const previewButton = screen.getByRole("button", {
-      name: "쓰기 전 변경 사항 dry-run 미리보기 열기",
+      name: "저장 상태 패널 열기 — 변경 예정 파일과 dry-run 명령 확인",
     });
     expect(previewButton.className).not.toContain(
       "bg-[color:var(--color-indigo-brand)]",
@@ -50,7 +50,7 @@ describe("BuilderWriteConfirmBar", () => {
     const onWrite = vi.fn();
     renderBar({ onDryRun, onWrite });
 
-    screen.getByRole("button", { name: "쓰기 전 변경 사항 dry-run 미리보기 열기" }).click();
+    screen.getByRole("button", { name: "저장 상태 패널 열기 — 변경 예정 파일과 dry-run 명령 확인" }).click();
     expect(onDryRun).toHaveBeenCalledTimes(1);
 
     screen.getByRole("button", { name: "지금 vault 에 쓸 변경 없음" }).click();
@@ -64,7 +64,7 @@ describe("BuilderWriteConfirmBar", () => {
       screen.getByRole("button", { name: "지금 vault 에 쓸 변경 없음" }),
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "쓰기 전 변경 사항 dry-run 미리보기 열기" }),
+      screen.getByRole("button", { name: "저장 상태 패널 열기 — 변경 예정 파일과 dry-run 명령 확인" }),
     ).not.toBeDisabled();
   });
 });

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -285,6 +285,8 @@ export function OntologyEditCanvas({
   ephemeralEdges,
   onSelectionChange,
   onNodeOpen,
+  onEdgeOpen,
+  onNodeBoxesChange,
   onConnect,
   onVaultConnect,
   onConnectToEmpty,
@@ -302,6 +304,14 @@ export function OntologyEditCanvas({
   ephemeralEdges: EphemeralEdge[];
   onSelectionChange?: (selectedId: string | null) => void;
   onNodeOpen?: (selectedId: string) => void;
+  /** 저장된(vault) 엣지 클릭 시 호출 — 부모가 source 노드 상세를 열고
+   *  인스펙터 관계 탭으로 포커스해 기존 관계를 편집할 진입로를 준다 (B-3). */
+  onEdgeOpen?: (edge: { source: string; target: string }) => void;
+  /** 캔버스에 현재 그려진 노드들의 bbox 를 부모에 보고 — 부모가 새 노드
+   *  스폰 위치를 기존 노드와 안 겹치게 계산하는 데 쓴다 (B-2). */
+  onNodeBoxesChange?: (
+    boxes: Array<{ x: number; y: number; width: number; height: number }>,
+  ) => void;
   onConnect?: (connection: Connection) => void;
   /** vault↔vault edge 생성 시 호출 — source frontmatter array patch. */
   onVaultConnect?: (
@@ -403,6 +413,11 @@ export function OntologyEditCanvas({
 
   const handleSelectionChange = useCallback(
     (params: OnSelectionChangeParams) => {
+      // B-3 — 엣지만 선택된 경우(노드 0개)엔 노드 선택을 초기화하지 않는다.
+      // 예전엔 저장된 엣지를 클릭하면 nodes[0] 가 undefined → null 로 리셋돼
+      // 인스펙터가 빈 상태로 돌아가, 기존 관계 편집 진입로가 사라졌다.
+      // 엣지 클릭은 onEdgeClick → onEdgeOpen 이 별도로 처리한다.
+      if (params.nodes.length === 0 && params.edges.length > 0) return;
       const next = params.nodes[0]?.id ?? null;
       onSelectionChange?.(next);
     },
@@ -512,6 +527,23 @@ export function OntologyEditCanvas({
     setLocalNodes((current) => applyNodeChanges(changes, current));
   }, []);
   const allNodes = localNodes;
+  // B-2 — 부모(page)가 새 노드 스폰 위치를 기존 노드와 안 겹치게 계산할 수
+  // 있도록 현재 캔버스 노드들의 bbox 를 보고한다. 부모는 이 값을 ref 에만
+  // 저장(재렌더 없음)하므로 드래그 프레임마다 호출돼도 비용이 낮다.
+  useEffect(() => {
+    if (!onNodeBoxesChange) return;
+    onNodeBoxesChange(
+      allNodes.map((n) => {
+        const measured = (n as { measured?: { width?: number; height?: number } }).measured;
+        return {
+          x: n.position.x,
+          y: n.position.y,
+          width: n.width ?? measured?.width ?? 220,
+          height: n.height ?? measured?.height ?? 64,
+        };
+      }),
+    );
+  }, [allNodes, onNodeBoxesChange]);
   const graphAnchorNodeId = useMemo(() => {
     const project = allNodes.find((node) => {
       const data = node.data as { kind?: string } | undefined;
@@ -736,6 +768,13 @@ export function OntologyEditCanvas({
         onSelectionChange={handleSelectionChange}
         onPaneClick={() => onSelectionChange?.(null)}
         onNodeClick={(_, node) => onNodeOpen?.(node.id)}
+        // B-3 — 저장된 vault 엣지 클릭 → 부모가 source 노드 상세를 열고
+        // 인스펙터 관계 탭으로 포커스한다(기존 관계 편집 진입로). 임시
+        // 엣지(ephemeral-edge-*)는 자체 "저장" 칩이 있으므로 제외한다.
+        onEdgeClick={(_, edge) => {
+          if (edge.id.startsWith("ephemeral-edge-")) return;
+          onEdgeOpen?.({ source: edge.source, target: edge.target });
+        }}
         // 단일 클릭과 동일한 의도 — ReactFlow 는 더블클릭을 별도로 처리하지
         // 않으므로 명시적으로 같은 핸들러를 연결해 "더블클릭도 상세를 연다"는
         // 계약을 코드로 보장한다 (persona QA: 더블클릭 무반응 신고 방어).

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -54,6 +54,7 @@ import {
 } from "../lib/relation-proposal";
 import { buildFocusedBuilderManifest } from "../lib/build-focused-builder-manifest";
 import { shouldShowFocusedCensus } from "../lib/builder-census-label";
+import { findFreeSpawnPosition } from "../lib/find-free-spawn-position";
 import { resolveBuilderQueryNodeSlug } from "../lib/resolve-builder-query-node";
 import { resolveBuilderShortcut } from "../lib/resolve-builder-shortcut";
 import {
@@ -108,6 +109,10 @@ const OntologyEditCanvas = dynamic<{
   ephemeralEdges: ReturnType<typeof useEphemeralEdges>["edges"];
   onSelectionChange?: (selectedId: string | null) => void;
   onNodeOpen?: (selectedId: string) => void;
+  onEdgeOpen?: (edge: { source: string; target: string }) => void;
+  onNodeBoxesChange?: (
+    boxes: Array<{ x: number; y: number; width: number; height: number }>,
+  ) => void;
   onConnect?: (connection: import("@xyflow/react").Connection) => void;
   onVaultConnect?: (
     sourceSlug: string,
@@ -192,14 +197,41 @@ export function OntologyEditPage() {
 
   const { nodes: ephemeralNodes, addNode: addNodeRaw, clearAll, updateNode, findById, removeNode } =
     useEphemeralNodes();
+  // B-2 — 캔버스가 보고한 현재 노드 bbox 최신값. ref 라 재렌더 없음.
+  const nodeBoxesRef = useRef<
+    Array<{ x: number; y: number; width: number; height: number }>
+  >([]);
+  const handleNodeBoxesChange = useCallback(
+    (boxes: Array<{ x: number; y: number; width: number; height: number }>) => {
+      nodeBoxesRef.current = boxes;
+    },
+    [],
+  );
   // ephemeral 노드의 kindLabel / placeholder 도 locale 별로 caller 가
   // 미리 만들어 hook 에 주입 — hook 자체는 i18n 무지.
   const addNode = useCallback(
-    (kind: 'project' | 'domain' | 'capability' | 'element') =>
-      addNodeRaw(kind, {
+    (kind: 'project' | 'domain' | 'capability' | 'element') => {
+      // B-2 — 고정 좌표 스폰은 기존 노드를 덮었다. 현재 노드들의 중심 근처
+      // 빈 자리를 찾아 겹치지 않게 앉힌다. 빈 캔버스면 중심 기본값(240,160).
+      const boxes = nodeBoxesRef.current;
+      const center =
+        boxes.length > 0
+          ? {
+              x:
+                boxes.reduce((sum, b) => sum + b.x + b.width / 2, 0) / boxes.length -
+                98,
+              y:
+                boxes.reduce((sum, b) => sum + b.y + b.height / 2, 0) / boxes.length -
+                28,
+            }
+          : { x: 240, y: 160 };
+      const position = findFreeSpawnPosition({ boxes, center });
+      return addNodeRaw(kind, {
         kindLabel: tKinds(kind),
         defaultTitle: t('untitledPlaceholder'),
-      }),
+        position,
+      });
+    },
     [addNodeRaw, tKinds, t],
   );
   const {
@@ -251,6 +283,9 @@ export function OntologyEditPage() {
     () => false,
   );
   const [detailsOpen, setDetailsOpen] = useState(false);
+  // B-3 — 저장된 엣지 클릭 시 증가. 인스펙터가 이 토큰을 보고 관계 탭으로
+  // 포커스한다(기존 관계를 편집할 진입로). 노드 선택과 별개의 신호.
+  const [relationsFocusToken, setRelationsFocusToken] = useState(0);
   const [anchorsOpen, setAnchorsOpen] = useState(false);
   const [anchorRailOpen, setAnchorRailOpen] = useState(false);
   const [writeSummaryOpen, setWriteSummaryOpen] = useState(false);
@@ -450,13 +485,20 @@ export function OntologyEditPage() {
     [effectiveManifest, focusNodeId, selectedId],
   );
   const shownNodeCount = useMemo(() => {
-    if (!focusedCensusManifest.isFocused) return builderGraphStats.persistedNodes;
-    let count = 0;
-    for (const doc of focusedCensusManifest.manifest.docs) {
-      if (typeof doc.frontmatter.kind === "string" && doc.frontmatter.kind) count += 1;
+    // B-1: 캔버스에 실제로 그려지는 노드 수 = (focus 로 축소된) 저장 노드 +
+    // 아직 vault 에 안 쓴 임시 노드. "도메인 추가" 로 임시 노드가 생기면 이
+    // 값이 곧바로 올라가 "캔버스 N개 표시" 가 실물과 일치한다.
+    let base: number;
+    if (!focusedCensusManifest.isFocused) {
+      base = builderGraphStats.persistedNodes;
+    } else {
+      base = 0;
+      for (const doc of focusedCensusManifest.manifest.docs) {
+        if (typeof doc.frontmatter.kind === "string" && doc.frontmatter.kind) base += 1;
+      }
     }
-    return count;
-  }, [focusedCensusManifest, builderGraphStats.persistedNodes]);
+    return base + ephemeralNodes.length;
+  }, [focusedCensusManifest, builderGraphStats.persistedNodes, ephemeralNodes.length]);
   // builderEntryAnchors 는 위(초기 selectedId/focusNodeId state 근처)로 이동.
   const focusBuilderAnchor = useCallback((id: string) => {
     setSelectedId(id);
@@ -470,6 +512,15 @@ export function OntologyEditPage() {
     setFocusToken((n) => n + 1);
     setDetailsOpen(true);
   }, []);
+  // B-3 — 저장된 엣지 클릭 → source 노드 상세를 열고 인스펙터를 관계 탭으로
+  // 포커스. 캔버스에서 기존 관계를 만나 유형 변경·삭제로 가는 진입로를 준다.
+  const openNodeRelations = useCallback(
+    (slug: string) => {
+      openNodeDetails(slug);
+      setRelationsFocusToken((n) => n + 1);
+    },
+    [openNodeDetails],
+  );
   const handleCanvasSelectionChange = useCallback((id: string | null) => {
     setSelectedId(id);
   }, []);
@@ -1176,6 +1227,7 @@ export function OntologyEditPage() {
     onEditVaultLiteral: editVaultLiteral,
     onDeleteVault: deleteVaultDoc,
     saving: savingId !== null || renamingId !== null,
+    relationsFocusToken,
   };
 
   return (
@@ -1242,7 +1294,6 @@ export function OntologyEditPage() {
               className="hidden font-mono text-[10.5px] tracking-[0.06em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)] sm:inline"
             >
               {shouldShowFocusedCensus({
-                isFocused: focusedCensusManifest.isFocused,
                 shownCount: shownNodeCount,
                 totalCount: builderGraphStats.persistedNodes,
               })
@@ -1644,6 +1695,8 @@ export function OntologyEditPage() {
               focusToken={focusToken}
               selectedId={selectedId}
               onNodeOpen={openNodeDetails}
+              onEdgeOpen={(edge) => openNodeRelations(edge.source)}
+              onNodeBoxesChange={handleNodeBoxesChange}
             />
             <BuilderOnboarding
               empty={

--- a/src/views/ontology-edit/ui/OntologyInspector.relations-focus.test.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.relations-focus.test.tsx
@@ -1,0 +1,87 @@
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render as rtlRender } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import koMessages from "../../../../messages/ko.json";
+import { OntologyInspector, type VaultSelected } from "./OntologyInspector";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: React.ComponentProps<"a">) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+/**
+ * B-3 회귀 가드 — 저장된 엣지를 캔버스에서 클릭하면 부모가
+ * `relationsFocusToken` 을 증가시킨다. 인스펙터는 그 신호를 받아 관계 탭으로
+ * 전환해, 방금 클릭한 관계를 바로 보고 편집으로 이어갈 진입로를 준다.
+ * 예전에는 저장된 엣지 클릭이 선택을 리셋하기만 해 편집 진입로가 없었다.
+ */
+const node: VaultSelected = {
+  slug: "ontology/capabilities/sample",
+  kind: "capability",
+  title: "Sample",
+  description: "a sample node",
+  domain: "sample-domain",
+  domains: ["d1"],
+  capabilities: ["c1"],
+  elements: ["e1"],
+  dependencies: ["dep1"],
+  contains: [],
+  describes: [],
+  relates: [],
+};
+
+function renderInspector(relationsFocusToken: number) {
+  return rtlRender(
+    <NextIntlClientProvider locale="ko" messages={koMessages}>
+      <OntologyInspector
+        ephemeralSelected={null}
+        vaultSelected={node}
+        vaultReadOnly={false}
+        onEditVaultLiteral={() => {}}
+        onEditVaultArrayKey={() => {}}
+        onRenameEphemeral={() => {}}
+        onClearSelection={() => {}}
+        relationsFocusToken={relationsFocusToken}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+function relationsTab(container: HTMLElement): HTMLElement {
+  const tab = container.querySelector<HTMLElement>("#vault-detail-tab-relations");
+  if (!tab) throw new Error("relations tab not found");
+  return tab;
+}
+
+describe("OntologyInspector 관계 탭 포커스 (B-3)", () => {
+  it("초기(토큰 0)에는 개요 탭이 선택돼 있다", () => {
+    const { container } = renderInspector(0);
+    expect(relationsTab(container).getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("relationsFocusToken 이 증가하면 관계 탭으로 전환한다", () => {
+    const { container, rerender } = renderInspector(0);
+    expect(relationsTab(container).getAttribute("aria-selected")).toBe("false");
+
+    rerender(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <OntologyInspector
+          ephemeralSelected={null}
+          vaultSelected={node}
+          vaultReadOnly={false}
+          onEditVaultLiteral={() => {}}
+          onEditVaultArrayKey={() => {}}
+          onRenameEphemeral={() => {}}
+          onClearSelection={() => {}}
+          relationsFocusToken={1}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    expect(relationsTab(container).getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -114,6 +114,9 @@ export interface OntologyInspectorProps {
   /** 이 세션에서 아직 vault 에 쓰지 않은 변경 미리보기 — 고정 사이드바에서만
    *  노출 (파일 diff 프리뷰). 빌더-final 스펙 §우측 인스펙터. */
   sessionDiffLines?: BuilderSessionDiffLine[];
+  /** B-3 — 저장된 엣지 클릭 시 부모가 증가시키는 토큰. 값이 바뀌면 vault
+   *  상세가 관계 탭으로 포커스한다(기존 관계 편집 진입로). */
+  relationsFocusToken?: number;
 }
 
 type InspectorTranslator = ReturnType<typeof useTranslations>;
@@ -142,6 +145,7 @@ export function OntologyInspector({
   onToggleCollapsed,
   surface = "sidebar",
   sessionDiffLines = [],
+  relationsFocusToken = 0,
 }: OntologyInspectorProps) {
   const t = useTranslations("ontologyPages.edit.inspector");
   // canonical kind 라벨 — kinds.* i18n namespace 기반. 이전엔 inspector 자체
@@ -288,6 +292,7 @@ export function OntologyInspector({
               onDelete={onDeleteVault}
               saving={Boolean(saving)}
               onDeselect={onClearSelection}
+              relationsFocusToken={relationsFocusToken}
             />
           </motion.div>
         ) : null}
@@ -605,6 +610,7 @@ function VaultDetail({
   onDelete,
   saving,
   onDeselect,
+  relationsFocusToken,
 }: {
   t: InspectorTranslator;
   kindLabel: KindLabelResolver;
@@ -627,6 +633,7 @@ function VaultDetail({
   onDelete?: (slug: string) => Promise<void> | void;
   saving: boolean;
   onDeselect: () => void;
+  relationsFocusToken?: number;
 }) {
   // local draft — 사용자가 입력 중에 patch 가 일어나지 않게 buffer.
   const [draftState, setDraftState] = useState(() => ({
@@ -645,6 +652,16 @@ function VaultDetail({
   const dirty = trimmed !== "" && trimmed !== node.title;
   const canSave = !readOnly && dirty && Boolean(onSaveRename) && !saving;
   const [activeTab, setActiveTab] = useState<VaultDetailTab>("overview");
+  // B-3 — 캔버스에서 저장된 엣지를 클릭하면 부모가 relationsFocusToken 을
+  // 증가시킨다. 그 신호를 받아 관계 탭으로 전환해, 방금 클릭한 관계를 바로
+  // 보고 유형 변경·삭제로 이어갈 수 있게 한다. token 0(초기)에는 반응 안 함.
+  const relationsFocusRef = useRef(relationsFocusToken);
+  useEffect(() => {
+    if (relationsFocusToken === undefined) return;
+    if (relationsFocusToken === relationsFocusRef.current) return;
+    relationsFocusRef.current = relationsFocusToken;
+    setActiveTab("relations");
+  }, [relationsFocusToken]);
   // 탭 아이콘 + 툴팁 — 레이블("개요"/"관계"/"문서")은 그대로 평문 유지하고,
   // 아이콘은 스캔 속도만 돕는 보조 신호. 툴팁은 짧은 레이블만으론 처음
   // 보는 사용자에게 모호할 수 있는 탭 의미를 hover 로 한 번 더 풀어준다.


### PR DESCRIPTION
## Summary
UX 라운드 S4 (opus 슬라이스):
- B-3: 저장 엣지 클릭 → 선택+인스펙터 관계 탭 자동 포커스 (엣지-only 선택이 노드 선택 리셋하던 회귀 차단)
- B-2: 새 노드 빈 자리 스폰 (`findFreeSpawnPosition` 링 탐색, 고정 좌표 폐기)
- B-1: "캔버스 N개 표시"에 임시 노드 합산 — 실 렌더 수와 일치
- B-4: "dry-run 미리보기" → "저장 점검 열기" 라벨 정직화 (ko/en + aria)

## Test plan
- ontology-edit 250 pass (신규 focused 3) · tsc · i18n · eslint(변경 파일 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)