### PR TITLE
fix: 타이포 근본 원인(twMerge 오분류) + 레일 사다리·명령 전문·카운터 흡수

### DIFF
--- a/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
@@ -164,6 +164,20 @@ describe('FirstRunStarterModule', () => {
     expect(screen.getByText('npx ontology-atlas init && npx ontology-atlas bootstrap')).toBeInTheDocument();
   });
 
+  // 소유자 실보고 2026-07-23 — 라벨·명령·복사가 한 행을 3분할해 명령이
+  // "npx ontology-atlas i…" 로 잘렸다. 코드 라인은 말줄임 대신 전폭 +
+  // 단어 경계 줄바꿈이어야 명령 전문이 복사 전에 눈으로 검증된다.
+  it('renders the command as a full-width wrapping code line — never mid-word ellipsis', () => {
+    render(<FirstRunStarterModule concepts={1} relations={1} domains={1} />);
+    fireEvent.click(screen.getByTestId('first-run-starter-cli-toggle'));
+
+    const code = screen.getByText('npx ontology-atlas init && npx ontology-atlas bootstrap');
+    expect(code.tagName).toBe('CODE');
+    expect(code.className).not.toContain('truncate');
+    expect(code.className).toContain('whitespace-pre-wrap');
+    expect(code.className).toContain('break-words');
+  });
+
   // ease-of-use G1 (2026-07-23) — Safari/Firefox 는 FSA 가 없어 가장 눈에
   // 띄는 인디고 CTA 가 "눌러야 실패"였다. 미지원 상태에선 사전에 정직하게
   // 강등: 폴더 열기·새 vault 만들기 대신 고지 한 줄 + /download 링크.

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
@@ -196,26 +196,31 @@ export function FirstRunStarterModule({
           {t("cliBridgeToggle")}
         </button>
         {cliOpen ? (
+          /* 소유자 실보고 2026-07-23 — 라벨·명령·복사 버튼이 한 행을 3분할해
+             명령이 중간-단어 말줄임("npx ontology-atlas i…")으로 잘렸다.
+             헤더행(라벨 + 복사)과 전폭 코드 라인(단어 경계 줄바꿈)으로 분리 —
+             복사할 명령 전문이 항상 보인다. */
           <div
             id="first-run-starter-cli-bridge"
             data-testid="first-run-starter-cli-bridge"
-            className="mt-2 flex items-center justify-between gap-2 rounded-md border border-[color:var(--topology-v2-panel-divider)] bg-[color:rgba(6,6,9,0.35)] px-2.5 py-2"
+            className="mt-2 rounded-md border border-[color:var(--topology-v2-panel-divider)] bg-[color:rgba(6,6,9,0.35)] px-2.5 py-2"
           >
-            <div className="min-w-0 flex-1">
-              <p className="text-[10px] leading-tight text-[color:var(--topology-v2-panel-text-quaternary)]">
+            <div className="flex items-center justify-between gap-2">
+              <p className="min-w-0 break-keep text-[10px] leading-tight text-[color:var(--topology-v2-panel-text-quaternary)]">
                 {t("cliBridgeLabel")}
               </p>
-              <code className="mt-0.5 block truncate font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-secondary)]">
-                {CLI_BOOTSTRAP_COMMAND}
-              </code>
+              <CompactCopyButton
+                copied={cliCopyState === "copied"}
+                label={cliCopyState === "copied" ? t("cliBridgeCopied") : t("cliBridgeCopy")}
+                ariaLabel={t("cliBridgeCopyAriaLabel")}
+                onClick={() => void copyCliCommand(CLI_BOOTSTRAP_COMMAND)}
+                data-testid="first-run-starter-cli-bridge-copy"
+                className="-my-1.5 -mr-1.5 shrink-0"
+              />
             </div>
-            <CompactCopyButton
-              copied={cliCopyState === "copied"}
-              label={cliCopyState === "copied" ? t("cliBridgeCopied") : t("cliBridgeCopy")}
-              ariaLabel={t("cliBridgeCopyAriaLabel")}
-              onClick={() => void copyCliCommand(CLI_BOOTSTRAP_COMMAND)}
-              data-testid="first-run-starter-cli-bridge-copy"
-            />
+            <code className="mt-1 block whitespace-pre-wrap break-words font-mono text-[10.5px] leading-[1.6] text-[color:var(--topology-v2-panel-text-secondary)]">
+              {CLI_BOOTSTRAP_COMMAND}
+            </code>
           </div>
         ) : null}
       </div>

--- a/src/shared/lib/cn.test.ts
+++ b/src/shared/lib/cn.test.ts
@@ -18,3 +18,27 @@ describe('cn', () => {
     expect(cn('base', { active: true, disabled: false })).toBe('base active');
   });
 });
+
+/**
+ * 타입 램프 × tailwind-merge 오분류 회귀 가드 (2026-07-23 소유자 실보고).
+ * 커스텀 램프 스텝이 색상으로 분류되면 `text-[color:...]` 와 충돌해 크기가
+ * 조용히 드롭된다 — 크롬 필이 루트 16px 로 렌더되던 근본 원인.
+ */
+describe('cn — 타입 램프와 색상 유틸 공존', () => {
+  it.each(['caption', 'label', 'body', 'body-lg', 'title', 'display', 'hero'])(
+    'text-%s 가 text-[color:...] 뒤에서도 살아남는다',
+    (step) => {
+      const out = cn(`text-${step}`, 'text-[color:var(--color-text-tertiary)]');
+      expect(out).toContain(`text-${step}`);
+      expect(out).toContain('text-[color:var(--color-text-tertiary)]');
+    },
+  );
+
+  it('같은 램프 스텝끼리는 여전히 나중 값이 이긴다', () => {
+    expect(cn('text-label', 'text-body')).toBe('text-body');
+  });
+
+  it('색상끼리도 나중 값이 이긴다 (기존 동작 보존)', () => {
+    expect(cn('text-[color:red]', 'text-[color:blue]')).toBe('text-[color:blue]');
+  });
+});

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -1,10 +1,29 @@
 import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
 
 /**
  * Tailwind 클래스명 결합 유틸리티.
  * clsx로 조건부 합치고 tailwind-merge로 충돌 해결 (나중 값이 이김).
+ *
+ * 소유자 실보고 근본 원인 (2026-07-23, "크롬 글자가 너무 크다"): tailwind-merge
+ * 는 자기 기본 스케일에 없는 `text-<step>` 을 **색상**으로 분류한다. 우리
+ * 타입 램프(`--text-caption`~`--text-hero`)의 `text-label`/`text-body` 가
+ * 색상으로 오분류된 채 뒤따르는 색상 arbitrary(text-[color:…] 꼴)와 "충돌"해 조용히
+ * 드롭됐고, 해당 표면들은 루트 16px 로 렌더돼 왔다 (크롬 필 실측으로 발견).
+ * 램프 7단을 font-size 그룹으로 등록해 크기·색상이 공존하게 한다.
+ * `app/globals.css` 의 `--text-*` 램프와 반드시 동기 — 스텝을 추가하면
+ * 여기도 추가할 것 (계약 테스트: cn.test.ts).
  */
+const TYPE_RAMP_STEPS = ['caption', 'label', 'body', 'body-lg', 'title', 'display', 'hero'] as const;
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      'font-size': [{ text: [...TYPE_RAMP_STEPS] }],
+    },
+  },
+});
+
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }

--- a/src/shared/ui/chrome-chip.tsx
+++ b/src/shared/ui/chrome-chip.tsx
@@ -24,7 +24,7 @@ export interface ChromeChipProps extends Omit<ButtonHTMLAttributes<HTMLButtonEle
 }
 
 const CHIP_CLASS =
-  'inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-body text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] active:bg-[color:var(--chrome-active-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] [&>svg]:size-3.5 [&>svg]:shrink-0';
+  'inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-label tracking-label text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] active:bg-[color:var(--chrome-active-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] [&>svg]:size-3.5 [&>svg]:shrink-0';
 
 /**
  * S10 결함 1 (소유자 실보고: 1920 에서 영역 칩이 검색/자동정렬 타일보다 큼) —
@@ -40,7 +40,7 @@ const CHIP_CLASS =
  * 소유한다.
  */
 export const CHROME_STATUS_CHIP_CLASS =
-  'topology-chrome-in pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-body text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
+  'topology-chrome-in pointer-events-auto flex h-[var(--chrome-tile-size)] max-w-full items-center gap-1.5 rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-3.5 text-label tracking-label text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)]';
 
 const ACTIVE_CLASS =
   'border-[color:var(--chrome-active-border)] bg-[color:var(--chrome-active-surface)] text-[color:var(--color-text-primary)]';

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -646,6 +646,11 @@ export function HomePage() {
           audiencePlain={audiencePlain}
           onChangeAudiencePlain={setAudiencePlain}
           changeVaultHref="/docs/?intent=local"
+          // 레일 하단 유틸 3타일(활동·발자취·설정)을 한 타일 문법에 앉힌다
+          // (소유자 실보고 2026-07-23 — 기어만 36px 보더 floating 표면 + 16px
+          // 아이콘이라 이질적이었다). `--app-nav-rail-tile-*` +
+          // `--app-nav-rail-utility-icon-size` 계약.
+          triggerVariant="rail-tile"
           popoverAlign="left"
           popoverSide="top"
           // M-4 (2) — keyboard-opened transients (⌘K palette, `D` docs drawer)
@@ -2697,28 +2702,40 @@ export function HomePage() {
                         active={spotlightOn}
                         // 그래프 토글과 같은 <2xl 아이콘-only 사다리(위 주석).
                         className="max-2xl:[&_[data-chip-label]]:hidden"
+                        // P2 결함④ 후속 (소유자 실보고 2026-07-23, 상단 크롬
+                        // 과밀) — 시간창/건수 카운트를 레인에 떠 있던 무라벨
+                        // mono 텍스트 대신 칩 내부 badge 로 흡수한다(문서 칩의
+                        // 고정 수 badge 와 같은 문법·토큰). INDEX 세그먼트가
+                        // 같은 "최근 N일 · count" 를 이미 노출하므로 중복
+                        // 문자열도 제거되고, badge 는 compact/축약 사다리와
+                        // 무관하게 항상 남아 <xl 에서도 건수가 보인다. 시간창은
+                        // aria-label·title 로 보존.
+                        badge={
+                          spotlightOn ? (
+                            <span
+                              aria-live="polite"
+                              data-testid="topology-spotlight-window-summary"
+                              data-utility-count-badge="spotlight-recent"
+                              data-surface-token="--topology-utility-lane-count-surface"
+                              data-text-token="--topology-utility-lane-count-text"
+                              className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[color:var(--topology-utility-lane-count-surface)] px-1.5 font-mono text-[10px] tabular-nums text-[color:var(--topology-utility-lane-count-text)]"
+                              aria-label={t('controls.spotlightWindowSummary', {
+                                days: recentChanges.windowDays,
+                                count: recentChanges.recentNodeIds.size,
+                              })}
+                              title={t('controls.spotlightWindowSummary', {
+                                days: recentChanges.windowDays,
+                                count: recentChanges.recentNodeIds.size,
+                              })}
+                            >
+                              {recentChanges.recentNodeIds.size}
+                            </span>
+                          ) : null
+                        }
                       >
                         {t('controls.spotlightLabel')}
                       </ChromeChip>
                     </Tooltip>
-                    {/* P2 결함④ — 렌즈 ON 인데 INDEX 가 접혀 있으면 적용
-                        시간창/건수를 알 텍스트가 화면 어디에도 없었다. 칩
-                        옆(유틸리티 레인 안, 같은 높이)에 조용한 mono 카운트.
-                        aria-live 로 접근성 겸용. <xl 에서는 레인 폭 보호를
-                        위해 숨긴다(검색 레인 겹침 재발 방지 — 다른 칩들과
-                        같은 축약 사다리). */}
-                    {spotlightOn ? (
-                      <span
-                        aria-live="polite"
-                        data-testid="topology-spotlight-window-summary"
-                        className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] tabular-nums text-[color:var(--color-text-quaternary)] xl:inline"
-                      >
-                        {t('controls.spotlightWindowSummary', {
-                          days: recentChanges.windowDays,
-                          count: recentChanges.recentNodeIds.size,
-                        })}
-                      </span>
-                    ) : null}
                     <Tooltip content={t('controls.docsTooltip')} side="bottom" withProvider={false}>
                     <ChromeChip
                       onClick={() => setDocsDrawerOpen((v) => !v)}

--- a/src/widgets/app-nav-rail/ui/AppNavRail.test.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.test.tsx
@@ -146,6 +146,25 @@ describe("AppNavRail", () => {
     expect(screen.getByRole("button", { name: "설정 슬롯" })).toBeInTheDocument();
   });
 
+  // 소유자 실보고 2026-07-23 — 레일 아이콘 사다리(로고 26 / 목적지 24+라벨 /
+  // 유틸 18). 하단 유틸 타일(활동)이 목적지 크기(--app-nav-rail-icon-size)를
+  // 그대로 쓰면 설정 기어보다 커 보이는 회귀가 재발한다.
+  it("keeps the agent utility tile icon on the utility ladder (--app-nav-rail-utility-icon-size), below the destination tier", () => {
+    renderRail();
+    const agentIcon = screen
+      .getByTestId("app-nav-rail-agent-status")
+      .querySelector("svg");
+    expect(agentIcon?.getAttribute("class") ?? "").toContain(
+      "--app-nav-rail-utility-icon-size",
+    );
+    const destinationIcon = screen
+      .getByTestId("app-nav-rail-item-map")
+      .querySelector("svg");
+    expect(destinationIcon?.getAttribute("class") ?? "").toContain(
+      "--app-nav-rail-icon-size",
+    );
+  });
+
   // 과제 ⑪ — LNB 컨텍스트 이월. 지도에서 노드를 선택한 채 문서함 항목으로
   // 이동하면 그 노드의 문서가 바로 열려야 한다(선택과 무관한 기본 화면 금지).
   it("overrides the docs item's href with contextHrefs.docs when provided", () => {

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -233,10 +233,14 @@ export function AppNavRail({
               "enabled:cursor-pointer enabled:hover:bg-[color:var(--color-overlay-2)] enabled:hover:text-[color:var(--color-text-primary)] enabled:active:translate-y-px enabled:active:bg-[color:var(--color-overlay-3)]",
           )}
         >
+          {/* 유틸리티 티어 아이콘 사다리(로고 26 / 목적지 24+라벨 / 유틸 18) —
+              소유자 실보고 2026-07-23: 하단 유틸 아이콘이 목적지 크기(24)를
+              그대로 써 설정 기어보다 커 보였다. 유틸 3타일(활동·발자취·설정)은
+              `--app-nav-rail-utility-icon-size` 하나로 앉는다. */}
           <Activity
             size={18}
             aria-hidden
-            className="h-[var(--app-nav-rail-icon-size)] w-[var(--app-nav-rail-icon-size)]"
+            className="h-[var(--app-nav-rail-utility-icon-size)] w-[var(--app-nav-rail-utility-icon-size)]"
           />
           {hasFreshHeartbeat ? (
             <span

--- a/src/widgets/app-nav-rail/ui/GitStatusTile.test.tsx
+++ b/src/widgets/app-nav-rail/ui/GitStatusTile.test.tsx
@@ -48,6 +48,13 @@ describe("GitStatusTile — 웹(브리지 없음)", () => {
     fireEvent.click(tile);
     expect(onActivate).toHaveBeenCalledTimes(1);
   });
+
+  // 소유자 실보고 2026-07-23 — 유틸 티어 아이콘 사다리(활동 타일과 동일 토큰).
+  it("keeps the History icon on the utility ladder (--app-nav-rail-utility-icon-size)", () => {
+    renderTile(<GitStatusTile onActivate={() => {}} />);
+    const icon = screen.getByTestId("app-nav-rail-git-tile").querySelector("svg");
+    expect(icon?.getAttribute("class") ?? "").toContain("--app-nav-rail-utility-icon-size");
+  });
 });
 
 describe("GitStatusTile — 데스크톱(Tauri)", () => {

--- a/src/widgets/app-nav-rail/ui/GitStatusTile.tsx
+++ b/src/widgets/app-nav-rail/ui/GitStatusTile.tsx
@@ -89,10 +89,12 @@ export function GitStatusTile({
         className,
       )}
     >
+      {/* 유틸리티 티어 아이콘 사다리 — `AppNavRail.tsx` 활동 타일과 동일 토큰
+          (`--app-nav-rail-utility-icon-size`, 소유자 실보고 2026-07-23). */}
       <History
         size={18}
         aria-hidden
-        className="h-[var(--app-nav-rail-icon-size)] w-[var(--app-nav-rail-icon-size)]"
+        className="h-[var(--app-nav-rail-utility-icon-size)] w-[var(--app-nav-rail-utility-icon-size)]"
       />
       {dirty ? (
         <span

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.test.tsx
@@ -286,3 +286,41 @@ describe("TopologyV2SettingsGear — 보기 모드(audience) 행 (슬라이스 C
     expect(screen.queryByTestId("topology-v2-settings-gear-audience-caption")).not.toBeInTheDocument();
   });
 });
+
+describe("TopologyV2SettingsGear — rail-tile trigger variant (레일 유틸 타일 문법)", () => {
+  // 소유자 실보고 2026-07-23 — 레일 하단 3타일(활동·발자취·설정) 중 기어만
+  // 36px 보더 floating 표면 + 16px 아이콘이라 이질적이었다. rail-tile 변형은
+  // `--app-nav-rail-tile-*` 지오메트리 + `--app-nav-rail-utility-icon-size`
+  // 아이콘 사다리를 활동/발자취 타일과 공유해야 한다.
+  it("rail-tile: trigger sits on the nav-rail utility tile contract (tile geometry + utility icon ladder)", () => {
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <TopologyV2SettingsGear
+          indexDefaultCollapsed={false}
+          onChangeIndexDefaultCollapsed={() => {}}
+          audiencePlain={false}
+          onChangeAudiencePlain={() => {}}
+          changeVaultHref="/docs/?intent=local"
+          labels={labels}
+          triggerVariant="rail-tile"
+        />
+      </NextIntlClientProvider>,
+    );
+    const trigger = screen.getByTestId("topology-v2-settings-gear-trigger");
+    expect(trigger).toHaveAttribute("data-trigger-variant", "rail-tile");
+    expect(trigger.className).toContain("--app-nav-rail-tile-height");
+    expect(trigger.className).toContain("--app-nav-rail-tile-width");
+    // floating 변형의 보더/그림자 표면 토큰이 섞이면 안 된다.
+    expect(trigger.className).not.toContain("--topology-floating-control-border");
+    const icon = trigger.querySelector("svg");
+    expect(icon?.getAttribute("class") ?? "").toContain("--app-nav-rail-utility-icon-size");
+  });
+
+  it("floating(default): keeps the original 16px icon (h-4 w-4) — no utility ladder leak", () => {
+    renderGear();
+    const trigger = screen.getByTestId("topology-v2-settings-gear-trigger");
+    expect(trigger).toHaveAttribute("data-trigger-variant", "floating");
+    const icon = trigger.querySelector("svg");
+    expect(icon?.getAttribute("class") ?? "").toContain("h-4");
+  });
+});

--- a/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2SettingsGear.tsx
@@ -108,8 +108,15 @@ export interface TopologyV2SettingsGearProps {
    * inside the top-right utility lane without breaking the row's uniform
    * control height (겹침 소탕 2026-07-23 — <lg 에서 내비 레일이 사라져 설정
    * 접근이 끊기던 결함의 진입점).
+   *
+   * `"rail-tile"` renders the trigger with the nav-rail utility-tile contract
+   * (`--app-nav-rail-tile-width/height` geometry · borderless overlay hover ·
+   * 1px active press · `--app-nav-rail-utility-icon-size` icon) so the rail's
+   * bottom stack (활동·발자취·설정) sits on ONE tile grammar — 소유자 실보고
+   * 2026-07-23: the floating 36px bordered tile + 16px icon made the gear a
+   * third, mismatched surface family inside the rail.
    */
-  triggerVariant?: "floating" | "chrome-tile";
+  triggerVariant?: "floating" | "chrome-tile" | "rail-tile";
   /**
    * Which side of the trigger the popover opens toward (default `"bottom"`,
    * the original placement — plenty of canvas below the right utility
@@ -206,10 +213,23 @@ export function TopologyV2SettingsGear({
             ? // 상단 utility lane 의 ChromeChip/ChromeTile 표면 계약 —
               // 같은 행의 44px 타일들과 높이·radius·표면이 일치해야 한다.
               "size-[var(--chrome-tile-size)] rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
-            : "h-9 w-9 rounded-md border border-[color:var(--topology-floating-control-border)] bg-[color:var(--topology-floating-control-surface)] text-[color:var(--topology-floating-control-icon)] shadow-[var(--topology-floating-control-shadow)] hover:bg-[color:var(--topology-floating-control-hover-surface)] hover:text-[color:var(--topology-floating-control-icon-hover)]",
+            : triggerVariant === "rail-tile"
+              ? // 내비 레일 유틸리티 타일 계약 — 활동(AppNavRail)·발자취
+                // (GitStatusTile)와 같은 지오메트리·상태 안무(rest → hover
+                // 색-웨이크 → active 1px 눌림 + overlay-3 → focus 링).
+                "h-[var(--app-nav-rail-tile-height)] w-[var(--app-nav-rail-tile-width)] rounded-card text-[color:var(--color-text-tertiary)] transition-[color,background-color,transform] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] active:translate-y-px active:bg-[color:var(--color-overlay-3)]"
+              : "h-9 w-9 rounded-md border border-[color:var(--topology-floating-control-border)] bg-[color:var(--topology-floating-control-surface)] text-[color:var(--topology-floating-control-icon)] shadow-[var(--topology-floating-control-shadow)] hover:bg-[color:var(--topology-floating-control-hover-surface)] hover:text-[color:var(--topology-floating-control-icon-hover)]",
         )}
       >
-        <Settings className="h-4 w-4" aria-hidden />
+        <Settings
+          className={
+            triggerVariant === "rail-tile"
+              ? // 유틸리티 티어 아이콘 사다리 — 활동·발자취 타일과 동일 토큰.
+                "h-[var(--app-nav-rail-utility-icon-size)] w-[var(--app-nav-rail-utility-icon-size)]"
+              : "h-4 w-4"
+          }
+          aria-hidden
+        />
       </button>
       {open ? (
         <div


### PR DESCRIPTION
## Summary
- **근본 원인**: tailwind-merge 가 커스텀 타입 램프(text-label/body 등)를 색상으로 오분류 → text-[color:…] 와 충돌 소거 → 크롬 등 다수 표면이 루트 16px 렌더. `extendTailwindMerge` 로 램프 7단을 font-size 그룹 등록 + 회귀 9종. 크롬 라벨 text-label(11px) 확정 — 44→36 필 + Pretendard 와 3종 세트.
- Guardian M·N·P: 레일 유틸 18px 통일·기어 rail-tile / 부트스트랩 명령 전문 표시 / 스포트라이트 카운터 badge 흡수(레인 −43px). verdict 3건 Build and verify.

## Test plan
- 전체 vitest 3395 ✅ (cn 수정 후) · focused rail/first-run/gear/shared ✅ · i18n ✅ · 1920 실측 11px + 홈/인사이트 풀샷 무결