### PR TITLE
docs: mcp verify README census 정정 — element candidate 37→39

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -737,7 +737,7 @@ A successful run looks like this:
 ✓ find_backlinks — project (1 backlink)
 ✓ query_concepts — 1 query result / 1 total query result
 ✓ query_concepts limited — 1 query result / 104 total query results (limited true)
-✓ analyze_repo_structure — fsd (6 domain candidates, 13 capability candidates, 37 element candidates)
+✓ analyze_repo_structure — fsd (6 domain candidates, 13 capability candidates, 39 element candidates)
 ✓ infer_imports — 938 files scanned, 547 module edges (elements/src/views/home->elements/src/entities/knowledge-graph x28 (static:28), elements/src/widgets/docs-vault->elements/src/entities/docs-vault x16 (static:16), +545 more)
 ✓ index_project — 56 concept candidates, 547 import relations, validation 0 problem files
 ✓ find_neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)


### PR DESCRIPTION
## Summary
세션 위젯 추가로 FSD element 폴더가 늘어 `analyze_repo_structure` 실측이 39가 됐으나 README 샘플이 37에 멈춰 `package:check` census 계약 테스트가 실패했다. README 를 실측(모든 maxDepth 결정적 39)에 정렬.

## Test plan
- `pnpm package:check` ✅ (census gate 통과)
- 라이브 `analyzeRepoStructure(cwd, {maxDepth:2..4,default})` = 39 결정적 확인