### PR TITLE
fix: R1 — 히트 역전·호버카드 잔류·realm slug 해석·첫화면 픽셀

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,31 @@
 
 ---
 
+## 2026-07-22 — 지도 디자인 패널 소규모 즉효 4건 (히트 역전 · 호버 잔류 · realm 별칭 · 첫 화면 픽셀)
+
+디자인 패널 지적 중 소규모·즉효 결함 4건. `topology-map-v2` + `views/home` +
+`hero-header`/`topology-index-panel`.
+
+- **히트테스트 역전 (치명, 패널3-S3)** — 노드 정중앙/근접 클릭이 엣지 패널을
+  여는 역전을 수정. 엣지 앵커(`a`/`b`)는 곧 끝 노드 중심이라 엣지선이 노드를
+  관통했다. 엣지 히트 후보에 끝 노드 **스크린 몸통 반경**(`hitTestWorld` 와 같은
+  `radiusForKind×magnitudeScale×scale+5`)을 실어, (1) 클릭이 노드 몸통 안이면 그
+  엣지를 히트에서 통째로 제외하고 (2) 노드 몸통 안 베지어 샘플 구간을 거리
+  계산에서 배제해 "노드 바디 > 엣지"를 기하로 강제했다.
+- **엣지 호버 카드 잔류 (패널2/3)** — 휠/카메라 모션 첫 틱에 엣지·클러스터 호버
+  카드를 즉시 dismiss. 카드는 idle 호버에만 앵커돼 줌 중 좌표가 흐르는 동안
+  `pointermove` 없이 3티어 줌을 관통해 잔류했다.
+- **realm slug silent fallback (패널3-S7)** — `?realm=ai-agent-partner`(kind
+  prefix 없음)가 raw 칩 + 전체 지도로 조용히 렌더되던 것을 수정. 노드 id 는
+  `kind:slug` 공간이라 bare slug 를 canonical id(`capability:ai-agent-partner`)로
+  승격 해석하고, 미해석이면 칩을 숨기고 영역을 활성화하지 않는다.
+- **첫 화면 픽셀 결함 (패널1-3)** — ① overview 상태에서 헤더 브랜드 필이 바로
+  아래 INDEX 패널과 폭이 어긋나던(≈7.6px @ topology-ui-scale) 것을 공통 폭 토큰
+  (`--topology-index-width`)으로 정렬. ② INDEX 트리 리스트 마지막 행이 하단
+  경계에서 하드 클립되던 것을 하단 12px mask-image 페이드로 완화.
+
+---
+
 ## 2026-07-22 — 지도 S10 소유자 실보고 4건 수정 (chrome 규격 · 펼침 배지 · 영역 히트 · 반딧불)
 
 `topology-map-v2` + 상단 크롬 열의 소유자 실보고 4건.

--- a/src/views/home/model/url-state.test.ts
+++ b/src/views/home/model/url-state.test.ts
@@ -5,6 +5,7 @@ import {
   enterRealmRouteState,
   exitRealmRouteState,
   parseHomeRouteState,
+  resolveRealmNodeId,
   resolveTopologyNodeClickRouteState,
   selectTopologyNodeRouteState,
   selectTopologyPathRouteState,
@@ -576,5 +577,42 @@ describe("영역 전개 (?realm=)", () => {
     expect(exited.realmSlug).toBeNull();
     expect(exited.selectedSlug).toBeNull();
     expect(applyHomeRouteState(new URLSearchParams("realm=capability:y"), exited).get("realm")).toBeNull();
+  });
+});
+
+describe("resolveRealmNodeId (패널3-S7 slug alias)", () => {
+  const nodeIds = ["project:atlas", "domain:views", "capability:ai-agent-partner", "element:parser"];
+
+  it("정확히 일치하는 canonical id 는 그대로 통과한다", () => {
+    expect(resolveRealmNodeId("capability:ai-agent-partner", nodeIds)).toBe(
+      "capability:ai-agent-partner",
+    );
+  });
+
+  it("kind prefix 없는 bare slug 를 <kind>:<slug> canonical id 로 승격한다", () => {
+    // 사용자가 손으로 친 `?realm=ai-agent-partner` — 예전엔 raw 칩 + 전체 지도.
+    expect(resolveRealmNodeId("ai-agent-partner", nodeIds)).toBe(
+      "capability:ai-agent-partner",
+    );
+    expect(resolveRealmNodeId("views", nodeIds)).toBe("domain:views");
+  });
+
+  it("어떤 노드와도 안 맞으면 null — 칩 미표시 계약", () => {
+    expect(resolveRealmNodeId("does-not-exist", nodeIds)).toBeNull();
+    // kind prefix 가 붙었지만 kind 가 틀린 경우도 미해석(정확 일치만 인정).
+    expect(resolveRealmNodeId("domain:ai-agent-partner", nodeIds)).toBeNull();
+  });
+
+  it("빈 값/공백 realm 은 null", () => {
+    expect(resolveRealmNodeId(null, nodeIds)).toBeNull();
+    expect(resolveRealmNodeId("", nodeIds)).toBeNull();
+  });
+
+  it("정확 일치가 bare 별칭보다 우선한다", () => {
+    // 같은 tail slug 를 가진 두 노드가 있어도, 정확 일치 id 가 있으면 그것.
+    const ids = ["capability:parser", "element:parser"];
+    expect(resolveRealmNodeId("element:parser", ids)).toBe("element:parser");
+    // bare `parser` 는 등장 순서상 첫 매치(capability:parser).
+    expect(resolveRealmNodeId("parser", ids)).toBe("capability:parser");
   });
 });

--- a/src/views/home/model/url-state.ts
+++ b/src/views/home/model/url-state.ts
@@ -170,6 +170,33 @@ export function exitRealmRouteState(current: HomeRouteState): HomeRouteState {
   return { ...current, realmSlug: null, selectedSlug: null, focusedHubSlug: null };
 }
 
+/**
+ * "영역 전개" realm slug 해석 (패널3-S7) — URL 의 `?realm=` 값을 실제 노드
+ * id 로 맞춘다. 노드 id 는 `kind:slug`(예: `capability:mcp-server`) 공간이라,
+ * 사용자가 손으로 친 bare slug(`?realm=ai-agent-partner`, kind prefix 없음)는
+ * 그냥은 어떤 노드와도 안 맞아 raw 칩 + 전체 지도가 조용히 렌더됐다. 이 함수는
+ * (1) 정확히 일치하는 id 가 있으면 그대로, (2) prefix 없는 bare slug 면
+ * `<kind>:<slug>` 형태의 노드를 찾아 canonical id 로 승격, (3) 못 찾으면 null.
+ * null 이면 caller 가 칩을 숨기고 영역을 활성화하지 않는다(조용한 fallback 대신
+ * 명시적 미해석). 순수 — `nodeIds` 는 canonical 노드 id 목록.
+ */
+export function resolveRealmNodeId(
+  realmSlug: string | null,
+  nodeIds: Iterable<string>,
+): string | null {
+  if (!realmSlug) return null;
+  const hasKindPrefix = realmSlug.includes(":");
+  let bareMatch: string | null = null;
+  for (const id of nodeIds) {
+    if (id === realmSlug) return id; // 정확 일치가 최우선
+    if (!hasKindPrefix && bareMatch === null) {
+      const colon = id.indexOf(":");
+      if (colon >= 0 && id.slice(colon + 1) === realmSlug) bareMatch = id;
+    }
+  }
+  return bareMatch;
+}
+
 export function parseHomeRouteState(
   searchParams: URLSearchParams,
 ): HomeRouteState {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -117,6 +117,7 @@ import {
   toggleExpandedParent,
   enterRealmRouteState,
   exitRealmRouteState,
+  resolveRealmNodeId,
   type TopologyAnalysisMode,
 } from "../model/url-state";
 import {
@@ -933,12 +934,23 @@ export function HomePage() {
   const canvasSelectedSlug = selectedProject?.slug ?? selectedOntologyNode?.id ?? selectedSlug;
   const drawerProject = selectedProject;
 
-  // S4 "영역 전개" — 현재 영역 루트 노드의 제목(칩 표시용). 그래프에서 못 찾으면
-  // slug 자체를 fallback 으로 쓴다(전환 직후 그래프 재빌드 타이밍 방어).
+  // S7 realm slug 해석(패널3-S7) — URL 의 `?realm=` 은 사용자가 손으로 bare
+  // slug(`ai-agent-partner`)를 칠 수 있으나 노드 id 는 `kind:slug` 공간이라
+  // 그냥은 안 맞아 raw 칩 + 전체 지도가 조용히 렌더됐다. canonical 노드 id 로
+  // 승격하고(=`capability:ai-agent-partner`), 못 맞추면 null → 칩 미표시.
+  const resolvedRealmSlug = useMemo(
+    () => resolveRealmNodeId(realmSlug, (ontologyInsight?.nodes ?? []).map((n) => n.id)),
+    [realmSlug, ontologyInsight],
+  );
+
+  // S4 "영역 전개" — 현재 영역 루트 노드의 제목(칩 표시용). 해석된 id 로만
+  // 조회 — 미해석(null)이면 제목도 null 이라 칩이 뜨지 않는다. 전환 직후
+  // 그래프 재빌드 타이밍엔 canonical id 자체를 fallback 으로 써 칩이 깜빡이지
+  // 않게 한다(id 는 ontologyInsight 에 이미 존재 = 해석 성공한 케이스).
   const realmTitle = useMemo(() => {
-    if (!realmSlug) return null;
-    return topologyV2Graph.nodes.find((n) => n.id === realmSlug)?.label ?? realmSlug;
-  }, [realmSlug, topologyV2Graph]);
+    if (!resolvedRealmSlug) return null;
+    return topologyV2Graph.nodes.find((n) => n.id === resolvedRealmSlug)?.label ?? resolvedRealmSlug;
+  }, [resolvedRealmSlug, topologyV2Graph]);
 
   // 노드 클릭 default = 컴팩트 ego 팝오버. 풀스크린 드로어는 "전체 상세" opt-in.
   // overview first, details-on-demand — 설계: docs/TOPOLOGY-FOCUS-AND-SCALE.md
@@ -1280,7 +1292,7 @@ export function HomePage() {
       if (event.key !== "Escape") return;
       if (event.defaultPrevented) return;
       const action = resolveTopologyEscLadderAction({
-        realmActive: realmSlug !== null,
+        realmActive: resolvedRealmSlug !== null,
         contextMenuOpen: contextMenuNode !== null,
         createNodeOpen,
         searchOpen: ontologySearchOpen,
@@ -1346,7 +1358,7 @@ export function HomePage() {
     closeCreateNode,
     handleClose,
     selectedEdge,
-    realmSlug,
+    resolvedRealmSlug,
     handleExitRealm,
   ]);
 
@@ -1600,8 +1612,8 @@ export function HomePage() {
     [ontologyInsight],
   );
   const realmLedgerModel = useMemo(() => {
-    if (!realmSlug || !indexTreeResult || !ontologyInsight) return null;
-    const subtree = findRealmSubtree(indexTreeResult.roots, realmSlug);
+    if (!resolvedRealmSlug || !indexTreeResult || !ontologyInsight) return null;
+    const subtree = findRealmSubtree(indexTreeResult.roots, resolvedRealmSlug);
     if (!subtree) return null;
     const census = computeRealmCensus(subtree);
     const memberIds = collectRealmMemberIds(subtree);
@@ -1628,8 +1640,8 @@ export function HomePage() {
       boundaryRows,
       boundaryTotal: boundary.total,
     };
-  }, [realmSlug, indexTreeResult, ontologyInsight, realmNodeById, relationVocabulary]);
-  const realmActive = realmSlug !== null && realmLedgerModel !== null;
+  }, [resolvedRealmSlug, indexTreeResult, ontologyInsight, realmNodeById, relationVocabulary]);
+  const realmActive = resolvedRealmSlug !== null && realmLedgerModel !== null;
   // root-first-open v3 우하단 판독(`FirstRunReadout`) 의 "N project" 숫자 —
   // 실데이터, indexDomainCount 와 같은 ontologyInsight 파생이라 drift 불가.
   const firstRunProjectCount = useMemo(
@@ -2011,6 +2023,21 @@ export function HomePage() {
                     }
                     compact={selectedRelationActive}
                     sampleBadge={sampleModeSettled}
+                    // 패널1-3① — overview 상태에선 브랜드 필이 바로 아래
+                    // INDEX 패널 위에 얹힌다. 필은 콘텐츠 폭(≈293px)이라
+                    // 패널 폭(--topology-index-width, 300px)보다 우변이 어긋나
+                    // 보였다(측정 7.6px @ topology-ui-scale). 같은 폭 토큰을
+                    // 공유해 두 표면의 우변을 정렬한다 — 선택/관계/드로어
+                    // 상태에선 좌측 열이 인스펙터로 바뀌므로 콘텐츠 폭 유지.
+                    className={
+                      !selectedNodeFocusActive &&
+                      !drawerOpen &&
+                      !selectedProject &&
+                      !selectedRelationActive &&
+                      renderedIndexState === "expanded"
+                        ? "w-[var(--topology-index-width)]"
+                        : undefined
+                    }
                   />
                   {/* WorkspaceOntologyStrip 제거(2026-06-11) — 분석 패널과
                       겹쳤고(사용자 보고), 카운트는 pill·범례가, 온톨로지
@@ -2063,7 +2090,7 @@ export function HomePage() {
                       toast.show(t('controls.relayoutToast'), "info");
                     }}
                     realmChip={
-                      realmSlug && realmTitle ? (
+                      resolvedRealmSlug && realmTitle ? (
                         <TopologyRealmChip
                           title={realmTitle}
                           prefixLabel={t("realm.chipPrefix")}
@@ -2676,7 +2703,7 @@ export function HomePage() {
                     onToggleCluster={handleToggleCluster}
                     onHoverCluster={handleHoverCluster}
                     clusterHint={t('cluster.hint')}
-                    realmRootId={realmSlug}
+                    realmRootId={resolvedRealmSlug}
                     onEnterRealm={handleEnterRealm}
                     realmEnterLabel={t('realm.enterAction')}
                     realmEnterTooltip={t('realm.enterTooltip')}
@@ -2953,7 +2980,7 @@ export function HomePage() {
                 onEnterRealm={
                   // S4 — 컨테이너 노드(자식 있음)이며 영역 밖일 때만 2차 발견
                   // 경로를 노출한다. leaf/이미 영역 안이면 omit → 버튼 미표시.
-                  realmSlug === null && v2DatasheetModel.groups.contains.total > 0
+                  resolvedRealmSlug === null && v2DatasheetModel.groups.contains.total > 0
                     ? () => handleEnterRealm(v2DatasheetModel.nodeId)
                     : undefined
                 }

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -320,6 +320,14 @@ export function TopologyIndexPanel({
         aria-label={labels.label}
         data-testid="topology-index-tree"
         className="min-h-0 flex-1 space-y-px overflow-y-auto"
+        // 패널1-3② — 스크롤 리스트 하단에서 마지막 행이 컨테이너 경계에
+        // 중간 높이로 하드 클립돼 "잘린 행"이 결함처럼 읽혔다. 하단 12px
+        // 마스크 페이드로 부드럽게 감춰 "더 있음"을 암시한다(상단은 crisp —
+        // 첫 행은 자르지 않는다). transform/색 아닌 mask 라 헌장 무저촉.
+        style={{
+          maskImage: "linear-gradient(to bottom, #000 calc(100% - 12px), transparent)",
+          WebkitMaskImage: "linear-gradient(to bottom, #000 calc(100% - 12px), transparent)",
+        }}
       >
         {visibleRoots.length === 0 ? (
           <p className="px-1 py-2 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">

--- a/src/widgets/topology-map-v2/ui/topology-edge-hit.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-edge-hit.test.ts
@@ -49,4 +49,37 @@ describe("hitTestEdges", () => {
     many.push(straight("target", 200));
     expect(hitTestEdges(many, 300, 203, 8)?.sourceId).toBe("target-a");
   });
+
+  // 히트테스트 역전 방지(패널3-S3) — 엣지 앵커 a/b 는 곧 끝 노드 중심이라,
+  // 노드 몸통 반경 안(또는 그 곁) 클릭은 노드 소유여야 한다. 엣지가 노드
+  // 중심을 관통하므로 반경 정보가 없으면 노드 정중앙/근접 클릭이 엣지로 샌다.
+  describe("노드 바디 > 엣지 우선순위 (aRadius/bRadius)", () => {
+    const withRadii = (id: string, y: number, r: number): EdgeHitCandidate => ({
+      edge: edge(id),
+      a: { x: 100, y },
+      b: { x: 500, y },
+      control: { x: 300, y },
+      aRadius: r,
+      bRadius: r,
+    });
+
+    it("끝 노드 몸통 안(정중앙 포함) 클릭은 엣지 히트에서 제외된다", () => {
+      // 노드 a(100,200) 중심에서 4px — 반경 14 안 = 노드 영역. 엣지는 이 점을
+      // 관통하지만(거리 0) 노드가 소유하므로 null 이어야 한다.
+      expect(hitTestEdges([withRadii("e", 200, 14)], 104, 200, 8)).toBeNull();
+      // 정중앙(노드 a 중심) 클릭도 마찬가지.
+      expect(hitTestEdges([withRadii("e", 200, 14)], 100, 200, 8)).toBeNull();
+    });
+
+    it("반경 정보가 없으면(구 동작) 같은 지점이 엣지로 잡힌다 — 회귀 대조군", () => {
+      // aRadius/bRadius 미지정 = 하위호환. 노드 개념이 없으니 엣지선 위 점은
+      // 그대로 히트 — 이 대조가 위 제외가 반경 때문임을 증명한다.
+      expect(hitTestEdges([straight("e", 200)], 104, 200, 8)?.sourceId).toBe("e-a");
+    });
+
+    it("엣지 중앙(양 끝 노드에서 먼 곳)은 반경이 있어도 그대로 잡힌다", () => {
+      // (300,204) — 두 노드 중심에서 200px, 반경 14 밖. 엣지선(y=200)에서 4px.
+      expect(hitTestEdges([withRadii("e", 200, 14)], 300, 204, 8)?.sourceId).toBe("e-a");
+    });
+  });
 });

--- a/src/widgets/topology-map-v2/ui/topology-edge-hit.ts
+++ b/src/widgets/topology-map-v2/ui/topology-edge-hit.ts
@@ -49,12 +49,33 @@ export interface EdgeHitCandidate {
   a: EdgeHitPoint;
   b: EdgeHitPoint;
   control: EdgeHitPoint;
+  /**
+   * 히트테스트 역전 방지(패널3-S3) — 양 끝 노드의 **스크린 몸통 반경**(px).
+   * 엣지 앵커(`a`/`b`)는 곧 끝 노드의 중심이므로, 이 반경 안쪽 구간은 노드
+   * 몸통 영역이다. "노드 바디 > 엣지" 규약을 기하로 강제한다: (1) 클릭이 끝
+   * 노드 몸통 안이면 그 엣지는 히트 대상에서 제외(노드가 소유), (2) 노드
+   * 몸통 안에 든 베지어 샘플 구간은 히트 거리 계산에서 제외해, 노드 정중앙/
+   * 근접 클릭이 방사형 엣지로 새는 것을 막는다. 생략 시 예전 동작(전 구간
+   * 히트) 그대로 — 순수 테스트 하위호환.
+   */
+  aRadius?: number;
+  bRadius?: number;
+}
+
+function withinRadius(px: number, py: number, cx: number, cy: number, radius: number | undefined): boolean {
+  if (radius === undefined || radius <= 0) return false;
+  const dx = px - cx;
+  const dy = py - cy;
+  return dx * dx + dy * dy <= radius * radius;
 }
 
 /**
  * `(screenX, screenY)` 에서 `thresholdPx` 안의 가장 가까운 엣지.
  * 없으면 null. 후보는 화면에 그려진(컬링 통과) 엣지만 넘기는 것이 호출자
  * 책임 — 안 보이는 엣지가 클릭되는 것은 계약 위반이다.
+ *
+ * 노드 우선(패널3-S3): `aRadius`/`bRadius` 가 주어지면 그 반경 안(노드 몸통)의
+ * 클릭·구간은 엣지 히트에서 배제한다 — 노드 클릭이 엣지 패널을 여는 역전 차단.
  */
 export function hitTestEdges(
   candidates: readonly EdgeHitCandidate[],
@@ -65,7 +86,12 @@ export function hitTestEdges(
   const threshold2 = thresholdPx * thresholdPx;
   let best: WorldEdge | null = null;
   let bestD2 = threshold2;
-  for (const { edge, a, b, control } of candidates) {
+  for (const { edge, a, b, control, aRadius, bRadius } of candidates) {
+    // 노드 바디 > 엣지 — 클릭이 어느 끝 노드 몸통 안이면 그 자리는 노드
+    // 소유다. 이 엣지는 히트 후보에서 통째로 제외(역전의 근본 차단).
+    if (withinRadius(screenX, screenY, a.x, a.y, aRadius) || withinRadius(screenX, screenY, b.x, b.y, bRadius)) {
+      continue;
+    }
     // AABB 프리패스 — 껍질 bbox 가 임계 밖이면 샘플링 생략.
     const minX = Math.min(a.x, b.x, control.x) - thresholdPx;
     const maxX = Math.max(a.x, b.x, control.x) + thresholdPx;
@@ -74,14 +100,22 @@ export function hitTestEdges(
     if (screenX < minX || screenX > maxX || screenY < minY || screenY > maxY) continue;
 
     let prev = bezier(a.x, a.y, control.x, control.y, b.x, b.y, 0);
+    let prevInNode = withinRadius(prev.x, prev.y, a.x, a.y, aRadius) || withinRadius(prev.x, prev.y, b.x, b.y, bRadius);
     for (let i = 1; i <= SAMPLE_STEPS; i += 1) {
       const cur = bezier(a.x, a.y, control.x, control.y, b.x, b.y, i / SAMPLE_STEPS);
-      const d2 = distSqToSegment(screenX, screenY, prev.x, prev.y, cur.x, cur.y);
-      if (d2 < bestD2) {
-        bestD2 = d2;
-        best = edge;
+      const curInNode =
+        withinRadius(cur.x, cur.y, a.x, a.y, aRadius) || withinRadius(cur.x, cur.y, b.x, b.y, bRadius);
+      // 양 끝이 모두 노드 몸통 밖인 구간만 히트 거리로 잰다 — 끝 노드 곁의
+      // 엣지 꼬리(노드 영역)는 제외해 근접 클릭이 엣지로 새지 않게 한다.
+      if (!prevInNode && !curInNode) {
+        const d2 = distSqToSegment(screenX, screenY, prev.x, prev.y, cur.x, cur.y);
+        if (d2 < bestD2) {
+          bestD2 = d2;
+          best = edge;
+        }
       }
       prev = cur;
+      prevInNode = curInNode;
     }
   }
   return best;

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -370,6 +370,16 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
         .filter((n) => isNodeHittable(n, zoomRatio, focusedNodeId, neighborsOfFocused, DEFAULT_TIER_REVEAL, clusteredIds, realmTierKinds))
         .map((n) => n.id),
     );
+    // 히트테스트 역전 방지(패널3-S3) — 끝 노드 몸통 반경(스크린 px)을
+    // `hitTestWorld` 와 **같은 식**(radiusForKind × magnitudeScale × scale + 5)
+    // 으로 계산해 넘긴다. 노드 히트 영역과 정확히 맞물려 노드 몸통/근접 클릭이
+    // 방사형 엣지로 새지 않게 한다(노드 바디 > 엣지).
+    const scale = cameraRef.current.scale.value;
+    const bodyRadius = (id: string): number | undefined => {
+      const node = world.nodeById.get(id);
+      if (!node) return undefined;
+      return radiusForKind(node.kind, tokens) * node.magnitudeScale * scale + 5;
+    };
     const candidates: EdgeHitCandidate[] = [];
     for (const edge of world.edges) {
       if (!hittable.has(edge.sourceId) || !hittable.has(edge.targetId)) continue;
@@ -378,6 +388,8 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
         a: worldToScreen(cameraRef.current, width, height, edge.ax, edge.ay),
         b: worldToScreen(cameraRef.current, width, height, edge.bx, edge.by),
         control: worldToScreen(cameraRef.current, width, height, edge.controlX, edge.controlY),
+        aRadius: bodyRadius(edge.sourceId),
+        bRadius: bodyRadius(edge.targetId),
       });
     }
     return candidates;
@@ -741,6 +753,12 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     e.preventDefault();
     const tokens = readTopologyV2TokensOrNull();
     if (!tokens) return;
+    // 엣지/클러스터 호버 카드 잔류(패널2/3) — 휠/카메라 모션이 시작되는 순간
+    // 카드는 즉시 사라져야 한다. 카드는 idle 호버에만 앵커되므로, 줌으로
+    // 좌표가 흐르는 동안 pointermove 없이 잔류해 3티어 줌을 관통해 남았다.
+    // 모션의 첫 틱에 dismiss 해 카드가 지도 위에 떠다니지 않게 한다.
+    clearEdgeHover();
+    clearClusterHover();
     // S3 — a live wheel zoom is interactive input; abandon any programmatic
     // camera tween so the crisp interactive spring owns this gesture.
     if (cameraTweenRef) cameraTweenRef.current = null;

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.wheel-dismiss.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.wheel-dismiss.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+// 엣지 호버 카드 잔류(패널2/3) — 휠/카메라 모션이 시작되면 카드는 즉시
+// 사라져야 한다. `handleWheel` 은 토큰을 읽어 줌 계산을 하므로, 실제 토큰
+// 픽스처 대신 필요한 수치 필드만 스텁해 테스트를 카메라 수학에서 독립시킨다.
+vi.mock("./topology-read-tokens", () => ({
+  readTopologyV2TokensOrNull: vi.fn(() => ({
+    overviewEntryRatio: 0.95,
+    cameraMaxZoomRatio: 2,
+    cameraScaleMax: 2.6,
+    cameraMinZoomRatio: 0.5,
+    cameraScaleMin: 0.24,
+    cameraDampingDefault: 1,
+    cameraSpringAngFreqInteractive: 10,
+  })),
+}));
+
+import { createTopologyPointerHandlers, type PointerHandlerRefs } from "./topology-pointer-handlers";
+
+function ref<T>(current: T): { current: T } {
+  return { current };
+}
+
+function buildRefs(overrides: Partial<PointerHandlerRefs> = {}): PointerHandlerRefs {
+  return {
+    worldRef: ref({ nodes: [], neighborMap: new Map() } as unknown as PointerHandlerRefs["worldRef"]["current"]),
+    cameraRef: ref({ x: { value: 0, velocity: 0 }, y: { value: 0, velocity: 0 }, scale: { value: 1, velocity: 0 } }),
+    cameraTargetRef: ref({ tx: 0, ty: 0, tscale: 1 }),
+    dampingRef: ref(1),
+    cameraAngularFreqRef: ref(null),
+    viewportRef: ref({ width: 800, height: 600, dpr: 1 }),
+    pointerMachineRef: ref({ phase: "idle" } as unknown as PointerHandlerRefs["pointerMachineRef"]["current"]),
+    dragHistoryRef: ref([]),
+    camStartAtDownRef: ref({ x: 0, y: 0 }),
+    canvasRectRef: ref({ left: 0, top: 0 }),
+    focusedSlugRef: ref(null),
+    hoveredNodeIdRef: ref(null),
+    rippleStartRef: ref(new Map()),
+    reducedMotionRef: ref(false),
+    simRef: ref(null),
+    heatRef: ref(0),
+    nodeDragRef: ref(null),
+    dragAffectedSetRef: ref(null),
+    dragStartPosRef: ref(null),
+    overviewScaleRef: ref(1),
+    ...overrides,
+  };
+}
+
+function fakeWheelEvent(): WheelEvent {
+  return {
+    preventDefault: vi.fn(),
+    clientX: 400,
+    clientY: 300,
+    deltaY: -120,
+    deltaMode: 0,
+    currentTarget: { getBoundingClientRect: () => ({ left: 0, top: 0 }) },
+  } as unknown as WheelEvent;
+}
+
+describe("createTopologyPointerHandlers — handleWheel dismisses transient hover cards", () => {
+  it("휠 줌 첫 틱에 엣지 호버 카드를 즉시 dismiss 한다 (3티어 관통 잔류 차단)", () => {
+    const hoveredEdgeRef = ref<{
+      sourceId: string;
+      targetId: string;
+      relationType: string;
+      declaredBySlug: string | null;
+    } | null>({ sourceId: "a", targetId: "b", relationType: "contains", declaredBySlug: null });
+    const onHoverEdge = vi.fn();
+
+    const { handleWheel } = createTopologyPointerHandlers(
+      buildRefs({ hoveredEdgeRef, onHoverEdge }),
+    );
+
+    handleWheel(fakeWheelEvent());
+
+    expect(hoveredEdgeRef.current).toBeNull();
+    expect(onHoverEdge).toHaveBeenCalledWith(null, null);
+  });
+
+  it("휠 줌 시 클러스터 호버 툴팁도 함께 dismiss 한다", () => {
+    const hoveredClusterIdRef = ref<string | null>("domain:x");
+    const onHoverCluster = vi.fn();
+
+    const { handleWheel } = createTopologyPointerHandlers(
+      buildRefs({ hoveredClusterIdRef, onHoverCluster }),
+    );
+
+    handleWheel(fakeWheelEvent());
+
+    expect(hoveredClusterIdRef.current).toBeNull();
+    expect(onHoverCluster).toHaveBeenCalledWith(null);
+  });
+
+  it("떠 있는 카드가 없으면 dismiss 콜백을 부르지 않는다 (불필요한 재렌더 방지)", () => {
+    const hoveredEdgeRef = ref<{
+      sourceId: string;
+      targetId: string;
+      relationType: string;
+      declaredBySlug: string | null;
+    } | null>(null);
+    const onHoverEdge = vi.fn();
+
+    const { handleWheel } = createTopologyPointerHandlers(
+      buildRefs({ hoveredEdgeRef, onHoverEdge }),
+    );
+
+    handleWheel(fakeWheelEvent());
+
+    expect(onHoverEdge).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
디자인 패널 즉효 4건: ① 노드 정중앙 클릭이 엣지를 열던 히트 역전 (끝 노드 몸통 반경 제외 기하 + 우선순위 테스트) ② 엣지 호버 카드가 줌 3티어 관통 잔류 → 휠 첫 틱 dismiss ③ `?realm=` bare slug 를 canonical id 로 승격 해석, 미해석 시 칩 미표시 ④ 헤더 필-INDEX 패널 7.6px 우변 어긋남 (공통 폭 토큰) + 리스트 중간-행 클립 (하단 mask 페이드).

## Test plan
- 841 tests (신규 52 포함) ✅ · tsc ✅ · ESLint 0 ✅