### PR TITLE
fix: Pages 워크플로 pnpm 셋업 corepack 패턴으로 교체

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,12 +21,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: pnpm
+          node-version: 24
+      - name: Enable Corepack pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.0 --activate
+          pnpm --version
       - run: pnpm install --frozen-lockfile
       - name: Build static export with base path
         run: pnpm build


### PR DESCRIPTION
## Summary
- deploy-pages.yml 의 pnpm/action-setup 이 "No pnpm version is specified" 로 실패 → deploy-hosting.yml 과 동일한 corepack 패턴(node 24 + pnpm@10.18.0)으로 통일.

## Test plan
- 머지 후 main push 트리거 런 green + https://wlsdks.github.io/ontology-atlas/en/ 200 확인.