### PR TITLE
fix: docs 사이드바 음각 숫자가 필터 집합을 세도록

### DIFF
--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.test.tsx
@@ -101,6 +101,36 @@ describe("DocsSidebarBody — P4a 최근 바뀐 문서 스트립", () => {
   });
 });
 
+describe("DocsSidebarBody — 헤더 음각 숫자는 필터 집합을 센다", () => {
+  function numeral() {
+    return document.querySelector('[data-token="engraved-numeral"]') as HTMLElement;
+  }
+
+  it("검색 필터 없을 때는 전체 문서 수를 보인다", () => {
+    renderSidebar([
+      makeDoc("payment", "결제 문서", new Date().toISOString()),
+      makeDoc("order", "주문 문서", new Date().toISOString()),
+      makeDoc("ship", "배송 문서", new Date().toISOString()),
+    ]);
+    expect(numeral()).toHaveTextContent("3");
+    expect(numeral()).not.toHaveAttribute("data-filtered");
+  });
+
+  it("검색어를 입력하면 숫자가 매칭 수로 줄고 data-filtered 가 켜진다", () => {
+    renderSidebar([
+      makeDoc("payment", "결제 문서", new Date().toISOString()),
+      makeDoc("order", "주문 문서", new Date().toISOString()),
+      makeDoc("ship", "배송 문서", new Date().toISOString()),
+    ]);
+    const search = screen.getByPlaceholderText(
+      koMessages.vaultWidgets.parts.sidebar.searchPlaceholder,
+    );
+    fireEvent.change(search, { target: { value: "결제" } });
+    expect(numeral()).toHaveTextContent("1");
+    expect(numeral()).toHaveAttribute("data-filtered", "true");
+  });
+});
+
 describe("DocsSidebarBody — 에이전트 파일 그룹 (읽기 전용 감지)", () => {
   const model: AgentFilesUiModel = {
     records: [

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
@@ -151,6 +151,13 @@ export function DocsSidebarBody({
         .includes(normalizedTreeQuery),
     ).length;
   }, [manifest.docs, normalizedTreeQuery]);
+  // 헤더 음각 숫자는 부제와 같은 집합을 세야 한다 — 검색/태그 필터가 걸린
+  // 상태에서 부제는 "N개 검색됨"인데 숫자만 전체 총계를 보이면 모순이다.
+  const headerCount = normalizedTreeQuery
+    ? queryMatchCount
+    : activeTag
+      ? (manifest.tags[activeTag]?.length ?? 0)
+      : manifest.docs.length;
   const collectionOptions: DocsVaultCollection[] = ["guides", "ontology"];
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -169,9 +176,10 @@ export function DocsSidebarBody({
         </div>
         <span
           data-token="engraved-numeral"
+          data-filtered={normalizedTreeQuery || activeTag ? "true" : undefined}
           className="flex-none font-mono text-body tabular-nums text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
         >
-          {manifest.docs.length}
+          {headerCount}
         </span>
         {/* [D-4] 트리 상단 "새 문서" 진입점 — 이전엔 샘플(읽기 전용) 모드에서
             진입로 자체가 통째로 사라져 기능 존재를 알 수 없었다. 비활성


### PR DESCRIPTION
## Summary
좌측 문서 트리 헤더의 음각 숫자가 항상 전체 문서 수를 표시해, 검색·태그 필터가 걸린 상태에서 부제("N개 검색됨")와 모순됐다(비개발자 experience 감사). 숫자를 부제와 동일한 필터 집합으로 통일.

## Test plan
- DocsSidebarBody.test.tsx 12 passed (음각 숫자 필터 반영 2건 신규)