### PR TITLE
fix: 데이터시트 파일경로 평문화 — slug 마지막 세그먼트 + hover 전문 (Toss C2)

### DIFF
--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -127,7 +127,7 @@ describe("TopologyV2DetailPanel — viewport clamp (P3-③)", () => {
 });
 
 describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYSTEM §4)", () => {
-  it("renders an evidence group with its row's title/path when evidence rows exist", () => {
+  it("renders an evidence group with its row's title when evidence rows exist", () => {
     renderPanel(undefined, {
       rows: [{ id: "capabilities/product-owner-operating-system", title: "product-owner-operating-system", path: "capabilities/" }],
       total: 1,
@@ -138,7 +138,22 @@ describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYST
     expect(group).not.toBeNull();
     expect(group!.textContent).toContain("evidence");
     expect(screen.getByText("product-owner-operating-system")).toBeInTheDocument();
-    expect(screen.getByText("capabilities/")).toBeInTheDocument();
+  });
+
+  // Toss C2 (2026-07-24) — the raw vault-path prefix (`row.path`) used to
+  // render as an always-visible mono span next to the title, opaque to a
+  // non-developer. It no longer renders in the visible DOM text; the row's
+  // link carries the full `row.id` slug as a native `title=` hover instead
+  // (information preserved, just no longer competing for first-read
+  // attention with the "근거" plain label).
+  it("folds the evidence row's path behind a hover title instead of always-visible text", () => {
+    renderPanel(undefined, {
+      rows: [{ id: "capabilities/product-owner-operating-system", title: "product-owner-operating-system", path: "capabilities/" }],
+      total: 1,
+    });
+    expect(screen.queryByText("capabilities/")).not.toBeInTheDocument();
+    const link = screen.getByText("product-owner-operating-system").closest("a");
+    expect(link).toHaveAttribute("title", "capabilities/product-owner-operating-system");
   });
 
   it("does not render the evidence group when there are no evidence rows", () => {
@@ -157,6 +172,53 @@ describe("TopologyV2DetailPanel — 근거(evidence) group promotion (RATIO-SYST
       "href",
       expect.stringContaining("product-owner-operating-system"),
     );
+  });
+});
+
+// Toss C2 (2026-07-24) — the sticky footer used to show the FULL `slug`
+// (`ontology/capabilities/mcp-server`) always visible, mono/quaternary but
+// still raw and unreadable to a non-developer. It now shows only the last
+// path segment and folds the full slug behind a native `title=` hover — the
+// "전체 상세 →" link already owns navigating to the full record.
+describe("TopologyV2DetailPanel — sticky 푸터 slug 평문화 (Toss C2)", () => {
+  it("shows only the slug's last segment in visible text, with the full slug as a hover title", () => {
+    render(
+      <TopologyV2DetailPanel
+        slug="ontology/capabilities/mcp-server"
+        title="MCP Server"
+        kind="capability"
+        domain={null}
+        powered={false}
+        metric={{ contains: 0, usedBy: 0, dependsOn: 0, evidence: 0 }}
+        groups={{
+          contains: { rows: [], total: 0 },
+          usedBy: { rows: [], total: 0 },
+          dependsOn: { rows: [], total: 0 },
+          belongsTo: { rows: [], total: 0 },
+        }}
+        evidence={{ rows: [], total: 0 }}
+        handoffText="node: ontology/capabilities/mcp-server"
+        documentHref={null}
+        builderEditHref="/ontology/edit/?node=ontology%2Fcapabilities%2Fmcp-server"
+        labels={labels}
+        onSelectConnection={() => {}}
+        onCopyHandoff={() => {}}
+        onClose={() => {}}
+        onSetPathSource={() => {}}
+      />,
+    );
+    const slugEl = screen.getByTestId("topology-v2-detail-panel-slug");
+    expect(slugEl).toHaveTextContent("mcp-server");
+    expect(slugEl.textContent).not.toContain("ontology/capabilities");
+    expect(slugEl).toHaveAttribute("title", "ontology/capabilities/mcp-server");
+  });
+
+  it("shows the slug as-is when it has no path segment to fold", () => {
+    renderPanel();
+    // fixture slug is "domains/views" — but a slug with no "/" should render
+    // unchanged (nothing to fold).
+    const slugEl = screen.getByTestId("topology-v2-detail-panel-slug");
+    expect(slugEl).toHaveTextContent("views");
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -7,6 +7,7 @@ import { buildDocsVaultHref } from "@/entities/docs-vault";
 import { isContainmentRelation } from "@/shared/lib/ontology-tree";
 import {
   buildV2MetricSegments,
+  slugDisplaySegment,
   V2_CONTAINS_SUMMARY_THRESHOLD,
   type V2ConnectionGroupsView,
   type V2ConnectionGroupView,
@@ -63,6 +64,16 @@ import { Tooltip } from "@/shared/ui/tooltip";
  * in the usedBy group when the underlying `contains` edge exists — this is
  * additive promotion, not a removal, since the group still needs to show
  * every direct edge for agent handoff completeness.
+ *
+ * Toss C2 (청중 언어 평문화, 2026-07-24): the "담는 것/쓰는 곳/기대는 곳/근거"
+ * plain labels used to sit right next to jargon that undercut them — the
+ * sticky footer's raw `slug` (`ontology/capabilities/mcp-server`) and each
+ * evidence row's raw vault-path prefix were ALWAYS visible, unreadable to a
+ * non-developer. Both now show only the readable leaf segment
+ * (`slugDisplaySegment` / `V2EvidenceRow.title`) and fold the full path
+ * behind a native `title=` hover tooltip — information is not lost (the
+ * "전체 상세 →" link already owns navigating to the full record), just no
+ * longer competing for first-read attention with the plain-language facts.
  */
 
 export interface TopologyV2DetailPanelLabels {
@@ -421,6 +432,13 @@ export function TopologyV2DetailPanel({
   // (unlike `onSelectConnection`'s canvas-node ids, which are a different
   // namespace). No TraceMark here: these aren't canvas edges. Same header/
   // list shape as usedBy/dependsOn.
+  //
+  // Toss C2 — `row.path` (the folder prefix, e.g. "capabilities/") used to
+  // render as an always-visible mono span next to the title. That's a raw
+  // vault path, opaque to a non-developer, sitting right next to the plain
+  // "근거" label. It now only surfaces via the row's native `title=` hover
+  // (full `row.id` slug) — the row's own link already takes you to the doc,
+  // so the path adds nothing a click doesn't already resolve.
   const renderEvidenceGroup = () => {
     if (evidence.total === 0) return null;
     return (
@@ -445,16 +463,12 @@ export function TopologyV2DetailPanel({
               <Link
                 href={buildDocsVaultHref({ slug: row.id })}
                 data-datasheet-evidence={row.id}
+                title={row.id}
                 className="flex min-h-[32px] w-full items-center gap-2 rounded-[var(--topology-v2-panel-row-radius)] px-1.5 py-2 transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]"
               >
                 <span className="min-w-0 flex-1 truncate text-[13px] text-[color:var(--topology-v2-panel-text-secondary)]">
                   {row.title}
                 </span>
-                {row.path ? (
-                  <span className="shrink-0 font-mono text-[10px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-                    {row.path}
-                  </span>
-                ) : null}
               </Link>
             </li>
           ))}
@@ -724,10 +738,18 @@ export function TopologyV2DetailPanel({
           넘기면 이 푸터가 스크롤 밖에 숨는데 스크롤 어포던스가 없어 "전체
           상세"가 존재하지 않는 것처럼 읽혔다(P3-③ 의 후속). 패널 스크롤
           컨테이너 안에서 sticky + 불투명 패널 surface 로 항상 보이게 한다 —
-          내용이 다 보일 땐 기존과 동일한 자리(sticky 비활성 상태와 동일). */}
+          내용이 다 보일 땐 기존과 동일한 자리(sticky 비활성 상태와 동일).
+          Toss C2 (2026-07-24) — 전체 `slug`(`ontology/capabilities/mcp-server`)
+          가 상시 노출돼 비개발자에겐 불투명했다. 화면엔 마지막 세그먼트만
+          남기고(`slugDisplaySegment`), 전체 경로는 `title=` hover 로 접는다 —
+          "전체 상세 →" 링크가 목적지를 이미 담당하므로 정보 손실은 없다. */}
       <div className="sticky -bottom-[var(--topology-v2-panel-pad)] -mx-[var(--topology-v2-panel-pad)] -mb-[var(--topology-v2-panel-pad)] flex items-center gap-2 rounded-b-[var(--topology-v2-panel-radius)] border-t border-[color:var(--topology-v2-panel-divider)] bg-[color:var(--topology-v2-panel-surface)] px-[var(--topology-v2-panel-pad)] py-2">
-        <span className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]">
-          {slug}
+        <span
+          data-testid="topology-v2-detail-panel-slug"
+          title={slug}
+          className="min-w-0 flex-1 truncate font-mono text-[10.5px] text-[color:var(--topology-v2-panel-text-quaternary)]"
+        >
+          {slugDisplaySegment(slug)}
         </span>
         {onOpenFullDetail ? (
           <button

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -8,6 +8,7 @@ import {
   buildV2MetricSegments,
   formatV2MetricLine,
   groupV2ConnectionsByDirection,
+  slugDisplaySegment,
   summarizeContainsByPathPrefix,
   type V2DatasheetConnection,
 } from "./topology-v2-datasheet";
@@ -324,6 +325,22 @@ describe("buildV2EvidenceRows — 근거(evidence) group promotion (RATIO-SYSTEM
     expect(buildV2EvidenceRows(["", "  ", "capabilities/x"])).toEqual([
       { id: "capabilities/x", title: "x", path: "capabilities/" },
     ]);
+  });
+});
+
+// Toss C2 (청중 언어 평문화, 2026-07-24) — the sticky footer folds the full
+// slug behind a hover title and shows only this segment in visible text.
+describe("slugDisplaySegment — sticky 푸터 slug 평문화 (Toss C2)", () => {
+  it("returns the last path segment of a folder-shaped slug", () => {
+    expect(slugDisplaySegment("ontology/capabilities/mcp-server")).toBe("mcp-server");
+  });
+
+  it("returns the slug unchanged when it has no folder segment", () => {
+    expect(slugDisplaySegment("standalone-doc")).toBe("standalone-doc");
+  });
+
+  it("returns an empty string for a trailing-slash slug (defensive, no crash)", () => {
+    expect(slugDisplaySegment("domains/")).toBe("");
   });
 });
 

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -312,6 +312,22 @@ export function buildV2EvidenceRows(
   return rows;
 }
 
+/**
+ * 파일경로형 문자열(슬러그/vault-path)의 마지막 세그먼트만 뽑는다 — sticky
+ * 푸터가 전체 slug(`ontology/capabilities/mcp-server`)를 상시 노출하던 것의
+ * 정리(Toss C2 청중 언어 평문화, 2026-07-24). `/`가 없으면 원문 그대로
+ * 반환(이미 짧으므로 자를 것이 없음). 순수/결정론 — `buildV2EvidenceRows`의
+ * title/path 분리와 같은 "마지막 슬래시 기준" 규칙을 재사용한다.
+ *
+ * 화면엔 이 결과만 보이고 원문 전체는 `title=` 네이티브 툴팁으로 접힌다 —
+ * "전체 상세 →" 링크가 이미 목적지를 담당하므로 정보 손실은 없다(패널 쪽
+ * 렌더는 `TopologyV2DetailPanel.tsx`의 sticky 푸터/근거 행 참고).
+ */
+export function slugDisplaySegment(slug: string): string {
+  const lastSlash = slug.lastIndexOf("/");
+  return lastSlash === -1 ? slug : slug.slice(lastSlash + 1);
+}
+
 export interface V2HandoffInput {
   slug: string;
   kind: string;


### PR DESCRIPTION
## Summary
- 데이터시트 sticky 푸터 slug(`ontology/capabilities/mcp-server`)를 마지막 세그먼트만 표시 + 전체는 hover title 로 접음(`slugDisplaySegment` 순수 헬퍼). 근거 행의 파일경로 상시 span 제거 → hover title 로. `담는 것/쓰는 곳/기대는 곳` 평문 라벨은 유지(위계 강등이지 은닉 아님, 정보 손실 0).
- 그룹 항목 표시명은 이미 `display ?? title` + `humanizeCodePathTitle` 로 평문 우선이라 무변경.

## Test plan
- DetailPanel + datasheet vitest 65 ✅ (경로 hover-only·slug 세그먼트·헬퍼 단위) · tsc ✅ · 신규 text-[Npx] 0