### PR TITLE
fix: 좌측 레일 아이콘 판독선 상향

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -747,9 +747,9 @@
      * 비율로 커져 좌측 레일만 상대적으로 작아 보이는 결함을 해소한다.
      */
     --app-nav-rail-width: calc(64px * var(--topology-ui-scale-factor));
-    --app-nav-rail-logo-size: calc(34px * var(--topology-ui-scale-factor));
-    --app-nav-rail-logo-icon-size: calc(20px * var(--topology-ui-scale-factor));
-    --app-nav-rail-icon-size: calc(18px * var(--topology-ui-scale-factor));
+    --app-nav-rail-logo-size: calc(38px * var(--topology-ui-scale-factor));
+    --app-nav-rail-logo-icon-size: calc(24px * var(--topology-ui-scale-factor));
+    --app-nav-rail-icon-size: calc(22px * var(--topology-ui-scale-factor));
     --app-nav-rail-label-size: calc(9.5px * var(--topology-ui-scale-factor));
     --app-nav-rail-tile-width: calc(38px * var(--topology-ui-scale-factor));
     --app-nav-rail-tile-height: calc(32px * var(--topology-ui-scale-factor));


### PR DESCRIPTION
## Summary
- 소유자 실보고: 레일 아이콘 과소 → 아이콘 18→22px · 로고 20→24px (레일 폭 64px 유지, 토큰만).

## Test plan
- app-nav-rail 테스트 green ✅ · 토큰 변경이라 :3107 재시작 후 시각 확인 예정