### PR TITLE
fix: QA 최종 스윕 결함 2건 (칩 크롬 매몰·데이터시트 행)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1534,7 +1534,7 @@
        CSS var 를 자동 추종하지 못하므로 인셋 변경 시 반드시 같이 갱신. */
     --topology-v2-safe-inset-left: 350;
     --topology-v2-safe-inset-right: 120;
-    --topology-v2-safe-inset-top: 96;
+    --topology-v2-safe-inset-top: 148; /* 96 크롬 + 상단 도킹 클러스터 칩(+N) 높이/갭 — QA-A D1: 첫 페인트에서 칩이 검색 바 뒤에 깔리던 결함 */
     --topology-v2-safe-inset-bottom: 96;
 
     /* 2.6 컴포넌트 데이터시트 패널 (`TopologyV2DetailPanel`, DOM 소비)

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -442,12 +442,12 @@ export function TopologyV2DetailPanel({
               type="button"
               onClick={() => onSelectConnection(domain.id)}
               data-testid="topology-v2-detail-panel-domain"
-              className="flex items-center gap-1 self-start pl-[13.5px] text-left transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+              className="flex min-w-0 max-w-full items-center gap-1 self-start pl-[13.5px] text-left transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
             >
-              <span className="text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
+              <span className="shrink-0 whitespace-nowrap text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
                 {labels.domainLabel}
               </span>
-              <span className="text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">·</span>
+              <span className="shrink-0 text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">·</span>
               <span className="truncate text-[11px] font-medium text-[color:var(--topology-v2-panel-text-secondary)]">
                 {domain.title}
               </span>


### PR DESCRIPTION
## Summary
- QA-A 전 표면 시각 스윕(76 스크린샷 + 자동 겹침 탐지, ko/en × 1920/1440)의 결함 2건 전부 수정: ① 첫 페인트에서 +N 클러스터 칩이 상단 검색 바에 매몰 (safe-inset-top 96→148, 칩 높이 반영) ② 데이터시트 도메인 행 "도메/인" 중간 줄바꿈 + en 값 하드 클립 (flex 계약).

## Test plan
- topology 609 tests ✅ · tsc ✅ · 실화면 첫 페인트: 칩-크롬 완전 분리 확인 ✅