### PR TITLE
refactor: 에이전트 연결 시트 조립 추출 — HomePage 모듈화 2차 (useAgentConnectModel)

### DIFF
--- a/src/views/home/model/use-agent-connect-model.test.ts
+++ b/src/views/home/model/use-agent-connect-model.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAgentConnectModel } from "./use-agent-connect-model";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+
+vi.mock("@/shared/lib/tauri-vault-fs", () => ({
+  getTauriVaultRootPath: () => null,
+}));
+
+const node = (id: string, kind: string, slug: string, title: string): KnowledgeGraphNode =>
+  ({ id, kind, title, evidenceIds: [slug], projectIds: [] }) as unknown as KnowledgeGraphNode;
+
+const heartbeat = (over: Record<string, unknown> = {}) => ({
+  valid: true,
+  stale: false,
+  heartbeat: {
+    updatedAt: new Date(Date.now() - 60_000).toISOString(),
+    agent: "claude-code",
+    focus: { ontologySlug: "capabilities/mcp-server" },
+    ...over,
+  },
+});
+
+describe("useAgentConnectModel (HomePage 모듈화 2차)", () => {
+  it("heartbeat 없음/무효 → none", () => {
+    const { result } = renderHook(() =>
+      useAgentConnectModel({
+        agentActivityStatus: null,
+        vaultHandle: null,
+        insightNodes: null,
+        defaultAgentLabel: "에이전트",
+      }),
+    );
+    expect(result.current.status).toEqual({ kind: "none" });
+    expect(result.current.snippets.needsManualPath).toBe(true);
+  });
+
+  it("openSheet 가 now 스냅샷을 찍고 connected 상태가 focus 제목을 되말한다", () => {
+    const nodes = [node("capability:mcp-server", "capability", "capabilities/mcp-server", "MCP Server")];
+    const { result } = renderHook(() =>
+      useAgentConnectModel({
+        agentActivityStatus: heartbeat(),
+        vaultHandle: null,
+        insightNodes: nodes,
+        defaultAgentLabel: "에이전트",
+      }),
+    );
+    act(() => result.current.openSheet());
+    expect(result.current.open).toBe(true);
+    expect(result.current.status).toMatchObject({
+      kind: "connected",
+      agentLabel: "claude-code",
+      focusTitle: "MCP Server",
+    });
+    act(() => result.current.closeSheet());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("stale heartbeat → stale, 도메인 제목 목록은 insight 파생", () => {
+    const nodes = [
+      node("domain:views", "domain", "domains/views", "Views"),
+      node("capability:c", "capability", "capabilities/c", "C"),
+    ];
+    const { result } = renderHook(() =>
+      useAgentConnectModel({
+        agentActivityStatus: { ...heartbeat(), stale: true },
+        vaultHandle: null,
+        insightNodes: nodes,
+        defaultAgentLabel: "에이전트",
+      }),
+    );
+    expect(result.current.status.kind).toBe("stale");
+    expect(result.current.domainTitles).toEqual(["Views"]);
+  });
+});

--- a/src/views/home/model/use-agent-connect-model.ts
+++ b/src/views/home/model/use-agent-connect-model.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { AgentConnectState } from "@/widgets/agent-connect";
+import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import {
+  buildCodexMcpAddCommandTemplate,
+  buildMcpConfigJson,
+} from "@/features/docs-vault-local";
+import { formatActivityAge } from "@/features/vault-ontology";
+import { getTauriVaultRootPath } from "@/shared/lib/tauri-vault-fs";
+
+/**
+ * "AI 에이전트 연결" 시트의 데이터 조립 — HomePage 모듈화 2차.
+ * heartbeat → 연결 상태, vault handle → 등록 스니펫, insight → 도메인
+ * 미리보기. "N분 전" 기준 시각은 시트가 열린 순간의 스냅샷
+ * (렌더 중 Date.now 금지 — 저장소 purity 관례).
+ */
+
+interface AgentHeartbeatStatus {
+  valid?: boolean;
+  stale?: boolean;
+  heartbeat?: {
+    updatedAt: string;
+    agent?: string | null;
+    focus: { ontologySlug: string | null };
+  } | null;
+}
+
+export interface UseAgentConnectModelArgs {
+  agentActivityStatus: AgentHeartbeatStatus | null;
+  vaultHandle: FileSystemDirectoryHandle | null;
+  insightNodes: readonly KnowledgeGraphNode[] | null;
+  /** i18n — heartbeat 에 agent 이름이 없을 때의 기본 라벨. */
+  defaultAgentLabel: string;
+}
+
+export interface AgentConnectModel {
+  open: boolean;
+  /** 열기 — now 스냅샷을 함께 찍는다. */
+  openSheet: () => void;
+  closeSheet: () => void;
+  status: AgentConnectState;
+  snippets: { mcpJson: string; codexCommand: string; needsManualPath: boolean };
+  domainTitles: string[];
+}
+
+export function useAgentConnectModel({
+  agentActivityStatus,
+  vaultHandle,
+  insightNodes,
+  defaultAgentLabel,
+}: UseAgentConnectModelArgs): AgentConnectModel {
+  const [open, setOpen] = useState(false);
+  const [nowMs, setNowMs] = useState(0);
+
+  const openSheet = useCallback(() => {
+    setNowMs(Date.now());
+    setOpen(true);
+  }, []);
+  const closeSheet = useCallback(() => setOpen(false), []);
+
+  const status = useMemo<AgentConnectState>(() => {
+    const hb = agentActivityStatus?.heartbeat ?? null;
+    if (!hb || !agentActivityStatus?.valid) return { kind: "none" };
+    const agoMs = nowMs - new Date(hb.updatedAt).getTime();
+    const ago = formatActivityAge(agoMs);
+    if (agentActivityStatus.stale) return { kind: "stale", agoLabel: ago };
+    const focusSlug = hb.focus.ontologySlug;
+    const focusTitle = focusSlug
+      ? ((insightNodes ?? []).find((n) => n.evidenceIds[0] === focusSlug || n.id === focusSlug)?.title ?? focusSlug)
+      : null;
+    return { kind: "connected", agentLabel: hb.agent ?? defaultAgentLabel, agoLabel: ago, focusTitle };
+  }, [agentActivityStatus, insightNodes, nowMs, defaultAgentLabel]);
+
+  const snippets = useMemo(() => {
+    const vaultName = vaultHandle?.name ?? "my-vault";
+    const desktopPath = vaultHandle ? (getTauriVaultRootPath(vaultHandle) ?? null) : null;
+    return {
+      mcpJson: buildMcpConfigJson(vaultName, desktopPath),
+      codexCommand: buildCodexMcpAddCommandTemplate(vaultName, desktopPath),
+      needsManualPath: desktopPath === null,
+    };
+  }, [vaultHandle]);
+
+  const domainTitles = useMemo(
+    () => (insightNodes ?? []).filter((n) => n.kind === "domain").map((n) => n.title),
+    [insightNodes],
+  );
+
+  return { open, openSheet, closeSheet, status, snippets, domainTitles };
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -115,6 +115,7 @@ import {
 } from "@/shared/lib/ontology-tree";
 import { useHomeRouteState } from "../model/use-home-route-state";
 import { useBootstrapFlow } from "../model/use-bootstrap-flow";
+import { useAgentConnectModel } from "../model/use-agent-connect-model";
 import {
   selectTopologyNodeRouteState,
   selectTopologyPathRouteState,
@@ -546,7 +547,6 @@ export function HomePage() {
   // P3d(E1) — 부트스트랩 완료 시 지도 리빌 연출 트리거.
   const [mapRevealToken, setMapRevealToken] = useState(0);
   // P2a — "AI 에이전트 연결" 시트.
-  const [agentConnectOpen, setAgentConnectOpen] = useState(false);
   // P3b — 선택된 엣지 (노드 선택과 배타: 노드를 고르면 해제).
   const [selectedEdge, setSelectedEdge] = useState<{
     sourceId: string;
@@ -588,33 +588,13 @@ export function HomePage() {
       why,
     };
   }, [selectedEdge, ontologyInsight, docFreshnessIndex, updatedAgoNowMs, t, relationVocabulary]);
-  // purity: "N분 전" 기준 시각은 시트가 열린 순간의 스냅샷 (렌더 중 Date.now 금지).
-  const [agentConnectNowMs, setAgentConnectNowMs] = useState(0);
-  const agentConnectStatus = useMemo<AgentConnectState>(() => {
-    const hb = agentActivityStatus?.heartbeat ?? null;
-    if (!hb || !agentActivityStatus?.valid) return { kind: "none" };
-    const agoMs = agentConnectNowMs - new Date(hb.updatedAt).getTime();
-    const ago = formatActivityAge(agoMs);
-    if (agentActivityStatus.stale) return { kind: "stale", agoLabel: ago };
-    const focusSlug = hb.focus.ontologySlug;
-    const focusTitle = focusSlug
-      ? (ontologyInsight?.nodes.find((n) => n.evidenceIds[0] === focusSlug || n.id === focusSlug)?.title ?? focusSlug)
-      : null;
-    return { kind: "connected", agentLabel: hb.agent ?? t("agentConnect.defaultAgentLabel"), agoLabel: ago, focusTitle };
-  }, [agentActivityStatus, ontologyInsight, agentConnectNowMs, t]);
-  const agentConnectSnippets = useMemo(() => {
-    const vaultName = vault.handle?.name ?? "my-vault";
-    const desktopPath = vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null;
-    return {
-      mcpJson: buildMcpConfigJson(vaultName, desktopPath),
-      codexCommand: buildCodexMcpAddCommandTemplate(vaultName, desktopPath),
-      needsManualPath: desktopPath === null,
-    };
-  }, [vault.handle]);
-  const agentConnectDomains = useMemo(
-    () => (ontologyInsight?.nodes ?? []).filter((n) => n.kind === "domain").map((n) => n.title),
-    [ontologyInsight],
-  );
+  // HomePage 모듈화 2차 — 에이전트 연결 시트 조립은 use-agent-connect-model 소유.
+  const agentConnect = useAgentConnectModel({
+    agentActivityStatus,
+    vaultHandle: vault.handle,
+    insightNodes: ontologyInsight?.nodes ?? null,
+    defaultAgentLabel: t("agentConnect.defaultAgentLabel"),
+  });
   // HomePage 모듈화 1차 — 부트스트랩 흐름은 use-bootstrap-flow 훅 소유.
   // 완료 연출(토스트·E1 리빌)만 여기 남는다.
   const { bootstrapOpen, setBootstrapOpen, bootstrapPlan, runBootstrap } = useBootstrapFlow({
@@ -2401,10 +2381,7 @@ export function HomePage() {
                     selectedId={canvasSelectedSlug}
                     onSelect={(id) => handleSelect(id)}
                     onCollapse={handleIndexCollapse}
-                    onOpenAgentConnect={() => {
-                      setAgentConnectNowMs(Date.now());
-                      setAgentConnectOpen(true);
-                    }}
+                    onOpenAgentConnect={agentConnect.openSheet}
                     domainCensus={indexDomainCensus}
                     // P4a — 렌즈 필터용 id 집합 + P4b 배지 대상.
                     recentChanges={{
@@ -2970,11 +2947,11 @@ export function HomePage() {
           onSelectProject={(project) => handleSelect(project.slug)}
         />
         <AgentConnectSheet
-          open={agentConnectOpen}
-          onClose={() => setAgentConnectOpen(false)}
-          status={agentConnectStatus}
-          snippets={agentConnectSnippets}
-          domainTitles={agentConnectDomains}
+          open={agentConnect.open}
+          onClose={agentConnect.closeSheet}
+          status={agentConnect.status}
+          snippets={agentConnect.snippets}
+          domainTitles={agentConnect.domainTitles}
           handoffText={indexAgentHandoffBriefText}
           onWriteConfigs={
             isTauriVaultRuntime() && vault.manifest ? () => void vault.ensureAgentConfigs() : null


### PR DESCRIPTION
heartbeat→상태·vault handle→등록 스니펫·insight→도메인 미리보기 조립과
"N분 전" 스냅샷(now purity) 을 views/home/model 훅으로. HomePage 는
openSheet/closeSheet 결선만 소유 (3,027→3,004줄). renderHook 3케이스로
none/connected(focus 되말하기)/stale + 스냅샷 계약 고정 — 종전 무테스트.

검증: home 173 pass (신규 3) · tsc · eslint 0 · knip clean
