### PR TITLE
fix: 샘플 상태 좌측 레일 정리 — 유지보수·에이전트 컨트롤 숨김 (Toss R3/R4)

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -3154,6 +3154,13 @@ export function HomePage() {
                     // 조용한 힌트 행 게이트. treeResult 는 이미 위에서
                     // element 를 제외했다(단일 진실원 무변경).
                     plainMode={audiencePlain}
+                    // 오버뷰 좌측 레일 attention winner 단일화 (2026-07-24) —
+                    // vault 미연결(정적 샘플) 동안은 "먼지 앉은 노드" 행과
+                    // "인계" 메뉴가 이 제품 자신의 dogfood vault 상태를
+                    // 서술해 첫 방문자에게 남의 저장소 잡음으로 읽힌다.
+                    // `canCreateNode`(= vault.manifest !== null)가 이미 이
+                    // 페이지의 "vault 로드됨" 단일 진실원이므로 그대로 재사용.
+                    vaultLoaded={canCreateNode}
                     onOpenAgentConnect={agentConnectLauncher.open}
                     // P4-② (2026-07-21 리텐션 라운드) — 이미 연결된
                     // 에이전트가 있는 2일차+ 사용자에게 "Updated with AI"

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.test.tsx
@@ -682,4 +682,101 @@ describe("TopologyIndexPanel", () => {
       expect(screen.queryByTestId("topology-index-plain-hint")).not.toBeInTheDocument();
     });
   });
+
+  // 오버뷰 좌측 레일 attention winner 단일화 (2026-07-24) — vault 미연결
+  // (정적 샘플) 상태에서 "먼지 앉은 노드"/"인계" 같은 유지보수·에이전트
+  // 컨트롤은 첫 방문자에게 노출하지 않는다. 실 데이터(dustyNodeCount,
+  // agentHandoff)는 그대로 받되 `vaultLoaded=false`면 렌더만 억제하고,
+  // `vaultLoaded=true`(또는 생략 — 하위호환 기본값)면 그대로 나타나야 한다.
+  describe("vault-connected gate for maintenance/agent controls (P1 오버뷰 레일)", () => {
+    const agentHandoffProp = {
+      briefText: "brief",
+      reanalyzeText: "reanalyze",
+      syncText: "sync",
+      labels: {
+        menuLabel: "인계",
+        menuAria: "인계 메뉴",
+        briefCopy: "브리핑 복사",
+        briefCopied: "복사됨",
+        briefCopyAriaLabel: "브리핑 복사",
+        briefCopiedAriaLabel: "복사됨",
+        reanalyzeCopy: "재분석 복사",
+        reanalyzeCopied: "복사됨",
+        reanalyzeCopyAriaLabel: "재분석 복사",
+        reanalyzeCopiedAriaLabel: "복사됨",
+        syncCopy: "동기화 복사",
+        syncCopied: "복사됨",
+        syncCopyAriaLabel: "동기화 복사",
+        syncCopiedAriaLabel: "복사됨",
+      },
+    };
+
+    it("hides the dusty-nodes row and the agent-handoff menu when vaultLoaded is false, even though counts/props are non-empty", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={labels}
+          dustyNodeCount={51}
+          agentHandoff={agentHandoffProp}
+          uncatalogedDocCount={3}
+          onPromoteUncatalogedDocs={() => {}}
+          vaultLoaded={false}
+        />,
+      );
+      expect(screen.queryByTestId("topology-index-dusty-nodes")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("topology-index-agent-handoff")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("topology-index-uncataloged-docs")).not.toBeInTheDocument();
+    });
+
+    it("shows the dusty-nodes row and the agent-handoff menu once vaultLoaded is true", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={labels}
+          dustyNodeCount={51}
+          agentHandoff={agentHandoffProp}
+          uncatalogedDocCount={3}
+          onPromoteUncatalogedDocs={() => {}}
+          vaultLoaded
+        />,
+      );
+      expect(screen.getByTestId("topology-index-dusty-nodes")).toBeInTheDocument();
+      expect(screen.getByTestId("topology-index-agent-handoff")).toBeInTheDocument();
+      expect(screen.getByTestId("topology-index-uncataloged-docs")).toBeInTheDocument();
+    });
+
+    it("defaults to shown (vaultLoaded omitted) for backward compatibility with existing callers", () => {
+      render(
+        <TopologyIndexPanel
+          treeResult={buildFixtureTree()}
+          totalConcepts={4}
+          totalRelations={3}
+          domainCount={1}
+          changedSlugs={new Set()}
+          selectedId={null}
+          onSelect={() => {}}
+          onCollapse={() => {}}
+          labels={labels}
+          dustyNodeCount={51}
+          agentHandoff={agentHandoffProp}
+        />,
+      );
+      expect(screen.getByTestId("topology-index-dusty-nodes")).toBeInTheDocument();
+      expect(screen.getByTestId("topology-index-agent-handoff")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -157,6 +157,19 @@ export interface TopologyIndexPanelProps {
    * "왜 안 보이는지"를 설명하는 힌트 행 렌더 여부만 결정한다(데이터 무변경).
    */
   plainMode?: boolean;
+  /**
+   * 오버뷰 좌측 레일 attention winner 단일화 (2026-07-24) — vault 미연결
+   * (정적 샘플) 상태에서 "먼지 앉은 노드 N" 행과 "인계" 메뉴는 노출하지
+   * 않는다. 두 표면 모두 *현재 로드된 그래프*를 서술한다 — 샘플 모드에선
+   * 그 그래프가 사용자의 프로젝트가 아니라 이 제품 자신의 dogfood
+   * vault라서, 방치 카운트도 에이전트 인계 명령도 첫 방문자에게는 남의
+   * 저장소 얘기라 잡음이다(`BlockImportModule`의 "vault 없인 기능 자체가
+   * 작동 안 함" 케이스와는 다른 문제 — 그쪽은 P1 결함②에 따라 여전히
+   * disabled+힌트로 존치, 완전 은폐 금지). 생략 시 기존 하위호환 동작
+   * (항상 노출)을 유지 — 실 vault 연결(`vaultLoaded=true`)이면 두 행이
+   * 그대로 다시 나타난다(값 삭제가 아니라 강등).
+   */
+  vaultLoaded?: boolean;
 }
 
 /**
@@ -201,6 +214,7 @@ export function TopologyIndexPanel({
   recentWindow = "auto",
   onWindowChange,
   plainMode = false,
+  vaultLoaded = true,
 }: TopologyIndexPanelProps) {
   const [query, setQuery] = useState("");
   const [openIds, setOpenIds] = useState<Set<string>>(
@@ -511,7 +525,7 @@ export function TopologyIndexPanel({
           (HomePage, `deriveBootstrapPlan` — 이미 kind 있는 문서는 제외된
           카운트) 를 그대로 받는다 — 새 파생 없음. 0 이거나 승격 핸들러가
           없으면 행 자체를 숨긴다. */}
-      {uncatalogedDocCount && uncatalogedDocCount > 0 && onPromoteUncatalogedDocs ? (
+      {vaultLoaded && uncatalogedDocCount && uncatalogedDocCount > 0 && onPromoteUncatalogedDocs ? (
         <button
           type="button"
           onClick={onPromoteUncatalogedDocs}
@@ -535,7 +549,7 @@ export function TopologyIndexPanel({
           신선도 탭은 도메인 단위 최신성 히트스트립이라 "51개가 오래 방치"
           라는 약속과 정반대 그림("오늘 다 갱신")으로 읽혔다. 실제 오래된
           노드 목록("오래 안 바뀐 허브" + 오늘의 손질)은 할 일 탭이 답한다. */}
-      {dustyNodeCount && dustyNodeCount > 0 ? (
+      {vaultLoaded && dustyNodeCount && dustyNodeCount > 0 ? (
         <Link
           href="/ontology/insights?tab=do-next"
           data-testid="topology-index-dusty-nodes"
@@ -598,7 +612,7 @@ export function TopologyIndexPanel({
         )}
         {footerGrowthText ? <span className="min-w-0 flex-1 truncate whitespace-nowrap">{footerGrowthText}</span> : null}
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          {agentHandoff ? (
+          {agentHandoff && vaultLoaded ? (
             <TopologyIndexAgentHandoff
               briefText={agentHandoff.briefText}
               reanalyzeText={agentHandoff.reanalyzeText}


### PR DESCRIPTION
## Summary
- 첫 방문(vault 미연결 샘플) 상태에서 `먼지 앉은 노드 N`·에이전트 인계 메뉴·`지도에 없는 문서 N` 행을 숨김 — 처음 온 비개발자에게 유지보수 지표/에이전트 컨트롤이 노출돼 불안·혼란 유발하던 것(Toss R3/R4). 내 vault 연결 시 다시 노출(progressive disclosure, 삭제 아님).
- `vaultLoaded` prop(기존 `vault.manifest !== null` 신호 재사용, 기본 true 하위호환). CTA 단일화는 이미 만족(코드 확인, 무변경), 온보딩 간결화는 시각 판단이라 보류.

## Test plan
- topology-index-panel + home vitest 327 ✅ (신규 3: 샘플서 숨김·연결서 노출·기본 노출) · tsc ✅