### PR TITLE
fix: 작은 마감 2건 — 첫 실행 카드 브랜드 한 줄 + 라벨 여유 파생화

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -221,6 +221,7 @@
     "trustLine": "Local-first · markdown is the source of truth · 0 backend"
   },
   "firstRunStarter": {
+    "brand": "Ontology Atlas",
     "caption": "First run",
     "sampleLabel": "Sample for now",
     "contextBold": "A map of what your product is made of and how the parts connect — at a glance.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -221,6 +221,7 @@
     "trustLine": "Local-first · 마크다운이 진실원 · 백엔드 0"
   },
   "firstRunStarter": {
+    "brand": "Ontology Atlas",
     "caption": "첫 실행",
     "sampleLabel": "지금은 샘플",
     "contextBold": "우리 제품이 어떤 부분들로 이루어져 있고, 서로 어떻게 연결돼 있는지 한눈에 보는 지도예요.",

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
@@ -59,6 +59,16 @@ describe('FirstRunStarterModule', () => {
     expect(screen.getByText('6')).toBeInTheDocument();
   });
 
+  // 페르소나 재조사 개선 후보 2 (2026-07-23) — 완전 초심자는 카드에서
+  // 화면 설명은 읽지만 제품 이름을 알 방법이 없었다. 브랜드 워드마크
+  // 한 줄이 캡션 위에 항상 렌더되는지 고정한다.
+  it('renders a brand wordmark line above the first-run caption', () => {
+    render(<FirstRunStarterModule concepts={1} relations={1} domains={1} />);
+
+    expect(screen.getByTestId('first-run-starter-brand')).toBeInTheDocument();
+    expect(screen.getByTestId('first-run-starter-brand')).toHaveTextContent('brand');
+  });
+
   it('does not render once a vault is active (local mode)', () => {
     mocks.mode = 'local';
     render(<FirstRunStarterModule concepts={1} relations={1} domains={1} />);

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
@@ -62,6 +62,18 @@ export function FirstRunStarterModule({
       data-testid="first-run-starter"
       className="relative border-b border-[color:var(--topology-v2-panel-divider)] bg-gradient-to-b from-[color:var(--color-indigo-a08)] via-[color:var(--color-indigo-a06)] to-transparent px-4 pb-3.5 pt-4"
     >
+      {/* 페르소나 재조사 개선 후보 2 (2026-07-23) — 첫 실행 카드가 "이
+          화면이 뭘 하는지"만 말하고 "이 제품이 뭔지"(이름)는 말하지
+          않아 완전 초심자에게 정체성 공백이 있었다. 로고 마크 없이
+          텍스트 워드마크 한 줄만 더한다 — 기존 미션 문장(contextBold)이
+          이미 "지도"라는 개념을 설명하므로 별도 미션 반 문장은 중복이라
+          판단해 넣지 않는다. */}
+      <p
+        data-testid="first-run-starter-brand"
+        className="mb-1 text-caption font-medium tracking-[0.01em] text-[color:var(--topology-v2-panel-text-quaternary)]"
+      >
+        {t("brand")}
+      </p>
       <p className="mb-3 flex items-center gap-2 font-mono text-[9.5px] uppercase tracking-[0.22em] text-[color:var(--topology-v2-panel-text-secondary)]">
         <span className="relative h-2 w-2 shrink-0" aria-hidden>
           <span className="absolute inset-0 rounded-full bg-[color:var(--color-status-warning)]" />

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_TIER_REVEAL } from "../model/tier-visibility";
+import { LABEL_OFFSET } from "../render/labels";
 import {
   computeEffectiveCameraScaleMax,
   computeEffectiveCameraScaleMin,
@@ -12,6 +13,11 @@ import {
 } from "./topology-camera-math";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import { computeEgoBounds, type TopologyWorld } from "./topology-world";
+
+// 라벨 하단 여유는 `topology-camera-math.ts` 안에서 LABEL_OFFSET 최댓값 + 4
+// 슬랙으로 파생된다(Guardian follow-up, 2026-07-23) — 테스트도 같은 파생식으로
+// 기대값을 계산해 LABEL_OFFSET 이 바뀌어도 리터럴이 드리프트하지 않게 한다.
+const OVERVIEW_LABEL_BOTTOM_ALLOWANCE = Math.max(...Object.values(LABEL_OFFSET)) + 4;
 
 /**
  * DECOUPLING (topology-map-v2 axis split): the overview entry scale is the
@@ -87,10 +93,14 @@ describe("computeOverviewCameraTarget — panel-aware safe insets", () => {
     };
     const centerScreen = worldToScreen(camera, W, H, 0, 0); // graph bounds center is (0,0)
     // Visible-area midpoint = (left + (W - right)) / 2, (top + (H - bottom)) / 2.
-    // 하단 인셋에는 라벨 여유 24px 가산 (검수 Pass B 결함 1 — 최하단 스파인
-    // 노드 라벨이 1440×900 핏에서 라벨 safe-rect 밖으로 밀리던 회귀의 예약분).
+    // 하단 인셋에는 라벨 여유(LABEL_OFFSET 파생분) 가산 (검수 Pass B 결함 1 —
+    // 최하단 스파인 노드 라벨이 1440×900 핏에서 라벨 safe-rect 밖으로 밀리던
+    // 회귀의 예약분).
     expect(centerScreen.x).toBeCloseTo((344 + (W - 120)) / 2, 4);
-    expect(centerScreen.y).toBeCloseTo((96 + (H - 96 - 24)) / 2, 4);
+    expect(centerScreen.y).toBeCloseTo(
+      (96 + (H - 96 - OVERVIEW_LABEL_BOTTOM_ALLOWANCE)) / 2,
+      4,
+    );
   });
 
   it("with a wider left panel than right, shifts the camera left so content clears the panel", () => {

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -14,6 +14,7 @@
  */
 
 import type { CameraAxes, CameraTarget } from "../engine/camera";
+import { LABEL_OFFSET } from "../render/labels";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import { computeClusterDiscBounds, computeEgoBounds, radiusForKind, type TopologyWorld } from "./topology-world";
 import type { WorldNode } from "./topology-world";
@@ -142,10 +143,14 @@ interface SafeInsets {
  * 만 본다)가 라벨 safe-rect 컬 라인 바로 밖으로 밀려 1440×900 기본 뷰에서만
  * 조용히 사라졌다 (1920 은 가로 제약 핏이라 세로 여유가 남아 미발현). 핏
  * 계산에서만 하단 인셋에 여유를 예약한다 — 라벨 컬 rect 와 카메라 이동
- * 가능 영역은 불변. 값 = max LABEL_OFFSET(project 20) + 슬랙 4 (Guardian
- * 산술 검증 — `render/labels.ts` LABEL_OFFSET 변경 시 함께 갱신할 것).
+ * 가능 영역은 불변.
+ *
+ * 값은 `render/labels.ts` 의 `LABEL_OFFSET` 에서 파생 — max LABEL_OFFSET
+ * (현재 project 20) + 슬랙 4. 리터럴 24 를 따로 유지하면 LABEL_OFFSET 이
+ * 바뀔 때 이 예약분이 조용히 드리프트할 수 있어 (Guardian follow-up),
+ * 상수 대신 매 프레임 파생시켜 항상 동기화 상태를 보장한다.
  */
-const OVERVIEW_LABEL_BOTTOM_ALLOWANCE = 24;
+const OVERVIEW_LABEL_BOTTOM_ALLOWANCE = Math.max(...Object.values(LABEL_OFFSET)) + 4;
 
 function readSafeInsets(tokens: SafeInsetTokens): SafeInsets {
   return {


### PR DESCRIPTION
## Summary
- 첫 실행 카드 최상단에 "Ontology Atlas" 워드마크 한 줄 (text-caption + quaternary 토큰, 신규 색/크기 0) — 페르소나 재조사 개선 후보 2(제품 정체성 공백). 미션 반 문장은 기존 설명과 중복이라 의도적 미추가.
- `OVERVIEW_LABEL_BOTTOM_ALLOWANCE` 를 `max(LABEL_OFFSET)+4` 파생으로 교체 (Guardian follow-up — LABEL_OFFSET 변경 시 조용한 드리프트 차단), 테스트도 동일 파생식.

## Test plan
- topology-map-v2 621 ✅ · first-run-starter 36 ✅ · tsc ✅ · i18n ✅ · 실화면 1440 위계 확인 (본 세션 스크린샷)