### PR TITLE
refactor: R5 디자인 시스템 법전화 — Geometry & Type Codex

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -407,6 +407,61 @@
   --kind-tone-capability: 211, 159, 73;
   --kind-tone-element: 105, 177, 121;
   --kind-tone-unknown: 196, 92, 92;
+
+  /*
+   * ── Geometry & Type Codex (R5, 2026-07) ─────────────────────────────
+   * 규격 표: docs/DESIGN-SYSTEM.md "Geometry & Type Codex" 절이 박스별
+   * (칩·배지·패널·팝오버·카드·입력·버튼) 높이/radius/패딩/타이포 단을 토큰명
+   * 으로 못박는다. 이 램프 밖의 text-[Npx] / rounded-[Npx] 리터럴은 존재
+   * 금지 — 신규 값은 토큰 신설 PR 로만. ESLint no-restricted-syntax 가
+   * 마이그레이션 완료 디렉토리에서 error 로 차단한다.
+   *
+   * 실측 근거(치환 전): text-[Npx] 하드코딩 29종 크기(1,184건) → 7단 램프로
+   * 수렴, arbitrary radius 18종 → 3단. 간격 계단은 4/8 원칙(gap/space 유틸).
+   */
+
+  /* Type ramp — 7단. Tailwind v4 `--text-*` 네임스페이스가 text-<step>
+     font-size 유틸리티를 생성한다. letter-spacing 은 아래 `--tracking-*`
+     짝으로 분리 관리한다 — text-<step> 에 자동 결합하면 ~1천 element 의
+     tracking 이 한꺼번에 바뀌어 "법전화지 리디자인 아님" 원칙을 깬다. 코덱스
+     표가 어느 tracking 과 짝인지 명시하고, 신규 코드가 그 짝을 함께 적용한다.
+     Apple 광학 원칙: 작은 단은 양의 tracking 으로 판독선 확보, 큰 단은 음의
+     tracking 으로 응집. */
+  --text-caption: 9.5px; /* 마이크로 라벨·범례·타임스탬프 (짝: tracking-caption) */
+  --text-label: 11px; /* 칩·배지·보조 라벨 (짝: tracking-label) */
+  --text-body: 12.5px; /* 기본 본문·리스트 행 (짝: tracking-body) */
+  --text-body-lg: 14px; /* 강조 본문·부제 (짝: tracking-body-lg) */
+  --text-title: 16px; /* 패널/카드 제목 (짝: tracking-title) */
+  --text-display: 23px; /* 페이지 헤드라인 (짝: tracking-display) */
+  --text-hero: 30px; /* 히어로 헤드라인 (짝: tracking-hero) */
+
+  /* Type ramp letter-spacing 짝 — text-<step> 과 1:1. tracking-<step>
+     유틸리티로 쓴다. --tracking-display/hero 는 위 "Letter-spacing 스케일"
+     절에 이미 정의(−0.022em)돼 있어 램프 상단과 짝이 맞는다. */
+  --tracking-caption: 0.04em;
+  --tracking-label: 0.02em;
+  --tracking-body: 0.005em;
+  --tracking-body-lg: 0em;
+  --tracking-title: -0.01em;
+
+  /* Radius ramp — 3단. Tailwind v4 `--radius-*` 네임스페이스가 rounded-<step>
+     를 생성한다. 이 밖(sub-chip 헤어라인 1~4px, overlay sheet/card 18~28px)은
+     코덱스 표의 명시 예외로만 — eslint-disable + 사유 주석 필수. */
+  --radius-chip: 6px; /* 칩·배지·작은 버튼 */
+  --radius-card: 9px; /* 카드·인풋·중형 서피스 */
+  --radius-panel: 12px; /* 패널·모달·큰 서피스 */
+
+  /* Padding ramp — 2단. `p-[var(--pad-card)]` 형태로 명시 참조한다(패딩은
+     ESLint ban 대상이 아니라 대량 치환하지 않음 — 코덱스 표의 규격 근거이자
+     신규 코드 참조원). */
+  --pad-card: 16px; /* 카드 내부 패딩 (RATIO-SYSTEM --card-pad 와 동일값) */
+  --pad-panel: 12px; /* 패널 내부 패딩 */
+
+  /* Codex 인덱스 — 기하/모션 토큰은 이 파일 하단에 이미 정의됨:
+     · --chrome-tile-size (44px) 크롬 타일 정사각
+     · --topology-motion-* / --topology-*-duration 모션 패밀리(180ms 크롬,
+       200~420ms 카메라, damping/response spring 패밀리)
+     전체 규격 표는 docs/DESIGN-SYSTEM.md "Geometry & Type Codex". */
 }
 
 @layer base {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,28 @@
 
 ---
 
+## 2026-07-22 — 디자인 시스템 법전화 R5 (Geometry & Type Codex)
+
+디자인 토큰 산개를 **법전**으로 못박았다. 시각은 ±1px 스냅 수준 유지 —
+리디자인이 아니라 규격 통일이다.
+
+- **Type ramp 7단** — `text-[Npx]` 하드코딩 29종 크기(1,184건)를
+  `--text-caption`(9.5) … `--text-hero`(30) 7단으로 수렴. 각 단에
+  `--tracking-*` letter-spacing 짝(Apple 광학 원칙)을 분리 정의(자동 결합 시
+  ~1천 element tracking 이 한꺼번에 바뀌는 것 방지).
+- **Radius 3단 · Padding 2단** — arbitrary radius 18종을
+  `--radius-chip`(6)/`card`(9)/`panel`(12)로, `--pad-card`(16)/`--pad-panel`(12)
+  신설. 크롬 컴포넌트 사다리(`--chrome-radius` 10px)와는 별개 체계로 공존.
+- **법전 문서** — `docs/DESIGN-SYSTEM.md` "Geometry & Type Codex" 절 신설:
+  램프 표 + 박스별 규격 표 + 명시 예외(헤어라인 1~4px · overlay sheet
+  18~28px · display 34~40px) + 모션 문법 인덱스.
+- **Lint 봉쇄** — ESLint `no-restricted-syntax` 가 신규 `text-[Npx]`/
+  `rounded-[Npx]` 를 차단. 마이그레이션 완료 디렉토리(views 4곳 · `shared/ui` ·
+  `widgets` R6 제외) = error, 동시작업 중 R6(`topology-map-v2`/`hero-header`/
+  `views/home`) = warn.
+- **1단계 마이그레이션** — 위 디렉토리 76개 파일의 하드코딩 크기/radius 를
+  가장 가까운 램프 단으로 치환. R6 소유 3개 디렉토리는 미변경.
+
 ## 2026-07-22 — 지도 디자인 패널 소규모 즉효 4건 (히트 역전 · 호버 잔류 · realm 별칭 · 첫 화면 픽셀)
 
 디자인 패널 지적 중 소규모·즉효 결함 4건. `topology-map-v2` + `views/home` +

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -1314,6 +1314,121 @@ Example: `/ontology` page
 
 The public surfaces `/`, `/topology`, `/docs`, `/projects`, `/project/[slug]` use the standalone Korean h1 pattern (without an English eyebrow caption) — these are the browse surfaces, not the operations surfaces.
 
+## Geometry & Type Codex (R5, 2026-07)
+
+> **박스 하나하나 사이즈까지 싹 다 지정해서 모든 곳에서 동일하게.** 이 절은
+> 텍스트 크기·radius·패딩을 토큰명으로 못박는 **법전**이다. 값 소스:
+> `app/globals.css` `@theme` "Geometry & Type Codex" 블록. 아래 램프 밖의
+> `text-[Npx]` / `rounded-[Npx]` 리터럴은 **존재 금지** — 신규 값이 필요하면
+> 토큰을 신설하는 PR 로만 추가한다(인라인 arbitrary 로 몰래 넣지 않는다).
+
+**실측 근거(치환 전, 2026-07):** `text-[Npx]` 하드코딩 **29종 크기 · 1,184건**,
+arbitrary radius **18종**, 카드 패딩 4종. 이 산개를 아래 램프로 수렴했다.
+
+### Type ramp — 7단
+
+Tailwind v4 `--text-*` 네임스페이스가 `text-<step>` font-size 유틸리티를
+생성한다. letter-spacing 은 `--tracking-*` 짝으로 **분리** 관리한다 —
+`text-<step>` 에 자동 결합하면 ~1천 element 의 tracking 이 한꺼번에 바뀌어
+"법전화지 리디자인 아님" 원칙을 깨기 때문. 신규 코드는 아래 짝을 함께 건다
+(Apple 광학 원칙: 작은 단은 양의 tracking 으로 판독선 확보, 큰 단은 음의
+tracking 으로 응집).
+
+| 단 | 토큰 (유틸) | px | tracking 짝 (유틸) | 대상 |
+|---|---|---|---|---|
+| caption | `--text-caption` (`text-caption`) | 9.5 | `+0.04em` (`tracking-caption`) | 마이크로 라벨·범례·타임스탬프 |
+| label | `--text-label` (`text-label`) | 11 | `+0.02em` (`tracking-label`) | 칩·배지·보조 라벨 |
+| body | `--text-body` (`text-body`) | 12.5 | `+0.005em` (`tracking-body`) | 기본 본문·리스트 행 |
+| body-lg | `--text-body-lg` (`text-body-lg`) | 14 | `0` (`tracking-body-lg`) | 강조 본문·부제 |
+| title | `--text-title` (`text-title`) | 16 | `-0.01em` (`tracking-title`) | 패널/카드 제목 |
+| display | `--text-display` (`text-display`) | 23 | `-0.022em` (`tracking-display`) | 페이지 헤드라인 |
+| hero | `--text-hero` (`text-hero`) | 30 | `-0.022em` (`tracking-hero`) | 히어로 헤드라인 |
+
+**최근접 수렴 규칙**(치환 시): 각 리터럴 px 를 가장 가까운 단으로 스냅한다
+(±1px 은 램프로 흡수). 단 사이 정확히 중간(예: 15px)은 상위 단으로, 램프 밖
+값(≥1.5px 이탈)은 아래 "명시 예외"로만 남긴다.
+
+### Radius ramp — 3단 (일반 표면)
+
+Tailwind v4 `--radius-*` 네임스페이스가 `rounded-<step>` 를 생성한다.
+
+| 단 | 토큰 (유틸) | px | 대상 |
+|---|---|---|---|
+| chip | `--radius-chip` (`rounded-chip`) | 6 | 칩·배지·작은 버튼 |
+| card | `--radius-card` (`rounded-card`) | 9 | 카드·인풋·중형 서피스 |
+| panel | `--radius-panel` (`rounded-panel`) | 12 | 패널·모달·큰 서피스 |
+
+> **크롬 radius 사다리와의 관계.** 아래 "크롬 문법" 절의 `--chrome-radius`
+> (10px) · `--chrome-radius-inner`(7px) · 키캡(4px) 사다리는 **컴포넌트에
+> 캡슐화된 별개 체계**다(ChromeTile / ChromeChip / 상태 칩 전용). 이 codex 의
+> `rounded-chip/card/panel` 은 그 밖의 **일반 JSX 표면**을 지배한다. 크롬
+> 표면은 인라인 `rounded-[Npx]` 가 아니라 컴포넌트를 경유하므로 두 체계는
+> 충돌하지 않는다 — 크롬 박스는 크롬 사다리, 나머지는 이 램프.
+
+### Padding — 2단
+
+| 단 | 토큰 | px | 대상 |
+|---|---|---|---|
+| card | `--pad-card` | 16 | 카드 내부 패딩 (RATIO-SYSTEM `--card-pad` 와 동일값) |
+| panel | `--pad-panel` | 12 | 패널 내부 패딩 |
+
+간격 계단은 **4/8 원칙** — `gap-*` / `space-*` 는 1(4px)·2(8px)·3(12px)…
+스텝만. 패딩은 ESLint ban 대상이 아니라(대량 치환 없음) 위 토큰을
+`p-[var(--pad-card)]` 로 명시 참조한다.
+
+### 박스별 규격 표
+
+각 박스는 아래 토큰만 참조한다. 표 밖의 인라인 px/radius 재구현 금지.
+
+| 박스 | 높이 | radius | 패딩 | 타이포 단 |
+|---|---|---|---|---|
+| 크롬 타일 (ChromeTile) | `--chrome-tile-size` 44px | `--chrome-radius` 10px | `--chrome-inset` 정렬 | 아이콘 16px |
+| 상태 칩 (`CHROME_STATUS_CHIP_CLASS`) | 44px (타일과 동일) | `--chrome-radius` 10px | `px-3.5` | body / label |
+| 패널 (INDEX · 데이터시트) | 콘텐츠 | `--topology-v2-panel-radius` 12px (= `rounded-panel`) | `--pad-panel` | title 헤더 · body 행 |
+| 팝오버 (ego popover) | 콘텐츠 | `rounded-panel` | `--pad-card` | title + body/label |
+| 카드 (일반) | 콘텐츠 | `rounded-card` | `--pad-card` | title + body |
+| 배지·칩 (일반) | 콘텐츠 | `rounded-chip` | `px-2 py-0.5` | label (또는 caption) |
+| 입력 (input/search) | 콘텐츠 | `rounded-card` | `px-3 py-2` | body |
+| 버튼 (일반) | 콘텐츠 | `rounded-chip`~`card` | `px-3 py-1.5` | body |
+
+### 명시 예외 (램프 밖, 문서화된 것만)
+
+램프로 스냅하면 리디자인이 되는 소수 표면은 `// eslint-disable-next-line
+no-restricted-syntax -- <사유>` 로만 남긴다. 현재 등재분:
+
+- **헤어라인 반경 1~4px** — 2~14px 높이 progress/capacity 미터 트랙·fill
+  (`full-detail-a1-reach-panel`, `TopologyIndexTreeRow`, `FreshnessTab`,
+  reach 스텝 칩). chip(6px)로 올리면 pill 처럼 읽혀 유지.
+- **overlay sheet 반경 18~28px** — floating 카드/시트(`SearchPalette` 22px,
+  `GestureHint`/`PublicQuickActions` 18px, `ProjectDrawer` 20px, `detail-card`
+  28px 시그니처). panel(12px)로 내리면 표면 성격이 바뀌어 유지. `detail-card`
+  28px 은 `detail-card.test.tsx` 가 assert.
+- **display 숫자 34~40px** — 센서스 시그니처 대형 숫자(`InsightsHeroCensus`
+  40px), 반응형 히어로 강조(`DesktopVaultWelcome` md:34px). type 램프 상단
+  (hero 30px)을 넘는 의도적 display.
+
+### Lint 봉쇄
+
+`eslint.config.mjs` 의 `no-restricted-syntax` 가 신규 `text-[Npx]` ·
+`rounded-[Npx]` arbitrary 클래스를 차단한다.
+
+- **마이그레이션 완료 디렉토리 = error** — `src/views/{ontology-insights,
+  project-selector,ontology-edit,docs-vault}` · `src/shared/ui` · `src/widgets`
+  (R6 제외).
+- **미완(동시 작업) = warn** — `src/widgets/topology-map-v2` ·
+  `src/widgets/hero-header` · `src/views/home`. R6 치환 완료 시 error 로 승격.
+- 테스트 파일(`*.test.tsx`)은 렌더된 className 을 assert 하므로 룰에서 제외.
+
+### 모션 문법 인덱스
+
+기하와 짝인 모션 토큰(값 소스: `app/globals.css` 하단 `--topology-motion-*`):
+
+- **spring 패밀리** — `damping` / `response` 쌍으로 표기. 크롬 등장·카메라·
+  패널·드래그가 공유하는 단일 물리 어휘.
+- **크롬 등장** — 180ms.
+- **카메라/포커스 이동** — 200~420ms 구간.
+- `prefers-reduced-motion` 존중은 base layer 에서 이미 처리.
+
 ## 크롬 문법 (feat/chrome-system)
 
 Topology chrome (브랜드 pill · 상단 HUD lane · INDEX 패널 · 이후 좌측 내비 레일)이
@@ -1437,6 +1552,7 @@ JSX 안에 44px 정사각 버튼이나 라벨 버튼을 인라인 클래스로 �
 
 ## Changelog
 
+- 2026-07-21: Geometry & Type Codex (R5) — `text-[Npx]`(29종·1,184건)를 7단 type 램프(`--text-caption`…`--text-hero` + `--tracking-*` 짝)로, arbitrary radius(18종)를 3단(`--radius-chip/card/panel`)으로 수렴. 박스별 규격 표 + 명시 예외 등재. ESLint `no-restricted-syntax` 가 신규 arbitrary 를 차단(마이그레이션 완료 디렉토리 error / R6 동시작업 dir warn). 시각은 ±1px 스냅 수준 유지(리디자인 아님); see "Geometry & Type Codex" 절
 - 2026-07-18: 크롬 시스템(feat/chrome-system) — `--chrome-*` 토큰 + ChromeTile/ChromeChip 컴포넌트 신설, 24px 정렬 레일로 브랜드 필/INDEX 패널/분석 패널 좌측 인셋 수렴, INDEX 패널 v2.1(헤더 "INDEX · N" + 접기, 트리 행 grid + Lucide chevron + 인셋 capacity meter, 푸터로 에이전트 동기화 이관); see `docs/prototypes/index-panel-v2-full.html`
 - 2026-07-18: Brand mark replaced — "헥사 별자리" (candidate A) across favicon, macOS app icon, and `BrandMark` shared component; see "Brand mark" section above
 - 2026-07-18: v2 — B2+ "Circuit × Constellation" 언어를 페이지 롤아웃 규범으로 승격 (언어 6축 · 토큰 tier 카탈로그 · surface class 별 do/don't · v2 금지 추가 · 롤아웃 가드 · 토큰 drift 부채 감사); see [`TOPOLOGY-V2-DESIGN.md`](./TOPOLOGY-V2-DESIGN.md)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,79 @@ import boundaries from 'eslint-plugin-boundaries';
 // `boundaries/dependencies` + object-form selectors로 작성.
 //   문서: https://www.jsboundaries.dev/docs/rules/dependencies/
 
+// ── 디자인 헌장 §11 (기존): scale hover · 보라핑크 그라디언트 금지 ──────
+// 아래 셀렉터 배열은 여러 config object 에서 재사용된다. flat config 는 같은
+// rule 을 여러 번 선언하면 마지막이 "덮어쓰기"(배열 병합 아님)라, size 램프
+// 룰을 추가하는 config 도 이 셀렉터를 함께 실어야 scale/gradient 가드가 그
+// 파일에서 유실되지 않는다.
+const scaleGradientSelectors = [
+  {
+    selector: "Literal[value=/(^|\\s)(hover|active|focus|group-hover):scale-/]",
+    message: '디자인 헌장 §11 — scale hover 금지. bg/border 변경 또는 색 alpha 로 대체.',
+  },
+  {
+    selector:
+      "TemplateElement[value.raw=/(^|\\s)(hover|active|focus|group-hover):scale-/]",
+    message: '디자인 헌장 §11 — scale hover 금지 (template literal). bg/border 변경으로 대체.',
+  },
+  {
+    selector: "Literal[value=/from-(purple|fuchsia|pink)-\\d+.*to-(pink|fuchsia|purple)-\\d+/]",
+    message: '디자인 헌장 §11 — 보라핑크 그라디언트 금지. 단일 인디고 또는 무채색만.',
+  },
+  {
+    selector:
+      "TemplateElement[value.raw=/from-(purple|fuchsia|pink)-\\d+.*to-(pink|fuchsia|purple)-\\d+/]",
+    message: '디자인 헌장 §11 — 보라핑크 그라디언트 금지 (template literal).',
+  },
+];
+
+// ── Geometry & Type Codex (R5) 봉쇄 ─────────────────────────────────
+// text-[Npx] / rounded-[Npx] arbitrary 클래스 금지 — docs/DESIGN-SYSTEM.md
+// "Geometry & Type Codex" 램프(text-caption…text-hero / rounded-chip…panel)
+// 로만 표현한다. 램프 밖의 의도적 예외는 `// eslint-disable-next-line
+// no-restricted-syntax -- <사유>` 로 명시. 마이그레이션 완료 디렉토리 = error,
+// 미완(topology-map-v2 · views/home · hero-header) = warn.
+const arbitrarySizeSelectors = [
+  {
+    selector: 'Literal[value=/text-\\[[0-9.]+px\\]/]',
+    message:
+      'Geometry Codex — text-[Npx] 하드코딩 금지. text-caption/label/body/body-lg/title/display/hero 램프로. 램프 밖이면 eslint-disable + 사유.',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/text-\\[[0-9.]+px\\]/]',
+    message:
+      'Geometry Codex — text-[Npx] 하드코딩 금지 (template literal). text-* 램프로.',
+  },
+  {
+    selector: 'Literal[value=/rounded-\\[[0-9.]+px\\]/]',
+    message:
+      'Geometry Codex — rounded-[Npx] 하드코딩 금지. rounded-chip/card/panel 램프로. 램프 밖이면 eslint-disable + 사유.',
+  },
+  {
+    selector: 'TemplateElement[value.raw=/rounded-\\[[0-9.]+px\\]/]',
+    message:
+      'Geometry Codex — rounded-[Npx] 하드코딩 금지 (template literal). rounded-* 램프로.',
+  },
+];
+
+// 마이그레이션 완료(치환 끝 · error 봉쇄) 디렉토리.
+const codexMigratedGlobs = [
+  'src/views/ontology-insights/**/*.{ts,tsx}',
+  'src/views/project-selector/**/*.{ts,tsx}',
+  'src/views/ontology-edit/**/*.{ts,tsx}',
+  'src/views/docs-vault/**/*.{ts,tsx}',
+  'src/shared/ui/**/*.{ts,tsx}',
+  'src/widgets/**/*.{ts,tsx}',
+];
+// R6(다른 에이전트) 동시 작업 중 — 아직 미치환, warn 으로만 신규 유입 경고.
+const codexR6Globs = [
+  'src/widgets/topology-map-v2/**/*.{ts,tsx}',
+  'src/widgets/hero-header/**/*.{ts,tsx}',
+  'src/views/home/**/*.{ts,tsx}',
+];
+// 테스트는 렌더된 className 문자열을 assert 하므로 램프 룰에서 제외.
+const codexTestIgnores = ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'];
+
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
@@ -215,32 +288,32 @@ const eslintConfig = defineConfig([
   {
     files: ['src/**/*.{ts,tsx,jsx,js}', 'app/**/*.{ts,tsx,jsx,js}'],
     rules: {
+      'no-restricted-syntax': ['error', ...scaleGradientSelectors],
+    },
+  },
+  // Codex 램프 봉쇄 — 마이그레이션 완료 디렉토리 = error. scale/gradient
+  // 셀렉터도 함께 실어 flat config 덮어쓰기로 그 가드가 유실되지 않게 한다.
+  {
+    files: codexMigratedGlobs,
+    ignores: codexTestIgnores,
+    rules: {
       'no-restricted-syntax': [
         'error',
-        {
-          selector:
-            "Literal[value=/(^|\\s)(hover|active|focus|group-hover):scale-/]",
-          message:
-            '디자인 헌장 §11 — scale hover 금지. bg/border 변경 또는 색 alpha 로 대체.',
-        },
-        {
-          selector:
-            "TemplateElement[value.raw=/(^|\\s)(hover|active|focus|group-hover):scale-/]",
-          message:
-            '디자인 헌장 §11 — scale hover 금지 (template literal). bg/border 변경으로 대체.',
-        },
-        {
-          selector:
-            "Literal[value=/from-(purple|fuchsia|pink)-\\d+.*to-(pink|fuchsia|purple)-\\d+/]",
-          message:
-            '디자인 헌장 §11 — 보라핑크 그라디언트 금지. 단일 인디고 또는 무채색만.',
-        },
-        {
-          selector:
-            "TemplateElement[value.raw=/from-(purple|fuchsia|pink)-\\d+.*to-(pink|fuchsia|purple)-\\d+/]",
-          message:
-            '디자인 헌장 §11 — 보라핑크 그라디언트 금지 (template literal).',
-        },
+        ...scaleGradientSelectors,
+        ...arbitrarySizeSelectors,
+      ],
+    },
+  },
+  // R6 동시 작업 디렉토리 = warn (미치환 유입만 경고). 위 migrated 블록보다
+  // 뒤라 widgets/topology-map-v2·hero-header 는 여기서 warn 으로 내려간다.
+  {
+    files: codexR6Globs,
+    ignores: codexTestIgnores,
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        ...scaleGradientSelectors,
+        ...arbitrarySizeSelectors,
       ],
     },
   },

--- a/src/shared/ui/chip-list-editor.tsx
+++ b/src/shared/ui/chip-list-editor.tsx
@@ -100,7 +100,7 @@ export function ChipListEditor({
     return (
       <p
         className={cn(
-          "text-[12px] text-[color:var(--color-text-quaternary)]",
+          "text-body text-[color:var(--color-text-quaternary)]",
           className,
         )}
       >

--- a/src/shared/ui/chrome-chip.tsx
+++ b/src/shared/ui/chrome-chip.tsx
@@ -24,7 +24,7 @@ export interface ChromeChipProps extends Omit<ButtonHTMLAttributes<HTMLButtonEle
 }
 
 const CHIP_CLASS =
-  'inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-[12.5px] text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] active:bg-[color:var(--chrome-active-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] [&>svg]:size-3.5 [&>svg]:shrink-0';
+  'inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-body text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] active:bg-[color:var(--chrome-active-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] [&>svg]:size-3.5 [&>svg]:shrink-0';
 
 /**
  * S10 결함 1 (소유자 실보고: 1920 에서 영역 칩이 검색/자동정렬 타일보다 큼) —
@@ -40,7 +40,7 @@ const CHIP_CLASS =
  * 소유한다.
  */
 export const CHROME_STATUS_CHIP_CLASS =
-  'topology-chrome-in pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-[12.5px] text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
+  'topology-chrome-in pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-body text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
 
 const ACTIVE_CLASS =
   'border-[color:var(--chrome-active-border)] bg-[color:var(--chrome-active-surface)] text-[color:var(--color-text-primary)]';
@@ -64,7 +64,7 @@ export const ChromeChip = forwardRef<HTMLButtonElement, ChromeChipProps>(
         <span
           aria-hidden="true"
           className={cn(
-            'ml-auto shrink-0 rounded border border-[color:var(--color-border-soft)] px-1 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]',
+            'ml-auto shrink-0 rounded border border-[color:var(--color-border-soft)] px-1 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]',
             compact && 'hidden',
           )}
         >

--- a/src/shared/ui/compact-copy-button.tsx
+++ b/src/shared/ui/compact-copy-button.tsx
@@ -30,7 +30,7 @@ export function CompactCopyButton({
       {...attrs}
       type="button"
       onClick={onClick}
-      className={`inline-flex min-h-9 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-[color:var(--color-text-quaternary)] transition-[background-color,color,transform] duration-180 ease-out hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none ${className}`}
+      className={`inline-flex min-h-9 min-w-0 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-label text-[color:var(--color-text-quaternary)] transition-[background-color,color,transform] duration-180 ease-out hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none ${className}`}
       aria-label={ariaLabel}
       title={label}
     >

--- a/src/shared/ui/detail-card.tsx
+++ b/src/shared/ui/detail-card.tsx
@@ -35,6 +35,7 @@ export function DetailCard({
   return (
     <article
       className={cn(
+        // eslint-disable-next-line no-restricted-syntax -- 카드 시그니처 반경(28px)은 radius 램프(chip/card/panel) 밖의 의도적 예외. detail-card.test.tsx 가 이 값을 assert.
         'overflow-hidden rounded-[28px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)]',
         className,
       )}
@@ -43,7 +44,7 @@ export function DetailCard({
         <header className="flex items-start justify-between gap-4 border-b border-[color:var(--color-divider)] px-6 py-5 md:px-8">
           <div>
             {eyebrow ? (
-              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {eyebrow}
               </p>
             ) : null}
@@ -53,7 +54,7 @@ export function DetailCard({
               </h2>
             ) : null}
             {description ? (
-              <p className="mt-1 text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+              <p className="mt-1 text-body leading-5 text-[color:var(--color-text-tertiary)]">
                 {description}
               </p>
             ) : null}

--- a/src/shared/ui/empty-state.tsx
+++ b/src/shared/ui/empty-state.tsx
@@ -64,7 +64,7 @@ export function EmptyState({
       <p
         className={cn(
           'font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]',
-          size === 'compact' ? 'text-sm' : 'text-[15px]',
+          size === 'compact' ? 'text-sm' : 'text-title',
           // align=center 한 문장 패턴 — 본문 톤 (h1 무게 없이 secondary 색).
           align === 'center' && 'font-normal text-sm text-[color:var(--color-text-tertiary)]',
         )}

--- a/src/shared/ui/link-list-editor.tsx
+++ b/src/shared/ui/link-list-editor.tsx
@@ -99,7 +99,7 @@ export function LinkListEditor({
   if (!editable && value.length === 0) {
     if (!emptyHint) return null;
     return (
-      <p className={cn("text-[12px] text-[color:var(--color-text-quaternary)]", className)}>
+      <p className={cn("text-body text-[color:var(--color-text-quaternary)]", className)}>
         {emptyHint}
       </p>
     );
@@ -121,7 +121,7 @@ export function LinkListEditor({
             <span className="min-w-0 truncate">{link.label}</span>
             <span
               aria-hidden="true"
-              className="font-mono text-[11px] text-[color:var(--color-text-quaternary)]"
+              className="font-mono text-label text-[color:var(--color-text-quaternary)]"
             >
               ↗
             </span>
@@ -162,14 +162,14 @@ export function LinkListEditor({
               <button
                 type="button"
                 onClick={commit}
-                className="rounded-md border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a16)] px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)] hover:bg-[color:var(--color-indigo-a24)]"
+                className="rounded-md border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a16)] px-2 py-1 text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)] hover:bg-[color:var(--color-indigo-a24)]"
               >
                 {commitLabel}
               </button>
               <button
                 type="button"
                 onClick={cancel}
-                className="rounded-md border border-[color:var(--color-divider)] px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]"
+                className="rounded-md border border-[color:var(--color-divider)] px-2 py-1 text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]"
               >
                 {cancelLabel}
               </button>

--- a/src/shared/ui/node-explanation-edit.tsx
+++ b/src/shared/ui/node-explanation-edit.tsx
@@ -62,7 +62,7 @@ export function NodeExplanationEdit({
     return (
       <div data-testid="node-explanation-read">
         <div className="flex items-center justify-between gap-2">
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {labels.heading}
           </span>
           <button
@@ -78,8 +78,8 @@ export function NodeExplanationEdit({
         <p
           className={
             value
-              ? "mt-2 [overflow-wrap:anywhere] whitespace-pre-wrap text-[12px] leading-5 text-[color:var(--color-text-secondary)]"
-              : "mt-2 text-[12px] italic leading-5 text-[color:var(--color-text-quaternary)]"
+              ? "mt-2 [overflow-wrap:anywhere] whitespace-pre-wrap text-body leading-5 text-[color:var(--color-text-secondary)]"
+              : "mt-2 text-body italic leading-5 text-[color:var(--color-text-quaternary)]"
           }
         >
           {value || labels.empty}
@@ -91,7 +91,7 @@ export function NodeExplanationEdit({
   return (
     <div data-testid="node-explanation-edit">
       <div className="flex items-center justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {labels.heading}
         </span>
         <div className="flex items-center gap-1.5">
@@ -130,7 +130,7 @@ export function NodeExplanationEdit({
         }}
         aria-label={labels.heading}
         data-testid="node-explanation-input"
-        className="mt-2 w-full resize-y rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[12px] leading-5 text-[color:var(--color-text-primary)] transition-colors focus-visible:border-[color:var(--color-indigo-a46)] focus-visible:outline-none"
+        className="mt-2 w-full resize-y rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-body leading-5 text-[color:var(--color-text-primary)] transition-colors focus-visible:border-[color:var(--color-indigo-a46)] focus-visible:outline-none"
       />
     </div>
   );

--- a/src/shared/ui/tab-bar.tsx
+++ b/src/shared/ui/tab-bar.tsx
@@ -51,7 +51,7 @@ export function TabBar({
             id={`insights-tab-${item.key}`}
             onClick={() => onSelect(item.key)}
             className={
-              "-mb-px inline-flex items-baseline gap-2 border-b-[length:var(--tabbar-underline)] px-0.5 pb-[11px] font-mono text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-150 " +
+              "-mb-px inline-flex items-baseline gap-2 border-b-[length:var(--tabbar-underline)] px-0.5 pb-[11px] font-mono text-label font-semibold uppercase tracking-[0.14em] transition-colors duration-150 " +
               (active
                 ? "border-[color:var(--color-indigo-accent)] text-[color:var(--color-text-primary)]"
                 : "border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]")
@@ -59,7 +59,7 @@ export function TabBar({
           >
             {item.label}
             {item.count !== undefined ? (
-              <span className="font-mono text-[11px] font-semibold tracking-[0.02em] tabular-nums text-[color:var(--color-text-tertiary)]">
+              <span className="font-mono text-label font-semibold tracking-[0.02em] tabular-nums text-[color:var(--color-text-tertiary)]">
                 {item.count}
               </span>
             ) : null}

--- a/src/shared/ui/toast.tsx
+++ b/src/shared/ui/toast.tsx
@@ -52,7 +52,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         toastOptions={{
           classNames: {
             toast:
-              'rounded-full border bg-[color:var(--color-panel)] px-3.5 py-2 text-[12px] shadow-[0_10px_28px_var(--color-shadow-a42)]',
+              'rounded-full border bg-[color:var(--color-panel)] px-3.5 py-2 text-body shadow-[0_10px_28px_var(--color-shadow-a42)]',
             success:
               'border-[color:var(--color-success-a35)] text-[color:var(--color-text-primary)]',
             info: 'border-[color:var(--color-indigo-line-a35)] text-[color:var(--color-text-primary)]',

--- a/src/shared/ui/tooltip.tsx
+++ b/src/shared/ui/tooltip.tsx
@@ -35,7 +35,7 @@ export const TooltipContent = forwardRef<
     sideOffset={sideOffset}
     className={
       className ??
-      "z-[80] rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-panel)] px-2 py-1 text-[11px] text-[color:var(--color-text-primary)] shadow-[0_8px_22px_var(--color-shadow-a50)] data-[state=delayed-open]:animate-in data-[state=closed]:animate-out"
+      "z-[80] rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-panel)] px-2 py-1 text-label text-[color:var(--color-text-primary)] shadow-[0_8px_22px_var(--color-shadow-a50)] data-[state=delayed-open]:animate-in data-[state=closed]:animate-out"
     }
     {...props}
   />

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -1340,7 +1340,7 @@ function DocsVaultContent() {
       {/* Crumbs row — engraved vault census (docs-vault-final spec §상단 헤더). */}
       <nav
         aria-label={t('header.breadcrumbAriaLabel')}
-        className="flex h-8 flex-none items-center gap-2 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3 text-[11.5px] text-[color:var(--color-text-tertiary)] md:px-4"
+        className="flex h-8 flex-none items-center gap-2 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3 text-label text-[color:var(--color-text-tertiary)] md:px-4"
       >
         <Link
           href={workspaceHref}
@@ -1398,7 +1398,7 @@ function DocsVaultContent() {
           <button
             type="button"
             onClick={() => setSourceTreeOpen(true)}
-            className="inline-flex h-8 flex-none items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] px-2 text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] lg:hidden"
+            className="inline-flex h-8 flex-none items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] px-2 text-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] lg:hidden"
             aria-label={t('header.openTreeAriaLabel')}
             title={t('header.openTreeTitle')}
           >
@@ -1464,7 +1464,7 @@ function DocsVaultContent() {
           {/* Source 토글 — 이전엔 advanced dropdown 안 깊숙이 묻혀 있던 가장
               중요한 결정 (샘플 vs 내 vault) 를 헤더에 직접 노출. */}
           <div
-            className="flex min-h-9 items-center gap-0.5 rounded-lg border border-[color:var(--color-border-soft)] p-0.5 text-[11px]"
+            className="flex min-h-9 items-center gap-0.5 rounded-lg border border-[color:var(--color-border-soft)] p-0.5 text-label"
             role="radiogroup"
             aria-label={t('header.sourceAriaLabel')}
           >
@@ -1589,7 +1589,7 @@ function DocsVaultContent() {
       (localVault.status === 'error' ||
         localVault.status === 'permission-needed') ? (
         <div
-          className="flex flex-none items-center gap-2 border-b border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-4 py-2 text-[12px] text-[color:var(--color-status-danger)]"
+          className="flex flex-none items-center gap-2 border-b border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-4 py-2 text-body text-[color:var(--color-status-danger)]"
           role="status"
         >
           <span className="flex-1">
@@ -1606,7 +1606,7 @@ function DocsVaultContent() {
                 ? localVault.requestPermission()
                 : void openLocalVault()
             }
-            className="rounded-sm border border-[color:var(--color-danger-a32)] px-2 py-0.5 text-[11px] transition-colors hover:bg-[color:var(--color-danger-a12)]"
+            className="rounded-sm border border-[color:var(--color-danger-a32)] px-2 py-0.5 text-label transition-colors hover:bg-[color:var(--color-danger-a12)]"
           >
             {t('vaultStatus.openPicker')}
           </button>
@@ -1638,7 +1638,7 @@ function DocsVaultContent() {
             />
             <aside className="relative flex w-[300px] max-w-[84vw] flex-col overflow-auto border-r border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] shadow-[0_0_24px_var(--color-shadow-a50)] md:w-[340px]">
               <div className="flex h-12 flex-none items-center justify-between border-b border-[color:var(--color-border-soft)] px-3">
-                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                   {t('mobileDrawer.title')}
                 </span>
                 <button
@@ -1686,7 +1686,7 @@ function DocsVaultContent() {
               {/* ehead — dir/file mono + preview/edit seg + sync status
                   (docs-vault-final spec §우 에디터/프리뷰 헤더). */}
               <div className="flex flex-none items-center gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-2.5">
-                <span className="min-w-0 flex-1 truncate font-mono text-[12.5px] text-[color:var(--color-text-secondary)]">
+                <span className="min-w-0 flex-1 truncate font-mono text-body text-[color:var(--color-text-secondary)]">
                   <span className="text-[color:var(--color-text-quaternary)]">
                     {splitVaultSlugPath(selectedDoc.slug).dir}
                   </span>
@@ -1703,7 +1703,7 @@ function DocsVaultContent() {
                       role="tab"
                       aria-selected={!editing}
                       onClick={() => setEditing(false)}
-                      className={`rounded-sm px-2.5 py-1 font-mono text-[10.5px] transition-colors ${
+                      className={`rounded-sm px-2.5 py-1 font-mono text-label transition-colors ${
                         !editing
                           ? 'border border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]'
                           : 'border border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]'
@@ -1716,7 +1716,7 @@ function DocsVaultContent() {
                       role="tab"
                       aria-selected={editing}
                       onClick={() => setEditing(true)}
-                      className={`rounded-sm px-2.5 py-1 font-mono text-[10.5px] transition-colors ${
+                      className={`rounded-sm px-2.5 py-1 font-mono text-label transition-colors ${
                         editing
                           ? 'border border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]'
                           : 'border border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]'
@@ -1726,7 +1726,7 @@ function DocsVaultContent() {
                     </button>
                   </div>
                 ) : null}
-                <span className="flex-none font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+                <span className="flex-none font-mono text-label text-[color:var(--color-text-quaternary)]">
                   <span className="power mr-1.5 inline-block h-[5px] w-[5px] rounded-full bg-[color:var(--color-indigo-accent)] align-middle" aria-hidden />
                   {isLocalSourceLoaded ? t('editorHeader.localSynced') : t('editorHeader.readOnlySample')}
                 </span>
@@ -1855,13 +1855,13 @@ function DocsVaultContent() {
                       layout="strip"
                     />
                   ) : (
-                    <p className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--color-text-quaternary)]">
+                    <p className="min-w-0 flex-1 truncate text-body text-[color:var(--color-text-quaternary)]">
                       {t('backlinksStrip.empty')}
                     </p>
                   )}
                   <Link
                     href={buildOntologyDeeplinkForDoc(selectedDoc) ?? '/ontology/'}
-                    className="flex-none text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                    className="flex-none text-body text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
                   >
                     {t('backlinksStrip.openInOntology')}
                   </Link>

--- a/src/views/docs-vault/ui/parts/BackToTopButton.tsx
+++ b/src/views/docs-vault/ui/parts/BackToTopButton.tsx
@@ -24,7 +24,7 @@ export function BackToTopButton({
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
       data-testid="back-to-top-button"
-      className={`absolute bottom-6 right-7 z-10 inline-flex h-[var(--chrome-tile-size)] items-center gap-2 rounded-full border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-4 font-mono text-[12px] text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)] transition-opacity duration-150 ${
+      className={`absolute bottom-6 right-7 z-10 inline-flex h-[var(--chrome-tile-size)] items-center gap-2 rounded-full border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-4 font-mono text-body text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)] transition-opacity duration-150 ${
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
     >

--- a/src/views/docs-vault/ui/parts/DesktopVaultWelcome.tsx
+++ b/src/views/docs-vault/ui/parts/DesktopVaultWelcome.tsx
@@ -84,29 +84,30 @@ export function DesktopVaultWelcome({
       <div className="mx-auto grid w-full max-w-6xl content-start gap-8 px-5 py-8 md:px-8 md:py-12 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start lg:gap-12">
         <div className="grid min-w-0 gap-7">
           <section className="grid max-w-3xl gap-3">
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+            <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
               {t("desktopWelcome.eyebrow")}
             </p>
-            <h2 className="max-w-2xl text-[28px] font-semibold leading-tight text-[color:var(--color-text-primary)] md:text-[34px]">
+            {/* eslint-disable-next-line no-restricted-syntax -- md 반응형 히어로 강조(34px)는 램프 상단(hero 30px)을 넘는 의도적 예외. base 는 text-hero. */}
+            <h2 className="max-w-2xl text-hero font-semibold leading-tight text-[color:var(--color-text-primary)] md:text-[34px]">
               {showDogfoodHint
                 ? t("desktopWelcome.dogfoodTitle")
                 : t("desktopWelcome.title")}
             </h2>
-            <p className="max-w-2xl text-[14px] leading-6 text-[color:var(--color-text-tertiary)]">
+            <p className="max-w-2xl text-body-lg leading-6 text-[color:var(--color-text-tertiary)]">
               {showDogfoodHint
                 ? t("desktopWelcome.dogfoodBody")
                 : t("desktopWelcome.body")}
             </p>
             {showDogfoodHint ? (
               <div className="flex max-w-2xl flex-wrap items-center gap-2">
-                <code className="min-w-0 flex-1 truncate rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-[11px] text-[color:var(--color-text-secondary)]">
+                <code className="min-w-0 flex-1 truncate rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-label text-[color:var(--color-text-secondary)]">
                   {DOGFOOD_VAULT_PATH}
                 </code>
                 <button
                   type="button"
                   onClick={() => void copyDogfoodPath(DOGFOOD_VAULT_PATH)}
                   aria-label={dogfoodPathCopyAriaLabel}
-                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] px-2.5 py-1.5 font-mono text-[10px] text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]"
+                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] px-2.5 py-1.5 font-mono text-caption text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]"
                 >
                   {dogfoodPathCopied ? <Check size={12} aria-hidden /> : <Clipboard size={12} aria-hidden />}
                   {t("desktopWelcome.copyDogfoodPath")}
@@ -115,7 +116,7 @@ export function DesktopVaultWelcome({
                   type="button"
                   onClick={() => void copyDogfoodLoop(DOGFOOD_VERIFICATION_LOOP)}
                   aria-label={dogfoodLoopCopyAriaLabel}
-                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a32)] hover:text-[color:var(--color-text-primary)]"
+                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a32)] hover:text-[color:var(--color-text-primary)]"
                 >
                   {dogfoodLoopCopied ? <Check size={12} aria-hidden /> : <Terminal size={12} aria-hidden />}
                   {t("desktopWelcome.copyDogfoodLoop")}
@@ -145,13 +146,13 @@ export function DesktopVaultWelcome({
                       <Icon size={14} aria-hidden />
                     </span>
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                      <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                         {item.label}
                       </p>
-                      <p className="mt-0.5 text-[12.5px] font-semibold text-[color:var(--color-text-primary)]">
+                      <p className="mt-0.5 text-body font-semibold text-[color:var(--color-text-primary)]">
                         {item.value}
                       </p>
-                      <p className="mt-1.5 break-keep text-[11.5px] leading-5 text-[color:var(--color-text-tertiary)]">
+                      <p className="mt-1.5 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
                         {item.body}
                       </p>
                     </div>
@@ -177,7 +178,7 @@ export function DesktopVaultWelcome({
                 <FolderOpen size={17} aria-hidden />
               </span>
               <span className="min-w-0">
-                <span className="block text-[14px] font-semibold text-[color:var(--color-text-primary)]">
+                <span className="block text-body-lg font-semibold text-[color:var(--color-text-primary)]">
                   {busy
                     ? status === "opening"
                       ? t("desktopWelcome.openingTitle")
@@ -186,7 +187,7 @@ export function DesktopVaultWelcome({
                       ? t("desktopWelcome.dogfoodOpenTitle")
                       : t("desktopWelcome.openTitle")}
                 </span>
-                <span className="mt-1 block text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+                <span className="mt-1 block text-body leading-5 text-[color:var(--color-text-tertiary)]">
                   {showDogfoodHint
                     ? t("desktopWelcome.dogfoodOpenBody")
                     : t("desktopWelcome.openBody")}
@@ -205,10 +206,10 @@ export function DesktopVaultWelcome({
                   <Bot size={15} aria-hidden />
                 </span>
                 <span className="min-w-0">
-                  <span className="block text-[13px] font-semibold text-[color:var(--color-text-primary)]">
+                  <span className="block text-body font-semibold text-[color:var(--color-text-primary)]">
                     {t("desktopWelcome.dogfoodDirectTitle")}
                   </span>
-                  <span className="mt-0.5 block text-[11.5px] leading-5 text-[color:var(--color-text-tertiary)]">
+                  <span className="mt-0.5 block text-label leading-5 text-[color:var(--color-text-tertiary)]">
                     {t("desktopWelcome.dogfoodDirectBody")}
                   </span>
                 </span>
@@ -225,10 +226,10 @@ export function DesktopVaultWelcome({
                 <FilePlus size={15} aria-hidden />
               </span>
               <span className="min-w-0">
-                <span className="block text-[13px] font-semibold text-[color:var(--color-text-primary)]">
+                <span className="block text-body font-semibold text-[color:var(--color-text-primary)]">
                   {t("desktopWelcome.createTitle")}
                 </span>
-                <span className="mt-0.5 block text-[11.5px] leading-5 text-[color:var(--color-text-tertiary)]">
+                <span className="mt-0.5 block text-label leading-5 text-[color:var(--color-text-tertiary)]">
                   {t("desktopWelcome.createBody")}
                 </span>
               </span>
@@ -243,10 +244,10 @@ export function DesktopVaultWelcome({
                 <Package size={15} aria-hidden />
               </span>
               <span className="min-w-0">
-                <span className="block text-[13px] font-semibold text-[color:var(--color-text-primary)]">
+                <span className="block text-body font-semibold text-[color:var(--color-text-primary)]">
                   {t("desktopWelcome.sampleTitle")}
                 </span>
-                <span className="mt-0.5 block text-[11.5px] leading-5 text-[color:var(--color-text-tertiary)]">
+                <span className="mt-0.5 block text-label leading-5 text-[color:var(--color-text-tertiary)]">
                   {t("desktopWelcome.sampleBody")}
                 </span>
               </span>
@@ -254,7 +255,7 @@ export function DesktopVaultWelcome({
           </section>
 
           <section className="grid gap-2">
-            <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+            <h3 className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
               {t("desktopWelcome.recentTitle")}
             </h3>
             {recentVaults.length > 0 ? (
@@ -273,11 +274,11 @@ export function DesktopVaultWelcome({
                       <HardDrive size={13} aria-hidden />
                     </span>
                     <span className="min-w-0">
-                      <span className="block truncate text-[12.5px] font-medium text-[color:var(--color-text-primary)]">
+                      <span className="block truncate text-body font-medium text-[color:var(--color-text-primary)]">
                         {record.name}
                       </span>
                       {record.desktopRootPath ? (
-                        <span className="block truncate font-mono text-[9.5px] text-[color:var(--color-text-quaternary)]">
+                        <span className="block truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
                           {record.desktopRootPath}
                         </span>
                       ) : null}
@@ -286,7 +287,7 @@ export function DesktopVaultWelcome({
                 ))}
               </div>
             ) : (
-              <p className="border-t border-[color:var(--color-border-soft)] pt-2 text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+              <p className="border-t border-[color:var(--color-border-soft)] pt-2 text-body leading-5 text-[color:var(--color-text-tertiary)]">
                 {t("desktopWelcome.recentEmpty")}
               </p>
             )}

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -161,7 +161,7 @@ export function DocFrontmatterBlock({
       <details
         open={open}
         onToggle={(event) => setOpen(event.currentTarget.open)}
-        className="group rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-4 py-3 font-mono text-[12px] leading-[1.85] text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]"
+        className="group rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-4 py-3 font-mono text-body leading-[1.85] text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]"
       >
         <summary
           data-testid="doc-frontmatter-summary"
@@ -214,13 +214,13 @@ export function DocFrontmatterBlock({
         {canQuickPatch ? (
           editing ? (
             <div className="mt-3 flex flex-col gap-2 border-t border-[color:var(--color-divider)] pt-3 font-sans">
-              <label className="flex flex-col gap-1 text-[11px] text-[color:var(--color-text-tertiary)]">
+              <label className="flex flex-col gap-1 text-label text-[color:var(--color-text-tertiary)]">
                 {t("editKindLabel")}
                 <select
                   value={draftKind}
                   onChange={(event) => setDraftKind(event.target.value)}
                   disabled={saving}
-                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)]"
+                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-body text-[color:var(--color-text-primary)]"
                 >
                   {EDITABLE_KINDS.map((kind) => (
                     <option key={kind} value={kind}>
@@ -229,13 +229,13 @@ export function DocFrontmatterBlock({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col gap-1 text-[11px] text-[color:var(--color-text-tertiary)]">
+              <label className="flex flex-col gap-1 text-label text-[color:var(--color-text-tertiary)]">
                 {t("editDomainLabel")}
                 <select
                   value={draftDomain}
                   onChange={(event) => setDraftDomain(event.target.value)}
                   disabled={saving}
-                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)]"
+                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-body text-[color:var(--color-text-primary)]"
                 >
                   <option value="">{t("editDomainNone")}</option>
                   {domainOptions.map((option) => (
@@ -245,18 +245,18 @@ export function DocFrontmatterBlock({
                   ))}
                 </select>
               </label>
-              <label className="flex flex-col gap-1 text-[11px] text-[color:var(--color-text-tertiary)]">
+              <label className="flex flex-col gap-1 text-label text-[color:var(--color-text-tertiary)]">
                 {t("editTitleLabel")}
                 <input
                   type="text"
                   value={draftTitle}
                   onChange={(event) => setDraftTitle(event.target.value)}
                   disabled={saving}
-                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)]"
+                  className="rounded-sm border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-body text-[color:var(--color-text-primary)]"
                 />
               </label>
               {error ? (
-                <p role="alert" className="text-[11px] text-[color:var(--color-status-danger)]">
+                <p role="alert" className="text-label text-[color:var(--color-status-danger)]">
                   {error}
                 </p>
               ) : null}
@@ -265,7 +265,7 @@ export function DocFrontmatterBlock({
                   type="button"
                   onClick={() => void handleSave()}
                   disabled={saving}
-                  className="rounded-sm border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a10)] px-2.5 py-1 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-a16)] disabled:opacity-60"
+                  className="rounded-sm border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a10)] px-2.5 py-1 text-label text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-a16)] disabled:opacity-60"
                 >
                   {saving ? t("editSaving") : t("editSave")}
                 </button>
@@ -273,7 +273,7 @@ export function DocFrontmatterBlock({
                   type="button"
                   onClick={() => setEditing(false)}
                   disabled={saving}
-                  className="text-[11px] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                  className="text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
                 >
                   {t("editCancel")}
                 </button>
@@ -283,14 +283,14 @@ export function DocFrontmatterBlock({
             <button
               type="button"
               onClick={startEditing}
-              className="mt-2 inline-flex items-center gap-1.5 font-sans text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              className="mt-2 inline-flex items-center gap-1.5 font-sans text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
             >
               <Pencil size={11} aria-hidden />
               {t("editAction")}
             </button>
           )
         ) : null}
-        <p className="mt-2 flex items-center gap-1.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+        <p className="mt-2 flex items-center gap-1.5 text-label text-[color:var(--color-text-quaternary)]">
           <svg width="16" height="6" viewBox="0 0 16 6" aria-hidden="true" className="shrink-0">
             <line
               x1="1"

--- a/src/views/docs-vault/ui/parts/DocMetaBar.tsx
+++ b/src/views/docs-vault/ui/parts/DocMetaBar.tsx
@@ -14,7 +14,7 @@ import { estimateReadingMinutes } from "./reading-minutes";
 export { estimateReadingMinutes };
 
 const actionLinkClass =
-  "inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-[11px] text-[color:var(--color-text-tertiary)] underline-offset-2 transition-[background-color,border-color,color,transform] hover:-translate-y-0.5 hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] active:translate-y-px active:border-[color:var(--color-indigo-line-a54)] active:bg-[color:var(--color-indigo-line-a13)] motion-reduce:transform-none";
+  "inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-label text-[color:var(--color-text-tertiary)] underline-offset-2 transition-[background-color,border-color,color,transform] hover:-translate-y-0.5 hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] active:translate-y-px active:border-[color:var(--color-indigo-line-a54)] active:bg-[color:var(--color-indigo-line-a13)] motion-reduce:transform-none";
 
 /**
  * 문서 본문 위 메타 바 — 단어 수 / 읽기 시간 / kind 점프 / 태그 / 갱신일.
@@ -43,14 +43,14 @@ export function DocMetaBar({ doc }: { doc: VaultDoc }) {
   return (
     <section
       aria-label={t("recordProofAria")}
-      className="mx-auto flex max-w-[760px] flex-col gap-2 border-b border-[color:var(--color-overlay-2)] px-6 py-3 text-[11px] text-[color:var(--color-text-quaternary)] md:px-10"
+      className="mx-auto flex max-w-[760px] flex-col gap-2 border-b border-[color:var(--color-overlay-2)] px-6 py-3 text-label text-[color:var(--color-text-quaternary)] md:px-10"
     >
       <div className="flex min-w-0 flex-wrap items-start gap-x-2 gap-y-1.5">
-        <span className="inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-[11px] text-[color:var(--color-text-secondary)]">
+        <span className="inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-label text-[color:var(--color-text-secondary)]">
           <FileText className="h-3.5 w-3.5" aria-hidden="true" />
           {t("recordProofLabel")}
         </span>
-        <span className="min-h-7 min-w-0 rounded-md border border-[color:var(--color-overlay-1)] bg-[color:var(--color-overlay-1)] px-2 py-1 font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+        <span className="min-h-7 min-w-0 rounded-md border border-[color:var(--color-overlay-1)] bg-[color:var(--color-overlay-1)] px-2 py-1 font-mono text-label text-[color:var(--color-text-tertiary)]">
           <span className="sr-only">{t("pathLabel")}: </span>
           <span className="break-all">{sourcePath}</span>
         </span>

--- a/src/views/docs-vault/ui/parts/DocReadingOutlineRail.tsx
+++ b/src/views/docs-vault/ui/parts/DocReadingOutlineRail.tsx
@@ -39,10 +39,10 @@ export function DocReadingOutlineRail({
       data-testid="doc-reading-outline-rail"
       className="absolute bottom-6 left-6 top-6 hidden w-[168px] flex-col overflow-y-auto min-[1440px]:flex min-[1536px]:w-[200px]"
     >
-      <span className="mb-2 flex-none font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <span className="mb-2 flex-none font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
         {t("railLabel")} · {headings.length}
       </span>
-      <ul className="flex flex-col gap-0.5 text-[12.5px]">
+      <ul className="flex flex-col gap-0.5 text-body">
         {headings.map((heading, index) => {
           const isActive = activeHeadingSlug === heading.slug;
           return (

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
@@ -58,7 +58,7 @@ export interface DocsSidebarBodyProps {
 
 function SectionLabel({ children }: { children: ReactNode }) {
   return (
-    <h3 className="flex-none px-3 pb-1.5 pt-3 font-mono text-[9.5px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+    <h3 className="flex-none px-3 pb-1.5 pt-3 font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
       {children}
     </h3>
   );
@@ -138,10 +138,10 @@ export function DocsSidebarBody({
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex flex-none items-center justify-between gap-2 border-b border-[color:var(--color-overlay-2)] px-3 py-2.5">
         <div className="min-w-0">
-          <h2 className="truncate text-[12px] font-medium text-[color:var(--color-text-primary)]">
+          <h2 className="truncate text-body font-medium text-[color:var(--color-text-primary)]">
             {t("treeHeader")}
           </h2>
-          <p className="mt-0.5 truncate text-[10.5px] text-[color:var(--color-text-quaternary)]">
+          <p className="mt-0.5 truncate text-label text-[color:var(--color-text-quaternary)]">
             {normalizedTreeQuery
               ? t("treeSearchCount", { count: queryMatchCount })
               : activeTag
@@ -151,7 +151,7 @@ export function DocsSidebarBody({
         </div>
         <span
           data-token="engraved-numeral"
-          className="flex-none font-mono text-[13px] tabular-nums text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+          className="flex-none font-mono text-body tabular-nums text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
         >
           {manifest.docs.length}
         </span>
@@ -196,10 +196,10 @@ export function DocsSidebarBody({
                   : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
               }`}
             >
-              <span className="block truncate text-[11.5px] font-medium">
+              <span className="block truncate text-label font-medium">
                 {t(`collection.${option}.label`)}
               </span>
-              <span className="mt-0.5 block truncate text-[10px] text-[color:var(--color-text-quaternary)]">
+              <span className="mt-0.5 block truncate text-caption text-[color:var(--color-text-quaternary)]">
                 {t(`collection.${option}.count`, {
                   count: collectionCounts[option],
                 })}
@@ -215,7 +215,7 @@ export function DocsSidebarBody({
           value={treeQuery}
           onChange={(event) => setTreeQuery(event.target.value)}
           placeholder={t("searchPlaceholder")}
-          className="min-w-0 flex-1 bg-transparent text-[12px] text-[color:var(--color-text-secondary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
+          className="min-w-0 flex-1 bg-transparent text-body text-[color:var(--color-text-secondary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           type="text"
           autoComplete="off"
         />
@@ -231,7 +231,7 @@ export function DocsSidebarBody({
         ) : null}
       </label>
       {(activeTag || normalizedTreeQuery) ? (
-        <div className="mx-3 mt-2 flex flex-none items-center justify-between gap-2 rounded-sm border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a06)] px-2 py-1 text-[10.5px] text-[color:var(--color-indigo-pale-a90)]">
+        <div className="mx-3 mt-2 flex flex-none items-center justify-between gap-2 rounded-sm border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a06)] px-2 py-1 text-label text-[color:var(--color-indigo-pale-a90)]">
           <span className="truncate">
             {activeTag ? t("activeTagSummary", { tag: activeTag }) : t("treeSearchCount", { count: queryMatchCount })}
           </span>
@@ -262,7 +262,7 @@ export function DocsSidebarBody({
             className="flex w-full items-center gap-1.5 px-3 pb-1.5 pt-3 text-left transition-colors hover:text-[color:var(--color-text-secondary)]"
           >
             <Clock size={10} className="flex-none text-[color:var(--color-text-quaternary)]" aria-hidden />
-            <span className="flex-1 font-mono text-[9.5px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+            <span className="flex-1 font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
               {t("recentlyChangedHeader", { count: recentlyChangedDocs.length })}
             </span>
             <ChevronDown
@@ -283,7 +283,7 @@ export function DocsSidebarBody({
                     <button
                       type="button"
                       onClick={() => onSelect(doc.slug)}
-                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-[12px] transition-colors ${
+                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors ${
                         active
                           ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
                           : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
@@ -318,7 +318,7 @@ export function DocsSidebarBody({
                       <button
                         type="button"
                         onClick={() => onSelect(slug)}
-                        className={`flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 pr-7 text-left text-[12px] transition-colors ${
+                        className={`flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 pr-7 text-left text-body transition-colors ${
                           active
                             ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
                             : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
@@ -379,7 +379,7 @@ export function DocsSidebarBody({
                     <button
                       type="button"
                       onClick={() => onSelect(slug)}
-                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-[12px] transition-colors ${
+                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors ${
                         active
                           ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
                           : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
@@ -406,7 +406,7 @@ export function DocsSidebarBody({
             className="group"
             open={activeTag !== null ? true : undefined}
           >
-            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[11px] text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]">
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]">
               <Hash size={11} aria-hidden />
               <span className="font-medium">{t("tagsHeader", { count: tagEntries.length })}</span>
               <ChevronDown
@@ -424,7 +424,7 @@ export function DocsSidebarBody({
                     type="button"
                     onClick={() => onTagSelect(active ? null : tag)}
                     aria-pressed={active}
-                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10.5px] transition-colors ${
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-label transition-colors ${
                       active
                         ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--color-indigo-pale-a95)]"
                         : "bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-text-primary)]"

--- a/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
@@ -189,13 +189,13 @@ export function DocsVaultAuditModal({
               <div className="min-w-0 flex-1">
                 <p
                   id="docs-audit-modal-title"
-                  className="text-[15px] font-[650] text-[color:var(--color-text-primary)]"
+                  className="text-title font-[650] text-[color:var(--color-text-primary)]"
                 >
                   {t("header.contractToggleLabel")}
                 </p>
                 <p
                   id="docs-audit-modal-subtitle"
-                  className="mt-0.5 text-[12px] text-[color:var(--color-text-tertiary)]"
+                  className="mt-0.5 text-body text-[color:var(--color-text-tertiary)]"
                 >
                   {t("sourceContract.modalSubtitle")}
                 </p>
@@ -223,17 +223,17 @@ export function DocsVaultAuditModal({
                   </span>
                   <div className="min-w-0">
                     <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                      <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-pale-a82)]">
+                      <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-pale-a82)]">
                         {cell.label}
                       </span>
-                      <span className="rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                      <span className="rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                         {cell.chip}
                       </span>
                     </div>
-                    <p className="mt-0.5 truncate text-[12.5px] font-semibold text-[color:var(--color-text-primary)]">
+                    <p className="mt-0.5 truncate text-body font-semibold text-[color:var(--color-text-primary)]">
                       {cell.value}
                     </p>
-                    <p className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-0.5 text-label leading-4 text-[color:var(--color-text-tertiary)]">
                       {cell.body}
                     </p>
                     {"proofMarkers" in cell ? (
@@ -241,7 +241,7 @@ export function DocsVaultAuditModal({
                         {cell.proofMarkers.map((marker) => (
                           <span
                             key={marker}
-                            className="rounded-sm border border-[color:var(--color-indigo-line-a15)] bg-[color:var(--color-indigo-a06)] px-1.5 py-0.5 font-mono text-[9px] text-[color:var(--color-text-quaternary)]"
+                            className="rounded-sm border border-[color:var(--color-indigo-line-a15)] bg-[color:var(--color-indigo-a06)] px-1.5 py-0.5 font-mono text-caption text-[color:var(--color-text-quaternary)]"
                           >
                             {marker}
                           </span>
@@ -252,7 +252,7 @@ export function DocsVaultAuditModal({
                   <div className="col-span-2 ml-[48px] flex min-w-0 flex-wrap items-center gap-1.5 sm:col-span-1 sm:ml-0 sm:flex-col sm:items-end">
                     <Link
                       href={cell.href}
-                      className="inline-flex h-7 min-w-0 items-center rounded-sm border border-[color:var(--color-divider)] px-2 text-[10.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+                      className="inline-flex h-7 min-w-0 items-center rounded-sm border border-[color:var(--color-divider)] px-2 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
                     >
                       {cell.cta}
                     </Link>
@@ -261,7 +261,7 @@ export function DocsVaultAuditModal({
                         type="button"
                         aria-label={cell.copyAriaLabel}
                         onClick={() => void handleCopyGate(cell.copyText, cell.copySuccess)}
-                        className="inline-flex h-6 min-w-0 items-center gap-1 rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+                        className="inline-flex h-6 min-w-0 items-center gap-1 rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
                       >
                         {copiedGate ? <Check size={10} aria-hidden /> : <Clipboard size={10} aria-hidden />}
                         <span className="truncate">{cell.copyCta}</span>

--- a/src/views/docs-vault/ui/parts/DocsVaultDocOutlinePanel.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultDocOutlinePanel.tsx
@@ -60,11 +60,11 @@ export function DocsVaultDocOutlinePanel({
     <aside className="hidden w-[220px] flex-none flex-col overflow-auto border-l border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-3 py-3 lg:flex">
       <section className="flex items-center justify-between gap-1.5 border-b border-[color:var(--color-overlay-2)] pb-3">
         <div className="min-w-0">
-          <span className="block truncate text-[12px] font-medium text-[color:var(--color-text-secondary)]">
+          <span className="block truncate text-body font-medium text-[color:var(--color-text-secondary)]">
             {t("inspectorLabel")}
           </span>
           {activeOutlineHeading ? (
-            <span className="mt-0.5 block truncate text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="mt-0.5 block truncate text-label text-[color:var(--color-text-quaternary)]">
               {activeOutlineHeading.text}
             </span>
           ) : null}
@@ -115,7 +115,7 @@ export function DocsVaultDocOutlinePanel({
       {outlineHeadings.length > 0 ? (
         <details className="group border-b border-[color:var(--color-overlay-2)] py-3">
           <summary className="flex cursor-pointer list-none items-center justify-between rounded-sm py-1 text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-line-a45)]">
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em]">
+            <span className="font-mono text-caption uppercase tracking-[0.14em]">
               {t("tableOfContents")} · {outlineHeadings.length}
             </span>
             <ChevronDown
@@ -124,7 +124,7 @@ export function DocsVaultDocOutlinePanel({
               className="transition-transform group-open:rotate-180"
             />
           </summary>
-          <ul className="mt-3 flex max-h-[42vh] flex-col gap-1 overflow-auto pr-1 text-[12px]">
+          <ul className="mt-3 flex max-h-[42vh] flex-col gap-1 overflow-auto pr-1 text-body">
             {outlineHeadings.map((h, index) => {
               const isActive = activeHeadingSlug === h.slug;
               return (
@@ -159,7 +159,7 @@ export function DocsVaultDocOutlinePanel({
                       <span className="truncate">{h.text}</span>
                       {h.duplicate ? (
                         <span
-                          className="inline-flex h-4 min-w-4 flex-none items-center justify-center rounded-sm border border-[color:var(--color-divider)] px-1 font-mono text-[9px] text-[color:var(--color-text-quaternary)]"
+                          className="inline-flex h-4 min-w-4 flex-none items-center justify-center rounded-sm border border-[color:var(--color-divider)] px-1 font-mono text-caption text-[color:var(--color-text-quaternary)]"
                           aria-label={t("duplicateAria", { text: h.text, n: h.occurrence })}
                           title={t("duplicateAria", { text: h.text, n: h.occurrence })}
                         >
@@ -176,7 +176,7 @@ export function DocsVaultDocOutlinePanel({
       ) : null}
       <details className="group border-b border-[color:var(--color-overlay-2)] py-3">
         <summary className="flex cursor-pointer list-none items-center justify-between rounded-sm py-1 text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-line-a45)]">
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em]">
+          <span className="font-mono text-caption uppercase tracking-[0.14em]">
             {t("shareSection")}
           </span>
           <ChevronDown
@@ -190,7 +190,7 @@ export function DocsVaultDocOutlinePanel({
             <button
               type="button"
               onClick={() => onCopyUrl(selectedDoc.slug)}
-              className={`inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${
+              className={`inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-label transition-colors ${
                 copiedSlug === selectedDoc.slug
                   ? "border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-line-a06)] text-[color:var(--color-indigo-pale-a95)]"
                   : "border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-indigo-pale-a90)]"
@@ -215,7 +215,7 @@ export function DocsVaultDocOutlinePanel({
               onClick={() => {
                 if (typeof window !== "undefined") window.print();
               }}
-              className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]"
             >
               <Printer size={12} aria-hidden />
               {t("print")}
@@ -226,7 +226,7 @@ export function DocsVaultDocOutlinePanel({
       {canEditCurrent ? (
         <details className="group border-b border-[color:var(--color-overlay-2)] py-3">
           <summary className="flex cursor-pointer list-none items-center justify-between rounded-sm py-1 text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-line-a45)]">
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em]">
+            <span className="font-mono text-caption uppercase tracking-[0.14em]">
               {t("fileSection")}
             </span>
             <ChevronDown
@@ -240,7 +240,7 @@ export function DocsVaultDocOutlinePanel({
               <button
                 type="button"
                 onClick={() => void onDeleteCurrent()}
-                className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-danger-a46)] hover:text-[color:var(--color-danger-text-strong)]"
+                className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-danger-a46)] hover:text-[color:var(--color-danger-text-strong)]"
               >
                 <Trash2 size={12} aria-hidden />
                 {t("deleteAction")}

--- a/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
@@ -101,7 +101,7 @@ export function DocsVaultTabStrip({
                 onClose(tab.slug);
               }}
               className={cn(
-                "flex min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-[12px] transition-colors",
+                "flex min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-body transition-colors",
                 active
                   ? "text-[color:var(--color-text-primary)]"
                   : "text-[color:var(--color-text-tertiary)] group-hover:text-[color:var(--color-text-secondary)]",

--- a/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
@@ -47,7 +47,7 @@ export function DocsVaultVaultChip({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t("vaultChip.menuAriaLabel")}
-        className="inline-flex h-7 min-w-0 max-w-[200px] flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 font-mono text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+        className="inline-flex h-7 min-w-0 max-w-[200px] flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 font-mono text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
       >
         <HardDrive size={12} aria-hidden className="flex-none" />
         <span className="hidden min-w-0 truncate text-[color:var(--color-text-secondary)] sm:inline">
@@ -68,14 +68,14 @@ export function DocsVaultVaultChip({
           aria-label={t("vaultChip.menuAriaLabel")}
           className="absolute left-0 top-[calc(100%+6px)] z-50 w-72 max-w-[84vw] rounded-[var(--chrome-radius-inner)] border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] p-2 shadow-[var(--chrome-shadow)]"
         >
-          <p className="truncate rounded-sm px-1.5 py-1 font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+          <p className="truncate rounded-sm px-1.5 py-1 font-mono text-label text-[color:var(--color-text-tertiary)]">
             {path}
           </p>
-          <p className="px-1.5 py-1 text-[11px] text-[color:var(--color-text-secondary)]">
+          <p className="px-1.5 py-1 text-label text-[color:var(--color-text-secondary)]">
             {t("header.vaultPillFolders", { count: folderCount })}
           </p>
           {isLocalSourceLoaded ? (
-            <p className="inline-flex items-center gap-1 px-1.5 py-1 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-pale-a86)]">
+            <p className="inline-flex items-center gap-1 px-1.5 py-1 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-pale-a86)]">
               <HardDrive size={10} aria-hidden />
               {t("header.localBadge")}
             </p>
@@ -84,12 +84,12 @@ export function DocsVaultVaultChip({
             type="button"
             role="menuitem"
             onClick={onSwap}
-            className="mt-1 flex w-full items-center rounded-sm px-1.5 py-1.5 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1 flex w-full items-center rounded-sm px-1.5 py-1.5 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
           >
             {t("header.vaultPillSwap")}
           </button>
           {toolsMovedHint ? (
-            <p className="mt-1 border-t border-[color:var(--color-border-soft)] px-1.5 pt-1.5 text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 border-t border-[color:var(--color-border-soft)] px-1.5 pt-1.5 text-caption leading-4 text-[color:var(--color-text-tertiary)]">
               {toolsMovedHint}
             </p>
           ) : null}

--- a/src/views/docs-vault/ui/parts/EmptyState.tsx
+++ b/src/views/docs-vault/ui/parts/EmptyState.tsx
@@ -20,20 +20,20 @@ export function EmptyState({
   return (
     <div className="flex h-full flex-col items-center justify-center p-8 text-center">
       <div className="w-full max-w-[560px] rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-5 shadow-[0_18px_60px_var(--color-shadow-a16)]">
-        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t("eyebrow", { count: docCount })}
         </p>
-        <h2 className="mt-3 text-[20px] font-semibold tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+        <h2 className="mt-3 text-display font-semibold tracking-[-0.01em] text-[color:var(--color-text-primary)]">
           {t("title")}
         </h2>
-        <p className="mx-auto mt-2 max-w-[440px] text-[13px] leading-[1.7] text-[color:var(--color-text-tertiary)]">
+        <p className="mx-auto mt-2 max-w-[440px] text-body leading-[1.7] text-[color:var(--color-text-tertiary)]">
           {t("body")}
         </p>
         <div className="mt-5 grid gap-2 sm:grid-cols-3">
           <button
             type="button"
             onClick={onOpenTree}
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a10)] px-3 text-[12px] font-medium text-[color:rgba(220,225,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)]"
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a10)] px-3 text-body font-medium text-[color:rgba(220,225,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)]"
           >
             <PanelLeftOpen size={14} aria-hidden />
             {t("openTree")}
@@ -41,14 +41,14 @@ export function EmptyState({
           <button
             type="button"
             onClick={onOpenAgentWorkflow}
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border-soft)] px-3 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border-soft)] px-3 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
           >
             <Bot size={14} aria-hidden />
             {t("openAgent")}
           </button>
           <Link
             href="/topology/"
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border-soft)] px-3 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border-soft)] px-3 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
           >
             <Network size={14} aria-hidden />
             {t("openTopology")}

--- a/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
+++ b/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
@@ -55,11 +55,11 @@ export function NewDocKindDialog({
       >
         <p
           id="new-doc-kind-dialog-title"
-          className="text-[13.5px] font-[650] text-[color:var(--color-text-primary)]"
+          className="text-body-lg font-[650] text-[color:var(--color-text-primary)]"
         >
           {t("title")}
         </p>
-        <p className="mt-1 text-[11.5px] leading-4 text-[color:var(--color-text-tertiary)]">
+        <p className="mt-1 text-label leading-4 text-[color:var(--color-text-tertiary)]">
           {t("subtitle")}
         </p>
         <ul className="mt-3 grid grid-cols-2 gap-2">
@@ -71,7 +71,7 @@ export function NewDocKindDialog({
                 className="flex w-full items-center gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2 text-left transition-colors hover:border-[color:var(--color-border-strong)]"
               >
                 <TopologyV2KindGlyph kind={kind} size={16} />
-                <span className="text-[12px] text-[color:var(--color-text-secondary)]">
+                <span className="text-body text-[color:var(--color-text-secondary)]">
                   {kindLabel(kind)}
                 </span>
               </button>
@@ -81,7 +81,7 @@ export function NewDocKindDialog({
         <button
           type="button"
           onClick={onClose}
-          className="mt-3 text-[11px] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+          className="mt-3 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
         >
           {t("cancel")}
         </button>

--- a/src/views/docs-vault/ui/parts/SampleNotice.tsx
+++ b/src/views/docs-vault/ui/parts/SampleNotice.tsx
@@ -28,7 +28,7 @@ export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticePr
       data-testid="docs-vault-sample-notice"
       className="flex flex-none flex-wrap items-center gap-3 border-b border-l-2 border-b-[color:var(--color-divider)] border-l-[color:var(--color-indigo-brand)] bg-[color:var(--color-elevated)] px-6 py-2.5 md:px-10"
     >
-      <p className="min-w-0 flex-1 text-[12.5px] leading-[1.5] text-[color:var(--color-text-secondary)]">
+      <p className="min-w-0 flex-1 text-body leading-[1.5] text-[color:var(--color-text-secondary)]">
         <span className="font-semibold text-[color:var(--color-text-primary)]">
           {t("sampleNotice.title")}
         </span>{" "}
@@ -38,7 +38,7 @@ export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticePr
         <button
           type="button"
           onClick={onOpenFolder}
-          className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a12)] px-2.5 py-1.5 font-mono text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a18)]"
+          className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a12)] px-2.5 py-1.5 font-mono text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a18)]"
         >
           <FolderOpen size={12} aria-hidden />
           {t("sampleNotice.openFolderCta")}
@@ -46,7 +46,7 @@ export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticePr
       ) : (
         <Link
           href="/download/"
-          className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a12)] px-2.5 py-1.5 font-mono text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a18)]"
+          className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a12)] px-2.5 py-1.5 font-mono text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a18)]"
         >
           <Download size={12} aria-hidden />
           {t("vaultStatus.downloadAppCta")}

--- a/src/views/ontology-edit/ui/AlignToolbar.tsx
+++ b/src/views/ontology-edit/ui/AlignToolbar.tsx
@@ -68,7 +68,7 @@ export function AlignToolbar({
       aria-label={t("ariaLabel")}
       className="pointer-events-auto absolute top-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1.5 rounded-lg border border-[var(--color-overlay-3)] bg-[var(--color-elevated)] px-2.5 py-1.5 shadow-[var(--shadow-elevation-1)]"
     >
-      <span className="px-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[var(--color-text-quaternary)]">
+      <span className="px-1 font-mono text-caption uppercase tracking-[0.10em] text-[var(--color-text-quaternary)]">
         {t("selectedCount", { count: selected.length })}
       </span>
       <span aria-hidden className="mx-1 h-4 w-px bg-[var(--color-overlay-3)]" />

--- a/src/views/ontology-edit/ui/BlastRadiusConfirm.tsx
+++ b/src/views/ontology-edit/ui/BlastRadiusConfirm.tsx
@@ -89,11 +89,11 @@ export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onC
             <div>
               <p
                 id="blast-radius-title"
-                className="text-[15px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
+                className="text-title font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]"
               >
                 {hasBacklinks ? t('titleWithBacklinks', { count: backlinks.length }) : t('titleClean')}
               </p>
-              <p className="mt-1 font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+              <p className="mt-1 font-mono text-label text-[color:var(--color-text-tertiary)]">
                 {title ? `${title} · ${slug}` : slug}
               </p>
             </div>
@@ -109,7 +109,7 @@ export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onC
         </header>
 
         <div className="px-6 py-4">
-          <p className="text-[13px] leading-relaxed text-[color:var(--color-text-secondary)]">
+          <p className="text-body leading-relaxed text-[color:var(--color-text-secondary)]">
             {hasBacklinks ? t('bodyWithBacklinks') : t('bodyClean')}
           </p>
 
@@ -119,28 +119,28 @@ export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onC
                 {backlinks.slice(0, previewCount).map((b) => (
                   <li key={b.slug} className="px-3 py-2.5">
                     <div className="flex items-baseline justify-between gap-3">
-                      <span className="truncate text-[13px] text-[color:var(--color-text-primary)]">
+                      <span className="truncate text-body text-[color:var(--color-text-primary)]">
                         {b.title}
                       </span>
-                      <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                      <span className="shrink-0 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                         {b.matchedKeys.join(' · ')}
                       </span>
                     </div>
-                    <p className="mt-0.5 truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-0.5 truncate font-mono text-label text-[color:var(--color-text-tertiary)]">
                       {b.slug}
                     </p>
                   </li>
                 ))}
               </ul>
               {backlinks.length > previewCount ? (
-                <p className="border-t border-[color:var(--color-divider)] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <p className="border-t border-[color:var(--color-divider)] px-3 py-2 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {t('moreCount', { count: backlinks.length - previewCount })}
                 </p>
               ) : null}
             </div>
           ) : null}
 
-          <p className="mt-4 text-[12px] text-[color:var(--color-text-tertiary)]">
+          <p className="mt-4 text-body text-[color:var(--color-text-tertiary)]">
             {hasBacklinks ? t('hintWithBacklinks') : t('hintClean')}
           </p>
         </div>
@@ -150,7 +150,7 @@ export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onC
             ref={cancelRef}
             type="button"
             onClick={onCancel}
-            className="inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
           >
             {t('cancel')}
           </button>
@@ -159,8 +159,8 @@ export function BlastRadiusConfirm({ open, slug, title, backlinks, onCancel, onC
             onClick={onConfirm}
             className={
               hasBacklinks
-                ? 'inline-flex h-9 items-center rounded-md border border-[color:var(--color-danger-a42)] bg-[color:var(--color-danger-a12)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:rgba(255,141,138,0.95)] transition-colors hover:border-[color:var(--color-danger-a50)] hover:bg-[color:var(--color-danger-a12)]'
-                : 'inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)]'
+                ? 'inline-flex h-9 items-center rounded-md border border-[color:var(--color-danger-a42)] bg-[color:var(--color-danger-a12)] px-4 text-body font-[var(--font-weight-signature)] text-[color:rgba(255,141,138,0.95)] transition-colors hover:border-[color:var(--color-danger-a50)] hover:bg-[color:var(--color-danger-a12)]'
+                : 'inline-flex h-9 items-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)]'
             }
           >
             {hasBacklinks ? t('confirmWithBacklinks') : t('confirmClean')}

--- a/src/views/ontology-edit/ui/BuilderCanvasEntryRail.tsx
+++ b/src/views/ontology-edit/ui/BuilderCanvasEntryRail.tsx
@@ -86,7 +86,7 @@ export function BuilderCanvasEntryRail({
           aria-label={collapsedRailLabel}
           title={t("hint")}
           onClick={onToggleExpanded}
-          className="pointer-events-auto flex h-8 max-w-full items-center gap-1.5 rounded-lg border border-[color:var(--color-indigo-a24)] bg-[color:var(--color-panel-overlay-a88)] px-2.5 text-left text-[11px] text-[color:var(--color-text-secondary)] shadow-[var(--shadow-elevation-1)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)]"
+          className="pointer-events-auto flex h-8 max-w-full items-center gap-1.5 rounded-lg border border-[color:var(--color-indigo-a24)] bg-[color:var(--color-panel-overlay-a88)] px-2.5 text-left text-label text-[color:var(--color-text-secondary)] shadow-[var(--shadow-elevation-1)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)]"
         >
           <Network size={12} className="shrink-0 text-[color:var(--color-indigo-accent)]" />
           <span className="shrink-0 font-[var(--font-weight-signature)]">
@@ -95,13 +95,13 @@ export function BuilderCanvasEntryRail({
           {selectedAnchorSlug ? (
             <span
               aria-label={t("activeFocusAriaLabel", { slug: selectedAnchorSlug })}
-              className="min-w-0 truncate text-[10px] text-[color:var(--color-text-quaternary)]"
+              className="min-w-0 truncate text-caption text-[color:var(--color-text-quaternary)]"
               title={selectedAnchorLabel ?? undefined}
             >
               {formatBuilderActiveFocusLabel(t("activeFocusVisibleLabel"), selectedAnchorSlug)}
             </span>
           ) : (
-            <span className="min-w-0 truncate font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+            <span className="min-w-0 truncate font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
               {t("collapsedStats", { nodes: nodeCount, relations: relationCount })}
             </span>
           )}
@@ -123,11 +123,11 @@ export function BuilderCanvasEntryRail({
       <div className="flex items-center gap-1.5">
         <div className="flex min-w-0 items-center gap-1.5">
           <Network size={12} className="text-[color:var(--color-indigo-accent)]" />
-          <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {t("label")}
           </p>
         </div>
-        <p className="hidden font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-tertiary)] lg:block">
+        <p className="hidden font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-tertiary)] lg:block">
           {t("stats", { nodes: nodeCount, relations: relationCount })}
         </p>
         <button
@@ -135,12 +135,12 @@ export function BuilderCanvasEntryRail({
           aria-expanded={true}
           aria-controls="builder-canvas-entry-rail"
           onClick={onToggleExpanded}
-          className="pointer-events-auto hidden h-6 shrink-0 items-center rounded-md border border-[color:var(--color-border-soft)] px-1.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:text-[color:var(--color-text-primary)] sm:inline-flex"
+          className="pointer-events-auto hidden h-6 shrink-0 items-center rounded-md border border-[color:var(--color-border-soft)] px-1.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:text-[color:var(--color-text-primary)] sm:inline-flex"
         >
           {t("collapseAction")}
         </button>
         <span
-          className="hidden rounded-md border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)] sm:inline-flex"
+          className="hidden rounded-md border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)] sm:inline-flex"
           title={t("hint")}
         >
           {t("focusChip")}
@@ -148,7 +148,7 @@ export function BuilderCanvasEntryRail({
         {selectedAnchorSlug ? (
           <span
             aria-label={t("activeFocusAriaLabel", { slug: selectedAnchorSlug })}
-            className="max-w-[230px] truncate rounded-md border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]"
+            className="max-w-[230px] truncate rounded-md border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-secondary)]"
             title={selectedAnchorLabel ?? undefined}
           >
             {t("activeFocus", { slug: selectedAnchorSlug })}
@@ -168,8 +168,8 @@ export function BuilderCanvasEntryRail({
             data-anchor-slug={primaryAnchor.id}
             className={
               selectedAnchorId === primaryAnchor.id
-                ? "pointer-events-auto flex h-7 min-w-0 max-w-[250px] shrink items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-line-a15)] px-2 text-left text-[10px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)]"
-                : "pointer-events-auto flex h-7 min-w-0 max-w-[250px] shrink items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-2 text-left text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:bg-[color:var(--color-indigo-a13)] hover:text-[color:var(--color-text-primary)]"
+                ? "pointer-events-auto flex h-7 min-w-0 max-w-[250px] shrink items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-line-a15)] px-2 text-left text-caption text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)]"
+                : "pointer-events-auto flex h-7 min-w-0 max-w-[250px] shrink items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-2 text-left text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:bg-[color:var(--color-indigo-a13)] hover:text-[color:var(--color-text-primary)]"
             }
             title={t("anchorTitle", {
               kind: primaryAnchorKindLabel,
@@ -191,8 +191,8 @@ export function BuilderCanvasEntryRail({
               aria-label={t("degreeAriaLabel", { degree: primaryAnchor.degree })}
               className={
                 selectedAnchorId === primaryAnchor.id
-                  ? "ml-auto shrink-0 rounded border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-overlay-recessed-a20)] px-1 font-mono text-[9px] tabular-nums text-[color:var(--color-text-secondary)]"
-                  : "ml-auto shrink-0 rounded border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-recessed)] px-1 font-mono text-[9px] tabular-nums text-[color:var(--color-text-quaternary)]"
+                  ? "ml-auto shrink-0 rounded border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-overlay-recessed-a20)] px-1 font-mono text-caption tabular-nums text-[color:var(--color-text-secondary)]"
+                  : "ml-auto shrink-0 rounded border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-recessed)] px-1 font-mono text-caption tabular-nums text-[color:var(--color-text-quaternary)]"
               }
             >
               {primaryAnchor.degree}
@@ -203,7 +203,7 @@ export function BuilderCanvasEntryRail({
               type="button"
               onClick={onOpenAnchors}
               aria-label={t("openAnchorDialogAriaLabel", { count: hiddenAnchorCount })}
-              className="pointer-events-auto flex h-7 shrink-0 items-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-a03)] px-2 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:text-[color:var(--color-text-primary)]"
+              className="pointer-events-auto flex h-7 shrink-0 items-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-a03)] px-2 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a38)] hover:text-[color:var(--color-text-primary)]"
             >
               {t("openAnchorDialog", { count: hiddenAnchorCount })}
             </button>

--- a/src/views/ontology-edit/ui/BuilderCommandStrip.tsx
+++ b/src/views/ontology-edit/ui/BuilderCommandStrip.tsx
@@ -50,14 +50,14 @@ export function BuilderCommandStrip({
       className="flex min-w-[min(100%,280px)] max-w-full flex-1 flex-col items-stretch gap-2 rounded-md border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-indigo-a06)] px-2 py-1 sm:flex-row sm:items-center"
     >
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+        <p className="truncate text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {t(`${state}.title`, {
             nodes: draftNodes,
             edges: draftEdges,
             title: selectedTitle ?? t("selectedFallback"),
           })}
         </p>
-        <p className="hidden truncate text-[10px] leading-4 text-[color:var(--color-text-quaternary)] xl:block">
+        <p className="hidden truncate text-caption leading-4 text-[color:var(--color-text-quaternary)] xl:block">
           {t(`${state}.body`, {
             nodes: draftNodes,
             edges: draftEdges,
@@ -71,7 +71,7 @@ export function BuilderCommandStrip({
           onClick={onPrimaryAction}
           aria-label={primaryLabel}
           title={primaryLabel}
-          className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-indigo-a34)] bg-[color:var(--color-indigo-a14)] px-2.5 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+          className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-indigo-a34)] bg-[color:var(--color-indigo-a14)] px-2.5 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
           <PrimaryIcon size={12} />
           <span>{primaryLabel}</span>
@@ -81,7 +81,7 @@ export function BuilderCommandStrip({
             href={secondaryHref}
             aria-label={contextualSecondaryLabel}
             title={contextualSecondaryLabel}
-            className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a10)] px-2.5 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] shadow-[0_1px_0_var(--color-tap-highlight)_inset] transition-[border-color,background-color,transform] hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a16)] active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] focus-visible:ring-inset motion-reduce:transition-colors motion-reduce:active:translate-y-0"
+            className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a10)] px-2.5 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] shadow-[0_1px_0_var(--color-tap-highlight)_inset] transition-[border-color,background-color,transform] hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a16)] active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] focus-visible:ring-inset motion-reduce:transition-colors motion-reduce:active:translate-y-0"
           >
             <ShieldCheck size={12} />
             <span>{secondaryLabel}</span>
@@ -92,7 +92,7 @@ export function BuilderCommandStrip({
             onClick={onSecondaryAction}
             aria-label={contextualSecondaryLabel}
             title={contextualSecondaryLabel}
-            className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-a03)] px-2.5 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+            className="inline-flex h-8 items-center justify-center gap-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-a03)] px-2.5 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
           >
             <ShieldCheck size={12} />
             <span>{secondaryLabel}</span>

--- a/src/views/ontology-edit/ui/BuilderDetailsDraftCallout.tsx
+++ b/src/views/ontology-edit/ui/BuilderDetailsDraftCallout.tsx
@@ -26,13 +26,13 @@ export function BuilderDetailsDraftCallout({
           className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--color-indigo-accent)]"
         />
         <div className="min-w-0">
-          <p className="truncate text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          <p className="truncate text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
             {t("detailsDraftStatusTitle", {
               nodes: draftNodes,
               edges: draftEdges,
             })}
           </p>
-          <p className="mt-0.5 hidden truncate text-[10px] leading-4 text-[color:var(--color-text-tertiary)] sm:block">
+          <p className="mt-0.5 hidden truncate text-caption leading-4 text-[color:var(--color-text-tertiary)] sm:block">
             {t("detailsDraftStatusBody")}
           </p>
         </div>
@@ -40,7 +40,7 @@ export function BuilderDetailsDraftCallout({
       <button
         type="button"
         onClick={onOpenWriteSummary}
-        className="inline-flex h-8 shrink-0 items-center rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a13)] px-2.5 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+        className="inline-flex h-8 shrink-0 items-center rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a13)] px-2.5 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a52)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
       >
         {t("detailsDraftStatusAction")}
       </button>

--- a/src/views/ontology-edit/ui/BuilderOnboarding.tsx
+++ b/src/views/ontology-edit/ui/BuilderOnboarding.tsx
@@ -68,13 +68,13 @@ export function BuilderOnboarding({
         >
           <header className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-indigo-accent)]">
+              <p className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--color-indigo-accent)]">
                 {t("eyebrow")}
               </p>
-              <h2 className="mt-1 text-[15px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+              <h2 className="mt-1 text-title font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                 {t("title")}
               </h2>
-              <p className="mt-1 text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+              <p className="mt-1 text-body leading-5 text-[color:var(--color-text-tertiary)]">
                 {t("intro")}
               </p>
             </div>
@@ -87,7 +87,7 @@ export function BuilderOnboarding({
               <X size={13} />
             </button>
           </header>
-          <ol className="space-y-2.5 text-[12px] leading-5 text-[color:var(--color-text-secondary)]">
+          <ol className="space-y-2.5 text-body leading-5 text-[color:var(--color-text-secondary)]">
             <li className="flex gap-2.5">
               <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] text-[color:var(--color-indigo-accent)]">
                 <MousePointerClick size={12} />
@@ -127,21 +127,21 @@ export function BuilderOnboarding({
             </li>
           </ol>
           <footer className="mt-4 flex flex-col items-stretch gap-3 border-t border-[color:var(--color-border-soft)] pt-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="break-keep font-mono text-[10px] tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
+            <p className="break-keep font-mono text-caption tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
               {t("shortcutsHint")}
             </p>
             <div className="flex shrink-0 items-center gap-2">
               <button
                 type="button"
                 onClick={() => dismiss(true)}
-                className="whitespace-nowrap break-keep rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className="whitespace-nowrap break-keep rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
               >
                 {t("dontShowAgain")}
               </button>
               <button
                 type="button"
                 onClick={() => dismiss(false)}
-                className="whitespace-nowrap break-keep rounded-md border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a18)] px-3 py-1.5 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-a26)]"
+                className="whitespace-nowrap break-keep rounded-md border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a18)] px-3 py-1.5 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-a26)]"
               >
                 {t("getStarted")}
               </button>

--- a/src/views/ontology-edit/ui/BuilderReaderIntentStrip.tsx
+++ b/src/views/ontology-edit/ui/BuilderReaderIntentStrip.tsx
@@ -27,19 +27,19 @@ export function BuilderReaderIntentStrip({
     >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
-          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
             {label}
           </p>
-          <p className="mt-1 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          <p className="mt-1 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
             {title}
           </p>
-          <p className="mt-1 max-w-3xl break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-1 max-w-3xl break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
             {body}
           </p>
         </div>
         <Link
           href={actionHref}
-          className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a36)] hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] focus-visible:ring-inset"
+          className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a36)] hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a42)] focus-visible:ring-inset"
         >
           {actionLabel}
         </Link>

--- a/src/views/ontology-edit/ui/BuilderWriteConfirmBar.tsx
+++ b/src/views/ontology-edit/ui/BuilderWriteConfirmBar.tsx
@@ -50,15 +50,15 @@ export function BuilderWriteConfirmBar({
       aria-label={t("ariaLabel")}
       className="mt-2 hidden shrink-0 flex-wrap items-center gap-3 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3 py-2.5 md:flex"
     >
-      <span className="shrink-0 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+      <span className="shrink-0 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
         {t("label")}
       </span>
-      <p className="min-w-0 flex-1 truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+      <p className="min-w-0 flex-1 truncate font-mono text-label text-[color:var(--color-text-tertiary)]">
         {payload}
       </p>
       {/* 쓰기(주 액션)/미리보기(보조) 위계 — 로컬 alpha 톤을 손으로 반복하는
           대신 공유 `Button` variant(primary=인디고 solid · outline=중립)를
-          재사용해 앱 전역 버튼 문법과 맞춘다. 밀도(h-8/text-[11px]/rounded-md)
+          재사용해 앱 전역 버튼 문법과 맞춘다. 밀도(h-8/text-label/rounded-md)
           는 size="sm" 사다리 + 이 바의 기존 컴팩트 크롬에 맞춘 최소 override. */}
       <div className="flex shrink-0 items-center gap-1.5">
         {readOnlySource ? (
@@ -70,7 +70,7 @@ export function BuilderWriteConfirmBar({
             size="sm"
             onClick={onConnectSource}
             aria-label={t("connectSourceAriaLabel")}
-            className="rounded-md px-2.5 text-[11px] focus-visible:ring-offset-[color:var(--color-panel)]"
+            className="rounded-md px-2.5 text-label focus-visible:ring-offset-[color:var(--color-panel)]"
           >
             {t("connectSourceButton")}
           </Button>
@@ -86,7 +86,7 @@ export function BuilderWriteConfirmBar({
               // 않도록 표시한다(감사 #1 ④).
               data-builder-popover-trigger=""
               aria-label={t("dryRunAriaLabel")}
-              className="rounded-md px-2.5 text-[11px] font-normal focus-visible:ring-offset-[color:var(--color-panel)]"
+              className="rounded-md px-2.5 text-label font-normal focus-visible:ring-offset-[color:var(--color-panel)]"
             >
               {t("dryRunButton")}
             </Button>
@@ -97,7 +97,7 @@ export function BuilderWriteConfirmBar({
               onClick={onWrite}
               disabled={writeDisabled}
               aria-label={writeAriaLabel}
-              className="rounded-md px-2.5 text-[11px] focus-visible:ring-offset-[color:var(--color-panel)]"
+              className="rounded-md px-2.5 text-label focus-visible:ring-offset-[color:var(--color-panel)]"
             >
               {t("writeButton")}
             </Button>

--- a/src/views/ontology-edit/ui/BuilderWriteSummary.tsx
+++ b/src/views/ontology-edit/ui/BuilderWriteSummary.tsx
@@ -260,10 +260,10 @@ export function BuilderWriteSummary({
     >
       <header className="flex min-w-0 max-w-full items-center justify-between gap-3 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2 lg:col-span-2">
         <div className="min-w-0">
-          <h2 className="text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+          <h2 className="text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
             {t("summaryTitle")}
           </h2>
-          <p className="mt-0.5 truncate text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-0.5 truncate text-caption leading-4 text-[color:var(--color-text-tertiary)]">
             <span className="font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)]">
               {t("nextStepLabel")}
             </span>{" "}
@@ -292,13 +292,13 @@ export function BuilderWriteSummary({
               {item.icon}
             </span>
             <div className="min-w-0 flex-1 basis-[12rem]">
-              <p className="min-w-0 truncate text-[11px] font-medium text-[color:var(--color-text-tertiary)]">
+              <p className="min-w-0 truncate text-label font-medium text-[color:var(--color-text-tertiary)]">
                 {item.label}
               </p>
-              <p className="mt-0.5 truncate text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+              <p className="mt-0.5 truncate text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                 {item.value}
               </p>
-              <p className="mt-0.5 truncate text-[10px] text-[color:var(--color-text-quaternary)]">
+              <p className="mt-0.5 truncate text-caption text-[color:var(--color-text-quaternary)]">
                 {item.chip} · {item.flow}
               </p>
               {item.draftPreviews && item.draftPreviews.length > 0 ? (
@@ -313,16 +313,16 @@ export function BuilderWriteSummary({
                       role="listitem"
                       className="min-w-0 rounded border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-overlay-recessed-a12)] px-1.5 py-1"
                     >
-                      <p className="truncate text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)]">
+                      <p className="truncate text-caption font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)]">
                         {draft.kindLabel} · {draft.title}
                       </p>
-                      <p className="mt-0.5 truncate font-mono text-[9px] text-[color:var(--color-text-quaternary)]">
+                      <p className="mt-0.5 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
                         {draft.path}
                       </p>
                     </div>
                   ))}
                   {item.draftPreviewMore ? (
-                    <p className="truncate text-[9px] text-[color:var(--color-text-quaternary)]">
+                    <p className="truncate text-caption text-[color:var(--color-text-quaternary)]">
                       {item.draftPreviewMore}
                     </p>
                   ) : null}
@@ -334,8 +334,8 @@ export function BuilderWriteSummary({
               <p
                 className={
                   item.statusTone === "indigo"
-                    ? "hidden rounded border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-text-strong)] xl:block"
-                    : "hidden rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] xl:block"
+                    ? "hidden rounded border border-[color:var(--color-indigo-a22)] bg-[color:var(--color-indigo-a08)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-indigo-text-strong)] xl:block"
+                    : "hidden rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] xl:block"
                 }
               >
                 {item.status}
@@ -350,7 +350,7 @@ export function BuilderWriteSummary({
                 {item.href && item.actionLabel ? (
                   <Link
                     href={item.href}
-                    className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)]"
+                    className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)]"
                   >
                     {item.actionLabel}
                   </Link>
@@ -360,7 +360,7 @@ export function BuilderWriteSummary({
                     type="button"
                     onClick={item.onAction}
                     aria-label={item.actionAriaLabel ?? item.actionLabel}
-                    className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+                    className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
                   >
                     {item.actionLabel}
                   </button>
@@ -393,7 +393,7 @@ export function BuilderWriteSummary({
                     onClick={() => void copyProof(item.agentCopyText!, item.agentCopySuccess!)}
                     aria-label={item.agentCopyAriaLabel}
                     title={item.agentCopyLabel}
-                    className="inline-flex h-7 items-center gap-1 rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-[10px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+                    className="inline-flex h-7 items-center gap-1 rounded-md border border-[color:var(--color-indigo-a24)] px-2 text-caption font-[var(--font-weight-signature)] text-[color:var(--color-indigo-text-strong)] transition-colors hover:border-[color:var(--color-indigo-a42)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
                   >
                     <Clipboard size={11} aria-hidden />
                     <span>{item.agentCopyLabel}</span>

--- a/src/views/ontology-edit/ui/EphemeralEdge.tsx
+++ b/src/views/ontology-edit/ui/EphemeralEdge.tsx
@@ -79,7 +79,7 @@ export function EphemeralEdge({
             transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
             pointerEvents: "all",
           }}
-          className="inline-flex items-center gap-1 rounded-full border border-[color:var(--topology-v2-indigo-bright)] bg-[color:var(--color-panel)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--topology-v2-indigo-bright)] transition-colors hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-v2-indigo-bright)]"
+          className="inline-flex items-center gap-1 rounded-full border border-[color:var(--topology-v2-indigo-bright)] bg-[color:var(--color-panel)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--topology-v2-indigo-bright)] transition-colors hover:bg-[color:var(--color-overlay-2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-v2-indigo-bright)]"
           aria-label={t("ephemeralEdgeSaveAria")}
           title={t("ephemeralEdgeSaveTooltip")}
         >

--- a/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditCanvas.tsx
@@ -209,7 +209,7 @@ function ZoomLevelIndicator() {
   return (
     <div
       data-token="engraved-numeral"
-      className="pointer-events-none absolute bottom-3 left-3 z-10 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-1 font-mono text-[10.5px] tabular-nums tracking-[0.04em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+      className="pointer-events-none absolute bottom-3 left-3 z-10 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-1 font-mono text-label tabular-nums tracking-[0.04em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
     >
       {percent}%
     </div>
@@ -880,7 +880,7 @@ export function OntologyEditCanvas({
           formal 레지스터로 교체 — 지도 범례·인사이트와 동일한 단어. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute bottom-3 right-3 flex items-center gap-3 font-mono text-[10.5px] tracking-[0.03em] text-[color:var(--color-text-quaternary)]"
+        className="pointer-events-none absolute bottom-3 right-3 flex items-center gap-3 font-mono text-label tracking-[0.03em] text-[color:var(--color-text-quaternary)]"
       >
         <TraceLegendMark dash="" /> {relationVocabulary("contains", "formal")}
         <TraceLegendMark dash="6 4" /> {relationVocabulary("depends_on", "formal")}

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -1293,14 +1293,14 @@ export function OntologyEditPage() {
   ]);
 
   const helpTooltip = (
-    <div className="max-w-xs space-y-2 text-[12px] leading-5">
+    <div className="max-w-xs space-y-2 text-body leading-5">
       <p>{t("helpIntro")}</p>
       <ul className="space-y-1 pl-3 text-[color:var(--color-text-tertiary)]">
         <li>· {t("helpStepPalette")}</li>
         <li>· {t("helpStepConnect")}</li>
         <li>· {t("helpStepEphemeral")}</li>
       </ul>
-      <p className="font-mono text-[10px] tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+      <p className="font-mono text-caption tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
         {t("helpShortcuts")}
       </p>
     </div>
@@ -1381,7 +1381,7 @@ export function OntologyEditPage() {
           <h1 className="sr-only">{t("title")}</h1>
           <nav
             aria-label={t("headerBreadcrumbAriaLabel")}
-            className="flex min-w-0 shrink-0 items-center gap-2 text-[12px] text-[color:var(--color-text-tertiary)]"
+            className="flex min-w-0 shrink-0 items-center gap-2 text-body text-[color:var(--color-text-tertiary)]"
           >
             <Link
               href="/ontology/"
@@ -1399,7 +1399,7 @@ export function OntologyEditPage() {
             </span>
             <span
               data-token="engraved-numeral"
-              className="hidden font-mono text-[10.5px] tracking-[0.06em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)] sm:inline"
+              className="hidden font-mono text-label tracking-[0.06em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)] sm:inline"
             >
               {shouldShowFocusedCensus({
                 shownCount: shownNodeCount,
@@ -1428,7 +1428,7 @@ export function OntologyEditPage() {
           <p
             role="status"
             aria-live="polite"
-            className="mx-auto hidden min-w-0 truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)] md:block"
+            className="mx-auto hidden min-w-0 truncate font-mono text-label text-[color:var(--color-text-tertiary)] md:block"
           >
             <span
               aria-hidden="true"
@@ -1479,7 +1479,7 @@ export function OntologyEditPage() {
                     ephemeralEdges,
                   })
                 }
-                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2.5 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:bg-[color:var(--color-indigo-a16)]"
+                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2.5 text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:bg-[color:var(--color-indigo-a16)]"
                 aria-label={t("exportAriaLabel")}
               >
                 <Download size={12} />
@@ -1503,7 +1503,7 @@ export function OntologyEditPage() {
                     setLayoutSettingsOpen((open) => !open);
                   }}
                   aria-label={layoutSettingsActionLabel.ariaLabel}
-                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
                   <SlidersHorizontal size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                   <span className="min-w-0 flex-1 truncate">{t("layoutSettingsButton")}</span>
@@ -1517,7 +1517,7 @@ export function OntologyEditPage() {
                     setWriteSummaryOpen((open) => !open);
                   }}
                   aria-label={writeSummaryActionLabel.ariaLabel}
-                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
                   <ShieldCheck size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                   <span className="min-w-0 flex-1 truncate">{t("writeSummaryCollapsedLabel")}</span>
@@ -1536,7 +1536,7 @@ export function OntologyEditPage() {
                     aria-label={t("openDetailsAriaLabel", {
                       title: ephemeralSelected?.title ?? vaultSelected?.title ?? "",
                     })}
-                    className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                    className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                   >
                     <Info size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                     <span className="min-w-0 flex-1 truncate">{t("openDetailsButton")}</span>
@@ -1550,7 +1550,7 @@ export function OntologyEditPage() {
                     setFullscreen((current) => !current);
                   }}
                   aria-label={fullscreen ? t("fullscreenExit") : t("fullscreenEnter")}
-                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
                   {fullscreen ? (
                     <Minimize2 size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
@@ -1572,7 +1572,7 @@ export function OntologyEditPage() {
                         downloadJsonLd({ ephemeralNodes, ephemeralEdges });
                       }}
                       aria-label={t("exportJsonLdAriaLabel")}
-                      className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                      className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                     >
                       <FileJson size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                       <span className="min-w-0 flex-1 truncate">{t("exportJsonLdButton")}</span>
@@ -1585,7 +1585,7 @@ export function OntologyEditPage() {
                         downloadGraphML({ ephemeralNodes, ephemeralEdges });
                       }}
                       aria-label={t("exportGraphMlAriaLabel")}
-                      className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+                      className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                     >
                       <Network size={13} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
                       <span className="min-w-0 flex-1 truncate">{t("exportGraphMlButton")}</span>
@@ -1610,8 +1610,8 @@ export function OntologyEditPage() {
                       })}
                       className={
                         clearConfirming
-                          ? "flex w-full items-center gap-2.5 rounded-md border border-[color:var(--color-danger-a42)] bg-[color:var(--color-danger-a12)] px-2.5 py-2 text-left text-[11px] text-[color:var(--color-danger-text-strong)] transition-colors"
-                          : "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-danger-text-strong)]"
+                          ? "flex w-full items-center gap-2.5 rounded-md border border-[color:var(--color-danger-a42)] bg-[color:var(--color-danger-a12)] px-2.5 py-2 text-left text-label text-[color:var(--color-danger-text-strong)] transition-colors"
+                          : "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-danger-text-strong)]"
                       }
                     >
                       <Trash2 size={13} className="shrink-0" />
@@ -1697,10 +1697,10 @@ export function OntologyEditPage() {
                   >
                     <span className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-[color:var(--color-indigo-text-dot)] opacity-80" />
                     <span>
-                      <span className="block text-[11px] font-[var(--font-weight-signature)]">
+                      <span className="block text-label font-[var(--font-weight-signature)]">
                         {t("layoutDagre")}
                       </span>
-                      <span className="mt-0.5 block text-[10px] leading-4 text-[color:var(--color-text-quaternary)]">
+                      <span className="mt-0.5 block text-caption leading-4 text-[color:var(--color-text-quaternary)]">
                         {t("layoutDagreTitle")}
                       </span>
                     </span>
@@ -1721,10 +1721,10 @@ export function OntologyEditPage() {
                   >
                     <span className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-[color:var(--color-indigo-text-dot)] opacity-80" />
                     <span>
-                      <span className="block text-[11px] font-[var(--font-weight-signature)]">
+                      <span className="block text-label font-[var(--font-weight-signature)]">
                         {t("layoutForce")}
                       </span>
-                      <span className="mt-0.5 block text-[10px] leading-4 text-[color:var(--color-text-quaternary)]">
+                      <span className="mt-0.5 block text-caption leading-4 text-[color:var(--color-text-quaternary)]">
                         {t("layoutForceTitle")}
                       </span>
                     </span>
@@ -1742,10 +1742,10 @@ export function OntologyEditPage() {
                   >
                     <Wand2 size={12} className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
                     <span>
-                      <span className="block text-[11px] font-[var(--font-weight-signature)]">
+                      <span className="block text-label font-[var(--font-weight-signature)]">
                         {t("autoLayoutButton")}
                       </span>
-                      <span className="mt-0.5 block text-[10px] leading-4 text-[color:var(--color-text-quaternary)]">
+                      <span className="mt-0.5 block text-caption leading-4 text-[color:var(--color-text-quaternary)]">
                         {t("autoLayoutDescription")}
                       </span>
                     </span>
@@ -2134,7 +2134,7 @@ export function OntologyEditPage() {
             <div className="w-full max-w-[720px] overflow-hidden rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] shadow-[var(--shadow-elevation-3)]">
               <header className="flex items-center justify-between gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-3">
                 <div className="min-w-0">
-                  <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
                     {t("detailsSheetEyebrow")}
                   </p>
                   <h2 className="mt-0.5 truncate text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
@@ -2184,13 +2184,13 @@ export function OntologyEditPage() {
             <div className="w-full max-w-[680px] overflow-hidden rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] shadow-[var(--shadow-elevation-3)]">
               <header className="flex items-start justify-between gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-3">
                 <div>
-                  <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
                     {t("anchorDialogEyebrow")}
                   </p>
                   <h2 className="mt-0.5 text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                     {t("anchorDialogTitle")}
                   </h2>
-                  <p className="mt-1 text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 text-label leading-4 text-[color:var(--color-text-tertiary)]">
                     {t("anchorDialogBody")}
                   </p>
                 </div>
@@ -2222,13 +2222,13 @@ export function OntologyEditPage() {
                           : "rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2 text-left transition-colors hover:border-[color:var(--color-indigo-a36)]"
                       }
                     >
-                      <span className="block truncate text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+                      <span className="block truncate text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                         {anchor.label}
                       </span>
-                      <span className="mt-1 block truncate font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                      <span className="mt-1 block truncate font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                         {anchorKindLabel} · {anchor.id}
                       </span>
-                      <span className="mt-2 inline-flex rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 font-mono text-[9px] text-[color:var(--color-text-tertiary)]">
+                      <span className="mt-2 inline-flex rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 font-mono text-caption text-[color:var(--color-text-tertiary)]">
                         {formatBuilderAnchorDegreeBadge(
                           t("canvasEntryRail.degreeBadge"),
                           anchor.degree,
@@ -2245,32 +2245,32 @@ export function OntologyEditPage() {
             안내 + 트리 / 토폴로지 진입점 노출. */}
         <section className="flex flex-1 flex-col items-center justify-center gap-4 rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-6 py-10 text-center md:hidden">
           <div className="flex flex-col gap-2">
-            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-indigo-accent)]">
+            <p className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--color-indigo-accent)]">
               {t("mobileEyebrow")}
             </p>
             <h2 className="text-base font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
               {t("mobileTitle")}
             </h2>
-            <p className="max-w-xs break-keep text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="max-w-xs break-keep text-body leading-5 text-[color:var(--color-text-tertiary)]">
               {t("mobileBody")}
             </p>
           </div>
           <div className="flex flex-wrap items-center justify-center gap-2">
             <Link
               href={treeHref}
-              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a14)] px-3 text-[12px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)]"
+              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a14)] px-3 text-body text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)]"
             >
               {t("mobileTreeCta")}
             </Link>
             <Link
               href="/topology/"
-              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
             >
               {t("mobileTopologyCta")}
             </Link>
             <Link
               href="/ontology/insights/"
-              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-green-a28)] bg-[color:var(--color-green-a08)] px-3 text-[12px] text-[color:var(--color-green-text)] transition-colors hover:border-[color:var(--color-green-a44)] hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex h-9 items-center gap-1.5 rounded-full border border-[color:var(--color-green-a28)] bg-[color:var(--color-green-a08)] px-3 text-body text-[color:var(--color-green-text)] transition-colors hover:border-[color:var(--color-green-a44)] hover:text-[color:var(--color-text-primary)]"
             >
               <ShieldCheck size={13} aria-hidden />
               {t("mobileValidateCta")}

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -189,7 +189,7 @@ export function OntologyInspector({
         {selected ? (
           <span
             aria-hidden
-            className="rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]"
+            className="rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]"
             title={selected.title}
           >
             ●
@@ -209,10 +209,10 @@ export function OntologyInspector({
     >
       <header className="flex items-center justify-between gap-2 px-1">
         <div className="flex-1">
-          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
             {t("eyebrow")}
           </p>
-          <p className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+          <p className="mt-0.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
             {t("subtitle")}
           </p>
         </div>
@@ -233,11 +233,11 @@ export function OntologyInspector({
           aria-label={t("sessionDiffAriaLabel")}
           className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5"
         >
-          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {t("sessionDiffTitle")}
           </p>
           {sessionDiffLines.length > 0 ? (
-            <ul className="mt-1.5 flex flex-col gap-1 font-mono text-[11px] leading-5">
+            <ul className="mt-1.5 flex flex-col gap-1 font-mono text-label leading-5">
               {sessionDiffLines.map((line) => (
                 <li
                   key={`${line.changeType}-${line.path}`}
@@ -261,7 +261,7 @@ export function OntologyInspector({
               ))}
             </ul>
           ) : (
-            <p className="mt-1.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+            <p className="mt-1.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
               {t("sessionDiffEmpty")}
             </p>
           )}
@@ -274,7 +274,7 @@ export function OntologyInspector({
             {...FADE_MOTION}
             className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-elevated)] p-2.5"
           >
-            <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+            <p className="text-label leading-4 text-[color:var(--color-text-quaternary)]">
               {t("emptyHint")}
             </p>
           </motion.div>
@@ -486,7 +486,7 @@ function EphemeralDetail({
       <div className="flex items-center justify-between gap-2">
         <span className="inline-flex items-center gap-1.5">
           <TopologyV2KindGlyph kind={node.kind} size={15} />
-          <span className="inline-flex items-center rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-primary)]">
+          <span className="inline-flex items-center rounded-full border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-2 py-0.5 text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-primary)]">
             {t("ephemeralBadge")} · {kindLabel(node.kind)}
           </span>
         </span>
@@ -501,7 +501,7 @@ function EphemeralDetail({
         </button>
       </div>
       <label className="flex flex-col gap-1.5">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t("nameLabel")}
         </span>
         <input
@@ -526,20 +526,20 @@ function EphemeralDetail({
             }
           }}
           placeholder={t("namePlaceholder")}
-          className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[13px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
+          className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-body text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
         />
       </label>
       {/* 저장 시 실제 생성될 vault 파일 경로 미리보기. 좌표(감사 #8)는
           사용자에게 의미 없는 내부 캔버스 수치라 제거했다. 파일명은 길어도
           break-all 로 4줄씩 꺾이지 않게 truncate + 전체는 title 툴팁으로
           (감사 #7) — 복사 버튼으로 정확한 전체 경로를 얻는다. */}
-      <div className="min-w-0 text-[10px]">
+      <div className="min-w-0 text-caption">
         <p className="font-mono uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t("saveIdLabel")}
         </p>
         <div className="mt-1 flex min-w-0 items-center gap-1.5">
           <p
-            className="min-w-0 flex-1 truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)]"
+            className="min-w-0 flex-1 truncate font-mono text-label text-[color:var(--color-text-tertiary)]"
             title={savePath}
           >
             {savePath}
@@ -551,7 +551,7 @@ function EphemeralDetail({
             }}
             aria-label={t("copySavePathAriaLabel", { path: savePath })}
             title={t("copySavePathAriaLabel", { path: savePath })}
-            className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+            className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
           >
             {copyPathIcon}
             <span>{copyPathLabel}</span>
@@ -561,14 +561,14 @@ function EphemeralDetail({
       {saveConflict ? (
         <div
           role="status"
-          className="rounded-md border border-[color:var(--color-amber-muted-a34)] bg-[color:var(--color-amber-muted-a10)] px-2.5 py-2 text-[11px] leading-4 text-[color:var(--color-text-secondary)]"
+          className="rounded-md border border-[color:var(--color-amber-muted-a34)] bg-[color:var(--color-amber-muted-a10)] px-2.5 py-2 text-label leading-4 text-[color:var(--color-text-secondary)]"
         >
           <p>{t("ephemeralSaveConflict", { path: savePath })}</p>
           {saveSuggestion ? (
             <button
               type="button"
               onClick={() => onRename(node.id, saveSuggestion.title)}
-              className="mt-2 inline-flex h-7 items-center rounded-md border border-[color:var(--color-amber-muted-a42)] bg-[color:var(--color-amber-muted-a12)] px-2.5 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-amber-muted-a62)] hover:bg-[color:var(--color-amber-muted-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-amber-muted-a42)] focus-visible:ring-inset"
+              className="mt-2 inline-flex h-7 items-center rounded-md border border-[color:var(--color-amber-muted-a42)] bg-[color:var(--color-amber-muted-a12)] px-2.5 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-amber-muted-a62)] hover:bg-[color:var(--color-amber-muted-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-amber-muted-a42)] focus-visible:ring-inset"
             >
               {t("ephemeralUseSuggestedName", {
                 title: saveSuggestion.title,
@@ -585,7 +585,7 @@ function EphemeralDetail({
           type="button"
           onClick={() => onConnectSource?.()}
           aria-label={t("connectSourceAriaLabel")}
-          className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+          className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
           <FolderOpen size={13} aria-hidden />
           {t("connectSourceButton")}
@@ -596,7 +596,7 @@ function EphemeralDetail({
           onClick={() => onSave(node.id)}
           disabled={!canSave}
           aria-label={t("saveButtonAriaLabel")}
-          className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+          className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
           {saving ? t("savingButton") : t("saveButton")}
         </button>
@@ -615,7 +615,7 @@ function EphemeralDetail({
           }}
           aria-label={t("copyDraftAgentPacketAriaLabel", { path: savePath })}
           title={t("copyDraftAgentPacketAriaLabel", { path: savePath })}
-          className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:bg-[color:var(--color-indigo-a08)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+          className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2.5 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:bg-[color:var(--color-indigo-a08)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
         >
           {agentPacketIcon}
           <span>{agentPacketLabel}</span>
@@ -627,10 +627,10 @@ function EphemeralDetail({
           className={`mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full ${saveStateDotClass}`}
         />
         <div className="min-w-0">
-          <p className="text-[11px] font-[var(--font-weight-signature)] leading-4 text-[color:var(--color-text-secondary)]">
+          <p className="text-label font-[var(--font-weight-signature)] leading-4 text-[color:var(--color-text-secondary)]">
             {saveStateLabel}
           </p>
-          <p className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+          <p className="mt-0.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
             {saveStateBody}
           </p>
         </div>
@@ -675,7 +675,7 @@ function AddRelationPicker({
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t("addRelationAriaLabel")}
-        className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a12)] px-2.5 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a58)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+        className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a12)] px-2.5 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a58)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
       >
         <Plus size={13} aria-hidden />
         {t("addRelationButton")}
@@ -685,7 +685,7 @@ function AddRelationPicker({
   return (
     <div className="flex flex-col gap-2 rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a06)] p-2.5">
       <div className="flex items-center justify-between gap-2">
-        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t("addRelationTitle")}
         </p>
         <button
@@ -708,7 +708,7 @@ function AddRelationPicker({
         onChange={(e) => setQuery(e.target.value)}
         placeholder={t("addRelationSearchPlaceholder")}
         aria-label={t("addRelationSearchAriaLabel")}
-        className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[12px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
+        className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-body text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)]"
       />
       {matches.length > 0 ? (
         <ul className="flex max-h-48 flex-col gap-1 overflow-y-auto">
@@ -724,11 +724,11 @@ function AddRelationPicker({
                 aria-label={t("addRelationSelectAriaLabel", {
                   title: candidate.title,
                 })}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
               >
                 <TopologyV2KindGlyph kind={candidate.kind} size={13} />
                 <span className="min-w-0 flex-1 truncate">{candidate.title}</span>
-                <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="shrink-0 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {kindLabel(candidate.kind)}
                 </span>
               </button>
@@ -736,7 +736,7 @@ function AddRelationPicker({
           ))}
         </ul>
       ) : (
-        <p className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+        <p className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
           {t("addRelationNoMatch")}
         </p>
       )}
@@ -846,7 +846,7 @@ function VaultDetail({
       <div className="flex items-center justify-between gap-2">
         <span className="inline-flex items-center gap-1.5">
           <TopologyV2KindGlyph kind={node.kind} size={15} />
-          <span className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+          <span className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
             {readOnly ? t("dogfoodBadge") : t("vaultBadge")} · {kindLabel(node.kind)}
           </span>
         </span>
@@ -860,7 +860,7 @@ function VaultDetail({
           ×
         </button>
       </div>
-      <p className="-mt-2 truncate pl-[22px] font-mono text-[10.5px] tracking-[0.02em] text-[color:var(--color-text-quaternary)]">
+      <p className="-mt-2 truncate pl-[22px] font-mono text-label tracking-[0.02em] text-[color:var(--color-text-quaternary)]">
         {kindPathLine}
       </p>
       <div
@@ -882,8 +882,8 @@ function VaultDetail({
                 onClick={() => setActiveTab(tab.id)}
                 className={
                   active
-                    ? "flex h-7 items-center justify-center gap-1 rounded-sm bg-[color:var(--color-indigo-a22)] px-2 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
-                    : "flex h-7 items-center justify-center gap-1 rounded-sm px-2 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+                    ? "flex h-7 items-center justify-center gap-1 rounded-sm bg-[color:var(--color-indigo-a22)] px-2 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+                    : "flex h-7 items-center justify-center gap-1 rounded-sm px-2 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
                 }
               >
                 <Icon size={12} aria-hidden="true" className="shrink-0" />
@@ -903,40 +903,40 @@ function VaultDetail({
           <div className="rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a08)] p-2.5">
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
-                <p className="text-[11px] font-[var(--font-weight-signature)] leading-4 text-[color:var(--color-text-secondary)]">
+                <p className="text-label font-[var(--font-weight-signature)] leading-4 text-[color:var(--color-text-secondary)]">
                   {t("objectProofLabel")}
                 </p>
-                <p className="mt-1 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+                <p className="mt-1 text-label leading-4 text-[color:var(--color-text-quaternary)]">
                   {t("objectProofBody")}
                 </p>
               </div>
-              <span className="shrink-0 rounded-full border border-[color:var(--color-indigo-a36)] bg-[color:var(--color-indigo-a14)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]">
+              <span className="shrink-0 rounded-full border border-[color:var(--color-indigo-a36)] bg-[color:var(--color-indigo-a14)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]">
                 {t("objectProofChip")}
               </span>
             </div>
             <div className="mt-2 grid grid-cols-3 gap-1.5">
               <div className="min-w-0 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-recessed)] px-2 py-1.5">
-                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("objectProofOutgoing")}
                 </p>
-                <p className="mt-0.5 font-mono text-[15px] text-[color:var(--color-text-primary)]">
+                <p className="mt-0.5 font-mono text-title text-[color:var(--color-text-primary)]">
                   {outgoingCount}
                 </p>
               </div>
               <div className="min-w-0 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-recessed)] px-2 py-1.5">
-                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("objectProofIncoming")}
                 </p>
-                <p className="mt-0.5 font-mono text-[15px] text-[color:var(--color-text-primary)]">
+                <p className="mt-0.5 font-mono text-title text-[color:var(--color-text-primary)]">
                   {backlinks.length}
                 </p>
               </div>
               <div className="min-w-0 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-recessed)] px-2 py-1.5">
-                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("objectProofSource")}
                 </p>
                 <p
-                  className="mt-0.5 truncate font-mono text-[11px] text-[color:var(--color-text-primary)]"
+                  className="mt-0.5 truncate font-mono text-label text-[color:var(--color-text-primary)]"
                   title={`${node.slug}.md`}
                 >
                   {node.slug}.md
@@ -947,21 +947,21 @@ function VaultDetail({
               <button
                 type="button"
                 onClick={() => setActiveTab("relations")}
-                className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a12)] px-2 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a58)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+                className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a12)] px-2 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a58)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
               >
                 {t("objectProofRelationsAction")}
               </button>
               <button
                 type="button"
                 onClick={() => setActiveTab("document")}
-                className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
+                className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-border-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a38)] focus-visible:ring-inset"
               >
                 {t("objectProofDocumentAction")}
               </button>
             </div>
           </div>
           <label className="flex flex-col gap-1.5">
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("vaultTitleLabel")}
             </span>
             <input
@@ -976,14 +976,14 @@ function VaultDetail({
                 }
               }}
               disabled={readOnly}
-              className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-[13px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-60"
+              className="rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2.5 py-1.5 text-body text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-60"
             />
           </label>
           <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("vaultSlugLabel")}
             </p>
-            <p className="mt-1 break-all font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-all font-mono text-label text-[color:var(--color-text-tertiary)]">
               {node.slug}
             </p>
           </div>
@@ -993,7 +993,7 @@ function VaultDetail({
               onClick={() => onSaveRename(node.slug, draft)}
               disabled={!canSave}
               aria-label={t("vaultSaveAriaLabel")}
-              className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+              className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-3 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
             >
               {saving
                 ? t("vaultSavingButton")
@@ -1059,7 +1059,7 @@ function VaultDetail({
               onSelectBacklink={onSelectBacklink}
             />
           ) : (
-            <p className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] p-2.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+            <p className="rounded-md border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] p-2.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
               {t("backlinksEmpty")}
             </p>
           )}
@@ -1073,23 +1073,23 @@ function VaultDetail({
           className="flex flex-col gap-3"
         >
           <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("sourceDocumentLabel")}
             </p>
-            <p className="mt-1 break-all font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-all font-mono text-label text-[color:var(--color-text-tertiary)]">
               {node.slug}.md
             </p>
-            <p className="mt-2 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+            <p className="mt-2 text-label leading-4 text-[color:var(--color-text-quaternary)]">
               {t("sourceDocumentHint")}
             </p>
             <Link
               href={sourceDocHref}
-              className="mt-2 inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a12)] px-3 text-[11px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a62)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+              className="mt-2 inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a12)] px-3 text-label font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a62)] hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
             >
               {t("sourceDocumentAction")}
             </Link>
           </div>
-          <p className="text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+          <p className="text-label leading-4 text-[color:var(--color-text-quaternary)]">
             {readOnly
               ? t(
                   isDesktopRuntime
@@ -1126,7 +1126,7 @@ function VaultDetail({
               onClick={() => onDelete(node.slug)}
               disabled={saving}
               aria-label={t("deleteAriaLabel")}
-              className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-danger-a32)] bg-transparent px-3 text-[11px] text-[color:var(--color-danger-text)] transition-colors hover:border-[color:var(--color-danger-a50)] hover:bg-[color:var(--color-danger-a08)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-danger-a50)] focus-visible:ring-inset"
+              className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--color-danger-a32)] bg-transparent px-3 text-label text-[color:var(--color-danger-text)] transition-colors hover:border-[color:var(--color-danger-a50)] hover:bg-[color:var(--color-danger-a08)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-danger-a50)] focus-visible:ring-inset"
             >
               {t("deleteButton")}
             </button>
@@ -1171,7 +1171,7 @@ function BacklinksSummary({
   };
   return (
     <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
         {t("backlinksLabel", { count: backlinks.length })}
       </p>
       <ul className="mt-2 flex flex-wrap gap-1">
@@ -1185,12 +1185,12 @@ function BacklinksSummary({
                 title: bl.title,
                 keys: bl.matchedKeys.map(edgeKeyLabel).join(", "),
               })}
-              className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a08)] px-2 py-0.5 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a55)] hover:bg-[color:var(--color-indigo-a16)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+              className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a08)] px-2 py-0.5 text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a55)] hover:bg-[color:var(--color-indigo-a16)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
             >
               <span className="break-keep">{bl.title}</span>
               <span
                 aria-hidden
-                className="rounded-sm bg-[color:var(--color-indigo-a22)] px-1 font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--color-indigo-text-strong)]"
+                className="rounded-sm bg-[color:var(--color-indigo-a22)] px-1 font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--color-indigo-text-strong)]"
               >
                 {edgeKeyLabel(bl.matchedKeys[0])}
               </span>
@@ -1298,12 +1298,12 @@ function LiteralEditor({
     onCommit(draft);
   };
   const sharedClass =
-    "w-full rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 text-[12px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50";
+    "w-full rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 text-body text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50";
   return (
     <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
       <label
         htmlFor={`literal-${fieldKey}`}
-        className="block font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
+        className="block font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
       >
         {literalLabel(t, fieldKey)}
       </label>
@@ -1339,7 +1339,7 @@ function LiteralEditor({
           className={`mt-1.5 ${sharedClass}`}
         />
       )}
-      <p className="mt-1 text-[10px] text-[color:var(--color-text-quaternary)]">
+      <p className="mt-1 text-caption text-[color:var(--color-text-quaternary)]">
         {dirty ? t("literalAutoSaveDirty") : t("literalAutoSaveClean")}
       </p>
     </div>
@@ -1381,11 +1381,11 @@ function ArrayEditorGroup({
             aria-hidden
             className="text-[color:var(--color-text-quaternary)] transition-transform group-open:rotate-90"
           />
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {title}
           </span>
         </span>
-        <span className="rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-1.5 font-mono text-[9px] tabular-nums text-[color:var(--color-text-tertiary)]">
+        <span className="rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-1.5 font-mono text-caption tabular-nums text-[color:var(--color-text-tertiary)]">
           {count}
         </span>
       </summary>
@@ -1464,7 +1464,7 @@ function ArrayKeyEditor({
     <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
       <label
         htmlFor={`array-${fieldKey}`}
-        className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
+        className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
       >
         <RelationTraceMarkIcon mark={resolveRelationTraceMark(fieldKey)} />
         {arrayLabel(t, fieldKey)}
@@ -1482,8 +1482,8 @@ function ArrayKeyEditor({
                   aria-label={t("arrayRemoveAriaLabel", { slug })}
                   className={
                     isNew
-                      ? "inline-flex items-center gap-1 rounded-full border border-[color:var(--color-amber-signal-a60)] bg-[color:var(--color-amber-signal-a16)] px-2 py-0.5 text-[11px] text-[color:var(--color-text-primary)] transition-[background,border] duration-1000 ease-out"
-                      : "inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2 py-0.5 text-[11px] text-[color:var(--color-text-primary)] transition-[background,border] duration-1000 ease-out hover:border-[color:var(--color-danger-a46)] hover:bg-[color:var(--color-danger-a10)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-danger-a46)] focus-visible:ring-inset"
+                      ? "inline-flex items-center gap-1 rounded-full border border-[color:var(--color-amber-signal-a60)] bg-[color:var(--color-amber-signal-a16)] px-2 py-0.5 text-label text-[color:var(--color-text-primary)] transition-[background,border] duration-1000 ease-out"
+                      : "inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2 py-0.5 text-label text-[color:var(--color-text-primary)] transition-[background,border] duration-1000 ease-out hover:border-[color:var(--color-danger-a46)] hover:bg-[color:var(--color-danger-a10)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-danger-a46)] focus-visible:ring-inset"
                   }
                 >
                   <span className="font-mono break-all">{slug}</span>
@@ -1511,14 +1511,14 @@ function ArrayKeyEditor({
           }}
           disabled={disabled}
           placeholder={t("arrayInputPlaceholder")}
-          className="flex-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 font-mono text-[11px] text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50"
+          className="flex-1 rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-2 py-1 font-mono text-label text-[color:var(--color-text-primary)] outline-none transition-colors focus:border-[color:var(--color-indigo-brand)] disabled:opacity-50"
         />
         <button
           type="button"
           onClick={submit}
           disabled={disabled || !input.trim() || values.includes(input.trim())}
           aria-label={t("arrayAddAriaLabel")}
-          className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-2 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
+          className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-border-a46)] bg-[color:var(--color-indigo-a18)] px-2 text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a66)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
           +
         </button>
@@ -1559,7 +1559,7 @@ function ReadOnlyArraySummary({
           key={key}
           className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5"
         >
-          <p className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             <RelationTraceMarkIcon mark={resolveRelationTraceMark(key)} />
             {arrayLabel(t, key)}
           </p>
@@ -1567,7 +1567,7 @@ function ReadOnlyArraySummary({
             {values.map((slug) => (
               <li
                 key={slug}
-                className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--color-text-tertiary)]"
+                className="inline-flex items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 font-mono text-label text-[color:var(--color-text-tertiary)]"
               >
                 {slug}
               </li>

--- a/src/views/ontology-edit/ui/OntologyKindPalette.tsx
+++ b/src/views/ontology-edit/ui/OntologyKindPalette.tsx
@@ -82,7 +82,7 @@ export function OntologyKindPalette({
                 <span
                   aria-hidden="true"
                   data-palette-add-badge={entry.kind}
-                  className="pointer-events-none absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[color:var(--color-panel)] bg-[color:var(--color-indigo-brand)] text-[9px] font-bold leading-none text-[color:var(--color-text-primary)]"
+                  className="pointer-events-none absolute -bottom-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[color:var(--color-panel)] bg-[color:var(--color-indigo-brand)] text-caption font-bold leading-none text-[color:var(--color-text-primary)]"
                 >
                   +
                 </span>
@@ -101,10 +101,10 @@ export function OntologyKindPalette({
     >
       <header className="flex items-center justify-between gap-2 px-1">
         <div className="flex-1">
-          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
             {t("eyebrow")}
           </p>
-          <p className="mt-0.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)]">
+          <p className="mt-0.5 text-label leading-4 text-[color:var(--color-text-quaternary)]">
             {t("subtitle")}
           </p>
         </div>
@@ -129,23 +129,23 @@ export function OntologyKindPalette({
               <button
                 type="button"
                 onClick={() => onAddNode(entry.kind)}
-                className="group flex w-full items-center gap-2.5 rounded-[10px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-3 py-2.5 text-left transition-colors hover:border-[color:var(--color-border-strong)]"
+                className="group flex w-full items-center gap-2.5 rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-3 py-2.5 text-left transition-colors hover:border-[color:var(--color-border-strong)]"
                 aria-label={t("addAriaLabel", { label, hint })}
               >
                 <TopologyV2KindGlyph kind={entry.kind} size={18} />
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <span className="flex items-center justify-between gap-2">
-                    <span className="text-[13px] font-medium text-[color:var(--color-text-primary)]">
+                    <span className="text-body font-medium text-[color:var(--color-text-primary)]">
                       {label}
                     </span>
                     <kbd
                       aria-hidden
-                      className="shrink-0 rounded border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--color-text-quaternary)] transition-colors group-hover:text-[color:var(--color-text-tertiary)]"
+                      className="shrink-0 rounded border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-1.5 py-px font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--color-text-quaternary)] transition-colors group-hover:text-[color:var(--color-text-tertiary)]"
                     >
                       {entry.shortcut}
                     </kbd>
                   </span>
-                  <span className="font-mono text-[10px] leading-4 tracking-[0.01em] text-[color:var(--color-text-quaternary)] transition-colors group-hover:text-[color:var(--color-text-tertiary)]">
+                  <span className="font-mono text-caption leading-4 tracking-[0.01em] text-[color:var(--color-text-quaternary)] transition-colors group-hover:text-[color:var(--color-text-tertiary)]">
                     {hint}
                   </span>
                 </span>
@@ -155,7 +155,7 @@ export function OntologyKindPalette({
         })}
       </ul>
       <footer className="mt-auto border-t border-[color:var(--color-divider)] px-1 pt-3">
-        <p className="text-[11px] leading-[1.65] text-[color:var(--color-text-quaternary)]">
+        <p className="text-label leading-[1.65] text-[color:var(--color-text-quaternary)]">
           {t("footerHint")}
         </p>
       </footer>

--- a/src/views/ontology-edit/ui/RelationPostSaveHandoff.tsx
+++ b/src/views/ontology-edit/ui/RelationPostSaveHandoff.tsx
@@ -83,7 +83,7 @@ export function RelationPostSaveHandoff({
             <p className="text-xs font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
               {labels.title}
             </p>
-            <p className="mt-1 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
               {labels.body}
             </p>
           </div>
@@ -97,7 +97,7 @@ export function RelationPostSaveHandoff({
           <X size={14} />
         </button>
       </div>
-      <p className="mt-3 truncate rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 font-mono text-[10px] text-[color:var(--color-text-secondary)]">
+      <p className="mt-3 truncate rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 font-mono text-caption text-[color:var(--color-text-secondary)]">
         <span className="text-[color:var(--color-text-quaternary)]">
           {labels.relationLabel}
         </span>{" "}
@@ -108,26 +108,26 @@ export function RelationPostSaveHandoff({
       <div className="mt-3 flex flex-wrap gap-1.5">
         <Link
           href={buildRelationTopologyPathHref(relation.sourceSlug, relation.targetSlug)}
-          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {labels.openPath}
         </Link>
         <Link
           href={buildRelationTopologyFocusHref(relation.sourceSlug)}
-          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {labels.sourceFocus}
         </Link>
         <Link
           href={buildRelationTopologyFocusHref(relation.targetSlug)}
-          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {labels.targetFocus}
         </Link>
         <Link
           href={buildRelationQueryCockpitHref(relation.targetSlug)}
           aria-label={labels.queryCockpitAriaLabel}
-          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a28)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {labels.queryCockpit}
         </Link>
@@ -135,7 +135,7 @@ export function RelationPostSaveHandoff({
           type="button"
           onClick={() => void handleCopyProofPacket()}
           aria-label={proofCopyStatusLabel || labels.copyProofPacket}
-          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-[background-color,border-color,color,transform] duration-180 ease-out hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-[background-color,border-color,color,transform] duration-180 ease-out hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {proofCopyState === "copied" ? (
             <Check size={12} aria-hidden />
@@ -148,7 +148,7 @@ export function RelationPostSaveHandoff({
           type="button"
           onClick={() => void handleCopySyncGate()}
           aria-label={copyStatusLabel || labels.copySyncGate}
-          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-[background-color,border-color,color,transform] duration-180 ease-out hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-[background-color,border-color,color,transform] duration-180 ease-out hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
         >
           {copyState === "copied" ? (
             <Check size={12} aria-hidden />

--- a/src/views/ontology-edit/ui/RelationWriteConfirm.tsx
+++ b/src/views/ontology-edit/ui/RelationWriteConfirm.tsx
@@ -367,7 +367,7 @@ export function RelationWriteConfirm({
             <h2 className="text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
               {labels.title}
             </h2>
-            <p className="mt-1 break-keep text-[12px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-keep text-body leading-5 text-[color:var(--color-text-tertiary)]">
               {labels.body}
             </p>
           </div>
@@ -385,17 +385,17 @@ export function RelationWriteConfirm({
 
       <div className="grid gap-2 md:grid-cols-[1fr_1.2fr]">
         <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-3">
-          <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
             {labels.inferred}
           </p>
-          <p className="mt-2 truncate font-mono text-[11px] text-[color:var(--color-text-secondary)]">
+          <p className="mt-2 truncate font-mono text-label text-[color:var(--color-text-secondary)]">
             {proposal.sourceSlug}
           </p>
           <p className="my-1 text-[color:var(--color-text-quaternary)]">→</p>
-          <p className="truncate font-mono text-[11px] text-[color:var(--color-text-secondary)]">
+          <p className="truncate font-mono text-label text-[color:var(--color-text-secondary)]">
             {proposal.targetSlug}
           </p>
-          <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-2 border-t border-[color:var(--color-border-soft)] pt-2 font-mono text-[10px]">
+          <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-2 border-t border-[color:var(--color-border-soft)] pt-2 font-mono text-caption">
             <dt className="text-[color:var(--color-text-quaternary)]">
               {labels.inferredKey}
             </dt>
@@ -412,7 +412,7 @@ export function RelationWriteConfirm({
         </div>
 
         <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-3">
-          <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
             {labels.alternatives}
           </p>
           <div className="mt-2 grid grid-cols-2 gap-1.5">
@@ -431,10 +431,10 @@ export function RelationWriteConfirm({
                       : "border-[color:var(--color-overlay-3)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-a30)] hover:text-[color:var(--color-text-primary)]"
                   }`}
                 >
-                  <span className="block font-mono text-[10px]">
+                  <span className="block font-mono text-caption">
                     {labels.relationKeyLabels[key]}
                   </span>
-                  <span className="mt-0.5 block truncate text-[10px] text-[color:var(--color-text-quaternary)]">
+                  <span className="mt-0.5 block truncate text-caption text-[color:var(--color-text-quaternary)]">
                     {labels.relationKeyHints[key]}
                   </span>
                 </button>
@@ -447,25 +447,25 @@ export function RelationWriteConfirm({
       <div className="rounded-md border border-[color:var(--color-indigo-a24)] bg-[color:var(--color-indigo-a08)] p-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
-            <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+            <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
               {labels.preflight}
             </p>
-            <p className="mt-1 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+            <p className="mt-1 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
               {labels.decisionLabels[preflight.decision]}
             </p>
           </div>
-          <span className="rounded-sm border border-[color:var(--color-indigo-a28)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
+          <span className="rounded-sm border border-[color:var(--color-indigo-a28)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
             {preflight.decision}
           </span>
         </div>
-        <p className="mt-2 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+        <p className="mt-2 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
           {labels.decisionHints[preflight.decision]}
         </p>
         <div className="mt-3 rounded-md border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-overlay-recessed-a08)] p-2">
-          <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
             {labels.preflightEvidence}
           </p>
-          <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 font-mono text-[10px]">
+          <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 font-mono text-caption">
             <PreflightEvidenceRow
               label={labels.preflightExact}
               present={preflight.exactExists}
@@ -487,39 +487,39 @@ export function RelationWriteConfirm({
           </dl>
         </div>
         <details className="mt-2 rounded-md border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-overlay-recessed-a08)] p-2">
-          <summary className="cursor-pointer select-none font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
+          <summary className="cursor-pointer select-none font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
             {labels.traversalCheck}
           </summary>
           <div className="mt-2">
-            <p className="break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
               {labels.traversalCheckBody}
             </p>
-            <p className="mt-1 break-all font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-all font-mono text-caption text-[color:var(--color-text-tertiary)]">
               {buildAllPathsCheckCommand({ proposal })}
             </p>
             <div className="mt-2 border-t border-[color:var(--color-indigo-a14)] pt-2">
-              <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 {labels.traversalContract}
               </p>
-              <p className="mt-1 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+              <p className="mt-1 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
                 {labels.traversalContractBody}
               </p>
             </div>
             {preflight.path.length > 1 ? (
-              <p className="mt-2 truncate font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+              <p className="mt-2 truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
                 <span className="text-[color:var(--color-text-quaternary)]">
                   {labels.path}
                 </span>{" "}
                 {preflight.path.join(" → ")}
               </p>
             ) : null}
-            <p className="mt-2 truncate font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+            <p className="mt-2 truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
               <span className="text-[color:var(--color-text-quaternary)]">
                 {labels.agentCheck}
               </span>{" "}
               {agentCheckCommand}
             </p>
-            <div className="mt-1 font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+            <div className="mt-1 font-mono text-caption text-[color:var(--color-text-tertiary)]">
               <span className="text-[color:var(--color-text-quaternary)]">
                 {labels.postSaveCheck}
               </span>{" "}
@@ -535,7 +535,7 @@ export function RelationWriteConfirm({
               <button
                 type="button"
                 onClick={() => void handleCopyCliPreflight()}
-                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
               >
                 <Clipboard size={12} aria-hidden />
                 {copyCliPreflightLabel}
@@ -543,7 +543,7 @@ export function RelationWriteConfirm({
               <button
                 type="button"
                 onClick={() => void handleCopyMcpPreflight()}
-                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
               >
                 <Clipboard size={12} aria-hidden />
                 {copyMcpPreflightLabel}
@@ -551,7 +551,7 @@ export function RelationWriteConfirm({
               <button
                 type="button"
                 onClick={() => void handleCopyPostSaveSyncGate()}
-                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
               >
                 <Clipboard size={12} aria-hidden />
                 {copyPostSaveSyncGateLabel}
@@ -562,10 +562,10 @@ export function RelationWriteConfirm({
       </div>
 
       <div className="rounded-md border border-[color:var(--color-success-a18)] bg-[color:var(--color-success-a045)] p-3">
-        <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-success-text-a92)]">
+        <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-success-text-a92)]">
           {labels.graphEffect}
         </p>
-        <dl className="mt-2 grid gap-x-3 gap-y-1 font-mono text-[10px] text-[color:var(--color-text-tertiary)] sm:grid-cols-[auto_1fr]">
+        <dl className="mt-2 grid gap-x-3 gap-y-1 font-mono text-caption text-[color:var(--color-text-tertiary)] sm:grid-cols-[auto_1fr]">
           <dt className="text-[color:var(--color-text-quaternary)]">
             {labels.graphEdge}
           </dt>
@@ -580,40 +580,40 @@ export function RelationWriteConfirm({
           <dd className="min-w-0 truncate">{labels.graphSurfacesValue}</dd>
         </dl>
         {!graphEffect.inferredMatchesSelected ? (
-          <p className="mt-2 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-2 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
             {labels.graphAlternativeWarning}
           </p>
         ) : null}
         <details className="mt-3 rounded-md border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-overlay-recessed-a08)] p-2">
-          <summary className="cursor-pointer select-none font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
+          <summary className="cursor-pointer select-none font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
             {labels.endpointReview}
           </summary>
           <div className="mt-2">
-            <p className="break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
               {labels.endpointReviewBody}
             </p>
             <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
             <Link
               href={sourceOntologyHref}
-              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-center text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-center text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.sourceOntology}
             </Link>
             <Link
               href={targetOntologyHref}
-              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-center text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-center text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.targetOntology}
             </Link>
             <Link
               href={sourceBuilderHref}
-              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-center text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-center text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.sourceBuilder}
             </Link>
             <Link
               href={targetBuilderHref}
-              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-center text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-center text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.targetBuilder}
             </Link>
@@ -621,35 +621,35 @@ export function RelationWriteConfirm({
           </div>
         </details>
         <details className="mt-2 rounded-md border border-[color:var(--color-indigo-a18)] bg-[color:var(--color-overlay-recessed-a08)] p-2">
-          <summary className="cursor-pointer select-none font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
+          <summary className="cursor-pointer select-none font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
             {labels.postSaveGraphHandoff}
           </summary>
           <div className="mt-2">
-            <p className="break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]">
+            <p className="break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]">
               {labels.postSaveGraphHandoffBody}
             </p>
             <div className="mt-2 flex flex-wrap gap-1.5">
             <Link
               href={topologyPathHref}
-              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.postSavePathHandoff}
             </Link>
             <Link
               href={sourceTopologyFocusHref}
-              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.postSaveSourceFocus}
             </Link>
             <Link
               href={targetTopologyFocusHref}
-              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-overlay-3)] px-2 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.postSaveTargetFocus}
             </Link>
             <Link
               href={queryCockpitHref}
-              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+              className="inline-flex h-7 items-center rounded-md border border-[color:var(--color-indigo-a26)] bg-[color:var(--color-indigo-a08)] px-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
             >
               {labels.postSaveQueryCockpit}
             </Link>
@@ -659,7 +659,7 @@ export function RelationWriteConfirm({
       </div>
 
       <div className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-3">
-        <p className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+        <p className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
           {labels.saveChecklist}
         </p>
         <dl className="mt-2 grid gap-1.5">
@@ -668,11 +668,11 @@ export function RelationWriteConfirm({
               key={row.key}
               className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-sm border border-[color:var(--color-indigo-a14)] bg-[color:var(--color-overlay-recessed-a08)] px-2 py-1.5"
             >
-              <dt className="min-w-0 truncate text-[11px] text-[color:var(--color-text-secondary)]">
+              <dt className="min-w-0 truncate text-label text-[color:var(--color-text-secondary)]">
                 {row.label}
               </dt>
               <dd
-                className={`rounded-sm border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] ${
+                className={`rounded-sm border px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.12em] ${
                   row.status === "ready"
                     ? "border-[color:var(--color-success-a28)] text-[color:var(--color-success-text-a92)]"
                     : row.status === "blocked"
@@ -689,7 +689,7 @@ export function RelationWriteConfirm({
           aria-label={labels.agentDecisionLens}
           className="mt-2 rounded-sm border border-[color:var(--color-indigo-line-a14)] bg-[color:var(--color-overlay-recessed-a08)] p-2"
         >
-          <p className="truncate font-mono text-[8px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+          <p className="truncate font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
             {labels.agentDecisionLens}
           </p>
           <div className="mt-1.5 grid gap-1 sm:grid-cols-5">
@@ -700,10 +700,10 @@ export function RelationWriteConfirm({
                 title={row.body}
                 className="min-w-0 rounded-sm border border-[color:var(--color-indigo-a12)] bg-[color:var(--color-overlay-1)] px-1.5 py-1"
               >
-                <p className="truncate font-mono text-[8.5px] text-[color:var(--color-text-secondary)]">
+                <p className="truncate font-mono text-caption text-[color:var(--color-text-secondary)]">
                   {row.title}
                 </p>
-                <p className="mt-0.5 truncate text-[8.5px] text-[color:var(--color-text-quaternary)]">
+                <p className="mt-0.5 truncate text-caption text-[color:var(--color-text-quaternary)]">
                   {row.body}
                 </p>
               </div>
@@ -718,10 +718,10 @@ export function RelationWriteConfirm({
       >
         <div className="min-w-0 flex-1">
           <details>
-            <summary className="cursor-pointer select-none font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
+            <summary className="cursor-pointer select-none font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)] marker:text-[color:var(--color-indigo-accent)]">
               {labels.writeScope}
             </summary>
-            <dl className="mt-1 grid gap-x-3 gap-y-1 font-mono text-[10px] text-[color:var(--color-text-tertiary)] sm:grid-cols-[auto_1fr]">
+            <dl className="mt-1 grid gap-x-3 gap-y-1 font-mono text-caption text-[color:var(--color-text-tertiary)] sm:grid-cols-[auto_1fr]">
               <dt className="text-[color:var(--color-text-quaternary)]">
                 {labels.writeFile}
               </dt>
@@ -776,7 +776,7 @@ export function RelationWriteConfirm({
           </details>
           <p
             data-testid="builder-relation-preflight-action"
-            className="mt-2 break-keep text-[11px] leading-5 text-[color:var(--color-text-tertiary)]"
+            className="mt-2 break-keep text-label leading-5 text-[color:var(--color-text-tertiary)]"
           >
             {preflightAction}
           </p>

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -318,12 +318,12 @@ export function OntologyInsightsPage() {
         <MountedGlobalSearch />
 
         <header className="flex flex-wrap items-end gap-4">
-          <h1 className="text-[23px] font-[var(--font-weight-signature)] tracking-[-0.015em] text-[color:var(--color-text-primary)]">
+          <h1 className="text-display font-[var(--font-weight-signature)] tracking-[-0.015em] text-[color:var(--color-text-primary)]">
             {t("title")}
           </h1>
-          <p className="max-w-xl pb-0.5 text-[12.5px] text-[color:var(--color-text-tertiary)]">{t("subtitle")}</p>
+          <p className="max-w-xl pb-0.5 text-body text-[color:var(--color-text-tertiary)]">{t("subtitle")}</p>
           {insight ? (
-            <span className="ml-auto pb-0.5 font-mono text-[11.5px] tracking-[0.1em] text-[color:var(--topology-v2-numeral-face)]">
+            <span className="ml-auto pb-0.5 font-mono text-label tracking-[0.1em] text-[color:var(--topology-v2-numeral-face)]">
               {totalNodes} {t("censusConcepts")}
               <span className="mx-1.5 text-[color:var(--color-text-quaternary)]">·</span>
               {totalEdges} {t("censusRelations")}

--- a/src/views/ontology-insights/ui/parts/CopyAgentTextButton.tsx
+++ b/src/views/ontology-insights/ui/parts/CopyAgentTextButton.tsx
@@ -43,7 +43,7 @@ export function CopyAgentTextButton({
         type="button"
         onClick={handleCopy}
         className={[
-          "inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border font-mono text-[10px] transition-[background-color,border-color,color,transform] duration-180 ease-out active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none",
+          "inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border font-mono text-caption transition-[background-color,border-color,color,transform] duration-180 ease-out active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none",
           toneClass,
           compact ? "min-h-8 px-2.5 py-1.5" : "min-h-9 px-3 py-2",
         ].join(" ")}

--- a/src/views/ontology-insights/ui/parts/InsightsHandoffRow.tsx
+++ b/src/views/ontology-insights/ui/parts/InsightsHandoffRow.tsx
@@ -21,10 +21,10 @@ export function InsightsHandoffRow({
   return (
     <section
       aria-label={label}
-      className="mt-[var(--section-gap)] flex items-center gap-3.5 rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-3"
+      className="mt-[var(--section-gap)] flex items-center gap-3.5 rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-3"
     >
-      <span className="flex-none text-[13px] font-medium text-[color:var(--color-text-primary)]">{label}</span>
-      <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-[color:var(--color-text-tertiary)]">
+      <span className="flex-none text-body font-medium text-[color:var(--color-text-primary)]">{label}</span>
+      <span className="min-w-0 flex-1 truncate font-mono text-body text-[color:var(--color-text-tertiary)]">
         {payload}
       </span>
       <CopyAgentTextButton label={copyLabel} copiedLabel={copiedLabel} text={payload} compact />

--- a/src/views/ontology-insights/ui/parts/InsightsHeroCensus.tsx
+++ b/src/views/ontology-insights/ui/parts/InsightsHeroCensus.tsx
@@ -34,7 +34,7 @@ export function InsightsHeroCensus({
   labels: InsightsHeroCensusLabels;
 }) {
   return (
-    <div className="flex flex-col items-stretch gap-3 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-4 sm:flex-row sm:gap-0">
+    <div className="flex flex-col items-stretch gap-3 rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-4 sm:flex-row sm:gap-0">
       <HeroSegment label={labels.concepts} gcap="concepts">
         <BigNum value={totalNodes} />
         <SubStrip items={kindsSummary} />
@@ -45,7 +45,7 @@ export function InsightsHeroCensus({
       </HeroSegment>
       <HeroSegment label={labels.health} gcap="health">
         <BigNum value={health.edgesPerConcept.toFixed(2)} unit="edge/concept" />
-        <div className="mt-auto flex flex-wrap items-center gap-3.5 text-[11.5px] text-[color:var(--color-text-tertiary)]">
+        <div className="mt-auto flex flex-wrap items-center gap-3.5 text-label text-[color:var(--color-text-tertiary)]">
           <HealthStat label={labels.orphan} value={health.orphanCount} />
           <HealthStat label={labels.cycle} value={health.cycleCount} />
           <HealthStat label={labels.domainMembership} value={`${health.domainMembershipPct}%`} />
@@ -59,9 +59,9 @@ export function InsightsHeroCensus({
 function HeroSegment({ label, gcap, children }: { label: string; gcap: string; children: ReactNode }) {
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-2.5 border-t border-[color:var(--color-divider)] px-6 py-0.5 pt-3 first:border-t-0 first:pt-0.5 sm:border-t-0 sm:border-l sm:pt-0.5 sm:first:border-l-0">
-      <div className="flex items-baseline gap-2 text-[13px] font-medium text-[color:var(--color-text-secondary)]">
+      <div className="flex items-baseline gap-2 text-body font-medium text-[color:var(--color-text-secondary)]">
         {label}
-        <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {gcap}
         </span>
       </div>
@@ -73,12 +73,13 @@ function HeroSegment({ label, gcap, children }: { label: string; gcap: string; c
 function BigNum({ value, unit }: { value: number | string; unit?: string }) {
   return (
     <div
+      // eslint-disable-next-line no-restricted-syntax -- 센서스 시그니처 대형 숫자(40px)는 type 램프 상단(hero 30px)을 넘는 의도적 display 예외.
       className="font-mono text-[40px] font-semibold leading-none tabular-nums tracking-[0.01em] text-[color:var(--topology-v2-numeral-face)]"
       style={{ textShadow: "0 2px 0 var(--topology-v2-numeral-shadow)" }}
     >
       {value}
       {unit ? (
-        <span className="ml-1.5 text-[13px] tracking-[0.06em] text-[color:var(--color-text-quaternary)]" style={{ textShadow: "none" }}>
+        <span className="ml-1.5 text-body tracking-[0.06em] text-[color:var(--color-text-quaternary)]" style={{ textShadow: "none" }}>
           {unit}
         </span>
       ) : null}
@@ -90,18 +91,18 @@ function HealthStat({ label, value }: { label: string; value: number | string })
   return (
     <span className="inline-flex items-center gap-1.5">
       {label}
-      <span className="font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">{value}</span>
+      <span className="font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">{value}</span>
     </span>
   );
 }
 
 function SubStrip({ items }: { items: Array<{ key: string; label: string; count: number }> }) {
   return (
-    <div className="mt-auto flex flex-wrap items-center gap-3.5 text-[11.5px] text-[color:var(--color-text-tertiary)]">
+    <div className="mt-auto flex flex-wrap items-center gap-3.5 text-label text-[color:var(--color-text-tertiary)]">
       {items.map((item) => (
         <span key={item.key} className="inline-flex items-center gap-1.5">
           {item.label}
-          <span className="font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">{item.count}</span>
+          <span className="font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">{item.count}</span>
         </span>
       ))}
     </div>

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -112,7 +112,7 @@ function HandoffCopyButton({ payload, labels }: { payload: string; labels: DoNex
           window.setTimeout(() => setCopied(false), 1600);
         }
       }}
-      className="inline-flex min-h-8 items-center gap-1 rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+      className="inline-flex min-h-8 items-center gap-1 rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
     >
       {copied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
       {copied ? labels.handoffCopied : labels.handoffCopy}
@@ -142,8 +142,8 @@ function QueueSection({
   return (
     <section aria-label={title} className="flex flex-col">
       <div className="flex items-baseline gap-2 border-b border-[color:var(--color-divider)] pb-2">
-        <span className="text-[13px] font-medium text-[color:var(--color-text-primary)]">{title}</span>
-        <span className="font-mono text-[11px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+        <span className="text-body font-medium text-[color:var(--color-text-primary)]">{title}</span>
+        <span className="font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">
           {totalCount}
         </span>
       </div>
@@ -158,24 +158,24 @@ function QueueSection({
             className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-[color:var(--color-divider)] py-2.5 last:border-b-0"
           >
             <TopologyV2KindGlyph kind={row.nodeKind} size={13} />
-            <span className="min-w-0 flex-1 truncate text-[13px] text-[color:var(--color-text-secondary)]">
+            <span className="min-w-0 flex-1 truncate text-body text-[color:var(--color-text-secondary)]">
               {row.title}
             </span>
             {metricText ? (
-              <span className="shrink-0 font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+              <span className="shrink-0 font-mono text-label text-[color:var(--color-text-quaternary)]">
                 {metricText}
               </span>
             ) : null}
             <span className="flex w-full items-center justify-end gap-1.5 sm:w-auto sm:shrink-0">
               <Link
                 href={mapHref(row.nodeId)}
-                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
               >
                 {labels.openMap}
               </Link>
               <Link
                 href={builderHref(row.nodeId)}
-                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
               >
                 {labels.openBuilder}
               </Link>
@@ -185,7 +185,7 @@ function QueueSection({
         );
       })}
       {hiddenCount > 0 ? (
-        <p className="pt-2 text-[11px] text-[color:var(--color-text-quaternary)]">{labels.moreCount(hiddenCount)}</p>
+        <p className="pt-2 text-label text-[color:var(--color-text-quaternary)]">{labels.moreCount(hiddenCount)}</p>
       ) : null}
     </section>
   );
@@ -214,11 +214,11 @@ function CycleSection({
   return (
     <section aria-label={labels.sectionCycle} data-testid="do-next-cycles" className="flex flex-col">
       <div className="flex items-baseline gap-2 border-b border-[color:var(--color-divider)] pb-2">
-        <span className="flex items-center gap-1.5 text-[13px] font-medium text-[color:var(--color-text-primary)]">
+        <span className="flex items-center gap-1.5 text-body font-medium text-[color:var(--color-text-primary)]">
           <AlertTriangle size={12} aria-hidden className="text-[color:var(--color-status-warning)]" />
           {labels.sectionCycle}
         </span>
-        <span className="font-mono text-[11px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+        <span className="font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">
           {cycles.totalCycles}
         </span>
       </div>
@@ -230,7 +230,7 @@ function CycleSection({
             data-testid="do-next-cycle-row"
             className="flex min-w-0 items-center gap-2.5 border-b border-[color:var(--color-divider)] py-2.5 last:border-b-0"
           >
-            <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-[color:var(--color-text-secondary)]">
+            <span className="min-w-0 flex-1 truncate font-mono text-body text-[color:var(--color-text-secondary)]">
               {cycle.nodeIds.map((nodeId, i) => (
                 <span key={`${cycle.id}:${nodeId}:${i}`}>
                   {i > 0 ? <span className="text-[color:var(--color-text-quaternary)]"> → </span> : null}
@@ -246,13 +246,13 @@ function CycleSection({
               <span className="text-[color:var(--color-text-quaternary)]"> → </span>
               {nodeTitle(firstNodeId)}
             </span>
-            <span className="shrink-0 font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">
+            <span className="shrink-0 font-mono text-label text-[color:var(--color-text-quaternary)]">
               {labels.cycleMetric(cycle.length)}
             </span>
             <span className="flex shrink-0 items-center gap-1.5">
               <Link
                 href={mapHref(firstNodeId)}
-                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className="inline-flex min-h-8 items-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
               >
                 {labels.openMap}
               </Link>
@@ -262,7 +262,7 @@ function CycleSection({
         );
       })}
       {cycles.hiddenCycles > 0 ? (
-        <p className="pt-2 text-[11px] text-[color:var(--color-text-quaternary)]">
+        <p className="pt-2 text-label text-[color:var(--color-text-quaternary)]">
           {labels.moreCount(cycles.hiddenCycles)}
         </p>
       ) : null}
@@ -300,13 +300,13 @@ export function DoNextTab({
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-[1.2fr_1fr]">
       <section
         aria-label={labels.queueTitle}
-        className="flex min-h-0 min-w-0 flex-col gap-4 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col gap-4 rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
-        <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+        <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
           {labels.queueTitle}
         </span>
         {queueEmpty ? (
-          <p className="text-[12.5px] text-[color:var(--color-text-quaternary)]">{labels.emptyQueue}</p>
+          <p className="text-body text-[color:var(--color-text-quaternary)]">{labels.emptyQueue}</p>
         ) : (
           <>
             <QueueSection
@@ -355,7 +355,7 @@ export function DoNextTab({
         aria-label={labels.agentReadinessTitle}
         // Guardian 관찰 — 수리 큐가 얕을 때 카드가 좌측 큐 높이까지 늘어나
         // 빈 여백으로 읽혔다: 내용 높이만큼만 (lg 그리드에서 self-start).
-        className="flex min-h-0 min-w-0 flex-col self-start rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col self-start rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <div
           aria-label={`${labels.agentReadinessTitle}: ${agentReadiness.ready} ${labels.agentReadinessReady} · ${agentReadiness.preflight} ${labels.agentReadinessPreflight} · ${agentReadiness.review} ${labels.agentReadinessReview}`}
@@ -363,25 +363,25 @@ export function DoNextTab({
           className="mb-3.5 border-b border-[color:var(--color-divider)] pb-3.5"
         >
           <div className="flex items-baseline gap-2">
-            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+            <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
               {labels.agentReadinessTitle}
             </span>
-            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">
               <span>
                 {agentReadiness.ready}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.agentReadinessReady}
                 </span>
               </span>
               <span>
                 {agentReadiness.preflight}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.agentReadinessPreflight}
                 </span>
               </span>
               <span>
                 {agentReadiness.review}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.agentReadinessReview}
                 </span>
               </span>
@@ -410,25 +410,25 @@ export function DoNextTab({
         </div>
         <div data-testid="insights-repair-queue">
           <div className="flex items-baseline gap-2">
-            <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+            <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
               {labels.repairQueueTitle}
             </span>
-            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+            <span className="ml-auto flex flex-wrap items-baseline gap-x-3 gap-y-0.5 font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">
               <span>
                 {healthQueue.staleCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.repairQueueStale}
                 </span>
               </span>
               <span>
                 {healthQueue.orphanCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.repairQueueOrphan}
                 </span>
               </span>
               <span>
                 {healthQueue.promotionCount}{" "}
-                <span className="text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <span className="text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {labels.repairQueuePromotion}
                 </span>
               </span>
@@ -439,9 +439,9 @@ export function DoNextTab({
               data-testid="insights-repair-queue-target"
               className="mt-2.5 flex min-w-0 items-center justify-between gap-2"
             >
-              <span className="flex min-w-0 items-center gap-1.5 text-[13px] text-[color:var(--color-text-secondary)]">
+              <span className="flex min-w-0 items-center gap-1.5 text-body text-[color:var(--color-text-secondary)]">
                 {repairActionKindLabel ? (
-                  <span className="shrink-0 rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 text-[10px] leading-none text-[color:var(--color-text-tertiary)]">
+                  <span className="shrink-0 rounded border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-0.5 text-caption leading-none text-[color:var(--color-text-tertiary)]">
                     {repairActionKindLabel}
                   </span>
                 ) : null}
@@ -451,20 +451,20 @@ export function DoNextTab({
                 <Link
                   href={healthQueue.builderHref(healthQueue.actionTarget.slug)}
                   data-testid="insights-repair-queue-builder-link"
-                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-[11px] font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-overlay-2)]"
+                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 text-label font-medium text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-overlay-2)]"
                 >
                   {labels.repairQueueOpenBuilder}
                 </Link>
                 <Link
                   href={healthQueue.ontologyHref(healthQueue.actionTarget.slug)}
-                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                  className="inline-flex min-h-8 items-center justify-center rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
                 >
                   {labels.repairQueueOpenOntology}
                 </Link>
               </span>
             </div>
           ) : (
-            <p className="mt-2 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.repairQueueEmpty}</p>
+            <p className="mt-2 text-body text-[color:var(--color-text-quaternary)]">{labels.repairQueueEmpty}</p>
           )}
         </div>
         {activityDigest && activityDigest.latest.length > 0 ? (
@@ -473,17 +473,17 @@ export function DoNextTab({
             className="mt-3.5 border-t border-[color:var(--color-divider)] pt-3.5"
           >
             <div className="flex items-baseline gap-2">
-              <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
                 {labels.digestTitle}
               </span>
-              <span className="ml-auto font-mono text-[11.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+              <span className="ml-auto font-mono text-label tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                 {labels.digestToday(activityDigest.todayCount)}
               </span>
             </div>
             <div className="mt-2 flex flex-col gap-1.5">
               {activityDigest.latest.map((entry, index) => (
                 <div key={`${entry.at}-${index}`} data-testid="do-next-digest-entry">
-                  <p className="truncate font-mono text-[11px] text-[color:var(--color-text-tertiary)]">
+                  <p className="truncate font-mono text-label text-[color:var(--color-text-tertiary)]">
                     {entry.summary}
                     {entry.agent ? (
                       <span className="text-[color:var(--color-text-quaternary)]"> · {entry.agent}</span>
@@ -496,7 +496,7 @@ export function DoNextTab({
                   {entry.why ? (
                     <p
                       data-testid="do-next-digest-why"
-                      className="truncate font-mono text-[10.5px] italic text-[color:var(--color-text-quaternary)]"
+                      className="truncate font-mono text-label italic text-[color:var(--color-text-quaternary)]"
                     >
                       {labels.digestWhyPrefix}
                       {entry.why}
@@ -505,7 +505,7 @@ export function DoNextTab({
                 </div>
               ))}
             </div>
-            <p className="mt-2 text-[11px] text-[color:var(--color-text-quaternary)]">{labels.digestApproveHint}</p>
+            <p className="mt-2 text-label text-[color:var(--color-text-quaternary)]">{labels.digestApproveHint}</p>
           </div>
         ) : null}
       </section>

--- a/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
@@ -66,30 +66,30 @@ export function FreshnessTab({
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-2">
       <section
         aria-label={labels.domainFreshnessTitle}
-        className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <div className="flex items-baseline gap-2">
-          <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+          <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
             {labels.domainFreshnessTitle}
           </span>
-          <span className="ml-auto font-mono text-[10.5px] text-[color:var(--color-text-quaternary)]">{labels.windowCaption}</span>
+          <span className="ml-auto font-mono text-label text-[color:var(--color-text-quaternary)]">{labels.windowCaption}</span>
         </div>
         {domainRows.length === 0 ? (
-          <p className="mt-3.5 flex-1 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.noDomains}</p>
+          <p className="mt-3.5 flex-1 text-body text-[color:var(--color-text-quaternary)]">{labels.noDomains}</p>
         ) : (
           <div className="mt-3.5 flex flex-1 flex-col justify-evenly gap-1.5">
             {domainRows.map((row) => (
               <div key={row.domainId} className="flex items-center gap-2">
                 <span
                   className={
-                    "flex w-[136px] flex-none items-center gap-1.5 truncate text-[11.5px] " +
+                    "flex w-[136px] flex-none items-center gap-1.5 truncate text-label " +
                     (row.stale ? "text-[color:var(--color-text-quaternary)]" : "text-[color:var(--color-text-secondary)]")
                   }
                 >
                   <TopologyV2KindGlyph kind="domain" size={12} />
                   <span className="truncate">{row.domainTitle}</span>
                   {row.stale ? (
-                    <span className="flex-none rounded border border-dashed border-[color:var(--color-border-strong)] px-1 text-[9px] text-[color:var(--color-text-quaternary)]">
+                    <span className="flex-none rounded border border-dashed border-[color:var(--color-border-strong)] px-1 text-caption text-[color:var(--color-text-quaternary)]">
                       {labels.stale}
                     </span>
                   ) : null}
@@ -99,6 +99,7 @@ export function FreshnessTab({
                     <i
                       key={i}
                       title={week.isCurrentWeek ? labels.currentWeek : undefined}
+                      // eslint-disable-next-line no-restricted-syntax -- 14px 높이 주간 신선도 바의 3px 헤어라인 반경은 chip(6px)로 올리면 pill 이 돼 램프 밖 예외.
                       className="h-3.5 flex-1 max-w-6 rounded-[3px]"
                       style={{
                         backgroundColor: week.isCurrentWeek
@@ -108,12 +109,12 @@ export function FreshnessTab({
                     />
                   ))}
                 </span>
-                <span className="w-12 flex-none text-right font-mono text-[9.5px] text-[color:var(--color-text-quaternary)]">
+                <span className="w-12 flex-none text-right font-mono text-caption text-[color:var(--color-text-quaternary)]">
                   {row.daysAgo !== null ? labels.daysAgo(row.daysAgo) : labels.unknownDate}
                 </span>
               </div>
             ))}
-            <div className="flex items-center gap-2 text-[9.5px] text-[color:var(--color-text-quaternary)]">
+            <div className="flex items-center gap-2 text-caption text-[color:var(--color-text-quaternary)]">
               <span className="w-[136px] flex-none" aria-hidden />
               <span className="flex flex-1 items-center justify-between">
                 <span>{labels.axisStart}</span>
@@ -123,7 +124,7 @@ export function FreshnessTab({
             </div>
           </div>
         )}
-        <div className="mt-2.5 flex items-center justify-end gap-1.5 border-t border-[color:var(--color-divider)] pt-2.5 text-[9.5px] text-[color:var(--color-text-quaternary)]">
+        <div className="mt-2.5 flex items-center justify-end gap-1.5 border-t border-[color:var(--color-divider)] pt-2.5 text-caption text-[color:var(--color-text-quaternary)]">
           <span>{labels.older}</span>
           {([0, 1, 2, 3] as const).map((level) => (
             <i key={level} className="h-2.5 w-2.5 flex-none rounded-sm" style={{ backgroundColor: LEVEL_BACKGROUND[level] }} />
@@ -134,28 +135,28 @@ export function FreshnessTab({
         </div>
         <div className="mt-3 border-t border-[color:var(--color-divider)] pt-3">
           <div className="flex items-baseline gap-2">
-            <span className="text-[12px] font-medium text-[color:var(--color-text-secondary)]">{labels.trendTitle}</span>
+            <span className="text-body font-medium text-[color:var(--color-text-secondary)]">{labels.trendTitle}</span>
           </div>
           <FreshnessTrendSparkline weeklyTotals={weeklyTotals} />
-          <p className="mt-1.5 text-[10px] text-[color:var(--color-text-quaternary)]">{labels.trendCaption}</p>
+          <p className="mt-1.5 text-caption text-[color:var(--color-text-quaternary)]">{labels.trendCaption}</p>
         </div>
       </section>
 
       <section
         aria-label={labels.recentUpdatesTitle}
-        className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <div className="flex items-baseline gap-2">
-          <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+          <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
             {labels.recentUpdatesTitle}
           </span>
-          <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             recent updates
           </span>
         </div>
         <div className="mt-2 flex flex-1 flex-col">
           {recent.length === 0 ? (
-            <p className="py-2 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.noRecentUpdates}</p>
+            <p className="py-2 text-body text-[color:var(--color-text-quaternary)]">{labels.noRecentUpdates}</p>
           ) : (
             recent.map((row) => (
               <Link
@@ -167,13 +168,13 @@ export function FreshnessTab({
               >
                 <TopologyV2KindGlyph kind={row.kind} size={14} />
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[13px] text-[color:var(--color-text-primary)]">{row.title}</span>
-                  <span className="block text-[10.5px] text-[color:var(--color-text-quaternary)]">
+                  <span className="block truncate text-body text-[color:var(--color-text-primary)]">{row.title}</span>
+                  <span className="block text-label text-[color:var(--color-text-quaternary)]">
                     {kindLabel(row.kind)}
                     {row.domainTitle ? ` · ${row.domainTitle}` : ""}
                   </span>
                 </span>
-                <span className="flex-none font-mono text-[10.5px] tabular-nums text-[color:var(--color-text-tertiary)]">
+                <span className="flex-none font-mono text-label tabular-nums text-[color:var(--color-text-tertiary)]">
                   {/* P4-③ — 로컬 타임존 기준 날짜(`formatDate`). 이전엔
                       toISOString() 이 UTC 로 렌더해 자정 부근 갱신이 하루
                       전날짜로 표시됐다(예: 03:12 KST → UTC 로는 전날). */}
@@ -183,9 +184,9 @@ export function FreshnessTab({
             ))
           )}
         </div>
-        <div className="mt-2.5 flex items-center justify-between border-t border-[color:var(--color-divider)] pt-2.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+        <div className="mt-2.5 flex items-center justify-between border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">
           <span>{labels.staleCountLabel}</span>
-          <span className="font-mono text-[13px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">{staleCount}</span>
+          <span className="font-mono text-body tabular-nums text-[color:var(--topology-v2-numeral-face)]">{staleCount}</span>
         </div>
       </section>
     </div>

--- a/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
@@ -64,7 +64,7 @@ export function OverviewTab({
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-2">
         <section
           aria-label={labels.kindCensusTitle}
-          className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+          className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
         >
           <CardHead label={labels.kindCensusTitle} gcap="kind census" count={totalNodes} />
           <div
@@ -87,7 +87,7 @@ export function OverviewTab({
               const width = kindMax > 0 ? Math.max(2, Math.round((row.count / kindMax) * 100)) : 0;
               return (
                 <div key={row.kind} className="flex items-center gap-3 py-0.5">
-                  <span className="flex w-[136px] flex-none items-center gap-2 text-[14px] text-[color:var(--color-text-secondary)]">
+                  <span className="flex w-[136px] flex-none items-center gap-2 text-body-lg text-[color:var(--color-text-secondary)]">
                     <TopologyV2KindGlyph kind={row.kind} size={16} />
                     {kindLabel(row.kind)}
                   </span>
@@ -97,25 +97,25 @@ export function OverviewTab({
                       style={{ width: `${width}%`, backgroundColor: getOntologyKindTone(row.kind).fill }}
                     />
                   </span>
-                  <span className="w-10 flex-none text-right font-mono text-[15px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+                  <span className="w-10 flex-none text-right font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                     {row.count}
                   </span>
                 </div>
               );
             })}
           </div>
-          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">
             {labels.kindGlyphCaption}
           </p>
         </section>
 
         <section
           aria-label={labels.domainCapacityTitle}
-          className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+          className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
         >
           <CardHead label={labels.domainCapacityTitle} gcap="domain capacity" count={domainRows.length} />
           {domainRows.length === 0 ? (
-            <p className="mt-3.5 flex-1 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.noDomains}</p>
+            <p className="mt-3.5 flex-1 text-body text-[color:var(--color-text-quaternary)]">{labels.noDomains}</p>
           ) : (
             <div className="mt-3.5 flex flex-1 flex-col justify-evenly gap-1">
               {domainRows.map((row) => {
@@ -123,7 +123,7 @@ export function OverviewTab({
                 const elWidth = domainMax > 0 ? (row.elementCount / domainMax) * 100 : 0;
                 return (
                   <div key={row.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-0.5">
-                    <span className="flex w-full shrink-0 items-center gap-2 truncate text-[14px] text-[color:var(--color-text-secondary)] sm:w-[220px]">
+                    <span className="flex w-full shrink-0 items-center gap-2 truncate text-body-lg text-[color:var(--color-text-secondary)] sm:w-[220px]">
                       <TopologyV2KindGlyph kind="domain" size={15} />
                       <span className="truncate">{row.title}</span>
                     </span>
@@ -138,10 +138,10 @@ export function OverviewTab({
                       />
                     </span>
                     <span className="flex-none text-right">
-                      <span className="block font-mono text-[15px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+                      <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                         {row.total}
                       </span>
-                      <span className="block font-mono text-[9.5px] text-[color:var(--color-text-quaternary)]">
+                      <span className="block font-mono text-caption text-[color:var(--color-text-quaternary)]">
                         {labels.capabilityUnit} {row.capabilityCount} · {labels.elementUnit} {row.elementCount}
                       </span>
                     </span>
@@ -150,7 +150,7 @@ export function OverviewTab({
               })}
             </div>
           )}
-          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">
             {labels.domainCapacityCaption}
           </p>
         </section>
@@ -162,11 +162,11 @@ export function OverviewTab({
 function CardHead({ label, gcap, count }: { label: string; gcap: string; count: number }) {
   return (
     <div className="flex items-baseline gap-2.5">
-      <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">{label}</span>
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">{label}</span>
+      <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
         {gcap}
       </span>
-      <span className="ml-auto font-mono text-[13px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+      <span className="ml-auto font-mono text-body tabular-nums text-[color:var(--topology-v2-numeral-face)]">
         {count}
       </span>
     </div>

--- a/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/RelationsTab.tsx
@@ -73,7 +73,7 @@ export function RelationsTab({
     <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-[1.2fr_1fr]">
       <section
         aria-label={labels.relationTypesTitle}
-        className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <CardHead label={labels.relationTypesTitle} gcap="relation breakdown" count={totalEdges} />
         <div
@@ -96,7 +96,7 @@ export function RelationsTab({
                 className="flex items-center gap-3.5 border-t border-[color:var(--color-divider)] py-3.5 first:border-t-0"
               >
                 <TopologyV2TraceMark containment={isContainmentRelation(row.type)} />
-                <span className="w-[112px] flex-none font-mono text-[13px] text-[color:var(--color-text-primary)]">
+                <span className="w-[112px] flex-none font-mono text-body text-[color:var(--color-text-primary)]">
                   {edgeTypeLabel(row.type)}
                 </span>
                 <span className="h-2 flex-1 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
@@ -106,10 +106,10 @@ export function RelationsTab({
                   />
                 </span>
                 <span className="min-w-[52px] flex-none text-right">
-                  <span className="block font-mono text-[15px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+                  <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                     {row.count}
                   </span>
-                  <span className="block font-mono text-[9.5px] text-[color:var(--color-text-quaternary)]">{pct}%</span>
+                  <span className="block font-mono text-caption text-[color:var(--color-text-quaternary)]">{pct}%</span>
                 </span>
               </div>
             );
@@ -117,19 +117,19 @@ export function RelationsTab({
         </div>
 
         <div className="mt-4 flex items-baseline gap-2">
-          <span className="text-[13px] font-medium text-[color:var(--color-text-primary)]">{labels.topDependsOnTitle}</span>
-          <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="text-body font-medium text-[color:var(--color-text-primary)]">{labels.topDependsOnTitle}</span>
+          <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             top depends_on
           </span>
         </div>
         <div className="mt-1 flex flex-1 flex-col justify-evenly">
           {dependsOnRows.length === 0 ? (
-            <p className="py-2 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.noDependsOn}</p>
+            <p className="py-2 text-body text-[color:var(--color-text-quaternary)]">{labels.noDependsOn}</p>
           ) : (
             dependsOnRows.map((row) => (
               <div
                 key={`${row.fromId}->${row.toId}`}
-                className="flex items-center gap-2.5 border-t border-[color:var(--color-divider)] py-2.5 text-[13px] text-[color:var(--color-text-secondary)] first:border-t-0"
+                className="flex items-center gap-2.5 border-t border-[color:var(--color-divider)] py-2.5 text-body text-[color:var(--color-text-secondary)] first:border-t-0"
               >
                 <TopologyV2TraceMark containment={false} />
                 <Link
@@ -149,7 +149,7 @@ export function RelationsTab({
                 >
                   {row.toTitle}
                 </Link>
-                <span className="ml-auto flex-none font-mono text-[12.5px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+                <span className="ml-auto flex-none font-mono text-body tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                   {row.count}
                 </span>
               </div>
@@ -160,19 +160,19 @@ export function RelationsTab({
 
       <section
         aria-label={labels.hubsTitle}
-        className="flex min-h-0 min-w-0 flex-col rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        className="flex min-h-0 min-w-0 flex-col rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <div className="flex items-baseline gap-2">
-          <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+          <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
             {labels.hubsTitle}
           </span>
-          <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             hubs by degree
           </span>
         </div>
         <div className="mt-2 flex flex-1 flex-col">
           {hubs.length === 0 ? (
-            <p className="py-2 text-[12px] text-[color:var(--color-text-quaternary)]">{labels.noHubs}</p>
+            <p className="py-2 text-body text-[color:var(--color-text-quaternary)]">{labels.noHubs}</p>
           ) : (
             hubs.map((hub) => {
               const meterPct = hubDegreeMax > 0 ? Math.max(6, Math.round((hub.degree / hubDegreeMax) * 100)) : 0;
@@ -186,16 +186,16 @@ export function RelationsTab({
               >
                 <HubEgoThumbnailSvg kind={hub.kind} thumbnail={hub.thumbnail} />
                 <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[14px] font-medium text-[color:var(--color-text-primary)]">
+                  <span className="block truncate text-body-lg font-medium text-[color:var(--color-text-primary)]">
                     {hub.title}
                   </span>
-                  <span className="block text-[11px] text-[color:var(--color-text-quaternary)]">{kindLabel(hub.kind)}</span>
+                  <span className="block text-label text-[color:var(--color-text-quaternary)]">{kindLabel(hub.kind)}</span>
                 </span>
                 <span className="flex-none text-right">
-                  <span className="block font-mono text-[18px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+                  <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
                     {hub.degree}
                   </span>
-                  <span className="block font-mono text-[9.5px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                  <span className="block font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                     {labels.connectionsUnit}
                   </span>
                   <span
@@ -214,11 +214,11 @@ export function RelationsTab({
           )}
         </div>
         {hubTotalCount > hubs.length ? (
-          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+          <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">
             {labels.hubTruncated(hubs.length, hubTotalCount)}
           </p>
         ) : null}
-        <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-[11px] text-[color:var(--color-text-quaternary)]">
+        <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">
           {labels.hubThumbnailCaption}
         </p>
       </section>
@@ -229,11 +229,11 @@ export function RelationsTab({
 function CardHead({ label, gcap, count }: { label: string; gcap: string; count: number }) {
   return (
     <div className="flex items-baseline gap-2.5">
-      <span className="text-[14px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">{label}</span>
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">{label}</span>
+      <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
         {gcap}
       </span>
-      <span className="ml-auto font-mono text-[13px] tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+      <span className="ml-auto font-mono text-body tabular-nums text-[color:var(--topology-v2-numeral-face)]">
         {count}
       </span>
     </div>

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -94,7 +94,7 @@ export function ProjectSelectorPage() {
           <AppSettingsMenu mode={dataSourceMode} />
         </div>
         <div className="mx-auto px-5 py-6 md:px-10 md:py-10" style={{ maxWidth: PAGE_MAX_WIDTH }}>
-        <nav className="mb-5 flex flex-wrap items-center gap-2.5 text-[12px] text-[color:var(--color-text-tertiary)]">
+        <nav className="mb-5 flex flex-wrap items-center gap-2.5 text-body text-[color:var(--color-text-tertiary)]">
           <Link
             href="/"
             className="text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
@@ -103,7 +103,7 @@ export function ProjectSelectorPage() {
           </Link>
           <span aria-hidden className="text-[color:var(--color-text-quaternary)]">/</span>
           <span>{t("crumbCurrent")}</span>
-          <span className={`ml-auto text-[11px] tracking-[0.08em] ${numeralClass}`}>
+          <span className={`ml-auto text-label tracking-[0.08em] ${numeralClass}`}>
             {census.conceptCount} {t("censusTopConceptsLabel")}
             <span aria-hidden className="mx-1.5 text-[color:var(--color-text-quaternary)]">·</span>
             {census.relationCount} {t("censusTopRelationsLabel")}
@@ -111,10 +111,10 @@ export function ProjectSelectorPage() {
         </nav>
 
         <header className="flex flex-wrap items-end gap-4">
-          <h1 className="text-[23px] font-[var(--font-weight-signature)] tracking-[-0.015em] text-[color:var(--color-text-primary)]">
+          <h1 className="text-display font-[var(--font-weight-signature)] tracking-[-0.015em] text-[color:var(--color-text-primary)]">
             {t("headerTitle")}
           </h1>
-          <span className="flex items-baseline gap-1.5 pb-[3px] text-[11.5px] tracking-[0.06em] text-[color:var(--color-text-tertiary)]">
+          <span className="flex items-baseline gap-1.5 pb-[3px] text-label tracking-[0.06em] text-[color:var(--color-text-tertiary)]">
             <b className={numeralClass}>{census.projectCount}</b> {t("censusLineProjectLabel")}
             <span aria-hidden className="text-[color:var(--color-text-quaternary)]">·</span>
             <b className={numeralClass}>{census.domainCount}</b> {t("censusLineDomainsLabel")}
@@ -124,28 +124,28 @@ export function ProjectSelectorPage() {
           <Link
             href={newProjectHref}
             data-testid="project-selector-new-cta"
-            className="ml-auto inline-flex h-9 items-center rounded-md border border-[color:var(--color-indigo-a50)] bg-[color:var(--topology-v2-panel-action-surface,var(--color-indigo-a06))] px-4 text-[12.5px] font-medium text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:var(--color-overlay-2)]"
+            className="ml-auto inline-flex h-9 items-center rounded-md border border-[color:var(--color-indigo-a50)] bg-[color:var(--topology-v2-panel-action-surface,var(--color-indigo-a06))] px-4 text-body font-medium text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:var(--color-overlay-2)]"
           >
             {t("ctaNewProject")}
           </Link>
         </header>
-        <p className="mt-2 max-w-[720px] text-[12.5px] leading-6 text-[color:var(--color-text-tertiary)]">
+        <p className="mt-2 max-w-[720px] text-body leading-6 text-[color:var(--color-text-tertiary)]">
           {t("lede")}
         </p>
 
         {recentActivityRows.length > 0 ? (
           <section className="mt-7">
             <div className="mb-3 flex items-center gap-2.5">
-              <span className="text-[13.5px] font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
                 {t("activityHeading")}
               </span>
-              <span className="font-mono text-[9.5px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {t("activityCaption")}
               </span>
             </div>
-            <div className="rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-2 shadow-[inset_0_1px_0_var(--color-overlay-2)]">
+            <div className="rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-2 shadow-[inset_0_1px_0_var(--color-overlay-2)]">
               {recentActivityRows.map((row, index) => {
-                const rowClassName = `flex items-center gap-2.5 py-1.5 text-[12.5px] text-[color:var(--color-text-secondary)] ${
+                const rowClassName = `flex items-center gap-2.5 py-1.5 text-body text-[color:var(--color-text-secondary)] ${
                   index > 0 ? "border-t border-[color:var(--color-divider)]" : ""
                 } ${row.nodeId ? "-mx-1.5 rounded-md px-1.5 transition-colors hover:bg-[color:var(--color-overlay-1)]" : ""}`;
                 const rowContent = (
@@ -153,14 +153,14 @@ export function ProjectSelectorPage() {
                     <TopologyV2KindGlyph kind={row.kind} size={14} />
                     <span
                       title={row.slug}
-                      className="min-w-0 shrink truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]"
+                      className="min-w-0 shrink truncate font-mono text-label text-[color:var(--color-text-secondary)]"
                     >
                       {row.slug}
                     </span>
                     {row.what ? (
                       <span
                         title={row.what}
-                        className="min-w-0 flex-1 truncate text-[12px] text-[color:var(--color-text-tertiary)]"
+                        className="min-w-0 flex-1 truncate text-body text-[color:var(--color-text-tertiary)]"
                       >
                         {row.what}
                       </span>
@@ -169,11 +169,11 @@ export function ProjectSelectorPage() {
                     )}
                     <span
                       title={row.domainTitle ?? undefined}
-                      className="max-w-[150px] shrink truncate font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] sm:max-w-[220px]"
+                      className="max-w-[150px] shrink truncate font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] sm:max-w-[220px]"
                     >
                       {row.domainTitle ?? t("activityNoDomain")}
                     </span>
-                    <span className={`shrink-0 whitespace-nowrap text-[11px] ${numeralClass}`}>
+                    <span className={`shrink-0 whitespace-nowrap text-label ${numeralClass}`}>
                       {formatAgo(resolveRecentActivityAgo(row.updatedAt, new Date()), t)}
                     </span>
                   </>
@@ -217,40 +217,40 @@ export function ProjectSelectorPage() {
             ))}
           </div>
         ) : (
-          <p className="mt-7 text-[12.5px] text-[color:var(--color-text-tertiary)]">
+          <p className="mt-7 text-body text-[color:var(--color-text-tertiary)]">
             {t("emptyStateDesc")}
           </p>
         )}
 
-        <section className="mt-7 rounded-[11px] border border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)] px-5 py-4">
+        <section className="mt-7 rounded-panel border border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)] px-5 py-4">
           <div className="flex items-center gap-3">
             <TopologyV2KindGlyph kind="project" size={18} />
-            <h3 className="text-[13.5px] font-semibold tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+            <h3 className="text-body-lg font-semibold tracking-[-0.01em] text-[color:var(--color-text-primary)]">
               {t("nextSlotTitle")}
             </h3>
-            <span className="text-[12px] text-[color:var(--color-text-tertiary)]">
+            <span className="text-body text-[color:var(--color-text-tertiary)]">
               {t("nextSlotSub")}
             </span>
           </div>
-          <div className="mt-3 flex items-center gap-3 rounded-[7px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-3 py-2 text-[12px] text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]">
-            <span className="w-[108px] shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <div className="mt-3 flex items-center gap-3 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-3 py-2 text-body text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]">
+            <span className="w-[108px] shrink-0 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("nextSlotCliLabel")}
             </span>
-            <code className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
+            <code className="min-w-0 flex-1 truncate font-mono text-label text-[color:var(--color-text-secondary)]">
               {t("nextSlotCliCommand")}
             </code>
-            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
+            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-label text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotCliCaption")}
             </span>
           </div>
-          <div className="mt-2 flex items-center gap-3 rounded-[7px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-3 py-2 text-[12px] text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]">
-            <span className="w-[108px] shrink-0 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <div className="mt-2 flex items-center gap-3 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] px-3 py-2 text-body text-[color:var(--color-text-tertiary)] shadow-[inset_0_1px_2px_var(--color-shadow-a35)]">
+            <span className="w-[108px] shrink-0 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("nextSlotAgentLabel")}
             </span>
-            <code className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-[color:var(--color-text-secondary)]">
+            <code className="min-w-0 flex-1 truncate font-mono text-label text-[color:var(--color-text-secondary)]">
               {t("nextSlotAgentCommand")}
             </code>
-            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-[10.5px] text-[color:var(--color-text-quaternary)] sm:inline">
+            <span className="ml-auto hidden shrink-0 whitespace-nowrap font-mono text-label text-[color:var(--color-text-quaternary)] sm:inline">
               {t("nextSlotAgentCaption")}
             </span>
           </div>
@@ -276,15 +276,15 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
   return (
     <article
       data-testid="project-selector-card"
-      className="rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-6 py-5 shadow-[inset_0_1px_0_var(--color-overlay-2),0_14px_34px_var(--color-shadow-a16)] transition-colors hover:border-[color:var(--color-border-strong)]"
+      className="rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-6 py-5 shadow-[inset_0_1px_0_var(--color-overlay-2),0_14px_34px_var(--color-shadow-a16)] transition-colors hover:border-[color:var(--color-border-strong)]"
     >
       <div className="flex items-start gap-3.5">
         <TopologyV2KindGlyph kind="project" size={26} className="mt-1 shrink-0" />
         <div className="min-w-0 flex-1">
-          <h2 className="truncate text-[19px] font-semibold tracking-[-0.012em] text-[color:var(--color-text-primary)]">
+          <h2 className="truncate text-title font-semibold tracking-[-0.012em] text-[color:var(--color-text-primary)]">
             {project.name}
           </h2>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-[12.5px] text-[color:var(--color-text-tertiary)]">
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-body text-[color:var(--color-text-tertiary)]">
             <span aria-hidden className="h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--color-indigo-brand)]" />
             <span>{t("cardUpdatedPrefix")} {ago}</span>
             <span aria-hidden className="text-[color:var(--color-text-quaternary)]">·</span>
@@ -293,12 +293,12 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
             </span>
           </div>
         </div>
-        <span className="mt-1.5 shrink-0 font-mono text-[11px] text-[color:var(--color-text-quaternary)]">
+        <span className="mt-1.5 shrink-0 font-mono text-label text-[color:var(--color-text-quaternary)]">
           {project.slug}
         </span>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-baseline gap-5 rounded-[7px] border border-[color:var(--color-border-soft)] bg-[color:var(--topology-v2-panel-metric-surface,var(--color-overlay-1))] px-4 py-2.5 text-[12.5px]">
+      <div className="mt-4 flex flex-wrap items-baseline gap-5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--topology-v2-panel-metric-surface,var(--color-overlay-1))] px-4 py-2.5 text-body">
         <FactItem label={t("factDomain")} value={facts.domain} />
         <FactItem label={t("factCapability")} value={facts.capability} />
         <FactItem label={t("factElement")} value={facts.element} />
@@ -310,7 +310,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
         <div className="mt-4 flex flex-col gap-2">
           {domainRows.map((row, index) => (
             <div key={row.domainId} className="flex items-center gap-3 sm:gap-4">
-              <span className="flex w-[84px] min-w-0 shrink-0 items-center gap-2 truncate text-[12.5px] text-[color:var(--color-text-secondary)] sm:w-[200px] md:w-[280px]">
+              <span className="flex w-[84px] min-w-0 shrink-0 items-center gap-2 truncate text-body text-[color:var(--color-text-secondary)] sm:w-[200px] md:w-[280px]">
                 <TopologyV2KindGlyph kind="domain" size={14} />
                 {row.title}
               </span>
@@ -329,7 +329,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
                   cap: row.capabilityCount,
                   el: row.elementCount,
                 })}
-                className={`max-w-[120px] shrink truncate text-right text-[10.5px] sm:max-w-none sm:shrink-0 sm:whitespace-nowrap ${numeralClass}`}
+                className={`max-w-[120px] shrink truncate text-right text-label sm:max-w-none sm:shrink-0 sm:whitespace-nowrap ${numeralClass}`}
               >
                 {t("domainRowSummary", {
                   total: row.total,
@@ -342,7 +342,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
         </div>
       ) : null}
 
-      <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-[color:var(--color-divider)] pt-2 text-[12.5px] text-[color:var(--color-text-tertiary)]">
+      <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-[color:var(--color-divider)] pt-2 text-body text-[color:var(--color-text-tertiary)]">
         <Link
           href={getProjectDetailHref(project.slug)}
           prefetch={false}
@@ -358,7 +358,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
         >
           {t("footTopologyView")}
         </Link>
-        <span className="ml-auto whitespace-nowrap font-mono text-[10.5px] tracking-[0.04em] text-[color:var(--color-text-quaternary)]">
+        <span className="ml-auto whitespace-nowrap font-mono text-label tracking-[0.04em] text-[color:var(--color-text-quaternary)]">
           {t("footUpdated", {
             date: formatDate(project.updatedAt),
             path: docPath ?? project.slug,

--- a/src/widgets/agent-connect/ui/AgentConnectSheet.tsx
+++ b/src/widgets/agent-connect/ui/AgentConnectSheet.tsx
@@ -52,7 +52,7 @@ function CopyBlock({ label, value, testId }: { label: string; value: string; tes
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
           {label}
         </span>
         <button
@@ -64,13 +64,13 @@ function CopyBlock({ label, value, testId }: { label: string; value: string; tes
               window.setTimeout(() => setCopied(false), 1600);
             }
           }}
-          className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+          className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
         >
           {copied ? <Check size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
           {copied ? "복사됨" : "복사"}
         </button>
       </div>
-      <pre className="max-h-36 overflow-auto rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2 font-mono text-[10.5px] leading-relaxed text-[color:var(--color-text-secondary)]">
+      <pre className="max-h-36 overflow-auto rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2 font-mono text-label leading-relaxed text-[color:var(--color-text-secondary)]">
         {value}
       </pre>
     </div>
@@ -140,11 +140,11 @@ export function AgentConnectSheet({
           >
             <header className="flex shrink-0 items-center justify-between border-b border-[color:var(--color-border-soft)] px-5 py-4">
               <div>
-                <p className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
                   <Cable size={11} aria-hidden />
                   {t("title")}
                 </p>
-                <p className="mt-1 text-[13px] text-[color:var(--color-text-secondary)]">{t("subtitle")}</p>
+                <p className="mt-1 text-body text-[color:var(--color-text-secondary)]">{t("subtitle")}</p>
               </div>
               <button
                 type="button"
@@ -161,7 +161,7 @@ export function AgentConnectSheet({
               {/* 연결 상태 — heartbeat 파일 기반 (조용한 수집 0: 에이전트가
                   스스로 남긴 로컬 파일을 읽을 뿐이다) */}
               <section aria-label={t("statusLabel")} data-testid="agent-connect-status">
-                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("statusLabel")}
                 </p>
                 <div className="mt-1.5 flex items-center gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5">
@@ -177,7 +177,7 @@ export function AgentConnectSheet({
                             : "var(--color-text-quaternary)",
                     }}
                   />
-                  <p className="min-w-0 flex-1 text-[12.5px] leading-relaxed text-[color:var(--color-text-secondary)]">
+                  <p className="min-w-0 flex-1 text-body leading-relaxed text-[color:var(--color-text-secondary)]">
                     {status.kind === "connected"
                       ? status.focusTitle
                         ? t("statusConnectedFocus", {
@@ -195,17 +195,17 @@ export function AgentConnectSheet({
 
               {/* 등록 스니펫 */}
               <section aria-label={t("registerLabel")} className="flex flex-col gap-3">
-                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("registerLabel")}
                 </p>
                 {snippets.needsManualPath ? (
-                  <p className="text-[11.5px] leading-relaxed text-[color:var(--color-text-tertiary)]">
+                  <p className="text-label leading-relaxed text-[color:var(--color-text-tertiary)]">
                     {t("manualPathHint")}
                   </p>
                 ) : null}
                 <CopyBlock label={t("claudeCode")} value={snippets.mcpJson} testId="agent-connect-copy-mcp" />
                 <CopyBlock label={t("codex")} value={snippets.codexCommand} testId="agent-connect-copy-codex" />
-                <p className="text-[11px] leading-relaxed text-[color:var(--color-text-quaternary)]">
+                <p className="text-label leading-relaxed text-[color:var(--color-text-quaternary)]">
                   {t("genericHint")}
                 </p>
                 {onWriteConfigs ? (
@@ -213,7 +213,7 @@ export function AgentConnectSheet({
                     type="button"
                     onClick={onWriteConfigs}
                     data-testid="agent-connect-write-configs"
-                    className="inline-flex h-8 w-fit items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-3 text-[11.5px] text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)]"
+                    className="inline-flex h-8 w-fit items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-3 text-label text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)]"
                   >
                     {t("writeConfigs")}
                   </button>
@@ -222,13 +222,13 @@ export function AgentConnectSheet({
 
               {/* 이해받음의 순간 — 에이전트가 내 지도를 되말한다 */}
               <section aria-label={t("previewLabel")} className="flex flex-col gap-2">
-                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("previewLabel")}
                 </p>
                 {previewDomains.length > 0 ? (
                   <p
                     data-testid="agent-connect-preview"
-                    className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5 text-[12.5px] leading-relaxed text-[color:var(--color-text-secondary)]"
+                    className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5 text-body leading-relaxed text-[color:var(--color-text-secondary)]"
                   >
                     {t("previewSentence", { domains: domainsLabel })}
                   </p>
@@ -242,7 +242,7 @@ export function AgentConnectSheet({
                       window.setTimeout(() => setHandoffCopied(false), 1600);
                     }
                   }}
-                  className="inline-flex h-8 w-fit items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-3 text-[11.5px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+                  className="inline-flex h-8 w-fit items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-3 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
                 >
                   {handoffCopied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
                   {handoffCopied ? t("handoffCopied") : t("copyHandoff")}

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -152,7 +152,7 @@ export function AppNavRail({ settingsSlot, hidden, className }: AppNavRailProps)
                   ) : null}
                   <span
                     className={cn(
-                      "flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-[8px] transition-colors",
+                      "flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-card transition-colors",
                       isActive
                         ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-indigo-accent)] shadow-[inset_0_0_0_1px_var(--color-indigo-line-a22)]"
                         : "text-[color:var(--color-text-tertiary)] group-hover:bg-[color:var(--color-overlay-2)] group-hover:text-[color:var(--color-text-primary)]",
@@ -186,7 +186,7 @@ export function AppNavRail({ settingsSlot, hidden, className }: AppNavRailProps)
           title={agentTitle}
           aria-label={agentTitle}
           data-testid="app-nav-rail-agent-status"
-          className="relative flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-[8px] text-[color:var(--color-text-tertiary)]"
+          className="relative flex h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] items-center justify-center rounded-card text-[color:var(--color-text-tertiary)]"
         >
           <Activity
             size={18}

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -192,7 +192,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
         className="inline-flex h-8 cursor-pointer list-none items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-2 text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset [&::-webkit-details-marker]:hidden"
       >
         <Settings size={14} aria-hidden />
-        <span className="hidden font-mono text-[10px] uppercase tracking-[0.08em] sm:inline">
+        <span className="hidden font-mono text-caption uppercase tracking-[0.08em] sm:inline">
           {t('settingsLabel')}
         </span>
       </summary>
@@ -215,7 +215,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
           role="dialog"
           aria-labelledby={titleId}
           tabIndex={-1}
-          className="flex h-[calc(100dvh-1.5rem)] max-h-[48rem] w-full max-w-[64rem] flex-col overflow-hidden rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] text-[13px] shadow-[0_28px_90px_var(--color-shadow-a58)] sm:h-[calc(100dvh-3rem)]"
+          className="flex h-[calc(100dvh-1.5rem)] max-h-[48rem] w-full max-w-[64rem] flex-col overflow-hidden rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] text-body shadow-[0_28px_90px_var(--color-shadow-a58)] sm:h-[calc(100dvh-3rem)]"
           data-testid="app-settings-popover"
         >
           <div className="flex shrink-0 items-start justify-between gap-3 border-b border-[color:var(--color-border-soft)] p-4 pb-3">
@@ -228,7 +228,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                 >
                   {t('title')}
                 </h2>
-                <p className="mt-1 break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <p className="mt-1 break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                   {t('subtitle')}
                 </p>
               </div>
@@ -270,10 +270,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                         : "min-w-[7.25rem] rounded-md border border-transparent px-2.5 py-2 text-left text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] md:min-h-[4rem]"
                     }
                   >
-                    <span className="block font-mono text-[10px] uppercase tracking-[0.08em]">
+                    <span className="block font-mono text-caption uppercase tracking-[0.08em]">
                       {tab.label}
                     </span>
-                    <span className="mt-1 hidden text-[10px] leading-4 text-[color:var(--color-text-tertiary)] md:block">
+                    <span className="mt-1 hidden text-caption leading-4 text-[color:var(--color-text-tertiary)] md:block">
                       {tab.description}
                     </span>
                   </button>
@@ -291,7 +291,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
               >
                 <h3
                   id={mcpTitleId}
-                  className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]"
+                  className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]"
                 >
                   {t('connectionStatusTitle')}
                 </h3>
@@ -300,29 +300,29 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   data-testid="mcp-live-verdict-strip"
                 >
                   <div className="min-w-0 rounded-md border border-[color:var(--color-success-a20)] bg-[color:var(--color-success-a06)] p-2">
-                    <p className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
+                    <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
                       <Check size={11} aria-hidden />
                       {t('liveVerdictSetup')}
                     </p>
-                    <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                       {t('liveVerdictSetupMeta')}
                     </p>
                   </div>
                   <div className="min-w-0 rounded-md border border-[color:var(--color-amber-signal-a24)] bg-[color:var(--color-amber-signal-a07)] p-2">
-                    <p className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
+                    <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
                       <Terminal size={11} aria-hidden />
                       {t('liveVerdictSession')}
                     </p>
-                    <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                       {t('liveVerdictSessionMeta')}
                     </p>
                   </div>
                   <div className="min-w-0 rounded-md border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] p-2">
-                    <p className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                    <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                       <Terminal size={11} aria-hidden />
                       {t('liveVerdictFallback')}
                     </p>
-                    <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                       {t('liveVerdictFallbackMeta')}
                     </p>
                   </div>
@@ -331,10 +331,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   className="mt-2 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5"
                   data-testid="mcp-connection-state-ladder"
                 >
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                     {t('stateLadderTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('stateLadderBody')}
                   </p>
                   <div className="mt-2 grid gap-1.5 sm:grid-cols-2 xl:grid-cols-5">
@@ -350,10 +350,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                           style={{ color: iconColor }}
                         />
                         <div className="min-w-0">
-                          <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+                          <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
                             {t(labelKey)}
                           </p>
-                          <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                          <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                             {t(bodyKey)}
                           </p>
                         </div>
@@ -366,10 +366,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   <div className="flex items-start gap-2">
                     <Check size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-success-text-a95)]" />
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
+                      <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
                         {t('setupReadyTitle')}
                       </p>
-                      <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                      <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                         {t('setupReadyBody')}
                       </p>
                     </div>
@@ -379,10 +379,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   <div className="flex items-start gap-2">
                     <Terminal size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-amber-docs-a95)]" />
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
+                      <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
                         {t('directProofTitle')}
                       </p>
-                      <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                      <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                         {t('directProofBody')}
                       </p>
                     </div>
@@ -392,10 +392,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   <div className="flex items-start gap-2">
                     <Terminal size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                      <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                         {t('fallbackProofTitle')}
                       </p>
-                      <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                      <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                         {t('fallbackProofBody')}
                       </p>
                     </div>
@@ -405,10 +405,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   <div className="flex items-start gap-2">
                     <Terminal size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-amber-docs-a95)]" />
                     <div className="min-w-0">
-                      <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
+                      <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
                         {t('staleCacheTitle')}
                       </p>
-                      <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                      <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                         {t('staleCacheBody')}
                       </p>
                     </div>
@@ -419,10 +419,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                 className="mt-3 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5"
                 data-testid="mcp-proof-decision-order"
               >
-                <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t('proofDecisionTitle')}
                 </p>
-                <ol className="mt-2 grid gap-1.5 text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <ol className="mt-2 grid gap-1.5 text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                   <li className="flex gap-2">
                     <span className="font-mono text-[color:var(--color-success-text-a95)]">1</span>
                     <span>{t('proofDecisionSetup')}</span>
@@ -454,7 +454,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
           >
             <h3
               id={generalTitleId}
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
+              className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]"
             >
               {t('generalSettingsTitle')}
             </h3>
@@ -464,13 +464,13 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
             >
               <Bot size={14} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
               <span className="min-w-0">
-                <span className="block font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <span className="block font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t('agentTitle')}
                 </span>
-                <span className="mt-1 block break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <span className="mt-1 block break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                   {t('agentBody')}
                 </span>
-                <span className="mt-1 block font-mono text-[9px] text-[color:var(--color-indigo-accent)]">
+                <span className="mt-1 block font-mono text-caption text-[color:var(--color-indigo-accent)]">
                   {t('agentCta')}
                 </span>
               </span>
@@ -494,13 +494,13 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
             >
               <FolderOpen size={14} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
               <span className="min-w-0">
-                <span className="block font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <span className="block font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t('vaultTitle')}
                 </span>
-                <span className="mt-1 block break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <span className="mt-1 block break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                   {vaultBody}
                 </span>
-                <span className="mt-1 block font-mono text-[9px] text-[color:var(--color-indigo-accent)]">
+                <span className="mt-1 block font-mono text-caption text-[color:var(--color-indigo-accent)]">
                   {vaultCta}
                 </span>
               </span>
@@ -530,7 +530,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                   onReveal={handleRevealVaultPath}
                 />
                 {vaultRevealError ? (
-                  <p className="rounded-sm border border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-2 py-1 text-[10.5px] leading-4 text-[color:var(--color-status-danger)]">
+                  <p className="rounded-sm border border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-2 py-1 text-label leading-4 text-[color:var(--color-status-danger)]">
                     {t('vaultRevealError', { message: vaultRevealError })}
                   </p>
                 ) : null}
@@ -551,10 +551,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
               <div className="flex min-w-0 items-start gap-2">
                 <Languages size={14} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
                 <div className="min-w-0">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                     {t('languageTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('languageBody')}
                   </p>
                 </div>
@@ -593,10 +593,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
               <div className="flex min-w-0 items-start gap-2">
                 <Terminal size={14} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-indigo-accent)]" />
                 <div className="min-w-0">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                     {t('mcpProofTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('mcpProofBody')}
                   </p>
                 </div>
@@ -604,13 +604,13 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
               <button
                 type="button"
                 onClick={() => void copy(mcpFirstCalls)}
-                className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[color:var(--color-indigo-line-a32)] px-2 font-mono text-[9px] text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-line-a13)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+                className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[color:var(--color-indigo-line-a32)] px-2 font-mono text-caption text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-line-a13)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
               >
                 {copyState === 'copied' ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
                 {copyState === 'copied' ? t('mcpProofCopied') : t('mcpProofCopy')}
               </button>
             </div>
-            <div className="mt-3 grid gap-2 text-[10px] leading-4 text-[color:var(--color-text-secondary)] sm:grid-cols-2">
+            <div className="mt-3 grid gap-2 text-caption leading-4 text-[color:var(--color-text-secondary)] sm:grid-cols-2">
               <div
                 data-testid="direct-mcp-proof"
                 className="rounded-lg border border-[color:var(--color-success-a26)] bg-[color:var(--color-success-a06)] p-2.5"
@@ -618,10 +618,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                 <div className="flex items-start gap-2">
                   <Check size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-success-text-a95)]" />
                   <div className="min-w-0">
-                    <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
+                    <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-success-text-a95)]">
                       {t('mcpProofDirectLabel')}
                     </p>
-                    <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                       {t('mcpProofDirectBody')}
                     </p>
                   </div>
@@ -641,10 +641,10 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
                 <div className="flex items-start gap-2">
                   <Terminal size={13} aria-hidden className="mt-0.5 shrink-0 text-[color:var(--color-amber-docs-a95)]" />
                   <div className="min-w-0">
-                    <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
+                    <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
                       {t('mcpProofFallbackLabel')}
                     </p>
-                    <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                    <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                       {t('mcpProofFallbackBody')}
                     </p>
                   </div>
@@ -671,42 +671,42 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
               className="mt-3 border-t border-[color:var(--color-border-soft)] pt-3"
               data-testid="mcp-client-proof-locations"
             >
-              <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+              <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                 {t('clientProofTitle')}
               </p>
-              <p className="mt-1 break-keep text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+              <p className="mt-1 break-keep text-label leading-4 text-[color:var(--color-text-tertiary)]">
                 {t('clientProofBody')}
               </p>
               <div className="mt-2 grid gap-2 sm:grid-cols-2">
                 <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
                     {t('clientCodexTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('clientCodexBody')}
                   </p>
                 </div>
                 <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
                     {t('clientClaudeTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('clientClaudeBody')}
                   </p>
                 </div>
                 <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
                     {t('clientCursorVsCodeTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('clientCursorVsCodeBody')}
                   </p>
                 </div>
                 <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-2.5">
-                  <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-secondary)]">
                     {t('clientInspectorTitle')}
                   </p>
-                  <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                  <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                     {t('clientInspectorBody')}
                   </p>
                 </div>

--- a/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
+++ b/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
@@ -694,11 +694,11 @@ export function VaultAgentSetupPanel({
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
-            <h3 className="text-[11.5px] font-medium text-[color:var(--color-text-primary)]">
+            <h3 className="text-label font-medium text-[color:var(--color-text-primary)]">
               {t('agentSetup.title')}
             </h3>
             <span
-              className={`rounded-sm px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.12em] ${
+              className={`rounded-sm px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.12em] ${
                 agentSetupReady
                   ? 'bg-[color:var(--color-success-a12)] text-[color:var(--color-success-text-a92)]'
                   : 'bg-[color:var(--color-amber-source-a12)] text-[color:var(--color-amber-docs-a92)]'
@@ -709,13 +709,13 @@ export function VaultAgentSetupPanel({
                 : t('agentSetup.missing')}
             </span>
           </div>
-          <p className="mt-1 text-[11px] leading-4 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-1 text-label leading-4 text-[color:var(--color-text-tertiary)]">
             {t('agentSetup.statusSummary', {
               ready: agentSetupReadyCount,
               total: agentSetupFiles.length,
             })}
             {nextMissingAgentConfig ? (
-              <span className="block font-mono text-[10px] text-[color:var(--color-amber-docs-a92)]">
+              <span className="block font-mono text-caption text-[color:var(--color-amber-docs-a92)]">
                 {agentStatus[nextMissingAgentConfig.key]
                   ? t('agentSetup.nextInvalid', {
                       path: nextMissingAgentConfig.path,
@@ -726,7 +726,7 @@ export function VaultAgentSetupPanel({
               </span>
             ) : null}
           </p>
-          <p className="mt-1 text-[10.5px] leading-4 text-[color:var(--color-indigo-pale-a82)]">
+          <p className="mt-1 text-label leading-4 text-[color:var(--color-indigo-pale-a82)]">
             {agentSetupReady
               ? t('agentSetup.rootSummaryReady')
               : t('agentSetup.rootSummaryMissing')}
@@ -759,11 +759,11 @@ export function VaultAgentSetupPanel({
                   )}
                   <span className="min-w-0">
                     <span className="flex items-center justify-between gap-2">
-                      <span className="truncate text-[10.5px] font-medium text-[color:var(--color-text-secondary)]">
+                      <span className="truncate text-label font-medium text-[color:var(--color-text-secondary)]">
                         {label}
                       </span>
                       <span
-                        className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[9.5px] ${
+                        className={`shrink-0 rounded-sm px-1.5 py-0.5 text-caption ${
                           ready
                             ? 'bg-[color:var(--color-success-a10)] text-[color:var(--color-success-text-a92)]'
                             : 'bg-[color:var(--color-amber-source-a10)] text-[color:var(--color-amber-docs-a92)]'
@@ -774,7 +774,7 @@ export function VaultAgentSetupPanel({
                           : t('agentSetup.connectionNeedsReview')}
                       </span>
                     </span>
-                    <span className="mt-0.5 block truncate font-mono text-[9.5px] text-[color:var(--color-text-tertiary)]">
+                    <span className="mt-0.5 block truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
                       {check}
                     </span>
                   </span>
@@ -782,10 +782,10 @@ export function VaultAgentSetupPanel({
               );
             })}
           </ul>
-          <p className="mt-1.5 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-1.5 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
             {t('agentSetup.connectionHint')}
           </p>
-          <p className="mt-2 break-keep rounded-sm border border-[color:var(--color-indigo-line-a14)] bg-[color:var(--color-overlay-recessed-a12)] px-2 py-1.5 text-[10.5px] leading-4 text-[color:var(--color-text-tertiary)]">
+          <p className="mt-2 break-keep rounded-sm border border-[color:var(--color-indigo-line-a14)] bg-[color:var(--color-overlay-recessed-a12)] px-2 py-1.5 text-label leading-4 text-[color:var(--color-text-tertiary)]">
             <span className="font-medium text-[color:var(--color-text-secondary)]">
               {t('agentSetup.boundaryTitle')}
             </span>{' '}
@@ -821,11 +821,11 @@ export function VaultAgentSetupPanel({
             )}
             <span className="min-w-0">
               <span className="flex items-center justify-between gap-2">
-                <span className="text-[10.5px] font-medium text-[color:var(--color-text-secondary)]">
+                <span className="text-label font-medium text-[color:var(--color-text-secondary)]">
                   {t('agentSetup.validationGateTitle')}
                 </span>
                 <span
-                  className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-[9.5px] uppercase ${
+                  className={`shrink-0 rounded-sm px-1.5 py-0.5 font-mono text-caption uppercase ${
                     validationGateTone === 'ready'
                       ? 'bg-[color:var(--color-success-a10)] text-[color:var(--color-success-text-a92)]'
                       : validationGateTone === 'blocked'
@@ -836,16 +836,16 @@ export function VaultAgentSetupPanel({
                   {validationGateStatus}
                 </span>
               </span>
-              <span className="mt-0.5 block text-[10.5px] leading-4 text-[color:var(--color-text-secondary)]">
+              <span className="mt-0.5 block text-label leading-4 text-[color:var(--color-text-secondary)]">
                 {validationGateSummary}
               </span>
-              <span className="mt-0.5 block break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+              <span className="mt-0.5 block break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                 {validationGateDesc}
               </span>
             </span>
           </div>
           <details className="mt-2 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-recessed-a12)] px-2 py-1.5">
-            <summary className="cursor-pointer select-none text-[10.5px] font-medium text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]">
+            <summary className="cursor-pointer select-none text-label font-medium text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]">
               {t('agentSetup.nextStepsSummary')}
             </summary>
             <ol
@@ -858,7 +858,7 @@ export function VaultAgentSetupPanel({
                   className="grid grid-cols-[18px_1fr] items-start gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-1.5 py-1"
                 >
                   <span
-                    className={`inline-flex h-4 w-4 items-center justify-center rounded-sm font-mono text-[9px] ${
+                    className={`inline-flex h-4 w-4 items-center justify-center rounded-sm font-mono text-caption ${
                       step.complete
                         ? 'bg-[color:var(--color-success-a12)] text-[color:var(--color-success-text-a90)]'
                         : 'bg-[color:var(--color-indigo-a14)] text-[color:var(--color-indigo-pale-a90)]'
@@ -866,7 +866,7 @@ export function VaultAgentSetupPanel({
                   >
                     {step.complete ? '✓' : index + 1}
                   </span>
-                  <span className="break-keep text-[10.5px] leading-4 text-[color:var(--color-text-secondary)]">
+                  <span className="break-keep text-label leading-4 text-[color:var(--color-text-secondary)]">
                     {step.label}
                   </span>
                 </li>
@@ -907,10 +907,10 @@ export function VaultAgentSetupPanel({
                     className="mt-0.5 text-[color:var(--color-amber-docs-a92)]"
                   />
                 )}
-                <dt className="truncate font-mono text-[9.5px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                <dt className="truncate font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                   {row.label}
                 </dt>
-                <dd className="break-keep text-[10.5px] leading-4 text-[color:var(--color-text-secondary)]">
+                <dd className="break-keep text-label leading-4 text-[color:var(--color-text-secondary)]">
                   {row.value}
                 </dd>
               </div>
@@ -925,13 +925,13 @@ export function VaultAgentSetupPanel({
                 key={row.key}
                 className="grid grid-cols-[18px_88px_1fr] items-start gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a13)] bg-[color:var(--color-indigo-a06)] px-1.5 py-1"
               >
-                <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-[color:var(--color-indigo-a14)] font-mono text-[9px] text-[color:var(--color-indigo-pale-a90)]">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-[color:var(--color-indigo-a14)] font-mono text-caption text-[color:var(--color-indigo-pale-a90)]">
                   {index + 1}
                 </span>
-                <dt className="truncate font-mono text-[9.5px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-pale-a82)]">
+                <dt className="truncate font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-indigo-pale-a82)]">
                   {row.label}
                 </dt>
-                <dd className="break-keep text-[10.5px] leading-4 text-[color:var(--color-text-secondary)]">
+                <dd className="break-keep text-label leading-4 text-[color:var(--color-text-secondary)]">
                   {row.value}
                 </dd>
               </div>
@@ -944,7 +944,7 @@ export function VaultAgentSetupPanel({
               return (
                 <div
                   key={key}
-                  className="grid grid-cols-[14px_1fr] items-start gap-1.5 text-[11px] leading-4 text-[color:var(--color-text-secondary)]"
+                  className="grid grid-cols-[14px_1fr] items-start gap-1.5 text-label leading-4 text-[color:var(--color-text-secondary)]"
                 >
                   {present && valid ? (
                     <CheckCircle2
@@ -960,7 +960,7 @@ export function VaultAgentSetupPanel({
                     />
                   )}
                   <span>
-                    <code className="font-mono text-[10.5px] text-[color:var(--color-text-primary)]">
+                    <code className="font-mono text-label text-[color:var(--color-text-primary)]">
                       {path}
                     </code>{' '}
                     <span className="text-[color:var(--color-text-tertiary)]">
@@ -982,7 +982,7 @@ export function VaultAgentSetupPanel({
               onClick={() => void handleEnsureAgentConfigs()}
               disabled={agentSetupBusy}
               title={t('agentSetup.repairTitle')}
-              className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a10)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-indigo-pale-a94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)] disabled:opacity-60"
+              className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a10)] px-2 py-1.5 text-label text-[color:var(--color-indigo-pale-a94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)] disabled:opacity-60"
             >
               <Bot size={12} aria-hidden />
               {agentSetupBusy
@@ -991,11 +991,11 @@ export function VaultAgentSetupPanel({
             </button>
           ) : null}
           {hasInvalidAgentConfig ? (
-            <p className="mt-2 break-keep rounded-sm border border-[color:var(--color-amber-docs-a18)] bg-[color:var(--color-amber-source-a08)] px-2 py-1.5 text-[10.5px] leading-4 text-[color:var(--color-amber-docs-a92)]">
+            <p className="mt-2 break-keep rounded-sm border border-[color:var(--color-amber-docs-a18)] bg-[color:var(--color-amber-source-a08)] px-2 py-1.5 text-label leading-4 text-[color:var(--color-amber-docs-a92)]">
               {t('agentSetup.invalidRepairHint')}
             </p>
           ) : null}
-          <div className="mt-2 text-[10px] font-medium uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
+          <div className="mt-2 text-caption font-medium uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
             {t('agentSetup.verifyGroup')}
           </div>
           <dl
@@ -1024,10 +1024,10 @@ export function VaultAgentSetupPanel({
                 key={mode.term}
                 className="rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-recessed-a12)] px-2 py-1"
               >
-                <dt className="text-[10.5px] font-medium text-[color:var(--color-text-secondary)]">
+                <dt className="text-label font-medium text-[color:var(--color-text-secondary)]">
                   {mode.term}
                 </dt>
-                <dd className="mt-0.5 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <dd className="mt-0.5 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                   {mode.desc}
                 </dd>
               </div>
@@ -1037,7 +1037,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={onOpenWorkflowGuide}
             title={t('agentSetup.openWorkflowGuideTitle')}
-            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a08)] px-2 py-1.5 text-[11.5px] text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a14)]"
+            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a08)] px-2 py-1.5 text-label text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a14)]"
           >
             <BookOpen size={12} aria-hidden />
             {t('agentSetup.openWorkflowGuide')}
@@ -1046,7 +1046,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentSetupPacket()}
             title={t('agentSetup.copyPacketTitle')}
-            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a10)] px-2 py-1.5 text-[11.5px] text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-a62)] hover:bg-[color:var(--color-indigo-a16)]"
+            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a10)] px-2 py-1.5 text-label text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-a62)] hover:bg-[color:var(--color-indigo-a16)]"
           >
             <ClipboardCopy size={12} aria-hidden />
             {copyPacketLabel}
@@ -1055,7 +1055,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentVerifyPrompt()}
             title={t('agentSetup.copyPromptTitle')}
-            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <ClipboardCopy size={12} aria-hidden />
             {copyPromptLabel}
@@ -1064,7 +1064,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentVerifyCli()}
             title={t('agentSetup.copyCliTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <Terminal size={12} aria-hidden />
             {copyCliLabel}
@@ -1073,7 +1073,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentFirstContactProof()}
             title={t('agentSetup.copyFirstContactProofTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <Terminal size={12} aria-hidden />
             {copyFirstContactProofLabel}
@@ -1082,7 +1082,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentJsonGate()}
             title={t('agentSetup.copyJsonGateTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-success-a28)] bg-[color:var(--color-success-a07)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-success-text-a94)] transition-colors hover:border-[color:var(--color-success-a42)] hover:bg-[color:var(--color-success-a11)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-success-a28)] bg-[color:var(--color-success-a07)] px-2 py-1.5 text-label text-[color:var(--color-success-text-a94)] transition-colors hover:border-[color:var(--color-success-a42)] hover:bg-[color:var(--color-success-a11)]"
           >
             <Terminal size={12} aria-hidden />
             {copyJsonGateLabel}
@@ -1091,18 +1091,18 @@ export function VaultAgentSetupPanel({
             aria-label={t('agentSetup.mcpVerifyPreviewAriaLabel')}
             className="mt-1.5 rounded-sm border border-[color:var(--color-indigo-a20)] bg-[color:var(--color-overlay-recessed)] px-2 py-1.5"
           >
-            <div className="text-[9.5px] font-medium uppercase tracking-[0.12em] text-[color:var(--color-indigo-pale-a82)]">
+            <div className="text-caption font-medium uppercase tracking-[0.12em] text-[color:var(--color-indigo-pale-a82)]">
               {t('agentSetup.mcpVerifyLabel')}
             </div>
-            <code className="mt-1 block truncate font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+            <code className="mt-1 block truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
               {agentMcpVerifyPreview}
             </code>
           </div>
           <div className="mt-1.5 rounded-sm border border-[color:var(--color-success-a18)] bg-[color:var(--color-overlay-recessed)] px-2 py-1.5">
-            <div className="text-[9.5px] font-medium uppercase tracking-[0.12em] text-[color:var(--color-success-text-a78)]">
+            <div className="text-caption font-medium uppercase tracking-[0.12em] text-[color:var(--color-success-text-a78)]">
               {t('agentSetup.jsonGateLabel')}
             </div>
-            <code className="mt-1 block truncate font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+            <code className="mt-1 block truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
               {agentJsonGatePreview}
             </code>
           </div>
@@ -1128,27 +1128,27 @@ export function VaultAgentSetupPanel({
                 key={rule.term}
                 className="grid grid-cols-[92px_1fr] gap-2 rounded-sm border border-[color:var(--color-success-a12)] bg-[color:var(--color-success-a035)] px-2 py-1"
               >
-                <dt className="truncate font-mono text-[9.5px] text-[color:var(--color-success-text-a94)]">
+                <dt className="truncate font-mono text-caption text-[color:var(--color-success-text-a94)]">
                   {rule.term}
                 </dt>
-                <dd className="break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <dd className="break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                   {rule.desc}
                 </dd>
               </div>
             ))}
           </dl>
           <div className="mt-1.5 rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-2 py-1.5">
-            <p className="text-[9.5px] font-medium uppercase tracking-[0.12em] text-[color:var(--color-indigo-pale-a82)]">
+            <p className="text-caption font-medium uppercase tracking-[0.12em] text-[color:var(--color-indigo-pale-a82)]">
               {t('agentSetup.syncAfterChangeTitle')}
             </p>
-            <p className="mt-1 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+            <p className="mt-1 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
               {t('agentSetup.syncAfterChangeDesc')}
             </p>
             <button
               type="button"
               onClick={() => void handleCopyAgentPostChangeSyncGate()}
               title={t('agentSetup.copyPostChangeSyncTitle')}
-              className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a08)] px-2 py-1.5 text-[11px] text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-a13)]"
+              className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a08)] px-2 py-1.5 text-label text-[color:rgba(210,216,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-a13)]"
             >
               <ClipboardCopy size={12} aria-hidden />
               {copyPostChangeSyncLabel}
@@ -1160,16 +1160,16 @@ export function VaultAgentSetupPanel({
                 key={command}
                 className="grid grid-cols-[18px_1fr] items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-recessed-a14)] px-1.5 py-1"
               >
-                <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-[color:var(--color-indigo-a14)] font-mono text-[9px] text-[color:var(--color-indigo-pale-a90)]">
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-sm bg-[color:var(--color-indigo-a14)] font-mono text-caption text-[color:var(--color-indigo-pale-a90)]">
                   {index + 1}
                 </span>
-                <code className="truncate font-mono text-[10px] text-[color:var(--color-text-tertiary)]">
+                <code className="truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
                   ontology-atlas {command}
                 </code>
               </li>
             ))}
           </ol>
-          <div className="mt-2 text-[10px] font-medium uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
+          <div className="mt-2 text-caption font-medium uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
             {t('agentSetup.connectGroup')}
           </div>
           <dl
@@ -1190,10 +1190,10 @@ export function VaultAgentSetupPanel({
                 key={rootMode.term}
                 className="rounded-sm border border-[color:var(--color-indigo-line-a13)] bg-[color:var(--color-indigo-a06)] px-2 py-1"
               >
-                <dt className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-pale-a82)]">
+                <dt className="font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-indigo-pale-a82)]">
                   {rootMode.term}
                 </dt>
-                <dd className="mt-0.5 break-keep text-[10px] leading-4 text-[color:var(--color-text-tertiary)]">
+                <dd className="mt-0.5 break-keep text-caption leading-4 text-[color:var(--color-text-tertiary)]">
                   {rootMode.desc}
                 </dd>
               </div>
@@ -1203,7 +1203,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentSetupCheckCliCommand()}
             title={t('agentSetup.copySetupCheckCliTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-success-a28)] bg-[color:var(--color-success-a07)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-success-text-a94)] transition-colors hover:border-[color:var(--color-success-a42)] hover:bg-[color:var(--color-success-a11)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-success-a28)] bg-[color:var(--color-success-a07)] px-2 py-1.5 text-label text-[color:var(--color-success-text-a94)] transition-colors hover:border-[color:var(--color-success-a42)] hover:bg-[color:var(--color-success-a11)]"
           >
             <Terminal size={12} aria-hidden />
             {copySetupCheckCliLabel}
@@ -1212,7 +1212,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentSetupCliCommand()}
             title={t('agentSetup.copySetupCliTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-amber-docs-a28)] bg-[color:var(--color-amber-source-a07)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-amber-docs-a94)] transition-colors hover:border-[color:var(--color-amber-docs-a42)] hover:bg-[color:var(--color-amber-source-a11)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-amber-docs-a28)] bg-[color:var(--color-amber-source-a07)] px-2 py-1.5 text-label text-[color:var(--color-amber-docs-a94)] transition-colors hover:border-[color:var(--color-amber-docs-a42)] hover:bg-[color:var(--color-amber-source-a11)]"
           >
             <Terminal size={12} aria-hidden />
             {copySetupCliLabel}
@@ -1221,7 +1221,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyAgentConfigTemplate()}
             title={t('agentSetup.copyTemplateTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <ClipboardCopy size={12} aria-hidden />
             {copyTemplateLabel}
@@ -1230,7 +1230,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyCodexConfigTemplate()}
             title={t('agentSetup.copyCodexTemplateTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <ClipboardCopy size={12} aria-hidden />
             {copyCodexTemplateLabel}
@@ -1239,7 +1239,7 @@ export function VaultAgentSetupPanel({
             type="button"
             onClick={() => void handleCopyCodexMcpAddCommand()}
             title={t('agentSetup.copyCodexCliTitle')}
-            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11.5px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
             <Terminal size={12} aria-hidden />
             {copyCodexCliLabel}
@@ -1247,7 +1247,7 @@ export function VaultAgentSetupPanel({
           {agentSetupError ? (
             <p
               role="alert"
-              className="mt-2 text-[11px] leading-4 text-[color:var(--color-status-danger)]"
+              className="mt-2 text-label leading-4 text-[color:var(--color-status-danger)]"
             >
               {agentSetupError}
             </p>

--- a/src/widgets/bottom-tab-bar/ui/BottomTabBar.tsx
+++ b/src/widgets/bottom-tab-bar/ui/BottomTabBar.tsx
@@ -81,7 +81,7 @@ export function BottomTabBar() {
             >
               <Icon size={17} aria-hidden />
             </span>
-            <span className="text-[10px] font-[var(--font-weight-signature)] leading-none">{tRail(tab.labelKey)}</span>
+            <span className="text-caption font-[var(--font-weight-signature)] leading-none">{tRail(tab.labelKey)}</span>
           </Link>
         );
       })}

--- a/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
+++ b/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
@@ -149,7 +149,7 @@ function TreeBranch({
         href={getDocHref(node.slug)}
         onClick={onPick}
         className={cn(
-          "group flex items-center gap-2 rounded-[8px] px-2 py-1.5 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-indigo-a10)] hover:text-[color:var(--color-text-primary)]",
+          "group flex items-center gap-2 rounded-card px-2 py-1.5 text-body text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-indigo-a10)] hover:text-[color:var(--color-text-primary)]",
           isFocused &&
             "bg-[color:var(--color-indigo-a18)] text-[color:var(--color-text-primary)] ring-1 ring-[color:var(--color-indigo-a40)]",
         )}
@@ -171,7 +171,7 @@ function TreeBranch({
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="flex w-full items-center gap-1.5 rounded-[8px] px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)]"
+          className="flex w-full items-center gap-1.5 rounded-card px-2 py-1.5 text-left font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)]"
           style={{ paddingLeft: `${depth * 12 + 4}px` }}
           aria-expanded={effectiveOpen}
         >
@@ -182,7 +182,7 @@ function TreeBranch({
           )}
           <Folder size={11} />
           <span className="truncate">{node.name}</span>
-          <span className="ml-auto font-mono text-[9px] text-[color:var(--color-text-quaternary)]">
+          <span className="ml-auto font-mono text-caption text-[color:var(--color-text-quaternary)]">
             {node.children.filter((c) => c.type === "doc" || (c.children?.length ?? 0) > 0).length}
           </span>
         </button>
@@ -223,12 +223,12 @@ function DocRow({
   const t = useTranslations("vaultWidgets.docsDrawer");
   const hasExcerpt = doc.excerpt.trim().length > 0;
   return (
-    <div className="group flex flex-col rounded-[8px] transition-colors hover:bg-[color:var(--color-indigo-a10)]">
+    <div className="group flex flex-col rounded-card transition-colors hover:bg-[color:var(--color-indigo-a10)]">
       <div className="flex items-center gap-1">
         <Link
           href={getDocHref(doc.slug)}
           onClick={onClose}
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-[8px] px-2 py-1.5 text-[13px] text-[color:var(--color-text-secondary)] transition-colors group-hover:text-[color:var(--color-text-primary)]"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-card px-2 py-1.5 text-body text-[color:var(--color-text-secondary)] transition-colors group-hover:text-[color:var(--color-text-primary)]"
         >
           <FileText
             size={13}
@@ -236,7 +236,7 @@ function DocRow({
           />
           <span className="truncate">{doc.title}</span>
           {trailingText ? (
-            <span className="ml-auto shrink-0 font-mono text-[9px] text-[color:var(--color-text-quaternary)]">
+            <span className="ml-auto shrink-0 font-mono text-caption text-[color:var(--color-text-quaternary)]">
               {trailingText}
             </span>
           ) : null}
@@ -267,7 +267,7 @@ function DocRow({
       {hasExcerpt && (
         // hover 시에만 렌더되는 본문 첫 단락 프리뷰. 터치 기기 (hover: none)
         // 에선 안 뜨게 hover: hover 미디어 쿼리로 게이팅.
-        <p className="hidden line-clamp-2 px-2 pb-1.5 text-[11px] leading-4 text-[color:var(--color-text-quaternary)] [@media(hover:hover)]:group-hover:block">
+        <p className="hidden line-clamp-2 px-2 pb-1.5 text-label leading-4 text-[color:var(--color-text-quaternary)] [@media(hover:hover)]:group-hover:block">
           {doc.excerpt}
         </p>
       )}
@@ -491,10 +491,10 @@ export function DocsQuickDrawer({
             <header className="shrink-0 border-b border-[color:var(--color-border-soft)] px-5 py-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
                     {t("eyebrow")}
                   </p>
-                  <p className="mt-1 text-[13px] text-[color:var(--color-text-secondary)]">
+                  <p className="mt-1 text-body text-[color:var(--color-text-secondary)]">
                     {t("totalLine", { count: totalDocs })}
                   </p>
                 </div>
@@ -502,7 +502,7 @@ export function DocsQuickDrawer({
                   <Link
                     href={getDocHref()}
                     onClick={onClose}
-                    className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 py-1 text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]"
+                    className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-3 py-1 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]"
                     aria-label={t("openAllAriaLabel")}
                   >
                     <BookOpen size={11} />
@@ -543,7 +543,7 @@ export function DocsQuickDrawer({
                     flatTreeSlugs.length;
                   setFocusedSlug(flatTreeSlugs[nextIdx]);
                 }}
-                className="mt-3 flex items-center gap-2 rounded-[10px] border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-3 py-2 transition-[border-color,box-shadow] focus-within:border-[color:var(--color-indigo-a50)] focus-within:ring-2 focus-within:ring-[color:var(--color-indigo-a24)]"
+                className="mt-3 flex items-center gap-2 rounded-card border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-3 py-2 transition-[border-color,box-shadow] focus-within:border-[color:var(--color-indigo-a50)] focus-within:ring-2 focus-within:ring-[color:var(--color-indigo-a24)]"
               >
                 <Search size={13} className="text-[color:var(--color-text-quaternary)]" />
                 <input
@@ -554,7 +554,7 @@ export function DocsQuickDrawer({
                   placeholder={t("filterPlaceholder")}
                   name="docsQuickFilter"
                   autoComplete="off"
-                  className="flex-1 bg-transparent text-[13px] text-[color:var(--color-text-primary)] placeholder-[color:var(--color-text-quaternary)] outline-none"
+                  className="flex-1 bg-transparent text-body text-[color:var(--color-text-primary)] placeholder-[color:var(--color-text-quaternary)] outline-none"
                   aria-label={t("filterAriaLabel")}
                 />
                 {query ? (
@@ -579,7 +579,7 @@ export function DocsQuickDrawer({
                     <button
                       type="button"
                       onClick={() => setActiveTag(null)}
-                      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[10px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+                      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
                       aria-label={t("tagClearAriaLabel")}
                     >
                       <X size={10} />
@@ -597,7 +597,7 @@ export function DocsQuickDrawer({
                         }
                         aria-pressed={selected}
                         className={cn(
-                          "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-1 text-[10px] transition-colors",
+                          "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-1 text-caption transition-colors",
                           selected
                             ? "border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a16)] text-[color:var(--color-text-primary)]"
                             : "border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-a34)] hover:text-[color:var(--color-text-primary)]",
@@ -605,7 +605,7 @@ export function DocsQuickDrawer({
                       >
                         <Hash size={9} />
                         <span className="max-w-[96px] truncate">{tag}</span>
-                        <span className="font-mono text-[9px] text-[color:var(--color-text-quaternary)]">
+                        <span className="font-mono text-caption text-[color:var(--color-text-quaternary)]">
                           {count}
                         </span>
                       </button>
@@ -619,8 +619,8 @@ export function DocsQuickDrawer({
               {trimmedQuery || activeTag ? null : (
                 <>
                   {contextProject && relatedDocs.length > 0 && (
-                    <section className="mb-4 rounded-[12px] border border-[color:var(--color-indigo-a24)] bg-[color:var(--color-indigo-a06)] p-2">
-                      <p className="mb-1.5 flex items-center gap-1 px-1 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                    <section className="mb-4 rounded-panel border border-[color:var(--color-indigo-a24)] bg-[color:var(--color-indigo-a06)] p-2">
+                      <p className="mb-1.5 flex items-center gap-1 px-1 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
                         <Link2 size={10} />
                         {t("relatedSection", { name: contextProject.name, count: relatedDocs.length })}
                       </p>
@@ -630,12 +630,12 @@ export function DocsQuickDrawer({
                             key={`rel-${m.doc.slug}`}
                             href={getDocHref(m.doc.slug)}
                             onClick={onClose}
-                            className="group flex items-center gap-2 rounded-[8px] px-2 py-1.5 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-indigo-a14)] hover:text-[color:var(--color-text-primary)]"
+                            className="group flex items-center gap-2 rounded-card px-2 py-1.5 text-body text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-indigo-a14)] hover:text-[color:var(--color-text-primary)]"
                           >
                             <FileText size={13} className="shrink-0 text-[color:var(--color-text-quaternary)] group-hover:text-[color:var(--color-indigo-accent)]" />
                             <span className="truncate">{m.doc.title}</span>
                             <span
-                              className="ml-auto shrink-0 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]"
+                              className="ml-auto shrink-0 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]"
                               title={m.reasons.join(", ")}
                             >
                               {m.reasons[0]}
@@ -648,7 +648,7 @@ export function DocsQuickDrawer({
 
                   {pinnedDocs.length > 0 && (
                     <section className="mb-4">
-                      <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                      <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
                         <Star size={10} />
                         {t("pinnedSection", { count: pinnedDocs.length })}
                       </p>
@@ -669,7 +669,7 @@ export function DocsQuickDrawer({
 
                   {recentViewed.length > 0 && (
                     <section className="mb-4">
-                      <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                      <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                         <Clock size={10} />
                         {t("recentSection", { count: recentViewed.length })}
                       </p>
@@ -689,7 +689,7 @@ export function DocsQuickDrawer({
                   )}
 
                   <section className="mb-4">
-                    <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                    <p className="mb-1.5 flex items-center gap-1 px-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                       <Clock size={10} />
                       {t("modifiedSection", { count: modifiedDocs.length })}
                     </p>
@@ -711,7 +711,7 @@ export function DocsQuickDrawer({
               )}
 
               <section>
-                <p className="mb-1.5 px-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                <p className="mb-1.5 px-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                   {trimmedQuery
                     ? t("searchHeader", { query })
                     : activeTag
@@ -729,8 +729,8 @@ export function DocsQuickDrawer({
                     focusedSlug={focusedSlug}
                   />
                 ) : (
-                  <div className="rounded-[10px] border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-4 py-5 text-center">
-                    <p className="text-[12px] text-[color:var(--color-text-tertiary)]">
+                  <div className="rounded-card border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-4 py-5 text-center">
+                    <p className="text-body text-[color:var(--color-text-tertiary)]">
                       {trimmedQuery
                         ? t("emptySearch", { query })
                         : activeTag
@@ -746,7 +746,7 @@ export function DocsQuickDrawer({
                             setActiveTag(null);
                             searchRef.current?.focus();
                           }}
-                          className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] px-2.5 py-1 text-[11px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]"
+                          className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] px-2.5 py-1 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]"
                         >
                           {t("clearFilters")}
                         </button>
@@ -754,7 +754,7 @@ export function DocsQuickDrawer({
                       <Link
                         href={getDocHref()}
                         onClick={onClose}
-                        className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2.5 py-1 text-[11px] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a50)]"
+                        className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-indigo-a32)] bg-[color:var(--color-indigo-a10)] px-2.5 py-1 text-label text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a50)]"
                       >
                         <BookOpen size={11} />
                         {t("openVault")}
@@ -770,7 +770,7 @@ export function DocsQuickDrawer({
                 "shrink-0 border-t border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-5 py-2.5",
               )}
             >
-              <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 <kbd className="rounded border border-[color:var(--color-overlay-3)] px-1 py-0.5 tabular-nums">↑↓</kbd>
                 {" "}{t("footerMove")} ·{" "}
                 <kbd className="rounded border border-[color:var(--color-overlay-3)] px-1 py-0.5 tabular-nums">↵</kbd>

--- a/src/widgets/docs-vault/ui/DocsVaultBacklinks.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultBacklinks.tsx
@@ -40,7 +40,7 @@ export function DocsVaultBacklinks({
     return (
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
         {hideHeading ? null : (
-          <span className="flex-none font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <span className="flex-none font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {t('heading', { count: entries.length })}
           </span>
         )}
@@ -54,7 +54,7 @@ export function DocsVaultBacklinks({
               key={entry.fromSlug}
               type="button"
               onClick={() => onNavigate(doc.slug)}
-              className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
             >
               {kindStr && isTopologyV2RenderableKind(kindStr) ? (
                 <TopologyV2KindGlyph kind={kindStr} size={11} />
@@ -71,11 +71,11 @@ export function DocsVaultBacklinks({
   return (
     <section>
       {hideHeading ? null : (
-        <h3 className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+        <h3 className="mb-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t('heading', { count: entries.length })}
         </h3>
       )}
-      <ul className="flex flex-col gap-1.5 text-[12px]">
+      <ul className="flex flex-col gap-1.5 text-body">
         {entries.map((entry) => (
           <BacklinkItem
             key={entry.fromSlug}
@@ -130,7 +130,7 @@ function BacklinkItem({
       </div>
       {open ? (
         <p
-          className="mt-1 whitespace-normal rounded-sm bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-[11px] leading-[1.55] text-[color:var(--color-text-quaternary)]"
+          className="mt-1 whitespace-normal rounded-sm bg-[color:var(--color-overlay-1)] px-2 py-1.5 text-label leading-[1.55] text-[color:var(--color-text-quaternary)]"
           dangerouslySetInnerHTML={{
             __html: formatContext(entry.context),
           }}

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -421,16 +421,16 @@ export function DocsVaultEditor({
   if (!loading && error && content === null) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
-        <div className="text-[13px] text-[color:var(--color-text-tertiary)]">
+        <div className="text-body text-[color:var(--color-text-tertiary)]">
           {t('loadFailed')}
         </div>
-        <div className="font-mono text-[11px] text-[color:var(--color-text-quaternary)]">
+        <div className="font-mono text-label text-[color:var(--color-text-quaternary)]">
           {error}
         </div>
         <button
           type="button"
           onClick={requestClose}
-          className="mt-2 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+          className="mt-2 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
         >
           {t('close')}
         </button>
@@ -449,17 +449,17 @@ export function DocsVaultEditor({
   return (
     <div className="flex h-full flex-col">
       {/* 상단 액션 바 */}
-      <div className="flex flex-none items-center gap-2 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-4 py-2 text-[11.5px]">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+      <div className="flex flex-none items-center gap-2 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-4 py-2 text-label">
+        <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
           {t('editorEyebrow', { slug: doc.slug })}
         </span>
         <span
           className={
             saveState.tone === 'dirty'
-              ? "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-amber-docs-a25)] bg-[color:var(--color-amber-docs-a08)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-amber-docs-a95)]"
+              ? "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-amber-docs-a25)] bg-[color:var(--color-amber-docs-a08)] px-2 py-1 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-amber-docs-a95)]"
               : saveState.tone === 'saved'
-                ? "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a08)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-indigo-line-a90)]"
-                : "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)]"
+                ? "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a08)] px-2 py-1 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-indigo-line-a90)]"
+                : "inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)]"
           }
           aria-live="polite"
         >
@@ -470,7 +470,7 @@ export function DocsVaultEditor({
           </span>
         </span>
         <span
-          className="hidden min-w-0 items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[10.5px] text-[color:var(--color-text-tertiary)] lg:inline-flex"
+          className="hidden min-w-0 items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] lg:inline-flex"
           aria-label={t('saveContractAriaLabel')}
         >
           <Check size={11} className="text-[color:var(--color-text-quaternary)]" aria-hidden />
@@ -510,7 +510,7 @@ export function DocsVaultEditor({
           </span>
         </span>
         <span
-          className="hidden min-w-0 items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-[10.5px] text-[color:var(--color-text-tertiary)] 2xl:inline-flex"
+          className="hidden min-w-0 items-center gap-1.5 rounded-sm border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] 2xl:inline-flex"
           aria-label={t('saveWorkflowAriaLabel')}
         >
           <CheckSquare
@@ -557,7 +557,7 @@ export function DocsVaultEditor({
           <button
             type="button"
             onClick={() => setPreview((v) => !v)}
-            className={`inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${
+            className={`inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-label transition-colors ${
               preview
                 ? 'border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-a08)] text-[color:var(--color-indigo-pale-a92)]'
                 : 'border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]'
@@ -576,7 +576,7 @@ export function DocsVaultEditor({
             type="button"
             onClick={() => void doSave()}
             disabled={saving || !dirty}
-            className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a14)] px-2 py-1 text-[11px] text-[color:var(--color-indigo-pale-a95)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a14)] px-2 py-1 text-label text-[color:var(--color-indigo-pale-a95)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] disabled:cursor-not-allowed disabled:opacity-50"
             title={t('saveTooltip')}
           >
             {saving ? (
@@ -595,7 +595,7 @@ export function DocsVaultEditor({
             type="button"
             onClick={requestClose}
             disabled={saving}
-            className="inline-flex items-center gap-1 rounded-sm border border-transparent px-2 py-1 text-[11px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center gap-1 rounded-sm border border-transparent px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
             title={dirty ? t('closeUnsavedTooltip') : t('closeTooltip')}
           >
             <X size={11} aria-hidden />
@@ -605,7 +605,7 @@ export function DocsVaultEditor({
       </div>
       {error ? (
         <div
-          className="break-keep border-b border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-4 py-1.5 text-[11px] leading-4 text-[color:var(--color-danger-text-strong)]"
+          className="break-keep border-b border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-4 py-1.5 text-label leading-4 text-[color:var(--color-danger-text-strong)]"
           aria-live="polite"
         >
           {error}
@@ -738,11 +738,11 @@ export function DocsVaultEditor({
               });
             }}
             spellCheck={false}
-            className="absolute inset-0 resize-none bg-[color:var(--color-surface-deep-a40)] px-6 py-6 font-mono text-[13px] leading-[1.7] text-[color:rgba(220,226,240,0.92)] outline-none md:px-10"
+            className="absolute inset-0 resize-none bg-[color:var(--color-surface-deep-a40)] px-6 py-6 font-mono text-body leading-[1.7] text-[color:rgba(220,226,240,0.92)] outline-none md:px-10"
           />
           {autocomplete && acMatches.length > 0 ? (
             <div className="pointer-events-auto absolute bottom-3 left-3 z-10 w-[320px] overflow-hidden rounded-md border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-surface-deep-a98)] shadow-[0_10px_30px_var(--color-shadow-a50)]">
-              <div className="border-b border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <div className="border-b border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 {t('wikilinkLabel', { query: autocomplete.query })}
               </div>
               <ul className="max-h-[220px] overflow-auto py-0.5">
@@ -762,17 +762,17 @@ export function DocsVaultEditor({
                           : 'hover:bg-[color:var(--color-overlay-1)]'
                       }`}
                     >
-                      <span className="truncate text-[12px] text-[color:var(--color-text-primary)]">
+                      <span className="truncate text-body text-[color:var(--color-text-primary)]">
                         {d.title}
                       </span>
-                      <span className="ml-auto truncate font-mono text-[9.5px] text-[color:var(--color-text-quaternary)]">
+                      <span className="ml-auto truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
                         {d.slug}
                       </span>
                     </button>
                   </li>
                 ))}
               </ul>
-              <div className="border-t border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-[9.5px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <div className="border-t border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {t('wikilinkFooter')}
               </div>
             </div>
@@ -786,37 +786,37 @@ export function DocsVaultEditor({
                 components={{
                   h1: (props) => (
                     <h1
-                      className="mt-0 mb-4 text-[22px] font-semibold text-[color:var(--color-text-primary)]"
+                      className="mt-0 mb-4 text-display font-semibold text-[color:var(--color-text-primary)]"
                       {...props}
                     />
                   ),
                   h2: (props) => (
                     <h2
-                      className="mt-8 mb-2 text-[16px] font-semibold text-[color:var(--color-text-primary)]"
+                      className="mt-8 mb-2 text-title font-semibold text-[color:var(--color-text-primary)]"
                       {...props}
                     />
                   ),
                   h3: (props) => (
                     <h3
-                      className="mt-6 mb-2 text-[14px] font-semibold text-[color:var(--color-text-primary)]"
+                      className="mt-6 mb-2 text-body-lg font-semibold text-[color:var(--color-text-primary)]"
                       {...props}
                     />
                   ),
                   p: (props) => (
                     <p
-                      className="my-3 text-[13px] leading-[1.65] text-[color:var(--color-text-secondary)]"
+                      className="my-3 text-body leading-[1.65] text-[color:var(--color-text-secondary)]"
                       {...props}
                     />
                   ),
                   ul: (props) => (
                     <ul
-                      className="my-3 list-disc pl-6 text-[13px] leading-[1.7] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
+                      className="my-3 list-disc pl-6 text-body leading-[1.7] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
                       {...props}
                     />
                   ),
                   ol: (props) => (
                     <ol
-                      className="my-3 list-decimal pl-6 text-[13px] leading-[1.7] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
+                      className="my-3 list-decimal pl-6 text-body leading-[1.7] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
                       {...props}
                     />
                   ),
@@ -825,7 +825,7 @@ export function DocsVaultEditor({
                     if (!isBlock) {
                       return (
                         <code
-                          className="rounded-sm bg-[color:var(--color-indigo-line-a06)] px-1 py-0.5 font-mono text-[11.5px] text-[color:var(--color-indigo-pale-a95)]"
+                          className="rounded-sm bg-[color:var(--color-indigo-line-a06)] px-1 py-0.5 font-mono text-label text-[color:var(--color-indigo-pale-a95)]"
                           {...rest}
                         >
                           {children}
@@ -840,7 +840,7 @@ export function DocsVaultEditor({
                   },
                   pre: (props) => (
                     <pre
-                      className="my-3 overflow-x-auto rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-surface-deep-a80)] p-3 font-mono text-[12px] text-[color:var(--color-indigo-pale-a92)]"
+                      className="my-3 overflow-x-auto rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-surface-deep-a80)] p-3 font-mono text-body text-[color:var(--color-indigo-pale-a92)]"
                       {...props}
                     />
                   ),

--- a/src/widgets/docs-vault/ui/DocsVaultTree.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultTree.tsx
@@ -134,7 +134,7 @@ function TreeNode({
         type="button"
         onClick={() => onSelect(node.slug!)}
         aria-current={active ? 'page' : undefined}
-        className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-[12px] transition-[background-color,color,transform] duration-150 motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-inset ${
+        className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-[background-color,color,transform] duration-150 motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-inset ${
           active
             ? 'bg-[color:var(--color-indigo-a12)] text-[color:var(--color-text-primary)]'
             : 'text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]'
@@ -161,7 +161,7 @@ function TreeNode({
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[12px] font-medium text-[color:var(--color-text-quaternary)] transition-[background-color,color,transform] duration-150 motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
+        className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1 text-left text-body font-medium text-[color:var(--color-text-quaternary)] transition-[background-color,color,transform] duration-150 motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
         style={{ paddingLeft: `${16 + depth * 12}px` }}
       >
         {open ? (
@@ -174,7 +174,7 @@ function TreeNode({
         {docCount > 0 ? (
           <span
             data-token="engraved-numeral"
-            className="flex-none font-mono text-[10.5px] tabular-nums text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+            className="flex-none font-mono text-label tabular-nums text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
           >
             {docCount}
           </span>

--- a/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.tsx
@@ -478,7 +478,7 @@ export function DocsVaultUnifiedPalette({
             aria-activedescendant={
               rows.length > 0 ? paletteOptionId(activeIdx) : undefined
             }
-            className="min-w-0 flex-1 bg-transparent text-[13px] text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
+            className="min-w-0 flex-1 bg-transparent text-body text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           />
           <button
             type="button"
@@ -496,7 +496,7 @@ export function DocsVaultUnifiedPalette({
           role="listbox"
         >
           {rows.length === 0 ? (
-            <li className="px-3 py-8 text-center text-[12px] text-[color:var(--color-text-tertiary)]">
+            <li className="px-3 py-8 text-center text-body text-[color:var(--color-text-tertiary)]">
               {t('noMatches')}
             </li>
           ) : (
@@ -508,7 +508,7 @@ export function DocsVaultUnifiedPalette({
                   {sectionHeader ? (
                     <li
                       key={`h-${sectionHeader.title}`}
-                      className="mb-0.5 mt-1.5 flex items-center gap-1.5 px-3 pb-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]"
+                      className="mb-0.5 mt-1.5 flex items-center gap-1.5 px-3 pb-0.5 font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]"
                     >
                       {sectionHeader.icon}
                       {sectionHeader.title}
@@ -535,7 +535,7 @@ export function DocsVaultUnifiedPalette({
           )}
         </ul>
         <LiveAnnouncer message={resultAnnouncement} />
-        <div className="flex items-center gap-3 border-t border-[color:var(--color-overlay-2)] px-3 py-2 font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+        <div className="flex items-center gap-3 border-t border-[color:var(--color-overlay-2)] px-3 py-2 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
           <span>
             <kbd className="rounded border border-[color:var(--color-divider)] px-1">
               ↑↓
@@ -596,11 +596,11 @@ function ResultRow({
       <span className="flex h-5 w-5 flex-none items-center justify-center text-[color:var(--color-text-quaternary)]">
         {row.icon}
       </span>
-      <span className="flex-1 truncate text-[13px] text-[color:var(--color-text-primary)]">
+      <span className="flex-1 truncate text-body text-[color:var(--color-text-primary)]">
         {row.label}
       </span>
       {row.meta ? (
-        <span className="truncate font-mono text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+        <span className="truncate font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
           {row.meta}
         </span>
       ) : null}

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
@@ -287,7 +287,7 @@ export function DocsVaultViewer({
         return (
           <h2
             id={slug}
-            className="group relative mt-0 mb-6 text-[26px] font-semibold leading-tight text-[color:var(--color-text-primary)]"
+            className="group relative mt-0 mb-6 text-display font-semibold leading-tight text-[color:var(--color-text-primary)]"
             {...rest}
           >
             {highlightChildren(children, 'h1')}
@@ -300,7 +300,7 @@ export function DocsVaultViewer({
         return (
           <h2
             id={slug}
-            className="group relative mt-10 mb-3 text-[18px] font-semibold leading-tight text-[color:var(--color-text-primary)]"
+            className="group relative mt-10 mb-3 text-title font-semibold leading-tight text-[color:var(--color-text-primary)]"
             {...rest}
           >
             {highlightChildren(children, 'h2')}
@@ -313,7 +313,7 @@ export function DocsVaultViewer({
         return (
           <h3
             id={slug}
-            className="group relative mt-6 mb-2 text-[15px] font-semibold leading-tight text-[color:var(--color-text-primary)]"
+            className="group relative mt-6 mb-2 text-title font-semibold leading-tight text-[color:var(--color-text-primary)]"
             {...rest}
           >
             {highlightChildren(children, 'h3')}
@@ -324,7 +324,7 @@ export function DocsVaultViewer({
       p({ children, ...rest }) {
         return (
           <p
-            className="my-3 text-[14px] leading-[1.7] text-[color:var(--color-text-secondary)]"
+            className="my-3 text-body-lg leading-[1.7] text-[color:var(--color-text-secondary)]"
             {...rest}
           >
             {highlightChildren(children, 'p')}
@@ -334,7 +334,7 @@ export function DocsVaultViewer({
       ul(props) {
         return (
           <ul
-            className="my-3 list-disc pl-6 text-[14px] leading-[1.75] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
+            className="my-3 list-disc pl-6 text-body-lg leading-[1.75] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
             {...props}
           />
         );
@@ -342,7 +342,7 @@ export function DocsVaultViewer({
       ol(props) {
         return (
           <ol
-            className="my-3 list-decimal pl-6 text-[14px] leading-[1.75] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
+            className="my-3 list-decimal pl-6 text-body-lg leading-[1.75] text-[color:var(--color-text-secondary)] marker:text-[color:var(--color-text-quaternary)]"
             {...props}
           />
         );
@@ -359,7 +359,7 @@ export function DocsVaultViewer({
         if (!isBlock) {
           return (
             <code
-              className="rounded-sm bg-[color:var(--color-indigo-line-a06)] px-1 py-0.5 font-mono text-[11px] text-[color:var(--color-indigo-pale-a95)] md:text-[12px]"
+              className="rounded-sm bg-[color:var(--color-indigo-line-a06)] px-1 py-0.5 font-mono text-label text-[color:var(--color-indigo-pale-a95)] md:text-body"
               {...rest}
             >
               {children}
@@ -367,7 +367,7 @@ export function DocsVaultViewer({
           );
         }
         return (
-          <code className={`${className} font-mono text-[11px] md:text-[12.5px]`} {...rest}>
+          <code className={`${className} font-mono text-label md:text-body`} {...rest}>
             {children}
           </code>
         );
@@ -375,7 +375,7 @@ export function DocsVaultViewer({
       pre(props) {
         return (
           <pre
-            className="my-4 overflow-x-auto rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-surface-deep-a80)] p-3 font-mono text-[10.5px] leading-[1.55] text-[color:var(--color-indigo-pale-a92)] md:text-[12.5px]"
+            className="my-4 overflow-x-auto rounded-md border border-[color:var(--color-overlay-2)] bg-[color:var(--color-surface-deep-a80)] p-3 font-mono text-label leading-[1.55] text-[color:var(--color-indigo-pale-a92)] md:text-body"
             {...props}
           />
         );
@@ -406,7 +406,7 @@ export function DocsVaultViewer({
         return (
           <div className="my-4 overflow-x-auto">
             <table
-              className="w-full border-collapse text-[13px] text-[color:var(--color-text-secondary)]"
+              className="w-full border-collapse text-body text-[color:var(--color-text-secondary)]"
               {...props}
             />
           </div>
@@ -479,10 +479,10 @@ export function DocsVaultViewer({
   if (error) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
-        <div className="text-[13px] text-[color:var(--color-text-tertiary)]">
+        <div className="text-body text-[color:var(--color-text-tertiary)]">
           {t('loadFailed')}
         </div>
-        <div className="font-mono text-[11px] text-[color:var(--color-text-quaternary)]">
+        <div className="font-mono text-label text-[color:var(--color-text-quaternary)]">
           {error}
         </div>
       </div>
@@ -619,13 +619,13 @@ function CalloutBlock({
       style={{ borderLeftColor: s.border, backgroundColor: s.bg }}
     >
       <div
-        className="mb-1 flex items-center gap-1.5 text-[12px] font-semibold"
+        className="mb-1 flex items-center gap-1.5 text-body font-semibold"
         style={{ color: s.title }}
       >
         <span aria-hidden>{s.icon}</span>
         <span>{title}</span>
       </div>
-      <div className="text-[13px] leading-[1.65] text-[color:var(--color-text-secondary)]">
+      <div className="text-body leading-[1.65] text-[color:var(--color-text-secondary)]">
         {children}
       </div>
     </aside>
@@ -695,7 +695,7 @@ function VaultImage({
   if (error) {
     return (
       <span
-        className="my-3 inline-block rounded-sm border border-dashed border-[color:var(--color-amber-source-a50)] px-2 py-1 font-mono text-[10px] text-[color:var(--color-amber-source-text-a80)]"
+        className="my-3 inline-block rounded-sm border border-dashed border-[color:var(--color-amber-source-a50)] px-2 py-1 font-mono text-caption text-[color:var(--color-amber-source-text-a80)]"
         title={t('imageMissing', { src })}
       >
         🖼 {alt || src}

--- a/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
+++ b/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
@@ -148,7 +148,7 @@ export function FullDetailA1({
       data-fulldetail-node={node.id}
       className={["full-detail-a1 mx-auto flex max-w-[1240px] flex-col px-6 py-7", className ?? ""].join(" ")}
     >
-      <nav className="mb-6 flex items-center gap-2.5 text-[12px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+      <nav className="mb-6 flex items-center gap-2.5 text-body text-[color:var(--topology-v2-panel-text-tertiary)]">
         {onBackToMap ? (
           <button
             type="button"
@@ -171,7 +171,7 @@ export function FullDetailA1({
         </span>
         <span>{getKindLabel(node.kind)}</span>
         {breadcrumb?.totalConcepts != null && breadcrumb?.totalRelations != null ? (
-          <span className="ml-auto font-mono text-[11px] tracking-[0.08em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
+          <span className="ml-auto font-mono text-label tracking-[0.08em] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
             {t("census", {
               concepts: breadcrumb.totalConcepts,
               relations: breadcrumb.totalRelations,
@@ -185,10 +185,10 @@ export function FullDetailA1({
           <TopologyV2KindGlyph kind={node.kind} size={22} />
         </span>
         <div className="min-w-0 flex-1">
-          <h1 className="text-[24px] font-semibold tracking-[-0.015em] text-[color:var(--topology-v2-panel-text-primary)]">
+          <h1 className="text-display font-semibold tracking-[-0.015em] text-[color:var(--topology-v2-panel-text-primary)]">
             {node.title}
           </h1>
-          <div className="mt-1 flex items-center gap-2 text-[12.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+          <div className="mt-1 flex items-center gap-2 text-body text-[color:var(--topology-v2-panel-text-tertiary)]">
             <span
               aria-hidden="true"
               className="h-[6px] w-[6px] shrink-0 rounded-full"
@@ -204,7 +204,7 @@ export function FullDetailA1({
           </div>
         </div>
         <div className="mt-2.5 flex shrink-0 items-center gap-3">
-          <span className="font-mono text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+          <span className="font-mono text-label text-[color:var(--topology-v2-panel-text-quaternary)]">
             {node.slug}
           </span>
           <button
@@ -213,7 +213,7 @@ export function FullDetailA1({
             aria-label={t("copyLink")}
             title={t("copyLink")}
             data-testid="full-detail-a1-copy-link"
-            className="rounded-[5px] p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+            className="rounded-chip p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
           >
             <Link2 size={14} />
           </button>
@@ -222,7 +222,7 @@ export function FullDetailA1({
             onClick={onClose}
             aria-label={t("close")}
             data-testid="full-detail-a1-close"
-            className="rounded-[5px] p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+            className="rounded-chip p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
           >
             <X size={16} />
           </button>
@@ -231,7 +231,7 @@ export function FullDetailA1({
 
       <div
         data-fulldetail-metric="engraved"
-        className="mt-4.5 flex flex-wrap items-baseline gap-x-4.5 gap-y-1 rounded-[7px] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-metric-surface)] px-3.5 py-2.5 font-mono text-[12.5px] tracking-[0.01em] text-[color:var(--topology-v2-panel-metric-text)]"
+        className="mt-4.5 flex flex-wrap items-baseline gap-x-4.5 gap-y-1 rounded-chip border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-metric-surface)] px-3.5 py-2.5 font-mono text-body tracking-[0.01em] text-[color:var(--topology-v2-panel-metric-text)]"
       >
         {metricLine}
       </div>
@@ -275,26 +275,26 @@ export function FullDetailA1({
 
       <section
         data-fulldetail-handoff
-        className="mt-6.5 flex items-center gap-3.5 rounded-[9px] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] px-3.5 py-3"
+        className="mt-6.5 flex items-center gap-3.5 rounded-card border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] px-3.5 py-3"
       >
-        <span className="shrink-0 text-[12.5px] font-medium text-[color:var(--topology-v2-panel-text-primary)]">
+        <span className="shrink-0 text-body font-medium text-[color:var(--topology-v2-panel-text-primary)]">
           {t("handoff.label")}
         </span>
-        <span className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+        <span className="min-w-0 flex-1 truncate font-mono text-label text-[color:var(--topology-v2-panel-text-tertiary)]">
           {handoffChain}
         </span>
         <button
           type="button"
           onClick={handleCopyHandoff}
           data-testid="full-detail-a1-handoff-copy"
-          className="shrink-0 rounded-[6px] border border-[color:var(--topology-v2-indigo-border)] bg-[color:var(--topology-v2-panel-action-surface)] px-3 py-1.5 text-[12px] font-medium text-[color:var(--topology-v2-indigo-bright)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:border-[color:var(--topology-v2-indigo)]"
+          className="shrink-0 rounded-chip border border-[color:var(--topology-v2-indigo-border)] bg-[color:var(--topology-v2-panel-action-surface)] px-3 py-1.5 text-body font-medium text-[color:var(--topology-v2-indigo-bright)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:border-[color:var(--topology-v2-indigo)]"
         >
           {t("handoff.copy")}
         </button>
         {documentHref ? (
           <Link
             href={documentHref}
-            className="shrink-0 text-[12px] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+            className="shrink-0 text-body text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
           >
             {t("handoff.openDocument")}
           </Link>
@@ -302,7 +302,7 @@ export function FullDetailA1({
         <Link
           href={`/ontology/edit?node=${encodeURIComponent(node.slug)}`}
           data-testid="full-detail-a1-open-builder"
-          className="shrink-0 text-[12px] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+          className="shrink-0 text-body text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
         >
           {t("handoff.openBuilder")}
         </Link>
@@ -317,15 +317,15 @@ export function FullDetailA1({
           />
         ) : (
           <>
-            <h2 className="mb-2 text-[13px] font-medium text-[color:var(--topology-v2-panel-text-primary)]">
+            <h2 className="mb-2 text-body font-medium text-[color:var(--topology-v2-panel-text-primary)]">
               {t("body.title")}
             </h2>
             {bodyMarkdown && bodyMarkdown.trim().length > 0 ? (
-              <div className="prose prose-invert max-w-none text-[13.5px] leading-[1.7] text-[color:var(--topology-v2-panel-text-secondary)]">
+              <div className="prose prose-invert max-w-none text-body-lg leading-[1.7] text-[color:var(--topology-v2-panel-text-secondary)]">
                 <ReactMarkdown>{bodyMarkdown}</ReactMarkdown>
               </div>
             ) : (
-              <p className="text-[12.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+              <p className="text-body text-[color:var(--topology-v2-panel-text-tertiary)]">
                 {t("body.empty")}
               </p>
             )}

--- a/src/widgets/full-detail-a1/ui/full-detail-a1-groups-panel.tsx
+++ b/src/widgets/full-detail-a1/ui/full-detail-a1-groups-panel.tsx
@@ -42,7 +42,7 @@ function Row({
       type="button"
       onClick={() => onSelectNode(row.id)}
       data-fulldetail-row={row.id}
-      className="flex min-w-0 items-center gap-2 rounded-[5px] border border-transparent px-1.5 py-1 text-left text-[12.5px] text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:border-[color:var(--topology-v2-panel-text-quaternary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+      className="flex min-w-0 items-center gap-2 rounded-chip border border-transparent px-1.5 py-1 text-left text-body text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:border-[color:var(--topology-v2-panel-text-quaternary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
     >
       <TopologyV2TraceMark containment={row.containment} />
       <TopologyV2KindGlyph kind={row.kind} size={14} />
@@ -56,7 +56,7 @@ function Row({
         />
       ) : null}
       {row.childCount > 0 ? (
-        <span className="shrink-0 font-mono text-[11px] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
+        <span className="shrink-0 font-mono text-label text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
           {row.childCount}
         </span>
       ) : null}
@@ -88,24 +88,24 @@ function GroupCard({
   return (
     <section
       data-fulldetail-group={dataGroup}
-      className="rounded-[9px] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] p-3"
+      className="rounded-card border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] p-3"
     >
       <div className="mb-2 flex items-center gap-2">
-        <span className="text-[13px] font-medium tracking-[-0.01em] text-[color:var(--topology-v2-panel-text-primary)]">
+        <span className="text-body font-medium tracking-[-0.01em] text-[color:var(--topology-v2-panel-text-primary)]">
           {title}
         </span>
-        <span className="font-mono text-[9.5px] uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--topology-v2-panel-text-quaternary)]">
           {caption}
         </span>
         <span
           data-fulldetail-group-total={dataGroup}
-          className="ml-auto font-mono text-[12px] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+          className="ml-auto font-mono text-body text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
         >
           {total}
         </span>
       </div>
       {rows.length === 0 ? (
-        <p className="text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+        <p className="text-label text-[color:var(--topology-v2-panel-text-tertiary)]">
           {emptyLabel}
         </p>
       ) : (

--- a/src/widgets/full-detail-a1/ui/full-detail-a1-reach-panel.tsx
+++ b/src/widgets/full-detail-a1/ui/full-detail-a1-reach-panel.tsx
@@ -67,11 +67,11 @@ export function FullDetailA1ReachPanel({
 
   return (
     <section data-fulldetail-reach className={className}>
-      <p className="max-w-[760px] text-[14.5px] leading-[1.65] tracking-[-0.005em] text-[color:var(--topology-v2-panel-text-secondary)]">
+      <p className="max-w-[760px] text-body-lg leading-[1.65] tracking-[-0.005em] text-[color:var(--topology-v2-panel-text-secondary)]">
         {labels.leadIn}{" "}
         <span
           data-fulldetail-reach-steps
-          className="mx-1 inline-flex items-baseline gap-1.5 align-baseline font-mono text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+          className="mx-1 inline-flex items-baseline gap-1.5 align-baseline font-mono text-label text-[color:var(--topology-v2-panel-text-quaternary)]"
         >
           {STEPS.map((candidate) => (
             <button
@@ -81,6 +81,7 @@ export function FullDetailA1ReachPanel({
               data-active={candidate === step ? "true" : "false"}
               onClick={() => onChangeStep(candidate)}
               className={[
+                // eslint-disable-next-line no-restricted-syntax -- 작은 인라인 스텝 칩의 4px 반경은 chip(6px)로 올리면 pill 처럼 읽혀 램프 밖 예외 유지.
                 "rounded-[4px] border px-1 py-0.5 transition-colors",
                 candidate === step
                   ? "border-[color:var(--topology-v2-indigo-border)] text-[color:var(--topology-v2-indigo-bright)]"
@@ -92,7 +93,7 @@ export function FullDetailA1ReachPanel({
           ))}
         </span>{" "}
         {labels.stepUnit} {labels.afterSteps}{" "}
-        <span className="font-mono text-[13.5px] font-semibold text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
+        <span className="font-mono text-body-lg font-semibold text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]">
           {labels.ofTotal(atDepth.reachableCount, reach.totalNodes)}
         </span>
         {" — "}
@@ -131,7 +132,7 @@ function DomainBarRow({
     <>
       <span
         className={[
-          "truncate text-[12px]",
+          "truncate text-body",
           row.isSelf
             ? "text-[color:var(--topology-v2-panel-text-secondary)]"
             : "text-[color:var(--topology-v2-panel-text-tertiary)]",
@@ -139,8 +140,10 @@ function DomainBarRow({
       >
         {displayName}
       </span>
+      {/* eslint-disable-next-line no-restricted-syntax -- 3px 높이 게이지 트랙의 2px 헤어라인 반경은 chip(6px) 밖 예외. */}
       <span className="relative h-[3px] overflow-hidden rounded-[2px] bg-[color:var(--topology-v2-panel-border)]">
         <span
+          // eslint-disable-next-line no-restricted-syntax -- 위 게이지 트랙과 짝인 fill 의 2px 헤어라인 반경.
           className="absolute inset-y-0 left-0 rounded-[2px]"
           style={{
             width: `${widthPercent}%`,
@@ -150,7 +153,7 @@ function DomainBarRow({
           }}
         />
       </span>
-      <span className="text-right text-[11.5px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+      <span className="text-right text-label text-[color:var(--topology-v2-panel-text-tertiary)]">
         {row.count}
       </span>
     </>

--- a/src/widgets/gesture-hint/ui/GestureHint.tsx
+++ b/src/widgets/gesture-hint/ui/GestureHint.tsx
@@ -52,6 +52,7 @@ export function GestureHint({ disabled = false }: { disabled?: boolean }) {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 12 }}
           transition={MOTION.medium}
+          // eslint-disable-next-line no-restricted-syntax -- 모바일 제스처 힌트 시트(18px)는 overlay sheet 반경으로 panel(12px) 램프 밖 의도적 예외.
           className="pointer-events-auto fixed left-1/2 top-[calc(max(0.85rem,env(safe-area-inset-top))+4rem)] z-30 flex w-[min(320px,calc(100vw-2rem))] -translate-x-1/2 items-start gap-3 rounded-[18px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] px-3.5 py-3 shadow-[0_16px_40px_var(--color-shadow-a25)] md:hidden"
           role="status"
           aria-live="polite"
@@ -60,15 +61,15 @@ export function GestureHint({ disabled = false }: { disabled?: boolean }) {
             <Hand size={14} />
           </span>
           <div className="flex-1">
-            <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+            <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               {t("eyebrow")}
             </p>
-            <p className="mt-1 text-[12px] leading-[1.45] text-[color:var(--color-text-secondary)]">
+            <p className="mt-1 text-body leading-[1.45] text-[color:var(--color-text-secondary)]">
               {t("body")}
             </p>
             <div className="mt-2 flex items-center gap-1.5">
               <Pointer size={10} className="text-[color:var(--color-text-quaternary)]" />
-              <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {t("tapDetail")}
               </span>
             </div>

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -204,7 +204,7 @@ export function GlobalSearch({
             }
             className="flex-1 bg-transparent text-sm text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           />
-          <kbd className="hidden shrink-0 rounded border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--color-text-quaternary)] sm:inline-block">
+          <kbd className="hidden shrink-0 rounded border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-2)] px-1.5 py-0.5 font-mono text-caption text-[color:var(--color-text-quaternary)] sm:inline-block">
             ESC
           </kbd>
           <button
@@ -229,7 +229,7 @@ export function GlobalSearch({
         >
           <div className="flex items-center gap-2 overflow-x-auto">
             <span
-              className="shrink-0 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]"
+              className="shrink-0 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]"
               aria-hidden
             >
               {t('kindLabel')}
@@ -244,8 +244,8 @@ export function GlobalSearch({
                   aria-pressed={active}
                   className={
                     active
-                      ? "shrink-0 rounded-full border border-[color:var(--color-indigo-a50)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-indigo-accent)]"
-                      : "shrink-0 rounded-full border border-[color:var(--color-divider)] bg-transparent px-2 py-0.5 text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]"
+                      ? "shrink-0 rounded-full border border-[color:var(--color-indigo-a50)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 text-caption uppercase tracking-[0.10em] text-[color:var(--color-indigo-accent)]"
+                      : "shrink-0 rounded-full border border-[color:var(--color-divider)] bg-transparent px-2 py-0.5 text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]"
                   }
                 >
                   {kindLabel(kind)}
@@ -259,7 +259,7 @@ export function GlobalSearch({
                   setSelectedKinds(new Set());
                   setSelectedProjectIds(new Set());
                 }}
-                className="ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                className="ml-auto shrink-0 rounded-full px-2 py-0.5 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
               >
                 {t('clearFilter')}
               </button>
@@ -268,7 +268,7 @@ export function GlobalSearch({
           {projectChipSource.length > 0 ? (
             <div className="flex items-center gap-2">
               <span
-                className="shrink-0 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]"
+                className="shrink-0 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]"
                 aria-hidden
               >
                 {t('projectLabel', { count: projectChipSource.length })}
@@ -310,8 +310,8 @@ export function GlobalSearch({
                         }}
                         className={
                           active
-                            ? "rounded-full border border-[color:var(--color-indigo-a50)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 text-[10px] text-[color:var(--color-indigo-accent)] mr-1.5 whitespace-nowrap"
-                            : "rounded-full border border-[color:var(--color-divider)] bg-transparent px-2 py-0.5 text-[10px] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] mr-1.5 whitespace-nowrap"
+                            ? "rounded-full border border-[color:var(--color-indigo-a50)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 text-caption text-[color:var(--color-indigo-accent)] mr-1.5 whitespace-nowrap"
+                            : "rounded-full border border-[color:var(--color-divider)] bg-transparent px-2 py-0.5 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] mr-1.5 whitespace-nowrap"
                         }
                       >
                         {label}
@@ -338,7 +338,7 @@ export function GlobalSearch({
           {ontologyResults.length > 0 ? (
             <Command.Group
               heading={
-                <span className="px-2 pb-1 pt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                <span className="px-2 pb-1 pt-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                   {isEmptyQuery ? t('groupConceptRecent') : t('groupConceptMatch')} · {ontologyResults.length}
                   {isEmptyQuery && ontologySize > ontologyResults.length ? ` / ${ontologySize}` : ""}
                 </span>
@@ -367,7 +367,7 @@ export function GlobalSearch({
                     }}
                     className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-[color:var(--color-text-secondary)] aria-selected:bg-[color:var(--color-indigo-a14)] aria-selected:text-[color:var(--color-text-primary)]"
                   >
-                    <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
+                    <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-1.5 py-[1px] font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
                       {kindLabel(node.kind)}
                     </span>
                     <span
@@ -375,7 +375,7 @@ export function GlobalSearch({
                       className={cn(
                         "min-w-0 flex-1 truncate",
                         pathLike
-                          ? "font-mono text-[12.5px] text-[color:var(--color-text-quaternary)]"
+                          ? "font-mono text-body text-[color:var(--color-text-quaternary)]"
                           : "text-[color:var(--color-text-primary)]",
                       )}
                     >
@@ -395,7 +395,7 @@ export function GlobalSearch({
           {projects && projectResults.length > 0 && onSelectProject ? (
             <Command.Group
               heading={
-                <span className="px-2 pb-1 pt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                <span className="px-2 pb-1 pt-2 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                   {isEmptyQuery ? t('groupProjectRecent') : t('groupProjectMatch')} · {projectResults.length}
                   {isEmptyQuery && projectSize > projectResults.length ? ` / ${projectSize}` : ""}
                 </span>
@@ -411,16 +411,16 @@ export function GlobalSearch({
                   }}
                   className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-[color:var(--color-text-secondary)] aria-selected:bg-[color:var(--color-indigo-a14)] aria-selected:text-[color:var(--color-text-primary)]"
                 >
-                  <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-indigo-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 py-[1px] font-mono text-[9px] uppercase tracking-[0.10em] text-[color:rgba(159,170,235,0.95)]">
+                  <span className="inline-flex shrink-0 items-center rounded-full border border-[color:var(--color-indigo-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 py-[1px] font-mono text-caption uppercase tracking-[0.10em] text-[color:rgba(159,170,235,0.95)]">
                     {project.isHub ? t('hub') : t('project')}
                   </span>
                   <span className="min-w-0 flex-1 truncate text-[color:var(--color-text-primary)]">
                     {project.name}
                   </span>
-                  <span className="hidden shrink-0 font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)] md:inline">
+                  <span className="hidden shrink-0 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)] md:inline">
                     {project.slug}
                   </span>
-                  <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
+                  <span className="shrink-0 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
                     {project.status}
                   </span>
                 </Command.Item>
@@ -429,7 +429,7 @@ export function GlobalSearch({
           ) : null}
         </Command.List>
 
-        <div className="flex items-center justify-between gap-3 border-t border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
+        <div className="flex items-center justify-between gap-3 border-t border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-4 py-2 font-mono text-caption uppercase tracking-[0.10em] text-[color:var(--color-text-quaternary)]">
           <span>
             {isEmptyQuery
               ? t('indexed', { count: totalCorpus })

--- a/src/widgets/project-drawer/ui/ProjectDrawer.tsx
+++ b/src/widgets/project-drawer/ui/ProjectDrawer.tsx
@@ -380,24 +380,24 @@ export function ProjectDrawer({
             </div>
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
-                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
+                <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
                   {isContainerNode ? t("categoryProject") : categoryLabel(project.category)}
                 </span>
                 {containerLabel && !isContainerNode ? (
-                  <span className="rounded-full border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a12)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
+                  <span className="rounded-full border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a12)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
                     Project · {containerLabel}
                   </span>
                 ) : null}
                 {isContainerNode ? (
-                  <span className="rounded-full border border-[color:var(--color-amber-docs-a45)] bg-[color:var(--color-amber-docs-a12)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
+                  <span className="rounded-full border border-[color:var(--color-amber-docs-a45)] bg-[color:var(--color-amber-docs-a12)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-amber-docs-a95)]">
                     {t("containerBadge")}
                   </span>
                 ) : project.isHub ? (
-                  <span className="rounded-full border border-[color:rgba(113,112,255,0.5)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                  <span className="rounded-full border border-[color:rgba(113,112,255,0.5)] bg-[color:var(--color-indigo-a16)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
                     {t("hubBadge")}
                   </span>
                 ) : (
-                  <span className="rounded-full border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
+                  <span className="rounded-full border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-2)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)]">
                     {t("serviceBadge")}
                   </span>
                 )}
@@ -426,6 +426,7 @@ export function ProjectDrawer({
                 initial={{ opacity: 0, y: 8 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={MOTION.medium}
+                // eslint-disable-next-line no-restricted-syntax -- 드로어 히어로 카드(20px)는 overlay sheet 반경으로 panel(12px) 램프 밖 의도적 예외.
                 className="overflow-hidden rounded-[20px] border border-[color:var(--color-divider)] bg-[linear-gradient(180deg,var(--color-overlay-1)_0%,transparent_100%)]"
               >
               <div className="relative px-5 py-5">
@@ -456,11 +457,11 @@ export function ProjectDrawer({
                         Container 일 땐 eyebrow 라인 자체를 숨긴다. */}
                     {!isContainerNode && (
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                        <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                           {statusLabel(project.status)}
                         </span>
                         {project.progress !== undefined && (
-                          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                          <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                             {project.progress}%
                           </span>
                         )}
@@ -469,7 +470,7 @@ export function ProjectDrawer({
 
                     <h2
                       className={cn(
-                        "mt-2 text-[30px] leading-[1.04] tracking-[var(--tracking-section)] font-[var(--font-weight-signature)]",
+                        "mt-2 text-hero leading-[1.04] tracking-[var(--tracking-section)] font-[var(--font-weight-signature)]",
                         isContainerNode
                           ? "text-[color:var(--color-amber-docs-a95)]"
                           : project.isHub
@@ -491,7 +492,7 @@ export function ProjectDrawer({
                 <p
                   data-testid="project-drawer-meta"
                   id={`project-drawer-summary-${project.slug}`}
-                  className="mt-5 line-clamp-4 text-[15px] leading-7 text-[color:var(--color-text-secondary)]"
+                  className="mt-5 line-clamp-4 text-title leading-7 text-[color:var(--color-text-secondary)]"
                 >
                   {project.description}
                 </p>
@@ -586,7 +587,7 @@ export function ProjectDrawer({
                   className="mt-5 md:mt-6"
                 >
                   <div className="flex items-center justify-between gap-4">
-                    <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                    <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                       {t("connectionsTitle")}
                     </h3>
                   </div>
@@ -596,7 +597,7 @@ export function ProjectDrawer({
                     </p>
                     {relatedProjects.length > 0 && (
                       <div className="mt-4">
-                        <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                        <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                           {t("nextProjects")}
                         </p>
                         <div className="mt-2 flex flex-col items-start gap-2">
@@ -643,7 +644,7 @@ export function ProjectDrawer({
                       data-testid="project-drawer-integrity"
                       className="rounded-2xl border border-[color:var(--color-amber-source-a25)] bg-[color:var(--color-amber-source-a08)] px-4 py-3.5"
                     >
-                      <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-status-warning)]">
+                      <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-status-warning)]">
                         {t("integrityTitle")}
                       </h3>
                       <ul className="mt-2 space-y-1.5 text-xs leading-5 text-[color:var(--color-text-secondary)]">
@@ -655,7 +656,7 @@ export function ProjectDrawer({
                   )}
                   <section>
                     <div className="flex items-center justify-between gap-4">
-                      <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                      <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                         {t("basicInfo")}
                       </h3>
                       {impactInsight ? (
@@ -677,7 +678,7 @@ export function ProjectDrawer({
                       <div className="mt-3 grid gap-2 sm:grid-cols-2">
                         {completenessInsight ? (
                           <div className="rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3.5 py-3">
-                            <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("completeness")}
                             </p>
                             <p className="mt-1 text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
@@ -687,7 +688,7 @@ export function ProjectDrawer({
                         ) : null}
                         {freshnessInsight ? (
                           <div className="rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3.5 py-3">
-                            <p className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("freshness")}
                             </p>
                             <p className="mt-1 text-sm font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
@@ -715,7 +716,7 @@ export function ProjectDrawer({
                               aria-pressed={active}
                               aria-describedby="project-drawer-impact-help"
                               className={cn(
-                                "rounded-full border px-3 py-2 font-mono text-[9px] uppercase tracking-[0.08em] transition-colors",
+                                "rounded-full border px-3 py-2 font-mono text-caption uppercase tracking-[0.08em] transition-colors",
                                 active
                                   ? "border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a12)] text-[color:var(--color-text-primary)]"
                                   : "border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]",
@@ -740,20 +741,20 @@ export function ProjectDrawer({
 
                   {(project.tags.length > 0 || project.stack.length > 0) && (
                     <section>
-                      <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                      <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                         {t("tagsAndStack")}
                       </h3>
                       <div className="mt-3 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4">
                         {project.tags.length > 0 && (
                           <div>
-                            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("tags")}
                             </p>
                             <div className="mt-2 flex flex-wrap gap-1.5">
                               {project.tags.map((tag) => (
                                 <span
                                   key={`tag-${tag}`}
-                                  className="rounded-full border border-[color:var(--color-divider)] px-2.5 py-1 text-[10px] leading-none text-[color:var(--color-text-tertiary)]"
+                                  className="rounded-full border border-[color:var(--color-divider)] px-2.5 py-1 text-caption leading-none text-[color:var(--color-text-tertiary)]"
                                 >
                                   {tag}
                                 </span>
@@ -764,14 +765,14 @@ export function ProjectDrawer({
 
                         {project.stack.length > 0 && (
                           <div className={cn(project.tags.length > 0 && "mt-4")}>
-                            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("stack")}
                             </p>
                             <div className="mt-2 flex flex-wrap gap-1.5">
                               {project.stack.map((item) => (
                                 <span
                                   key={`stack-${item}`}
-                                  className="rounded-full bg-[color:var(--color-elevated)] px-2.5 py-1 font-mono text-[10px] leading-none text-[color:var(--color-text-secondary)]"
+                                  className="rounded-full bg-[color:var(--color-elevated)] px-2.5 py-1 font-mono text-caption leading-none text-[color:var(--color-text-secondary)]"
                                 >
                                   {item}
                                 </span>
@@ -787,14 +788,14 @@ export function ProjectDrawer({
                     referencedBy.length > 0 ||
                     missingDependencyIssues.length > 0) && (
                     <section>
-                      <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                      <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                         {t("connections")}
                       </h3>
                       <div className="mt-3 grid gap-3">
                         {(project.dependencies.length > 0 ||
                           missingDependencyIssues.length > 0) && (
                           <div className="rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4">
-                            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("dependsOn")}
                             </p>
                             <ul className="mt-3 flex flex-wrap gap-1.5">
@@ -806,7 +807,7 @@ export function ProjectDrawer({
                                       onClick={() => onSelectProject(item.project.slug)}
                                       className="inline-flex items-center gap-2 rounded-md border border-[color:var(--color-divider)] px-2.5 py-1 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:text-[color:var(--color-text-primary)]"
                                     >
-                                      <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                                      <span className="font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                                         {item.relationship.label}
                                       </span>
                                       <span>{item.project.name}</span>
@@ -830,7 +831,7 @@ export function ProjectDrawer({
 
                         {referencedBy.length > 0 && (
                           <div className="rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4">
-                            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("usedBy")}
                             </p>
                             <ul className="mt-3 flex flex-wrap gap-1.5">
@@ -840,7 +841,7 @@ export function ProjectDrawer({
                                     onClick={() => onSelectProject(item.project.slug)}
                                     className="inline-flex items-center gap-2 rounded-md border border-[color:var(--color-divider)] px-2.5 py-1 text-xs text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:text-[color:var(--color-text-primary)]"
                                   >
-                                    <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                                    <span className="font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                                       {item.relationship.label}
                                     </span>
                                     <span>{item.project.name}</span>
@@ -852,7 +853,7 @@ export function ProjectDrawer({
                         )}
                         {relatedDocs.length > 0 && (
                           <div className="rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4">
-                            <p className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               <BookOpen size={11} aria-hidden />
                               {t("relatedDocs", { count: relatedDocs.length })}
                             </p>
@@ -863,21 +864,21 @@ export function ProjectDrawer({
                                   <li key={m.doc.slug}>
                                     <Link
                                       href={buildDocsVaultHref({ slug: m.doc.slug })}
-                                      className="group flex flex-col gap-1 rounded-md border border-transparent px-2 py-1 text-left text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+                                      className="group flex flex-col gap-1 rounded-md border border-transparent px-2 py-1 text-left text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
                                     >
                                       <span className="flex items-center gap-2">
                                         <span className="flex-1 truncate">
                                           {m.doc.title}
                                         </span>
                                         <span
-                                          className="font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]"
+                                          className="font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]"
                                           title={m.reasons.join(', ')}
                                         >
                                           {m.reasons[0]}
                                         </span>
                                       </span>
                                       {hasExcerpt && (
-                                        <p className="hidden line-clamp-2 text-[11px] leading-4 text-[color:var(--color-text-quaternary)] [@media(hover:hover)]:group-hover:block">
+                                        <p className="hidden line-clamp-2 text-label leading-4 text-[color:var(--color-text-quaternary)] [@media(hover:hover)]:group-hover:block">
                                           {m.doc.excerpt}
                                         </p>
                                       )}
@@ -903,7 +904,7 @@ export function ProjectDrawer({
                       <div className="mt-4 space-y-5 border-t border-[color:var(--color-border-soft)] pt-4">
                         {project.screenshots[0] && (
                           <section>
-                            <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("screenshotsTitle")}
                             </h3>
                             <div className="mt-3 overflow-hidden rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)]">
@@ -922,7 +923,7 @@ export function ProjectDrawer({
 
                         {(project.timeline?.startedAt || project.timeline?.launchedAt) && (
                           <section>
-                            <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("timelineTitle")}
                             </h3>
                             <dl className="mt-3 space-y-2 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4 text-sm text-[color:var(--color-text-secondary)]">
@@ -952,7 +953,7 @@ export function ProjectDrawer({
 
                         {project.links.length > 0 && (
                           <section>
-                            <h3 className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                            <h3 className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                               {t("linksTitle")}
                             </h3>
                             <ul className="mt-3 space-y-2 rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-4">
@@ -988,7 +989,7 @@ export function ProjectDrawer({
               </div>
 
               <footer className="mt-6 border-t border-[color:var(--color-overlay-2)] pt-4 md:mt-8">
-                <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                   {t("footerUpdated", { slug: project.slug, date: formatDate(project.updatedAt) })}
                 </p>
               </footer>

--- a/src/widgets/public-quick-actions/ui/PublicQuickActions.tsx
+++ b/src/widgets/public-quick-actions/ui/PublicQuickActions.tsx
@@ -54,12 +54,13 @@ export function PublicQuickActions({
     <section
       aria-label={label ?? t("sectionAriaDefault")}
       className={cn(
+        // eslint-disable-next-line no-restricted-syntax -- 퀵액션 시트(18px)는 overlay sheet 반경으로 panel(12px) 램프 밖 의도적 예외.
         "rounded-[18px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] px-3 py-3 shadow-[0_22px_44px_var(--color-shadow-a22)]",
         className,
       )}
     >
       <div className="mb-3 flex items-center justify-between gap-3">
-        <p className="text-[11px] text-[color:var(--color-text-quaternary)]">
+        <p className="text-label text-[color:var(--color-text-quaternary)]">
           {t("sectionTitle")}
         </p>
         <InfoHint label={t("infoHintLabel")}>

--- a/src/widgets/search-palette/ui/SearchPalette.tsx
+++ b/src/widgets/search-palette/ui/SearchPalette.tsx
@@ -331,6 +331,7 @@ function SearchPaletteDialog({
         aria-modal="true"
         aria-labelledby="search-palette-title"
         aria-describedby="search-palette-help"
+        // eslint-disable-next-line no-restricted-syntax -- 검색 팔레트 floating 카드(22px)는 overlay sheet 반경으로 panel(12px) 램프 밖 의도적 예외.
         className="relative flex h-full w-full flex-col overflow-hidden border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] shadow-2xl md:h-auto md:max-w-xl md:rounded-[22px]"
       >
         <div className="flex items-center gap-3 border-b border-[color:var(--color-overlay-2)] px-4 py-3">
@@ -357,9 +358,9 @@ function SearchPaletteDialog({
                   ? `search-result-project-${activeRow.result.project.slug}`
                   : undefined
             }
-            className="flex-1 bg-transparent text-[15px] text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
+            className="flex-1 bg-transparent text-title text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           />
-          <kbd className="hidden rounded border border-[color:var(--color-divider)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-[color:var(--color-text-quaternary)] sm:inline-block">
+          <kbd className="hidden rounded border border-[color:var(--color-divider)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-wider text-[color:var(--color-text-quaternary)] sm:inline-block">
             ESC
           </kbd>
           <button
@@ -376,19 +377,19 @@ function SearchPaletteDialog({
           <div className="flex items-center gap-2">
             <p
               id="search-palette-title"
-              className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]"
+              className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]"
             >
               {query.trim() ? t('headingResults') : t('headingRecent')}
             </p>
             {containerLabel ? (
-              <span className="rounded-full border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a12)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
+              <span className="rounded-full border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a12)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-line-a90)]">
                 {t('containerBadge', { name: containerLabel })}
               </span>
             ) : null}
           </div>
           <span
             aria-live="polite"
-            className="font-mono text-[9px] uppercase tracking-[0.12em] tabular-nums text-[color:var(--color-text-quaternary)]"
+            className="font-mono text-caption uppercase tracking-[0.12em] tabular-nums text-[color:var(--color-text-quaternary)]"
           >
             {t('rowsCount', { count: rows.length })}
           </span>
@@ -412,7 +413,7 @@ function SearchPaletteDialog({
                   setLayerFilter(option.value);
                   setActiveIndex(0);
                 }}
-                className={`rounded-full border px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] ${
+                className={`rounded-full border px-2.5 py-1 font-mono text-caption uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] ${
                   active
                     ? 'border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] text-[color:var(--color-indigo-line-a90)]'
                     : 'border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]'
@@ -425,7 +426,7 @@ function SearchPaletteDialog({
         </div>
         {!query.trim() && recentProjects.length > 0 ? (
           <div className="border-b border-[color:var(--color-overlay-2)] px-4 py-2.5">
-            <p className="mb-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+            <p className="mb-2 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
               {t('recentSection')}
             </p>
             <div className="flex flex-wrap gap-1.5">
@@ -438,7 +439,7 @@ function SearchPaletteDialog({
                     onSelect(p.slug);
                     onClose();
                   }}
-                  className="rounded-full border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a08)] px-2.5 py-1 text-[11px] text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a16)]"
+                  className="rounded-full border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-a08)] px-2.5 py-1 text-label text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a16)]"
                 >
                   {p.name}
                 </button>
@@ -470,7 +471,7 @@ function SearchPaletteDialog({
         >
           {docResults.length > 0 ? (
             <div className="border-b border-[color:var(--color-overlay-2)] px-3 py-2">
-              <div className="mb-1 flex items-center gap-1.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <div className="mb-1 flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 <BookOpen size={10} aria-hidden />
                 {t('docsSection', { count: docResults.length })}
               </div>
@@ -488,7 +489,7 @@ function SearchPaletteDialog({
                         onClick={onClose}
                         onMouseEnter={() => setActiveIndex(idx)}
                         className={cn(
-                          "flex items-center gap-2 rounded-sm px-2 py-1 text-left text-[12px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
+                          "flex items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
                           isActive
                             ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
                             : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]",
@@ -500,7 +501,7 @@ function SearchPaletteDialog({
                           className="shrink-0 text-[color:var(--color-indigo-accent)]"
                         />
                         <span className="min-w-0 flex-1 truncate">{d.title}</span>
-                        <span className="min-w-0 truncate font-mono text-[9.5px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                        <span className="min-w-0 truncate font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                           {d.slug}
                         </span>
                       </Link>
@@ -522,7 +523,7 @@ function SearchPaletteDialog({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="mt-4 rounded-full border border-[color:var(--color-overlay-3)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+                  className="mt-4 rounded-full border border-[color:var(--color-overlay-3)] px-3 py-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
                 >
                   {t('emptyClose')}
                 </button>
@@ -546,7 +547,7 @@ function SearchPaletteDialog({
                     setLayerFilter('all');
                     setActiveIndex(0);
                   }}
-                  className="mt-4 rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+                  className="mt-4 rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-3 py-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
                 >
                   {t('emptyLayerReset')}
                 </button>
@@ -560,7 +561,7 @@ function SearchPaletteDialog({
                 <button
                   type="button"
                   onClick={() => setQuery('')}
-                  className="mt-4 rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+                  className="mt-4 rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-3 py-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-line-a90)] transition-colors hover:bg-[color:var(--color-indigo-a18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
                 >
                   {t('emptyNoMatchClear')}
                 </button>
@@ -612,7 +613,7 @@ function SearchPaletteDialog({
                             {highlightMatch(r.project.name, query)}
                           </span>
                           {r.project.isHub ? (
-                            <span className="rounded-full bg-[color:var(--color-indigo-brand)] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]">
+                            <span className="rounded-full bg-[color:var(--color-indigo-brand)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-primary)]">
                               {t('hub')}
                             </span>
                           ) : null}
@@ -621,24 +622,24 @@ function SearchPaletteDialog({
                           {r.project.description}
                         </p>
                         <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                             {categoryLabel(r.project.category)}
                           </span>
-                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                          <span className="rounded-full border border-[color:var(--color-divider)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                             {statusLabel(r.project.status)}
                           </span>
                           {query.trim() && (
-                            <span className="rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)]">
+                            <span className="rounded-full border border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a08)] px-2 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-indigo-accent)]">
                               {t(MATCH_FIELD_KEYS[r.matchedField])}
                             </span>
                           )}
                         </div>
                       </div>
                       <div className="hidden shrink-0 self-center text-right sm:block">
-                        <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+                        <div className="font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
                           {String(rowIndex + 1).padStart(2, '0')}
                         </div>
-                        <div className="mt-1 font-mono text-[8px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                        <div className="mt-1 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                           {r.project.slug}
                         </div>
                       </div>
@@ -650,7 +651,7 @@ function SearchPaletteDialog({
           )}
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[color:var(--color-overlay-2)] bg-[color:var(--color-elevated)] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[color:var(--color-overlay-2)] bg-[color:var(--color-elevated)] px-4 py-2 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
           <div className="flex flex-wrap items-center gap-3">
             <span>
               <kbd>↑↓</kbd> {t('shortcutMove')}

--- a/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
+++ b/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
@@ -219,10 +219,10 @@ export function ShortcutSheet({ open, onClose }: Props) {
           >
             <header className="flex shrink-0 items-center justify-between border-b border-[color:var(--color-border-soft)] px-5 py-4">
               <div>
-                <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
                   {t("title")}
                 </p>
-                <p className="mt-1 text-[13px] text-[color:var(--color-text-secondary)]">
+                <p className="mt-1 text-body text-[color:var(--color-text-secondary)]">
                   {t("subtitle")}
                 </p>
                 <p id="shortcut-sheet-help" className="sr-only">
@@ -255,7 +255,7 @@ export function ShortcutSheet({ open, onClose }: Props) {
                         : "px-5 py-4"
                     }
                   >
-                    <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+                    <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                       {t(`sections.${section.titleKey}`)}
                     </p>
                     <dl className="mt-3 space-y-2.5">
@@ -267,14 +267,14 @@ export function ShortcutSheet({ open, onClose }: Props) {
                           key={`${section.titleKey}-${rowIdx}-${row.labelKey}`}
                           className="flex items-center justify-between gap-4"
                         >
-                          <dt className="text-[13px] text-[color:var(--color-text-secondary)]">
+                          <dt className="text-body text-[color:var(--color-text-secondary)]">
                             {t(`rows.${row.labelKey}`)}
                           </dt>
                           <dd className="flex shrink-0 items-center gap-1">
                             {row.keys.map((key, i) => (
                               <kbd
                                 key={`${row.labelKey}-${i}`}
-                                className="inline-flex h-6 min-w-[24px] items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-1.5 font-mono text-[11px] tabular-nums text-[color:var(--color-text-secondary)]"
+                                className="inline-flex h-6 min-w-[24px] items-center justify-center rounded-md border border-[color:var(--color-overlay-3)] bg-[color:var(--color-elevated)] px-1.5 font-mono text-label tabular-nums text-[color:var(--color-text-secondary)]"
                               >
                                 {typeof key === "string" ? key : t(`keys.${key.i18nKey}`)}
                               </kbd>
@@ -289,12 +289,12 @@ export function ShortcutSheet({ open, onClose }: Props) {
             </div>
 
             <footer className="shrink-0 border-t border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-5 py-3">
-              <p className="font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 {t("glossary.title")}
               </p>
               <dl className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
                 {GLOSSARY_TERMS.map((term) => (
-                  <div key={term} className="flex items-baseline gap-1.5 text-[12px]">
+                  <div key={term} className="flex items-baseline gap-1.5 text-body">
                     <dt className="shrink-0 font-medium text-[color:var(--color-text-secondary)]">
                       {t(`glossary.${term}Term`)}
                     </dt>
@@ -304,7 +304,7 @@ export function ShortcutSheet({ open, onClose }: Props) {
                   </div>
                 ))}
               </dl>
-              <p className="mt-2.5 font-mono text-[9px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+              <p className="mt-2.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                 <kbd className="rounded border border-[color:var(--color-overlay-3)] px-1 py-0.5 tabular-nums">
                   ?
                 </kbd>{" "}

--- a/src/widgets/topology-controls/ui/HubRail.tsx
+++ b/src/widgets/topology-controls/ui/HubRail.tsx
@@ -128,7 +128,7 @@ export function HubRail({
       className="pointer-events-auto absolute bottom-[212px] left-4 top-[140px] z-10 hidden max-h-[calc(100vh-352px)] w-[180px] flex-col gap-1 overflow-auto rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2 py-2 md:left-6 md:flex xl:left-8"
     >
       <div className="flex items-center justify-between px-1 pb-1">
-        <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-quaternary)]">
           {railLabel} · {hubs.length}
         </span>
         <Tooltip content={t('collapseTooltip')} side="right" withProvider={false}>
@@ -179,7 +179,7 @@ export function HubRail({
               }
             }}
             title={t('itemTitle', { name: hub.name, degree })}
-            className={`relative flex items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[11px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-strong)] focus-visible:ring-inset ${
+            className={`relative flex items-center gap-2 rounded-sm px-2 py-1.5 text-left text-label transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-strong)] focus-visible:ring-inset ${
               active
                 ? 'bg-[color:var(--color-overlay-2)] text-[color:var(--color-text-primary)]'
                 : 'text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]'
@@ -198,7 +198,7 @@ export function HubRail({
             />
             <span className="flex-1 truncate">{shortenName(hub.name)}</span>
             <span
-              className={`shrink-0 font-mono text-[9px] tabular-nums tracking-[0.04em] ${
+              className={`shrink-0 font-mono text-caption tabular-nums tracking-[0.04em] ${
                 active
                   ? 'text-[color:var(--color-text-secondary)]'
                   : 'text-[color:var(--color-text-quaternary)]'

--- a/src/widgets/topology-controls/ui/TopologyEmptyState.tsx
+++ b/src/widgets/topology-controls/ui/TopologyEmptyState.tsx
@@ -57,17 +57,17 @@ export function TopologyEmptyState({
         aria-label={isNoProjects ? t('titleNoProjects') : t('titleNoDeps')}
         aria-live="polite"
       >
-        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
+        <p className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--color-text-quaternary)]">
           {kicker}
         </p>
-        <h2 className="mt-2 text-[16px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+        <h2 className="mt-2 text-title font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {hasDocsToBootstrap
             ? t('titleDocsFound')
             : isNoProjects
               ? t('titleNoProjects')
               : t('titleNoDeps')}
         </h2>
-        <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--color-text-tertiary)]">
+        <p className="mt-2 text-body leading-relaxed text-[color:var(--color-text-tertiary)]">
           {hasDocsToBootstrap
             ? t('bodyDocsFound', { count: docsFoundCount })
             : isNoProjects
@@ -78,7 +78,7 @@ export function TopologyEmptyState({
                 )
               : t('bodyNoDeps')}
         </p>
-        <p className="mt-3 text-[11px] leading-relaxed text-[color:var(--color-text-tertiary)]">
+        <p className="mt-3 text-label leading-relaxed text-[color:var(--color-text-tertiary)]">
           {t('crossViewHint')}
         </p>
         <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:flex-wrap sm:justify-center">
@@ -87,7 +87,7 @@ export function TopologyEmptyState({
               type="button"
               onClick={onStartFromDocs}
               data-testid="empty-start-from-docs"
-              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
             >
               <MapIcon size={14} aria-hidden="true" />
               {t('ctaStartFromDocs')}
@@ -98,7 +98,7 @@ export function TopologyEmptyState({
               type="button"
               onClick={onCreateNode}
               data-testid="empty-create-node"
-              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a16)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] transition-colors hover:bg-[color:var(--color-indigo-a24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
             >
               <Plus size={14} aria-hidden="true" />
               {t('ctaCreateNode')}
@@ -106,14 +106,14 @@ export function TopologyEmptyState({
           ) : null}
           <Link
             href="/ontology/"
-            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a40)] bg-[color:var(--color-indigo-a14)] px-4 text-[12px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a60)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-indigo-a40)] bg-[color:var(--color-indigo-a14)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-a60)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
           >
             <Network size={14} aria-hidden="true" />
             {t('ctaTree')}
           </Link>
           <Link
             href="/ontology/edit/"
-            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
           >
             <GitBranch size={14} aria-hidden="true" />
             {t(isNoProjects ? 'ctaBuilder' : 'ctaBuilderNoDeps')}
@@ -121,7 +121,7 @@ export function TopologyEmptyState({
           {hasDocsToBootstrap ? null : (
           <Link
             href={isDesktopRuntime ? "/docs/?intent=local" : "/download/"}
-            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-[12px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+            className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-overlay-3)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
           >
             <FolderOpen size={14} aria-hidden="true" />
             {t(

--- a/src/widgets/topology-index-panel/ui/TopologyIndexAgentHandoff.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexAgentHandoff.tsx
@@ -75,7 +75,7 @@ export function TopologyIndexAgentHandoff({
       <summary
         aria-label={labels.menuAria}
         data-testid="topology-index-agent-handoff-summary"
-        className="inline-flex min-h-[26px] cursor-pointer list-none items-center gap-1 rounded border border-[color:var(--topology-v2-panel-border)] px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:border-[color:var(--topology-v2-panel-action-border)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+        className="inline-flex min-h-[26px] cursor-pointer list-none items-center gap-1 rounded border border-[color:var(--topology-v2-panel-border)] px-1.5 py-0.5 font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:border-[color:var(--topology-v2-panel-action-border)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
       >
         {labels.menuLabel}
         <ChevronUp

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -225,7 +225,7 @@ export function TopologyIndexPanel({
         data-testid="topology-index-fold"
         className="group mb-3 flex w-full cursor-pointer items-center gap-1.5 rounded-[var(--chrome-radius-inner)] px-0.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
       >
-        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
+        <span className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
           {labels.label}
         </span>
         {/* 수렴 판정 ①: 시각 카운트 "· N" 삭제 — 지형도 HUD 가 이미 라벨과
@@ -271,7 +271,7 @@ export function TopologyIndexPanel({
           placeholder={labels.searchPlaceholder}
           autoComplete="off"
           data-testid="topology-index-search"
-          className="w-full rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-canvas)] py-1.5 pl-7 pr-2.5 text-[12px] text-[color:var(--topology-v2-panel-text-primary)] outline-none transition-colors placeholder:text-[color:var(--topology-v2-panel-text-quaternary)] focus:border-[color:var(--topology-v2-indigo)]"
+          className="w-full rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-canvas)] py-1.5 pl-7 pr-2.5 text-body text-[color:var(--topology-v2-panel-text-primary)] outline-none transition-colors placeholder:text-[color:var(--topology-v2-panel-text-quaternary)] focus:border-[color:var(--topology-v2-indigo)]"
         />
       </div>
 
@@ -290,7 +290,7 @@ export function TopologyIndexPanel({
             aria-selected={!lensActive}
             data-testid="topology-index-segment-all"
             onClick={() => setLens("all")}
-            className={`min-w-0 rounded-[var(--chrome-radius-inner)] px-2 py-1 text-[11px] transition-colors ${
+            className={`min-w-0 rounded-[var(--chrome-radius-inner)] px-2 py-1 text-label transition-colors ${
               !lensActive
                 ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--topology-v2-panel-text-primary)]"
                 : "text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
@@ -304,7 +304,7 @@ export function TopologyIndexPanel({
             aria-selected={lensActive}
             data-testid="topology-index-segment-recent"
             onClick={() => setLens("recent")}
-            className={`min-w-0 truncate rounded-[var(--chrome-radius-inner)] px-2 py-1 text-[11px] transition-colors ${
+            className={`min-w-0 truncate rounded-[var(--chrome-radius-inner)] px-2 py-1 text-label transition-colors ${
               lensActive
                 ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--topology-v2-panel-text-primary)]"
                 : "text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
@@ -330,7 +330,7 @@ export function TopologyIndexPanel({
         }}
       >
         {visibleRoots.length === 0 ? (
-          <p className="px-1 py-2 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+          <p className="px-1 py-2 text-label text-[color:var(--topology-v2-panel-text-quaternary)]">
             {lensActive ? labels.recentEmptyHint : labels.emptyHint}
           </p>
         ) : (
@@ -362,7 +362,7 @@ export function TopologyIndexPanel({
           type="button"
           onClick={onPromoteUncatalogedDocs}
           data-testid="topology-index-uncataloged-docs"
-          className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+          className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-label transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
         >
           <span className="min-w-0 flex-1 truncate text-[color:var(--topology-v2-panel-text-tertiary)]">
             {labels.uncatalogedDocsLabel}
@@ -378,7 +378,7 @@ export function TopologyIndexPanel({
           hotkey — 여기선 재확인용 표기, 별도 바인딩 아님). */}
       <div
         data-testid="topology-index-footer"
-        className="mt-2.5 flex shrink-0 items-center gap-1.5 border-t border-[color:var(--topology-v2-panel-divider)] px-1 pt-2.5 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+        className="mt-2.5 flex shrink-0 items-center gap-1.5 border-t border-[color:var(--topology-v2-panel-divider)] px-1 pt-2.5 text-label text-[color:var(--topology-v2-panel-text-quaternary)]"
       >
         {/* P4-② — 연결된 상태(agentActivityHref 제공)면 활동 다이제스트로
             딥링크, 아니면 기존처럼 등록 시트를 여는 버튼. */}
@@ -425,7 +425,7 @@ export function TopologyIndexPanel({
           ) : null}
           <span
             aria-hidden="true"
-            className="shrink-0 rounded border border-[color:var(--topology-v2-panel-border)] px-1 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--topology-v2-panel-text-quaternary)]"
+            className="shrink-0 rounded border border-[color:var(--topology-v2-panel-border)] px-1 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--topology-v2-panel-text-quaternary)]"
           >
             ⇧⌘K
           </span>

--- a/src/widgets/topology-index-panel/ui/TopologyIndexTab.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexTab.tsx
@@ -34,7 +34,7 @@ export function TopologyIndexTab({ onExpand, labels, className }: TopologyIndexT
         className="h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--topology-v2-panel-power-on)]"
       />
       <span
-        className="font-mono text-[9.5px] uppercase tracking-[0.18em] text-[color:var(--topology-v2-panel-text-tertiary)]"
+        className="font-mono text-caption uppercase tracking-[0.18em] text-[color:var(--topology-v2-panel-text-tertiary)]"
         style={{ writingMode: "vertical-rl" }}
       >
         Index

--- a/src/widgets/topology-index-panel/ui/TopologyIndexTreeRow.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexTreeRow.tsx
@@ -122,7 +122,7 @@ export function TopologyIndexTreeRow({
         onClick={() => onSelect(node.id)}
         onKeyDown={handleRowKeyDown}
         style={{ marginLeft: depth * 16 }}
-        className={`grid min-h-[34px] grid-cols-[14px_15px_1fr_auto] items-center gap-x-2 rounded-md border px-2 py-1 text-[12.5px] transition-colors ${
+        className={`grid min-h-[34px] grid-cols-[14px_15px_1fr_auto] items-center gap-x-2 rounded-md border px-2 py-1 text-body transition-colors ${
           selected
             ? "border-[color:var(--color-indigo-a55)] bg-[color:var(--topology-v2-panel-metric-surface)] text-[color:var(--topology-v2-panel-text-primary)]"
             : "border-transparent text-[color:var(--topology-v2-panel-text-secondary)] hover:border-[color:var(--topology-v2-panel-action-border)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
@@ -155,7 +155,7 @@ export function TopologyIndexTreeRow({
             {agentAttributed && labels.agentBadge ? (
               <span
                 data-testid="topology-index-agent-badge"
-                className="shrink-0 font-mono text-[9px] uppercase tracking-[0.06em] text-[color:var(--topology-v2-panel-text-tertiary)]"
+                className="shrink-0 font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--topology-v2-panel-text-tertiary)]"
               >
                 {labels.agentBadge}
               </span>
@@ -169,14 +169,16 @@ export function TopologyIndexTreeRow({
           </div>
           {isDomain && subcounts ? (
             <div className="mt-[3.5px] flex items-center gap-1.5">
-              <span className="shrink-0 font-mono text-[9.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+              <span className="shrink-0 font-mono text-caption text-[color:var(--topology-v2-panel-text-quaternary)]">
                 {labels.capabilitiesShort} {subcounts.capabilityCount} · {labels.elementsShort}{" "}
                 {subcounts.elementCount}
               </span>
               {/* 인셋 capacity meter — 라벨 아래 리세스드 트랙(기존 basis-full
                   회색 미터 폐기). 인디고 잉크: 미선택 .45 / 선택 .8. */}
+              {/* eslint-disable-next-line no-restricted-syntax -- 2px 높이 capacity 미터 트랙의 1px 헤어라인 반경은 chip(6px) 밖 예외. */}
               <span className="h-[2px] max-w-[76px] flex-1 overflow-hidden rounded-[1px] bg-[var(--color-overlay-recessed-a45)] shadow-[inset_0_1px_1px_var(--color-shadow-a50)]">
                 <span
+                  // eslint-disable-next-line no-restricted-syntax -- 위 미터 트랙과 짝인 fill 의 1px 헤어라인 반경.
                   className="block h-full rounded-[1px] bg-[var(--color-indigo-line-a45)] data-[selected=true]:bg-[var(--color-indigo-line-a90)]"
                   data-selected={selected}
                   style={{ width: `${Math.round(capacityRatio * 100)}%` }}
@@ -190,7 +192,7 @@ export function TopologyIndexTreeRow({
             // M-6 — 도메인 배지 합이 census 총계를 넘는 이유(다중 소속
             // 중복 계상)를 셈해 보는 사용자에게 즉석에서 설명한다.
             title={isDomain ? labels.domainCountTitle : undefined}
-            className="justify-self-end font-mono text-[11px] text-[color:var(--topology-v2-numeral-face)] [text-shadow:0_1px_0_var(--topology-v2-numeral-shadow)]"
+            className="justify-self-end font-mono text-label text-[color:var(--topology-v2-numeral-face)] [text-shadow:0_1px_0_var(--topology-v2-numeral-shadow)]"
           >
             {count}
           </span>

--- a/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
@@ -141,7 +141,7 @@ export function TopologyRealmLedger({
       {/* ── 1. 헤더 ── caps eyebrow + 제목 + census 한 줄 + 조용한 해제. */}
       <header className="mb-3 shrink-0 px-0.5">
         <div className="mb-1 flex items-center justify-between gap-2">
-          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
+          <span className="font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--topology-v2-panel-text-tertiary)]">
             {labels.label}
           </span>
           <button
@@ -149,7 +149,7 @@ export function TopologyRealmLedger({
             onClick={onExit}
             aria-label={labels.exitAria}
             data-testid="topology-realm-exit"
-            className="shrink-0 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+            className="shrink-0 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-label text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
           >
             {labels.exit}
           </button>
@@ -160,14 +160,14 @@ export function TopologyRealmLedger({
           </span>
           <p
             data-testid="topology-realm-title"
-            className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-[color:var(--topology-v2-panel-text-primary)]"
+            className="min-w-0 flex-1 truncate text-body-lg font-medium text-[color:var(--topology-v2-panel-text-primary)]"
           >
             {rootTitle}
           </p>
         </div>
         <p
           data-testid="topology-realm-census"
-          className="mt-1 truncate font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+          className="mt-1 truncate font-mono text-caption text-[color:var(--topology-v2-panel-text-quaternary)]"
         >
           {labels.elementsShort} {census.elementCount} · {labels.capabilitiesShort}{" "}
           {census.capabilityCount} · {labels.depthShort} {census.depth}
@@ -196,7 +196,7 @@ export function TopologyRealmLedger({
           placeholder={labels.searchPlaceholder}
           autoComplete="off"
           data-testid="topology-realm-search"
-          className="w-full rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-canvas)] py-1.5 pl-7 pr-2.5 text-[12px] text-[color:var(--topology-v2-panel-text-primary)] outline-none transition-colors placeholder:text-[color:var(--topology-v2-panel-text-quaternary)] focus:border-[color:var(--topology-v2-indigo)]"
+          className="w-full rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-canvas)] py-1.5 pl-7 pr-2.5 text-body text-[color:var(--topology-v2-panel-text-primary)] outline-none transition-colors placeholder:text-[color:var(--topology-v2-panel-text-quaternary)] focus:border-[color:var(--topology-v2-indigo)]"
         />
       </div>
 
@@ -208,7 +208,7 @@ export function TopologyRealmLedger({
         className="min-h-0 flex-1 space-y-px overflow-y-auto"
       >
         {visibleRoots.length === 0 ? (
-          <p className="px-1 py-2 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+          <p className="px-1 py-2 text-label text-[color:var(--topology-v2-panel-text-quaternary)]">
             {labels.emptyHint}
           </p>
         ) : (
@@ -241,7 +241,7 @@ export function TopologyRealmLedger({
         className="mt-2.5 shrink-0 border-t border-[color:var(--topology-v2-panel-divider)] pt-2"
       >
         {boundaryTotal === 0 ? (
-          <p className="px-1 text-[11px] text-[color:var(--topology-v2-panel-text-quaternary)]">
+          <p className="px-1 text-label text-[color:var(--topology-v2-panel-text-quaternary)]">
             {labels.boundaryEmpty}
           </p>
         ) : (
@@ -254,7 +254,7 @@ export function TopologyRealmLedger({
               data-testid="topology-realm-boundary-toggle"
               className="flex w-full items-center gap-1.5 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
             >
-              <span className="min-w-0 flex-1 truncate text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+              <span className="min-w-0 flex-1 truncate text-label text-[color:var(--topology-v2-panel-text-tertiary)]">
                 {labels.boundaryHeading}
               </span>
               <ChevronDown
@@ -271,7 +271,7 @@ export function TopologyRealmLedger({
                     data-testid="topology-realm-boundary-row"
                     className="group flex items-center gap-2 rounded-md px-1 py-1 transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
                   >
-                    <span className="min-w-0 flex-1 truncate text-[11.5px] text-[color:var(--topology-v2-panel-text-secondary)]">
+                    <span className="min-w-0 flex-1 truncate text-label text-[color:var(--topology-v2-panel-text-secondary)]">
                       <span className="text-[color:var(--topology-v2-panel-text-primary)]">
                         {row.fromTitle}
                       </span>
@@ -290,7 +290,7 @@ export function TopologyRealmLedger({
                       aria-label={labels.boundaryJumpAria}
                       title={labels.boundaryJump}
                       data-testid="topology-realm-boundary-jump"
-                      className="inline-flex shrink-0 items-center gap-1 rounded-[var(--chrome-radius-inner)] px-1.5 py-0.5 text-[10.5px] text-[color:var(--color-indigo-accent)] opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset group-hover:opacity-100 motion-reduce:transition-none"
+                      className="inline-flex shrink-0 items-center gap-1 rounded-[var(--chrome-radius-inner)] px-1.5 py-0.5 text-label text-[color:var(--color-indigo-accent)] opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset group-hover:opacity-100 motion-reduce:transition-none"
                     >
                       <CornerUpRight size={11} aria-hidden="true" />
                       {labels.boundaryJump}


### PR DESCRIPTION
## Summary
- 소유자 지시("박스 하나하나 사이즈까지 싹 다 지정, 모든 곳 동일하게") 실행: Type ramp 7단(+광학 tracking 짝) · radius 3단 · 패딩 2단 토큰 법전 + DESIGN-SYSTEM.md "Geometry & Type Codex" 절 (박스별 규격 표, "표 밖 값 존재 금지").
- ESLint 봉쇄: 신규 `text-[Npx]`/`rounded-[Npx]` 차단 (마이그레이션 dir=error, R6 진행 dir=warn).
- 마이그레이션 1단계 76파일: 텍스트 26종→7단(836건, 예외 2), radius 16종→3단(예외 11 — 사유 주석). 시각 변화 ±1px 스냅 수준.

## Test plan
- tsc ✅ · eslint 0 errors (신규 룰 자기검증 포함) ✅ · 마이그레이션 dir 606 tests ✅ · next build + Tailwind 유틸 emit 확인 (에이전트) ✅ · 실화면: 인사이트 시각 리듬 보존 + 토큰 라이브 확인 ✅