### PR TITLE
fix: 읽기 모드 frontmatter 참조 슬러그 클릭 내비게이션

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -821,6 +821,24 @@ function DocsVaultContent() {
     () => new Set(manifest.docs.map((d) => d.slug)),
     [manifest],
   );
+  // frontmatter 참조는 맨슬러그(ai-agent-partner)로 쓰지만 doc.slug 는 경로형
+  // (ontology/domains/ai-agent-partner)이다. 맨슬러그·frontmatter.slug·경로
+  // 꼬리 세 표기를 실제 네비게이션 slug 로 해소한다(경로형 우선, frontmatter
+  // 맨슬러그가 꼬리보다 authoritative). 미해소 참조는 링크로 만들지 않는다.
+  const refSlugResolver = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const d of manifest.docs) map.set(d.slug, d.slug);
+    for (const d of manifest.docs) {
+      const fmSlug =
+        typeof d.frontmatter?.slug === "string" ? d.frontmatter.slug.trim() : "";
+      if (fmSlug && !map.has(fmSlug)) map.set(fmSlug, d.slug);
+    }
+    for (const d of manifest.docs) {
+      const tail = d.slug.split("/").pop() ?? "";
+      if (tail && !map.has(tail)) map.set(tail, d.slug);
+    }
+    return map;
+  }, [manifest]);
   // 열린 문서 탭 워킹셋 — docs-chrome-round 슬라이스 B. sourceKey 는
   // useDocsVaultPersistence 의 recentKey 를 그대로 재사용해 vault 별 분리
   // 규약을 새로 만들지 않는다('server' | `local:<handle.name>`). 활성
@@ -1871,6 +1889,8 @@ function DocsVaultContent() {
                             canEdit={canEditCurrent}
                             domainOptions={domainOptions}
                             onPatch={handlePatchDocFrontmatter}
+                            onNavigate={handleSelect}
+                            resolveRef={(token) => refSlugResolver.get(token) ?? null}
                           />
                         ) : null}
                         <DocMetaBar doc={selectedDoc} />

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
@@ -75,6 +75,47 @@ describe("DocFrontmatterBlock", () => {
     expect(summary.getByText("6 fields")).toBeInTheDocument();
   });
 
+  it("linkifies resolvable reference slugs and navigates on click, leaving unresolved ones plain", () => {
+    const onNavigate = vi.fn();
+    // domain(developer-experience)·depends_on(mcp-server) 은 vault 에 있고,
+    // ghost-ref 는 없다고 가정.
+    const resolveRef = (token: string) =>
+      token === "developer-experience"
+        ? "domains/developer-experience"
+        : token === "mcp-server"
+          ? "capabilities/mcp-server"
+          : null;
+    const docWithGhost: VaultDoc = {
+      ...doc,
+      frontmatter: { ...doc.frontmatter, depends_on: ["mcp-server", "ghost-ref"] },
+    };
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={docWithGhost} onNavigate={onNavigate} resolveRef={resolveRef} />
+      </NextIntlClientProvider>,
+    );
+    fireEvent.click(screen.getByTestId("doc-frontmatter-summary"));
+
+    const domainRef = screen.getByTestId("doc-frontmatter-ref-developer-experience");
+    expect(domainRef.tagName).toBe("BUTTON");
+    fireEvent.click(domainRef);
+    expect(onNavigate).toHaveBeenCalledWith("domains/developer-experience");
+
+    fireEvent.click(screen.getByTestId("doc-frontmatter-ref-mcp-server"));
+    expect(onNavigate).toHaveBeenCalledWith("capabilities/mcp-server");
+
+    // 미해소 참조는 버튼이 되지 않는다.
+    expect(screen.queryByTestId("doc-frontmatter-ref-ghost-ref")).not.toBeInTheDocument();
+    expect(screen.getByText("ghost-ref")).toBeInTheDocument();
+  });
+
+  it("keeps reference fields plain text when no resolveRef/onNavigate is supplied", () => {
+    renderBlock();
+    fireEvent.click(screen.getByTestId("doc-frontmatter-summary"));
+    expect(screen.queryByTestId("doc-frontmatter-ref-developer-experience")).not.toBeInTheDocument();
+    expect(screen.getByText("developer-experience")).toBeInTheDocument();
+  });
+
   it("hides the quick-patch action when canEdit/onPatch are not supplied (read-only default)", () => {
     renderBlock();
     fireEvent.click(screen.getByTestId("doc-frontmatter-summary"));

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { ChevronRight, Pencil } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { buildNewNodeDoc, type VaultDoc } from "@/entities/docs-vault";
@@ -63,6 +63,34 @@ function isEditableKind(kind: string): kind is EditableKind {
   return (EDITABLE_KINDS as readonly string[]).includes(kind);
 }
 
+// 다른 vault 노드를 슬러그로 가리키는 참조 키 — 읽기 모드에서 해소 가능한
+// 토큰은 클릭 내비게이션을 준다. evidence(파일 경로) / category / status(enum)
+// 는 노드 참조가 아니라 제외한다.
+const REFERENCE_KEYS = new Set<string>([
+  "domain",
+  "depends_on",
+  "relates_to",
+  "contains",
+  "belongs_to",
+]);
+
+function toRefTokens(value: unknown): { tokens: string[]; isArray: boolean } {
+  if (Array.isArray(value)) {
+    return {
+      tokens: value
+        .filter((v): v is string => typeof v === "string")
+        .map((v) => v.trim())
+        .filter(Boolean),
+      isArray: true,
+    };
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return { tokens: trimmed ? [trimmed] : [], isArray: false };
+  }
+  return { tokens: [], isArray: false };
+}
+
 function formatValue(value: unknown): string | null {
   if (value == null) return null;
   if (Array.isArray(value)) {
@@ -93,6 +121,11 @@ export interface DocFrontmatterBlockProps {
   /** 확정된 필드만 담아 호출 — 저장은 caller (updateFrontmatter conflict
    *  guard 경유) 책임. */
   onPatch?: (patch: DocFrontmatterPatch) => Promise<void>;
+  /** 참조 슬러그를 클릭했을 때 해당 문서로 이동 — 없으면 참조는 평문. */
+  onNavigate?: (slug: string) => void;
+  /** 맨슬러그(frontmatter 참조 표기)를 실제 네비게이션 슬러그로 해소.
+   *  null 이면 vault 에 없는 참조라 링크로 만들지 않는다. */
+  resolveRef?: (token: string) => string | null;
 }
 
 export function DocFrontmatterBlock({
@@ -100,6 +133,8 @@ export function DocFrontmatterBlock({
   canEdit = false,
   domainOptions = [],
   onPatch,
+  onNavigate,
+  resolveRef,
 }: DocFrontmatterBlockProps) {
   const t = useTranslations("docsVault.frontmatterBlock");
   const kindLabel = useOntologyKindLabel();
@@ -173,10 +208,23 @@ export function DocFrontmatterBlock({
     }
   }, [currentKind, domainOptions, kindLabel, t]);
 
-  const fields = GRAPH_KEYS.map((key) => ({
-    key: key as string,
-    value: formatValue(doc.frontmatter?.[key]),
-  })).filter((f): f is { key: string; value: string } => f.value !== null);
+  const fields = GRAPH_KEYS.map((key) => {
+    const raw = doc.frontmatter?.[key];
+    const ref = REFERENCE_KEYS.has(key) ? toRefTokens(raw) : null;
+    return {
+      key: key as string,
+      value: formatValue(raw),
+      refTokens: ref?.tokens ?? null,
+      refIsArray: ref?.isArray ?? false,
+    };
+  }).filter(
+    (f): f is {
+      key: string;
+      value: string;
+      refTokens: string[] | null;
+      refIsArray: boolean;
+    } => f.value !== null,
+  );
 
   if (fields.length === 0) return null;
 
@@ -260,20 +308,52 @@ export function DocFrontmatterBlock({
           <div className="text-[color:var(--color-text-quaternary)]" aria-hidden>
             ---
           </div>
-          {fields.map(({ key, value }) => (
-            <div key={key} className="flex min-w-0 flex-wrap gap-x-1.5">
-              <span className="text-[color:var(--color-text-quaternary)]">{key}:</span>
-              <span
-                className={
-                  key === "kind"
-                    ? "font-semibold text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
-                    : "min-w-0 truncate text-[color:var(--color-text-secondary)]"
-                }
-              >
-                {value}
-              </span>
-            </div>
-          ))}
+          {fields.map(({ key, value, refTokens }) => {
+            const linkable =
+              refTokens != null &&
+              refTokens.length > 0 &&
+              onNavigate != null &&
+              refTokens.some((tok) => resolveRef?.(tok) != null);
+            return (
+              <div key={key} className="flex min-w-0 flex-wrap gap-x-1.5">
+                <span className="text-[color:var(--color-text-quaternary)]">{key}:</span>
+                {linkable ? (
+                  <span className="min-w-0 break-words text-[color:var(--color-text-secondary)]">
+                    {refTokens!.map((tok, index) => {
+                      const target = resolveRef?.(tok) ?? null;
+                      return (
+                        <Fragment key={`${tok}-${index}`}>
+                          {index > 0 ? <span aria-hidden>, </span> : null}
+                          {target != null ? (
+                            <button
+                              type="button"
+                              onClick={() => onNavigate!(target)}
+                              data-testid={`doc-frontmatter-ref-${tok}`}
+                              className="rounded-sm text-[color:var(--color-indigo-pale-a90)] underline decoration-[color:var(--color-indigo-line-a35)] underline-offset-2 transition-colors hover:text-[color:var(--color-text-primary)] hover:decoration-[color:var(--color-indigo-line-a45)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[color:var(--color-indigo-line-a45)]"
+                            >
+                              {tok}
+                            </button>
+                          ) : (
+                            <span>{tok}</span>
+                          )}
+                        </Fragment>
+                      );
+                    })}
+                  </span>
+                ) : (
+                  <span
+                    className={
+                      key === "kind"
+                        ? "font-semibold text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+                        : "min-w-0 truncate text-[color:var(--color-text-secondary)]"
+                    }
+                  >
+                    {value}
+                  </span>
+                )}
+              </div>
+            );
+          })}
           <div className="text-[color:var(--color-text-quaternary)]" aria-hidden>
             ---
           </div>


### PR DESCRIPTION
## Summary
읽기 모드에서 `domain`/`depends_on`/`relates_to`/`contains`/`belongs_to` 참조 슬러그가 죽은 평문으로만 렌더돼 다른 노드로 이동할 길이 없었다(비개발자 experience 감사). 해소 가능한 토큰만 인디고 언더라인 링크로 만들고 클릭 시 해당 문서로 이동.

- frontmatter 참조는 맨슬러그, doc.slug 는 경로형 → 경로형·frontmatter.slug·경로꼬리 순 해소기(`refSlugResolver`)
- 미해소 참조·비참조 필드는 평문 유지, evidence/category/status 는 링크 제외
- 브라우저 검증: dogfood `domain: ai-agent-partner` → 클릭 → 도메인 문서 이동 확인

## Test plan
- DocFrontmatterBlock.test.tsx 13 passed (클릭 내비/미해소 평문/무 prop 평문 3건 신규)
- tsc ✅ · 브라우저 end-to-end 이동 확인