### PR TITLE
fix: 크롬 기본 밀도 44→36px (프로 툴바 급)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1171,7 +1171,10 @@
      * 이 토큰만 참조하고 인라인 hex/px 재구현 금지(`design.md` "인라인
      * 재구현 금지" 규범).
      */
-    --chrome-tile-size: 44px;
+    /* 44 → 36 (소유자 3차 보고 2026-07-23: zoom 제거 후에도 "딱봐도 크다")
+       — 크롬 밀도 자체를 프로 툴바 급(32~36)으로. 단일 토큰이므로 전 크롬
+       필/타일/상태 칩/플로팅 스택이 함께 내려간다. */
+    --chrome-tile-size: 36px;
     --chrome-radius: 10px;
     --chrome-radius-inner: 7px;
     --chrome-icon: 16px;

--- a/src/shared/ui/chrome-chip.test.tsx
+++ b/src/shared/ui/chrome-chip.test.tsx
@@ -15,7 +15,7 @@ describe('ChromeChip', () => {
     expect(chip).toHaveTextContent('D');
   });
 
-  it('uses the 44px chrome-tile-size height + 10px chrome-radius token contract', () => {
+  it('uses the chrome-tile-size(36px) height + 10px chrome-radius token contract', () => {
     render(<ChromeChip>자동 정렬</ChromeChip>);
     const chip = screen.getByRole('button');
     expect(chip.className).toContain('h-[var(--chrome-tile-size)]');

--- a/src/shared/ui/chrome-tile.test.tsx
+++ b/src/shared/ui/chrome-tile.test.tsx
@@ -19,7 +19,7 @@ describe('ChromeTile', () => {
     expect(tile).toHaveAttribute('title', '문서함');
   });
 
-  it('uses the 44px chrome-tile-size + 10px chrome-radius token contract', () => {
+  it('uses the chrome-tile-size(36px) + 10px chrome-radius token contract', () => {
     render(<ChromeTile icon={<svg />} title="설정" />);
     const tile = screen.getByRole('button');
     expect(tile.className).toContain('size-[var(--chrome-tile-size)]');


### PR DESCRIPTION
## Summary
- zoom 제거(#561) 후에도 크다는 소유자 3차 보고 — 원인은 배율이 아니라 기본 크롬 밀도. `--chrome-tile-size` 44→36px 단일 토큰 강하로 전 크롬 필/타일/상태 칩/플로팅 컨트롤 동반 축소. 테스트명 2건 현행화(본문은 토큰 참조 검사라 무변).

## Test plan
- shared/ui 144 + 칩 지오메트리 ✅ · 1920 실측 36px + 전폭 스크린샷 무결