### PR TITLE
feat: GitHub Pages 서브패스 배포 (트래픽 하드컷 없는 무료 데모 경로)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,66 @@
+# GitHub Pages 데모 배포 — 정적 export 를 /ontology-atlas 서브패스로 서빙.
+# Firebase Hosting(deploy-hosting.yml)과 병행: Pages 는 일 단위 하드컷이 없어
+# 트래픽 스파이크에도 데모가 죽지 않는 기본 경로다.
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build static export with base path
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /ontology-atlas
+          NEXT_PUBLIC_OATLAS_FIRST_RELEASE_PENDING: '0'
+      - name: Adapt static PWA manifest to base path
+        run: |
+          test -f out/manifest.webmanifest
+          node -e '
+            const fs = require("fs");
+            const p = "out/manifest.webmanifest";
+            const m = JSON.parse(fs.readFileSync(p, "utf8"));
+            const bp = "/ontology-atlas";
+            for (const k of ["id", "scope", "start_url"]) {
+              if (typeof m[k] === "string" && m[k].startsWith("/") && !m[k].startsWith(bp)) m[k] = bp + (m[k] === "/" ? "/" : m[k]);
+            }
+            for (const icon of m.icons ?? []) {
+              if (icon.src?.startsWith("/") && !icon.src.startsWith(bp)) icon.src = bp + icon.src;
+            }
+            fs.writeFileSync(p, JSON.stringify(m, null, 2));
+          '
+      - name: Disable Jekyll (serve _next/*)
+        run: touch out/.nojekyll
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
 import { SITE_URL } from '@/shared/config';
+import { withBasePath } from '@/shared/lib/base-path';
 import './globals.css';
 
 const inter = Inter({
@@ -18,7 +19,8 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  manifest: '/manifest.webmanifest',
+  // metadata 필드는 next.config basePath 자동 프리픽스 대상이 아니다.
+  manifest: withBasePath('/manifest.webmanifest'),
   // Title template is owned by app/[locale]/layout.tsx so the locale-aware
   // string ends up in <title>. We only set a fallback default here for the
   // root `/` redirect page (which the user sees for ~50ms before redirect).

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,9 +13,14 @@ const allowedDevOrigins = [
     .filter(Boolean) ?? []),
 ];
 
+// GitHub Pages 프로젝트 사이트(`/ontology-atlas` 서브패스) 배포용 —
+// 루트 배포(Firebase, dev)에서는 미설정. src/shared/lib/base-path.ts 와 짝.
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;
+
 const nextConfig: NextConfig = {
   allowedDevOrigins,
   output: 'export',
+  basePath,
   images: {
     unoptimized: true,
   },

--- a/src/shared/lib/base-path.test.ts
+++ b/src/shared/lib/base-path.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { withBasePath } from './base-path';
+
+// NEXT_PUBLIC_BASE_PATH 는 빌드 타임 인라인이라 vitest 에서는 빈 문자열 —
+// 루트 배포 계약(무프리픽스 pass-through)을 고정한다.
+describe('withBasePath (root deploy)', () => {
+  it('passes absolute paths through unchanged when no base path is set', () => {
+    expect(withBasePath('/logo.png')).toBe('/logo.png');
+    expect(withBasePath('/en/')).toBe('/en/');
+  });
+
+  it('passes relative paths through unchanged', () => {
+    expect(withBasePath('docs-vault/a.md')).toBe('docs-vault/a.md');
+  });
+});

--- a/src/shared/lib/base-path.ts
+++ b/src/shared/lib/base-path.ts
@@ -1,0 +1,17 @@
+/**
+ * 정적 export 를 서브패스(예: GitHub Pages 프로젝트 사이트 `/ontology-atlas`)에
+ * 배포할 때의 base path. 빌드 타임에 `NEXT_PUBLIC_BASE_PATH` 로 주입되며,
+ * 루트 배포(Firebase Hosting, 로컬 dev)에서는 빈 문자열이다.
+ *
+ * next/link · next/router 는 next.config 의 `basePath` 가 자동 처리하지만,
+ * raw `<a href>` · next/image `src` · metadata 링크 · 수동 fetch URL 은
+ * 자동 프리픽스가 없어 이 헬퍼를 거쳐야 한다.
+ */
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+export function withBasePath(path: string): string {
+  if (!BASE_PATH) return path;
+  if (!path.startsWith('/')) return path;
+  if (path === BASE_PATH || path.startsWith(`${BASE_PATH}/`)) return path;
+  return `${BASE_PATH}${path}`;
+}

--- a/src/shared/ui/locale-redirect.tsx
+++ b/src/shared/ui/locale-redirect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { withBasePath } from '../lib/base-path';
 import { isRestorableRoute, ROUTE_MEMORY_KEY } from './route-memory';
 
 const STORAGE_KEY = 'ontology-atlas:locale';
@@ -31,7 +32,7 @@ function restoreTarget(locale: Supported): string {
 
 export function LocaleRedirect() {
   useEffect(() => {
-    window.location.replace(restoreTarget(detect()));
+    window.location.replace(withBasePath(restoreTarget(detect())));
   }, []);
 
   return (
@@ -60,12 +61,12 @@ export function LocaleRedirect() {
       >
         Opening Ontology Atlas…
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- root redirect fallback must survive failed hydration */}
-        <a style={{ color: 'var(--color-indigo-accent)' }} href="/en/">
+        <a style={{ color: 'var(--color-indigo-accent)' }} href={withBasePath('/en/')}>
           English
         </a>
         <span aria-hidden="true">·</span>
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- root redirect fallback must survive failed hydration */}
-        <a style={{ color: 'var(--color-indigo-accent)' }} href="/ko/">
+        <a style={{ color: 'var(--color-indigo-accent)' }} href={withBasePath('/ko/')}>
           한국어
         </a>
         <noscript>

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { withBasePath } from "@/shared/lib/base-path";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
@@ -1712,7 +1713,7 @@ export function HomePage() {
             <div className="pointer-events-none absolute left-4 top-[22px] z-10 -translate-y-1/2 md:hidden">
               <div className="flex items-center gap-2">
                 <Image
-                  src="/logo.png"
+                  src={withBasePath('/logo.png')}
                   alt=""
                   aria-hidden="true"
                   width={26}

--- a/src/widgets/docs-vault/lib/server-doc-content.ts
+++ b/src/widgets/docs-vault/lib/server-doc-content.ts
@@ -1,3 +1,5 @@
+import { BASE_PATH } from '@/shared/lib/base-path';
+
 function encodeSlugPath(slug: string): string {
   return slug
     .split('/')
@@ -11,7 +13,11 @@ export function buildDocsVaultAssetCandidates(
   locationHref?: string,
 ): string[] {
   const assetPath = `docs-vault/${encodeSlugPath(slug)}.md`;
-  const candidates = [`/${assetPath}`];
+  // 서브패스 배포(GitHub Pages)에서는 base path 후보를 1순위로 — 루트 배포에서는
+  // BASE_PATH 가 빈 문자열이라 기존 후보 순서가 그대로 유지된다.
+  const candidates = BASE_PATH
+    ? [`${BASE_PATH}/${assetPath}`, `/${assetPath}`]
+    : [`/${assetPath}`];
 
   if (locationHref) {
     try {


### PR DESCRIPTION
## Summary
- Firebase Spark 하루 360MB 하드컷 대비책: GitHub Pages 병행 배포 (월 100GB 소프트 리밋 — 월 1만 방문 ≈ 16GB 무료 커버).
- `NEXT_PUBLIC_BASE_PATH=/ontology-atlas` 환경변수로 basePath 주입. next/link·router 는 자동, 자동이 아닌 4곳만 `withBasePath` 헬퍼로 보정 (raw locale 앵커, HomePage 로고 next/image, metadata manifest 링크, docs-vault md fetch 1순위 후보).
- `.github/workflows/deploy-pages.yml`: main push + dispatch 시 basePath 빌드 → PWA manifest 후처리 → `.nojekyll` → Pages 배포.
- 루트 배포(Firebase·dev)는 BASE_PATH 빈 문자열 → 동작 무변경.

## Test plan
- `pnpm exec tsc --noEmit` ✅ · base-path/server-doc-content 유닛 6 passed ✅ · ESLint 0 ✅
- 로컬 서브패스 스모크: basePath 빌드 → `:3907/ontology-atlas/en/` 정적 서빙 → 캔버스 렌더 OK, 실패 리소스 0 (헤드리스 실측) ✅