### PR TITLE
fix: 데이터시트 푸터 sticky (1440 '전체 상세' 가시성)

### DIFF
--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -589,8 +589,13 @@ export function TopologyV2DetailPanel({
 
       {/* Footer — slug + opt-in full-detail link. The agent-handoff button
           moved up into the W2-A action row (`data-testid=".../action-handoff"`)
-          — this row no longer duplicates it. */}
-      <div className="flex items-center gap-2 border-t border-[color:var(--topology-v2-panel-divider)] pt-2">
+          — this row no longer duplicates it.
+          검수 Pass A 소견 (2026-07-23) — 1440×900에서 콘텐츠가 max-height 를
+          넘기면 이 푸터가 스크롤 밖에 숨는데 스크롤 어포던스가 없어 "전체
+          상세"가 존재하지 않는 것처럼 읽혔다(P3-③ 의 후속). 패널 스크롤
+          컨테이너 안에서 sticky + 불투명 패널 surface 로 항상 보이게 한다 —
+          내용이 다 보일 땐 기존과 동일한 자리(sticky 비활성 상태와 동일). */}
+      <div className="sticky -bottom-[var(--topology-v2-panel-pad)] -mx-[var(--topology-v2-panel-pad)] -mb-[var(--topology-v2-panel-pad)] flex items-center gap-2 rounded-b-[var(--topology-v2-panel-radius)] border-t border-[color:var(--topology-v2-panel-divider)] bg-[color:var(--topology-v2-panel-surface)] px-[var(--topology-v2-panel-pad)] py-2">
         <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
           {slug}
         </span>


### PR DESCRIPTION
## Summary
- Pass A 스윕 소견: 1440×900에서 연결 많은 노드의 데이터시트 푸터("전체 상세 →")가 내부 스크롤 밖에 숨고 어포던스가 없어 액션 부재로 오독 (P3-③ 소유자 실보고 계열 후속). 푸터를 스크롤 컨테이너 내 sticky + 불투명 패널 surface 로 상시 가시화 — 기존 토큰 5종 재사용, 신규 0.
- Guardian verdict Build and verify (부분 절단 콘텐츠 자체가 표준 스크롤 큐 — 페이드 마스크 불필요 판정).

## Test plan
- tsc ✅ · topology-map-v2 vitest 621 ✅ · 1440×900 실측 linkBottom 883≤900 + 스크린샷 Guardian 확인 ✅