### PR TITLE
fix: INDEX 푸터 영어 줄바꿈 + 빌더 스트립 정렬

### DIFF
--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -1636,7 +1636,9 @@ export function OntologyEditPage() {
         {/* CommandStrip — 예전엔 헤더 1행 안에 있었다. 헤더가 시안 문법(브레드
             크럼+census / dirty / 유틸+내보내기)대로 단일 행이 되면서 컨텍스트
             액션 줄로 내려왔다 — 기능(선택 상태별 primary/secondary 액션) 무변. */}
-        <div className="mb-2 px-2">
+        {/* px-0 + mt-1.5 — 헤더 박스와 좌우 가장자리를 정확히 맞추고(구 px-2
+            는 8px 안쪽으로 들어가 삐뚤어 보임 — 소유자 실보고) 위 간격 확보. */}
+        <div className="mb-2 mt-1.5 px-0">
           <BuilderCommandStrip
             state={commandStripState}
             draftNodes={ephemeralNodes.length}

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -384,7 +384,7 @@ export function TopologyIndexPanel({
               aria-hidden="true"
               className="h-[5px] w-[5px] shrink-0 rounded-full bg-[color:var(--topology-v2-panel-power-on)]"
             />
-            <span className="text-[color:var(--topology-v2-panel-text-tertiary)]">
+            <span className="min-w-0 truncate whitespace-nowrap text-[color:var(--topology-v2-panel-text-tertiary)]">
               {labels.agentSync}
             </span>
           </Link>
@@ -400,12 +400,12 @@ export function TopologyIndexPanel({
               aria-hidden="true"
               className="h-[5px] w-[5px] shrink-0 rounded-full bg-[color:var(--topology-v2-panel-power-on)]"
             />
-            <span className="text-[color:var(--topology-v2-panel-text-tertiary)]">
+            <span className="min-w-0 truncate whitespace-nowrap text-[color:var(--topology-v2-panel-text-tertiary)]">
               {labels.agentSync}
             </span>
           </button>
         )}
-        {footerGrowthText ? <span>{footerGrowthText}</span> : null}
+        {footerGrowthText ? <span className="min-w-0 flex-1 truncate whitespace-nowrap">{footerGrowthText}</span> : null}
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           {agentHandoff ? (
             <TopologyIndexAgentHandoff


### PR DESCRIPTION
## Summary
- 소유자 스크린샷 실보고 2건: ① INDEX 푸터 "Updated with AI · +1 project this week" 영어에서 3줄 깨짐 → truncate 단일 라인, ② 빌더 커맨드 스트립이 헤더 박스보다 8px 안쪽(px-2)이라 삐뚤 + 위와 밀착 → px-0 정렬 + mt-1.5.

## Test plan
- topology-index-panel + ontology-edit: 45 files, 285 passed ✅ · tsc ✅ · ESLint 0 ✅
- /en/ 실화면: 푸터 span 전부 단일 라인(h=19) 실측 ✅