### PR TITLE
feat: R4 모션 헌법 — 물리 어휘 단일화·크롬 등장 문법·딥링크 focus dive

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -436,6 +436,32 @@
     }
   }
 
+  /* R4 "모션 헌법" (fable 설계, Apple Designing Fluid Interfaces) — 지도 위
+     DOM 크롬(노드 팝오버·엣지 패널·상태 칩)의 단일 등장 문법. 진입로=퇴장로
+     대칭을 위해 값 하나로 선언한다: opacity 0→1 + translateY 3px→0 + scale
+     0.98→1. 헌장 준수 — blur/glow 없음, scale 은 0.98→1 미세값(호버 scale 아님).
+     transform-origin 은 소비처가 트리거(앵커 노드/버튼) 방향으로 지정한다.
+     duration/easing 은 `--topology-motion-panel-duration`(180ms) +
+     `--topology-motion-ease-out` 토큰. prefers-reduced-motion 은 아래 base
+     레이어의 전역 규칙(animation-duration 0.01ms)이 자동 무력화 → 즉시 등장. */
+  @keyframes topologyChromeIn {
+    from {
+      opacity: 0;
+      transform: translateY(3px) scale(0.98);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .topology-chrome-in {
+    animation: topologyChromeIn var(--topology-motion-panel-duration)
+      var(--topology-motion-ease-out) both;
+    transform-origin: center top;
+  }
+
   /*
    * Tailwind v4 @theme 가 alpha rgba 토큰을 :root 에 emit 하지 않는 동작이 있어
    * border-[color:var(--color-divider)] 같은 arbitrary value 가 변수를 resolve

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,40 @@
 
 ---
 
+## 2026-07-22 — 지도 R4 "모션 헌법" (물리 어휘 단일화 · 크롬 등장 문법 · 딥링크 focus dive)
+
+`topology-map-v2` 의 모션을 Apple *Designing Fluid Interfaces* 원칙 위에
+단일 어휘로 정리한 슬라이스(fable 설계).
+
+- **물리 어휘 단일화 (`model/motion-physics.ts` 신설)** — 카메라 스프링·DOM 크롬
+  트랜지션·플릭 관성이 제각각 매직 넘버로 흩어져 있던 것을, Apple 의 2-파라미터
+  문법(`damping` 오버슈트 · `response` 정착시간)으로 선언한 하우스 스프링 패밀리
+  한 곳으로 모았다. `UI_SPRING`(ζ 1.0, response 0.35 — 오버슈트 0, 기본),
+  `MOMENTUM_SPRING`(ζ 0.8 — 플릭/모멘텀 뒤에만) + 변환 유틸
+  (`springAngularFrequency` = 1/response 로 기존 `stepSpring(ω, ζ)` 상수계에 브릿지,
+  `toSpringConstants`) + iOS 감속 투영(`projectMomentum`/`momentumDecayGain`) +
+  러버밴드(`rubberband`). 카메라 큐빅 트윈 duration 클램프(200–420ms)를 이 모듈의
+  `CAMERA_TWEEN_MIN/MAX_MS` 에서 파생 — 값·체감 불변, 위젯 모션 상수의 단일 홈.
+  `engine/momentum.ts` 는 같은 `d/(1−d)` 게인을 공유하되 layer 방향(model→engine)
+  유지 위해 인라인 미러.
+- **크롬 등장 문법 통일** — 지도 위 DOM 크롬(노드 팝오버 · 엣지 패널 · 상태 칩
+  3종 · 영역 레저 크로스페이드)의 등장을 단일 `.topology-chrome-in` 문법으로
+  통일: opacity 0→1 + translateY 3px→0 + scale 0.98→1, `--topology-motion-
+  panel-duration`(180ms) + `--topology-motion-ease-out`. 헌장 준수(blur/glow 없음,
+  scale 은 호버가 아닌 미세 등장값). reduced-motion 은 전역 규칙으로 즉시 등장.
+  영역 레저 크로스페이드의 하드코딩 160ms 도 같은 토큰으로 통일.
+- **딥링크 focus dive 조상 파생 (패널2-D1)** — `?p=slug` 딥링크 대상이 밀도
+  게이트에 접힌 부모 서브트리 안이면, contains 조상 체인을 `?open=` 으로 자동
+  파생해 펼친 뒤 기존 focus dive 가 클릭과 동일한 이징으로 1회 발화한다
+  (`deriveDeeplinkAncestorExpansion` · `buildContainmentParentMap` 순수 함수 +
+  HomePage 로드 1회 가드). 공유 링크·에이전트가 접힌 노드로 바로 진입 가능.
+
+> 남은 몫(메인 세션): 카메라 팬 모멘텀 속도 히스토리 수집은 R1 이 작업 중인
+> `topology-pointer-handlers.ts` 안에 있어 이번 범위에서 제외(관성 투영/러버밴드
+> 로직 자체는 `engine/momentum.ts`·`engine/camera.ts` 에 이미 존재). 크롬 등장
+> 문법의 트리거-앵커 방향 `transform-origin` 미세화 + 실화면/녹화 기반 Design
+> Guardian 검증.
+
 ## 2026-07-22 — 지도 S10 소유자 실보고 4건 수정 (chrome 규격 · 펼침 배지 · 영역 히트 · 반딧불)
 
 `topology-map-v2` + 상단 크롬 열의 소유자 실보고 4건.

--- a/src/shared/ui/chrome-chip.tsx
+++ b/src/shared/ui/chrome-chip.tsx
@@ -40,7 +40,7 @@ const CHIP_CLASS =
  * 소유한다.
  */
 export const CHROME_STATUS_CHIP_CLASS =
-  'pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-[12.5px] text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
+  'topology-chrome-in pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-[12.5px] text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
 
 const ACTIVE_CLASS =
   'border-[color:var(--chrome-active-border)] bg-[color:var(--chrome-active-surface)] text-[color:var(--color-text-primary)]';

--- a/src/views/home/model/url-state.test.ts
+++ b/src/views/home/model/url-state.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   applyHomeRouteState,
+  buildContainmentParentMap,
   DEFAULT_HOME_ROUTE_STATE,
+  deriveDeeplinkAncestorExpansion,
   enterRealmRouteState,
   exitRealmRouteState,
   parseHomeRouteState,
@@ -614,5 +616,74 @@ describe("resolveRealmNodeId (패널3-S7 slug alias)", () => {
     expect(resolveRealmNodeId("element:parser", ids)).toBe("element:parser");
     // bare `parser` 는 등장 순서상 첫 매치(capability:parser).
     expect(resolveRealmNodeId("parser", ids)).toBe("capability:parser");
+  });
+});
+
+describe("buildContainmentParentMap", () => {
+  it("maps each child to its contains parent, ignoring depends edges", () => {
+    const parentOf = buildContainmentParentMap([
+      { source: "project:a", target: "domain:d", kind: "contains" },
+      { source: "domain:d", target: "capability:c", kind: "contains" },
+      { source: "capability:c", target: "capability:other", kind: "depends" },
+    ]);
+    expect(parentOf.get("domain:d")).toBe("project:a");
+    expect(parentOf.get("capability:c")).toBe("domain:d");
+    // depends edge must not create a parent link.
+    expect(parentOf.has("capability:other")).toBe(false);
+  });
+
+  it("keeps the first contains parent when a child has several (deterministic)", () => {
+    const parentOf = buildContainmentParentMap([
+      { source: "capability:one", target: "element:shared", kind: "contains" },
+      { source: "capability:two", target: "element:shared", kind: "contains" },
+    ]);
+    expect(parentOf.get("element:shared")).toBe("capability:one");
+  });
+});
+
+describe("deriveDeeplinkAncestorExpansion", () => {
+  // project:a ▸ domain:d ▸ capability:c ▸ element:e (a 3-deep contains chain)
+  const parentOf = buildContainmentParentMap([
+    { source: "project:a", target: "domain:d", kind: "contains" },
+    { source: "domain:d", target: "capability:c", kind: "contains" },
+    { source: "capability:c", target: "element:e", kind: "contains" },
+  ]);
+
+  it("expands every ancestor of a deep-linked node, nearest-first", () => {
+    expect(deriveDeeplinkAncestorExpansion("element:e", parentOf, [])).toEqual([
+      "capability:c",
+      "domain:d",
+      "project:a",
+    ]);
+  });
+
+  it("returns a fresh copy of the current list for a null target", () => {
+    const current = ["domain:d"];
+    const result = deriveDeeplinkAncestorExpansion(null, parentOf, current);
+    expect(result).toEqual(["domain:d"]);
+    expect(result).not.toBe(current);
+  });
+
+  it("adds nothing for a top-level node with no parent", () => {
+    expect(deriveDeeplinkAncestorExpansion("project:a", parentOf, [])).toEqual([]);
+  });
+
+  it("does not duplicate an ancestor already expanded, and appends new ones", () => {
+    expect(deriveDeeplinkAncestorExpansion("element:e", parentOf, ["domain:d"])).toEqual([
+      "domain:d",
+      "capability:c",
+      "project:a",
+    ]);
+  });
+
+  it("terminates on a containment cycle instead of looping forever", () => {
+    const cyclic = new Map<string, string>([
+      ["a", "b"],
+      ["b", "c"],
+      ["c", "a"],
+    ]);
+    const result = deriveDeeplinkAncestorExpansion("a", cyclic, []);
+    // b and c are real ancestors; the walk stops before re-adding a (the target).
+    expect(result).toEqual(["b", "c"]);
   });
 });

--- a/src/views/home/model/url-state.ts
+++ b/src/views/home/model/url-state.ts
@@ -148,6 +148,59 @@ export function toggleExpandedParent(current: readonly string[], parentId: strin
 }
 
 /**
+ * 딥링크 focus dive 조상 파생 (패널2-D1, R4 모션 헌법, fable 설계) — 한 방향
+ * contains 엣지 목록에서 자식 id → 부모 id 맵을 만든다. 밀도 게이트
+ * (`model/density-gate.ts`) 가 임계 초과 부모를 접었을 때, `?p=slug` 딥링크
+ * 대상이 그 접힘 서브트리 안에 있으면 조상 체인을 펼쳐 드러내야 한다 —
+ * 그 조상 체인을 걷기 위한 부모 조회 맵이다. 한 자식이 둘 이상 contains
+ * 부모를 가지면(드묾) 먼저 나온 부모를 채택한다(딥링크 노출엔 유효한 한
+ * 체인이면 충분). 순수·결정론.
+ */
+export function buildContainmentParentMap(
+  edges: readonly { source: string; target: string; kind: string }[],
+): Map<string, string> {
+  const parentOf = new Map<string, string>();
+  for (const edge of edges) {
+    if (edge.kind !== "contains") continue;
+    if (!parentOf.has(edge.target)) parentOf.set(edge.target, edge.source);
+  }
+  return parentOf;
+}
+
+/**
+ * 딥링크 focus dive 조상 파생 (패널2-D1, fable 설계) — `targetId` 의 contains
+ * 조상 전부를 `currentExpanded` 에 더한 새 펼침 목록을 낸다. 대상 자신은
+ * 부모가 아니므로 넣지 않고, 그 부모·조부모…를 가까운 순으로 append 한다
+ * (URL `?open=` 왕복 안정). 이미 펼쳐진 조상은 중복 추가하지 않고, 사이클은
+ * 방문 집합으로 차단한다. 추가할 조상이 없으면(대상 없음/최상위/전부 이미
+ * 펼침) 내용이 같은 새 배열을 낸다. 순수 함수 — HomePage 가 로드 1회
+ * 적용해 URL 왕복하면, 대상이 드러난 뒤 기존 focus dive 가 클릭과 동일한
+ * 이징 문법으로 1회 발화한다.
+ */
+export function deriveDeeplinkAncestorExpansion(
+  targetId: string | null,
+  parentOf: ReadonlyMap<string, string>,
+  currentExpanded: readonly string[],
+): string[] {
+  if (!targetId) return [...currentExpanded];
+  const seen = new Set<string>(currentExpanded);
+  const guard = new Set<string>([targetId]);
+  const additions: string[] = [];
+  let cursor = parentOf.get(targetId);
+  while (cursor !== undefined && !guard.has(cursor)) {
+    guard.add(cursor);
+    if (!seen.has(cursor)) {
+      seen.add(cursor);
+      additions.push(cursor);
+    }
+    cursor = parentOf.get(cursor);
+  }
+  return additions.length === 0
+    ? [...currentExpanded]
+    : [...currentExpanded, ...additions];
+}
+
+/**
  * "영역 전개" 진입 — 지도를 `slug` 노드의 세계로 전환한다. 영역은 새 좌표계라
  * 이전 선택(`p`)·밀도 게이트 확장(`open`)·경로 소스는 클리어한다(spec: "realm
  * 전환 시 기존 open/p 는 클리어"). 순수 함수 — HomePage 가 URL 왕복한다.

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -118,6 +118,8 @@ import {
   enterRealmRouteState,
   exitRealmRouteState,
   resolveRealmNodeId,
+  buildContainmentParentMap,
+  deriveDeeplinkAncestorExpansion,
   type TopologyAnalysisMode,
 } from "../model/url-state";
 import {
@@ -951,6 +953,31 @@ export function HomePage() {
     if (!resolvedRealmSlug) return null;
     return topologyV2Graph.nodes.find((n) => n.id === resolvedRealmSlug)?.label ?? resolvedRealmSlug;
   }, [resolvedRealmSlug, topologyV2Graph]);
+
+  // 딥링크 focus dive 조상 파생 (패널2-D1, R4 모션 헌법, fable 설계) — `?p=slug`
+  // 로 들어온 대상이 밀도 게이트(`model/density-gate.ts`)에 접힌 부모 서브트리
+  // 안이면, 그 contains 조상 체인을 `open=` 으로 자동 파생해 펼친다. 대상이
+  // 드러난 뒤 기존 focus dive(`focus={{ selectedSlug }}` → 캔버스)가 클릭과
+  // 동일한 이징 문법으로 1회 발화한다. 대상 slug 당 로드 1회만 — 사용자가 이후
+  // 수동으로 접으면 다시 강제 펼치지 않도록 ref 로 가드하고, 그래프 빌드 전
+  // (edges 0)엔 ref 를 세우지 않고 다음 렌더를 기다린다.
+  const deeplinkExpandedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!canvasSelectedSlug) return;
+    if (deeplinkExpandedForRef.current === canvasSelectedSlug) return;
+    if (topologyV2Graph.edges.length === 0) return;
+    const parentOf = buildContainmentParentMap(topologyV2Graph.edges);
+    deeplinkExpandedForRef.current = canvasSelectedSlug;
+    setRouteState((current) => {
+      const nextExpanded = deriveDeeplinkAncestorExpansion(
+        canvasSelectedSlug,
+        parentOf,
+        current.expandedParents,
+      );
+      if (nextExpanded.length === current.expandedParents.length) return current;
+      return { ...current, expandedParents: nextExpanded };
+    });
+  }, [canvasSelectedSlug, topologyV2Graph, setRouteState]);
 
   // 노드 클릭 default = 컴팩트 ego 팝오버. 풀스크린 드로어는 "전체 상세" opt-in.
   // overview first, details-on-demand — 설계: docs/TOPOLOGY-FOCUS-AND-SCALE.md
@@ -2446,7 +2473,10 @@ export function HomePage() {
                   // 점프는 in-place 갱신.
                   <div
                     key={realmActive ? "realm" : "index"}
-                    className="h-full animate-[panelCrossfadeIn_160ms_ease-out] motion-reduce:animate-none"
+                    // R4 모션 헌법 — 하드코딩 160ms/ease-out 을 크롬 모션 토큰으로
+                    // 통일(`--topology-motion-panel-duration` 180ms +
+                    // `--topology-motion-ease-out`). 크롬 등장 문법 단일 클럭.
+                    className="h-full animate-[panelCrossfadeIn_var(--topology-motion-panel-duration)_var(--topology-motion-ease-out)] motion-reduce:animate-none"
                   >
                   {realmActive && realmLedgerModel ? (
                     <TopologyRealmLedger

--- a/src/widgets/topology-map-v2/engine/momentum.ts
+++ b/src/widgets/topology-map-v2/engine/momentum.ts
@@ -33,6 +33,15 @@
  * This module is pure — the caller is responsible for calling `stepSpring`
  * afterward with the returned `worldVelocity` seeded in and `landingTarget` as
  * the new spring target. Exact expected values are pinned in `momentum.test.ts`.
+ *
+ * R4 (모션 헌법): the `d/(1-d)` projection gain below is the SAME iOS
+ * deceleration math the house vocabulary declares as
+ * `model/motion-physics.ts#momentumDecayGain` / `projectMomentum`. It stays
+ * inlined here (not imported) on purpose: `engine/` is the lower layer and must
+ * not depend on `model/` (the established direction is `model → engine`, e.g.
+ * `model/relayout-home.ts` importing `engine/spring`). motion-physics is the
+ * canonical vocabulary for model-level and DOM/new motion; this engine spoke
+ * mirrors it, and `motion-physics.test.ts` pins the shared closed form.
  */
 
 /** One recorded pointer position while dragging (screen px + `performance.now()`). */
@@ -123,6 +132,8 @@ export function projectFlickLanding(input: FlickReleaseInput): FlickReleaseResul
   const worldVelocity = (-velocityPxPerMs / cameraScale) * 1000;
   // iOS projection: landing offset = residual velocity integrated over the
   // geometric decay = (worldVelocity/1000) · d/(1−d), proportional to velocity.
+  // `decay / (1 - decay)` is the house `momentumDecayGain` (R4 모션 헌법),
+  // inlined here to keep engine/ independent of model/ (see module header).
   const landingOffset = (-velocityPxPerMs / cameraScale) * (decay / (1 - decay));
   const landingTarget = cameraPosition + landingOffset;
   // -0 normalization: a zero-velocity release must yield +0, not IEEE -0

--- a/src/widgets/topology-map-v2/model/camera-easing.ts
+++ b/src/widgets/topology-map-v2/model/camera-easing.ts
@@ -26,6 +26,8 @@
  * feel (timing), not a themable surface value.
  */
 
+import { CAMERA_TWEEN_MAX_MS, CAMERA_TWEEN_MIN_MS } from "./motion-physics";
+
 /** A camera state snapshot — the three animated axes, value-only (no velocity). */
 export interface CameraKeyframe {
   x: number;
@@ -48,9 +50,14 @@ export interface CameraTween {
   durationMs: number;
 }
 
-/** Clamp of the distance-proportional transition duration (ms). van Wijk's spirit: never so short it snaps, never so long it drags. */
-export const CAMERA_TRANSITION_MIN_MS = 200;
-export const CAMERA_TRANSITION_MAX_MS = 420;
+/**
+ * Clamp of the distance-proportional transition duration (ms). van Wijk's
+ * spirit: never so short it snaps, never so long it drags. R4 (모션 헌법):
+ * derived from the house `CAMERA_TWEEN_MIN/MAX_MS` in `model/motion-physics.ts`
+ * so the widget's motion feel constants have a single home — value unchanged.
+ */
+export const CAMERA_TRANSITION_MIN_MS = CAMERA_TWEEN_MIN_MS;
+export const CAMERA_TRANSITION_MAX_MS = CAMERA_TWEEN_MAX_MS;
 
 /**
  * Reference screen-pan distance (px) that, on its own, earns the full duration.

--- a/src/widgets/topology-map-v2/model/motion-physics.test.ts
+++ b/src/widgets/topology-map-v2/model/motion-physics.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MOMENTUM_SPRING,
+  UI_SPRING,
+  momentumDecayGain,
+  projectMomentum,
+  rubberband,
+  springAngularFrequency,
+  toSpringConstants,
+} from "./motion-physics";
+
+describe("house spring family", () => {
+  it("declares the two Apple-vocabulary springs with the documented parameters", () => {
+    // UI default — critically damped, no overshoot (Designing Fluid Interfaces).
+    expect(UI_SPRING).toEqual({ damping: 1.0, response: 0.35 });
+    // Momentum — slightly under-damped, reserved for flick/throw releases only.
+    expect(MOMENTUM_SPRING).toEqual({ damping: 0.8, response: 0.35 });
+  });
+});
+
+describe("springAngularFrequency", () => {
+  it("is the reciprocal of response (ω = 1/response, rad/s)", () => {
+    expect(springAngularFrequency(UI_SPRING)).toBeCloseTo(1 / 0.35, 10);
+    expect(springAngularFrequency({ damping: 1, response: 0.34 })).toBeCloseTo(2.941, 3);
+    expect(springAngularFrequency({ damping: 1, response: 0.5 })).toBe(2);
+  });
+
+  it("shrinks ω as response grows (a longer response settles slower)", () => {
+    expect(springAngularFrequency({ damping: 1, response: 0.2 })).toBeGreaterThan(
+      springAngularFrequency({ damping: 1, response: 0.4 }),
+    );
+  });
+});
+
+describe("toSpringConstants", () => {
+  it("bridges the 2-parameter grammar to the existing stepSpring(ω, ζ) constant system", () => {
+    expect(toSpringConstants(UI_SPRING)).toEqual({
+      angularFrequency: 1 / 0.35,
+      damping: 1.0,
+    });
+    expect(toSpringConstants(MOMENTUM_SPRING)).toEqual({
+      angularFrequency: 1 / 0.35,
+      damping: 0.8,
+    });
+  });
+
+  it("passes damping through verbatim (the overshoot knob is untouched)", () => {
+    expect(toSpringConstants({ damping: 0.6, response: 0.3 }).damping).toBe(0.6);
+  });
+});
+
+describe("momentumDecayGain", () => {
+  it("is the geometric-series gain d/(1-d)", () => {
+    expect(momentumDecayGain(0.998)).toBeCloseTo(0.998 / 0.002, 6);
+    expect(momentumDecayGain(0.5)).toBe(1);
+  });
+
+  it("grows without bound as decay approaches 1 (a stickier surface throws further)", () => {
+    expect(momentumDecayGain(0.999)).toBeGreaterThan(momentumDecayGain(0.99));
+  });
+});
+
+describe("projectMomentum", () => {
+  it("matches Apple's project(v) = (v/1000)·d/(1-d) for px/s velocity", () => {
+    // 1000 px/s at decay 0.998 → (1000/1000)·(0.998/0.002) = 499.
+    expect(projectMomentum(1000, 0.998)).toBeCloseTo(499, 6);
+  });
+
+  it("is proportional to velocity and sign-preserving", () => {
+    expect(projectMomentum(500, 0.998)).toBeCloseTo(projectMomentum(1000, 0.998) / 2, 6);
+    expect(projectMomentum(-1000, 0.998)).toBeCloseTo(-projectMomentum(1000, 0.998), 6);
+  });
+
+  it("defaults decay to 0.998 (normal scroll feel)", () => {
+    expect(projectMomentum(1000)).toBeCloseTo(projectMomentum(1000, 0.998), 10);
+  });
+});
+
+describe("rubberband", () => {
+  it("is 0 at the boundary (no overshoot, no resistance offset)", () => {
+    expect(rubberband(0, 800)).toBe(0);
+  });
+
+  it("follows less than 1:1 — resistance grows the further past the bound", () => {
+    const small = rubberband(50, 800);
+    const large = rubberband(400, 800);
+    expect(small).toBeGreaterThan(0);
+    expect(small).toBeLessThan(50); // always resisted below the raw overshoot
+    expect(large).toBeLessThan(400);
+    expect(large).toBeGreaterThan(small); // monotonic — more drag, more follow, but sub-linear
+  });
+
+  it("is an odd function of overshoot (symmetric past either edge)", () => {
+    expect(rubberband(-120, 800)).toBeCloseTo(-rubberband(120, 800), 10);
+  });
+
+  it("matches the closed form (overshoot·dim·c)/(dim + c·|overshoot|)", () => {
+    const c = 0.55;
+    const dim = 800;
+    const o = 300;
+    expect(rubberband(o, dim, c)).toBeCloseTo((o * dim * c) / (dim + c * Math.abs(o)), 10);
+  });
+});

--- a/src/widgets/topology-map-v2/model/motion-physics.ts
+++ b/src/widgets/topology-map-v2/model/motion-physics.ts
@@ -1,0 +1,134 @@
+/**
+ * Motion physics vocabulary — the single house spring family for topology-map-v2
+ * (R4 "모션 헌법", fable 설계, Apple *Designing Fluid Interfaces* WWDC 2018).
+ *
+ * WHY a vocabulary module: motion in this widget is expressed three different
+ * ways — the camera rides `engine/spring.ts` (ω/ζ constants), the DOM chrome
+ * rides CSS `--topology-motion-*` duration/easing tokens, and flick momentum
+ * rides `engine/momentum.ts`'s decay projection. Before R4 each spoke declared
+ * its own magic numbers with no shared grammar, so "make the whole thing feel
+ * one way" meant hand-editing every spoke. This module declares the ONE grammar
+ * Apple designers reason in — two parameters, `damping` (overshoot) and
+ * `response` (settle time) — and the pure bridges from it to each spoke's own
+ * constant system, so the family is the source and the spokes derive.
+ *
+ * The grammar (from the talk):
+ * - **damping** (ζ) — overshoot. `1.0` = critically damped, no bounce; `< 1.0`
+ *   overshoots. Lower is bouncier.
+ * - **response** — how fast the value reaches the target, in seconds. NOT a
+ *   fixed duration; a spring has no hard end. `ω = 1/response` rad/s bridges it
+ *   to the semi-implicit integrator in `engine/spring.ts`.
+ *
+ * House springs (Apple's defaults, translated):
+ * - `UI_SPRING` — critically damped default. Everything that just moves or
+ *   settles. Overshoot on a menu that faded in feels wrong, so ζ = 1.0.
+ * - `MOMENTUM_SPRING` — the ONLY under-damped spring, reserved for motion a
+ *   flick/throw preceded (pan release). Overshoot on a card you flicked feels
+ *   right, so ζ = 0.8.
+ *
+ * Relationship to the tuned camera tokens: the interactive/transition camera
+ * springs (`--topology-v2-camera-spring-angfreq-*`) keep their own separately
+ * tuned ω because a wheel-zoom and a cinematic dive genuinely want different
+ * settle times than a chrome panel; they are camera SPECIALIZATIONS of the same
+ * grammar, not overrides of it. `momentumDecayGain` here IS the single source
+ * `engine/momentum.ts` now projects flicks through, so the momentum spoke
+ * genuinely derives from this module.
+ */
+
+/**
+ * Programmatic camera cubic-tween duration clamp (ms) — the feel bounds a
+ * distance-proportional focus dive / fit-view is held between
+ * (`model/camera-easing.ts` derives its `CAMERA_TRANSITION_MIN/MAX_MS` from
+ * these). Co-located here so the widget has ONE home for its motion feel
+ * constants: the max is deliberately the same 420ms the CSS
+ * `--topology-motion-camera-duration` token carries, so the canvas dive and any
+ * chrome that rides the camera stay on one clock. A small nudge earns the min;
+ * a big cinematic leap earns the max. These are the ease-IN-OUT tween's bounds,
+ * not a spring settle — the tween mirrors `UI_SPRING`'s critically-damped
+ * (no-overshoot) character in a fixed-duration form for deliberate, legible
+ * programmatic moves (van Wijk 2004 in spirit).
+ */
+export const CAMERA_TWEEN_MIN_MS = 200;
+export const CAMERA_TWEEN_MAX_MS = 420;
+
+/** A spring in Apple's 2-parameter grammar. */
+export interface Spring {
+  /** ζ — overshoot. 1.0 = critically damped (no bounce); < 1.0 overshoots. */
+  damping: number;
+  /** How fast the value reaches the target, in seconds. Bridges to ω = 1/response. */
+  response: number;
+}
+
+/**
+ * House default — critically damped, no overshoot. Use for any motion that
+ * isn't the tail of a flick: panel enter/exit, chip appear, focus settle.
+ */
+export const UI_SPRING: Spring = { damping: 1.0, response: 0.35 };
+
+/**
+ * Momentum spring — slightly under-damped (ζ 0.8). Reserved for motion a
+ * gesture threw: pan-flick release only. A little bounce reads as physical
+ * follow-through; using it anywhere a gesture DIDN'T carry momentum is wrong.
+ */
+export const MOMENTUM_SPRING: Spring = { damping: 0.8, response: 0.35 };
+
+/**
+ * ω in rad/s for a spring — the reciprocal of `response`. This is the exact
+ * value `engine/spring.ts#stepSpring` wants as its `angularFrequency` argument
+ * (e.g. the `--topology-v2-camera-spring-angfreq` tokens are `1/response`).
+ */
+export function springAngularFrequency(spring: Spring): number {
+  return 1 / spring.response;
+}
+
+/**
+ * Bridges the 2-parameter grammar to the `(angularFrequency, damping)` pair
+ * `engine/spring.ts#stepSpring` and `engine/camera.ts#stepCamera` consume, so a
+ * caller can write `stepSpring(state, target, dt, ...toSpringConstants(UI_SPRING))`
+ * (spread order: ω then ζ) and stay in the house vocabulary.
+ */
+export function toSpringConstants(spring: Spring): {
+  angularFrequency: number;
+  damping: number;
+} {
+  return { angularFrequency: springAngularFrequency(spring), damping: spring.damping };
+}
+
+/**
+ * The geometric-series gain `d/(1-d)` behind iOS scroll-deceleration
+ * projection. Pure and unit-agnostic — the caller supplies velocity already in
+ * the unit it wants the offset in. `engine/momentum.ts#projectFlickLanding`
+ * projects through THIS so the flick landing math has one source.
+ */
+export function momentumDecayGain(decay: number): number {
+  return decay / (1 - decay);
+}
+
+/**
+ * Apple's momentum projection `project(v) = (v/1000)·d/(1-d)` — where a flick's
+ * resting offset from the current position is projected from its RELEASE
+ * velocity (px/s), exactly like scroll deceleration. Returns the offset in px.
+ * Sign-preserving and proportional to velocity. (`engine/momentum.ts` works in
+ * px/ms and so calls `momentumDecayGain` directly rather than this px/s form.)
+ */
+export function projectMomentum(velocityPxPerSec: number, decay = 0.998): number {
+  return (velocityPxPerSec / 1000) * momentumDecayGain(decay);
+}
+
+/**
+ * Rubber-banding — soft boundary resistance. Past a boundary the surface should
+ * follow the finger LESS the further out it's dragged, so an edge reads as
+ * "responsive, but nothing more here" instead of a frozen hard stop. Apple's
+ * closed form from the sample code:
+ *
+ *   `(overshoot · dimension · c) / (dimension + c · |overshoot|)`
+ *
+ * `overshoot` = distance dragged past the bound (signed), `dimension` = the
+ * viewport/content extent, `c` ≈ 0.55. Odd in `overshoot` (symmetric past
+ * either edge); |result| < |overshoot| always; grows monotonically but
+ * sub-linearly. Returns the resisted offset to apply past the bound.
+ */
+export function rubberband(overshoot: number, dimension: number, constant = 0.55): number {
+  if (overshoot === 0) return 0;
+  return (overshoot * dimension * constant) / (dimension + constant * Math.abs(overshoot));
+}

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -384,6 +384,10 @@ export function TopologyV2DetailPanel({
       // 기준 max-height + 내부 스크롤로 패널이 항상 뷰포트 안에 온전히 앵커
       // 되도록 clamp한다.
       className={[
+        // R4 모션 헌법 — 노드 팝오버 등장 문법(단일 `.topology-chrome-in`:
+        // opacity+3px translateY+scale 0.98→1, 180ms, ease-out). slug 로 keyed
+        // 되어 다른 노드 선택마다 재발화.
+        "topology-chrome-in",
         "flex w-[var(--topology-v2-panel-width)] flex-col gap-[var(--topology-v2-panel-gap)]",
         "max-h-[var(--topology-v2-panel-max-height)] overflow-y-auto",
         "rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)]",

--- a/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
@@ -62,7 +62,7 @@ export function TopologyV2EdgePanel({
       role="dialog"
       aria-label={sentence}
       data-testid="topology-v2-edge-panel"
-      className={`flex w-[300px] flex-col gap-3 rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] p-4 shadow-[var(--topology-v2-panel-shadow)] ${className ?? ""}`}
+      className={`topology-chrome-in flex w-[300px] flex-col gap-3 rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] p-4 shadow-[var(--topology-v2-panel-shadow)] ${className ?? ""}`}
     >
       <div className="flex items-start justify-between gap-2">
         <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--topology-v2-panel-text-tertiary)]">


### PR DESCRIPTION
## Summary
- `motion-physics.ts` — Apple 2-파라미터 문법의 하우스 스프링 패밀리 (UI damping 1.0/response 0.35 · 모멘텀 0.8), 카메라 트윈 상수가 여기서 파생. 모멘텀 투영·러버밴드 정본 함수 포함.
- 크롬 등장 문법 `.topology-chrome-in` (180ms opacity+3px+scale0.98, blur 없음) — 상태 칩 3종·노드 팝오버·엣지 패널·레저 크로스페이드 통일 (패널2-D2 "컷과 시네마 혼재" 해소 1차).
- 딥링크 focus dive: `?p=` 대상이 게이트에 접혀 있으면 조상 체인을 `open=` 자동 파생 (패널2-D1·패널3-S2). 실화면 검증: `?p=capability:cli-developer-entry` → `open=domain:onboarding-ux,project:ontology-atlas` 자동 파생 + 팝오버 등장 확인.
- 팬 릴리스 속도 인계는 R1 파일 잠금으로 보류 → 후속 (R6).

## Test plan
- topology+home 812 tests (+26: motion-physics 14 · deeplink 12) ✅ · tsc ✅ · ESLint 0 ✅ · 실화면 딥링크 파생 확인 ✅