### PR TITLE
fix: Pass B 결함 2건 + 페르소나 최대 마찰 (라벨 소실·탭 스크롤·배지 목적지)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2359,7 +2359,7 @@
       "uncatalogedDocsLabel": "{count} docs not on the map",
       "uncatalogedDocsAction": "Promote",
       "dustyNodesLabel": "{count} nodes gathering dust — untouched for a while",
-      "dustyNodesAction": "See freshness"
+      "dustyNodesAction": "See to-dos"
     },
     "deeplinkNotFound": "Node not found: {query}",
     "bootstrap": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2359,7 +2359,7 @@
       "uncatalogedDocsLabel": "지도에 없는 문서 {count}개",
       "uncatalogedDocsAction": "올리기",
       "dustyNodesLabel": "먼지 앉은 노드 {count}개 — 오래 손대지 않았어요",
-      "dustyNodesAction": "신선도 보기"
+      "dustyNodesAction": "할 일 보기"
     },
     "deeplinkNotFound": "노드를 찾을 수 없습니다: {query}",
     "bootstrap": {

--- a/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
@@ -55,12 +55,33 @@ export function DocsVaultTabStrip({
     const reduced =
       typeof window !== "undefined" &&
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    activeTabRef.current?.scrollIntoView({
-      behavior: reduced ? "auto" : "smooth",
-      inline: "nearest",
-      block: "nearest",
+    // 검수 Pass B 결함 2 (2026-07-23) — scrollIntoView(inline:"nearest") 는
+    // 탭 추가로 스트립 폭이 같은 프레임에 변하면 활성 탭을 절반만 노출한 채
+    // 멈출 수 있다(EN 1440 실측: 말줄임 없이 글리프가 스트립 경계에서 잘리고
+    // × 도 안 보임 — flaky). 레이아웃 확정 후(rAF) scrollLeft 를 직접 계산해
+    // 활성 탭 전체가 항상 뷰포트 안에 오도록 결정론화한다. 탭 개수도 의존성에
+    // 포함 — 새 탭이 열려 폭이 변한 프레임에도 재보정된다.
+    const frame = requestAnimationFrame(() => {
+      const el = activeTabRef.current;
+      const strip = el?.closest("nav");
+      if (!el || !strip) return;
+      const cell = el.parentElement ?? el; // 탭 칼럼(wrapper) 기준 — 닫기 버튼 포함 전폭.
+      // Guardian 교정 — offsetLeft 의 offsetParent 는 nav 가 아니라 상위
+      // header(relative) 라 zone-l 폭만큼 인플레이트된다. rect 차이로
+      // 스크롤러 콘텐츠 좌표를 직접 계산해 중간 탭 활성화에서도 정확히 맞춘다.
+      const cellRect = cell.getBoundingClientRect();
+      const stripRect = strip.getBoundingClientRect();
+      const left = cellRect.left - stripRect.left + strip.scrollLeft;
+      const right = left + cellRect.width;
+      let target = strip.scrollLeft;
+      if (right > strip.scrollLeft + strip.clientWidth) target = right - strip.clientWidth;
+      if (left < target) target = left;
+      if (target !== strip.scrollLeft) {
+        strip.scrollTo({ left: target, behavior: reduced ? "auto" : "smooth" });
+      }
     });
-  }, [activeSlug]);
+    return () => cancelAnimationFrame(frame);
+  }, [activeSlug, tabs.length]);
 
   if (tabs.length === 0) return null;
 

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -440,12 +440,15 @@ export function TopologyIndexPanel({
 
       {/* ④ 살아있는 지도 드리프트 — "먼지 앉은 노드 N" 조용한 행. dusty
           판정(HomePage `deriveDustySlugs`, vault mtime 중앙값+30일 이중
-          조건)의 카운트만 받고, 클릭은 /ontology/insights 신선도 탭 딥링크.
-          0 이면 행 자체가 없다(성공 배지 금지). 중립 톤만 — 방치는 경고가
-          아니라 지도의 상태다. */}
+          조건)의 카운트만 받는다. 0 이면 행 자체가 없다(성공 배지 금지).
+          중립 톤만 — 방치는 경고가 아니라 지도의 상태다.
+          목적지는 할 일 탭 (페르소나 재조사 2026-07-23 최대 마찰 항목) —
+          신선도 탭은 도메인 단위 최신성 히트스트립이라 "51개가 오래 방치"
+          라는 약속과 정반대 그림("오늘 다 갱신")으로 읽혔다. 실제 오래된
+          노드 목록("오래 안 바뀐 허브" + 오늘의 손질)은 할 일 탭이 답한다. */}
       {dustyNodeCount && dustyNodeCount > 0 ? (
         <Link
-          href="/ontology/insights?tab=freshness"
+          href="/ontology/insights?tab=do-next"
           data-testid="topology-index-dusty-nodes"
           className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-label transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
         >

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
@@ -87,8 +87,10 @@ describe("computeOverviewCameraTarget — panel-aware safe insets", () => {
     };
     const centerScreen = worldToScreen(camera, W, H, 0, 0); // graph bounds center is (0,0)
     // Visible-area midpoint = (left + (W - right)) / 2, (top + (H - bottom)) / 2.
+    // 하단 인셋에는 라벨 여유 24px 가산 (검수 Pass B 결함 1 — 최하단 스파인
+    // 노드 라벨이 1440×900 핏에서 라벨 safe-rect 밖으로 밀리던 회귀의 예약분).
     expect(centerScreen.x).toBeCloseTo((344 + (W - 120)) / 2, 4);
-    expect(centerScreen.y).toBeCloseTo((96 + (H - 96)) / 2, 4);
+    expect(centerScreen.y).toBeCloseTo((96 + (H - 96 - 24)) / 2, 4);
   });
 
   it("with a wider left panel than right, shifts the camera left so content clears the panel", () => {

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -135,12 +135,29 @@ interface SafeInsets {
   bottom: number;
 }
 
+/**
+ * 검수 Pass B 결함 1 (2026-07-23) — 오버뷰 핏은 노드 지오메트리 bounds 만
+ * safe 영역에 맞춰, 최하단 스파인 노드의 라벨 anchor(= 노드 아래
+ * `radius + LABEL_OFFSET`, frame-draw:794 — 컬은 폰트 높이가 아니라 anchor
+ * 만 본다)가 라벨 safe-rect 컬 라인 바로 밖으로 밀려 1440×900 기본 뷰에서만
+ * 조용히 사라졌다 (1920 은 가로 제약 핏이라 세로 여유가 남아 미발현). 핏
+ * 계산에서만 하단 인셋에 여유를 예약한다 — 라벨 컬 rect 와 카메라 이동
+ * 가능 영역은 불변. 값 = max LABEL_OFFSET(project 20) + 슬랙 4 (Guardian
+ * 산술 검증 — `render/labels.ts` LABEL_OFFSET 변경 시 함께 갱신할 것).
+ */
+const OVERVIEW_LABEL_BOTTOM_ALLOWANCE = 24;
+
 function readSafeInsets(tokens: SafeInsetTokens): SafeInsets {
   return {
     left: tokens.safeInsetLeft ?? 0,
     right: tokens.safeInsetRight ?? 0,
     top: tokens.safeInsetTop ?? 0,
-    bottom: tokens.safeInsetBottom ?? 0,
+    // 인셋 미지정(= 크롬 없는 순수 핏 테스트 계약)은 종전과 동일하게 0 —
+    // 라벨 여유는 실제 하단 크롬 인셋이 존재할 때만 얹는다.
+    bottom:
+      tokens.safeInsetBottom == null
+        ? 0
+        : tokens.safeInsetBottom + OVERVIEW_LABEL_BOTTOM_ALLOWANCE,
   };
 }
 


### PR DESCRIPTION
## Summary
- **1440 하단 스파인 라벨 소실**: 오버뷰 핏이 노드 bounds 만 safe 영역에 맞춰 라벨 anchor 가 컬 라인 밖으로 밀림 → 핏 전용 하단 여유 24px (컬 rect·카메라 가동 영역 불변, 무인셋 테스트 계약 보존).
- **EN 1440 활성 탭 절반 노출 (flaky)**: scrollIntoView(nearest) → rAF + rect 기반 scrollLeft 결정론화. Guardian 이 offsetParent 좌표 인플레이트를 잡아 교정, 중간 탭 활성화 실측 통과 (scrollLeft 60, 완전 가시).
- **먼지 배지 목적지**: `?tab=freshness` → `?tab=do-next` + 라벨 "할 일 보기"/"See to-dos" — 페르소나 재조사 최대 마찰(신선도 탭이 약속과 정반대 그림) 해소. Guardian: "실사용 관찰이 사전 verdict 를 이긴다" 승인.
- 백링크 칩 부분 가시는 표준 스크롤 연속 큐로 비결함 판정 (칩 내부 truncate 정상).

## Test plan
- tsc ✅ · 관련 vitest 792 ✅ · i18n ✅ · 실화면: Ontology Core 라벨 복귀 + 활성/중간 탭 완전 가시 실측 + Guardian verdict 3건 Build and verify