### PR TITLE
fix: 한글 타이포 정합 — Pretendard Variable 셀프호스팅

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -227,7 +227,7 @@
   --color-backdrop-medium: rgba(8, 9, 10, 0.6);
 
   /* 폰트 패밀리 */
-  --font-sans: var(--font-inter), system-ui, sans-serif;
+  --font-sans: var(--font-pretendard), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains), ui-monospace, monospace;
 
   /* Linear 고유 — 510 weight (regular와 medium 사이) */
@@ -887,6 +887,16 @@
     --app-nav-rail-logo-size: calc(38px * var(--topology-ui-scale-factor));
     --app-nav-rail-logo-icon-size: calc(26px * var(--topology-ui-scale-factor));
     --app-nav-rail-icon-size: calc(24px * var(--topology-ui-scale-factor));
+    /*
+     * 레일 하단 유틸리티 티어(활동·발자취·설정) 아이콘 사다리 — 목적지
+     * 티어(24px + 라벨)보다 한 단계 아래(18px = lucide 기본, 각 타일이
+     * 이미 `size={18}` 로 선언하던 값). 소유자 실보고 2026-07-23: 유틸
+     * 아이콘(24px)이 설정 기어(16px)보다 커 레일 하단 3타일의 시각 무게가
+     * 제각각이었다. 유틸 3타일은 이 토큰 + `--app-nav-rail-tile-*` 지오메트리
+     * 하나로 앉는다 (`AppNavRail.tsx` · `GitStatusTile.tsx` ·
+     * `TopologyV2SettingsGear.tsx` rail-tile variant).
+     */
+    --app-nav-rail-utility-icon-size: calc(18px * var(--topology-ui-scale-factor));
     --app-nav-rail-label-size: calc(9.5px * var(--topology-ui-scale-factor));
     --app-nav-rail-tile-width: calc(38px * var(--topology-ui-scale-factor));
     --app-nav-rail-tile-height: calc(32px * var(--topology-ui-scale-factor));

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,20 @@
 import type { Metadata, Viewport } from 'next';
-import { Inter, JetBrains_Mono } from 'next/font/google';
+import { JetBrains_Mono } from 'next/font/google';
+import localFont from 'next/font/local';
 import { SITE_URL } from '@/shared/config';
 import { withBasePath } from '@/shared/lib/base-path';
 import './globals.css';
 
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
+// 소유자 실보고 (2026-07-23): Inter latin 서브셋만 로드되어 한글이 시스템
+// 폴백(Apple SD Gothic)으로 떨어짐 — 라틴/숫자와 한글의 굵기·x-height 가
+// 어긋나 버튼 라벨이 "이상하게" 보였다. Pretendard 는 Inter 와 메트릭
+// 호환으로 설계된 한글 폰트라 라틴 룩은 유지하면서 한·영 혼용이 한 가족으로
+// 렌더된다. 셀프호스팅(npm 패키지, CDN 0 — local-first).
+const pretendard = localFont({
+  src: '../node_modules/pretendard/dist/web/variable/woff2/PretendardVariable.woff2',
+  variable: '--font-pretendard',
   display: 'swap',
-  axes: ['opsz'],
+  weight: '45 920',
 });
 
 const jetbrainsMono = JetBrains_Mono({
@@ -74,7 +80,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable} h-full overflow-x-hidden`}
+      className={`${pretendard.variable} ${jetbrainsMono.variable} h-full overflow-x-hidden`}
     >
       <body className="flex min-h-full flex-col overflow-x-hidden pb-[calc(56px+env(safe-area-inset-bottom))] md:pb-0">
         <script

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "lucide-react": "^1.25.0",
     "next": "16.2.11",
     "next-intl": "^4.13.3",
+    "pretendard": "^1.3.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-hook-form": "^7.82.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       next-intl:
         specifier: ^4.13.3
         version: 4.13.3(@typescript/typescript6@6.0.2)(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -3621,6 +3624,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretendard@1.3.9:
+    resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -7868,6 +7874,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  pretendard@1.3.9: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
## Summary
- "한글이 이상함"의 원인 = Inter `subsets:['latin']` → 한글만 Apple SD Gothic 폴백으로 혼합 렌더. Pretendard Variable(Inter 메트릭 호환)로 sans 전면 교체 — 한·영·숫자가 단일 가족. next/font/local 셀프호스팅(외부 CDN 0), JetBrains Mono 는 유지.
- 신규 의존성 `pretendard`: 한글 커버리지 본문 폰트는 번들 자산 필요, 국문 제품 표준 선택.

## Test plan
- tsc ✅ · 1920 실화면 크롬 크롭에서 한글/라틴 정합 확인 · computedStyle=pretendard 확인