### PR TITLE
fix: 토폴로지 미배치 노드 (0,0) 적층 블롭 해소

### DIFF
--- a/src/widgets/topology-map-v2/model/layout.test.ts
+++ b/src/widgets/topology-map-v2/model/layout.test.ts
@@ -146,3 +146,75 @@ describe("computeConcentricLayout — deterministic de-pileup", () => {
     expect(relaxedAgain).toEqual(relaxed);
   });
 });
+
+describe("computeConcentricLayout — 비표준 계보 / 고아 (2026-07 블롭 회귀)", () => {
+  // 도메인이 element 를 직접 담는 vault(capability 경유 없음). 종전에는 이런
+  // 노드가 아예 배치되지 않고 전원 (0,0) 적층 → 라이브 물리가 허브 쪽으로
+  // 끌어간 자리에서 라벨까지 겹치는 "블롭"이 됐다 (소유자 실보고).
+  const DOMAIN_DIRECT: readonly LayoutGraphNode[] = [
+    { id: "p", kind: "project", parentId: null },
+    { id: "d", kind: "domain", parentId: "p" },
+    { id: "el-1", kind: "element", parentId: "d" },
+    { id: "el-2", kind: "element", parentId: "d" },
+    { id: "el-3", kind: "element", parentId: "d" },
+  ];
+
+  it("도메인 직속 element 를 (0,0) 적층 없이 도메인 주변에 부채꼴 배치한다", () => {
+    const points = computeConcentricLayout(DOMAIN_DIRECT, RINGS);
+    const d = byId(points, "d");
+    for (const id of ["el-1", "el-2", "el-3"]) {
+      const p = byId(points, id);
+      expect(Math.hypot(p.x, p.y)).toBeGreaterThan(1); // 원점 적층 금지
+      // fan 3개 ≤ 밀도 임계 → 정확히 element 링 반지름에서 도메인을 두른다.
+      expect(Math.hypot(p.x - d.x, p.y - d.y)).toBeCloseTo(RINGS.element, 4);
+    }
+    // 서로 겹치지 않는다.
+    const [a, b, c] = ["el-1", "el-2", "el-3"].map((id) => byId(points, id));
+    expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThan(1);
+    expect(Math.hypot(b.x - c.x, b.y - c.y)).toBeGreaterThan(1);
+  });
+
+  it("element ⊃ element 체인의 자식도 배치된 부모 주변에 놓인다", () => {
+    const chain: readonly LayoutGraphNode[] = [
+      { id: "p", kind: "project", parentId: null },
+      { id: "d", kind: "domain", parentId: "p" },
+      { id: "c", kind: "capability", parentId: "d" },
+      { id: "el-parent", kind: "element", parentId: "c" },
+      { id: "el-child", kind: "element", parentId: "el-parent" },
+    ];
+    const points = computeConcentricLayout(chain, RINGS);
+    const parent = byId(points, "el-parent");
+    const child = byId(points, "el-child");
+    expect(Math.hypot(child.x, child.y)).toBeGreaterThan(1);
+    // 단일 자식 + relax 무충돌 → 정확히 element 링 반지름.
+    expect(Math.hypot(child.x - parent.x, child.y - parent.y)).toBeCloseTo(RINGS.element, 4);
+  });
+
+  it("containment 밖 고아 노드는 도메인 링 바깥 나선에 서로 떨어져 배치된다", () => {
+    const withOrphans: readonly LayoutGraphNode[] = [
+      { id: "p", kind: "project", parentId: null },
+      { id: "d", kind: "domain", parentId: "p" },
+      { id: "orphan-1", kind: "element", parentId: null },
+      { id: "orphan-2", kind: "element", parentId: "ghost-missing" },
+      { id: "orphan-3", kind: "element", parentId: null },
+    ];
+    const points = computeConcentricLayout(withOrphans, RINGS);
+    const orphans = ["orphan-1", "orphan-2", "orphan-3"].map((id) => byId(points, id));
+    for (const o of orphans) {
+      expect(Math.hypot(o.x, o.y)).toBeGreaterThanOrEqual(RINGS.domain + RINGS.capability - 1);
+    }
+    expect(Math.hypot(orphans[0].x - orphans[1].x, orphans[0].y - orphans[1].y)).toBeGreaterThan(1);
+    expect(Math.hypot(orphans[1].x - orphans[2].x, orphans[1].y - orphans[2].y)).toBeGreaterThan(1);
+  });
+
+  it("표준형 vault 출력은 종전과 동일하게 유지된다 (fan 합류 no-op 계약)", () => {
+    // FIXTURE 는 직속 element 없음 → 신규 패스 전부 no-op. 핵심 링 계약 재확인.
+    const points = computeConcentricLayout(FIXTURE, RINGS);
+    for (const capId of ["cap-a1", "cap-a2", "cap-b1"]) {
+      const cap = FIXTURE.find((n) => n.id === capId)!;
+      const capPoint = byId(points, capId);
+      const domainPoint = byId(points, cap.parentId!);
+      expect(Math.hypot(capPoint.x - domainPoint.x, capPoint.y - domainPoint.y)).toBeCloseTo(RINGS.capability, 4);
+    }
+  });
+});

--- a/src/widgets/topology-map-v2/model/layout.ts
+++ b/src/widgets/topology-map-v2/model/layout.ts
@@ -132,17 +132,25 @@ export function computeConcentricLayout(
     const domainPoint = placed.get(domain.id);
     if (!domainPoint) return;
     const caps = nodes.filter((n) => n.kind === "capability" && n.parentId === domain.id);
+    // 도메인이 element 를 직접 담는 vault(capability 경유 없음)도 실존한다 —
+    // 이들을 빼먹으면 (0,0) 적층 후 라이브 물리가 허브 쪽으로 끌어가 "블롭"
+    // 결함이 된다 (2026-07 소유자 실보고). capability 팬과 한 부채꼴로 합쳐
+    // 배치하되, 직접 element 가 없으면 기존 출력과 바이트 동일하다.
+    const directElements = nodes.filter((n) => n.kind === "element" && n.parentId === domain.id);
+    const fan = [...caps, ...directElements];
     // High-child-count de-pileup: push the ring out and widen the arc
     // proportionally so a dense fan starts spread apart (small fans keep the
     // exact base ring — `layout.test.ts`).
-    const capR = rings.capability * Math.max(1, caps.length / CAP_DENSITY_THRESHOLD);
-    const spread = Math.min(CAP_SPREAD_MAX, 0.32 + caps.length * 0.22);
-    caps.forEach((cap, i) => {
-      const t = caps.length === 1 ? 0 : i / (caps.length - 1) - 0.5;
+    const capR = rings.capability * Math.max(1, fan.length / CAP_DENSITY_THRESHOLD);
+    const elR = rings.element * Math.max(1, fan.length / ELEMENT_DENSITY_THRESHOLD);
+    const spread = Math.min(CAP_SPREAD_MAX, 0.32 + fan.length * 0.22);
+    fan.forEach((child, i) => {
+      const t = fan.length === 1 ? 0 : i / (fan.length - 1) - 0.5;
       const angle = domainPoint.angle + t * spread;
-      placed.set(cap.id, {
-        x: domainPoint.x + Math.cos(angle) * capR,
-        y: domainPoint.y + Math.sin(angle) * capR,
+      const r = child.kind === "capability" ? capR : elR;
+      placed.set(child.id, {
+        x: domainPoint.x + Math.cos(angle) * r,
+        y: domainPoint.y + Math.sin(angle) * r,
         angle,
       });
     });
@@ -167,11 +175,80 @@ export function computeConcentricLayout(
     });
   });
 
+  placeRemainingByParentChain(nodes, rings, placed);
+  placeOrphans(nodes, rings, placed);
+
   relaxCollisions(nodes, placed, options);
 
   return nodes.map((n) => {
     const point = placed.get(n.id);
     return { id: n.id, x: point?.x ?? 0, y: point?.y ?? 0 };
+  });
+}
+
+/**
+ * 잔여 배치 1 — 부모는 배치됐지만 위 표준 팬(project→domain→capability→element)
+ * 이 다루지 않는 계보(element ⊃ element, project 직속 element, capability ⊃
+ * capability 등)를 부모 기준 부채꼴로 배치한다. 표준형 vault 에서는 아무것도
+ * 남지 않아 no-op — 기존 픽스처 좌표가 바이트 동일하게 유지된다.
+ */
+function placeRemainingByParentChain(
+  nodes: readonly LayoutGraphNode[],
+  rings: LayoutRings,
+  placed: Map<string, PlacedPoint>,
+): void {
+  // 깊은 체인도 수렴하도록 진행이 있는 동안 반복 (입력 순서 고정 → 결정론).
+  for (let pass = 0; pass < nodes.length; pass += 1) {
+    const pending = nodes.filter((n) => !placed.has(n.id) && n.parentId !== null && placed.has(n.parentId));
+    if (pending.length === 0) return;
+    const byParent = new Map<string, LayoutGraphNode[]>();
+    for (const n of pending) {
+      const list = byParent.get(n.parentId as string) ?? [];
+      list.push(n);
+      byParent.set(n.parentId as string, list);
+    }
+    for (const [parentId, kids] of byParent) {
+      const parentPoint = placed.get(parentId);
+      if (!parentPoint) continue;
+      const r = rings.element * Math.max(1, kids.length / ELEMENT_DENSITY_THRESHOLD);
+      const spread = Math.min(ELEMENT_SPREAD_MAX, 0.26 + kids.length * 0.26);
+      kids.forEach((kid, i) => {
+        const t = kids.length === 1 ? 0 : i / (kids.length - 1) - 0.5;
+        const angle = parentPoint.angle + t * spread;
+        placed.set(kid.id, {
+          x: parentPoint.x + Math.cos(angle) * r,
+          y: parentPoint.y + Math.sin(angle) * r,
+          angle,
+        });
+      });
+    }
+  }
+}
+
+/** 황금각 — 고아 나선 배치의 각 간격 (phyllotaxis, 결정론). */
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+/**
+ * 잔여 배치 2 — 부모가 끝내 배치되지 않는 고아(containment 밖 노드)를
+ * 도메인 링 바깥의 황금각 나선에 얹는다. 종전에는 전원 (0,0) 적층 →
+ * 라이브 물리가 끌어간 자리에서 라벨까지 겹치는 블롭이 됐다.
+ */
+function placeOrphans(
+  nodes: readonly LayoutGraphNode[],
+  rings: LayoutRings,
+  placed: Map<string, PlacedPoint>,
+): void {
+  const orphans = nodes.filter((n) => !placed.has(n.id));
+  if (orphans.length === 0) return;
+  const baseR = rings.domain + rings.capability;
+  orphans.forEach((orphan, i) => {
+    const angle = i * GOLDEN_ANGLE;
+    const r = baseR + rings.element * 0.35 * Math.sqrt(i);
+    placed.set(orphan.id, {
+      x: Math.cos(angle) * r,
+      y: Math.sin(angle) * r,
+      angle,
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- 소유자 실보고("108개가 이상하게 뭉침")의 근본 원인: `computeConcentricLayout` 이 표준 계보만 배치 → 도메인 직속 element·비표준 체인·고아가 전원 (0,0) 적층 → 라이브 물리가 허브 쪽으로 끌어가 라벨 겹침 블롭.
- 수정: ① 도메인 직속 element 를 capability 팬에 합류 (직속 0개면 기존 좌표와 바이트 동일 — no-op 계약 테스트로 핀), ② 잔여 계보는 배치된 부모 기준 부채꼴 패스, ③ 고아는 도메인 링 바깥 황금각 나선. 모두 결정론 유지.

## Test plan
- layout.test.ts 14/14 (기존 10 + 신규 4: 직속 element 팬·element 체인·고아 나선·no-op 계약) ✅
- topology-map-v2 전체 36 files / 399 passed ✅ · `tsc --noEmit` ✅
- :3107 실화면: Onboarding & UX 영역 블롭 해소 스크린샷 확인 ✅