### PR TITLE
fix: 엣지 선택 — 바닥 클릭 해제 + pale 인디고 톤다운 (소유자 실보고)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1244,7 +1244,7 @@
     /* B3 잔여 — dust 시차 깊이 범위 (그리드 1.0 대비 느린 흐름). */
     /* 엣지 선택(페어 포커스) — 인디고 pale 사다리: 노드 선택(#5e6ad2)과
        같은 계열, 밝은 값으로 구분 (채색 시스템 증식 없음). */
-    --topology-v2-edge-selected: rgba(200, 210, 255, 0.95);
+    --topology-v2-edge-selected: rgba(200, 210, 255, 0.66);
     --topology-v2-dust-parallax-min: 0.15;
     --topology-v2-dust-parallax-max: 0.45;
     --topology-v2-edge-depends: #4c4c63;

--- a/src/widgets/topology-map-v2/render/traces.ts
+++ b/src/widgets/topology-map-v2/render/traces.ts
@@ -168,7 +168,9 @@ export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, token
   if (state.selected === true) {
     // 페어 포커스의 주인공 — pale 인디고, 최상 잉크.
     stroke = tokens.edgeSelected ?? tokens.indigoBright;
-    width = (isDepends ? 2.2 : 2.0) - farT * 0.5;
+    // 톤다운 (소유자: "색이 너무 진하다") — dim 장면 위에서 잉크가 아니라
+    // 빛으로 읽히게 얇고 옅게. 생동감은 depends 코멧 테일이 계속 탄다.
+    width = (isDepends ? 1.7 : 1.5) - farT * 0.4;
   } else if (egoState === "dim") {
     stroke = tokens.edgeDim;
     width = 1;

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -41,7 +41,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-edge-contains": "#28282e",
   "--topology-v2-edge-depends": "#39394a",
   "--topology-v2-edge-dim": "#1e1e22",
-  "--topology-v2-edge-selected": "rgba(200, 210, 255, 0.95)",
+  "--topology-v2-edge-selected": "rgba(200, 210, 255, 0.66)",
   "--topology-v2-hull-stroke": "#3a3a42",
   "--topology-v2-label-project": "#d4b478",
   "--topology-v2-label-domain": "#b8b8c1",

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -122,6 +122,8 @@ export interface PointerHandlerRefs {
    * 미리보기 — 사용 신호(소유자 요청) 확인 후 게이트 해제.
    */
   hoveredEdgeRef?: Ref<{ sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null>;
+  /** 엣지 선택(페어 포커스) 상태 미러 — 바닥 클릭 해제 판정에 필요. */
+  selectedEdgeRef?: Ref<{ sourceId: string; targetId: string } | null>;
   onHoverEdge?: (
     edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
     position: { x: number; y: number } | null,
@@ -188,6 +190,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     dragStartPosRef,
     overviewScaleRef,
     hoveredEdgeRef,
+    selectedEdgeRef,
     onSelect,
     onSelectEdge,
     onHoverEdge,
@@ -531,7 +534,12 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
         return;
       }
     }
-    if (action.type === "deselect") onPaneClick?.();
+    // 엣지만 선택된 상태(노드 포커스 없음)의 바닥 클릭도 해제다 —
+    // resolveClickAction 은 노드 포커스만 보므로 여기서 보강 (사용자
+    // 실보고: "선 클릭했다가 바닥 클릭하면 원래대로 돌아와야").
+    const emptyGroundWithEdgeSelected =
+      commitClick !== null && commitClick.nodeId === null && (selectedEdgeRef?.current ?? null) !== null;
+    if (action.type === "deselect" || emptyGroundWithEdgeSelected) onPaneClick?.();
   };
 
   const clearEdgeHover = () => {

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -814,6 +814,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     dragStartPosRef,
     overviewScaleRef,
     hoveredEdgeRef,
+    selectedEdgeRef,
     onSelect,
     onSelectEdge,
     onHoverEdge,


### PR DESCRIPTION
- 바닥 클릭 미해제: resolveClickAction 이 노드 포커스만 보고 deselect 를
  판정 — 엣지만 선택된 상태의 빈 공간 클릭이 none 으로 떨어졌다.
  selectedEdgeRef 를 핸들러에 미러해 해제 조건 보강 (라이브 실증 ✓)
- "색이 너무 진하다": 선택 스트로크 0.95→0.66 알파, 굵기 2.2/2.0→1.7/1.5
  — dim 장면 위에서 잉크가 아니라 빛으로. 생동감은 depends 코멧 테일 유지
검증: topology-map-v2 395 pass · tsc · 라이브(선택→바닥 클릭 복귀) ✓
