### PR TITLE
test: verify-script add_relation 픽스처 why 복원 (상시 실패 1건)

### DIFF
--- a/mcp/src/verify-script.test.mjs
+++ b/mcp/src/verify-script.test.mjs
@@ -887,6 +887,10 @@ describe('verify.mjs first-contact gates', () => {
               type: 'string',
               enum: WRITE_RELATION_TYPE_VALUES,
             },
+            // P6 회귀 가드와 짝 — 실제 서버 inputSchema 의 why(relation_notes
+            // rationale) 블록. 픽스처에서 빠지면 base fixture 자체가 drift 로
+            // 판정돼 negative test 가 성립하지 않는다.
+            why: { type: 'string', maxLength: 300 },
             expected_mtime: { type: 'number', minimum: 0 },
           },
         },


### PR DESCRIPTION
## Summary
- `verify-script.test.mjs` 의 add_relation base fixture 에 실제 서버 inputSchema 의 `why` 블록이 빠져 있어 schema-drift negative test 가 base 에서부터 실패 (122 중 1건 상시). 픽스처 복원으로 122/122.

## Test plan
- `node --test mcp/src/verify-script.test.mjs` 122/122 ✅