### PR TITLE
fix: 소유자 라이브 실보고 웨이브 — 영역 복구·패널 강등·경계·인사이트·코멧/shimmer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1317,6 +1317,13 @@
     --topology-v2-selection-ring-indigo: var(--topology-v2-indigo-bright);
     --topology-v2-selection-ring-hairline: rgba(94, 106, 210, 0.45);
     --topology-v2-hover-ring: rgba(94, 106, 210, 0.55);
+    /* Design Guardian 승인 처방 L — 호버 circuit-trace shimmer. 정지 호버
+       링(위) 위에 저속 순회하는 밝은 아크 1개(글로우 0 — `strokeKindOutline`
+       패스 재사용 + `setLineDash`/`lineDashOffset` 시간 애니메이션만). seg 는
+       둘레 비율, period 는 1회전(ms, linear, 시계방향). 순수 위상 계산은
+       `model/hover-shimmer.ts`. */
+    --topology-v2-hover-shimmer-seg: 0.16;
+    --topology-v2-hover-shimmer-period-ms: 2400;
 
     /* 2.2 엣지 · 라벨 · 배경 */
     /* B1 잉크 위계 (Guardian 2026-07-20): 장식 입자가 데이터 엣지보다 3.2배

--- a/app/globals.css
+++ b/app/globals.css
@@ -1561,7 +1561,13 @@
        그 offset 을 뺀 나머지 뷰포트 높이로 clamp 하고 내부 스크롤을 연다 —
        패널 max-height 토큰들이 공유하는 "calc(100vh - top offset)" 패턴.
        하단 8px 여유도 그 관례와 동일. */
-    --topology-v2-panel-max-height: calc(100dvh - var(--topology-node-popover-top) - 8px);
+    /* zoom(--topology-ui-scale) 컨텍스트 보정 (소유자 실보고 2026-07-23,
+       1920 에서 데이터시트가 화면 하단 관통) — zoom 된 서브트리 안에서
+       100dvh(CSS px)는 시각적으로 zoom 배가 되므로 factor 로 나눠 실제
+       보이는 뷰포트 높이에 clamp 한다. factor 1 에서는 종전과 동일. */
+    --topology-v2-panel-max-height: calc(
+      100dvh / var(--topology-ui-scale-factor) - var(--topology-node-popover-top) - 8px
+    );
     /* 9→12px (feat/chrome-system §9, INDEX 패널 v2.1) — 데이터시트와
        INDEX 가 공유하는 패널 계층의 radius 를 크롬 시스템의 4계층 스텝
        (키캡4·inner7·타일/칩/필10·패널12) 마지막 단으로 승격. */
@@ -1730,21 +1736,23 @@
   @media (min-width: 1920px) {
     :root {
       --topology-relation-legend-inset: 32px;
-      --topology-ui-scale-factor: 1.15;
+      /* 1.15 → 1.08 (소유자 실보고 2026-07-23: 1920 에서 버튼이 커 보임 —
+         "아주 약간만") — zoom 과 factor 는 항상 짝으로 움직인다. */
+      --topology-ui-scale-factor: 1.08;
     }
 
     .topology-ui-scale {
-      zoom: 1.15;
+      zoom: 1.08;
     }
   }
 
   @media (min-width: 2400px) {
     :root {
-      --topology-ui-scale-factor: 1.3;
+      --topology-ui-scale-factor: 1.2;
     }
 
     .topology-ui-scale {
-      zoom: 1.3;
+      zoom: 1.2;
     }
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1598,6 +1598,8 @@
       "older": "Older",
       "axisStart": "{weeks} weeks ago",
       "axisEnd": "This week",
+      "weekCell": "{weeks}w ago · {count} updates",
+      "weekCellCurrent": "This week · {count} updates",
       "recentUpdatesTitle": "Recent updates",
       "noRecentUpdates": "No known update dates yet.",
       "staleCountLabel": "Not updated in 90+ days",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1598,6 +1598,8 @@
       "older": "오래됨",
       "axisStart": "{weeks}주 전",
       "axisEnd": "이번 주",
+      "weekCell": "{weeks}주 전 · 갱신 {count}건",
+      "weekCellCurrent": "이번 주 · 갱신 {count}건",
       "recentUpdatesTitle": "최근 갱신",
       "noRecentUpdates": "알려진 갱신일이 없습니다.",
       "staleCountLabel": "90일 이상 미갱신",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -354,10 +354,17 @@ export function HomePage() {
     indexPanelCollapsedStored ? "collapsed" : "expanded",
   );
   const leftSlotOwner = resolveLeftSlotOwner({ analysisMode });
-  const renderedIndexState = resolveRenderedIndexPanelState(
+  const baseRenderedIndexState = resolveRenderedIndexPanelState(
     leftSlotOwner,
     indexPreference,
   );
+  // C (소유자 실보고 2026-07-23, "어지럽다 — 모든 패널이 다 열려있어서") —
+  // 노드 선택(데이터시트 활성) 동안 좌측 스택은 접힘 탭으로 물러나고,
+  // 캔버스 빈 곳 클릭(선택 해제)이 원래 선호를 복귀시킨다. 선택 중 사용자가
+  // 탭으로 수동 전개하면 그 선택이 끝날 때까지 전개가 우선한다. 영구 선호
+  // (localStorage)는 건드리지 않는 순수 세션 강등.
+  const [indexManualExpandDuringSelection, setIndexManualExpandDuringSelection] =
+    useState(false);
   const setIndexPreference = useCallback(
     (next: IndexPanelState) => {
       try {
@@ -430,6 +437,9 @@ export function HomePage() {
   // mode (focus/path/health), so returning to overview is always enough.
   const handleIndexTabExpand = useCallback(() => {
     setIndexPreference("expanded");
+    // C — 선택 중 수동 전개는 그 선택 동안 자동 강등을 이긴다 (선택 해제
+    // 시 리셋; 비선택 상태에선 무해한 no-op 플래그).
+    setIndexManualExpandDuringSelection(true);
     if (analysisMode !== "overview") {
       setRouteState((current) => ({ ...current, analysisMode: "overview" }));
     }
@@ -441,20 +451,8 @@ export function HomePage() {
   // reads CSS vars once per `read-topology-v2-tokens.ts`'s own contract),
   // then force a re-fit via the existing "지도 맞추기" token so the camera
   // actually re-centers against the new width instead of just changing CSS.
-  useEffect(() => {
-    const root = document.documentElement;
-    root.dataset.topologyIndex = renderedIndexState;
-    clearTopologyV2TokensCache();
-    let cancelled = false;
-    // 동기 setState 회피(cascading-render 경고) — microtask 로 defer.
-    window.queueMicrotask(() => {
-      if (!cancelled) setFitViewToken((count) => count + 1);
-    });
-    return () => {
-      cancelled = true;
-      delete root.dataset.topologyIndex;
-    };
-  }, [renderedIndexState]);
+  // (dataset/fit 이펙트는 selection-aware 최종 renderedIndexState 파생 뒤로
+  //  이동 — C 자동 강등 참조.)
   const selectedProject = useMemo(
     () =>
       selectedSlug
@@ -1187,6 +1185,35 @@ export function HomePage() {
     [v2DatasheetModel?.documentHref],
   );
   useNavRailContextHrefs(navRailContextHrefs);
+  // C — 최종 INDEX 렌더 상태: 선택 활성 + 수동 전개 없음 + (영역 밖) 이면
+  // 자동 강등. 영역 대장은 영역의 유일한 탈출/탐색 표면이라 예외.
+  // M-7 Esc 사다리 존중 — rung 1(팝오버만 닫힘, 선택 유지) 상태에선 좌측이
+  // 돌아와야 하므로 "모델 존재"가 아니라 "데이터시트 실표시"에 결속한다.
+  const topologySelectionActive = Boolean(v2DatasheetModel) && !nodePopoverDismissed;
+  useEffect(() => {
+    if (!topologySelectionActive) setIndexManualExpandDuringSelection(false);
+  }, [topologySelectionActive]);
+  const renderedIndexState: IndexPanelState =
+    topologySelectionActive &&
+    resolvedRealmSlug === null &&
+    !indexManualExpandDuringSelection &&
+    baseRenderedIndexState === "expanded"
+      ? "collapsed"
+      : baseRenderedIndexState;
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.topologyIndex = renderedIndexState;
+    clearTopologyV2TokensCache();
+    let cancelled = false;
+    // 동기 setState 회피(cascading-render 경고) — microtask 로 defer.
+    window.queueMicrotask(() => {
+      if (!cancelled) setFitViewToken((count) => count + 1);
+    });
+    return () => {
+      cancelled = true;
+      delete root.dataset.topologyIndex;
+    };
+  }, [renderedIndexState]);
   const copyV2NodeHandoff = useCallback(
     async (text: string) => {
       const ok = await copyText(text);
@@ -2596,7 +2623,16 @@ export function HomePage() {
                 className="topology-ui-scale absolute z-20"
                 style={{
                   left: renderedIndexState === "expanded" ? "var(--topology-index-inset)" : 0,
-                  top: "var(--topology-index-top)",
+                  // J (소유자 실보고 2026-07-23) — 상시 "지형도" 헤더가
+                  // 은퇴한 뒤 전개 스택 위 84px 이 빈 띠로 남았다. 전개
+                  // 상태는 크롬 인셋(24px)까지 올린다. 브랜드 pill 이 뜨는
+                  // 상태(선택/드로어)에선 C 자동 강등으로 스택이 접힘 탭이
+                  // 되므로 pill 과의 겹침이 구조적으로 없다. 접힘 탭은
+                  // pill 아래 정렬을 위해 기존 84px 유지.
+                  top:
+                    renderedIndexState === "expanded"
+                      ? "var(--topology-index-inset)"
+                      : "var(--topology-index-top)",
                   bottom: renderedIndexState === "expanded" ? "var(--topology-index-inset)" : undefined,
                 }}
               >

--- a/src/views/ontology-insights/lib/freshness.test.ts
+++ b/src/views/ontology-insights/lib/freshness.test.ts
@@ -40,6 +40,11 @@ describe("computeFreshnessSummary", () => {
     expect(row.weeks).toHaveLength(12);
     expect(row.weeks[11].isCurrentWeek).toBe(true);
     expect(row.weeks[11].level).toBeGreaterThanOrEqual(1);
+    // 셀 툴팁 진실원 — level 은 3에서 포화되므로 원본 건수도 함께 노출한다.
+    expect(row.weeks[11].count).toBe(1);
+    // domain-views 자신의 갱신(5/1, 11주 전)은 weeks[0] 버킷 — 중간 주는 0.
+    expect(row.weeks[0].count).toBe(1);
+    expect(row.weeks[5].count).toBe(0);
     expect(row.daysAgo).toBe(1);
     expect(row.stale).toBe(false);
   });

--- a/src/views/ontology-insights/lib/freshness.ts
+++ b/src/views/ontology-insights/lib/freshness.ts
@@ -14,6 +14,9 @@ export interface FreshnessWeekCell {
   level: FreshnessLevel;
   /** 가장 최근 주(이번 주) 여부 — 인디고로 별도 강조. */
   isCurrentWeek: boolean;
+  /** 그 주의 실제 갱신 건수 — 셀 툴팁("N주 전 · 갱신 M건")의 진실원.
+   * level 은 3에서 포화되므로 원본 카운트를 함께 노출한다. */
+  count: number;
 }
 
 export interface DomainFreshnessRow {
@@ -134,6 +137,7 @@ export function computeFreshnessSummary(
       const weeks: FreshnessWeekCell[] = counts.map((count, i) => ({
         level: levelFromCount(count),
         isCurrentWeek: i === HEATSTRIP_WEEKS - 1,
+        count,
       }));
       const latestMs = latestByDomain.get(domain.id) ?? null;
       const daysAgo = latestMs !== null ? Math.floor((referenceDate.getTime() - latestMs) / DAY_MS) : null;

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -332,6 +332,8 @@ export function OntologyInsightsPage() {
     older: t("older"),
     axisStart: t("axisStart", { weeks: FRESHNESS_WINDOW_WEEKS }),
     axisEnd: t("axisEnd"),
+    weekCell: (weeksAgo: number, count: number) => t("weekCell", { weeks: weeksAgo, count }),
+    weekCellCurrent: (count: number) => t("weekCellCurrent", { count }),
     recentUpdatesTitle: t("recentUpdatesTitle"),
     noRecentUpdates: t("noRecentUpdates"),
     staleCountLabel: t("staleCountLabel"),
@@ -444,6 +446,10 @@ export function OntologyInsightsPage() {
               />
             ) : null}
             {tab === "structure" ? (
+              /* 구조 탭은 두 컴포넌트(개요 그리드 + 관계 그리드)를 세로로 잇는다 —
+                 수평 카드 갭과 같은 --card-gap 으로 수직 리듬을 맞춰 4카드가
+                 한 클러스터로 읽히게 한다(갭 0 이면 카드 보더가 맞붙는다). */
+              <div className="flex min-h-0 flex-1 flex-col gap-[var(--card-gap)]">
               <OverviewTab
                 totalNodes={totalNodes}
                 totalEdges={totalEdges}
@@ -454,8 +460,6 @@ export function OntologyInsightsPage() {
                 kindLabel={kindLabel}
                 labels={overviewLabels}
               />
-            ) : null}
-            {tab === "structure" ? (
               <RelationsTab
                 edgeTypeRows={edgeTypeRows}
                 totalEdges={totalEdges}
@@ -474,6 +478,7 @@ export function OntologyInsightsPage() {
                 }}
                 labels={relationsLabels}
               />
+              </div>
             ) : null}
             {tab === "freshness" ? (
               <FreshnessTab

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -595,7 +595,10 @@ export function DoNextTab({
       <div className="grid min-h-0 flex-1 grid-cols-1 gap-[var(--card-gap)] lg:grid-cols-[1.2fr_1fr]">
       <section
         aria-label={labels.queueTitle}
-        className="flex min-h-0 min-w-0 flex-col gap-4 rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
+        // 섹션 간 갭 16px 는 행 피치(~53px)보다 약해 다음 섹션 헤딩이 위
+        // 목록에 붙어 읽혔다(게슈탈트 근접성 역전) — 24px 로 섹션 경계를
+        // 행 간격 위로 올린다.
+        className="flex min-h-0 min-w-0 flex-col gap-6 rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)]"
       >
         <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
           {labels.queueTitle}

--- a/src/views/ontology-insights/ui/tabs/FreshnessTab.test.tsx
+++ b/src/views/ontology-insights/ui/tabs/FreshnessTab.test.tsx
@@ -22,6 +22,8 @@ const labels: FreshnessTabLabels = {
   older: "Older",
   axisStart: "12 weeks ago",
   axisEnd: "Now",
+  weekCell: (weeksAgo, count) => `${weeksAgo}w ago · ${count} updates`,
+  weekCellCurrent: (count) => `This week · ${count} updates`,
   recentUpdatesTitle: "Recent updates",
   noRecentUpdates: "No recent updates",
   staleCountLabel: "Stale (90d+)",
@@ -98,6 +100,42 @@ describe("FreshnessTab", () => {
     expect(link).toHaveAttribute("href", "/ontology/?node=domain%3Aauth");
     expect(link).toHaveAttribute("aria-label", "Auth — view on the map");
     expect(link).toHaveTextContent("Auth");
+  });
+
+  it("히트스트립 셀마다 주차·실건수 툴팁을 단다 — 이번 주 셀은 전용 문구", () => {
+    const weeks = Array.from({ length: 12 }, (_, i) => ({
+      level: (i === 11 ? 2 : i === 9 ? 1 : 0) as 0 | 1 | 2 | 3,
+      isCurrentWeek: i === 11,
+      count: i === 11 ? 2 : i === 9 ? 1 : 0,
+    }));
+    render(
+      <FreshnessTab
+        domainRows={[
+          {
+            domainId: "domain:views",
+            domainTitle: "Views",
+            weeks,
+            mostRecentUpdatedAt: "2026-07-20T00:00:00.000Z",
+            daysAgo: 1,
+            stale: false,
+          },
+        ]}
+        recent={[]}
+        staleCount={0}
+        weeklyTotals={[]}
+        kindLabel={(kind) => kind}
+        recentLink={recentLink}
+        labels={labels}
+      />,
+    );
+
+    const row = screen.getByTestId("insights-freshness-domain-row");
+    const cells = row.querySelectorAll("i[title]");
+    // 12개 셀 전부 툴팁 — 마지막(우측)이 이번 주, 그 앞은 "N주 전".
+    expect(cells).toHaveLength(12);
+    expect(cells[11]).toHaveAttribute("title", "This week · 2 updates");
+    expect(cells[9]).toHaveAttribute("title", "2w ago · 1 updates");
+    expect(cells[0]).toHaveAttribute("title", "11w ago · 0 updates");
   });
 
   it("shows the empty state instead of a list when there are no recent updates", () => {

--- a/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
@@ -22,6 +22,10 @@ export interface FreshnessTabLabels {
   /** 히트스트립 시간축 방향 라벨 — 좌측(과거) / 우측(현재). */
   axisStart: string;
   axisEnd: string;
+  /** 셀 툴팁 — "N주 전 · 갱신 M건" (weeksAgo ≥ 1). */
+  weekCell: (weeksAgo: number, count: number) => string;
+  /** 이번 주 셀 툴팁 — "이번 주 · 갱신 M건". */
+  weekCellCurrent: (count: number) => string;
   recentUpdatesTitle: string;
   noRecentUpdates: string;
   staleCountLabel: string;
@@ -79,7 +83,14 @@ export function FreshnessTab({
         ) : (
           <div className="mt-3.5 flex flex-1 flex-col justify-evenly gap-1.5">
             {domainRows.map((row) => (
-              <div key={row.domainId} className="flex items-center gap-2">
+              // 행 호버 하이라이트 — 700px 가로 스캔(라벨→12셀→날짜)을 돕는
+              // 기존 hub/최근갱신 행과 같은 -mx/px 상쇄 패턴이라 셀·축 정렬은
+              // 그대로다(콘텐츠 x 위치 불변).
+              <div
+                key={row.domainId}
+                data-testid="insights-freshness-domain-row"
+                className="-mx-1.5 flex items-center gap-2 rounded-md px-1.5 transition-colors hover:bg-[color:var(--color-overlay-1)]"
+              >
                 <span
                   className={
                     "flex w-[136px] flex-none items-center gap-1.5 truncate text-label " +
@@ -98,9 +109,16 @@ export function FreshnessTab({
                   {row.weeks.map((week, i) => (
                     <i
                       key={i}
-                      title={week.isCurrentWeek ? labels.currentWeek : undefined}
+                      // 셀 = 한 주의 갱신 건수. max-w 캡을 두면 스트립이 좌측에
+                      // 뭉쳐 아래 축 라벨("이번 주")이 마지막 셀과 어긋난다 —
+                      // flex-1 충만으로 축·범례·날짜 열과 같은 폭을 공유한다.
+                      title={
+                        week.isCurrentWeek
+                          ? labels.weekCellCurrent(week.count)
+                          : labels.weekCell(row.weeks.length - 1 - i, week.count)
+                      }
                       // eslint-disable-next-line no-restricted-syntax -- 14px 높이 주간 신선도 바의 3px 헤어라인 반경은 chip(6px)로 올리면 pill 이 돼 램프 밖 예외.
-                      className="h-3.5 flex-1 max-w-6 rounded-[3px]"
+                      className="h-3.5 flex-1 rounded-[3px]"
                       style={{
                         backgroundColor: week.isCurrentWeek
                           ? "var(--color-indigo-brand)"

--- a/src/widgets/topology-map-v2/model/hover-shimmer.test.ts
+++ b/src/widgets/topology-map-v2/model/hover-shimmer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { clampSegRatio, computeHoverShimmer } from "./hover-shimmer";
+
+describe("clampSegRatio", () => {
+  it("[0,1] 안은 그대로", () => {
+    expect(clampSegRatio(0.16)).toBe(0.16);
+    expect(clampSegRatio(0)).toBe(0);
+    expect(clampSegRatio(1)).toBe(1);
+  });
+
+  it("음수는 0 으로 클램프", () => {
+    expect(clampSegRatio(-0.5)).toBe(0);
+  });
+
+  it("1 초과는 1 로 클램프", () => {
+    expect(clampSegRatio(1.4)).toBe(1);
+  });
+});
+
+describe("computeHoverShimmer", () => {
+  const PERIMETER = 100;
+  const PERIOD = 2400;
+
+  it("결정론 — 같은 입력은 같은 결과", () => {
+    const a = computeHoverShimmer(1000, PERIOD, PERIMETER, 0.16);
+    const b = computeHoverShimmer(1000, PERIOD, PERIMETER, 0.16);
+    expect(a).toEqual(b);
+  });
+
+  it("seg 비율대로 dash 세그먼트/간격 길이를 낸다", () => {
+    const { dash } = computeHoverShimmer(0, PERIOD, PERIMETER, 0.16);
+    expect(dash[0]).toBeCloseTo(16, 6);
+    expect(dash[1]).toBeCloseTo(84, 6);
+  });
+
+  it("seg=0 클램프 경계 — 세그먼트 0, 간격 = 전체 둘레", () => {
+    const { dash } = computeHoverShimmer(0, PERIOD, PERIMETER, -1);
+    expect(dash[0]).toBe(0);
+    expect(dash[1]).toBe(PERIMETER);
+  });
+
+  it("seg=1 클램프 경계 — 세그먼트 = 전체 둘레, 간격 0", () => {
+    const { dash } = computeHoverShimmer(0, PERIOD, PERIMETER, 2);
+    expect(dash[0]).toBe(PERIMETER);
+    expect(dash[1]).toBe(0);
+  });
+
+  it("now=0 → offset 0(위상 시작점)", () => {
+    // -0*perimeter === -0 — Object.is 는 -0 !== 0 으로 보므로 toBeCloseTo 사용.
+    expect(computeHoverShimmer(0, PERIOD, PERIMETER, 0.16).offset).toBeCloseTo(0, 9);
+  });
+
+  it("등속 순환 — half period 에서 정확히 절반 둘레만큼 전진", () => {
+    const { offset } = computeHoverShimmer(PERIOD / 2, PERIOD, PERIMETER, 0.16);
+    expect(offset).toBeCloseTo(-PERIMETER / 2, 6);
+  });
+
+  it("한 바퀴(now=period)에서 시작점으로 랩", () => {
+    const { offset } = computeHoverShimmer(PERIOD, PERIOD, PERIMETER, 0.16);
+    expect(offset).toBeCloseTo(0, 6);
+  });
+
+  it("여러 바퀴를 돌아도 phase 는 항상 같은 위치로 랩(결정론 순환)", () => {
+    const oneLap = computeHoverShimmer(300, PERIOD, PERIMETER, 0.16);
+    const threeLaps = computeHoverShimmer(300 + PERIOD * 3, PERIOD, PERIMETER, 0.16);
+    expect(threeLaps.offset).toBeCloseTo(oneLap.offset, 6);
+  });
+
+  it("단조 진행 — period 안에서 now 증가에 따라 offset 크기(진행 거리)도 단조 증가", () => {
+    const times = [0, 200, 600, 1200, 2000];
+    const offsets = times.map((t) => Math.abs(computeHoverShimmer(t, PERIOD, PERIMETER, 0.16).offset));
+    for (let i = 1; i < offsets.length; i += 1) {
+      expect(offsets[i]).toBeGreaterThan(offsets[i - 1]);
+    }
+  });
+
+  it("perimeter<=0 이면 그릴 게 없다 — dash [0,0], offset 0", () => {
+    expect(computeHoverShimmer(500, PERIOD, 0, 0.16)).toEqual({ dash: [0, 0], offset: 0 });
+    expect(computeHoverShimmer(500, PERIOD, -10, 0.16)).toEqual({ dash: [0, 0], offset: 0 });
+  });
+
+  it("periodMs<=0 이면 그릴 게 없다 — dash [0,0], offset 0", () => {
+    expect(computeHoverShimmer(500, 0, PERIMETER, 0.16)).toEqual({ dash: [0, 0], offset: 0 });
+  });
+});

--- a/src/widgets/topology-map-v2/model/hover-shimmer.ts
+++ b/src/widgets/topology-map-v2/model/hover-shimmer.ts
@@ -1,0 +1,52 @@
+/**
+ * Design Guardian 승인 처방 L — 호버 circuit-trace shimmer 의 순수 위상 모델.
+ * 정지 호버 링(1px, r+3) 위에 저속 순회하는 밝은 아크 1개를
+ * `ctx.setLineDash`/`ctx.lineDashOffset` 로 얹는다(글로우/그림자 0 — 같은
+ * `strokeKindOutline` 형상 패스를 재사용하는 게 렌더 쪽 계약).
+ *
+ * 이 모듈은 **시간→위상**만 안다: 둘레(perimeter)는 kind/farT 에 따라
+ * hex/사각/원으로 달라지는 지오메트리라 호출부(`render/node-shapes.ts`)가
+ * 이미 갖고 있는 `bodyPoints`/`FULL_CIRCLE_FAR_T` 분기로 계산해 인자로 넘긴다
+ * — 여기선 순수 산수만(캔버스/DOM 모름), vitest 로 결정론·클램프·등속 순환을
+ * 핀한다. reduced-motion 게이트는 호출부 책임(이 모듈에 새 분기 없음).
+ */
+
+/** seg 비율 클램프 [0,1] — 토큰 drift(음수/1 초과)가 들어와도 안전. */
+export function clampSegRatio(segRatio: number): number {
+  if (segRatio < 0) return 0;
+  if (segRatio > 1) return 1;
+  return segRatio;
+}
+
+export interface ShimmerDash {
+  /** `ctx.setLineDash` 인자 — [세그먼트 길이, 나머지(간격) 길이]. */
+  dash: readonly [number, number];
+  /** `ctx.lineDashOffset`. */
+  offset: number;
+}
+
+/**
+ * `now`(ms) 시점의 shimmer dash/offset — 등속(linear) 순환, 1회전
+ * `periodMs`, 시계 방향 1개 아크(`strokeKindOutline`이 그리는 패스 자체가
+ * 이미 각도 증가 = 시계 방향이라 offset 은 그 방향으로만 전진). `perimeter`
+ * 또는 `periodMs` 가 0 이하면(아직 지오메트리를 못 구했거나 토큰 drift) 그릴
+ * 게 없어 dash `[0,0]`/offset 0 을 낸다 — 호출부는 `dash[0] <= 0` 이면
+ * stroke 를 건너뛰면 된다.
+ */
+export function computeHoverShimmer(
+  now: number,
+  periodMs: number,
+  perimeter: number,
+  segRatio: number,
+): ShimmerDash {
+  if (perimeter <= 0 || periodMs <= 0) {
+    return { dash: [0, 0], offset: 0 };
+  }
+  const seg = clampSegRatio(segRatio);
+  const segLen = perimeter * seg;
+  const gapLen = perimeter - segLen;
+  // now 가 음수로 들어와도(이론상 없지만 방어) phase 는 항상 [0,1).
+  const phase = (((now % periodMs) + periodMs) % periodMs) / periodMs;
+  const offset = -phase * perimeter;
+  return { dash: [segLen, gapLen], offset };
+}

--- a/src/widgets/topology-map-v2/render/edge-fireflies.test.ts
+++ b/src/widgets/topology-map-v2/render/edge-fireflies.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   advanceParticlePhase,
+  edgePairKey,
+  EGO_CONTAINS_COMET_LIMIT,
   fireflySeed,
   PULSE_DURATION_MS,
   PULSE_TRAIL_LAG,
   pulseHeadTrail,
   pulseScale,
+  selectEgoContainsComets,
   spawnHoverPulses,
   updateParticles,
   updatePulses,
@@ -93,6 +96,71 @@ describe("updateParticles", () => {
     updateParticles(edges, 0.016, false, (e) => (e.sourceId === "a" ? 0 : 0.2));
     expect(edges[0].t).toBe(0.1); // speed 0 → 정지
     expect(edges[2].t).not.toBe(0.9); // speed 0.2 → 전진
+  });
+
+  it("처방 E — isEgoContainsEligible 이 true 인 contains 엣지는 depends 처럼 전진한다", () => {
+    const edges = makeEdges();
+    updateParticles(
+      edges,
+      0.016,
+      false,
+      () => 0.075,
+      (e) => e.kind === "contains" && e.sourceId === "a" && e.targetId === "c",
+    );
+    expect(edges[1].t).toBeGreaterThan(0.1); // 이제 eligible contains 도 전진
+  });
+
+  it("처방 E — isEgoContainsEligible 이 false 인 contains 는 여전히 불변", () => {
+    const edges = makeEdges();
+    updateParticles(edges, 0.016, false, () => 0.075, () => false);
+    expect(edges[1].t).toBe(0.1);
+  });
+
+  it("처방 E — 인자 생략 시 기존 계약(contains 항상 불변) 유지", () => {
+    const edges = makeEdges();
+    updateParticles(edges, 0.016, false, () => 0.075);
+    expect(edges[1].t).toBe(0.1);
+  });
+});
+
+describe("edgePairKey", () => {
+  it("source target 순서로 조인한다", () => {
+    expect(edgePairKey("a", "b")).toBe("a b");
+  });
+});
+
+describe("selectEgoContainsComets", () => {
+  const edges = [
+    { sourceId: "hub", targetId: "x1" },
+    { sourceId: "hub", targetId: "x2" },
+    { sourceId: "hub", targetId: "x3" },
+  ];
+
+  it("결정론 — 같은 입력은 같은 결과(seed 랭크)", () => {
+    const a = selectEgoContainsComets(edges);
+    const b = selectEgoContainsComets(edges);
+    expect([...a].sort()).toEqual([...b].sort());
+  });
+
+  it("limit 미만이면 전부 포함", () => {
+    const selected = selectEgoContainsComets(edges, 24);
+    expect(selected.size).toBe(3);
+    for (const e of edges) expect(selected.has(edgePairKey(e.sourceId, e.targetId))).toBe(true);
+  });
+
+  it("limit 초과분은 seed 순 상위만 선택 — 총 개수는 limit 을 넘지 않는다", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ sourceId: "hub", targetId: `n${i}` }));
+    const selected = selectEgoContainsComets(many, EGO_CONTAINS_COMET_LIMIT);
+    expect(selected.size).toBe(EGO_CONTAINS_COMET_LIMIT);
+  });
+
+  it("기본 limit = EGO_CONTAINS_COMET_LIMIT(24)", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ sourceId: "hub", targetId: `n${i}` }));
+    expect(selectEgoContainsComets(many).size).toBe(24);
+  });
+
+  it("빈 입력은 빈 Set", () => {
+    expect(selectEgoContainsComets([]).size).toBe(0);
   });
 });
 

--- a/src/widgets/topology-map-v2/render/edge-fireflies.ts
+++ b/src/widgets/topology-map-v2/render/edge-fireflies.ts
@@ -63,21 +63,55 @@ export interface ParticleEdge {
   targetId: string;
 }
 
+/** 엣지 양 끝 id 를 세트/맵 키로 정규화 — `fireflySeed`와 같은 순서(source target)를 쓴다. */
+export function edgePairKey(sourceId: string, targetId: string): string {
+  return `${sourceId} ${targetId}`;
+}
+
 /**
- * 프로토타입 `updateParticles` — depends 엣지의 위상을 in place 전진한다.
+ * Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지 코멧 캡.
+ * 포커스 노드의 팬아웃이 크면(예: 자식 90개 domain) 전부 점등이 판독 불가한
+ * 파티클 다발이 된다. `fireflySeed` 오름차순(결정론, RNG 상태 없음)으로
+ * 랭크해 상위 `limit`개만 코멧 대상으로 고르고 나머지는 파티클 없이 기존 ego
+ * 밝기만 유지한다(호출부가 이 Set 을 `updateParticles`의 진행 게이트와
+ * `render/traces.ts`의 드로우 게이트 양쪽에 동일하게 적용).
+ */
+export const EGO_CONTAINS_COMET_LIMIT = 24;
+
+export function selectEgoContainsComets(
+  incidentContainsEdges: readonly { sourceId: string; targetId: string }[],
+  limit: number = EGO_CONTAINS_COMET_LIMIT,
+): ReadonlySet<string> {
+  const ranked = [...incidentContainsEdges].sort((a, b) => {
+    const seedDiff = fireflySeed(a.sourceId, a.targetId) - fireflySeed(b.sourceId, b.targetId);
+    if (seedDiff !== 0) return seedDiff;
+    const ka = edgePairKey(a.sourceId, a.targetId);
+    const kb = edgePairKey(b.sourceId, b.targetId);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+  return new Set(ranked.slice(0, Math.max(0, limit)).map((e) => edgePairKey(e.sourceId, e.targetId)));
+}
+
+/**
+ * 프로토타입 `updateParticles` — depends 엣지의 위상을 항상 in place 전진한다.
  * reduced-motion 이면 아무 것도 하지 않는다(정지). `speedOf`로 엣지별 속도를
  * 받는다(ego 가속 등은 호출부가 결정 — 이 모듈은 모델/model 을 import 하지
  * 않아 순수하게 유지).
+ *
+ * 처방 E — contains 엣지는 기본적으로 정지지만, `isEgoContainsEligible`이
+ * true 를 낸 엣지(선택 노드에 물린 + 캡 안쪽)만 depends 와 똑같이 전진한다.
+ * 인자를 생략하면 전부 false(기존 "contains 는 항상 불변" 계약 그대로).
  */
 export function updateParticles(
   edges: readonly ParticleEdge[],
   dt: number,
   reducedMotion: boolean,
   speedOf: (edge: ParticleEdge) => number,
+  isEgoContainsEligible: (edge: ParticleEdge) => boolean = () => false,
 ): void {
   if (reducedMotion) return;
   for (const edge of edges) {
-    if (edge.kind !== "depends") continue;
+    if (edge.kind !== "depends" && !(edge.kind === "contains" && isEgoContainsEligible(edge))) continue;
     edge.t = advanceParticlePhase(edge.t, dt, speedOf(edge));
   }
 }

--- a/src/widgets/topology-map-v2/render/node-shapes.ts
+++ b/src/widgets/topology-map-v2/render/node-shapes.ts
@@ -20,6 +20,7 @@
  */
 
 import { smoothstep } from "../model/altitude";
+import { computeHoverShimmer } from "../model/hover-shimmer";
 
 export interface Point {
   x: number;
@@ -108,6 +109,15 @@ export interface NodeShapeDrawState {
    * whenever there's no fresh focus (fabrication 0).
    */
   agentFocus: boolean;
+  /**
+   * Design Guardian 처방 L — 호버 circuit-trace shimmer 의 시간원. 프레임의
+   * `performance.now()` 호환 타임스탬프(픽셀 드로우 자체는 시간을 모르는
+   * 순수 계층이 아니므로 여기서만 받는다) + reduced-motion 게이트. 정지 호버
+   * 링(`isHovered` 블록)은 이 값과 무관하게 항상 그려지고, shimmer 아크만
+   * `!reducedMotion` 일 때 그 위에 얹힌다.
+   */
+  now: number;
+  reducedMotion: boolean;
 }
 
 export interface NodeShapeTokens {
@@ -131,6 +141,12 @@ export interface NodeShapeTokens {
   selectionHairline: string;
   /** Canvas-emphasis slice — the hover preview ring's color (spec §C), a static 1px indigo hairline distinct from the brighter selection ring. */
   hoverRing: string;
+  /** Design Guardian 처방 L — 호버 shimmer 아크 길이(둘레 비율, `--topology-v2-hover-shimmer-seg`). */
+  hoverShimmerSeg: number;
+  /** Design Guardian 처방 L — 호버 shimmer 1회전 주기(ms, `--topology-v2-hover-shimmer-period-ms`). */
+  hoverShimmerPeriodMs: number;
+  /** Design Guardian 처방 L — 호버 shimmer 아크 색(`--topology-v2-indigo-bright` 재사용, 새 hue 없음). */
+  hoverShimmerColor: string;
 }
 
 /** Full convergence to a plain circle above this farT — avoids float-precision polygon/circle seams (prototype: `farT > 0.985`). */
@@ -347,6 +363,69 @@ function strokeKindOutline(
 }
 
 /**
+ * Approximate perimeter of the node's own outline at this farT/kind — the
+ * straight-edge sum of `bodyPoints` (ignoring the small corner-rounding
+ * inset `roundedPolygonPath` trims off) for the polygon range, or a plain
+ * circle circumference past `FULL_CIRCLE_FAR_T` — mirrors the exact same
+ * polygon/circle branch `strokeKindOutline` draws with. Used only to size
+ * the hover-shimmer dash pattern (a decorative overlay, not a hit-test), so
+ * this approximation is enough — no separate test needed the way the pure
+ * `model/hover-shimmer.ts` time math is.
+ */
+function outlinePerimeter(kind: NodeShapeDrawState["kind"], radius: number, farT: number): number {
+  const points = bodyPoints(kind, 0, 0, radius);
+  if (points === null || farT > FULL_CIRCLE_FAR_T) return 2 * Math.PI * radius;
+  let perimeter = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % points.length];
+    perimeter += Math.hypot(p2.x - p1.x, p2.y - p1.y);
+  }
+  return perimeter;
+}
+
+/**
+ * Design Guardian 처방 L — 정지 호버 링(`strokeKindOutline`) 위에 저속 순회
+ * 아크 1개를 얹는다. 같은 형상 패스(hex/사각/원, farT 수렴 규칙까지 동일)를
+ * 다시 그리되 `setLineDash`/`lineDashOffset` 로 일부만 보이게 해 "회로를
+ * 순회하는 신호" 를 표현한다 — 글로우/그림자 0(design.md), 색은 인디고
+ * bright 표준 톤 재사용. 세그먼트 길이가 0 이면(토큰 drift 등) 아무 것도
+ * 그리지 않는다.
+ */
+function drawHoverShimmer(
+  ctx: CanvasRenderingContext2D,
+  kind: NodeShapeDrawState["kind"],
+  x: number,
+  y: number,
+  radius: number,
+  farT: number,
+  now: number,
+  periodMs: number,
+  segRatio: number,
+  color: string,
+): void {
+  const perimeter = outlinePerimeter(kind, radius, farT);
+  const { dash, offset } = computeHoverShimmer(now, periodMs, perimeter, segRatio);
+  if (dash[0] <= 0) return;
+  const points = bodyPoints(kind, x, y, radius);
+  if (points === null || farT > FULL_CIRCLE_FAR_T) {
+    ctx.beginPath();
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+  } else {
+    roundedPolygonPath(ctx, points, interpolateCornerRadius(minCornerRadius(kind, radius), radius, farT));
+  }
+  ctx.setLineDash([...dash]);
+  ctx.lineDashOffset = offset;
+  ctx.globalAlpha = 0.9;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.lineDashOffset = 0;
+  ctx.globalAlpha = 1;
+}
+
+/**
  * Draws one node body (fill/stroke/dash + kind-specific shape morph + hub
  * ring + engraved numeral + via-hole for elements). Does NOT draw the
  * diffraction spike overlay (`render/starfield.ts#drawDiffractionSpike`
@@ -371,6 +450,8 @@ export function draw(ctx: CanvasRenderingContext2D, state: NodeShapeDrawState, t
     isHovered,
     selectionPulse,
     agentFocus,
+    now,
+    reducedMotion,
   } = state;
 
   ctx.setLineDash([...dash]);
@@ -466,6 +547,23 @@ export function draw(ctx: CanvasRenderingContext2D, state: NodeShapeDrawState, t
   // ring below — but the `egoState` guards stay as defense in depth.
   if (isHovered && egoState !== "dim" && egoState !== "center") {
     strokeKindOutline(ctx, kind, x, y, r + HOVER_RING_OFFSET, farT, tokens.hoverRing, 1, 1);
+    // Design Guardian 처방 L — shimmer 아크는 정지 링 위의 순수 모션 오버레이라
+    // reduced-motion 사용자에겐 정지 링만 남기고 완전히 미표시(새 분기 없이
+    // 여기 한 곳에서만 게이트).
+    if (!reducedMotion) {
+      drawHoverShimmer(
+        ctx,
+        kind,
+        x,
+        y,
+        r + HOVER_RING_OFFSET,
+        farT,
+        now,
+        tokens.hoverShimmerPeriodMs,
+        tokens.hoverShimmerSeg,
+        tokens.hoverShimmerColor,
+      );
+    }
   }
 
   // Canvas-emphasis slice §B — the selected node's STATIC double ring (2px on

--- a/src/widgets/topology-map-v2/render/traces.test.ts
+++ b/src/widgets/topology-map-v2/render/traces.test.ts
@@ -79,9 +79,13 @@ describe("bezierPoint", () => {
  * Comet-tail contract (R6 상시 혜성 복원 — 소유자 지시 "예전 걸 살려줘"). The
  * prototype's ambient comet is back: EVERY non-dim `depends` edge carries the
  * three-dot tail regardless of focus (the old A1 "focus signal only" retirement
- * is reversed). ego/selected edges get a bigger, brighter tail; contains edges
- * and dimmed edges never draw it; reduced-motion suppresses it entirely (so the
- * canvas can still reach a genuine idle state for those users).
+ * is reversed). ego/selected edges get a bigger, brighter tail; dimmed edges
+ * never draw it; reduced-motion suppresses it entirely (so the canvas can
+ * still reach a genuine idle state for those users). Design Guardian 처방 E —
+ * `contains` edges normally never draw a tail EXCEPT the incident ego edges
+ * the caller marks `containsCometEligible: true` (seed-ranked top-24 cap
+ * upstream in `render/edge-fireflies.ts#selectEgoContainsComets`) — see the
+ * dedicated `describe` block below.
  */
 describe("draw — comet tail is an always-on depends signal", () => {
   const TOKENS = {
@@ -147,6 +151,99 @@ describe("draw — comet tail is an always-on depends signal", () => {
   it("suppresses the tail under prefers-reduced-motion (idle-gate contract)", () => {
     expect(drawAndCountTailDots({ ...base, egoState: "normal", reducedMotion: true })).toBe(0);
     expect(drawAndCountTailDots({ ...base, egoState: "ego", reducedMotion: true })).toBe(0);
+  });
+});
+
+/**
+ * Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지도 코멧
+ * 흐름을 탄다(depends 와 같은 지속 위상, 일회성 아님). 캡(`containsCometEligible`)
+ * 을 통과 못 한 엣지·ego 아닌 엣지·dim·reduced-motion 은 여전히 0.
+ */
+describe("draw — ego contains comet (Guardian E)", () => {
+  const TOKENS = {
+    edgeContains: "#3a3a42",
+    edgeDepends: "#4c4c63",
+    edgeDim: "#1a1a1f",
+    indigo: "#5e6ad2",
+    indigoBright: "#8b97ff",
+  };
+
+  function drawAndCountTailDots(state: TraceDrawState): number {
+    let arcs = 0;
+    const ctx = {
+      beginPath() {},
+      moveTo() {},
+      lineTo() {},
+      quadraticCurveTo() {},
+      stroke() {},
+      fill() {},
+      setLineDash() {},
+      arc() {
+        arcs += 1;
+      },
+      strokeStyle: "",
+      fillStyle: "",
+      lineWidth: 0,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineDashOffset: 0,
+    } as unknown as CanvasRenderingContext2D;
+    draw(ctx, state, TOKENS);
+    return arcs;
+  }
+
+  const base: TraceDrawState = {
+    a: { x: 0, y: 0 },
+    b: { x: 100, y: 0 },
+    control: { x: 50, y: 20 },
+    relationType: "contains",
+    egoState: "ego",
+    farT: 0,
+    t: 0.5,
+    containsCometEligible: true,
+  };
+
+  it("draws the three-dot tail on an eligible ego contains edge", () => {
+    expect(drawAndCountTailDots(base)).toBe(3);
+  });
+
+  it("no tail when containsCometEligible is false/absent (cap excluded) even if ego", () => {
+    expect(drawAndCountTailDots({ ...base, containsCometEligible: false })).toBe(0);
+    const { containsCometEligible: _omit, ...withoutFlag } = base;
+    expect(drawAndCountTailDots(withoutFlag)).toBe(0);
+  });
+
+  it("no tail when eligible but not ego (normal/dim contains never comet)", () => {
+    expect(drawAndCountTailDots({ ...base, egoState: "normal" })).toBe(0);
+    expect(drawAndCountTailDots({ ...base, egoState: "dim" })).toBe(0);
+  });
+
+  it("reduced-motion suppresses even an eligible ego contains comet", () => {
+    expect(drawAndCountTailDots({ ...base, reducedMotion: true })).toBe(0);
+  });
+
+  it("uses the standard indigo tone (not bright) — NORMAL tail tier one step below depends ego", () => {
+    let fillStyle = "";
+    const ctx = {
+      beginPath() {},
+      moveTo() {},
+      lineTo() {},
+      quadraticCurveTo() {},
+      stroke() {},
+      fill() {
+        fillStyle = String((this as { fillStyle?: unknown }).fillStyle);
+      },
+      setLineDash() {},
+      arc() {},
+      strokeStyle: "",
+      fillStyle: "",
+      lineWidth: 0,
+      lineCap: "butt",
+      lineJoin: "miter",
+      lineDashOffset: 0,
+    } as unknown as CanvasRenderingContext2D;
+    draw(ctx, base, TOKENS);
+    expect(fillStyle).toBe(TOKENS.indigo);
   });
 });
 

--- a/src/widgets/topology-map-v2/render/traces.ts
+++ b/src/widgets/topology-map-v2/render/traces.ts
@@ -128,6 +128,14 @@ export interface TraceDrawState {
    * of five uncovered motion sources).
    */
   reducedMotion?: boolean;
+  /**
+   * Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 `contains` 엣지 코멧
+   * 흐름의 게이트. `egoState === "ego"`인 contains 엣지 중, 캐퍼(`render/
+   * edge-fireflies.ts#selectEgoContainsComets`, seed 순 상위 24개)를 통과한
+   * 엣지만 true — 캡 밖 엣지는 파티클 없이 기존 ego 밝기(본체 stroke)만
+   * 유지한다. `depends` 엣지는 이 필드를 쓰지 않는다(항상 기존 규칙).
+   */
+  containsCometEligible?: boolean;
 }
 
 export interface TraceTokens {
@@ -261,28 +269,54 @@ export function draw(ctx: CanvasRenderingContext2D, state: TraceDrawState, token
   }
   ctx.setLineDash([]);
 
-  if (!isDepends || egoState === "dim") return;
-  // R6 상시 혜성 복원(소유자 지시 "예전 걸 살려줘" — 구 Guardian A1 "코멧테일=
-  // 포커스 신호" 강등을 되돌림): 코멧 꼬리는 dim 이 아닌 모든 depends 엣지에서
-  // 포커스와 무관하게 흐른다(프로토타입 §13 `drawEdge`의 `state !== "dim"`).
-  // 위상 전진은 `updateParticles`(reduced-motion 이면 정지)가 소유하므로
-  // reduced-motion 사용자에겐 여기서도 미표시 → "아무 것도 안 움직인다" 유지.
-  if (state.reducedMotion === true) return;
+  if (isDepends) {
+    if (egoState === "dim") return;
+    // R6 상시 혜성 복원(소유자 지시 "예전 걸 살려줘" — 구 Guardian A1 "코멧테일=
+    // 포커스 신호" 강등을 되돌림): 코멧 꼬리는 dim 이 아닌 모든 depends 엣지에서
+    // 포커스와 무관하게 흐른다(프로토타입 §13 `drawEdge`의 `state !== "dim"`).
+    // 위상 전진은 `updateParticles`(reduced-motion 이면 정지)가 소유하므로
+    // reduced-motion 사용자에겐 여기서도 미표시 → "아무 것도 안 움직인다" 유지.
+    if (state.reducedMotion === true) return;
 
-  // comet tail — three shrinking dots trailing the live pulse position,
-  // thinning toward hairline dust as altitude rises rather than fading via
-  // alpha (forbidden.md bans glow/alpha-based "signal" motifs). ego/선택
-  // 엣지는 더 큰 꼬리 + bright 인디고, normal 은 옅은 인디고(프로토타입 대칭).
-  const ego = egoState === "ego" || state.selected === true;
-  const baseSizes = emphasized ? COMET_TAIL_BASE_EMPHASIZED : ego ? COMET_TAIL_BASE_EGO : COMET_TAIL_BASE_NORMAL;
-  const tailColor = ego ? tokens.indigoBright : tokens.indigo;
+    // comet tail — three shrinking dots trailing the live pulse position,
+    // thinning toward hairline dust as altitude rises rather than fading via
+    // alpha (forbidden.md bans glow/alpha-based "signal" motifs). ego/선택
+    // 엣지는 더 큰 꼬리 + bright 인디고, normal 은 옅은 인디고(프로토타입 대칭).
+    const ego = egoState === "ego" || state.selected === true;
+    const baseSizes = emphasized ? COMET_TAIL_BASE_EMPHASIZED : ego ? COMET_TAIL_BASE_EGO : COMET_TAIL_BASE_NORMAL;
+    const tailColor = ego ? tokens.indigoBright : tokens.indigo;
+    COMET_TAIL_STEPS.forEach((step, i) => {
+      let tt = t - step;
+      if (tt < 0) tt += 1;
+      const point = bezierPoint(a, control, b, tt);
+      const size = baseSizes[i] + (COMET_TAIL_FAR_SIZES[i] - baseSizes[i]) * farT;
+      ctx.beginPath();
+      ctx.fillStyle = tailColor;
+      ctx.arc(point.x, point.y, size, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    return;
+  }
+
+  // Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지도 코멧
+  // 흐름(일회성 버스트 아님, `updateParticles`가 소유한 지속 위상). 방향은
+  // source→target 그대로(부모→자식 typed fact, depends 처럼 역방향/방사
+  // 없음 — a/b 는 이미 source/target 스크린 좌표라 depends 와 동일한
+  // `bezierPoint(a, control, b, t)` 호출이면 자동으로 지켜진다). 꼬리는 항상
+  // NORMAL 티어([2.1,1.5,0.9], depends ego 의 [2.9,2.1,1.3]보다 한 단계
+  // 작게 — 잉크 위계 보존) + 표준 인디고(bright 금지) — ego/emphasized 승격
+  // 없음. `containsCometEligible`(캡 통과 여부)이 false 면 파티클 없이 본체
+  // stroke(위에서 이미 그려짐)만 유지. 선택 해제 시 egoState 가 "ego"를 벗어나
+  // 즉시(다음 프레임) 미표시 — 별도 소멸 애니메이션 불필요.
+  if (egoState !== "ego" || state.containsCometEligible !== true) return;
+  if (state.reducedMotion === true) return;
   COMET_TAIL_STEPS.forEach((step, i) => {
     let tt = t - step;
     if (tt < 0) tt += 1;
     const point = bezierPoint(a, control, b, tt);
-    const size = baseSizes[i] + (COMET_TAIL_FAR_SIZES[i] - baseSizes[i]) * farT;
+    const size = COMET_TAIL_BASE_NORMAL[i] + (COMET_TAIL_FAR_SIZES[i] - COMET_TAIL_BASE_NORMAL[i]) * farT;
     ctx.beginPath();
-    ctx.fillStyle = tailColor;
+    ctx.fillStyle = tokens.indigo;
     ctx.arc(point.x, point.y, size, 0, Math.PI * 2);
     ctx.fill();
   });

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -37,6 +37,8 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-selection-ring-indigo": "#8890e0",
   "--topology-v2-selection-ring-hairline": "rgba(94, 106, 210, .45)",
   "--topology-v2-hover-ring": "rgba(94, 106, 210, .55)",
+  "--topology-v2-hover-shimmer-seg": "0.16",
+  "--topology-v2-hover-shimmer-period-ms": "2400",
 
   "--topology-v2-edge-contains": "#28282e",
   "--topology-v2-edge-depends": "#39394a",
@@ -168,6 +170,8 @@ describe("resolveTopologyV2Tokens", () => {
     expect(tokens.selectionRingIndigo).toBe("#8890e0");
     expect(tokens.selectionRingHairline).toBe("rgba(94, 106, 210, .45)");
     expect(tokens.hoverRing).toBe("rgba(94, 106, 210, .55)");
+    expect(tokens.hoverShimmerSeg).toBeCloseTo(0.16, 3);
+    expect(tokens.hoverShimmerPeriodMs).toBe(2400);
     expect(tokens.selectPulseDurationMs).toBe(180);
   });
 

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -47,6 +47,10 @@ export interface TopologyV2Tokens {
   selectionRingHairline: string;
   /** Canvas-emphasis slice — the hovered node's static 1px preview ring color (spec §C). */
   hoverRing: string;
+  /** Design Guardian 처방 L — 호버 shimmer 아크 길이(둘레 비율, `--topology-v2-hover-shimmer-seg`). */
+  hoverShimmerSeg: number;
+  /** Design Guardian 처방 L — 호버 shimmer 1회전 주기(ms, `--topology-v2-hover-shimmer-period-ms`). */
+  hoverShimmerPeriodMs: number;
 
   // 2.2 엣지 · 라벨 · 배경
   edgeContains: string;
@@ -208,6 +212,8 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "selectionRingIndigo", cssVar: "--topology-v2-selection-ring-indigo", kind: "color" },
   { key: "selectionRingHairline", cssVar: "--topology-v2-selection-ring-hairline", kind: "color" },
   { key: "hoverRing", cssVar: "--topology-v2-hover-ring", kind: "color" },
+  { key: "hoverShimmerSeg", cssVar: "--topology-v2-hover-shimmer-seg", kind: "number" },
+  { key: "hoverShimmerPeriodMs", cssVar: "--topology-v2-hover-shimmer-period-ms", kind: "number" },
 
   { key: "edgeContains", cssVar: "--topology-v2-edge-contains", kind: "color" },
   { key: "edgeDepends", cssVar: "--topology-v2-edge-depends", kind: "color" },

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
@@ -218,7 +218,7 @@ describe("computeFocusCameraTarget — fit-to-ego dive (dive-framing fix)", () =
     const nodeById = new Map(
       Object.entries(nodeXY).map(([id, v]) => [
         id,
-        { id, kind: v.kind, label: id, x: v.x, y: v.y, homeX: v.x, homeY: v.y, isHub: false, fresh: false, stale: false, count: 0, magnitudeScale: 1 },
+        { id, kind: v.kind, label: id, x: v.x, y: v.y, homeX: v.x, homeY: v.y, parentId: null, isHub: false, fresh: false, stale: false, count: 0, magnitudeScale: 1 },
       ]),
     );
     const neighborMap = new Map(Object.entries(neighbors).map(([id, ns]) => [id, new Set(ns)]));

--- a/src/widgets/topology-map-v2/ui/topology-cluster-state.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-cluster-state.test.ts
@@ -15,6 +15,7 @@ function node(id: string, x: number, y: number, kind: WorldNode["kind"] = "capab
     id,
     kind,
     label: id,
+    parentId: null,
     x,
     y,
     homeX: x,

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -41,7 +41,7 @@ import type { ClusterChip } from "../model/density-gate";
 import { drawDiffractionSpike, drawRealmCosmos, drawStarDust, type DustPoint } from "../render/starfield";
 import { isEdgeCulled, isNodeCulled, isPassthroughEdge } from "../render/viewport-cull";
 import { draw as tracesDraw } from "../render/traces";
-import { drawPulses, type Pulse } from "../render/edge-fireflies";
+import { drawPulses, edgePairKey, selectEgoContainsComets, type Pulse } from "../render/edge-fireflies";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import { worldToScreen } from "./topology-camera-math";
 
@@ -70,6 +70,8 @@ const EXPANDED_AURA_ALPHA = 0.55;
 const BACKGROUND_DIM_WHEN_EXPANDED = 0.5;
 
 const EMPTY_NEIGHBOR_SET: ReadonlySet<string> = new Set();
+/** Design Guardian 처방 E — 포커스 없음(또는 인시던트 contains 0개)일 때 재사용하는 빈 캡 Set. */
+const EMPTY_EGO_CONTAINS_COMETS: ReadonlySet<string> = new Set();
 // perf sweep 2026-07 — reused frame-scratch Maps, see their `.clear()` call
 // site in `drawTopologyFrame` below for why this is safe.
 const tierAlphaByIdReused = new Map<string, number>();
@@ -396,6 +398,20 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     );
   }
 
+  // Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지 코멧
+  // 캡. `topology-physics-step.ts`가 위상 전진을 게이트하는 것과 정확히 같은
+  // 결정론 로직(포커스 노드에 물린 contains 엣지 → seed 순 상위 24개)이라,
+  // 상태 공유 없이 같은 프레임에서 같은 Set 이 나온다 — 드로우 게이트만 별도
+  // 계산해도 drift 없음.
+  const egoContainsComets =
+    focusedNodeId === null
+      ? EMPTY_EGO_CONTAINS_COMETS
+      : selectEgoContainsComets(
+          world.edges.filter(
+            (edge) => edge.kind === "contains" && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId),
+          ),
+        );
+
   for (const kind of ["contains", "depends"] as const) {
     for (const edge of world.edges) {
       if (edge.kind !== kind) continue;
@@ -442,6 +458,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
           emphasized,
           reducedMotion,
           level: edge.level,
+          containsCometEligible: kind === "contains" ? egoContainsComets.has(edgePairKey(edge.sourceId, edge.targetId)) : undefined,
         },
         {
           edgeContains: tokens.edgeContains,
@@ -589,6 +606,8 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
         isHovered,
         selectionPulse: selectionPulseVisual,
         agentFocus: agentFocusNodeId !== null && node.id === agentFocusNodeId,
+        now,
+        reducedMotion,
       },
       {
         amberHub: tokens.amberHub,
@@ -600,6 +619,9 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
         selectionIndigo: tokens.selectionRingIndigo,
         selectionHairline: tokens.selectionRingHairline,
         hoverRing: tokens.hoverRing,
+        hoverShimmerSeg: tokens.hoverShimmerSeg,
+        hoverShimmerPeriodMs: tokens.hoverShimmerPeriodMs,
+        hoverShimmerColor: tokens.indigoBright,
       },
     );
 

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -11,11 +11,14 @@
 import { computePanBounds, stepCamera, type CameraAxes, type CameraTarget } from "../engine/camera";
 import { computeAltitudeBand, computeFarT } from "../model/altitude";
 import { isNodeEmphasisActive, resolveEdgePulseSpeed, stepEmphasis } from "../model/focus-state";
-import { updateParticles } from "../render/edge-fireflies";
+import { edgePairKey, selectEgoContainsComets, updateParticles } from "../render/edge-fireflies";
 import { computeZoomRatio, DEFAULT_TIER_REVEAL, isSpineOnlyZoom } from "../model/tier-visibility";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import { computeEffectiveCameraScaleMax, computeEffectiveCameraScaleMin } from "./topology-camera-math";
 import type { TopologyWorld } from "./topology-world";
+
+/** No focus → no ego contains comets. Reused so the no-focus path allocates nothing. */
+const EMPTY_EGO_CONTAINS_COMETS: ReadonlySet<string> = new Set();
 
 export interface PhysicsStepInput {
   world: TopologyWorld;
@@ -233,16 +236,38 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     );
   }
 
+  // Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지도 코멧
+  // 흐름을 태운다. 포커스 노드에 물린 contains 엣지만 후보(= "인시던트"), 그
+  // 중 seed 순 상위 24개만 실제로 전진(`selectEgoContainsComets` 캡 — 팬아웃
+  // 큰 노드가 파티클 다발이 되지 않게). `render/traces.ts`의 드로우 게이트도
+  // 같은 캡 판정을 써야 하므로 이 Set 은 프레임 드로우(`topology-frame-draw.ts`)
+  // 에서 동일 로직으로 재계산한다(둘 다 결정론이라 같은 프레임 안에서 값이
+  // 일치 — 상태 공유 없이도 drift 없음).
+  const egoContainsComets =
+    focusedNodeId === null
+      ? EMPTY_EGO_CONTAINS_COMETS
+      : selectEgoContainsComets(
+          world.edges.filter(
+            (edge) => edge.kind === "contains" && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId),
+          ),
+        );
+
   // R6 상시 혜성 — depends 엣지의 코멧 위상을 항상 전진시킨다(`updateParticles`,
   // 순수 모델 `render/edge-fireflies.ts`). ambient(edgePulseSpeed)로 포커스와
   // 무관하게 흐르되, 포커스 서브그래프에 물린 엣지는 "전류가 더 흐른다"고
   // 가속(edgePulseSpeedEgo, `resolveEdgePulseSpeed`, lead spec §2). reduced-motion
   // 이면 updateParticles 가 전진을 건너뛰어(정지) 유휴 게이트가 성립한다.
-  updateParticles(world.edges, dt, reducedMotion, (edge) => {
-    const touchesFocused =
-      focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
-    return resolveEdgePulseSpeed(touchesFocused, focusedNodeId, tokens.edgePulseSpeed, tokens.edgePulseSpeedEgo);
-  });
+  updateParticles(
+    world.edges,
+    dt,
+    reducedMotion,
+    (edge) => {
+      const touchesFocused =
+        focusedNodeId !== null && (edge.sourceId === focusedNodeId || edge.targetId === focusedNodeId);
+      return resolveEdgePulseSpeed(touchesFocused, focusedNodeId, tokens.edgePulseSpeed, tokens.edgePulseSpeedEgo);
+    },
+    (edge) => egoContainsComets.has(edgePairKey(edge.sourceId, edge.targetId)),
+  );
 
   return { camera: nextCamera, farT, zoomRatio };
 }

--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
@@ -95,7 +95,12 @@ function collectVisibleMemberTargets(
   const { clusteredIds } = computeTopologyClusterState(world, expandedParents);
   const out: Array<[string, { x: number; y: number }]> = [];
   for (const id of memberIds) {
-    if (clusteredIds.has(id)) continue;
+    if (clusteredIds.has(id)) {
+      // 접은 부모가 영역 **안** 멤버일 때만 접힘 유지 — 바깥 부모(공유 요소의
+      // 1차 귀속처 등)의 밀도 게이트는 영역 내부를 가리지 못한다.
+      const parentId = world.nodeById.get(id)?.parentId ?? null;
+      if (parentId && memberIds.has(parentId)) continue;
+    }
     const t = insideTargets.get(id);
     if (t) out.push([id, t]);
   }
@@ -140,7 +145,19 @@ export function buildRealmRuntimeData(
   expandedParents: ReadonlySet<string> = EMPTY_EXPANDED,
 ): RealmRuntimeData | null {
   if (!world.nodeById.has(rootId)) return null;
-  const subtree = extractRealmSubtree(rootId, world.childrenByParent);
+  // 멤버십은 원장/데이터시트와 같은 의미론 — **모든 contains edge** 를 걸어
+  // 공유(다중 부모) 요소도 데려온다. `childrenByParent` 는 밀도 게이트용
+  // 단일-부모 맵(마지막 edge 승자독식)이라 다른 역량에 주로 귀속된 공유
+  // 요소가 빠져 "요소 2 인데 영역이 텅 빈 링" 이 됐다 (소유자 실보고
+  // 2026-07-23, capability:builder-deep-link-focus 실증).
+  const containsChildren = new Map<string, string[]>();
+  for (const e of world.edges) {
+    if (e.kind !== "contains") continue;
+    const list = containsChildren.get(e.sourceId);
+    if (list) list.push(e.targetId);
+    else containsChildren.set(e.sourceId, [e.targetId]);
+  }
+  const subtree = extractRealmSubtree(rootId, containsChildren);
   const rings: LayoutRings = {
     domain: tokens.layoutRingDomain,
     capability: tokens.layoutRingCapability,

--- a/src/widgets/topology-map-v2/ui/topology-world.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.test.ts
@@ -31,6 +31,7 @@ const tokens = {
 function node(partial: Partial<WorldNode> & Pick<WorldNode, "id" | "kind" | "x" | "y">): WorldNode {
   return {
     label: partial.id,
+    parentId: null,
     isHub: false,
     fresh: false,
     stale: false,

--- a/src/widgets/topology-map-v2/ui/topology-world.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.ts
@@ -29,6 +29,10 @@ export interface WorldNode {
    */
   homeX: number;
   homeY: number;
+  /** contains 단일(1차) 부모 id — 밀도 게이트의 접힘 귀속처. 다중 부모 공유
+   *  노드는 마지막 contains edge 의 부모 하나만 담는다 (영역 언클러스터
+   *  규칙이 "접은 부모가 영역 밖인가" 판정에 사용). */
+  parentId: string | null;
   isHub: boolean;
   fresh: boolean;
   /** Adapter contract (`TopologyV2Node`) has no staleness signal yet — always false until a follow-up adds one. */
@@ -328,6 +332,7 @@ export function buildTopologyWorld(
       y,
       homeX: x,
       homeY: y,
+      parentId: containsParentById.get(n.id) ?? null,
       isHub: n.isHub,
       fresh: n.recentlyUpdated,
       // 살아있는 지도 드리프트 — 어댑터가 vault mtime 으로 판정한 dusty 를

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -293,6 +293,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
    * 읽어 depth1 element 자식이 그려질 때 함께 잡히게 한다.
    */
   const realmTierKindsRef = useRef<ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null>(null);
+  /** 영역 루트의 contains 조상 체인 캐시 — 바깥 밀도 게이트가 영역 내부를 가리지 않게 펼침 취급할 집합. */
+  const realmExpandChainRef = useRef<{ rootId: string; chain: ReadonlySet<string> } | null>(null);
 
   const cameraRef = useRef<CameraAxes>({
     x: { value: 0, velocity: 0 },
@@ -1343,9 +1345,36 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // ref 를 읽는다 — 프레임 클로저가 stale realmRootId 를 캡처해 버튼
       // 클릭 진입에선 펼침이 안 먹던 결함(녹화 프레임 검수 실증).
       const liveRealmRootId = realmDataRef.current?.rootId ?? null;
-      const effectiveExpanded = liveRealmRootId
-        ? new Set([...expandedParentsRef.current, liveRealmRootId])
-        : expandedParentsRef.current;
+      // 소유자 실보고 (2026-07-23, capability 영역 텅 빈 링) — 루트만 펼침
+      // 취급하면 부족하다: 루트 자신이 바깥 세계에서 밀도 게이트에 접힌
+      // 자식(예: 역량 28개 도메인의 capability)이면 루트·멤버 전원이
+      // clusteredIds 에 걸려 영역이 통째로 비어 보인다. 루트의 contains
+      // 조상 체인까지 펼침 취급해 바깥 게이트가 영역 내부를 가리지 못하게
+      // 한다 (조상의 다른 자식들은 어차피 realm 밖 하드 컬 대상).
+      let effectiveExpanded: ReadonlySet<string> = expandedParentsRef.current;
+      if (liveRealmRootId) {
+        // 조상 체인은 rootId 기준으로 1회만 계산해 캐시 (프레임 루프 내부).
+        if (realmExpandChainRef.current?.rootId !== liveRealmRootId) {
+          const chain = new Set<string>([liveRealmRootId]);
+          let cursor: string | null = liveRealmRootId;
+          while (cursor) {
+            let parent: string | null = null;
+            for (const [pid, kids] of world.childrenByParent) {
+              if (kids.includes(cursor)) {
+                parent = pid;
+                break;
+              }
+            }
+            if (!parent || chain.has(parent)) break;
+            chain.add(parent);
+            cursor = parent;
+          }
+          realmExpandChainRef.current = { rootId: liveRealmRootId, chain };
+        }
+        const withRealm = new Set(expandedParentsRef.current);
+        for (const id of realmExpandChainRef.current.chain) withRealm.add(id);
+        effectiveExpanded = withRealm;
+      }
       const clusterState = computeTopologyClusterState(world, effectiveExpanded);
 
       // S2 파트 3a — 선택적 ego: 포커스 노드의 이웃이 limit 을 넘으면 DOI 상위
@@ -1354,6 +1383,34 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 렌더/히트 경로를 타는 ClusterChip(ego:true)로 얹는다. 세션 임시 상태.
       let frameClusteredIds: ReadonlySet<string> = clusterState.clusteredIds;
       let frameChips: readonly ClusterChip[] = clusterState.chips;
+      // 영역 활성 시 — 멤버가 **바깥** 부모의 밀도 게이트로 접혀 있으면 해제
+      // (공유 요소의 1차 귀속처가 영역 밖 역량인 케이스). 영역 안 부모의
+      // 게이트(내부 +N 칩)는 유지한다. realmVisibleBounds 의 가시-멤버
+      // 규칙과 동일해야 결계/프레이밍과 드로우가 갈라지지 않는다.
+      if (liveRealmRootId && realmDataRef.current) {
+        const memberIds = realmDataRef.current.memberIds;
+        let needsFilter = false;
+        for (const id of frameClusteredIds) {
+          if (memberIds.has(id)) {
+            const pid = world.nodeById.get(id)?.parentId ?? null;
+            if (!pid || !memberIds.has(pid)) {
+              needsFilter = true;
+              break;
+            }
+          }
+        }
+        if (needsFilter) {
+          const filtered = new Set<string>();
+          for (const id of frameClusteredIds) {
+            if (memberIds.has(id)) {
+              const pid = world.nodeById.get(id)?.parentId ?? null;
+              if (!pid || !memberIds.has(pid)) continue;
+            }
+            filtered.add(id);
+          }
+          frameClusteredIds = filtered;
+        }
+      }
       {
         const focusId = focusedSlugRef.current;
         const neighbors = focusId ? world.neighborMap.get(focusId) : undefined;
@@ -1366,7 +1423,9 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           const ranked = rankEgoNeighborsByDOI(entries);
           const sel = selectiveEgoNeighbors(ranked, egoRevealBatchesRef.current);
           if (sel.hiddenCount > 0) {
-            frameClusteredIds = new Set<string>([...clusterState.clusteredIds, ...sel.hiddenNeighbors]);
+            // 영역 언클러스터 필터가 적용된 frameClusteredIds 를 기반으로 합친다
+            // (clusterState 원본을 다시 쓰면 위 realm 보정이 무효화된다).
+            frameClusteredIds = new Set<string>([...frameClusteredIds, ...sel.hiddenNeighbors]);
             const focusNode = world.nodeById.get(focusId);
             if (focusNode) {
               // 포커스 노드 바로 아래(월드)에 앵커 — 반지름 + 여유만큼 내린다.

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -403,6 +403,15 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
    * 빌드 시 1회 계산). 없으면 코멧이 없어 유휴 판정이 성립한다.
    */
   const hasDependsEdgesRef = useRef(false);
+  /**
+   * Design Guardian 승인 처방 E — 선택(ego) 시 인시던트 contains 엣지도 코멧이
+   * 흐르므로, 포커스가 걸려 있고 그래프에 contains 엣지가 하나라도 있으면
+   * 유휴 게이트가 얼지 않아야 한다(정확한 "이 포커스 노드에 물린 캡 안쪽
+   * 엣지가 있는가"까지는 굳이 안 따진다 — `hasDependsEdgesRef`와 같은 결의
+   * 월드-단위 coarse 플래그로 충분하고, 포커스가 없으면 어차피 깨어있을
+   * 이유가 없다).
+   */
+  const hasContainsEdgesRef = useRef(false);
   /** A2 — 마지막 활동 시각. 활동 플래그가 참인 프레임마다 갱신. */
   const lastActiveMsRef = useRef(0);
   /** A2 — 직전 프레임 카메라 값 (움직임 감지용). */
@@ -563,6 +572,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     worldRef.current = world;
     // R6 상시 혜성 — 유휴 게이트가 코멧 상시성을 알 수 있게 depends 유무를 캐시.
     hasDependsEdgesRef.current = world.edges.some((e) => e.kind === "depends");
+    hasContainsEdgesRef.current = world.edges.some((e) => e.kind === "contains");
     // 새 월드 = 이전 월드의 엣지를 겨냥한 펄스는 무효(엣지 id 가 옛 것).
     pulsesRef.current = [];
     // Seed the force sim off the concentric layout (spatial memory) and warm it
@@ -964,6 +974,9 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           // rAF 자체가 브라우저에 의해 정지돼 배터리를 지킨다.
           egoTailAnimating:
             (!reducedMotionRef.current && hasDependsEdgesRef.current && tokens.edgePulseSpeed > 0) ||
+            // Design Guardian 처방 E — 포커스 중 인시던트 contains 코멧도 상시
+            // 흐름이라 유휴 게이트가 얼면 안 된다(depends 와 같은 idle-gate 결).
+            (!reducedMotionRef.current && focusedSlugRef.current !== null && hasContainsEdgesRef.current) ||
             pulsesRef.current.length > 0,
           emphasisTarget: hoveredNodeIdRef.current !== null || panelEmphasisNodeIdRef.current !== null || hoveredClusterIdRef.current !== null,
           breathing: !reducedMotionRef.current && world.nodes.some((n) => n.fresh),


### PR DESCRIPTION
## Summary
소유자 실사용 중 실보고 11건 일괄 (4커밋):
- **영역 전개 빈 링 복구**: 루트 조상 게이트 펼침·공유 요소 contains 전체 인접 BFS·바깥 부모 게이트 언클러스터 (3중 원인, WorldNode.parentId 정식화)
- **선택 시 좌측 자동 강등**(C) + 전개 패널 상단 84→24px(J) + 데이터시트 zoom 경계 보정(D) + 1920 크롬 1.15→1.08(I)
- **인사이트 3탭** Guardian 처방: 카드 갭·섹션 리듬·히트스트립 축 정합+툴팁+행 호버
- **E·L**: ego contains 코멧 흐름(캡 24)·호버 circuit-trace shimmer(신규 토큰 2종, 글로우 0). K(kind 기본 테두리)는 Guardian 기각.
- 엣지 호버 "화면 흔들림"은 stale 번들 에러 폭풍으로 판명 — 서버 정상화로 해소 (코드 변경 무관)

## Test plan
- topology-map-v2 649 + home/insights/index-panel 합산 green ✅ · tsc ✅ · i18n ✅
- 실검증: 영역(요소 2 렌더)·C 왕복·D 1920 실측(941≤950)·E 코멧 영상·L shimmer 3프레임 순회 · Guardian verdict 3회(인사이트/E·K·L 판정/사전 A 검수)