### PR TITLE
fix: 트랙패드 글라이드 가드 (엣지 호버 시 화면 움직임 유입로 차단)

### DIFF
--- a/src/widgets/topology-map-v2/interaction/wheel.test.ts
+++ b/src/widgets/topology-map-v2/interaction/wheel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeWheelZoomFactor, normalizeWheelDeltaY, WHEEL_LINE_HEIGHT_PX, WHEEL_ZOOM_SENSITIVITY } from "./wheel";
+import { computeWheelZoomFactor, normalizeWheelDeltaY, shouldIgnoreWheelGlide, WHEEL_LINE_HEIGHT_PX, WHEEL_ZOOM_SENSITIVITY } from "./wheel";
 
 describe("normalizeWheelDeltaY", () => {
   it("passes pixel-mode (deltaMode 0) deltas through unchanged", () => {
@@ -59,5 +59,20 @@ describe("computeWheelZoomFactor", () => {
   it("is monotonically more extreme for a larger-magnitude delta", () => {
     expect(computeWheelZoomFactor(-240)).toBeGreaterThan(computeWheelZoomFactor(-120));
     expect(computeWheelZoomFactor(240)).toBeLessThan(computeWheelZoomFactor(120));
+  });
+});
+
+describe("shouldIgnoreWheelGlide — 트랙패드 글라이드 가드", () => {
+  it("미세 델타(|d|<4)는 무시한다", () => {
+    expect(shouldIgnoreWheelGlide(1, false)).toBe(true);
+    expect(shouldIgnoreWheelGlide(-3.9, false)).toBe(true);
+  });
+  it("의도적 델타(|d|>=4)는 통과한다", () => {
+    expect(shouldIgnoreWheelGlide(4, false)).toBe(false);
+    expect(shouldIgnoreWheelGlide(-120, false)).toBe(false);
+  });
+  it("핀치(ctrlKey)는 델타 크기와 무관하게 항상 통과한다", () => {
+    expect(shouldIgnoreWheelGlide(0.5, true)).toBe(false);
+    expect(shouldIgnoreWheelGlide(-1, true)).toBe(false);
   });
 });

--- a/src/widgets/topology-map-v2/interaction/wheel.ts
+++ b/src/widgets/topology-map-v2/interaction/wheel.ts
@@ -58,3 +58,22 @@ export const WHEEL_ZOOM_SENSITIVITY = 0.002;
 export function computeWheelZoomFactor(pixelDeltaY: number, sensitivity: number = WHEEL_ZOOM_SENSITIVITY): number {
   return Math.exp(-pixelDeltaY * sensitivity);
 }
+
+/**
+ * 트랙패드 글라이드 가드 (소유자 실보고 2026-07-23 — "노드 연결선에 마우스
+ * 올리면 화면이 움직인다/흔들린다"): macOS 트랙패드는 두 손가락이 얹힌 채
+ * 미끄러지거나 관성이 남으면 |deltaY| 1~3px 의 미세 wheel 이벤트를 흘린다.
+ * 이 노이즈가 전부 줌으로 합성되면 커서를 올려두기만 해도 화면이 떨린다.
+ * 의도적 제스처와의 구분:
+ * - 핀치 줌은 브라우저가 `ctrlKey: true` wheel 로 전달 — 항상 통과.
+ * - 마우스 노치/의도적 두-손가락 스크롤은 정규화 후 |delta| 가 크다 — 통과.
+ * - 그 외 미세 델타만 무시한다. 문턱은 장치 입력 사실이라 디자인 토큰 없음
+ *   (`WHEEL_LINE_HEIGHT_PX` 선례).
+ */
+export const WHEEL_GLIDE_IGNORE_THRESHOLD_PX = 4;
+
+/** 미세 글라이드 노이즈면 true — 호출부는 줌을 건너뛴다 (핀치는 예외). */
+export function shouldIgnoreWheelGlide(pixelDeltaY: number, ctrlKey: boolean): boolean {
+  if (ctrlKey) return false;
+  return Math.abs(pixelDeltaY) < WHEEL_GLIDE_IGNORE_THRESHOLD_PX;
+}

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -41,7 +41,7 @@ import {
   transitionPointerState,
   type PointerMachineState,
 } from "../interaction/pointer-state-machine";
-import { computeWheelZoomFactor, normalizeWheelDeltaY } from "../interaction/wheel";
+import { computeWheelZoomFactor, normalizeWheelDeltaY, shouldIgnoreWheelGlide } from "../interaction/wheel";
 import { computeEffectiveCameraScaleMax, computeEffectiveCameraScaleMin, hitTestWorld, screenToWorld, worldToScreen } from "./topology-camera-math";
 import { readTopologyV2TokensOrNull } from "./topology-read-tokens";
 import { radiusForKind, type TopologyWorld } from "./topology-world";
@@ -941,6 +941,14 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     e.preventDefault();
     const tokens = readTopologyV2TokensOrNull();
     if (!tokens) return;
+    // 트랙패드 글라이드 가드 (소유자 실보고 2026-07-23) — 손가락이 얹힌 채
+    // 흘러나오는 |delta| < 4px 미세 wheel 노이즈는 줌으로 합성하지 않는다.
+    // 이 노이즈가 "엣지에 마우스만 올려도 화면이 움직/흔들림"의 유입로였다.
+    // 핀치(ctrlKey wheel)와 의도적 노치/스크롤은 그대로 통과. preventDefault
+    // 는 유지(페이지 스크롤 유출 방지), 호버 카드도 유지(모션이 없으므로).
+    const { height: vpH } = viewportRef.current;
+    const glideDeltaY = normalizeWheelDeltaY(e.deltaY, e.deltaMode, vpH);
+    if (shouldIgnoreWheelGlide(glideDeltaY, e.ctrlKey)) return;
     // 엣지/클러스터 호버 카드 잔류(패널2/3) — 휠/카메라 모션이 시작되는 순간
     // 카드는 즉시 사라져야 한다. 카드는 idle 호버에만 앵커되므로, 줌으로
     // 좌표가 흐르는 동안 pointermove 없이 잔류해 3티어 줌을 관통해 남았다.


### PR DESCRIPTION
## Summary
- "노드 연결선에 마우스 올리면 화면이 움직임" — 호버 경로는 카메라 불변(코드 추적 + 정지/횡단/그래프모드 픽셀 diff 98-99% 동일로 확정). 남은 유입로 = macOS 트랙패드 글라이드/관성의 미세 wheel(|Δ|<4px)이 전부 줌으로 합성 → 커서를 올려두기만 해도 화면이 밀림.
- `shouldIgnoreWheelGlide(pixelDeltaY, ctrlKey)`: 핀치(ctrl+wheel)·의도적 노치/스크롤 통과, 미세 노이즈만 차단. 카드 유지·preventDefault 유지.

## Test plan
- interaction 42/42 ✅ (신규 3 케이스) · tsc ✅ · 소유자 트랙패드 실확인 요청 항목