### PR TITLE
fix: 팝오버 typed fact·Esc 사다리·설정 팝오버·readout·검색 Esc·백링크 (S3)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -231,7 +231,10 @@
     "readout": {
       "projectUnit": "project",
       "domainUnit": "domains",
-      "hint": "Spine view · zoom in to reveal elements"
+      "tier_spine": "Spine view",
+      "tier_circuit": "Circuit view",
+      "tier_element": "Element view",
+      "zoomHint": "zoom in to reveal elements"
     }
   },
   "rootEntry": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -231,7 +231,10 @@
     "readout": {
       "projectUnit": "project",
       "domainUnit": "domains",
-      "hint": "Spine view · 줌인하면 요소가 나타납니다"
+      "tier_spine": "Spine view",
+      "tier_circuit": "Circuit view",
+      "tier_element": "Element view",
+      "zoomHint": "줌인하면 요소가 나타납니다"
     }
   },
   "rootEntry": {

--- a/scripts/build-docs-vault.mjs
+++ b/scripts/build-docs-vault.mjs
@@ -569,6 +569,69 @@ async function buildDocsVault({ check = false } = {}) {
     }
   }
 
+  // D-1 — register FRONTMATTER relation-ref backlinks (mirrors
+  // `src/entities/docs-vault/lib/build-local-manifest.ts`). The body pass above
+  // only saw markdown links, so a doc referenced purely through frontmatter
+  // (`dependencies: [capabilities/mcp-server]`, …) showed a false "no
+  // backlinks" in the sample (build-time) reader. Same relation-key set as the
+  // MCP `find_backlinks` tool. Deduped by fromSlug in the assembly below, so a
+  // body link to the same target keeps its richer context.
+  {
+    const RELATION_REF_ARRAY_KEYS = [
+      'domains',
+      'capabilities',
+      'elements',
+      'dependencies',
+      'relates',
+      'contains',
+      'describes',
+    ];
+    const RELATION_REF_STRING_KEYS = ['domain'];
+    const slugSet = new Set(docs.map((doc) => doc.slug));
+    const tailToSlug = new Map(); // tail -> slug | null (null = ambiguous)
+    for (const doc of docs) {
+      const tail = doc.slug.split('/').pop() ?? doc.slug;
+      tailToSlug.set(tail, tailToSlug.has(tail) ? null : doc.slug);
+    }
+    const refStrings = (frontmatter) => {
+      const out = [];
+      for (const key of RELATION_REF_ARRAY_KEYS) {
+        const value = frontmatter[key];
+        if (Array.isArray(value)) {
+          for (const item of value)
+            if (typeof item === 'string' && item.trim()) out.push(item.trim());
+        } else if (typeof value === 'string' && value.trim()) {
+          out.push(value.trim());
+        }
+      }
+      for (const key of RELATION_REF_STRING_KEYS) {
+        const value = frontmatter[key];
+        if (typeof value === 'string' && value.trim()) out.push(value.trim());
+      }
+      return out;
+    };
+    const resolveRef = (ref) => {
+      const normalized = ref.replace(/\.md$/i, '');
+      if (slugSet.has(normalized)) return normalized;
+      const tail = normalized.split('/').pop() ?? normalized;
+      return tailToSlug.get(tail) ?? null;
+    };
+    for (const doc of docs) {
+      const seenTargets = new Set();
+      for (const ref of refStrings(doc.frontmatter)) {
+        const target = resolveRef(ref);
+        if (!target || target === doc.slug || seenTargets.has(target)) continue;
+        seenTargets.add(target);
+        if (!backlinksDetailMap.has(target)) backlinksDetailMap.set(target, []);
+        backlinksDetailMap.get(target).push({
+          fromSlug: doc.slug,
+          context: `frontmatter · **[${ref}]**`,
+          linkText: ref,
+        });
+      }
+    }
+  }
+
   docs.sort((a, b) => a.slug.localeCompare(b.slug, 'ko'));
 
   const tree = { name: 'docs', path: '', type: 'dir' };

--- a/scripts/check-package-contracts.test.mjs
+++ b/scripts/check-package-contracts.test.mjs
@@ -1376,12 +1376,11 @@ describe('package contract helpers', () => {
     );
     assert.match(
       verifySection,
-      // infer_imports "files scanned" is intentionally NOT pinned to the exact
-      // live count: it changes on every source-file add/remove (incidental), so
-      // pinning it forced a README bump on unrelated PRs. The module-edge count
-      // and top-edge summary stay pinned — they reflect the actual dependency
-      // graph, which is the meaningful contract.
-      new RegExp(`✓ infer_imports — \\d+ files? scanned, ${countLabel(inferredImports.moduleEdges.length, 'module edge')} \\(${topModuleEdgeSummary}`),
+      // infer_imports "files scanned" 와 "module edges" 둘 다 exact-pin 하지
+      // 않는다: 2026-07 스윕에서 모듈 엣지 수가 기능 PR 마다 바뀌어 하루 세
+      // 번 README 재생성을 강요했다 (496→498→499) — 부수 지표다. 의미 있는
+      // 계약은 top-edge 요약(실제 최상위 의존 경로)이라 그것만 유지한다.
+      new RegExp(`✓ infer_imports — \\d+ files? scanned, \\d+ module edges? \\(${topModuleEdgeSummary}`),
     );
     assert.match(verifySection, new RegExp(`✓ find_neighbors — ${neighborSmokeLine}`));
     assert.match(verifySection, new RegExp(`✓ find_path — ${regexEscape(neighborSmokeSlug)} → project \\(2 hops, 2 edges\\)`));

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "2026-04-23",
-  "generatedAt": "2026-07-20T22:46:50.321Z",
+  "generatedAt": "2026-07-20T23:48:13.712Z",
   "docs": [
     {
       "slug": "AGENT-GRAPH-WORKFLOW",
@@ -10641,6 +10641,11 @@
         "fromSlug": "ontology/capabilities/ontology-extract-skill",
         "context": "(capability / element / domain) 가 자란다 — LLM 이 매개라서 가능한 path. ## 다른 두 skill 과의 관계 | Skill | 입력 | 출력 | |---|---|---| | **[capabilities/ontology-bootstrap-skill]** | 빈 vault + 코드 (analyze_repo_structure) | 첫 5–15 노드 | | [[capabilities/ontology-sync-skill]] | code change (git diff) |",
         "linkText": "capabilities/ontology-bootstrap-skill"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[ontology-bootstrap-skill]**",
+        "linkText": "ontology-bootstrap-skill"
       }
     ],
     "ontology/capabilities/ontology-sync-skill": [
@@ -10648,12 +10653,27 @@
         "fromSlug": "ontology/capabilities/ontology-extract-skill",
         "context": "출력 | |---|---|---| | [[capabilities/ontology-bootstrap-skill]] | 빈 vault + 코드 (analyze_repo_structure) | 첫 5–15 노드 | | **[capabilities/ontology-sync-skill]** | code change (git diff) | 코드↔vault drift 0 | | **이 skill** | **사용자 prose** | **prose 안 개념 → vault 노드** | bootstrap 은",
         "linkText": "capabilities/ontology-sync-skill"
+      },
+      {
+        "fromSlug": "ontology/capabilities/session-start-ontology-context",
+        "context": "frontmatter · **[capabilities/ontology-sync-skill]**",
+        "linkText": "capabilities/ontology-sync-skill"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[ontology-sync-skill]**",
+        "linkText": "ontology-sync-skill"
       }
     ],
     "ontology/capabilities/topology-skeleton-entry": [
       {
         "fromSlug": "ontology/capabilities/topology-canvas-render",
         "context": "UI를 담당한다. ## 진입 & 확장 기본 진입은 ForceAtlas2 scatter 가 아니라 결정론적 중앙-방사형 골격(project → domain ring → 대표 capability) — 자세한 내용은 **[capabilities/topology-skeleton-entry]**. 노드 클릭은 ego 포커스 + 컴팩트 팝오버(`TopologyV2DetailPanel`)를 연다 — 풀스크린 모달이 아니라 Shneiderman 의 overview-first, details-on-demand 원",
+        "linkText": "capabilities/topology-skeleton-entry"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/topology-skeleton-entry]**",
         "linkText": "capabilities/topology-skeleton-entry"
       }
     ],
@@ -10662,6 +10682,11 @@
         "fromSlug": "ontology/capabilities/topology-canvas-render",
         "context": "idgets/topology-map-v2/README` 또는 코드 자체를 1차 출처로 본다). ## 노드 표현 kind(`domain`/`capability`/`element`) 별 fill·size 위계는 **[capabilities/topology-kind-legibility]** 가 소유. 노드 hover 요약 문구는 `elements/ontology-description-helper`(`src/shared/lib/ontology-description.ts`)가 body excerpt 를",
         "linkText": "capabilities/topology-kind-legibility"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/topology-kind-legibility]**",
+        "linkText": "capabilities/topology-kind-legibility"
       }
     ],
     "ontology/elements/sigma-graphology": [
@@ -10669,20 +10694,1919 @@
         "fromSlug": "ontology/capabilities/topology-canvas-render",
         "context": "/docs-vault/ui/DocsVaultFolderTopology.tsx`)만 여전히 Sigma.js + `@sigma/node-border` 를 직접 쓴다 — `/`, `/topology` 는 대상이 아니다. **[elements/sigma-graphology]** 도 같은 구분을 반영해 갱신했다.",
         "linkText": "elements/sigma-graphology"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[sigma-graphology]**",
+        "linkText": "sigma-graphology"
       }
     ],
     "ontology/capabilities/topology-ontology-inspection": [
       {
+        "fromSlug": "ontology/capabilities/product-owner-operating-system",
+        "context": "frontmatter · **[capabilities/topology-ontology-inspection]**",
+        "linkText": "capabilities/topology-ontology-inspection"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-change-visualization",
+        "context": "frontmatter · **[capabilities/topology-ontology-inspection]**",
+        "linkText": "capabilities/topology-ontology-inspection"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-direct-edit",
+        "context": "frontmatter · **[capabilities/topology-ontology-inspection]**",
+        "linkText": "capabilities/topology-ontology-inspection"
+      },
+      {
         "fromSlug": "ontology/capabilities/topology-node-significance",
         "context": "override (approach C, 얇은 레이어)** — frontmatter `significance:` 가 있으면 \"왜 중요한가\" 줄을 그걸로 우선. 미지정 키는 파서가 보존하므로 schema 변경 0. **[capabilities/topology-ontology-inspection]** 의 drawer/inspection 과 짝 — 그쪽이 \"전체 상세(에이전트 핸드오프 포함)\"라면 이쪽은 \"첫 클릭의 평문 의미\".",
         "linkText": "capabilities/topology-ontology-inspection"
+      },
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[capabilities/topology-ontology-inspection]**",
+        "linkText": "capabilities/topology-ontology-inspection"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-ontology-inspection]**",
+        "linkText": "topology-ontology-inspection"
       }
     ],
     "ontology/capabilities/topology-canvas-render": [
       {
+        "fromSlug": "ontology/capabilities/vault-live-updates",
+        "context": "frontmatter · **[capabilities/topology-canvas-render]**",
+        "linkText": "capabilities/topology-canvas-render"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-canvas-render]**",
+        "linkText": "topology-canvas-render"
+      },
+      {
         "fromSlug": "ontology/elements/sigma-graphology",
         "context": "전용 상호작용(노드 클릭 → source/target path pick, Shift+click fallback)은 `/docs` 미니맵 범위에서만 유효하다. `/`, `/topology` 의 동일한 사용자 경험은 **[capabilities/topology-canvas-render]** 가 다룬다.",
         "linkText": "capabilities/topology-canvas-render"
+      }
+    ],
+    "ontology/project": [
+      {
+        "fromSlug": "ontology/README",
+        "context": "frontmatter · **[project]**",
+        "linkText": "project"
+      }
+    ],
+    "ontology/elements/app-settings-menu": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[elements/app-settings-menu]**",
+        "linkText": "elements/app-settings-menu"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[elements/app-settings-menu]**",
+        "linkText": "elements/app-settings-menu"
+      },
+      {
+        "fromSlug": "ontology/capabilities/project-ontology-indexing",
+        "context": "frontmatter · **[elements/app-settings-menu]**",
+        "linkText": "elements/app-settings-menu"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/app-settings-menu]**",
+        "linkText": "elements/app-settings-menu"
+      }
+    ],
+    "ontology/src/views/docs-vault/ui/DocsVaultPage.tsx": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[src/views/docs-vault/ui/DocsVaultPage.tsx]**",
+        "linkText": "src/views/docs-vault/ui/DocsVaultPage.tsx"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[src/views/docs-vault/ui/DocsVaultPage.tsx]**",
+        "linkText": "src/views/docs-vault/ui/DocsVaultPage.tsx"
+      }
+    ],
+    "ontology/capabilities/mcp-server": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/cli-developer-entry",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mcp-conflict-guard",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-sync-skill",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/capabilities/project-ontology-indexing",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/documents/agent-practice-research",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[mcp-server]**",
+        "linkText": "mcp-server"
+      },
+      {
+        "fromSlug": "ontology/elements/mcp-sdk",
+        "context": "frontmatter · **[capabilities/mcp-server]**",
+        "linkText": "capabilities/mcp-server"
+      }
+    ],
+    "ontology/capabilities/vault-live-updates": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[capabilities/vault-live-updates]**",
+        "linkText": "capabilities/vault-live-updates"
+      },
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[capabilities/vault-live-updates]**",
+        "linkText": "capabilities/vault-live-updates"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[vault-live-updates]**",
+        "linkText": "vault-live-updates"
+      }
+    ],
+    "ontology/domains/onboarding-ux": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[domains/onboarding-ux]**",
+        "linkText": "domains/onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/capabilities/cli-developer-entry",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/capabilities/product-owner-operating-system",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/cli/src/commands/agent-activity.mjs",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[domains/onboarding-ux]**",
+        "linkText": "domains/onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/app-nav-rail",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/app-settings-menu",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/first-run-page",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/landing-first-impression",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/locale-switch",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/product-owner-operating-system-doc",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/elements/root-locale-redirect",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      },
+      {
+        "fromSlug": "ontology/src/widgets/bottom-tab-bar",
+        "context": "frontmatter · **[onboarding-ux]**",
+        "linkText": "onboarding-ux"
+      }
+    ],
+    "ontology/domains/ai-agent-partner": [
+      {
+        "fromSlug": "ontology/capabilities/agent-config-onboarding",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-connect-sheet",
+        "context": "frontmatter · **[domains/ai-agent-partner]**",
+        "linkText": "domains/ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[domains/ai-agent-partner]**",
+        "linkText": "domains/ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[domains/ai-agent-partner]**",
+        "linkText": "domains/ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[domains/ai-agent-partner]**",
+        "linkText": "domains/ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/firebase-deploy-skill",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mcp-conflict-guard",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mcp-server",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-bootstrap-skill",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-extract-skill",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-sync-skill",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/project-ontology-indexing",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/capabilities/session-start-ontology-context",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/elements/agent-activity-hooks",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/elements/macos-webview-content-verifier",
+        "context": "frontmatter · **[domains/ai-agent-partner]**",
+        "linkText": "domains/ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/elements/mcp-sdk",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[ai-agent-partner]**",
+        "linkText": "ai-agent-partner"
+      }
+    ],
+    "ontology/src/features/vault-ontology/ui/LiveActivityIndicator.tsx": [
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[src/features/vault-ontology/ui/LiveActivityIndicator.tsx]**",
+        "linkText": "src/features/vault-ontology/ui/LiveActivityIndicator.tsx"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-live-activity-contract",
+        "context": "frontmatter · **[src/features/vault-ontology/ui/LiveActivityIndicator.tsx]**",
+        "linkText": "src/features/vault-ontology/ui/LiveActivityIndicator.tsx"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[src/features/vault-ontology/ui/LiveActivityIndicator.tsx]**",
+        "linkText": "src/features/vault-ontology/ui/LiveActivityIndicator.tsx"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[src/features/vault-ontology/ui/LiveActivityIndicator.tsx]**",
+        "linkText": "src/features/vault-ontology/ui/LiveActivityIndicator.tsx"
+      }
+    ],
+    "ontology/capabilities/ontology-hub-mode-aware": [
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[capabilities/ontology-hub-mode-aware]**",
+        "linkText": "capabilities/ontology-hub-mode-aware"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[capabilities/ontology-hub-mode-aware]**",
+        "linkText": "capabilities/ontology-hub-mode-aware"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mode-aware-adapter",
+        "context": "frontmatter · **[capabilities/ontology-hub-mode-aware]**",
+        "linkText": "capabilities/ontology-hub-mode-aware"
+      },
+      {
+        "fromSlug": "ontology/domains/mode-aware-adapters",
+        "context": "frontmatter · **[ontology-hub-mode-aware]**",
+        "linkText": "ontology-hub-mode-aware"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[ontology-hub-mode-aware]**",
+        "linkText": "ontology-hub-mode-aware"
+      }
+    ],
+    "ontology/domains/views": [
+      {
+        "fromSlug": "ontology/capabilities/agent-graph-readiness",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-live-activity-contract",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/builder-deep-link-focus",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/builder-relation-write-confirm",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/builder-vault-write",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/changes-only-review",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/collaborator-reader-brief",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/edge-meaning-popover",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-analysis-modes",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-canvas-render",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-change-visualization",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-direct-edit",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-node-significance",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-skeleton-entry",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-command-strip",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-detail-sheet",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-graph-anchor-rail",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-node-query-focus",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-proposal",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-write-confirm-panel",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-write-summary",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/business-ontology-lens",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/dev-route-smoke",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/macos-webview-content-verifier",
+        "context": "frontmatter · **[domains/views]**",
+        "linkText": "domains/views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-atlas-quality-bar",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-concept-detail-workbench",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-deeplink-node-resolver",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-description-helper",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-design-surface-guard",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-domain-tint-contract",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-edit-canvas",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-kind-tone-contract",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-node-detail-modal",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-reader-intent-contract",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-review-brief",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-tree-view",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/sigma-graphology",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-analysis-state",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-classification-contract",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-color-legend",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-color-research-basis",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-color-tests",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-color-tones",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-map-canvas",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-ontology-drawer",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-ontology-drawer-model",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-owner-tint-overlay",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-path-chip",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-selected-node-resolver",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/elements/xyflow",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/src/features/vault-ontology/ui/LiveActivityIndicator.tsx",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      },
+      {
+        "fromSlug": "ontology/src/views/project-detail",
+        "context": "frontmatter · **[views]**",
+        "linkText": "views"
+      }
+    ],
+    "ontology/cli/src/commands/agent-activity.mjs": [
+      {
+        "fromSlug": "ontology/capabilities/agent-live-activity-contract",
+        "context": "frontmatter · **[cli/src/commands/agent-activity.mjs]**",
+        "linkText": "cli/src/commands/agent-activity.mjs"
+      },
+      {
+        "fromSlug": "ontology/capabilities/cli-developer-entry",
+        "context": "frontmatter · **[cli/src/commands/agent-activity.mjs]**",
+        "linkText": "cli/src/commands/agent-activity.mjs"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[cli/src/commands/agent-activity.mjs]**",
+        "linkText": "cli/src/commands/agent-activity.mjs"
+      }
+    ],
+    "ontology/elements/agent-activity-hooks": [
+      {
+        "fromSlug": "ontology/capabilities/agent-live-activity-contract",
+        "context": "frontmatter · **[elements/agent-activity-hooks]**",
+        "linkText": "elements/agent-activity-hooks"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[elements/agent-activity-hooks]**",
+        "linkText": "elements/agent-activity-hooks"
+      }
+    ],
+    "ontology/src/features/docs-vault-local/model/agent-activity-status.ts": [
+      {
+        "fromSlug": "ontology/capabilities/agent-live-activity-contract",
+        "context": "frontmatter · **[src/features/docs-vault-local/model/agent-activity-status.ts]**",
+        "linkText": "src/features/docs-vault-local/model/agent-activity-status.ts"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[src/features/docs-vault-local/model/agent-activity-status.ts]**",
+        "linkText": "src/features/docs-vault-local/model/agent-activity-status.ts"
+      }
+    ],
+    "ontology/elements/business-ontology-lens": [
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[elements/business-ontology-lens]**",
+        "linkText": "elements/business-ontology-lens"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/business-ontology-lens]**",
+        "linkText": "elements/business-ontology-lens"
+      },
+      {
+        "fromSlug": "ontology/elements/product-owner-operating-system-doc",
+        "context": "frontmatter · **[elements/business-ontology-lens]**",
+        "linkText": "elements/business-ontology-lens"
+      }
+    ],
+    "ontology/elements/ontology-node-detail-modal": [
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      },
+      {
+        "fromSlug": "ontology/capabilities/collaborator-reader-brief",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-concept-detail-workbench",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-deeplink-node-resolver",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-review-brief",
+        "context": "frontmatter · **[elements/ontology-node-detail-modal]**",
+        "linkText": "elements/ontology-node-detail-modal"
+      }
+    ],
+    "ontology/capabilities/agent-graph-readiness": [
+      {
+        "fromSlug": "ontology/capabilities/agent-onboarding-brief",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/documents/agent-practice-research",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[agent-graph-readiness]**",
+        "linkText": "agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-write-confirm-panel",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-node-detail-modal",
+        "context": "frontmatter · **[capabilities/agent-graph-readiness]**",
+        "linkText": "capabilities/agent-graph-readiness"
+      }
+    ],
+    "ontology/capabilities/agent-onboarding-brief": [
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[capabilities/agent-onboarding-brief]**",
+        "linkText": "capabilities/agent-onboarding-brief"
+      },
+      {
+        "fromSlug": "ontology/capabilities/product-owner-operating-system",
+        "context": "frontmatter · **[capabilities/agent-onboarding-brief]**",
+        "linkText": "capabilities/agent-onboarding-brief"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/agent-onboarding-brief]**",
+        "linkText": "capabilities/agent-onboarding-brief"
+      }
+    ],
+    "ontology/capabilities/mcp-conflict-guard": [
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[capabilities/mcp-conflict-guard]**",
+        "linkText": "capabilities/mcp-conflict-guard"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-live-updates",
+        "context": "frontmatter · **[capabilities/mcp-conflict-guard]**",
+        "linkText": "capabilities/mcp-conflict-guard"
+      },
+      {
+        "fromSlug": "ontology/documents/agent-practice-research",
+        "context": "frontmatter · **[capabilities/mcp-conflict-guard]**",
+        "linkText": "capabilities/mcp-conflict-guard"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[mcp-conflict-guard]**",
+        "linkText": "mcp-conflict-guard"
+      }
+    ],
+    "ontology/capabilities/session-start-ontology-context": [
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[capabilities/session-start-ontology-context]**",
+        "linkText": "capabilities/session-start-ontology-context"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[session-start-ontology-context]**",
+        "linkText": "session-start-ontology-context"
+      }
+    ],
+    "ontology/documents/agent-practice-research": [
+      {
+        "fromSlug": "ontology/capabilities/agent-practitioner-concerns-map",
+        "context": "frontmatter · **[documents/agent-practice-research]**",
+        "linkText": "documents/agent-practice-research"
+      }
+    ],
+    "ontology/elements/builder-command-strip": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/builder-command-strip]**",
+        "linkText": "elements/builder-command-strip"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/builder-command-strip]**",
+        "linkText": "elements/builder-command-strip"
+      }
+    ],
+    "ontology/elements/builder-detail-sheet": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/builder-detail-sheet]**",
+        "linkText": "elements/builder-detail-sheet"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/builder-detail-sheet]**",
+        "linkText": "elements/builder-detail-sheet"
+      }
+    ],
+    "ontology/elements/builder-graph-anchor-rail": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/builder-graph-anchor-rail]**",
+        "linkText": "elements/builder-graph-anchor-rail"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/builder-graph-anchor-rail]**",
+        "linkText": "elements/builder-graph-anchor-rail"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-design-surface-guard",
+        "context": "frontmatter · **[elements/builder-graph-anchor-rail]**",
+        "linkText": "elements/builder-graph-anchor-rail"
+      }
+    ],
+    "ontology/elements/builder-write-summary": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/builder-write-summary]**",
+        "linkText": "elements/builder-write-summary"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/builder-write-summary]**",
+        "linkText": "elements/builder-write-summary"
+      }
+    ],
+    "ontology/elements/ontology-design-surface-guard": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/ontology-design-surface-guard]**",
+        "linkText": "elements/ontology-design-surface-guard"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-design-surface-guard]**",
+        "linkText": "elements/ontology-design-surface-guard"
+      }
+    ],
+    "ontology/elements/ontology-edit-canvas": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[elements/ontology-edit-canvas]**",
+        "linkText": "elements/ontology-edit-canvas"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-edit-canvas]**",
+        "linkText": "elements/ontology-edit-canvas"
+      }
+    ],
+    "ontology/capabilities/builder-vault-write": [
+      {
+        "fromSlug": "ontology/capabilities/builder-canvas-polish",
+        "context": "frontmatter · **[capabilities/builder-vault-write]**",
+        "linkText": "capabilities/builder-vault-write"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-live-updates",
+        "context": "frontmatter · **[capabilities/builder-vault-write]**",
+        "linkText": "capabilities/builder-vault-write"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-vault-write]**",
+        "linkText": "builder-vault-write"
+      }
+    ],
+    "ontology/elements/builder-node-query-focus": [
+      {
+        "fromSlug": "ontology/capabilities/builder-deep-link-focus",
+        "context": "frontmatter · **[builder-node-query-focus]**",
+        "linkText": "builder-node-query-focus"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[builder-node-query-focus]**",
+        "linkText": "builder-node-query-focus"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-node-query-focus]**",
+        "linkText": "builder-node-query-focus"
+      }
+    ],
+    "ontology/elements/ontology-deeplink-node-resolver": [
+      {
+        "fromSlug": "ontology/capabilities/builder-deep-link-focus",
+        "context": "frontmatter · **[ontology-deeplink-node-resolver]**",
+        "linkText": "ontology-deeplink-node-resolver"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[ontology-deeplink-node-resolver]**",
+        "linkText": "ontology-deeplink-node-resolver"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[ontology-deeplink-node-resolver]**",
+        "linkText": "ontology-deeplink-node-resolver"
+      }
+    ],
+    "ontology/elements/builder-relation-proposal": [
+      {
+        "fromSlug": "ontology/capabilities/builder-relation-write-confirm",
+        "context": "frontmatter · **[builder-relation-proposal]**",
+        "linkText": "builder-relation-proposal"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-relation-proposal]**",
+        "linkText": "builder-relation-proposal"
+      }
+    ],
+    "ontology/elements/builder-relation-write-confirm-panel": [
+      {
+        "fromSlug": "ontology/capabilities/builder-relation-write-confirm",
+        "context": "frontmatter · **[builder-relation-write-confirm-panel]**",
+        "linkText": "builder-relation-write-confirm-panel"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-relation-write-confirm-panel]**",
+        "linkText": "builder-relation-write-confirm-panel"
+      }
+    ],
+    "ontology/capabilities/topology-change-visualization": [
+      {
+        "fromSlug": "ontology/capabilities/changes-only-review",
+        "context": "frontmatter · **[capabilities/topology-change-visualization]**",
+        "linkText": "capabilities/topology-change-visualization"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/topology-change-visualization]**",
+        "linkText": "capabilities/topology-change-visualization"
+      }
+    ],
+    "ontology/capabilities/vault-validator": [
+      {
+        "fromSlug": "ontology/capabilities/cli-developer-entry",
+        "context": "frontmatter · **[capabilities/vault-validator]**",
+        "linkText": "capabilities/vault-validator"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[vault-validator]**",
+        "linkText": "vault-validator"
+      }
+    ],
+    "ontology/elements/ontology-reader-intent-contract": [
+      {
+        "fromSlug": "ontology/capabilities/collaborator-reader-brief",
+        "context": "frontmatter · **[elements/ontology-reader-intent-contract]**",
+        "linkText": "elements/ontology-reader-intent-contract"
+      },
+      {
+        "fromSlug": "ontology/documents/business-to-code-dogfood-audit",
+        "context": "frontmatter · **[elements/ontology-reader-intent-contract]**",
+        "linkText": "elements/ontology-reader-intent-contract"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-reader-intent-contract]**",
+        "linkText": "elements/ontology-reader-intent-contract"
+      }
+    ],
+    "ontology/elements/topology-ontology-drawer-model": [
+      {
+        "fromSlug": "ontology/capabilities/collaborator-reader-brief",
+        "context": "frontmatter · **[topology-ontology-drawer-model]**",
+        "linkText": "topology-ontology-drawer-model"
+      },
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[topology-ontology-drawer-model]**",
+        "linkText": "topology-ontology-drawer-model"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-ontology-drawer-model]**",
+        "linkText": "topology-ontology-drawer-model"
+      }
+    ],
+    "ontology/documents/business-to-code-dogfood-audit": [
+      {
+        "fromSlug": "ontology/capabilities/collaborator-reader-brief",
+        "context": "frontmatter · **[documents/business-to-code-dogfood-audit]**",
+        "linkText": "documents/business-to-code-dogfood-audit"
+      },
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[documents/business-to-code-dogfood-audit]**",
+        "linkText": "documents/business-to-code-dogfood-audit"
+      }
+    ],
+    "ontology/elements/macos-webview-content-verifier": [
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[elements/macos-webview-content-verifier]**",
+        "linkText": "elements/macos-webview-content-verifier"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[elements/macos-webview-content-verifier]**",
+        "linkText": "elements/macos-webview-content-verifier"
+      }
+    ],
+    "ontology/capabilities/agent-config-onboarding": [
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[capabilities/agent-config-onboarding]**",
+        "linkText": "capabilities/agent-config-onboarding"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[agent-config-onboarding]**",
+        "linkText": "agent-config-onboarding"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[agent-config-onboarding]**",
+        "linkText": "agent-config-onboarding"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-kind-classification-contract",
+        "context": "frontmatter · **[capabilities/agent-config-onboarding]**",
+        "linkText": "capabilities/agent-config-onboarding"
+      }
+    ],
+    "ontology/capabilities/frontmatter-to-ontology": [
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[capabilities/frontmatter-to-ontology]**",
+        "linkText": "capabilities/frontmatter-to-ontology"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mcp-server",
+        "context": "frontmatter · **[capabilities/frontmatter-to-ontology]**",
+        "linkText": "capabilities/frontmatter-to-ontology"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[capabilities/frontmatter-to-ontology]**",
+        "linkText": "capabilities/frontmatter-to-ontology"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-migrator",
+        "context": "frontmatter · **[capabilities/frontmatter-to-ontology]**",
+        "linkText": "capabilities/frontmatter-to-ontology"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-validator",
+        "context": "frontmatter · **[capabilities/frontmatter-to-ontology]**",
+        "linkText": "capabilities/frontmatter-to-ontology"
+      },
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[frontmatter-to-ontology]**",
+        "linkText": "frontmatter-to-ontology"
+      }
+    ],
+    "ontology/domains/vault-local-first": [
+      {
+        "fromSlug": "ontology/capabilities/desktop-app-distribution",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/capabilities/frontmatter-to-ontology",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/capabilities/mode-aware-adapter",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-live-updates",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-migrator",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-validator",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/domains/mode-aware-adapters",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/elements/file-system-access-api",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/elements/first-run-page",
+        "context": "frontmatter · **[domains/vault-local-first]**",
+        "linkText": "domains/vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/elements/macos-webview-content-verifier",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/src/features/docs-vault-local/model/agent-activity-status.ts",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/src/views/docs-vault/ui/DocsVaultPage.tsx",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      },
+      {
+        "fromSlug": "ontology/src/widgets/docs-vault/ui/DocsVaultEditor.tsx",
+        "context": "frontmatter · **[vault-local-first]**",
+        "linkText": "vault-local-first"
+      }
+    ],
+    "ontology/capabilities/relation-rationale": [
+      {
+        "fromSlug": "ontology/capabilities/edge-meaning-popover",
+        "context": "frontmatter · **[capabilities/relation-rationale]**",
+        "linkText": "capabilities/relation-rationale"
+      },
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[capabilities/relation-rationale]**",
+        "linkText": "capabilities/relation-rationale"
+      }
+    ],
+    "ontology/domains/ontology-core": [
+      {
+        "fromSlug": "ontology/capabilities/frontmatter-to-ontology",
+        "context": "frontmatter · **[ontology-core]**",
+        "linkText": "ontology-core"
+      },
+      {
+        "fromSlug": "ontology/capabilities/relation-rationale",
+        "context": "frontmatter · **[domains/ontology-core]**",
+        "linkText": "domains/ontology-core"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[domains/ontology-core]**",
+        "linkText": "domains/ontology-core"
+      },
+      {
+        "fromSlug": "ontology/domains/mode-aware-adapters",
+        "context": "frontmatter · **[domains/ontology-core]**",
+        "linkText": "domains/ontology-core"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[domains/ontology-core]**",
+        "linkText": "domains/ontology-core"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[domains/ontology-core]**",
+        "linkText": "domains/ontology-core"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-relation-key-inference",
+        "context": "frontmatter · **[ontology-core]**",
+        "linkText": "ontology-core"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[ontology-core]**",
+        "linkText": "ontology-core"
+      },
+      {
+        "fromSlug": "ontology/src/views/ontology-edit/ui/VaultEdge.tsx",
+        "context": "frontmatter · **[ontology-core]**",
+        "linkText": "ontology-core"
+      }
+    ],
+    "ontology/domains/mode-aware-adapters": [
+      {
+        "fromSlug": "ontology/capabilities/mode-aware-adapter",
+        "context": "frontmatter · **[mode-aware-adapters]**",
+        "linkText": "mode-aware-adapters"
+      },
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[mode-aware-adapters]**",
+        "linkText": "mode-aware-adapters"
+      },
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[domains/mode-aware-adapters]**",
+        "linkText": "domains/mode-aware-adapters"
+      },
+      {
+        "fromSlug": "ontology/project",
+        "context": "frontmatter · **[mode-aware-adapters]**",
+        "linkText": "mode-aware-adapters"
+      }
+    ],
+    "ontology/elements/app-nav-rail": [
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[elements/app-nav-rail]**",
+        "linkText": "elements/app-nav-rail"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/app-nav-rail]**",
+        "linkText": "elements/app-nav-rail"
+      },
+      {
+        "fromSlug": "ontology/elements/app-settings-menu",
+        "context": "frontmatter · **[elements/app-nav-rail]**",
+        "linkText": "elements/app-nav-rail"
+      },
+      {
+        "fromSlug": "ontology/src/widgets/bottom-tab-bar",
+        "context": "frontmatter · **[elements/app-nav-rail]**",
+        "linkText": "elements/app-nav-rail"
+      }
+    ],
+    "ontology/elements/ontology-concept-detail-workbench": [
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[elements/ontology-concept-detail-workbench]**",
+        "linkText": "elements/ontology-concept-detail-workbench"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-concept-detail-workbench]**",
+        "linkText": "elements/ontology-concept-detail-workbench"
+      }
+    ],
+    "ontology/capabilities/mode-aware-adapter": [
+      {
+        "fromSlug": "ontology/capabilities/ontology-hub-mode-aware",
+        "context": "frontmatter · **[capabilities/mode-aware-adapter]**",
+        "linkText": "capabilities/mode-aware-adapter"
+      },
+      {
+        "fromSlug": "ontology/domains/mode-aware-adapters",
+        "context": "frontmatter · **[mode-aware-adapter]**",
+        "linkText": "mode-aware-adapter"
+      }
+    ],
+    "ontology/elements/product-owner-operating-system-doc": [
+      {
+        "fromSlug": "ontology/capabilities/product-owner-operating-system",
+        "context": "frontmatter · **[elements/product-owner-operating-system-doc]**",
+        "linkText": "elements/product-owner-operating-system-doc"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/product-owner-operating-system-doc]**",
+        "linkText": "elements/product-owner-operating-system-doc"
+      }
+    ],
+    "ontology/capabilities/cli-developer-entry": [
+      {
+        "fromSlug": "ontology/capabilities/project-ontology-indexing",
+        "context": "frontmatter · **[capabilities/cli-developer-entry]**",
+        "linkText": "capabilities/cli-developer-entry"
+      },
+      {
+        "fromSlug": "ontology/capabilities/session-start-ontology-context",
+        "context": "frontmatter · **[capabilities/cli-developer-entry]**",
+        "linkText": "capabilities/cli-developer-entry"
+      },
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[cli-developer-entry]**",
+        "linkText": "cli-developer-entry"
+      }
+    ],
+    "ontology/elements/topology-analysis-state": [
+      {
+        "fromSlug": "ontology/capabilities/topology-analysis-modes",
+        "context": "frontmatter · **[topology-analysis-state]**",
+        "linkText": "topology-analysis-state"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-analysis-state]**",
+        "linkText": "topology-analysis-state"
+      }
+    ],
+    "ontology/elements/topology-path-chip": [
+      {
+        "fromSlug": "ontology/capabilities/topology-analysis-modes",
+        "context": "frontmatter · **[topology-path-chip]**",
+        "linkText": "topology-path-chip"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-path-chip]**",
+        "linkText": "elements/topology-path-chip"
+      }
+    ],
+    "ontology/elements/ontology-description-helper": [
+      {
+        "fromSlug": "ontology/capabilities/topology-canvas-render",
+        "context": "frontmatter · **[elements/ontology-description-helper]**",
+        "linkText": "elements/ontology-description-helper"
+      },
+      {
+        "fromSlug": "ontology/capabilities/vault-live-updates",
+        "context": "frontmatter · **[elements/ontology-description-helper]**",
+        "linkText": "elements/ontology-description-helper"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-description-helper]**",
+        "linkText": "elements/ontology-description-helper"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-ontology-drawer",
+        "context": "frontmatter · **[elements/ontology-description-helper]**",
+        "linkText": "elements/ontology-description-helper"
+      }
+    ],
+    "ontology/elements/ontology-domain-tint-contract": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/ontology-domain-tint-contract]**",
+        "linkText": "elements/ontology-domain-tint-contract"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-domain-tint-contract]**",
+        "linkText": "elements/ontology-domain-tint-contract"
+      }
+    ],
+    "ontology/elements/ontology-kind-tone-contract": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/ontology-kind-tone-contract]**",
+        "linkText": "elements/ontology-kind-tone-contract"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-kind-tone-contract]**",
+        "linkText": "elements/ontology-kind-tone-contract"
+      }
+    ],
+    "ontology/elements/topology-kind-classification-contract": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/topology-kind-classification-contract]**",
+        "linkText": "elements/topology-kind-classification-contract"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-kind-classification-contract]**",
+        "linkText": "elements/topology-kind-classification-contract"
+      }
+    ],
+    "ontology/elements/topology-kind-color-legend": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/topology-kind-color-legend]**",
+        "linkText": "elements/topology-kind-color-legend"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-kind-color-legend]**",
+        "linkText": "elements/topology-kind-color-legend"
+      }
+    ],
+    "ontology/elements/topology-kind-color-research-basis": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/topology-kind-color-research-basis]**",
+        "linkText": "elements/topology-kind-color-research-basis"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-kind-color-research-basis]**",
+        "linkText": "elements/topology-kind-color-research-basis"
+      }
+    ],
+    "ontology/elements/topology-kind-color-tests": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/topology-kind-color-tests]**",
+        "linkText": "elements/topology-kind-color-tests"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-kind-color-tests]**",
+        "linkText": "elements/topology-kind-color-tests"
+      }
+    ],
+    "ontology/elements/topology-kind-color-tones": [
+      {
+        "fromSlug": "ontology/capabilities/topology-kind-legibility",
+        "context": "frontmatter · **[elements/topology-kind-color-tones]**",
+        "linkText": "elements/topology-kind-color-tones"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-kind-color-tones]**",
+        "linkText": "elements/topology-kind-color-tones"
+      }
+    ],
+    "ontology/elements/topology-ontology-drawer": [
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[topology-ontology-drawer]**",
+        "linkText": "topology-ontology-drawer"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-ontology-drawer]**",
+        "linkText": "topology-ontology-drawer"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-description-helper",
+        "context": "frontmatter · **[elements/topology-ontology-drawer]**",
+        "linkText": "elements/topology-ontology-drawer"
+      }
+    ],
+    "ontology/elements/topology-selected-node-resolver": [
+      {
+        "fromSlug": "ontology/capabilities/topology-ontology-inspection",
+        "context": "frontmatter · **[topology-selected-node-resolver]**",
+        "linkText": "topology-selected-node-resolver"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-selected-node-resolver]**",
+        "linkText": "topology-selected-node-resolver"
+      }
+    ],
+    "ontology/capabilities/agent-practitioner-concerns-map": [
+      {
+        "fromSlug": "ontology/documents/agent-practice-research",
+        "context": "frontmatter · **[capabilities/agent-practitioner-concerns-map]**",
+        "linkText": "capabilities/agent-practitioner-concerns-map"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[capabilities/agent-practitioner-concerns-map]**",
+        "linkText": "capabilities/agent-practitioner-concerns-map"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-write-confirm-panel",
+        "context": "frontmatter · **[capabilities/agent-practitioner-concerns-map]**",
+        "linkText": "capabilities/agent-practitioner-concerns-map"
+      }
+    ],
+    "ontology/capabilities/collaborator-reader-brief": [
+      {
+        "fromSlug": "ontology/documents/business-to-code-dogfood-audit",
+        "context": "frontmatter · **[capabilities/collaborator-reader-brief]**",
+        "linkText": "capabilities/collaborator-reader-brief"
+      },
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[capabilities/collaborator-reader-brief]**",
+        "linkText": "capabilities/collaborator-reader-brief"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[collaborator-reader-brief]**",
+        "linkText": "collaborator-reader-brief"
+      }
+    ],
+    "ontology/documents/views-domain-boundary-audit": [
+      {
+        "fromSlug": "ontology/documents/business-to-code-dogfood-audit",
+        "context": "frontmatter · **[documents/views-domain-boundary-audit]**",
+        "linkText": "documents/views-domain-boundary-audit"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[documents/views-domain-boundary-audit]**",
+        "linkText": "documents/views-domain-boundary-audit"
+      }
+    ],
+    "ontology/capabilities/project-ontology-indexing": [
+      {
+        "fromSlug": "ontology/documents/business-to-code-dogfood-audit",
+        "context": "frontmatter · **[capabilities/project-ontology-indexing]**",
+        "linkText": "capabilities/project-ontology-indexing"
+      },
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[capabilities/project-ontology-indexing]**",
+        "linkText": "capabilities/project-ontology-indexing"
+      }
+    ],
+    "ontology/capabilities/builder-canvas-polish": [
+      {
+        "fromSlug": "ontology/documents/views-domain-boundary-audit",
+        "context": "frontmatter · **[capabilities/builder-canvas-polish]**",
+        "linkText": "capabilities/builder-canvas-polish"
+      },
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-canvas-polish]**",
+        "linkText": "builder-canvas-polish"
+      }
+    ],
+    "ontology/capabilities/agent-connect-sheet": [
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[capabilities/agent-connect-sheet]**",
+        "linkText": "capabilities/agent-connect-sheet"
+      }
+    ],
+    "ontology/capabilities/firebase-deploy-skill": [
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[firebase-deploy-skill]**",
+        "linkText": "firebase-deploy-skill"
+      }
+    ],
+    "ontology/capabilities/ontology-extract-skill": [
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[ontology-extract-skill]**",
+        "linkText": "ontology-extract-skill"
+      }
+    ],
+    "ontology/elements/mcp-sdk": [
+      {
+        "fromSlug": "ontology/domains/ai-agent-partner",
+        "context": "frontmatter · **[mcp-sdk]**",
+        "linkText": "mcp-sdk"
+      }
+    ],
+    "ontology/capabilities/product-owner-operating-system": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[product-owner-operating-system]**",
+        "linkText": "product-owner-operating-system"
+      }
+    ],
+    "ontology/elements/first-run-page": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/first-run-page]**",
+        "linkText": "elements/first-run-page"
+      }
+    ],
+    "ontology/elements/landing-first-impression": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/landing-first-impression]**",
+        "linkText": "elements/landing-first-impression"
+      }
+    ],
+    "ontology/elements/locale-switch": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/locale-switch]**",
+        "linkText": "elements/locale-switch"
+      },
+      {
+        "fromSlug": "ontology/elements/app-settings-menu",
+        "context": "frontmatter · **[elements/locale-switch]**",
+        "linkText": "elements/locale-switch"
+      },
+      {
+        "fromSlug": "ontology/elements/landing-first-impression",
+        "context": "frontmatter · **[elements/locale-switch]**",
+        "linkText": "elements/locale-switch"
+      }
+    ],
+    "ontology/elements/root-locale-redirect": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[elements/root-locale-redirect]**",
+        "linkText": "elements/root-locale-redirect"
+      },
+      {
+        "fromSlug": "ontology/elements/landing-first-impression",
+        "context": "frontmatter · **[elements/root-locale-redirect]**",
+        "linkText": "elements/root-locale-redirect"
+      },
+      {
+        "fromSlug": "ontology/src/widgets/bottom-tab-bar",
+        "context": "frontmatter · **[elements/root-locale-redirect]**",
+        "linkText": "elements/root-locale-redirect"
+      }
+    ],
+    "ontology/src/widgets/bottom-tab-bar": [
+      {
+        "fromSlug": "ontology/domains/onboarding-ux",
+        "context": "frontmatter · **[src/widgets/bottom-tab-bar]**",
+        "linkText": "src/widgets/bottom-tab-bar"
+      }
+    ],
+    "ontology/elements/ontology-relation-key-inference": [
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[elements/ontology-relation-key-inference]**",
+        "linkText": "elements/ontology-relation-key-inference"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-proposal",
+        "context": "frontmatter · **[elements/ontology-relation-key-inference]**",
+        "linkText": "elements/ontology-relation-key-inference"
+      },
+      {
+        "fromSlug": "ontology/elements/topology-analysis-state",
+        "context": "frontmatter · **[elements/ontology-relation-key-inference]**",
+        "linkText": "elements/ontology-relation-key-inference"
+      }
+    ],
+    "ontology/src/views/ontology-edit/ui/VaultEdge.tsx": [
+      {
+        "fromSlug": "ontology/domains/ontology-core",
+        "context": "frontmatter · **[src/views/ontology-edit/ui/VaultEdge.tsx]**",
+        "linkText": "src/views/ontology-edit/ui/VaultEdge.tsx"
+      }
+    ],
+    "ontology/capabilities/desktop-app-distribution": [
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[desktop-app-distribution]**",
+        "linkText": "desktop-app-distribution"
+      },
+      {
+        "fromSlug": "ontology/elements/first-run-page",
+        "context": "frontmatter · **[capabilities/desktop-app-distribution]**",
+        "linkText": "capabilities/desktop-app-distribution"
+      }
+    ],
+    "ontology/capabilities/vault-migrator": [
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[vault-migrator]**",
+        "linkText": "vault-migrator"
+      }
+    ],
+    "ontology/elements/file-system-access-api": [
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[file-system-access-api]**",
+        "linkText": "file-system-access-api"
+      }
+    ],
+    "ontology/src/widgets/docs-vault/ui/DocsVaultEditor.tsx": [
+      {
+        "fromSlug": "ontology/domains/vault-local-first",
+        "context": "frontmatter · **[src/widgets/docs-vault/ui/DocsVaultEditor.tsx]**",
+        "linkText": "src/widgets/docs-vault/ui/DocsVaultEditor.tsx"
+      }
+    ],
+    "ontology/capabilities/builder-deep-link-focus": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-deep-link-focus]**",
+        "linkText": "builder-deep-link-focus"
+      }
+    ],
+    "ontology/capabilities/builder-relation-write-confirm": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[builder-relation-write-confirm]**",
+        "linkText": "builder-relation-write-confirm"
+      },
+      {
+        "fromSlug": "ontology/elements/builder-relation-write-confirm-panel",
+        "context": "frontmatter · **[capabilities/builder-relation-write-confirm]**",
+        "linkText": "capabilities/builder-relation-write-confirm"
+      }
+    ],
+    "ontology/capabilities/agent-live-activity-contract": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/agent-live-activity-contract]**",
+        "linkText": "capabilities/agent-live-activity-contract"
+      }
+    ],
+    "ontology/capabilities/changes-only-review": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/changes-only-review]**",
+        "linkText": "capabilities/changes-only-review"
+      }
+    ],
+    "ontology/capabilities/edge-meaning-popover": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/edge-meaning-popover]**",
+        "linkText": "capabilities/edge-meaning-popover"
+      }
+    ],
+    "ontology/capabilities/topology-direct-edit": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/topology-direct-edit]**",
+        "linkText": "capabilities/topology-direct-edit"
+      }
+    ],
+    "ontology/capabilities/topology-node-significance": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[capabilities/topology-node-significance]**",
+        "linkText": "capabilities/topology-node-significance"
+      }
+    ],
+    "ontology/capabilities/topology-analysis-modes": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[topology-analysis-modes]**",
+        "linkText": "topology-analysis-modes"
+      }
+    ],
+    "ontology/elements/dev-route-smoke": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/dev-route-smoke]**",
+        "linkText": "elements/dev-route-smoke"
+      }
+    ],
+    "ontology/elements/ontology-atlas-quality-bar": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-atlas-quality-bar]**",
+        "linkText": "elements/ontology-atlas-quality-bar"
+      }
+    ],
+    "ontology/elements/ontology-review-brief": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-review-brief]**",
+        "linkText": "elements/ontology-review-brief"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-node-detail-modal",
+        "context": "frontmatter · **[elements/ontology-review-brief]**",
+        "linkText": "elements/ontology-review-brief"
+      }
+    ],
+    "ontology/elements/ontology-tree-view": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/ontology-tree-view]**",
+        "linkText": "elements/ontology-tree-view"
+      },
+      {
+        "fromSlug": "ontology/elements/business-ontology-lens",
+        "context": "frontmatter · **[elements/ontology-tree-view]**",
+        "linkText": "elements/ontology-tree-view"
+      },
+      {
+        "fromSlug": "ontology/elements/ontology-node-detail-modal",
+        "context": "frontmatter · **[elements/ontology-tree-view]**",
+        "linkText": "elements/ontology-tree-view"
+      }
+    ],
+    "ontology/elements/topology-map-canvas": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-map-canvas]**",
+        "linkText": "elements/topology-map-canvas"
+      }
+    ],
+    "ontology/elements/topology-owner-tint-overlay": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[elements/topology-owner-tint-overlay]**",
+        "linkText": "elements/topology-owner-tint-overlay"
+      }
+    ],
+    "ontology/src/views/project-detail": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[src/views/project-detail]**",
+        "linkText": "src/views/project-detail"
+      }
+    ],
+    "ontology/elements/xyflow": [
+      {
+        "fromSlug": "ontology/domains/views",
+        "context": "frontmatter · **[xyflow]**",
+        "linkText": "xyflow"
       }
     ]
   },

--- a/src/entities/docs-vault/lib/build-local-manifest.backlinks.test.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.backlinks.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import { buildLocalManifest } from './build-local-manifest';
+
+/**
+ * D-1 — the doc reader's backlink strip showed a FALSE "no backlinks" for docs
+ * referenced only through frontmatter relation keys (`dependencies`,
+ * `relates`, `describes`, …). The backlink index used to scan BODY markdown
+ * links ONLY, so `capabilities/mcp-server` — referenced by 13 docs via
+ * frontmatter — read as unreferenced. These tests lock in that frontmatter
+ * relation refs now contribute to `backlinksDetail`, matching the graph's
+ * `find_backlinks` semantics.
+ */
+
+interface FakeFile {
+  text: string;
+  lastModified: number;
+}
+
+function makeFileHandle(name: string, file: FakeFile): FileSystemFileHandle {
+  return {
+    kind: 'file',
+    name,
+    getFile: async () =>
+      ({ text: async () => file.text, lastModified: file.lastModified }) as unknown as File,
+  } as unknown as FileSystemFileHandle;
+}
+
+function makeRoot(files: Record<string, FakeFile>): FileSystemDirectoryHandle {
+  const groups: Record<string, Record<string, FakeFile>> = {};
+  for (const [path, file] of Object.entries(files)) {
+    const parts = path.split('/');
+    const dir = parts.slice(0, -1).join('/');
+    const name = parts[parts.length - 1];
+    if (!groups[dir]) groups[dir] = {};
+    groups[dir][name] = file;
+  }
+  const buildHandle = (dirKey: string): FileSystemDirectoryHandle => {
+    const myFiles = groups[dirKey] ?? {};
+    const subDirs = new Set<string>();
+    for (const k of Object.keys(groups)) {
+      if (k === dirKey) continue;
+      if (dirKey === '' && !k.includes('/')) subDirs.add(k);
+      else if (dirKey !== '' && k.startsWith(dirKey + '/')) {
+        const tail = k.slice(dirKey.length + 1);
+        if (!tail.includes('/')) subDirs.add(k);
+      }
+    }
+    return {
+      kind: 'directory',
+      name: dirKey || 'root',
+      entries: async function* () {
+        for (const [name, file] of Object.entries(myFiles)) {
+          yield [name, makeFileHandle(name, file)] as const;
+        }
+        for (const sub of subDirs) {
+          const subName = sub.includes('/') ? sub.slice(sub.lastIndexOf('/') + 1) : sub;
+          yield [subName, buildHandle(sub)] as const;
+        }
+      },
+    } as unknown as FileSystemDirectoryHandle;
+  };
+  return buildHandle('');
+}
+
+function md(frontmatter: string[], body = ''): FakeFile {
+  return { text: ['---', ...frontmatter, '---', body].join('\n'), lastModified: 1000 };
+}
+
+describe('build-local-manifest — D-1 frontmatter relation backlinks', () => {
+  it('counts folder-prefixed frontmatter refs (dependencies/relates/describes) as backlinks to the target doc', async () => {
+    const manifest = await buildLocalManifest(
+      makeRoot({
+        'capabilities/mcp-server.md': md(['title: MCP Server', 'kind: capability']),
+        'capabilities/cli-entry.md': md([
+          'title: CLI Entry',
+          'kind: capability',
+          'dependencies: [capabilities/mcp-server, capabilities/vault-validator]',
+        ]),
+        'capabilities/agent-brief.md': md([
+          'title: Agent Brief',
+          'kind: capability',
+          'relates: [capabilities/mcp-server]',
+        ]),
+        'documents/research.md': md([
+          'title: Research',
+          'kind: document',
+          'describes: [capabilities/mcp-server]',
+        ]),
+      }),
+    );
+
+    const backlinks = manifest.manifest.backlinksDetail['capabilities/mcp-server'] ?? [];
+    const fromSlugs = backlinks.map((b) => b.fromSlug).sort();
+    expect(fromSlugs).toEqual([
+      'capabilities/agent-brief',
+      'capabilities/cli-entry',
+      'documents/research',
+    ]);
+  });
+
+  it('does NOT mint phantom backlinks for element/file-path refs that match no doc slug', async () => {
+    const manifest = await buildLocalManifest(
+      makeRoot({
+        'capabilities/mcp-server.md': md([
+          'title: MCP Server',
+          'kind: capability',
+          'elements: [mcp/src/index.js, mcp/src/vault.mjs]',
+        ]),
+      }),
+    );
+    // `mcp/src/index.js` is a source-file ref, not a doc — no backlink target.
+    expect(manifest.manifest.backlinksDetail['mcp/src/index.js']).toBeUndefined();
+    expect(Object.keys(manifest.manifest.backlinksDetail)).not.toContain('mcp/src/index.js');
+  });
+
+  it('resolves a bare inline `domain:` ref to the domain doc by its unique tail', async () => {
+    const manifest = await buildLocalManifest(
+      makeRoot({
+        'domains/ai-agent-partner.md': md(['title: AI Agent Partner', 'kind: domain']),
+        'capabilities/mcp-server.md': md([
+          'title: MCP Server',
+          'kind: capability',
+          'domain: ai-agent-partner',
+        ]),
+      }),
+    );
+    const backlinks = manifest.manifest.backlinksDetail['domains/ai-agent-partner'] ?? [];
+    expect(backlinks.map((b) => b.fromSlug)).toContain('capabilities/mcp-server');
+  });
+
+  it('does not create a self-backlink when a doc references its own slug', async () => {
+    const manifest = await buildLocalManifest(
+      makeRoot({
+        'capabilities/self.md': md([
+          'title: Self',
+          'kind: capability',
+          'relates: [capabilities/self]',
+        ]),
+      }),
+    );
+    expect(manifest.manifest.backlinksDetail['capabilities/self']).toBeUndefined();
+  });
+
+  it('keeps the richer BODY-link context when a doc references a target through both body and frontmatter', async () => {
+    const manifest = await buildLocalManifest(
+      makeRoot({
+        'capabilities/mcp-server.md': md(['title: MCP Server', 'kind: capability']),
+        'capabilities/cli-entry.md': {
+          text: [
+            '---',
+            'title: CLI Entry',
+            'kind: capability',
+            'dependencies: [capabilities/mcp-server]',
+            '---',
+            'See [[capabilities/mcp-server]] for the server.',
+          ].join('\n'),
+          lastModified: 1000,
+        },
+      }),
+    );
+    const backlinks = manifest.manifest.backlinksDetail['capabilities/mcp-server'] ?? [];
+    // one entry per fromSlug (deduped), and it's the body-link one (richer context)
+    const fromCli = backlinks.filter((b) => b.fromSlug === 'capabilities/cli-entry');
+    expect(fromCli).toHaveLength(1);
+    expect(fromCli[0].context).not.toContain('frontmatter ·');
+  });
+});

--- a/src/entities/docs-vault/lib/build-local-manifest.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.ts
@@ -13,6 +13,67 @@ import type {
   VaultTreeNode,
 } from '../model/types';
 
+/**
+ * D-1 — frontmatter keys that hold graph relation refs to OTHER docs. A doc
+ * that names another doc here (e.g. `dependencies: [capabilities/mcp-server]`)
+ * is a backlink to that doc, exactly as the MCP `find_backlinks` tool counts it
+ * (same key set: `mcp/src/vault.mjs` NEIGHBOR_KEYS + INLINE_NEIGHBOR_KEYS).
+ * The old backlink index only scanned BODY markdown links, so a doc referenced
+ * purely through frontmatter (the common vault case) showed a false "no
+ * backlinks" — the exact defect the UX round caught on `capabilities/mcp-server`
+ * (13 real referrers, footer said "none"). Kept in sync with the build-time
+ * script (`scripts/build-docs-vault.mjs`).
+ */
+const RELATION_REF_ARRAY_KEYS = [
+  'domains',
+  'capabilities',
+  'elements',
+  'dependencies',
+  'relates',
+  'contains',
+  'describes',
+] as const;
+const RELATION_REF_STRING_KEYS = ['domain'] as const;
+
+/** Frontmatter value → the doc slugs it references (folder-prefixed or bare). */
+function frontmatterRefStrings(frontmatter: Record<string, unknown>): string[] {
+  const out: string[] = [];
+  for (const key of RELATION_REF_ARRAY_KEYS) {
+    const value = frontmatter[key];
+    if (Array.isArray(value)) {
+      for (const item of value) if (typeof item === 'string' && item.trim()) out.push(item.trim());
+    } else if (typeof value === 'string' && value.trim()) {
+      // tolerate a scalar where an array is expected
+      out.push(value.trim());
+    }
+  }
+  for (const key of RELATION_REF_STRING_KEYS) {
+    const value = frontmatter[key];
+    if (typeof value === 'string' && value.trim()) out.push(value.trim());
+  }
+  return out;
+}
+
+/**
+ * Resolve a frontmatter ref to a known doc slug, or null. Folder-prefixed refs
+ * (`capabilities/mcp-server`) match a slug directly; bare refs (`mcp-server`,
+ * `ai-agent-partner`) resolve by unique tail segment. Refs that match no doc
+ * (e.g. `elements: [mcp/src/index.js]` — a source-file ref with no `.md`) are
+ * skipped, so no phantom backlinks are minted.
+ */
+function resolveRefToDocSlug(
+  ref: string,
+  slugSet: ReadonlySet<string>,
+  tailToSlug: ReadonlyMap<string, string | null>,
+): string | null {
+  const normalized = ref.replace(/\.md$/i, '');
+  if (slugSet.has(normalized)) return normalized;
+  const tail = normalized.split('/').pop() ?? normalized;
+  const byTail = tailToSlug.get(tail);
+  // `byTail === null` marks an ambiguous tail (2+ docs share it) — don't guess.
+  return byTail ?? null;
+}
+
 // FileSystemDirectoryHandle 을 재귀 순회해 .md 파일만 수집. 파일 핸들 맵을
 // 같이 반환해 뷰어가 slug → 파일 content 를 읽을 수 있게 한다. Next.js
 // 정적 타입에 FSAccess API 타입이 이미 lib.dom.d.ts 로 들어와 있어서 외부
@@ -250,6 +311,35 @@ function aggregateBuild(
       tagsMap.get(tag)!.add(doc.slug);
     }
     docs.push(doc);
+  }
+
+  // D-1 — second pass: register FRONTMATTER relation-ref backlinks (the body
+  // pass above only saw markdown links). A ref that resolves to a known doc
+  // slug adds a backlink from the declaring doc to that target — deduped by
+  // fromSlug in the final assembly below, so a doc that references a target
+  // through BOTH a body link and frontmatter keeps the richer body context.
+  const slugSet = new Set(docs.map((doc) => doc.slug));
+  const tailToSlug = new Map<string, string | null>();
+  for (const doc of docs) {
+    const tail = doc.slug.split('/').pop() ?? doc.slug;
+    // First occurrence wins; a second doc with the same tail marks it ambiguous
+    // (null) so `resolveRefToDocSlug` won't guess.
+    tailToSlug.set(tail, tailToSlug.has(tail) ? null : doc.slug);
+  }
+  for (const doc of docs) {
+    const seenTargets = new Set<string>();
+    for (const ref of frontmatterRefStrings(doc.frontmatter as Record<string, unknown>)) {
+      const target = resolveRefToDocSlug(ref, slugSet, tailToSlug);
+      // No self-backlinks; dedup repeated refs to the same target within a doc.
+      if (!target || target === doc.slug || seenTargets.has(target)) continue;
+      seenTargets.add(target);
+      if (!backlinksDetailMap.has(target)) backlinksDetailMap.set(target, []);
+      backlinksDetailMap.get(target)!.push({
+        fromSlug: doc.slug,
+        context: `frontmatter · **[${ref}]**`,
+        linkText: ref,
+      });
+    }
   }
 
   docs.sort((a, b) => a.slug.localeCompare(b.slug, 'ko'));

--- a/src/features/first-run-starter/ui/FirstRunReadout.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunReadout.test.tsx
@@ -27,6 +27,27 @@ describe('FirstRunReadout', () => {
     expect(screen.getByText('6')).toBeInTheDocument();
   });
 
+  it('M-5: defaults to the spine tier label and shows the "zoom in to see elements" hint', () => {
+    render(<FirstRunReadout projectCount={1} domainCount={6} />);
+    // translations are mocked to echo the key
+    expect(screen.getByTestId('first-run-readout-tier')).toHaveTextContent('tier_spine');
+    expect(screen.getByTestId('first-run-readout-zoom-hint')).toHaveTextContent('zoomHint');
+    expect(screen.getByTestId('first-run-readout')).toHaveAttribute('data-zoom-tier', 'spine');
+  });
+
+  it('M-5: at the circuit tier the label updates but the zoom hint still shows (elements not yet revealed)', () => {
+    render(<FirstRunReadout projectCount={1} domainCount={6} tier="circuit" />);
+    expect(screen.getByTestId('first-run-readout-tier')).toHaveTextContent('tier_circuit');
+    expect(screen.getByTestId('first-run-readout-zoom-hint')).toBeInTheDocument();
+  });
+
+  it('M-5: at the element tier the label switches to ELEMENT and the "zoom in to see elements" hint is dropped (no orientation lie)', () => {
+    render(<FirstRunReadout projectCount={1} domainCount={6} tier="element" />);
+    expect(screen.getByTestId('first-run-readout-tier')).toHaveTextContent('tier_element');
+    expect(screen.queryByTestId('first-run-readout-zoom-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('first-run-readout')).toHaveAttribute('data-zoom-tier', 'element');
+  });
+
   it('renders nothing once a vault is active (sample mode not settled to static)', () => {
     mocks.visible = false;
     render(<FirstRunReadout projectCount={1} domainCount={6} />);

--- a/src/features/first-run-starter/ui/FirstRunReadout.tsx
+++ b/src/features/first-run-starter/ui/FirstRunReadout.tsx
@@ -6,6 +6,14 @@ import { useFirstRunSampleModeSettled } from "../model/use-first-run-sample-mode
 export interface FirstRunReadoutProps {
   projectCount: number;
   domainCount: number;
+  /**
+   * M-5 — the current semantic-zoom altitude tier, reported by the map engine
+   * (`TopologyMapV2#onZoomTierChange`). Drives the readout's orientation label
+   * (SPINE → CIRCUIT → ELEMENT) and, once elements are actually on screen
+   * ("element"), drops the now-false "zoom in to see elements" hint. Defaults
+   * to "spine" (the overview entry) when the map hasn't reported yet.
+   */
+  tier?: "spine" | "circuit" | "element";
 }
 
 /**
@@ -15,20 +23,34 @@ export interface FirstRunReadoutProps {
  * 바꿨다("소개·macOS 앱·GitHub" 링크는 기존 크롬/설정 기어 경로로 충분,
  * 별도 스트립 불필요).
  *
+ * M-5 — the tier label + zoom hint used to be one frozen string
+ * (`readout.hint` = "Spine view · 줌인하면 요소가 나타납니다"). It stayed
+ * "Spine view · zoom in to see elements" even at max zoom with element nodes
+ * on screen — an orientation instrument that lies. The label now tracks the
+ * live `tier`, and the "zoom in to see elements" hint only shows while
+ * elements are NOT yet revealed (spine / circuit); at the element tier it is
+ * dropped.
+ *
  * `useFirstRunStarter` 의 `visible`(= sample mode settled && !dismissed) 과
  * 달리 dismiss 에 묶이지 않는다 — 시작하기 모듈을 닫아도 정적 샘플을 계속
  * 둘러보는 동안은 방향성 지표로 남아있는 게 유용하다(이전 오픈소스 스트립과
  * 같은 지속성).
  */
-export function FirstRunReadout({ projectCount, domainCount }: FirstRunReadoutProps) {
+export function FirstRunReadout({ projectCount, domainCount, tier = "spine" }: FirstRunReadoutProps) {
   const t = useTranslations("firstRunStarter.readout");
   const visible = useFirstRunSampleModeSettled();
 
   if (!visible) return null;
 
+  const tierLabel = t(`tier_${tier}`);
+  // At the element tier the "zoom in to see elements" promise is already
+  // fulfilled — showing it would be a lie (M-5). Below it, keep the guidance.
+  const showZoomHint = tier !== "element";
+
   return (
     <div
       data-testid="first-run-readout"
+      data-zoom-tier={tier}
       className="pointer-events-none hidden items-center gap-3.5 font-mono text-[9px] uppercase tracking-[0.2em] text-[color:var(--color-text-quaternary)] md:flex"
     >
       <span>
@@ -41,7 +63,13 @@ export function FirstRunReadout({ projectCount, domainCount }: FirstRunReadoutPr
         {t("domainUnit")}
       </span>
       <Dot />
-      <span>{t("hint")}</span>
+      <span data-testid="first-run-readout-tier">{tierLabel}</span>
+      {showZoomHint ? (
+        <>
+          <Dot />
+          <span data-testid="first-run-readout-zoom-hint">{t("zoomHint")}</span>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/shared/lib/ontology-tree/connections.ts
+++ b/src/shared/lib/ontology-tree/connections.ts
@@ -12,6 +12,8 @@
  * its tests) needed zero changes.
  */
 
+import { isContainmentRelation } from "./relations";
+
 export interface DatasheetConnection {
   id: string;
   title: string;
@@ -62,6 +64,91 @@ export function groupConnectionsByDirection(
     }
   }
   return { usedBy, dependsOn };
+}
+
+/**
+ * M-2 — connections split by relation ROLE, not just direction. `usedBy` /
+ * `dependsOn` are the non-containment incoming/outgoing groups (same as
+ * `groupConnectionsByDirection`); containment edges are pulled OUT into their
+ * own `contains` (this node is the parent) / `belongsTo` (this node is the
+ * child) groups instead of folding into usedBy/dependsOn by raw direction.
+ *
+ * The compact canvas popover used to group by DIRECTION only, so a domain's
+ * 18 `contains` children landed in "기대는 곳" (dependsOn) — the exact typed-
+ * fact collapse the UX round flagged (popover "쓰는 곳 5 · 기대는 곳 20" vs
+ * full-detail "담는 것 18 · 쓰는 곳 4 · 기대는 곳 2 · 속한 곳 1"). This is the
+ * SAME bucketing the full-detail surface uses (`buildFullDetailGroups` now
+ * delegates here), so the two surfaces can never disagree on the counts.
+ */
+export interface RoleGroupedConnections {
+  /** Outgoing containment — what this node contains. */
+  contains: DatasheetConnection[];
+  /** Incoming non-containment — places that use this node. */
+  usedBy: DatasheetConnection[];
+  /** Outgoing non-containment — places this node leans on. */
+  dependsOn: DatasheetConnection[];
+  /** Incoming containment — the (usually single) parent this node belongs to. */
+  belongsTo: DatasheetConnection[];
+}
+
+/**
+ * True when a containment connection means `nodeId` is the PARENT (→ contains)
+ * vs the CHILD (→ belongsTo). `contains` edges point parent→child (so an
+ * OUTGOING one makes nodeId the parent); `belongs_to` edges point child→parent
+ * (so an INCOMING one makes nodeId the parent). Same rule as
+ * `buildContainmentParents` (insights.ts) — getting it wrong would file a
+ * `belongs_to`-authored parent under "담는 것" instead of "속한 곳".
+ */
+function containmentNodeIsParent(connection: DatasheetConnection): boolean {
+  return connection.relationType === "belongs_to"
+    ? connection.direction === "incoming"
+    : connection.direction === "outgoing";
+}
+
+/**
+ * Split direct connections into the four role groups (contains / usedBy /
+ * dependsOn / belongsTo), each deduped by neighbor `id` within its own bucket
+ * (a neighbor genuinely reachable by two relationTypes in the same role — the
+ * live `depends_on` + `related_to` dogfood case — collapses to one row, same
+ * guard `groupConnectionsByDirection` already applies). Input order preserved
+ * inside each bucket for deterministic rendering.
+ */
+export function groupConnectionsByRole(
+  connections: readonly DatasheetConnection[],
+): RoleGroupedConnections {
+  const contains: DatasheetConnection[] = [];
+  const usedBy: DatasheetConnection[] = [];
+  const dependsOn: DatasheetConnection[] = [];
+  const belongsTo: DatasheetConnection[] = [];
+  const seen = {
+    contains: new Set<string>(),
+    usedBy: new Set<string>(),
+    dependsOn: new Set<string>(),
+    belongsTo: new Set<string>(),
+  };
+  for (const connection of connections) {
+    let bucket: DatasheetConnection[];
+    let seenSet: Set<string>;
+    if (isContainmentRelation(connection.relationType)) {
+      if (containmentNodeIsParent(connection)) {
+        bucket = contains;
+        seenSet = seen.contains;
+      } else {
+        bucket = belongsTo;
+        seenSet = seen.belongsTo;
+      }
+    } else if (connection.direction === "incoming") {
+      bucket = usedBy;
+      seenSet = seen.usedBy;
+    } else {
+      bucket = dependsOn;
+      seenSet = seen.dependsOn;
+    }
+    if (seenSet.has(connection.id)) continue;
+    seenSet.add(connection.id);
+    bucket.push(connection);
+  }
+  return { contains, usedBy, dependsOn, belongsTo };
 }
 
 /** Minimal structural shapes — keeps this module pure + testable without

--- a/src/shared/lib/ontology-tree/index.ts
+++ b/src/shared/lib/ontology-tree/index.ts
@@ -38,12 +38,14 @@ export {
 export {
   buildConnections,
   groupConnectionsByDirection,
+  groupConnectionsByRole,
 } from "./connections";
 export type {
   ConnectionSourceEdge,
   ConnectionSourceNode,
   DatasheetConnection,
   GroupedConnections,
+  RoleGroupedConnections,
 } from "./connections";
 export type {
   AgentReadinessActionKey,

--- a/src/views/home/lib/topology-esc-ladder.test.ts
+++ b/src/views/home/lib/topology-esc-ladder.test.ts
@@ -11,6 +11,7 @@ const BASE: TopologyEscLadderInput = {
   fullDetailOpen: false,
   selectedRelationActive: false,
   hasSelection: false,
+  nodePopoverOpen: false,
   hasLocalGraphRoot: false,
 };
 
@@ -116,11 +117,43 @@ describe("resolveTopologyEscLadderAction", () => {
     ).toBe("close-relation-lens");
   });
 
-  it("deselects the node before popping the local-graph breadcrumb", () => {
+  it("M-7: closes the node popover (keeping ego focus) before deselecting when the popover is open", () => {
     expect(
       resolveTopologyEscLadderAction({
         ...BASE,
         hasSelection: true,
+        nodePopoverOpen: true,
+        hasLocalGraphRoot: true,
+      }),
+    ).toBe("close-node-popover");
+  });
+
+  it("M-7: Escape#1 closes the popover, Escape#2 (popover now dismissed) deselects — two rungs, not one", () => {
+    // Step 1: node clicked — popover + ego focus both up. First Escape closes
+    // only the popover.
+    const step1 = resolveTopologyEscLadderAction({
+      ...BASE,
+      hasSelection: true,
+      nodePopoverOpen: true,
+    });
+    expect(step1).toBe("close-node-popover");
+
+    // Step 2: popover dismissed (nodePopoverOpen now false) but the selection
+    // (ego focus/dim) survived — the next Escape releases focus.
+    const step2 = resolveTopologyEscLadderAction({
+      ...BASE,
+      hasSelection: true,
+      nodePopoverOpen: false,
+    });
+    expect(step2).toBe("deselect");
+  });
+
+  it("M-7: a selection with no node popover (e.g. a project, or an already-dismissed popover) deselects in one press", () => {
+    expect(
+      resolveTopologyEscLadderAction({
+        ...BASE,
+        hasSelection: true,
+        nodePopoverOpen: false,
         hasLocalGraphRoot: true,
       }),
     ).toBe("deselect");

--- a/src/views/home/lib/topology-esc-ladder.ts
+++ b/src/views/home/lib/topology-esc-ladder.ts
@@ -42,8 +42,20 @@ export interface TopologyEscLadderInput {
   fullDetailOpen: boolean;
   /** Relation lens active — replaces the popover with a relation-focused view. */
   selectedRelationActive: boolean;
-  /** A node/project is selected, so the popover/datasheet is showing. */
+  /** A node/project is selected, so the ego focus (dim) is active. */
   hasSelection: boolean;
+  /**
+   * M-7 — the compact node popover/datasheet is currently VISIBLE (a node is
+   * selected AND the popover has not yet been dismissed). Clicking a node sets
+   * BOTH the ego focus (dim) and the popover; a single Escape used to clear
+   * both at once (`hasSelection → deselect`), collapsing the two-rung "close
+   * popover, THEN release focus" contract the shortcut sheet promises. When
+   * this is true, Escape#1 closes only the popover (ego focus survives);
+   * Escape#2 then falls through to `deselect`. A selected *project* (no node
+   * popover) or a popover already dismissed leaves this false, so those
+   * deselect in one press as before.
+   */
+  nodePopoverOpen: boolean;
   /** Local-graph ego-drill stack has at least one entry to pop. */
   hasLocalGraphRoot: boolean;
 }
@@ -53,6 +65,7 @@ export type TopologyEscLadderAction =
   | "close-create-node"
   | "close-full-detail"
   | "close-relation-lens"
+  | "close-node-popover"
   | "deselect"
   | "pop-local-graph"
   | "none";
@@ -60,10 +73,11 @@ export type TopologyEscLadderAction =
 /**
  * Resolves what a single Escape keypress should do, in priority order:
  * context menu → create-node composer → search palette (deferred to its own
- * handler) → full-detail drawer → relation lens → deselect the current node
- * → pop one level of the local-graph breadcrumb → nothing. Each tier closes
- * exactly one thing; the caller re-evaluates on the next keypress, which is
- * what makes this "one step at a time" rather than "close everything".
+ * handler) → full-detail drawer → relation lens → close the node popover (ego
+ * focus survives) → deselect the current node → pop one level of the
+ * local-graph breadcrumb → nothing. Each tier closes exactly one thing; the
+ * caller re-evaluates on the next keypress, which is what makes this "one step
+ * at a time" rather than "close everything".
  */
 export function resolveTopologyEscLadderAction(
   input: TopologyEscLadderInput,
@@ -77,6 +91,10 @@ export function resolveTopologyEscLadderAction(
   if (input.searchOpen) return "none";
   if (input.fullDetailOpen) return "close-full-detail";
   if (input.selectedRelationActive) return "close-relation-lens";
+  // M-7 — Escape#1 closes only the node popover, leaving the ego focus (dim)
+  // in place; the NEXT Escape (with the popover now dismissed, so
+  // `nodePopoverOpen` false) falls through to `deselect` and releases focus.
+  if (input.hasSelection && input.nodePopoverOpen) return "close-node-popover";
   if (input.hasSelection) return "deselect";
   if (input.hasLocalGraphRoot) return "pop-local-graph";
   return "none";

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -208,6 +208,12 @@ export function HomePage() {
     localGraphStack.length > 0 ? localGraphStack[localGraphStack.length - 1] : null;
   const [fitViewToken, setFitViewToken] = useState(0);
   const [topologyVisibleCount, setTopologyVisibleCount] = useState<number | null>(null);
+  // M-5 — semantic-zoom altitude tier reported by the map engine, for the
+  // corner readout's orientation label. "spine" at the overview entry; drops
+  // the "zoom in to see elements" hint once it reaches "element".
+  const [mapZoomTier, setMapZoomTier] = useState<"spine" | "circuit" | "element">(
+    "spine",
+  );
   const [topologyGraphStats, setTopologyGraphStats] = useState<{
     key: string;
     nodes: number;
@@ -345,6 +351,13 @@ export function HomePage() {
         changeVaultHref="/docs/?intent=local"
         popoverAlign="left"
         popoverSide="top"
+        // M-4 (2) — keyboard-opened transients (⌘K palette, `D` docs drawer)
+        // don't fire the `mousedown`-outside the gear's own outside-click
+        // handler relies on, so they'd leave the gear stacked underneath.
+        // Signal them here so the gear demotes itself. Pointer-driven surfaces
+        // (node/edge click, context menu, graph toggle) already close it via
+        // outside-click.
+        suppressed={ontologySearchOpen || docsDrawerOpen}
         labels={{
           trigger: t('controls.settingsGearAriaLabel'),
           heading: t('controls.settingsGearHeading'),
@@ -357,7 +370,13 @@ export function HomePage() {
         }}
       />
     ),
-    [indexPanelCollapsedStored, handleChangeIndexDefaultCollapsed, t],
+    [
+      indexPanelCollapsedStored,
+      handleChangeIndexDefaultCollapsed,
+      ontologySearchOpen,
+      docsDrawerOpen,
+      t,
+    ],
   );
   useNavRailSettingsSlot(navRailSettingsSlot);
   // Clicking the collapsed edge tab always means "give the slot back to
@@ -890,6 +909,11 @@ export function HomePage() {
   ] = useState<string | null>(null);
   const interactionSelectedSlugRef = useRef<string | null>(null);
   const [selectedRelationActive, setSelectedRelationActive] = useState(false);
+  // M-7 — Escape rung 1 dismisses the node popover WITHOUT releasing the ego
+  // focus (dim); rung 2 (with this true) then deselects. Reset to false on
+  // every fresh node selection so re-clicking a node always re-opens its
+  // popover. `null` selection also clears it via handleClose.
+  const [nodePopoverDismissed, setNodePopoverDismissed] = useState(false);
   const fullDetailOpen =
     fullDetailSlug != null && fullDetailSlug === selectedOntologyNode?.id;
   const topologyShortcutHelpPhoneVisible =
@@ -981,7 +1005,12 @@ export function HomePage() {
     );
     const groups = buildV2ConnectionGroups(connections);
     const evidenceRows = buildV2EvidenceRows(selectedOntologyNode.evidenceIds);
+    // M-2 — typed-fact metric: containment ("담는 것") is its own count, split
+    // out of the old direction-only "기대는 곳" so a domain's contained
+    // capabilities stop reading as things the domain depends ON. Numbers come
+    // from the SAME `groups` the panel renders, so header and metric agree.
     const metric = {
+      contains: groups.contains.total,
       usedBy: groups.usedBy.total,
       dependsOn: groups.dependsOn.total,
       evidence: evidenceRows.length,
@@ -990,9 +1019,11 @@ export function HomePage() {
       slug,
       kind: nodeFocus.kind,
       domainTitle: nodeFocusData?.significance.ownerDomainTitle ?? null,
+      contains: metric.contains,
       usedBy: metric.usedBy,
       dependsOn: metric.dependsOn,
       evidence: metric.evidence,
+      containsNames: groups.contains.rows.map((connection) => connection.title),
       usedByNames: groups.usedBy.rows.map((connection) => connection.title),
       dependsNames: groups.dependsOn.rows.map((connection) => connection.title),
     });
@@ -1098,9 +1129,11 @@ export function HomePage() {
       slug,
       kind: node.kind,
       domainTitle: null,
+      contains: groups.contains.total,
       usedBy: groups.usedBy.total,
       dependsOn: groups.dependsOn.total,
       evidence: evidenceRows.length,
+      containsNames: groups.contains.rows.map((connection) => connection.title),
       usedByNames: groups.usedBy.rows.map((connection) => connection.title),
       dependsNames: groups.dependsOn.rows.map((connection) => connection.title),
     });
@@ -1184,6 +1217,15 @@ export function HomePage() {
         !fullDetailOpen &&
         analysisMode !== "path",
     );
+  // M-7 — the compact node popover is actually on screen (same condition the
+  // popover JSX renders under). Drives both the Escape ladder's
+  // `nodePopoverOpen` rung and the popover's own render guard, so the two can
+  // never disagree about whether Escape#1 should close it.
+  const nodePopoverVisible =
+    selectedNodeFocusActive &&
+    !selectedRelationActive &&
+    !createNodeOpen &&
+    !nodePopoverDismissed;
   const selectedInspectorSupportRailVisible =
     selectedNodeFocusActive && selectedInspectorSupportRailSlug === selectedSlug;
   const selectedNodeOwnsRightRail = selectedNodeFocusActive;
@@ -1226,6 +1268,7 @@ export function HomePage() {
       interactionSelectedSlugRef.current = slug;
       setFullDetailSlug(null);
       setSelectedRelationActive(false);
+      setNodePopoverDismissed(false);
       const project = projectBySlug.get(slug);
       // path 모드/일반 선택 분기는 `resolveTopologyNodeClickRouteState` 가
       // 담당 — persona QA fix/persona-findings ②, 자세한 배경은 그 함수의
@@ -1301,6 +1344,7 @@ export function HomePage() {
         fullDetailOpen,
         selectedRelationActive,
         hasSelection: canvasSelectedSlug != null,
+        nodePopoverOpen: nodePopoverVisible,
         hasLocalGraphRoot: localGraphRoot !== null,
       });
       switch (action) {
@@ -1315,6 +1359,12 @@ export function HomePage() {
           break;
         case "close-relation-lens":
           setSelectedRelationActive(false);
+          break;
+        case "close-node-popover":
+          // M-7 rung 1 — hide the popover but keep the ego focus (dim). The
+          // NEXT Escape sees `nodePopoverOpen: false` and falls through to
+          // "deselect".
+          setNodePopoverDismissed(true);
           break;
         case "deselect":
           handleClose();
@@ -1335,10 +1385,13 @@ export function HomePage() {
     fullDetailOpen,
     selectedRelationActive,
     canvasSelectedSlug,
+    nodePopoverVisible,
     localGraphRoot,
     closeContextMenu,
     closeCreateNode,
-    handleClose,, selectedEdge]);
+    handleClose,
+    selectedEdge,
+  ]);
 
   const handleSelectImpactMode = useCallback(
     (nextMode: ProjectImpactMode) => {
@@ -2590,6 +2643,7 @@ export function HomePage() {
                     }}
                     onVisibleCountChange={setTopologyVisibleCount}
                     onGraphStatsChange={handleTopologyGraphStatsChange}
+                    onZoomTierChange={setMapZoomTier}
                     onContextMenuNode={handleContextMenuNode}
                     minimal={localGraphRoot !== null}
                     agentFocusNodeId={agentFocusNodeId}
@@ -2749,6 +2803,7 @@ export function HomePage() {
                 <FirstRunReadout
                   projectCount={firstRunProjectCount}
                   domainCount={indexDomainCount}
+                  tier={mapZoomTier}
                 />
               </div>
 
@@ -2794,7 +2849,8 @@ export function HomePage() {
         analysisMode !== "path" &&
         !fullDetailOpen &&
         !selectedRelationActive &&
-        !createNodeOpen ? (
+        !createNodeOpen &&
+        !nodePopoverDismissed ? (
           <div
             data-testid="topology-node-popover-positioner"
             data-position-contract="selected-inspector-aligns-to-right-inset"
@@ -2836,6 +2892,10 @@ export function HomePage() {
                   // 옮겨 지도/빌더와 같은 단어(의미)를 한 곳에서 관리한다 —
                   // 문구 값 자체는 기존과 동일("기대는 곳"/"근거"), 드리프트
                   // 방지가 목적.
+                  // M-2 — "담는 것" from the shared relation vocabulary (plain
+                  // register), same source as depends_on/describes below so the
+                  // typed groups read in one consistent word family.
+                  metricContains: relationVocabulary("contains", "plain"),
                   metricUsedBy: t("nodeDatasheet.metricUsedBy"),
                   metricDependsOn: relationVocabulary("depends_on", "plain"),
                   metricEvidence: relationVocabulary("describes", "plain"),

--- a/src/widgets/full-detail-a1/lib/full-detail-groups.ts
+++ b/src/widgets/full-detail-a1/lib/full-detail-groups.ts
@@ -14,8 +14,10 @@
  */
 import {
   buildConnections,
+  groupConnectionsByRole,
   type ConnectionSourceEdge,
   type ConnectionSourceNode,
+  type DatasheetConnection,
 } from "@/shared/lib/ontology-tree/connections";
 import { isContainmentRelation } from "@/shared/lib/ontology-tree/relations";
 
@@ -75,73 +77,34 @@ export function buildFullDetailGroups(
   edges: readonly ConnectionSourceEdge[],
   changedIds?: ReadonlySet<string>,
 ): FullDetailGroups {
+  // The four-bucket role split (contains / usedBy / dependsOn / belongsTo) +
+  // per-bucket neighbor dedup lives in the shared `groupConnectionsByRole`
+  // (M-2) so the compact canvas popover renders the SAME numbers from the SAME
+  // construction — the two surfaces can't drift. This widget only enriches
+  // each row with `childCount` / `fresh` / `containment` for its denser view.
   const connections = buildConnections(nodeId, nodes, edges);
-  const contains: FullDetailConnectionRow[] = [];
-  const usedBy: FullDetailConnectionRow[] = [];
-  const dependsOn: FullDetailConnectionRow[] = [];
-  const belongsTo: FullDetailConnectionRow[] = [];
-  // `buildConnections` dedups by (neighbor, relationType, direction) — a
-  // neighbor with BOTH a `depends_on` AND a `related_to` edge in the SAME
-  // direction (live dogfood case: `capability:ontology-hub-mode-aware`) is
-  // genuinely two distinct relationType facts there, but this surface shows
-  // only one row per neighbor per bucket (no relationType-keyed row), so two
-  // rows for the same neighbor in the same bucket read as a visible
-  // duplicate AND collide on the React list key — same failure mode
-  // `groupConnectionsByDirection` already guards against for usedBy/dependsOn;
-  // contains/belongsTo need the identical per-bucket neighbor dedup.
-  const seenByBucket = {
-    contains: new Set<string>(),
-    usedBy: new Set<string>(),
-    dependsOn: new Set<string>(),
-    belongsTo: new Set<string>(),
-  };
+  const grouped = groupConnectionsByRole(connections);
 
-  for (const connection of connections) {
-    const containment = isContainmentRelation(connection.relationType);
-    const row: FullDetailConnectionRow = {
-      id: connection.id,
-      title: connection.title,
-      kind: connection.kind,
-      containment,
-      childCount: countContainmentChildren(connection.id, edges),
-      fresh: changedIds?.has(connection.id) ?? false,
-    };
-    let bucket: FullDetailConnectionRow[];
-    let seen: Set<string>;
-    if (containment) {
-      // `contains` edges point parent→child (outgoing from `nodeId` = nodeId
-      // is the parent); `belongs_to` edges point child→parent, so the SAME
-      // direction check is inverted for that type — `buildContainmentParents`
-      // (shared/lib/ontology-tree/insights.ts) resolves parentage the same
-      // way. Getting this wrong would put a `belongs_to`-authored parent
-      // into "담는 것" instead of "속한 곳".
-      const nodeIsParent =
-        connection.relationType === "belongs_to"
-          ? connection.direction === "incoming"
-          : connection.direction === "outgoing";
-      bucket = nodeIsParent ? contains : belongsTo;
-      seen = nodeIsParent ? seenByBucket.contains : seenByBucket.belongsTo;
-    } else if (connection.direction === "incoming") {
-      bucket = usedBy;
-      seen = seenByBucket.usedBy;
-    } else {
-      bucket = dependsOn;
-      seen = seenByBucket.dependsOn;
-    }
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-    bucket.push(row);
-  }
-
-  const toView = (rows: FullDetailConnectionRow[]): FullDetailGroupView => ({
-    rows,
-    total: rows.length,
+  const toRow = (connection: DatasheetConnection): FullDetailConnectionRow => ({
+    id: connection.id,
+    title: connection.title,
+    kind: connection.kind,
+    containment: isContainmentRelation(connection.relationType),
+    childCount: countContainmentChildren(connection.id, edges),
+    fresh: changedIds?.has(connection.id) ?? false,
   });
 
+  const toView = (
+    connections: readonly DatasheetConnection[],
+  ): FullDetailGroupView => {
+    const rows = connections.map(toRow);
+    return { rows, total: rows.length };
+  };
+
   return {
-    contains: toView(contains),
-    usedBy: toView(usedBy),
-    dependsOn: toView(dependsOn),
-    belongsTo: toView(belongsTo),
+    contains: toView(grouped.contains),
+    usedBy: toView(grouped.usedBy),
+    dependsOn: toView(grouped.dependsOn),
+    belongsTo: toView(grouped.belongsTo),
   };
 }

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -192,6 +192,67 @@ describe("TopologyIndexPanel", () => {
     expect(screen.queryByText("CLI Developer Entry")).not.toBeInTheDocument();
   });
 
+  it("M-10: Escape in the search field with a query clears it and stops the keypress (search-scoped, not a canvas deselect)", () => {
+    const treeResult = buildFixtureTree();
+    render(
+      <TopologyIndexPanel
+        treeResult={treeResult}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+      />,
+    );
+
+    const input = screen.getByTestId("topology-index-search") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "agent brief" } });
+    expect(input.value).toBe("agent brief");
+    // the filter is active — sibling with no match is pruned
+    expect(screen.queryByText("CLI Developer Entry")).not.toBeInTheDocument();
+
+    const windowHandler = vi.fn();
+    window.addEventListener("keydown", windowHandler);
+    const notPrevented = fireEvent.keyDown(input, { key: "Escape", bubbles: true });
+    window.removeEventListener("keydown", windowHandler);
+
+    // query cleared, filter released
+    expect(input.value).toBe("");
+    // the keypress was consumed — the window-level topology Esc ladder never sees it
+    expect(windowHandler).not.toHaveBeenCalled();
+    // fireEvent returns false when preventDefault was called
+    expect(notPrevented).toBe(false);
+  });
+
+  it("M-10: Escape in an EMPTY search field is not consumed — it bubbles to the window ladder", () => {
+    const treeResult = buildFixtureTree();
+    render(
+      <TopologyIndexPanel
+        treeResult={treeResult}
+        totalConcepts={4}
+        totalRelations={3}
+        domainCount={1}
+        changedSlugs={new Set()}
+        selectedId={null}
+        onSelect={() => {}}
+        onCollapse={() => {}}
+        labels={labels}
+      />,
+    );
+
+    const input = screen.getByTestId("topology-index-search") as HTMLInputElement;
+    const windowHandler = vi.fn();
+    window.addEventListener("keydown", windowHandler);
+    fireEvent.keyDown(input, { key: "Escape", bubbles: true });
+    window.removeEventListener("keydown", windowHandler);
+
+    // nothing to clear → the keypress reaches the window (the ladder can act)
+    expect(windowHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the census row with the same totals passed in", () => {
     const treeResult = buildFixtureTree();
     render(

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -241,6 +241,20 @@ export function TopologyIndexPanel({
           type="text"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            // M-10 — Escape in the INDEX search is a search-scoped clear (the
+            // macOS workbench convention), NOT a canvas deselect. When there
+            // IS a query, rung 1 clears it + blurs and stops the keypress so
+            // the window-level topology Esc ladder doesn't ALSO deselect the
+            // node underneath on the same press. An empty field lets Escape
+            // bubble through to that ladder unchanged.
+            if (event.key === "Escape" && query.length > 0) {
+              event.preventDefault();
+              event.stopPropagation();
+              setQuery("");
+              event.currentTarget.blur();
+            }
+          }}
           placeholder={labels.searchPlaceholder}
           autoComplete="off"
           data-testid="topology-index-search"

--- a/src/widgets/topology-map-v2/model/tier-visibility.test.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  classifyZoomTier,
   computeZoomRatio,
   DEFAULT_TIER_REVEAL,
   edgeTierAlpha,
@@ -177,5 +178,31 @@ describe("isNodeHittable", () => {
     expect(isNodeHittable({ id: "capability:full", kind: "capability", isHub: false }, DEFAULT_TIER_REVEAL.capability.fullRatio, null, undefined)).toBe(
       true,
     );
+  });
+});
+
+describe("classifyZoomTier (M-5 — corner readout orientation)", () => {
+  const C = DEFAULT_TIER_REVEAL;
+
+  it("is 'spine' at the overview entry (nothing below the spine revealed yet)", () => {
+    expect(classifyZoomTier(ENTRY, C)).toBe("spine");
+  });
+
+  it("is 'spine' while capabilities are still less than half-revealed", () => {
+    expect(classifyZoomTier(C.capability.enterRatio, C)).toBe("spine");
+  });
+
+  it("is 'circuit' once capabilities are fully revealed but elements are not", () => {
+    expect(classifyZoomTier(C.capability.fullRatio, C)).toBe("circuit");
+  });
+
+  it("is 'element' once elements are fully revealed — the point the 'zoom in to see elements' hint becomes false", () => {
+    expect(classifyZoomTier(C.element.fullRatio, C)).toBe("element");
+    expect(classifyZoomTier(ZOOMED_IN, C)).toBe("element");
+  });
+
+  it("never reports 'element' while still at the spine (the exact orientation lie the UX round caught)", () => {
+    expect(classifyZoomTier(ENTRY, C)).not.toBe("element");
+    expect(classifyZoomTier(ZOOMED_OUT, C)).not.toBe("element");
   });
 });

--- a/src/widgets/topology-map-v2/model/tier-visibility.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.ts
@@ -157,3 +157,29 @@ export function isNodeHittable(
 export function isSpineOnlyZoom(zoomRatio: number, config: TierRevealConfig): boolean {
   return zoomRatio < config.capability.enterRatio;
 }
+
+/**
+ * The altitude tier the reader is currently at, for the corner readout's
+ * orientation label (M-5). Derived from the SAME reveal bands the draw pass
+ * gates node visibility with, so the readout can never claim "zoom in to see
+ * elements" while elements are actually on screen (the exact orientation lie
+ * the UX round caught). A tier is "reached" once its band is at least
+ * half-revealed (`revealAlpha ≥ 0.5`), matching the `HITTABLE_MIN_TIER_ALPHA`
+ * threshold — the point where the tier's nodes become legible/clickable, not
+ * the instant their alpha leaves zero.
+ *
+ *   spine     — only project/domain/hub drawn (capabilities not yet revealed)
+ *   circuit   — capabilities revealed, elements not yet
+ *   element   — elements revealed (the "zoom in to see elements" hint is now
+ *               false and must be dropped)
+ */
+export type ZoomTier = "spine" | "circuit" | "element";
+
+export function classifyZoomTier(
+  zoomRatio: number,
+  config: TierRevealConfig = DEFAULT_TIER_REVEAL,
+): ZoomTier {
+  if (revealAlpha(zoomRatio, config.element) >= HITTABLE_MIN_TIER_ALPHA) return "element";
+  if (revealAlpha(zoomRatio, config.capability) >= HITTABLE_MIN_TIER_ALPHA) return "circuit";
+  return "spine";
+}

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -98,6 +98,12 @@ export interface TopologyMapV2Props {
   onVisibleCountChange?: (visible: number) => void;
   onGraphStatsChange?: (stats: { nodes: number; relations: number }) => void;
   /**
+   * M-5 — semantic-zoom tier (spine → circuit → element) changed. Fires only
+   * on transitions; HomePage feeds it to the corner readout so the "zoom in to
+   * see elements" hint drops once elements are actually on screen.
+   */
+  onZoomTierChange?: (tier: "spine" | "circuit" | "element") => void;
+  /**
    * W2-B node right-click context menu — called with the hit node's id and
    * viewport-space cursor position. Omitted keeps right-click behavior
    * unchanged (browser default menu everywhere, same as before this slice).
@@ -115,7 +121,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onContextMenuNode, agentFocusNodeId } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId } = props;
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
@@ -133,6 +139,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       onPaneClick,
       onVisibleCountChange,
       onGraphStatsChange,
+      onZoomTierChange,
       onContextMenuNode,
       agentFocusNodeId,
     });

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -20,6 +20,7 @@ const labels = {
   domainLabel: "domain",
   poweredOn: "fresh",
   poweredOff: "idle",
+  metricContains: "contains",
   metricUsedBy: "used by",
   metricDependsOn: "leans on",
   metricEvidence: "evidence",
@@ -55,8 +56,13 @@ function renderPanel(
       kind="domain"
       domain={overrides.domain !== undefined ? overrides.domain : null}
       powered={false}
-      metric={{ usedBy: 1, dependsOn: 2, evidence: evidence.total }}
-      groups={{ usedBy: { rows: [], total: 1 }, dependsOn: { rows: [], total: 2 } }}
+      metric={{ contains: 0, usedBy: 1, dependsOn: 2, evidence: evidence.total }}
+      groups={{
+        contains: { rows: [], total: 0 },
+        usedBy: { rows: [], total: 1 },
+        dependsOn: { rows: [], total: 2 },
+        belongsTo: { rows: [], total: 0 },
+      }}
       evidence={evidence}
       handoffText="node: domains/views"
       documentHref={
@@ -119,6 +125,62 @@ describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYST
       "href",
       expect.stringContaining("product-owner-operating-system"),
     );
+  });
+});
+
+describe("TopologyV2DetailPanel — M-2 typed containment split", () => {
+  it("renders a 담는 것(contains) group with the parent's children (not folded into 기대는 곳)", () => {
+    render(
+      <TopologyV2DetailPanel
+        slug="domains/ai-agent-partner"
+        title="AI Agent Partner"
+        kind="domain"
+        domain={null}
+        powered={false}
+        metric={{ contains: 2, usedBy: 1, dependsOn: 0, evidence: 0 }}
+        groups={{
+          contains: {
+            rows: [
+              { id: "capability:mcp-server", title: "MCP Server", kind: "capability", relationType: "contains", direction: "outgoing" },
+              { id: "capability:agent-config", title: "Agent Config", kind: "capability", relationType: "contains", direction: "outgoing" },
+            ],
+            total: 2,
+          },
+          usedBy: {
+            rows: [
+              { id: "capability:x", title: "Consumer X", kind: "capability", relationType: "depends_on", direction: "incoming" },
+            ],
+            total: 1,
+          },
+          dependsOn: { rows: [], total: 0 },
+          belongsTo: { rows: [], total: 0 },
+        }}
+        evidence={{ rows: [], total: 0 }}
+        handoffText="node: domains/ai-agent-partner"
+        documentHref={null}
+        builderEditHref="/ontology/edit/?node=domains%2Fai-agent-partner"
+        labels={labels}
+        onSelectConnection={() => {}}
+        onCopyHandoff={() => {}}
+        onClose={() => {}}
+        onSetPathSource={() => {}}
+      />,
+    );
+    // the contains group exists and holds the contained capabilities
+    const group = document.querySelector("[data-datasheet-group='contains']");
+    expect(group).not.toBeNull();
+    expect(screen.getByText("MCP Server")).toBeInTheDocument();
+    expect(screen.getByText("Agent Config")).toBeInTheDocument();
+    // the metric line leads with the "contains" typed segment
+    const metric = screen.getByTestId("topology-v2-detail-panel").querySelector("[data-datasheet-metric='engraved']");
+    expect(metric?.textContent).toContain("contains 2");
+  });
+
+  it("omits the 담는 것 segment + group for a leaf node (contains 0)", () => {
+    renderPanel();
+    expect(document.querySelector("[data-datasheet-group='contains']")).toBeNull();
+    const metric = screen.getByTestId("topology-v2-detail-panel").querySelector("[data-datasheet-metric='engraved']");
+    expect(metric?.textContent).not.toContain("contains");
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -30,13 +30,16 @@ import { TopologyV2KindGlyph, TopologyV2TraceMark } from "@/shared/ui/topology-v
  * `TopologyNodeFocusModel` into these props, so the import direction stays
  * view → widget. Colors/sizes come from `--topology-v2-panel-*` tokens.
  *
- * R+ 카운트 시맨틱 통일: connection groups are DIRECTION-based (usedBy /
- * dependsOn) — the SAME axis the metric line counts — so the group header's
- * number and the metric line's number are the same number by construction.
- * Group headers reuse `labels.metricUsedBy`/`labels.metricDependsOn` (no
- * separate group-label strings) so the words match too. Relation TYPE
- * (containment vs depends) demotes to a per-row `TraceMark`, one per
- * connection row instead of one per group header.
+ * M-2 카운트 시맨틱: connection groups are ROLE-based (contains / usedBy /
+ * dependsOn) — the SAME buckets the metric line counts and the full-detail
+ * surface renders — so the group header's number and the metric line's number
+ * are the same number by construction, and the popover never disagrees with
+ * full-detail. Containment is its OWN "담는 것" group/segment (rendered only
+ * when non-empty, i.e. container nodes) instead of folding into "기대는 곳" by
+ * raw direction — the exact typed-fact collapse the UX round flagged. Group
+ * headers reuse `labels.metricContains`/`metricUsedBy`/`metricDependsOn` (no
+ * separate group-label strings) so the words match too; the per-row `TraceMark`
+ * still marks containment vs depends within a row.
  *
  * RATIO-SYSTEM §4 scale-up (`docs/prototypes/chrome-datasheet-final.html`,
  * owner: "정보는 좋은데 너무 작고 그래") promotes a THIRD group — 근거
@@ -66,6 +69,8 @@ export interface TopologyV2DetailPanelLabels {
   domainLabel: string;
   poweredOn: string;
   poweredOff: string;
+  /** M-2 — "담는 것" (contains). Only rendered for container nodes. */
+  metricContains: string;
   metricUsedBy: string;
   metricDependsOn: string;
   metricEvidence: string;
@@ -175,12 +180,16 @@ export function TopologyV2DetailPanel({
   className,
 }: TopologyV2DetailPanelProps) {
   const metricLine = formatV2MetricLine(metric, {
+    contains: labels.metricContains,
     usedBy: labels.metricUsedBy,
     dependsOn: labels.metricDependsOn,
     evidence: labels.metricEvidence,
   });
   const hasConnections =
-    groups.usedBy.total > 0 || groups.dependsOn.total > 0 || evidence.total > 0;
+    groups.contains.total > 0 ||
+    groups.usedBy.total > 0 ||
+    groups.dependsOn.total > 0 ||
+    evidence.total > 0;
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -198,7 +207,7 @@ export function TopologyV2DetailPanel({
   // match too, or the reconciliation reads as a coincidence instead of a
   // guarantee.
   const renderGroup = (
-    group: "usedBy" | "dependsOn",
+    group: "contains" | "usedBy" | "dependsOn",
     label: string,
     view: V2ConnectionGroupView,
   ) => {
@@ -451,6 +460,7 @@ export function TopologyV2DetailPanel({
       <div className="flex flex-col gap-2.5">
         {hasConnections ? (
           <>
+            {renderGroup("contains", labels.metricContains, groups.contains)}
             {renderGroup("usedBy", labels.metricUsedBy, groups.usedBy)}
             {renderGroup("dependsOn", labels.metricDependsOn, groups.dependsOn)}
             {renderEvidenceGroup()}

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
@@ -96,6 +96,52 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
     expect(windowHandler).not.toHaveBeenCalled();
   });
 
+  it("M-4: closes on Escape even when focus has moved OUT of the popover (window-level, not focus-scoped)", () => {
+    renderGear();
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    expect(screen.getByTestId("topology-v2-settings-gear-popover")).toBeInTheDocument();
+
+    // Persona case: focus left the gear (e.g. clicked the graph toggle). The
+    // Escape now originates on document.body, not inside the popover.
+    const windowHandler = vi.fn();
+    window.addEventListener("keydown", windowHandler);
+    fireEvent.keyDown(document.body, { key: "Escape", bubbles: true });
+    window.removeEventListener("keydown", windowHandler);
+
+    expect(screen.queryByTestId("topology-v2-settings-gear-popover")).not.toBeInTheDocument();
+    // still consumed — the global Esc ladder must not also act on this press
+    expect(windowHandler).not.toHaveBeenCalled();
+  });
+
+  it("M-4: closes when `suppressed` flips true (another transient surface opened)", () => {
+    const { rerender } = render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <TopologyV2SettingsGear
+          indexDefaultCollapsed={false}
+          onChangeIndexDefaultCollapsed={() => {}}
+          changeVaultHref="/docs/?intent=local"
+          labels={labels}
+          suppressed={false}
+        />
+      </NextIntlClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    expect(screen.getByTestId("topology-v2-settings-gear-popover")).toBeInTheDocument();
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <TopologyV2SettingsGear
+          indexDefaultCollapsed={false}
+          onChangeIndexDefaultCollapsed={() => {}}
+          changeVaultHref="/docs/?intent=local"
+          labels={labels}
+          suppressed={true}
+        />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("topology-v2-settings-gear-popover")).not.toBeInTheDocument();
+  });
+
   it("shows a 'switch vault' row that links back to /docs so a revisiting user can change folders from the map", () => {
     renderGear();
     fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FolderCog, Settings } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { LocaleSwitch } from "@/features/locale-switch";
@@ -25,6 +25,19 @@ import { cn } from "@/shared/lib/cn";
  * global search dialog already rely on (see that ladder's `searchOpen`
  * tier's doc comment). Outside-click follows the SAME pattern as
  * `OperationsNav`'s `AppSettingsMenu` (document `mousedown` + a ref check).
+ *
+ * M-4 — two fixes to the transient contract the UX round caught:
+ *   1. Escape must close the popover even when focus has left it (the persona
+ *      opened the gear, then clicked the graph toggle, then pressed Escape —
+ *      focus was no longer inside the gear so the old focus-scoped React
+ *      `onKeyDown` never fired). The Escape listener is now a WINDOW capture
+ *      listener installed while open, so it fires regardless of focus and
+ *      still `stopPropagation`s so the global ladder doesn't double-act.
+ *   2. Opening another transient surface (search palette, node/edge popover,
+ *      docs drawer, create composer, context menu) must demote this popover.
+ *      The caller passes `suppressed` = "some other transient is open"; when
+ *      it flips true the gear closes itself. Outside-click already covered
+ *      pointer-driven surfaces; `suppressed` covers keyboard-opened ones.
  */
 
 export interface TopologyV2SettingsGearLabels {
@@ -61,6 +74,14 @@ export interface TopologyV2SettingsGearProps {
    */
   popoverAlign?: "left" | "right";
   /**
+   * M-4 — "some other transient surface is now open, demote me". When this
+   * flips to `true` while the gear popover is open, the gear closes itself so
+   * two transient surfaces never stack. Keyboard-opened surfaces (⌘K palette,
+   * the `D` docs drawer) don't fire the `mousedown` the outside-click handler
+   * relies on, so the caller signals them here instead.
+   */
+  suppressed?: boolean;
+  /**
    * Which side of the trigger the popover opens toward (default `"bottom"`,
    * the original placement — plenty of canvas below the right utility
    * rail's top-anchored gear). feat/chrome-system's nav-rail placement sits
@@ -77,6 +98,7 @@ export function TopologyV2SettingsGear({
   changeVaultHref,
   labels,
   className,
+  suppressed = false,
   popoverAlign = "right",
   popoverSide = "bottom",
 }: TopologyV2SettingsGearProps) {
@@ -95,17 +117,35 @@ export function TopologyV2SettingsGear({
       if (rootRef.current?.contains(event.target as Node)) return;
       close(false);
     };
+    // M-4 (1) — WINDOW capture keydown so Escape closes the gear even when
+    // focus has moved out of it (the persona case). Capture phase runs before
+    // the global ladder's bubble-phase window listener, and stopPropagation
+    // halts the event there so the ladder never also acts on this press.
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      close(true);
+    };
     document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
   }, [open, close]);
 
-  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Escape") return;
-    // Own this keypress — the global topology Esc ladder must not ALSO act
-    // (e.g. deselect a node) on the same press. See module doc.
-    event.stopPropagation();
-    close(true);
-  };
+  // M-4 (2) — another transient surface opened; demote this popover. Handled
+  // as a set-state-DURING-render off a previous-value latch (React's official
+  // "adjusting state when a prop changes" pattern), NOT an effect — so it
+  // demotes in the same render `suppressed` flips true without a cascading
+  // effect pass. Latching on the transition (not `suppressed` alone) lets the
+  // user re-open the gear while a suppressor is still up if they choose to.
+  const [prevSuppressed, setPrevSuppressed] = useState(suppressed);
+  if (suppressed !== prevSuppressed) {
+    setPrevSuppressed(suppressed);
+    if (suppressed && open) setOpen(false);
+  }
 
   // Two wrappers on purpose — outer takes the CALLER's page-level position
   // classes (e.g. `absolute right-6 top-[...]` for the utility rail), inner
@@ -117,7 +157,7 @@ export function TopologyV2SettingsGear({
   // live QA — the gear rendered off-screen at x:-32).
   return (
     <div className={className ?? "inline-block"}>
-      <div ref={rootRef} className="relative" onKeyDown={handleKeyDown}>
+      <div ref={rootRef} className="relative">
       <button
         ref={triggerRef}
         type="button"

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -129,90 +129,120 @@ describe("buildV2Connections", () => {
   });
 });
 
-describe("buildV2ConnectionGroups — direction axis, single source for metric + header parity", () => {
-  it("caps each group independently and keeps the TRUE total (contains-heavy node bug analog)", () => {
-    // 8 outgoing + 2 incoming — a naive outgoing-first slice would starve
-    // the incoming (usedBy) group to empty; per-group capping keeps both
-    // totals honest regardless of relation type mix.
+describe("buildV2ConnectionGroups — M-2 ROLE axis, single source for metric + header parity", () => {
+  it("splits containment into its OWN 담는 것/속한 곳 groups instead of folding by direction (the domain-popover bug)", () => {
+    // The exact UX-round case: a domain node with 18 `contains` children + a
+    // few depends/used edges. Direction-only grouping put the 18 children in
+    // "기대는 곳" (dependsOn); role grouping keeps them in `contains`.
+    const connections: V2DatasheetConnection[] = [
+      ...Array.from({ length: 18 }, (_, i) =>
+        conn({ id: `child-${i}`, relationType: "contains", direction: "outgoing" }),
+      ),
+      conn({ id: "user-a", relationType: "depends_on", direction: "incoming" }),
+      conn({ id: "user-b", relationType: "uses", direction: "incoming" }),
+      conn({ id: "user-c", relationType: "implements", direction: "incoming" }),
+      conn({ id: "user-d", relationType: "related_to", direction: "incoming" }),
+      conn({ id: "dep-a", relationType: "depends_on", direction: "outgoing" }),
+      conn({ id: "dep-b", relationType: "related_to", direction: "outgoing" }),
+      conn({ id: "parent", relationType: "belongs_to", direction: "outgoing" }),
+    ];
+    const groups = buildV2ConnectionGroups(connections, 6);
+    // 담는 것 18 · 쓰는 곳 4 · 기대는 곳 2 · 속한 곳 1 — matches full-detail.
+    expect(groups.contains.total).toBe(18);
+    expect(groups.contains.rows).toHaveLength(6); // capped, true total preserved
+    expect(groups.usedBy.total).toBe(4);
+    expect(groups.dependsOn.total).toBe(2);
+    expect(groups.belongsTo.total).toBe(1);
+  });
+
+  it("caps each group independently and never starves the smaller ones", () => {
     const connections: V2DatasheetConnection[] = [
       ...Array.from({ length: 8 }, (_, i) =>
-        conn({ id: `d${i}`, relationType: "contains", direction: "outgoing" }),
+        conn({ id: `c${i}`, relationType: "contains", direction: "outgoing" }),
       ),
       conn({ id: "u0", relationType: "depends_on", direction: "incoming" }),
       conn({ id: "u1", relationType: "uses", direction: "incoming" }),
     ];
     const groups = buildV2ConnectionGroups(connections, 6);
-    expect(groups.dependsOn.total).toBe(8);
-    expect(groups.dependsOn.rows).toHaveLength(6); // capped
+    expect(groups.contains.total).toBe(8);
+    expect(groups.contains.rows).toHaveLength(6); // capped
     expect(groups.usedBy.total).toBe(2);
     expect(groups.usedBy.rows.map((r) => r.id)).toEqual(["u0", "u1"]); // never starved
   });
 
-  it("handles an empty set with zero totals", () => {
+  it("handles an empty set with zero totals across all four role groups", () => {
     const groups = buildV2ConnectionGroups([]);
     expect(groups).toEqual({
+      contains: { rows: [], total: 0 },
       usedBy: { rows: [], total: 0 },
       dependsOn: { rows: [], total: 0 },
+      belongsTo: { rows: [], total: 0 },
     });
   });
 
-  it("the group totals are the SAME numbers the metric line reports for the same connection set (the reconciliation guarantee)", () => {
-    // This is the actual persona bug: header said "used by 10 / depends on
-    // 73" while the groups below said "포함 71 / 의존 12" — two different
-    // axes computed independently. With direction as the ONLY axis, the
-    // group totals ARE the metric numbers by construction.
+  it("a leaf node (no containment) still splits cleanly into usedBy/dependsOn with empty contains", () => {
     const connections: V2DatasheetConnection[] = [
-      conn({ id: "in-1", relationType: "contains", direction: "incoming" }),
-      conn({ id: "in-2", relationType: "depends_on", direction: "incoming" }),
+      conn({ id: "in-1", relationType: "depends_on", direction: "incoming" }),
+      conn({ id: "in-2", relationType: "uses", direction: "incoming" }),
       conn({ id: "out-1", relationType: "depends_on", direction: "outgoing" }),
     ];
     const groups = buildV2ConnectionGroups(connections);
-    const metricUsedBy = groups.usedBy.total;
-    const metricDependsOn = groups.dependsOn.total;
-    expect(metricUsedBy).toBe(2);
-    expect(metricDependsOn).toBe(1);
+    expect(groups.contains.total).toBe(0);
+    expect(groups.usedBy.total).toBe(2);
+    expect(groups.dependsOn.total).toBe(1);
+    expect(groups.belongsTo.total).toBe(0);
   });
 });
 
-describe("formatV2MetricLine", () => {
-  const labels = { usedBy: "쓰는 곳", dependsOn: "기대는 곳", evidence: "근거" };
+describe("formatV2MetricLine — M-2 typed segments", () => {
+  const labels = { contains: "담는 것", usedBy: "쓰는 곳", dependsOn: "기대는 곳", evidence: "근거" };
 
-  it("joins the three plain-language facts as ONE engraved line (no triplication)", () => {
+  it("prepends 담는 것 for a container node (contains > 0) — the typed split", () => {
     expect(
-      formatV2MetricLine({ usedBy: 3, dependsOn: 5, evidence: 2 }, labels),
+      formatV2MetricLine({ contains: 18, usedBy: 4, dependsOn: 2, evidence: 1 }, labels),
+    ).toBe("담는 것 18 · 쓰는 곳 4 · 기대는 곳 2 · 근거 1");
+  });
+
+  it("hides the 담는 것 segment for a leaf (contains === 0) so it isn't a noisy '담는 것 0'", () => {
+    expect(
+      formatV2MetricLine({ contains: 0, usedBy: 3, dependsOn: 5, evidence: 2 }, labels),
     ).toBe("쓰는 곳 3 · 기대는 곳 5 · 근거 2");
   });
 
-  it("keeps zeros explicit so the line always has three segments", () => {
+  it("keeps the remaining three facts' zeros explicit", () => {
     expect(
-      formatV2MetricLine({ usedBy: 0, dependsOn: 0, evidence: 0 }, labels),
+      formatV2MetricLine({ contains: 0, usedBy: 0, dependsOn: 0, evidence: 0 }, labels),
     ).toBe("쓰는 곳 0 · 기대는 곳 0 · 근거 0");
   });
 });
 
-describe("formatV2HandoffText", () => {
-  it("emits a deterministic MCP/CLI-style payload with slug, typed facts, and direction-grouped name lists", () => {
+describe("formatV2HandoffText — M-2 contains split", () => {
+  it("emits a deterministic payload with contains split out of depends_on, matching the panel's typed groups", () => {
     const text = formatV2HandoffText({
-      slug: "mcp-server",
-      kind: "capability",
+      slug: "ai-agent-partner",
+      kind: "domain",
       domainTitle: "AI Agent Partner",
-      usedBy: 5,
+      contains: 18,
+      usedBy: 4,
       dependsOn: 2,
-      evidence: 3,
+      evidence: 1,
+      containsNames: ["mcp-server", "agent-config-onboarding"],
       usedByNames: ["frontmatter-to-ontology"],
       dependsNames: ["relation-graph"],
     });
     expect(text).toBe(
       [
-        "node: mcp-server",
-        "kind: capability",
+        "node: ai-agent-partner",
+        "kind: domain",
         "domain: AI Agent Partner",
-        "used_by: 5",
+        "contains: 18",
+        "used_by: 4",
         "depends_on: 2",
-        "evidence: 3",
+        "evidence: 1",
+        "contains_names: mcp-server, agent-config-onboarding",
         "used_by_names: frontmatter-to-ontology",
         "depends_names: relation-graph",
-        'next: get_concept("mcp-server") → review context, then patch_concept / add_relation as needed',
+        'next: get_concept("ai-agent-partner") → review context, then patch_concept / add_relation as needed',
       ].join("\n"),
     );
   });
@@ -222,13 +252,16 @@ describe("formatV2HandoffText", () => {
       slug: "orphan",
       kind: "element",
       domainTitle: null,
+      contains: 0,
       usedBy: 0,
       dependsOn: 0,
       evidence: 0,
+      containsNames: [],
       usedByNames: [],
       dependsNames: [],
     });
     expect(text).toContain("domain: -");
+    expect(text).toContain("contains_names: -");
     expect(text).toContain("used_by_names: -");
     expect(text).toContain("depends_names: -");
   });

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -36,80 +36,98 @@ export {
   type DatasheetConnection as V2DatasheetConnection,
   type GroupedConnections as V2GroupedConnections,
 } from "@/shared/lib/ontology-tree/connections";
-import { groupConnectionsByDirection } from "@/shared/lib/ontology-tree/connections";
+import { groupConnectionsByRole } from "@/shared/lib/ontology-tree/connections";
 import type { DatasheetConnection as V2DatasheetConnection } from "@/shared/lib/ontology-tree/connections";
 
-/** One direction group as the panel renders it: a capped preview of rows +
+/** One relation-role group as the panel renders it: a capped preview of rows +
  * the group's TRUE total (so the header can say "쓰는 곳 23" while showing 6). */
 export interface V2ConnectionGroupView {
   rows: V2DatasheetConnection[];
   total: number;
 }
 export interface V2ConnectionGroupsView {
+  /** Outgoing containment — plain "담는 것" (what this node contains). */
+  contains: V2ConnectionGroupView;
+  /** Incoming non-containment — plain "쓰는 곳" (places that use this). */
   usedBy: V2ConnectionGroupView;
+  /** Outgoing non-containment — plain "기대는 곳" (places this leans on). */
   dependsOn: V2ConnectionGroupView;
+  /** Incoming containment — plain "속한 곳" (the parent this belongs to).
+   *  Kept for handoff/count completeness; the panel surfaces it as the domain
+   *  header (N6) rather than a group. */
+  belongsTo: V2ConnectionGroupView;
 }
 
 /** Default rows shown per group before the typed "+N" overflow. */
 export const V2_CONNECTION_ROW_CAP = 6;
 
 /**
- * Group the full connection set by DIRECTION and cap each group to
- * `perGroupCap` rows, keeping the true total. This guarantees BOTH groups can
- * render their real count independently — a hub node with many outgoing
- * containment edges must not starve the (usually smaller) incoming group to
- * empty. Because direction is the SAME axis the metric line counts, callers
- * should source `metric.usedBy`/`metric.dependsOn` from `.usedBy.total`/
- * `.dependsOn.total` here, not recompute them separately — that's what
- * guarantees the metric line and the group headers can never diverge.
+ * Group the full connection set by relation ROLE (contains / usedBy /
+ * dependsOn / belongsTo) and cap each group to `perGroupCap` rows, keeping the
+ * true total. M-2: containment is pulled into its OWN `contains`/`belongsTo`
+ * groups instead of folding into usedBy/dependsOn by raw direction — so a
+ * domain's 18 `contains` children read as "담는 것 18", not "기대는 곳". This
+ * is the SAME split `buildFullDetailGroups` uses (both delegate to
+ * `groupConnectionsByRole`), so the popover and full-detail can never disagree.
+ * Callers source `metric.contains`/`usedBy`/`dependsOn` from these `.total`s so
+ * the metric line and the group headers stay the same number by construction.
  */
 export function buildV2ConnectionGroups(
   connections: readonly V2DatasheetConnection[],
   perGroupCap: number = V2_CONNECTION_ROW_CAP,
 ): V2ConnectionGroupsView {
-  const grouped = groupConnectionsByDirection(connections);
+  const grouped = groupConnectionsByRole(connections);
   const cap = Math.max(0, perGroupCap);
+  const toView = (rows: readonly V2DatasheetConnection[]): V2ConnectionGroupView => ({
+    rows: rows.slice(0, cap),
+    total: rows.length,
+  });
   return {
-    usedBy: {
-      rows: grouped.usedBy.slice(0, cap),
-      total: grouped.usedBy.length,
-    },
-    dependsOn: {
-      rows: grouped.dependsOn.slice(0, cap),
-      total: grouped.dependsOn.length,
-    },
+    contains: toView(grouped.contains),
+    usedBy: toView(grouped.usedBy),
+    dependsOn: toView(grouped.dependsOn),
+    belongsTo: toView(grouped.belongsTo),
   };
 }
 
 export interface V2MetricValues {
-  /** Direct incoming — plain "쓰는 곳" (places that use this). */
+  /** Outgoing containment — plain "담는 것" (what this node contains). Only
+   *  rendered when > 0 (leaf nodes contain nothing, so the segment is hidden
+   *  for them rather than showing a noisy "담는 것 0"). */
+  contains: number;
+  /** Direct incoming non-containment — plain "쓰는 곳" (places that use this). */
   usedBy: number;
-  /** Direct outgoing — plain "기대는 곳" (places this leans on). */
+  /** Direct outgoing non-containment — plain "기대는 곳" (places this leans on). */
   dependsOn: number;
   /** Node-level evidence references — plain "근거". */
   evidence: number;
 }
 
 export interface V2MetricLabels {
+  contains: string;
   usedBy: string;
   dependsOn: string;
   evidence: string;
 }
 
 /**
- * The ONE engraved metric line — "쓰는 곳 3 · 기대는 곳 5 · 근거 2". Replaces the
- * old subtitle + two big count boxes (the owner's "정보가 세 번 나온다" complaint);
- * every fact appears exactly once. Always three segments, zeros explicit.
+ * The ONE engraved metric line — "담는 것 18 · 쓰는 곳 4 · 기대는 곳 2 · 근거 1".
+ * Replaces the old subtitle + count boxes (the owner's "정보가 세 번 나온다"
+ * complaint); every fact appears exactly once. M-2: the leading "담는 것"
+ * segment appears ONLY for container nodes (`contains > 0`) — a leaf's line
+ * stays "쓰는 곳 · 기대는 곳 · 근거", so the typed split adds signal for
+ * domains without adding a "담는 것 0" to every element.
  */
 export function formatV2MetricLine(
   values: V2MetricValues,
   labels: V2MetricLabels,
 ): string {
-  return [
-    `${labels.usedBy} ${values.usedBy}`,
-    `${labels.dependsOn} ${values.dependsOn}`,
-    `${labels.evidence} ${values.evidence}`,
-  ].join(" · ");
+  const segments: string[] = [];
+  if (values.contains > 0) segments.push(`${labels.contains} ${values.contains}`);
+  segments.push(`${labels.usedBy} ${values.usedBy}`);
+  segments.push(`${labels.dependsOn} ${values.dependsOn}`);
+  segments.push(`${labels.evidence} ${values.evidence}`);
+  return segments.join(" · ");
 }
 
 /** One row in the promoted 근거(evidence) group — RATIO-SYSTEM §4 scale-up
@@ -154,13 +172,18 @@ export interface V2HandoffInput {
   slug: string;
   kind: string;
   domainTitle: string | null;
+  /** Outgoing containment count (M-2) — `contains` edges, split out from the
+   * old direction-only `depends_on` so an agent reading the handoff sees the
+   * same typed facts the panel shows. */
+  contains: number;
   usedBy: number;
   dependsOn: number;
   evidence: number;
-  /** Names of the direct-incoming (usedBy) group's rows — same direction axis
-   * as `usedBy`, so the count and the list can never contradict. */
+  /** Names of the containment-child (contains) group's rows. */
+  containsNames: readonly string[];
+  /** Names of the incoming non-containment (usedBy) group's rows. */
   usedByNames: readonly string[];
-  /** Names of the direct-outgoing (dependsOn) group's rows. */
+  /** Names of the outgoing non-containment (dependsOn) group's rows. */
   dependsNames: readonly string[];
 }
 
@@ -170,10 +193,11 @@ export interface V2HandoffInput {
  * so it pastes cleanly into a coding agent regardless of UI locale; the button
  * label is localized, this payload is intentionally not. Deterministic.
  *
- * R+ payload shape change: `contains`/`depends` name-list fields (relation
- * TYPE axis) renamed to `used_by_names`/`depends_names` (relation DIRECTION
- * axis) — matching the datasheet's groups now that direction is the single
- * grouping axis everywhere. Agents parsing the old field names must update.
+ * M-2 payload shape change: containment is now its own `contains` /
+ * `contains_names` fields, split OUT of `depends_on` / `depends_names` (which
+ * previously folded containment children in via the direction-only grouping).
+ * `used_by` no longer includes the parent (`belongs_to`) either — the counts
+ * match the panel's typed groups and the full-detail surface exactly.
  */
 export function formatV2HandoffText(input: V2HandoffInput): string {
   const list = (names: readonly string[]) =>
@@ -182,9 +206,11 @@ export function formatV2HandoffText(input: V2HandoffInput): string {
     `node: ${input.slug}`,
     `kind: ${input.kind}`,
     `domain: ${input.domainTitle ?? "-"}`,
+    `contains: ${input.contains}`,
     `used_by: ${input.usedBy}`,
     `depends_on: ${input.dependsOn}`,
     `evidence: ${input.evidence}`,
+    `contains_names: ${list(input.containsNames)}`,
     `used_by_names: ${list(input.usedByNames)}`,
     `depends_names: ${list(input.dependsNames)}`,
     `next: get_concept("${input.slug}") → review context, then patch_concept / add_relation as needed`,

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -14,6 +14,7 @@ import { useEffect, useRef, type RefObject } from "react";
 import type { CameraAxes, CameraTarget } from "../engine/camera";
 import { stepTugAxis, tugFactorForHop, tugFalloffForDistance } from "../interaction/drag-tug";
 import { isCameraUnsettled, isCanvasActive, shouldSkipFrame } from "../model/idle-gate";
+import { classifyZoomTier, type ZoomTier } from "../model/tier-visibility";
 import { relaxNodeSeparation, type SeparationNode } from "../model/separation";
 import { createForceSimulation, type ForceSimulation } from "../model/force-layout";
 import { INITIAL_POINTER_MACHINE_STATE, type PointerMachineState } from "../interaction/pointer-state-machine";
@@ -97,6 +98,14 @@ export interface UseTopologyLoopArgs {
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
   onGraphStatsChange?: (stats: { nodes: number; relations: number }) => void;
+  /**
+   * M-5 — the semantic-zoom altitude tier changed (spine → circuit → element).
+   * Fires only on transitions (not per-frame), driven by the same reveal bands
+   * the draw pass gates node visibility with, so the corner readout's
+   * orientation label can never claim "zoom in to see elements" while elements
+   * are on screen.
+   */
+  onZoomTierChange?: (tier: ZoomTier) => void;
   /** W2-B node right-click context menu — see `topology-pointer-handlers.ts#createTopologyPointerHandlers`'s `onContextMenuNode` doc. */
   onContextMenuNode?: (slug: string, position: { x: number; y: number }) => void;
   /**
@@ -114,7 +123,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onContextMenuNode, agentFocusNodeId = null } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -210,6 +219,14 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   const prevCameraSampleRef = useRef<{ x: number; y: number; s: number } | null>(null);
   /** W6 agent visibility — mirrors `agentFocusNodeId` prop into a ref for the rAF closure, same pattern as `focusedSlugRef`. */
   const agentFocusNodeIdRef = useRef<string | null>(agentFocusNodeId);
+  /** M-5 — mirror the tier-change callback into a ref for the rAF closure, and
+   * track the last emitted tier so the callback fires only on transitions. */
+  const onZoomTierChangeRef = useRef<typeof onZoomTierChange>(onZoomTierChange);
+  const lastZoomTierRef = useRef<ZoomTier | null>(null);
+
+  useEffect(() => {
+    onZoomTierChangeRef.current = onZoomTierChange;
+  }, [onZoomTierChange]);
 
   useEffect(() => {
     focusedSlugRef.current = focusedSlug;
@@ -688,6 +705,16 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         egoRevealById: egoRevealRef.current,
       });
       cameraRef.current = camera;
+
+      // M-5 — emit the semantic-zoom tier only when it changes (spine →
+      // circuit → element), so the corner readout's orientation hint tracks
+      // what's actually drawn. Same reveal bands as the draw pass (default
+      // config), so the label and the visible nodes can't contradict.
+      const nextZoomTier = classifyZoomTier(zoomRatio);
+      if (nextZoomTier !== lastZoomTierRef.current) {
+        lastZoomTierRef.current = nextZoomTier;
+        onZoomTierChangeRef.current?.(nextZoomTier);
+      }
 
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
## Summary
UX 라운드 S3 (opus 슬라이스, 3커밋 cherry-pick + 충돌 해소):
- M-2: 팝오버 관계 카운트를 shared `groupConnectionsByRole` 4버킷(담는것/쓰는곳/기대는곳/속한곳)으로 — 전체 상세와 parity 보장
- M-4: 설정 팝오버 Esc capture + 타 표면 열림 시 demote (transient 상호배제)
- M-5: 우하단 readout 이 줌 티어 전환을 따라감 (요소 티어에서 힌트 소거)
- M-7: Esc 사다리에 close-node-popover 단 추가 — Esc#1 팝오버, Esc#2 포커스
- M-10: INDEX 검색 Esc 1단 = 검색어만 소거
- D-1: 백링크 인덱스에 frontmatter 관계 ref 포함 (런타임+빌드타임, mcp-server 0→11 실증)
- 부수: infer_imports 모듈 엣지 exact-pin 완화 (하루 3회 재생성 강요하던 부수 지표)

## Test plan
- 영향권 1156 pass · contracts 55/55 · tsc · eslint 0 error · i18n
- 워크트리 검증: 1151 vitest + contract 195 (에이전트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)