### PR TITLE
fix: 검수 1바퀴 시각 결함 2건 (EN 1440 툴바 겹침·코너 파편)

### DIFF
--- a/src/shared/ui/chrome-chip.tsx
+++ b/src/shared/ui/chrome-chip.tsx
@@ -63,6 +63,7 @@ export const ChromeChip = forwardRef<HTMLButtonElement, ChromeChipProps>(
       {kbd ? (
         <span
           aria-hidden="true"
+          data-chip-kbd
           className={cn(
             'ml-auto shrink-0 rounded border border-[color:var(--color-border-soft)] px-1 py-0.5 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]',
             compact && 'hidden',

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { withBasePath } from "@/shared/lib/base-path";
+import { cn } from "@/shared/lib/cn";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
@@ -3029,7 +3030,17 @@ export function HomePage() {
                   `--topology-relation-legend-inset` 토큰(base 24px, ≥1920 32px)에
                   연결 — ≥1920 에서 나머지 크롬이 1.15 로 커질 때 이 스택도 코너에서
                   더 물러나 지도 라벨과 충돌하지 않는다. */}
-              <div className="pointer-events-none absolute bottom-[var(--topology-relation-legend-inset)] right-[var(--topology-relation-legend-inset)] z-20 flex flex-col items-end gap-3 whitespace-nowrap">
+              {/* 검수 1바퀴 결함 2 (2026-07-23) — 우측 데이터시트가 열리면 이
+                  코너 스택(범례+판독)이 패널 뒤·왼편으로 파편처럼 비쳐 보였다
+                  (4개 로케일×해상도 전 조합 재현). 앰비언트 정보라 조사 중엔
+                  필요 없으므로 패널이 열려 있는 동안 조용히 사라진다. */}
+              <div
+                className={cn(
+                  "pointer-events-none absolute bottom-[var(--topology-relation-legend-inset)] right-[var(--topology-relation-legend-inset)] z-20 flex flex-col items-end gap-3 whitespace-nowrap transition-opacity duration-180 ease-out motion-reduce:transition-none",
+                  v2DatasheetModel ? "opacity-0" : "opacity-100",
+                )}
+                aria-hidden={v2DatasheetModel ? true : undefined}
+              >
                 <TopologyRelationLegend />
                 <FirstRunReadout
                   projectCount={firstRunProjectCount}

--- a/src/widgets/search-hint/ui/SearchHint.tsx
+++ b/src/widgets/search-hint/ui/SearchHint.tsx
@@ -149,7 +149,11 @@ export function SearchHint({
           compact={compact}
           icon={<Search />}
           kbd={isMac ? '⌘K' : 'CtrlK'}
-          className={compact ? undefined : 'md:min-w-[176px] xl:min-w-[208px]'}
+          // 검수 1바퀴 결함 1 (2026-07-23) — EN 로케일 1440 폭에서 중앙 레인의
+          // 오른끝(검색 필)이 우측 클러스터("Switch to my data")와 겹쳤다.
+          // 영어 라벨이 길어질 때 예약 폭이 밀어내는 문제라, min-width 와 ⌘K
+          // 캡 예약을 2xl(1536+ — 1440 은 xl 이라 겹침 구간)부터로 미룬다.
+          className={compact ? undefined : '2xl:min-w-[208px] max-2xl:[&_[data-chip-kbd]]:hidden'}
           aria-label={t('searchAriaLabel')}
           title={t('searchTitle')}
         >


### PR DESCRIPTION
## Summary
- 40조합 시각 스윕에서 발견된 2종 8조합 결함 수정: ① EN 1440 툴바 겹침 — 검색 칩 폭 예약 2xl 게이트 ② 데이터시트 열림 시 우하단 앰비언트 스택 demote (opacity 180ms·reduced-motion 존중·aria-hidden).
- Guardian verdict Build and verify (⌘K 강등은 INDEX 푸터 ⇧⌘K 잔존으로 발견성 유지, demote 는 헌장 계약 그대로).

## Test plan
- tsc ✅ · 관련 vitest 185 ✅ · 실화면 재검증: EN 1440 겹침 0, ko 1440 선택 상태 파편 0 (스크린샷 Guardian 확인)