### PR TITLE
refactor: 부트스트랩 흐름 추출 — HomePage 모듈화 1차 (executeBootstrapPlan + useBootstrapFlow)

### DIFF
--- a/src/features/docs-vault-local/index.ts
+++ b/src/features/docs-vault-local/index.ts
@@ -33,3 +33,8 @@ export {
   type BootstrapElementCandidate,
   type BootstrapPlan,
 } from './lib/bootstrap-candidates';
+export {
+  executeBootstrapPlan,
+  type BootstrapVaultWriter,
+  type ExecuteBootstrapResult,
+} from './lib/execute-bootstrap-plan';

--- a/src/features/docs-vault-local/lib/execute-bootstrap-plan.test.ts
+++ b/src/features/docs-vault-local/lib/execute-bootstrap-plan.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { deriveBootstrapPlan } from './bootstrap-candidates';
+import { executeBootstrapPlan, type BootstrapVaultWriter } from './execute-bootstrap-plan';
+
+type Call =
+  | { op: 'updateFrontmatter'; slug: string; updates: Record<string, unknown>; skipRefresh: boolean }
+  | { op: 'createDoc'; slug: string; skipRefresh: boolean }
+  | { op: 'refresh' };
+
+function fakeVault(docs: Array<{ slug: string; frontmatter: Record<string, unknown> }>) {
+  const calls: Call[] = [];
+  const vault: BootstrapVaultWriter = {
+    manifest: { docs },
+    async updateFrontmatter(slug, updates, opts) {
+      calls.push({ op: 'updateFrontmatter', slug, updates, skipRefresh: opts?.skipRefresh === true });
+    },
+    async createDoc(slug, _content, opts) {
+      calls.push({ op: 'createDoc', slug, skipRefresh: opts?.skipRefresh === true });
+    },
+    async refresh() {
+      calls.push({ op: 'refresh' });
+    },
+  };
+  return { vault, calls };
+}
+
+const doc = (slug: string, fm: Record<string, unknown> = {}, title = slug) => ({
+  slug,
+  title,
+  frontmatter: fm,
+});
+
+describe('executeBootstrapPlan (HomePage 모듈화 1차 — batch 쓰기 계약)', () => {
+  it('모든 쓰기 skipRefresh + 마지막 refresh 정확히 1회 (batch 회귀 고정)', async () => {
+    const docs = [doc('guides/a'), doc('guides/b')];
+    const { vault, calls } = fakeVault(docs);
+    const plan = deriveBootstrapPlan(docs, 'my-vault');
+
+    const result = await executeBootstrapPlan(vault, plan, {
+      projectTitle: 'My Vault',
+      acceptedDomains: new Set(['guides']),
+    });
+
+    expect(result).toMatchObject({ addedToExisting: false, elementCount: 2 });
+    const refreshes = calls.filter((c) => c.op === 'refresh');
+    expect(refreshes).toHaveLength(1);
+    expect(calls[calls.length - 1].op).toBe('refresh');
+    for (const call of calls) {
+      if (call.op !== 'refresh') expect(call.skipRefresh).toBe(true);
+    }
+  });
+
+  it('승인 도메인은 실제 .md 로 생성, 동명 domain 문서가 있으면 생략 (마찰 D)', async () => {
+    const docs = [doc('guides/a'), doc('guides/guides', { kind: 'domain' })];
+    const { vault, calls } = fakeVault(docs);
+    const plan = deriveBootstrapPlan(docs, 'x');
+
+    await executeBootstrapPlan(vault, plan, { projectTitle: 'x', acceptedDomains: new Set(['guides']) });
+
+    expect(calls.filter((c) => c.op === 'createDoc' && c.slug === 'guides/guides')).toHaveLength(0);
+  });
+
+  it('기존 kind:project 가 있으면 파일 생성 대신 domains 병합 (마찰 A)', async () => {
+    const docs = [
+      doc('project', { kind: 'project', title: 'P', domains: ['old'] }),
+      doc('guides/a'),
+    ];
+    const { vault, calls } = fakeVault(docs);
+    const plan = deriveBootstrapPlan(docs, 'x');
+
+    const result = await executeBootstrapPlan(vault, plan, {
+      projectTitle: 'P',
+      acceptedDomains: new Set(['guides']),
+    });
+
+    expect(result?.addedToExisting).toBe(true);
+    const projectWrite = calls.find((c) => c.op === 'updateFrontmatter' && c.slug === 'project');
+    expect(projectWrite && projectWrite.op === 'updateFrontmatter' ? projectWrite.updates : null).toEqual({
+      domains: ['old', 'guides'],
+    });
+    expect(calls.filter((c) => c.op === 'createDoc' && c.slug === plan.projectSlug)).toHaveLength(0);
+  });
+
+  it('manifest 없으면 아무것도 쓰지 않고 null', async () => {
+    const { vault, calls } = fakeVault([]);
+    vault.manifest = null;
+    const plan = deriveBootstrapPlan([], 'x');
+    expect(await executeBootstrapPlan(vault, plan, { projectTitle: 'x', acceptedDomains: new Set() })).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/features/docs-vault-local/lib/execute-bootstrap-plan.ts
+++ b/src/features/docs-vault-local/lib/execute-bootstrap-plan.ts
@@ -1,0 +1,93 @@
+import {
+  buildDomainMarkdown,
+  buildProjectMarkdown,
+  domainDocSlug,
+  selectedElements,
+  type BootstrapPlan,
+} from './bootstrap-candidates';
+
+/**
+ * 부트스트랩("내 문서에서 온톨로지 시작하기") 승인분을 vault 에 쓰는
+ * 오케스트레이션 — HomePage 모듈화 1차로 인라인 runBootstrap 에서 추출.
+ *
+ * 계약 (전부 회귀 이력 있음 — 테스트가 고정):
+ * - 모든 쓰기는 skipRefresh, 마지막에 refresh() 정확히 1회 (batch — 마지막
+ *   쓰기가 no-op 이어도 반영 보장).
+ * - 요소: frontmatter 만 추가 (본문 무변경).
+ * - 도메인(재검 마찰 D): 실제 .md 생성 — 같은 경로/동명 domain 문서가
+ *   있으면 생략.
+ * - 프로젝트(재검 마찰 A): 기존 kind:project 가 있으면 두 번째 파일 대신
+ *   그 문서의 domains 에 승인분 병합.
+ */
+
+/**
+ * vault write 표면의 최소 계약 — use-local-vault 반환값의 부분집합 (fake 로
+ * 테스트 가능). 메서드 축약 표기 — use-local-vault 의 더 넓은
+ * FrontmatterUpdateValue 시그니처가 그대로 대입되도록.
+ */
+export interface BootstrapVaultWriter {
+  manifest: {
+    docs: ReadonlyArray<{ slug: string; frontmatter: Record<string, unknown> }>;
+  } | null;
+  updateFrontmatter(
+    slug: string,
+    updates: Record<string, string | string[]>,
+    opts?: { skipRefresh?: boolean },
+  ): Promise<void>;
+  createDoc(slug: string, content: string, opts?: { skipRefresh?: boolean }): Promise<void>;
+  refresh(): Promise<void>;
+}
+
+export interface ExecuteBootstrapResult {
+  /** 기존 프로젝트에 덧붙였는가 (토스트 분기용). */
+  addedToExisting: boolean;
+  /** 승격된 요소 수. */
+  elementCount: number;
+}
+
+export async function executeBootstrapPlan(
+  vault: BootstrapVaultWriter,
+  basePlan: BootstrapPlan,
+  input: { projectTitle: string; acceptedDomains: ReadonlySet<string> },
+): Promise<ExecuteBootstrapResult | null> {
+  if (!vault.manifest) return null;
+  const plan = { ...basePlan, projectTitle: input.projectTitle };
+  const elements = selectedElements(plan, input.acceptedDomains);
+
+  for (const el of elements) {
+    await vault.updateFrontmatter(
+      el.slug,
+      el.domain ? { kind: 'element', title: el.title, domain: el.domain } : { kind: 'element', title: el.title },
+      { skipRefresh: true },
+    );
+  }
+
+  const acceptedDomainCandidates = plan.domains.filter((d) => input.acceptedDomains.has(d.name));
+  for (const domain of acceptedDomainCandidates) {
+    const slug = domainDocSlug(domain.name);
+    const tail = slug.split('/').pop();
+    const taken =
+      vault.manifest.docs.some((d) => d.slug === slug) ||
+      vault.manifest.docs.some(
+        (d) => d.frontmatter.kind === 'domain' && d.slug.split('/').pop() === tail,
+      );
+    if (!taken) await vault.createDoc(slug, buildDomainMarkdown(domain), { skipRefresh: true });
+  }
+
+  if (plan.existingProjectSlug) {
+    const existing = vault.manifest.docs.find((d) => d.slug === plan.existingProjectSlug);
+    const prevDomains = Array.isArray(existing?.frontmatter.domains)
+      ? (existing.frontmatter.domains as string[])
+      : [];
+    const accepted = acceptedDomainCandidates.map((d) => d.name);
+    const mergedDomains = [...new Set([...prevDomains, ...accepted])];
+    await vault.updateFrontmatter(plan.existingProjectSlug, { domains: mergedDomains }, { skipRefresh: true });
+  } else {
+    await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains), {
+      skipRefresh: true,
+    });
+  }
+
+  await vault.refresh();
+  return { addedToExisting: plan.existingProjectSlug !== null, elementCount: elements.length };
+}

--- a/src/views/home/model/use-bootstrap-flow.ts
+++ b/src/views/home/model/use-bootstrap-flow.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  deriveBootstrapPlan,
+  executeBootstrapPlan,
+  type BootstrapPlan,
+  type BootstrapVaultWriter,
+  type ExecuteBootstrapResult,
+} from "@/features/docs-vault-local";
+
+/**
+ * "내 문서에서 온톨로지 시작하기" 흐름의 상태 조합 — HomePage 모듈화 1차.
+ * 계획 파생(deriveBootstrapPlan) + 다이얼로그 open 상태 + 실행
+ * (executeBootstrapPlan, features 레벨 batch 쓰기 계약) 만 소유하고,
+ * 완료 후 연출(토스트·E1 리빌)은 onCompleted 콜백으로 호출자(HomePage)에
+ * 남긴다 — 이 훅은 지도/토스트를 모른다.
+ */
+export interface UseBootstrapFlowArgs {
+  vault: BootstrapVaultWriter & { handle?: { name: string } | null };
+  onCompleted: (result: ExecuteBootstrapResult) => void;
+}
+
+export interface BootstrapFlow {
+  bootstrapOpen: boolean;
+  setBootstrapOpen: (open: boolean) => void;
+  bootstrapPlan: BootstrapPlan | null;
+  runBootstrap: (input: { projectTitle: string; acceptedDomains: ReadonlySet<string> }) => Promise<void>;
+}
+
+export function useBootstrapFlow({ vault, onCompleted }: UseBootstrapFlowArgs): BootstrapFlow {
+  const [bootstrapOpen, setBootstrapOpen] = useState(false);
+
+  const bootstrapPlan = useMemo(() => {
+    if (!vault.manifest) return null;
+    return deriveBootstrapPlan(
+      vault.manifest.docs.map((d) => ({
+        slug: d.slug,
+        title: (d as { title?: string }).title ?? d.slug,
+        frontmatter: d.frontmatter,
+      })),
+      vault.handle?.name ?? "my-project",
+    );
+  }, [vault.manifest, vault.handle]);
+
+  const runBootstrap = useCallback(
+    async (input: { projectTitle: string; acceptedDomains: ReadonlySet<string> }) => {
+      if (!bootstrapPlan) return;
+      const result = await executeBootstrapPlan(vault, bootstrapPlan, input);
+      if (!result) return;
+      setBootstrapOpen(false);
+      onCompleted(result);
+    },
+    [bootstrapPlan, vault, onCompleted],
+  );
+
+  return { bootstrapOpen, setBootstrapOpen, bootstrapPlan, runBootstrap };
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -16,11 +16,6 @@ import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
 import { useProjects } from "@/features/project-data-source";
 import { useAdaptiveRecentChanges, useOntologyInsight, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
 import {
-  buildDomainMarkdown,
-  buildProjectMarkdown,
-  deriveBootstrapPlan,
-  domainDocSlug,
-  selectedElements,
   useLocalVault,
   buildMcpConfigJson,
   buildCodexMcpAddCommandTemplate,} from "@/features/docs-vault-local";
@@ -119,6 +114,7 @@ import {
   useChangeBaseline,
 } from "@/shared/lib/ontology-tree";
 import { useHomeRouteState } from "../model/use-home-route-state";
+import { useBootstrapFlow } from "../model/use-bootstrap-flow";
 import {
   selectTopologyNodeRouteState,
   selectTopologyPathRouteState,
@@ -547,7 +543,6 @@ export function HomePage() {
   const canCreateNode = vault.manifest !== null;
   // Slice 1 (discovery.md F1~F6) — "내 문서로 지도 만들기". 열린 vault 에
   // .md 는 있는데 지도 노드가 0 인 순간의 부트스트랩 다이얼로그.
-  const [bootstrapOpen, setBootstrapOpen] = useState(false);
   // P3d(E1) — 부트스트랩 완료 시 지도 리빌 연출 트리거.
   const [mapRevealToken, setMapRevealToken] = useState(0);
   // P2a — "AI 에이전트 연결" 시트.
@@ -620,70 +615,19 @@ export function HomePage() {
     () => (ontologyInsight?.nodes ?? []).filter((n) => n.kind === "domain").map((n) => n.title),
     [ontologyInsight],
   );
-  const bootstrapPlan = useMemo(() => {
-    if (!vault.manifest) return null;
-    return deriveBootstrapPlan(
-      vault.manifest.docs.map((d) => ({ slug: d.slug, title: d.title, frontmatter: d.frontmatter })),
-      vault.handle?.name ?? "my-project",
-    );
-  }, [vault.manifest, vault.handle]);
-  const runBootstrap = useCallback(
-    async (input: { projectTitle: string; acceptedDomains: ReadonlySet<string> }) => {
-      if (!bootstrapPlan || !vault.manifest) return;
-      const plan = { ...bootstrapPlan, projectTitle: input.projectTitle };
-      const elements = selectedElements(plan, input.acceptedDomains);
-      // frontmatter 만 추가 (본문 무변경) — 마지막 createDoc 의 내부 리로드가
-      // 전체를 한 번에 반영하도록 개별 write 는 refresh 를 생략한다.
-      for (const el of elements) {
-        await vault.updateFrontmatter(
-          el.slug,
-          el.domain ? { kind: "element", title: el.title, domain: el.domain } : { kind: "element", title: el.title },
-          { skipRefresh: true },
-        );
-      }
-      // 재검 마찰 D — 승인 도메인을 스텁이 아닌 실제 .md 로. 같은 경로에
-      // 문서가 이미 있거나(요소로 승격됨) 동명 domain 문서가 있으면 생략.
-      const acceptedDomainCandidates = plan.domains.filter((d) => input.acceptedDomains.has(d.name));
-      for (const domain of acceptedDomainCandidates) {
-        const slug = domainDocSlug(domain.name);
-        const tail = slug.split("/").pop();
-        const taken =
-          vault.manifest.docs.some((d) => d.slug === slug) ||
-          vault.manifest.docs.some(
-            (d) => d.frontmatter.kind === "domain" && d.slug.split("/").pop() === tail,
-          );
-        // batch — 마지막 프로젝트 쓰기의 리로드가 전체를 한 번에 반영한다
-        // (도메인 수만큼 전체 매니페스트 재스캔·깜빡임 하던 것 제거).
-        if (!taken) await vault.createDoc(slug, buildDomainMarkdown(domain), { skipRefresh: true });
-      }
-      if (plan.existingProjectSlug) {
-        // 재검 마찰 A — 이미 프로젝트가 있는 vault: 두 번째 프로젝트를
-        // 만들지 않고 기존 프로젝트의 domains 에 승인분을 덧붙인다.
-        const existing = vault.manifest.docs.find((d) => d.slug === plan.existingProjectSlug);
-        const prevDomains = Array.isArray(existing?.frontmatter.domains)
-          ? (existing.frontmatter.domains as string[])
-          : [];
-        const accepted = plan.domains.filter((d) => input.acceptedDomains.has(d.name)).map((d) => d.name);
-        const mergedDomains = [...new Set([...prevDomains, ...accepted])];
-        await vault.updateFrontmatter(plan.existingProjectSlug, { domains: mergedDomains }, { skipRefresh: true });
-      } else {
-        await vault.createDoc(plan.projectSlug, buildProjectMarkdown(plan, input.acceptedDomains), {
-          skipRefresh: true,
-        });
-      }
-      // batch 마감 — 위 쓰기 전부 skipRefresh 이므로 여기서 정확히 1회만
-      // 재스캔한다 (마지막 쓰기가 no-op 이어도 반영 보장).
-      await vault.refresh();
-      setBootstrapOpen(false);
+  // HomePage 모듈화 1차 — 부트스트랩 흐름은 use-bootstrap-flow 훅 소유.
+  // 완료 연출(토스트·E1 리빌)만 여기 남는다.
+  const { bootstrapOpen, setBootstrapOpen, bootstrapPlan, runBootstrap } = useBootstrapFlow({
+    vault,
+    onCompleted: ({ addedToExisting, elementCount }) => {
       // E1 — 리로드된 그래프가 "내 문서들이 모이는" 연출로 등장한다.
       setMapRevealToken((n) => n + 1);
       toast.show(
-        t(plan.existingProjectSlug ? "bootstrap.toastAdded" : "bootstrap.toastDone", { count: elements.length }),
+        t(addedToExisting ? "bootstrap.toastAdded" : "bootstrap.toastDone", { count: elementCount }),
         "success",
       );
     },
-    [bootstrapPlan, vault, toast, t],
-  );
+  });
   const createNode = useCallback(
     async (input: { title: string; kind: CreateNodeKind; domain?: string }) => {
       try {


### PR DESCRIPTION
HomePage.tsx(3,083줄, 모듈 예산 300줄의 10배)의 최대 부채를 줄이는 첫 절개:
- executeBootstrapPlan (features) — 쓰기 오케스트레이션을 최소 vault-writer
  계약 인터페이스로 분리. batch 계약(전 쓰기 skipRefresh + refresh 정확히
  1회)·마찰 A(기존 프로젝트 병합)·마찰 D(도메인 파일화 생략 규칙)를
  fake writer 4케이스로 처음 고정 — 지금까지 이 오케스트레이션은 무테스트.
- useBootstrapFlow (views/home/model) — 계획 파생+다이얼로그 상태+실행
  조합. 완료 연출(토스트·E1 리빌)은 onCompleted 로 HomePage 에 남긴다.

검증: 신규 4케이스 포함 home+docs-vault-local 306 pass · tsc · eslint 0
