### PR TITLE
fix: 영역 전개 녹화 검수 — stale 클로저 + 카메라 콘텐츠 fit

### DIFF
--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.test.ts
@@ -96,11 +96,11 @@ describe("buildRealmRuntimeData", () => {
     expect(buildRealmRuntimeData(buildFixtureWorld(), "missing", tokens)).toBeNull();
   });
 
-  it("realmCameraTarget centers on the realm origin and clamps scale", () => {
+  it("realmCameraTarget centers on the content bbox (결계가 아니라 콘텐츠가 주인공) and clamps scale", () => {
     const data = buildRealmRuntimeData(buildFixtureWorld(), "d", tokens)!;
     const target = realmCameraTarget(data, tokens, 1000, 800);
-    expect(target.tx).toBeCloseTo(0);
-    expect(target.ty).toBeCloseTo(0);
+    expect(target.tx).toBeCloseTo((data.bounds.minX + data.bounds.maxX) / 2, 4);
+    expect(target.ty).toBeCloseTo((data.bounds.minY + data.bounds.maxY) / 2, 4);
     expect(target.tscale).toBeLessThanOrEqual(2.6);
     expect(target.tscale).toBeGreaterThanOrEqual(0.24);
   });

--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
@@ -118,12 +118,18 @@ export function buildRealmRuntimeData(
   const root = world.nodeById.get(rootId);
   const flingCenter = { x: root?.homeX ?? 0, y: root?.homeY ?? 0 };
 
-  const bounds = {
-    minX: -wardingRadius,
-    minY: -wardingRadius,
-    maxX: wardingRadius,
-    maxY: wardingRadius,
-  };
+  // 카메라 fit 은 결계(여유 포함 큰 원)가 아니라 **콘텐츠 bbox** 기준 —
+  // 결계에 맞추면 세계가 화면 중앙에 조그맣게 보인다 (녹화 프레임 검수).
+  // 결계는 화면 밖 가장자리에 걸려도 좋다: 콘텐츠가 주인공.
+  let bMinX = Infinity, bMinY = Infinity, bMaxX = -Infinity, bMaxY = -Infinity;
+  for (const t of insideTargets.values()) {
+    bMinX = Math.min(bMinX, t.x); bMaxX = Math.max(bMaxX, t.x);
+    bMinY = Math.min(bMinY, t.y); bMaxY = Math.max(bMaxY, t.y);
+  }
+  const contentMargin = 40 + maxNodeRadius;
+  const bounds = Number.isFinite(bMinX)
+    ? { minX: bMinX - contentMargin, minY: bMinY - contentMargin, maxX: bMaxX + contentMargin, maxY: bMaxY + contentMargin }
+    : { minX: -wardingRadius, minY: -wardingRadius, maxX: wardingRadius, maxY: wardingRadius };
 
   return {
     rootId,

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -1053,9 +1053,12 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 판정 로직은 순수 모델(`density-gate.ts`), 여긴 좌표 주입만.
       // 영역 전개 중엔 영역 루트를 항상 펼침 취급 — 루트 직속 자식은 그
       // 세계의 스파인이라 게이트로 접으면 영역이 텅 빈 링으로 보인다
-      // (전역 도메인 면제와 같은 논리, /?synth=2000 실증).
-      const effectiveExpanded = realmRootId
-        ? new Set([...expandedParentsRef.current, realmRootId])
+      // (전역 도메인 면제와 같은 논리, /?synth=2000 실증). prop 이 아니라
+      // ref 를 읽는다 — 프레임 클로저가 stale realmRootId 를 캡처해 버튼
+      // 클릭 진입에선 펼침이 안 먹던 결함(녹화 프레임 검수 실증).
+      const liveRealmRootId = realmDataRef.current?.rootId ?? null;
+      const effectiveExpanded = liveRealmRootId
+        ? new Set([...expandedParentsRef.current, liveRealmRootId])
         : expandedParentsRef.current;
       const clusterState = computeTopologyClusterState(world, effectiveExpanded);
 


### PR DESCRIPTION
## Summary
- 동영상 캡처 프레임 검수로 발견한 2건: ① 버튼 클릭 진입 경로에서 루트 자동 펼침 미동작 (프레임 클로저가 stale prop 캡처 — ref 로 교체) ② 카메라가 결계 원에 fit 돼 세계가 작게 보임 → 콘텐츠 bbox fit.
- Esc 해제는 실키 검증 정상 (헤드리스 녹화의 포커스 특성만 이슈).

## Test plan
- topology 503 tests green (fit 중심 계약 테스트 의도 갱신 1건) ✅ · tsc ✅ · ESLint 0 ✅
- 녹화 검증: 버튼 진입 → 34요소 세계 + 중첩 칩 → ✕ 해제 전 과정, URL round-trip 확인 ✅