### PR TITLE
fix: 인사이트 관계 타입 헤더-분포바 간격 보정

### DIFF
--- a/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
@@ -78,7 +78,7 @@ export function RelationsTab({
         <CardHead label={labels.relationTypesTitle} gcap="relation breakdown" count={totalEdges} />
         <div
           aria-hidden
-          className="mt-2 flex h-2 w-full overflow-hidden rounded-full border border-[color:var(--color-divider)]"
+          className="mt-4 flex h-2 w-full overflow-hidden rounded-full border border-[color:var(--color-divider)]"
         >
           {edgeTypeRows.map((row) => {
             const share = totalEdges > 0 ? row.count / totalEdges : 0;
@@ -86,7 +86,7 @@ export function RelationsTab({
             return <span key={row.type} style={{ flexGrow: share, backgroundColor: relationTypeIndigo(row.type) }} />;
           })}
         </div>
-        <div className="mt-1 flex flex-col">
+        <div className="mt-2.5 flex flex-col">
           {edgeTypeRows.map((row) => {
             const width = edgeMax > 0 ? Math.max(2, Math.round((row.count / edgeMax) * 100)) : 0;
             const pct = totalEdges > 0 ? Math.round((row.count / totalEdges) * 100) : 0;


### PR DESCRIPTION
## Summary
- 소유자 스크린샷 리포트: "관계 타입 위에 박스가 붙어있다, 간격도 완벽해야" — 분포 바가 헤더에 8px 로 밀착돼 있던 것을 mt-4/mt-2.5 로 보정.

## Test plan
- 스타일 2클래스 변경 — :3107 핫리로드 스크린샷으로 간격 확인 완료.