### PR TITLE
feat: 인사이트 재편 — "할 일" 기본 탭 신설, 재고와 행동의 분리 (S5)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1538,8 +1538,8 @@
       "censusDomains": "DOMAINS",
       "tabsAriaLabel": "Insights tabs",
       "tab": {
-        "overview": "Overview",
-        "relations": "Relations",
+        "do-next": "Do next",
+        "structure": "Structure",
         "freshness": "Freshness"
       },
       "weeksUnit": "w",
@@ -1605,7 +1605,19 @@
       "noRecentUpdates": "No known update dates yet.",
       "staleCountLabel": "Not updated in 90+ days",
       "trendTitle": "Weekly trend",
-      "trendCaption": "Total updates per week, summed across every domain — same {weeks}w window as the heatstrip."
+      "trendCaption": "Total updates per week, summed across every domain — same {weeks}w window as the heatstrip.",
+      "doNext": {
+        "queueTitle": "Worth doing now",
+        "sectionNeglectedHub": "Neglected hubs — heavily referenced, long unchanged",
+        "sectionOrphan": "Orphans — not connected to anything yet",
+        "sectionPromotion": "Promotion candidates — references piling up",
+        "neglectedHubMetric": "{degree} links · unchanged {days}d",
+        "openMap": "Map",
+        "openBuilder": "Builder",
+        "handoffCopy": "To agent",
+        "emptyQueue": "Nothing needs attention — the graph is healthy.",
+        "moreCount": "+{count} more — full list via agent handoff"
+      }
     }
   },
   "projectPages": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1538,8 +1538,8 @@
       "censusDomains": "DOMAINS",
       "tabsAriaLabel": "인사이트 탭",
       "tab": {
-        "overview": "개요",
-        "relations": "관계",
+        "do-next": "할 일",
+        "structure": "구조",
         "freshness": "신선도"
       },
       "weeksUnit": "주",
@@ -1605,7 +1605,19 @@
       "noRecentUpdates": "알려진 갱신일이 없습니다.",
       "staleCountLabel": "90일 이상 미갱신",
       "trendTitle": "주간 추이",
-      "trendCaption": "전 도메인 합산 주간 갱신 건수 — 히트스트립과 같은 {weeks}주 창."
+      "trendCaption": "전 도메인 합산 주간 갱신 건수 — 히트스트립과 같은 {weeks}주 창.",
+      "doNext": {
+        "queueTitle": "지금 하면 좋은 일",
+        "sectionNeglectedHub": "방치된 허브 — 많이 참조되는데 오래 안 바뀜",
+        "sectionOrphan": "고아 — 아직 아무 데도 안 이어짐",
+        "sectionPromotion": "승격 후보 — 참조가 많이 몰림",
+        "neglectedHubMetric": "연결 {degree} · {days}일째 그대로",
+        "openMap": "지도",
+        "openBuilder": "빌더",
+        "handoffCopy": "에이전트에게",
+        "emptyQueue": "지금은 손볼 것이 없어요 — 그래프가 건강합니다.",
+        "moreCount": "외 {count}개 — 전체는 에이전트 핸드오프로"
+      }
     }
   },
   "projectPages": {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1702,9 +1702,8 @@ export function HomePage() {
       mcpWorkspaceCheck: t("analysis.overviewBriefMcpWorkspaceCheck"),
     },
     url: typeof window === "undefined" ? null : window.location.href,
-    // 분석 패널 완전 소멸 2단계 §c — health 는 지도에 진입점이 없다. 수리 큐는
-    // insights 관계 탭으로 이동했으니 이 딥링크도 거기를 직접 가리킨다.
-    healthUrl: "/ontology/insights/?tab=relations",
+    // S5 재편 — 수리 큐는 이제 인사이트 기본 탭 "할 일"에 있다.
+    healthUrl: "/ontology/insights/",
     insightsUrl: "/ontology/insights/",
   });
   const indexAgentHandoffReanalyzeText = formatOntologyReanalysisAgentCommand();

--- a/src/views/ontology-insights/lib/do-next-queue.test.ts
+++ b/src/views/ontology-insights/lib/do-next-queue.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import { buildDoNextQueue } from "./do-next-queue";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-07-21T12:00:00Z");
+
+function n(id: string, kind: string, slug?: string, title = id): KnowledgeGraphNode {
+  return {
+    id,
+    title,
+    kind,
+    projectIds: [],
+    evidenceIds: slug ? [slug] : [],
+    lastApprovedAt: new Date(0),
+    lastApprovedBy: "vault-frontmatter",
+  } as KnowledgeGraphNode;
+}
+
+function e(from: string, to: string, type = "relates"): KnowledgeGraphEdge {
+  return { from, to, type } as KnowledgeGraphEdge;
+}
+
+function iso(daysAgo: number): string {
+  return new Date(NOW.getTime() - daysAgo * DAY_MS).toISOString();
+}
+
+describe("buildDoNextQueue (S5 — 할 일 큐)", () => {
+  it("방치된 허브 — degree 높고 오래된 노드를 degree×경과일 순으로", () => {
+    const hub = n("capability:hub", "capability", "capabilities/hub", "Hub");
+    const spokes = Array.from({ length: 5 }, (_, i) => n(`element:s${i}`, "element", `elements/s${i}`));
+    const edges = spokes.map((s) => e(s.id, hub.id));
+    const fresh = new Map([["capabilities/hub", iso(60)]]);
+    const queue = buildDoNextQueue([hub, ...spokes], edges, fresh, { now: NOW });
+    const hubRow = queue.rows.find((r) => r.rowKind === "neglected-hub");
+    expect(hubRow).toMatchObject({ nodeId: "capability:hub", degree: 5, agoDays: 60 });
+    expect(hubRow?.handoffPayload).toContain('blast_radius');
+    expect(hubRow?.handoffPayload).toContain("capabilities/hub");
+  });
+
+  it("최근 갱신된 허브·갱신 시점 미상 허브는 방치로 단정하지 않는다", () => {
+    const hub = n("capability:hub", "capability", "capabilities/hub");
+    const unknown = n("capability:u", "capability"); // evidence 없음
+    const spokes = Array.from({ length: 5 }, (_, i) => n(`element:s${i}`, "element"));
+    const edges = [
+      ...spokes.map((s) => e(s.id, hub.id)),
+      ...spokes.map((s) => e(s.id, unknown.id)),
+    ];
+    const fresh = new Map([["capabilities/hub", iso(3)]]);
+    const queue = buildDoNextQueue([hub, unknown, ...spokes], edges, fresh, { now: NOW });
+    expect(queue.counts.neglectedHub).toBe(0);
+  });
+
+  it("고아·승격은 지도 health 칩과 같은 entities 신호를 재사용하고, 핸드오프는 vault slug 를 쓴다", () => {
+    const orphan = n("element:alone", "element", "elements/alone", "Alone");
+    const other = n("capability:c", "capability", "capabilities/c");
+    const queue = buildDoNextQueue([orphan, other], [], new Map(), { now: NOW });
+    const orphanRows = queue.rows.filter((r) => r.rowKind === "orphan");
+    expect(orphanRows.map((r) => r.nodeId)).toContain("element:alone");
+    const row = orphanRows.find((r) => r.nodeId === "element:alone");
+    expect(row?.handoffPayload).toContain('elements/alone');
+    expect(row?.handoffPayload).toContain("add_relation");
+    expect(row?.handoffPayload).toContain("why");
+  });
+
+  it("유형별 perKindLimit 로 자르되 counts 는 전체를 정직하게 보고한다", () => {
+    const orphans = Array.from({ length: 8 }, (_, i) => n(`element:o${i}`, "element", `elements/o${i}`));
+    const queue = buildDoNextQueue(orphans, [], new Map(), { now: NOW, perKindLimit: 3 });
+    expect(queue.rows.filter((r) => r.rowKind === "orphan")).toHaveLength(3);
+    expect(queue.counts.orphan).toBe(8);
+  });
+});

--- a/src/views/ontology-insights/lib/do-next-queue.ts
+++ b/src/views/ontology-insights/lib/do-next-queue.ts
@@ -1,0 +1,130 @@
+import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import { buildOntologyHealthSignals } from "@/entities/knowledge-graph";
+import { rankAllByDegree } from "@/shared/lib/ontology-tree";
+
+/**
+ * "할 일" 탭 (S5, 전략 verdict B) — 인사이트를 재고 나열에서 "그래서 뭘
+ * 해야 하는데?"로. 이 페이지에 이미 로드된 파생(healthSignals ·
+ * rankAllByDegree · docFreshnessIndex)만 조합한다 — maintenance_plan 급
+ * 정밀 순위의 client 재구현은 의도적으로 하지 않는다(패널 반대 의견 절충:
+ * 단일 진실원 유지, 정밀 판정은 행별 에이전트 핸드오프로 위임).
+ */
+
+export type DoNextRowKind = "neglected-hub" | "orphan" | "promotion";
+
+export interface DoNextRow {
+  /** 행 고유 id — `${kind}:${nodeId}`. */
+  id: string;
+  rowKind: DoNextRowKind;
+  nodeId: string;
+  title: string;
+  nodeKind: string;
+  /** 연결도 (neglected-hub · promotion). */
+  degree?: number;
+  /** 마지막 갱신 후 일수 (neglected-hub). */
+  agoDays?: number;
+  /** 행별 에이전트 핸드오프 — MCP 호출 순서 제안 (복사용). */
+  handoffPayload: string;
+}
+
+export interface DoNextQueue {
+  rows: DoNextRow[];
+  counts: { neglectedHub: number; orphan: number; promotion: number };
+}
+
+export interface BuildDoNextQueueOptions {
+  /** 허브로 볼 최소 연결도. 기본 4. */
+  hubMinDegree?: number;
+  /** "방치"로 볼 최소 경과 일수. 기본 30. */
+  neglectMinDays?: number;
+  /** 유형별 최대 행 수. 기본 5. */
+  perKindLimit?: number;
+  now?: Date;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function nodeSlug(node: KnowledgeGraphNode): string | null {
+  return node.evidenceIds[0] ?? null;
+}
+
+export function buildDoNextQueue(
+  nodes: readonly KnowledgeGraphNode[],
+  edges: readonly KnowledgeGraphEdge[],
+  freshnessIndex: ReadonlyMap<string, string>,
+  options: BuildDoNextQueueOptions = {},
+): DoNextQueue {
+  const hubMinDegree = options.hubMinDegree ?? 4;
+  const neglectMinDays = options.neglectMinDays ?? 30;
+  const perKindLimit = options.perKindLimit ?? 5;
+  const nowMs = (options.now ?? new Date()).getTime();
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
+  // ① 방치된 허브 — degree 높음 × 갱신 오래됨. 둘 다 이미 페이지에 있는
+  // 신호의 곱이라 계산 비용은 랭킹 한 번이다.
+  const neglectedHubs: DoNextRow[] = [];
+  for (const { node, degree } of rankAllByDegree(nodes, edges)) {
+    if (degree < hubMinDegree) break; // 내림차순 — 임계 밑이면 종료
+    const slug = nodeSlug(node);
+    const iso = slug ? freshnessIndex.get(slug) : undefined;
+    if (!iso) continue; // 갱신 시점을 모르면 "방치"라 단정하지 않는다
+    const agoDays = Math.floor((nowMs - Date.parse(iso)) / DAY_MS);
+    if (!Number.isFinite(agoDays) || agoDays < neglectMinDays) continue;
+    neglectedHubs.push({
+      id: `neglected-hub:${node.id}`,
+      rowKind: "neglected-hub",
+      nodeId: node.id,
+      title: node.title,
+      nodeKind: node.kind,
+      degree,
+      agoDays,
+      handoffPayload: `query_ontology({operation:"blast_radius", slug:"${slug}"}) 로 영향권 확인 → 문서 내용 검토 후 patch_concept("${slug}", …) 로 갱신`,
+    });
+  }
+  neglectedHubs.sort((a, b) => (b.degree ?? 0) * (b.agoDays ?? 0) - (a.degree ?? 0) * (a.agoDays ?? 0));
+
+  // ②③ 고아 · 승격 후보 — 지도 health 칩과 같은 entities 함수 재사용
+  // (진실원 1벌 — 지도 칩과 이 큐의 숫자가 갈라질 수 없다).
+  const signals = buildOntologyHealthSignals(nodes, edges, { now: options.now });
+
+  // candidate.slug 는 그래프 노드 id (`capability:mcp-server`) — MCP 호출엔
+  // vault slug(evidenceIds[0])가 맞다. 없으면 id tail 로 fallback (alias 해석).
+  const mcpRef = (graphId: string): string => {
+    const node = nodeById.get(graphId);
+    return node?.evidenceIds[0] ?? graphId.split(":").pop() ?? graphId;
+  };
+
+  const orphans: DoNextRow[] = signals.orphan.map(({ slug, name }) => ({
+    id: `orphan:${slug}`,
+    rowKind: "orphan",
+    nodeId: slug,
+    title: name,
+    nodeKind: nodeById.get(slug)?.kind ?? "unknown",
+    handoffPayload: `find_neighbors({slug:"${mcpRef(slug)}"}) 로 이웃 후보 확인 → relation_check 사전 점검 → add_relation({from:"${mcpRef(slug)}", to:"<대상>", type:"relates", why:"<근거 한 줄>"})`,
+  }));
+
+  const promotions: DoNextRow[] = signals.promotion.map(({ slug, name }) => ({
+    id: `promotion:${slug}`,
+    rowKind: "promotion",
+    nodeId: slug,
+    title: name,
+    nodeKind: nodeById.get(slug)?.kind ?? "unknown",
+    handoffPayload: `query_ontology({operation:"node_profile", slug:"${mcpRef(slug)}"}) 로 fan-in 확인 → 승격이 맞으면 patch_concept 로 kind 상향 또는 add_concept 로 상위 개념 신설`,
+  }));
+
+  const rows = [
+    ...neglectedHubs.slice(0, perKindLimit),
+    ...orphans.slice(0, perKindLimit),
+    ...promotions.slice(0, perKindLimit),
+  ];
+
+  return {
+    rows,
+    counts: {
+      neglectedHub: neglectedHubs.length,
+      orphan: orphans.length,
+      promotion: promotions.length,
+    },
+  };
+}

--- a/src/views/ontology-insights/lib/insights-tab-state.test.ts
+++ b/src/views/ontology-insights/lib/insights-tab-state.test.ts
@@ -6,16 +6,21 @@ import {
 } from "./insights-tab-state";
 
 describe("parseInsightsTab", () => {
-  it("defaults to overview when the param is missing", () => {
-    expect(parseInsightsTab(null)).toBe("overview");
-    expect(parseInsightsTab(undefined)).toBe("overview");
-    expect(parseInsightsTab("")).toBe("overview");
+  it("defaults to do-next when the param is missing", () => {
+    expect(parseInsightsTab(null)).toBe("do-next");
+    expect(parseInsightsTab(undefined)).toBe("do-next");
+    expect(parseInsightsTab("")).toBe("do-next");
   });
 
   it("accepts the three known tabs", () => {
-    expect(parseInsightsTab("overview")).toBe("overview");
-    expect(parseInsightsTab("relations")).toBe("relations");
+    expect(parseInsightsTab("do-next")).toBe("do-next");
+    expect(parseInsightsTab("structure")).toBe("structure");
     expect(parseInsightsTab("freshness")).toBe("freshness");
+  });
+
+  it("S5 재편 전 공유 링크 호환 — overview/relations 는 구조 탭으로", () => {
+    expect(parseInsightsTab("overview")).toBe("structure");
+    expect(parseInsightsTab("relations")).toBe("structure");
   });
 
   it("falls back to the default tab for unknown values (old reader-intent tabs included)", () => {
@@ -27,11 +32,11 @@ describe("parseInsightsTab", () => {
 
 describe("buildInsightsTabHref", () => {
   it("omits the query string for the default tab", () => {
-    expect(buildInsightsTabHref("overview")).toBe("/ontology/insights/");
+    expect(buildInsightsTabHref("do-next")).toBe("/ontology/insights/");
   });
 
   it("appends ?tab= for non-default tabs", () => {
-    expect(buildInsightsTabHref("relations")).toBe("/ontology/insights/?tab=relations");
+    expect(buildInsightsTabHref("structure")).toBe("/ontology/insights/?tab=structure");
     expect(buildInsightsTabHref("freshness")).toBe("/ontology/insights/?tab=freshness");
   });
 });

--- a/src/views/ontology-insights/lib/insights-tab-state.ts
+++ b/src/views/ontology-insights/lib/insights-tab-state.ts
@@ -3,24 +3,31 @@
  * final round. URL `?tab=` 이 진실원 — 새로고침/공유 링크에서도 같은 탭이
  * 열려야 하므로 컴포넌트 local state 가 아니라 순수 함수로 파싱/직렬화한다.
  *
- * 탭 3 종 고정: 개요(overview) · 관계(relations) · 신선도(freshness).
+ * 탭 3 종 고정 (S5 재편): 할 일(do-next, 기본) · 구조(structure = 구 개요+관계 병합) · 신선도(freshness).
  * 이전 라운드의 4-tab 리더 페르소나 시스템(proof/collaboration/agent/census)
  * 은 insights-final.html 승인안에 없어 제거 — 탭 바 자체가 유일한 내비게이션.
  */
-export const INSIGHTS_TABS = ["overview", "relations", "freshness"] as const;
+export const INSIGHTS_TABS = ["do-next", "structure", "freshness"] as const;
 
 export type InsightsTab = (typeof INSIGHTS_TABS)[number];
 
-export const DEFAULT_INSIGHTS_TAB: InsightsTab = "overview";
+export const DEFAULT_INSIGHTS_TAB: InsightsTab = "do-next";
 
 function isInsightsTab(value: string): value is InsightsTab {
   return (INSIGHTS_TABS as readonly string[]).includes(value);
 }
 
+/** S5 재편 전 URL 호환 — 공유/북마크된 ?tab=overview|relations 는 구조 탭으로. */
+const LEGACY_TAB_ALIASES: Record<string, InsightsTab> = {
+  overview: "structure",
+  relations: "structure",
+};
+
 /** `searchParams.get("tab")` 의 raw 값 (string | null) → 유효 탭. 모르는 값/누락은 기본 탭. */
 export function parseInsightsTab(raw: string | null | undefined): InsightsTab {
   if (!raw) return DEFAULT_INSIGHTS_TAB;
-  return isInsightsTab(raw) ? raw : DEFAULT_INSIGHTS_TAB;
+  if (isInsightsTab(raw)) return raw;
+  return LEGACY_TAB_ALIASES[raw] ?? DEFAULT_INSIGHTS_TAB;
 }
 
 /** 탭 전환 시 갈 pathname — 기본 탭은 `?tab=` 을 아예 붙이지 않아 URL 이 깔끔. */

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -41,11 +41,13 @@ import {
   type InsightsTab,
 } from "../lib/insights-tab-state";
 import { computeDomainCapacityRows } from "../lib/domain-capacity";
+import { buildDoNextQueue } from "../lib/do-next-queue";
 import { computeCensusHealth } from "../lib/census-health";
 import { buildDependsOnRows } from "../lib/depends-on-rows";
 import { buildHubEgoThumbnail } from "../lib/hub-ego-thumbnail";
 import { FRESHNESS_WINDOW_WEEKS, computeFreshnessSummary } from "../lib/freshness";
 import { OverviewTab } from "./tabs/OverviewTab";
+import { DoNextTab } from "./tabs/DoNextTab";
 import { RelationsTab, type RelationHubRow } from "./tabs/RelationsTab";
 import { FreshnessTab } from "./tabs/FreshnessTab";
 import { InsightsHandoffRow } from "./parts/InsightsHandoffRow";
@@ -57,8 +59,8 @@ const DEPENDS_ON_DISPLAY_LIMIT = 5;
 const RECENT_UPDATES_LIMIT = 8;
 
 const HANDOFF_PAYLOAD: Record<InsightsTab, string> = {
-  overview: 'query_ontology({operation:"health"}) → query_ontology({operation:"growth_plan"}) → query_ontology({operation:"maintenance_plan"})',
-  relations: 'query_ontology({operation:"match_edges", type:"depends_on"}) → query_ontology({operation:"blast_radius", slug:"<hub-slug>"})',
+  "do-next": 'query_ontology({operation:"maintenance_plan"}) → 항목별 실행 → query_ontology({operation:"health"}) 로 재확인',
+  structure: 'query_ontology({operation:"health"}) → query_ontology({operation:"match_edges", type:"depends_on"}) → query_ontology({operation:"blast_radius", slug:"<hub-slug>"})',
   freshness: 'query_ontology({operation:"maintenance_plan"}) → find_orphans({}) → query_ontology({operation:"growth_plan"})',
 };
 
@@ -161,6 +163,12 @@ export function OntologyInsightsPage() {
     [nodes, edges, docFreshnessIndex],
   );
 
+  // S5 — "할 일" 큐: 이미 로드된 파생(healthSignals·degree·freshness)의 조합.
+  const doNextQueue = useMemo(
+    () => buildDoNextQueue(nodes, edges, docFreshnessIndex),
+    [nodes, edges, docFreshnessIndex],
+  );
+
   const setTab = (next: string) => {
     router.replace(buildInsightsTabHref(next as InsightsTab), { scroll: false });
   };
@@ -193,6 +201,8 @@ export function OntologyInsightsPage() {
     connectionsUnit: t("connectionsUnit"),
     hubTruncated: (shown: number, total: number) => t("hubTruncated", { shown, total }),
     hubThumbnailCaption: t("hubThumbnailCaption"),
+  };
+  const doNextLabels = {
     agentReadinessTitle: t("agentReadinessTitle"),
     agentReadinessReady: t("agentReadinessReady"),
     agentReadinessPreflight: t("agentReadinessPreflight"),
@@ -202,12 +212,23 @@ export function OntologyInsightsPage() {
     repairQueueOrphan: t("repairQueueOrphan"),
     repairQueuePromotion: t("repairQueuePromotion"),
     repairQueueEmpty: t("repairQueueEmpty"),
-    repairQueueTargetLabel: t("repairQueueTargetLabel"),
     repairQueueActionKindStale: t("repairQueueActionKindStale"),
     repairQueueActionKindOrphan: t("repairQueueActionKindOrphan"),
     repairQueueActionKindPromotion: t("repairQueueActionKindPromotion"),
     repairQueueOpenBuilder: t("repairQueueOpenBuilder"),
     repairQueueOpenOntology: t("repairQueueOpenOntology"),
+    queueTitle: t("doNext.queueTitle"),
+    sectionNeglectedHub: t("doNext.sectionNeglectedHub"),
+    sectionOrphan: t("doNext.sectionOrphan"),
+    sectionPromotion: t("doNext.sectionPromotion"),
+    neglectedHubMetric: (degree: number, agoDays: number) =>
+      t("doNext.neglectedHubMetric", { degree, days: agoDays }),
+    openMap: t("doNext.openMap"),
+    openBuilder: t("doNext.openBuilder"),
+    handoffCopy: t("doNext.handoffCopy"),
+    handoffCopied: t("agentCopied"),
+    emptyQueue: t("doNext.emptyQueue"),
+    moreCount: (count: number) => t("doNext.moreCount", { count }),
   };
   const formatDaysAgo = (days: number) => {
     if (days <= 0) return t("daysAgoToday");
@@ -268,7 +289,12 @@ export function OntologyInsightsPage() {
             items={INSIGHTS_TABS.map((key) => ({
               key,
               label: t(`tab.${key}`),
-              count: key === "overview" ? totalNodes : key === "relations" ? totalEdges : `${FRESHNESS_WINDOW_WEEKS}${t("weeksUnit")}`,
+              count:
+                key === "do-next"
+                  ? doNextQueue.counts.neglectedHub + doNextQueue.counts.orphan + doNextQueue.counts.promotion
+                  : key === "structure"
+                    ? totalNodes
+                    : `${FRESHNESS_WINDOW_WEEKS}${t("weeksUnit")}`,
             }))}
           />
         </nav>
@@ -313,7 +339,17 @@ export function OntologyInsightsPage() {
             aria-labelledby={`insights-tab-${tab}`}
             className="mt-[var(--section-gap)] flex min-h-0 flex-1 flex-col"
           >
-            {tab === "overview" ? (
+            {tab === "do-next" ? (
+              <DoNextTab
+                queue={doNextQueue}
+                agentReadiness={agentReadiness}
+                healthQueue={healthQueue}
+                mapHref={buildOntologyNodeHref}
+                builderHref={buildOntologyBuilderNodeHrefFromGraphId}
+                labels={doNextLabels}
+              />
+            ) : null}
+            {tab === "structure" ? (
               <OverviewTab
                 totalNodes={totalNodes}
                 totalEdges={totalEdges}
@@ -325,7 +361,7 @@ export function OntologyInsightsPage() {
                 labels={overviewLabels}
               />
             ) : null}
-            {tab === "relations" ? (
+            {tab === "structure" ? (
               <RelationsTab
                 edgeTypeRows={edgeTypeRows}
                 totalEdges={totalEdges}
@@ -334,8 +370,6 @@ export function OntologyInsightsPage() {
                 hubs={hubs}
                 hubTotalCount={hubRanking.length}
                 kindLabel={kindLabel}
-                agentReadiness={agentReadiness}
-                healthQueue={healthQueue}
                 hubLink={{
                   href: buildOntologyNodeHref,
                   ariaLabel: (title) => t("hubRowAriaLabel", { title }),

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.test.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DoNextTab, type DoNextTabLabels } from "./DoNextTab";
+import type { DoNextQueue } from "../../lib/do-next-queue";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: React.ComponentProps<"a">) => (
+    <a href={String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const labels: DoNextTabLabels = {
+  agentReadinessTitle: "Agent readiness",
+  agentReadinessReady: "ready",
+  agentReadinessPreflight: "preflight",
+  agentReadinessReview: "review",
+  repairQueueTitle: "Repair queue",
+  repairQueueStale: "stale",
+  repairQueueOrphan: "orphan",
+  repairQueuePromotion: "promotion",
+  repairQueueEmpty: "Nothing to repair right now.",
+  repairQueueActionKindStale: "Stale evidence",
+  repairQueueActionKindOrphan: "Orphan",
+  repairQueueActionKindPromotion: "Promotion",
+  repairQueueOpenBuilder: "Builder",
+  repairQueueOpenOntology: "Map",
+  queueTitle: "Worth doing now",
+  sectionNeglectedHub: "Neglected hubs",
+  sectionOrphan: "Orphans",
+  sectionPromotion: "Promotion candidates",
+  neglectedHubMetric: (degree, agoDays) => `${degree} links · ${agoDays}d`,
+  openMap: "Map",
+  openBuilder: "Builder",
+  handoffCopy: "To agent",
+  handoffCopied: "Copied",
+  emptyQueue: "Nothing needs attention.",
+  moreCount: (count) => `+${count} more`,
+};
+
+const emptyHealthQueue = {
+  staleCount: 0,
+  orphanCount: 0,
+  promotionCount: 0,
+  actionTarget: null,
+  builderHref: (slug: string) => `/ontology/edit/?node=${slug}`,
+  ontologyHref: (slug: string) => `/ontology/?node=${slug}`,
+};
+
+const queue: DoNextQueue = {
+  rows: [
+    {
+      id: "neglected-hub:capability:hub",
+      rowKind: "neglected-hub",
+      nodeId: "capability:hub",
+      title: "MCP Server",
+      nodeKind: "capability",
+      degree: 12,
+      agoDays: 45,
+      handoffPayload: 'query_ontology({operation:"blast_radius", slug:"capabilities/mcp-server"})',
+    },
+    {
+      id: "orphan:element:alone",
+      rowKind: "orphan",
+      nodeId: "element:alone",
+      title: "Alone",
+      nodeKind: "element",
+      handoffPayload: "find_neighbors …",
+    },
+  ],
+  counts: { neglectedHub: 3, orphan: 1, promotion: 0 },
+};
+
+describe("DoNextTab", () => {
+  it("행동 큐 — 방치 허브·고아 행 + 지도/빌더 딥링크 + 행별 핸드오프 복사 버튼", () => {
+    render(
+      <DoNextTab
+        queue={queue}
+        agentReadiness={{ ready: 82, preflight: 4, review: 2 }}
+        healthQueue={emptyHealthQueue}
+        mapHref={(id) => `/ontology/?node=${encodeURIComponent(id)}`}
+        builderHref={(id) => `/ontology/edit/?node=${encodeURIComponent(id)}`}
+        labels={labels}
+      />,
+    );
+
+    const rows = screen.getAllByTestId("do-next-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("MCP Server");
+    expect(rows[0]).toHaveTextContent("12 links · 45d");
+    expect(screen.getAllByTestId("do-next-handoff-copy")).toHaveLength(2);
+    // 잘린 만큼 정직 표기 (+2 more = counts 3 - rows 1)
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+
+  it("이관된 readiness 계기·수리 큐를 렌더한다 (RelationsTab 에서 이동)", () => {
+    render(
+      <DoNextTab
+        queue={{ rows: [], counts: { neglectedHub: 0, orphan: 0, promotion: 0 } }}
+        agentReadiness={{ ready: 82, preflight: 4, review: 2 }}
+        healthQueue={emptyHealthQueue}
+        mapHref={(id) => id}
+        builderHref={(id) => id}
+        labels={labels}
+      />,
+    );
+
+    const gauge = screen.getByTestId("insights-agent-readiness");
+    expect(gauge).toHaveTextContent("Agent readiness");
+    expect(gauge).toHaveAttribute("aria-label", "Agent readiness: 82 ready · 4 preflight · 2 review");
+    expect(screen.getByTestId("insights-repair-queue")).toHaveTextContent("Nothing to repair right now.");
+    expect(screen.getByText("Nothing needs attention.")).toBeInTheDocument();
+  });
+
+  it("수리 대상이 있으면 빌더 딥링크를 노출한다", () => {
+    render(
+      <DoNextTab
+        queue={{ rows: [], counts: { neglectedHub: 0, orphan: 0, promotion: 0 } }}
+        agentReadiness={{ ready: 1, preflight: 0, review: 0 }}
+        healthQueue={{
+          ...emptyHealthQueue,
+          staleCount: 1,
+          actionTarget: { kind: "stale", slug: "capability:foo", title: "Foo" },
+        }}
+        mapHref={(id) => id}
+        builderHref={(id) => id}
+        labels={labels}
+      />,
+    );
+
+    expect(screen.getByTestId("insights-repair-queue-target")).toHaveTextContent("Foo");
+    expect(screen.getByTestId("insights-repair-queue-builder-link")).toHaveAttribute(
+      "href",
+      "/ontology/edit/?node=capability:foo",
+    );
+  });
+});

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { copyText } from "@/shared/lib/copy-text";
+import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
+import type { OntologyHealthActionTarget } from "@/entities/knowledge-graph";
+import type { DoNextQueue, DoNextRow } from "../../lib/do-next-queue";
+
+/**
+ * 탭1 "할 일" (S5, 전략 verdict B 채택) — 인사이트의 기본 탭. "무엇이
+ * 있나"(재고)가 아니라 "그래서 뭘 해야 하나"에 답한다:
+ *
+ * 1. Agent readiness 계기 + 수리 큐 요약 — 관계 탭에서 이관 (행동 요소가
+ *    재고 탭에 묻혀 있던 것이 "인사이트 부족" 체감의 원인).
+ * 2. 행동 큐 — 방치된 허브(연결도×방치일) · 고아 · 승격 후보. 각 행에
+ *    [지도에서 보기 · 빌더 열기 · 에이전트에게(행별 MCP 핸드오프 복사)].
+ *
+ * 자동화 계약: 정밀 순위(maintenance_plan)는 client 재구현하지 않는다 —
+ * 사람은 여기서 고르고, 실행은 행별 핸드오프로 에이전트에게 넘긴다.
+ */
+
+export interface DoNextTabLabels {
+  agentReadinessTitle: string;
+  agentReadinessReady: string;
+  agentReadinessPreflight: string;
+  agentReadinessReview: string;
+  repairQueueTitle: string;
+  repairQueueStale: string;
+  repairQueueOrphan: string;
+  repairQueuePromotion: string;
+  repairQueueEmpty: string;
+  repairQueueActionKindStale: string;
+  repairQueueActionKindOrphan: string;
+  repairQueueActionKindPromotion: string;
+  repairQueueOpenBuilder: string;
+  repairQueueOpenOntology: string;
+  queueTitle: string;
+  sectionNeglectedHub: string;
+  sectionOrphan: string;
+  sectionPromotion: string;
+  neglectedHubMetric: (degree: number, agoDays: number) => string;
+  openMap: string;
+  openBuilder: string;
+  handoffCopy: string;
+  handoffCopied: string;
+  emptyQueue: string;
+  moreCount: (count: number) => string;
+}
+
+export interface DoNextTabAgentReadiness {
+  ready: number;
+  preflight: number;
+  review: number;
+}
+
+export interface DoNextTabHealthQueue {
+  staleCount: number;
+  orphanCount: number;
+  promotionCount: number;
+  actionTarget: OntologyHealthActionTarget | null;
+  builderHref: (slug: string) => string;
+  ontologyHref: (slug: string) => string;
+}
+
+export interface DoNextTabProps {
+  queue: DoNextQueue;
+  agentReadiness: DoNextTabAgentReadiness;
+  healthQueue: DoNextTabHealthQueue;
+  mapHref: (nodeId: string) => string;
+  builderHref: (nodeId: string) => string;
+  labels: DoNextTabLabels;
+}
+
+function HandoffCopyButton({ payload, labels }: { payload: string; labels: DoNextTabLabels }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      data-testid="do-next-handoff-copy"
+      onClick={async () => {
+        if (await copyText(payload)) {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1600);
+        }
+      }}
+      className="inline-flex min-h-8 items-center gap-1 rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+    >
+      {copied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
+      {copied ? labels.handoffCopied : labels.handoffCopy}
+    </button>
+  );
+}
+
+function QueueSection({
+  title,
+  rows,
+  totalCount,
+  metric,
+  mapHref,
+  builderHref,
+  labels,
+}: {
+  title: string;
+  rows: DoNextRow[];
+  totalCount: number;
+  metric: (row: DoNextRow) => string | null;
+  mapHref: (nodeId: string) => string;
+  builderHref: (nodeId: string) => string;
+  labels: DoNextTabLabels;
+}) {
+  if (rows.length === 0) return null;
+  const hiddenCount = Math.max(0, totalCount - rows.length);
+  return (
+    <section aria-label={title} className="flex flex-col">
+      <div className="flex items-baseline gap-2 border-b border-[color:var(--color-divider)] pb-2">
+        <span className="text-[13px] font-medium text-[color:var(--color-text-primary)]">{title}</span>
+        <span className="font-mono text-[11px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+          {totalCount}
+        </span>
+      </div>
+      {rows.map((row) => {
+        const metricText = metric(row);
+        return (
+          <div
+            key={row.id}
+            data-testid="do-next-row"
+            className="flex min-w-0 items-center gap-2.5 border-b border-[color:var(--color-divider)] py-2.5 last:border-b-0"
+          >
+            <TopologyV2KindGlyph kind={row.nodeKind} size={13} />
+            <span className="min-w-0 flex-1 truncate text-[13px] text-[color:var(--color-text-secondary)]">
+              {row.title}
+            </span>
+            {metricText ? (
+              <span className="shrink-0 font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+                {metricText}
+              </span>
+            ) : null}
+            <span className="flex shrink-0 items-center gap-1.5">
+              <Link
+                href={mapHref(row.nodeId)}
+                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              >
+                {labels.openMap}
+              </Link>
+              <Link
+                href={builderHref(row.nodeId)}
+                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              >
+                {labels.openBuilder}
+              </Link>
+              <HandoffCopyButton payload={row.handoffPayload} labels={labels} />
+            </span>
+          </div>
+        );
+      })}
+      {hiddenCount > 0 ? (
+        <p className="pt-2 text-[11px] text-[color:var(--color-text-quaternary)]">{labels.moreCount(hiddenCount)}</p>
+      ) : null}
+    </section>
+  );
+}
+
+export function DoNextTab({ queue, agentReadiness, healthQueue, mapHref, builderHref, labels }: DoNextTabProps) {
+  const readinessTotal = agentReadiness.ready + agentReadiness.preflight + agentReadiness.review;
+  const repairActionKindLabel = healthQueue.actionTarget
+    ? healthQueue.actionTarget.kind === "stale"
+      ? labels.repairQueueActionKindStale
+      : healthQueue.actionTarget.kind === "orphan"
+        ? labels.repairQueueActionKindOrphan
+        : labels.repairQueueActionKindPromotion
+    : null;
+  const neglectedRows = queue.rows.filter((row) => row.rowKind === "neglected-hub");
+  const orphanRows = queue.rows.filter((row) => row.rowKind === "orphan");
+  const promotionRows = queue.rows.filter((row) => row.rowKind === "promotion");
+  const queueEmpty = queue.rows.length === 0;
+
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-[1.2fr_1fr]">
+      <section
+        aria-label={labels.queueTitle}
+        className="flex min-h-0 min-w-0 flex-col gap-4 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+      >
+        <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+          {labels.queueTitle}
+        </span>
+        {queueEmpty ? (
+          <p className="text-[12.5px] text-[color:var(--color-text-quaternary)]">{labels.emptyQueue}</p>
+        ) : (
+          <>
+            <QueueSection
+              title={labels.sectionNeglectedHub}
+              rows={neglectedRows}
+              totalCount={queue.counts.neglectedHub}
+              metric={(row) =>
+                row.degree !== undefined && row.agoDays !== undefined
+                  ? labels.neglectedHubMetric(row.degree, row.agoDays)
+                  : null
+              }
+              mapHref={mapHref}
+              builderHref={builderHref}
+              labels={labels}
+            />
+            <QueueSection
+              title={labels.sectionOrphan}
+              rows={orphanRows}
+              totalCount={queue.counts.orphan}
+              metric={() => null}
+              mapHref={mapHref}
+              builderHref={builderHref}
+              labels={labels}
+            />
+            <QueueSection
+              title={labels.sectionPromotion}
+              rows={promotionRows}
+              totalCount={queue.counts.promotion}
+              metric={() => null}
+              mapHref={mapHref}
+              builderHref={builderHref}
+              labels={labels}
+            />
+          </>
+        )}
+      </section>
+
+      <section
+        aria-label={labels.agentReadinessTitle}
+        className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+      >
+        <div
+          aria-label={`${labels.agentReadinessTitle}: ${agentReadiness.ready} ${labels.agentReadinessReady} · ${agentReadiness.preflight} ${labels.agentReadinessPreflight} · ${agentReadiness.review} ${labels.agentReadinessReview}`}
+          data-testid="insights-agent-readiness"
+          className="mb-3.5 border-b border-[color:var(--color-divider)] pb-3.5"
+        >
+          <div className="flex items-baseline gap-2">
+            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              {labels.agentReadinessTitle}
+            </span>
+            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+              <span>
+                {agentReadiness.ready}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.agentReadinessReady}
+                </span>
+              </span>
+              <span>
+                {agentReadiness.preflight}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.agentReadinessPreflight}
+                </span>
+              </span>
+              <span>
+                {agentReadiness.review}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.agentReadinessReview}
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            data-testid="insights-agent-readiness-meter"
+            className="mt-2 flex h-1.5 w-full overflow-hidden rounded-full border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-2)]"
+          >
+            <span
+              aria-hidden
+              className="bg-[color:var(--topology-overview-readiness-ready-meter,var(--color-overlay-3))]"
+              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.ready : 1 }}
+            />
+            <span
+              aria-hidden
+              className="bg-[color:var(--topology-overview-readiness-preflight-meter,var(--color-status-warning))]"
+              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.preflight : 0 }}
+            />
+            <span
+              aria-hidden
+              className="bg-[color:var(--topology-overview-readiness-review-meter,var(--color-status-danger))]"
+              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.review : 0 }}
+            />
+          </div>
+        </div>
+        <div data-testid="insights-repair-queue">
+          <div className="flex items-baseline gap-2">
+            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              {labels.repairQueueTitle}
+            </span>
+            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+              <span>
+                {healthQueue.staleCount}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.repairQueueStale}
+                </span>
+              </span>
+              <span>
+                {healthQueue.orphanCount}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.repairQueueOrphan}
+                </span>
+              </span>
+              <span>
+                {healthQueue.promotionCount}{" "}
+                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                  {labels.repairQueuePromotion}
+                </span>
+              </span>
+            </span>
+          </div>
+          {healthQueue.actionTarget ? (
+            <div
+              data-testid="insights-repair-queue-target"
+              className="mt-2.5 flex min-w-0 items-center justify-between gap-2"
+            >
+              <span className="flex min-w-0 items-center gap-1.5 text-[13px] text-[color:var(--color-text-secondary)]">
+                {repairActionKindLabel ? (
+                  <span className="shrink-0 rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 text-[10px] leading-none text-[color:var(--color-text-tertiary)]">
+                    {repairActionKindLabel}
+                  </span>
+                ) : null}
+                <span className="min-w-0 truncate">{healthQueue.actionTarget.title}</span>
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5">
+                <Link
+                  href={healthQueue.builderHref(healthQueue.actionTarget.slug)}
+                  data-testid="insights-repair-queue-builder-link"
+                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-[11px] font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-overlay-2)]"
+                >
+                  {labels.repairQueueOpenBuilder}
+                </Link>
+                <Link
+                  href={healthQueue.ontologyHref(healthQueue.actionTarget.slug)}
+                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                >
+                  {labels.repairQueueOpenOntology}
+                </Link>
+              </span>
+            </div>
+          ) : (
+            <p className="mt-2 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.repairQueueEmpty}</p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/views/ontology-insights/ui/tabs/RelationsTab.test.tsx
+++ b/src/views/ontology-insights/ui/tabs/RelationsTab.test.tsx
@@ -11,6 +11,9 @@ vi.mock("@/i18n/navigation", () => ({
   ),
 }));
 
+// S5 재편: agent readiness 계기·수리 큐는 "할 일" 탭(DoNextTab)으로 이관 —
+// 그 렌더 계약은 DoNextTab.test.tsx 가 소유한다. 여기는 관계 재고(타입
+// 분포·depends_on·허브)만 남는다.
 const labels: RelationsTabLabels = {
   relationTypesTitle: "Relation types",
   topDependsOnTitle: "Top depends_on",
@@ -20,21 +23,6 @@ const labels: RelationsTabLabels = {
   connectionsUnit: "connections",
   hubTruncated: (shown, total) => `Showing ${shown} of ${total}`,
   hubThumbnailCaption: "Thumbnails are mini ego maps.",
-  agentReadinessTitle: "Agent readiness",
-  agentReadinessReady: "ready",
-  agentReadinessPreflight: "preflight",
-  agentReadinessReview: "review",
-  repairQueueTitle: "Repair queue",
-  repairQueueStale: "stale evidence",
-  repairQueueOrphan: "open question",
-  repairQueuePromotion: "hub candidate",
-  repairQueueEmpty: "Nothing to repair right now.",
-  repairQueueTargetLabel: "Next repair target",
-  repairQueueActionKindStale: "Stale evidence",
-  repairQueueActionKindOrphan: "Open question",
-  repairQueueActionKindPromotion: "Hub candidate",
-  repairQueueOpenBuilder: "Edit relations",
-  repairQueueOpenOntology: "Concept doc",
 };
 
 const hubLink = {
@@ -42,17 +30,8 @@ const hubLink = {
   ariaLabel: (title: string) => `${title} — view on the map`,
 };
 
-const emptyHealthQueue = {
-  staleCount: 0,
-  orphanCount: 0,
-  promotionCount: 0,
-  actionTarget: null,
-  builderHref: (slug: string) => `/ontology/edit/?node=${slug}`,
-  ontologyHref: (slug: string) => `/ontology/?node=${slug}`,
-};
-
 describe("RelationsTab", () => {
-  it("renders the agent readiness gauge with ready/preflight/review counts (W3 분석 보기 이관)", () => {
+  it("does not render the moved readiness/repair instruments (S5 이관 회귀)", () => {
     render(
       <RelationsTab
         edgeTypeRows={[{ type: "contains", count: 10 }]}
@@ -62,101 +41,14 @@ describe("RelationsTab", () => {
         hubs={[]}
         hubTotalCount={0}
         kindLabel={(kind) => kind}
-        agentReadiness={{ ready: 82, preflight: 4, review: 2 }}
-        healthQueue={emptyHealthQueue}
         hubLink={hubLink}
         labels={labels}
       />,
     );
 
-    const gauge = screen.getByTestId("insights-agent-readiness");
-    expect(gauge).toHaveTextContent("Agent readiness");
-    expect(gauge).toHaveTextContent("82");
-    expect(gauge).toHaveTextContent("ready");
-    expect(gauge).toHaveTextContent("4");
-    expect(gauge).toHaveTextContent("preflight");
-    expect(gauge).toHaveTextContent("2");
-    expect(gauge).toHaveTextContent("review");
-    expect(gauge).toHaveAttribute(
-      "aria-label",
-      "Agent readiness: 82 ready · 4 preflight · 2 review",
-    );
-  });
-
-  it("does not divide by zero when there are no relations yet", () => {
-    render(
-      <RelationsTab
-        edgeTypeRows={[]}
-        totalEdges={0}
-        edgeTypeLabel={(type) => type}
-        dependsOnRows={[]}
-        hubs={[]}
-        hubTotalCount={0}
-        kindLabel={(kind) => kind}
-        agentReadiness={{ ready: 0, preflight: 0, review: 0 }}
-        healthQueue={emptyHealthQueue}
-        hubLink={hubLink}
-        labels={labels}
-      />,
-    );
-
-    expect(screen.getByTestId("insights-agent-readiness-meter")).toBeInTheDocument();
-  });
-
-  it("shows the repair queue empty state below the readiness gauge when nothing needs repair (분석 패널 완전 소멸 2단계 §c)", () => {
-    render(
-      <RelationsTab
-        edgeTypeRows={[]}
-        totalEdges={0}
-        edgeTypeLabel={(type) => type}
-        dependsOnRows={[]}
-        hubs={[]}
-        hubTotalCount={0}
-        kindLabel={(kind) => kind}
-        agentReadiness={{ ready: 0, preflight: 0, review: 0 }}
-        healthQueue={emptyHealthQueue}
-        hubLink={hubLink}
-        labels={labels}
-      />,
-    );
-
-    const queue = screen.getByTestId("insights-repair-queue");
-    expect(queue).toHaveTextContent("Repair queue");
-    expect(queue).toHaveTextContent("Nothing to repair right now.");
-    expect(screen.queryByTestId("insights-repair-queue-target")).toBeNull();
-  });
-
-  it("shows the next repair target with a builder ?node= deep link when the queue has an actionable target", () => {
-    render(
-      <RelationsTab
-        edgeTypeRows={[]}
-        totalEdges={0}
-        edgeTypeLabel={(type) => type}
-        dependsOnRows={[]}
-        hubs={[]}
-        hubTotalCount={0}
-        kindLabel={(kind) => kind}
-        agentReadiness={{ ready: 0, preflight: 0, review: 0 }}
-        hubLink={hubLink}
-        healthQueue={{
-          staleCount: 2,
-          orphanCount: 1,
-          promotionCount: 0,
-          actionTarget: { slug: "capability:foo", title: "Foo", kind: "stale" },
-          builderHref: (slug) => `/ontology/edit/?node=${encodeURIComponent(slug)}`,
-          ontologyHref: (slug) => `/ontology/?node=${encodeURIComponent(slug)}`,
-        }}
-        labels={labels}
-      />,
-    );
-
-    const target = screen.getByTestId("insights-repair-queue-target");
-    expect(target).toHaveTextContent("Stale evidence");
-    expect(target).toHaveTextContent("Foo");
-    expect(screen.getByTestId("insights-repair-queue-builder-link")).toHaveAttribute(
-      "href",
-      "/ontology/edit/?node=capability%3Afoo",
-    );
+    expect(screen.queryByTestId("insights-agent-readiness")).toBeNull();
+    expect(screen.queryByTestId("insights-repair-queue")).toBeNull();
+    expect(screen.getByText("Relation types")).toBeInTheDocument();
   });
 
   it("renders each hub row as a map-focus deeplink (UX 부대 — 허브 행 비클릭 해소)", () => {
@@ -177,9 +69,7 @@ describe("RelationsTab", () => {
         ]}
         hubTotalCount={1}
         kindLabel={(kind) => kind}
-        agentReadiness={{ ready: 0, preflight: 0, review: 0 }}
         hubLink={hubLink}
-        healthQueue={emptyHealthQueue}
         labels={labels}
       />,
     );

--- a/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
@@ -2,7 +2,6 @@ import { Link } from "@/i18n/navigation";
 import { TopologyV2KindGlyph, TopologyV2TraceMark } from "@/shared/ui";
 import { isContainmentRelation } from "@/shared/lib/ontology-tree";
 import { getOntologyKindTone } from "@/entities/ontology-class";
-import type { OntologyHealthActionTarget } from "@/entities/knowledge-graph";
 import type { DependsOnPairRow } from "../../lib/depends-on-rows";
 import type { HubEgoThumbnail } from "../../lib/hub-ego-thumbnail";
 import { relationTypeIndigo } from "../../lib/relation-type-tone";
@@ -24,36 +23,6 @@ export interface RelationsTabLabels {
   connectionsUnit: string;
   hubTruncated: (shown: number, total: number) => string;
   hubThumbnailCaption: string;
-  agentReadinessTitle: string;
-  agentReadinessReady: string;
-  agentReadinessPreflight: string;
-  agentReadinessReview: string;
-  repairQueueTitle: string;
-  repairQueueStale: string;
-  repairQueueOrphan: string;
-  repairQueuePromotion: string;
-  repairQueueEmpty: string;
-  repairQueueTargetLabel: string;
-  repairQueueActionKindStale: string;
-  repairQueueActionKindOrphan: string;
-  repairQueueActionKindPromotion: string;
-  repairQueueOpenBuilder: string;
-  repairQueueOpenOntology: string;
-}
-
-export interface RelationsTabAgentReadiness {
-  ready: number;
-  preflight: number;
-  review: number;
-}
-
-export interface RelationsTabHealthQueue {
-  staleCount: number;
-  orphanCount: number;
-  promotionCount: number;
-  actionTarget: OntologyHealthActionTarget | null;
-  builderHref: (slug: string) => string;
-  ontologyHref: (slug: string) => string;
 }
 
 export interface RelationsTabHubLink {
@@ -70,17 +39,6 @@ export interface RelationsTabProps {
   hubs: RelationHubRow[];
   hubTotalCount: number;
   kindLabel: (kind: string) => string;
-  /** relation evidence quality rolled up into a handoff-readiness read — ready
-   *  (strong ∪ supported evidence) / preflight (weak, `related_to`) / review
-   *  (no evidence yet). Derivation: `classifyRelationQuality` +
-   *  `summarizeAgentReadiness` (`@/entities/knowledge-graph`) — moved here
-   *  from the topology map's overview mode (W3 분석 보기 은퇴), which is now
-   *  the single place this reads before an agent starts writing relations. */
-  agentReadiness: RelationsTabAgentReadiness;
-  /** 수리 큐 — 분석 패널 완전 소멸 2단계 §c 로 지도 좌측 레일의 health 모드
-   *  에서 이관. `buildOntologyHealthActionTarget`(entities 레벨, 지도의 health
-   *  칩과 같은 소스)로 고른 다음 수리 대상 + 빌더 ?node= 딥링크. */
-  healthQueue: RelationsTabHealthQueue;
   hubLink: RelationsTabHubLink;
   labels: RelationsTabLabels;
 }
@@ -101,22 +59,12 @@ export function RelationsTab({
   hubs,
   hubTotalCount,
   kindLabel,
-  agentReadiness,
-  healthQueue,
   hubLink,
   labels,
 }: RelationsTabProps) {
   const edgeMax = edgeTypeRows.reduce((m, r) => Math.max(m, r.count), 0);
   // hubs 는 이미 degree 내림차순 — hubs[0] 이 이 목록 안의 최대치.
   const hubDegreeMax = hubs.reduce((m, h) => Math.max(m, h.degree), 0);
-  const readinessTotal = agentReadiness.ready + agentReadiness.preflight + agentReadiness.review;
-  const repairActionKindLabel = healthQueue.actionTarget
-    ? healthQueue.actionTarget.kind === "stale"
-      ? labels.repairQueueActionKindStale
-      : healthQueue.actionTarget.kind === "orphan"
-        ? labels.repairQueueActionKindOrphan
-        : labels.repairQueueActionKindPromotion
-    : null;
 
   return (
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-[1.2fr_1fr]">
@@ -124,112 +72,6 @@ export function RelationsTab({
         aria-label={labels.relationTypesTitle}
         className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
-        <div
-          aria-label={`${labels.agentReadinessTitle}: ${agentReadiness.ready} ${labels.agentReadinessReady} · ${agentReadiness.preflight} ${labels.agentReadinessPreflight} · ${agentReadiness.review} ${labels.agentReadinessReview}`}
-          data-testid="insights-agent-readiness"
-          className="mb-3.5 border-b border-[color:var(--color-divider)] pb-3.5"
-        >
-          <div className="flex items-baseline gap-2">
-            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
-              {labels.agentReadinessTitle}
-            </span>
-            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
-              <span>
-                {agentReadiness.ready} <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">{labels.agentReadinessReady}</span>
-              </span>
-              <span>
-                {agentReadiness.preflight} <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">{labels.agentReadinessPreflight}</span>
-              </span>
-              <span>
-                {agentReadiness.review} <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">{labels.agentReadinessReview}</span>
-              </span>
-            </span>
-          </div>
-          <div
-            data-testid="insights-agent-readiness-meter"
-            className="mt-2 flex h-1.5 w-full overflow-hidden rounded-full border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-2)]"
-          >
-            <span
-              aria-hidden
-              className="bg-[color:var(--topology-overview-readiness-ready-meter,var(--color-overlay-3))]"
-              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.ready : 1 }}
-            />
-            <span
-              aria-hidden
-              className="bg-[color:var(--topology-overview-readiness-preflight-meter,var(--color-status-warning))]"
-              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.preflight : 0 }}
-            />
-            <span
-              aria-hidden
-              className="bg-[color:var(--topology-overview-readiness-review-meter,var(--color-status-danger))]"
-              style={{ flexGrow: readinessTotal > 0 ? agentReadiness.review : 0 }}
-            />
-          </div>
-        </div>
-        <div
-          data-testid="insights-repair-queue"
-          className="mb-3.5 border-b border-[color:var(--color-divider)] pb-3.5"
-        >
-          <div className="flex items-baseline gap-2">
-            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
-              {labels.repairQueueTitle}
-            </span>
-            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
-              <span>
-                {healthQueue.staleCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
-                  {labels.repairQueueStale}
-                </span>
-              </span>
-              <span>
-                {healthQueue.orphanCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
-                  {labels.repairQueueOrphan}
-                </span>
-              </span>
-              <span>
-                {healthQueue.promotionCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
-                  {labels.repairQueuePromotion}
-                </span>
-              </span>
-            </span>
-          </div>
-          {healthQueue.actionTarget ? (
-            <div
-              data-testid="insights-repair-queue-target"
-              className="mt-2.5 flex min-w-0 items-center justify-between gap-2"
-            >
-              <span className="flex min-w-0 items-center gap-1.5 text-[13px] text-[color:var(--color-text-secondary)]">
-                {repairActionKindLabel ? (
-                  <span className="shrink-0 rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 text-[10px] leading-none text-[color:var(--color-text-tertiary)]">
-                    {repairActionKindLabel}
-                  </span>
-                ) : null}
-                <span className="min-w-0 truncate">{healthQueue.actionTarget.title}</span>
-              </span>
-              <span className="flex shrink-0 items-center gap-1.5">
-                <Link
-                  href={healthQueue.builderHref(healthQueue.actionTarget.slug)}
-                  data-testid="insights-repair-queue-builder-link"
-                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-[11px] font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-overlay-2)]"
-                >
-                  {labels.repairQueueOpenBuilder}
-                </Link>
-                <Link
-                  href={healthQueue.ontologyHref(healthQueue.actionTarget.slug)}
-                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
-                >
-                  {labels.repairQueueOpenOntology}
-                </Link>
-              </span>
-            </div>
-          ) : (
-            <p className="mt-2 text-[12px] text-[color:var(--color-text-quaternary)]">
-              {labels.repairQueueEmpty}
-            </p>
-          )}
-        </div>
         <CardHead label={labels.relationTypesTitle} gcap="relation breakdown" count={totalEdges} />
         <div
           aria-hidden


### PR DESCRIPTION
전략 패널 verdict 채택: 3탭이 전부 census 재고 나열이라 "그래서 뭘 해야
하는데?"에 답하지 못했다 (소유자 "인사이트가 부족" 체감의 원인).

- 탭 재편: **할 일**(신설·기본) / **구조**(구 개요+관계 병합) / 신선도.
  구 ?tab=overview|relations 공유 링크는 구조 탭으로 호환 매핑.
- "할 일" = buildDoNextQueue — 방치된 허브(연결도×방치일, 이미 로드된
  degree·freshness 신호의 곱) · 고아 · 승격 후보. 각 행에 지도/빌더
  딥링크 + 행별 MCP 핸드오프 복사(vault slug 기반). maintenance_plan 의
  client 재구현은 의도적으로 안 함 — 정밀 실행은 에이전트에게 위임
  (자동화 계약: 사람은 고르고 승인만).
- readiness 계기·수리 큐를 관계 탭에서 "할 일"로 이관 (행동 요소가 재고
  탭에 묻혀 있던 문제). RelationsTab 은 관계 재고 전용으로 축소.
- 지도 INDEX 의 수리 큐 딥링크도 기본 탭으로 갱신.

검증: do-next-queue 4 · DoNextTab 3 · tab-state/RelationsTab 갱신 포함
insights 46 + home 합산 214 pass · tsc · eslint 0 · i18n · 라이브 :3107
"할 일 28" 탭 콘솔 에러 0
