### PR TITLE
fix: 스포트라이트 가시성 + 사용성 전수 검수 수정 일괄 (P0~P3) + 이것만 보기 재설계

### DIFF
--- a/.agents/skills/motion-verify/SKILL.md
+++ b/.agents/skills/motion-verify/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: motion-verify
+description: Verify a canvas/UI animation objectively with a real macOS screen recording — record with screencapture, extract uniform 30fps frames with ffmpeg, build a phase strip for visual inspection, and compute frame-to-frame pixel-diff uniformity to prove (or disprove) smoothness. Use after implementing or tuning any topology-map motion (rings, comets, ramps, camera), before claiming "the motion is smooth". Screenshots alone sample too sparsely to catch jank.
+---
+
+# /motion-verify — 녹화 기반 모션 판정 파이프라인
+
+스크린샷 몇 장으로는 "돌아간다"까지만 증명된다. **끊김(jank)·정지 프레임**은
+80~200ms 간격 샘플 사이에 숨는다. 이 스킬은 macOS 화면 녹화(60fps 원본)를
+30fps 프레임으로 균일 추출해 ① 육안 위상 대조(스트립) ② 프레임간 diff
+정량(정지/스파이크 검출) 두 축으로 판정한다. (2026-07-23 스포트라이트 링
+검증에서 확립 — 회전 500→750ms 감속과 r+6 궤도 브레이드 결함이 이 방법의
+전신인 프레임 검수로 잡혔고, 최종 무결 판정은 이 파이프라인으로 했다.)
+
+## 전제
+
+- 검증 대상 화면이 **실제 모니터에 보이는 상태**여야 한다 (chrome-devtools
+  로 조종하는 Chrome 창이 열려 있으면 됨. headless 는 녹화 불가 — 그 경우
+  Playwright 로 연속 스크린샷을 뽑는 차선책 사용).
+- `ffmpeg` 필요 (`/opt/homebrew/bin/ffmpeg` — 이 프로젝트 머신에 있음).
+- 작업 파일은 세션 scratchpad 디렉토리에 둔다 (레포 오염 금지).
+
+## 1. 대상 상태 준비
+
+chrome-devtools 로 검증할 URL/줌/상태를 화면에 세팅한다. 모션이 유휴
+게이트에 얼지 않는 상태인지 먼저 확인 (예: 스포트라이트는 fresh breathing
+이 캔버스를 깨워 둠 — reduced-motion 에뮬레이션이 켜져 있으면 끄기).
+
+## 2. 녹화 → 프레임 추출
+
+```bash
+cd <scratchpad>
+screencapture -v -V 4 motion.mov          # 4초 전체 화면 녹화
+mkdir -p vidframes
+ffmpeg -y -loglevel error -i motion.mov -vf fps=30 vidframes/f%03d.png
+ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 motion.mov
+```
+
+## 3. 대상 영역 찾기 — ⚠️ 함정 주의
+
+전체 화면 녹화라 페이지 좌표 ≠ 프레임 좌표(Retina 2x + 창 오프셋). 색으로
+후보를 찾되, **정적인 같은 색 요소를 잡는 함정**이 있다 (실례: 앰버 링을
+찾다가 정적 프로젝트 헥사곤을 크롭해 diff≈0 오판 직전까지 감). 반드시
+크롭 스트립을 **눈으로 확인**해 움직이는 대상이 맞는지 검증한 뒤 정량으로
+넘어간다.
+
+```python
+# 색 버킷 밀집 셀 찾기 (예: 앰버 r>150, g<r, b<g) → 상위 셀들 각각 크롭해
+# 스트립을 만들어 보고, "움직이는" 셀을 고른다.
+```
+
+## 4. 위상 스트립 (육안 판정)
+
+166ms 간격(매 5번째 프레임) 6장을 한 줄로 이어 붙인 스트립을 만들어 Read
+로 본다 — 파선/펄스 위상이 프레임마다 진행하면 회전/흐름 확인.
+
+```python
+from PIL import Image
+box = (x0, y0, x1, y1)  # 3에서 확정한 크롭
+strip = Image.new("RGB", (320*6, 320))
+for k, i in enumerate([1, 6, 11, 16, 21, 26]):
+    strip.paste(Image.open(f"vidframes/f{i:03d}.png").convert("RGB").crop(box).resize((320,320)), (k*320, 0))
+strip.save("phase-strip.png")
+```
+
+## 5. diff 정량 (jank 판정)
+
+```python
+from PIL import Image
+import statistics
+prev, diffs = None, []
+for i in range(1, 121):
+    f = Image.open(f"vidframes/f{i:03d}.png").convert("L").crop(box)
+    if prev is not None:
+        a, b = f.tobytes(), prev.tobytes()
+        diffs.append(sum(abs(a[j]-b[j]) for j in range(0, len(a), 7)) / (len(a)/7))
+    prev = f
+mean, sd = statistics.mean(diffs), statistics.pstdev(diffs)
+stalls = [i for i, d in enumerate(diffs) if d < mean*0.25]
+spikes = [i for i, d in enumerate(diffs) if d > mean*3]
+print(f"mean={mean:.3f} cv={sd/mean:.2f} min={min(diffs):.3f} stalls={len(stalls)} spikes={len(spikes)}")
+```
+
+**판정 기준**:
+- `stalls == 0` (min diff 가 mean 의 25% 아래로 안 떨어짐) → 정지 프레임
+  없음 = 연속 모션. **이게 핵심 합격선.**
+- `stalls > 0` 이 연속 구간이면 → 유휴 게이트 동결/rAF 드랍 의심 —
+  `idle-gate.ts` 활동 플래그부터 조사.
+- cv ≤ ~0.4 는 압축 노이즈 수준. 주기적 스파이크는 다른 애니메이션(코멧
+  통과 등) 간섭일 수 있으니 스트립으로 원인 확인.
+- 속도 감각 판정(빠르다/느리다)은 정량이 아니라 **위상 스트립을 보고**
+  HIG deference("모션이 콘텐츠와 경쟁 금지") 렌즈로 — 지속 모드 모션이
+  ~2Hz 이상이면 재촉 의심(스포트라이트 링은 이 근거로 750ms/주기 감속).
+
+## 6. 보고
+
+판정문에 반드시 포함: 녹화 길이·fps, 크롭 대상(무엇을 보았나), stalls/cv
+수치, 스트립 육안 소견, (조정했다면) before/after. 프레임 원본은
+scratchpad 에 보존한다 — 레포에 커밋하지 않는다.

--- a/.agents/skills/responsive-sweep/SKILL.md
+++ b/.agents/skills/responsive-sweep/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: responsive-sweep
+description: Live-verify a UI change across the tablet/laptop/wide breakpoint matrix with chrome-devtools — resize through the band widths, probe occlusion with elementFromPoint, check bottom-tab-bar reserve clearances, and screenshot the key states. Use after any change touching layout, floating panels, chrome rows, or breakpoint-gated markup, before claiming "responsive is fine". Static reasoning about Tailwind variants misses cascade-order and overlap defects that only rects reveal.
+---
+
+# /responsive-sweep — 브레이크포인트 매트릭스 실측
+
+반응형 결함은 코드만 봐서는 안 잡힌다 — 실례 3건이 근거다: ① `max-lg:pb-*`
+가 `md:py-*` 보다 스타일시트 앞에 emit 되어 768–1023 에서 조용히 패배(예약고
+16px 실측으로만 발견) ② 상단 크롬 3표면 겹침(rect 실측 79px 침범) ③ 탭바
+뒤 콘텐츠 도달 불가(elementFromPoint 로만 확정). 이 스킬은 그 실측 루프를
+표준화한다. (2026-07-23 태블릿 소탕 라운드에서 확립.)
+
+## 폭 매트릭스
+
+대상 표면이 닿는 밴드만 골라도 되지만, 전면 스윕은 이 7폭이 기준이다:
+
+| 폭×높이 | 밴드 | 브레이크포인트 관계 |
+|---|---|---|
+| 600×900 | 폰/소형 태블릿 포트레이트 | <md — INDEX 풀-블리드 시트 모드 |
+| 768×1024 | 태블릿 포트레이트 | md 경계 — 사이드 패널 시작, 탭바 존재 |
+| 834×1112 | 11" 태블릿 | md–lg 사이 |
+| 1024×768 | 태블릿 랜드/12.9" 포트 | lg 경계 — nav-rail 시작, 탭바 소멸 |
+| 1440×900 | 14" 노트북 | xl–2xl 사이 — 라벨 사다리 구간 |
+| 1920×1080 | FHD | 2xl+ — zoom 1.15 |
+| 2560×1440 | QHD | zoom 1.3 |
+
+## 루프 (폭마다)
+
+1. `resize_page` → 대상 URL `navigate_page` (상태 파라미터 포함 —
+   `?index=expanded`, `?recent=auto` 등 검증 상태를 URL 로 재현).
+2. **rect 실측** — `evaluate_script` 로:
+   - 고정/절대 요소끼리 겹침: 의심 요소들의 `getBoundingClientRect()` 를
+     받아 교차 폭을 계산해 수치로 남긴다 ("겹쳐 보임"이 아니라 "18px 침범").
+   - **클릭 차단**: 상호작용 요소 중심점에 `document.elementFromPoint(cx,cy)`
+     — 반환이 그 요소(또는 자손)가 아니면 무엇이 가로채는지 기록.
+   - **탭바 예약고** (<lg 만): `nav[data-tabbar="primary"]` 의 top 과, 스크롤
+     끝까지 내린 뒤 마지막 콘텐츠 요소 bottom 을 비교 — 콘텐츠가 탭바 top
+     을 넘으면 결함. 하단 앵커 패널(INDEX·판독계·데이터시트)도 bottom 이
+     탭바 top 미만인지 확인.
+3. `take_screenshot` — before/after 를 남겨 시각 판정 병행.
+
+## 알려진 계약 (판정 기준)
+
+- `docs/DESIGN-SYSTEM.md` "Touch & tablet responsive contract" 절이 규범:
+  탭바 구간(<lg)의 하단 앵커/스크롤 끝은 `--topology-mobile-bottom-tab-reserve`
+  계약 필수 — "탭바 뒤 가려짐"은 결함. `<md` 확장 INDEX 는 풀-블리드 시트.
+  coarse-pointer 44px 은 `@media (pointer: coarse)` 단일 출처.
+- **캐스케이드 함정**: `max-*` 변형은 `min-*` 변형보다 스타일시트 앞에
+  emit 될 수 있다 — `max-lg:pb-X` + `md:py-Y` 조합은 768–1023 에서 pb 가
+  질 수 있으니 base + `lg:` 오버라이드의 결정론 구성을 쓰고, 반드시
+  computed `paddingBottom` 을 실측한다.
+- 상단 유틸리티 레인은 칩 축약 사다리(<2xl kbd 접기, 토글류 <2xl 라벨
+  접기)가 계약 — 칩을 추가했으면 1440 에서 검색 레인과의 교차 폭을 재라.
+
+## 보고
+
+폭×표면 표로: 통과/결함(수치 근거), 스크린샷 포인트, 적용한 수정과 after
+실측. "습관적 전체 스윕"은 하지 않는다 — 변경이 닿는 밴드 우선, 전면
+스윕은 layout/chrome/브레이크포인트 게이트 변경 시에만.

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -10,7 +10,11 @@
   뷰에서는 **단일 hub 링 + Layer 0 컨테이너 1개**의 공존까지가 승인 범위다
   (2026-07 소유자 라이브 테스트 + Guardian 검증 통과 설계 — 구 "동시 금지"
   문구는 v2 이전 뷰 기준이라 현행화). 그 외 노드/표면으로의 앰버 확장은
-  여전히 금지 — 앰버가 셋 이상 보이면 결함이다. (docs 표면의 장식적 gold 악센트는 별개의 `--color-amber-docs-*` **quarantine 토큰** — 헌장 승인 아님, 확장 금지, 후속 강등 검토 대기.)
+  여전히 금지 — 앰버가 셋 이상 보이면 결함이다. **명문화된 예외 2건**:
+  ① 에이전트 포커스 링(W6 — heartbeat 실데이터 1노드), ② **최근 변경
+  스포트라이트 렌즈 ON(`?recent=`) 동안 변경-노드 회전 파선 링**(소유자
+  지시 2026-07-23 + Guardian 모션 검수 승인 — 명시적 모드 한정이라 상시
+  앰버 확장이 아니며, 렌즈 off 시 램프로 소멸). 그 외 앰버는 여전히 결함. (docs 표면의 장식적 gold 악센트는 별개의 `--color-amber-docs-*` **quarantine 토큰** — 헌장 승인 아님, 확장 금지, 후속 강등 검토 대기.)
 - ontology kind 색상은 예외적으로 허용하지만 data mark 로만 쓴다. graph fill 은 작은 점의 3:1 대비를 위해 선명할 수 있고, panel/card 에서는 neutral surface + compact marker/swatch + label/icon 으로 낮춘다. detail card 내부의 full-height colored rail 은 AI SaaS callout 처럼 읽히므로 금지한다.
 - 카테고리 구분은 **색이 아닌 보더 스타일** (작업중: 인디고 underline, 예정: dashed).
 - **선택 색 사다리**: 노드 선택 = 표준 인디고(#5e6ad2), 엣지 선택(페어

--- a/.claude/skills/motion-verify/SKILL.md
+++ b/.claude/skills/motion-verify/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: motion-verify
+description: Verify a canvas/UI animation objectively with a real macOS screen recording — record with screencapture, extract uniform 30fps frames with ffmpeg, build a phase strip for visual inspection, and compute frame-to-frame pixel-diff uniformity to prove (or disprove) smoothness. Use after implementing or tuning any topology-map motion (rings, comets, ramps, camera), before claiming "the motion is smooth". Screenshots alone sample too sparsely to catch jank.
+---
+
+# /motion-verify — 녹화 기반 모션 판정 파이프라인
+
+스크린샷 몇 장으로는 "돌아간다"까지만 증명된다. **끊김(jank)·정지 프레임**은
+80~200ms 간격 샘플 사이에 숨는다. 이 스킬은 macOS 화면 녹화(60fps 원본)를
+30fps 프레임으로 균일 추출해 ① 육안 위상 대조(스트립) ② 프레임간 diff
+정량(정지/스파이크 검출) 두 축으로 판정한다. (2026-07-23 스포트라이트 링
+검증에서 확립 — 회전 500→750ms 감속과 r+6 궤도 브레이드 결함이 이 방법의
+전신인 프레임 검수로 잡혔고, 최종 무결 판정은 이 파이프라인으로 했다.)
+
+## 전제
+
+- 검증 대상 화면이 **실제 모니터에 보이는 상태**여야 한다 (chrome-devtools
+  로 조종하는 Chrome 창이 열려 있으면 됨. headless 는 녹화 불가 — 그 경우
+  Playwright 로 연속 스크린샷을 뽑는 차선책 사용).
+- `ffmpeg` 필요 (`/opt/homebrew/bin/ffmpeg` — 이 프로젝트 머신에 있음).
+- 작업 파일은 세션 scratchpad 디렉토리에 둔다 (레포 오염 금지).
+
+## 1. 대상 상태 준비
+
+chrome-devtools 로 검증할 URL/줌/상태를 화면에 세팅한다. 모션이 유휴
+게이트에 얼지 않는 상태인지 먼저 확인 (예: 스포트라이트는 fresh breathing
+이 캔버스를 깨워 둠 — reduced-motion 에뮬레이션이 켜져 있으면 끄기).
+
+## 2. 녹화 → 프레임 추출
+
+```bash
+cd <scratchpad>
+screencapture -v -V 4 motion.mov          # 4초 전체 화면 녹화
+mkdir -p vidframes
+ffmpeg -y -loglevel error -i motion.mov -vf fps=30 vidframes/f%03d.png
+ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 motion.mov
+```
+
+## 3. 대상 영역 찾기 — ⚠️ 함정 주의
+
+전체 화면 녹화라 페이지 좌표 ≠ 프레임 좌표(Retina 2x + 창 오프셋). 색으로
+후보를 찾되, **정적인 같은 색 요소를 잡는 함정**이 있다 (실례: 앰버 링을
+찾다가 정적 프로젝트 헥사곤을 크롭해 diff≈0 오판 직전까지 감). 반드시
+크롭 스트립을 **눈으로 확인**해 움직이는 대상이 맞는지 검증한 뒤 정량으로
+넘어간다.
+
+```python
+# 색 버킷 밀집 셀 찾기 (예: 앰버 r>150, g<r, b<g) → 상위 셀들 각각 크롭해
+# 스트립을 만들어 보고, "움직이는" 셀을 고른다.
+```
+
+## 4. 위상 스트립 (육안 판정)
+
+166ms 간격(매 5번째 프레임) 6장을 한 줄로 이어 붙인 스트립을 만들어 Read
+로 본다 — 파선/펄스 위상이 프레임마다 진행하면 회전/흐름 확인.
+
+```python
+from PIL import Image
+box = (x0, y0, x1, y1)  # 3에서 확정한 크롭
+strip = Image.new("RGB", (320*6, 320))
+for k, i in enumerate([1, 6, 11, 16, 21, 26]):
+    strip.paste(Image.open(f"vidframes/f{i:03d}.png").convert("RGB").crop(box).resize((320,320)), (k*320, 0))
+strip.save("phase-strip.png")
+```
+
+## 5. diff 정량 (jank 판정)
+
+```python
+from PIL import Image
+import statistics
+prev, diffs = None, []
+for i in range(1, 121):
+    f = Image.open(f"vidframes/f{i:03d}.png").convert("L").crop(box)
+    if prev is not None:
+        a, b = f.tobytes(), prev.tobytes()
+        diffs.append(sum(abs(a[j]-b[j]) for j in range(0, len(a), 7)) / (len(a)/7))
+    prev = f
+mean, sd = statistics.mean(diffs), statistics.pstdev(diffs)
+stalls = [i for i, d in enumerate(diffs) if d < mean*0.25]
+spikes = [i for i, d in enumerate(diffs) if d > mean*3]
+print(f"mean={mean:.3f} cv={sd/mean:.2f} min={min(diffs):.3f} stalls={len(stalls)} spikes={len(spikes)}")
+```
+
+**판정 기준**:
+- `stalls == 0` (min diff 가 mean 의 25% 아래로 안 떨어짐) → 정지 프레임
+  없음 = 연속 모션. **이게 핵심 합격선.**
+- `stalls > 0` 이 연속 구간이면 → 유휴 게이트 동결/rAF 드랍 의심 —
+  `idle-gate.ts` 활동 플래그부터 조사.
+- cv ≤ ~0.4 는 압축 노이즈 수준. 주기적 스파이크는 다른 애니메이션(코멧
+  통과 등) 간섭일 수 있으니 스트립으로 원인 확인.
+- 속도 감각 판정(빠르다/느리다)은 정량이 아니라 **위상 스트립을 보고**
+  HIG deference("모션이 콘텐츠와 경쟁 금지") 렌즈로 — 지속 모드 모션이
+  ~2Hz 이상이면 재촉 의심(스포트라이트 링은 이 근거로 750ms/주기 감속).
+
+## 6. 보고
+
+판정문에 반드시 포함: 녹화 길이·fps, 크롭 대상(무엇을 보았나), stalls/cv
+수치, 스트립 육안 소견, (조정했다면) before/after. 프레임 원본은
+scratchpad 에 보존한다 — 레포에 커밋하지 않는다.

--- a/.claude/skills/responsive-sweep/SKILL.md
+++ b/.claude/skills/responsive-sweep/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: responsive-sweep
+description: Live-verify a UI change across the tablet/laptop/wide breakpoint matrix with chrome-devtools — resize through the band widths, probe occlusion with elementFromPoint, check bottom-tab-bar reserve clearances, and screenshot the key states. Use after any change touching layout, floating panels, chrome rows, or breakpoint-gated markup, before claiming "responsive is fine". Static reasoning about Tailwind variants misses cascade-order and overlap defects that only rects reveal.
+---
+
+# /responsive-sweep — 브레이크포인트 매트릭스 실측
+
+반응형 결함은 코드만 봐서는 안 잡힌다 — 실례 3건이 근거다: ① `max-lg:pb-*`
+가 `md:py-*` 보다 스타일시트 앞에 emit 되어 768–1023 에서 조용히 패배(예약고
+16px 실측으로만 발견) ② 상단 크롬 3표면 겹침(rect 실측 79px 침범) ③ 탭바
+뒤 콘텐츠 도달 불가(elementFromPoint 로만 확정). 이 스킬은 그 실측 루프를
+표준화한다. (2026-07-23 태블릿 소탕 라운드에서 확립.)
+
+## 폭 매트릭스
+
+대상 표면이 닿는 밴드만 골라도 되지만, 전면 스윕은 이 7폭이 기준이다:
+
+| 폭×높이 | 밴드 | 브레이크포인트 관계 |
+|---|---|---|
+| 600×900 | 폰/소형 태블릿 포트레이트 | <md — INDEX 풀-블리드 시트 모드 |
+| 768×1024 | 태블릿 포트레이트 | md 경계 — 사이드 패널 시작, 탭바 존재 |
+| 834×1112 | 11" 태블릿 | md–lg 사이 |
+| 1024×768 | 태블릿 랜드/12.9" 포트 | lg 경계 — nav-rail 시작, 탭바 소멸 |
+| 1440×900 | 14" 노트북 | xl–2xl 사이 — 라벨 사다리 구간 |
+| 1920×1080 | FHD | 2xl+ — zoom 1.15 |
+| 2560×1440 | QHD | zoom 1.3 |
+
+## 루프 (폭마다)
+
+1. `resize_page` → 대상 URL `navigate_page` (상태 파라미터 포함 —
+   `?index=expanded`, `?recent=auto` 등 검증 상태를 URL 로 재현).
+2. **rect 실측** — `evaluate_script` 로:
+   - 고정/절대 요소끼리 겹침: 의심 요소들의 `getBoundingClientRect()` 를
+     받아 교차 폭을 계산해 수치로 남긴다 ("겹쳐 보임"이 아니라 "18px 침범").
+   - **클릭 차단**: 상호작용 요소 중심점에 `document.elementFromPoint(cx,cy)`
+     — 반환이 그 요소(또는 자손)가 아니면 무엇이 가로채는지 기록.
+   - **탭바 예약고** (<lg 만): `nav[data-tabbar="primary"]` 의 top 과, 스크롤
+     끝까지 내린 뒤 마지막 콘텐츠 요소 bottom 을 비교 — 콘텐츠가 탭바 top
+     을 넘으면 결함. 하단 앵커 패널(INDEX·판독계·데이터시트)도 bottom 이
+     탭바 top 미만인지 확인.
+3. `take_screenshot` — before/after 를 남겨 시각 판정 병행.
+
+## 알려진 계약 (판정 기준)
+
+- `docs/DESIGN-SYSTEM.md` "Touch & tablet responsive contract" 절이 규범:
+  탭바 구간(<lg)의 하단 앵커/스크롤 끝은 `--topology-mobile-bottom-tab-reserve`
+  계약 필수 — "탭바 뒤 가려짐"은 결함. `<md` 확장 INDEX 는 풀-블리드 시트.
+  coarse-pointer 44px 은 `@media (pointer: coarse)` 단일 출처.
+- **캐스케이드 함정**: `max-*` 변형은 `min-*` 변형보다 스타일시트 앞에
+  emit 될 수 있다 — `max-lg:pb-X` + `md:py-Y` 조합은 768–1023 에서 pb 가
+  질 수 있으니 base + `lg:` 오버라이드의 결정론 구성을 쓰고, 반드시
+  computed `paddingBottom` 을 실측한다.
+- 상단 유틸리티 레인은 칩 축약 사다리(<2xl kbd 접기, 토글류 <2xl 라벨
+  접기)가 계약 — 칩을 추가했으면 1440 에서 검색 레인과의 교차 폭을 재라.
+
+## 보고
+
+폭×표면 표로: 통과/결함(수치 근거), 스크린샷 포인트, 적용한 수정과 after
+실측. "습관적 전체 스윕"은 하지 않는다 — 변경이 닿는 밴드 우선, 전면
+스윕은 layout/chrome/브레이크포인트 게이트 변경 시에만.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1359,9 +1359,13 @@
        뷰에서 변경 노드가 안 읽혀(실보고 Image #14), 렌즈 ON 동안 변경
        노드에 amberHub 파선 링을 lineDashOffset 으로 회전시킨다. glow/blur
        0 — 헌장의 회전 금지 아님(코멧=상시 모션 선례, 에이전트 포커스 링
-       =amberHub 선례). 0.018 ≈ 파선 한 주기(9px)/500ms — 시선을 끌되
-       조급하지 않게. reduced-motion 은 정적 파선(회전 0). */
-    --topology-v2-spotlight-ring-speed: 0.018;
+       =amberHub 선례). 0.012 ≈ 파선 한 주기(9px)/750ms — 렌즈는 지도를
+       *읽는 동안* 켜 두는 지속 모드라, 초기값 500ms(2Hz)는 다수 링에서
+       조급하게 읽혔다(모션 검수 2026-07-23 프레임 증거). HIG deference
+       (모션이 콘텐츠와 경쟁 금지) + Toss 인지부하 최소화에 따라 ~1.3Hz 로
+       감속 — "살아있음"은 유지, 재촉은 제거. reduced-motion 은 정적
+       파선(회전 0). */
+    --topology-v2-spotlight-ring-speed: 0.012;
     --topology-v2-node-fill-stale: #141418;
     --topology-v2-node-stroke-stale: #454549;
     --topology-v2-node-hole-fill: #0c0c10;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1354,6 +1354,14 @@
        map 렌즈. 반응형: 값 자체는 폭 무관(알파 스칼라). marker: 렌즈 상태는
        URL `?recent=` 로 결정론 재현 가능. */
     --topology-v2-spotlight-rest-alpha: 0.35;
+    /* 스포트라이트 변경-노드 링의 파선 회전 속도(px/ms) — 소유자 지시
+       2026-07-23 "변경된 것만 테두리가 돌아가게": 침강 대비만으론 element
+       뷰에서 변경 노드가 안 읽혀(실보고 Image #14), 렌즈 ON 동안 변경
+       노드에 amberHub 파선 링을 lineDashOffset 으로 회전시킨다. glow/blur
+       0 — 헌장의 회전 금지 아님(코멧=상시 모션 선례, 에이전트 포커스 링
+       =amberHub 선례). 0.018 ≈ 파선 한 주기(9px)/500ms — 시선을 끌되
+       조급하지 않게. reduced-motion 은 정적 파선(회전 0). */
+    --topology-v2-spotlight-ring-speed: 0.018;
     --topology-v2-node-fill-stale: #141418;
     --topology-v2-node-stroke-stale: #454549;
     --topology-v2-node-hole-fill: #0c0c10;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1478,6 +1478,10 @@
     --topology-v2-layout-ring-domain: 250;
     --topology-v2-layout-ring-capability: 145;
     --topology-v2-layout-ring-element: 90;
+    /* 영역 전개 깊이 파생 링 — 얕은 서브트리 빈 annulus 제거, 소유자 실보고 2026-07. */
+    --topology-v2-realm-fill-radius-1: 130;
+    --topology-v2-realm-fill-radius-2: 190;
+    --topology-v2-realm-fill-radius-3: 250;
     --topology-v2-edge-bow-contains: 70;
     --topology-v2-edge-bow-depends: 92;
     --topology-v2-edge-blend-contains: 0.46;

--- a/messages/en.json
+++ b/messages/en.json
@@ -234,6 +234,7 @@
     "createLabel": "✚ Create a new vault",
     "createBusy": "Writing starter structure…",
     "dismissLabel": "Just looking around here",
+    "plainModeHint": "Need an easier view? Turn on \"General\" in the gear at the bottom left",
     "errorFallback": "Could not open the folder. Try again.",
     "unsupportedNotice": "This browser can't open local folders. Open it in the macOS app or Chrome/Edge and the map lights up with your markdown folder.",
     "unsupportedCta": "Get the macOS app",
@@ -252,7 +253,8 @@
       "tier_spine": "Spine view",
       "tier_circuit": "Circuit view",
       "tier_element": "Element view",
-      "zoomHint": "zoom in to reveal elements"
+      "zoomHint": "zoom in to reveal elements",
+      "zoomHintPlain": "click a dot to reveal its elements"
     }
   },
   "ontologyBlocks": {
@@ -262,6 +264,7 @@
     "exportDone": "Exported {count}",
     "exportError": "Could not export. Try again.",
     "exportUnsupportedHint": "This environment can't pick a folder",
+    "vaultRequiredHint": "Open your folder to use this",
     "importAction": "Import block",
     "importAria": "Pick a block folder to open a merge preview",
     "importEmpty": "No .md files to import",
@@ -2368,7 +2371,9 @@
       "settingsGearChangeVaultAriaLabel": "Open the workspace to pick a different local vault folder",
       "settingsGearAudience": "View mode",
       "settingsGearAudienceDev": "Developer",
-      "settingsGearAudiencePlain": "General"
+      "settingsGearAudiencePlain": "General",
+      "settingsGearAudienceCaption": "General — folds away code elements and uses plain language",
+      "spotlightWindowSummary": "Last {days}d · {count}"
     },
     "empty": {
       "noMatchesTitle": "No matching items",
@@ -2434,7 +2439,8 @@
       "uncatalogedDocsLabel": "{count} docs not on the map",
       "uncatalogedDocsAction": "Promote",
       "dustyNodesLabel": "{count} nodes gathering dust — untouched for a while",
-      "dustyNodesAction": "See to-dos"
+      "dustyNodesAction": "See to-dos",
+      "plainHint": "Elements are hidden — click a dot on the map to reveal its elements"
     },
     "deeplinkNotFound": "Node not found: {query}",
     "bootstrap": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1879,7 +1879,22 @@
       "editTitleLabel": "Title",
       "editSave": "Save",
       "editSaving": "Saving…",
-      "editCancel": "Cancel"
+      "editCancel": "Cancel",
+      "validatorWarningsAriaLabel": "Vault validation warnings",
+      "validatorIssues": {
+        "unclosedFrontmatter": "The frontmatter block never closes, so this document isn't recognized as a node.",
+        "emptyKind": "The kind value is empty — it won't be recognized as a graph node.",
+        "missingKind": "No kind — this document isn't a graph node yet.",
+        "unknownKind": "This kind isn't one of the recognized values — it may not show up in the graph.",
+        "missingExpectedField": "A field this kind expects (e.g. domain) is empty — the tree can't find its parent.",
+        "nonCanonicalGraphArray": "A relation list isn't sorted/deduplicated — it can be cleaned up automatically.",
+        "parseZeroKeys": "There's a frontmatter block but no values could be read from it — check the formatting."
+      },
+      "exampleToggle": "View spec example",
+      "exampleTitleFor": "Example {kind}",
+      "exampleCopy": "Copy",
+      "exampleCopied": "Copied",
+      "exampleCopyAriaLabel": "Copy the example frontmatter"
     },
     "readingAids": {
       "backToTop": "Back to top",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2947,7 +2947,7 @@
     "webNodesRemoved": "nodes removed {count}",
     "webEdgesAdded": "relations added {count}",
     "webEdgesRemoved": "relations removed {count}",
-    "webNoChanges": "No changes detected this session.",
+    "webNoChanges": "Nothing yet — edit a document and it shows up here.",
     "webCommandHint": "Run this in a terminal to record the current changes as a git snapshot.",
     "webCopyCommand": "Copy command",
     "webCopied": "Copied",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2479,18 +2479,19 @@
       "tooltipExpanded": "“{name}” — {total} total under it · {hidden} expanded at this tier. Click to collapse"
     },
     "realm": {
-      "enterAction": "Expand realm",
-      "enterTooltip": "Expand just this node’s realm",
-      "chipPrefix": "Realm",
-      "chipClear": "Exit realm",
+      "enterAction": "View only this",
+      "enterTooltip": "See only this node and what’s inside",
+      "chipViewing": "Viewing only {title}",
+      "chipClear": "Full map",
       "ledger": {
+        "heading": "Viewing only",
         "depthShort": "depth",
-        "searchPlaceholder": "Search this realm",
-        "exit": "Exit realm",
+        "searchPlaceholder": "Search here",
+        "exit": "Full map",
         "boundaryHeading": "Reaches outside · {count}",
         "boundaryToggleAria": "Expand or collapse the boundary-relation list",
-        "boundaryJump": "Go to this realm",
-        "boundaryJumpAria": "Jump to the realm this outside node belongs to",
+        "boundaryJump": "View only that area",
+        "boundaryJumpAria": "View only the area this outside node belongs to",
         "boundaryEmpty": "No relations reach outside"
       }
     },
@@ -2902,7 +2903,7 @@
     "otherToolsSeeDocs": "Same standard triple · see each tool's docs for the config location"
   },
   "atlasGit": {
-    "tileLabel": "Snapshot",
+    "tileLabel": "Footprints",
     "tileTitleClean": "Footprints — no unrecorded changes",
     "tileTitleDirty": "Footprints — {count} unrecorded changes",
     "title": "Footprints",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2365,7 +2365,10 @@
       "settingsGearIndexDefaultExpanded": "Expanded",
       "settingsGearIndexDefaultCollapsed": "Collapsed",
       "settingsGearChangeVault": "Switch vault",
-      "settingsGearChangeVaultAriaLabel": "Open the workspace to pick a different local vault folder"
+      "settingsGearChangeVaultAriaLabel": "Open the workspace to pick a different local vault folder",
+      "settingsGearAudience": "View mode",
+      "settingsGearAudienceDev": "Developer",
+      "settingsGearAudiencePlain": "General"
     },
     "empty": {
       "noMatchesTitle": "No matching items",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -234,6 +234,7 @@
     "createLabel": "✚ 새 vault 만들기",
     "createBusy": "시작 구조 작성 중…",
     "dismissLabel": "여기서 둘러볼게요",
+    "plainModeHint": "더 쉬운 보기가 필요하면 왼쪽 아래 톱니에서 '일반'을 켜세요",
     "errorFallback": "폴더를 열지 못했습니다. 다시 시도해 주세요.",
     "unsupportedNotice": "이 브라우저는 로컬 폴더 열기를 지원하지 않아요. macOS 앱이나 Chrome/Edge 에서 열면 내 마크다운 폴더로 지도가 켜져요.",
     "unsupportedCta": "macOS 앱 받기",
@@ -252,7 +253,8 @@
       "tier_spine": "Spine view",
       "tier_circuit": "Circuit view",
       "tier_element": "Element view",
-      "zoomHint": "줌인하면 요소가 나타납니다"
+      "zoomHint": "줌인하면 요소가 나타납니다",
+      "zoomHintPlain": "점을 누르면 그 안의 요소가 보여요"
     }
   },
   "ontologyBlocks": {
@@ -262,6 +264,7 @@
     "exportDone": "{count}개 내보냄",
     "exportError": "내보내지 못했습니다. 다시 시도해 주세요.",
     "exportUnsupportedHint": "이 환경은 폴더 선택을 지원하지 않아요",
+    "vaultRequiredHint": "내 폴더를 열면 쓸 수 있어요",
     "importAction": "블록 가져오기",
     "importAria": "블록 폴더를 골라 병합 미리보기 열기",
     "importEmpty": "가져올 .md 없음",
@@ -2368,7 +2371,9 @@
       "settingsGearChangeVaultAriaLabel": "다른 로컬 vault 폴더를 고르러 워크스페이스 열기",
       "settingsGearAudience": "보기 모드",
       "settingsGearAudienceDev": "개발",
-      "settingsGearAudiencePlain": "일반"
+      "settingsGearAudiencePlain": "일반",
+      "settingsGearAudienceCaption": "일반 — 코드 요소를 접고 쉬운 말로 보여줘요",
+      "spotlightWindowSummary": "최근 {days}일 · {count}"
     },
     "empty": {
       "noMatchesTitle": "필터에 맞는 항목 없음",
@@ -2434,7 +2439,8 @@
       "uncatalogedDocsLabel": "지도에 없는 문서 {count}개",
       "uncatalogedDocsAction": "올리기",
       "dustyNodesLabel": "먼지 앉은 노드 {count}개 — 오래 손대지 않았어요",
-      "dustyNodesAction": "할 일 보기"
+      "dustyNodesAction": "할 일 보기",
+      "plainHint": "요소는 숨겨져 있어요 — 지도의 점을 누르면 그 요소들이 보여요"
     },
     "deeplinkNotFound": "노드를 찾을 수 없습니다: {query}",
     "bootstrap": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2479,18 +2479,19 @@
       "tooltipExpanded": "「{name}」 — 하위 전체 {total}개 · 이 티어 {hidden}개 펼침. 클릭하면 접어요"
     },
     "realm": {
-      "enterAction": "영역 전개",
-      "enterTooltip": "이 노드의 영역만 펼쳐요",
-      "chipPrefix": "영역",
-      "chipClear": "영역 나가기",
+      "enterAction": "이것만 보기",
+      "enterTooltip": "이 노드 안쪽만 봐요",
+      "chipViewing": "{title}만 보는 중",
+      "chipClear": "전체 지도",
       "ledger": {
+        "heading": "이것만 보는 중",
         "depthShort": "깊이",
-        "searchPlaceholder": "이 영역에서 검색",
-        "exit": "영역 해제",
+        "searchPlaceholder": "여기서 검색",
+        "exit": "전체 지도",
         "boundaryHeading": "바깥과 닿은 관계 {count}",
-        "boundaryToggleAria": "결계 관계 목록 펼치기 · 접기",
-        "boundaryJump": "이 영역으로 이동",
-        "boundaryJumpAria": "이 밖 노드가 속한 영역으로 이동",
+        "boundaryToggleAria": "바깥과 닿은 관계 목록 펼치기 · 접기",
+        "boundaryJump": "저쪽만 보기",
+        "boundaryJumpAria": "이 바깥 노드가 속한 쪽만 보기",
         "boundaryEmpty": "바깥과 닿은 관계가 없어요"
       }
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1879,7 +1879,22 @@
       "editTitleLabel": "Title",
       "editSave": "저장",
       "editSaving": "저장 중…",
-      "editCancel": "취소"
+      "editCancel": "취소",
+      "validatorWarningsAriaLabel": "Vault 검증 경고",
+      "validatorIssues": {
+        "unclosedFrontmatter": "frontmatter 가 닫히지 않아 이 문서는 노드로 인식되지 않아요.",
+        "emptyKind": "kind 값이 비어 있어요 — 그래프 노드로 인식되지 않아요.",
+        "missingKind": "kind 가 없어서 이 문서는 아직 그래프 노드가 아니에요.",
+        "unknownKind": "kind 값이 알려진 종류가 아니에요 — 그래프에서 인식되지 않을 수 있어요.",
+        "missingExpectedField": "이 kind 에 필요한 필드(예: domain)가 비어 있어요 — 트리에서 부모를 찾지 못해요.",
+        "nonCanonicalGraphArray": "관계 목록의 정렬/중복 상태가 정리되지 않았어요 — 자동으로 정리할 수 있어요.",
+        "parseZeroKeys": "frontmatter 블록은 있지만 값을 하나도 읽지 못했어요 — 형식을 확인해 주세요."
+      },
+      "exampleToggle": "규격 예시 보기",
+      "exampleTitleFor": "{kind} 예시",
+      "exampleCopy": "복사",
+      "exampleCopied": "복사됨",
+      "exampleCopyAriaLabel": "예시 frontmatter 복사"
     },
     "readingAids": {
       "backToTop": "맨 위로",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2365,7 +2365,10 @@
       "settingsGearIndexDefaultExpanded": "펼침",
       "settingsGearIndexDefaultCollapsed": "접힘",
       "settingsGearChangeVault": "vault 바꾸기",
-      "settingsGearChangeVaultAriaLabel": "다른 로컬 vault 폴더를 고르러 워크스페이스 열기"
+      "settingsGearChangeVaultAriaLabel": "다른 로컬 vault 폴더를 고르러 워크스페이스 열기",
+      "settingsGearAudience": "보기 모드",
+      "settingsGearAudienceDev": "개발",
+      "settingsGearAudiencePlain": "일반"
     },
     "empty": {
       "noMatchesTitle": "필터에 맞는 항목 없음",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2947,7 +2947,7 @@
     "webNodesRemoved": "노드 삭제 {count}",
     "webEdgesAdded": "관계 추가 {count}",
     "webEdgesRemoved": "관계 삭제 {count}",
-    "webNoChanges": "이 세션에서 감지된 변경이 없어요.",
+    "webNoChanges": "아직 없어요 — 문서를 고치면 여기에 나타나요.",
     "webCommandHint": "터미널에서 실행하면 지금 변경이 git 스냅샷으로 남아요.",
     "webCopyCommand": "명령 복사",
     "webCopied": "복사됨",

--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
@@ -371,3 +371,55 @@ describe("domains[] folder-prefixed ref (리텐션 P4-① 팬텀 도메인 회�
     expect(result.nodes.some((n) => n.id === "domain:auth")).toBe(true);
   });
 });
+
+describe("element display 인간화 — 슬라이스 B (코드 경로 → 사람 이름)", () => {
+  it("elements[] 로 합성되는 element 노드 — title 은 원문 경로, display 는 인간화", () => {
+    const manifest = makeManifest([
+      makeDoc({
+        slug: "capabilities/writer",
+        frontmatter: {
+          kind: "capability",
+          title: "Writer",
+          elements: ["src/foo/bar-baz.ts"],
+        },
+      }),
+    ]);
+    const result = deriveOntologyFromVault(manifest);
+    const el = result.nodes.find((n) => n.kind === "element" && n.title === "src/foo/bar-baz.ts");
+    expect(el).toBeDefined();
+    expect(el?.title).toBe("src/foo/bar-baz.ts");
+    expect(el?.display).toBe("Bar Baz");
+  });
+
+  it("element doc 에 display: 가 명시되면 인간화가 지지 않는다", () => {
+    const manifest = makeManifest([
+      makeDoc({
+        slug: "elements/bar-baz",
+        title: "src/foo/bar-baz.ts",
+        frontmatter: {
+          kind: "element",
+          title: "src/foo/bar-baz.ts",
+          display: "커스텀 이름",
+        },
+      }),
+    ]);
+    const result = deriveOntologyFromVault(manifest);
+    const el = result.nodes.find((n) => n.id === "element:bar-baz");
+    expect(el?.title).toBe("src/foo/bar-baz.ts");
+    expect(el?.display).toBe("커스텀 이름");
+  });
+
+  it("element 가 아닌 kind 는 경로처럼 보여도 인간화되지 않는다", () => {
+    const manifest = makeManifest([
+      makeDoc({
+        slug: "capabilities/src-tool",
+        title: "src/tools/exporter.ts",
+        frontmatter: { kind: "capability", title: "src/tools/exporter.ts" },
+      }),
+    ]);
+    const result = deriveOntologyFromVault(manifest);
+    const cap = result.nodes.find((n) => n.id === "capability:src-tool");
+    expect(cap?.title).toBe("src/tools/exporter.ts");
+    expect(cap?.display).toBe("src/tools/exporter.ts");
+  });
+});

--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
@@ -1,4 +1,5 @@
 import { deriveDisplayTitle } from '@/shared/lib/derive-display-title';
+import { humanizeCodePathTitle } from '@/shared/lib/humanize-code-path-title';
 import type { VaultDoc, VaultManifest } from '../model/types';
 
 /**
@@ -165,10 +166,19 @@ function deriveDocNode(doc: VaultDoc): OntologyStubNode | null {
     idSlug = doc.slug.split('/').pop() || doc.slug;
   }
   const id = `${rawKind}:${idSlug}`;
+  const baseDisplay = deriveDisplayTitle(fm, title);
+  // element 노드는 title 이 코드 경로 원문(`src/foo/bar-baz.ts`)인 경우가
+  // 많아 비개발자에게 그대로 노출하면 가독성이 떨어진다. display 필드도
+  // 괄호 컷도 없어 baseDisplay 가 title 그대로일 때만 경로 → 사람 이름
+  // 변환을 시도한다 (명시적 display: 는 여전히 최우선).
+  const display =
+    rawKind === 'element' && baseDisplay === title
+      ? humanizeCodePathTitle(title) ?? baseDisplay
+      : baseDisplay;
   return {
     id,
     title,
-    display: deriveDisplayTitle(fm, title),
+    display,
     kind: rawKind,
     sourceSlug: doc.slug,
     source: 'frontmatter',
@@ -310,7 +320,9 @@ function deriveOntologyFromVaultUncached(
         nodes.set(elId, {
           id: elId,
           title: folderRef?.kind === 'element' ? folderRef.title : el,
-          display: deriveDisplayTitle(undefined, folderRef?.kind === 'element' ? folderRef.title : el),
+          display:
+            humanizeCodePathTitle(el) ??
+            deriveDisplayTitle(undefined, folderRef?.kind === 'element' ? folderRef.title : el),
           kind: 'element',
           sourceSlug: doc.slug,
           source: 'frontmatter',

--- a/src/features/first-run-starter/ui/FirstRunReadout.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunReadout.test.tsx
@@ -62,4 +62,25 @@ describe('FirstRunReadout', () => {
     render(<FirstRunReadout projectCount={1} domainCount={6} />);
     expect(screen.getByTestId('first-run-readout')).toBeInTheDocument();
   });
+
+  // P1 결함①(b), 사용성 전수 검수 2026-07-23 — 비개발(plain) 모드에서는
+  // element 티어가 도달 불가(`PLAIN_TIER_REVEAL`)라 "줌인하면 요소가
+  // 나타납니다"가 영원히 거짓으로 남는다. plain 모드는 tier 와 무관하게
+  // 항상 클릭 기반 plain 문구를 보여준다.
+  describe('audiencePlain (P1 결함①b)', () => {
+    it('shows the plain click-based hint instead of the zoom hint, regardless of tier', () => {
+      render(<FirstRunReadout projectCount={1} domainCount={6} tier="circuit" audiencePlain />);
+      expect(screen.getByTestId('first-run-readout-zoom-hint')).toHaveTextContent('zoomHintPlain');
+    });
+
+    it('never drops the plain hint even at the element tier (zoom cannot reveal elements in plain mode)', () => {
+      render(<FirstRunReadout projectCount={1} domainCount={6} tier="element" audiencePlain />);
+      expect(screen.getByTestId('first-run-readout-zoom-hint')).toHaveTextContent('zoomHintPlain');
+    });
+
+    it('leaves the developer-mode zoom hint untouched when audiencePlain is false/omitted', () => {
+      render(<FirstRunReadout projectCount={1} domainCount={6} tier="spine" />);
+      expect(screen.getByTestId('first-run-readout-zoom-hint')).toHaveTextContent('zoomHint');
+    });
+  });
 });

--- a/src/features/first-run-starter/ui/FirstRunReadout.tsx
+++ b/src/features/first-run-starter/ui/FirstRunReadout.tsx
@@ -14,6 +14,14 @@ export interface FirstRunReadoutProps {
    * to "spine" (the overview entry) when the map hasn't reported yet.
    */
   tier?: "spine" | "circuit" | "element";
+  /**
+   * P1 결함①b (사용성 전수 검수 2026-07-23) — 비개발(plain) 모드에서는
+   * element 티어가 도달 불가 밴드로 밀려 있어(`PLAIN_TIER_REVEAL`) 줌으로는
+   * 절대 element 가 드러나지 않는다. "줌인하면 요소가 나타납니다"는 이
+   * 모드에서 항상 거짓이므로, `tier` 와 무관하게 클릭 기반 plain 문구로
+   * 치환한다(드롭하지 않음 — 이 모드에선 그 안내가 항상 유효하다).
+   */
+  audiencePlain?: boolean;
 }
 
 /**
@@ -36,7 +44,12 @@ export interface FirstRunReadoutProps {
  * 둘러보는 동안은 방향성 지표로 남아있는 게 유용하다(이전 오픈소스 스트립과
  * 같은 지속성).
  */
-export function FirstRunReadout({ projectCount, domainCount, tier = "spine" }: FirstRunReadoutProps) {
+export function FirstRunReadout({
+  projectCount,
+  domainCount,
+  tier = "spine",
+  audiencePlain = false,
+}: FirstRunReadoutProps) {
   const t = useTranslations("firstRunStarter.readout");
   const visible = useFirstRunSampleModeSettled();
 
@@ -45,7 +58,10 @@ export function FirstRunReadout({ projectCount, domainCount, tier = "spine" }: F
   const tierLabel = t(`tier_${tier}`);
   // At the element tier the "zoom in to see elements" promise is already
   // fulfilled — showing it would be a lie (M-5). Below it, keep the guidance.
-  const showZoomHint = tier !== "element";
+  // P1 결함①b — plain 모드는 이 tier 판정 자체가 무의미하다(줌으로는 절대
+  // element 에 도달 못 함) — 항상 보여주고 문구만 클릭 기반으로 바꾼다.
+  const showZoomHint = audiencePlain || tier !== "element";
+  const zoomHintText = audiencePlain ? t("zoomHintPlain") : t("zoomHint");
 
   return (
     <div
@@ -67,7 +83,7 @@ export function FirstRunReadout({ projectCount, domainCount, tier = "spine" }: F
       {showZoomHint ? (
         <>
           <Dot />
-          <span data-testid="first-run-readout-zoom-hint">{t("zoomHint")}</span>
+          <span data-testid="first-run-readout-zoom-hint">{zoomHintText}</span>
         </>
       ) : null}
     </div>

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
@@ -182,6 +182,15 @@ describe('FirstRunStarterModule', () => {
     expect(screen.getByTestId('first-run-starter-dismiss')).toBeInTheDocument();
   });
 
+  // P2 결함③ (사용성 전수 검수 2026-07-23) — 비개발자가 "일반" 보기 모드
+  // 토글의 존재를 알 방법이 없었다. dismiss 행 근처에 조용한 유도 한 줄.
+  it('P2 결함③ — renders a quiet nudge toward the plain-mode gear toggle near the dismiss row', () => {
+    render(<FirstRunStarterModule concepts={1} relations={1} domains={1} />);
+
+    const hint = screen.getByTestId('first-run-starter-plain-mode-hint');
+    expect(hint).toHaveTextContent('plainModeHint');
+  });
+
   it('copies the CLI bootstrap command to the clipboard once the disclosure is open', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
@@ -161,6 +161,16 @@ export function FirstRunStarterModule({
         </button>
       </p>
 
+      {/* P2 결함③ (사용성 전수 검수 2026-07-23) — 비개발자가 기어 속 "보기
+          모드" 토글의 존재를 알 방법이 0 이었다. 배너/팝업 없이, dismiss 행
+          바로 아래 조용한 한 줄로 유도 경로 하나만 확보한다. */}
+      <p
+        data-testid="first-run-starter-plain-mode-hint"
+        className="mt-1 text-[10.5px] leading-[1.5] text-[color:var(--topology-v2-panel-text-quaternary)]"
+      >
+        {t("plainModeHint")}
+      </p>
+
       {/* P1-① — 코드베이스 자동 부트스트랩(CLI/에이전트 전용)으로 가는 다리.
           위 두 버튼(폴더 열기 / 새 vault 만들기)은 빈 vault 를 여는 경로일
           뿐, "내 리포를 분석해서 채워줘"에는 답하지 못한다 — 그 답은

--- a/src/features/ontology-blocks/ui/BlockImportModule.test.tsx
+++ b/src/features/ontology-blocks/ui/BlockImportModule.test.tsx
@@ -107,10 +107,17 @@ describe('BlockImportModule', () => {
     stubPicker(fakeBlockDir(BLOCK_FILES));
   });
 
-  it('renders nothing without a loaded vault (static sample mode)', () => {
+  it('P1 결함② — is disabled with a "open your folder" hint (not hidden) without a loaded vault', () => {
+    // 정적 샘플 모드에서 "블록 가져오기" 가 흔적 없이 사라져 기능 존재를
+    // 은폐했다(사용성 전수 검수). null 렌더 대신 같은 자리에 disabled + 힌트.
     mocks.vault = makeVault({ status: 'idle', manifest: null });
     render(<BlockImportModule />);
-    expect(screen.queryByTestId('block-import-open')).not.toBeInTheDocument();
+    const button = screen.getByTestId('block-import-open');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'vaultRequiredHint');
+    fireEvent.click(button);
+    expect(screen.queryByTestId('block-import-dialog')).not.toBeInTheDocument();
   });
 
   it('opens a merge preview after picking a folder WITHOUT writing to the vault (dry-run 절대 계약)', async () => {

--- a/src/features/ontology-blocks/ui/BlockImportModule.tsx
+++ b/src/features/ontology-blocks/ui/BlockImportModule.tsx
@@ -23,14 +23,19 @@ interface PreviewSource {
 
 /**
  * 온톨로지 블록 Slice A — "블록 가져오기" (병합 프리뷰). 전역 INDEX 패널
- * (`TopologyIndexPanel`)의 vault 로드 상태에서만 렌더되는 자립 모듈 —
- * FirstRunStarterModule 과 같은 계약(상태·라벨 자급, 호스트 prop 표면 0).
+ * (`TopologyIndexPanel`) 안에 상시 마운트되는 자립 모듈 — FirstRunStarterModule
+ * 과 같은 계약(상태·라벨 자급, 호스트 prop 표면 0).
  *
  * 절대 계약: **승인 전 쓰기 0.** 폴더 선택 → 공유 파서로 .md 파싱 →
  * `planBlockImport` 순수 dry-run 으로 신규/충돌 리포트만 만든 뒤, 사용자가
  * scrim 딸린 다이얼로그에서 확인해야만 기존 vault 쓰기 경로(`createDoc`)로
  * 기록한다. 충돌 해소는 건너뛰기(기본) 또는 블록명 자동 접두사 — CLI
  * `import --rename` 과 같은 -2/-3 폴백까지 정합 (`merge-plan.ts` 참고).
+ *
+ * P1 결함② (사용성 전수 검수 2026-07-23) — 로컬 vault 미로드(정적 샘플)일 때
+ * "블록 가져오기" 행이 흔적 없이 사라져 "기능 존재 은폐"로 읽혔다. 이제
+ * 같은 자리에 disabled + "내 폴더를 열면 쓸 수 있어요" 힌트로 남는다 —
+ * `RealmBlockExportAction` G1 강등과 같은 문법.
  */
 export function BlockImportModule() {
   const t = useTranslations("ontologyBlocks");
@@ -43,6 +48,7 @@ export function BlockImportModule() {
   );
   const [dialogError, setDialogError] = useState(false);
 
+  const vaultLoaded = status === "loaded" && Boolean(manifest);
   const open = preview !== null;
   useBodyScrollLock(open);
 
@@ -69,11 +75,10 @@ export function BlockImportModule() {
     });
   }, [preview, existingSlugs, resolution]);
 
-  if (status !== "loaded" || !manifest) return null;
-
   const supported = typeof window !== "undefined" && "showDirectoryPicker" in window;
 
   const pickBlockFolder = async () => {
+    if (!vaultLoaded) return;
     setInlineText(null);
     try {
       const dir = (await (
@@ -133,8 +138,14 @@ export function BlockImportModule() {
       <button
         type="button"
         onClick={() => void pickBlockFolder()}
-        disabled={!supported}
-        title={supported ? t("importAria") : t("exportUnsupportedHint")}
+        disabled={!vaultLoaded || !supported}
+        title={
+          !vaultLoaded
+            ? t("vaultRequiredHint")
+            : supported
+              ? t("importAria")
+              : t("exportUnsupportedHint")
+        }
         data-testid="block-import-open"
         className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-label transition-colors enabled:hover:bg-[color:var(--topology-v2-panel-row-hover)] disabled:opacity-50"
       >

--- a/src/features/ontology-blocks/ui/RealmBlockExportAction.test.tsx
+++ b/src/features/ontology-blocks/ui/RealmBlockExportAction.test.tsx
@@ -109,10 +109,17 @@ describe('RealmBlockExportAction', () => {
     delete (window as unknown as { showDirectoryPicker?: unknown }).showDirectoryPicker;
   });
 
-  it('renders nothing without a loaded vault (정적 샘플 모드 — 액션 숨김)', () => {
+  it('P1 결함② — is disabled with a "open your folder" hint (not hidden) when no vault is loaded', () => {
+    // 정적 샘플 모드에서 이 액션이 흔적 없이 사라져 "기능 존재 은폐"로 읽혔다
+    // (사용성 전수 검수). null 렌더 대신 같은 자리에 disabled + 힌트.
     mocks.vault = { ...makeVault(), status: 'idle', manifest: null };
     render(<RealmBlockExportAction rootTitle="Views" census={census} subtree={subtree} />);
-    expect(screen.queryByTestId('realm-block-export')).not.toBeInTheDocument();
+    const button = screen.getByTestId('realm-block-export');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'vaultRequiredHint');
+    fireEvent.click(button);
+    expect(mocks.vault.fileHandles).toBeDefined(); // no crash / no-op click
   });
 
   it('is disabled with a hint when the environment has no directory picker (G1 — 눌러야 실패 금지)', () => {

--- a/src/features/ontology-blocks/ui/RealmBlockExportAction.tsx
+++ b/src/features/ontology-blocks/ui/RealmBlockExportAction.tsx
@@ -29,9 +29,13 @@ type ExportPhase = "idle" | "exporting" | "done" | "error";
  *
  * FirstRunStarterModule 과 같은 자립 모듈 계약 — vault 상태(`useLocalVault`)
  * 와 라벨(`ontologyBlocks` i18n)을 스스로 읽어, 호스트 위젯의 prop 표면을
- * 늘리지 않는다. 로컬 vault 미로드(정적 샘플)면 렌더 자체를 하지 않고,
- * 디렉터리 picker 가 없는 환경(Safari/Firefox·일부 WebView)은 비활성 +
- * 짧은 힌트로 사전 강등한다 (G1 — 눌러야 실패 금지).
+ * 늘리지 않는다.
+ *
+ * P1 결함② (사용성 전수 검수 2026-07-23) — 로컬 vault 미로드(정적 샘플)일 때
+ * 이 액션이 흔적 없이 사라져 "기능 존재 은폐"로 읽혔다. 이제 같은 자리에
+ * disabled + "내 폴더를 열면 쓸 수 있어요" 힌트로 남는다 — G1 이 이미 세운
+ * "디렉터리 picker 없는 환경은 비활성 + 힌트" 사전 강등 패턴과 동일 문법을
+ * vault-미로드 사유로 확장한 것뿐, 새 패턴 아님.
  */
 export function RealmBlockExportAction({
   rootTitle,
@@ -43,13 +47,12 @@ export function RealmBlockExportAction({
   const [phase, setPhase] = useState<ExportPhase>("idle");
   const [exportedCount, setExportedCount] = useState(0);
 
-  if (status !== "loaded" || !manifest) return null;
-
+  const vaultLoaded = status === "loaded" && Boolean(manifest);
   const supported =
     typeof window !== "undefined" && "showDirectoryPicker" in window;
 
   const runExport = async () => {
-    if (phase === "exporting") return;
+    if (phase === "exporting" || !vaultLoaded || !manifest) return;
     setPhase("exporting");
     try {
       const target = (await (
@@ -116,9 +119,15 @@ export function RealmBlockExportAction({
       <button
         type="button"
         onClick={() => void runExport()}
-        disabled={!supported || phase === "exporting"}
+        disabled={!vaultLoaded || !supported || phase === "exporting"}
         aria-label={t("exportAria")}
-        title={supported ? t("exportAria") : t("exportUnsupportedHint")}
+        title={
+          !vaultLoaded
+            ? t("vaultRequiredHint")
+            : supported
+              ? t("exportAria")
+              : t("exportUnsupportedHint")
+        }
         data-testid="realm-block-export"
         className="inline-flex shrink-0 items-center gap-1 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-label text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors enabled:hover:text-[color:var(--topology-v2-panel-text-primary)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
       >

--- a/src/shared/lib/highlight-match.test.ts
+++ b/src/shared/lib/highlight-match.test.ts
@@ -56,4 +56,38 @@ describe("splitHighlightSegments", () => {
     const segs = splitHighlightSegments("Capability: token issue", "token");
     expect(segs.map((s) => s.text).join("")).toBe("Capability: token issue");
   });
+
+  // 착지 결함 (P1 검수) — 문서 본문은 ~80자에서 줄바꿈된다(AGENTS.md 컨벤션).
+  // 사용자가 타이핑한 구절 쿼리의 공백이 실제로는 소스의 줄바꿈일 수 있다.
+  // 리터럴 substring 매칭은 이 경우 0건이라 mark 가 안 생기고 스크롤도
+  // 무산됐다 — 공백 런(스페이스/개행/탭)을 유연하게 매치해야 한다.
+  it("멀티 토큰 쿼리는 소스의 줄바꿈도 공백처럼 매치한다 (줄-랩 구절)", () => {
+    const text = "Give it a local, git-backed\nmental model it can read.";
+    const segs = splitHighlightSegments(text, "git-backed mental model");
+    const matched = segs.filter((s) => s.match).map((s) => s.text);
+    expect(matched).toEqual(["git-backed\nmental model"]);
+    // 무손실 재조합 계약은 공백-유연 매칭에서도 유지.
+    expect(segs.map((s) => s.text).join("")).toBe(text);
+  });
+
+  it("멀티 토큰 쿼리는 연속 다중 공백/탭도 매치한다", () => {
+    const text = "before  needle\tphrase  after";
+    const segs = splitHighlightSegments(text, "needle phrase");
+    expect(segs.filter((s) => s.match).map((s) => s.text)).toEqual([
+      "needle\tphrase",
+    ]);
+  });
+
+  it("멀티 토큰이어도 특수문자는 여전히 리터럴 이스케이프", () => {
+    const segs = splitHighlightSegments("a.b c(d)", "a.b c(d)");
+    expect(segs.filter((s) => s.match).map((s) => s.text)).toEqual([
+      "a.b c(d)",
+    ]);
+  });
+
+  it("모든 occurrence 매치 — 멀티 토큰도 전역 매치", () => {
+    const text = "needle phrase here, another needle phrase there";
+    const segs = splitHighlightSegments(text, "needle phrase");
+    expect(segs.filter((s) => s.match)).toHaveLength(2);
+  });
 });

--- a/src/shared/lib/highlight-match.ts
+++ b/src/shared/lib/highlight-match.ts
@@ -5,36 +5,64 @@
  *
  * - 대소문자 무시, 모든 occurrence 매치.
  * - query 가 비었거나(trim 후) 매치가 없으면 전체를 단일 비매치 세그먼트로.
- * - 리터럴 substring 매칭(정규식 아님) — 사용자 입력의 특수문자 안전.
+ * - 정규식 특수문자는 이스케이프해 리터럴처럼 안전하게 매칭한다.
+ * - 멀티 토큰(공백 포함) 쿼리는 토큰 사이 공백을 "임의 개수의 공백류
+ *   문자(스페이스/개행/탭)"로 유연하게 매치한다 — 문서 본문은 ~80자에서
+ *   줄바꿈되므로(AGENTS.md 컨벤션), 사용자가 타이핑한 구절이 소스에서는
+ *   줄바꿈을 사이에 두고 있을 수 있다. 리터럴 substring 매칭만 쓰면 이
+ *   경우 0건이 나 하이라이트/스크롤이 무산된다(P1 검수 착지 결함).
  */
 export interface HighlightSegment {
   text: string;
   match: boolean;
 }
 
+function escapeRegExpToken(token: string): string {
+  return token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * 쿼리를 공백-유연 정규식으로 컴파일한다. 토큰 사이 공백은 `\s+` 로 이어
+ * 붙여 원문의 임의 공백류(스페이스/개행/탭 연속)와 매치한다. 각 토큰
+ * 자체는 이스케이프된 리터럴이라 특수문자 안전성은 그대로 유지.
+ * 쿼리가 비어 있으면 null.
+ */
+export function buildPhraseMatcher(
+  query: string,
+  flags = 'gi',
+): RegExp | null {
+  const tokens = query.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  const pattern = tokens.map(escapeRegExpToken).join('\\s+');
+  return new RegExp(pattern, flags);
+}
+
 export function splitHighlightSegments(
   text: string,
   query: string,
 ): HighlightSegment[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return [{ text, match: false }];
-
-  const lower = text.toLowerCase();
-  if (!lower.includes(q)) return [{ text, match: false }];
+  const re = buildPhraseMatcher(query);
+  if (!re) return [{ text, match: false }];
 
   const segments: HighlightSegment[] = [];
   let cursor = 0;
-  while (cursor < text.length) {
-    const idx = lower.indexOf(q, cursor);
-    if (idx === -1) {
-      segments.push({ text: text.slice(cursor), match: false });
-      break;
+  let match: RegExpExecArray | null;
+  let matchedAny = false;
+  re.lastIndex = 0;
+  while ((match = re.exec(text)) !== null) {
+    matchedAny = true;
+    if (match.index > cursor) {
+      segments.push({ text: text.slice(cursor, match.index), match: false });
     }
-    if (idx > cursor) {
-      segments.push({ text: text.slice(cursor, idx), match: false });
-    }
-    segments.push({ text: text.slice(idx, idx + q.length), match: true });
-    cursor = idx + q.length;
+    segments.push({ text: match[0], match: true });
+    cursor = match.index + match[0].length;
+    // 이론상 토큰이 모두 non-empty 라 zero-length 매치는 없지만, 방어적으로
+    // 무한루프를 막는다.
+    if (match[0].length === 0) re.lastIndex += 1;
+  }
+  if (!matchedAny) return [{ text, match: false }];
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), match: false });
   }
   return segments;
 }

--- a/src/shared/lib/humanize-code-path-title.test.ts
+++ b/src/shared/lib/humanize-code-path-title.test.ts
@@ -75,4 +75,24 @@ describe("humanizeCodePathTitle", () => {
     const input = "src/widgets/topology-map-v2/ui/topology-world.ts";
     expect(humanizeCodePathTitle(input)).toBe(humanizeCodePathTitle(input));
   });
+
+  it("SKILL.md 는 확장자 제거 후 generic 흡수되어 부모 디렉토리명을 쓴다", () => {
+    expect(
+      humanizeCodePathTitle(".claude/skills/ontology-sync/SKILL.md"),
+    ).toBe("Ontology Sync");
+  });
+
+  it("index.ts 의 부모마저 generic(lib) 이면 한 단계 더 승격한다(최대 2단계)", () => {
+    expect(humanizeCodePathTitle("src/lib/index.ts")).toBe("Src");
+  });
+
+  it("3글자 이하의 짧은 잔재 세그먼트(목록 밖 단어)는 부모 세그먼트로 승격한다", () => {
+    expect(
+      humanizeCodePathTitle("src/widgets/topology-map-v2/db.ts"),
+    ).toBe("Topology Map V2");
+  });
+
+  it("generic 목록에 새로 추가된 단어(src/lib/ui/api/util 등)도 승격 대상이다", () => {
+    expect(humanizeCodePathTitle("cli/src")).toBe("Cli");
+  });
 });

--- a/src/shared/lib/humanize-code-path-title.test.ts
+++ b/src/shared/lib/humanize-code-path-title.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  humanizeCodePathTitle,
+  looksLikeCodePath,
+} from "./humanize-code-path-title";
+
+describe("looksLikeCodePath", () => {
+  it("알려진 확장자를 가진 경로를 코드 경로로 판정한다", () => {
+    expect(looksLikeCodePath("src/widgets/topology-map-v2/ui/topology-world.ts")).toBe(
+      true,
+    );
+  });
+
+  it("알려진 루트 폴더 prefix 를 가진 경로를 코드 경로로 판정한다", () => {
+    expect(looksLikeCodePath("cli/src/commands/agent-brief.mjs")).toBe(true);
+  });
+
+  it("공백을 포함하면 코드 경로가 아니다", () => {
+    expect(looksLikeCodePath("MCP Server")).toBe(false);
+  });
+
+  it("슬래시가 없으면 코드 경로가 아니다", () => {
+    expect(looksLikeCodePath("readme.md")).toBe(false);
+  });
+
+  it("알려진 prefix/확장자가 없는 슬래시 경로는 코드 경로가 아니다", () => {
+    expect(looksLikeCodePath("elements/agent-activity-hooks")).toBe(false);
+  });
+});
+
+describe("humanizeCodePathTitle", () => {
+  it("kebab-case 파일명을 사람이 읽는 제목으로 변환한다", () => {
+    expect(
+      humanizeCodePathTitle(
+        "src/widgets/topology-map-v2/ui/topology-world.ts",
+      ),
+    ).toBe("Topology World");
+  });
+
+  it("kebab-case .mjs 파일명을 사람이 읽는 제목으로 변환한다", () => {
+    expect(humanizeCodePathTitle("cli/src/commands/agent-brief.mjs")).toBe(
+      "Agent Brief",
+    );
+  });
+
+  it("index.ts 는 부모 세그먼트를 승격한다", () => {
+    expect(humanizeCodePathTitle("src/features/user-auth/index.ts")).toBe(
+      "User Auth",
+    );
+  });
+
+  it("camelCase 파일명은 단어 경계에서 공백화한다", () => {
+    expect(humanizeCodePathTitle("src/lib/parseFrontmatter.ts")).toBe(
+      "Parse Frontmatter",
+    );
+  });
+
+  it("코드 경로처럼 보이지 않으면 null 을 반환한다", () => {
+    expect(humanizeCodePathTitle("MCP Server")).toBeNull();
+  });
+
+  it("prefix 목록에 없는 folder-prefixed 경로는 null 을 반환한다", () => {
+    expect(humanizeCodePathTitle("elements/agent-activity-hooks")).toBeNull();
+  });
+
+  it("공백을 포함한 문자열은 null 을 반환한다", () => {
+    expect(humanizeCodePathTitle("src/foo bar.ts")).toBeNull();
+  });
+
+  it("슬래시가 없는 문자열은 null 을 반환한다", () => {
+    expect(humanizeCodePathTitle("topology-world.ts")).toBeNull();
+  });
+
+  it("결정론적이다 — 동일 입력에 동일 출력", () => {
+    const input = "src/widgets/topology-map-v2/ui/topology-world.ts";
+    expect(humanizeCodePathTitle(input)).toBe(humanizeCodePathTitle(input));
+  });
+});

--- a/src/shared/lib/humanize-code-path-title.ts
+++ b/src/shared/lib/humanize-code-path-title.ts
@@ -11,7 +11,28 @@ const KNOWN_CODE_EXT =
   /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts|md|mdx|css|scss|json|ya?ml|py|rs|go|java|rb|swift|kt|vue|svelte|html|sql|sh)$/i;
 const CODE_PATH_PREFIX =
   /^(src|app|cli|mcp|tests?|scripts?|docs|packages?|lib|apps?|internal|pkg)\//;
-const GENERIC_LEAF = new Set(["index", "mod", "main", "readme"]);
+// 사용성 검수 — "Src"·"SKILL"·"Verify" 같은 1단어 잔재가 그대로 display 로
+// 새는 결함. 알려진 generic 세그먼트 단어 + (목록 밖이라도) 3글자 이하의
+// 짧은 한 세그먼트는 "잔재"로 보고 부모 세그먼트로 승격한다.
+const GENERIC_LEAF = new Set([
+  "index",
+  "mod",
+  "main",
+  "readme",
+  "src",
+  "lib",
+  "ui",
+  "api",
+  "util",
+  "utils",
+  "core",
+  "base",
+  "types",
+  "test",
+  "spec",
+  "skill",
+]);
+const MAX_PROMOTIONS = 2;
 
 /** 코드 경로처럼 보이는 title 판정 — 공백 없고 '/' 포함, 그리고 (알려진 확장자 or 알려진 루트 폴더 prefix). */
 export function looksLikeCodePath(title: string): boolean {
@@ -20,21 +41,38 @@ export function looksLikeCodePath(title: string): boolean {
   return KNOWN_CODE_EXT.test(t) || CODE_PATH_PREFIX.test(t);
 }
 
+/** 세그먼트가 "잔재" 단어인가 — GENERIC_LEAF 목록에 있거나, 목록 밖이라도
+ * 3글자 이하로 짧아 그대로 노출하면 뜻을 알기 어려운 경우. */
+function isGenericSegment(segment: string): boolean {
+  const lower = segment.toLowerCase();
+  return GENERIC_LEAF.has(lower) || lower.length <= 3;
+}
+
 /**
  * 경로 → 사람 이름. 코드 경로가 아니면 null (호출부가 기존 display 유지).
- * 규칙: 마지막 세그먼트 → 확장자 제거 → index/mod/main/README 면 부모 세그먼트
- * 승격 → kebab/snake/camel 경계 공백화 → 단어별 첫 글자 대문자.
+ * 규칙: 마지막 세그먼트 → 확장자 제거 → generic 잔재 세그먼트면 부모 세그먼트로
+ * 승격(승격 후에도 generic 이면 한 단계 더, 최대 2단계) → kebab/snake/camel
+ * 경계 공백화 → 단어별 첫 글자 대문자.
  * 예: "src/widgets/topology-map-v2/ui/topology-world.ts" → "Topology World"
  *     "cli/src/commands/agent-brief.mjs" → "Agent Brief"
  *     "src/features/user-auth/index.ts" → "User Auth"
+ *     ".claude/skills/ontology-sync/SKILL.md" → "Ontology Sync"
+ *     "src/lib/index.ts" → "Src" (부모(lib)도 generic 이라 2단계 승격, 그 이상
+ *     승격할 세그먼트가 없으면 거기서 멈춘다)
  * 순수·결정론 — 렌더 전용(매칭 금지 계약은 derive-display-title.ts 와 동일).
  */
 export function humanizeCodePathTitle(title: string): string | null {
   if (!looksLikeCodePath(title)) return null;
   const segs = title.trim().split("/").filter(Boolean);
   if (segs.length === 0) return null;
-  let leaf = segs[segs.length - 1].replace(KNOWN_CODE_EXT, "");
-  if (GENERIC_LEAF.has(leaf.toLowerCase()) && segs.length >= 2) leaf = segs[segs.length - 2];
+  let idx = segs.length - 1;
+  let leaf = segs[idx].replace(KNOWN_CODE_EXT, "");
+  let promotions = 0;
+  while (isGenericSegment(leaf) && idx > 0 && promotions < MAX_PROMOTIONS) {
+    idx -= 1;
+    leaf = segs[idx];
+    promotions += 1;
+  }
   const words = leaf
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .split(/[-_.\s]+/)

--- a/src/shared/lib/humanize-code-path-title.ts
+++ b/src/shared/lib/humanize-code-path-title.ts
@@ -1,0 +1,44 @@
+/**
+ * element 노드의 title 이 코드 경로 원문(`src/widgets/foo/bar-baz.ts`)일 때
+ * 사람이 읽는 이름으로 변환하는 순수 함수 — display 레이어 전용.
+ *
+ * `derive-display-title.ts` 와 동일한 계약: 순수·결정론·렌더링 표면 전용.
+ * **검색/매칭에는 쓰지 않는다** — vault frontmatter / title / slug 는 원문
+ * 그대로 유지되고, 이 함수의 결과는 표시(display) 값 파생에만 쓰인다.
+ */
+
+const KNOWN_CODE_EXT =
+  /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts|md|mdx|css|scss|json|ya?ml|py|rs|go|java|rb|swift|kt|vue|svelte|html|sql|sh)$/i;
+const CODE_PATH_PREFIX =
+  /^(src|app|cli|mcp|tests?|scripts?|docs|packages?|lib|apps?|internal|pkg)\//;
+const GENERIC_LEAF = new Set(["index", "mod", "main", "readme"]);
+
+/** 코드 경로처럼 보이는 title 판정 — 공백 없고 '/' 포함, 그리고 (알려진 확장자 or 알려진 루트 폴더 prefix). */
+export function looksLikeCodePath(title: string): boolean {
+  const t = title.trim();
+  if (!t.includes("/") || /\s/.test(t)) return false;
+  return KNOWN_CODE_EXT.test(t) || CODE_PATH_PREFIX.test(t);
+}
+
+/**
+ * 경로 → 사람 이름. 코드 경로가 아니면 null (호출부가 기존 display 유지).
+ * 규칙: 마지막 세그먼트 → 확장자 제거 → index/mod/main/README 면 부모 세그먼트
+ * 승격 → kebab/snake/camel 경계 공백화 → 단어별 첫 글자 대문자.
+ * 예: "src/widgets/topology-map-v2/ui/topology-world.ts" → "Topology World"
+ *     "cli/src/commands/agent-brief.mjs" → "Agent Brief"
+ *     "src/features/user-auth/index.ts" → "User Auth"
+ * 순수·결정론 — 렌더 전용(매칭 금지 계약은 derive-display-title.ts 와 동일).
+ */
+export function humanizeCodePathTitle(title: string): string | null {
+  if (!looksLikeCodePath(title)) return null;
+  const segs = title.trim().split("/").filter(Boolean);
+  if (segs.length === 0) return null;
+  let leaf = segs[segs.length - 1].replace(KNOWN_CODE_EXT, "");
+  if (GENERIC_LEAF.has(leaf.toLowerCase()) && segs.length >= 2) leaf = segs[segs.length - 2];
+  const words = leaf
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[-_.\s]+/)
+    .filter(Boolean);
+  if (words.length === 0) return null;
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}

--- a/src/shared/lib/ontology-tree/filter-tree.test.ts
+++ b/src/shared/lib/ontology-tree/filter-tree.test.ts
@@ -5,6 +5,7 @@ import {
   countMatchingTreeNodes,
   filterTreeByNodeIds,
   filterTreeByQuery,
+  filterTreeExcludeKind,
   knowledgeNodeMatchesQuery,
 } from "./filter-tree";
 
@@ -250,5 +251,75 @@ describe("filterTreeByNodeIds", () => {
   it("트리에 없는 id 는 무시 (제거된 노드 등)", () => {
     const r = filterTreeByNodeIds(tree.roots, new Set(["ghost"]));
     expect(r).toEqual([]);
+  });
+});
+
+// 슬라이스 C (개발/비개발 모드 토글) — 비개발(plain) 모드의 INDEX 트리에서
+// element 행을 제외한다. 데이터 자체는 무변경 — 이 함수는 트리 뷰만 가지치기
+// 한다(카운트/census 는 이 함수의 출력을 쓰지 않는다).
+describe("filterTreeExcludeKind (슬라이스 C — 비개발 모드 element 행 제외)", () => {
+  // root (project)
+  // ├─ child-1 (capability, 로그인)
+  // │  └─ grand-1 (element, 세션)
+  // └─ child-2 (capability, 로그아웃)
+  const nodes = [
+    node("root", "프로젝트", "project"),
+    withParent(node("child-1", "로그인", "capability")),
+    withParent(node("grand-1", "세션", "element")),
+    withParent(node("child-2", "로그아웃", "capability")),
+  ];
+  const edges = [
+    { id: "e1", from: "root", to: "child-1", type: "contains", projectIds: [], evidenceIds: [], lastApprovedAt: APPROVED_AT, lastApprovedBy: "test" },
+    { id: "e2", from: "child-1", to: "grand-1", type: "contains", projectIds: [], evidenceIds: [], lastApprovedAt: APPROVED_AT, lastApprovedBy: "test" },
+    { id: "e3", from: "root", to: "child-2", type: "contains", projectIds: [], evidenceIds: [], lastApprovedAt: APPROVED_AT, lastApprovedBy: "test" },
+  ];
+  const tree = buildOntologyTree(nodes, edges);
+
+  it("해당 kind 의 서브트리를 제거한다 (자손 포함)", () => {
+    const r = filterTreeExcludeKind(tree.roots, "element");
+    expect(r).toHaveLength(1); // root
+    expect(r[0]?.children).toHaveLength(2); // child-1, child-2 그대로
+    const child1 = r[0]?.children.find((c) => c.node.id === "child-1");
+    expect(child1?.children).toHaveLength(0); // grand-1(element) 제거됨
+  });
+
+  it("구조를 보존한다 — 제외 대상이 아닌 노드는 그대로 남는다", () => {
+    const r = filterTreeExcludeKind(tree.roots, "element");
+    expect(r[0]?.node.id).toBe("root");
+    expect(r[0]?.children.map((c) => c.node.id).sort()).toEqual(["child-1", "child-2"]);
+  });
+
+  it("입력을 변경하지 않는다 (불변)", () => {
+    const beforeIds = tree.roots.map((r) => r.node.id);
+    const beforeChildCounts = tree.roots.map((r) => r.children.length);
+    filterTreeExcludeKind(tree.roots, "element");
+    expect(tree.roots.map((r) => r.node.id)).toEqual(beforeIds);
+    expect(tree.roots.map((r) => r.children.length)).toEqual(beforeChildCounts);
+    // grand-1(element) 는 여전히 원본 트리 안에 남아 있다.
+    const child1 = tree.roots[0]?.children.find((c) => c.node.id === "child-1");
+    expect(child1?.children).toHaveLength(1);
+    expect(child1?.children[0]?.node.id).toBe("grand-1");
+  });
+
+  it("결정론적이다 — 같은 입력에 같은 출력", () => {
+    const r1 = filterTreeExcludeKind(tree.roots, "element");
+    const r2 = filterTreeExcludeKind(tree.roots, "element");
+    expect(r1).toEqual(r2);
+  });
+
+  it("제외 대상 kind 가 root 자체면 그 root 를 제거한다", () => {
+    const rootIsElement = [
+      node("solo-root", "고아", "element"),
+    ];
+    const soloTree = buildOntologyTree(rootIsElement, []);
+    const r = filterTreeExcludeKind(soloTree.roots, "element");
+    expect(r).toEqual([]);
+  });
+
+  it("해당 kind 가 없으면 트리 전체를 그대로 반환한다", () => {
+    const r = filterTreeExcludeKind(tree.roots, "document");
+    expect(r).toHaveLength(1);
+    expect(r[0]?.children).toHaveLength(2);
+    expect(r[0]?.children.find((c) => c.node.id === "child-1")?.children).toHaveLength(1);
   });
 });

--- a/src/shared/lib/ontology-tree/filter-tree.ts
+++ b/src/shared/lib/ontology-tree/filter-tree.ts
@@ -83,6 +83,35 @@ export function filterTreeByQuery(
 }
 
 /**
+ * 슬라이스 C (개발/비개발 모드 토글) — 지정한 `kind` 의 노드와 그 서브트리를
+ * 통째로 제외한다. 비개발(일반) 모드의 INDEX 트리가 element 행을 기본
+ * 숨기는 데 쓴다 — **데이터 무변경**: 이 함수는 원본 `roots`/그래프를
+ * 건드리지 않고 표시용 파생 트리만 가지치기한다. 카운트/census 는 이 함수의
+ * 출력이 아니라 전체 그래프에서 별도로 계산돼야 한다(호출자 책임 — 표시
+ * 필터가 진실 숫자를 왜곡하면 안 된다).
+ *
+ * `filterTreeByQuery`/`filterTreeByNodeIds` 와 달리 조상 chain 을 "보존"하지
+ * 않는다 — 제외 kind 자체가 조상이면(흔치 않지만) 그 서브트리 전체가
+ * 사라진다. 순수 함수(입력 불변), 결정론적.
+ */
+export function filterTreeExcludeKind(
+  roots: readonly OntologyTreeNode[],
+  kind: string,
+): OntologyTreeNode[] {
+  function visit(node: OntologyTreeNode): OntologyTreeNode | null {
+    if (node.node.kind === kind) return null;
+    const filteredChildren = node.children
+      .map(visit)
+      .filter((c): c is OntologyTreeNode => c !== null);
+    return { ...node, children: filteredChildren };
+  }
+
+  return roots
+    .map(visit)
+    .filter((n): n is OntologyTreeNode => n !== null);
+}
+
+/**
  * 트리에서 주어진 id 집합(`ids`)에 속한 노드만 남기되 **부모 chain 보존** —
  * "변경점만 보기"(B2) 의 트리 스코핑.
  *

--- a/src/shared/lib/ontology-tree/index.ts
+++ b/src/shared/lib/ontology-tree/index.ts
@@ -18,6 +18,7 @@ export { buildRadialEgoLayout } from "./ego-layout";
 export {
   filterTreeByQuery,
   filterTreeByNodeIds,
+  filterTreeExcludeKind,
   countMatchingTreeNodes,
   knowledgeNodeMatchesQuery,
 } from "./filter-tree";

--- a/src/shared/lib/vault-issue-plain-message.test.ts
+++ b/src/shared/lib/vault-issue-plain-message.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { mapVaultIssueCodeToPlainMessage } from "./vault-issue-plain-message";
+
+describe("mapVaultIssueCodeToPlainMessage", () => {
+  it("returns the dict's plain-language message for a known code", () => {
+    const message = mapVaultIssueCodeToPlainMessage("missing-expected-field", {
+      "missing-expected-field": "A required field is empty.",
+    });
+    expect(message).toBe("A required field is empty.");
+  });
+
+  it("falls back to the raw code for a code the dict has never heard of, instead of dropping it silently", () => {
+    const message = mapVaultIssueCodeToPlainMessage("some-future-code", {
+      "missing-kind": "No kind yet.",
+    });
+    expect(message).toBe("some-future-code");
+  });
+
+  it("falls back to the raw code when a known code has no dict entry", () => {
+    const message = mapVaultIssueCodeToPlainMessage("empty-kind", {});
+    expect(message).toBe("empty-kind");
+  });
+});

--- a/src/shared/lib/vault-issue-plain-message.ts
+++ b/src/shared/lib/vault-issue-plain-message.ts
@@ -1,0 +1,22 @@
+import type { VaultIssueCode } from "./validate-vault-document";
+
+/**
+ * validator warning code → 이미 로컬라이즈된 평문 문자열 사전. next-intl
+ * 의 `t()` 결과를 호출부(DocFrontmatterBlock)가 만들어 넘긴다 — 이 모듈은
+ * next-intl 을 직접 참조하지 않는 순수 함수라 스텁 dict 만으로 단위
+ * 테스트가 가능하다.
+ */
+export type VaultIssuePlainMessageDict = Partial<Record<VaultIssueCode, string>>;
+
+/**
+ * validator 의 machine code(`missing-expected-field` 등)를 UI 가 그대로
+ * 노출하지 않도록 평문으로 바꾼다. dict 에 없는(알 수 없는) code 는 조용히
+ * 누락하지 않고 원본 code 문자열을 그대로 반환한다 — 새 코드가 추가됐는데
+ * dict 갱신을 깜빡해도 화면에서 흔적이 남는다(silent drop 금지).
+ */
+export function mapVaultIssueCodeToPlainMessage(
+  code: string,
+  dict: VaultIssuePlainMessageDict,
+): string {
+  return (dict as Record<string, string | undefined>)[code] ?? code;
+}

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
@@ -122,4 +122,52 @@ describe("DocFrontmatterBlock", () => {
     fireEvent.click(screen.getByTestId("doc-frontmatter-summary"));
     expect(screen.queryByText("kind / domain / title 수정")).not.toBeInTheDocument();
   });
+
+  it("renders no validator-warnings row when the frontmatter is clean", () => {
+    renderBlock();
+    expect(screen.queryByTestId("doc-frontmatter-validator-warnings")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a plain-language validator warning for a capability missing domain — no raw code exposed", () => {
+    const noDomainDoc: VaultDoc = {
+      ...doc,
+      frontmatter: { kind: "capability", slug: doc.slug, title: doc.title },
+    };
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={noDomainDoc} />
+      </NextIntlClientProvider>,
+    );
+    const warnings = screen.getByTestId("doc-frontmatter-validator-warnings");
+    expect(within(warnings).getByText(/domain/)).toBeInTheDocument();
+    expect(within(warnings).queryByText("missing-expected-field")).not.toBeInTheDocument();
+  });
+
+  it("offers a collapsed spec-example disclosure for a known kind, derived from the shared new-doc starter", () => {
+    renderBlock();
+    expect(screen.queryByTestId("doc-frontmatter-example")).not.toBeInTheDocument();
+
+    const toggle = screen.getByTestId("doc-frontmatter-example-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    const example = screen.getByTestId("doc-frontmatter-example");
+    expect(within(example).getByText(/kind: capability/)).toBeInTheDocument();
+    expect(within(example).getByText(/domain: example-domain/)).toBeInTheDocument();
+  });
+
+  it("hides the spec-example disclosure when the document has no recognizable kind", () => {
+    const noKindDoc: VaultDoc = {
+      ...doc,
+      frontmatter: { status: "draft", slug: doc.slug, title: doc.title },
+    };
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={noKindDoc} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("doc-frontmatter-example-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("doc-frontmatter-validator-warnings")).not.toBeInTheDocument();
+  });
 });

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -1,8 +1,16 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ChevronRight, Pencil } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { VaultDoc } from "@/entities/docs-vault";
+import { buildNewNodeDoc, type VaultDoc } from "@/entities/docs-vault";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
+import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
+import {
+  validateVaultDocFrontmatter,
+  type VaultDocumentIssue,
+  type VaultIssueCode,
+} from "@/shared/lib/validate-vault-document";
+import { mapVaultIssueCodeToPlainMessage } from "@/shared/lib/vault-issue-plain-message";
+import { CompactCopyButton } from "@/shared/ui";
 
 /**
  * Engraved frontmatter visualization — "frontmatter 가 곧 그래프" made literal
@@ -105,6 +113,65 @@ export function DocFrontmatterBlock({
   const [draftKind, setDraftKind] = useState(currentKind ?? "");
   const [draftDomain, setDraftDomain] = useState(currentDomain);
   const [draftTitle, setDraftTitle] = useState(currentTitle);
+
+  // ② validator warning 인라인 — 편집 중이면 draft(kind/domain), 아니면
+  // 저장된 frontmatter 를 대상으로 debounce(400ms) 후 검증. "missing-expected-
+  // field" 같은 warning 만 조용한 인라인 행으로 보여준다(error 는 별개 —
+  // 이 슬라이스는 validator *warning* 만 다룬다).
+  const activeKind = editing ? draftKind : currentKind ?? "";
+  const activeDomain = editing ? draftDomain : currentDomain;
+  const [debouncedValidation, setDebouncedValidation] = useState({
+    kind: activeKind,
+    domain: activeDomain,
+  });
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebouncedValidation({ kind: activeKind, domain: activeDomain });
+    }, 400);
+    return () => window.clearTimeout(handle);
+  }, [activeKind, activeDomain]);
+
+  const validationWarnings = useMemo<VaultDocumentIssue[]>(() => {
+    if (!debouncedValidation.kind) return [];
+    const frontmatterForValidation: Record<string, unknown> = {
+      ...(doc.frontmatter ?? {}),
+      kind: debouncedValidation.kind,
+      domain: debouncedValidation.domain,
+    };
+    return validateVaultDocFrontmatter(frontmatterForValidation).issues.filter(
+      (issue) => issue.severity === "warning",
+    );
+  }, [doc.frontmatter, debouncedValidation]);
+
+  const issueMessageDict = useMemo<Partial<Record<VaultIssueCode, string>>>(
+    () => ({
+      "unclosed-frontmatter": t("validatorIssues.unclosedFrontmatter"),
+      "empty-kind": t("validatorIssues.emptyKind"),
+      "missing-kind": t("validatorIssues.missingKind"),
+      "unknown-kind": t("validatorIssues.unknownKind"),
+      "missing-expected-field": t("validatorIssues.missingExpectedField"),
+      "non-canonical-graph-array": t("validatorIssues.nonCanonicalGraphArray"),
+      "parse-zero-keys": t("validatorIssues.parseZeroKeys"),
+    }),
+    [t],
+  );
+
+  // ③ "규격 예시 보기" — 현재 문서 kind 의 완성 예시를, 새 문서 생성이 이미
+  // 쓰는 스키마 스타터(NewDocKindDialog 선택 → buildNewNodeDoc →
+  // buildVaultMarkdown)에서 그대로 파생한다. 복제 없음, 같은 원천 재사용.
+  const [exampleOpen, setExampleOpen] = useState(false);
+  const { state: exampleCopyState, copy: copyExample } = useCopyFeedback();
+  const exampleDoc = useMemo(() => {
+    if (!currentKind) return null;
+    try {
+      const exampleTitle = t("exampleTitleFor", { kind: kindLabel(currentKind) });
+      const needsDomain = currentKind === "capability" || currentKind === "element";
+      const domain = needsDomain ? domainOptions[0]?.slug ?? "example-domain" : undefined;
+      return buildNewNodeDoc({ title: exampleTitle, kind: currentKind, domain }).markdown;
+    } catch {
+      return null;
+    }
+  }, [currentKind, domainOptions, kindLabel, t]);
 
   const fields = GRAPH_KEYS.map((key) => ({
     key: key as string,
@@ -305,6 +372,61 @@ export function DocFrontmatterBlock({
           {t("note")}
         </p>
       </details>
+      {validationWarnings.length > 0 ? (
+        <div
+          data-testid="doc-frontmatter-validator-warnings"
+          aria-label={t("validatorWarningsAriaLabel")}
+          className="mt-2 flex flex-col gap-1 font-sans"
+        >
+          {validationWarnings.map((issue, index) => (
+            <p
+              key={`${issue.code}-${index}`}
+              className="rounded-sm border border-[color:var(--color-amber-docs-a18)] bg-[color:var(--color-amber-source-a08)] px-2 py-1.5 text-label leading-4 text-[color:var(--color-amber-docs-a92)]"
+            >
+              {mapVaultIssueCodeToPlainMessage(issue.code, issueMessageDict)}
+            </p>
+          ))}
+        </div>
+      ) : null}
+      {exampleDoc ? (
+        <div className="mt-2 font-sans">
+          <button
+            type="button"
+            onClick={() => setExampleOpen((v) => !v)}
+            aria-expanded={exampleOpen}
+            aria-controls="doc-frontmatter-example"
+            data-testid="doc-frontmatter-example-toggle"
+            className="flex items-center gap-1 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+          >
+            <ChevronRight
+              size={11}
+              aria-hidden
+              className={`transition-transform duration-150 motion-reduce:transition-none ${
+                exampleOpen ? "rotate-90" : ""
+              }`}
+            />
+            {t("exampleToggle")}
+          </button>
+          {exampleOpen ? (
+            <div
+              id="doc-frontmatter-example"
+              data-testid="doc-frontmatter-example"
+              className="mt-2 flex items-start gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2"
+            >
+              <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-label leading-[1.6] text-[color:var(--color-text-secondary)]">
+                {exampleDoc}
+              </pre>
+              <CompactCopyButton
+                copied={exampleCopyState === "copied"}
+                label={exampleCopyState === "copied" ? t("exampleCopied") : t("exampleCopy")}
+                ariaLabel={t("exampleCopyAriaLabel")}
+                onClick={() => void copyExample(exampleDoc)}
+                data-testid="doc-frontmatter-example-copy"
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/views/home/model/use-node-datasheet-model.ts
+++ b/src/views/home/model/use-node-datasheet-model.ts
@@ -52,6 +52,12 @@ export interface NodeDatasheetDerivation {
     slug: string;
     nodeId: string;
     title: string;
+    /**
+     * 슬라이스 B (라벨 인간화) — 표시 제목이 원문 title 과 다를 때(경로
+     * 인간화 등)만 원문을 담는다. 데이터시트가 모노 서브라인으로 보존 렌더.
+     * 같으면 null(서브라인 미렌더).
+     */
+    sourceTitle: string | null;
     kind: string;
     domain: { id: string; title: string } | null;
     powered: boolean;
@@ -119,6 +125,8 @@ export function useNodeDatasheetModel({
       nodeId: selectedOntologyNode.id,
       // 과제 ⑩ — 컴팩트 팝오버 헤더는 표시용 짧은 제목.
       title: nodeFocus.displayTitle,
+      sourceTitle:
+        selectedOntologyNode.title !== nodeFocus.displayTitle ? selectedOntologyNode.title : null,
       kind: nodeFocus.kind,
       domain: nodeFocusData?.significance.ownerDomainId
         ? {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -3433,6 +3433,7 @@ export function HomePage() {
                 presence={nodePanelPresence.exiting ? "exiting" : "entering"}
                 slug={panelDatasheetModel.slug}
                 title={panelDatasheetModel.title}
+                sourceTitle={panelDatasheetModel.sourceTitle}
                 kind={panelDatasheetModel.kind}
                 domain={panelDatasheetModel.domain}
                 powered={panelDatasheetModel.powered}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2032,6 +2032,17 @@ export function HomePage() {
     };
   }, [resolvedRealmSlug, indexTreeResult, ontologyInsight, realmNodeById, relationVocabulary]);
   const realmActive = resolvedRealmSlug !== null && realmLedgerModel !== null;
+  // 결계 하단 각인 — "○○ · 요소 N" (사용자 어휘 "이것만 보기", 2026-07-23 소유자
+  // 결정). 원장 패널과 **같은 census 객체 + 같은 단위 키**(index.elementsShort /
+  // capabilitiesShort)를 쓰므로 한 화면의 같은 사실이 두 숫자로 갈라질 수 없다.
+  const realmCaption = useMemo(() => {
+    if (!realmLedgerModel) return null;
+    const { census, rootTitle } = realmLedgerModel;
+    const parts: string[] = [];
+    if (census.elementCount > 0) parts.push(`${t("index.elementsShort")} ${census.elementCount}`);
+    if (census.capabilityCount > 0) parts.push(`${t("index.capabilitiesShort")} ${census.capabilityCount}`);
+    return parts.length > 0 ? `${rootTitle} · ${parts.join(" · ")}` : rootTitle;
+  }, [realmLedgerModel, t]);
   // root-first-open v3 우하단 판독(`FirstRunReadout`) 의 "N project" 숫자 —
   // 실데이터, indexDomainCount 와 같은 ontologyInsight 파생이라 drift 불가.
   const firstRunProjectCount = useMemo(
@@ -2438,9 +2449,13 @@ export function HomePage() {
                     }}
                     realmChip={
                       resolvedRealmSlug && realmTitle ? (
+                        // 사용자 어휘는 "이것만 보기"(2026-07-23 소유자 결정), 내부명 realm 유지.
+                        // chipViewing 템플릿("Viewing only {title}" / "{title}만 보는 중")을
+                        // sentinel 로 쪼개 제목 앞/뒤 문구를 로케일 무관하게 얻는다.
                         <TopologyRealmChip
                           title={realmTitle}
-                          prefixLabel={t("realm.chipPrefix")}
+                          beforeLabel={t("realm.chipViewing", { title: "\u0000" }).split("\u0000")[0] ?? ""}
+                          afterLabel={t("realm.chipViewing", { title: "\u0000" }).split("\u0000")[1] ?? ""}
                           clearAriaLabel={t("realm.chipClear")}
                           onClear={handleExitRealm}
                         />
@@ -2975,7 +2990,7 @@ export function HomePage() {
                       maxDomainDescendantCount={indexMaxDomainDescendantCount}
                       domainCensus={indexDomainCensus}
                       labels={{
-                        label: t("realm.chipPrefix"),
+                        label: t("realm.ledger.heading"),
                         elementsShort: t("index.elementsShort"),
                         capabilitiesShort: t("index.capabilitiesShort"),
                         depthShort: t("realm.ledger.depthShort"),
@@ -3256,6 +3271,7 @@ export function HomePage() {
                     onEnterRealm={handleEnterRealm}
                     realmEnterLabel={t('realm.enterAction')}
                     realmEnterTooltip={t('realm.enterTooltip')}
+                    realmCaption={realmCaption}
                     canvasLabel={t('canvas.ariaLabel')}
                     visitedTrail={footprintVisitedIds}
                     // 슬라이스 C — 비개발(plain) 모드는 element 티어를 도달

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -15,7 +15,9 @@ import {
 } from "react";
 import { useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
-import { BookOpen, FolderOpen, HelpCircle, History, Plus, Waypoints, X } from "lucide-react";
+// `History as HistoryIcon` — 전역 DOM History 생성자와의 충돌 원천 차단
+// (사용성 검수 P0, AtlasGitPanel 과 동일 처방).
+import { BookOpen, FolderOpen, HelpCircle, History as HistoryIcon, Plus, Waypoints, X } from "lucide-react";
 import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
 import { useProjects } from "@/features/project-data-source";
 import { useAdaptiveRecentChanges, useOntologyInsight, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
@@ -2619,7 +2621,7 @@ export function HomePage() {
                         data-utility-action-shadow-token="--chrome-shadow"
                         data-utility-action-focus-ring-token="--color-indigo-accent"
                         compact={topologyUtilityChromeCompact}
-                        icon={<History />}
+                        icon={<HistoryIcon />}
                         active={spotlightOn}
                         // 그래프 토글과 같은 <2xl 아이콘-only 사다리(위 주석).
                         className="max-2xl:[&_[data-chip-label]]:hidden"

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -480,6 +480,18 @@ export function HomePage() {
       recentWindow: current.recentWindow === null ? "auto" : null,
     }));
   }, [setRouteState]);
+  // 소유자 지시 (Image #14): "전체 변경점을 보여주는 거면 아예 zoom out 을
+  // 크게" — 렌즈가 켜지는 순간 카메라를 전체 fit 으로 물러나 변경 지점
+  // 전부(자동 전개 포함)가 한 화면에 들어오게 한다. off→on 전이에서만 1회
+  // (렌즈 중 수동 탐색을 방해하지 않음), 기존 fit 토큰 재사용 — 신규 카메라
+  // 프리미티브 0.
+  const prevSpotlightOnRef = useRef(spotlightOn);
+  useEffect(() => {
+    if (spotlightOn && !prevSpotlightOnRef.current) {
+      setFitViewToken((token) => token + 1);
+    }
+    prevSpotlightOnRef.current = spotlightOn;
+  }, [spotlightOn]);
   // "N일 전" 계산의 기준 시각 — 일 단위 해상도라 세션 시작 스냅샷이면 충분
   // (render 중 Date.now() 는 react-hooks/purity 위반; 세션 동안 라벨이
   // 흔들리지 않는 것도 changeBaseline 과 같은 이유로 오히려 바람직하다).

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -112,6 +112,7 @@ import {
   computeDomainCensusRows,
   computeOntologyChangeset,
   domainCensusById,
+  filterTreeExcludeKind,
   formatAgentPostChangeSyncPacket,
   useChangeBaseline,
 } from "@/shared/lib/ontology-tree";
@@ -158,6 +159,7 @@ import { CreateNodeForm, type CreateNodeKind } from "./CreateNodeForm";
 import { OntologyBootstrapForm } from "./OntologyBootstrapForm";
 import { AgentConnectSheet, useAgentConnectLauncher } from "@/widgets/agent-connect";
 import { TopologyV2EdgePanel } from "@/widgets/topology-map-v2/ui/TopologyV2EdgePanel";
+import { PLAIN_TIER_REVEAL } from "@/widgets/topology-map-v2/model/tier-visibility";
 import { parseFrontmatter } from "@/shared/lib/parse-frontmatter";
 import { replaceVaultBody } from "@/shared/lib/replace-vault-body";
 import { buildFullDetailGroups, buildFullDetailReachModel } from "@/widgets/full-detail-a1";
@@ -245,12 +247,45 @@ const LEFT_PANEL_COLLAPSED_KEY = "demo:left-panel-collapsed:v2";
 /** INDEX panel preference (B3 허브가 곧 지도) — separate key from the legacy
  * hero-rail `LEFT_PANEL_COLLAPSED_KEY` above, a different feature entirely. */
 const INDEX_PANEL_COLLAPSED_KEY = "demo:index-panel-collapsed:v1";
+/**
+ * 슬라이스 C (개발/비개발 모드 토글) — 표시-렌즈 필터(데이터 무변경). true 면
+ * 비개발(일반) 모드: element 티어 기본 숨김(클릭 ego 는 예외 공개) + plain
+ * 어휘 + 경로 서브정보 숨김 + 개발자 크롬 숨김. localStorage 만 진실원 —
+ * `useLocalStorageBoolean` 은 setItem 후 리렌더 트리거가 없어(구독만) 여기선
+ * useState 미러 + setter 에서 setItem 동기화 패턴을 쓴다(기존
+ * `setIndexPreference` 의 "저장+즉시 적용" 계약과 동일).
+ */
+const AUDIENCE_PLAIN_KEY = "demo:audience-plain:v1";
+
+function readAudiencePlainPreference(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(AUDIENCE_PLAIN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
 
 export function HomePage() {
   const t = useTranslations('topology');
   const tKinds = useTranslations('kinds');
   const tAgentConnect = useTranslations('agentConnect');
   const relationVocabulary = useRelationVocabulary();
+  // 슬라이스 C — lazy initializer 는 클라이언트에서만 실제 실행(SSR 은 항상
+  // false), 클라이언트 hydration 도 localStorage 없는 서버 프리렌더 기준
+  // false 와 같아 hydration mismatch 없음(다른 세션 플래그와 같은 패턴).
+  const [audiencePlain, setAudiencePlainState] = useState<boolean>(readAudiencePlainPreference);
+  const setAudiencePlain = useCallback((next: boolean) => {
+    try {
+      window.localStorage.setItem(AUDIENCE_PLAIN_KEY, next ? "1" : "0");
+    } catch {
+      /* private mode — session-only, no persistence */
+    }
+    setAudiencePlainState(next);
+  }, []);
+  // 슬라이스 C — 지도 표면의 관계 어휘 레지스터. 비개발(plain) 모드는
+  // 데이터시트와 같은 plain 레지스터로 통일.
+  const relationRegister: "formal" | "plain" = audiencePlain ? "plain" : "formal";
   const [localGraphStack, setLocalGraphStack] = useState<string[]>([]);
   const localGraphRoot =
     localGraphStack.length > 0 ? localGraphStack[localGraphStack.length - 1] : null;
@@ -583,15 +618,21 @@ export function HomePage() {
   const navRailSettingsSlot = useMemo(
     () => (
       <>
-        <GitStatusTile
-          onActivate={() => setGitPanelOpen(true)}
-          panelOpen={gitPanelOpen}
-          vaultPath={gitVaultPath}
-          sessionDirty={ontologyChangeset.touchedNodeIds.size > 0}
-        />
+        {/* 슬라이스 C — 비개발(plain) 모드는 발자취(Atlas Git) 타일을 개발자
+            크롬으로 간주해 숨긴다. */}
+        {audiencePlain ? null : (
+          <GitStatusTile
+            onActivate={() => setGitPanelOpen(true)}
+            panelOpen={gitPanelOpen}
+            vaultPath={gitVaultPath}
+            sessionDirty={ontologyChangeset.touchedNodeIds.size > 0}
+          />
+        )}
         <TopologyV2SettingsGear
           indexDefaultCollapsed={indexPanelCollapsedStored}
           onChangeIndexDefaultCollapsed={handleChangeIndexDefaultCollapsed}
+          audiencePlain={audiencePlain}
+          onChangeAudiencePlain={setAudiencePlain}
           changeVaultHref="/docs/?intent=local"
           popoverAlign="left"
           popoverSide="top"
@@ -611,6 +652,9 @@ export function HomePage() {
             indexDefaultCollapsed: t('controls.settingsGearIndexDefaultCollapsed'),
             changeVault: t('controls.settingsGearChangeVault'),
             changeVaultAriaLabel: t('controls.settingsGearChangeVaultAriaLabel'),
+            audience: t('controls.settingsGearAudience'),
+            audienceDev: t('controls.settingsGearAudienceDev'),
+            audiencePlain: t('controls.settingsGearAudiencePlain'),
           }}
         />
       </>
@@ -618,6 +662,8 @@ export function HomePage() {
     [
       indexPanelCollapsedStored,
       handleChangeIndexDefaultCollapsed,
+      audiencePlain,
+      setAudiencePlain,
       ontologySearchOpen,
       docsDrawerOpen,
       gitPanelOpen,
@@ -700,7 +746,7 @@ export function HomePage() {
       (e) => e.from === selectedEdge.sourceId && e.to === selectedEdge.targetId,
     );
     const why = edgeRecord?.label?.trim() || null;
-    const typeLabel = relationVocabulary(selectedEdge.relationType, "formal");
+    const typeLabel = relationVocabulary(selectedEdge.relationType, relationRegister);
     // 과제 ⑩ — 엣지 문장/양 끝 노드 라벨은 표시용 짧은 제목.
     const fromDisplay = from.display ?? from.title;
     const toDisplay = to.display ?? to.title;
@@ -728,7 +774,7 @@ export function HomePage() {
       builderEditHref: buildOntologyBuilderNodeHrefFromGraphId(from.id),
       why,
     };
-  }, [selectedEdge, ontologyInsight, docFreshnessIndex, updatedAgoNowMs, t, relationVocabulary]);
+  }, [selectedEdge, ontologyInsight, docFreshnessIndex, updatedAgoNowMs, t, relationVocabulary, relationRegister]);
   // P3c — 엣지 호버 마이크로카드 (클릭 팝오버의 가벼운 전신).
   const [hoverEdge, setHoverEdge] = useState<{
     edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null };
@@ -757,12 +803,12 @@ export function HomePage() {
         from: from.title,
         to: to.title,
       }),
-      typeLabel: relationVocabulary(hoverEdge.edge.relationType, "formal"),
+      typeLabel: relationVocabulary(hoverEdge.edge.relationType, relationRegister),
       why: edgeRecord?.label?.trim() || null,
       x: hoverEdge.x,
       y: hoverEdge.y,
     };
-  }, [hoverEdge, ontologyInsight, t, relationVocabulary]);
+  }, [hoverEdge, ontologyInsight, t, relationVocabulary, relationRegister]);
   // S2 파트 5C — 클러스터 칩 호버 툴팁 상태 + 문장 모델. 부모 제목/카운트를
   // i18n(`cluster.tooltipCollapsed/Expanded`) 에 넣어 완성한 평문 한 줄.
   const [hoverCluster, setHoverCluster] = useState<{
@@ -2669,6 +2715,8 @@ export function HomePage() {
                       <TopologyV2SettingsGear
                         indexDefaultCollapsed={indexPanelCollapsedStored}
                         onChangeIndexDefaultCollapsed={handleChangeIndexDefaultCollapsed}
+                        audiencePlain={audiencePlain}
+                        onChangeAudiencePlain={setAudiencePlain}
                         changeVaultHref="/docs/?intent=local"
                         triggerVariant="chrome-tile"
                         popoverAlign="right"
@@ -2683,6 +2731,9 @@ export function HomePage() {
                           indexDefaultCollapsed: t('controls.settingsGearIndexDefaultCollapsed'),
                           changeVault: t('controls.settingsGearChangeVault'),
                           changeVaultAriaLabel: t('controls.settingsGearChangeVaultAriaLabel'),
+                          audience: t('controls.settingsGearAudience'),
+                          audienceDev: t('controls.settingsGearAudienceDev'),
+                          audiencePlain: t('controls.settingsGearAudiencePlain'),
                         }}
                       />
                     </div>
@@ -2943,7 +2994,14 @@ export function HomePage() {
                     />
                   ) : (
                   <TopologyIndexPanel
-                    treeResult={indexTreeResult}
+                    // 슬라이스 C — 비개발(plain) 모드는 element 행만 제외한
+                    // 파생 트리를 내린다(표시 게이트, 데이터 무변경). realm
+                    // 대장/census/카운트는 여전히 `indexTreeResult` 원본을 쓴다.
+                    treeResult={
+                      audiencePlain
+                        ? { ...indexTreeResult, roots: filterTreeExcludeKind(indexTreeResult.roots, "element") }
+                        : indexTreeResult
+                    }
                     totalConcepts={topologyTotalNodes}
                     totalRelations={topologyTotalRelations}
                     domainCount={indexDomainCount}
@@ -3004,27 +3062,34 @@ export function HomePage() {
                         ? t('workspace.growthThisWeek', { count: recentlyUpdatedCount })
                         : undefined
                     }
-                    agentHandoff={{
-                      briefText: indexAgentHandoffBriefText,
-                      reanalyzeText: indexAgentHandoffReanalyzeText,
-                      syncText: indexAgentHandoffSyncText,
-                      labels: {
-                        menuLabel: t("index.agentHandoff"),
-                        menuAria: t("index.agentHandoffAria"),
-                        briefCopy: t("analysis.overviewBriefCopy"),
-                        briefCopied: t("analysis.overviewBriefCopied"),
-                        briefCopyAriaLabel: t("analysis.overviewBriefCopyAriaLabel"),
-                        briefCopiedAriaLabel: t("analysis.overviewBriefCopiedAriaLabel"),
-                        reanalyzeCopy: t("analysis.overviewReanalyzeCopy"),
-                        reanalyzeCopied: t("analysis.overviewReanalyzeCopied"),
-                        reanalyzeCopyAriaLabel: t("analysis.overviewReanalyzeCopyAriaLabel"),
-                        reanalyzeCopiedAriaLabel: t("analysis.overviewReanalyzeCopiedAriaLabel"),
-                        syncCopy: t("analysis.overviewSyncCopy"),
-                        syncCopied: t("analysis.overviewSyncCopied"),
-                        syncCopyAriaLabel: t("analysis.overviewSyncCopyAriaLabel"),
-                        syncCopiedAriaLabel: t("analysis.overviewSyncCopiedAriaLabel"),
-                      },
-                    }}
+                    // 슬라이스 C — 비개발(plain) 모드는 인계 메뉴를 개발자
+                    // 크롬으로 간주해 undefined 전달(위젯 기존 계약 — 미전달
+                    // 시 메뉴 미렌더).
+                    agentHandoff={
+                      audiencePlain
+                        ? undefined
+                        : {
+                            briefText: indexAgentHandoffBriefText,
+                            reanalyzeText: indexAgentHandoffReanalyzeText,
+                            syncText: indexAgentHandoffSyncText,
+                            labels: {
+                              menuLabel: t("index.agentHandoff"),
+                              menuAria: t("index.agentHandoffAria"),
+                              briefCopy: t("analysis.overviewBriefCopy"),
+                              briefCopied: t("analysis.overviewBriefCopied"),
+                              briefCopyAriaLabel: t("analysis.overviewBriefCopyAriaLabel"),
+                              briefCopiedAriaLabel: t("analysis.overviewBriefCopiedAriaLabel"),
+                              reanalyzeCopy: t("analysis.overviewReanalyzeCopy"),
+                              reanalyzeCopied: t("analysis.overviewReanalyzeCopied"),
+                              reanalyzeCopyAriaLabel: t("analysis.overviewReanalyzeCopyAriaLabel"),
+                              reanalyzeCopiedAriaLabel: t("analysis.overviewReanalyzeCopiedAriaLabel"),
+                              syncCopy: t("analysis.overviewSyncCopy"),
+                              syncCopied: t("analysis.overviewSyncCopied"),
+                              syncCopyAriaLabel: t("analysis.overviewSyncCopyAriaLabel"),
+                              syncCopiedAriaLabel: t("analysis.overviewSyncCopiedAriaLabel"),
+                            },
+                          }
+                    }
                     labels={{
                       label: t("index.label"),
                       fold: t("index.fold"),
@@ -3191,6 +3256,9 @@ export function HomePage() {
                     realmEnterTooltip={t('realm.enterTooltip')}
                     canvasLabel={t('canvas.ariaLabel')}
                     visitedTrail={footprintVisitedIds}
+                    // 슬라이스 C — 비개발(plain) 모드는 element 티어를 도달
+                    // 불가 밴드로 밀어 상시 숨김(ego 예외는 그대로).
+                    tierReveal={audiencePlain ? PLAIN_TIER_REVEAL : undefined}
                   />
                 ) : null}
                 {topologyRenderState.renderCanvas ? (
@@ -3357,7 +3425,7 @@ export function HomePage() {
                 )}
                 aria-hidden={v2DatasheetModel ? true : undefined}
               >
-                <TopologyRelationLegend />
+                <TopologyRelationLegend register={relationRegister} />
                 <FirstRunReadout
                   projectCount={firstRunProjectCount}
                   domainCount={indexDomainCount}
@@ -3506,6 +3574,10 @@ export function HomePage() {
                     ? () => setFullDetailSlug(selectedOntologyNode.id)
                     : undefined
                 }
+                // 슬라이스 C — 비개발(plain) 모드는 인계 복사 타일 + 원문
+                // 경로 서브라인(슬라이스 B)을 개발자 크롬으로 간주해 숨긴다.
+                showHandoff={!audiencePlain}
+                showSourcePath={!audiencePlain}
                 className="max-lg:w-[min(520px,calc(100vw-1.5rem))]"
               />
             ) : null}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -272,6 +272,9 @@ export function HomePage() {
   const t = useTranslations('topology');
   const tKinds = useTranslations('kinds');
   const tAgentConnect = useTranslations('agentConnect');
+  // P2 결함⑤ — <lg 발자취 chrome-tile 진입점의 aria-label/title (`atlasGit`
+  // 네임스페이스는 이미 `GitStatusTile` 이 쓰는 것과 같은 키를 재사용한다).
+  const tAtlasGit = useTranslations('atlasGit');
   const relationVocabulary = useRelationVocabulary();
   // 슬라이스 C — lazy initializer 는 클라이언트에서만 실제 실행(SSR 은 항상
   // false), 클라이언트 hydration 도 localStorage 없는 서버 프리렌더 기준
@@ -657,6 +660,9 @@ export function HomePage() {
             audience: t('controls.settingsGearAudience'),
             audienceDev: t('controls.settingsGearAudienceDev'),
             audiencePlain: t('controls.settingsGearAudiencePlain'),
+            // P2 결함③ — "보기 모드" 행 아래 caption. 발견은 됐어도 뜻이
+            // 없던 결함.
+            audienceCaption: t('controls.settingsGearAudienceCaption'),
           }}
         />
       </>
@@ -2644,6 +2650,24 @@ export function HomePage() {
                         {t('controls.spotlightLabel')}
                       </ChromeChip>
                     </Tooltip>
+                    {/* P2 결함④ — 렌즈 ON 인데 INDEX 가 접혀 있으면 적용
+                        시간창/건수를 알 텍스트가 화면 어디에도 없었다. 칩
+                        옆(유틸리티 레인 안, 같은 높이)에 조용한 mono 카운트.
+                        aria-live 로 접근성 겸용. <xl 에서는 레인 폭 보호를
+                        위해 숨긴다(검색 레인 겹침 재발 방지 — 다른 칩들과
+                        같은 축약 사다리). */}
+                    {spotlightOn ? (
+                      <span
+                        aria-live="polite"
+                        data-testid="topology-spotlight-window-summary"
+                        className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] tabular-nums text-[color:var(--color-text-quaternary)] xl:inline"
+                      >
+                        {t('controls.spotlightWindowSummary', {
+                          days: recentChanges.windowDays,
+                          count: recentChanges.recentNodeIds.size,
+                        })}
+                      </span>
+                    ) : null}
                     <Tooltip content={t('controls.docsTooltip')} side="bottom" withProvider={false}>
                     <ChromeChip
                       onClick={() => setDocsDrawerOpen((v) => !v)}
@@ -2722,6 +2746,35 @@ export function HomePage() {
                         </button>
                       </Tooltip>
                     ) : null}
+                    {/* 발자취(Atlas Git) <lg 진입점 (P2 결함⑤, 사용성 전수
+                        검수 2026-07-23) — <lg 에서 내비 레일이 사라지며
+                        스포트라이트·설정은 이 유틸리티 레인으로 이식됐는데
+                        발자취(GitStatusTile) 만 진입 경로가 완전히
+                        소실됐다. 설정 기어와 같은 --chrome-tile-size
+                        문법으로 같은 열에 추가 — 클릭은 레일 슬롯과 동일한
+                        setGitPanelOpen(true). 비개발(plain) 모드는 레일
+                        슬롯(위 navRailSettingsSlot)과 같은 계약으로 숨긴다. */}
+                    {audiencePlain ? null : (
+                      <button
+                        type="button"
+                        onClick={() => setGitPanelOpen(true)}
+                        aria-label={tAtlasGit('tileLabel')}
+                        title={tAtlasGit('tileLabel')}
+                        aria-haspopup="dialog"
+                        aria-expanded={gitPanelOpen}
+                        data-testid="topology-footprint-lg-tile"
+                        className="relative lg:hidden flex size-[var(--chrome-tile-size)] items-center justify-center rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)]"
+                      >
+                        <HistoryIcon className="size-[var(--topology-chrome-icon-size)]" aria-hidden />
+                        {ontologyChangeset.touchedNodeIds.size > 0 ? (
+                          <span
+                            aria-hidden="true"
+                            data-testid="topology-footprint-lg-tile-dot"
+                            className="absolute right-1.5 top-1 h-1.5 w-1.5 rounded-full bg-[color:var(--color-status-warning)]"
+                          />
+                        ) : null}
+                      </button>
+                    )}
                     {/* 설정 기어 <lg 진입점 (겹침 소탕 2026-07-23) — 내비 레일
                         (lg+ 전용)의 기어 슬롯이 사라지는 <lg 에서 지도의 설정
                         (언어·INDEX 기본 상태·vault 교체) 접근 수단이 0 이었다.
@@ -2751,6 +2804,7 @@ export function HomePage() {
                           audience: t('controls.settingsGearAudience'),
                           audienceDev: t('controls.settingsGearAudienceDev'),
                           audiencePlain: t('controls.settingsGearAudiencePlain'),
+                          audienceCaption: t('controls.settingsGearAudienceCaption'),
                         }}
                       />
                     </div>
@@ -3026,6 +3080,10 @@ export function HomePage() {
                     selectedId={canvasSelectedSlug}
                     onSelect={(id) => handleSelect(id)}
                     onCollapse={handleIndexCollapse}
+                    // P1 결함①a — element 행이 왜 안 보이는지 설명하는
+                    // 조용한 힌트 행 게이트. treeResult 는 이미 위에서
+                    // element 를 제외했다(단일 진실원 무변경).
+                    plainMode={audiencePlain}
                     onOpenAgentConnect={agentConnectLauncher.open}
                     // P4-② (2026-07-21 리텐션 라운드) — 이미 연결된
                     // 에이전트가 있는 2일차+ 사용자에게 "Updated with AI"
@@ -3143,6 +3201,8 @@ export function HomePage() {
                       uncatalogedDocsAction: t("index.uncatalogedDocsAction"),
                       dustyNodesLabel: t("index.dustyNodesLabel", { count: dustySlugs.size }),
                       dustyNodesAction: t("index.dustyNodesAction"),
+                      // P1 결함①a — plainMode 일 때만 실제 렌더(패널 게이트).
+                      plainHint: t("index.plainHint"),
                     }}
                   />
                   )}
@@ -3448,6 +3508,10 @@ export function HomePage() {
                   projectCount={firstRunProjectCount}
                   domainCount={indexDomainCount}
                   tier={mapZoomTier}
+                  // P1 결함①b — plain 모드는 element 티어에 절대 도달하지
+                  // 않으므로(PLAIN_TIER_REVEAL) tier 기반 힌트 드롭 로직이
+                  // 항상 거짓을 말했다. plain 문구로 치환.
+                  audiencePlain={audiencePlain}
                 />
               </div>
 

--- a/src/views/home/ui/TopologyRealmChip.tsx
+++ b/src/views/home/ui/TopologyRealmChip.tsx
@@ -4,24 +4,31 @@ import { Orbit, X } from "lucide-react";
 
 import { CHROME_STATUS_CHIP_CLASS } from "@/shared/ui/chrome-chip";
 
+// 사용자 어휘는 "이것만 보기"(2026-07-23 소유자 결정) — 내부명 realm 은 유지.
 export interface TopologyRealmChipProps {
   /** 현재 영역 루트 노드의 제목 (없으면 slug fallback 을 HomePage 가 넣는다). */
   title: string;
-  /** i18n prefix — "영역" / "Realm". */
-  prefixLabel: string;
+  /**
+   * 제목 앞 문구 — en "Viewing only". 빈 문자열이면 렌더하지 않는다.
+   * (`realm.chipViewing` 템플릿을 HomePage 가 {title} 기준으로 쪼개 주입.)
+   */
+  beforeLabel: string;
+  /** 제목 뒤 문구 — ko "만 보는 중". 제목에 붙여(공백 없이) 렌더한다. */
+  afterLabel: string;
   clearAriaLabel: string;
   onClear: () => void;
 }
 
 /**
- * S4 "영역 전개" 상단 중앙 상태 칩 — 지도가 어느 노드의 세계로 전환됐는지 알리고
- * (`영역: {title}`) ✕ 로 전체 지도로 복귀한다. `TopologyPathChip` 과 같은 "크롬
- * 그래머" 계약: 상단 중앙 flex 열에 얹혀 새 부유 패널을 늘리지 않는다. 지도 렌더
- * 로직 없음 — 순수 크롬.
+ * "이것만 보기" 상단 중앙 상태 칩 — 지도가 어느 노드만 보는 상태인지 알리고
+ * (`{title}만 보는 중` / `Viewing only {title}`) ✕ 로 전체 지도로 복귀한다.
+ * `TopologyPathChip` 과 같은 "크롬 그래머" 계약: 상단 중앙 flex 열에 얹혀 새
+ * 부유 패널을 늘리지 않는다. 지도 렌더 로직 없음 — 순수 크롬.
  */
 export function TopologyRealmChip({
   title,
-  prefixLabel,
+  beforeLabel,
+  afterLabel,
   clearAriaLabel,
   onClear,
 }: TopologyRealmChipProps) {
@@ -32,9 +39,24 @@ export function TopologyRealmChip({
       className={CHROME_STATUS_CHIP_CLASS}
     >
       <Orbit size={14} aria-hidden className="shrink-0 text-[color:var(--color-text-tertiary)]" />
-      <span className="shrink-0 text-[color:var(--color-text-tertiary)]">{prefixLabel}</span>
-      <span data-testid="topology-realm-chip-title" className="min-w-0 truncate font-medium text-[color:var(--color-text-primary)]">
-        {title}
+      {beforeLabel.trim().length > 0 ? (
+        <span className="shrink-0 text-[color:var(--color-text-tertiary)]">{beforeLabel.trim()}</span>
+      ) : null}
+      {/* 제목은 7rem 캡 + 말줄임 — 상단 중앙 레인은 우측 utility 클러스터와
+          고정폭 협상이 없어 긴 제목이 14-inch 에서 검색 타일을 파고든다
+          (2026-07-23 실측: "Viewing only" + 무캡 제목 → Search 타일 잘림).
+          전체 이름은 원장 헤더·지도 중심 라벨·hover title 이 담당한다.
+          suffix("만 보는 중")는 shrink-0 로 항상 생존. */}
+      <span className="flex min-w-0 items-baseline" title={`${beforeLabel}${title}${afterLabel}`.trim()}>
+        <span
+          data-testid="topology-realm-chip-title"
+          className="max-w-[7rem] truncate font-medium text-[color:var(--color-text-primary)]"
+        >
+          {title}
+        </span>
+        {afterLabel.trim().length > 0 ? (
+          <span className="shrink-0 text-[color:var(--color-text-tertiary)]">{afterLabel}</span>
+        ) : null}
       </span>
       <button
         type="button"

--- a/src/views/home/ui/TopologyRelationLegend.test.tsx
+++ b/src/views/home/ui/TopologyRelationLegend.test.tsx
@@ -14,12 +14,13 @@ describe("TopologyRelationLegend", () => {
     // Both labels come from the shared relation-vocabulary dictionary
     // (`useRelationVocabulary(type, "formal")`); the mocked `useTranslations`
     // is an identity function, so the formal register resolves to the raw
-    // edge-type keys "contains" / "depends".
+    // edge-type keys "contains" / "depends_on" (canonical — 축약형 "depends"
+    // 는 사전 미지 타입이라 ko 에서 raw fallback 노출 버그가 있었다).
     // 2026-07-23 (Image #9): the old right-hand item was a decorative
     // "confidence" gradient with no backing data — replaced by the real
     // `depends` (dashed) encoding the map actually draws.
     expect(legend).toHaveTextContent("contains");
-    expect(legend).toHaveTextContent("depends");
+    expect(legend).toHaveTextContent("depends_on");
     expect(legend).not.toHaveTextContent("overviewRelationLegendQuality");
   });
 });

--- a/src/views/home/ui/TopologyRelationLegend.tsx
+++ b/src/views/home/ui/TopologyRelationLegend.tsx
@@ -63,7 +63,10 @@ export function TopologyRelationLegend({
               "repeating-linear-gradient(90deg, var(--topology-relation-spine-halo) 0 4px, transparent 4px 7px)",
           }}
         />
-        {relationVocabulary("depends", register)}
+        {/* 어휘 사전 canonical 키는 `depends_on` — 렌더 축약형 "depends" 를
+            넘기면 미지 타입 raw fallback 으로 ko 에서 "DEPENDS" 가 노출됐다
+            (소유자 스크린샷 실발견 2026-07-23). */}
+        {relationVocabulary("depends_on", register)}
       </span>
     </div>
   );

--- a/src/views/home/ui/TopologyRelationLegend.tsx
+++ b/src/views/home/ui/TopologyRelationLegend.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRelationVocabulary } from "@/entities/knowledge-graph";
+import { useRelationVocabulary, type RelationRegister } from "@/entities/knowledge-graph";
 
 /**
  * 지도 우하단 상시 계기 — 선 인코딩(spine/terminal · quality stroke) 을
@@ -28,8 +28,16 @@ import { useRelationVocabulary } from "@/entities/knowledge-graph";
  * stroke-weak, 217,161,65)라 hub/Layer-0 예약 톤을 관계선에 흘렸다. 지도가
  * 실제로 그리는 인코딩은 "타입"이다 — contains=실선 spine, depends=파선.
  * 그래서 범례를 실제 인코딩(contains 실선 / depends 파선) 설명으로 교체한다.
+ *
+ * 슬라이스 C (개발/비개발 모드 토글) — `register` prop (기본 `"formal"`).
+ * 비개발(plain) 모드에서 HomePage 가 `"plain"` 을 넘겨 데이터시트와 같은
+ * 어휘(plain 레지스터)로 통일한다.
  */
-export function TopologyRelationLegend() {
+export function TopologyRelationLegend({
+  register = "formal",
+}: {
+  register?: RelationRegister;
+} = {}) {
   const relationVocabulary = useRelationVocabulary();
 
   return (
@@ -42,7 +50,7 @@ export function TopologyRelationLegend() {
           <span className="absolute left-0 right-1 top-1/2 h-px -translate-y-1/2 rounded-full bg-[color:var(--topology-relation-spine-halo)]" />
           <span className="absolute right-0 top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-[color:var(--topology-relation-spine-terminal)]" />
         </span>
-        {relationVocabulary("contains", "formal")}
+        {relationVocabulary("contains", register)}
       </span>
       <span className="flex items-center gap-2">
         {/* depends 엣지는 파선으로 그려진다 — 범례도 파선 스와치로 실제
@@ -55,7 +63,7 @@ export function TopologyRelationLegend() {
               "repeating-linear-gradient(90deg, var(--topology-relation-spine-halo) 0 4px, transparent 4px 7px)",
           }}
         />
-        {relationVocabulary("depends", "formal")}
+        {relationVocabulary("depends", register)}
       </span>
     </div>
   );

--- a/src/views/home/ui/topology-chrome-chip-geometry.test.tsx
+++ b/src/views/home/ui/topology-chrome-chip-geometry.test.tsx
@@ -35,7 +35,7 @@ describe("상단 크롬 상태 칩 규격 (S10 결함 1)", () => {
 
   it("영역 칩이 규격 클래스를 그대로 쓴다 (자기 scale 재적용 없음)", () => {
     render(
-      <TopologyRealmChip title="AI Agent Partner" prefixLabel="영역" clearAriaLabel="전체 지도로" onClear={() => {}} />,
+      <TopologyRealmChip title="AI Agent Partner" beforeLabel="" afterLabel="만 보는 중" clearAriaLabel="전체 지도" onClear={() => {}} />,
     );
     const chip = screen.getByTestId("topology-realm-chip");
     expect(chip.className).toBe(CHROME_STATUS_CHIP_CLASS);

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -32,7 +32,7 @@ import { isTauriVaultRuntime } from "@/shared/lib/tauri-vault-fs";
 import { slugify } from "@/shared/lib/slugify";
 import { useNavRailHidden } from "@/widgets/app-nav-rail";
 import { AppSettingsMenu } from "@/widgets/app-settings-menu";
-import { MountedGlobalSearch } from "@/widgets/global-search";
+import { MountedGlobalSearch, useGlobalSearchHotkey } from "@/widgets/global-search";
 import { ChromeTile, HexMark, Tooltip, useToast } from "@/shared/ui";
 import {
   BUILDER_WRITE_BAR_RESERVE_PX,
@@ -321,6 +321,23 @@ export function OntologyEditPage() {
   // (JSON-LD/GraphML)·지우기 7개 버튼을 "⋯" 오버플로 팝오버 하나로 축약.
   // 기능은 무손실 — 각 항목이 기존 핸들러/상태를 그대로 재사용한다.
   const [headerOverflowOpen, setHeaderOverflowOpen] = useState(false);
+  // P3 결함⑥ (사용성 전수 검수 2026-07-23) — 검색 팔레트(⌘K)와 앱 설정
+  // 다이얼로그가 각자 self-managed open state 였던 탓에 둘이 동시에 뜰 수
+  // 있었다(transient 강등 위반). 두 state 를 이 페이지가 소유해 대칭으로
+  // 서로를 닫는다 — 열리는 쪽이 이긴다, 스택 금지. `MountedGlobalSearch` 를
+  // controlled 로 돌리면 내장 ⌘K 바인딩이 꺼지므로(controlled mount 계약)
+  // 같은 hotkey 훅을 여기서 직접 걸어 대칭 로직을 함께 태운다.
+  const [searchPaletteOpen, setSearchPaletteOpenState] = useState(false);
+  const [appSettingsOpen, setAppSettingsOpenState] = useState(false);
+  const setSearchPaletteOpen = useCallback((next: boolean) => {
+    setSearchPaletteOpenState(next);
+    if (next) setAppSettingsOpenState(false);
+  }, []);
+  const setAppSettingsOpen = useCallback((next: boolean) => {
+    setAppSettingsOpenState(next);
+    if (next) setSearchPaletteOpenState(false);
+  }, []);
+  useGlobalSearchHotkey(searchPaletteOpen, setSearchPaletteOpen);
   // Blast-radius modal state — driven by deleteVaultDoc requesting a
   // confirmation. Stays null when the user is not actively confirming a
   // delete; opens when delete is clicked and resolves on cancel/confirm.
@@ -1380,6 +1397,8 @@ export function OntologyEditPage() {
             미작동으로 읽혔다(페르소나 N9). resolveBuilderShortcut 의
             P/D/C/E 단축키도 metaKey 조합은 무시하므로 충돌 없음. */}
         <MountedGlobalSearch
+          open={searchPaletteOpen}
+          onOpenChange={setSearchPaletteOpen}
           onSelectNode={(node) => {
             openNodeDetails(node.id);
           }}
@@ -1494,7 +1513,7 @@ export function OntologyEditPage() {
             {fullscreen ? null : (
               <>
                 <LiveActivityIndicator agentActivityStatus={vault.agentActivityStatus} />
-                <AppSettingsMenu mode={dataSourceMode} />
+                <AppSettingsMenu mode={dataSourceMode} open={appSettingsOpen} onOpenChange={setAppSettingsOpen} />
               </>
             )}
             <ChromeTile

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -31,7 +31,7 @@ import {
   computeKindDistribution,
   rankAllByDegree,
 } from "@/shared/lib/ontology-tree";
-import { MountedGlobalSearch } from "@/widgets/global-search";
+import { MountedGlobalSearch, useGlobalSearchHotkey } from "@/widgets/global-search";
 import { AppSettingsMenu } from "@/widgets/app-settings-menu";
 import { EmptyState, HexMark, TabBar } from "@/shared/ui";
 import {
@@ -86,6 +86,24 @@ export function OntologyInsightsPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const tab = parseInsightsTab(searchParams.get("tab"));
+
+  // P3 결함⑥ (사용성 전수 검수 2026-07-23) — 검색 팔레트(⌘K)와 앱 설정
+  // 다이얼로그가 각자 self-managed open state 였던 탓에 둘이 동시에 뜰 수
+  // 있었다(transient 강등 위반). 두 state 를 이 페이지가 소유해 대칭으로
+  // 서로를 닫는다 — 열리는 쪽이 이긴다, 스택 금지. `MountedGlobalSearch` 를
+  // controlled 로 돌리면 내장 ⌘K 바인딩이 꺼지므로(controlled mount 계약)
+  // 같은 hotkey 훅을 여기서 직접 걸어 대칭 로직을 함께 태운다.
+  const [searchPaletteOpen, setSearchPaletteOpenState] = useState(false);
+  const [appSettingsOpen, setAppSettingsOpenState] = useState(false);
+  const setSearchPaletteOpen = useCallback((next: boolean) => {
+    setSearchPaletteOpenState(next);
+    if (next) setAppSettingsOpenState(false);
+  }, []);
+  const setAppSettingsOpen = useCallback((next: boolean) => {
+    setAppSettingsOpenState(next);
+    if (next) setSearchPaletteOpenState(false);
+  }, []);
+  useGlobalSearchHotkey(searchPaletteOpen, setSearchPaletteOpen);
 
   // 지도 딥링크에 출처 마커(`via=insights:<tab>`)를 새긴다 — 지도(HomePage)가
   // 이 마커로 "인사이트로 돌아가기" 복귀 칩을 렌더하고, 클릭 시 이 탭으로
@@ -353,10 +371,10 @@ export function OntologyInsightsPage() {
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-end gap-2 px-4 pt-3 md:px-6">
           <LiveActivityIndicator agentActivityStatus={vault.agentActivityStatus} />
-          <AppSettingsMenu mode={dataSourceMode} />
+          <AppSettingsMenu mode={dataSourceMode} open={appSettingsOpen} onOpenChange={setAppSettingsOpen} />
         </div>
         <main id="main" className="mx-auto w-full max-w-[var(--page-max)] px-6 py-8 max-lg:pb-[calc(var(--topology-mobile-bottom-tab-reserve)+24px)] md:px-10">
-        <MountedGlobalSearch />
+        <MountedGlobalSearch open={searchPaletteOpen} onOpenChange={setSearchPaletteOpen} />
 
         <header className="flex flex-wrap items-end gap-4">
           <h1 className="inline-flex items-center gap-2 text-display font-[var(--font-weight-signature)] tracking-[-0.015em] text-[color:var(--color-text-primary)]">

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.test.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.test.tsx
@@ -138,3 +138,59 @@ describe('AppSettingsMenu vault-tools merge', () => {
     expect(screen.getByText('nav.settingsMenu.mcpProofTitle')).toBeInTheDocument();
   });
 });
+
+/**
+ * P3 결함⑥ (사용성 전수 검수 2026-07-23) — 검색 팔레트(⌘K)가 이 다이얼로그
+ * 위에 중첩되는 결함의 처방. 기존엔 `open` 이 전부 내부 state 라 호출부가
+ * "팔레트가 열렸다"는 사실을 이 위젯에 전달할 방법이 없었다. `MountedGlobalSearch`
+ * 와 같은 controlled/uncontrolled 겸용 패턴 — `open`/`onOpenChange` 를 주면
+ * controlled, 생략하면 기존 self-managed 동작 그대로(하위호환, DocsVaultPage
+ * 등 미변경 호출부는 영향 없음).
+ */
+describe('AppSettingsMenu controlled open (P3 결함⑥)', () => {
+  beforeEach(() => {
+    mocks.isDesktopRuntime = false;
+  });
+
+  it('stays uncontrolled (self-managed) when open/onOpenChange are omitted — existing behavior unchanged', () => {
+    render(<AppSettingsMenu mode="static" />);
+    expect(screen.getByTestId('app-settings-trigger')).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(screen.getByTestId('app-settings-trigger'));
+    expect(screen.getByTestId('app-settings-trigger')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('app-settings-popover')).toBeInTheDocument();
+  });
+
+  it('renders open when the controlled `open` prop is true, without needing a trigger click', () => {
+    render(<AppSettingsMenu mode="static" open onOpenChange={() => {}} />);
+    expect(screen.getByTestId('app-settings-trigger')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('app-settings-popover')).toBeInTheDocument();
+  });
+
+  it('clicking the trigger reports the toggle via onOpenChange instead of managing its own state', () => {
+    const onOpenChange = vi.fn();
+    render(<AppSettingsMenu mode="static" open={false} onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByTestId('app-settings-trigger'));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    // controlled — the prop the test passed in never changed, so the component
+    // still reports itself closed until the caller re-renders it open.
+    expect(screen.getByTestId('app-settings-trigger')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('⌘K while controlled-open reports close via onOpenChange (Guardian B2 — palette wins, settings demotes)', () => {
+    const onOpenChange = vi.fn();
+    render(<AppSettingsMenu mode="static" open onOpenChange={onOpenChange} />);
+    fireEvent.keyDown(screen.getByTestId('app-settings-popover'), {
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('the close button reports close via onOpenChange when controlled', () => {
+    const onOpenChange = vi.fn();
+    render(<AppSettingsMenu mode="static" open onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByLabelText('nav.settingsMenu.closeLabel'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Bot, Check, Copy, FolderOpen, Languages, Settings, Terminal, X } from 'lucide-react';
 import { Link, useRouter } from '@/i18n/navigation';
@@ -26,13 +26,38 @@ type SettingsMenuTab = 'general' | 'mcpAgents' | 'vault' | 'appearance' | 'verif
  * 개별 마운트). general / mcpAgents / vault / appearance / verification 5
  * 탭 — 언어 전환(appearance)도 여기 흡수돼 있어 AppNavRail 자체에는
  * 별도 설정 트리거가 없어도 기능 손실이 없다.
+ *
+ * P3 결함⑥ (사용성 전수 검수 2026-07-23) — 이 다이얼로그가 열린 채 ⌘K 를
+ * 누르면 검색 팔레트가 그 위에 겹쳤다. 아래 `onKeyDown` 은 이미 "팔레트가
+ * 열리면 설정을 demote" 하는 절반(Guardian B2)을 처리하지만, 반대 방향
+ * ("설정을 열면 팔레트를 닫는다")은 이 위젯이 팔레트의 open state 를 모르면
+ * 불가능했다 — `open`/`onOpenChange` 를 optional controlled prop 으로 열어
+ * `MountedGlobalSearch` 와 같은 계약을 준다. 둘 다 생략하면 기존 self-managed
+ * 그대로(하위호환 — DocsVaultPage 등 미변경 호출부는 영향 없음).
  */
-export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
+export interface AppSettingsMenuProps {
+  mode: 'static' | 'local';
+  /** controlled open state. 미지정 시 self-managed(기존 동작). */
+  open?: boolean;
+  /** controlled 모드에서 open 이 바뀔 때마다 호출 — 호출자가 실제 state 를 갱신한다. */
+  onOpenChange?: (next: boolean) => void;
+}
+
+export function AppSettingsMenu({ mode, open: openProp, onOpenChange }: AppSettingsMenuProps) {
   const t = useTranslations('nav.settingsMenu');
   const { state: copyState, copy } = useCopyFeedback();
   const router = useRouter();
   const localVault = useLocalVault();
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : internalOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) onOpenChange?.(next);
+      else setInternalOpen(next);
+    },
+    [isControlled, onOpenChange],
+  );
   const [activeSettingsTab, setActiveSettingsTab] = useState<SettingsMenuTab>('general');
   const [vaultRevealError, setVaultRevealError] = useState<string | null>(null);
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
@@ -133,6 +158,15 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
     ['disconnected', 'mcpStateDisconnectedLabel', 'mcpStateDisconnectedBody', X, 'var(--color-text-tertiary)'],
   ] as const;
 
+  // P3 결함⑥ — controlled 모드에서 이 `<details>` 는 React state 가 곧
+  // 진실원이어야 한다. `<summary>` 클릭의 preventDefault() 는 보통 native
+  // toggle 을 막지만, 그 타이밍에 기대는 대신 매 렌더마다 DOM 의 `open`
+  // 프로퍼티를 React 값으로 명시적으로 되맞춰 race 자체를 구조적으로 없앤다
+  // (uncontrolled 모드에서도 안전 — 같은 값이면 no-op).
+  useEffect(() => {
+    if (detailsRef.current) detailsRef.current.open = open;
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const timer = window.setTimeout(() => {
@@ -152,7 +186,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
 
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [open]);
+  }, [open, setOpen]);
 
   const closePanel = (returnFocus = true) => {
     setOpen(false);
@@ -187,7 +221,7 @@ export function AppSettingsMenu({ mode }: { mode: 'static' | 'local' }) {
         data-testid="app-settings-trigger"
         onClick={(event) => {
           event.preventDefault();
-          setOpen((current) => !current);
+          setOpen(!open);
         }}
         className="inline-flex h-8 cursor-pointer list-none items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-2 text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset [&::-webkit-details-marker]:hidden"
       >

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
@@ -122,7 +122,9 @@ describe("AtlasGitPanel — 웹(브라우저 vault) 강등", () => {
 
   it("shows the empty-session message when the changeset has no changes", async () => {
     renderPanel(<AtlasGitPanel sessionChangeset={null} onClose={() => {}} />);
-    expect(await screen.findByText("이 세션에서 감지된 변경이 없어요.")).toBeInTheDocument();
+    // Image #16 재구성 — 빈 상태 문장이 섹션 라벨("이 세션에서 감지된 변경")을
+    // 반복하지 않는 짧은 상태 카피로 교체됨.
+    expect(await screen.findByText("아직 없어요 — 문서를 고치면 여기에 나타나요.")).toBeInTheDocument();
   });
 });
 

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
-import { Check, Copy, History, Monitor, X } from "lucide-react";
+// `History as HistoryIcon` — 사용성 검수 P0 (2026-07-23): 특정 HMR/번들 상태에서
+// bare `History` 식별자가 전역 DOM History 생성자로 해석돼 `<History>` JSX 가
+// "Illegal constructor" 로 화면 전체를 에러 바운더리로 추락시켰다(스택 확보,
+// 간헐). 전역과 절대 충돌하지 않는 별칭으로 원천 차단.
+import { Check, Copy, History as HistoryIcon, Monitor, X } from "lucide-react";
 import { copyText } from "@/shared/lib/copy-text";
 import {
   formatSnapshotSummary,
@@ -176,7 +180,7 @@ export function AtlasGitPanel({
       <header className="flex shrink-0 items-start justify-between gap-2 border-b border-[color:var(--color-border-soft)] px-5 py-4">
         <div>
           <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
-            <History size={11} aria-hidden />
+            <HistoryIcon size={11} aria-hidden />
             {t("title")}
           </p>
           <p className="mt-1 text-body leading-relaxed text-[color:var(--color-text-secondary)]">{t("subtitle")}</p>

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useTranslations } from "next-intl";
-import { Check, Copy, X } from "lucide-react";
+import { Check, Copy, History, Monitor, X } from "lucide-react";
 import { copyText } from "@/shared/lib/copy-text";
 import {
   formatSnapshotSummary,
@@ -166,29 +166,33 @@ export function AtlasGitPanel({
     <section
       aria-label={t("title")}
       data-testid="atlas-git-panel"
-      className={cn(
-        "flex w-full flex-col gap-4 rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-4",
-        className,
-      )}
+      // 시트 골격은 호스트(HomePage 의 scrim+카드 셸)가 소유한다 — 여기서
+      // 보더/배경을 또 얹으면 이중 카드가 된다(소유자 실보고 2026-07-23
+      // "보기 안 좋고"). AgentConnectSheet 와 같은 역할 분담: 패널은 내용만.
+      className={cn("flex w-full flex-col", className)}
     >
-      <header className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-0.5">
-          <h2 className="text-body font-medium text-[color:var(--color-text-primary)]">
+      {/* AgentConnectSheet 헤더 문법 — 인디고 mono eyebrow + body 서브타이틀,
+          border-b 로 본문과 분리. 글자 크기 한 단 승격(소유자: "글자 너무 작아"). */}
+      <header className="flex shrink-0 items-start justify-between gap-2 border-b border-[color:var(--color-border-soft)] px-5 py-4">
+        <div>
+          <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+            <History size={11} aria-hidden />
             {t("title")}
-          </h2>
-          <p className="text-caption text-[color:var(--color-text-tertiary)]">{t("subtitle")}</p>
+          </p>
+          <p className="mt-1 text-body leading-relaxed text-[color:var(--color-text-secondary)]">{t("subtitle")}</p>
         </div>
         <button
           type="button"
           aria-label={t("close")}
           data-testid="atlas-git-close"
           onClick={onClose}
-          className="rounded p-1 text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+          className="rounded p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
         >
-          <X size={14} aria-hidden />
+          <X size={15} aria-hidden />
         </button>
       </header>
 
+      <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-5 py-4">
       {desktop ? (
         <DesktopBody
           t={t}
@@ -221,6 +225,7 @@ export function AtlasGitPanel({
           copyCliCommand={copyCliCommand}
         />
       )}
+      </div>
     </section>
   );
 }
@@ -523,45 +528,61 @@ function WebBody({
     : [];
 
   return (
-    <div className="flex flex-col gap-3" data-testid="atlas-git-web-body">
-      <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-5" data-testid="atlas-git-web-body">
+      {/* 세션 변경 — AgentConnectSheet 상태 블록 문법(라벨 + 표면 카드 +
+          상태 점). 이전엔 라벨("이 세션에서 감지된 변경")과 빈 상태 문장
+          ("...감지된 변경이 없어요")이 사실상 중복이었다(소유자 실보고
+          Image #16) — 카드 안 문장은 라벨을 반복하지 않는 짧은 상태로. */}
+      <section aria-label={t("webSummaryTitle")} className="flex flex-col gap-1.5">
         <SectionLabel>{t("webSummaryTitle")}</SectionLabel>
-        {rows.length > 0 ? (
-          <ul className="flex flex-wrap gap-x-3 gap-y-1">
-            {rows.map(([key, count]) => (
-              <li key={key} className="text-label text-[color:var(--color-text-secondary)]">
-                {t(key, { count })}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-label text-[color:var(--color-text-tertiary)]">{t("webNoChanges")}</p>
-        )}
-      </div>
+        <div className="flex items-center gap-2.5 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5">
+          <span
+            aria-hidden
+            className="h-2 w-2 shrink-0 rounded-full"
+            style={{
+              backgroundColor:
+                rows.length > 0 ? "var(--color-status-warning)" : "var(--color-text-quaternary)",
+            }}
+          />
+          {rows.length > 0 ? (
+            <ul className="flex flex-wrap gap-x-3 gap-y-1">
+              {rows.map(([key, count]) => (
+                <li key={key} className="text-body text-[color:var(--color-text-secondary)]">
+                  {t(key, { count })}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-body text-[color:var(--color-text-tertiary)]">{t("webNoChanges")}</p>
+          )}
+        </div>
+      </section>
 
-      <div className="flex flex-col gap-1.5">
-        <p className="text-caption text-[color:var(--color-text-quaternary)]">
+      {/* CLI 인계 — FirstRunStarter cli-bridge 행 문법(설명 + code + 복사
+          버튼을 한 카드로 묶음). 코드/버튼 크기 한 단 승격. */}
+      <section aria-label={t("webCommandHint")} className="flex flex-col gap-1.5">
+        <p className="text-label leading-relaxed text-[color:var(--color-text-tertiary)]">
           {t("webCommandHint")}
         </p>
-        <div className="flex items-center gap-2">
-          <code className="rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 font-mono text-label text-[color:var(--color-text-secondary)]">
+        <div className="flex items-center justify-between gap-2 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2">
+          <code className="min-w-0 truncate font-mono text-[12.5px] text-[color:var(--color-text-secondary)]">
             {SNAPSHOT_CLI_COMMAND}
           </code>
           <button
             type="button"
             data-testid="atlas-git-web-copy"
             onClick={copyCliCommand}
-            className="inline-flex items-center gap-1 rounded border border-[color:var(--color-border-soft)] px-1.5 py-0.5 text-caption text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
           >
-            {commandCopied ? <Check size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
+            {commandCopied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
             {commandCopied ? t("webCopied") : t("webCopyCommand")}
           </button>
         </div>
-      </div>
-
-      <p className="text-caption text-[color:var(--color-text-quaternary)]">
-        {t("webDesktopHint")}
-      </p>
+        <p className="flex items-center gap-1.5 text-label text-[color:var(--color-text-quaternary)]">
+          <Monitor size={11} aria-hidden className="shrink-0" />
+          {t("webDesktopHint")}
+        </p>
+      </section>
     </div>
   );
 }

--- a/src/widgets/docs-vault/lib/search.test.ts
+++ b/src/widgets/docs-vault/lib/search.test.ts
@@ -72,9 +72,12 @@ describe('searchDocs — 본문(body) 최하위 티어', () => {
     expect(out[0].titleHit).toBeNull();
     expect(out[0].bodyHit).not.toBeNull();
     const hit = out[0].bodyHit!;
+    // 정확 구절 부스트 — 스니펫은 첫 토큰이 아니라 매치된 전체 구절을
+    // 하이라이트한다(P1 검수 #2: 클릭한 결과의 스니펫에 실제 매치어가
+    // 있어야 함).
     expect(
       hit.text.slice(hit.hit.start, hit.hit.end).toLowerCase(),
-    ).toBe('deterministic');
+    ).toBe('deterministic compile');
     expect(hit.text).toContain('deterministic compile phrase');
   });
 
@@ -121,6 +124,62 @@ describe('searchDocs — 본문(body) 최하위 티어', () => {
     const bodyIndex = bodyIndexOf({ a: 'compile is discussed here' });
     const out = searchDocs('graph compile', docs, 30, bodyIndex);
     expect(out.map((m) => m.doc.slug)).toEqual(['a']);
+  });
+
+  // 착지 결함 (P1 검수) #2 — 정확 구절 매치 문서가 흩어진 토큰 AND 매치
+  // 문서보다 랭킹 상위에 와야 신뢰 회복. 그래야 클릭한 1위 결과의 스니펫에
+  // 실제로 하이라이트 가능한 매치어가 존재한다(뷰어 착지 전제조건).
+  it('정확 구절 매치 문서가 흩어진 토큰 매치 문서보다 위 (본문 정확-구절 부스트)', () => {
+    const docs = [
+      // 토큰이 각각은 있지만 구절로 안 이어짐(흩어진 매치) — idx 0 이라
+      // 기존 로직이면 오히려 이 문서가 앞서던 회귀 케이스.
+      doc('scattered', 'zzz'),
+      // "deterministic compile" 이 그대로 이어지는 정확 구절.
+      doc('exact', 'yyy'),
+    ];
+    const bodyIndex = bodyIndexOf({
+      scattered: 'deterministic is discussed, and later compile appears too',
+      exact: `${'filler '.repeat(50)}the deterministic compile phrase lives here`,
+    });
+    const out = searchDocs('deterministic compile', docs, 30, bodyIndex);
+    expect(out.map((m) => m.doc.slug)).toEqual(['exact', 'scattered']);
+    // 1위 스니펫엔 실제 매치어(전체 구절)가 있어야 한다.
+    expect(out[0].bodyHit).not.toBeNull();
+    const hit = out[0].bodyHit!;
+    expect(hit.text.slice(hit.hit.start, hit.hit.end).toLowerCase()).toBe(
+      'deterministic compile',
+    );
+  });
+
+  it('정확 구절 매치는 줄바꿈으로 쪼개져도(줄-랩) 찾아 부스트한다', () => {
+    const docs = [doc('wrapped', 'zzz')];
+    const bodyIndex = bodyIndexOf({
+      wrapped: 'Give it a local, git-backed\nmental model it can read.',
+    });
+    const out = searchDocs('git-backed mental model', docs, 30, bodyIndex);
+    expect(out).toHaveLength(1);
+    expect(out[0].bodyHit).not.toBeNull();
+    const hit = out[0].bodyHit!;
+    // extractBodySnippet 이 개행을 표시용 공백으로 눌러도(한 줄 스니펫),
+    // hit 범위는 실제 매치된 구절 길이(개행 포함 원문 기준)를 그대로
+    // 보존해야 한다 — 부스트가 올바른 위치/길이를 찾았다는 증거.
+    expect(hit.text.slice(hit.hit.start, hit.hit.end)).toBe(
+      'git-backed mental model',
+    );
+  });
+
+  it('정확-구절 부스트 최댓값(idx 0)도 제목 최저점(20) 은 절대 못 이긴다', () => {
+    const docs = [
+      // title 매치가 idx 80 초과로 잘려 최저 title 점수(20)만 받는 최악 케이스.
+      doc('title-hit', `${'x'.repeat(90)}needle phrase`),
+      doc('body-exact', 'zzz'),
+    ];
+    // 본문 idx 0 — 정확-구절 부스트가 최댓값을 받는 최유리 케이스.
+    const bodyIndex = bodyIndexOf({
+      'body-exact': 'needle phrase right at the very start of the body',
+    });
+    const out = searchDocs('needle phrase', docs, 30, bodyIndex);
+    expect(out.map((m) => m.doc.slug)).toEqual(['title-hit', 'body-exact']);
   });
 
   it('메타데이터에도 매치된 문서는 bodyHit 스니펫을 같이 들 수 있다', () => {

--- a/src/widgets/docs-vault/lib/search.ts
+++ b/src/widgets/docs-vault/lib/search.ts
@@ -1,4 +1,5 @@
 import type { VaultDoc } from '@/entities/docs-vault';
+import { buildPhraseMatcher } from '@/shared/lib/highlight-match';
 import type { DocsBodyIndex } from './body-index';
 
 /** 본문 히트 스니펫 — 매치 앞뒤 {@link BODY_SNIPPET_CONTEXT}자 문맥 + 스니펫
@@ -50,9 +51,20 @@ export function extractBodySnippet(
 /**
  * 본문 티어 점수 — 어떤 메타데이터 히트(최저: excerpt 말단 매치 = 2점)보다도
  * 항상 낮도록 (1, 2) 구간에 가둔다. 본문끼리는 매치가 앞쪽일수록 근소 우위.
+ * 이 티어는 흩어진 멀티 토큰 AND 매치(구절이 실제로 안 이어짐)에 쓴다.
  */
 function bodyTierScore(idx: number): number {
   return 1 + Math.max(0, 0.9 - idx / 10000);
+}
+
+/**
+ * 본문 "정확 구절" 부스트 점수 — 랭킹 신뢰 회복(P1 검수 #2): 흩어진 토큰
+ * AND 매치보다는 훨씬 위지만, 제목 히트 최저값(20, `bodyTierScore` 위
+ * `titleIdx` 클램프 참고)은 절대 못 이기도록 (10, 16] 구간에 가둔다.
+ * idx 0(문서 맨 앞 정확 구절)이 최댓값, 뒤로 갈수록 10에 점근.
+ */
+function bodyPhraseScore(idx: number): number {
+  return 10 + Math.max(0, 6 - idx / 10000);
 }
 
 /**
@@ -62,12 +74,19 @@ function bodyTierScore(idx: number): number {
  *  - slug 매치: 25점
  *  - excerpt 매치: 20점 - min(매치 시작, 18) (최저 2)
  *  - tag 매치: 15점씩
- *  - body 매치: 1점대 (최하위 티어 — 어떤 메타데이터 히트도 본문 히트에
- *    밀리지 않는다. 본문끼리는 앞쪽 매치가 근소 우위)
+ *  - body 매치(흩어진 토큰): 1점대 (최하위 티어 — 어떤 메타데이터 히트도
+ *    본문 히트에 밀리지 않는다. 본문끼리는 앞쪽 매치가 근소 우위)
+ *  - body 매치(정확 구절, 멀티 토큰 쿼리가 본문에 연속으로 존재): 10~16점
+ *    (P1 검수 #2 — 흩어진 토큰 매치보다 신뢰도가 높으므로 상위지만, 여전히
+ *    제목 최저점(20)은 못 이긴다)
  * 멀티 토큰은 모든 토큰이 title|excerpt|slug|tags|body 중 하나라도 매치해야
- * 포함. bodyIndex (사전 소문자 정규화, `body-index.ts`) 를 넘기면 본문
- * 티어가 활성화된다 — 305 docs 기준 선형 스캔 실측 ~0.1–0.2ms/키라
- * debounce·역색인 불필요.
+ * 포함(구절로 안 이어져도 OK — AND 자격 요건). bodyIndex (사전 소문자
+ * 정규화, `body-index.ts`) 를 넘기면 본문 티어가 활성화된다 — 305 docs
+ * 기준 선형 스캔 실측 ~0.1–0.2ms/키라 debounce·역색인 불필요. 정확-구절
+ * 탐지는 `buildPhraseMatcher` (공용, `shared/lib/highlight-match.ts`) 를
+ * 재사용해 뷰어의 하이라이트 매칭과 동일한 공백-유연 규칙(줄바꿈도 공백
+ * 취급)을 쓴다 — 검색이 "매치됐다"고 본 위치가 뷰어에서도 실제로
+ * mark+스크롤 가능해야 하기 때문(랭킹과 착지의 일관성).
  */
 export function searchDocs(
   query: string,
@@ -100,13 +119,39 @@ export function searchDocs(
     const needle = tokens[0];
     const titleIdx = titleLc.indexOf(needle);
     const excerptIdx = excerptLc.indexOf(needle);
-    const bodyIdx = body !== undefined ? body.lower.indexOf(needle) : -1;
+
+    // 본문 매치 위치 — 멀티 토큰 쿼리면 먼저 정확 구절(공백-유연, 줄바꿈도
+    // 공백 취급)을 찾는다. 있으면 그 위치/길이로 부스트 티어를 쓰고, 없으면
+    // (토큰이 흩어져 있으면) 기존처럼 첫 토큰 위치로 최하위 티어에 둔다.
+    let bodyIdx = -1;
+    let bodyMatchLength = needle.length;
+    let bodyPhraseMatched = false;
+    if (body !== undefined) {
+      if (tokens.length > 1) {
+        const phraseRe = buildPhraseMatcher(q, 'i');
+        const phraseMatch = phraseRe?.exec(body.raw) ?? null;
+        if (phraseMatch) {
+          bodyIdx = phraseMatch.index;
+          bodyMatchLength = phraseMatch[0].length;
+          bodyPhraseMatched = true;
+        }
+      }
+      if (bodyIdx === -1) {
+        bodyIdx = body.lower.indexOf(needle);
+        bodyMatchLength = needle.length;
+      }
+    }
+
     let score = 0;
     if (titleIdx !== -1) score += 100 - Math.min(titleIdx, 80);
     if (excerptIdx !== -1) score += 20 - Math.min(excerptIdx, 18);
     if (slugLc.includes(needle)) score += 25;
     for (const t of tagLc) if (t.includes(needle)) score += 15;
-    if (bodyIdx !== -1) score += bodyTierScore(bodyIdx);
+    if (bodyIdx !== -1) {
+      score += bodyPhraseMatched
+        ? bodyPhraseScore(bodyIdx)
+        : bodyTierScore(bodyIdx);
+    }
     out.push({
       doc,
       score,
@@ -120,7 +165,7 @@ export function searchDocs(
           : null,
       bodyHit:
         bodyIdx !== -1 && body !== undefined
-          ? extractBodySnippet(body.raw, bodyIdx, needle.length)
+          ? extractBodySnippet(body.raw, bodyIdx, bodyMatchLength)
           : null,
     });
   }

--- a/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.body.test.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.body.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render as rtlRender, screen } from '@testing-library/react';
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../../messages/ko.json';
 import { DocsVaultUnifiedPalette } from './DocsVaultUnifiedPalette';
@@ -105,10 +105,21 @@ describe('DocsVaultUnifiedPalette — 본문 검색 결과', () => {
     ).toBeInTheDocument();
   });
 
-  it('본문 히트 행 선택 시 onDocSelect 에 쿼리가 전달된다 (뷰어 착지)', () => {
+  it('본문 히트 행 선택 시 onDocSelect 에 쿼리가 전달된다 (뷰어 착지 — 마우스)', () => {
     const onDocSelect = vi.fn();
     renderPalette({ initialQuery: 'deterministic', bodyIndex, onDocSelect });
     screen.getByText('Beta Doc').closest('a')!.click();
+    expect(onDocSelect).toHaveBeenCalledWith('beta', 'deterministic');
+  });
+
+  // 착지 결함 (P1 검수) — 키보드(Enter) 경로도 마우스와 동일하게 쿼리를
+  // 넘겨야 한다. row.onRun 참조는 공유되지만 실측 회귀 방지를 위해 별도
+  // assertion 으로 고정.
+  it('본문 히트 행 선택 시 onDocSelect 에 쿼리가 전달된다 (뷰어 착지 — 키보드 Enter)', () => {
+    const onDocSelect = vi.fn();
+    renderPalette({ initialQuery: 'deterministic', bodyIndex, onDocSelect });
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'Enter' });
     expect(onDocSelect).toHaveBeenCalledWith('beta', 'deterministic');
   });
 

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.test.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.test.tsx
@@ -96,4 +96,52 @@ describe("DocsVaultViewer", () => {
     expect(label.tagName).toBe("SPAN");
     expect(screen.queryByRole("link", { name: /MCP docs/ })).toBeNull();
   });
+
+  // 착지 결함 (P1 검수) — 팔레트에서 넘어온 highlightQuery 로 본문 content
+  // 가 비동기 로드된 *이후* 정확히 1회 mark+scrollIntoView 되는 계약.
+  // 콘텐츠 도착 전에는 mark 자체가 존재할 수 없으므로, 이 test 는 async
+  // fetcher (findByText 로 로드 완료를 기다림)를 써서 그 타이밍을 실측한다.
+  describe("highlightQuery 착지 — 본문 로드 후 mark + scrollIntoView", () => {
+    it("본문 로드 완료 후 매치어를 mark 로 감싸고 스크롤한다", async () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+      renderViewer("Intro line.\n\nThe deterministic compile phrase lives here.", {
+        highlightQuery: "deterministic compile",
+      });
+
+      const mark = await screen.findByText("deterministic compile", {
+        selector: "mark.docs-match",
+      });
+      expect(mark).toBeInTheDocument();
+      await vi.waitFor(() => expect(scrollSpy).toHaveBeenCalled());
+    });
+
+    // 실측 회귀 재현: 본문이 ~80자에서 줄바꿈돼 매치 구절 중간에 개행이
+    // 끼어드는 실제 vault 문서 형태(AGENTS.md 컨벤션)에서도 착지돼야 한다.
+    it("본문이 줄바꿈으로 쪼개진 구절(line-wrap)도 mark + 스크롤된다", async () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+      renderViewer(
+        "Give it a local, git-backed\nmental model it can read, query, and maintain.",
+        { highlightQuery: "git-backed mental model" },
+      );
+
+      await screen.findByText((_, node) => {
+        if (node?.tagName !== "MARK") return false;
+        return (node.textContent ?? "").replace(/\s+/g, " ") ===
+          "git-backed mental model";
+      });
+      await vi.waitFor(() => expect(scrollSpy).toHaveBeenCalled());
+    });
+
+    it("highlightQuery 없으면 mark 를 만들지 않고 스크롤도 안 한다", async () => {
+      const scrollSpy = vi.fn();
+      Element.prototype.scrollIntoView = scrollSpy;
+      renderViewer("Intro line.\n\nThe deterministic compile phrase lives here.");
+
+      await screen.findByText(/deterministic compile phrase/);
+      expect(document.querySelector("mark.docs-match")).toBeNull();
+      expect(scrollSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -621,4 +621,65 @@ describe("TopologyIndexPanel", () => {
       expect(onOpenAgentConnect).not.toHaveBeenCalled();
     });
   });
+
+  // P1 결함①a (사용성 전수 검수 2026-07-23) — 일반(비개발) 모드는
+  // element 행을 트리에서 제외하는데(호출자의 filterTreeExcludeKind), 그
+  // 사실을 설명하는 텍스트가 어디에도 없어 "역량 2 · 요소 7"인데 펼치면
+  // 2행만 보이는 정합성 결함으로 읽혔다.
+  describe("plainMode hint (P1 결함①a)", () => {
+    it("renders the quiet plain-mode hint when plainMode is true and the label is provided", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={{ ...labels, plainHint: "요소는 숨겨져 있어요" }}
+          plainMode
+        />,
+      );
+      expect(screen.getByTestId("topology-index-plain-hint")).toHaveTextContent(
+        "요소는 숨겨져 있어요",
+      );
+    });
+
+    it("does not render the hint in developer mode (plainMode omitted/false)", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={{ ...labels, plainHint: "요소는 숨겨져 있어요" }}
+        />,
+      );
+      expect(screen.queryByTestId("topology-index-plain-hint")).not.toBeInTheDocument();
+    });
+
+    it("does not render the hint when plainMode is true but no label is given (backward-compat)", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={labels}
+          plainMode
+        />,
+      );
+      expect(screen.queryByTestId("topology-index-plain-hint")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -69,6 +69,12 @@ export interface TopologyIndexPanelLabels {
    *  신선도 탭 이동 액션. 중립 톤만 — warning 사다리 금지 (Guardian 1차). */
   dustyNodesLabel: string;
   dustyNodesAction: string;
+  /**
+   * P1 결함①a (사용성 전수 검수 2026-07-23) — 일반(비개발) 모드에서 element
+   * 행이 트리에서 빠졌다는 사실을 설명하는 조용한 한 줄 힌트. `plainMode`
+   * 와 함께 있을 때만 렌더 — 생략하면 힌트 자체가 없다(하위호환).
+   */
+  plainHint?: string;
 }
 
 export interface TopologyIndexPanelProps {
@@ -145,6 +151,12 @@ export interface TopologyIndexPanelProps {
   recentWindow?: "auto" | 1 | 7 | 30;
   /** 프리셋 칩 클릭 → 창 전환(즉시 적용 — 팝업/확인 금지 계약). */
   onWindowChange?: (window: "auto" | 1 | 7 | 30) => void;
+  /**
+   * P1 결함①a — 일반(비개발) 모드 표시 게이트. `treeResult` 자체에서 element
+   * 행을 빼는 건 호출자(HomePage, `filterTreeExcludeKind`)의 일 — 이 플래그는
+   * "왜 안 보이는지"를 설명하는 힌트 행 렌더 여부만 결정한다(데이터 무변경).
+   */
+  plainMode?: boolean;
 }
 
 /**
@@ -188,6 +200,7 @@ export function TopologyIndexPanel({
   onLensChange,
   recentWindow = "auto",
   onWindowChange,
+  plainMode = false,
 }: TopologyIndexPanelProps) {
   const [query, setQuery] = useState("");
   const [openIds, setOpenIds] = useState<Set<string>>(
@@ -439,6 +452,17 @@ export function TopologyIndexPanel({
             </button>
           ))}
         </div>
+      ) : null}
+
+      {/* P1 결함①a — 일반(비개발) 모드에서 element 행이 빠져 있는 이유를
+          설명하는 조용한 한 줄. 트리 위, 렌즈/프리셋 칩 아래. */}
+      {plainMode && labels.plainHint ? (
+        <p
+          data-testid="topology-index-plain-hint"
+          className="mb-2 shrink-0 text-label text-[color:var(--topology-v2-panel-text-quaternary)]"
+        >
+          {labels.plainHint}
+        </p>
       ) : null}
 
       <nav

--- a/src/widgets/topology-map-v2/model/realm.test.ts
+++ b/src/widgets/topology-map-v2/model/realm.test.ts
@@ -7,6 +7,8 @@ import {
   computeWardingRadius,
   extractRealmSubtree,
   realmLayoutKind,
+  realmMaxDepth,
+  realmRingsForDepth,
   WARDING_VISIBLE_MARGIN_RATIO,
   WARDING_VISIBLE_MIN_MARGIN,
 } from "./realm";
@@ -77,6 +79,57 @@ describe("realmLayoutKind", () => {
   });
 });
 
+describe("realmMaxDepth", () => {
+  it("is 0 for a root-only subtree (no children)", () => {
+    const sub = extractRealmSubtree("leaf", new Map());
+    expect(realmMaxDepth(sub)).toBe(0);
+  });
+
+  it("is the chain length for a linear chain", () => {
+    const chain = new Map<string, string[]>([
+      ["a", ["b"]],
+      ["b", ["c"]],
+      ["c", ["d"]],
+    ]);
+    const sub = extractRealmSubtree("a", chain);
+    expect(realmMaxDepth(sub)).toBe(3);
+  });
+
+  it("is 1 for a fan (root with only direct children)", () => {
+    const fan = new Map<string, string[]>([["root", ["a", "b", "c"]]]);
+    const sub = extractRealmSubtree("root", fan);
+    expect(realmMaxDepth(sub)).toBe(1);
+  });
+});
+
+describe("realmRingsForDepth", () => {
+  const BASE: LayoutRings = { domain: 250, capability: 145, element: 90 };
+  const FILL = { depth1: 130, depth2: 190, depth3: 250 };
+
+  it("pulls rings in for a shallow (maxDepth=1) subtree", () => {
+    const rings = realmRingsForDepth(1, BASE, FILL);
+    expect(rings.domain).toBeCloseTo(130, 5);
+    expect(rings.capability).toBeCloseTo(75.4, 5);
+    expect(rings.element).toBeCloseTo(46.8, 5);
+  });
+
+  it("pulls rings in less for maxDepth=2", () => {
+    const rings = realmRingsForDepth(2, BASE, FILL);
+    expect(rings.domain).toBeCloseTo(190, 5);
+    expect(rings.capability).toBeCloseTo(110.2, 5);
+    expect(rings.element).toBeCloseTo(68.4, 5);
+  });
+
+  it("is byte-identical to base rings at maxDepth>=3 (deep realms unaffected — regression guard)", () => {
+    expect(realmRingsForDepth(3, BASE, FILL)).toEqual(BASE);
+    expect(realmRingsForDepth(5, BASE, FILL)).toEqual(BASE);
+  });
+
+  it("is deterministic — same input yields the same output", () => {
+    expect(realmRingsForDepth(1, BASE, FILL)).toEqual(realmRingsForDepth(1, BASE, FILL));
+  });
+});
+
 describe("computeRealmLayout", () => {
   it("places the root at the origin and depth-1 children on the domain ring", () => {
     const sub = extractRealmSubtree("c", fixtureChildren());
@@ -125,9 +178,10 @@ describe("computeWardingRadius", () => {
 
 describe("computeVisibleWardingRadius (S9 결함 2)", () => {
   it("가장 먼 reach + 콘텐츠 비례 마진", () => {
-    // outer=200 → margin = max(60, 200*0.15=30) = 60 → 260.
+    // outer=200 → margin = max(40, 200*0.1=20) = 40 → 240.
     expect(computeVisibleWardingRadius([50, 120, 200])).toBe(200 + Math.max(WARDING_VISIBLE_MIN_MARGIN, 200 * WARDING_VISIBLE_MARGIN_RATIO));
-    // outer=800 → margin = max(60, 120) = 120 → 920.
+    expect(computeVisibleWardingRadius([50, 120, 200])).toBe(240);
+    // outer=800 → margin = max(40, 80) = 80 → 880.
     expect(computeVisibleWardingRadius([800])).toBe(800 + 800 * WARDING_VISIBLE_MARGIN_RATIO);
   });
 

--- a/src/widgets/topology-map-v2/model/realm.test.ts
+++ b/src/widgets/topology-map-v2/model/realm.test.ts
@@ -12,7 +12,7 @@ import {
   WARDING_VISIBLE_MARGIN_RATIO,
   WARDING_VISIBLE_MIN_MARGIN,
 } from "./realm";
-import type { LayoutRadii, LayoutRings } from "./layout";
+import { computeConcentricLayout, type LayoutRadii, type LayoutRings } from "./layout";
 
 const RINGS: LayoutRings = { domain: 250, capability: 145, element: 90 };
 const RADII: LayoutRadii = { project: 25, domain: 17, capability: 11, element: 7 };
@@ -152,6 +152,60 @@ describe("computeRealmLayout", () => {
     const a = computeRealmLayout(extractRealmSubtree("c", fixtureChildren()), RINGS, RADII);
     const b = computeRealmLayout(extractRealmSubtree("c", fixtureChildren()), RINGS, RADII);
     expect([...a.entries()]).toEqual([...b.entries()]);
+  });
+});
+
+describe("computeRealmLayout — 소수-자식 수평 구도 (소유자 실보고 2026-07-23)", () => {
+  it("depth1 자식 2개는 수평축에 앉는다 — 첫 자식 왼쪽, 둘째 오른쪽", () => {
+    const sub = extractRealmSubtree("c", new Map([["c", ["e1", "e2"]]]));
+    const layout = computeRealmLayout(sub, RINGS, RADII);
+    expect(layout.get("c")).toEqual({ id: "c", x: 0, y: 0 });
+    const e1 = layout.get("e1")!;
+    const e2 = layout.get("e2")!;
+    // TAU 등분(위/아래 덤벨)의 −90° 강체 회전: (0,−R)→(−R,0), (0,R)→(R,0).
+    expect(e1.x).toBeLessThan(0);
+    expect(Math.abs(e1.y)).toBeLessThan(1e-9);
+    expect(e2.x).toBeGreaterThan(0);
+    expect(Math.abs(e2.y)).toBeLessThan(1e-9);
+  });
+
+  it("depth1 자식 1개는 수평축(왼쪽)에 앉는다 — 같은 −90° 강체 회전 규칙", () => {
+    const sub = extractRealmSubtree("c", new Map([["c", ["only"]]]));
+    const layout = computeRealmLayout(sub, RINGS, RADII);
+    const only = layout.get("only")!;
+    expect(only.x).toBeLessThan(0); // (0,−R)→(−R,0)
+    expect(Math.abs(only.y)).toBeLessThan(1e-9);
+  });
+
+  it("회전은 강체다 — 미회전 concentric 레이아웃의 정확한 (x,y)→(y,−x) 사상", () => {
+    const children = new Map([
+      ["c", ["e1", "e2"]],
+      ["e1", ["g1"]],
+    ]);
+    const sub = extractRealmSubtree("c", children);
+    const rotated = computeRealmLayout(sub, RINGS, RADII);
+    // 동일 입력을 직접 concentric 에 태운 미회전 기준과 좌표 단위로 대조한다.
+    const rawInput = [...sub.depthById.keys()].map((id) => ({
+      id,
+      kind: realmLayoutKind(sub.depthById.get(id) ?? 0),
+      parentId: id === sub.rootId ? null : sub.parentById.get(id) ?? null,
+    }));
+    const raw = new Map(computeConcentricLayout(rawInput, RINGS, { radii: RADII }).map((p) => [p.id, p]));
+    for (const id of ["e1", "e2", "g1"]) {
+      const r = raw.get(id)!;
+      const p = rotated.get(id)!;
+      expect(p.x).toBeCloseTo(r.y, 10);
+      expect(p.y).toBeCloseTo(-r.x, 10);
+    }
+  });
+
+  it("depth1 자식 3개 이상은 미회전 — 첫 자식이 위(-90°) 그대로 (깊은/넓은 영역 회귀 0)", () => {
+    const sub = extractRealmSubtree("c", new Map([["c", ["a", "b", "d"]]]));
+    const layout = computeRealmLayout(sub, RINGS, RADII);
+    const a = layout.get("a")!;
+    // TAU 등분 시작각 −90°: 첫 자식은 위쪽(x≈0, y<0).
+    expect(Math.abs(a.x)).toBeLessThan(1e-9);
+    expect(a.y).toBeLessThan(0);
   });
 });
 

--- a/src/widgets/topology-map-v2/model/realm.ts
+++ b/src/widgets/topology-map-v2/model/realm.ts
@@ -107,9 +107,24 @@ export function realmRingsForDepth(
 }
 
 /**
+ * 소수-자식 수평 구도 상한 — depth1 자식이 이 수 이하면 전체 레이아웃을 −90°
+ * 회전해 자식을 **수평축**에 앉힌다. TAU 등분은 N=1(위 꼭짓점 하나), N=2(위/
+ * 아래 덤벨)에서 "우연히 원 안에 있는 점들"로 읽히고, 세로 엣지가 자식 라벨을
+ * 관통한다 (소유자 실보고 2026-07-23, 얕은 capability 영역 실증). 수평 구도는
+ * 라벨(가로 텍스트)·읽기 방향과 정렬되고, 원 하단을 결계 캡션 자리로 비운다.
+ * N≥3 은 TAU 등분이 이미 의도적 다각형(삼각/다이아)으로 읽히므로 미변경 —
+ * 깊은 영역 좌표 회귀 0.
+ */
+export const REALM_HORIZON_MAX_DEPTH1 = 2;
+
+/**
  * 영역 로컬 좌표 — 서브트리를 깊이 기준으로 `computeConcentricLayout` 에 태워
  * 루트를 원점에 둔 재배치 좌표를 낸다. 렌더 kind 는 무시하고 깊이만 매핑하므로,
  * 예컨대 element 를 루트로 전개해도 그 직속 자식이 도메인 링에 앉는다.
+ *
+ * depth1 자식이 `REALM_HORIZON_MAX_DEPTH1` 이하인 얕은-팬 영역은 비루트 전체를
+ * 원점 기준 −90° 강체 회전한다((x,y)→(y,−x)) — 첫 자식이 왼쪽, 둘째가 오른쪽.
+ * 강체 회전이라 상대 기하(부채꼴·분리·결계 반경)는 바이트 동일하게 보존된다.
  */
 export function computeRealmLayout(
   subtree: RealmSubtree,
@@ -117,8 +132,10 @@ export function computeRealmLayout(
   radii: LayoutRadii,
 ): Map<string, LayoutPoint> {
   const layoutInput: LayoutGraphNode[] = [];
+  let depth1Count = 0;
   for (const id of subtree.depthById.keys()) {
     const depth = subtree.depthById.get(id) ?? 0;
+    if (depth === 1) depth1Count += 1;
     layoutInput.push({
       id,
       kind: realmLayoutKind(depth),
@@ -126,6 +143,11 @@ export function computeRealmLayout(
     });
   }
   const points = computeConcentricLayout(layoutInput, rings, { radii });
+  if (depth1Count >= 1 && depth1Count <= REALM_HORIZON_MAX_DEPTH1) {
+    return new Map(
+      points.map((p) => (p.id === subtree.rootId ? [p.id, p] : [p.id, { id: p.id, x: p.y, y: -p.x }])),
+    );
+  }
   return new Map(points.map((p) => [p.id, p]));
 }
 

--- a/src/widgets/topology-map-v2/model/realm.ts
+++ b/src/widgets/topology-map-v2/model/realm.ts
@@ -79,6 +79,33 @@ export function realmLayoutKind(depth: number): LayoutNodeKind {
   return "element";
 }
 
+/** 영역 링 스케일이 전역 스파인과 일치하는 깊이 상한 — depth 3+ 는 스파인 링 그대로. */
+export const REALM_FILL_FULL_DEPTH = 3;
+
+/** 서브트리 최대 깊이 (루트만이면 0). 순수·결정론. */
+export function realmMaxDepth(subtree: RealmSubtree): number {
+  let max = 0;
+  for (const d of subtree.depthById.values()) if (d > max) max = d;
+  return max;
+}
+
+/**
+ * 깊이 파생 영역 링 — maxDepth 가 얕을수록 depth1 링을 안으로 당겨
+ * "빈 annulus" 를 없앤다. 스케일 s = fill(min(maxDepth,3)) / base.domain 을
+ * 세 링에 동일 적용해 비율 보존. maxDepth ≥ 3 이면 s = 1 → 기존 좌표와
+ * 바이트 동일 (깊은 영역 회귀 0).
+ */
+export function realmRingsForDepth(
+  maxDepth: number,
+  base: LayoutRings,
+  fill: { depth1: number; depth2: number; depth3: number },
+): LayoutRings {
+  const capped = Math.max(1, Math.min(maxDepth, REALM_FILL_FULL_DEPTH));
+  const target = capped === 1 ? fill.depth1 : capped === 2 ? fill.depth2 : fill.depth3;
+  const s = base.domain > 0 ? target / base.domain : 1;
+  return { domain: base.domain * s, capability: base.capability * s, element: base.element * s };
+}
+
 /**
  * 영역 로컬 좌표 — 서브트리를 깊이 기준으로 `computeConcentricLayout` 에 태워
  * 루트를 원점에 둔 재배치 좌표를 낸다. 렌더 kind 는 무시하고 깊이만 매핑하므로,
@@ -121,9 +148,9 @@ export function computeWardingRadius(
 }
 
 /** 가시-멤버 결계 마진 = 콘텐츠 반경(가장 먼 엣지 도달거리)의 이 비율. */
-export const WARDING_VISIBLE_MARGIN_RATIO = 0.15;
+export const WARDING_VISIBLE_MARGIN_RATIO = 0.1;
 /** 가시-멤버 결계 마진 하한(월드 유닛) — 루트만 보일 때도 최소 이만큼 감싼다. */
-export const WARDING_VISIBLE_MIN_MARGIN = 60;
+export const WARDING_VISIBLE_MIN_MARGIN = 40;
 
 /**
  * S9 결함 2 — **현재 렌더되는 멤버**만으로 낸 결계 반경. 밀도 게이트로 접혀

--- a/src/widgets/topology-map-v2/model/tier-visibility.test.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.test.ts
@@ -10,6 +10,7 @@ import {
   isNodeHittable,
   isSpineOnlyZoom,
   nodeTierAlpha,
+  PLAIN_TIER_REVEAL,
 } from "./tier-visibility";
 
 // zoomRatio: 1 = overview entry, >1 zoomed IN, <1 zoomed OUT.
@@ -214,6 +215,64 @@ describe("isNodeHittable", () => {
     expect(isNodeHittable({ id: "capability:full", kind: "capability", isHub: false }, DEFAULT_TIER_REVEAL.capability.fullRatio, null, undefined)).toBe(
       true,
     );
+  });
+});
+
+/**
+ * 슬라이스 C (개발/비개발 모드 토글) — 비개발(plain) 렌즈는 element 티어를
+ * 도달 불가 밴드(1e6/2e6)로 밀어 상시 숨김. capability 는 DEFAULT 와 동일
+ * (지도 상위 구조는 그대로), ego 예외(effectiveNodeAlpha)는 이 config 와
+ * 무관하게 그대로 작동한다.
+ */
+describe("PLAIN_TIER_REVEAL (슬라이스 C — 비개발 모드 element 상시 숨김)", () => {
+  const REALISTIC_RATIOS = [0.5, 1, 1.5, 2, 2.85, 4, 10, 50];
+
+  it("hides elements at every realistic zoom ratio (0.5~50)", () => {
+    for (const ratio of REALISTIC_RATIOS) {
+      expect(nodeTierAlpha("element", false, ratio, PLAIN_TIER_REVEAL)).toBe(0);
+    }
+  });
+
+  it("never produces NaN even far past the finite sentinel band", () => {
+    for (const ratio of [...REALISTIC_RATIOS, 1e6, 2e6, 1e7]) {
+      const alpha = nodeTierAlpha("element", false, ratio, PLAIN_TIER_REVEAL);
+      expect(Number.isNaN(alpha)).toBe(false);
+    }
+  });
+
+  it("leaves other kinds identical to DEFAULT_TIER_REVEAL", () => {
+    for (const ratio of REALISTIC_RATIOS) {
+      expect(nodeTierAlpha("project", false, ratio, PLAIN_TIER_REVEAL)).toBe(
+        nodeTierAlpha("project", false, ratio, DEFAULT_TIER_REVEAL),
+      );
+      expect(nodeTierAlpha("domain", false, ratio, PLAIN_TIER_REVEAL)).toBe(
+        nodeTierAlpha("domain", false, ratio, DEFAULT_TIER_REVEAL),
+      );
+      expect(nodeTierAlpha("capability", false, ratio, PLAIN_TIER_REVEAL)).toBe(
+        nodeTierAlpha("capability", false, ratio, DEFAULT_TIER_REVEAL),
+      );
+    }
+  });
+
+  it("classifyZoomTier never reports 'element' under the plain config", () => {
+    for (const ratio of REALISTIC_RATIOS) {
+      expect(classifyZoomTier(ratio, PLAIN_TIER_REVEAL)).not.toBe("element");
+    }
+  });
+
+  it("still reveals a hidden element once it's the ego-focused node (click-to-reveal exception)", () => {
+    const tierAlpha = nodeTierAlpha("element", false, 1, PLAIN_TIER_REVEAL);
+    expect(tierAlpha).toBe(0);
+    // ego exemption is a separate function, config-independent — a focused
+    // element still reaches full opacity via effectiveNodeAlpha's ramp.
+    expect(effectiveNodeAlpha(tierAlpha, true, 1)).toBe(1);
+  });
+
+  it("isNodeHittable also gates a non-focused element out under the plain config", () => {
+    const hiddenElement = { id: "element:hidden", kind: "element" as const, isHub: false };
+    expect(isNodeHittable(hiddenElement, 1, null, undefined, PLAIN_TIER_REVEAL)).toBe(false);
+    // But the ego exception still makes the focused element itself hittable.
+    expect(isNodeHittable(hiddenElement, 1, "element:hidden", new Set(), PLAIN_TIER_REVEAL)).toBe(true);
   });
 });
 

--- a/src/widgets/topology-map-v2/model/tier-visibility.ts
+++ b/src/widgets/topology-map-v2/model/tier-visibility.ts
@@ -56,6 +56,14 @@ export const DEFAULT_TIER_REVEAL: TierRevealConfig = {
   element: { enterRatio: 2.3, fullRatio: 2.85 },
 };
 
+/** 비개발(plain) 렌즈 — element 티어를 도달 불가 밴드로 밀어 상시 숨김.
+ * ego 예외(effectiveNodeAlpha)는 그대로 — "클릭하면 그 노드의 요소는
+ * 보인다"(기본 숨김 + opt-in 공개). 유한 센티널이라 smoothstep NaN 없음. */
+export const PLAIN_TIER_REVEAL: TierRevealConfig = {
+  capability: DEFAULT_TIER_REVEAL.capability,
+  element: { enterRatio: 1e6, fullRatio: 2e6 },
+};
+
 /**
  * Zoom ratio = `cameraScale / overviewEntryScale`. `1.0` exactly at the overview
  * entry (where `cameraScale === overviewEntryScale`), `>1` zoomed in, `<1`

--- a/src/widgets/topology-map-v2/render/labels.ts
+++ b/src/widgets/topology-map-v2/render/labels.ts
@@ -313,6 +313,24 @@ function drawTrackedText(
 }
 
 /**
+ * 계기 캡션 — 지도 주석(결계 센서스 등)용 tracked-caps 한 줄. 도메인 워터마크와
+ * 정확히 같은 문법(10px 600 + 1.6 트래킹 + 대문자)을 화면 고정 크기로 그린다 —
+ * 줌과 무관하게 항상 판독계 크기로 읽히는 annotation 잉크. 신규 폰트/토큰 0.
+ */
+export function drawInstrumentCaption(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  cx: number,
+  cy: number,
+  color: string,
+  alpha: number,
+): void {
+  if (alpha <= 0.02) return;
+  ctx.font = scaledLabelFont("domain", 1);
+  drawTrackedText(ctx, text.toUpperCase(), cx, cy, color, DOMAIN_TRACKING, alpha);
+}
+
+/**
  * Draws one node's label. Domain draws up to TWO things at the same anchor —
  * the always-readable compact label (`computeLabelAlpha`) and the separate
  * far-field spaced-caps watermark (`computeDomainWatermarkAlpha`) — since

--- a/src/widgets/topology-map-v2/render/node-shapes.ts
+++ b/src/widgets/topology-map-v2/render/node-shapes.ts
@@ -120,6 +120,16 @@ export interface NodeShapeDrawState {
    */
   agentFocus: boolean;
   /**
+   * 스포트라이트 변경-노드 링 (소유자 지시 2026-07-23, Image #14 — "변경된
+   * 것만 테두리가 돌아가게"). 렌즈 ON 동안 mtime 창 안 노드에 amberHub
+   * **회전 파선** kind-outline 을 얹는다 — 침강 대비만으론 element 뷰에서
+   * 변경 노드가 안 읽히던 실보고의 처방. glow/blur 0(발광 대신 재질),
+   * amberHub 는 에이전트 포커스 링과 같은 신호 톤 선례. `alpha` = 렌즈
+   * 램프(켜고 끄기 페이드), `dashOffset` = 회전 위상(px, reduced-motion 은
+   * 호출자가 0 고정 → 정적 파선). null = 미표시.
+   */
+  spotlightRing: { alpha: number; dashOffset: number } | null;
+  /**
    * Design Guardian 처방 L — 호버 circuit-trace shimmer 의 시간원. 프레임의
    * `performance.now()` 호환 타임스탬프(픽셀 드로우 자체는 시간을 모르는
    * 순수 계층이 아니므로 여기서만 받는다) + reduced-motion 게이트. 정지 호버
@@ -461,6 +471,7 @@ export function draw(ctx: CanvasRenderingContext2D, state: NodeShapeDrawState, t
     hoverEmphasis,
     selectionPulse,
     agentFocus,
+    spotlightRing,
     now,
     reducedMotion,
   } = state;
@@ -526,6 +537,18 @@ export function draw(ctx: CanvasRenderingContext2D, state: NodeShapeDrawState, t
   // each other.
   if (agentFocus && egoState !== "dim") {
     strokeKindOutline(ctx, kind, x, y, r + AGENT_FOCUS_RING_OFFSET, farT, tokens.amberHub, 1, 1);
+  }
+
+  // 스포트라이트 변경-노드 링 (Image #14 처방) — amberHub **회전 파선**
+  // kind-outline. 오프셋 r+6: hub(r+4)·agentFocus(r+8) 사이의 자기 자리 —
+  // 셋이 공존해도 스택(대체 아님). lineDashOffset 이 회전 위상; reduced-
+  // motion 은 호출자가 dashOffset 0 을 고정해 정적 파선이 된다. glow 0.
+  if (spotlightRing !== null && egoState !== "dim") {
+    ctx.setLineDash([5, 4]);
+    ctx.lineDashOffset = -spotlightRing.dashOffset;
+    strokeKindOutline(ctx, kind, x, y, r + 6, farT, tokens.amberHub, 1.2, spotlightRing.alpha);
+    ctx.setLineDash([]);
+    ctx.lineDashOffset = 0;
   }
 
   // Canvas-emphasis slice §A — project hexagon's own decorative identity

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -94,6 +94,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-focus-dim-tau": "0.16",
   "--topology-v2-cluster-reveal-tau": "0.17",
   "--topology-v2-spotlight-rest-alpha": "0.35",
+  "--topology-v2-spotlight-ring-speed": "0.018",
   "--topology-v2-ripple-stagger-ms": "55",
   "--topology-v2-breathe-amplitude": "0.04",
   "--topology-v2-breathe-freq-rad": "1.15",
@@ -149,6 +150,7 @@ describe("resolveTopologyV2Tokens", () => {
     expect(tokens.nodeHomeSpringAngFreq).toBeCloseTo(7.5, 3);
     expect(tokens.focusDimTau).toBeCloseTo(0.16, 3);
     expect(tokens.spotlightRestAlpha).toBeCloseTo(0.35, 3);
+    expect(tokens.spotlightRingSpeed).toBeCloseTo(0.018, 4);
     expect(tokens.egoRevealRiseTau).toBeCloseTo(0.22, 3);
     expect(tokens.egoRevealDecayTau).toBeCloseTo(0.12, 3);
     expect(tokens.rippleStaggerMaxMs).toBeCloseTo(180, 3);

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -94,7 +94,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-focus-dim-tau": "0.16",
   "--topology-v2-cluster-reveal-tau": "0.17",
   "--topology-v2-spotlight-rest-alpha": "0.35",
-  "--topology-v2-spotlight-ring-speed": "0.018",
+  "--topology-v2-spotlight-ring-speed": "0.012",
   "--topology-v2-ripple-stagger-ms": "55",
   "--topology-v2-breathe-amplitude": "0.04",
   "--topology-v2-breathe-freq-rad": "1.15",
@@ -150,7 +150,7 @@ describe("resolveTopologyV2Tokens", () => {
     expect(tokens.nodeHomeSpringAngFreq).toBeCloseTo(7.5, 3);
     expect(tokens.focusDimTau).toBeCloseTo(0.16, 3);
     expect(tokens.spotlightRestAlpha).toBeCloseTo(0.35, 3);
-    expect(tokens.spotlightRingSpeed).toBeCloseTo(0.018, 4);
+    expect(tokens.spotlightRingSpeed).toBeCloseTo(0.012, 4);
     expect(tokens.egoRevealRiseTau).toBeCloseTo(0.22, 3);
     expect(tokens.egoRevealDecayTau).toBeCloseTo(0.12, 3);
     expect(tokens.rippleStaggerMaxMs).toBeCloseTo(180, 3);

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -64,6 +64,9 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-layout-ring-domain": "250",
   "--topology-v2-layout-ring-capability": "145",
   "--topology-v2-layout-ring-element": "90",
+  "--topology-v2-realm-fill-radius-1": "130",
+  "--topology-v2-realm-fill-radius-2": "190",
+  "--topology-v2-realm-fill-radius-3": "250",
   "--topology-v2-edge-bow-contains": "70",
   "--topology-v2-edge-bow-depends": "92",
   "--topology-v2-edge-blend-contains": "0.46",
@@ -163,6 +166,9 @@ describe("resolveTopologyV2Tokens", () => {
     expect(tokens.nodeSheenBlend).toBeCloseTo(0.6, 3);
     expect(tokens.radiusProject).toBe(30);
     expect(tokens.radiusElement).toBe(7);
+    expect(tokens.realmFillRadius1).toBe(130);
+    expect(tokens.realmFillRadius2).toBe(190);
+    expect(tokens.realmFillRadius3).toBe(250);
     expect(tokens.cameraSpringAngFreqInteractive).toBeCloseTo(12, 3);
     expect(tokens.cameraSpringAngFreqTransition).toBeCloseTo(4.7, 3);
     expect(tokens.cameraMomentumDecay).toBe(0.998);

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -79,6 +79,12 @@ export interface TopologyV2Tokens {
   layoutRingDomain: number;
   layoutRingCapability: number;
   layoutRingElement: number;
+  /** `--topology-v2-realm-fill-radius-1` — 영역 전개 maxDepth=1 서브트리의 도메인 링(월드 유닛, `model/realm.ts#realmRingsForDepth`). */
+  realmFillRadius1: number;
+  /** `--topology-v2-realm-fill-radius-2` — 영역 전개 maxDepth=2 서브트리의 도메인 링. */
+  realmFillRadius2: number;
+  /** `--topology-v2-realm-fill-radius-3` — 영역 전개 maxDepth≥3 서브트리의 도메인 링(= 전역 스파인 링과 동일). */
+  realmFillRadius3: number;
   edgeBowContains: number;
   edgeBowDepends: number;
   edgeBlendContains: number;
@@ -262,6 +268,9 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "layoutRingDomain", cssVar: "--topology-v2-layout-ring-domain", kind: "number" },
   { key: "layoutRingCapability", cssVar: "--topology-v2-layout-ring-capability", kind: "number" },
   { key: "layoutRingElement", cssVar: "--topology-v2-layout-ring-element", kind: "number" },
+  { key: "realmFillRadius1", cssVar: "--topology-v2-realm-fill-radius-1", kind: "number" },
+  { key: "realmFillRadius2", cssVar: "--topology-v2-realm-fill-radius-2", kind: "number" },
+  { key: "realmFillRadius3", cssVar: "--topology-v2-realm-fill-radius-3", kind: "number" },
   { key: "edgeBowContains", cssVar: "--topology-v2-edge-bow-contains", kind: "number" },
   { key: "edgeBowDepends", cssVar: "--topology-v2-edge-bow-depends", kind: "number" },
   { key: "edgeBlendContains", cssVar: "--topology-v2-edge-blend-contains", kind: "number" },

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -144,6 +144,8 @@ export interface TopologyV2Tokens {
    * 전이는 기존 `focusDimTau` 램프를 재사용한다(신규 easing 0).
    */
   spotlightRestAlpha: number;
+  /** `--topology-v2-spotlight-ring-speed` — 변경-노드 파선 링 회전 속도(px/ms). */
+  spotlightRingSpeed: number;
   rippleStaggerMs: number;
   breatheAmplitude: number;
   breatheFreqRad: number;
@@ -289,6 +291,7 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "emphasisDecayTau", cssVar: "--topology-v2-emphasis-decay-tau", kind: "number" },
   { key: "focusDimTau", cssVar: "--topology-v2-focus-dim-tau", kind: "number" },
   { key: "spotlightRestAlpha", cssVar: "--topology-v2-spotlight-rest-alpha", kind: "number" },
+  { key: "spotlightRingSpeed", cssVar: "--topology-v2-spotlight-ring-speed", kind: "number" },
   { key: "clusterRevealTau", cssVar: "--topology-v2-cluster-reveal-tau", kind: "number" },
   { key: "rippleStaggerMs", cssVar: "--topology-v2-ripple-stagger-ms", kind: "number" },
   { key: "breatheAmplitude", cssVar: "--topology-v2-breathe-amplitude", kind: "number" },

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import { Orbit } from "lucide-react";
 import { useTopologyLoop } from "./use-topology-loop";
+import type { TierRevealConfig } from "../model/tier-visibility";
 
 /**
  * `TopologyMapV2` — the single canvas-2D render engine that replaces
@@ -175,10 +176,16 @@ export interface TopologyMapV2Props {
    * 발자국 없음.
    */
   visitedTrail?: readonly string[];
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 표시-렌즈 티어 게이트 config. 생략
+   * 시 `DEFAULT_TIER_REVEAL`(개발 모드). HomePage 가 비개발(plain) 모드에서
+   * `PLAIN_TIER_REVEAL`(element 상시 숨김)을 넘긴다.
+   */
+  tierReveal?: TierRevealConfig;
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, canvasLabel, visitedTrail } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, canvasLabel, visitedTrail, tierReveal } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -212,6 +219,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       onEnterRealm,
       realmEnterButtonRef,
       visitedTrail,
+      tierReveal,
     });
 
   return (

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -158,10 +158,16 @@ export interface TopologyMapV2Props {
   realmRootId?: string | null;
   /** S4 — 궤도 "전개" 버튼 클릭 → 이 slug 로 영역 진입 (HomePage 가 URL 왕복). */
   onEnterRealm?: (slug: string) => void;
-  /** S4 — 궤도 버튼 접근성 라벨 (i18n, HomePage 주입). */
+  /** S4 — 궤도 버튼 접근성 라벨 (i18n, HomePage 주입). 사용자 어휘는 "이것만 보기"(2026-07-23 소유자 결정), 내부명 realm 유지. */
   realmEnterLabel?: string;
-  /** S4 — 궤도 버튼 호버 마이크로 툴팁 문구 ("이 노드의 영역만 펼쳐요"). */
+  /** S4 — 궤도 버튼 호버 마이크로 툴팁 문구 ("이 노드 안쪽만 봐요"). */
   realmEnterTooltip?: string;
+  /**
+   * 결계 하단 센서스 각인 — "○○ · 요소 N" (i18n, HomePage 주입). 원장 패널의
+   * census 와 단일 출처가 되도록 위젯이 직접 세지 않고 문자열로 받는다.
+   * null/생략 = 각인 없음.
+   */
+  realmCaption?: string | null;
   /**
    * H3 P2 — 캔버스 접근성 라벨(i18n, HomePage 주입). canvas 는 회화 픽셀이라
    * 스크린리더에 빈 그래픽으로 읽힌다 → `role="img"` + 이 라벨로 "무엇인지 +
@@ -185,7 +191,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, canvasLabel, visitedTrail, tierReveal } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, canvasLabel, visitedTrail, tierReveal } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -218,6 +224,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       realmRootId,
       onEnterRealm,
       realmEnterButtonRef,
+      realmCaption,
       visitedTrail,
       tierReveal,
     });

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -51,12 +51,14 @@ function renderPanel(
     onSetPathSource?: () => void;
     domain?: { id: string; title: string } | null;
     onSelectConnection?: (id: string) => void;
+    sourceTitle?: string | null;
   } = {},
 ) {
   render(
     <TopologyV2DetailPanel
       slug="domains/views"
       title="Views"
+      sourceTitle={overrides.sourceTitle ?? null}
       kind="domain"
       domain={overrides.domain !== undefined ? overrides.domain : null}
       powered={false}
@@ -151,6 +153,32 @@ describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYST
       "href",
       expect.stringContaining("product-owner-operating-system"),
     );
+  });
+});
+
+// 슬라이스 B (element 라벨 인간화) — display 로 인간화된 title 이 렌더될 때
+// 원문 코드 경로를 모노 서브라인으로 보존한다. 호출자가 display !== 원문일
+// 때만 sourceTitle 을 넘기는 계약이므로 패널 자체는 sourceTitle 유무 +
+// title 과의 동일 여부만으로 렌더 여부를 결정한다.
+describe("TopologyV2DetailPanel — 원문 경로 서브라인 (슬라이스 B)", () => {
+  it("sourceTitle 이 title 과 다르면 모노 서브라인으로 원문을 보존해 렌더한다", () => {
+    renderPanel(undefined, undefined, { sourceTitle: "src/foo/bar-baz.ts" });
+    const subline = screen.getByTestId("topology-v2-detail-panel-source-path");
+    expect(subline).toHaveTextContent("src/foo/bar-baz.ts");
+  });
+
+  it("sourceTitle 이 없으면(null/undefined) 서브라인을 렌더하지 않는다", () => {
+    renderPanel(undefined, undefined, {});
+    expect(
+      screen.queryByTestId("topology-v2-detail-panel-source-path"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sourceTitle 이 title 과 같으면(중복) 서브라인을 렌더하지 않는다", () => {
+    renderPanel(undefined, undefined, { sourceTitle: "Views" });
+    expect(
+      screen.queryByTestId("topology-v2-detail-panel-source-path"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -52,6 +52,8 @@ function renderPanel(
     domain?: { id: string; title: string } | null;
     onSelectConnection?: (id: string) => void;
     sourceTitle?: string | null;
+    showHandoff?: boolean;
+    showSourcePath?: boolean;
   } = {},
 ) {
   render(
@@ -83,6 +85,8 @@ function renderPanel(
       onClose={() => {}}
       onSetPathSource={overrides.onSetPathSource ?? (() => {})}
       onOpenFullDetail={onOpenFullDetail}
+      showHandoff={overrides.showHandoff}
+      showSourcePath={overrides.showSourcePath}
     />,
   );
 }
@@ -176,6 +180,38 @@ describe("TopologyV2DetailPanel — 원문 경로 서브라인 (슬라이스 B)"
 
   it("sourceTitle 이 title 과 같으면(중복) 서브라인을 렌더하지 않는다", () => {
     renderPanel(undefined, undefined, { sourceTitle: "Views" });
+    expect(
+      screen.queryByTestId("topology-v2-detail-panel-source-path"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// 슬라이스 C (개발/비개발 모드 토글) — 비개발(plain) 모드는 인계 복사 액션과
+// 원문 경로 서브라인을 개발자 크롬으로 간주해 숨긴다. 기본(생략)은 둘 다 true
+// (기존 렌더 유지 — 회귀 0).
+describe("TopologyV2DetailPanel — showHandoff / showSourcePath (슬라이스 C)", () => {
+  it("showHandoff 생략 시 기본으로 인계 복사 타일을 렌더한다", () => {
+    renderPanel();
+    expect(screen.getByTestId("topology-v2-detail-panel-action-handoff")).toBeInTheDocument();
+  });
+
+  it("showHandoff=false 면 인계 복사 타일을 렌더하지 않는다", () => {
+    renderPanel(undefined, undefined, { showHandoff: false });
+    expect(
+      screen.queryByTestId("topology-v2-detail-panel-action-handoff"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("showSourcePath 생략 시 기본으로 원문 경로 서브라인을 렌더한다 (sourceTitle 이 있을 때)", () => {
+    renderPanel(undefined, undefined, { sourceTitle: "src/foo/bar-baz.ts" });
+    expect(screen.getByTestId("topology-v2-detail-panel-source-path")).toBeInTheDocument();
+  });
+
+  it("showSourcePath=false 면 sourceTitle 이 있어도 원문 경로 서브라인을 렌더하지 않는다", () => {
+    renderPanel(undefined, undefined, {
+      sourceTitle: "src/foo/bar-baz.ts",
+      showSourcePath: false,
+    });
     expect(
       screen.queryByTestId("topology-v2-detail-panel-source-path"),
     ).not.toBeInTheDocument();

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -124,6 +124,13 @@ export interface TopologyV2DetailPanelLabels {
 export interface TopologyV2DetailPanelProps {
   slug: string;
   title: string;
+  /**
+   * 슬라이스 B (element 라벨 인간화) — `title` 이 표시용으로 변환된 값일 때
+   * (예: element 노드의 코드 경로 원문 → "Bar Baz" 같은 사람 이름), 원문을
+   * 보존해서 보여주는 모노 서브라인. 호출자가 display !== 원문 title 일
+   * 때만 넘긴다 — 같으면 undefined/null 로 생략해 중복 렌더를 막는다.
+   */
+  sourceTitle?: string | null;
   kind: string;
   /**
    * N6 (persona-ux-2026-07 report — PM 페르소나 "어디 소속?" 1차 질문에
@@ -229,6 +236,7 @@ const ACTION_TILE_DISABLED_CLASS =
 export function TopologyV2DetailPanel({
   slug,
   title,
+  sourceTitle = null,
   kind,
   domain,
   powered,
@@ -495,6 +503,14 @@ export function TopologyV2DetailPanel({
               {title}
             </h2>
           </div>
+          {sourceTitle && sourceTitle !== title ? (
+            <div
+              data-testid="topology-v2-detail-panel-source-path"
+              className="pl-[13.5px] font-mono text-[11px] text-[color:var(--color-text-quaternary)] break-all"
+            >
+              {sourceTitle}
+            </div>
+          ) : null}
           <div className="flex items-center gap-1.5 pl-[13.5px]">
             <span className="text-[11px] text-[color:var(--topology-v2-panel-text-tertiary)]">
               {labels.kindLabel}

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -204,6 +204,17 @@ export interface TopologyV2DetailPanelProps {
    */
   presence?: "entering" | "exiting";
   className?: string;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 인계 복사(handoff) 액션 타일. 기본
+   * `true`(기존 렌더 유지). 비개발(plain) 모드에서 HomePage 가 `false` 를
+   * 넘겨 개발자 크롬으로 숨긴다.
+   */
+  showHandoff?: boolean;
+  /**
+   * 슬라이스 C — 원문 경로 서브라인(슬라이스 B, `sourceTitle`). 기본
+   * `true`. 비개발(plain) 모드에서 `false` — 코드 경로는 개발자 어휘.
+   */
+  showSourcePath?: boolean;
 }
 
 // 데이터시트 내부 정제 (2026-07-23) — `justify-start` + 고정 상단 패딩: 라벨이
@@ -256,6 +267,8 @@ export function TopologyV2DetailPanel({
   onOpenFullDetail,
   presence = "entering",
   className,
+  showHandoff = true,
+  showSourcePath = true,
 }: TopologyV2DetailPanelProps) {
   const metricSegments = buildV2MetricSegments(metric, {
     contains: labels.metricContains,
@@ -503,7 +516,7 @@ export function TopologyV2DetailPanel({
               {title}
             </h2>
           </div>
-          {sourceTitle && sourceTitle !== title ? (
+          {showSourcePath && sourceTitle && sourceTitle !== title ? (
             <div
               data-testid="topology-v2-detail-panel-source-path"
               className="pl-[13.5px] font-mono text-[11px] text-[color:var(--color-text-quaternary)] break-all"
@@ -636,19 +649,21 @@ export function TopologyV2DetailPanel({
             <span>{labels.actionEditRelations}</span>
           </Link>,
         )}
-        {withActionTip(
-          labels.actionCopyHandoffTip,
-          <button
-            type="button"
-            onClick={() => onCopyHandoff(handoffText)}
-            aria-label={labels.handoff}
-            data-testid="topology-v2-detail-panel-action-handoff"
-            className={ACTION_TILE_CLASS}
-          >
-            <Copy size={15} aria-hidden="true" />
-            <span>{labels.actionCopyHandoff}</span>
-          </button>,
-        )}
+        {showHandoff
+          ? withActionTip(
+              labels.actionCopyHandoffTip,
+              <button
+                type="button"
+                onClick={() => onCopyHandoff(handoffText)}
+                aria-label={labels.handoff}
+                data-testid="topology-v2-detail-panel-action-handoff"
+                className={ACTION_TILE_CLASS}
+              >
+                <Copy size={15} aria-hidden="true" />
+                <span>{labels.actionCopyHandoff}</span>
+              </button>,
+            )
+          : null}
         {withActionTip(
           labels.actionPathTip,
           <button

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -226,13 +226,15 @@ export interface TopologyV2DetailPanelProps {
 // transition-colors(150ms)로 하드 토글 방지 — transform/scale 없음.
 /**
  * 결과-설명 툴팁 래퍼 — tip 이 있으면 shared Tooltip 으로 감싸고, 없으면
- * 트리거를 그대로 반환(하위호환·DOM 무증가). side="bottom": 타일 행이 패널
- * 상단부라 위로 띄우면 메트릭 라인을 가린다.
+ * 트리거를 그대로 반환(하위호환·DOM 무증가). side="top": 타일 바로 아래에
+ * "영역 전개" 같은 다음 행동 버튼이 있어 side="bottom" 이면 hover 중 그
+ * 버튼을 덮어 클릭을 방해한다(사용성 검수 판정). 위로 띄우면 메트릭 라인을
+ * 잠깐 가리지만 그건 hover 중에만이고, 다음 행동을 막지는 않는다.
  */
 function withActionTip(tip: string | undefined, trigger: ReactElement): ReactElement {
   if (!tip) return trigger;
   return (
-    <Tooltip content={tip} side="bottom">
+    <Tooltip content={tip} side="top">
       {trigger}
     </Tooltip>
   );

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
@@ -33,6 +33,7 @@ const labels = {
   audience: "View mode",
   audienceDev: "Developer",
   audiencePlain: "General",
+  audienceCaption: "General — folds away code elements and uses plain language",
 };
 
 function renderGear(
@@ -257,5 +258,31 @@ describe("TopologyV2SettingsGear — 보기 모드(audience) 행 (슬라이스 C
       "aria-pressed",
       "false",
     );
+  });
+
+  // P2 결함③ (사용성 전수 검수 2026-07-23) — 토글에 설명이 전혀 없어 비개발자가
+  // "일반" 이 뭘 바꾸는지 알 방법이 없었다. 행 아래 caption 한 줄.
+  it("P2 결함③ — renders a caption line under the 보기 모드 row when provided", () => {
+    renderGear();
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    const popover = screen.getByTestId("topology-v2-settings-gear-popover");
+    expect(within(popover).getByText(labels.audienceCaption)).toBeInTheDocument();
+  });
+
+  it("P2 결함③ — omits the caption line when the label isn't provided (backward-compat)", () => {
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <TopologyV2SettingsGear
+          indexDefaultCollapsed={false}
+          onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
+          changeVaultHref="/docs/?intent=local"
+          labels={{ ...labels, audienceCaption: undefined }}
+        />
+      </NextIntlClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    expect(screen.queryByTestId("topology-v2-settings-gear-audience-caption")).not.toBeInTheDocument();
   });
 });

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
@@ -30,11 +30,16 @@ const labels = {
   indexDefaultCollapsed: "Collapsed",
   changeVault: "Switch vault",
   changeVaultAriaLabel: "Open the workspace to pick a different local vault folder",
+  audience: "View mode",
+  audienceDev: "Developer",
+  audiencePlain: "General",
 };
 
 function renderGear(
   onChangeIndexDefaultCollapsed: (next: boolean) => void = () => {},
   indexDefaultCollapsed = false,
+  onChangeAudiencePlain: (next: boolean) => void = () => {},
+  audiencePlain = false,
 ) {
   return render(
     <NextIntlClientProvider locale="en" messages={enMessages}>
@@ -43,6 +48,8 @@ function renderGear(
         onChangeIndexDefaultCollapsed={onChangeIndexDefaultCollapsed}
         changeVaultHref="/docs/?intent=local"
         labels={labels}
+        audiencePlain={audiencePlain}
+        onChangeAudiencePlain={onChangeAudiencePlain}
       />
     </NextIntlClientProvider>,
   );
@@ -119,6 +126,8 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
         <TopologyV2SettingsGear
           indexDefaultCollapsed={false}
           onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
           changeVaultHref="/docs/?intent=local"
           labels={labels}
           suppressed={false}
@@ -133,6 +142,8 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
         <TopologyV2SettingsGear
           indexDefaultCollapsed={false}
           onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
           changeVaultHref="/docs/?intent=local"
           labels={labels}
           suppressed={true}
@@ -172,6 +183,8 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
         <TopologyV2SettingsGear
           indexDefaultCollapsed={false}
           onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
           changeVaultHref="/docs/?intent=local"
           labels={labels}
           popoverAlign="left"
@@ -190,6 +203,8 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
         <TopologyV2SettingsGear
           indexDefaultCollapsed={false}
           onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
           changeVaultHref="/docs/?intent=local"
           labels={labels}
           popoverAlign="left"
@@ -201,5 +216,46 @@ describe("TopologyV2SettingsGear — utility-rail settings popover", () => {
     const popover = screen.getByTestId("topology-v2-settings-gear-popover");
     expect(popover.className).toContain("bottom-[calc(100%+8px)]");
     expect(popover.className).not.toContain("top-[calc(100%+8px)]");
+  });
+});
+
+// 슬라이스 C (개발/비개발 모드 토글) — "INDEX 기본 상태" 행과 같은 SettingsRow
+// + 2-세그먼트 토글 패턴의 새 "보기 모드" 행.
+describe("TopologyV2SettingsGear — 보기 모드(audience) 행 (슬라이스 C)", () => {
+  it("renders the 보기 모드 row with its label in the popover", () => {
+    renderGear();
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    const popover = screen.getByTestId("topology-v2-settings-gear-popover");
+    expect(within(popover).getByTestId("topology-v2-settings-gear-audience")).toBeInTheDocument();
+    expect(within(popover).getByText(labels.audience)).toBeInTheDocument();
+  });
+
+  it("calls onChangeAudiencePlain(true) when the 일반(plain) option is picked", () => {
+    const onChangeAudiencePlain = vi.fn();
+    renderGear(() => {}, false, onChangeAudiencePlain, false);
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    fireEvent.click(screen.getByRole("button", { name: labels.audiencePlain }));
+    expect(onChangeAudiencePlain).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onChangeAudiencePlain(false) when the 개발(dev) option is picked", () => {
+    const onChangeAudiencePlain = vi.fn();
+    renderGear(() => {}, false, onChangeAudiencePlain, true);
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    fireEvent.click(screen.getByRole("button", { name: labels.audienceDev }));
+    expect(onChangeAudiencePlain).toHaveBeenCalledWith(false);
+  });
+
+  it("reflects the current mode via aria-pressed on the active segment", () => {
+    renderGear(() => {}, false, () => {}, true);
+    fireEvent.click(screen.getByTestId("topology-v2-settings-gear-trigger"));
+    expect(screen.getByRole("button", { name: labels.audiencePlain })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: labels.audienceDev })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 });

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
@@ -60,6 +60,12 @@ export interface TopologyV2SettingsGearLabels {
   audience: string;
   audienceDev: string;
   audiencePlain: string;
+  /**
+   * P2 결함③ (사용성 전수 검수 2026-07-23) — "보기 모드" 토글 자체엔 존재
+   * 발견성이 있어도(기어 안), 무엇을 바꾸는지 설명이 0 이었다. 행 아래
+   * caption 한 줄. 생략하면 렌더하지 않는다(하위호환).
+   */
+  audienceCaption?: string;
 }
 
 export interface TopologyV2SettingsGearProps {
@@ -258,6 +264,14 @@ export function TopologyV2SettingsGear({
                 })}
               </div>
             </SettingsRow>
+            {labels.audienceCaption ? (
+              <p
+                data-testid="topology-v2-settings-gear-audience-caption"
+                className="-mt-2 text-[10.5px] leading-[1.5] text-[color:var(--color-text-quaternary)]"
+              >
+                {labels.audienceCaption}
+              </p>
+            ) : null}
             <SettingsRow label={labels.indexDefault}>
               <div
                 role="group"

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
@@ -53,12 +53,25 @@ export interface TopologyV2SettingsGearLabels {
    *  open a different local folder without leaving the map to hunt for it. */
   changeVault: string;
   changeVaultAriaLabel: string;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — "보기 모드" 행. `audience` 는 행
+   * 라벨, `audienceDev`/`audiencePlain` 은 2-세그먼트 토글의 두 옵션 라벨.
+   */
+  audience: string;
+  audienceDev: string;
+  audiencePlain: string;
 }
 
 export interface TopologyV2SettingsGearProps {
   /** Current INDEX-panel-collapsed-by-default preference. */
   indexDefaultCollapsed: boolean;
   onChangeIndexDefaultCollapsed: (next: boolean) => void;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 현재 "비개발(plain)" 모드인가. true 면
+   * element 티어 상시 숨김 + plain 어휘 + 개발자 크롬 숨김(HomePage 가 적용).
+   */
+  audiencePlain: boolean;
+  onChangeAudiencePlain: (next: boolean) => void;
   /** `/docs` href that lets the user pick a different vault folder. */
   changeVaultHref: string;
   labels: TopologyV2SettingsGearLabels;
@@ -105,6 +118,8 @@ export interface TopologyV2SettingsGearProps {
 export function TopologyV2SettingsGear({
   indexDefaultCollapsed,
   onChangeIndexDefaultCollapsed,
+  audiencePlain,
+  onChangeAudiencePlain,
   changeVaultHref,
   labels,
   className,
@@ -207,6 +222,41 @@ export function TopologyV2SettingsGear({
           <div className="flex flex-col gap-3 p-3">
             <SettingsRow label={labels.locale}>
               <LocaleSwitch />
+            </SettingsRow>
+            {/* 슬라이스 C (개발/비개발 모드 토글) — "INDEX 기본 상태" 바로 위,
+                같은 SettingsRow + 2-세그먼트 토글 패턴. */}
+            <SettingsRow label={labels.audience}>
+              <div
+                role="group"
+                aria-label={labels.audience}
+                data-testid="topology-v2-settings-gear-audience"
+                className="inline-flex items-center gap-px rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] p-px text-[11px]"
+              >
+                {(
+                  [
+                    { value: false, label: labels.audienceDev },
+                    { value: true, label: labels.audiencePlain },
+                  ] as const
+                ).map((option) => {
+                  const active = option.value === audiencePlain;
+                  return (
+                    <button
+                      key={String(option.value)}
+                      type="button"
+                      onClick={() => onChangeAudiencePlain(option.value)}
+                      aria-pressed={active}
+                      className={[
+                        "flex h-8 items-center justify-center rounded-[4px] px-2 font-medium transition-colors",
+                        active
+                          ? "bg-[color:var(--color-panel)] text-[color:var(--color-text-primary)]"
+                          : "text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-secondary)]",
+                      ].join(" ")}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
             </SettingsRow>
             <SettingsRow label={labels.indexDefault}>
               <div

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -851,6 +851,15 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
         hoverEmphasis: emphasis,
         selectionPulse: selectionPulseVisual,
         agentFocus: agentFocusNodeId !== null && node.id === agentFocusNodeId,
+        // 스포트라이트 변경-노드 링 (Image #14) — 렌즈 ON + 창 안 노드에만.
+        // dashOffset = now×speed 회전 위상(reduced-motion 정적), alpha = 램프.
+        spotlightRing:
+          spotlightLensActive && spotlightIds !== null && spotlightIds.has(node.id)
+            ? {
+                alpha: spotlightRamp,
+                dashOffset: reducedMotion ? 0 : (now * tokens.spotlightRingSpeed) % 9,
+              }
+            : null,
         now,
         reducedMotion,
       },

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -923,7 +923,15 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
 
     // S8 결함 1 — 펼친 부모 구분: 노드 디스크 바깥에 파선 오라 링(선택 ego 링은
     // 실선이라 채널 충돌 없음). 노드 위에 얹되 알파는 노드 티어 알파를 따른다.
-    if (expandedParentIds.has(node.id)) {
+    // 단, 스포트라이트 변경-노드 링(앰버 파선, 같은 r+6 궤도)이 활성인 노드에선
+    // 오라를 양보한다 — 두 파선이 같은 반경에서 인터리브되어 두-색 브레이드로
+    // 읽히는 결함(모션 검수 2026-07-23 프레임 증거). 렌즈 중 변경 노드는 앰버
+    // 링 하나가 "전개+변경"을 다 말한다(궤도당 신호 1개); 변경 아닌 전개
+    // 조상(티어 관통 전개)은 기존 인디고 오라 유지.
+    if (
+      expandedParentIds.has(node.id) &&
+      !(spotlightLensActive && spotlightIds !== null && spotlightIds.has(node.id))
+    ) {
       ctx.save();
       ctx.setLineDash([...EXPANDED_AURA_DASH]);
       ctx.globalAlpha = tierAlpha * EXPANDED_AURA_ALPHA;

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -12,7 +12,7 @@ import { computeSelectionPulse, type SelectionPulseVisual } from "../model/selec
 import { footprintRingStyle, FOOTPRINT_RING_OFFSET } from "../model/footprint-ring";
 import { depthParallaxOffsetFor, ZERO_PARALLAX } from "../model/realm-depth-parallax";
 import { realmDepthClarityAlpha, realmDepthClarityScale } from "../model/realm-transition";
-import { classifyZoomTier, DEFAULT_TIER_REVEAL, edgeTierAlpha, effectiveNodeAlpha, nodeTierAlpha } from "../model/tier-visibility";
+import { classifyZoomTier, DEFAULT_TIER_REVEAL, edgeTierAlpha, effectiveNodeAlpha, nodeTierAlpha, type TierRevealConfig } from "../model/tier-visibility";
 import { DISC_LABEL_TOP_K, LABEL_TOP_K, selectDiscLabelEligible, selectTopKLabels, type LabelRankEntry } from "../model/label-lod";
 import { draw as gridDraw, lerpColorHex } from "../render/grid";
 import {
@@ -403,6 +403,13 @@ export interface FrameDrawParams {
   spotlightIds: ReadonlySet<string> | null;
   /** 스포트라이트 on/off 지수 램프 0..1 — loop 가 `stepFocusRamp`(focusDimTau 재사용)로 step. */
   spotlightRamp: number;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 티어 게이트 config. 생략 시
+   * `DEFAULT_TIER_REVEAL`(개발 모드). 비개발(plain) 모드는 HomePage 가
+   * `PLAIN_TIER_REVEAL`(element 상시 숨김)을 넘긴다 — 그리기 게이트도 히트/
+   * 팬-클램프와 같은 config 를 봐야 lockstep 이 깨지지 않는다.
+   */
+  tierReveal?: TierRevealConfig;
 }
 
 /** The full per-frame paint, in the prototype's `render()` order (§13): background -> dust -> edges (contains, depends) -> nodes (+ bright-star spikes) -> labels. */
@@ -449,6 +456,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     footprintRanksById,
     spotlightIds,
     spotlightRamp,
+    tierReveal = DEFAULT_TIER_REVEAL,
   } = params;
 
   // 스포트라이트 침강 배수 — 렌즈 ON + 램프 진행 중 + 포커스/엣지선택 비활성
@@ -539,7 +547,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   const effectiveAlphaById = effectiveAlphaByIdReused;
   for (const node of world.nodes) {
     const tierKind = realmTierKinds?.get(node.id) ?? node.kind;
-    const tierAlpha = nodeTierAlpha(tierKind, node.isHub, zoomRatio, DEFAULT_TIER_REVEAL);
+    const tierAlpha = nodeTierAlpha(tierKind, node.isHub, zoomRatio, tierReveal);
     tierAlphaById.set(node.id, tierAlpha);
     const isPairMember =
       focusedNodeId === null &&
@@ -1072,7 +1080,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   // (circuit) bands the label budget goes to the highest-degree nodes; at the
   // deepest element zoom the budget lifts and every label returns. Exempt from
   // the budget: ego focus members and the hovered node only.
-  const applyLabelTopK = classifyZoomTier(zoomRatio) !== "element";
+  const applyLabelTopK = classifyZoomTier(zoomRatio, tierReveal) !== "element";
   // High-fan disc 밀도 처방: an expanded phyllotaxis disc can hold dozens–
   // hundreds of children. Blanket-exempting them all (the old behavior) punched
   // a wall of ~60 labels across the map. Instead, per disc only the DOI top-K

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -21,6 +21,7 @@ import {
   computeDomainWatermarkAlpha,
   computeLabelAlpha,
   draw as labelsDraw,
+  drawInstrumentCaption,
   LABEL_OFFSET,
   labelZoomScale,
   measureLabelWidth,
@@ -62,6 +63,11 @@ import { isSpineNode, radiusForKind, type TopologyWorld, type WorldNode } from "
  */
 const EXPANDED_AURA_RING_OFFSET = 6;
 const EXPANDED_AURA_DASH: readonly number[] = [3, 3];
+/** 영역 루트 앵커 링 알파 — 결계(0.5)보다 한 단계 또렷한 실선 헤어라인(중심이 주인공). */
+const REALM_ROOT_ANCHOR_ALPHA = 0.7;
+/** 결계 센서스 각인 — 원 하단 바깥 오프셋(px, 화면 고정)과 잉크 알파. */
+const WARDING_CAPTION_OFFSET_PX = 24;
+const WARDING_CAPTION_ALPHA = 0.62;
 const EXPANDED_AURA_ALPHA = 0.55;
 /**
  * S8 결함 1 — 확장 디스크와 무관한 배경 노드를 확장 중 미세 dim 해 "어지러움"을
@@ -361,7 +367,7 @@ export interface FrameDrawParams {
    * 반경에 1px 인디고 헤어라인 원을 두른다. `drawProgress` 0..1 로 stroke 를
    * 자기 드로잉한다(전환 초반 ~200ms). null 이면 미표시(회귀 0).
    */
-  wardingRing: { centerX: number; centerY: number; radius: number; drawProgress: number } | null;
+  wardingRing: { centerX: number; centerY: number; radius: number; drawProgress: number; caption: string | null } | null;
   /** S4 — 멤버별 깊이 기반 티어 kind 오버라이드 (영역 세계의 티어 = 재배치 깊이). */
   realmTierKinds: ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null;
   /**
@@ -951,6 +957,22 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
       ctx.setLineDash([]);
       ctx.restore();
     }
+
+    // 영역 루트 앵커 링 (소유자 실보고 2026-07-23 "루트가 유령 같다") — 영역
+    // 전개 중 루트(depth 0)에 결계와 **같은 인디고 실선 헤어라인** 링을 두른다.
+    // 세계의 경계(큰 원)와 그 중심(작은 링)이 같은 잉크로 호응해 "이 원은 이
+    // 노드의 세계" 가 기하만으로 읽힌다. 파선 오라(확장)·앰버 링과 채널 분리,
+    // glow 0, 신규 토큰 0 (tokens.indigo 재사용).
+    if (realmDepthById !== null && realmDepthById.get(node.id) === 0 && wardingRing !== null) {
+      ctx.save();
+      ctx.globalAlpha = tierAlpha * REALM_ROOT_ANCHOR_ALPHA * wardingRing.drawProgress;
+      ctx.strokeStyle = tokens.indigo;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(screen.x, screen.y, screenRadius + EXPANDED_AURA_RING_OFFSET, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+    }
     ctx.globalAlpha = 1;
   }
 
@@ -972,6 +994,21 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     ctx.stroke();
     ctx.restore();
     ctx.globalAlpha = 1;
+
+    // 결계 센서스 각인 — 원 하단 바깥, tracked-caps 계기 문법(도메인 워터마크와
+    // 동일 폰트/트래킹, 화면 고정 크기). 원이 "무엇의 경계인지" 스스로 말한다
+    // ("2 ELEMENTS" 류). 잉크는 노드 라벨과 같은 neutral(labelDomain), 링
+    // 자기드로잉 진행도에 실려 함께 나타나고 함께 지워진다. 신규 토큰 0.
+    if (wardingRing.caption && wardingRing.drawProgress > 0.05) {
+      drawInstrumentCaption(
+        ctx,
+        wardingRing.caption,
+        center.x,
+        center.y + screenRadius + WARDING_CAPTION_OFFSET_PX,
+        tokens.labelDomain,
+        WARDING_CAPTION_ALPHA * wardingRing.drawProgress,
+      );
+    }
   }
 
   // --- 밀도 게이트 클러스터 칩 (fable 설계) — 노드 위, 라벨 아래에 그린다.

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -12,7 +12,7 @@ import { computePanBounds, stepCamera, type CameraAxes, type CameraTarget } from
 import { computeAltitudeBand, computeFarT } from "../model/altitude";
 import { isNodeEmphasisActive, resolveEdgePulseSpeed, stepEmphasis, stepFocusRamp } from "../model/focus-state";
 import { edgePairKey, selectEgoContainsComets, updateParticles } from "../render/edge-fireflies";
-import { computeZoomRatio, DEFAULT_TIER_REVEAL, isSpineOnlyZoom } from "../model/tier-visibility";
+import { computeZoomRatio, DEFAULT_TIER_REVEAL, isSpineOnlyZoom, type TierRevealConfig } from "../model/tier-visibility";
 import type { TopologyV2Tokens } from "../tokens/read-topology-v2-tokens";
 import { computeEffectiveCameraScaleMax, computeEffectiveCameraScaleMin } from "./topology-camera-math";
 import type { TopologyWorld } from "./topology-world";
@@ -114,6 +114,12 @@ export interface PhysicsStepInput {
    * fades an untracked node).
    */
   appearById: Map<string, number>;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 티어 게이트 config. 생략 시
+   * `DEFAULT_TIER_REVEAL`. 팬-클램프의 spine-only 판정이 드로우/히트와 같은
+   * config 를 봐야 한다.
+   */
+  tierReveal?: TierRevealConfig;
 }
 
 export interface PhysicsStepResult {
@@ -152,6 +158,7 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     egoRevealById,
     focusRampById,
     appearById,
+    tierReveal = DEFAULT_TIER_REVEAL,
   } = input;
 
   // Tier visibility rides a SEPARATE zoom-ratio signal (not farT): entry scale
@@ -188,7 +195,7 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
         tokens.cameraFocusPanMargin,
       )
     : computePanBounds(
-        isSpineOnlyZoom(preStepZoomRatio, DEFAULT_TIER_REVEAL) ? world.spineBounds : world.bounds,
+        isSpineOnlyZoom(preStepZoomRatio, tierReveal) ? world.spineBounds : world.bounds,
       );
 
   // C1 A1: the camera's real zoom-in ceiling is now ratio-based (viewport-

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -28,7 +28,7 @@ import { projectFlickLanding, sampleReleaseVelocity } from "../engine/momentum";
 import { EGO_NEIGHBOR_CHIP_ID, parseClusterMoreChipId, scheduleRipple } from "../model/focus-state";
 import { type Pulse } from "../render/edge-fireflies";
 import type { ForceSimulation } from "../model/force-layout";
-import { computeZoomRatio, DEFAULT_TIER_REVEAL, isNodeHittable, isSpineOnlyZoom } from "../model/tier-visibility";
+import { computeZoomRatio, DEFAULT_TIER_REVEAL, isNodeHittable, isSpineOnlyZoom, type TierRevealConfig } from "../model/tier-visibility";
 import { computeDragTugSets, type DragTugSets } from "../interaction/drag-tug";
 import { hitTestEdges, type EdgeHitCandidate } from "./topology-edge-hit";
 import { clusterBadgeLabel, clusterBadgeRect, clusterChipLabel, clusterChipRect, clusterChipScale } from "../render/cluster-chips";
@@ -188,6 +188,12 @@ export interface PointerHandlerRefs {
    * 프레임 드로우와 **같은 게이트**로 채운다(영역 비활성이면 null).
    */
   realmTierKindsRef?: Ref<ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null>;
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 티어 게이트 config 미러(드로우와
+   * **같은** config 여야 히트/팬-클램프가 그려진 것과 lockstep). 생략 시
+   * `DEFAULT_TIER_REVEAL`.
+   */
+  tierRevealRef?: Ref<TierRevealConfig>;
   onHoverEdge?: (
     edge: { sourceId: string; targetId: string; relationType: string; declaredBySlug: string | null } | null,
     position: { x: number; y: number } | null,
@@ -295,6 +301,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     hoveredClusterIdRef,
     realmParallaxRef,
     realmTierKindsRef,
+    tierRevealRef,
     onSelect,
     onSelectEdge,
     onHoverEdge,
@@ -385,7 +392,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       tokens,
       px,
       py,
-      (node) => isNodeHittable(node, zoomRatio, focusedNodeId, neighborsOfFocused, DEFAULT_TIER_REVEAL, clusteredIds, realmTierKinds),
+      (node) => isNodeHittable(node, zoomRatio, focusedNodeId, neighborsOfFocused, tierRevealRef?.current ?? DEFAULT_TIER_REVEAL, clusteredIds, realmTierKinds),
       renderOffsetForNode,
     );
   };
@@ -416,7 +423,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     const realmTierKinds = realmTierKindsRef?.current ?? null;
     const hittable = new Set(
       world.nodes
-        .filter((n) => isNodeHittable(n, zoomRatio, focusedNodeId, neighborsOfFocused, DEFAULT_TIER_REVEAL, clusteredIds, realmTierKinds))
+        .filter((n) => isNodeHittable(n, zoomRatio, focusedNodeId, neighborsOfFocused, tierRevealRef?.current ?? DEFAULT_TIER_REVEAL, clusteredIds, realmTierKinds))
         .map((n) => n.id),
     );
     // 히트테스트 역전 방지(패널3-S3) — 끝 노드 몸통 반경(스크린 px)을
@@ -817,7 +824,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
       if (world) {
         const overviewEntryScale = overviewScaleRef.current * tokens.overviewEntryRatio;
         const zoomRatio = computeZoomRatio(cameraRef.current.scale.value, overviewEntryScale);
-        const boundsSource = isSpineOnlyZoom(zoomRatio, DEFAULT_TIER_REVEAL) ? world.spineBounds : world.bounds;
+        const boundsSource = isSpineOnlyZoom(zoomRatio, tierRevealRef?.current ?? DEFAULT_TIER_REVEAL) ? world.spineBounds : world.bounds;
         clampedLanding = clampPointToPanBounds(px.landingTarget, py.landingTarget, computePanBounds(boundsSource));
       }
       cameraTargetRef.current = { tx: clampedLanding.x, ty: clampedLanding.y, tscale: cameraTargetRef.current.tscale };

--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.test.ts
@@ -5,6 +5,8 @@ import { buildTopologyWorld } from "./topology-world";
 import type { TopologyV2Edge, TopologyV2Node } from "./TopologyMapV2";
 import { buildRealmRuntimeData, realmCameraTarget, realmVisibleBounds } from "./topology-realm-runtime";
 import { DENSITY_GATE_THRESHOLD } from "../model/density-gate";
+import { computeRealmLayout, extractRealmSubtree } from "../model/realm";
+import type { LayoutRings } from "../model/layout";
 
 const tokens = {
   radiusProject: 20,
@@ -14,6 +16,9 @@ const tokens = {
   layoutRingDomain: 250,
   layoutRingCapability: 145,
   layoutRingElement: 90,
+  realmFillRadius1: 130,
+  realmFillRadius2: 190,
+  realmFillRadius3: 250,
   edgeBowContains: 70,
   edgeBowDepends: 92,
   edgeBlendContains: 0.46,
@@ -122,6 +127,71 @@ describe("buildRealmRuntimeData", () => {
     expect(target.ty).toBeCloseTo((data.bounds.minY + data.bounds.maxY) / 2, 4);
     expect(target.tscale).toBeLessThanOrEqual(2.6);
     expect(target.tscale).toBeGreaterThanOrEqual(0.24);
+  });
+});
+
+/**
+ * 슬라이스 A — 영역(realm) 링이 서브트리 최대 깊이에서 파생되는지. 얕은
+ * 서브트리(capability 루트 + element 자식 2개, maxDepth=1)는 250 전역
+ * 스파인 링이 아니라 130(`realmFillRadius1`)으로 당겨야 "빈 annulus" 가
+ * 없다(소유자 실보고 2026-07-23).
+ */
+describe("buildRealmRuntimeData — depth-derived realm ring fill (Slice A)", () => {
+  function buildShallowCapabilityWorld() {
+    const nodes: TopologyV2Node[] = [
+      inputNode({ id: "c", kind: "capability" }),
+      inputNode({ id: "e1", kind: "element" }),
+      inputNode({ id: "e2", kind: "element" }),
+    ];
+    const edges: TopologyV2Edge[] = [containsEdge("c", "e1"), containsEdge("c", "e2")];
+    return buildTopologyWorld(nodes, edges, tokens);
+  }
+
+  it("pulls a shallow (maxDepth=1) realm's depth-1 children to ≈130, not the 250 global spine ring", () => {
+    const world = buildShallowCapabilityWorld();
+    const data = buildRealmRuntimeData(world, "c", tokens)!;
+    for (const id of ["e1", "e2"]) {
+      const p = data.insideTargets.get(id)!;
+      const r = Math.hypot(p.x, p.y);
+      expect(r).toBeCloseTo(tokens.realmFillRadius1, 0);
+      expect(r).toBeLessThan(tokens.layoutRingDomain);
+    }
+  });
+
+  it("tightens the warding radius for the shallow realm (no longer stretched to the 250-ring scale)", () => {
+    const world = buildShallowCapabilityWorld();
+    const shallow = buildRealmRuntimeData(world, "c", tokens)!;
+    // 자식이 ~130 반경에 앉으므로 결계도 그 근방이어야 한다 — 250 스파인 기준이면
+    // 훨씬 커야 할 값(> 250)보다 뚜렷이 작다.
+    expect(shallow.wardingRadius).toBeLessThan(tokens.layoutRingDomain);
+  });
+
+  it("leaves a deep (maxDepth≥3) realm's coordinates identical to the unscaled base rings — regression guard", () => {
+    const world = buildFixtureWorld();
+    const data = buildRealmRuntimeData(world, "p", tokens)!;
+    // p ⊃ d(⊃ c ⊃ e) + p ⊃ d2(⊃ x) — maxDepth from "p" is 3 (p→d→c→e), so
+    // realmRingsForDepth caps at depth3 → s=1 → base rings unscaled.
+    const childrenByParent = new Map<string, string[]>([
+      ["p", ["d", "d2"]],
+      ["d", ["c"]],
+      ["c", ["e"]],
+      ["d2", ["x"]],
+    ]);
+    const subtree = extractRealmSubtree("p", childrenByParent);
+    const baseRings: LayoutRings = {
+      domain: tokens.layoutRingDomain,
+      capability: tokens.layoutRingCapability,
+      element: tokens.layoutRingElement,
+    };
+    const expected = computeRealmLayout(subtree, baseRings, {
+      project: tokens.radiusProject,
+      domain: tokens.radiusDomain,
+      capability: tokens.radiusCapability,
+      element: tokens.radiusElement,
+    });
+    for (const [id, p] of expected) {
+      expect(data.insideTargets.get(id)).toEqual({ x: p.x, y: p.y });
+    }
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
@@ -121,13 +121,36 @@ export function realmVisibleBounds(
   tokens: TopologyV2Tokens,
 ): RealmBounds {
   const points: { x: number; y: number }[] = [];
+  const reaches: number[] = [];
   let maxNodeRadius = 0;
   for (const [id, t] of collectVisibleMemberTargets(world, data.memberIds, data.insideTargets, expandedParents)) {
     const n = world.nodeById.get(id);
-    if (n) maxNodeRadius = Math.max(maxNodeRadius, radiusForKind(n.kind, tokens) * n.magnitudeScale);
+    const nr = n ? radiusForKind(n.kind, tokens) * n.magnitudeScale : 0;
+    if (nr > maxNodeRadius) maxNodeRadius = nr;
     points.push(t);
+    reaches.push(Math.hypot(t.x, t.y) + nr);
   }
-  return computeVisibleBounds(points, CONTENT_BOUNDS_MARGIN + maxNodeRadius, data.bounds);
+  const contentBounds = computeVisibleBounds(points, CONTENT_BOUNDS_MARGIN + maxNodeRadius, data.bounds);
+  // 결계 원 포함 프레이밍 — 같은 가시 집합으로 잰 결계 반경과 합집합 (아래
+  // `buildRealmRuntimeData` 의 프레이밍 계약과 동일).
+  return unionWithWardingCircle(contentBounds, computeVisibleWardingRadius(reaches));
+}
+
+/**
+ * 카메라 fit bbox = 콘텐츠 bbox ∪ 결계 원 bbox. 결계 원은 영역 표면의 프레임
+ * (하단 센서스 각인 포함)이라 잘리면 "우연한 호" 로 읽힌다 (소유자 실보고
+ * 2026-07-23 "원이 왜 존재하는지 모르겠다"). S9 의 "콘텐츠가 주인공(결계는
+ * 화면 밖 가장자리에 걸려도 좋다)" 은 접힌 자식까지 세던 유령 반경 시절의
+ * 계약 — 가시-멤버 반경(S9 결함 2)이 된 지금 결계는 콘텐츠 +10% 여백이라
+ * 원을 담아도 과대 축소가 없다. 순수.
+ */
+function unionWithWardingCircle(bounds: RealmBounds, wardingRadius: number): RealmBounds {
+  return {
+    minX: Math.min(bounds.minX, -wardingRadius),
+    minY: Math.min(bounds.minY, -wardingRadius),
+    maxX: Math.max(bounds.maxX, wardingRadius),
+    maxY: Math.max(bounds.maxY, wardingRadius),
+  };
 }
 
 /**
@@ -207,15 +230,17 @@ export function buildRealmRuntimeData(
   }
   const wardingRadius = computeVisibleWardingRadius(reaches);
 
-  // 카메라 fit 은 결계(마진 포함 원)가 아니라 **가시 콘텐츠 bbox** 기준 — 결계에
-  // 맞추면 세계가 화면 중앙에 조그맣게 보인다. 결계는 화면 밖 가장자리에 걸려도
-  // 좋다: 콘텐츠가 주인공.
-  const bounds = computeVisibleBounds(visibleMemberPoints, CONTENT_BOUNDS_MARGIN + maxNodeRadius, {
-    minX: -wardingRadius,
-    minY: -wardingRadius,
-    maxX: wardingRadius,
-    maxY: wardingRadius,
-  });
+  // 카메라 fit = 가시 콘텐츠 bbox ∪ 결계 원 bbox (`unionWithWardingCircle` 주석
+  // 참조 — 결계 원은 영역 표면의 프레임이므로 잘리지 않게 담는다).
+  const bounds = unionWithWardingCircle(
+    computeVisibleBounds(visibleMemberPoints, CONTENT_BOUNDS_MARGIN + maxNodeRadius, {
+      minX: -wardingRadius,
+      minY: -wardingRadius,
+      maxX: wardingRadius,
+      maxY: wardingRadius,
+    }),
+    wardingRadius,
+  );
 
   return {
     rootId,

--- a/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
+++ b/src/widgets/topology-map-v2/ui/topology-realm-runtime.ts
@@ -13,6 +13,8 @@ import {
   computeVisibleBounds,
   computeVisibleWardingRadius,
   extractRealmSubtree,
+  realmMaxDepth,
+  realmRingsForDepth,
   type RealmBounds,
 } from "../model/realm";
 import type { LayoutRadii, LayoutRings } from "../model/layout";
@@ -158,11 +160,11 @@ export function buildRealmRuntimeData(
     else containsChildren.set(e.sourceId, [e.targetId]);
   }
   const subtree = extractRealmSubtree(rootId, containsChildren);
-  const rings: LayoutRings = {
-    domain: tokens.layoutRingDomain,
-    capability: tokens.layoutRingCapability,
-    element: tokens.layoutRingElement,
-  };
+  const rings: LayoutRings = realmRingsForDepth(
+    realmMaxDepth(subtree),
+    { domain: tokens.layoutRingDomain, capability: tokens.layoutRingCapability, element: tokens.layoutRingElement },
+    { depth1: tokens.realmFillRadius1, depth2: tokens.realmFillRadius2, depth3: tokens.realmFillRadius3 },
+  );
   const radii: LayoutRadii = {
     project: tokens.radiusProject,
     domain: tokens.radiusDomain,

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -203,6 +203,12 @@ export interface UseTopologyLoopArgs {
   /** S4 — 궤도 "전개" 버튼 DOM (캔버스 좌표 앵커, 매 프레임 카메라 추종). */
   realmEnterButtonRef?: RefObject<HTMLButtonElement | null>;
   /**
+   * 결계 하단 센서스 각인 문구 — "○○ · 요소 N" (사용자 어휘 "이것만 보기",
+   * 2026-07-23 소유자 결정 — 내부명 realm 유지). HomePage 가 원장 census 와
+   * 같은 출처로 포맷해 내려보낸다(위젯은 i18n/census 를 직접 만지지 않는다).
+   */
+  realmCaption?: string | null;
+  /**
    * 발자국 트레일 (fable 설계) — 세션 동안 방문(ego 포커스)한 노드 id 목록
    * (오래된 → 최근 순서). HomePage 세션 state 가 내려보낸다. 각 방문 노드에
    * 최근성 감쇠 헤어라인 링을 얹는다 — URL 비영속·정적 표기. 생략/빈 배열 =
@@ -227,7 +233,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, spotlightIds = null, livePhysics = false, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, visitedTrail = EMPTY_TRAIL, tierReveal = DEFAULT_TIER_REVEAL } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, spotlightIds = null, livePhysics = false, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, tierReveal = DEFAULT_TIER_REVEAL } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -258,6 +264,16 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   /** C1 B3 — active auto-arrange homing springs, keyed by node id; empty/absent when no relayout is in flight. */
   const homeSpringsRef = useRef<Map<string, HomeSpringState>>(new Map());
   const homingActiveRef = useRef(false);
+  /**
+   * 결계 불변식 (소유자 실보고 2026-07-23, 루트가 자기 결계 밖) — 영역 active 중
+   * 호밍의 노드별 목표 오버라이드. null 이면 전역 `homeX`/`homeY`, 영역 중엔
+   * `insideTargets`(영역 좌표계) 가 목표다. 전역 홈으로 호밍하면 결계 원은 영역
+   * 원점에 남는데 노드는 스파인 좌표로 날아가 "루트가 원 밖" 이 됐다. 호밍
+   * 수렴/취소 시 함께 클리어.
+   */
+  const homeTargetOverrideRef = useRef<ReadonlyMap<string, { x: number; y: number }> | null>(null);
+  /** 결계 불변식 — 직전 프레임의 pin-drag 노드 id (릴리즈 전이 감지). */
+  const prevPinnedNodeIdRef = useRef<string | null>(null);
 
   // --- S4 "영역 전개" 상태 ---
   /** 전환 상태기계 (idle/entering/active/exiting). */
@@ -314,6 +330,9 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   const realmTierKindsRef = useRef<ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null>(null);
   /** 영역 루트의 contains 조상 체인 캐시 — 바깥 밀도 게이트가 영역 내부를 가리지 않게 펼침 취급할 집합. */
   const realmExpandChainRef = useRef<{ rootId: string; chain: ReadonlySet<string> } | null>(null);
+  /** 결계 센서스 캡션 prop 미러 — rAF 프레임 클로저가 최신 문구를 읽는다. */
+  const realmCaptionRef = useRef<string | null>(realmCaption);
+  realmCaptionRef.current = realmCaption;
 
   const cameraRef = useRef<CameraAxes>({
     x: { value: 0, velocity: 0 },
@@ -733,6 +752,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     dragTugOffsetsRef.current.clear();
     homeSpringsRef.current.clear();
     homingActiveRef.current = false;
+    homeTargetOverrideRef.current = null;
+    prevPinnedNodeIdRef.current = null;
     onVisibleCountChange?.(nodes.length);
     onGraphStatsChange?.({ nodes: nodes.length, relations: edges.length });
     trySnapInitialCamera(tokens);
@@ -802,6 +823,26 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     const world = worldRef.current;
     const { width, height } = viewportRef.current;
     if (!tokens || !world || width <= 0 || height <= 0 || !hasInitializedRef.current) return;
+    // 결계 불변식 (소유자 실보고 2026-07-23) — 영역 전개 중의 fit/재배치 카메라는
+    // 전역 스파인이 아니라 **영역 콘텐츠 bbox** 로 복귀한다. 전역 overview 로
+    // 트윈하면 카메라가 결계 세계를 떠나 "빈 원 + 어딘가의 노드들" 이 된다
+    // (S9 결함 1 의 deselect 복귀와 같은 계약).
+    const realmData = realmDataRef.current;
+    const realmPhase = realmTransitionRef.current.phase;
+    if (realmData !== null && (realmPhase === "entering" || realmPhase === "active")) {
+      const bounds = realmVisibleBounds(
+        world,
+        realmData,
+        new Set([...expandedParentsRef.current, realmData.rootId]),
+        tokens,
+      );
+      const target = realmCameraTarget(bounds, tokens, width, height);
+      cameraTargetRef.current = target;
+      dampingRef.current = tokens.cameraDampingDefault;
+      cameraAngularFreqRef.current = tokens.cameraSpringAngFreqTransition;
+      beginCameraTween(target);
+      return;
+    }
     // Panel-aware: spring back to the overview centered in the VISIBLE area, not
     // behind the left ReaderLens panel (Design Guardian 카메라 반려). Fits the
     // SPINE bbox (not the full 295-node bounds) so "fit view" reframes the same
@@ -840,6 +881,34 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     dragAffectedSetRef.current = null;
     dragStartPosRef.current = null;
     dragTugOffsetsRef.current.clear();
+
+    // 결계 불변식 (소유자 실보고 2026-07-23, 재현 경로 ②) — 영역 전개 중의
+    // Auto-arrange 는 "이 세계를 다시 정돈" 이다: 호밍 목표는 전역 `homeX/homeY`
+    // 가 아니라 **영역 재배치 좌표**(insideTargets). 전역 홈으로 보내면 결계
+    // 원은 영역 원점에 남고 멤버 전원이 스파인 좌표로 날아가 "루트가 자기 결계
+    // 밖" 이 됐다. 밖 노드는 하드 컬 상태라 스프링을 만들지 않는다.
+    // 이탈(exiting) 중의 재배치는 전역 경로 — 역재생의 목적지가 전역 홈이므로
+    // 영역 타깃 호밍이 닫히는 세계로 노드를 되돌리면 안 된다.
+    const realmData = realmDataRef.current;
+    const realmPhase = realmTransitionRef.current.phase;
+    if (realmData !== null && (realmPhase === "entering" || realmPhase === "active")) {
+      simRef.current = createForceSimulation(
+        world.nodes.map((n) => {
+          const t = realmData.insideTargets.get(n.id);
+          return { id: n.id, x: t?.x ?? n.x, y: t?.y ?? n.y };
+        }),
+        world.edges.map((e) => ({ source: e.sourceId, target: e.targetId })),
+      );
+      const springs = new Map<string, HomeSpringState>();
+      for (const node of world.nodes) {
+        if (realmData.insideTargets.has(node.id)) springs.set(node.id, initHomeSpring(node.x, node.y));
+      }
+      homeSpringsRef.current = springs;
+      homeTargetOverrideRef.current = realmData.insideTargets;
+      homingActiveRef.current = true;
+      return;
+    }
+
     simRef.current = createForceSimulation(
       world.nodes.map((n) => ({ id: n.id, x: n.homeX, y: n.homeY })),
       world.edges.map((e) => ({ source: e.sourceId, target: e.targetId })),
@@ -850,6 +919,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       springs.set(node.id, initHomeSpring(node.x, node.y));
     }
     homeSpringsRef.current = springs;
+    homeTargetOverrideRef.current = null;
     homingActiveRef.current = true;
   }, [relayoutToken]);
 
@@ -987,6 +1057,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 호밍은 진입 중 realm 이 좌표를 소유하므로 끈다.
       homingActiveRef.current = false;
       homeSpringsRef.current.clear();
+      homeTargetOverrideRef.current = null;
       // 카메라: 결계 원 fit 으로 돌리 인 (기존 큐빅 트윈 재사용).
       if (width > 0 && height > 0 && hasInitializedRef.current) {
         // S8 결함 2 — 해제 시 복귀할 "원래 보던 곳" 키프레임을 진입 직전 카메라
@@ -1026,11 +1097,13 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         const springs = new Map<string, HomeSpringState>();
         for (const node of world.nodes) springs.set(node.id, initHomeSpring(node.x, node.y));
         homeSpringsRef.current = springs;
+        homeTargetOverrideRef.current = null; // 이탈 목표는 전역 홈
         homingActiveRef.current = true;
       } else {
         // 안 노드 역FLIP + 밖 노드 역중력 귀환은 realm 데이터가 소유 → 홈 스프링 끔.
         homingActiveRef.current = false;
         homeSpringsRef.current.clear();
+        homeTargetOverrideRef.current = null;
         // S8 결함 5 — 정착 후 드래그로 멤버가 옮겨졌을 수 있으므로, 역FLIP 시작점
         // (insideTargets)을 현재 라이브 좌표로 갱신해 이탈 첫 프레임의 튐을 없앤다.
         const data = realmDataRef.current;
@@ -1159,6 +1232,67 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       if (pinned && homingActiveRef.current) {
         homingActiveRef.current = false;
         homeSpringsRef.current.clear();
+        homeTargetOverrideRef.current = null;
+      }
+
+      // --- 결계 불변식 (소유자 실보고 2026-07-23, 재현 경로 ①) — 영역 멤버가
+      // 결계 **밖**에서 릴리즈되면 영역 타깃으로 재홈잉한다(고무줄 복귀). 결계는
+      // 경계다: 루트(타깃=원점)를 끌어내 놓으면 "자기 결계 밖의 루트" 로 세계
+      // 문법이 깨진다. 안쪽 릴리즈는 자유 배치 유지(MindNode 식) — Auto-arrange
+      // 가 언제든 정돈한다. 기존 홈 스프링 + 목표 오버라이드 재사용, 신규 모션 0. ---
+      {
+        const pinnedId = nodeDragRef.current?.nodeId ?? null;
+        const releasedId = prevPinnedNodeIdRef.current !== null && pinnedId === null ? prevPinnedNodeIdRef.current : null;
+        prevPinnedNodeIdRef.current = pinnedId;
+        const realmData = realmDataRef.current;
+        if (releasedId !== null && realmData !== null && realmTransitionRef.current.phase === "active") {
+          const target = realmData.insideTargets.get(releasedId);
+          const released = world.nodeById.get(releasedId);
+          const radius = wardingFitRef.current?.value ?? realmData.wardingRadius;
+          const outside =
+            released !== undefined &&
+            Math.hypot(released.x - realmData.wardingCenter.x, released.y - realmData.wardingCenter.y) > radius;
+          if (target && released && outside) {
+            // 재홈잉 대상 = 릴리즈 노드 + 이번 드래그의 터그 영향권(1/2-hop) 중
+            // 영역 멤버. 릴리즈 노드만 스프링하면 터그로 끌려온 이웃이 변위
+            // 채로 동결된다(정상 릴리즈의 settle 이 터그를 0 으로 되감는 경로를
+            // 아래 heat=0 이 끊으므로) — 결계 위반은 흐트러진 무리 전체를
+            // 제자리로 정돈한다 (스코프 좁힌 relayout 과 같은 문법).
+            const affected = dragAffectedSetRef.current;
+            const springIds = new Set<string>([releasedId]);
+            if (affected !== null && affected.draggedId === releasedId) {
+              for (const id of affected.oneHop) springIds.add(id);
+              for (const id of affected.twoHop) springIds.add(id);
+            }
+            // settle burst 대신 홈 스프링이 좌표를 소유 — 둘이 같은 노드를 놓고
+            // 싸우지 않게 열/터그를 접는다 (relayout 과 같은 배타 계약).
+            heatRef.current = 0;
+            dragAffectedSetRef.current = null;
+            dragTugOffsetsRef.current.clear();
+            const springs = new Map(homeSpringsRef.current);
+            const override = new Map(homeTargetOverrideRef.current ?? []);
+            for (const id of springIds) {
+              const t = realmData.insideTargets.get(id);
+              const n = world.nodeById.get(id);
+              if (!t || !n) continue;
+              springs.set(id, initHomeSpring(n.x, n.y));
+              override.set(id, t);
+            }
+            homeSpringsRef.current = springs;
+            homeTargetOverrideRef.current = override;
+            homingActiveRef.current = true;
+            // sim 내부 좌표도 복귀 목표로 재시드 — 다음 드래그의 applyForcePositions
+            // 가 stale 드롭 좌표를 되쓰지 않게 (S8 결함 5와 같은 계약). heat=0 이라
+            // 스프링 수렴 전엔 sim 이 tick 하지 않아 목표 좌표 시드가 안전하다.
+            simRef.current = createForceSimulation(
+              world.nodes.map((n) => {
+                const t = override.get(n.id);
+                return { id: n.id, x: t?.x ?? n.x, y: t?.y ?? n.y };
+              }),
+              world.edges.map((e) => ({ source: e.sourceId, target: e.targetId })),
+            );
+          }
+        }
       }
       if (sim && (heatRef.current > 0 || pinned)) {
         // C1 B2 — radius-limited release settle: restrict BOTH the live-drag
@@ -1257,33 +1391,42 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // run in the same frame in practice).
       if (homingActiveRef.current) {
         // A8 — reduced-motion users get the relayout RESULT, not the journey.
+        // 결계 불변식 — 영역 중 호밍 목표는 오버라이드(영역 insideTargets)가
+        // 우선한다. null 이면 기존 전역 homeX/homeY 계약 그대로.
+        const homeOverride = homeTargetOverrideRef.current;
         if (reducedMotionRef.current) {
           for (const node of world.nodes) {
             if (!homeSpringsRef.current.has(node.id)) continue;
-            node.x = node.homeX;
-            node.y = node.homeY;
+            const t = homeOverride?.get(node.id);
+            node.x = t?.x ?? node.homeX;
+            node.y = t?.y ?? node.homeY;
           }
           recomputeWorldGeometry(world, tokens);
           homingActiveRef.current = false;
           homeSpringsRef.current.clear();
+          homeTargetOverrideRef.current = null;
         } else {
           let allConverged = true;
           for (const node of world.nodes) {
             const spring = homeSpringsRef.current.get(node.id);
             if (!spring) continue;
+            const t = homeOverride?.get(node.id);
+            const targetX = t?.x ?? node.homeX;
+            const targetY = t?.y ?? node.homeY;
             // A5 — homing has its own ω (7.5): a relayout is a layout
             // CORRECTION and should end decisively, unlike the camera's
             // cinematic transition spring (4.7) this used to borrow.
-            const nextSpring = stepHomeSpring(spring, node.homeX, node.homeY, dt, tokens.nodeHomeSpringAngFreq, tokens.cameraDampingDefault);
+            const nextSpring = stepHomeSpring(spring, targetX, targetY, dt, tokens.nodeHomeSpringAngFreq, tokens.cameraDampingDefault);
             homeSpringsRef.current.set(node.id, nextSpring);
             node.x = nextSpring.x.value;
             node.y = nextSpring.y.value;
-            if (!isHomeSpringConverged(nextSpring, node.homeX, node.homeY, HOME_CONVERGE_EPSILON)) allConverged = false;
+            if (!isHomeSpringConverged(nextSpring, targetX, targetY, HOME_CONVERGE_EPSILON)) allConverged = false;
           }
           recomputeWorldGeometry(world, tokens);
           if (allConverged) {
             homingActiveRef.current = false;
             homeSpringsRef.current.clear();
+            homeTargetOverrideRef.current = null;
           }
         }
       }
@@ -1750,7 +1893,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // --- S4 "영역 전개" — 밖 노드 하드 컬(fling 완료 후) + 결계 링 파라미터 ---
       const realmState = realmTransitionRef.current;
       const realmData = realmDataRef.current;
-      let realmWarding: { centerX: number; centerY: number; radius: number; drawProgress: number } | null = null;
+      let realmWarding: { centerX: number; centerY: number; radius: number; drawProgress: number; caption: string | null } | null = null;
       let realmTierKinds: ReadonlyMap<string, "project" | "domain" | "capability" | "element"> | null = null;
       let realmDustParallax = 0;
       // S5 — 깊이 연출용: 선명도(entering+active)는 depthById, 시차(active 만)는
@@ -1814,6 +1957,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           drawProgress: exiting
             ? realmWardingEraseProgress(now - realmState.startMs)
             : realmWardingDrawProgress(now - realmState.startMs - REALM_WARDING_DRAW_DELAY_MS),
+          // 결계 센서스 각인 — 원이 "무엇의 경계인지" 스스로 말한다 (진입 시 1회 파생).
+          caption: realmCaptionRef.current,
         };
       }
 

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -15,7 +15,7 @@ import type { CameraAxes, CameraTarget } from "../engine/camera";
 import { cameraTransitionDurationMs, easeCameraKeyframe, type CameraKeyframe, type CameraTween } from "../model/camera-easing";
 import { stepTugAxis, tugFactorForHop, tugFalloffForDistance } from "../interaction/drag-tug";
 import { isCameraUnsettled, isCanvasActive, shouldSkipFrame } from "../model/idle-gate";
-import { classifyZoomTier, type ZoomTier } from "../model/tier-visibility";
+import { classifyZoomTier, DEFAULT_TIER_REVEAL, type TierRevealConfig, type ZoomTier } from "../model/tier-visibility";
 import { relaxNodeSeparation, type SeparationNode } from "../model/separation";
 import { createForceSimulation, type ForceSimulation } from "../model/force-layout";
 import { INITIAL_POINTER_MACHINE_STATE, type PointerMachineState } from "../interaction/pointer-state-machine";
@@ -209,6 +209,13 @@ export interface UseTopologyLoopArgs {
    * 발자국 없음(회귀 0).
    */
   visitedTrail?: readonly string[];
+  /**
+   * 슬라이스 C (개발/비개발 모드 토글) — 표시-렌즈 티어 게이트 config. 생략 시
+   * `DEFAULT_TIER_REVEAL`(개발 모드 — capability/element 모두 정상 줌 반응).
+   * HomePage 가 비개발(plain) 모드에서 `PLAIN_TIER_REVEAL`(element 상시 숨김)
+   * 을 넘긴다 — 드로우/히트/팬-클램프 전부 이 값 하나로 정합된다.
+   */
+  tierReveal?: TierRevealConfig;
 }
 
 const EMPTY_EXPANDED_SET: ReadonlySet<string> = new Set();
@@ -220,7 +227,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, spotlightIds = null, livePhysics = false, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, visitedTrail = EMPTY_TRAIL } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, spotlightIds = null, livePhysics = false, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, visitedTrail = EMPTY_TRAIL, tierReveal = DEFAULT_TIER_REVEAL } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -501,6 +508,8 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
    * track the last emitted tier so the callback fires only on transitions. */
   const onZoomTierChangeRef = useRef<typeof onZoomTierChange>(onZoomTierChange);
   const lastZoomTierRef = useRef<ZoomTier | null>(null);
+  /** 슬라이스 C — 티어 게이트 config 미러(같은 패턴). rAF 클로저 + 포인터 핸들러가 공유. */
+  const tierRevealRef = useRef<TierRevealConfig>(tierReveal);
 
   /**
    * S3 마감 폴리시 (fable 설계) — begin a cubic ease-in-out camera transition
@@ -553,6 +562,10 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   useEffect(() => {
     livePhysicsRef.current = livePhysics;
   }, [livePhysics]);
+
+  useEffect(() => {
+    tierRevealRef.current = tierReveal;
+  }, [tierReveal]);
 
   useEffect(() => {
     selectedEdgeRef.current = selectedEdge;
@@ -1425,6 +1438,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         egoRevealById: egoRevealRef.current,
         focusRampById: focusRampRef.current,
         appearById: appearRef.current,
+        tierReveal: tierRevealRef.current,
       });
       cameraRef.current = camera;
 
@@ -1504,7 +1518,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 미루고, 정착(active/idle) 후 아래 비교가 최종 tier 를 한 번만 방출한다.
       const realmTransitioning =
         realmTransitionRef.current.phase === "entering" || realmTransitionRef.current.phase === "exiting";
-      const nextZoomTier = classifyZoomTier(zoomRatio);
+      const nextZoomTier = classifyZoomTier(zoomRatio, tierRevealRef.current);
       if (!realmTransitioning && nextZoomTier !== lastZoomTierRef.current) {
         lastZoomTierRef.current = nextZoomTier;
         onZoomTierChangeRef.current?.(nextZoomTier);
@@ -1947,6 +1961,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         footprintRanksById,
         spotlightIds: spotlightIdsRef.current,
         spotlightRamp: spotlightRampRef.current,
+        tierReveal: tierRevealRef.current,
       });
 
       handle = requestAnimationFrame(frame);
@@ -1997,6 +2012,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     hoveredClusterIdRef,
     realmParallaxRef,
     realmTierKindsRef,
+    tierRevealRef,
     onSelect,
     onSelectEdge,
     onHoverEdge,


### PR DESCRIPTION
## Summary

오늘의 사용성 전수 검수·소유자 실보고 후속 일괄 브랜치. 13 커밋:

- **스포트라이트 가시성** — 앰버 회전 파선 링 + 렌즈 자동 핏 + 모션 검수 감속 (Image #14, Guardian 프레임 회의)
- **P0** — 발자취 `<History>` Illegal constructor 전체 화면 추락 원천 차단
- **P1** — 본문 검색 착지·랭킹 단선 근본 원인 수정 (하드랩 개행 vs 리터럴 매칭 → `buildPhraseMatcher` \s+ 유연 매칭 + 구문 랭킹 부스트)
- **P1/P2 잔여 6건** — 일반모드 숫자/힌트 정합 · 블록 silent 게이트 → 설명형 disabled · 보기모드 발견성 · 스포트라이트 시간창 aria-live 배지 · <768 발자취 진입점 · 팔레트/설정 상호 강등
- **"이것만 보기" 재설계** — realm → 사용자 어휘 교체, 루트 불변식(realm-aware homing + 탄성 경계), 수평 구도, Guardian verdict
- **개발/비개발 보기 모드 토글** · **element 라벨 인간화** · **규격 인라인 가이드** · **realm 깊이 파생 링** · **커스텀 스킬 2종** (/motion-verify · /responsive-sweep)

## Test plan

- `pnpm exec tsc --noEmit` 클린 (stableTypeOrdering 기왕 경고 제외)
- vitest 터치 표면 1487 pass · i18n 18/18 · contract suite 포함
- 1440/768/1024 라이브 스윕 (chrome-devtools) — 스포트라이트 배지 간섭 0, 발자취 타일 오픈 확인
- /motion-verify 스크린 레코딩 검증 (스포트라이트 링 회전 0 stall @30fps)
- Guardian verdict: realm 재설계·스포트라이트 링·발자취 시트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)