### PR TITLE
feat: H5 — 노드 식별 URL 계약 통일 (kind:slug canonical)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,6 +186,58 @@ pages that need them (Projects list, Builder, Insights) — the narrow rail
 can't host their wide popovers, so this is a "same feature, different
 mount point" move, not a removal.
 
+## URL contract (query-param + node id grammar)
+
+Deep links are the app's shared address space — a copied URL, an agent
+handoff, and a browser-back all rebuild the same view. So one node must have
+one identity across every screen. The **canonical node id grammar is
+`<kind>:<slug>`** (singular kind + colon, e.g. `capability:mcp-server`,
+`domain:views`, `project:ontology-atlas`). This is the value that travels in
+`?node=` / `?p=` / `?realm=` and the id used inside agent packets.
+
+### Query params
+
+| Param | Screen(s) | Meaning | Value shape |
+|---|---|---|---|
+| `p` | `/`, `/topology` | focused/selected node | canonical `<kind>:<slug>` (bare slug tolerated) |
+| `open` | `/`, `/topology` | density-gate expanded parents | comma list of node ids |
+| `realm` | `/`, `/topology` | "realm" containment-subtree root | canonical `<kind>:<slug>` (bare slug promoted) |
+| `mode` | `/`, `/topology` | analysis mode | `overview`\|`graph`\|`focus`\|`path`\|`health` |
+| `pathFrom` / `pathTo` (aliases `from` / `to`) | `/`, `/topology` | path source / target | node id |
+| `hub` · `c` · `impact` · `pulse` · `index` · `create` | `/`, `/topology` | focused hub · category · impact mode · pulse window · INDEX panel state · create-node intent | see `src/views/home/model/url-state.ts` |
+| `via` | `/`, `/topology`, `/ontology` | origin marker for the return chip | `insights:<tab>` |
+| `node` | `/ontology` (redirect) | node to focus after redirect → `?p=` | node id (translated by `translateOntologyDeeplinkToTopologyParam`) |
+| `node` | `/ontology/edit` (builder) | node to select in the inspector | canonical `<kind>:<slug>` **first-class**; plural vault-folder form (`capabilities/foo`) kept as a **legacy alias** |
+| `node` | `/ontology/insights` | node to focus (builder-proof link) | vault slug (`capabilities/foo`) |
+| `slug` | `/docs` | vault file to open | vault file path (`ontology/capabilities/foo`), not a node id — file paths are the docs vault's own address space |
+| `reader` | `/ontology/edit` | reader-intent flag | see `parseOntologyReaderIntent` |
+| `tab` | `/ontology/insights` | active insights tab | tab slug |
+
+### id grammar single source of truth
+
+- **Emit** (map · insights · popover "관계 편집"/데이터시트/컨텍스트 메뉴 →
+  builder): `buildOntologyBuilderNodeHrefFromGraphId` in
+  `src/entities/knowledge-graph/lib/ontology-node-href.ts`. It normalizes any
+  input to canonical via `translateOntologyDeeplinkToTopologyParam`
+  (`capabilities/foo` → `capability:foo`; already-canonical / bare /
+  evidence-path pass through).
+- **Receive** (builder `?node=`): `resolveBuilderQueryNodeSlug` in
+  `src/views/ontology-edit/lib/resolve-builder-query-node.ts`. It accepts
+  canonical `<kind>:<slug>` as first-class and still resolves the legacy
+  plural-folder alias (`?node=capabilities/foo`, `?node=domains/views`) so
+  previously-shared links never break.
+- **Node id → docs file slug** conversion lives in one pure place: the
+  popover/datasheet carry the focus model's `sourceSlug` (a vault file path)
+  straight into `buildDocsVaultHref({ slug })`. `/docs` addresses files, not
+  nodes, so `?slug=` intentionally stays a file path.
+- Round-trip is pinned by `resolve-builder-query-node.test.ts` (emit →
+  receive → doc) and `ontology-node-href.test.ts`.
+
+Residual (out of the H5 slice, safe because resolvers tolerate it): a few
+topology `?p=` / `?pathFrom=` links copied from the builder's relation-write
+packet still carry the plural vault-slug form; the topology resolver's
+bare-slug fallback resolves them unchanged.
+
 ## Build pipeline
 
 ```bash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,30 @@
 - 렌더 테스트로 갈음(스크린샷 검증은 메인 세션): `HexMark` 유닛 6종 +
   레일 워드마크 존재/aria-hidden 테스트. tsc·ESLint·터치 vitest green.
 
+## 2026-07-23 — 노드 식별 URL 계약 통일 (H5)
+
+같은 "노드 보기"가 화면마다 다른 문법으로 흩어져 있던 문제를 정리했다.
+발신은 canonical `<kind>:<slug>`(단수 kind + 콜론, 예: `capability:mcp-server`)
+하나로 통일하고, 수신은 canonical 을 1급으로 받으면서 기존 복수-슬래시 링크를
+레거시 별칭으로 계속 받아 공유 링크 하위호환을 지킨다.
+
+- **빌더 발신 링크 canonical 화** — 인사이트·팝오버(데이터시트/컨텍스트 메뉴/
+  엣지)·토폴로지 헬스 패킷·빌더 관계-쓰기 확인 패널이 `/ontology/edit/?node=`
+  으로 보낼 때 예전 복수-슬래시(`capabilities/foo`) 대신 canonical
+  (`capability:foo`)을 싣는다. 발신 정규화기는 지도 `?p=`·`/ontology` 리다이렉트와
+  같은 `translateOntologyDeeplinkToTopologyParam` 로 수렴한다.
+- **빌더 `?node=` 수신 확장** — `resolveBuilderQueryNodeSlug` 가 canonical
+  `<kind>:<slug>` 을 1급으로 해석하고, 복수-슬래시/`ontology/` prefix/frontmatter
+  slug 레거시 경로를 모두 유지한다. 예전에 공유된 `?node=capabilities/foo`·
+  `?node=domains/views` 링크는 안 깨진다.
+- **문서함 `?slug=` 은 유지** — `/docs` 는 노드가 아니라 vault 파일 경로를 여는
+  주소 공간이라 `?slug=` 는 파일 경로 그대로. 노드 id → 문서 slug 변환은
+  focus 모델의 `sourceSlug` 한 곳에서만 나온다.
+- **문서** — `docs/ARCHITECTURE.md` 에 "URL contract" 절 신설(파라미터 표 +
+  id 문법 진실원 + 왕복 계약). 왕복 테스트는
+  `resolve-builder-query-node.test.ts`(발신→수신→doc)와
+  `ontology-node-href.test.ts` 에 고정.
+
 ## 2026-07-22 — 온보딩 진입점 영속화 + 빌더 선택 배선 (H4)
 
 온보딩/토스 디자이너 상위 지적을 첫 실행 표면과 빌더 인스펙터에서 고쳤다.

--- a/src/entities/knowledge-graph/lib/ontology-node-href.test.ts
+++ b/src/entities/knowledge-graph/lib/ontology-node-href.test.ts
@@ -156,7 +156,8 @@ describe("buildOntologyBuilderNodeHref", () => {
 });
 
 describe("buildOntologyBuilderNodeHrefFromGraphId", () => {
-  it("topology graph id 를 canonical builder node query 로 변환", () => {
+  // H5 URL 계약: 빌더 발신 링크는 canonical `<kind>:<slug>` 로 통일한다.
+  it("canonical graph id 를 그대로 실어 보낸다", () => {
     expect(resolveOntologyBuilderNodeSlugFromGraphId("domain:views")).toBe(
       "domains/views",
     );
@@ -164,21 +165,21 @@ describe("buildOntologyBuilderNodeHrefFromGraphId", () => {
       buildOntologyBuilderNodeHrefFromGraphId("capability:topology-analysis-modes"),
     ).toBe(
       `/ontology/edit/?node=${encodeURIComponent(
-        "capabilities/topology-analysis-modes",
+        "capability:topology-analysis-modes",
       )}`,
     );
   });
 
-  it("project graph id 는 project frontmatter slug 로 넘긴다", () => {
+  it("project graph id 도 canonical `project:<slug>` 로 넘긴다", () => {
     expect(resolveOntologyBuilderNodeSlugFromGraphId("project:ontology-atlas")).toBe(
       "ontology-atlas",
     );
     expect(buildOntologyBuilderNodeHrefFromGraphId("project:ontology-atlas")).toBe(
-      `/ontology/edit/?node=${encodeURIComponent("ontology-atlas")}`,
+      `/ontology/edit/?node=${encodeURIComponent("project:ontology-atlas")}`,
     );
   });
 
-  it("이미 vault source slug 이거나 ontology prefix 가 있으면 query 호환 slug 로 정규화", () => {
+  it("복수-슬래시/ontology-prefix vault 폴더형은 canonical 로 승격해 보낸다", () => {
     expect(
       resolveOntologyBuilderNodeSlugFromGraphId(
         "ontology/capabilities/topology-analysis-modes",
@@ -188,7 +189,7 @@ describe("buildOntologyBuilderNodeHrefFromGraphId", () => {
       buildOntologyBuilderNodeHrefFromGraphId("capabilities/topology-analysis-modes"),
     ).toBe(
       `/ontology/edit/?node=${encodeURIComponent(
-        "capabilities/topology-analysis-modes",
+        "capability:topology-analysis-modes",
       )}`,
     );
   });

--- a/src/entities/knowledge-graph/lib/ontology-node-href.ts
+++ b/src/entities/knowledge-graph/lib/ontology-node-href.ts
@@ -1,4 +1,5 @@
 import type { KnowledgeGraphNode } from "../model";
+import { translateOntologyDeeplinkToTopologyParam } from "./translate-ontology-deeplink";
 
 /**
  * Ontology view 의 노드 deeplink 빌더 — `/ontology/?node=<encoded-id>`.
@@ -73,9 +74,22 @@ export function resolveOntologyBuilderNodeSlugFromGraphId(nodeId: string): strin
   return folder ? `${folder}/${tail}` : normalized;
 }
 
+/**
+ * 빌더 딥링크 발신자 (지도·인사이트·팝오버 → `/ontology/edit`) — URL 계약의
+ * 공통 id 문법인 canonical `<kind>:<slug>` 를 실어 보낸다. 예전엔 복수-슬래시
+ * vault 폴더형(`capabilities/foo`)을 실었지만, 그 표기는 화면마다 갈라진
+ * 4파라미터·2문법의 한 축이었다(H5). 이제 발신은 canonical 한 문법으로 통일하고,
+ * 수신부(`resolveBuilderQueryNodeSlug`)가 canonical 을 1급으로 받으며 복수-슬래시는
+ * 레거시 별칭으로 남겨 기존 공유 링크를 깨지 않는다.
+ *
+ * `translateOntologyDeeplinkToTopologyParam` 로 정규화하는 이유: 입력이 이미
+ * canonical(`capability:foo`)이면 그대로, 복수-슬래시(`capabilities/foo`)면
+ * `capability:foo` 로 승격, bare/evidence-path 는 통과 — 지도(`?p=`)·온톨로지
+ * 리다이렉트와 같은 정규화기를 재사용해 한 문법으로 수렴한다.
+ */
 export function buildOntologyBuilderNodeHrefFromGraphId(nodeId: string): string {
   return `/ontology/edit/?node=${encodeURIComponent(
-    resolveOntologyBuilderNodeSlugFromGraphId(nodeId),
+    translateOntologyDeeplinkToTopologyParam(nodeId),
   )}`;
 }
 

--- a/src/views/home/lib/topology-analysis.test.ts
+++ b/src/views/home/lib/topology-analysis.test.ts
@@ -277,7 +277,7 @@ describe("formatTopologyHealthBrief", () => {
         "- URL: http://localhost:3000/en/topology?mode=health",
         "- Inspect URL: http://localhost:3000/en/topology?mode=health&p=capability%3Atopology-analysis-modes",
         "- Ontology URL: /ontology/?node=capability%3Atopology-analysis-modes",
-        "- Repair URL: /ontology/edit/?node=capabilities%2Ftopology-analysis-modes",
+        "- Repair URL: /ontology/edit/?node=capability%3Atopology-analysis-modes",
         "- Next action: Review whether this high-signal node should become a domain or capability entrypoint.",
         "- Agent check: ontology-atlas node capability:topology-analysis-modes [vault] --limit 12",
         '- MCP check: query_ontology({"operation":"node_profile","slug":"capability:topology-analysis-modes","depth":2,"limit":12})',
@@ -355,12 +355,13 @@ describe("formatTopologyHealthBrief", () => {
     );
   });
 
-  it("maps graph ids to builder repair URLs", () => {
+  it("maps graph ids to canonical builder repair URLs (H5 발신 문법 통일)", () => {
     expect(buildTopologyHealthRepairHref("domain:views")).toBe(
-      "/ontology/edit/?node=domains%2Fviews",
+      "/ontology/edit/?node=domain%3Aviews",
     );
+    // 복수-슬래시 레거시 입력도 canonical 로 승격해 발신.
     expect(buildTopologyHealthRepairHref("capabilities/topology-analysis-modes")).toBe(
-      "/ontology/edit/?node=capabilities%2Ftopology-analysis-modes",
+      "/ontology/edit/?node=capability%3Atopology-analysis-modes",
     );
   });
 });
@@ -433,8 +434,8 @@ describe("formatTopologyPathAgentPacket", () => {
         "- Hops: 2",
         "- Source ontology URL: /ontology/?node=domains%2Fviews",
         "- Target ontology URL: /ontology/?node=capability%3Atopology-analysis-modes",
-        "- Source builder URL: /ontology/edit/?node=domains%2Fviews",
-        "- Target builder URL: /ontology/edit/?node=capabilities%2Ftopology-analysis-modes",
+        "- Source builder URL: /ontology/edit/?node=domain%3Aviews",
+        "- Target builder URL: /ontology/edit/?node=capability%3Atopology-analysis-modes",
         '- MCP check: query_ontology({"operation":"path","from":"domains/views","to":"capability:topology-analysis-modes","maxHops":5})',
       ].join("\n"),
     );

--- a/src/views/home/model/use-node-datasheet-model.ts
+++ b/src/views/home/model/use-node-datasheet-model.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useMemo } from "react";
-import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
+import {
+  buildOntologyBuilderNodeHrefFromGraphId,
+  type KnowledgeGraphEdge,
+  type KnowledgeGraphNode,
+} from "@/entities/knowledge-graph";
 import { buildDocsVaultHref } from "@/entities/docs-vault";
 import { isWithinRecentWindow } from "@/shared/lib/ontology-tree";
 import { computeUpdatedAgo } from "../lib/format-updated-ago";
@@ -127,8 +131,12 @@ export function useNodeDatasheetModel({
       groups,
       evidence: { rows: evidenceRows, total: evidenceRows.length },
       handoffText,
+      // 문서 딥링크는 vault 파일 경로(`?slug=`)로 — 노드 id → 문서 slug 변환은
+      // sourceSlug(focus 모델의 순수 파생) 한 곳에서만 나온다(H5 계약 item 2).
       documentHref: nodeFocus.sourceSlug ? buildDocsVaultHref({ slug: nodeFocus.sourceSlug }) : null,
-      builderEditHref: `/ontology/edit/?node=${encodeURIComponent(slug)}`,
+      // 빌더 딥링크는 canonical `<kind>:<slug>`(그래프 node id) 그대로 — 발신 문법
+      // 통일(H5 계약 item 1). 예전 `?node=<vault slug>` 인라인 링크를 대체.
+      builderEditHref: buildOntologyBuilderNodeHrefFromGraphId(selectedOntologyNode.id),
     };
   }, [nodeFocus, selectedOntologyNode, insight, nodeFocusData, docFreshnessIndex, updatedAgoNowMs, formatUpdatedLabel]);
 

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -96,6 +96,7 @@ import {
 } from "@/entities/project";
 import { buildDocsVaultHref, buildNewNodeDoc } from "@/entities/docs-vault";
 import {
+  buildOntologyBuilderNodeHrefFromGraphId,
   buildOntologyHealthSignals,
   buildOntologyInsightsReturnHref,
   useRelationVocabulary,
@@ -628,7 +629,9 @@ export function HomePage() {
         ? { slug: selectedEdge.declaredBySlug, href: buildDocsVaultHref({ slug: selectedEdge.declaredBySlug }) }
         : null,
       updatedAtLabel: ago ? t(`nodeDatasheet.updated_${ago.key}`, { count: ago.count }) : null,
-      builderEditHref: `/ontology/edit/?node=${encodeURIComponent(from.evidenceIds[0] ?? from.id)}`,
+      // 빌더 딥링크는 canonical `<kind>:<slug>`(그래프 node id)로 통일(H5) —
+      // 예전 `from.evidenceIds[0] ?? from.id` 인라인 vault-slug 링크를 대체.
+      builderEditHref: buildOntologyBuilderNodeHrefFromGraphId(from.id),
       why,
     };
   }, [selectedEdge, ontologyInsight, docFreshnessIndex, updatedAgoNowMs, t, relationVocabulary]);
@@ -1150,7 +1153,8 @@ export function HomePage() {
       nodeId: node.id,
       slug,
       documentHref: sourceSlug ? buildDocsVaultHref({ slug: sourceSlug }) : null,
-      builderEditHref: `/ontology/edit/?node=${encodeURIComponent(slug)}`,
+      // 빌더 딥링크는 canonical `<kind>:<slug>`(그래프 node id)로 통일(H5).
+      builderEditHref: buildOntologyBuilderNodeHrefFromGraphId(node.id),
       handoffText,
     };
   }, [contextMenuNode, ontologyInsight]);

--- a/src/views/ontology-edit/lib/resolve-builder-query-node.test.ts
+++ b/src/views/ontology-edit/lib/resolve-builder-query-node.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { buildOntologyBuilderNodeHrefFromGraphId } from "@/entities/knowledge-graph";
 import { resolveBuilderQueryNodeSlug } from "./resolve-builder-query-node";
 
 const docs = [
@@ -32,9 +33,57 @@ describe("resolveBuilderQueryNodeSlug", () => {
     ).toBe("ontology/capabilities/topology-analysis-modes");
   });
 
+  // H5 URL 계약: canonical `<kind>:<slug>` 를 1급으로 받는다.
+  it("accepts canonical `<kind>:<slug>` ids for live-vault nodes", () => {
+    expect(resolveBuilderQueryNodeSlug("domain:views", docs)).toBe("domains/views");
+  });
+
+  it("accepts canonical `<kind>:<slug>` ids for dogfood nodes", () => {
+    expect(
+      resolveBuilderQueryNodeSlug("capability:topology-analysis-modes", docs),
+    ).toBe("ontology/capabilities/topology-analysis-modes");
+  });
+
   it("returns null for unknown or empty query nodes", () => {
     expect(resolveBuilderQueryNodeSlug("missing/node", docs)).toBeNull();
+    expect(resolveBuilderQueryNodeSlug("unknown:node", docs)).toBeNull();
     expect(resolveBuilderQueryNodeSlug("", docs)).toBeNull();
     expect(resolveBuilderQueryNodeSlug(null, docs)).toBeNull();
+  });
+});
+
+// 왕복 계약(H5 item 4): 발신부(`buildOntologyBuilderNodeHrefFromGraphId`, 인사이트·
+// 팝오버가 쓰는 canonical 링크 빌더)가 만든 `?node=` 값을 수신부가 다시 doc 으로
+// 풀어낸다. 두 끝이 같은 문법으로 만나는지 한 테스트로 못 박는다.
+describe("builder deep-link round trip (canonical)", () => {
+  function nodeParamFromHref(href: string): string {
+    const query = href.slice(href.indexOf("?") + 1);
+    return decodeURIComponent(new URLSearchParams(query).get("node") ?? "");
+  }
+
+  it("insights/popover canonical link resolves back to the dogfood doc", () => {
+    const href = buildOntologyBuilderNodeHrefFromGraphId(
+      "capability:topology-analysis-modes",
+    );
+    expect(href).toContain(
+      encodeURIComponent("capability:topology-analysis-modes"),
+    );
+    expect(resolveBuilderQueryNodeSlug(nodeParamFromHref(href), docs)).toBe(
+      "ontology/capabilities/topology-analysis-modes",
+    );
+  });
+
+  it("canonical link resolves back to the live-vault doc", () => {
+    const href = buildOntologyBuilderNodeHrefFromGraphId("domain:views");
+    expect(resolveBuilderQueryNodeSlug(nodeParamFromHref(href), docs)).toBe(
+      "domains/views",
+    );
+  });
+
+  it("legacy plural-slash `?node=` alias still resolves (기존 공유 링크 하위호환)", () => {
+    expect(
+      resolveBuilderQueryNodeSlug("capabilities/topology-analysis-modes", docs),
+    ).toBe("ontology/capabilities/topology-analysis-modes");
+    expect(resolveBuilderQueryNodeSlug("domains/views", docs)).toBe("domains/views");
   });
 });

--- a/src/views/ontology-edit/lib/resolve-builder-query-node.ts
+++ b/src/views/ontology-edit/lib/resolve-builder-query-node.ts
@@ -1,13 +1,38 @@
+import { resolveOntologyBuilderNodeSlugFromGraphId } from "@/entities/knowledge-graph";
+
 interface BuilderQueryDoc {
   slug: string;
   frontmatter?: Record<string, unknown>;
 }
 
+/**
+ * 빌더 `?node=` 수신부 — URL 계약(H5)의 공통 id 문법 canonical `<kind>:<slug>`
+ * 를 1급으로 받는다. 발신부(`buildOntologyBuilderNodeHrefFromGraphId`)가 이제
+ * canonical 을 실어 보내므로, 그 문법이 어떤 라이브/도그푸드 doc slug 와도 맞도록
+ * 먼저 canonical → 복수-슬래시 vault 폴더형으로 정규화한 뒤 매칭한다
+ * (`resolveOntologyBuilderNodeSlugFromGraphId`: `capability:foo` → `capabilities/foo`,
+ * 복수-슬래시/evidence-path 는 통과). 정규화 결과가 안 맞으면 raw 로도 한 번 더
+ * 시도해 예전 공유 링크(`?node=capabilities/foo`, `?node=domains/views`)를 깨지
+ * 않는 레거시 별칭으로 유지한다.
+ */
 export function resolveBuilderQueryNodeSlug(
   queryNodeId: string | null,
   docs: readonly BuilderQueryDoc[],
 ): string | null {
-  const normalized = queryNodeId?.trim().replace(/^\/+/, "");
+  const raw = queryNodeId?.trim().replace(/^\/+/, "");
+  if (!raw) return null;
+
+  // canonical `<kind>:<slug>` → 복수-슬래시 vault 폴더형으로 정규화(slash·bare 는
+  // 그대로). 그런 뒤 아래 매칭이 라이브 slug·`ontology/` prefix·frontmatter slug
+  // 세 경로로 doc 을 찾는다. canonical 을 먼저, raw 를 fallback 으로 시도한다.
+  const canonicalized = resolveOntologyBuilderNodeSlugFromGraphId(raw);
+  return matchBuilderDocSlug(canonicalized, docs) ?? matchBuilderDocSlug(raw, docs);
+}
+
+function matchBuilderDocSlug(
+  normalized: string,
+  docs: readonly BuilderQueryDoc[],
+): string | null {
   if (!normalized) return null;
 
   const bySlug = new Map(docs.map((doc) => [doc.slug, doc]));

--- a/src/views/ontology-edit/ui/RelationWriteConfirm.test.tsx
+++ b/src/views/ontology-edit/ui/RelationWriteConfirm.test.tsx
@@ -294,11 +294,11 @@ describe("RelationWriteConfirm", () => {
     );
     expect(screen.getByRole("link", { name: "Edit source" })).toHaveAttribute(
       "href",
-      expect.stringContaining("/ontology/edit/?node=capabilities%2Fmcp-server"),
+      expect.stringContaining("/ontology/edit/?node=capability%3Amcp-server"),
     );
     expect(screen.getByRole("link", { name: "Edit target" })).toHaveAttribute(
       "href",
-      expect.stringContaining("/ontology/edit/?node=elements%2Fmcp-index"),
+      expect.stringContaining("/ontology/edit/?node=element%3Amcp-index"),
     );
     expect(screen.getByText("Post-save graph handoff")).toBeInTheDocument();
     expect(
@@ -462,7 +462,7 @@ describe("RelationWriteConfirm", () => {
     );
     expect(copyTextMock).toHaveBeenCalledWith(
       expect.stringContaining(
-        "- Target builder URL: /ontology/edit/?node=elements%2Fmcp-index",
+        "- Target builder URL: /ontology/edit/?node=element%3Amcp-index",
       ),
     );
     expect(copyTextMock).toHaveBeenCalledWith(

--- a/src/views/ontology-edit/ui/RelationWriteConfirm.tsx
+++ b/src/views/ontology-edit/ui/RelationWriteConfirm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Clipboard, GitBranch, X } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { buildOntologyBuilderNodeHrefFromGraphId } from "@/entities/knowledge-graph";
 import { copyText } from "@/shared/lib/copy-text";
 import { formatQueryOntologyCall } from "@/shared/lib/ontology-query-call";
 import { explainOntologyRelationKeyInference } from "@/shared/lib/ontology-relation-key";
@@ -1218,8 +1219,11 @@ function buildRelationOntologyHref(slug: string): string {
   return `/ontology/?node=${encodeURIComponent(slug)}`;
 }
 
+// 빌더 발신 링크는 canonical `<kind>:<slug>` 로 통일(H5). proposal.sourceSlug 는
+// 복수-슬래시 vault 폴더형(`domains/views`)이라 canonical(`domain:views`)로 승격해
+// 보낸다 — 수신부는 canonical 1급 + 복수-슬래시 레거시 별칭 둘 다 받는다.
 function buildRelationBuilderHref(slug: string): string {
-  return `/ontology/edit/?node=${encodeURIComponent(slug)}`;
+  return buildOntologyBuilderNodeHrefFromGraphId(slug);
 }
 
 export function buildRelationTopologyPathHref(sourceSlug: string, targetSlug: string): string {


### PR DESCRIPTION
## Summary
- IA 디자이너 1순위: `<kind>:<slug>` (단수+콜론)를 전 발신 링크 공통 문법으로 — 빌더 수신은 canonical 1급 + 기존 복수슬래시 레거시 별칭 유지 (공유 링크 무파손). 인사이트/팝오버/데이터시트/컨텍스트메뉴/관계확인 패널 발신 전부 단일 빌더 함수 경유.
- `docs/ARCHITECTURE.md` 에 "URL contract" 절 신설 (파라미터 표 + id 문법 진실원 + 잔여 명시).

## Test plan
- 왕복 테스트 (발신→수신→문서) 포함 535 tests ✅ · tsc ✅ · ESLint 0 ✅