### PR TITLE
fix: 데이터시트 내부 세련화 (Guardian 처방)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2175,7 +2175,7 @@
       "actionsGroupLabel": "Node actions",
       "actionDocument": "Document",
       "actionEditRelations": "Edit relations",
-      "actionCopyHandoff": "Copy agent handoff",
+      "actionCopyHandoff": "Copy handoff",
       "actionPath": "Path",
       "updated_today": "changed today",
       "updated_yesterday": "changed yesterday",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2175,7 +2175,7 @@
       "actionsGroupLabel": "노드 행동",
       "actionDocument": "문서",
       "actionEditRelations": "관계 편집",
-      "actionCopyHandoff": "에이전트 인계 복사",
+      "actionCopyHandoff": "인계 복사",
       "actionPath": "경로",
       "updated_today": "오늘 바뀜",
       "updated_yesterday": "어제 바뀜",

--- a/src/widgets/topology-map-v2/index.ts
+++ b/src/widgets/topology-map-v2/index.ts
@@ -26,6 +26,7 @@ export {
   buildV2Connections,
   buildV2ConnectionGroups,
   buildV2EvidenceRows,
+  buildV2MetricSegments,
   formatV2HandoffText,
   formatV2MetricLine,
   groupV2ConnectionsByDirection,
@@ -42,6 +43,7 @@ export type {
   V2DatasheetConnection,
   V2EvidenceRow,
   V2GroupedConnections,
+  V2MetricSegment,
   V2HandoffInput,
   V2MetricValues,
 } from './ui/topology-v2-datasheet';

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -126,8 +126,11 @@ describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYST
       rows: [{ id: "capabilities/product-owner-operating-system", title: "product-owner-operating-system", path: "capabilities/" }],
       total: 1,
     });
-    const group = screen.getByText("evidence").closest("[data-datasheet-group='evidence']");
+    // 잉크 분리 후 메트릭 스트립에도 "evidence" 라벨 span 이 생겨 getByText 는
+    // 다중 매치 — 그룹 마커로 직접 조회한다.
+    const group = document.querySelector("[data-datasheet-group='evidence']");
     expect(group).not.toBeNull();
+    expect(group!.textContent).toContain("evidence");
     expect(screen.getByText("product-owner-operating-system")).toBeInTheDocument();
     expect(screen.getByText("capabilities/")).toBeInTheDocument();
   });
@@ -204,6 +207,35 @@ describe("TopologyV2DetailPanel — M-2 typed containment split", () => {
     expect(document.querySelector("[data-datasheet-group='contains']")).toBeNull();
     const metric = screen.getByTestId("topology-v2-detail-panel").querySelector("[data-datasheet-metric='engraved']");
     expect(metric?.textContent).not.toContain("contains");
+  });
+});
+
+// 데이터시트 내부 정제 (2026-07-23) — 메트릭 스트립이 한 덩어리 문자열로
+// 읽히던 문제: 라벨은 tertiary, 값은 `--topology-v2-panel-metric-text` 잉크로
+// 분리하고, 그룹 헤더 카운트도 같은 값 잉크를 쓴다 — 스트립의 각 카운트가
+// 아래 자기 그룹으로 잉크 페어링만으로 시선 연결되는 계약(신규 인터랙션 0).
+describe("TopologyV2DetailPanel — metric strip label/value ink split", () => {
+  it("renders each metric segment structured (label + value spans) instead of one joined string", () => {
+    renderPanel();
+    const metric = screen
+      .getByTestId("topology-v2-detail-panel")
+      .querySelector("[data-datasheet-metric='engraved']");
+    expect(metric).not.toBeNull();
+    const seg = metric!.querySelector("[data-metric-segment='usedBy']");
+    expect(seg).not.toBeNull();
+    expect(seg!.textContent).toContain("used by 1");
+    // the value carries the engraved-number ink token, the label does not
+    const valueSpan = Array.from(seg!.querySelectorAll("span")).find(
+      (s) => s.textContent === "1",
+    );
+    expect(valueSpan?.className).toContain("--topology-v2-panel-metric-text");
+  });
+
+  it("pairs the group header count with the SAME engraved-number ink as the strip value", () => {
+    renderPanel();
+    const total = document.querySelector("[data-datasheet-group-total='usedBy']");
+    expect(total).not.toBeNull();
+    expect(total!.className).toContain("--topology-v2-panel-metric-text");
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -6,7 +6,7 @@ import { Link } from "@/i18n/navigation";
 import { buildDocsVaultHref } from "@/entities/docs-vault";
 import { isContainmentRelation } from "@/shared/lib/ontology-tree";
 import {
-  formatV2MetricLine,
+  buildV2MetricSegments,
   V2_CONTAINS_SUMMARY_THRESHOLD,
   type V2ConnectionGroupsView,
   type V2ConnectionGroupView,
@@ -179,8 +179,12 @@ export interface TopologyV2DetailPanelProps {
   className?: string;
 }
 
+// 데이터시트 내부 정제 (2026-07-23) — `justify-start` + 고정 상단 패딩: 라벨이
+// 로케일에 따라 1줄/2줄로 갈려도 네 타일의 아이콘이 같은 y 에 정렬된다
+// (grid 가 높이는 이미 균등화하므로, 남는 공백은 아래로만 빠진다). 2줄 라벨은
+// `leading-[1.2]` 로 조인다.
 const ACTION_TILE_CLASS =
-  "flex flex-col items-center justify-center gap-1 rounded-[var(--topology-v2-panel-row-radius)] border border-[color:var(--topology-v2-panel-action-border)] bg-[color:var(--topology-v2-panel-action-surface)] px-1 py-1.5 text-center text-[10.5px] font-medium text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]";
+  "flex flex-col items-center justify-start gap-1 rounded-[var(--topology-v2-panel-row-radius)] border border-[color:var(--topology-v2-panel-action-border)] bg-[color:var(--topology-v2-panel-action-surface)] px-1 pt-2 pb-1.5 text-center text-[10.5px] font-medium leading-[1.2] text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]";
 const ACTION_TILE_DISABLED_CLASS =
   "pointer-events-none opacity-40";
 
@@ -206,7 +210,7 @@ export function TopologyV2DetailPanel({
   onOpenFullDetail,
   className,
 }: TopologyV2DetailPanelProps) {
-  const metricLine = formatV2MetricLine(metric, {
+  const metricSegments = buildV2MetricSegments(metric, {
     contains: labels.metricContains,
     usedBy: labels.metricUsedBy,
     dependsOn: labels.metricDependsOn,
@@ -264,9 +268,12 @@ export function TopologyV2DetailPanel({
           >
             {label}
           </span>
+          {/* 그룹 카운트는 메트릭 스트립의 값과 "같은 숫자" (M-2 계약) —
+              같은 잉크(`--topology-v2-panel-metric-text`)로 페어링해 스트립의
+              각 카운트가 아래 자기 그룹으로 시선 연결되게 한다. */}
           <span
             data-datasheet-group-total={group}
-            className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+            className="font-mono text-[10px] text-[color:var(--topology-v2-panel-metric-text)]"
           >
             {view.total}
           </span>
@@ -365,7 +372,7 @@ export function TopologyV2DetailPanel({
           </span>
           <span
             data-datasheet-group-total="evidence"
-            className="font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+            className="font-mono text-[10px] text-[color:var(--topology-v2-panel-metric-text)]"
           >
             {evidence.total}
           </span>
@@ -420,6 +427,12 @@ export function TopologyV2DetailPanel({
         className ?? "",
       ].join(" ")}
     >
+      {/* 정체 클러스터 (2026-07-23 내부 정제) — 헤더와 각인 메트릭은 둘 다
+          "이 노드가 무엇인가"를 말하므로 root 의 14px 섹션 리듬보다 조이는
+          8px 로 근접시킨다. gap 사다리: 14(섹션) / 8(정체 내부) / 4(액션·
+          그룹 헤더-행) — 균일 14px 단일 리듬이 그룹 경계를 못 만들던 문제의
+          근접성(proximity) 처방. */}
+      <div className="flex flex-col gap-2">
       {/* Header — kind miniature + name + power dot + close */}
       <div className="flex items-start gap-2">
         <div className="mt-[1px]">
@@ -489,17 +502,39 @@ export function TopologyV2DetailPanel({
         </button>
       </div>
 
-      {/* One engraved metric line — no subtitle + boxes triplication */}
+      {/* One engraved metric line — no subtitle + boxes triplication.
+          라벨(tertiary)과 값(metric-text)의 잉크를 분리 — 숫자가 데이터,
+          단어는 눈금(Tufte data-ink). 값 잉크는 아래 그룹 헤더 카운트와 같아
+          스트립 카운트 → 해당 그룹의 시선 연결을 잉크 페어링만으로 만든다
+          (스크롤 등 신규 인터랙션 없음). */}
       <div
         data-datasheet-metric="engraved"
         title={labels.metricHelp}
         className="rounded-[var(--topology-v2-panel-row-radius)] bg-[color:var(--topology-v2-panel-metric-surface)] px-2 py-1.5"
       >
-        <span className="font-mono text-[12.5px] tracking-[0.01em] text-[color:var(--topology-v2-panel-metric-text)]">
-          {metricLine}
+        <span className="font-mono text-[12.5px] tracking-[0.01em]">
+          {metricSegments.map((seg, i) => (
+            <span key={seg.key} data-metric-segment={seg.key}>
+              {i > 0 ? (
+                <span className="text-[color:var(--topology-v2-panel-text-quaternary)]">
+                  {" · "}
+                </span>
+              ) : null}
+              <span className="text-[color:var(--topology-v2-panel-text-tertiary)]">
+                {seg.label}
+              </span>{" "}
+              <span className="text-[color:var(--topology-v2-panel-metric-text)]">
+                {seg.value}
+              </span>
+            </span>
+          ))}
         </span>
       </div>
+      </div>
 
+      {/* 액션 클러스터 — 4-up 타일과 "영역 전개"는 같은 재질(보더+표면 토큰)의
+          한 계기 묶음이므로 그리드 내부와 같은 4px 로 묶는다. */}
+      <div className="flex flex-col gap-1">
       {/* W2-A action row — 4-up tile grid (문서/관계 편집/인계 복사/경로).
           Same construction for every tile (border + hover surface tokens) so
           the row reads as one instrument, not four unrelated buttons. */}
@@ -570,9 +605,13 @@ export function TopologyV2DetailPanel({
           <span>{labels.actionRealm}</span>
         </button>
       ) : null}
+      </div>
 
-      {/* Connections grouped by relation type */}
-      <div className="flex flex-col gap-2.5">
+      {/* Connections grouped by relation type — 그룹 사이는 root 와 같은
+          `--topology-v2-panel-gap`(14px): 각 typed-fact 그룹이 자체 섹션으로
+          읽히게 한다 (구 10px 는 행 자체 패딩(12px 시각 간격)과 구분이 안 돼
+          그룹 경계가 뭉개졌다). */}
+      <div className="flex flex-col gap-[var(--topology-v2-panel-gap)]">
         {hasConnections ? (
           <>
             {renderGroup("contains", labels.metricContains, labels.metricContainsHelp, groups.contains)}

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -5,6 +5,7 @@ import {
   buildV2ConnectionGroups,
   buildV2EvidenceRows,
   formatV2HandoffText,
+  buildV2MetricSegments,
   formatV2MetricLine,
   groupV2ConnectionsByDirection,
   summarizeContainsByPathPrefix,
@@ -215,6 +216,29 @@ describe("formatV2MetricLine — M-2 typed segments", () => {
     expect(
       formatV2MetricLine({ contains: 0, usedBy: 0, dependsOn: 0, evidence: 0 }, labels),
     ).toBe("쓰는 곳 0 · 기대는 곳 0 · 근거 0");
+  });
+
+  // 데이터시트 내부 정제 (2026-07-23) — 패널이 라벨/값 잉크를 분리 렌더할 수
+  // 있게 세그먼트를 구조화해 노출한다. key 는 아래 연결 그룹의
+  // `data-datasheet-group` id 와 동일 — 스트립 카운트와 그룹 카운트가 구성상
+  // 같은 사실임을 타입으로 고정한다.
+  it("buildV2MetricSegments exposes the same segments structured, keyed by the group ids", () => {
+    expect(
+      buildV2MetricSegments({ contains: 18, usedBy: 4, dependsOn: 2, evidence: 1 }, labels),
+    ).toEqual([
+      { key: "contains", label: "담는 것", value: 18 },
+      { key: "usedBy", label: "쓰는 곳", value: 4 },
+      { key: "dependsOn", label: "기대는 곳", value: 2 },
+      { key: "evidence", label: "근거", value: 1 },
+    ]);
+  });
+
+  it("buildV2MetricSegments omits the contains segment for a leaf, like the joined line", () => {
+    expect(
+      buildV2MetricSegments({ contains: 0, usedBy: 3, dependsOn: 5, evidence: 2 }, labels).map(
+        (s) => s.key,
+      ),
+    ).toEqual(["usedBy", "dependsOn", "evidence"]);
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -226,24 +226,52 @@ export interface V2MetricLabels {
   evidence: string;
 }
 
+/** One typed segment of the engraved metric line — `key` matches the
+ * connection-group id below it (`data-datasheet-group`), so the strip and the
+ * groups stay reconciled by construction. */
+export interface V2MetricSegment {
+  key: "contains" | "usedBy" | "dependsOn" | "evidence";
+  label: string;
+  value: number;
+}
+
 /**
- * The ONE engraved metric line — "담는 것 18 · 쓰는 곳 4 · 기대는 곳 2 · 근거 1".
- * Replaces the old subtitle + count boxes (the owner's "정보가 세 번 나온다"
- * complaint); every fact appears exactly once. M-2: the leading "담는 것"
- * segment appears ONLY for container nodes (`contains > 0`) — a leaf's line
- * stays "쓰는 곳 · 기대는 곳 · 근거", so the typed split adds signal for
- * domains without adding a "담는 것 0" to every element.
+ * The ONE engraved metric line's segments — "담는 것 18 · 쓰는 곳 4 · 기대는
+ * 곳 2 · 근거 1". Replaces the old subtitle + count boxes (the owner's
+ * "정보가 세 번 나온다" complaint); every fact appears exactly once. M-2: the
+ * leading "담는 것" segment appears ONLY for container nodes (`contains > 0`)
+ * — a leaf's line stays "쓰는 곳 · 기대는 곳 · 근거", so the typed split adds
+ * signal for domains without adding a "담는 것 0" to every element.
+ *
+ * 데이터시트 내부 정제 (2026-07-23) — segments are exposed structured (not
+ * only joined) so the panel can set label ink (tertiary) apart from value ink
+ * (`--topology-v2-panel-metric-text`): the numbers are the data, the words
+ * are the scale markings (Tufte data-ink). Each segment's ink pairing is the
+ * SAME pairing the group headers use, which is what visually links a strip
+ * count to its group below without any new interaction.
  */
+export function buildV2MetricSegments(
+  values: V2MetricValues,
+  labels: V2MetricLabels,
+): V2MetricSegment[] {
+  const segments: V2MetricSegment[] = [];
+  if (values.contains > 0)
+    segments.push({ key: "contains", label: labels.contains, value: values.contains });
+  segments.push({ key: "usedBy", label: labels.usedBy, value: values.usedBy });
+  segments.push({ key: "dependsOn", label: labels.dependsOn, value: values.dependsOn });
+  segments.push({ key: "evidence", label: labels.evidence, value: values.evidence });
+  return segments;
+}
+
+/** Joined-string form of `buildV2MetricSegments` — kept for handoff/plain
+ * text consumers and as the single source of the "label value · …" grammar. */
 export function formatV2MetricLine(
   values: V2MetricValues,
   labels: V2MetricLabels,
 ): string {
-  const segments: string[] = [];
-  if (values.contains > 0) segments.push(`${labels.contains} ${values.contains}`);
-  segments.push(`${labels.usedBy} ${values.usedBy}`);
-  segments.push(`${labels.dependsOn} ${values.dependsOn}`);
-  segments.push(`${labels.evidence} ${values.evidence}`);
-  return segments.join(" · ");
+  return buildV2MetricSegments(values, labels)
+    .map((s) => `${s.label} ${s.value}`)
+    .join(" · ");
 }
 
 /** One row in the promoted 근거(evidence) group — RATIO-SYSTEM §4 scale-up


### PR DESCRIPTION
## Summary
- 소유자 실보고 "내부 디자인 세련되게": 카운트 스트립 구조화(숫자=데이터 잉크, 라벨=눈금 잉크 — 그룹 헤더와 페어링), 액션 타일 1줄·아이콘 y 정렬, 섹션 리듬 14/8/4, 그룹 간 panel-gap. 신규 토큰/색/모션 0. 행별 kind 글리프는 잉크 과밀로 기각.

## Test plan
- topology-map-v2 653 ✅ (신규 4) · tsc ✅ · 1440/1920 before/after 스크린샷 Guardian 검증