### PR TITLE
chore: 공식 데모를 GitHub Pages 로 일원화 (Firebase Hosting 해제)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Open it | Link |
 |---|---|
 | **App brand** | **Ontology Atlas** (repo, CLI, MCP package, and release assets stay `ontology-atlas`) |
-| **Website / downloads** | **https://ontology-atlas.web.app** |
+| **Website / downloads** | **https://wlsdks.github.io/ontology-atlas/** |
 | **GitHub repository** | https://github.com/wlsdks/ontology-atlas |
 | **MCP docs** | [`mcp/README.md`](mcp/README.md) |
 
@@ -48,7 +48,7 @@ promotion candidates, agent readiness:
 
 ![Graph insights — do-next queue and agent readiness](docs/assets/readme/insights.png)
 
-Or skip the install entirely: the **[live demo](https://ontology-atlas.web.app)**
+Or skip the install entirely: the **[live demo](https://wlsdks.github.io/ontology-atlas/)**
 serves this exact map (read-only sample) — pick your own markdown folder and it
 becomes your data.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ---
 
+## 2026-07-22 — 공식 데모 GitHub Pages 로 이전 (Firebase Hosting 해제)
+
+- 공식 라이브 데모가 `https://wlsdks.github.io/ontology-atlas/` 로 이전.
+  `main` push 마다 `.github/workflows/deploy-pages.yml` 이 서브패스
+  (`NEXT_PUBLIC_BASE_PATH=/ontology-atlas`) 빌드로 자동 배포한다.
+- 이유: Firebase Spark 는 전송 하루 360MB 하드컷이라 트래픽이 몰리는 날
+  데모가 내려간다. GitHub Pages 는 월 100GB 소프트 리밋 — 월 1만 방문
+  (실측 1.6MB/방문) 도 무료로 견딘다.
+- `SITE_URL`(canonical/OG/sitemap 진실원) 과 README 주소를 Pages 로 교체.
+  Firebase Hosting 은 해제 — `firebase.json` 등 설정 파일은 셀프호스터용
+  레퍼런스로 유지 (`docs/DEPLOYMENT.md` 참고).
+
 ## 2026-07-22 — 인사이트 → 지도 딥링크 복귀 칩
 
 소유자 리포트: 인사이트의 허브 행/"지도" 버튼으로 지도에 진입하면 보던 인사이트

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -15,6 +15,14 @@ This produces an `out/` directory with HTML/JS/CSS only. No server runtime.
 
 Any static host works. Pick one:
 
+> **Official demo (2026-07): GitHub Pages.** The canonical live site is
+> `https://wlsdks.github.io/ontology-atlas/`, deployed automatically on every
+> `main` push by `.github/workflows/deploy-pages.yml` (subpath build via
+> `NEXT_PUBLIC_BASE_PATH=/ontology-atlas`). Firebase Hosting was disabled the
+> same round — Spark's 360 MB/day transfer hard-cap can take the demo down on
+> a busy day, while Pages' 100 GB/month soft limit cannot. The Firebase path
+> below remains valid for self-hosters.
+
 ### Firebase Hosting
 
 ```bash

--- a/src/shared/config/site.ts
+++ b/src/shared/config/site.ts
@@ -5,10 +5,11 @@
  * 이 값을 써야 검색엔진이 일관된 canonical 로 인덱싱. 자기 도메인에
  * 배포하는 OSS 사용자는 이 상수 하나만 바꾸면 전체 SEO 가 따라간다.
  *
- * default 는 공식 Firebase Hosting 배포 주소. 로컬 개발 서버에서도 canonical
+ * default 는 공식 GitHub Pages 배포 주소 (2026-07 Firebase Hosting 해제 —
+ * Spark 일 360MB 하드컷 회피, 소유자 결정). 로컬 개발 서버에서도 canonical
  * metadata 는 공개 사이트를 가리키게 유지한다.
  */
-export const SITE_URL = "https://ontology-atlas.web.app";
+export const SITE_URL = "https://wlsdks.github.io/ontology-atlas";
 
 /**
  * canonical path helper. `/project/foo/` 같은 상대 경로를 받아 절대 URL 로.


### PR DESCRIPTION
## Summary
- 소유자 결정: GitHub Pages 만 유지. README/`SITE_URL`(canonical·OG·sitemap 진실원)/DEPLOYMENT/CHANGELOG 를 `https://wlsdks.github.io/ontology-atlas/` 로 교체.
- Firebase 설정 파일·워크플로는 셀프호스터 레퍼런스로 잔존 (배포는 별도로 해제).

## Test plan
- `tsc --noEmit` ✅ · shared/config 유닛 5 passed ✅ · sitemap/robots 는 SITE_URL 자동 추종.