### PR TITLE
fix: 병합 후 계약 드리프트 (census 골든값·README 개편 추종)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -737,7 +737,7 @@ A successful run looks like this:
 ✓ find_backlinks — project (1 backlink)
 ✓ query_concepts — 1 query result / 1 total query result
 ✓ query_concepts limited — 1 query result / 104 total query results (limited true)
-✓ analyze_repo_structure — fsd (6 domain candidates, 12 capability candidates, 37 element candidates)
+✓ analyze_repo_structure — fsd (6 domain candidates, 13 capability candidates, 37 element candidates)
 ✓ infer_imports — 938 files scanned, 547 module edges (elements/src/views/home->elements/src/entities/knowledge-graph x28 (static:28), elements/src/widgets/docs-vault->elements/src/entities/docs-vault x16 (static:16), +545 more)
 ✓ index_project — 56 concept candidates, 547 import relations, validation 0 problem files
 ✓ find_neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)

--- a/scripts/check-package-contracts.test.mjs
+++ b/scripts/check-package-contracts.test.mjs
@@ -2050,9 +2050,12 @@ describe('package contract helpers', () => {
     assert.match(vaultTooling, /static dogfood manifest freshness/);
     assert.match(vaultTooling, /pnpm test:vault:audit/);
     assert.match(vaultTooling, /focused vault audit CLI argument contract/);
-    assert.match(readme, /\*\*Static dogfood manifest\*\* \| `pnpm docs-vault:check` keeps committed `src\/entities\/docs-vault\/data\/manifest\.json` and `public\/docs-vault\/` in sync with `docs\/`/);
-    assert.match(readme, /pnpm docs-vault:check\s+# committed docs-vault output freshness/);
-    assert.match(readme, /CI runs `docs-vault:check`, `vault:validate`, `test:vault:validate`,\s+`vault:audit`, `test:vault:audit`, and `package:check`/);
+    // README 제품 쇼케이스 전면 개편(#555) 추종 — "Verifiable promises" 표와
+    // CI 나열 문단이 은퇴하고 dogfood/계약 게이트 코드블록으로 압축됐다.
+    // 발견 가능성 계약의 본질(docs-vault:check 와 package:check 가 README 에서
+    // 보인다)만 현행 문구로 고정한다.
+    assert.match(readme, /pnpm docs-vault:check\s+# committed app sample matches docs\//);
+    assert.match(readme, /pnpm package:check\s+# MCP\/CLI\/docs\/performance contracts/);
     assert.match(agents, /pnpm test:vault:validate\s+# focused validator CLI argument contract/);
     assert.match(agents, /pnpm test:contracts\s+# focused cross-package contract suite/);
     assert.match(agents, /pnpm vault:audit\s+# capability\/element path drift guard \(R12\)/);


### PR DESCRIPTION
## Summary
- 42커밋 병합 직후 package:check 상시 실패 2건 현행화: mcp-verify census 샘플 실값 갱신 + README #555 개편 추종 (docs-vault:check/package:check 발견 가능성 계약을 새 문구로 고정).

## Test plan
- check-package-contracts 55/55 ✅ · `pnpm package:check` green ✅