### PR TITLE
fix: 영역 이탈 카메라 과소줌 고착 (노드 핸즈온 감사 HIGH)

### DIFF
--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -1535,9 +1535,19 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
             }
           }
           recomputeWorldGeometry(world, tokens);
+          // 이탈 프레이밍 결함(노드 감사 2026-07-24): 진입 시 collapse 된 영역
+          // 레이아웃에서 `overviewScaleRef` 가 collapsed spineFit(≈0.24)로 굳어,
+          // 이탈 후 stepCamera 의 scale 상한(overviewEntryScale×maxZoomRatio)이
+          // ≈0.73 으로 눌려 카메라가 canonical overview(≈1.14)에 못 오르고
+          // 축소 프레임에 고착됐다. 역재생으로 노드가 홈으로 돌아오는 매 프레임
+          // spineBounds 가 회복되므로 상한 anchor 를 라이브로 재계산해 트윈→스프링
+          // 인계 시점에 상한이 목표를 누르지 않게 한다(fresh/deselect 경로와 동치).
+          overviewScaleRef.current = computeOverviewFitScale(world.spineBounds, width, height, tokens);
         } else if (rt.phase === "idle" && realmDataRef.current !== null) {
-          // 이탈 완료 — 역재생이 홈으로 되돌렸으니 realm 데이터 정리.
+          // 이탈 완료 — 역재생이 홈으로 되돌렸으니 realm 데이터 정리 + 홈 spineBounds
+          // 기준으로 overview anchor 를 최종 확정(위 exiting 재계산의 마감).
           realmDataRef.current = null;
+          overviewScaleRef.current = computeOverviewFitScale(world.spineBounds, width, height, tokens);
         }
       }
 


### PR DESCRIPTION
## Summary
- 영역(realm) 이탈 시 지도가 좌상단에 작게(scale 0.73 vs 정상 1.14, −36%) 고착돼 사용자가 휠로 되돌려야 했던 결함. 근인: 진입 시 collapse 레이아웃에서 overviewScaleRef 가 collapsed spineFit(≈0.24)로 굳어 stepCamera scale 상한이 트윈 목표를 누름. 역재생 exiting 프레임 + idle 정착에서 홈 spineBounds 로 anchor 라이브 재계산.
- 검증: 실 ✕/딥링크 ✕/Esc 전부 1.14 재측정(delta 0%), before/after 스크린샷.

## Test plan
- topology-map-v2 유닛 717 ✅ · tsc ✅ · Playwright 실측 scale 1.139