### PR TITLE
feat: Atlas Git 견고화(CLI) + Tauri git 계층

### DIFF
--- a/cli/src/commands/snapshot.mjs
+++ b/cli/src/commands/snapshot.mjs
@@ -16,6 +16,7 @@ import { resolveVaultRoot, VaultRootError } from '../lib/resolve-vault.mjs';
 import {
   addPaths,
   buildChangeSummary,
+  classifyGitError,
   commitPathspec,
   findGitRepoRoot,
   findStagedOutsideVault,
@@ -26,19 +27,24 @@ import {
   getPorcelainStatus,
   getRemoteUrl,
   getUpstreamRef,
+  getVaultDiff,
+  getVaultLog,
+  pullCurrentBranch,
   pushCurrentBranch,
   vaultPathspec,
 } from '../lib/git-snapshot.mjs';
 import {
   formatUnknownFlagError,
+  parseBoundedPositiveIntegerFlag,
   parseRawRequiredFlagValue,
   parseVaultFlag,
   resolveExclusiveVaultArg,
 } from '../lib/cli-args.mjs';
 
-const ALLOWED_FLAGS = ['--vault', '--dry-run', '--push', '--message', '--json'];
-const STATUS_MARK = { added: 'A', modified: 'M', deleted: 'D' };
-const STATUS_COLOR = { added: COLORS.green, modified: COLORS.yellow, deleted: COLORS.red };
+const ALLOWED_FLAGS = ['--vault', '--dry-run', '--push', '--message', '--json', '--history', '--diff', '--pull'];
+const STATUS_MARK = { added: 'A', modified: 'M', deleted: 'D', renamed: 'R' };
+const STATUS_COLOR = { added: COLORS.green, modified: COLORS.yellow, deleted: COLORS.red, renamed: COLORS.blue };
+const DEFAULT_HISTORY_LIMIT = 10;
 
 export async function runSnapshot(args) {
   const parsed = parseArgs(args);
@@ -69,6 +75,18 @@ export async function runSnapshot(args) {
   }
 
   const pathspec = vaultPathspec(repoRoot, vaultRoot);
+
+  // 패리티 모드 — 각기 커밋 흐름을 short-circuit 한다 (읽기 전용 / opt-in 전송).
+  if (parsed.history !== null) {
+    return emitHistory({ json: parsed.json, vaultRoot, repoRoot, pathspec, limit: parsed.history });
+  }
+  if (parsed.diff) {
+    return emitDiff({ json: parsed.json, vaultRoot, repoRoot, pathspec });
+  }
+  if (parsed.pull) {
+    return runPull({ json: parsed.json, vaultRoot, repoRoot });
+  }
+
   const rows = getPorcelainStatus({ repoRoot, pathspec });
   if (rows === null) {
     process.stderr.write(`${COLORS.red}error${COLORS.reset}  git status failed for ${vaultRoot}\n`);
@@ -104,8 +122,14 @@ export async function runSnapshot(args) {
   }
 
   const untrackedPaths = rows.filter((r) => r.index === '?' && r.worktree === '?').map((r) => r.path);
-  addPaths({ repoRoot, paths: untrackedPaths });
-  commitPathspec({ repoRoot, pathspec, message: fullMessage });
+  // HIGH-1: commit throw (pre-commit 훅 거부 · gpg 서명 실패 · merge/rebase 진행
+  // 중) 를 raw 스택트레이스로 터뜨리지 않고 한 줄 원인 + 다음 행동으로 변환.
+  try {
+    addPaths({ repoRoot, paths: untrackedPaths });
+    commitPathspec({ repoRoot, pathspec, message: fullMessage });
+  } catch (err) {
+    return emitGitError(err, { operation: 'commit', json: parsed.json, vaultRoot });
+  }
   const commitHash = getHeadHash({ repoRoot });
 
   let push = null;
@@ -114,13 +138,26 @@ export async function runSnapshot(args) {
     const upstream = getUpstreamRef({ repoRoot });
     if (!upstream) {
       const branch = getCurrentBranch({ repoRoot });
-      push = { pushed: false, reason: 'no-upstream', guidance: `git push -u origin ${branch}` };
+      push = {
+        pushed: false,
+        reason: 'no-upstream',
+        message: 'push 실패 — 이 브랜치에 upstream 이 없어요. 커밋은 로컬에 기록됨.',
+        guidance: `git push -u origin ${branch}`,
+      };
       exitCode = 1;
     } else {
-      pushCurrentBranch({ repoRoot });
-      const remoteName = upstream.split('/')[0];
-      const remoteUrl = getRemoteUrl({ repoRoot, remoteName });
-      push = { pushed: true, remoteUrl };
+      // HIGH-1: push throw (원격이 앞섬 · 인증 실패 등) 도 우아하게. 커밋은
+      // 이미 로컬에 있으므로 안내만 하고 exit 1 (스택트레이스 없이).
+      try {
+        pushCurrentBranch({ repoRoot });
+        const remoteName = upstream.split('/')[0];
+        const remoteUrl = getRemoteUrl({ repoRoot, remoteName });
+        push = { pushed: true, remoteUrl };
+      } catch (err) {
+        const info = classifyGitError(err, { operation: 'push' });
+        push = { pushed: false, reason: info.reason, message: info.message, note: info.note, guidance: info.guidance };
+        exitCode = 1;
+      }
     }
   }
 
@@ -181,6 +218,164 @@ function emitNoChanges(json, vaultRoot) {
   return 0;
 }
 
+// HIGH-1: git 실패(commit throw / push throw)를 raw 스택트레이스 대신 한 줄
+// 원인 + 다음 행동으로. stderr 로 안내, stdout(사람 텍스트) 오염 금지.
+function emitGitError(err, { operation, json, vaultRoot }) {
+  const info = classifyGitError(err, { operation });
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          operation: 'snapshot',
+          ok: false,
+          reason: info.reason,
+          vaultRoot,
+          committed: false,
+          note: info.note ?? null,
+          guidance: info.guidance ?? null,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 1;
+  }
+  let out = `${COLORS.red}error${COLORS.reset}  ${info.message}\n`;
+  if (info.note) out += `${COLORS.dim}  ${info.note}${COLORS.reset}\n`;
+  if (info.guidance) out += `  ${COLORS.cyan}${info.guidance}${COLORS.reset}\n`;
+  process.stderr.write(out);
+  return 1;
+}
+
+// `snapshot --history [N]` — vault 경로에 닿은 최근 커밋 N개 (옵시디언 Git 패리티).
+function emitHistory({ json, vaultRoot, repoRoot, pathspec, limit }) {
+  const commits = getVaultLog({ repoRoot, pathspec, limit });
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          operation: 'snapshot-history',
+          ok: true,
+          vaultRoot,
+          repoRoot,
+          limit,
+          count: commits ? commits.length : 0,
+          commits: commits ?? [],
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+  if (commits === null || commits.length === 0) {
+    process.stdout.write(`${COLORS.dim}아직 vault 범위 커밋이 없어요${COLORS.reset} ${COLORS.dim}(vault=${vaultRoot})${COLORS.reset}\n`);
+    return 0;
+  }
+  process.stdout.write(
+    `${COLORS.cyan}history${COLORS.reset}  ${COLORS.dim}vault=${vaultRoot} · 최근 ${commits.length}개${COLORS.reset}\n`,
+  );
+  for (const c of commits) {
+    process.stdout.write(
+      `  ${COLORS.bold}${c.shortHash}${COLORS.reset}  ${c.subject}  ${COLORS.dim}(${c.relativeTime})${COLORS.reset}\n`,
+    );
+  }
+  return 0;
+}
+
+// `snapshot --diff` — 아직 커밋 안 된 vault 범위 변경 미리보기 (파일 목록 + diff).
+function emitDiff({ json, vaultRoot, repoRoot, pathspec }) {
+  const rows = getPorcelainStatus({ repoRoot, pathspec });
+  if (rows === null) {
+    process.stderr.write(`${COLORS.red}error${COLORS.reset}  git status failed for ${vaultRoot}\n`);
+    return 2;
+  }
+  const changes = buildChangeSummary(rows, { repoRoot, vaultRoot });
+  const diffText = getVaultDiff({ repoRoot, pathspec }) ?? '';
+
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          operation: 'snapshot-diff',
+          ok: true,
+          vaultRoot,
+          repoRoot,
+          count: changes.length,
+          files: changes.map((c) => ({ path: c.path, status: c.status, kind: c.kind, slug: c.slug, renamedFrom: c.renamedFrom })),
+          diff: diffText,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+
+  if (changes.length === 0) {
+    process.stdout.write(`${COLORS.dim}커밋 안 된 vault 변경 없음${COLORS.reset} ${COLORS.dim}(vault=${vaultRoot})${COLORS.reset}\n`);
+    return 0;
+  }
+
+  process.stdout.write(`${COLORS.cyan}diff${COLORS.reset}  ${COLORS.dim}vault=${vaultRoot} · 커밋 안 된 변경 ${changes.length}개${COLORS.reset}\n`);
+  for (const change of changes) {
+    const mark = STATUS_MARK[change.status] ?? '?';
+    const color = STATUS_COLOR[change.status] ?? COLORS.dim;
+    const kindLabel = change.kind ? `${KIND_COLORS[change.kind] ?? COLORS.dim}${change.kind}${COLORS.reset} ` : '';
+    const pathDisplay = change.renamedFrom ? `${change.renamedFrom} → ${change.path}` : change.path;
+    process.stdout.write(`  ${color}${mark}${COLORS.reset}  ${kindLabel}${pathDisplay}\n`);
+  }
+  if (diffText.trim()) {
+    process.stdout.write(`\n${diffText.replace(/\n$/, '')}\n`);
+  } else {
+    process.stdout.write(`\n${COLORS.dim}추적 파일의 텍스트 diff 없음 (신규 파일만) — 위 목록 참고${COLORS.reset}\n`);
+  }
+  return 0;
+}
+
+// `snapshot --pull` — upstream 에서 git pull (opt-in). 충돌/비-fast-forward/원격
+// 없음을 크래시 없이 안내. 신뢰 헌장: 전송은 명시 opt-in.
+function runPull({ json, vaultRoot, repoRoot }) {
+  const upstream = getUpstreamRef({ repoRoot });
+  if (!upstream) {
+    const branch = getCurrentBranch({ repoRoot });
+    if (json) {
+      process.stdout.write(
+        JSON.stringify(
+          { operation: 'snapshot-pull', ok: false, reason: 'no-upstream', vaultRoot, guidance: `git push -u origin ${branch}` },
+          null,
+          2,
+        ) + '\n',
+      );
+      return 1;
+    }
+    process.stderr.write(
+      `${COLORS.red}error${COLORS.reset}  이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요.\n` +
+        `  ${COLORS.cyan}git push -u origin ${branch}${COLORS.reset}\n`,
+    );
+    return 1;
+  }
+
+  let out;
+  try {
+    out = pullCurrentBranch({ repoRoot });
+  } catch (err) {
+    return emitGitError(err, { operation: 'pull', json, vaultRoot });
+  }
+
+  const summary = String(out ?? '').trim().split('\n').filter(Boolean).slice(-1)[0] || 'up to date';
+  if (json) {
+    process.stdout.write(
+      JSON.stringify({ operation: 'snapshot-pull', ok: true, vaultRoot, upstream, summary }, null, 2) + '\n',
+    );
+    return 0;
+  }
+  process.stdout.write(
+    `${COLORS.green}ok${COLORS.reset}    pull 완료 ${COLORS.dim}(${upstream})${COLORS.reset}\n  ${COLORS.dim}${summary}${COLORS.reset}\n`,
+  );
+  return 0;
+}
+
 function render({ json, dryRun, vaultRoot, repoRoot, subject, autoSummary, message, changes, stagedOutside, committed, commitHash, push }) {
   const added = changes.filter((c) => c.status === 'added').length;
   const modified = changes.filter((c) => c.status === 'modified').length;
@@ -222,7 +417,9 @@ function render({ json, dryRun, vaultRoot, repoRoot, subject, autoSummary, messa
     const mark = STATUS_MARK[change.status] ?? '?';
     const color = STATUS_COLOR[change.status] ?? COLORS.dim;
     const kindLabel = change.kind ? `${KIND_COLORS[change.kind] ?? COLORS.dim}${change.kind}${COLORS.reset} ` : '';
-    process.stdout.write(`  ${color}${mark}${COLORS.reset}  ${kindLabel}${change.path}\n`);
+    // LOW-5: rename 은 "이전 → 현재" 로 보여 히스토리 가독성을 높인다.
+    const pathDisplay = change.renamedFrom ? `${change.renamedFrom} → ${change.path}` : change.path;
+    process.stdout.write(`  ${color}${mark}${COLORS.reset}  ${kindLabel}${pathDisplay}\n`);
   }
 
   if (stagedOutside.length > 0) {
@@ -243,18 +440,18 @@ function render({ json, dryRun, vaultRoot, repoRoot, subject, autoSummary, messa
     if (push.pushed) {
       process.stdout.write(`\n${COLORS.green}ok${COLORS.reset}    원격으로 전송됨: ${COLORS.bold}${push.remoteUrl}${COLORS.reset}\n`);
     } else {
-      process.stdout.write(
-        `\n${COLORS.red}error${COLORS.reset}  push failed — no upstream configured for this branch.\n` +
-          `${COLORS.dim}  commit landed locally. set an upstream, then push:${COLORS.reset}\n` +
-          `  ${COLORS.cyan}${push.guidance}${COLORS.reset}\n`,
-      );
+      // 전송 실패는 안내(에러)이므로 stderr 로 — stdout(커밋 성공 요약) 오염 금지.
+      let out = `\n${COLORS.red}error${COLORS.reset}  ${push.message}\n`;
+      if (push.note) out += `${COLORS.dim}  ${push.note}${COLORS.reset}\n`;
+      if (push.guidance) out += `  ${COLORS.cyan}${push.guidance}${COLORS.reset}\n`;
+      process.stderr.write(out);
     }
   }
 }
 
 function parseArgs(args) {
   if (args.includes('--help') || args.includes('-h')) return { help: true };
-  const flags = { vault: null, json: false, dryRun: false, push: false, message: null };
+  const flags = { vault: null, json: false, dryRun: false, push: false, message: null, history: null, diff: false, pull: false };
   const positional = [];
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
@@ -263,13 +460,31 @@ function parseArgs(args) {
     else if (a === '--dry-run') flags.dryRun = true;
     else if (a === '--push') flags.push = true;
     else if (a === '--json') flags.json = true;
-    else if (a === '--message') flags.message = parseRawRequiredFlagValue('--message', args[++i]);
+    else if (a === '--diff') flags.diff = true;
+    else if (a === '--pull') flags.pull = true;
+    else if (a === '--history') {
+      // 선택적 정수 인자: 다음 토큰이 양의 정수면 소비, 아니면 기본값.
+      const next = args[i + 1];
+      if (next !== undefined && /^[1-9]\d*$/.test(next)) {
+        flags.history = parseBoundedPositiveIntegerFlag('--history', next, { max: 1000 });
+        i += 1;
+      } else {
+        flags.history = DEFAULT_HISTORY_LIMIT;
+      }
+    } else if (a.startsWith('--history=')) {
+      flags.history = parseBoundedPositiveIntegerFlag('--history', a.slice('--history='.length), { max: 1000 });
+    } else if (a === '--message') flags.message = parseRawRequiredFlagValue('--message', args[++i]);
     else if (a.startsWith('--message=')) flags.message = parseRawRequiredFlagValue('--message', a.slice('--message='.length));
     else if (a.startsWith('-')) return { error: formatUnknownFlagError(a, ALLOWED_FLAGS) };
     else positional.push(a);
   }
   for (const value of Object.values(flags)) {
     if (value instanceof Error) return { error: value.message };
+  }
+  // 패리티 모드(history/diff/pull)는 상호 배타 — 조합은 혼란만 준다.
+  const modeCount = (flags.history !== null ? 1 : 0) + (flags.diff ? 1 : 0) + (flags.pull ? 1 : 0);
+  if (modeCount > 1) {
+    return { error: 'pass only one of --history / --diff / --pull at a time' };
   }
   const vaultResult = resolveExclusiveVaultArg({ vault: flags.vault, positional });
   if (vaultResult.error) return vaultResult;
@@ -279,22 +494,30 @@ function parseArgs(args) {
     dryRun: flags.dryRun,
     push: flags.push,
     message: flags.message,
+    history: flags.history,
+    diff: flags.diff,
+    pull: flags.pull,
   };
 }
 
 function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
-      `  ontology-atlas snapshot [vault] [--dry-run] [--push] [--message "..."] [--json]\n\n` +
+      `  ontology-atlas snapshot [vault] [--dry-run] [--push] [--message "..."] [--json]\n` +
+      `  ontology-atlas snapshot [vault] --history [N] [--json]\n` +
+      `  ontology-atlas snapshot [vault] --diff [--json]\n` +
+      `  ontology-atlas snapshot [vault] --pull [--json]\n\n` +
       `${COLORS.bold}What it does:${COLORS.reset}\n` +
       `  Commits vault-scoped changes only (never files outside the vault), with a\n` +
-      `  semantic commit message summarizing kind-level add/update/remove counts and\n` +
-      `  up to 3 representative slugs, e.g.:\n` +
+      `  semantic commit message summarizing kind-level add/update/rename/remove counts\n` +
+      `  and up to 3 representative slugs, e.g.:\n` +
       `    ontology snapshot: +2 concepts, ~3 updated (capabilities/foo, elements/bar, +1)\n\n` +
       `  Exits 0 with no output change when there is nothing to snapshot. Never runs\n` +
       `  'git init' for you — if the vault is outside a git repo it exits 1 with that\n` +
       `  suggestion. Files already staged outside the vault are left untouched (git's\n` +
-      `  pathspec-scoped partial commit never touches them).\n\n` +
+      `  pathspec-scoped partial commit never touches them). A rejected commit (hook /\n` +
+      `  gpg / merge in progress) or a rejected push (remote ahead) prints a one-line\n` +
+      `  cause + next action to stderr instead of a raw stack trace.\n\n` +
       `${COLORS.bold}Flags:${COLORS.reset}\n` +
       `  ${COLORS.bold}--dry-run${COLORS.reset}   preview the summary + file list, no commit\n` +
       `  ${COLORS.bold}--push${COLORS.reset}      after committing, push to the current branch's existing\n` +
@@ -303,9 +526,17 @@ function printUsage(stream = process.stderr) {
       `              on success (trust charter: transport is opt-in and explicit).\n` +
       `  ${COLORS.bold}--message "..."${COLORS.reset} use this as the commit subject instead of the auto\n` +
       `              summary; the auto summary moves into the commit body instead.\n` +
-      `  ${COLORS.bold}--json${COLORS.reset}      machine-readable summary/counts/files/push result\n\n` +
+      `  ${COLORS.bold}--history [N]${COLORS.reset} list the last N (default ${DEFAULT_HISTORY_LIMIT}) commits touching the vault —\n` +
+      `              short hash + subject + relative time. Read-only.\n` +
+      `  ${COLORS.bold}--diff${COLORS.reset}      preview uncommitted vault-scoped changes (file list + diff),\n` +
+      `              nothing is written. Read-only.\n` +
+      `  ${COLORS.bold}--pull${COLORS.reset}      opt-in: pull the current branch from its upstream, handling\n` +
+      `              conflicts / non-fast-forward / no-remote gracefully (no crash).\n` +
+      `  ${COLORS.bold}--json${COLORS.reset}      machine-readable output for any of the modes above\n\n` +
       `${COLORS.bold}Example:${COLORS.reset}\n` +
       `  ontology-atlas snapshot docs/ontology --dry-run\n` +
+      `  ontology-atlas snapshot docs/ontology --history 20\n` +
+      `  ontology-atlas snapshot docs/ontology --diff\n` +
       `  ontology-atlas snapshot docs/ontology --push\n`,
   );
 }

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -89,6 +89,7 @@ ${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous inge
        --staged --depth N --json              ${COLORS.dim}non-blocking, silent when nothing matches${COLORS.reset}
   npx ontology-atlas snapshot [vault]         ${COLORS.green}Snapshot the vault${COLORS.reset} — vault-scoped git commit with a semantic summary
        --dry-run --push --message "..." --json ${COLORS.dim}local commit by default · --push sends to your existing upstream${COLORS.reset}
+       --history [N] --diff --pull             ${COLORS.dim}vault commit log · uncommitted preview · graceful pull (opt-in)${COLORS.reset}
 
 ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   ${COLORS.dim}Set OATLAS_CLI_MCP_TIMEOUT_MS=N when a large / slow vault needs a longer one-shot MCP call window.${COLORS.reset}

--- a/cli/src/lib/git-snapshot.mjs
+++ b/cli/src/lib/git-snapshot.mjs
@@ -91,9 +91,10 @@ function parsePorcelain(out) {
     });
 }
 
-/** porcelain 행 하나를 'added' | 'modified' | 'deleted' 로 분류. */
+/** porcelain 행 하나를 'added' | 'modified' | 'deleted' | 'renamed' 로 분류. */
 export function classifyChange(row) {
   if (row.index === 'D' || row.worktree === 'D') return 'deleted';
+  if (row.index === 'R') return 'renamed';
   if ((row.index === '?' && row.worktree === '?') || row.index === 'A') return 'added';
   return 'modified';
 }
@@ -123,7 +124,9 @@ export function buildChangeSummary(rows, { repoRoot, vaultRoot }) {
         // 읽기 실패 — kind 없이 경로 기반 slug 로 진행 (커밋 자체는 막지 않음).
       }
     }
-    return { path: row.path, absPath, status, kind, slug };
+    // LOW-5: rename 은 이전 경로를 보존해 히스토리에서 "renamed A → B" 로 읽히게 한다.
+    const renamedFrom = status === 'renamed' && row.renamedFrom ? row.renamedFrom : null;
+    return { path: row.path, absPath, status, kind, slug, renamedFrom };
   });
 }
 
@@ -135,10 +138,12 @@ export function formatSnapshotSummary(changes) {
   const added = changes.filter((c) => c.status === 'added').length;
   const modified = changes.filter((c) => c.status === 'modified').length;
   const removed = changes.filter((c) => c.status === 'deleted').length;
+  const renamed = changes.filter((c) => c.status === 'renamed').length;
 
   const parts = [];
   if (added > 0) parts.push(`+${added} concept${added === 1 ? '' : 's'}`);
   if (modified > 0) parts.push(`~${modified} updated`);
+  if (renamed > 0) parts.push(`→${renamed} renamed`);
   if (removed > 0) parts.push(`-${removed} removed`);
 
   const headline = parts.length > 0 ? `ontology snapshot: ${parts.join(', ')}` : 'ontology snapshot: no concept changes';
@@ -207,4 +212,198 @@ export function pushCurrentBranch({ repoRoot, run = defaultRun }) {
 
 export function getRemoteUrl({ repoRoot, remoteName, run = defaultRun }) {
   return run(['remote', 'get-url', remoteName], repoRoot).trim();
+}
+
+// ── 우아한 실패 (HIGH-1) ──────────────────────────────────────────────────
+// commitPathspec / pushCurrentBranch / pullCurrentBranch 는 execFileSync 의
+// throw 를 그대로 전파한다. 커맨드 래퍼는 그 에러를 `classifyGitError` 로
+// 넘겨 raw 스택트레이스 크래시 대신 "한 줄 원인 + 다음 행동" 으로 바꾼다.
+// 순수 함수 — I/O 없음, stderr 는 래퍼가 쓴다.
+
+/** execFileSync 에러의 stderr/stdout/message 를 하나의 문자열로 합친다. */
+function gitErrorText(err) {
+  if (!err) return '';
+  const parts = [];
+  for (const key of ['stderr', 'stdout']) {
+    const v = err[key];
+    if (typeof v === 'string') parts.push(v);
+    else if (v && typeof v.toString === 'function') parts.push(v.toString('utf-8'));
+  }
+  if (typeof err.message === 'string') parts.push(err.message);
+  return parts.join('\n');
+}
+
+/**
+ * git 실패 에러를 사용자가 이해할 한 줄 + 다음 행동으로 분류.
+ * @param {Error} err execFileSync 가 던진 에러
+ * @param {{ operation?: 'commit'|'push'|'pull'|'git' }} opts
+ * @returns {{ reason: string, message: string, note: string|null, guidance: string|null }}
+ */
+export function classifyGitError(err, { operation = 'git' } = {}) {
+  const raw = gitErrorText(err);
+  const text = raw.toLowerCase();
+  const firstLine = raw.split('\n').map((l) => l.trim()).filter(Boolean)[0] || null;
+
+  // push: 원격이 앞섬 (non-fast-forward). 커밋은 이미 로컬에 있으므로 안내만.
+  if (
+    text.includes('non-fast-forward') ||
+    text.includes('updates were rejected') ||
+    (text.includes('[rejected]') && text.includes('fetch first'))
+  ) {
+    return {
+      reason: 'push-non-fast-forward',
+      message: '원격이 앞섰어요 — `git pull` 후 다시 스냅샷하세요.',
+      note: '커밋은 이미 로컬에 기록됨',
+      guidance: 'git pull',
+    };
+  }
+
+  // gpg 서명 실패
+  if (
+    text.includes('gpg failed to sign') ||
+    text.includes('signing failed') ||
+    (text.includes('gpg') && text.includes('sign'))
+  ) {
+    return {
+      reason: 'gpg-sign-failed',
+      message: '커밋 서명(gpg)에 실패했어요 — 서명 키를 확인하세요.',
+      note: firstLine,
+      guidance: 'git config commit.gpgsign false   # 서명을 끄고 다시 스냅샷',
+    };
+  }
+
+  // merge / rebase 진행 중 — pathspec 부분 커밋 불가
+  if (
+    text.includes('cannot do a partial commit during a merge') ||
+    text.includes('cannot do a partial commit during a rebase') ||
+    text.includes('cannot do a partial commit')
+  ) {
+    return {
+      reason: 'merge-in-progress',
+      message: '머지/리베이스가 진행 중이라 vault 범위만 커밋할 수 없어요 — 진행 중인 작업을 먼저 마치거나 중단하세요.',
+      note: null,
+      guidance: 'git status   # 진행 중 상태 확인',
+    };
+  }
+
+  // pull: 충돌
+  if (text.includes('conflict') || text.includes('automatic merge failed')) {
+    return {
+      reason: 'pull-conflict',
+      message: 'pull 중 충돌이 났어요 — 충돌 파일을 해결한 뒤 커밋하세요.',
+      note: null,
+      guidance: 'git status   # 충돌 파일 확인',
+    };
+  }
+
+  // 커밋 안 된 로컬 변경이 pull 로 덮어써질 위험
+  if (text.includes('would be overwritten') || text.includes('overwritten by merge')) {
+    return {
+      reason: 'local-changes',
+      message: '커밋 안 된 로컬 변경이 있어 막혔어요 — 먼저 snapshot 으로 커밋하거나 stash 하세요.',
+      note: null,
+      guidance: 'ontology-atlas snapshot   # 로컬 변경을 먼저 커밋',
+    };
+  }
+
+  // pull: 원격/추적 정보 없음
+  if (
+    text.includes('no tracking information') ||
+    text.includes("couldn't find remote ref") ||
+    text.includes('no such remote')
+  ) {
+    return {
+      reason: 'no-upstream',
+      message: '이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요.',
+      note: null,
+      guidance: 'git push -u origin <branch>',
+    };
+  }
+
+  // pre-commit / commit-msg 훅 거부 (훅이 "hook"/"pre-commit" 을 남긴 경우)
+  if (text.includes('pre-commit') || text.includes('commit-msg') || text.includes('hook')) {
+    return {
+      reason: 'pre-commit-hook',
+      message: '커밋 훅이 스냅샷을 거부했어요 — 훅이 보고한 문제를 고친 뒤 다시 스냅샷하세요.',
+      note: firstLine,
+      guidance: null,
+    };
+  }
+
+  // 미분류 — raw 스택트레이스 대신 operation 별 깔끔한 fallback + git 첫 줄.
+  if (operation === 'commit') {
+    return {
+      reason: 'commit-rejected',
+      message: '커밋이 거부됐어요 (커밋 훅이 막았을 수 있어요).',
+      note: firstLine,
+      guidance: null,
+    };
+  }
+  return {
+    reason: 'git-command-failed',
+    message: `git ${operation} 명령이 실패했어요.`,
+    note: firstLine,
+    guidance: null,
+  };
+}
+
+// ── 옵시디언 Git 패리티 (읽기 전용 + opt-in 전송) ─────────────────────────
+const LOG_FIELD_SEP = '\x1f';
+
+/**
+ * vault pathspec 에 닿은 최근 커밋 N개 (git log -- <pathspec>).
+ * 커밋이 하나도 없거나 repo 오류면 null (호출자가 "히스토리 없음" 안내).
+ * @returns {{ shortHash: string, hash: string, subject: string, relativeTime: string, isoTime: string }[] | null}
+ */
+export function getVaultLog({ repoRoot, pathspec, limit = 10, run = defaultRun }) {
+  let out;
+  try {
+    out = run(
+      [
+        'log',
+        `--max-count=${limit}`,
+        `--pretty=format:%h${LOG_FIELD_SEP}%H${LOG_FIELD_SEP}%s${LOG_FIELD_SEP}%cr${LOG_FIELD_SEP}%cI`,
+        '--',
+        pathspec,
+      ],
+      repoRoot,
+    );
+  } catch {
+    return null; // 아직 커밋 없음 / repo 아님
+  }
+  if (typeof out !== 'string') return null;
+  const trimmed = out.trim();
+  if (!trimmed) return [];
+  return trimmed
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [shortHash, hash, subject, relativeTime, isoTime] = line.split(LOG_FIELD_SEP);
+      return { shortHash, hash, subject, relativeTime, isoTime };
+    });
+}
+
+/**
+ * 아직 커밋 안 된 vault 범위 변경의 diff (git diff HEAD -- <pathspec>).
+ * HEAD 가 없으면 (커밋 0개) 인덱스 기준으로 폴백. 실패 시 null.
+ * (untracked 신규 파일은 diff 에 안 잡히므로 파일 목록으로 별도 표시한다.)
+ */
+export function getVaultDiff({ repoRoot, pathspec, run = defaultRun }) {
+  try {
+    return run(['diff', 'HEAD', '--', pathspec], repoRoot);
+  } catch {
+    try {
+      return run(['diff', '--', pathspec], repoRoot);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * 현재 브랜치를 upstream 에서 pull (opt-in). 충돌/비-fast-forward/원격 없음은
+ * throw 로 전파 → 래퍼가 `classifyGitError` 로 우아하게 변환한다.
+ */
+export function pullCurrentBranch({ repoRoot, run = defaultRun }) {
+  return run(['pull'], repoRoot);
 }

--- a/cli/src/lib/git-snapshot.test.mjs
+++ b/cli/src/lib/git-snapshot.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, unlinkSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -9,6 +9,7 @@ import {
   addPaths,
   buildChangeSummary,
   classifyChange,
+  classifyGitError,
   commitPathspec,
   findGitRepoRoot,
   findStagedOutsideVault,
@@ -19,6 +20,9 @@ import {
   getPorcelainStatus,
   getRemoteUrl,
   getUpstreamRef,
+  getVaultDiff,
+  getVaultLog,
+  pullCurrentBranch,
   pushCurrentBranch,
   vaultPathspec,
 } from './git-snapshot.mjs';
@@ -317,6 +321,250 @@ test('getPorcelainStatus / findGitRepoRoot — a vault directory with no .git an
     assert.equal(findGitRepoRoot(vaultRoot), null);
   } finally {
     cleanup(dir);
+  }
+});
+
+// ── LOW-5: rename 표기 ────────────────────────────────────────────────────
+
+test('classifyChange — R index is a rename', () => {
+  assert.equal(classifyChange({ index: 'R', worktree: ' ' }), 'renamed');
+});
+
+test('buildChangeSummary + formatSnapshotSummary — rename keeps the previous path and counts as →renamed', () => {
+  const repoRoot = initRepo();
+  try {
+    writeMd(repoRoot, 'docs/ontology/capabilities/old.md', { kind: 'capability', slug: 'capabilities/old' });
+    sh(['add', '.'], repoRoot);
+    sh(['commit', '-m', 'baseline'], repoRoot);
+
+    // Staged rename via `git mv` — porcelain reports it as `R  old -> new`.
+    sh(['mv', 'docs/ontology/capabilities/old.md', 'docs/ontology/capabilities/new.md'], repoRoot);
+
+    const vaultRoot = join(repoRoot, 'docs', 'ontology');
+    const rows = getPorcelainStatus({ repoRoot, pathspec: 'docs/ontology' });
+    const renameRow = rows.find((r) => r.index === 'R');
+    assert.ok(renameRow, 'expected a rename row');
+    assert.equal(renameRow.renamedFrom, 'docs/ontology/capabilities/old.md');
+
+    const changes = buildChangeSummary(rows, { repoRoot, vaultRoot });
+    const renamed = changes.find((c) => c.status === 'renamed');
+    assert.ok(renamed, 'expected a renamed change');
+    assert.equal(renamed.renamedFrom, 'docs/ontology/capabilities/old.md');
+    assert.equal(renamed.path, 'docs/ontology/capabilities/new.md');
+
+    assert.match(formatSnapshotSummary(changes), /→1 renamed/);
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+// ── HIGH-1: 우아한 git 실패 분류 ──────────────────────────────────────────
+
+test('classifyGitError — maps common git failure stderr to clean reasons + guidance', () => {
+  assert.equal(
+    classifyGitError({ stderr: 'error: failed to push some refs\nhint: Updates were rejected because the remote contains work\n ! [rejected] main -> main (non-fast-forward)' }, { operation: 'push' }).reason,
+    'push-non-fast-forward',
+  );
+  assert.equal(
+    classifyGitError({ stderr: 'error: gpg failed to sign the data\nfatal: failed to write commit object' }, { operation: 'commit' }).reason,
+    'gpg-sign-failed',
+  );
+  assert.equal(
+    classifyGitError({ stderr: 'fatal: cannot do a partial commit during a merge.' }, { operation: 'commit' }).reason,
+    'merge-in-progress',
+  );
+  assert.equal(
+    classifyGitError({ stderr: 'CONFLICT (content): Merge conflict in x.md\nAutomatic merge failed; fix conflicts and then commit the result.' }, { operation: 'pull' }).reason,
+    'pull-conflict',
+  );
+  assert.equal(
+    classifyGitError({ stderr: 'There is no tracking information for the current branch.' }, { operation: 'pull' }).reason,
+    'no-upstream',
+  );
+  assert.equal(
+    classifyGitError({ stderr: 'pre-commit hook failed: policy violation' }, { operation: 'commit' }).reason,
+    'pre-commit-hook',
+  );
+  // Unknown commit failure never surfaces a raw stack trace — it degrades to a
+  // clean, hook-aware message with the git first line preserved as a note.
+  const generic = classifyGitError({ stderr: 'some unexpected git output' }, { operation: 'commit' });
+  assert.equal(generic.reason, 'commit-rejected');
+  assert.equal(generic.note, 'some unexpected git output');
+});
+
+test('commitPathspec — a rejecting pre-commit hook throws and classifies as pre-commit-hook (no raw crash)', () => {
+  const repoRoot = initRepo();
+  try {
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a' });
+    sh(['add', '.'], repoRoot);
+    sh(['commit', '-m', 'baseline'], repoRoot);
+
+    const hookPath = join(repoRoot, '.git', 'hooks', 'pre-commit');
+    writeFileSync(hookPath, '#!/bin/sh\necho "pre-commit: blocked by policy" >&2\nexit 1\n');
+    chmodSync(hookPath, 0o755);
+
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a', title: 'Updated' });
+
+    let thrown = null;
+    try {
+      commitPathspec({ repoRoot, pathspec: 'docs/ontology', message: 'ontology snapshot: ~1 updated' });
+    } catch (err) {
+      thrown = err;
+    }
+    assert.ok(thrown, 'a rejecting hook must throw so the wrapper can classify it');
+    const info = classifyGitError(thrown, { operation: 'commit' });
+    assert.equal(info.reason, 'pre-commit-hook');
+    assert.equal(typeof info.message, 'string');
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test('pushCurrentBranch — a remote that moved ahead rejects the push and classifies as non-fast-forward', () => {
+  const bareRoot = makeTmpDir('oatlas-snapshot-bare-');
+  const repoA = initRepo();
+  const repoB = makeTmpDir('oatlas-snapshot-clone-');
+  try {
+    sh(['init', '--bare', '-b', 'main'], bareRoot);
+    sh(['remote', 'add', 'origin', bareRoot], repoA);
+
+    writeMd(repoA, 'docs/ontology/project.md', { kind: 'project', slug: 'project' });
+    sh(['add', '.'], repoA);
+    sh(['commit', '-m', 'baseline'], repoA);
+    sh(['push', '-u', 'origin', 'main'], repoA);
+
+    // repoB clones the bare — it tracks origin/main at the baseline commit.
+    sh(['clone', bareRoot, repoB], tmpdir());
+    sh(['config', 'user.email', 'b@example.com'], repoB);
+    sh(['config', 'user.name', 'Repo B'], repoB);
+    sh(['config', 'commit.gpgsign', 'false'], repoB);
+
+    // repoA advances the remote.
+    writeMd(repoA, 'docs/ontology/capabilities/fromA.md', { kind: 'capability', slug: 'capabilities/fromA' });
+    sh(['add', '.'], repoA);
+    sh(['commit', '-m', 'from A'], repoA);
+    sh(['push'], repoA);
+
+    // repoB makes a divergent local commit and pushes — the remote is ahead.
+    writeMd(repoB, 'docs/ontology/capabilities/fromB.md', { kind: 'capability', slug: 'capabilities/fromB' });
+    sh(['add', '.'], repoB);
+    sh(['commit', '-m', 'from B'], repoB);
+
+    let thrown = null;
+    try {
+      pushCurrentBranch({ repoRoot: repoB });
+    } catch (err) {
+      thrown = err;
+    }
+    assert.ok(thrown, 'pushing to a remote that moved ahead must throw');
+    assert.equal(classifyGitError(thrown, { operation: 'push' }).reason, 'push-non-fast-forward');
+  } finally {
+    cleanup(repoA);
+    cleanup(repoB);
+    cleanup(bareRoot);
+  }
+});
+
+// ── 패리티: --history / --diff / --pull ───────────────────────────────────
+
+test('getVaultLog — returns only commits touching the vault pathspec, newest first', () => {
+  const repoRoot = initRepo();
+  try {
+    // commit 1 — touches the vault.
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a' });
+    sh(['add', '.'], repoRoot);
+    sh(['commit', '-m', 'vault: add a'], repoRoot);
+
+    // commit 2 — outside the vault only, must NOT appear.
+    writeFileSync(join(repoRoot, 'src-file.ts'), 'export const x = 1;\n');
+    sh(['add', '.'], repoRoot);
+    sh(['commit', '-m', 'code: unrelated'], repoRoot);
+
+    // commit 3 — touches the vault again.
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a', title: 'Updated' });
+    sh(['commit', '-am', 'vault: update a'], repoRoot);
+
+    const commits = getVaultLog({ repoRoot, pathspec: 'docs/ontology' });
+    assert.ok(Array.isArray(commits));
+    const subjects = commits.map((c) => c.subject);
+    assert.deepEqual(subjects, ['vault: update a', 'vault: add a']);
+    assert.ok(!subjects.includes('code: unrelated'));
+    assert.match(commits[0].shortHash, /^[0-9a-f]{7,}$/);
+    assert.ok(commits[0].relativeTime.length > 0);
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test('getVaultLog — respects the limit and returns null before the first commit', () => {
+  const repoRoot = initRepo();
+  try {
+    // No commits yet — git log fails, we degrade to null (caller prints "no history").
+    assert.equal(getVaultLog({ repoRoot, pathspec: 'docs/ontology' }), null);
+
+    for (let i = 0; i < 4; i += 1) {
+      writeMd(repoRoot, `docs/ontology/capabilities/c${i}.md`, { kind: 'capability', slug: `capabilities/c${i}` });
+      sh(['add', '.'], repoRoot);
+      sh(['commit', '-m', `vault: c${i}`], repoRoot);
+    }
+    const limited = getVaultLog({ repoRoot, pathspec: 'docs/ontology', limit: 2 });
+    assert.equal(limited.length, 2);
+    assert.deepEqual(limited.map((c) => c.subject), ['vault: c3', 'vault: c2']);
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test('getVaultDiff — shows uncommitted vault changes and never leaks outside-vault changes', () => {
+  const repoRoot = initRepo();
+  try {
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a' });
+    writeFileSync(join(repoRoot, 'src-file.ts'), 'export const x = 1;\n');
+    sh(['add', '.'], repoRoot);
+    sh(['commit', '-m', 'baseline'], repoRoot);
+
+    writeMd(repoRoot, 'docs/ontology/capabilities/a.md', { kind: 'capability', slug: 'capabilities/a', title: 'Updated title' });
+    writeFileSync(join(repoRoot, 'src-file.ts'), 'export const x = 2;\n');
+
+    const diff = getVaultDiff({ repoRoot, pathspec: 'docs/ontology' });
+    assert.ok(typeof diff === 'string');
+    assert.match(diff, /docs\/ontology\/capabilities\/a\.md/);
+    assert.ok(!diff.includes('src-file.ts'), 'the outside-vault change must never appear in the scoped diff');
+  } finally {
+    cleanup(repoRoot);
+  }
+});
+
+test('pullCurrentBranch — fast-forwards from a remote that moved ahead', () => {
+  const bareRoot = makeTmpDir('oatlas-snapshot-bare-');
+  const repoA = initRepo();
+  const repoB = makeTmpDir('oatlas-snapshot-clone-');
+  try {
+    sh(['init', '--bare', '-b', 'main'], bareRoot);
+    sh(['remote', 'add', 'origin', bareRoot], repoA);
+    writeMd(repoA, 'docs/ontology/project.md', { kind: 'project', slug: 'project' });
+    sh(['add', '.'], repoA);
+    sh(['commit', '-m', 'baseline'], repoA);
+    sh(['push', '-u', 'origin', 'main'], repoA);
+
+    sh(['clone', bareRoot, repoB], tmpdir());
+    sh(['config', 'user.email', 'b@example.com'], repoB);
+    sh(['config', 'user.name', 'Repo B'], repoB);
+
+    // repoA advances the remote; repoB has an upstream and no local changes.
+    writeMd(repoA, 'docs/ontology/capabilities/fromA.md', { kind: 'capability', slug: 'capabilities/fromA' });
+    sh(['add', '.'], repoA);
+    sh(['commit', '-m', 'from A'], repoA);
+    sh(['push'], repoA);
+
+    assert.equal(getUpstreamRef({ repoRoot: repoB }), 'origin/main');
+    pullCurrentBranch({ repoRoot: repoB }); // must not throw
+    const log = sh(['log', '--oneline', 'main'], repoB);
+    assert.match(log, /from A/);
+  } finally {
+    cleanup(repoA);
+    cleanup(repoB);
+    cleanup(bareRoot);
   }
 });
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1,0 +1,1095 @@
+// Atlas Git — Tauri 네이티브 git 계층 (데스크톱 앱이 vault 를 git 으로 버전
+// 기록하게 하는 IPC). 웹 GUI 는 다음 단계가 이 `#[tauri::command]` 들을
+// invoke 한다. `std::process::Command` 로 시스템 git 을 셸아웃하며, 안전
+// 규칙은 JS `git-snapshot.mjs`(cli/ · mcp/ 미러)를 Rust 로 그대로 옮긴 것이다.
+//
+// ── Atlas Git 신뢰 헌장 (이 파일이 지켜야 하는 불변식) ─────────────────────
+//  1. 기본 로컬 커밋만 — 전송(push/pull)은 명시 인자/호출로만(opt-in).
+//  2. git 미초기화 시 자동 `git init` 절대 금지 — 상태로만 알린다.
+//  3. 토큰/로그인/자격증명 취급 0 — 오직 로컬 git 프로세스.
+//  4. vault 밖 파일은 절대 건드리지 않는다 — `git commit -m <msg> -- <pathspec>`
+//     의 "partial commit" 격리로 vault 밖에 이미 staged 된 변경은 그대로 두고
+//     pathspec 범위만 커밋한다. untracked 신규 파일도 vault 범위만 `git add`.
+//  5. 어떤 것도 자동 실행/자동 백업 강제 금지 — 전부 명시 호출로만.
+//
+// 우아한 실패: 예상 실패(레포 아님 · non-fast-forward · 훅 거부 · 충돌)는
+// 패닉/스택트레이스 대신 `Result<_, String>` 의 깔끔한 한 줄로 돌려준다.
+
+use serde::Serialize;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+// ── vault 경로 검증 (절대경로 인젝션 방어) ─────────────────────────────────
+// vault_path 는 JS(웹 GUI)에서 넘어온다. 존재 + 디렉토리임을 확인하고
+// canonicalize 해 심볼릭 링크/상대 조각을 실경로로 확정한 뒤에만 git 의
+// cwd 로 쓴다. pathspec 은 repo_root 기준 상대로 계산되므로 vault 밖으로
+// 새는 add/commit 이 원천적으로 불가능하다.
+fn validate_vault_dir(vault_path: &str) -> Result<PathBuf, String> {
+    if vault_path.trim().is_empty() {
+        return Err("vault 경로가 비어 있어요.".into());
+    }
+    let path = PathBuf::from(vault_path);
+    let metadata =
+        fs::metadata(&path).map_err(|_| "vault 경로가 존재하지 않아요.".to_string())?;
+    if !metadata.is_dir() {
+        return Err("vault 경로가 디렉토리가 아니에요.".into());
+    }
+    fs::canonicalize(&path).map_err(|err| format!("vault 경로를 확정할 수 없어요: {err}"))
+}
+
+// ── 저수준 git 셸아웃 ──────────────────────────────────────────────────────
+struct GitRun {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+/// git 을 `cwd` 에서 실행하고 stdout/stderr 를 캡처한다. spawn 자체가 실패할
+/// 때만(예: git 미설치) `Err`. non-zero exit 는 `success:false` 로 담아
+/// 호출자가 판단하게 한다 — stderr 가 사용자 터미널을 어지럽히지 않게 pipe.
+fn run_git(cwd: &Path, args: &[&str]) -> Result<GitRun, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|err| format!("git 을 실행할 수 없어요 (설치 확인): {err}"))?;
+    Ok(GitRun {
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+// ── 레포 발견 (자동 init 금지 — 상태로만) ──────────────────────────────────
+/// vault 를 담은 git repo 최상위. git repo 밖이면 `Ok(None)`.
+fn find_repo_root(vault_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let out = run_git(vault_dir, &["rev-parse", "--show-toplevel"])?;
+    if !out.success {
+        return Ok(None);
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    // git 이 돌려준 toplevel 을 canonicalize — pathspec 계산 시 vault_dir 과
+    // 같은 실경로 기준을 쓰기 위함(/var → /private/var 등 불일치 방지).
+    let root = PathBuf::from(trimmed);
+    Ok(Some(fs::canonicalize(&root).unwrap_or(root)))
+}
+
+/// 커밋/히스토리/diff/pull 처럼 repo 가 반드시 필요한 커맨드용. repo 밖이면
+/// "자동 init 안 함" 안내를 담은 `Err` — 신뢰 헌장 ②.
+fn require_repo_root(vault_dir: &Path) -> Result<PathBuf, String> {
+    match find_repo_root(vault_dir)? {
+        Some(root) => Ok(root),
+        None => Err("이 vault 는 git 저장소 안에 있지 않아요. Atlas 는 자동으로 `git init` 하지 않아요 — 버전 기록을 원하면 직접 실행하세요: git init".into()),
+    }
+}
+
+/// repo_root 기준 vault 의 pathspec — vault 가 repo root 자체면 ".".
+fn vault_pathspec(repo_root: &Path, vault_dir: &Path) -> String {
+    match vault_dir.strip_prefix(repo_root) {
+        Ok(rel) => {
+            let mut parts: Vec<String> = Vec::new();
+            for component in rel.components() {
+                if let Component::Normal(part) = component {
+                    parts.push(part.to_string_lossy().into_owned());
+                }
+            }
+            if parts.is_empty() {
+                ".".into()
+            } else {
+                parts.join("/")
+            }
+        }
+        Err(_) => ".".into(),
+    }
+}
+
+// ── porcelain 파싱 ─────────────────────────────────────────────────────────
+struct PorcelainRow {
+    index: char,
+    worktree: char,
+    path: String,
+    renamed_from: Option<String>,
+}
+
+fn parse_porcelain(out: &str) -> Vec<PorcelainRow> {
+    out.lines()
+        .filter(|line| line.len() >= 3)
+        .map(|line| {
+            let bytes = line.as_bytes();
+            let index = bytes[0] as char;
+            let worktree = bytes[1] as char;
+            // 첫 3바이트(상태 2 + 공백 1)는 항상 ASCII → byte 3 은 char 경계.
+            let rest = &line[3..];
+            let mut renamed_from = None;
+            let mut path = rest.to_string();
+            if let Some(arrow) = rest.find(" -> ") {
+                renamed_from = Some(rest[..arrow].to_string());
+                path = rest[arrow + 4..].to_string();
+            }
+            PorcelainRow {
+                index,
+                worktree,
+                path,
+                renamed_from,
+            }
+        })
+        .collect()
+}
+
+/// `git status --porcelain -- <pathspec>` → 행 배열. git 실패 시 `Err`.
+fn get_porcelain_status(repo_root: &Path, pathspec: &str) -> Result<Vec<PorcelainRow>, String> {
+    let out = run_git(
+        repo_root,
+        &[
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--",
+            pathspec,
+        ],
+    )?;
+    if !out.success {
+        return Err(format!(
+            "git status 실패: {}",
+            first_nonempty_line(&out.stderr).unwrap_or_else(|| "unknown error".into())
+        ));
+    }
+    Ok(parse_porcelain(&out.stdout))
+}
+
+/// pathspec 없는 전체 repo porcelain — staged-outside-vault 가드용. 실패 시 빈 목록.
+fn get_full_porcelain_status(repo_root: &Path) -> Vec<PorcelainRow> {
+    match run_git(
+        repo_root,
+        &["status", "--porcelain", "--untracked-files=all"],
+    ) {
+        Ok(out) if out.success => parse_porcelain(&out.stdout),
+        _ => Vec::new(),
+    }
+}
+
+fn classify_change(row: &PorcelainRow) -> &'static str {
+    if row.index == 'D' || row.worktree == 'D' {
+        return "deleted";
+    }
+    if row.index == 'R' {
+        return "renamed";
+    }
+    if (row.index == '?' && row.worktree == '?') || row.index == 'A' {
+        return "added";
+    }
+    "modified"
+}
+
+// ── frontmatter kind/slug (경량 파서) ──────────────────────────────────────
+// 의미 정보용 최소 추출 — 파일 선두 `---` 블록에서 top-level `kind:`/`slug:`만
+// 읽는다. 커밋을 막지 않는 best-effort(실패해도 경로 기반 slug 로 진행).
+fn read_kind_slug(abs_path: &Path) -> (Option<String>, Option<String>) {
+    let Ok(raw) = fs::read_to_string(abs_path) else {
+        return (None, None);
+    };
+    let mut lines = raw.lines();
+    if lines.next().map(|l| l.trim_end()) != Some("---") {
+        return (None, None);
+    }
+    let mut kind = None;
+    let mut slug = None;
+    for line in lines {
+        let trimmed = line.trim_end();
+        if trimmed == "---" {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("kind:") {
+            let value = unquote(rest.trim());
+            if !value.is_empty() {
+                kind = Some(value);
+            }
+        } else if let Some(rest) = line.strip_prefix("slug:") {
+            let value = unquote(rest.trim());
+            if !value.is_empty() {
+                slug = Some(value);
+            }
+        }
+    }
+    (kind, slug)
+}
+
+fn unquote(value: &str) -> String {
+    let bytes = value.as_bytes();
+    if value.len() >= 2
+        && ((bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[value.len() - 1] == b'\''))
+    {
+        value[1..value.len() - 1].to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+// ── 변경 요약 ──────────────────────────────────────────────────────────────
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChangeEntry {
+    path: String,
+    status: String,
+    kind: Option<String>,
+    slug: String,
+    renamed_from: Option<String>,
+}
+
+fn build_change_summary(
+    rows: &[PorcelainRow],
+    repo_root: &Path,
+    vault_dir: &Path,
+) -> Vec<ChangeEntry> {
+    rows.iter()
+        .map(|row| {
+            let abs_path = repo_root.join(&row.path);
+            let status = classify_change(row);
+            let mut kind = None;
+            let mut slug = path_based_slug(vault_dir, &abs_path);
+            if row.path.ends_with(".md") && status != "deleted" {
+                let (k, s) = read_kind_slug(&abs_path);
+                if k.is_some() {
+                    kind = k;
+                }
+                if let Some(s) = s {
+                    slug = s;
+                }
+            }
+            let renamed_from = if status == "renamed" {
+                row.renamed_from.clone()
+            } else {
+                None
+            };
+            ChangeEntry {
+                path: row.path.clone(),
+                status: status.to_string(),
+                kind,
+                slug,
+                renamed_from,
+            }
+        })
+        .collect()
+}
+
+fn path_based_slug(vault_dir: &Path, abs_path: &Path) -> String {
+    let rel = abs_path
+        .strip_prefix(vault_dir)
+        .unwrap_or(abs_path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    rel.strip_suffix(".md").unwrap_or(&rel).to_string()
+}
+
+/// 의미 단위 커밋 요약 한 줄 — kind별 카운트 + 대표 슬러그 최대 3개.
+fn format_snapshot_summary(changes: &[ChangeEntry]) -> String {
+    let added = changes.iter().filter(|c| c.status == "added").count();
+    let modified = changes.iter().filter(|c| c.status == "modified").count();
+    let removed = changes.iter().filter(|c| c.status == "deleted").count();
+    let renamed = changes.iter().filter(|c| c.status == "renamed").count();
+
+    let mut parts: Vec<String> = Vec::new();
+    if added > 0 {
+        parts.push(format!(
+            "+{added} concept{}",
+            if added == 1 { "" } else { "s" }
+        ));
+    }
+    if modified > 0 {
+        parts.push(format!("~{modified} updated"));
+    }
+    if renamed > 0 {
+        parts.push(format!("→{renamed} renamed"));
+    }
+    if removed > 0 {
+        parts.push(format!("-{removed} removed"));
+    }
+
+    let headline = if parts.is_empty() {
+        "ontology snapshot: no concept changes".to_string()
+    } else {
+        format!("ontology snapshot: {}", parts.join(", "))
+    };
+
+    let slugs: Vec<&str> = changes.iter().map(|c| c.slug.as_str()).collect();
+    let shown = &slugs[..slugs.len().min(3)];
+    let overflow = slugs.len() - shown.len();
+    if shown.is_empty() {
+        headline
+    } else {
+        let overflow_text = if overflow > 0 {
+            format!(", +{overflow}")
+        } else {
+            String::new()
+        };
+        format!("{headline} ({}{overflow_text})", shown.join(", "))
+    }
+}
+
+fn status_mark(status: &str) -> char {
+    match status {
+        "added" => 'A',
+        "modified" => 'M',
+        "deleted" => 'D',
+        "renamed" => 'R',
+        _ => '?',
+    }
+}
+
+/// custom 메시지면 auto summary 를 본문에 겹쳐 담아 의미 맥락을 보존한다.
+fn build_commit_message(
+    subject: &str,
+    auto_summary: &str,
+    changes: &[ChangeEntry],
+    has_custom_message: bool,
+) -> String {
+    let mut body: Vec<String> = Vec::new();
+    if has_custom_message {
+        body.push(auto_summary.to_string());
+        body.push(String::new());
+    }
+    for c in changes {
+        body.push(format!("  {}  {}", status_mark(&c.status), c.path));
+    }
+    format!("{subject}\n\n{}", body.join("\n"))
+}
+
+/// vault pathspec 밖에서 이미 staged 된 경로 — 보호 경고용(커밋엔 안 섞임).
+fn find_staged_outside_vault(rows: &[PorcelainRow], pathspec: &str) -> Vec<String> {
+    rows.iter()
+        .filter(|row| {
+            let is_staged = row.index != ' ' && row.index != '?';
+            is_staged && !is_under_pathspec(&row.path, pathspec)
+        })
+        .map(|row| row.path.clone())
+        .collect()
+}
+
+fn is_under_pathspec(path: &str, pathspec: &str) -> bool {
+    if pathspec == "." {
+        return true;
+    }
+    path == pathspec || path.starts_with(&format!("{pathspec}/"))
+}
+
+fn first_nonempty_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .map(|l| l.to_string())
+}
+
+// ── 우아한 실패 분류 (git-snapshot.mjs classifyGitError 미러) ──────────────
+struct GitErrorInfo {
+    #[allow(dead_code)]
+    reason: &'static str,
+    message: String,
+    note: Option<String>,
+    guidance: Option<String>,
+}
+
+fn classify_git_error(raw: &str, operation: &str) -> GitErrorInfo {
+    let text = raw.to_lowercase();
+    let first_line = first_nonempty_line(raw);
+
+    if text.contains("non-fast-forward")
+        || text.contains("updates were rejected")
+        || (text.contains("[rejected]") && text.contains("fetch first"))
+    {
+        return GitErrorInfo {
+            reason: "push-non-fast-forward",
+            message: "원격이 앞섰어요 — `git pull` 후 다시 스냅샷하세요.".into(),
+            note: Some("커밋은 이미 로컬에 기록됨".into()),
+            guidance: Some("git pull".into()),
+        };
+    }
+
+    if text.contains("gpg failed to sign")
+        || text.contains("signing failed")
+        || (text.contains("gpg") && text.contains("sign"))
+    {
+        return GitErrorInfo {
+            reason: "gpg-sign-failed",
+            message: "커밋 서명(gpg)에 실패했어요 — 서명 키를 확인하세요.".into(),
+            note: first_line,
+            guidance: Some("git config commit.gpgsign false   # 서명을 끄고 다시 스냅샷".into()),
+        };
+    }
+
+    if text.contains("cannot do a partial commit") {
+        return GitErrorInfo {
+            reason: "merge-in-progress",
+            message: "머지/리베이스가 진행 중이라 vault 범위만 커밋할 수 없어요 — 진행 중인 작업을 먼저 마치거나 중단하세요.".into(),
+            note: None,
+            guidance: Some("git status   # 진행 중 상태 확인".into()),
+        };
+    }
+
+    if text.contains("conflict") || text.contains("automatic merge failed") {
+        return GitErrorInfo {
+            reason: "pull-conflict",
+            message: "pull 중 충돌이 났어요 — 충돌 파일을 해결한 뒤 커밋하세요.".into(),
+            note: None,
+            guidance: Some("git status   # 충돌 파일 확인".into()),
+        };
+    }
+
+    if text.contains("would be overwritten") || text.contains("overwritten by merge") {
+        return GitErrorInfo {
+            reason: "local-changes",
+            message: "커밋 안 된 로컬 변경이 있어 막혔어요 — 먼저 스냅샷으로 커밋하거나 stash 하세요."
+                .into(),
+            note: None,
+            guidance: None,
+        };
+    }
+
+    if text.contains("no tracking information")
+        || text.contains("couldn't find remote ref")
+        || text.contains("no such remote")
+    {
+        return GitErrorInfo {
+            reason: "no-upstream",
+            message: "이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요.".into(),
+            note: None,
+            guidance: Some("git push -u origin <branch>".into()),
+        };
+    }
+
+    if text.contains("pre-commit") || text.contains("commit-msg") || text.contains("hook") {
+        return GitErrorInfo {
+            reason: "pre-commit-hook",
+            message: "커밋 훅이 스냅샷을 거부했어요 — 훅이 보고한 문제를 고친 뒤 다시 스냅샷하세요.".into(),
+            note: first_line,
+            guidance: None,
+        };
+    }
+
+    if operation == "commit" {
+        return GitErrorInfo {
+            reason: "commit-rejected",
+            message: "커밋이 거부됐어요 (커밋 훅이 막았을 수 있어요).".into(),
+            note: first_line,
+            guidance: None,
+        };
+    }
+    GitErrorInfo {
+        reason: "git-command-failed",
+        message: format!("git {operation} 명령이 실패했어요."),
+        note: first_line,
+        guidance: None,
+    }
+}
+
+/// 분류 결과를 사용자용 한 줄 문자열로 — Result<_, String> 의 Err 페이로드.
+fn classified_error_string(info: &GitErrorInfo) -> String {
+    let mut out = info.message.clone();
+    if let Some(note) = &info.note {
+        out.push_str(&format!(" ({note})"));
+    }
+    if let Some(guidance) = &info.guidance {
+        out.push_str(&format!(" → {guidance}"));
+    }
+    out
+}
+
+fn git_error_text(run: &GitRun) -> String {
+    let mut parts = Vec::new();
+    if !run.stderr.trim().is_empty() {
+        parts.push(run.stderr.clone());
+    }
+    if !run.stdout.trim().is_empty() {
+        parts.push(run.stdout.clone());
+    }
+    parts.join("\n")
+}
+
+// ── upstream / 브랜치 조회 ─────────────────────────────────────────────────
+fn get_current_branch(repo_root: &Path) -> Option<String> {
+    let out = run_git(repo_root, &["rev-parse", "--abbrev-ref", "HEAD"]).ok()?;
+    if !out.success {
+        return None;
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn get_upstream_ref(repo_root: &Path) -> Option<String> {
+    let out = run_git(
+        repo_root,
+        &["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+    )
+    .ok()?;
+    if !out.success {
+        return None;
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn get_head_hash(repo_root: &Path) -> Option<String> {
+    let out = run_git(repo_root, &["rev-parse", "HEAD"]).ok()?;
+    if !out.success {
+        return None;
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn get_remote_url(repo_root: &Path, remote_name: &str) -> Option<String> {
+    let out = run_git(repo_root, &["remote", "get-url", remote_name]).ok()?;
+    if !out.success {
+        return None;
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+// ── 결과 타입 (웹 GUI 가 소비) ─────────────────────────────────────────────
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitStatusResult {
+    /// vault 가 git repo 안인가 — 웹 GUI 버튼 상태 판단의 1차 신호.
+    initialized: bool,
+    /// repo 최상위 절대경로 (initialized 일 때만).
+    repo_root: Option<String>,
+    /// 현재 브랜치명.
+    branch: Option<String>,
+    /// upstream ref (예: origin/main) — 없으면 null(push 불가 안내).
+    upstream: Option<String>,
+    /// vault 범위의 미커밋 변경 수.
+    changed_count: usize,
+    /// vault 밖에 이미 staged 된 경로(스냅샷이 건드리지 않음 — 정보용).
+    staged_outside_vault: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushOutcome {
+    pushed: bool,
+    remote_url: Option<String>,
+    /// 실패 시 사용자용 한 줄.
+    message: Option<String>,
+    guidance: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitSnapshotResult {
+    committed: bool,
+    /// "no-changes" | null(커밋됨).
+    reason: Option<String>,
+    commit_hash: Option<String>,
+    subject: Option<String>,
+    /// 의미 단위 auto 요약 한 줄.
+    summary: Option<String>,
+    counts: SnapshotCounts,
+    files: Vec<ChangeEntry>,
+    staged_outside_vault: Vec<String>,
+    /// push 를 요청(opt-in)했을 때만 채워짐.
+    push: Option<PushOutcome>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotCounts {
+    added: usize,
+    modified: usize,
+    deleted: usize,
+    renamed: usize,
+    total: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCommitInfo {
+    short_hash: String,
+    hash: String,
+    subject: String,
+    relative_time: String,
+    iso_time: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitDiffResult {
+    count: usize,
+    files: Vec<ChangeEntry>,
+    /// 추적 파일의 텍스트 diff (신규 파일은 목록으로만).
+    diff: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitPullResult {
+    ok: bool,
+    upstream: String,
+    /// pull 결과 요약 마지막 줄 (예: "Already up to date.").
+    summary: String,
+}
+
+// ── #[tauri::command] 세트 ─────────────────────────────────────────────────
+
+/// vault 의 git 상태 요약 — 초기화 여부 + 브랜치/upstream + 미커밋 변경 수.
+/// 웹 GUI 가 "스냅샷/push/pull" 버튼 활성화를 판단하는 데 쓴다. repo 밖이면
+/// 에러가 아니라 `initialized:false` 로 알린다(자동 init 금지).
+#[tauri::command]
+pub fn git_status(vault_path: String) -> Result<GitStatusResult, String> {
+    let vault_dir = validate_vault_dir(&vault_path)?;
+    let Some(repo_root) = find_repo_root(&vault_dir)? else {
+        return Ok(GitStatusResult {
+            initialized: false,
+            repo_root: None,
+            branch: None,
+            upstream: None,
+            changed_count: 0,
+            staged_outside_vault: Vec::new(),
+        });
+    };
+    let pathspec = vault_pathspec(&repo_root, &vault_dir);
+    let rows = get_porcelain_status(&repo_root, &pathspec)?;
+    let full_rows = get_full_porcelain_status(&repo_root);
+    let staged_outside = find_staged_outside_vault(&full_rows, &pathspec);
+
+    Ok(GitStatusResult {
+        initialized: true,
+        repo_root: Some(repo_root.to_string_lossy().into_owned()),
+        branch: get_current_branch(&repo_root),
+        upstream: get_upstream_ref(&repo_root),
+        changed_count: rows.len(),
+        staged_outside_vault: staged_outside,
+    })
+}
+
+/// vault 범위만 add + commit 하는 의미 단위 스냅샷. `message` 없으면 auto
+/// 요약을 subject 로 쓴다. `push` 가 true 일 때만 upstream 으로 전송(opt-in).
+/// 커밋할 변경이 없으면 에러가 아니라 `committed:false, reason:"no-changes"`.
+#[tauri::command]
+pub fn git_snapshot(
+    vault_path: String,
+    message: Option<String>,
+    push: Option<bool>,
+) -> Result<GitSnapshotResult, String> {
+    let vault_dir = validate_vault_dir(&vault_path)?;
+    let repo_root = require_repo_root(&vault_dir)?;
+    let pathspec = vault_pathspec(&repo_root, &vault_dir);
+
+    let rows = get_porcelain_status(&repo_root, &pathspec)?;
+    if rows.is_empty() {
+        return Ok(GitSnapshotResult {
+            committed: false,
+            reason: Some("no-changes".into()),
+            commit_hash: None,
+            subject: None,
+            summary: None,
+            counts: SnapshotCounts {
+                added: 0,
+                modified: 0,
+                deleted: 0,
+                renamed: 0,
+                total: 0,
+            },
+            files: Vec::new(),
+            staged_outside_vault: Vec::new(),
+            push: None,
+        });
+    }
+
+    let changes = build_change_summary(&rows, &repo_root, &vault_dir);
+    let auto_summary = format_snapshot_summary(&changes);
+    let custom = message.as_deref().map(str::trim).filter(|m| !m.is_empty());
+    let subject = custom.unwrap_or(&auto_summary).to_string();
+    let full_message =
+        build_commit_message(&subject, &auto_summary, &changes, custom.is_some());
+
+    let full_rows = get_full_porcelain_status(&repo_root);
+    let staged_outside = find_staged_outside_vault(&full_rows, &pathspec);
+
+    // 신뢰 헌장 ④ — vault 범위의 untracked 신규 파일만 먼저 add. tracked 파일의
+    // 변경/삭제는 이어지는 pathspec partial-commit 이 index 를 건드리지 않고 담는다.
+    let untracked: Vec<&str> = rows
+        .iter()
+        .filter(|r| r.index == '?' && r.worktree == '?')
+        .map(|r| r.path.as_str())
+        .collect();
+    if !untracked.is_empty() {
+        let mut add_args: Vec<&str> = vec!["add", "--"];
+        add_args.extend_from_slice(&untracked);
+        let add_run = run_git(&repo_root, &add_args)?;
+        if !add_run.success {
+            let info = classify_git_error(&git_error_text(&add_run), "commit");
+            return Err(classified_error_string(&info));
+        }
+    }
+
+    let commit_run = run_git(
+        &repo_root,
+        &["commit", "-m", &full_message, "--", &pathspec],
+    )?;
+    if !commit_run.success {
+        let info = classify_git_error(&git_error_text(&commit_run), "commit");
+        return Err(classified_error_string(&info));
+    }
+
+    let commit_hash = get_head_hash(&repo_root);
+
+    let counts = SnapshotCounts {
+        added: changes.iter().filter(|c| c.status == "added").count(),
+        modified: changes.iter().filter(|c| c.status == "modified").count(),
+        deleted: changes.iter().filter(|c| c.status == "deleted").count(),
+        renamed: changes.iter().filter(|c| c.status == "renamed").count(),
+        total: changes.len(),
+    };
+
+    // push 는 opt-in 명시일 때만 — upstream 없으면 자동 `-u` 설정 안 함(헌장 ①).
+    let push_outcome = if push.unwrap_or(false) {
+        Some(run_push(&repo_root))
+    } else {
+        None
+    };
+
+    Ok(GitSnapshotResult {
+        committed: true,
+        reason: None,
+        commit_hash,
+        subject: Some(subject),
+        summary: Some(auto_summary),
+        counts,
+        files: changes,
+        staged_outside_vault: staged_outside,
+        push: push_outcome,
+    })
+}
+
+/// 커밋은 이미 로컬에 있으므로 push 실패는 Err 로 크래시시키지 않고
+/// `PushOutcome{pushed:false, ...}` 안내로 담는다.
+fn run_push(repo_root: &Path) -> PushOutcome {
+    let Some(upstream) = get_upstream_ref(repo_root) else {
+        let branch = get_current_branch(repo_root).unwrap_or_else(|| "<branch>".into());
+        return PushOutcome {
+            pushed: false,
+            remote_url: None,
+            message: Some("push 실패 — 이 브랜치에 upstream 이 없어요. 커밋은 로컬에 기록됨.".into()),
+            guidance: Some(format!("git push -u origin {branch}")),
+        };
+    };
+    match run_git(repo_root, &["push"]) {
+        Ok(out) if out.success => {
+            let remote_name = upstream.split('/').next().unwrap_or("origin");
+            PushOutcome {
+                pushed: true,
+                remote_url: get_remote_url(repo_root, remote_name),
+                message: None,
+                guidance: None,
+            }
+        }
+        Ok(out) => {
+            let info = classify_git_error(&git_error_text(&out), "push");
+            PushOutcome {
+                pushed: false,
+                remote_url: None,
+                message: Some(info.message),
+                guidance: info.guidance,
+            }
+        }
+        Err(err) => PushOutcome {
+            pushed: false,
+            remote_url: None,
+            message: Some(err),
+            guidance: None,
+        },
+    }
+}
+
+/// vault 경로에 닿은 최근 커밋 요약(해시/메시지/시간) — 옵시디언 Git 히스토리
+/// 패리티. 커밋이 하나도 없으면 빈 목록.
+#[tauri::command]
+pub fn git_history(
+    vault_path: String,
+    limit: Option<u32>,
+) -> Result<Vec<GitCommitInfo>, String> {
+    let vault_dir = validate_vault_dir(&vault_path)?;
+    let repo_root = require_repo_root(&vault_dir)?;
+    let pathspec = vault_pathspec(&repo_root, &vault_dir);
+    let max_count = limit.unwrap_or(10).max(1).to_string();
+    const SEP: char = '\x1f';
+    let format = format!("--pretty=format:%h{SEP}%H{SEP}%s{SEP}%cr{SEP}%cI");
+
+    let out = run_git(
+        &repo_root,
+        &[
+            "log",
+            &format!("--max-count={max_count}"),
+            &format,
+            "--",
+            &pathspec,
+        ],
+    )?;
+    if !out.success {
+        // 커밋 0개(아직 히스토리 없음) 등 — 빈 목록으로 우아하게.
+        return Ok(Vec::new());
+    }
+    let trimmed = out.stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let commits = trimmed
+        .lines()
+        .filter(|l| !l.is_empty())
+        .filter_map(|line| {
+            let mut fields = line.split(SEP);
+            Some(GitCommitInfo {
+                short_hash: fields.next()?.to_string(),
+                hash: fields.next()?.to_string(),
+                subject: fields.next().unwrap_or("").to_string(),
+                relative_time: fields.next().unwrap_or("").to_string(),
+                iso_time: fields.next().unwrap_or("").to_string(),
+            })
+        })
+        .collect();
+    Ok(commits)
+}
+
+/// 아직 커밋 안 된 vault 범위 변경의 파일 목록 + 텍스트 diff.
+#[tauri::command]
+pub fn git_diff(vault_path: String) -> Result<GitDiffResult, String> {
+    let vault_dir = validate_vault_dir(&vault_path)?;
+    let repo_root = require_repo_root(&vault_dir)?;
+    let pathspec = vault_pathspec(&repo_root, &vault_dir);
+
+    let rows = get_porcelain_status(&repo_root, &pathspec)?;
+    let changes = build_change_summary(&rows, &repo_root, &vault_dir);
+
+    // HEAD 있으면 HEAD 기준, 없으면(커밋 0개) index 기준으로 폴백.
+    let diff = match run_git(&repo_root, &["diff", "HEAD", "--", &pathspec]) {
+        Ok(out) if out.success => out.stdout,
+        _ => match run_git(&repo_root, &["diff", "--", &pathspec]) {
+            Ok(out) if out.success => out.stdout,
+            _ => String::new(),
+        },
+    };
+
+    Ok(GitDiffResult {
+        count: changes.len(),
+        files: changes,
+        diff,
+    })
+}
+
+/// upstream 에서 git pull (opt-in 전송). upstream 없음/충돌/비-fast-forward 를
+/// 크래시 없이 깔끔한 Err 로 안내한다.
+#[tauri::command]
+pub fn git_pull(vault_path: String) -> Result<GitPullResult, String> {
+    let vault_dir = validate_vault_dir(&vault_path)?;
+    let repo_root = require_repo_root(&vault_dir)?;
+
+    let Some(upstream) = get_upstream_ref(&repo_root) else {
+        let branch = get_current_branch(&repo_root).unwrap_or_else(|| "<branch>".into());
+        return Err(format!(
+            "이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요. → git push -u origin {branch}"
+        ));
+    };
+
+    let out = run_git(&repo_root, &["pull"])?;
+    if !out.success {
+        let info = classify_git_error(&git_error_text(&out), "pull");
+        return Err(classified_error_string(&info));
+    }
+    let summary = out
+        .stdout
+        .trim()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .last()
+        .unwrap_or("up to date")
+        .to_string();
+
+    Ok(GitPullResult {
+        ok: true,
+        upstream,
+        summary,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vault_pathspec_returns_dot_when_vault_is_repo_root() {
+        let root = Path::new("/repo");
+        assert_eq!(vault_pathspec(root, Path::new("/repo")), ".");
+    }
+
+    #[test]
+    fn vault_pathspec_returns_relative_when_vault_nested() {
+        let root = Path::new("/repo");
+        assert_eq!(
+            vault_pathspec(root, Path::new("/repo/docs/ontology")),
+            "docs/ontology"
+        );
+    }
+
+    #[test]
+    fn parse_porcelain_reads_status_codes_and_paths() {
+        let rows = parse_porcelain("?? docs/new.md\n M docs/edit.md\nD  docs/gone.md\n");
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].index, '?');
+        assert_eq!(rows[0].worktree, '?');
+        assert_eq!(rows[0].path, "docs/new.md");
+        assert_eq!(rows[1].index, ' ');
+        assert_eq!(rows[1].worktree, 'M');
+        assert_eq!(rows[2].index, 'D');
+    }
+
+    #[test]
+    fn parse_porcelain_reads_rename_source() {
+        let rows = parse_porcelain("R  docs/old.md -> docs/new.md\n");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].index, 'R');
+        assert_eq!(rows[0].renamed_from.as_deref(), Some("docs/old.md"));
+        assert_eq!(rows[0].path, "docs/new.md");
+    }
+
+    #[test]
+    fn classify_change_maps_status_codes() {
+        let mk = |i: char, w: char| PorcelainRow {
+            index: i,
+            worktree: w,
+            path: "x".into(),
+            renamed_from: None,
+        };
+        assert_eq!(classify_change(&mk('?', '?')), "added");
+        assert_eq!(classify_change(&mk('A', ' ')), "added");
+        assert_eq!(classify_change(&mk(' ', 'M')), "modified");
+        assert_eq!(classify_change(&mk('D', ' ')), "deleted");
+        assert_eq!(classify_change(&mk(' ', 'D')), "deleted");
+        assert_eq!(classify_change(&mk('R', ' ')), "renamed");
+    }
+
+    #[test]
+    fn find_staged_outside_vault_flags_staged_paths_beyond_pathspec() {
+        let rows = parse_porcelain("M  src/other.rs\nM  docs/inside.md\n?? docs/untracked.md\n");
+        let outside = find_staged_outside_vault(&rows, "docs");
+        assert_eq!(outside, vec!["src/other.rs".to_string()]);
+    }
+
+    #[test]
+    fn find_staged_outside_vault_dot_pathspec_never_flags() {
+        let rows = parse_porcelain("M  src/other.rs\n");
+        assert!(find_staged_outside_vault(&rows, ".").is_empty());
+    }
+
+    #[test]
+    fn format_snapshot_summary_counts_and_slugs() {
+        let changes = vec![
+            ChangeEntry {
+                path: "docs/a.md".into(),
+                status: "added".into(),
+                kind: None,
+                slug: "a".into(),
+                renamed_from: None,
+            },
+            ChangeEntry {
+                path: "docs/b.md".into(),
+                status: "modified".into(),
+                kind: None,
+                slug: "b".into(),
+                renamed_from: None,
+            },
+        ];
+        let summary = format_snapshot_summary(&changes);
+        assert!(summary.contains("+1 concept"));
+        assert!(summary.contains("~1 updated"));
+        assert!(summary.contains("(a, b)"));
+    }
+
+    #[test]
+    fn format_snapshot_summary_truncates_slug_list() {
+        let changes: Vec<ChangeEntry> = (0..5)
+            .map(|i| ChangeEntry {
+                path: format!("docs/n{i}.md"),
+                status: "added".into(),
+                kind: None,
+                slug: format!("n{i}"),
+                renamed_from: None,
+            })
+            .collect();
+        let summary = format_snapshot_summary(&changes);
+        assert!(summary.contains("+5 concepts"));
+        assert!(summary.contains("+2)")); // 3 shown + overflow 2
+    }
+
+    #[test]
+    fn build_commit_message_embeds_auto_summary_for_custom_message() {
+        let changes = vec![ChangeEntry {
+            path: "docs/a.md".into(),
+            status: "added".into(),
+            kind: None,
+            slug: "a".into(),
+            renamed_from: None,
+        }];
+        let msg = build_commit_message("my subject", "ontology snapshot: +1 concept (a)", &changes, true);
+        assert!(msg.starts_with("my subject\n\n"));
+        assert!(msg.contains("ontology snapshot: +1 concept (a)"));
+        assert!(msg.contains("  A  docs/a.md"));
+    }
+
+    #[test]
+    fn classify_git_error_detects_non_fast_forward() {
+        let info = classify_git_error("! [rejected] main -> main (non-fast-forward)", "push");
+        assert_eq!(info.reason, "push-non-fast-forward");
+        assert!(info.guidance.as_deref() == Some("git pull"));
+    }
+
+    #[test]
+    fn classify_git_error_detects_hook_rejection() {
+        let info = classify_git_error("pre-commit hook failed", "commit");
+        assert_eq!(info.reason, "pre-commit-hook");
+    }
+
+    #[test]
+    fn classify_git_error_commit_fallback() {
+        let info = classify_git_error("something weird happened", "commit");
+        assert_eq!(info.reason, "commit-rejected");
+    }
+
+    #[test]
+    fn validate_vault_dir_rejects_missing_path() {
+        let err = validate_vault_dir("/path/does/not/exist/atlas").unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn read_kind_slug_extracts_frontmatter_fields() {
+        let dir = std::env::temp_dir().join(format!("atlas-git-test-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let file = dir.join("node.md");
+        fs::write(&file, "---\nkind: capability\nslug: \"my-cap\"\n---\n# Body\n").unwrap();
+        let (kind, slug) = read_kind_slug(&file);
+        assert_eq!(kind.as_deref(), Some("capability"));
+        assert_eq!(slug.as_deref(), Some("my-cap"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,9 @@ use std::sync::Mutex;
 use std::time::{Duration, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, RunEvent, State};
 
+/// Atlas Git — vault 를 git 으로 버전 기록하는 네이티브 계층 (웹 GUI 가 invoke).
+mod git;
+
 const WEBVIEW_VERIFY_ENV: &str = "ONTOLOGY_ATLAS_VERIFY_WEBVIEW";
 const WEBVIEW_VERIFY_ROUTE_ENV: &str = "ONTOLOGY_ATLAS_VERIFY_ROUTE";
 const WEBVIEW_VERIFY_TOPOLOGY_DRAG_ENV: &str = "ONTOLOGY_ATLAS_VERIFY_TOPOLOGY_DRAG";
@@ -5734,6 +5737,11 @@ pub fn run() {
             open_vault_in_finder,
             ensure_default_vault_parent_dir,
             start_vault_watch,
+            git::git_status,
+            git::git_snapshot,
+            git::git_history,
+            git::git_diff,
+            git::git_pull,
         ])
         .build(tauri::generate_context!())
         .expect("error while building ontology-atlas desktop app")


### PR DESCRIPTION
## Summary

Atlas Git(vault→git 스냅샷)의 완결성 개선 — 감사가 지목한 크래시/타깃-도달 격차 해소. **MCP snapshot 도구는 #543 이 이미 `git_snapshot` 으로 추가했으므로 중복 제거**, 여기서는 CLI 견고화 + 데스크톱용 Tauri git 계층만 반영.

- **CLI 견고화**: push 거부(non-fast-forward)·pre-commit hook·gpg 서명 실패·mid-merge 를 raw 스택트레이스 대신 우아한 한 줄 + 다음 행동으로(`classifyGitError`). rename 표기(A → B).
- **옵시디언 패리티**: `snapshot --history / --diff / --pull` (전부 opt-in, pathspec 격리 유지, 로컬 커밋 기본).
- **Tauri git 계층**: `src-tauri/src/git.rs` — 데스크톱 GUI가 invoke 할 git IPC 5종(status/snapshot/history/diff/pull), 신규 의존성 0, pathspec 격리 Rust 이식.
- 헌장: 로컬 커밋 기본 · transport(push/pull) opt-in · 자동 init 금지 · vault 밖 파일 불가침.

## Test plan
- `pnpm exec tsc --noEmit` — clean
- `node --test cli/src/lib/git-snapshot.test.mjs` — 24/24 (push-reject/hook/history/diff/pull 케이스 포함)
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean, 15 rust 단위 테스트
- mktemp repo 스모크(사용자 저장소 오염 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
