### PR TITLE
fix: 흡수 파이프라인 품질 — 코드펜스 오분할·정책 어휘 복수형 (실측 라운드)

### DIFF
--- a/cli/src/lib/absorb.mjs
+++ b/cli/src/lib/absorb.mjs
@@ -23,6 +23,12 @@ import { folderForKind } from './schema.mjs';
 
 const H1_RE = /^#\s+(.+?)\s*$/;
 const SECTION_HEADING_RE = /^##\s+(.+?)\s*$/;
+// Fenced-code-block delimiter (``` or ~~~, 3+ chars, optional leading indent).
+// Lines inside a fence — and the delimiter lines themselves — are NEVER treated
+// as headings, so `## comment` / `# title` written inside a shell/markdown code
+// block don't spuriously split the document (real CONTRIBUTING/AGENTS docs are
+// full of these). See the code-fence contract fixtures in absorb-cases.mjs.
+const FENCE_RE = /^\s*(?:```+|~~~+)/;
 
 // ── section splitting ───────────────────────────────────────────────────
 
@@ -32,35 +38,66 @@ const SECTION_HEADING_RE = /^##\s+(.+?)\s*$/;
  * The first `# ` line anywhere before the first `##` is taken as the title;
  * everything else before the first `##` (minus that title line) is `intro`.
  *
+ * Fenced code blocks are respected: any `#`/`##` line inside a ``` or ~~~
+ * fence is code content, not a heading, and never splits the document.
+ *
  * @returns {{ title: string|null, intro: string, sections: Array<{heading: string, body: string, raw: string}> }}
  */
 export function splitDocumentSections(rawText) {
   const text = String(rawText || '');
   const lines = text.split(/\r?\n/);
-  const firstH2Index = lines.findIndex((line) => SECTION_HEADING_RE.test(line));
-  const preambleLines = firstH2Index === -1 ? lines : lines.slice(0, firstH2Index);
 
-  const titleIndex = preambleLines.findIndex((line) => H1_RE.test(line));
-  const title = titleIndex === -1 ? null : preambleLines[titleIndex].match(H1_RE)[1].trim();
-  const introLines =
-    titleIndex === -1
-      ? preambleLines
-      : [...preambleLines.slice(0, titleIndex), ...preambleLines.slice(titleIndex + 1)];
+  // Precompute which lines are inside a fenced code block (delimiter lines
+  // included) so heading detection can ignore them.
+  const inFence = new Array(lines.length).fill(false);
+  let fenceOpen = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (FENCE_RE.test(lines[i])) {
+      inFence[i] = true;
+      fenceOpen = !fenceOpen;
+      continue;
+    }
+    inFence[i] = fenceOpen;
+  }
+  const isSectionHeading = (i) => !inFence[i] && SECTION_HEADING_RE.test(lines[i]);
+  const isTitleHeading = (i) => !inFence[i] && H1_RE.test(lines[i]);
+
+  let firstH2Index = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (isSectionHeading(i)) {
+      firstH2Index = i;
+      break;
+    }
+  }
+  const preambleEnd = firstH2Index === -1 ? lines.length : firstH2Index;
+
+  let titleIndex = -1;
+  for (let i = 0; i < preambleEnd; i += 1) {
+    if (isTitleHeading(i)) {
+      titleIndex = i;
+      break;
+    }
+  }
+  const title = titleIndex === -1 ? null : lines[titleIndex].match(H1_RE)[1].trim();
+  const introLines = [];
+  for (let i = 0; i < preambleEnd; i += 1) {
+    if (i === titleIndex) continue;
+    introLines.push(lines[i]);
+  }
   const intro = introLines.join('\n').trim();
 
   const sections = [];
   if (firstH2Index !== -1) {
     let i = firstH2Index;
     while (i < lines.length) {
-      const match = lines[i].match(SECTION_HEADING_RE);
-      if (!match) {
+      if (!isSectionHeading(i)) {
         i += 1;
         continue;
       }
-      const heading = match[1].trim();
+      const heading = lines[i].match(SECTION_HEADING_RE)[1].trim();
       const bodyLines = [];
       let j = i + 1;
-      while (j < lines.length && !SECTION_HEADING_RE.test(lines[j])) {
+      while (j < lines.length && !isSectionHeading(j)) {
         bodyLines.push(lines[j]);
         j += 1;
       }
@@ -74,13 +111,18 @@ export function splitDocumentSections(rawText) {
 
 // ── kind-mapping heuristics ─────────────────────────────────────────────
 
+// Policy/convention vocabulary. Plurals and common variants are matched
+// explicitly — real AGENTS.md/CONTRIBUTING headings say "Conventions",
+// "Commits", "Tests", "Style Guide", "Best Practices", not the bare singular,
+// and missing them was the dominant driver of skipped policy sections.
 const POLICY_HEADING_RE =
-  /\b(rules?|polic(?:y|ies)|convention|guideline|governance|principles?|workflow|forbidden|do[-\s]?not|verification|testing|commit(?:ting)?|contributing|security)\b/i;
-const POLICY_HEADING_RE_KO = /(규칙|정책|가이드|원칙|규율|금지|워크플로우|절차|커밋|검증|보안)/;
+  /\b(rules?|polic(?:y|ies)|conventions?|guide(?:line)?s?|governance|principles?|practices?|workflows?|forbidden|do[-\s]?not|verification|test(?:s|ing)?|commit(?:s|ted|ting)?|contributing|security)\b/i;
+const POLICY_HEADING_RE_KO =
+  /(규칙|정책|가이드|원칙|규율|금지|워크플로우|절차|관례|컨벤션|커밋|테스트|검증|보안)/;
 const ARCH_HEADING_RE =
-  /\b(architecture|component|module|folder|structure|routes?|tech\s*stack|stack|layers?|schema|api)\b/i;
+  /\b(architecture|components?|modules?|folder|structure|routes?|tech\s*stack|stack|layers?|schemas?|api)\b/i;
 const ARCH_HEADING_RE_KO = /(아키텍처|구조|폴더|모듈|컴포넌트|스택|라우트|레이어|스키마)/;
-const ARCH_ELEMENT_HEADING_RE = /\b(component|module|schema|routes?)\b/i;
+const ARCH_ELEMENT_HEADING_RE = /\b(components?|modules?|schemas?|routes?)\b/i;
 const ARCH_ELEMENT_HEADING_RE_KO = /(컴포넌트|모듈|스키마|라우트)/;
 
 function countMatches(text, regexes) {

--- a/cli/src/lib/absorb.test.mjs
+++ b/cli/src/lib/absorb.test.mjs
@@ -29,6 +29,31 @@ describe('splitDocumentSections', () => {
     assert.equal(result.intro, 'intro para');
     assert.equal(result.sections.length, 1);
   });
+
+  it('does not split on a `##` line inside a fenced code block', () => {
+    const raw =
+      '# Doc\n\n## Real Section\n\nBefore.\n\n```bash\n## not a heading\necho hi\n```\n\nAfter.\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'Real Section');
+    assert.ok(result.sections[0].body.includes('## not a heading'));
+    assert.ok(result.sections[0].body.includes('After.'));
+  });
+
+  it('ignores a `#` title line inside a preamble code fence', () => {
+    const raw = '```sh\n# not the title\necho x\n```\n\n# Actual Title\n\n## Rules\n\nbody\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.title, 'Actual Title');
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'Rules');
+  });
+
+  it('handles ~~~ fences as well as ``` fences', () => {
+    const raw = '# Doc\n\n## S\n\n~~~\n## fenced comment\n~~~\n\ntail\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'S');
+  });
 });
 
 describe('classifySection', () => {
@@ -38,6 +63,21 @@ describe('classifySection', () => {
     const b = classifySection(section);
     assert.deepEqual(a, b);
   });
+
+  for (const heading of [
+    'TUI code conventions',
+    'Commits and PR Titles',
+    'Tests',
+    'Style Guide',
+    'App-server API Development Best Practices',
+  ]) {
+    it(`classifies plural/variant policy heading ${JSON.stringify(heading)} as policy/document`, () => {
+      const c = classifySection({ heading, body: '' });
+      assert.equal(c.category, 'policy');
+      assert.equal(c.kind, 'document');
+      assert.equal(c.role, 'policy');
+    });
+  }
 });
 
 describe('scanForInjection', () => {

--- a/mcp/src/absorb.mjs
+++ b/mcp/src/absorb.mjs
@@ -23,6 +23,12 @@ import { folderForKind } from './schema.mjs';
 
 const H1_RE = /^#\s+(.+?)\s*$/;
 const SECTION_HEADING_RE = /^##\s+(.+?)\s*$/;
+// Fenced-code-block delimiter (``` or ~~~, 3+ chars, optional leading indent).
+// Lines inside a fence — and the delimiter lines themselves — are NEVER treated
+// as headings, so `## comment` / `# title` written inside a shell/markdown code
+// block don't spuriously split the document (real CONTRIBUTING/AGENTS docs are
+// full of these). See the code-fence contract fixtures in absorb-cases.mjs.
+const FENCE_RE = /^\s*(?:```+|~~~+)/;
 
 // ── section splitting ───────────────────────────────────────────────────
 
@@ -32,35 +38,66 @@ const SECTION_HEADING_RE = /^##\s+(.+?)\s*$/;
  * The first `# ` line anywhere before the first `##` is taken as the title;
  * everything else before the first `##` (minus that title line) is `intro`.
  *
+ * Fenced code blocks are respected: any `#`/`##` line inside a ``` or ~~~
+ * fence is code content, not a heading, and never splits the document.
+ *
  * @returns {{ title: string|null, intro: string, sections: Array<{heading: string, body: string, raw: string}> }}
  */
 export function splitDocumentSections(rawText) {
   const text = String(rawText || '');
   const lines = text.split(/\r?\n/);
-  const firstH2Index = lines.findIndex((line) => SECTION_HEADING_RE.test(line));
-  const preambleLines = firstH2Index === -1 ? lines : lines.slice(0, firstH2Index);
 
-  const titleIndex = preambleLines.findIndex((line) => H1_RE.test(line));
-  const title = titleIndex === -1 ? null : preambleLines[titleIndex].match(H1_RE)[1].trim();
-  const introLines =
-    titleIndex === -1
-      ? preambleLines
-      : [...preambleLines.slice(0, titleIndex), ...preambleLines.slice(titleIndex + 1)];
+  // Precompute which lines are inside a fenced code block (delimiter lines
+  // included) so heading detection can ignore them.
+  const inFence = new Array(lines.length).fill(false);
+  let fenceOpen = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (FENCE_RE.test(lines[i])) {
+      inFence[i] = true;
+      fenceOpen = !fenceOpen;
+      continue;
+    }
+    inFence[i] = fenceOpen;
+  }
+  const isSectionHeading = (i) => !inFence[i] && SECTION_HEADING_RE.test(lines[i]);
+  const isTitleHeading = (i) => !inFence[i] && H1_RE.test(lines[i]);
+
+  let firstH2Index = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (isSectionHeading(i)) {
+      firstH2Index = i;
+      break;
+    }
+  }
+  const preambleEnd = firstH2Index === -1 ? lines.length : firstH2Index;
+
+  let titleIndex = -1;
+  for (let i = 0; i < preambleEnd; i += 1) {
+    if (isTitleHeading(i)) {
+      titleIndex = i;
+      break;
+    }
+  }
+  const title = titleIndex === -1 ? null : lines[titleIndex].match(H1_RE)[1].trim();
+  const introLines = [];
+  for (let i = 0; i < preambleEnd; i += 1) {
+    if (i === titleIndex) continue;
+    introLines.push(lines[i]);
+  }
   const intro = introLines.join('\n').trim();
 
   const sections = [];
   if (firstH2Index !== -1) {
     let i = firstH2Index;
     while (i < lines.length) {
-      const match = lines[i].match(SECTION_HEADING_RE);
-      if (!match) {
+      if (!isSectionHeading(i)) {
         i += 1;
         continue;
       }
-      const heading = match[1].trim();
+      const heading = lines[i].match(SECTION_HEADING_RE)[1].trim();
       const bodyLines = [];
       let j = i + 1;
-      while (j < lines.length && !SECTION_HEADING_RE.test(lines[j])) {
+      while (j < lines.length && !isSectionHeading(j)) {
         bodyLines.push(lines[j]);
         j += 1;
       }
@@ -74,13 +111,18 @@ export function splitDocumentSections(rawText) {
 
 // ── kind-mapping heuristics ─────────────────────────────────────────────
 
+// Policy/convention vocabulary. Plurals and common variants are matched
+// explicitly — real AGENTS.md/CONTRIBUTING headings say "Conventions",
+// "Commits", "Tests", "Style Guide", "Best Practices", not the bare singular,
+// and missing them was the dominant driver of skipped policy sections.
 const POLICY_HEADING_RE =
-  /\b(rules?|polic(?:y|ies)|convention|guideline|governance|principles?|workflow|forbidden|do[-\s]?not|verification|testing|commit(?:ting)?|contributing|security)\b/i;
-const POLICY_HEADING_RE_KO = /(규칙|정책|가이드|원칙|규율|금지|워크플로우|절차|커밋|검증|보안)/;
+  /\b(rules?|polic(?:y|ies)|conventions?|guide(?:line)?s?|governance|principles?|practices?|workflows?|forbidden|do[-\s]?not|verification|test(?:s|ing)?|commit(?:s|ted|ting)?|contributing|security)\b/i;
+const POLICY_HEADING_RE_KO =
+  /(규칙|정책|가이드|원칙|규율|금지|워크플로우|절차|관례|컨벤션|커밋|테스트|검증|보안)/;
 const ARCH_HEADING_RE =
-  /\b(architecture|component|module|folder|structure|routes?|tech\s*stack|stack|layers?|schema|api)\b/i;
+  /\b(architecture|components?|modules?|folder|structure|routes?|tech\s*stack|stack|layers?|schemas?|api)\b/i;
 const ARCH_HEADING_RE_KO = /(아키텍처|구조|폴더|모듈|컴포넌트|스택|라우트|레이어|스키마)/;
-const ARCH_ELEMENT_HEADING_RE = /\b(component|module|schema|routes?)\b/i;
+const ARCH_ELEMENT_HEADING_RE = /\b(components?|modules?|schemas?|routes?)\b/i;
 const ARCH_ELEMENT_HEADING_RE_KO = /(컴포넌트|모듈|스키마|라우트)/;
 
 function countMatches(text, regexes) {

--- a/mcp/src/absorb.test.mjs
+++ b/mcp/src/absorb.test.mjs
@@ -31,6 +31,56 @@ describe('splitDocumentSections', () => {
     assert.equal(result.intro, 'intro para');
     assert.equal(result.sections.length, 1);
   });
+
+  it('does not split on a `##` line inside a fenced code block', () => {
+    const raw =
+      '# Doc\n\n## Real Section\n\nBefore.\n\n```bash\n## not a heading\necho hi\n```\n\nAfter.\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'Real Section');
+    // the fenced shell comment stays inside the section body verbatim
+    assert.ok(result.sections[0].body.includes('## not a heading'));
+    assert.ok(result.sections[0].body.includes('After.'));
+  });
+
+  it('ignores a `#` title line inside a preamble code fence', () => {
+    const raw = '```sh\n# not the title\necho x\n```\n\n# Actual Title\n\n## Rules\n\nbody\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.title, 'Actual Title');
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'Rules');
+  });
+
+  it('handles ~~~ fences as well as ``` fences', () => {
+    const raw = '# Doc\n\n## S\n\n~~~\n## fenced comment\n~~~\n\ntail\n';
+    const result = splitDocumentSections(raw);
+    assert.equal(result.sections.length, 1);
+    assert.equal(result.sections[0].heading, 'S');
+  });
+});
+
+describe('classifySection — plural/variant policy vocabulary', () => {
+  const asPolicy = [
+    'TUI code conventions',
+    'Commits and PR Titles',
+    'Tests',
+    'Style Guide',
+    'Best Practices',
+    'App-server API Development Best Practices',
+  ];
+  for (const heading of asPolicy) {
+    it(`classifies ${JSON.stringify(heading)} as policy/document`, () => {
+      const c = classifySection({ heading, body: '' });
+      assert.equal(c.category, 'policy');
+      assert.equal(c.kind, 'document');
+      assert.equal(c.role, 'policy');
+    });
+  }
+
+  it('still classifies pure architecture headings as architecture (no regression)', () => {
+    assert.equal(classifySection({ heading: 'Folder map', body: '' }).category, 'architecture');
+    assert.equal(classifySection({ heading: 'Tech stack', body: '' }).category, 'architecture');
+  });
 });
 
 describe('classifySection', () => {

--- a/tests/fixtures/absorb-cases.mjs
+++ b/tests/fixtures/absorb-cases.mjs
@@ -56,6 +56,44 @@ export const SPLIT_CASES = [
       sections: [],
     },
   },
+  {
+    name: 'a `##` line inside a code fence does not split the document',
+    input:
+      '# Doc\n\n' +
+      '## Real Section\n\n' +
+      'Before the fence.\n\n' +
+      '```bash\n' +
+      '## not a heading — this is a shell comment\n' +
+      'echo hello\n' +
+      '```\n\n' +
+      'After the fence.\n',
+    expected: {
+      title: 'Doc',
+      intro: '',
+      sections: [
+        {
+          heading: 'Real Section',
+          body:
+            'Before the fence.\n\n```bash\n## not a heading — this is a shell comment\necho hello\n```\n\nAfter the fence.',
+        },
+      ],
+    },
+  },
+  {
+    name: 'a `# title` line inside a preamble code fence is not taken as the title',
+    input:
+      '```sh\n' +
+      '# install with a curl one-liner\n' +
+      'echo skip\n' +
+      '```\n\n' +
+      '# Actual Title\n\n' +
+      '## Rules\n\nbody\n',
+    expected: {
+      title: 'Actual Title',
+      intro: '```sh\n# install with a curl one-liner\necho skip\n```',
+      sections: [{ heading: 'Rules', body: 'body' }],
+    },
+  },
 ];
 
 export const CLASSIFY_CASES = [
@@ -113,6 +151,55 @@ export const CLASSIFY_CASES = [
     expectedCategory: 'architecture',
     expectedKind: 'element',
     expectedRole: null,
+    minConfidence: 0.5,
+  },
+  {
+    // Plural "Conventions" — the bare singular `convention` used to miss this.
+    name: 'Code Conventions (plural) → policy/document',
+    section: { heading: 'TUI code conventions', body: 'Prefer stylize helpers over raw ANSI.' },
+    expectedCategory: 'policy',
+    expectedKind: 'document',
+    expectedRole: 'policy',
+    minConfidence: 0.5,
+  },
+  {
+    // Plural "Commits" — the `commit(?:ting)?` form used to miss the plural.
+    name: 'Commits and PR Titles → policy/document',
+    section: { heading: 'Commits and PR Titles', body: 'Use conventional-commit prefixes.' },
+    expectedCategory: 'policy',
+    expectedKind: 'document',
+    expectedRole: 'policy',
+    minConfidence: 0.5,
+  },
+  {
+    // "Tests" / "Testing" — only `testing` used to match; bare "Tests" missed.
+    name: 'Tests → policy/document',
+    section: { heading: 'Tests', body: 'Run the snapshot suite before pushing.' },
+    expectedCategory: 'policy',
+    expectedKind: 'document',
+    expectedRole: 'policy',
+    minConfidence: 0.5,
+  },
+  {
+    // "Style Guide" — `guideline` used to miss the bare "guide".
+    name: 'Style Guide → policy/document',
+    section: { heading: 'Style Guide', body: 'Two-space indentation, no semicolons.' },
+    expectedCategory: 'policy',
+    expectedKind: 'document',
+    expectedRole: 'policy',
+    minConfidence: 0.5,
+  },
+  {
+    // "Best Practices" — used to be mis-kinded as an architecture capability
+    // whenever the heading also contained "API"; now correctly policy.
+    name: 'API Development Best Practices → policy/document (not architecture)',
+    section: {
+      heading: 'App-server API Development Best Practices',
+      body: 'Version endpoints; never break the wire format.',
+    },
+    expectedCategory: 'policy',
+    expectedKind: 'document',
+    expectedRole: 'policy',
     minConfidence: 0.5,
   },
   {


### PR DESCRIPTION
## Summary
- Slice 0 흡수를 실제 OSS 문서 3종(openai/codex·sst/opencode AGENTS.md, bun CONTRIBUTING)으로 실측 — **흡수전 무수정 수용률 ≈30% (kill 기준 50% 미달)** 확인 후 원인 2건 수정: ① 코드펜스 안 `##` 를 헤딩으로 오인하는 splitter (CONTRIBUTING 류 붕괴 주범) ② 정책 어휘 단수형만 매칭 ("Conventions/Tests/Commits/Style Guide" 미탐).
- 수정 후: 정책 섹션 캡처 ~90%+, **오기입 0건** — 자동 흡수(무마법사) 유지 가능 판정. 계산 시간 ms 단위 (매직 모먼트 ≤5분 여유).
- 잔여 보고 3건: 인젝션 `curl|sh` 오탐 라벨 (방어망 축소 트레이드오프라 소유자 판단 대기) · 프리앰블 미흡수 (설계 의도) · 아키텍처 섹션 보수적 miss.
- cli/mcp 미러 바이트 동일 유지 + 계약 fixture 에 펜스·복수어휘 케이스 추가.

## Test plan
- 계약 210 ✅ · mcp unit 224 ✅ · 실문서 재현→수정→통과 증명 (에이전트) ✅