### PR TITLE
fix: 영역 해제 알파 램프(모션 B) + 포커스 자식 라벨 LOD (A1)

### DIFF
--- a/src/widgets/topology-map-v2/model/label-lod.test.ts
+++ b/src/widgets/topology-map-v2/model/label-lod.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { DISC_LABEL_TOP_K, LABEL_TOP_K, selectDiscLabelEligible, selectTopKLabels, type LabelRankEntry } from "./label-lod";
+import {
+  DISC_LABEL_TOP_K,
+  LABEL_TOP_K,
+  isEgoNeighborLabelExempt,
+  selectDiscLabelEligible,
+  selectTopKLabels,
+  type LabelRankEntry,
+} from "./label-lod";
 
 const entry = (id: string, degree: number, exempt = false): LabelRankEntry => ({ id, degree, exempt });
 
@@ -98,5 +105,39 @@ describe("selectDiscLabelEligible (high-fan disc label budget)", () => {
   it("exposes a per-disc budget in the readable 6–8 band", () => {
     expect(DISC_LABEL_TOP_K).toBeGreaterThanOrEqual(6);
     expect(DISC_LABEL_TOP_K).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("isEgoNeighborLabelExempt (포커스 도메인 자식 라벨 겹침 LOD, 노드 감사 처방)", () => {
+  it("null eligible set (focus under the DISC_LABEL_TOP_K band) keeps every neighbor exempt", () => {
+    expect(isEgoNeighborLabelExempt("any-id", null)).toBe(true);
+  });
+
+  it("non-null eligible set only exempts the DOI winners", () => {
+    const eligible = new Set(["a", "b"]);
+    expect(isEgoNeighborLabelExempt("a", eligible)).toBe(true);
+    expect(isEgoNeighborLabelExempt("c", eligible)).toBe(false);
+  });
+
+  it("end-to-end: a focused domain's 18 same-kind children caps to DISC_LABEL_TOP_K exempt labels", () => {
+    // Reproduces the audited scenario: a focus with 18 neighbors, all the same
+    // kind/degree (a typical domain's capability children) — before this fix,
+    // `neighborsOfFocused.size > DISC_LABEL_TOP_K` would still exempt all 18
+    // unconditionally; now only the DOI-ranked top-K keep the exemption.
+    const neighborIds = Array.from({ length: 18 }, (_, i) => `child-${String(i).padStart(2, "0")}`);
+    const ranked = neighborIds; // identical kind/degree → DOI rank falls back to id-ascending, already sorted.
+    const eligible = selectDiscLabelEligible([ranked], DISC_LABEL_TOP_K);
+    const exemptCount = neighborIds.filter((id) => isEgoNeighborLabelExempt(id, eligible)).length;
+    expect(exemptCount).toBe(DISC_LABEL_TOP_K);
+    expect(isEgoNeighborLabelExempt("child-00", eligible)).toBe(true);
+    expect(isEgoNeighborLabelExempt("child-17", eligible)).toBe(false);
+  });
+
+  it("a small focus (≤ DISC_LABEL_TOP_K neighbors) is unaffected — caller passes null, regression 0", () => {
+    // The caller (`ui/topology-frame-draw.ts`) only computes a non-null eligible
+    // set when `neighborsOfFocused.size > DISC_LABEL_TOP_K`; below that, every
+    // neighbor stays exempt exactly as before this fix.
+    const neighborIds = ["a", "b", "c"];
+    expect(neighborIds.every((id) => isEgoNeighborLabelExempt(id, null))).toBe(true);
   });
 });

--- a/src/widgets/topology-map-v2/model/label-lod.ts
+++ b/src/widgets/topology-map-v2/model/label-lod.ts
@@ -64,6 +64,29 @@ export function selectDiscLabelEligible(
   return eligible;
 }
 
+/**
+ * 포커스(ego) 도메인 자식 라벨 겹침 LOD (노드 감사 처방). A focused node's
+ * 1-hop neighbors were unconditionally label-EXEMPT regardless of count — fine
+ * up to a handful, but a domain with more children than the readable
+ * `DISC_LABEL_TOP_K` band (the same "읽히는 라벨 한 줌" precedent the expanded-
+ * disc cut above uses) painted every child's label and let them collide. This
+ * mirrors that exact precedent for the ego-reveal path: below the cap every
+ * neighbor stays exempt (`doiEligibleIds === null` — caller's signal that no
+ * cut was needed, regression 0 for the common small-fan-out focus); at/above
+ * it, only the DOI-top-K neighbors (`selectDiscLabelEligible`) keep the
+ * exemption — everyone else falls back into the normal top-K/greedy
+ * competition, which still shows them if nothing collides ("과하지 않게" — no
+ * blanket label wipe, only the ones that would overlap get demoted to a dot).
+ * Pure — the caller computes `doiEligibleIds` (ranking needs edge/degree data
+ * this module doesn't own).
+ */
+export function isEgoNeighborLabelExempt(
+  neighborId: string,
+  doiEligibleIds: ReadonlySet<string> | null,
+): boolean {
+  return doiEligibleIds === null || doiEligibleIds.has(neighborId);
+}
+
 export interface LabelRankEntry {
   /** Node id (== vault slug id) — the deterministic tiebreaker on equal degree. */
   id: string;

--- a/src/widgets/topology-map-v2/model/realm-transition.test.ts
+++ b/src/widgets/topology-map-v2/model/realm-transition.test.ts
@@ -21,6 +21,7 @@ import {
   realmInsideFlipDelayFor,
   realmInsidePosition,
   realmOutsidePosition,
+  realmOutsideReturnAlpha,
   realmOutsideReturnPosition,
   realmOutsideReturnReach,
   realmTransitionReducer,
@@ -249,6 +250,33 @@ describe("realmOutsideReturnReach (S6 역중력 reach 1→0)", () => {
 
   it("duration<=0 이면 0", () => {
     expect(realmOutsideReturnReach(5, 0)).toBe(0);
+  });
+});
+
+describe("realmOutsideReturnAlpha (S7 밖 노드 귀환 materialize — 모션 감사 처방 B)", () => {
+  it("elapsed 0 → 0(완전 이탈, 안 보임), duration → 1(홈, 풀 알파)", () => {
+    expect(realmOutsideReturnAlpha(0)).toBeCloseTo(0);
+    expect(realmOutsideReturnAlpha(REALM_EXIT_OUTSIDE_RETURN_MS)).toBeCloseTo(1);
+  });
+
+  it("reach 의 정확한 보수다(1 - reach) — 항상 합이 1", () => {
+    const d = REALM_EXIT_OUTSIDE_RETURN_MS;
+    for (const t of [0, d * 0.25, d * 0.5, d * 0.75, d]) {
+      expect(realmOutsideReturnAlpha(t, d) + realmOutsideReturnReach(t, d)).toBeCloseTo(1);
+    }
+  });
+
+  it("단조 증가 — 귀환할수록 더 또렷해진다(팝인 없이 램프)", () => {
+    const d = REALM_EXIT_OUTSIDE_RETURN_MS;
+    const early = realmOutsideReturnAlpha(d * 0.2, d);
+    const mid = realmOutsideReturnAlpha(d * 0.5, d);
+    const late = realmOutsideReturnAlpha(d * 0.8, d);
+    expect(early).toBeLessThan(mid);
+    expect(mid).toBeLessThan(late);
+  });
+
+  it("duration<=0 이면 1(reduced-motion — 즉시 풀 알파, reach 0 의 보수)", () => {
+    expect(realmOutsideReturnAlpha(5, 0)).toBe(1);
   });
 });
 

--- a/src/widgets/topology-map-v2/model/realm-transition.ts
+++ b/src/widgets/topology-map-v2/model/realm-transition.ts
@@ -302,6 +302,25 @@ export function realmOutsideReturnReach(
 }
 
 /**
+ * 밖 노드 역중력 귀환 중 알파(0..1) — 모션 감사 처방 B (S7, fable 설계).
+ * 순수 위상→알파 사상: `1 - realmOutsideReturnReach(elapsed, duration)`.
+ * `realmOutsideReturnReach` 는 완전 이탈=1 → 홈=0 로 줄어드는 reach 팩터라,
+ * 그 보수(complement)는 완전 이탈=0(안 보임) → 홈=1(풀 알파)로 늘어나는
+ * "materialize" 알파다. 입장 fling 의 감산적(subtractive, 멀어질수록
+ * 사라짐) 우아함과 대칭인 가산적(additive, 가까워질수록 나타남) 우아함 —
+ * 이전엔 밖 노드가 하드 컬 상태에서 alpha 오버라이드 없이 위치만
+ * 되감겨, 뷰포트 컬(`isEdgeCulled`)에 걸리는 순간 풀 알파로 한 프레임에
+ * 팝인했다(온셋 ink 급증, 소유자 모션 감사). 새 easing/토큰 0 — 기존
+ * `realmOutsideReturnReach` 램프를 그대로 재사용. 순수·결정론.
+ */
+export function realmOutsideReturnAlpha(
+  elapsed: number,
+  duration: number = REALM_EXIT_OUTSIDE_RETURN_MS,
+): number {
+  return 1 - realmOutsideReturnReach(elapsed, duration);
+}
+
+/**
  * 밖 노드의 이번 프레임 귀환 좌표 — `realmOutsidePosition`(fling)의 역재생.
  * `from` 은 노드의 **원래(홈) 좌표**(입장 시 fling 출발점). reach 팩터가 1→0 로
  * 줄며 반경·컬이 되감겨 정확히 `from` 으로 착지한다(입장 궤적 완전 역전 — 튐

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -384,6 +384,15 @@ export interface FrameDrawParams {
   /** S4 — 전개 순간의 도트 방사 시차 팩터 0..1 (전환 중에만 >0). */
   realmDustParallax: number;
   /**
+   * S7 — 영역 퇴장(exiting) 중 하드 컬됐던 밖 노드의 귀환 materialize 알파
+   * (모션 감사 처방 B). `realm-transition.ts#realmOutsideReturnAlpha` 로 계산 —
+   * 완전 이탈=0(안 보임) → 홈=1(풀 알파). 이 노드의 `effectiveAlphaById` 항목에
+   * 곱해져 노드 자신과, `edgeTierAlpha`(min 결합)를 통해 그 노드로 향하는 엣지
+   * 모두를 램프시킨다 — 뷰포트 컬 경계에 걸리는 순간 풀 알파로 팝인하던 결함의
+   * 수정. null 이면 미적용(entering/active/idle — 회귀 0).
+   */
+  realmOutsideReturnAlphaById: ReadonlyMap<string, number> | null;
+  /**
    * 발자국 트레일 (fable 설계) — 세션 동안 방문(ego 포커스)한 노드의 최근성
    * rank(0 = 가장 최근). `model/footprint-ring.ts#buildFootprintRanks` 가 만든다.
    * 각 방문 노드에 옅은 pale 인디고 헤어라인 링을 최근성으로 감쇠해 얹는다
@@ -458,6 +467,7 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     realmDepthById,
     realmDepthParallax,
     realmDustParallax,
+    realmOutsideReturnAlphaById,
     realmCosmosPoints,
     footprintRanksById,
     spotlightIds,
@@ -569,14 +579,16 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     // 램프로 떠오른다(끄면 램프 감쇠로 자연 강하).
     const spotlightReveal =
       spotlightLensActive && spotlightIds !== null && spotlightIds.has(node.id) ? spotlightRamp : 0;
-    effectiveAlphaById.set(
-      node.id,
-      effectiveNodeAlpha(
-        tierAlpha,
-        isEgoMember,
-        Math.max(isPairMember ? 1 : (egoRevealById.get(node.id) ?? 0), spotlightReveal),
-      ),
+    const baseAlpha = effectiveNodeAlpha(
+      tierAlpha,
+      isEgoMember,
+      Math.max(isPairMember ? 1 : (egoRevealById.get(node.id) ?? 0), spotlightReveal),
     );
+    // S7 — 영역 퇴장 중 귀환하는 밖 노드는 이 램프로 강등(모션 감사 처방 B). 이
+    // 노드로 향하는 엣지는 `edgeTierAlpha`(min 결합)를 통해 같은 프레임에서
+    // 자동으로 따라온다 — 별도 엣지 경로 없이 노드 alpha 하나로 충분.
+    const returnAlpha = realmOutsideReturnAlphaById?.get(node.id);
+    effectiveAlphaById.set(node.id, returnAlpha !== undefined ? baseAlpha * returnAlpha : baseAlpha);
   }
 
   // S8 결함 1 — 펼친 부모(파선 오라 대상) + 그 디스크(부모 + contains 하위 전이

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -13,7 +13,14 @@ import { footprintRingStyle, FOOTPRINT_RING_OFFSET } from "../model/footprint-ri
 import { depthParallaxOffsetFor, ZERO_PARALLAX } from "../model/realm-depth-parallax";
 import { realmDepthClarityAlpha, realmDepthClarityScale } from "../model/realm-transition";
 import { classifyZoomTier, DEFAULT_TIER_REVEAL, edgeTierAlpha, effectiveNodeAlpha, nodeTierAlpha, type TierRevealConfig } from "../model/tier-visibility";
-import { DISC_LABEL_TOP_K, LABEL_TOP_K, selectDiscLabelEligible, selectTopKLabels, type LabelRankEntry } from "../model/label-lod";
+import {
+  DISC_LABEL_TOP_K,
+  LABEL_TOP_K,
+  isEgoNeighborLabelExempt,
+  selectDiscLabelEligible,
+  selectTopKLabels,
+  type LabelRankEntry,
+} from "../model/label-lod";
 import { draw as gridDraw, lerpColorHex } from "../render/grid";
 import {
   ACTIVITY_MARK_GAP,
@@ -1161,6 +1168,29 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     }
     return selectDiscLabelEligible(rankedByDisc, DISC_LABEL_TOP_K);
   })();
+  // 노드 감사 처방 — 포커스(ego) 도메인 자식 라벨 겹침 LOD. `neighborsOfFocused`
+  // 는 EGO_NEIGHBOR_LIMIT(24) 이하면 전원 full 점등되고(선택적 ego 컷은 >24 에서만
+  // 발동), 이전엔 그 전원이 무조건 라벨 exempt 였다 — 자식 18개짜리 도메인을
+  // 포커스하면 겹치는 라벨이 그대로 다 그려졌다(위 high-fan disc 처방과 같은
+  // 문제, 여긴 처방이 없었다). 같은 DOI-top-K 컷(`selectDiscLabelEligible`)을
+  // 이웃 집합에도 적용 — 상위 degree 이웃만 무조건 라벨, 컷 밖은 일반 greedy
+  // 경쟁으로 강등(겹치지 않으면 여전히 뜬다 — "과하지 않게", 라벨 다 지우지
+  // 않음). `DISC_LABEL_TOP_K` 이하 소규모 포커스는 전원 그대로 exempt(회귀 0).
+  const egoNeighborLabelEligibleIds: ReadonlySet<string> | null =
+    applyLabelTopK && focusedNodeId !== null && neighborsOfFocused.size > DISC_LABEL_TOP_K
+      ? selectDiscLabelEligible(
+          [
+            rankEgoNeighborsByDOI(
+              [...neighborsOfFocused].map((id) => ({
+                id,
+                kind: world.nodeById.get(id)?.kind ?? "element",
+                degree: world.neighborMap.get(id)?.size ?? 0,
+              })),
+            ),
+          ],
+          DISC_LABEL_TOP_K,
+        )
+      : null;
   const labelRankEntries: LabelRankEntry[] = [];
   const labelCandidates: LabelCandidate<LabelPayload>[] = [];
   world.nodes.forEach((node, index) => {
@@ -1231,10 +1261,14 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
     const shiftX = anchorX - screen.x;
     const shiftY = clampedAnchorY - anchorY;
     if (applyLabelTopK) {
-      // Real exempt = ego focus members + the hovered node only. Expanded-disc
-      // children are NOT exempt: the ones that survived the per-disc DOI cut
-      // above compete in the normal LABEL_TOP_K budget like any other node.
-      const exempt = egoState === "center" || egoState === "neighbor" || isHovered;
+      // Real exempt = the focused center + the hovered node, always. An ego
+      // NEIGHBOR is exempt too unless the focus is over the readable DOI-top-K
+      // band, in which case only the DOI winners keep the exemption (노드 감사
+      // 처방 — see `isEgoNeighborLabelExempt`).
+      const exempt =
+        egoState === "center" ||
+        isHovered ||
+        (egoState === "neighbor" && isEgoNeighborLabelExempt(node.id, egoNeighborLabelEligibleIds));
       labelRankEntries.push({ id: node.id, degree: world.neighborMap.get(node.id)?.size ?? 0, exempt });
     }
     labelCandidates.push({

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -43,6 +43,7 @@ import {
   realmInsideFlipDelayFor,
   realmInsidePosition,
   realmOutsidePosition,
+  realmOutsideReturnAlpha,
   realmOutsideReturnPosition,
   realmTransitionReducer,
   realmWardingDrawProgress,
@@ -1930,6 +1931,10 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 밴드 오프셋. 시차는 위 스텝이 이미 active+유의미일 때만 ref 를 채웠다.
       let realmDepthById: ReadonlyMap<string, number> | null = null;
       let realmDepthParallax: { depth2: DepthParallaxOffset; depth3: DepthParallaxOffset } | null = null;
+      // S7 — 이탈 중 귀환하는 밖 노드의 materialize 알파(모션 감사 처방 B).
+      // exiting 이고 reduced-motion 이 아닐 때만 채운다 — reduced-motion 은
+      // exit effect 가 이미 즉시 홈으로 스냅해 이 프레임을 지나가지 않는다.
+      let realmOutsideReturnAlphaById: Map<string, number> | null = null;
       if (
         realmData &&
         (realmState.phase === "entering" || realmState.phase === "active" || realmState.phase === "exiting")
@@ -1943,6 +1948,18 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           : null;
         if (realmState.phase === "entering" && !reducedMotionRef.current) {
           realmDustParallax = realmDustParallaxFactor(now - realmState.startMs);
+        }
+        // S7 — 귀환 중인 밖 노드마다 materialize 알파를 채운다. 위 좌표 스텝
+        // (S6)이 같은 `elapsed - REALM_EXIT_OUTSIDE_RETURN_DELAY_MS` 를 좌표에
+        // 쓰므로 여기서도 그대로 재사용해 위치와 알파가 항상 같은 프레임에서
+        // 일치한다(drift 0).
+        if (exiting && !reducedMotionRef.current) {
+          const elapsed = now - realmState.startMs - REALM_EXIT_OUTSIDE_RETURN_DELAY_MS;
+          const alphaMap = new Map<string, number>();
+          for (const id of realmData.outsideFrom.keys()) {
+            alphaMap.set(id, realmOutsideReturnAlpha(elapsed, REALM_EXIT_OUTSIDE_RETURN_MS));
+          }
+          realmOutsideReturnAlphaById = alphaMap;
         }
         // 이탈 중엔 밖 노드가 귀환하므로 컬하지 않는다(isRealmOutsideCulled 가
         // exiting 에 false). entering/active 에서만 fling 완료 후 하드 컬.
@@ -2150,6 +2167,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         realmDepthById,
         realmDepthParallax,
         realmDustParallax,
+        realmOutsideReturnAlphaById,
         // S8 결함 6 — 영역 활성 시에만 우주 도트를 넘긴다(결계로 클립).
         realmCosmosPoints: realmWarding ? cosmosPointsRef.current : null,
         footprintRanksById,


### PR DESCRIPTION
## Summary
- **영역 해제 abrupt 해소(모션 B)**: 퇴장 시 복귀 바깥 노드+엣지에 `realmOutsideReturnAlpha` 램프(입장 fling reach의 여집합, 0=이탈→1=홈)를 태워 materialize. 교차 엣지는 edgeTierAlpha min-결합으로 자동. 최근 머지된 카메라 재계산과 무충돌.
- **포커스 도메인 자식 라벨 겹침(노드 감사)**: ego 이웃(≤24)이 무제한 라벨 면제였던 갭 → 디스크 경로와 동일하게 DOI top-K(6~8)만 면제, 나머지는 greedy 경쟁. 캡 이하 무변경(회귀 0).

## Test plan
- topology-map-v2 731 ✅ (신규 8: 램프 여집합·단조·reduced-motion / 18자식 라벨 시나리오) · tsc ✅