### PR TITLE
perf: 부트스트랩 batch 리로드 — 쓰기 N회당 재스캔 1회로 (백로그 소진)

### DIFF
--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -801,7 +801,7 @@ export function useLocalVaultInternal() {
    * 중간 디렉터리는 자동 생성. 템플릿 content 를 써서 초기 본문 채움.
    */
   const createDoc = useCallback(
-    async (slug: string, content: string) => {
+    async (slug: string, content: string, opts: { skipRefresh?: boolean } = {}) => {
       if (state.fileHandles.has(slug)) {
         throw new Error(`Document already exists: "${slug}"`);
       }
@@ -814,7 +814,9 @@ export function useLocalVaultInternal() {
       await writable.write(content);
       await writable.close();
       markSelfWrite(slug);
-      if (state.handle) await load(state.handle);
+      // opts.skipRefresh — 부트스트랩처럼 연속 생성하는 호출자가 마지막
+      // 쓰기에서만 리로드하도록 (updateFrontmatter 와 같은 계약).
+      if (!opts.skipRefresh && state.handle) await load(state.handle);
     },
     [state.fileHandles, state.handle, getParentAndName, load, markSelfWrite],
   );

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -652,7 +652,9 @@ export function HomePage() {
           vault.manifest.docs.some(
             (d) => d.frontmatter.kind === "domain" && d.slug.split("/").pop() === tail,
           );
-        if (!taken) await vault.createDoc(slug, buildDomainMarkdown(domain));
+        // batch — 마지막 프로젝트 쓰기의 리로드가 전체를 한 번에 반영한다
+        // (도메인 수만큼 전체 매니페스트 재스캔·깜빡임 하던 것 제거).
+        if (!taken) await vault.createDoc(slug, buildDomainMarkdown(domain), { skipRefresh: true });
       }
       if (plan.existingProjectSlug) {
         // 재검 마찰 A — 이미 프로젝트가 있는 vault: 두 번째 프로젝트를
@@ -663,10 +665,15 @@ export function HomePage() {
           : [];
         const accepted = plan.domains.filter((d) => input.acceptedDomains.has(d.name)).map((d) => d.name);
         const mergedDomains = [...new Set([...prevDomains, ...accepted])];
-        await vault.updateFrontmatter(plan.existingProjectSlug, { domains: mergedDomains });
+        await vault.updateFrontmatter(plan.existingProjectSlug, { domains: mergedDomains }, { skipRefresh: true });
       } else {
-        await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains));
+        await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains), {
+          skipRefresh: true,
+        });
       }
+      // batch 마감 — 위 쓰기 전부 skipRefresh 이므로 여기서 정확히 1회만
+      // 재스캔한다 (마지막 쓰기가 no-op 이어도 반영 보장).
+      await vault.refresh();
       setBootstrapOpen(false);
       // E1 — 리로드된 그래프가 "내 문서들이 모이는" 연출로 등장한다.
       setMapRevealToken((n) => n + 1);


### PR DESCRIPTION
도메인 파일화(D) 이후 승격이 도메인 수만큼 전체 매니페스트 재스캔을
반복했다. createDoc 에 skipRefresh 옵션(updateFrontmatter 와 같은 계약)을
추가하고 runBootstrap 의 모든 쓰기를 batch 로 — 마지막에 명시적
vault.refresh() 1회 (마지막 쓰기가 no-op 이어도 반영 보장).

검증: docs-vault-local + home 302 pass · tsc · eslint
