### PR TITLE
fix: 문서함 정리 — 목차 우측·샘플 안내 노트·헤더 표시명 (A5)

### DIFF
--- a/src/views/docs-vault/lib/docs-vault-collection.test.ts
+++ b/src/views/docs-vault/lib/docs-vault-collection.test.ts
@@ -6,6 +6,7 @@ import {
   resolveDocsVaultSlugAlias,
   resolveDocsVaultCollection,
   shouldDeferDocsVaultDefaultSelection,
+  shouldShowSampleWelcomeNote,
 } from './docs-vault-collection';
 
 function doc(
@@ -94,6 +95,41 @@ describe('docs vault collections', () => {
       shouldDeferDocsVaultDefaultSelection({
         normalizedQuerySlug: null,
         selectedSlug: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows the sample welcome note only on a fresh, undismissed sample landing', () => {
+    expect(
+      shouldShowSampleWelcomeNote({
+        source: 'server',
+        normalizedQuerySlug: null,
+        dismissed: false,
+      }),
+    ).toBe(true);
+    // 명시적 딥링크(?slug=)로 들어오면 노트를 건너뛴다 — 공유 링크는
+    // 그 문서로 바로 가야 한다.
+    expect(
+      shouldShowSampleWelcomeNote({
+        source: 'server',
+        normalizedQuerySlug: 'ARCHITECTURE',
+        dismissed: false,
+      }),
+    ).toBe(false);
+    // 사용자가 실제 문서를 골랐으면(dismissed) 다시 밀어붙이지 않는다.
+    expect(
+      shouldShowSampleWelcomeNote({
+        source: 'server',
+        normalizedQuerySlug: null,
+        dismissed: true,
+      }),
+    ).toBe(false);
+    // 로컬(사용자 자신의) vault 에는 애초에 해당 없음.
+    expect(
+      shouldShowSampleWelcomeNote({
+        source: 'local',
+        normalizedQuerySlug: null,
+        dismissed: false,
       }),
     ).toBe(false);
   });

--- a/src/views/docs-vault/lib/docs-vault-collection.ts
+++ b/src/views/docs-vault/lib/docs-vault-collection.ts
@@ -1,4 +1,5 @@
 import type { VaultDoc } from '@/entities/docs-vault';
+import type { DocsVaultSource } from './persistence';
 
 export type DocsVaultCollection = 'guides' | 'ontology';
 
@@ -67,4 +68,27 @@ export function shouldDeferDocsVaultDefaultSelection({
   selectedSlug: string | null;
 }): boolean {
   return Boolean(normalizedQuerySlug && selectedSlug !== normalizedQuerySlug);
+}
+
+/**
+ * Toss D1 정리(2026-07) — 샘플(vault 미선택) 모드에서 명시적 딥링크
+ * (`?slug=`) 없이 착지했을 때만 "이 문서함은 무엇이고 어떻게 쓰나" 소개
+ * 노트를 보여준다. 기본 선택 로직(`README`/`FEATURES`/…)이 여전히
+ * 100% 영어 개발 문서를 고르더라도, 이 노트가 그 위에서 먼저 맥락을
+ * 준다 — 비개발자 방문자가 첫 화면에서 즉시 이탈하지 않도록.
+ *
+ * `dismissed` 는 caller(`DocsVaultPage`)가 사용자의 명시적 문서 선택
+ * (사이드바 클릭·팔레트·탭 활성화 등, `handleSelect` 경유) 시 true 로
+ * 넘긴다 — 한 번 실제 문서를 골랐다면 다시 밀어붙이지 않는다.
+ */
+export function shouldShowSampleWelcomeNote({
+  source,
+  normalizedQuerySlug,
+  dismissed,
+}: {
+  source: DocsVaultSource;
+  normalizedQuerySlug: string | null;
+  dismissed: boolean;
+}): boolean {
+  return source === 'server' && !normalizedQuerySlug && !dismissed;
 }

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -65,6 +65,7 @@ import {
   resolveDocsVaultSlugAlias,
   resolveDocsVaultCollection,
   shouldDeferDocsVaultDefaultSelection,
+  shouldShowSampleWelcomeNote,
   type DocsVaultCollection,
 } from '../lib/docs-vault-collection';
 import {
@@ -122,6 +123,7 @@ import { DocsVaultDocOutlinePanel } from "./parts/DocsVaultDocOutlinePanel";
 import { DocReadingOutlineRail } from "./parts/DocReadingOutlineRail";
 import { BackToTopButton } from "./parts/BackToTopButton";
 import { SampleNotice } from "./parts/SampleNotice";
+import { SampleWelcomeNote } from "./parts/SampleWelcomeNote";
 import { EmptyState } from "./parts/EmptyState";
 import { DocsHeaderTile } from "./parts/DocsHeaderTile";
 import { DocsVaultVaultChip } from "./parts/DocsVaultVaultChip";
@@ -195,6 +197,10 @@ function DocsVaultContent() {
     undefined,
   );
   const [editing, setEditing] = useState(false);
+  // Toss D1 정리(2026-07) — 샘플 진입 안내 노트를 사용자가 실제 문서를
+  // 골라(handleSelect) 스스로 닫았는지. `shouldShowSampleWelcomeNote` 가
+  // 이 값과 source/딥링크 여부를 합쳐 최종 표시를 판정한다.
+  const [sampleWelcomeDismissed, setSampleWelcomeDismissed] = useState(false);
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [docCollection, setDocCollection] =
     useState<DocsVaultCollection>('guides');
@@ -424,6 +430,9 @@ function DocsVaultContent() {
     // 소스 전환 시 선택 해제 — 동일 slug 가 다른 볼트에 있을 가능성 적음.
     setSelectedSlug(null);
     setActiveTag(null);
+    // 샘플 모드로 (재)진입할 때마다 안내 노트를 다시 보여준다 — 이전 세션에서
+    // 닫았더라도 "샘플 vs 내 vault" 전환은 방향 감각을 다시 짚어줄 가치가 있다.
+    if (next === 'server') setSampleWelcomeDismissed(false);
     replaceUrlState(
       next === 'server'
         ? { slug: null, view, intent: null }
@@ -785,6 +794,11 @@ function DocsVaultContent() {
     () => resolveDocsVaultSlugAlias(querySlug, manifest.docs),
     [manifest.docs, querySlug],
   );
+  const showSampleWelcomeNote = shouldShowSampleWelcomeNote({
+    source,
+    normalizedQuerySlug,
+    dismissed: sampleWelcomeDismissed,
+  });
   const prevQuerySlug = usePrevious(normalizedQuerySlug);
   useEffect(() => {
     if (prevQuerySlug !== normalizedQuerySlug && normalizedQuerySlug !== selectedSlug) {
@@ -1006,6 +1020,9 @@ function DocsVaultContent() {
       setHighlightQuery(query);
       setRecentSlugs(pushRecentDoc(recentKey, slug));
       replaceUrlState({ slug });
+      // 사용자가 직접 문서를 골랐으면 샘플 진입 안내 노트를 다시 밀어붙이지
+      // 않는다(기본 선택 effect 는 이 함수를 거치지 않아 영향받지 않음).
+      setSampleWelcomeDismissed(true);
     },
     [recentKey, replaceUrlState, setRecentSlugs],
   );
@@ -1719,15 +1736,34 @@ function DocsVaultContent() {
         <main id="main" className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {selectedDoc ? (
             <div className="flex min-h-0 flex-1 flex-col">
-              {/* ehead — dir/file mono + preview/edit seg + sync status
-                  (docs-vault-final spec §우 에디터/프리뷰 헤더). */}
-              <div className="flex flex-none items-center gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-2.5">
-                <span className="min-w-0 flex-1 truncate font-mono text-body text-[color:var(--color-text-secondary)]">
-                  <span className="text-[color:var(--color-text-quaternary)]">
-                    {splitVaultSlugPath(selectedDoc.slug).dir}
+              {/* 샘플 진입 안내 — Toss D1 정리(2026-07): 딥링크 없이 샘플
+                  모드로 착지하면 이 노트가 (개발 문서 본문보다 먼저) 이
+                  문서함이 무엇이고 어떻게 쓰는지 평문으로 짚어준다. 사용자가
+                  실제 문서를 고르면(handleSelect) 사라진다. */}
+              {!editing && showSampleWelcomeNote ? (
+                <SampleWelcomeNote
+                  canOpenLocalVault={!localSourceDisabled}
+                  onOpenFolder={() => handleSourceChange('local')}
+                  onDismiss={() => setSampleWelcomeDismissed(true)}
+                />
+              ) : null}
+              {/* ehead — 표시명(title) + preview/edit seg + sync status
+                  (docs-vault-final spec §우 에디터/프리뷰 헤더). Toss D2
+                  정리(2026-07) — 이전엔 `dir/file.md` 내부 파일명만 mono 로
+                  보여 비개발자에게 "README.md" 같은 raw 파일명이 1차
+                  레이블이었다. title 을 1행 주 레이블로 올리고, 파일 경로는
+                  2행 caption(secondary)으로 낮춘다 — 트리(`DocsVaultTree`)의
+                  `title ?? name` 우선순위와 같은 계약을 여기도 일관 적용. */}
+              <div className="flex flex-none items-center gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-2">
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-body font-medium text-[color:var(--color-text-primary)]">
+                    {selectedDoc.title}
                   </span>
-                  {splitVaultSlugPath(selectedDoc.slug).name}.md
-                </span>
+                  <span className="truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
+                    <span>{splitVaultSlugPath(selectedDoc.slug).dir}</span>
+                    {splitVaultSlugPath(selectedDoc.slug).name}.md
+                  </span>
+                </div>
                 {canEditCurrent ? (
                   <div
                     role="tablist"

--- a/src/views/docs-vault/ui/parts/BackToTopButton.tsx
+++ b/src/views/docs-vault/ui/parts/BackToTopButton.tsx
@@ -2,7 +2,12 @@ import { ArrowUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 /**
- * 아티클 스크롤 컨테이너 우하단에 뜨는 "맨 위로" floating pill.
+ * 아티클 스크롤 컨테이너 좌하단에 뜨는 "맨 위로" floating pill.
+ *
+ * 목차 레일(`DocReadingOutlineRail`)이 2026-07 GitHub 관례 정리로 우측으로
+ * 옮기면서(본문 오른쪽 "on this page") 같은 우하단 모서리에서 겹치지 않도록
+ * 이 버튼을 좌측으로 이동했다 — 두 표면 모두 `bottom-6` 라인을 공유하므로
+ * 좌/우로 나눠 충돌을 피한다.
  *
  * 기존 chrome floating 타일 언어(`--chrome-tile-size`/`--chrome-surface`/
  * `--chrome-shadow`/`--chrome-border`, 지형도 미니맵과 동일 표면)를 재사용 —
@@ -24,7 +29,7 @@ export function BackToTopButton({
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
       data-testid="back-to-top-button"
-      className={`absolute bottom-6 right-7 z-10 inline-flex h-[var(--chrome-tile-size)] items-center gap-2 rounded-full border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-4 font-mono text-body text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)] transition-opacity duration-150 ${
+      className={`absolute bottom-6 left-7 z-10 inline-flex h-[var(--chrome-tile-size)] items-center gap-2 rounded-full border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] px-4 font-mono text-body text-[color:var(--color-text-secondary)] shadow-[var(--chrome-shadow)] transition-opacity duration-150 ${
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
     >

--- a/src/views/docs-vault/ui/parts/DocReadingOutlineRail.tsx
+++ b/src/views/docs-vault/ui/parts/DocReadingOutlineRail.tsx
@@ -8,7 +8,12 @@ export interface DocReadingOutlineRailProps {
 }
 
 /**
- * 좌측 빈 띠(사이드바–본문 사이)에 상시 렌더하는 읽기 전용 목차 레일.
+ * 우측 빈 띠(본문–문서정보 인스펙터 사이)에 상시 렌더하는 읽기 전용 목차 레일.
+ *
+ * GitHub·대부분 문서 리더의 "on this page" 관례를 따라 본문 오른쪽에 둔다
+ * (2026-07 Apple TOC 배치 정리 — 이전엔 사이드바 바로 옆 좌측에 있어
+ * 레일·문서목록·TOC·본문 4컬럼처럼 읽혔다). `맨 위로` 버튼(`BackToTopButton`)
+ * 은 같은 우하단 모서리 충돌을 피해 좌측으로 이동.
  *
  * `DocsVaultDocOutlinePanel` 의 목차 부분과 별개 표면 — 그 패널은 공유·출력·
  * 파일관리 조작 chrome 전용으로 남기고, 이 레일은 순수 읽기 보조
@@ -21,9 +26,11 @@ export interface DocReadingOutlineRailProps {
  * 뷰포트 게이트는 CSS 가 결정 — 이 컴포넌트는 항상 렌더된 것을 전제로 한 순수 표시.
  *
  * 뷰포트 게이트가 `lg`(1024) 가 아니라 `min-[1440px]` 인 이유: 본문 불침범
- * 불변식의 산수. 본문 글리프 시작 x = (뷰포트 − 좌측 크롬 344 − 760)/2 + 40,
- * 레일 우변 = 24 + 폭. 168px 레일은 뷰포트 ≈1404px 아래에서, 200px 레일은
- * ≈1520px 아래에서 본문 텍스트와 겹친다. 그래서 1440px 부터 168px 로 표시하고
+ * 불변식의 산수. 본문은 `mx-auto max-w-760` 이라 좌우 여백이 대칭이므로
+ * 좌측 기준으로 유도했던 산수가 우측에도 그대로 적용된다: 본문 글리프
+ * 끝단까지의 여백 = (뷰포트 − 좌측 크롬 344 − 760)/2 − 40, 레일 좌변 =
+ * 24 + 폭. 168px 레일은 뷰포트 ≈1404px 아래에서, 200px 레일은 ≈1520px
+ * 아래에서 본문 텍스트와 겹친다. 그래서 1440px 부터 168px 로 표시하고
  * (1440 에서 글리프까지 16px 여유), 1536px 부터 200px 로 넓힌다 (32px 여유).
  * 그 아래 뷰포트는 레일 숨김 + 문서 정보 인스펙터의 목차가 fallback.
  */
@@ -37,7 +44,7 @@ export function DocReadingOutlineRail({
     <nav
       aria-label={t("railAria")}
       data-testid="doc-reading-outline-rail"
-      className="absolute bottom-6 left-6 top-6 hidden w-[168px] flex-col overflow-y-auto min-[1440px]:flex min-[1536px]:w-[200px]"
+      className="absolute bottom-6 right-6 top-6 hidden w-[168px] flex-col overflow-y-auto min-[1440px]:flex min-[1536px]:w-[200px]"
     >
       <span className="mb-2 flex-none font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
         {t("railLabel")} · {headings.length}

--- a/src/views/docs-vault/ui/parts/SampleWelcomeNote.test.tsx
+++ b/src/views/docs-vault/ui/parts/SampleWelcomeNote.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import { SampleWelcomeNote } from "./SampleWelcomeNote";
+
+function renderNote(
+  locale: "ko" | "en",
+  canOpenLocalVault: boolean,
+  onOpenFolder = vi.fn(),
+  onDismiss = vi.fn(),
+) {
+  return {
+    onOpenFolder,
+    onDismiss,
+    ...render(
+      <NextIntlClientProvider locale={locale} messages={{}}>
+        <SampleWelcomeNote
+          canOpenLocalVault={canOpenLocalVault}
+          onOpenFolder={onOpenFolder}
+          onDismiss={onDismiss}
+        />
+      </NextIntlClientProvider>,
+    ),
+  };
+}
+
+describe("SampleWelcomeNote", () => {
+  it("explains what this doc space is in plain Korean", () => {
+    renderNote("ko", false);
+    expect(screen.getByText("이 문서함은 무엇인가요?")).toBeInTheDocument();
+    expect(
+      screen.getByText(/ontology-atlas 프로젝트 자신의 문서를 읽기 전용 샘플로/),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to English copy for the en locale", () => {
+    renderNote("en", false);
+    expect(screen.getByText("What is this document space?")).toBeInTheDocument();
+  });
+
+  it("offers the open-folder CTA and calls it", () => {
+    const { onOpenFolder } = renderNote("ko", true);
+    const button = screen.getByRole("button", { name: "내 폴더 열기" });
+    fireEvent.click(button);
+    expect(onOpenFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the open-folder CTA when local vault access is unavailable", () => {
+    renderNote("ko", false);
+    expect(screen.queryByRole("button", { name: "내 폴더 열기" })).not.toBeInTheDocument();
+  });
+
+  it("dismisses via the close button", () => {
+    const { onDismiss } = renderNote("ko", false);
+    fireEvent.click(screen.getByRole("button", { name: "안내 닫기" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/docs-vault/ui/parts/SampleWelcomeNote.tsx
+++ b/src/views/docs-vault/ui/parts/SampleWelcomeNote.tsx
@@ -1,0 +1,80 @@
+import { FolderOpen, X } from "lucide-react";
+import { useLocale } from "next-intl";
+
+export interface SampleWelcomeNoteProps {
+  /** P1b — FSA 지원이면 웹에서도 폴더 열기(SampleNotice 와 동일 능력 계약). */
+  canOpenLocalVault: boolean;
+  onOpenFolder: () => void;
+  onDismiss: () => void;
+}
+
+// Toss D1 정리(2026-07) — 이 카피는 `src/views/docs-vault/` 파일 소유권
+// 제약 때문에 공유 `messages/ko.json` / `messages/en.json` 카탈로그에
+// 등록하지 못했다(다른 worktree 와 동시 편집 충돌 회피). 대신 이 컴포넌트
+// 안에서 로케일별 리터럴을 직접 스위치한다 — next-intl 관례에서 벗어난
+// 의도적 예외이며, 후속 정리에서 정식 메시지 키로 승격해야 한다.
+const COPY = {
+  ko: {
+    title: "이 문서함은 무엇인가요?",
+    body: "ontology-atlas 프로젝트 자신의 문서를 읽기 전용 샘플로 보여주고 있어요. 왼쪽 목록에서 아무 문서나 눌러 둘러보세요 — 대부분은 개발자용 기술 문서예요. 내 마크다운 폴더를 열면 그 폴더가 이 화면을 그대로 채워요.",
+    openFolderCta: "내 폴더 열기",
+    dismissAria: "안내 닫기",
+  },
+  en: {
+    title: "What is this document space?",
+    body: "You're browsing this project's own documentation as a read-only sample. Pick anything from the list on the left — most of it is developer reference material. Open your own markdown folder and it fills this screen instead.",
+    openFolderCta: "Open my folder",
+    dismissAria: "Dismiss",
+  },
+} as const;
+
+/**
+ * 샘플(vault 미선택) 모드에서 명시적 딥링크 없이 착지했을 때 첫 화면에
+ * 보이는 소개 노트 — "이 문서함은 무엇이고 어떻게 쓰나" 를 평문으로.
+ *
+ * 기존 기본 선택 로직(`README`/`FEATURES`/…)은 여전히 100% 영어 개발
+ * 문서를 고르지만, 이 노트가 그 위에서 먼저 맥락을 줘 비개발자 방문자가
+ * 첫 화면에서 곧장 이탈하지 않게 한다(po-pass Toss D1). 표시 조건은
+ * caller(`shouldShowSampleWelcomeNote`)가 판단 — 이 컴포넌트는 항상
+ * 렌더된 것을 전제로 한 순수 표시. `SampleNotice`(왜 읽기 전용인지) 와는
+ * 다른 관심사라 별도 표면으로 유지한다.
+ */
+export function SampleWelcomeNote({
+  canOpenLocalVault,
+  onOpenFolder,
+  onDismiss,
+}: SampleWelcomeNoteProps) {
+  const locale = useLocale();
+  const copy = locale === "ko" ? COPY.ko : COPY.en;
+  return (
+    <div
+      data-testid="docs-vault-sample-welcome-note"
+      className="relative flex flex-none flex-col gap-2 border-b border-l-2 border-b-[color:var(--color-divider)] border-l-[color:var(--color-indigo-brand)] bg-[color:var(--color-elevated)] px-6 py-4 md:px-10"
+    >
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label={copy.dismissAria}
+        className="absolute right-3 top-3 rounded-sm p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+      >
+        <X size={13} aria-hidden />
+      </button>
+      <p className="max-w-[560px] pr-6 text-body leading-[1.5] text-[color:var(--color-text-secondary)]">
+        <span className="block font-semibold text-[color:var(--color-text-primary)]">
+          {copy.title}
+        </span>
+        {copy.body}
+      </p>
+      {canOpenLocalVault ? (
+        <button
+          type="button"
+          onClick={onOpenFolder}
+          className="inline-flex w-fit flex-none items-center gap-1.5 rounded-md border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a18)] px-2.5 py-1.5 text-body font-medium text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a24)]"
+        >
+          <FolderOpen size={12} aria-hidden />
+          {copy.openFolderCta}
+        </button>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **목차 레일 우측 이동**: on-this-page 아웃라인을 본문 좌측(4번째 컬럼처럼 읽히던) → GitHub 관례대로 우측. 맨 위로 버튼은 좌하단으로 이동해 코너 충돌 회피.
- **샘플 진입 안내 노트**: 샘플 모드 + 딥링크 없을 때 "이 문서함은 무엇인가요?" 평문 노트(문서 선택 시 소멸). dogfood vault 파일 불변 — 오버레이 방식.
- **헤더 표시명 우선**: 문서 pane 헤더가 raw 파일경로만 mono 로 보이던 것 → title 주·경로 secondary.

## Test plan
- docs-vault vitest 134 ✅ (신규 2: SampleWelcomeNote·shouldShow 순수함수) · tsc ✅
- 참고: SampleWelcomeNote 는 워크트리 격리로 messages 공유 회피 위해 useLocale() 로컬 리터럴(의도적 이탈) — 후속에서 i18n 키 승격 예정