### PR TITLE
fix: 영역 전개 안무 리듬 재설계 (컷 전환 → 읽히는 3페이즈)

### DIFF
--- a/src/widgets/topology-map-v2/model/realm-transition.ts
+++ b/src/widgets/topology-map-v2/model/realm-transition.ts
@@ -18,16 +18,25 @@
  * 테마 표면을 지배하지 않는다.
  */
 
-/** 전환 총 상한(ms) — 안무 전체가 이 안에서 끝난다. */
-export const REALM_ENVELOPE_MS = 600;
+/**
+ * 전환 총 상한(ms). 처음 600ms 설계는 이탈/FLIP/결계가 동시에 몰려 5fps
+ * 녹화에서 중간 프레임이 0장 — "컷 전환" 으로 읽혔다 (소유자 실보고 +
+ * 프레임 검수). 페이즈를 시간축으로 분리해 각 동작이 읽히게 늘렸다:
+ * 이탈(0–420) → FLIP(240–900, 겹침 시작) → 결계 드로잉(700–1000).
+ */
+export const REALM_ENVELOPE_MS = 1000;
 /** 영역 안 노드 FLIP duration(ms) — ease-out. */
-export const REALM_INSIDE_FLIP_MS = 300;
+export const REALM_INSIDE_FLIP_MS = 660;
+/** FLIP 시작 지연(ms) — 밖 세계가 먼저 비워지는 걸 보여준 뒤 재배치. */
+export const REALM_INSIDE_FLIP_DELAY_MS = 240;
 /** 영역 밖 노드 이탈 fling duration(ms) — ease-in 가속. */
-export const REALM_OUTSIDE_FLING_MS = 240;
+export const REALM_OUTSIDE_FLING_MS = 420;
 /** 결계 링 자기 드로잉 duration(ms). */
-export const REALM_WARDING_DRAW_MS = 200;
+export const REALM_WARDING_DRAW_MS = 300;
+/** 결계 드로잉 시작 지연(ms) — 세계가 대략 자리잡은 뒤 봉인. */
+export const REALM_WARDING_DRAW_DELAY_MS = 700;
 /** 도트 그리드 시차 낙하 rise→settle duration(ms). */
-export const REALM_DUST_SETTLE_MS = 600;
+export const REALM_DUST_SETTLE_MS = 1000;
 
 /** 이탈 노드가 중심에서 추가로 밀려나는 거리(월드 유닛) — 화면 밖으로 확실히 보내는 양. */
 export const REALM_FLING_REACH = 4200;

--- a/src/widgets/topology-map-v2/render/starfield.ts
+++ b/src/widgets/topology-map-v2/render/starfield.ts
@@ -86,6 +86,12 @@ export interface StarDustDrawState {
   originY?: number;
   farT: number;
   devicePixelRatio: number;
+  /**
+   * S4 영역 전개 순간의 방사 시차 낙하 0..1 — 각 점이 화면 중심에서 depth
+   * 비례로 바깥으로 밀리며 "우주를 통과하는" 깊이감을 만든다. 이동량은
+   * 화면의 3% 이내(헌장: 어지럽지 않게), 전환 후 0 으로 복귀(지속 금지).
+   */
+  radialParallax?: number;
 }
 
 /** Draws the static dust texture, fading in with `farT` (never fully at circuit altitude). */
@@ -98,9 +104,19 @@ export function drawStarDust(ctx: CanvasRenderingContext2D, state: StarDustDrawS
   // 느림). 뷰포트 래핑으로 커버리지 유지 — 멀리 패닝해도 먼지는 남는다.
   const w = ctx.canvas.width / devicePixelRatio;
   const h = ctx.canvas.height / devicePixelRatio;
+  const rp = state.radialParallax ?? 0;
+  const maxShift = Math.min(w, h) * 0.03;
   points.forEach((point) => {
-    const px = w > 0 ? (((point.x + ox * point.depth) % w) + w) % w : point.x;
-    const py = h > 0 ? (((point.y + oy * point.depth) % h) + h) % h : point.y;
+    let px = w > 0 ? (((point.x + ox * point.depth) % w) + w) % w : point.x;
+    let py = h > 0 ? (((point.y + oy * point.depth) % h) + h) % h : point.y;
+    if (rp > 0) {
+      const dx = px - w / 2;
+      const dy = py - h / 2;
+      const d = Math.hypot(dx, dy) || 1;
+      const shift = rp * maxShift * point.depth;
+      px += (dx / d) * shift;
+      py += (dy / d) * shift;
+    }
     ctx.beginPath();
     ctx.fillStyle = `rgba(236,236,240,${point.alpha * farT})`;
     ctx.arc(px * devicePixelRatio, py * devicePixelRatio, point.r * devicePixelRatio, 0, Math.PI * 2);

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -225,6 +225,8 @@ export interface FrameDrawParams {
   realmMemberIds: ReadonlySet<string> | null;
   /** S4 — 멤버별 깊이 기반 티어 kind 오버라이드 (영역 세계의 티어 = 재배치 깊이). */
   realmTierKinds: ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null;
+  /** S4 — 전개 순간의 도트 방사 시차 팩터 0..1 (전환 중에만 >0). */
+  realmDustParallax: number;
 }
 
 /** The full per-frame paint, in the prototype's `render()` order (§13): background -> dust -> edges (contains, depends) -> nodes (+ bright-star spikes) -> labels. */
@@ -257,6 +259,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     wardingRing,
     realmMemberIds,
     realmTierKinds,
+    realmDustParallax,
   } = params;
 
   // Where world (0,0) currently lands on screen — the blueprint grid rides
@@ -278,7 +281,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   // devicePixelRatio: 1 — ctx is already DPR-transformed once by the caller
   // (`use-topology-loop.ts`), so dust points (already in CSS-pixel space)
   // must not be scaled a second time.
-  drawStarDust(ctx, { points: dustPoints, farT, devicePixelRatio: 1, originX: gridOrigin.x, originY: gridOrigin.y });
+  drawStarDust(ctx, { points: dustPoints, farT, devicePixelRatio: 1, originX: gridOrigin.x, originY: gridOrigin.y, radialParallax: realmDustParallax });
 
   const project = (x: number, y: number) => worldToScreen(camera, viewportWidth, viewportHeight, x, y);
   const neighborsOfFocused = focusedNodeId ? world.neighborMap.get(focusedNodeId) ?? EMPTY_NEIGHBOR_SET : EMPTY_NEIGHBOR_SET;

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -33,6 +33,9 @@ import {
   REALM_INSIDE_FLIP_MS,
   REALM_OUTSIDE_FLING_MS,
   isRealmOutsideCulled,
+  REALM_INSIDE_FLIP_DELAY_MS,
+  REALM_WARDING_DRAW_DELAY_MS,
+  realmDustParallaxFactor,
   realmInsidePosition,
   realmOutsidePosition,
   realmTransitionReducer,
@@ -334,7 +337,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
    * Stable identity (refs only) so listing it in the programmatic-move effects'
    * deps never re-fires them.
    */
-  const beginCameraTween = useCallback((target: CameraTarget) => {
+  const beginCameraTween = useCallback((target: CameraTarget, durationOverrideMs?: number) => {
     if (reducedMotionRef.current) {
       cameraTweenRef.current = null;
       return;
@@ -342,7 +345,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     const cam = cameraRef.current;
     const start: CameraKeyframe = { x: cam.x.value, y: cam.y.value, scale: cam.scale.value };
     const tgt: CameraKeyframe = { x: target.tx, y: target.ty, scale: target.tscale };
-    cameraTweenRef.current = { start, target: tgt, startMs: performance.now(), durationMs: cameraTransitionDurationMs(start, tgt) };
+    cameraTweenRef.current = { start, target: tgt, startMs: performance.now(), durationMs: durationOverrideMs ?? cameraTransitionDurationMs(start, tgt) };
   }, []);
 
   useEffect(() => {
@@ -701,7 +704,9 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         dampingRef.current = tokens.cameraDampingDefault;
         cameraTargetRef.current = target;
         cameraAngularFreqRef.current = tokens.cameraSpringAngFreqTransition;
-        beginCameraTween(target);
+        // 돌리 인은 안무 전체(이탈→FLIP→결계)를 타고 간다 — 거리 비례 단기
+        // 트윈이면 카메라만 먼저 끝나 "컷" 으로 읽힌다 (녹화 검수).
+        beginCameraTween(target, 860);
       }
     } else {
       // --- 이탈: 전 노드 홈 스프링 복귀 + 카메라 overview fit ---
@@ -955,7 +960,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
                 node.y = target.y;
               } else {
                 const from = data.insideFrom.get(node.id) ?? target;
-                const p = realmInsidePosition(from, target, elapsed, flipDur);
+                const p = realmInsidePosition(from, target, elapsed - REALM_INSIDE_FLIP_DELAY_MS, flipDur);
                 node.x = p.x;
                 node.y = p.y;
               }
@@ -1105,9 +1110,13 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       let realmWarding: { centerX: number; centerY: number; radius: number; drawProgress: number } | null = null;
       let realmMemberIds: ReadonlySet<string> | null = null;
       let realmTierKinds: ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null = null;
+      let realmDustParallax = 0;
       if (realmData && (realmState.phase === "entering" || realmState.phase === "active")) {
         realmMemberIds = realmData.memberIds;
         realmTierKinds = realmData.tierKindById;
+        if (realmState.phase === "entering" && !reducedMotionRef.current) {
+          realmDustParallax = realmDustParallaxFactor(now - realmState.startMs);
+        }
         if (isRealmOutsideCulled(realmState, now)) {
           frameClusteredIds = new Set<string>([...frameClusteredIds, ...realmData.outsideIds]);
         }
@@ -1118,7 +1127,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           centerX: realmData.wardingCenter.x,
           centerY: realmData.wardingCenter.y,
           radius: realmData.wardingRadius,
-          drawProgress: realmWardingDrawProgress(now - realmState.startMs),
+          drawProgress: realmWardingDrawProgress(now - realmState.startMs - REALM_WARDING_DRAW_DELAY_MS),
         };
       }
 
@@ -1182,6 +1191,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         wardingRing: realmWarding,
         realmMemberIds,
         realmTierKinds,
+        realmDustParallax,
       });
 
       handle = requestAnimationFrame(frame);


### PR DESCRIPTION
## Summary
- 소유자 실보고("약간 이상해") 원인: 안무 전체가 ≤0.4s 에 몰려 컷 전환처럼 보임 (녹화 프레임 검수로 확정 — 5fps 에서 중간 프레임 0장).
- 재설계: 이탈(0-420ms) → FLIP(240-900ms 겹침) → 결계 드로잉(700-1000ms), 카메라 돌리 860ms 동기. 미배선이던 배경 도트 방사 시차 낙하 연결 (이동량 화면 3% 이내, 전환 중에만).
- 재녹화 프레임 검수: 옛 세계 존속 → 새 세계 조립 → 이탈 완료·정착 3페이즈가 프레임 단위로 읽힘.

## Test plan
- topology 503 tests ✅ · tsc ✅ · ESLint 0 ✅ · 녹화 왕복 URL round-trip ✅