### PR TITLE
fix: 선택 프레이밍 상한·좌측 자동 닫힘 확장 + 사이즈 감사 잔재 정리

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1583,6 +1583,12 @@
        패딩도 비례해서 커진다(고정 px 라면 큰 fan 엔 패딩이 상대적으로 작아
        빡빡했을 것). `topology-camera-math.ts#computeFocusCameraTarget` 참고. */
     --topology-v2-focus-bbox-margin: 1.15;
+    /* 소유자 실보고 (2026-07-24, 기능점검): 스포트라이트처럼 이웃이 숨어
+       ego bbox 가 작아지면 클릭 fit 이 현미경 줌으로 치솟아 매번 휠로
+       되돌려야 했다. 선택 프레이밍의 줌인 상한 — overviewEntryScale ×
+       이 비율을 넘지 않는다 (ego 멤버는 tier 면제라 이 배율에서도 전부
+       보인다). 줌아웃 방향 fit 은 제한 없음. */
+    --topology-v2-focus-max-zoom-ratio: 1.8;
     --topology-v2-hysteresis-px: 7;
     --topology-v2-emphasis-rise-tau: 0.09;
     --topology-v2-emphasis-decay-tau: 0.15;

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -60,7 +60,7 @@ export function DownloadPage({ showFirstReleaseChecklist = true }: Props) {
                 Ontology Atlas
               </span>
             </span>
-            <span aria-hidden className="text-[color:var(--color-text-quaternary)]">/</span>
+            <span aria-hidden className="text-body text-[color:var(--color-text-quaternary)]">/</span>
             <Link
               href="/"
               className="inline-flex items-center gap-2 text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
@@ -68,7 +68,7 @@ export function DownloadPage({ showFirstReleaseChecklist = true }: Props) {
               <ArrowLeft size={14} />
               {t('back')}
             </Link>
-            <span aria-hidden className="text-[color:var(--color-text-quaternary)]">/</span>
+            <span aria-hidden className="text-body text-[color:var(--color-text-quaternary)]">/</span>
             <span className="text-[12px] text-[color:var(--color-text-tertiary)]">{t('eyebrow')}</span>
             <span className="ml-auto">
               <LocaleSwitch />

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1404,9 +1404,11 @@ export function HomePage() {
   useEffect(() => {
     if (!topologySelectionActive) setIndexManualExpandDuringSelection(false);
   }, [topologySelectionActive]);
+  // 소유자 후속 (2026-07-24): 영역/스포트라이트 원장도 노드 선택 중엔 닫는다
+  // — "좌/우 패널이 다 열려 불편". 탈출 어포던스는 상단 영역/렌즈 칩의 ✕ 와
+  // Esc 가 유지하므로 원장 상시 노출이 필수는 아니다. 선택 해제 시 복귀.
   const renderedIndexState: IndexPanelState =
     topologySelectionActive &&
-    resolvedRealmSlug === null &&
     !indexManualExpandDuringSelection &&
     baseRenderedIndexState === "expanded"
       ? "collapsed"

--- a/src/views/ontology-edit/ui/OntologyEditPage.tsx
+++ b/src/views/ontology-edit/ui/OntologyEditPage.tsx
@@ -2213,7 +2213,7 @@ export function OntologyEditPage() {
                   aria-label={t("detailsSheetClose")}
                   className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
-                  ×
+                  <X size={14} aria-hidden="true" />
                 </button>
               </header>
               {ephemeralSelected ? (
@@ -2266,7 +2266,7 @@ export function OntologyEditPage() {
                   aria-label={t("anchorDialogClose")}
                   className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
-                  ×
+                  <X size={14} aria-hidden="true" />
                 </button>
               </header>
               <div className="grid max-h-[min(70dvh,640px)] gap-2 overflow-y-auto p-4 sm:grid-cols-2">

--- a/src/views/ontology-edit/ui/OntologyInspector.tsx
+++ b/src/views/ontology-edit/ui/OntologyInspector.tsx
@@ -520,7 +520,7 @@ function EphemeralDetail({
           title={t("deselectAriaLabel")}
           className="rounded-md p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
-          ×
+          <X size={14} aria-hidden="true" />
         </button>
       </div>
       <label className="flex flex-col gap-1.5">
@@ -884,7 +884,7 @@ function VaultDetail({
           title={t("deselectAriaLabel")}
           className="rounded-md p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-ring-a46)] focus-visible:ring-inset"
         >
-          ×
+          <X size={14} aria-hidden="true" />
         </button>
       </div>
       <p className="-mt-2 truncate pl-[22px] font-mono text-label tracking-[0.02em] text-[color:var(--color-text-quaternary)]">
@@ -1515,7 +1515,7 @@ function ArrayKeyEditor({
                 >
                   <span className="font-mono break-all">{slug}</span>
                   <span aria-hidden className="text-[color:var(--color-text-tertiary)]">
-                    ×
+                    <X size={14} aria-hidden="true" />
                   </span>
                 </button>
               </li>

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.test.ts
@@ -91,6 +91,7 @@ const FIXTURE_VALUES: Record<string, string> = {
   "--topology-v2-overview-entry-ratio": "0.95",
   "--topology-v2-focus-fit-max-scale": "1.9",
   "--topology-v2-focus-bbox-margin": "70",
+  "--topology-v2-focus-max-zoom-ratio": "1.8",
   "--topology-v2-hysteresis-px": "7",
   "--topology-v2-emphasis-rise-tau": "0.09",
   "--topology-v2-emphasis-decay-tau": "0.15",

--- a/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
+++ b/src/widgets/topology-map-v2/tokens/read-topology-v2-tokens.ts
@@ -126,6 +126,8 @@ export interface TopologyV2Tokens {
   overviewEntryRatio: number;
   focusFitMaxScale: number;
   focusBboxMargin: number;
+  /** 선택(ego) 프레이밍의 줌인 상한 배율 — overviewEntryScale 기준 ratio. */
+  focusMaxZoomRatio: number;
   hysteresisPx: number;
   emphasisRiseTau: number;
   emphasisDecayTau: number;
@@ -295,6 +297,7 @@ const TOKEN_SPECS: readonly TokenSpec[] = [
   { key: "overviewEntryRatio", cssVar: "--topology-v2-overview-entry-ratio", kind: "number" },
   { key: "focusFitMaxScale", cssVar: "--topology-v2-focus-fit-max-scale", kind: "number" },
   { key: "focusBboxMargin", cssVar: "--topology-v2-focus-bbox-margin", kind: "number" },
+  { key: "focusMaxZoomRatio", cssVar: "--topology-v2-focus-max-zoom-ratio", kind: "number" },
   { key: "hysteresisPx", cssVar: "--topology-v2-hysteresis-px", kind: "number" },
   { key: "emphasisRiseTau", cssVar: "--topology-v2-emphasis-rise-tau", kind: "number" },
   { key: "emphasisDecayTau", cssVar: "--topology-v2-emphasis-decay-tau", kind: "number" },

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -318,7 +318,12 @@ export function computeFocusCameraTarget(
   const h = Math.max(1, (egoBounds.maxY - egoBounds.minY) * marginRatio);
   const fitScale = Math.min(viewportWidth / w, viewportHeight / h);
   const effectiveMax = computeEffectiveCameraScaleMax(overviewEntryScale, tokens.cameraMaxZoomRatio, tokens.cameraScaleMax);
-  const scale = Math.min(effectiveMax, Math.max(overviewEntryScale, fitScale));
+  // 소유자 실보고 (2026-07-24) — 이웃이 숨은 상태(스포트라이트 등)에선 ego
+  // bbox 가 작아 fit 이 현미경 줌으로 치솟는다. 선택 프레이밍의 줌인은
+  // overviewEntryScale × focusMaxZoomRatio 를 상한으로 — ego 멤버는 tier
+  // 면제라 이 배율에서도 전부 보이고, 줌아웃 방향 fit 은 제한하지 않는다.
+  const focusZoomInCeiling = overviewEntryScale * (tokens.focusMaxZoomRatio ?? Number.POSITIVE_INFINITY);
+  const scale = Math.min(effectiveMax, focusZoomInCeiling, Math.max(overviewEntryScale, fitScale));
 
   return {
     tx: centerX,
@@ -357,6 +362,11 @@ export function computeClusterFitTarget(
   const h = Math.max(1, (disc.maxY - disc.minY) * marginRatio);
   const fitScale = Math.min(viewportWidth / w, viewportHeight / h);
   const effectiveMax = computeEffectiveCameraScaleMax(overviewEntryScale, tokens.cameraMaxZoomRatio, tokens.cameraScaleMax);
-  const scale = Math.min(effectiveMax, Math.max(overviewEntryScale, fitScale));
+  // 소유자 실보고 (2026-07-24) — 이웃이 숨은 상태(스포트라이트 등)에선 ego
+  // bbox 가 작아 fit 이 현미경 줌으로 치솟는다. 선택 프레이밍의 줌인은
+  // overviewEntryScale × focusMaxZoomRatio 를 상한으로 — ego 멤버는 tier
+  // 면제라 이 배율에서도 전부 보이고, 줌아웃 방향 fit 은 제한하지 않는다.
+  const focusZoomInCeiling = overviewEntryScale * (tokens.focusMaxZoomRatio ?? Number.POSITIVE_INFINITY);
+  const scale = Math.min(effectiveMax, focusZoomInCeiling, Math.max(overviewEntryScale, fitScale));
   return { tx: centerX, ty: centerY, tscale: scale };
 }


### PR DESCRIPTION
## Summary
- **클릭 = 항상 최적 프레이밍**: `--topology-v2-focus-max-zoom-ratio`(1.8) — 스포트라이트 등 이웃 은닉 상태에서 ego bbox 과줌 차단, 줌아웃 fit 은 유지.
- **선택 시 좌측 완전 강등**: 영역/스포트라이트 원장 예외 제거 — 좌/우 동시 열림 해소 (탈출: 상단 칩·Esc, 해제 시 복귀).
- opus 전 페이지 사이즈 감사 결과 반영: 다운로드 브레드크럼 root-16px → text-body, edit 뷰 리터럴 × 5곳 → Lucide X(14) 통일. 그 외 위반 0 — 스케일 고정 계약 앱 전체 준수 실측 확인.

## Test plan
- tsc ✅ · 카메라/토큰/home/edit/download vitest 588 ✅ · 라이브: 스포트라이트+선택 딥링크에서 과줌 없음 + 좌측 접힘 실측