### PR TITLE
feat: 엣지 의미 표면 세트 — 호버 마이크로카드(P3c) + 페어 포커스 + pale 인디고 선택색

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -13,6 +13,9 @@
   여전히 금지 — 앰버가 셋 이상 보이면 결함이다. (docs 표면의 장식적 gold 악센트는 별개의 `--color-amber-docs-*` **quarantine 토큰** — 헌장 승인 아님, 확장 금지, 후속 강등 검토 대기.)
 - ontology kind 색상은 예외적으로 허용하지만 data mark 로만 쓴다. graph fill 은 작은 점의 3:1 대비를 위해 선명할 수 있고, panel/card 에서는 neutral surface + compact marker/swatch + label/icon 으로 낮춘다. detail card 내부의 full-height colored rail 은 AI SaaS callout 처럼 읽히므로 금지한다.
 - 카테고리 구분은 **색이 아닌 보더 스타일** (작업중: 인디고 underline, 예정: dashed).
+- **선택 색 사다리**: 노드 선택 = 표준 인디고(#5e6ad2), 엣지 선택(페어
+  포커스) = pale 인디고(`--topology-v2-edge-selected`, rgba(200,210,255)) —
+  같은 인디고 1계열 안에서 값으로만 구분한다. 새 hue 로의 확장 금지.
 
 ## 토폴로지 노드 포커스 & 스케일
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1242,6 +1242,9 @@
        단서이지 막대그래프가 아니다. */
     --topology-v2-radius-magnitude-k: 0.45;
     /* B3 잔여 — dust 시차 깊이 범위 (그리드 1.0 대비 느린 흐름). */
+    /* 엣지 선택(페어 포커스) — 인디고 pale 사다리: 노드 선택(#5e6ad2)과
+       같은 계열, 밝은 값으로 구분 (채색 시스템 증식 없음). */
+    --topology-v2-edge-selected: rgba(200, 210, 255, 0.95);
     --topology-v2-dust-parallax-min: 0.15;
     --topology-v2-dust-parallax-max: 0.45;
     --topology-v2-edge-depends: #4c4c63;

--- a/messages/en.json
+++ b/messages/en.json
@@ -2370,6 +2370,9 @@
       "describes": "{from} is evidence for {to}.",
       "belongsTo": "{from} belongs to {to}.",
       "related": "{from} and {to} are related."
+    },
+    "edgeHover": {
+      "clickHint": "Click for details · source doc"
     }
   },
   "fullDetailA1": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2370,6 +2370,9 @@
       "describes": "{from} 가 {to} 의 근거예요.",
       "belongsTo": "{from} 는 {to} 에 속해요.",
       "related": "{from} 와 {to} 가 서로 관련돼 있어요."
+    },
+    "edgeHover": {
+      "clickHint": "클릭하면 상세 · 출처 문서"
     }
   },
   "fullDetailA1": {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -153,6 +153,7 @@ import {
   TopologyMapV2,
   TopologyV2ContextMenu,
   TopologyV2DetailPanel,
+  TopologyV2EdgeHoverCard,
   TopologyV2SettingsGear,
   buildV2Connections,
   buildV2ConnectionGroups,
@@ -583,6 +584,40 @@ export function HomePage() {
       why,
     };
   }, [selectedEdge, ontologyInsight, docFreshnessIndex, updatedAgoNowMs, t, relationVocabulary]);
+  // P3c — 엣지 호버 마이크로카드 (클릭 팝오버의 가벼운 전신).
+  const [hoverEdge, setHoverEdge] = useState<{
+    edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null };
+    x: number;
+    y: number;
+  } | null>(null);
+  const handleHoverEdge = useCallback(
+    (
+      edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
+      position: { x: number; y: number } | null,
+    ) => {
+      setHoverEdge(edge && position ? { edge, x: position.x, y: position.y } : null);
+    },
+    [],
+  );
+  const hoverEdgeCardModel = useMemo(() => {
+    if (!hoverEdge || !ontologyInsight) return null;
+    const from = ontologyInsight.nodes.find((n) => n.id === hoverEdge.edge.sourceId);
+    const to = ontologyInsight.nodes.find((n) => n.id === hoverEdge.edge.targetId);
+    if (!from || !to) return null;
+    const edgeRecord = ontologyInsight.edges.find(
+      (e) => e.from === hoverEdge.edge.sourceId && e.to === hoverEdge.edge.targetId,
+    );
+    return {
+      sentence: t(`edgeSentence.${normalizeEdgeSentenceKey(hoverEdge.edge.relationType)}`, {
+        from: from.title,
+        to: to.title,
+      }),
+      typeLabel: relationVocabulary(hoverEdge.edge.relationType, "formal"),
+      why: edgeRecord?.label?.trim() || null,
+      x: hoverEdge.x,
+      y: hoverEdge.y,
+    };
+  }, [hoverEdge, ontologyInsight, t, relationVocabulary]);
   // HomePage 모듈화 2차 — 에이전트 연결 시트 조립은 use-agent-connect-model 소유.
   const agentConnect = useAgentConnectModel({
     agentActivityStatus,
@@ -2458,8 +2493,10 @@ export function HomePage() {
                     revealToken={mapRevealToken}
                     onSelectEdge={(edge) => {
                       setFullDetailSlug(null);
+                      setHoverEdge(null); // 팝오버가 열리면 마이크로카드는 강등
                       setSelectedEdge(edge);
                     }}
+                    onHoverEdge={handleHoverEdge}
                     onSelect={(slug) => {
                       setSelectedEdge(null);
                       handleSelect(slug);
@@ -2752,6 +2789,16 @@ export function HomePage() {
           </div>
         ) : null}
         {/* P3b — 엣지 팝오버: 노드 팝오버와 같은 포지셔너 계약, 배타 렌더. */}
+        {hoverEdgeCardModel && !selectedEdge && !selectedOntologyNode && !createNodeOpen ? (
+          <TopologyV2EdgeHoverCard
+            sentence={hoverEdgeCardModel.sentence}
+            typeLabel={hoverEdgeCardModel.typeLabel}
+            why={hoverEdgeCardModel.why}
+            clickHint={t("edgeHover.clickHint")}
+            x={hoverEdgeCardModel.x}
+            y={hoverEdgeCardModel.y}
+          />
+        ) : null}
         {edgePanelModel && !selectedOntologyNode && !createNodeOpen ? (
           <div
             data-testid="topology-edge-popover-positioner"

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2497,6 +2497,7 @@ export function HomePage() {
                       setSelectedEdge(edge);
                     }}
                     onHoverEdge={handleHoverEdge}
+                    selectedEdge={selectedEdge ? { sourceId: selectedEdge.sourceId, targetId: selectedEdge.targetId } : null}
                     onSelect={(slug) => {
                       setSelectedEdge(null);
                       handleSelect(slug);

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2789,7 +2789,10 @@ export function HomePage() {
           </div>
         ) : null}
         {/* P3b — 엣지 팝오버: 노드 팝오버와 같은 포지셔너 계약, 배타 렌더. */}
-        {hoverEdgeCardModel && !selectedEdge && !selectedOntologyNode && !createNodeOpen ? (
+        {/* 노드 포커스(팝오버) 중에도 렌더 — 사용자 실보고 "노드 클릭한
+            상태에선 선 호버 툴팁이 안 나온다". 엣지 팝오버와만 상호배제
+            (같은 의미의 중복 표면 금지). */}
+        {hoverEdgeCardModel && !selectedEdge && !createNodeOpen ? (
           <TopologyV2EdgeHoverCard
             sentence={hoverEdgeCardModel.sentence}
             typeLabel={hoverEdgeCardModel.typeLabel}

--- a/src/widgets/topology-map-v2/index.ts
+++ b/src/widgets/topology-map-v2/index.ts
@@ -8,6 +8,7 @@ export type {
   TopologyV2Forces,
 } from './ui/TopologyMapV2';
 export { TopologyV2DetailPanel } from './ui/TopologyV2DetailPanel';
+export { TopologyV2EdgeHoverCard } from './ui/TopologyV2EdgeHoverCard';
 export type {
   TopologyV2DetailPanelProps,
   TopologyV2DetailPanelLabels,

--- a/src/widgets/topology-map-v2/model/focus-state.test.ts
+++ b/src/widgets/topology-map-v2/model/focus-state.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   isNodeEmphasisActive,
   resolveEdgeEgoState,
+  resolveEdgeEgoStateWithPair,
   resolveEdgePulseSpeed,
   resolveNodeEgoState,
+  resolveNodeEgoStateWithPair,
   scheduleRipple,
   stepEmphasis,
 } from "./focus-state";
@@ -143,5 +145,27 @@ describe("stepEmphasis", () => {
     }
     expect(emphasis).toBeGreaterThan(0.99);
     expect(emphasis).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("edge pair focus (선 선택 = 페어 포커스)", () => {
+  const pair = { sourceId: "a", targetId: "b" };
+
+  it("노드 포커스 없이 페어만 있으면 양끝=neighbor, 나머지=dim", () => {
+    expect(resolveNodeEgoStateWithPair("a", null, new Set(), pair)).toBe("neighbor");
+    expect(resolveNodeEgoStateWithPair("b", null, new Set(), pair)).toBe("neighbor");
+    expect(resolveNodeEgoStateWithPair("c", null, new Set(), pair)).toBe("dim");
+  });
+
+  it("노드 포커스가 있으면 기존 ego 규칙이 우선한다 (클릭=안전 계약)", () => {
+    expect(resolveNodeEgoStateWithPair("x", "x", new Set(["y"]), pair)).toBe("center");
+    expect(resolveNodeEgoStateWithPair("a", "x", new Set(["y"]), pair)).toBe("dim");
+  });
+
+  it("페어 중 선택 엣지만 ego, 다른 엣지는 dim; 페어 없으면 종전 규칙", () => {
+    expect(resolveEdgeEgoStateWithPair(false, null, pair, true)).toBe("ego");
+    expect(resolveEdgeEgoStateWithPair(false, null, pair, false)).toBe("dim");
+    expect(resolveEdgeEgoStateWithPair(true, "x", pair, false)).toBe("ego");
+    expect(resolveEdgeEgoStateWithPair(false, null, null, false)).toBe("normal");
   });
 });

--- a/src/widgets/topology-map-v2/model/focus-state.ts
+++ b/src/widgets/topology-map-v2/model/focus-state.ts
@@ -59,6 +59,43 @@ export function resolveEdgeEgoState(
 }
 
 /**
+ * 엣지 선택 = 페어 포커스 (사용자 요청: "선을 클릭하면 그 선과 연결된
+ * 노드간만 표시"). 노드 포커스가 없고 엣지가 선택된 동안:
+ * - 양끝 노드는 "neighbor" 급 (주인공은 '선'이므로 center 링 없음)
+ * - 나머지 노드/엣지는 "dim"
+ * - 선택된 엣지 자체는 "ego" (+ 별도 selected 스트로크는 드로어 소관)
+ * 노드 포커스가 있으면 기존 ego 규칙이 우선한다 (클릭=안전 계약 유지).
+ */
+export interface EdgePairFocus {
+  sourceId: string;
+  targetId: string;
+}
+
+export function resolveNodeEgoStateWithPair(
+  nodeId: string,
+  focusedNodeId: string | null,
+  neighborsOfFocused: ReadonlySet<string>,
+  pair: EdgePairFocus | null,
+): NodeEgoState {
+  if (focusedNodeId === null && pair !== null) {
+    return nodeId === pair.sourceId || nodeId === pair.targetId ? "neighbor" : "dim";
+  }
+  return resolveNodeEgoState(nodeId, focusedNodeId, neighborsOfFocused);
+}
+
+export function resolveEdgeEgoStateWithPair(
+  edgeTouchesFocusedNode: boolean,
+  focusedNodeId: string | null,
+  pair: EdgePairFocus | null,
+  isSelectedEdge: boolean,
+): EdgeEgoState {
+  if (focusedNodeId === null && pair !== null) {
+    return isSelectedEdge ? "ego" : "dim";
+  }
+  return resolveEdgeEgoState(edgeTouchesFocusedNode, focusedNodeId);
+}
+
+/**
  * Ambient comet-tail advance speed for one `depends` edge (`world.edges[].t +=
  * dt * speed`). When a node is clicked ("powered"), its own incident edges carry
  * *more current* — the pulse advances at `egoSpeed` instead of the ambient

--- a/src/widgets/topology-map-v2/render/traces.ts
+++ b/src/widgets/topology-map-v2/render/traces.ts
@@ -110,6 +110,12 @@ export interface TraceDrawState {
    */
   emphasized?: boolean;
   /**
+   * 엣지 선택(페어 포커스) — 인디고 pale 사다리의 전용 스트로크로 그린다.
+   * 노드 선택(표준 인디고)과 같은 계열이되 값이 달라 한눈에 구분된다
+   * (채색 시스템 증식 없음 — 헌장 준수).
+   */
+  selected?: boolean;
+  /**
    * P3a — containment 잉크 레벨 (0 뼈대 · 1 중간 · 2 잔가지). contains 의
    * 비-ego 렌더에서만 소비: stroke 는 레벨별 토큰, width 는 레벨 계수.
    * depends/ego/dim 경로는 기존 그대로 (타입·주의 채널은 사다리와 직교).
@@ -133,6 +139,8 @@ export interface TraceTokens {
   edgeDim: string;
   indigo: string;
   indigoBright: string;
+  /** 엣지 선택 전용 스트로크 (`--topology-v2-edge-selected`) — 없으면 indigoBright 폴백. */
+  edgeSelected?: string;
 }
 
 /**
@@ -157,7 +165,11 @@ export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, token
 
   let stroke: string;
   let width: number;
-  if (egoState === "dim") {
+  if (state.selected === true) {
+    // 페어 포커스의 주인공 — pale 인디고, 최상 잉크.
+    stroke = tokens.edgeSelected ?? tokens.indigoBright;
+    width = (isDepends ? 2.2 : 2.0) - farT * 0.5;
+  } else if (egoState === "dim") {
     stroke = tokens.edgeDim;
     width = 1;
   } else if (egoState === "ego") {

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -41,6 +41,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-edge-contains": "#28282e",
   "--topology-v2-edge-depends": "#39394a",
   "--topology-v2-edge-dim": "#1e1e22",
+  "--topology-v2-edge-selected": "rgba(200, 210, 255, 0.95)",
   "--topology-v2-hull-stroke": "#3a3a42",
   "--topology-v2-label-project": "#d4b478",
   "--topology-v2-label-domain": "#b8b8c1",

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -52,6 +52,8 @@ export interface TopologyV2Tokens {
   edgeContains: string;
   edgeDepends: string;
   edgeDim: string;
+  /** 엣지 선택(페어 포커스) 스트로크 — 인디고 pale 사다리 (노드 선택 표준 인디고와 값으로 구분). */
+  edgeSelected: string;
   hullStroke: string;
   labelProject: string;
   labelDomain: string;
@@ -210,6 +212,7 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "edgeContains", cssVar: "--topology-v2-edge-contains", kind: "color" },
   { key: "edgeDepends", cssVar: "--topology-v2-edge-depends", kind: "color" },
   { key: "edgeDim", cssVar: "--topology-v2-edge-dim", kind: "color" },
+  { key: "edgeSelected", cssVar: "--topology-v2-edge-selected", kind: "color" },
   { key: "hullStroke", cssVar: "--topology-v2-hull-stroke", kind: "color" },
   { key: "labelProject", cssVar: "--topology-v2-label-project", kind: "color" },
   { key: "labelDomain", cssVar: "--topology-v2-label-domain", kind: "color" },

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -84,6 +84,8 @@ export interface TopologyMapV2Props {
   revealToken?: number;
   /** P3b — 엣지 클릭 (노드 미히트 지점). */
   onSelectEdge?: (edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null }) => void;
+  /** 엣지 선택 = 페어 포커스 — 양끝만 밝히고 나머지 dim, 선택 엣지는 pale 인디고. */
+  selectedEdge?: { sourceId: string; targetId: string } | null;
   /** P3c — 엣지 호버 마이크로카드 (식별 변경 시 발화, null=해제). */
   onHoverEdge?: (
     edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
@@ -126,7 +128,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, livePhysics, onHoverEdge } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, livePhysics, onHoverEdge, selectedEdge = null } = props;
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
@@ -141,6 +143,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       revealToken,
       onSelectEdge,
       onHoverEdge,
+      selectedEdge,
       onSelect,
       onPaneClick,
       onVisibleCountChange,

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -84,6 +84,11 @@ export interface TopologyMapV2Props {
   revealToken?: number;
   /** P3b — 엣지 클릭 (노드 미히트 지점). */
   onSelectEdge?: (edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null }) => void;
+  /** P3c — 엣지 호버 마이크로카드 (식별 변경 시 발화, null=해제). */
+  onHoverEdge?: (
+    edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
+    position: { x: number; y: number } | null,
+  ) => void;
   /**
    * The connected-node slug the user is hovering in the detail panel's
    * "연결된 노드" list. Under focus, that node + its connecting edge light up on
@@ -121,7 +126,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, livePhysics } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, livePhysics, onHoverEdge } = props;
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
@@ -135,6 +140,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       relayoutToken,
       revealToken,
       onSelectEdge,
+      onHoverEdge,
       onSelect,
       onPaneClick,
       onVisibleCountChange,

--- a/src/widgets/topology-map-v2/ui/TopologyV2EdgeHoverCard.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2EdgeHoverCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TopologyV2EdgeHoverCard } from "./TopologyV2EdgeHoverCard";
+
+describe("TopologyV2EdgeHoverCard (P3c)", () => {
+  it("평문 문장·타입·근거·클릭 힌트를 비인터랙티브 카드로 렌더한다", () => {
+    render(
+      <TopologyV2EdgeHoverCard
+        sentence="A 가 B 에 기대요"
+        typeLabel="의존"
+        why="쓰기 경로가 B 를 지난다"
+        clickHint="클릭하면 상세 · 출처 문서"
+        x={300}
+        y={200}
+      />,
+    );
+    const card = screen.getByTestId("topology-v2-edge-hover-card");
+    expect(card).toHaveTextContent("A 가 B 에 기대요");
+    expect(card).toHaveTextContent("의존");
+    expect(card).toHaveTextContent("쓰기 경로가 B 를 지난다");
+    expect(card).toHaveTextContent("클릭하면 상세");
+    expect(card.className).toContain("pointer-events-none");
+  });
+
+  it("why 없으면 근거 줄 생략", () => {
+    render(
+      <TopologyV2EdgeHoverCard sentence="S" typeLabel="포함" why={null} clickHint="힌트" x={0} y={0} />,
+    );
+    expect(screen.getByTestId("topology-v2-edge-hover-card").querySelectorAll("p")).toHaveLength(3);
+  });
+});

--- a/src/widgets/topology-map-v2/ui/TopologyV2EdgeHoverCard.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2EdgeHoverCard.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * P3c — 엣지 호버 마이크로카드. 클릭 팝오버(P3b, TopologyV2EdgePanel)의
+ * 가벼운 전신: 커서 근처에 평문 문장 + 타입 + (있으면) 근거 한 줄만.
+ * 게이트 해제 근거: 소유자 사용 신호("연결선에 호버하면 의미 표시") —
+ * 원래 P3c 는 3b 사용 검증 후로 보류돼 있었다.
+ *
+ * 계약: 비인터랙티브(pointer-events-none — 클릭을 훔치지 않는다), 뷰포트
+ * 클램프, 팝오버와 상호배제(엣지 선택 중엔 렌더하지 않음 — 호출자 책임).
+ */
+export interface TopologyV2EdgeHoverCardProps {
+  /** 평문 문장 — "A 가 B 에 기대요" (P3b 와 같은 어휘 사전 출처). */
+  sentence: string;
+  /** formal 타입 라벨 — "의존". */
+  typeLabel: string;
+  /** P6 relation_notes — 있으면 1줄 truncate. */
+  why: string | null;
+  /** 클릭 안내 힌트 (i18n). */
+  clickHint: string;
+  /** 커서 뷰포트 좌표 — 카드는 우하단 오프셋 + 뷰포트 클램프. */
+  x: number;
+  y: number;
+}
+
+const OFFSET = 14;
+const CARD_MAX_WIDTH = 280;
+const EDGE_MARGIN = 8;
+
+export function TopologyV2EdgeHoverCard({ sentence, typeLabel, why, clickHint, x, y }: TopologyV2EdgeHoverCardProps) {
+  const left = Math.min(x + OFFSET, (typeof window !== "undefined" ? window.innerWidth : 1920) - CARD_MAX_WIDTH - EDGE_MARGIN);
+  const top = Math.min(y + OFFSET, (typeof window !== "undefined" ? window.innerHeight : 1080) - 120 - EDGE_MARGIN);
+  return (
+    <div
+      data-testid="topology-v2-edge-hover-card"
+      role="status"
+      className="pointer-events-none fixed z-40 flex max-w-[280px] flex-col gap-1 rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] px-3 py-2 shadow-[var(--topology-v2-panel-shadow)]"
+      style={{ left, top }}
+    >
+      <p className="font-mono text-[9.5px] uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-tertiary)]">
+        {typeLabel}
+      </p>
+      <p className="text-[12.5px] font-medium leading-snug text-[color:var(--topology-v2-panel-text-primary)]">
+        {sentence}
+      </p>
+      {why ? (
+        <p className="truncate text-[11px] leading-snug text-[color:var(--topology-v2-panel-text-secondary)]">{why}</p>
+      ) : null}
+      <p className="text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">{clickHint}</p>
+    </div>
+  );
+}

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CameraAxes } from "../engine/camera";
-import { resolveEdgeEgoState, resolveNodeEgoState, type NodeEgoState } from "../model/focus-state";
+import { resolveEdgeEgoStateWithPair, resolveNodeEgoStateWithPair, type EdgePairFocus, type NodeEgoState } from "../model/focus-state";
 import { resolveFreshnessVisual } from "../model/freshness";
 import { computeSelectionPulse, type SelectionPulseVisual } from "../model/selection-pulse";
 import { DEFAULT_TIER_REVEAL, edgeTierAlpha, effectiveNodeAlpha, nodeTierAlpha } from "../model/tier-visibility";
@@ -174,6 +174,8 @@ export interface FrameDrawParams {
   emphasizedNeighborId: string | null;
   /** P3c — 호버 중 엣지 (마이크로카드와 같은 상태) — 해당 엣지 잉크 강조. */
   hoveredEdge: { sourceId: string; targetId: string; relationType: string } | null;
+  /** 엣지 선택 = 페어 포커스 — 양끝만 밝히고 나머지 dim, 선택 엣지는 pale 인디고. */
+  selectedEdge: EdgePairFocus | null;
   emphasisById: ReadonlyMap<string, number>;
   /** C1 A2 — ego tier-reveal ramp (`topology-physics-step.ts` steps it), consumed by `effectiveNodeAlpha`. */
   egoRevealById: ReadonlyMap<string, number>;
@@ -218,6 +220,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     hoveredNodeId,
     emphasizedNeighborId,
     hoveredEdge,
+    selectedEdge,
     emphasisById,
     egoRevealById,
     reducedMotion,
@@ -274,9 +277,17 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   for (const node of world.nodes) {
     const tierAlpha = nodeTierAlpha(node.kind, node.isHub, zoomRatio, DEFAULT_TIER_REVEAL);
     tierAlphaById.set(node.id, tierAlpha);
+    const isPairMember =
+      focusedNodeId === null &&
+      selectedEdge !== null &&
+      (node.id === selectedEdge.sourceId || node.id === selectedEdge.targetId);
     const isEgoMember =
-      focusedNodeId !== null && (node.id === focusedNodeId || neighborsOfFocused.has(node.id));
-    effectiveAlphaById.set(node.id, effectiveNodeAlpha(tierAlpha, isEgoMember, egoRevealById.get(node.id) ?? 0));
+      isPairMember ||
+      (focusedNodeId !== null && (node.id === focusedNodeId || neighborsOfFocused.has(node.id)));
+    effectiveAlphaById.set(
+      node.id,
+      effectiveNodeAlpha(tierAlpha, isEgoMember, isPairMember ? 1 : (egoRevealById.get(node.id) ?? 0)),
+    );
   }
 
   for (const kind of ["contains", "depends"] as const) {
@@ -294,6 +305,10 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
       // B2 잔여 — 끝점이 하나도 안 보이는 관통 엣지는 잉크 강등 (실타래 해소).
       const passthrough = isPassthroughEdge(a, b, 24, viewportWidth, viewportHeight);
       const touches = focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
+      const isSelectedEdge =
+        selectedEdge !== null &&
+        edge.sourceId === selectedEdge.sourceId &&
+        edge.targetId === selectedEdge.targetId;
       const hovered =
         hoveredEdge !== null &&
         edge.sourceId === hoveredEdge.sourceId &&
@@ -311,7 +326,8 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
           b,
           control,
           relationType: kind,
-          egoState: resolveEdgeEgoState(touches, focusedNodeId),
+          egoState: resolveEdgeEgoStateWithPair(touches, focusedNodeId, selectedEdge, isSelectedEdge),
+          selected: isSelectedEdge,
           farT,
           t: edge.t,
           emphasized,
@@ -326,6 +342,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
           edgeDim: tokens.edgeDim,
           indigo: tokens.indigo,
           indigoBright: tokens.indigoBright,
+          edgeSelected: tokens.edgeSelected,
         },
       );
       ctx.globalAlpha = 1;
@@ -335,7 +352,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   for (const node of world.nodes) {
     const tierAlpha = effectiveAlphaById.get(node.id) ?? 1;
     if (tierAlpha <= 0.02) continue;
-    const egoState = resolveNodeEgoState(node.id, focusedNodeId, neighborsOfFocused);
+    const egoState = resolveNodeEgoStateWithPair(node.id, focusedNodeId, neighborsOfFocused, selectedEdge);
     const emphasis = emphasisById.get(node.id) ?? 0;
     const isEmphasizedNeighbor = emphasizedNeighborId !== null && node.id === emphasizedNeighborId && egoState === "neighbor";
     const visual = resolveNodeVisual(node, egoState, emphasis, focusedNodeId, isEmphasizedNeighbor, tokens, reducedMotion);
@@ -464,7 +481,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     // 읽을 수 있다").
     const revealAlpha = effectiveAlphaById.get(node.id) ?? 1;
     if (revealAlpha <= 0.02) return;
-    const egoState = resolveNodeEgoState(node.id, focusedNodeId, neighborsOfFocused);
+    const egoState = resolveNodeEgoStateWithPair(node.id, focusedNodeId, neighborsOfFocused, selectedEdge);
     const isHovered = hoveredNodeId !== null && node.id === hoveredNodeId;
     const compactAlpha = computeLabelAlpha({ kind: node.kind, farT, egoState, isHovered, revealAlpha });
     // Domain draws TWO effects at once (the always-readable compact label AND

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -172,6 +172,8 @@ export interface FrameDrawParams {
    * Null in the common case (no panel hover).
    */
   emphasizedNeighborId: string | null;
+  /** P3c — 호버 중 엣지 (마이크로카드와 같은 상태) — 해당 엣지 잉크 강조. */
+  hoveredEdge: { sourceId: string; targetId: string; relationType: string } | null;
   emphasisById: ReadonlyMap<string, number>;
   /** C1 A2 — ego tier-reveal ramp (`topology-physics-step.ts` steps it), consumed by `effectiveNodeAlpha`. */
   egoRevealById: ReadonlyMap<string, number>;
@@ -215,6 +217,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     focusedNodeId,
     hoveredNodeId,
     emphasizedNeighborId,
+    hoveredEdge,
     emphasisById,
     egoRevealById,
     reducedMotion,
@@ -291,10 +294,15 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
       // B2 잔여 — 끝점이 하나도 안 보이는 관통 엣지는 잉크 강등 (실타래 해소).
       const passthrough = isPassthroughEdge(a, b, 24, viewportWidth, viewportHeight);
       const touches = focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
+      const hovered =
+        hoveredEdge !== null &&
+        edge.sourceId === hoveredEdge.sourceId &&
+        edge.targetId === hoveredEdge.targetId;
       const emphasized =
-        emphasizedNeighborId !== null &&
-        touches &&
-        (edge.sourceId === emphasizedNeighborId || edge.targetId === emphasizedNeighborId);
+        hovered ||
+        (emphasizedNeighborId !== null &&
+          touches &&
+          (edge.sourceId === emphasizedNeighborId || edge.targetId === emphasizedNeighborId));
       ctx.globalAlpha = passthrough ? edgeAlpha * tokens.edgePassthroughAlpha : edgeAlpha;
       tracesDraw(
         ctx,

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -115,6 +115,17 @@ export interface PointerHandlerRefs {
   onSelect?: (slug: string) => void;
   /** P3b — 노드가 잡히지 않은 지점의 클릭이 엣지 근접일 때. */
   onSelectEdge?: (edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null }) => void;
+  /**
+   * P3c — 엣지 호버 마이크로카드. idle 이동 중 노드 미히트 지점이 엣지
+   * 근접이면 발화(식별 변경 시에만), 벗어나면 null. 드로우 패스의 hover
+   * 잉크 강조가 같은 ref 를 읽는다. 클릭(P3b 상세)과 별개의 가벼운 의미
+   * 미리보기 — 사용 신호(소유자 요청) 확인 후 게이트 해제.
+   */
+  hoveredEdgeRef?: Ref<{ sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null>;
+  onHoverEdge?: (
+    edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
+    position: { x: number; y: number } | null,
+  ) => void;
   onPaneClick?: () => void;
   /**
    * W2-B node right-click context menu. Called with the hit node's id and the
@@ -176,8 +187,10 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     dragAffectedSetRef,
     dragStartPosRef,
     overviewScaleRef,
+    hoveredEdgeRef,
     onSelect,
     onSelectEdge,
+    onHoverEdge,
     onPaneClick,
     onContextMenuNode,
   } = refs;
@@ -227,6 +240,36 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     const snapshot = { left: rect.left, top: rect.top };
     canvasRectRef.current = snapshot;
     return snapshot;
+  };
+
+
+  /** P3b/P3c 공용 — 현재 tier 에서 양 끝이 히트 가능한 엣지의 스크린 투영 후보. */
+  const buildEdgeCandidates = (): EdgeHitCandidate[] => {
+    const world = worldRef.current;
+    if (!world) return [];
+    const tokens = readTopologyV2TokensOrNull();
+    if (!tokens) return [];
+    const { width, height } = viewportRef.current;
+    const overviewEntryScale = overviewScaleRef.current * tokens.overviewEntryRatio;
+    const zoomRatio = computeZoomRatio(cameraRef.current.scale.value, overviewEntryScale);
+    const focusedNodeId = focusedSlugRef.current;
+    const neighborsOfFocused = focusedNodeId ? world.neighborMap.get(focusedNodeId) : undefined;
+    const hittable = new Set(
+      world.nodes
+        .filter((n) => isNodeHittable(n, zoomRatio, focusedNodeId, neighborsOfFocused, DEFAULT_TIER_REVEAL))
+        .map((n) => n.id),
+    );
+    const candidates: EdgeHitCandidate[] = [];
+    for (const edge of world.edges) {
+      if (!hittable.has(edge.sourceId) || !hittable.has(edge.targetId)) continue;
+      candidates.push({
+        edge,
+        a: worldToScreen(cameraRef.current, width, height, edge.ax, edge.ay),
+        b: worldToScreen(cameraRef.current, width, height, edge.bx, edge.by),
+        control: worldToScreen(cameraRef.current, width, height, edge.controlX, edge.controlY),
+      });
+    }
+    return candidates;
   };
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
@@ -334,6 +377,35 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
 
     if (next.phase !== "idle" || focusedSlugRef.current) return; // pressed-not-dragging, or focus owns emphasis
     const hitNodeId = hitVisibleNode(world, cameraRef.current, tokens, point.x, point.y);
+
+    // P3c — 노드 미히트 지점의 엣지 근접 = 호버 마이크로카드. 식별이 바뀔
+    // 때만 발화 (같은 엣지 위 이동은 재발화 없음 — 카드 안정). 노드 위에
+    // 오르면 엣지 호버는 즉시 해제 (노드가 우선).
+    if (hoveredEdgeRef && onHoverEdge) {
+      const edgeHit = hitNodeId === null ? hitTestEdges(buildEdgeCandidates(), point.x, point.y, 6) : null;
+      const prev = hoveredEdgeRef.current;
+      const sameEdge =
+        edgeHit !== null &&
+        prev !== null &&
+        prev.sourceId === edgeHit.sourceId &&
+        prev.targetId === edgeHit.targetId &&
+        prev.relationType === edgeHit.relationType;
+      if (!sameEdge && (edgeHit !== null || prev !== null)) {
+        const payload = edgeHit
+          ? {
+              sourceId: edgeHit.sourceId,
+              targetId: edgeHit.targetId,
+              relationType: edgeHit.relationType,
+              declaredBySlug: edgeHit.declaredBySlug,
+            }
+          : null;
+        hoveredEdgeRef.current = payload;
+        onHoverEdge(payload, payload ? { x: e.clientX, y: e.clientY } : null);
+      }
+      // 커서 어포던스 — "잡을 수 있으면 읽을 수 있다".
+      e.currentTarget.style.cursor = edgeHit !== null || hitNodeId !== null ? "pointer" : "";
+    }
+
     if (hitNodeId === hoveredNodeIdRef.current) return;
     hoveredNodeIdRef.current = hitNodeId;
     if (hitNodeId) {
@@ -441,44 +513,29 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     // 후보는 양 끝점이 현재 tier 에서 히트 가능한 엣지로 제한 — 안 보이는
     // 엣지가 클릭되는 계약 위반 방지. 실패 시에만 기존 deselect.
     if (commitClick && commitClick.nodeId === null && clickPoint && onSelectEdge) {
-      const world = worldRef.current;
-      if (world) {
-        const { width, height } = viewportRef.current;
-        const overviewEntryScale = overviewScaleRef.current * tokens.overviewEntryRatio;
-        const zoomRatio = computeZoomRatio(cameraRef.current.scale.value, overviewEntryScale);
-        const focusedNodeId = focusedSlugRef.current;
-        const neighborsOfFocused = focusedNodeId ? world.neighborMap.get(focusedNodeId) : undefined;
-        const hittable = new Set(
-          world.nodes
-            .filter((n) => isNodeHittable(n, zoomRatio, focusedNodeId, neighborsOfFocused, DEFAULT_TIER_REVEAL))
-            .map((n) => n.id),
-        );
-        const candidates: EdgeHitCandidate[] = [];
-        for (const edge of world.edges) {
-          if (!hittable.has(edge.sourceId) || !hittable.has(edge.targetId)) continue;
-          candidates.push({
-            edge,
-            a: worldToScreen(cameraRef.current, width, height, edge.ax, edge.ay),
-            b: worldToScreen(cameraRef.current, width, height, edge.bx, edge.by),
-            control: worldToScreen(cameraRef.current, width, height, edge.controlX, edge.controlY),
-          });
-        }
-        const hit = hitTestEdges(candidates, clickPoint.x, clickPoint.y, 7);
-        if (hit) {
-          onSelectEdge({
-            sourceId: hit.sourceId,
-            targetId: hit.targetId,
-            relationType: hit.relationType,
-            declaredBySlug: hit.declaredBySlug,
-          });
-          return;
-        }
+      const hit = hitTestEdges(buildEdgeCandidates(), clickPoint.x, clickPoint.y, 7);
+      if (hit) {
+        onSelectEdge({
+          sourceId: hit.sourceId,
+          targetId: hit.targetId,
+          relationType: hit.relationType,
+          declaredBySlug: hit.declaredBySlug,
+        });
+        return;
       }
     }
     if (action.type === "deselect") onPaneClick?.();
   };
 
+  const clearEdgeHover = () => {
+    if (hoveredEdgeRef && hoveredEdgeRef.current !== null) {
+      hoveredEdgeRef.current = null;
+      onHoverEdge?.(null, null);
+    }
+  };
+
   const handlePointerCancel = () => {
+    clearEdgeHover();
     const tokens = readTopologyV2TokensOrNull();
     // Abort any in-flight node pin-drag cleanly (release the pin, let it settle).
     if (nodeDragRef.current !== null) {

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -348,6 +348,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       // Active node pin-drag: move the pin 1:1 in world space, keep the sim
       // warm so neighbors reflow. The camera does NOT pan (headline fix — a
       // node drag moves the NODE, not the whole viewport).
+      clearEdgeHover(); // 드래그 중 카드 잔존 방지
       const drag = nodeDragRef.current;
       if (drag && sim) {
         const pw = screenToWorld(cameraRef.current, width, height, point.x, point.y);
@@ -375,7 +376,12 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       return;
     }
 
-    if (next.phase !== "idle" || focusedSlugRef.current) return; // pressed-not-dragging, or focus owns emphasis
+    // 드래그(팬/노드 이동)는 위 블록에서 이미 return — 여기 도달은
+    // idle|pressed 뿐이다. 엣지 호버는 포커스(ego) 중에도 동작한다 —
+    // 엣지 클릭(P3b)이 포커스 중에도 되므로 호버도 같아야 한다("잡을 수
+    // 있으면 읽을 수 있다"; 사용자 실보고 "노드 클릭한 상태에선 선 호버
+    // 툴팁이 안 나온다"의 근원). 후보는 buildEdgeCandidates 가 포커스
+    // tier 히트 규칙을 이미 반영한다.
     const hitNodeId = hitVisibleNode(world, cameraRef.current, tokens, point.x, point.y);
 
     // P3c — 노드 미히트 지점의 엣지 근접 = 호버 마이크로카드. 식별이 바뀔
@@ -406,6 +412,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       e.currentTarget.style.cursor = edgeHit !== null || hitNodeId !== null ? "pointer" : "";
     }
 
+    if (next.phase !== "idle" || focusedSlugRef.current) return; // 리플은 idle+비포커스 전용 (기존 계약)
     if (hitNodeId === hoveredNodeIdRef.current) return;
     hoveredNodeIdRef.current = hitNodeId;
     if (hitNodeId) {

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -94,6 +94,11 @@ export interface UseTopologyLoopArgs {
    */
   revealToken?: number;
   onSelectEdge?: (edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null }) => void;
+  /** P3c — 엣지 호버 마이크로카드 (식별 변경 시에만 발화, null=해제). */
+  onHoverEdge?: (
+    edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
+    position: { x: number; y: number } | null,
+  ) => void;
   onSelect?: (slug: string) => void;
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
@@ -130,7 +135,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, livePhysics = false } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, livePhysics = false } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -205,6 +210,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   const lastFocusedSlugRef = useRef<string | null>(focusedSlug);
   const panelEmphasisNodeIdRef = useRef<string | null>(emphasizedNeighborSlug);
   const hoveredNodeIdRef = useRef<string | null>(null);
+  /** P3c — 호버 중 엣지 (드로우 잉크 강조 + 마이크로카드 공유 상태). */
+  const hoveredEdgeRef = useRef<{ sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null>(null);
   const emphasisRef = useRef<Map<string, number>>(new Map());
   /** C1 A2 — ego tier-reveal ramp, stepped in `stepTopologyPhysics`, consumed by `drawTopologyFrame`. */
   const egoRevealRef = useRef<Map<string, number>>(new Map());
@@ -751,6 +758,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         focusedNodeId,
         hoveredNodeId,
         emphasizedNeighborId: panelEmphasisNodeId,
+        hoveredEdge: hoveredEdgeRef.current,
         emphasisById: emphasisRef.current,
         egoRevealById: egoRevealRef.current,
         reducedMotion: reducedMotionRef.current,
@@ -794,8 +802,10 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     dragAffectedSetRef,
     dragStartPosRef,
     overviewScaleRef,
+    hoveredEdgeRef,
     onSelect,
     onSelectEdge,
+    onHoverEdge,
     onPaneClick,
     onContextMenuNode,
   });

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -127,6 +127,8 @@ export interface UseTopologyLoopArgs {
    * 가 자연 감쇠해 마지막 이완 위치에서 정지한다.
    */
   livePhysics?: boolean;
+  /** 엣지 선택 = 페어 포커스 (양끝만 표시, 선택 엣지 pale 인디고). */
+  selectedEdge?: { sourceId: string; targetId: string } | null;
 }
 
 export type UseTopologyLoopResult = TopologyPointerHandlers & {
@@ -135,7 +137,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, livePhysics = false } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, livePhysics = false, selectedEdge = null } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -212,6 +214,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   const hoveredNodeIdRef = useRef<string | null>(null);
   /** P3c — 호버 중 엣지 (드로우 잉크 강조 + 마이크로카드 공유 상태). */
   const hoveredEdgeRef = useRef<{ sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null>(null);
+  /** 엣지 선택(페어 포커스) prop 미러 — rAF 클로저용. */
+  const selectedEdgeRef = useRef<{ sourceId: string; targetId: string } | null>(selectedEdge);
   const emphasisRef = useRef<Map<string, number>>(new Map());
   /** C1 A2 — ego tier-reveal ramp, stepped in `stepTopologyPhysics`, consumed by `drawTopologyFrame`. */
   const egoRevealRef = useRef<Map<string, number>>(new Map());
@@ -255,6 +259,12 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   useEffect(() => {
     livePhysicsRef.current = livePhysics;
   }, [livePhysics]);
+
+  useEffect(() => {
+    selectedEdgeRef.current = selectedEdge;
+    // 선택 변경은 정적 상태 전이 — 유휴 스킵 중에도 한 번 다시 그린다.
+    lastActiveMsRef.current = performance.now();
+  }, [selectedEdge]);
 
   useEffect(() => {
     panelEmphasisNodeIdRef.current = emphasizedNeighborSlug;
@@ -759,6 +769,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         hoveredNodeId,
         emphasizedNeighborId: panelEmphasisNodeId,
         hoveredEdge: hoveredEdgeRef.current,
+        selectedEdge: selectedEdgeRef.current,
         emphasisById: emphasisRef.current,
         egoRevealById: egoRevealRef.current,
         reducedMotion: reducedMotionRef.current,


### PR DESCRIPTION
## Summary
소유자 요청 3건 (같은 엣지 의미 축):
- **호버 마이크로카드 (P3c 게이트 해제)**: 선 호버 즉시 평문 문장·타입·why — 커서 어포던스 + 잉크 강조 + 팝오버 상호배제
- **호버 실보고 수리**: 프레스/포커스 상태에서도 동작 (게이트 2겹 완화, 근원 주석화)
- **엣지 선택 = 페어 포커스**: 선 클릭 → 양끝만 남고 dim, 선택 선은 pale 인디고(신규 토큰) — 노드 인디고와 값으로 구분 (헌장 "선택 색 사다리" 명문화)

## Test plan
- 라이브 픽셀 실증 3종 (호버 카드·프레스/포커스 호버·dim 980→614+복귀)
- vitest topology-map-v2 395 + home + focus-state 신규 3 + 카드 2 · tsc · eslint 0 · i18n · 토큰 픽스처 계약

🤖 Generated with [Claude Code](https://claude.com/claude-code)