### PR TITLE
fix: main 잠복 계약 드리프트 4건 — README 재작성·vault 성장 추종

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -595,12 +595,12 @@ A successful run looks like this:
 ✓ list_concepts — vault total 105 nodes (vaultRoot /path/to/docs/ontology)
 ✓ get_concept — project (6 outgoing edges)
 ✓ get_concepts — 2 ok rows, 1 partial row
-✓ find_evidence — 54 evidence results for "project"
+✓ find_evidence — 56 evidence results for "project"
 ✓ find_backlinks — project (1 backlink)
 ✓ query_concepts — 1 query result / 1 total query result
 ✓ query_concepts limited — 1 query result / 104 total query results (limited true)
-✓ analyze_repo_structure — fsd (4 domain candidates, 18 capability candidates, 29 element candidates)
-✓ infer_imports — 820 files scanned, 503 module edges (elements/src/views/home->capabilities/knowledge-graph x23 (static:23), elements/src/views/ontology-insights->capabilities/knowledge-graph x15 (static:15), +501 more)
+✓ analyze_repo_structure — fsd (5 domain candidates, 18 capability candidates, 29 element candidates)
+✓ infer_imports — 820 files scanned, 510 module edges (elements/src/views/home->capabilities/knowledge-graph x27 (static:27), elements/src/views/ontology-insights->capabilities/knowledge-graph x15 (static:15), +508 more)
 ✓ index_project — 52 concept candidates, 503 import relations, validation 0 problem files
 ✓ find_neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)
 ✓ find_path — src/widgets/bottom-tab-bar → project (2 hops, 2 edges)
@@ -608,20 +608,20 @@ A successful run looks like this:
 ✓ list_kinds — 105 nodes (capability:39, document:3, domain:6, element:55, project:1, vault-readme:1)
 ✓ validate_vault — 105 files, 0 problem files
 ✓ project probe — 1 project node
-✓ workspace_brief — healthy (105 nodes, 1 next action, 5 health checks, growth actions:1 external:1 ignoredExternal:208)
+✓ workspace_brief — healthy (105 nodes, 1 next action, 5 health checks, growth actions:1 external:1 ignoredExternal:212)
 · workspace_brief non-blocking advisory nextActions — materialize_external_elements:info:1 - Materialize frequently referenced external files as element nodes when they should be first-class.
 ✓ agent_brief — healthy (ready 100/100, 3 entrypoints, 5 first calls, 6 graph DB pack items, 4 playbooks, 3 write guardrails, 3 result contracts)
-✓ workspace_brief_tuned — healthy (105 nodes, 2 next actions, 5 health checks, growth actions:1 external:1 ignoredExternal:208; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies; nodeLimit=3)
+✓ workspace_brief_tuned — healthy (105 nodes, 2 next actions, 5 health checks, growth actions:1 external:1 ignoredExternal:212; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies; nodeLimit=3)
 · workspace_brief_tuned non-blocking advisory nextActions — components/health_check:info:4 - The scoped ontology graph has disconnected actionable islands., materialize_external_elements:info:1 - Materialize frequently referenced external files as element nodes when they should be first-class.
 ✓ health — healthy (issues:0, unresolved:0, cycles:0, 5 checks: compile_issues:pass:0, unresolved_edges:pass:0, dependency_cycles:pass:0, relation_recommendations:pass:0, components:pass:1)
 ✓ health_tuned — healthy (issues:0, unresolved:0, cycles:0, 5 checks: compile_issues:pass:0, unresolved_edges:pass:0, dependency_cycles:pass:0, relation_recommendations:pass:0, components:info:4; dependencyTypes=dependencies; componentTypes=domains/domain/capabilities/dependencies)
 · health_tuned non-blocking advisory checks — components:info:4 - The scoped ontology graph has disconnected actionable islands.
-✓ compile_ontology — graph 368cafafd9aa (105 nodes, 557 edges, issues 0)
-✓ compile_ontology page — 1/105 nodes, 1/557 edges
-✓ compile_ontology indexes — out 105, in 104, edgeById 557, aliases 209, edges 348/209/0
-✓ overview — graph 368cafafd9aa (105 nodes, 557 edges, hubs 5)
-✓ overview query_plan — aggregate_scan (medium, nodes 105, edges 557)
-✓ project_map query_plan — aggregate_scan (medium, nodes 105, edges 557)
+✓ compile_ontology — graph 36f5e5268380 (105 nodes, 561 edges, issues 0)
+✓ compile_ontology page — 1/105 nodes, 1/561 edges
+✓ compile_ontology indexes — out 105, in 104, edgeById 561, aliases 209, edges 348/213/0
+✓ overview — graph 36f5e5268380 (105 nodes, 561 edges, hubs 5)
+✓ overview query_plan — aggregate_scan (medium, nodes 105, edges 561)
+✓ project_map query_plan — aggregate_scan (medium, nodes 105, edges 561)
 ✓ neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)
 ✓ path — src/widgets/bottom-tab-bar → project (2 hops, 2 edges)
 ✓ all_paths — src/widgets/bottom-tab-bar → project (5/15 paths, budget 1000, expanded 1000, exhaustive false, evidence partial)

--- a/scripts/check-package-contracts.test.mjs
+++ b/scripts/check-package-contracts.test.mjs
@@ -113,17 +113,20 @@ function runNodeScript(args) {
 }
 
 describe('package contract helpers', () => {
-  it('keeps the root README honest about the three visual views plus MCP', () => {
+  it('keeps the root README honest about the five surfaces plus MCP', () => {
     const readme = readFileSync('README.md', 'utf-8');
-    const section = readme.split('## Three views plus MCP, one vault')[1]?.split('## Quick start')[0] ?? '';
+    const section = readme.split('## Five surfaces, one vault')[1]?.split('## Agent Workflow')[0] ?? '';
 
-    assert.match(section, /rendered three ways and exposed to agents through MCP/);
-    assert.match(section, /\*\*Topology\*\*/);
-    assert.match(section, /\*\*Tree\*\*/);
-    assert.match(section, /\*\*ERD builder\*\*/);
-    assert.match(section, /\*\*MCP\*\*/);
-    assert.match(section, /All four read and write the same `\.md` files/);
+    assert.match(section, /\*\*Map\*\*/);
+    assert.match(section, /`\/docs`/);
+    assert.match(section, /`\/ontology\/edit`/);
+    assert.match(section, /`\/ontology\/insights`/);
+    assert.match(section, /`\/projects`/);
+    assert.match(section, /\*\*MCP server\*\*/);
+    assert.match(section, /16 read \+ 9 write/);
+    assert.match(section, /Every surface reads and writes the\nsame `\.md` files/);
     assert.doesNotMatch(readme, /## Three views, one vault/);
+    assert.doesNotMatch(readme, /## Three views plus MCP, one vault/);
     assert.doesNotMatch(readme, /## Four surfaces, one vault/);
   });
 
@@ -2037,7 +2040,7 @@ describe('package contract helpers', () => {
     assert.match(vaultTooling, /focused vault audit CLI argument contract/);
     assert.match(readme, /\*\*Static dogfood manifest\*\* \| `pnpm docs-vault:check` keeps committed `src\/entities\/docs-vault\/data\/manifest\.json` and `public\/docs-vault\/` in sync with `docs\/`/);
     assert.match(readme, /pnpm docs-vault:check\s+# committed docs-vault output freshness/);
-    assert.match(readme, /CI runs `pnpm docs-vault:check`, `pnpm vault:validate`, `pnpm test:vault:validate`,\s+`pnpm vault:audit`, `pnpm test:vault:audit`, and `pnpm package:check`/);
+    assert.match(readme, /CI runs `docs-vault:check`, `vault:validate`, `test:vault:validate`,\s+`vault:audit`, `test:vault:audit`, and `package:check`/);
     assert.match(agents, /pnpm test:vault:validate\s+# focused validator CLI argument contract/);
     assert.match(agents, /pnpm test:contracts\s+# focused cross-package contract suite/);
     assert.match(agents, /pnpm vault:audit\s+# capability\/element path drift guard \(R12\)/);
@@ -2098,7 +2101,9 @@ describe('package contract helpers', () => {
     const agentsGuide = readFileSync('AGENTS.md', 'utf-8');
     const dogfoodRow = readme.split('| **Dogfooding** |')[1]?.split('\n')[0] ?? '';
     const agentWorkflow = readme.split('## Agent Workflow')[1]?.split('## Web Routes')[0] ?? '';
-    const helpfulCommands = readme.split('Helpful vault commands:')[1]?.split('### Vault tooling')[0] ?? '';
+    // dogfood 유지보수 명령 상세는 README 마케팅 재작성(2026-07)에서
+    // docs/DEVELOPMENT-CHECKS.md 로 이관 — 발견 가능성 계약은 그 문서로 이어진다.
+    const helpfulCommands = readFileSync('docs/DEVELOPMENT-CHECKS.md', 'utf-8');
     const census = dogfoodVaultCensus(process.cwd());
 
     assert.match(dogfoodRow, new RegExp(`\\*\\*${census.total} nodes\\*\\*`));
@@ -2123,7 +2128,7 @@ describe('package contract helpers', () => {
     assert.match(helpfulCommands, /pnpm test:dogfood:status/);
     assert.match(helpfulCommands, /pnpm dogfood:verify/);
     assert.match(agentWorkflow, /`workspace-brief` is the cheap first-contact dashboard/);
-    assert.match(agentWorkflow, /`PROJECT별 포함 노드 수 \(project_scope\)`/);
+    assert.match(agentWorkflow, /per-project node counts \(`project_scope`\)/);
     assert.match(agentWorkflow, /health-check coverage as\s+`id:status:count`/);
     assert.match(agentWorkflow, /growth counts before the agent chooses where to read\s+deeper/);
   });


### PR DESCRIPTION
## Summary
- main 에서 상시 실패하던 check-package-contracts 4건 현행화: ① README "Five surfaces" 구조 반영 (구 "Three views" 단정 삭제) ② mcp/README mcp-verify 샘플 출력을 현 vault 실값(105 노드·561 edge·graphHash 36f5e5268380)으로 재생성 ③ CI 명령 나열 문구 추종 ④ dogfood 명령 발견 가능성 계약을 DEVELOPMENT-CHECKS.md 로 repoint.
- 산출물 코드 변경 0 — 문서 + 테스트만.

## Test plan
- `node --test scripts/check-package-contracts.test.mjs` 55/55 ✅ (main 은 4 fail)