### PR TITLE
feat: S7 영역 대장 패널 — 영역 중 좌측이 그 세계의 계기판으로

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -422,6 +422,20 @@
     }
   }
 
+  /* S7 "영역 대장" 좌측 패널 크로스페이드 — 전역 INDEX ↔ 영역 대장 전환 시
+     들어오는 표면의 짧은 페이드-인(<200ms). 두 표면이 같은 박스를 차지하므로
+     페이드-인이 크로스페이드로 읽힌다. prefers-reduced-motion 은 아래 base
+     레이어의 전역 규칙(animation-duration 0.01ms)이 자동 무력화 → 즉시 교체. */
+  @keyframes panelCrossfadeIn {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  }
+
   /*
    * Tailwind v4 @theme 가 alpha rgba 토큰을 :root 에 emit 하지 않는 동작이 있어
    * border-[color:var(--color-divider)] 같은 arbitrary value 가 변수를 resolve

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,23 @@
   setState → 페이지 전체 재렌더) 방출을 미루고 정착 후 한 번만 방출. 전환 프레임에
   섞이던 tier-crossing 재렌더 차단(코너 tier 읽기는 정착 시 갱신).
 
+## 2026-07-22 — 지도 S7 "영역 대장(Realm Ledger)": 영역 전개 중 좌측 패널 변신
+
+영역 전개(`?realm=slug`) 중 좌측 패널(첫 실행 카드 + 전역 INDEX)이 전역 콘텐츠를
+그대로 보여줘 몰입이 깨지던 것을, **영역 전용 패널**로 변신시켰다 (fable 설계).
+
+- **전역 콘텐츠 숨김** — 영역 활성 시 첫 실행/샘플 카드, 전역 census, 전역 INDEX
+  트리, "AI가 함께 갱신 중" 푸터가 전부 숨고 영역 대장으로 크로스페이드(<200ms,
+  reduced-motion 즉시)된다.
+- **영역 헤더** — 루트 kind 글리프 + 제목 + 영역 census("요소 N · 역량 N · 깊이 N",
+  containment 서브트리 파생) + "영역 해제" 버튼(상단 칩과 같은 핸들러 2차 경로).
+- **영역 트리** — 루트 서브트리만 깊이 들여쓰기로. 행 클릭 = 지도 포커스, 개념 검색도
+  영역 스코프. 기존 `TopologyIndexTreeRow` · `filterTreeByQuery` 재사용.
+- **결계 관계** — 영역 밖으로 나가는 관계(경계 엣지)를 "바깥과 닿은 관계 N" 요약 +
+  상위 몇 개 나열. 각 행 "이 영역으로 이동"은 밖 노드의 도메인급 상위로 realm 을
+  교체(realm-to-realm 점프). census/경계 파생은 `views/home/lib/realm-ledger.ts`
+  순수 함수 + 테스트. 새 hue 없이 기존 패널 토큰만.
+
 ## 2026-07-22 — 빌더 2라운드: 수치 중복 제거 · 도구 내부어 정리 · elevation 토큰 · 미명명 드래프트 누적 방지
 
 `/ontology/edit` Guardian 감사 Medium 4건 (감사 증거 `.qa-scratch/builder-audit-2026-07/`).

--- a/messages/en.json
+++ b/messages/en.json
@@ -2369,7 +2369,17 @@
       "enterAction": "Expand realm",
       "enterTooltip": "Expand just this node’s realm",
       "chipPrefix": "Realm",
-      "chipClear": "Exit realm"
+      "chipClear": "Exit realm",
+      "ledger": {
+        "depthShort": "depth",
+        "searchPlaceholder": "Search this realm",
+        "exit": "Exit realm",
+        "boundaryHeading": "Reaches outside · {count}",
+        "boundaryToggleAria": "Expand or collapse the boundary-relation list",
+        "boundaryJump": "Go to this realm",
+        "boundaryJumpAria": "Jump to the realm this outside node belongs to",
+        "boundaryEmpty": "No relations reach outside"
+      }
     }
   },
   "fullDetailA1": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2369,7 +2369,17 @@
       "enterAction": "영역 전개",
       "enterTooltip": "이 노드의 영역만 펼쳐요",
       "chipPrefix": "영역",
-      "chipClear": "영역 나가기"
+      "chipClear": "영역 나가기",
+      "ledger": {
+        "depthShort": "깊이",
+        "searchPlaceholder": "이 영역에서 검색",
+        "exit": "영역 해제",
+        "boundaryHeading": "바깥과 닿은 관계 {count}",
+        "boundaryToggleAria": "결계 관계 목록 펼치기 · 접기",
+        "boundaryJump": "이 영역으로 이동",
+        "boundaryJumpAria": "이 밖 노드가 속한 영역으로 이동",
+        "boundaryEmpty": "바깥과 닿은 관계가 없어요"
+      }
     }
   },
   "fullDetailA1": {

--- a/src/views/home/lib/realm-ledger.test.ts
+++ b/src/views/home/lib/realm-ledger.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import { buildOntologyTree } from "@/shared/lib/ontology-tree";
+import {
+  collectRealmMemberIds,
+  computeRealmBoundary,
+  computeRealmCensus,
+  findRealmSubtree,
+} from "./realm-ledger";
+
+/**
+ * S7 "영역 대장" 파생 테스트. 소형 온톨로지:
+ *   project P ─contains→ domain D1 ─contains→ cap C1 ─contains→ elem E1
+ *                     └─contains→ cap C2
+ *   project P ─contains→ domain D2 ─contains→ cap C3
+ *   경계(lateral): C1 ─depends_on→ C3   (D1 영역 밖 D2 로 나감)
+ *                  E1 ─uses→ E9 (그래프 밖 도메인 없는 element)
+ *   구조 엣지(contains)는 경계에서 제외되어야 한다.
+ */
+const node = (id: string, kind: string, title = id): KnowledgeGraphNode => ({
+  id,
+  title,
+  kind,
+  projectIds: [],
+  evidenceIds: [],
+  lastApprovedAt: new Date(0),
+  lastApprovedBy: "test",
+});
+
+const edge = (from: string, to: string, type: string): KnowledgeGraphEdge => ({
+  id: `${from}-${type}-${to}`,
+  from,
+  to,
+  type,
+  projectIds: [],
+  evidenceIds: [],
+  lastApprovedAt: new Date(0),
+  lastApprovedBy: "test",
+});
+
+const nodes: KnowledgeGraphNode[] = [
+  node("P", "project"),
+  node("D1", "domain"),
+  node("D2", "domain"),
+  node("C1", "capability"),
+  node("C2", "capability"),
+  node("C3", "capability"),
+  node("E1", "element"),
+  node("E9", "element"),
+];
+const edges: KnowledgeGraphEdge[] = [
+  edge("P", "D1", "contains"),
+  edge("P", "D2", "contains"),
+  edge("D1", "C1", "contains"),
+  edge("D1", "C2", "contains"),
+  edge("C1", "E1", "contains"),
+  edge("D2", "C3", "contains"),
+  edge("C1", "C3", "depends_on"),
+  edge("E1", "E9", "uses"),
+];
+
+const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
+const roots = buildOntologyTree(nodes, edges).roots;
+
+describe("findRealmSubtree", () => {
+  it("locates a nested (non-root) node's subtree", () => {
+    const subtree = findRealmSubtree(roots, "D1");
+    expect(subtree?.node.id).toBe("D1");
+    // D1 has C1, C2 (and C1 has E1) — the subtree carries its descendants.
+    expect(subtree?.children.map((c) => c.node.id).sort()).toEqual(["C1", "C2"]);
+  });
+
+  it("returns null for an unknown slug", () => {
+    expect(findRealmSubtree(roots, "nope")).toBeNull();
+  });
+});
+
+describe("computeRealmCensus", () => {
+  it("counts descendants by kind and reports the deepest relative depth", () => {
+    const subtree = findRealmSubtree(roots, "D1")!;
+    const census = computeRealmCensus(subtree);
+    // C1, C2 (capabilities) + E1 (element). D1 root itself not counted.
+    expect(census.capabilityCount).toBe(2);
+    expect(census.elementCount).toBe(1);
+    expect(census.domainCount).toBe(0);
+    expect(census.descendantCount).toBe(3);
+    // D1 → C1 → E1 = depth 2.
+    expect(census.depth).toBe(2);
+  });
+
+  it("reports zero for a leaf realm", () => {
+    const subtree = findRealmSubtree(roots, "E1")!;
+    expect(computeRealmCensus(subtree)).toEqual({
+      elementCount: 0,
+      capabilityCount: 0,
+      domainCount: 0,
+      descendantCount: 0,
+      depth: 0,
+    });
+  });
+});
+
+describe("collectRealmMemberIds", () => {
+  it("includes the root and every descendant", () => {
+    const subtree = findRealmSubtree(roots, "D1")!;
+    expect([...collectRealmMemberIds(subtree)].sort()).toEqual(["C1", "C2", "D1", "E1"]);
+  });
+});
+
+describe("computeRealmBoundary", () => {
+  it("keeps only lateral edges that cross the member boundary", () => {
+    const memberIds = collectRealmMemberIds(findRealmSubtree(roots, "D1")!);
+    const boundary = computeRealmBoundary({ edges, memberIds, nodeById });
+    // C1 -depends_on-> C3 (out to D2) and E1 -uses-> E9 (out to E9). The
+    // parent contains P->D1 is structural → excluded.
+    expect(boundary.total).toBe(2);
+    const byEdge = new Map(boundary.crossings.map((c) => [c.edgeId, c]));
+    expect(byEdge.get("C1-depends_on-C3")?.outsideId).toBe("C3");
+    // C3's nearest domain ancestor is D2 → jump target.
+    expect(byEdge.get("C1-depends_on-C3")?.jumpRealmId).toBe("D2");
+    // E9 has no domain ancestor → jump falls back to the node itself.
+    expect(byEdge.get("E1-uses-E9")?.jumpRealmId).toBe("E9");
+  });
+
+  it("excludes structural containment edges", () => {
+    const memberIds = collectRealmMemberIds(findRealmSubtree(roots, "D1")!);
+    const boundary = computeRealmBoundary({ edges, memberIds, nodeById });
+    expect(boundary.crossings.every((c) => c.relationType !== "contains")).toBe(true);
+  });
+
+  it("returns nothing when the realm has no outward relations", () => {
+    const memberIds = collectRealmMemberIds(findRealmSubtree(roots, "C2")!);
+    const boundary = computeRealmBoundary({ edges, memberIds, nodeById });
+    expect(boundary.total).toBe(0);
+  });
+
+  it("is deterministic in ordering", () => {
+    const memberIds = collectRealmMemberIds(findRealmSubtree(roots, "D1")!);
+    const a = computeRealmBoundary({ edges, memberIds, nodeById });
+    const b = computeRealmBoundary({ edges: [...edges].reverse(), memberIds, nodeById });
+    expect(a.crossings.map((c) => c.edgeId)).toEqual(b.crossings.map((c) => c.edgeId));
+  });
+});

--- a/src/views/home/lib/realm-ledger.ts
+++ b/src/views/home/lib/realm-ledger.ts
@@ -1,0 +1,168 @@
+/**
+ * "영역 대장(Realm Ledger)" 파생 (S7, fable 설계).
+ *
+ * 영역 전개(`?realm=slug`) 중 좌측 패널이 전역 콘텐츠 대신 이 노드의 세계만
+ * 보여줄 때 필요한 순수 파생 3종:
+ *   1. `findRealmSubtree`   — 전체 트리에서 영역 루트 서브트리 하나를 집어낸다.
+ *   2. `computeRealmCensus` — 그 서브트리의 요소/역량/도메인/깊이 통계.
+ *   3. `computeRealmBoundary` — 영역 밖으로 나가는 관계(경계 엣지)와 각 밖
+ *      노드로의 "이 영역으로 이동" 점프 대상(도메인급 상위 컨테이너).
+ *
+ * 모두 그래프(트리 노드 / 그래프 엣지 + 멤버 셋)만 입력받는 순수 함수라
+ * 렌더 로직 없이 단독 테스트 가능하다. topology-map-v2 를 건드리지 않고
+ * views/home 안에서 realm 데이터를 파생하기 위한 단일 진실원.
+ */
+
+import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import type { OntologyTreeNode } from "@/shared/lib/ontology-tree";
+import { buildContainmentParents, nearestDomainId } from "@/shared/lib/ontology-tree";
+
+export interface RealmCensus {
+  /** 서브트리 안(루트 제외) element 노드 수. */
+  elementCount: number;
+  /** 서브트리 안(루트 제외) capability 노드 수. */
+  capabilityCount: number;
+  /** 서브트리 안(루트 제외) domain 노드 수. */
+  domainCount: number;
+  /** 루트를 뺀 전체 하위 노드 수. */
+  descendantCount: number;
+  /** 루트(0) 기준 가장 깊은 하위 노드까지의 상대 깊이. 자식만 있으면 1. */
+  depth: number;
+}
+
+/** 결계 관계 한 줄 — 영역 안↔밖을 잇는 엣지 하나. */
+export interface RealmBoundaryCrossing {
+  edgeId: string;
+  fromId: string;
+  fromTitle: string;
+  toId: string;
+  toTitle: string;
+  relationType: string;
+  /** 이 엣지에서 영역 밖에 있는 끝점. */
+  outsideId: string;
+  /** "이 영역으로 이동" 대상 — 밖 노드의 도메인급 상위 컨테이너(없으면 밖 노드 자신). */
+  jumpRealmId: string;
+}
+
+export interface RealmBoundary {
+  total: number;
+  crossings: RealmBoundaryCrossing[];
+}
+
+/**
+ * 경계 판정에서 제외하는 구조 엣지. `contains`/`belongs_to` 는 트리 형태 자체를
+ * 정의하므로(부모 컨테이너로의 링크) "바깥과 닿은 관계"의 신호가 아니다 —
+ * 의존/사용/구현/근거 같은 lateral 관계만 남긴다.
+ */
+export const REALM_BOUNDARY_EXCLUDED_TYPES: ReadonlySet<string> = new Set([
+  "contains",
+  "belongs_to",
+]);
+
+function findInNode(node: OntologyTreeNode, id: string): OntologyTreeNode | null {
+  if (node.node.id === id) return node;
+  for (const child of node.children) {
+    const found = findInNode(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** 전체 트리 roots 에서 `realmSlug` 노드 서브트리를 찾는다. 없으면 null. */
+export function findRealmSubtree(
+  roots: readonly OntologyTreeNode[],
+  realmSlug: string,
+): OntologyTreeNode | null {
+  for (const root of roots) {
+    const found = findInNode(root, realmSlug);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** 영역 서브트리의 요소/역량/도메인/깊이 census. 루트 자신은 세지 않는다. */
+export function computeRealmCensus(subtree: OntologyTreeNode): RealmCensus {
+  let elementCount = 0;
+  let capabilityCount = 0;
+  let domainCount = 0;
+  let descendantCount = 0;
+  let depth = 0;
+
+  const walk = (node: OntologyTreeNode, relDepth: number): void => {
+    if (relDepth > 0) {
+      descendantCount += 1;
+      if (relDepth > depth) depth = relDepth;
+      if (node.node.kind === "element") elementCount += 1;
+      else if (node.node.kind === "capability") capabilityCount += 1;
+      else if (node.node.kind === "domain") domainCount += 1;
+    }
+    for (const child of node.children) walk(child, relDepth + 1);
+  };
+  walk(subtree, 0);
+
+  return { elementCount, capabilityCount, domainCount, descendantCount, depth };
+}
+
+/** 서브트리 전체(루트 포함) 노드 id 집합 — 경계 엣지 판정의 멤버 셋. */
+export function collectRealmMemberIds(subtree: OntologyTreeNode): Set<string> {
+  const ids = new Set<string>();
+  const walk = (node: OntologyTreeNode): void => {
+    ids.add(node.node.id);
+    for (const child of node.children) walk(child);
+  };
+  walk(subtree);
+  return ids;
+}
+
+/**
+ * 영역 밖으로 나가는 관계(경계 엣지)를 파생한다. 정확히 한 끝점만 멤버 셋에
+ * 속한 엣지 = 경계. 구조 엣지(contains/belongs_to)와 미해결 끝점은 제외한다.
+ * 결과는 결정론적으로 정렬(관계타입 → from → to → edgeId)된다.
+ */
+export function computeRealmBoundary(input: {
+  edges: readonly KnowledgeGraphEdge[];
+  memberIds: ReadonlySet<string>;
+  nodeById: ReadonlyMap<string, KnowledgeGraphNode>;
+}): RealmBoundary {
+  const { edges, memberIds, nodeById } = input;
+  const parentOf = buildContainmentParents(edges, nodeById);
+  const crossings: RealmBoundaryCrossing[] = [];
+  const seen = new Set<string>();
+
+  for (const edge of edges) {
+    if (REALM_BOUNDARY_EXCLUDED_TYPES.has(edge.type)) continue;
+    const fromInside = memberIds.has(edge.from);
+    const toInside = memberIds.has(edge.to);
+    // 둘 다 안 / 둘 다 밖 → 경계가 아니다.
+    if (fromInside === toInside) continue;
+    const from = nodeById.get(edge.from);
+    const to = nodeById.get(edge.to);
+    if (!from || !to) continue;
+    if (seen.has(edge.id)) continue;
+    seen.add(edge.id);
+
+    const outsideNode = fromInside ? to : from;
+    const jumpRealmId = nearestDomainId(outsideNode, parentOf, nodeById) ?? outsideNode.id;
+
+    crossings.push({
+      edgeId: edge.id,
+      fromId: from.id,
+      fromTitle: from.title,
+      toId: to.id,
+      toTitle: to.title,
+      relationType: edge.type,
+      outsideId: outsideNode.id,
+      jumpRealmId,
+    });
+  }
+
+  crossings.sort(
+    (a, b) =>
+      a.relationType.localeCompare(b.relationType) ||
+      a.fromTitle.localeCompare(b.fromTitle) ||
+      a.toTitle.localeCompare(b.toTitle) ||
+      a.edgeId.localeCompare(b.edgeId),
+  );
+
+  return { total: crossings.length, crossings };
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -166,11 +166,18 @@ import { clampSynthSize, synthesizeVaultGraph } from "../lib/synth-vault";
 import {
   TopologyIndexPanel,
   TopologyIndexTab,
+  TopologyRealmLedger,
   resolveIndexPanelState,
   resolveLeftSlotOwner,
   resolveRenderedIndexPanelState,
   type IndexPanelState,
 } from "@/widgets/topology-index-panel";
+import {
+  collectRealmMemberIds,
+  computeRealmBoundary,
+  computeRealmCensus,
+  findRealmSubtree,
+} from "../lib/realm-ledger";
 import {
   classifyTopologyRelationProvenance,
 } from "../lib/topology-ontology-drawer";
@@ -1576,6 +1583,53 @@ export function HomePage() {
         : null,
     [ontologyInsight],
   );
+  // 미터 분모 단일 진실원 — 도메인 census BFS total 의 최댓값. INDEX 패널이
+  // 내부에서 계산하는 값과 같은 소스라 영역 대장 트리 행의 capacity 미터가
+  // 전역 트리와 어긋나지 않는다.
+  const indexMaxDomainDescendantCount = useMemo(() => {
+    if (!indexDomainCensus || indexDomainCensus.size === 0) return 0;
+    let max = 0;
+    for (const row of indexDomainCensus.values()) if (row.total > max) max = row.total;
+    return max;
+  }, [indexDomainCensus]);
+  // S7 "영역 대장" — realm 활성 시 좌측 패널이 전역 콘텐츠 대신 이 노드의
+  // 세계만 보여줄 때 필요한 파생. 모두 그래프/트리에서만 나온다(순수 lib,
+  // `../lib/realm-ledger.ts` + 테스트) — topology-map-v2 를 건드리지 않는다.
+  const realmNodeById = useMemo(
+    () => new Map((ontologyInsight?.nodes ?? []).map((n) => [n.id, n] as const)),
+    [ontologyInsight],
+  );
+  const realmLedgerModel = useMemo(() => {
+    if (!realmSlug || !indexTreeResult || !ontologyInsight) return null;
+    const subtree = findRealmSubtree(indexTreeResult.roots, realmSlug);
+    if (!subtree) return null;
+    const census = computeRealmCensus(subtree);
+    const memberIds = collectRealmMemberIds(subtree);
+    const boundary = computeRealmBoundary({
+      edges: ontologyInsight.edges,
+      memberIds,
+      nodeById: realmNodeById,
+    });
+    // 경계 행에 관계 타입 평문 라벨을 붙인다(위젯은 i18n 을 모른다) + 상위
+    // 몇 개만 노출(총수는 헤딩이 말한다).
+    const boundaryRows = boundary.crossings.slice(0, 6).map((crossing) => ({
+      edgeId: crossing.edgeId,
+      fromTitle: crossing.fromTitle,
+      toTitle: crossing.toTitle,
+      relationLabel: relationVocabulary(crossing.relationType, "formal"),
+      outsideId: crossing.outsideId,
+      jumpRealmId: crossing.jumpRealmId,
+    }));
+    return {
+      rootKind: subtree.node.kind,
+      rootTitle: subtree.node.title,
+      census,
+      subtree,
+      boundaryRows,
+      boundaryTotal: boundary.total,
+    };
+  }, [realmSlug, indexTreeResult, ontologyInsight, realmNodeById, relationVocabulary]);
+  const realmActive = realmSlug !== null && realmLedgerModel !== null;
   // root-first-open v3 우하단 판독(`FirstRunReadout`) 의 "N project" 숫자 —
   // 실데이터, indexDomainCount 와 같은 ontologyInsight 파생이라 drift 불가.
   const firstRunProjectCount = useMemo(
@@ -2357,6 +2411,55 @@ export function HomePage() {
                 }}
               >
                 {renderedIndexState === "expanded" && indexTreeResult ? (
+                  // S7 "영역 대장" — 영역 활성 시 좌측 패널이 전역 콘텐츠 대신
+                  // 이 노드의 세계만 보여주는 변신 표면으로 교체된다. 두 표면이
+                  // 같은 박스를 차지하므로 keyed 래퍼의 짧은 페이드-인(<200ms,
+                  // reduced-motion 즉시)이 크로스페이드로 읽힌다. 전역↔영역
+                  // 전환에서만 key 가 바뀌어 remount → 페이드; 영역→영역
+                  // 점프는 in-place 갱신.
+                  <div
+                    key={realmActive ? "realm" : "index"}
+                    className="h-full animate-[panelCrossfadeIn_160ms_ease-out] motion-reduce:animate-none"
+                  >
+                  {realmActive && realmLedgerModel ? (
+                    <TopologyRealmLedger
+                      rootKind={realmLedgerModel.rootKind}
+                      rootTitle={realmLedgerModel.rootTitle}
+                      census={realmLedgerModel.census}
+                      subtree={realmLedgerModel.subtree}
+                      boundaryRows={realmLedgerModel.boundaryRows}
+                      boundaryTotal={realmLedgerModel.boundaryTotal}
+                      selectedId={canvasSelectedSlug}
+                      changedSlugs={changedSlugs}
+                      onSelect={(id) => handleSelect(id)}
+                      onExit={handleExitRealm}
+                      // 결계 관계 행의 "이 영역으로 이동" = 밖 노드의 도메인급
+                      // 상위로 realm 을 교체(realm-to-realm 점프). 진입 핸들러
+                      // 재사용 — 새 URL 로직 없음.
+                      onJumpRealm={handleEnterRealm}
+                      maxDomainDescendantCount={indexMaxDomainDescendantCount}
+                      domainCensus={indexDomainCensus}
+                      labels={{
+                        label: t("realm.chipPrefix"),
+                        elementsShort: t("index.elementsShort"),
+                        capabilitiesShort: t("index.capabilitiesShort"),
+                        depthShort: t("realm.ledger.depthShort"),
+                        searchPlaceholder: t("realm.ledger.searchPlaceholder"),
+                        exit: t("realm.ledger.exit"),
+                        exitAria: t("realm.chipClear"),
+                        emptyHint: t("index.emptyHint"),
+                        boundaryHeading: t("realm.ledger.boundaryHeading", {
+                          count: realmLedgerModel.boundaryTotal,
+                        }),
+                        boundaryToggleAria: t("realm.ledger.boundaryToggleAria"),
+                        boundaryJump: t("realm.ledger.boundaryJump"),
+                        boundaryJumpAria: t("realm.ledger.boundaryJumpAria"),
+                        boundaryEmpty: t("realm.ledger.boundaryEmpty"),
+                        freshTitle: t("index.freshTitle"),
+                        domainCountTitle: t("index.domainCountTitle"),
+                      }}
+                    />
+                  ) : (
                   <TopologyIndexPanel
                     treeResult={indexTreeResult}
                     totalConcepts={topologyTotalNodes}
@@ -2453,6 +2556,8 @@ export function HomePage() {
                       uncatalogedDocsAction: t("index.uncatalogedDocsAction"),
                     }}
                   />
+                  )}
+                  </div>
                 ) : (
                   <TopologyIndexTab
                     onExpand={handleIndexTabExpand}

--- a/src/widgets/topology-index-panel/index.ts
+++ b/src/widgets/topology-index-panel/index.ts
@@ -2,6 +2,12 @@ export { TopologyIndexPanel } from "./ui/TopologyIndexPanel";
 export type { TopologyIndexPanelProps, TopologyIndexPanelLabels } from "./ui/TopologyIndexPanel";
 export { TopologyIndexTab } from "./ui/TopologyIndexTab";
 export type { TopologyIndexTabProps, TopologyIndexTabLabels } from "./ui/TopologyIndexTab";
+export { TopologyRealmLedger } from "./ui/TopologyRealmLedger";
+export type {
+  TopologyRealmLedgerProps,
+  TopologyRealmLedgerLabels,
+  RealmBoundaryRow,
+} from "./ui/TopologyRealmLedger";
 export {
   parseIndexPanelStateParam,
   resolveIndexPanelState,

--- a/src/widgets/topology-index-panel/ui/TopologyRealmLedger.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyRealmLedger.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { buildOntologyTree } from "@/shared/lib/ontology-tree";
+import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import { TopologyRealmLedger, type RealmBoundaryRow } from "./TopologyRealmLedger";
+
+function makeNode(id: string, kind: string, title?: string): KnowledgeGraphNode {
+  return {
+    id,
+    title: title ?? id,
+    kind,
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date("2026-04-27"),
+    lastApprovedBy: "system",
+  };
+}
+function makeEdge(from: string, to: string): KnowledgeGraphEdge {
+  return {
+    id: `${from}-${to}`,
+    from,
+    to,
+    type: "contains",
+    projectIds: [],
+    evidenceIds: [],
+    lastApprovedAt: new Date("2026-04-27"),
+    lastApprovedBy: "system",
+  };
+}
+
+const nodes = [
+  makeNode("P", "project", "Product"),
+  makeNode("D1", "domain", "Views"),
+  makeNode("C1", "capability", "Render"),
+  makeNode("E1", "element", "Canvas"),
+];
+const edges = [makeEdge("P", "D1"), makeEdge("D1", "C1"), makeEdge("C1", "E1")];
+// D1 subtree = project root P → its only child D1 (findRealmSubtree is unit-
+// tested separately in views/home; navigating the tree directly here keeps
+// this widget test free of a views-layer import).
+const subtree = buildOntologyTree(nodes, edges).roots[0].children[0];
+
+const labels = {
+  label: "Realm",
+  elementsShort: "elements",
+  capabilitiesShort: "capabilities",
+  depthShort: "depth",
+  searchPlaceholder: "Search realm",
+  exit: "Exit realm",
+  exitAria: "Exit realm",
+  emptyHint: "No matches",
+  boundaryHeading: "Touches outside · 1",
+  boundaryToggleAria: "Toggle boundary list",
+  boundaryJump: "Go to this realm",
+  boundaryJumpAria: "Go to this realm",
+  boundaryEmpty: "Fully self-contained",
+  freshTitle: "recent",
+  domainCountTitle: "domain count",
+};
+
+const boundaryRows: RealmBoundaryRow[] = [
+  {
+    edgeId: "C1-C9",
+    fromTitle: "Render",
+    toTitle: "Billing",
+    relationLabel: "depends on",
+    outsideId: "C9",
+    jumpRealmId: "D2",
+  },
+];
+
+function renderLedger(overrides?: Partial<React.ComponentProps<typeof TopologyRealmLedger>>) {
+  const props: React.ComponentProps<typeof TopologyRealmLedger> = {
+    rootKind: "domain",
+    rootTitle: "Views",
+    census: { elementCount: 1, capabilityCount: 1, depth: 2 },
+    subtree,
+    boundaryRows,
+    boundaryTotal: 1,
+    selectedId: null,
+    changedSlugs: new Set(),
+    onSelect: vi.fn(),
+    onExit: vi.fn(),
+    onJumpRealm: vi.fn(),
+    maxDomainDescendantCount: 2,
+    domainCensus: null,
+    labels,
+    ...overrides,
+  };
+  render(<TopologyRealmLedger {...props} />);
+  return props;
+}
+
+describe("TopologyRealmLedger", () => {
+  it("renders the realm header title + census", () => {
+    renderLedger();
+    expect(screen.getByTestId("topology-realm-title")).toHaveTextContent("Views");
+    expect(screen.getByTestId("topology-realm-census")).toHaveTextContent(
+      "elements 1 · capabilities 1 · depth 2",
+    );
+  });
+
+  it("renders only the realm subtree rows (root's children), not the root itself", () => {
+    renderLedger();
+    const rows = screen.getAllByTestId("topology-index-row");
+    // C1 (Render) is the top-level child; E1 (Canvas) is its expanded child.
+    const labelsSeen = rows.map((r) => r.textContent);
+    expect(labelsSeen.some((t) => t?.includes("Render"))).toBe(true);
+    // The realm root "Views" is named by the header, never as a tree row.
+    expect(labelsSeen.some((t) => t?.includes("Views"))).toBe(false);
+  });
+
+  it("fires onExit from the 영역 해제 button", () => {
+    const props = renderLedger();
+    fireEvent.click(screen.getByTestId("topology-realm-exit"));
+    expect(props.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onSelect when a tree row is clicked", () => {
+    const props = renderLedger();
+    fireEvent.click(screen.getAllByTestId("topology-index-row")[0]);
+    expect(props.onSelect).toHaveBeenCalled();
+  });
+
+  it("keeps the boundary list collapsed to a one-line summary by default", () => {
+    renderLedger();
+    // Summary line present; the row list is hidden until the disclosure opens.
+    expect(screen.getByTestId("topology-realm-boundary-toggle")).toHaveTextContent(
+      "Touches outside · 1",
+    );
+    expect(screen.queryByTestId("topology-realm-boundary-row")).toBeNull();
+  });
+
+  it("expands the boundary list on demand and jumps to the outside node's realm", () => {
+    const props = renderLedger();
+    fireEvent.click(screen.getByTestId("topology-realm-boundary-toggle"));
+    const row = screen.getByTestId("topology-realm-boundary-row");
+    expect(row).toHaveTextContent("Render");
+    expect(row).toHaveTextContent("Billing");
+    expect(row).toHaveTextContent("(depends on)");
+    fireEvent.click(screen.getByTestId("topology-realm-boundary-jump"));
+    expect(props.onJumpRealm).toHaveBeenCalledWith("D2");
+  });
+
+  it("shows the self-contained hint (no toggle) when there are no boundary edges", () => {
+    renderLedger({ boundaryRows: [], boundaryTotal: 0 });
+    expect(screen.getByTestId("topology-realm-boundary")).toHaveTextContent(
+      "Fully self-contained",
+    );
+    expect(screen.queryByTestId("topology-realm-boundary-toggle")).toBeNull();
+    expect(screen.queryByTestId("topology-realm-boundary-jump")).toBeNull();
+  });
+
+  it("filters the realm tree by the scoped search", () => {
+    renderLedger();
+    fireEvent.change(screen.getByTestId("topology-realm-search"), {
+      target: { value: "zzz-no-match" },
+    });
+    expect(screen.getByTestId("topology-realm-tree")).toHaveTextContent("No matches");
+  });
+});

--- a/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, CornerUpRight, Search } from "lucide-react";
+import {
+  filterTreeByQuery,
+  type DomainCensusRow,
+  type OntologyTreeNode,
+} from "@/shared/lib/ontology-tree";
+import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
+import { TopologyIndexTreeRow } from "./TopologyIndexTreeRow";
+
+/** 결계 관계 한 줄 — 이미 i18n 라벨까지 조립된 표시용 행(HomePage 가 만든다). */
+export interface RealmBoundaryRow {
+  edgeId: string;
+  fromTitle: string;
+  toTitle: string;
+  /** 관계 타입의 평문 라벨(예: "의존") — HomePage 의 relationVocabulary 로 조립. */
+  relationLabel: string;
+  outsideId: string;
+  jumpRealmId: string;
+}
+
+export interface TopologyRealmLedgerLabels {
+  /** 상단 eyebrow — "영역". */
+  label: string;
+  /** 영역 census 조각 라벨. */
+  elementsShort: string;
+  capabilitiesShort: string;
+  depthShort: string;
+  /** 영역 트리 검색 placeholder. */
+  searchPlaceholder: string;
+  /** "영역 해제" 텍스트 버튼. */
+  exit: string;
+  exitAria: string;
+  /** 트리가 비었을 때(검색 결과 0 등) 한 줄 문구. */
+  emptyHint: string;
+  /** "바깥과 닿은 관계 N"(HomePage 가 count 포맷) — 기본 접힘 요약 한 줄. */
+  boundaryHeading: string;
+  boundaryToggleAria: string;
+  /** "이 영역으로 이동" 행 호버 액션. */
+  boundaryJump: string;
+  boundaryJumpAria: string;
+  /** 영역이 완전히 고립됐을 때 한 줄 문구. */
+  boundaryEmpty: string;
+  // TopologyIndexTreeRow 로 넘길 트리 행 라벨.
+  freshTitle: string;
+  domainCountTitle: string;
+}
+
+export interface TopologyRealmLedgerProps {
+  /** 영역 루트 노드 — 헤더 글리프/제목. */
+  rootKind: string;
+  rootTitle: string;
+  /** 영역 census 조각(요소/역량/깊이). HomePage 가 파생. */
+  census: { elementCount: number; capabilityCount: number; depth: number };
+  /** 영역 서브트리 — 루트의 자식들이 트리 최상위 행이 된다. */
+  subtree: OntologyTreeNode;
+  /** 경계 엣지 표시 행(상위 몇 개). */
+  boundaryRows: RealmBoundaryRow[];
+  /** 경계 엣지 총수(행 슬라이스와 무관한 전체). */
+  boundaryTotal: number;
+  selectedId: string | null;
+  changedSlugs: ReadonlySet<string>;
+  onSelect: (nodeId: string) => void;
+  onExit: () => void;
+  onJumpRealm: (realmId: string) => void;
+  maxDomainDescendantCount: number;
+  domainCensus?: ReadonlyMap<string, DomainCensusRow> | null;
+  labels: TopologyRealmLedgerLabels;
+  className?: string;
+}
+
+/**
+ * 영역 대장(Realm Ledger) — 영역 전개(`?realm=slug`) 중 좌측 패널이 전역 INDEX
+ * 대신 **이 노드의 세계만** 보여주는 변신 표면(S7, fable 설계 + 소유자 절제
+ * 지시). 전역 첫 실행 카드·전역 census·전역 트리·전역 푸터는 전부 숨고, 정확히
+ * 세 덩어리만 남는다:
+ *
+ *   1. 헤더 — 루트 글리프 + 제목 + census 한 줄 + 조용한 "영역 해제" 텍스트.
+ *   2. 영역 트리 — 루트 서브트리만(검색 포함).
+ *   3. 결계 관계 — 기본 접힘 요약 한 줄("바깥과 닿은 관계 N"), 펼쳐야 리스트.
+ *
+ * 절제 계약(소유자 반려 기준): 박스 안 박스 없음(섹션 구분은 caps eyebrow +
+ * 여백 + 헤어라인 divider 하나), 뱃지/칩 수프 없음(census 한 줄 텍스트, 점프는
+ * 행 호버에만 드러나는 조용한 액션), 빈 상태는 문구 한 줄. 전역
+ * `TopologyIndexPanel` 과 같은 `--topology-v2-panel-*` / `--topology-index-*`
+ * 토큰·같은 aside 셸·같은 `TopologyIndexTreeRow` 를 재사용한다 — 콘텐츠만 영역
+ * 스코프로 좁힌 자매 패널.
+ */
+export function TopologyRealmLedger({
+  rootKind,
+  rootTitle,
+  census,
+  subtree,
+  boundaryRows,
+  boundaryTotal,
+  selectedId,
+  changedSlugs,
+  onSelect,
+  onExit,
+  onJumpRealm,
+  maxDomainDescendantCount,
+  domainCensus = null,
+  labels,
+  className,
+}: TopologyRealmLedgerProps) {
+  const [query, setQuery] = useState("");
+  // 영역 트리 최상위 = 루트의 직속 자식들(루트 자신은 헤더가 이미 이름).
+  const childRoots = subtree.children;
+  const [openIds, setOpenIds] = useState<Set<string>>(
+    () => new Set(childRoots.map((child) => child.node.id)),
+  );
+  // 결계 관계는 기본 접힘 — 기본 화면은 헤더+트리 두 덩어리만 보이는 정갈함.
+  const [boundaryOpen, setBoundaryOpen] = useState(false);
+  const trimmedQuery = query.trim();
+  const isFiltering = trimmedQuery.length > 0;
+
+  const visibleRoots = useMemo(
+    () => (isFiltering ? filterTreeByQuery(childRoots, trimmedQuery) : childRoots),
+    [childRoots, isFiltering, trimmedQuery],
+  );
+
+  const toggleOpen = (nodeId: string) => {
+    setOpenIds((current) => {
+      const next = new Set(current);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  };
+  const isOpen = (nodeId: string) => isFiltering || openIds.has(nodeId);
+
+  return (
+    <aside
+      aria-label={labels.label}
+      data-testid="topology-realm-ledger"
+      className={`flex h-full flex-col rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] p-3 shadow-[var(--topology-v2-panel-shadow)] ${className ?? ""}`}
+      style={{ width: "var(--topology-index-width)" }}
+    >
+      {/* ── 1. 헤더 ── caps eyebrow + 제목 + census 한 줄 + 조용한 해제. */}
+      <header className="mb-3 shrink-0 px-0.5">
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
+            {labels.label}
+          </span>
+          <button
+            type="button"
+            onClick={onExit}
+            aria-label={labels.exitAria}
+            data-testid="topology-realm-exit"
+            className="shrink-0 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+          >
+            {labels.exit}
+          </button>
+        </div>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0">
+            <TopologyV2KindGlyph kind={rootKind} size={15} />
+          </span>
+          <p
+            data-testid="topology-realm-title"
+            className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-[color:var(--topology-v2-panel-text-primary)]"
+          >
+            {rootTitle}
+          </p>
+        </div>
+        <p
+          data-testid="topology-realm-census"
+          className="mt-1 truncate font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+        >
+          {labels.elementsShort} {census.elementCount} · {labels.capabilitiesShort}{" "}
+          {census.capabilityCount} · {labels.depthShort} {census.depth}
+        </p>
+      </header>
+
+      {/* 영역 스코프 검색 — 트리 섹션에 속한 필터(별도 카드 아님). */}
+      <div className="relative mb-2 shrink-0">
+        <Search
+          size={11}
+          aria-hidden
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[color:var(--topology-v2-panel-text-quaternary)]"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape" && query.length > 0) {
+              event.preventDefault();
+              event.stopPropagation();
+              setQuery("");
+              event.currentTarget.blur();
+            }
+          }}
+          placeholder={labels.searchPlaceholder}
+          autoComplete="off"
+          data-testid="topology-realm-search"
+          className="w-full rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-canvas)] py-1.5 pl-7 pr-2.5 text-[12px] text-[color:var(--topology-v2-panel-text-primary)] outline-none transition-colors placeholder:text-[color:var(--topology-v2-panel-text-quaternary)] focus:border-[color:var(--topology-v2-indigo)]"
+        />
+      </div>
+
+      {/* ── 2. 영역 트리 ── 루트 서브트리만, 깊이 들여쓰기. */}
+      <nav
+        role="tree"
+        aria-label={labels.label}
+        data-testid="topology-realm-tree"
+        className="min-h-0 flex-1 space-y-px overflow-y-auto"
+      >
+        {visibleRoots.length === 0 ? (
+          <p className="px-1 py-2 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+            {labels.emptyHint}
+          </p>
+        ) : (
+          visibleRoots.map((root) => (
+            <TopologyIndexTreeRow
+              key={root.node.id}
+              entry={root}
+              depth={0}
+              isOpen={isOpen}
+              onToggleOpen={toggleOpen}
+              onSelect={onSelect}
+              selectedId={selectedId}
+              changedSlugs={changedSlugs}
+              maxDomainDescendantCount={maxDomainDescendantCount}
+              domainCensus={domainCensus}
+              labels={{
+                capabilitiesShort: labels.capabilitiesShort,
+                elementsShort: labels.elementsShort,
+                freshTitle: labels.freshTitle,
+                domainCountTitle: labels.domainCountTitle,
+              }}
+            />
+          ))
+        )}
+      </nav>
+
+      {/* ── 3. 결계 관계 ── 헤어라인 하나로 구분, 기본 접힘 요약 한 줄. */}
+      <div
+        data-testid="topology-realm-boundary"
+        className="mt-2.5 shrink-0 border-t border-[color:var(--topology-v2-panel-divider)] pt-2"
+      >
+        {boundaryTotal === 0 ? (
+          <p className="px-1 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+            {labels.boundaryEmpty}
+          </p>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => setBoundaryOpen((open) => !open)}
+              aria-expanded={boundaryOpen}
+              aria-label={labels.boundaryToggleAria}
+              data-testid="topology-realm-boundary-toggle"
+              className="flex w-full items-center gap-1.5 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+            >
+              <span className="min-w-0 flex-1 truncate text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+                {labels.boundaryHeading}
+              </span>
+              <ChevronDown
+                size={12}
+                aria-hidden="true"
+                className={`shrink-0 text-[color:var(--topology-v2-panel-text-quaternary)] transition-transform ${boundaryOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+            {boundaryOpen ? (
+              <ul className="mt-1 max-h-[132px] space-y-px overflow-y-auto">
+                {boundaryRows.map((row) => (
+                  <li
+                    key={row.edgeId}
+                    data-testid="topology-realm-boundary-row"
+                    className="group flex items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-[11.5px] text-[color:var(--topology-v2-panel-text-secondary)]">
+                      <span className="text-[color:var(--topology-v2-panel-text-primary)]">
+                        {row.fromTitle}
+                      </span>
+                      <span className="mx-1 text-[color:var(--topology-v2-panel-text-quaternary)]">→</span>
+                      <span className="text-[color:var(--topology-v2-panel-text-primary)]">
+                        {row.toTitle}
+                      </span>
+                      <span className="ml-1 text-[color:var(--topology-v2-panel-text-quaternary)]">
+                        ({row.relationLabel})
+                      </span>
+                    </span>
+                    {/* 조용한 액션 — 행 호버/포커스 시에만 드러난다(상시 버튼 나열 금지). */}
+                    <button
+                      type="button"
+                      onClick={() => onJumpRealm(row.jumpRealmId)}
+                      aria-label={labels.boundaryJumpAria}
+                      title={labels.boundaryJump}
+                      data-testid="topology-realm-boundary-jump"
+                      className="inline-flex shrink-0 items-center gap-1 rounded-[var(--chrome-radius-inner)] px-1.5 py-0.5 text-[10.5px] text-[color:var(--color-indigo-accent)] opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset group-hover:opacity-100 motion-reduce:transition-none"
+                    >
+                      <CornerUpRight size={11} aria-hidden="true" />
+                      {labels.boundaryJump}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- `?realm=` 활성 시 좌측 INDEX 가 크로스페이드(160ms)로 영역 대장으로 교체: 헤더(루트 글리프+제목+census "요소 96 · 역량 2 · 깊이 2"+영역 해제) / 영역 스코프 검색+서브트리 / 접힌 "바깥과 닿은 관계 N" (펼치면 경계 관계 리스트 + 행 호버 시 "이 영역으로 이동" — realm-to-realm 점프).
- 소유자 절제 조항 5개 전부 준수 (박스 중첩 0 · 칩 수프 0 · 섹션 3 상한 · 경계 기본 접힘 · 빈 상태 한 줄) — 실화면 판정 통과.
- topology-map-v2 무접촉 (그래프+URL 상태에서 파생).

## Test plan
- views/home + index-panel 34 files / 245 passed ✅ · tsc ✅ · ESLint 0 ✅
- 실화면(/ko/?realm=domain:onboarding-ux): 대장 렌더·census·접힘 요약 확인 ✅ (synth 주입 그래프는 vault 트리 밖이라 전역 INDEX 유지 — 숨은 테스트 파라미터 한정 알려진 한계)