### PR TITLE
fix: 인사이트·프로젝트 통일 — 공유 컴포넌트·청중 배너·카드 카피 (A4)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1612,6 +1612,7 @@
     "insights": {
       "title": "Graph insights",
       "subtitle": "Your whole folder at a glance — every number is computed automatically from the documents",
+      "audienceBanner": "This screen is a maintenance board for the people and AI agents who keep the ontology in shape.",
       "censusConcepts": "Concepts",
       "censusRelations": "Relations",
       "censusDomains": "Domains",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1752,7 +1752,6 @@
       "factElement": "Elements",
       "factDocument": "Documents",
       "factRelations": "Relations",
-      "domainRowSummary": "{total} — {cap} capabilities · {el} elements",
       "footDetail": "Details →",
       "footTopologyView": "View in topology →",
       "footUpdated": "Updated {date} · {path}",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1752,7 +1752,6 @@
       "factElement": "요소",
       "factDocument": "문서",
       "factRelations": "관계",
-      "domainRowSummary": "{total} — 역량 {cap} · 요소 {el}",
       "footDetail": "상세 →",
       "footTopologyView": "지도에서 보기 →",
       "footUpdated": "갱신 {date} · {path}",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1612,6 +1612,7 @@
     "insights": {
       "title": "그래프 인사이트",
       "subtitle": "내 폴더 전체를 한눈에 — 모든 숫자는 문서에서 자동 계산됩니다",
+      "audienceBanner": "이 화면은 온톨로지를 관리하는 사람과 AI 에이전트를 위한 정비 보드예요.",
       "censusConcepts": "개념",
       "censusRelations": "관계",
       "censusDomains": "도메인",

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -392,6 +392,13 @@ export function OntologyInsightsPage() {
             </span>
           ) : null}
         </header>
+        {/* Toss I1 — 이 표면은 파워유저(온톨로지를 관리하는 사람·AI 에이전트)용
+            정비 보드다. 카피 전면 개편 대신 청중을 정직하게 선언해 기대치를
+            맞춘다 — 일반 방문자가 여기서 "내 프로젝트" 같은 걸 찾다가 헤매지
+            않도록. */}
+        <p className="mt-1 max-w-2xl text-label text-[color:var(--color-text-quaternary)]">
+          {t("audienceBanner")}
+        </p>
 
         <nav className="mt-4">
           <TabBar

--- a/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@/i18n/navigation";
 import { formatDate } from "@/shared/lib/format-date";
 import { TopologyV2KindGlyph } from "@/shared/ui";
+import { RecentNodeRow } from "@/widgets/recent-node-row";
 import type { DomainFreshnessRow, RecentUpdateRow } from "../../lib/freshness";
 
 const LEVEL_BACKGROUND: Record<0 | 1 | 2 | 3, string> = {
@@ -174,28 +174,19 @@ export function FreshnessTab({
             <p className="py-2 text-body text-[color:var(--color-text-quaternary)]">{labels.noRecentUpdates}</p>
           ) : (
             recent.map((row) => (
-              <Link
+              <RecentNodeRow
                 key={row.nodeId}
+                kind={row.kind}
+                title={row.title}
+                subtitle={`${kindLabel(row.kind)}${row.domainTitle ? ` · ${row.domainTitle}` : ""}`}
+                // P4-③ — 로컬 타임존 기준 날짜(`formatDate`). 이전엔
+                // toISOString() 이 UTC 로 렌더해 자정 부근 갱신이 하루
+                // 전날짜로 표시됐다(예: 03:12 KST → UTC 로는 전날).
+                trailing={formatDate(row.updatedAt)}
                 href={recentLink.href(row.nodeId)}
-                aria-label={recentLink.ariaLabel(row.title)}
-                data-testid="insights-freshness-row-link"
-                className="-mx-1.5 flex items-center gap-2.5 rounded-md border-t border-[color:var(--color-divider)] px-1.5 py-2.5 transition-colors first:border-t-0 hover:bg-[color:var(--color-overlay-1)]"
-              >
-                <TopologyV2KindGlyph kind={row.kind} size={14} />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-body text-[color:var(--color-text-primary)]">{row.title}</span>
-                  <span className="block text-label text-[color:var(--color-text-quaternary)]">
-                    {kindLabel(row.kind)}
-                    {row.domainTitle ? ` · ${row.domainTitle}` : ""}
-                  </span>
-                </span>
-                <span className="flex-none font-mono text-label tabular-nums text-[color:var(--color-text-tertiary)]">
-                  {/* P4-③ — 로컬 타임존 기준 날짜(`formatDate`). 이전엔
-                      toISOString() 이 UTC 로 렌더해 자정 부근 갱신이 하루
-                      전날짜로 표시됐다(예: 03:12 KST → UTC 로는 전날). */}
-                  {formatDate(row.updatedAt)}
-                </span>
-              </Link>
+                ariaLabel={recentLink.ariaLabel(row.title)}
+                testId="insights-freshness-row-link"
+              />
             ))
           )}
         </div>

--- a/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
@@ -1,5 +1,6 @@
 import { TopologyV2KindGlyph } from "@/shared/ui";
 import { getOntologyKindTone } from "@/entities/ontology-class";
+import { DomainCapacityBar } from "@/widgets/domain-capacity-bar";
 import { InsightsHeroCensus, type InsightsHeroCensusLabels } from "../parts/InsightsHeroCensus";
 import type { CensusHealthSummary } from "../../lib/census-health";
 import type { DomainCapacityRow } from "../../lib/domain-capacity";
@@ -118,36 +119,14 @@ export function OverviewTab({
             <p className="mt-3.5 flex-1 text-body text-[color:var(--color-text-quaternary)]">{labels.noDomains}</p>
           ) : (
             <div className="mt-3.5 flex flex-1 flex-col justify-evenly gap-1">
-              {domainRows.map((row) => {
-                const capWidth = domainMax > 0 ? (row.capabilityCount / domainMax) * 100 : 0;
-                const elWidth = domainMax > 0 ? (row.elementCount / domainMax) * 100 : 0;
-                return (
-                  <div key={row.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-0.5">
-                    <span className="flex w-full shrink-0 items-center gap-2 truncate text-body-lg text-[color:var(--color-text-secondary)] sm:w-[220px]">
-                      <TopologyV2KindGlyph kind="domain" size={15} />
-                      <span className="truncate">{row.title}</span>
-                    </span>
-                    <span className="flex h-2 min-w-[48px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
-                      <span
-                        className="block h-full"
-                        style={{ width: `${capWidth}%`, backgroundColor: getOntologyKindTone("capability").fill }}
-                      />
-                      <span
-                        className="block h-full"
-                        style={{ width: `${elWidth}%`, backgroundColor: getOntologyKindTone("element").fill }}
-                      />
-                    </span>
-                    <span className="flex-none text-right">
-                      <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
-                        {row.total}
-                      </span>
-                      <span className="block font-mono text-caption text-[color:var(--color-text-quaternary)]">
-                        {labels.capabilityUnit} {row.capabilityCount} · {labels.elementUnit} {row.elementCount}
-                      </span>
-                    </span>
-                  </div>
-                );
-              })}
+              {domainRows.map((row) => (
+                <DomainCapacityBar
+                  key={row.id}
+                  row={row}
+                  maxTotal={domainMax}
+                  labels={{ capabilityUnit: labels.capabilityUnit, elementUnit: labels.elementUnit }}
+                />
+              ))}
             </div>
           )}
           <p className="mt-2.5 border-t border-[color:var(--color-divider)] pt-2.5 text-label text-[color:var(--color-text-quaternary)]">

--- a/src/views/project-selector/lib/project-card-description.test.ts
+++ b/src/views/project-selector/lib/project-card-description.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { VaultDoc } from "@/entities/docs-vault";
+import { resolveProjectCardDescription } from "./project-card-description";
+
+function doc(frontmatter: Record<string, unknown>): VaultDoc {
+  return {
+    slug: "ontology-atlas",
+    path: "docs/ontology/project.md",
+    title: "ontology-atlas",
+    tags: [],
+    frontmatter,
+    headings: [],
+    excerpt: "정체성 (2026-07): agent-native, human-sovereign — internal positioning copy leaking in.",
+    description: "",
+    wordCount: 0,
+    updatedAt: "2026-07-17T00:00:00.000Z",
+    linksOut: [],
+  } as unknown as VaultDoc;
+}
+
+describe("resolveProjectCardDescription", () => {
+  it("returns the explicit frontmatter description when the user wrote one", () => {
+    expect(resolveProjectCardDescription(doc({ description: "A local-first ontology workbench." }))).toBe(
+      "A local-first ontology workbench.",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(resolveProjectCardDescription(doc({ description: "  Trimmed.  " }))).toBe("Trimmed.");
+  });
+
+  it("returns null when frontmatter has no description — never falls back to the body excerpt", () => {
+    expect(resolveProjectCardDescription(doc({}))).toBeNull();
+  });
+
+  it("returns null for a blank description string", () => {
+    expect(resolveProjectCardDescription(doc({ description: "   " }))).toBeNull();
+  });
+
+  it("returns null for a non-string description value", () => {
+    expect(resolveProjectCardDescription(doc({ description: 42 }))).toBeNull();
+  });
+
+  it("returns null when no doc is found for the project slug", () => {
+    expect(resolveProjectCardDescription(undefined)).toBeNull();
+  });
+});

--- a/src/views/project-selector/lib/project-card-description.ts
+++ b/src/views/project-selector/lib/project-card-description.ts
@@ -1,0 +1,25 @@
+import type { VaultDoc } from "@/entities/docs-vault";
+
+/**
+ * The /projects card body should show only a description the user
+ * deliberately wrote — never an auto-generated excerpt.
+ *
+ * `Project.description` (`derive-projects-from-vault.ts`) falls back to
+ * `doc.excerpt` (the first ~320 stripped characters of the whole document
+ * body) whenever frontmatter has no explicit `description:` key. That
+ * fallback is reasonable for the entity layer in general, but it means any
+ * project card can end up showing internal notes, strategy language, or
+ * scratch prose that just happened to be first in the file — this repo's
+ * own dogfood `docs/ontology/project.md` is a live example (no
+ * `description:` key, so the card fell back to an excerpt that opened with
+ * "정체성 (2026-07): agent-native, human-sovereign..." positioning copy
+ * meant for contributors reading the file, not workspace visitors scanning
+ * cards). This helper reads the vault doc's own frontmatter directly so the
+ * card only ever shows what was written *as* a description.
+ */
+export function resolveProjectCardDescription(doc: VaultDoc | undefined): string | null {
+  const raw = doc?.frontmatter?.description;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/views/project-selector/ui/ProjectSelectorPage.card-description-explicit.test.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.card-description-explicit.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import enMessages from "../../../../messages/en.json";
+import { ProjectSelectorPage } from "./ProjectSelectorPage";
+
+// Toss P2 companion — when the user *does* write a frontmatter
+// `description:`, the card must show exactly that, not the entity-layer
+// excerpt fallback.
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/features/project-data-source", () => ({
+  useProjects: () => ({
+    projects: [
+      {
+        slug: "ontology-atlas",
+        name: "ontology-atlas",
+        description: "정체성 (2026-07): agent-native, human-sovereign...",
+        tags: [],
+        stack: [],
+        links: [],
+        dependencies: [],
+        screenshots: [],
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+    ],
+    loaded: true,
+    error: null,
+    mode: "static",
+  }),
+}));
+
+vi.mock("@/features/vault-ontology", () => ({
+  useOntologyInsight: () => ({ insight: { nodes: [], edges: [] } }),
+  LiveActivityIndicator: () => <div data-testid="live-activity-indicator-stub" />,
+}));
+
+vi.mock("@/features/docs-vault-local", () => ({
+  useLocalVault: () => ({ agentActivityStatus: undefined }),
+}));
+
+vi.mock("@/features/data-source-mode", () => ({
+  useDataSourceMode: () => "static",
+}));
+
+vi.mock("@/widgets/app-settings-menu", () => ({
+  AppSettingsMenu: () => <button type="button" data-testid="app-settings-trigger-stub" />,
+}));
+
+vi.mock("../lib/use-vault-docs", () => ({
+  useVaultDocs: () => [
+    {
+      slug: "ontology-atlas",
+      path: "docs/ontology/project.md",
+      title: "ontology-atlas",
+      tags: [],
+      frontmatter: { kind: "project", description: "A local-first ontology workbench." },
+      headings: [],
+      excerpt: "정체성 (2026-07): agent-native, human-sovereign...",
+      wordCount: 0,
+      updatedAt: "2026-07-17T00:00:00.000Z",
+      linksOut: [],
+    },
+  ],
+}));
+
+function renderPage() {
+  render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <ProjectSelectorPage />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("ProjectSelectorPage card description with an explicit frontmatter description", () => {
+  it("shows the user-written description", () => {
+    renderPage();
+    const card = screen.getByTestId("project-selector-card");
+    expect(within(card).getByText("A local-first ontology workbench.")).toBeInTheDocument();
+    expect(within(card).queryByText(/agent-native, human-sovereign/)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/project-selector/ui/ProjectSelectorPage.card-description.test.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.card-description.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+import enMessages from "../../../../messages/en.json";
+import { ProjectSelectorPage } from "./ProjectSelectorPage";
+
+// Toss P2 — 카드는 사용자가 `description:` frontmatter 에 직접 쓴 한 줄만
+// 보여줘야 한다. `Project.description` (엔티티 레이어)은 frontmatter 에
+// description 이 없으면 body 발췌(excerpt)로 fallback 하는 계약이라, 이
+// mock 은 그 fallback 이 만들어낼 법한 "excerpt-shaped" 내부 포지셔닝 카피를
+// 일부러 흘려 넣어 카드가 그걸 절대 노출하지 않는지 검증한다 — 실제 사고
+// 사례가 `docs/ontology/project.md` (description 키 없이 정체성 문단이
+// excerpt 로 새 나갔다).
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/features/project-data-source", () => ({
+  useProjects: () => ({
+    projects: [
+      {
+        slug: "ontology-atlas",
+        name: "ontology-atlas",
+        description:
+          "정체성 (2026-07): agent-native, human-sovereign. 에이전트를 위한 메모리가 아니라...",
+        tags: [],
+        stack: [],
+        links: [],
+        dependencies: [],
+        screenshots: [],
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+    ],
+    loaded: true,
+    error: null,
+    mode: "static",
+  }),
+}));
+
+vi.mock("@/features/vault-ontology", () => ({
+  useOntologyInsight: () => ({ insight: { nodes: [], edges: [] } }),
+  LiveActivityIndicator: () => <div data-testid="live-activity-indicator-stub" />,
+}));
+
+vi.mock("@/features/docs-vault-local", () => ({
+  useLocalVault: () => ({ agentActivityStatus: undefined }),
+}));
+
+vi.mock("@/features/data-source-mode", () => ({
+  useDataSourceMode: () => "static",
+}));
+
+vi.mock("@/widgets/app-settings-menu", () => ({
+  AppSettingsMenu: () => <button type="button" data-testid="app-settings-trigger-stub" />,
+}));
+
+vi.mock("../lib/use-vault-docs", () => ({
+  useVaultDocs: () => [
+    {
+      slug: "ontology-atlas",
+      path: "docs/ontology/project.md",
+      title: "ontology-atlas",
+      tags: [],
+      frontmatter: { kind: "project" },
+      headings: [],
+      excerpt: "정체성 (2026-07): agent-native, human-sovereign. 에이전트를 위한 메모리가 아니라...",
+      wordCount: 0,
+      updatedAt: "2026-07-17T00:00:00.000Z",
+      linksOut: [],
+    },
+  ],
+}));
+
+function renderPage() {
+  render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <ProjectSelectorPage />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("ProjectSelectorPage card description without frontmatter description", () => {
+  it("falls back to the neutral empty-state copy, never the raw excerpt/entity description", () => {
+    renderPage();
+    const card = screen.getByTestId("project-selector-card");
+    expect(within(card).getByText("This project doesn't have a description yet.")).toBeInTheDocument();
+    expect(within(card).queryByText(/agent-native, human-sovereign/)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
@@ -140,7 +140,21 @@ describe("ProjectSelectorPage", () => {
     renderPage();
     expect(screen.getByTestId("project-selector-activity-row")).toBeInTheDocument();
     expect(screen.getByText("capabilities/mcp-server")).toBeInTheDocument();
-    expect(screen.getByText("write 도구로 확장")).toBeInTheDocument();
+    // 2줄 스택 통일 이후 subtitle 은 도메인 + 설명을 한 줄로 합친다
+    // (RecentNodeRow — Apple C3 unification). 이 파일의 mock 노드 id 는
+    // (kind:folder/slug) tailSlug 계산 규약과 우연히 불일치해 nodeId 매칭이
+    // 항상 실패하므로 domainTitle 은 fallback("—")으로 남는다 — 실제 매칭
+    // 경로는 ProjectSelectorPage.activity-link.test.tsx 가 전담 검증한다.
+    expect(screen.getByText("— · write 도구로 확장")).toBeInTheDocument();
+  });
+
+  it("puts the project cards before the recent-activity feed (Toss P1 — primary content first)", () => {
+    renderPage();
+    const card = screen.getByTestId("project-selector-card");
+    const activityRow = screen.getByTestId("project-selector-activity-row");
+    // DOM order === source order for sibling sections here — compareDocumentPosition
+    // confirms the card is earlier in document order than the activity row.
+    expect(card.compareDocumentPosition(activityRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("renders a full-width project card with fact strip and domain composition row", () => {

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -13,15 +13,19 @@ import { useProjects } from "@/features/project-data-source";
 import { LiveActivityIndicator, useOntologyInsight } from "@/features/vault-ontology";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { useLocalVault } from "@/features/docs-vault-local";
+import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { formatDate } from "@/shared/lib/format-date";
 import { buildContainmentParents } from "@/shared/lib/ontology-tree";
 import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
 import { HexMark } from "@/shared/ui/hex-mark";
 import { AppSettingsMenu } from "@/widgets/app-settings-menu";
+import { DomainCapacityBar } from "@/widgets/domain-capacity-bar";
+import { RecentNodeRow } from "@/widgets/recent-node-row";
 import { useDocumentTitle } from "@/shared/lib/use-document-title";
 import { computeWorkspaceCensus } from "../lib/workspace-census";
 import { buildProjectCardFacts } from "../lib/project-card-facts";
 import { buildDomainCompositionRows, type DomainCompositionRow } from "../lib/domain-composition";
+import { resolveProjectCardDescription } from "../lib/project-card-description";
 import {
   buildRecentActivityRows,
   resolveRecentActivityAgo,
@@ -50,6 +54,7 @@ function formatAgo(ago: RecentActivityAgo, t: SelectorTranslator) {
 
 export function ProjectSelectorPage() {
   const t = useTranslations("projectPages.selector");
+  const kindLabel = useOntologyKindLabel();
   useDocumentTitle(t("documentTitle"));
 
   const { projects } = useProjects();
@@ -133,78 +138,10 @@ export function ProjectSelectorPage() {
           {t("lede")}
         </p>
 
-        {recentActivityRows.length > 0 ? (
-          <section className="mt-7">
-            <div className="mb-3 flex items-center gap-2.5">
-              <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
-                {t("activityHeading")}
-              </span>
-              <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
-                {t("activityCaption")}
-              </span>
-            </div>
-            <div className="rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-2 shadow-[inset_0_1px_0_var(--color-overlay-2)]">
-              {recentActivityRows.map((row, index) => {
-                const rowClassName = `flex items-center gap-2.5 min-h-8 py-1.5 text-body text-[color:var(--color-text-secondary)] ${
-                  index > 0 ? "border-t border-[color:var(--color-divider)]" : ""
-                } ${row.nodeId ? "-mx-1.5 rounded-md px-1.5 transition-colors hover:bg-[color:var(--color-overlay-1)]" : ""}`;
-                const rowContent = (
-                  <>
-                    <TopologyV2KindGlyph kind={row.kind} size={14} />
-                    <span
-                      title={row.title}
-                      className="min-w-0 shrink truncate text-body text-[color:var(--color-text-secondary)]"
-                    >
-                      {row.title}
-                    </span>
-                    {row.what ? (
-                      <span
-                        title={row.what}
-                        className="min-w-0 flex-1 truncate text-body text-[color:var(--color-text-tertiary)]"
-                      >
-                        {row.what}
-                      </span>
-                    ) : (
-                      <span className="min-w-0 flex-1" />
-                    )}
-                    <span
-                      title={row.domainTitle ?? undefined}
-                      className="max-w-[150px] shrink truncate text-caption text-[color:var(--color-text-tertiary)] sm:max-w-[220px]"
-                    >
-                      {row.domainTitle ?? t("activityNoDomain")}
-                    </span>
-                    <span
-                      title={row.slug}
-                      className="hidden shrink-0 max-w-[160px] truncate font-mono text-caption text-[color:var(--color-text-quaternary)] md:inline"
-                    >
-                      {row.slug}
-                    </span>
-                    <span className={`shrink-0 whitespace-nowrap text-label ${numeralClass}`}>
-                      {formatAgo(resolveRecentActivityAgo(row.updatedAt, new Date()), t)}
-                    </span>
-                  </>
-                );
-
-                return row.nodeId ? (
-                  <Link
-                    key={row.slug}
-                    href={buildOntologyNodeHref(row.nodeId)}
-                    aria-label={t("activityRowAriaLabel", { slug: row.slug })}
-                    data-testid="project-selector-activity-row"
-                    className={rowClassName}
-                  >
-                    {rowContent}
-                  </Link>
-                ) : (
-                  <div key={row.slug} data-testid="project-selector-activity-row" className={rowClassName}>
-                    {rowContent}
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-        ) : null}
-
+        {/* Toss P1 — 프로젝트 카드가 이 페이지의 1차 콘텐츠, 최근 활동은
+            그 아래 보조 피드다. 이전엔 활동 피드가 카드보다 위에 있어
+            초점이 경쟁했다(방문자가 찾는 건 "내 프로젝트들"이지 "최근 어떤
+            문서가 바뀌었나"가 아니다). */}
         {projects.length > 0 ? (
           <div className="mt-7 flex flex-col gap-5">
             {projects.map((project) => (
@@ -217,7 +154,9 @@ export function ProjectSelectorPage() {
                     ? true
                     : (nodeById.get(row.domainId)?.projectIds ?? []).includes(project.slug),
                 )}
+                description={resolveProjectCardDescription(docs.find((d) => d.slug === project.slug))}
                 docPath={docs.find((d) => d.slug === project.slug)?.path}
+                kindLabel={kindLabel}
                 t={t}
               />
             ))}
@@ -227,6 +166,38 @@ export function ProjectSelectorPage() {
             {t("emptyStateDesc")}
           </p>
         )}
+
+        {recentActivityRows.length > 0 ? (
+          <section className="mt-7">
+            <div className="mb-3 flex items-center gap-2.5">
+              <span className="text-body-lg font-medium tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+                {t("activityHeading")}
+              </span>
+              <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                {t("activityCaption")}
+              </span>
+            </div>
+            <div className="rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-4 py-1 shadow-[inset_0_1px_0_var(--color-overlay-2)]">
+              {recentActivityRows.map((row) => (
+                <RecentNodeRow
+                  key={row.slug}
+                  kind={row.kind}
+                  title={row.title}
+                  subtitle={
+                    row.what
+                      ? `${row.domainTitle ?? t("activityNoDomain")} · ${row.what}`
+                      : (row.domainTitle ?? t("activityNoDomain"))
+                  }
+                  trailing={formatAgo(resolveRecentActivityAgo(row.updatedAt, new Date()), t)}
+                  trailingSecondary={row.slug}
+                  href={row.nodeId ? buildOntologyNodeHref(row.nodeId) : undefined}
+                  ariaLabel={t("activityRowAriaLabel", { slug: row.slug })}
+                  testId="project-selector-activity-row"
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         <section className="mt-7 rounded-panel border border-dashed border-[color:var(--color-border-strong)] bg-[color:var(--color-overlay-1)] px-5 py-4">
           <div className="flex items-center gap-3">
@@ -282,11 +253,17 @@ interface ProjectFullCardProps {
   project: Project;
   facts: ReturnType<typeof buildProjectCardFacts>;
   domainRows: DomainCompositionRow[];
+  /** Toss P2 — 사용자가 frontmatter `description:` 에 직접 쓴 한 줄만.
+   * `Project.description` (엔티티 레이어)은 없으면 body 발췌로 fallback 하는데,
+   * 그 발췌가 내부 포지셔닝 카피일 수 있어 카드에는 절대 쓰지 않는다
+   * (`resolveProjectCardDescription` 참고). */
+  description: string | null;
   docPath: string | undefined;
+  kindLabel: (kind: string) => string;
   t: SelectorTranslator;
 }
 
-function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFullCardProps) {
+function ProjectFullCard({ project, facts, domainRows, description, docPath, kindLabel, t }: ProjectFullCardProps) {
   const maxTotal = Math.max(1, ...domainRows.map((row) => row.total));
   const ago = formatAgo(resolveRecentActivityAgo(project.updatedAt, new Date()), t);
 
@@ -306,7 +283,7 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
             <span>{t("cardUpdatedPrefix")} {ago}</span>
           </div>
           <p className="mt-1.5 text-body leading-6 text-[color:var(--color-text-tertiary)] line-clamp-2">
-            {project.description || t("cardDescriptionFallback")}
+            {description ?? t("cardDescriptionFallback")}
           </p>
         </div>
         <span className="mt-1.5 shrink-0 font-mono text-label text-[color:var(--color-text-quaternary)]">
@@ -331,37 +308,21 @@ function ProjectFullCard({ project, facts, domainRows, docPath, t }: ProjectFull
       </div>
 
       {domainRows.length > 0 ? (
-        <div className="mt-4 flex flex-col gap-2">
-          {domainRows.map((row, index) => (
-            <div key={row.domainId} className="flex items-center gap-3 sm:gap-4">
-              <span className="flex w-[84px] min-w-0 shrink-0 items-center gap-2 truncate text-body text-[color:var(--color-text-secondary)] sm:w-[200px] md:w-[280px]">
-                <TopologyV2KindGlyph kind="domain" size={14} />
-                {row.title}
-              </span>
-              <span className="h-1 min-w-0 max-w-[640px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-border-soft)]">
-                <span
-                  className="block h-full rounded-full"
-                  style={{
-                    width: `${Math.round((row.total / maxTotal) * 100)}%`,
-                    backgroundColor: index === 0 ? "var(--color-indigo-brand)" : "var(--color-border-strong)",
-                  }}
-                />
-              </span>
-              <span
-                title={t("domainRowSummary", {
-                  total: row.total,
-                  cap: row.capabilityCount,
-                  el: row.elementCount,
-                })}
-                className={`max-w-[120px] shrink truncate text-right text-label sm:max-w-none sm:shrink-0 sm:whitespace-nowrap ${numeralClass}`}
-              >
-                {t("domainRowSummary", {
-                  total: row.total,
-                  cap: row.capabilityCount,
-                  el: row.elementCount,
-                })}
-              </span>
-            </div>
+        <div className="mt-4 flex flex-col gap-1">
+          {domainRows.map((row) => (
+            <DomainCapacityBar
+              key={row.domainId}
+              row={{
+                id: row.domainId,
+                title: row.title,
+                capabilityCount: row.capabilityCount,
+                elementCount: row.elementCount,
+                total: row.total,
+              }}
+              maxTotal={maxTotal}
+              labels={{ capabilityUnit: kindLabel("capability"), elementUnit: kindLabel("element") }}
+              titleWidthClassName="sm:w-[200px] md:w-[280px]"
+            />
           ))}
         </div>
       ) : null}

--- a/src/widgets/domain-capacity-bar/index.ts
+++ b/src/widgets/domain-capacity-bar/index.ts
@@ -1,0 +1,6 @@
+export { DomainCapacityBar } from "./ui/DomainCapacityBar";
+export type {
+  DomainCapacityBarRow,
+  DomainCapacityBarLabels,
+  DomainCapacityBarProps,
+} from "./ui/DomainCapacityBar";

--- a/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.test.tsx
+++ b/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { getOntologyKindTone } from "@/entities/ontology-class";
+import { DomainCapacityBar } from "./DomainCapacityBar";
+
+const labels = { capabilityUnit: "Capability", elementUnit: "Element" };
+
+describe("DomainCapacityBar", () => {
+  it("renders the domain title, total, and capability/element breakdown", () => {
+    render(
+      <DomainCapacityBar
+        row={{ id: "domain:auth", title: "Auth", capabilityCount: 3, elementCount: 5, total: 8 }}
+        maxTotal={8}
+        labels={labels}
+      />,
+    );
+    expect(screen.getByText("Auth")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("Capability 3 · Element 5")).toBeInTheDocument();
+  });
+
+  it("splits the bar fill using the ontology kind tones as data marks", () => {
+    render(
+      <DomainCapacityBar
+        row={{ id: "domain:auth", title: "Auth", capabilityCount: 3, elementCount: 1, total: 4 }}
+        maxTotal={8}
+        labels={labels}
+      />,
+    );
+    const row = screen.getByTestId("domain-capacity-bar-row");
+    const segments = row.querySelectorAll<HTMLSpanElement>("span[style]");
+    // 첫 두 style span 이 capability(37.5%)/element(12.5%) 세그먼트.
+    const [capSegment, elSegment] = Array.from(segments);
+    expect(capSegment.style.width).toBe("37.5%");
+    expect(capSegment.style.backgroundColor).not.toBe("");
+    expect(elSegment.style.width).toBe("12.5%");
+    expect(capSegment.style.backgroundColor).toContain(
+      rgbaToRgbPrefix(getOntologyKindTone("capability").fill),
+    );
+    expect(elSegment.style.backgroundColor).toContain(
+      rgbaToRgbPrefix(getOntologyKindTone("element").fill),
+    );
+  });
+
+  it("floors the fill at zero when maxTotal is zero (empty vault guard)", () => {
+    render(
+      <DomainCapacityBar
+        row={{ id: "domain:auth", title: "Auth", capabilityCount: 0, elementCount: 0, total: 0 }}
+        maxTotal={0}
+        labels={labels}
+      />,
+    );
+    const row = screen.getByTestId("domain-capacity-bar-row");
+    const segments = row.querySelectorAll<HTMLSpanElement>("span[style]");
+    for (const segment of Array.from(segments)) {
+      expect(segment.style.width).toBe("0%");
+    }
+  });
+});
+
+// jsdom normalizes `rgba(...)` to `rgb(...)` shorthand comparisons can miss —
+// compare on the shared numeric prefix instead of exact string equality.
+function rgbaToRgbPrefix(rgba: string): string {
+  const match = rgba.match(/rgba?\((\d+,\s*\d+,\s*\d+)/);
+  if (!match) throw new Error(`Cannot parse rgba color: ${rgba}`);
+  return match[1];
+}

--- a/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.tsx
+++ b/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.tsx
@@ -1,0 +1,87 @@
+import { TopologyV2KindGlyph } from "@/shared/ui";
+import { getOntologyKindTone } from "@/entities/ontology-class";
+
+export interface DomainCapacityBarRow {
+  id: string;
+  title: string;
+  capabilityCount: number;
+  elementCount: number;
+  total: number;
+}
+
+export interface DomainCapacityBarLabels {
+  capabilityUnit: string;
+  elementUnit: string;
+}
+
+export interface DomainCapacityBarProps {
+  row: DomainCapacityBarRow;
+  /** Denominator for the bar fill — typically the largest row's `total` in
+   * the current list, so the widest domain reads as a full track and the
+   * rest read proportionally shorter. */
+  maxTotal: number;
+  labels: DomainCapacityBarLabels;
+  /** Responsive width utility classes for the title column — callers place
+   * this row in containers of different widths (a dense insights list vs. a
+   * full-width project card), so the title column is the one thing left
+   * tunable per call site. Defaults to the insights list's column width. */
+  titleWidthClassName?: string;
+}
+
+/**
+ * One domain's capability/element composition — a single shared grammar for
+ * "how big is this domain, and what's it made of" wherever domain capacity
+ * data is shown (`/ontology/insights` structure tab, `/projects` cards).
+ *
+ * Guardian I-1 already fixed the *data* source (`computeDomainCensusRows`,
+ * shared BFS) so both surfaces count the same way; this component fixes the
+ * remaining *rendering* split — insights drew a 2-segment capability/element
+ * composition bar in kind tone (amber/eucalyptus), `/projects` drew a
+ * single-value monochrome-indigo ranking bar for the same row shape. Two
+ * visual grammars for one concept violates Apple HIG's consistency
+ * principle (a control or indicator should look and behave the same
+ * wherever it appears). The composition bar wins: `design.md`'s charter
+ * already carves out an explicit exception for ontology-kind color as a
+ * *data mark* in compact panel markers ("ontology kind 색상은 예외적으로
+ * 허용하지만 data mark 로만 쓴다") — this is exactly that exception in
+ * practice, not a new color system, and it keeps the capability/element
+ * split legible instead of collapsing it into a single number.
+ */
+export function DomainCapacityBar({
+  row,
+  maxTotal,
+  labels,
+  titleWidthClassName = "sm:w-[220px]",
+}: DomainCapacityBarProps) {
+  const capWidth = maxTotal > 0 ? (row.capabilityCount / maxTotal) * 100 : 0;
+  const elWidth = maxTotal > 0 ? (row.elementCount / maxTotal) * 100 : 0;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 py-0.5" data-testid="domain-capacity-bar-row">
+      <span
+        className={`flex w-full shrink-0 items-center gap-2 truncate text-body-lg text-[color:var(--color-text-secondary)] ${titleWidthClassName}`}
+      >
+        <TopologyV2KindGlyph kind="domain" size={15} />
+        <span className="truncate">{row.title}</span>
+      </span>
+      <span className="flex h-2 min-w-[48px] flex-1 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
+        <span
+          className="block h-full"
+          style={{ width: `${capWidth}%`, backgroundColor: getOntologyKindTone("capability").fill }}
+        />
+        <span
+          className="block h-full"
+          style={{ width: `${elWidth}%`, backgroundColor: getOntologyKindTone("element").fill }}
+        />
+      </span>
+      <span className="flex-none text-right">
+        <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
+          {row.total}
+        </span>
+        <span className="block font-mono text-caption text-[color:var(--color-text-quaternary)]">
+          {labels.capabilityUnit} {row.capabilityCount} · {labels.elementUnit} {row.elementCount}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/src/widgets/recent-node-row/index.ts
+++ b/src/widgets/recent-node-row/index.ts
@@ -1,0 +1,2 @@
+export { RecentNodeRow } from "./ui/RecentNodeRow";
+export type { RecentNodeRowProps } from "./ui/RecentNodeRow";

--- a/src/widgets/recent-node-row/ui/RecentNodeRow.test.tsx
+++ b/src/widgets/recent-node-row/ui/RecentNodeRow.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { RecentNodeRow } from "./RecentNodeRow";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("RecentNodeRow", () => {
+  it("stacks title over subtitle and shows trailing metadata", () => {
+    render(
+      <RecentNodeRow
+        kind="capability"
+        title="MCP Server"
+        subtitle="Capability · Views"
+        trailing="2d ago"
+        testId="row"
+      />,
+    );
+    const row = screen.getByTestId("row");
+    expect(row.tagName).toBe("DIV");
+    expect(screen.getByText("MCP Server")).toBeInTheDocument();
+    expect(screen.getByText("Capability · Views")).toBeInTheDocument();
+    expect(screen.getByText("2d ago")).toBeInTheDocument();
+  });
+
+  it("renders as a link when href is provided", () => {
+    render(
+      <RecentNodeRow
+        kind="element"
+        title="CLI"
+        subtitle="Element"
+        trailing="Today"
+        href="/ontology/?node=element%3Acli"
+        ariaLabel="CLI — view on the map"
+        testId="row"
+      />,
+    );
+    const row = screen.getByTestId("row");
+    expect(row.tagName).toBe("A");
+    expect(row).toHaveAttribute("href", "/ontology/?node=element%3Acli");
+    expect(row).toHaveAttribute("aria-label", "CLI — view on the map");
+  });
+
+  it("renders an optional secondary trailing line without disturbing the primary date", () => {
+    render(
+      <RecentNodeRow
+        kind="capability"
+        title="MCP Server"
+        subtitle="Views · write 도구로 확장"
+        trailing="Today"
+        trailingSecondary="capabilities/mcp-server"
+        testId="row"
+      />,
+    );
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("capabilities/mcp-server")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/recent-node-row/ui/RecentNodeRow.tsx
+++ b/src/widgets/recent-node-row/ui/RecentNodeRow.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+import { Link } from "@/i18n/navigation";
+import { TopologyV2KindGlyph } from "@/shared/ui";
+
+export interface RecentNodeRowProps {
+  kind: string;
+  title: string;
+  /** Second stacked line — kind/domain and, where the surface has it, a
+   * short description. Composed by the caller so each surface keeps its own
+   * exact wording; only the two-line stack shape is shared. */
+  subtitle: ReactNode;
+  /** Right-aligned primary metadata — usually a relative date. */
+  trailing: ReactNode;
+  /** Optional smaller line under `trailing` — e.g. the vault doc slug, kept
+   * for the agent/developer audience without competing with the date. */
+  trailingSecondary?: ReactNode;
+  /** Present → renders as a map-focus link; absent → an inert row (dangling
+   * doc with no resolvable graph node). */
+  href?: string;
+  ariaLabel?: string;
+  testId?: string;
+}
+
+/**
+ * One row of "a concept changed recently" — the shared grammar for
+ * `/ontology/insights` freshness tab's recent-updates list and `/projects`'
+ * recent-activity strip. Both surfaces show the same fact (title, kind,
+ * domain, when) but used to disagree on layout: insights stacked title over
+ * kind·domain (two lines, easy to scan top-to-bottom), `/projects` ran
+ * everything into one line (title + inline gray description + domain + slug
+ * + date), which reads as five competing columns rather than one row per
+ * Apple HIG's consistency guidance — the same fact should look the same
+ * wherever it appears. The two-line stack wins because it's the version
+ * that's actually easy to scan a list of; unifying on it here means both
+ * surfaces get row-hover/link chrome fixes for free going forward.
+ */
+export function RecentNodeRow({
+  kind,
+  title,
+  subtitle,
+  trailing,
+  trailingSecondary,
+  href,
+  ariaLabel,
+  testId,
+}: RecentNodeRowProps) {
+  const content = (
+    <>
+      <TopologyV2KindGlyph kind={kind} size={14} />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-body text-[color:var(--color-text-primary)]">{title}</span>
+        <span className="block truncate text-label text-[color:var(--color-text-quaternary)]">{subtitle}</span>
+      </span>
+      <span className="flex-none text-right">
+        <span className="block font-mono text-label tabular-nums text-[color:var(--color-text-tertiary)]">
+          {trailing}
+        </span>
+        {trailingSecondary ? (
+          <span className="block truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
+            {trailingSecondary}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+
+  // 클릭 대상이 없는 행(지도 노드로 못 찾은 dangling doc)엔 hover 배경을
+  // 주지 않는다 — 누를 수 없는데 인터랙티브해 보이면 그 자체가 결함.
+  const className = `flex items-center gap-2.5 rounded-md border-t border-[color:var(--color-divider)] px-1.5 py-2.5 transition-colors first:border-t-0 ${
+    href ? "-mx-1.5 hover:bg-[color:var(--color-overlay-1)]" : ""
+  }`;
+
+  if (href) {
+    return (
+      <Link href={href} aria-label={ariaLabel} data-testid={testId} className={className}>
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <div data-testid={testId} className={className}>
+      {content}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **DomainCapacityBar 통일**: insights 2톤(앰버=역량/유칼립투스=요소) 합성 바로 통일(tone.ts 가 이 pair 를 승인 data-mark 로 명시, /projects 단색보다 정보량 우위). `src/widgets/domain-capacity-bar/`.
- **RecentNodeRow 통일**: 2줄 스택 문법으로 통일(/projects run-on 교체), hover 는 실제 링크일 때만. `src/widgets/recent-node-row/`.
- **insights 청중 배너**: "정비 보드" 선언(i18n).
- **projects 카드 사용자 언어**: project.md 에 description 없어 body 발췌(내부 포지셔닝 카피)로 폴백하던 것 → frontmatter 직접 읽기(vault 불변, 뷰 레이어).
- **활동 피드 재배치**: 프로젝트 카드 먼저, 활동 아래.

## Test plan
- insights+projects+신규 위젯 vitest 384 ✅ · tsc ✅ · i18n ✅