### PR TITLE
fix: docs 탭 스트립 오버플로 엣지 페이드 신호 (rank 3)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1338,6 +1338,10 @@
        data-token="docs-tab". */
     --docs-tab-min: 132px;
     --docs-tab-max: 208px;
+    /* 탭 스트립 오버플로 엣지 페이드 — 열린 문서가 넘칠 때 "더 있음"을
+       알리는 정적 mask 폭. 색/glow/모션 0(mask-image 알파만). 숨은 콘텐츠가
+       있는 방향에만 적용(DocsVaultTabStrip 스크롤 상태로 조건부). */
+    --docs-tab-edge-fade: 22px;
     /* 문서함 점검 모달 — 세로 3행 스택 단일 폭. 브레이크포인트 0 계약(3-across
        그리드 폐기) 이라 뷰포트별 분기 없이 이 값 하나만 쓴다. 마커
        data-token="docs-audit-modal". */

--- a/src/views/docs-vault/ui/parts/DocsVaultTabStrip.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultTabStrip.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import koMessages from "../../../../../messages/ko.json";
+import type { useTranslations } from "next-intl";
+import { DocsVaultTabStrip } from "./DocsVaultTabStrip";
+import type { DocTab } from "../../lib/doc-tabs";
+
+// jsdom 엔 ResizeObserver 가 없다 — 최소 stub.
+beforeAll(() => {
+  if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
+  }
+});
+
+function makeTabs(n: number): DocTab[] {
+  return Array.from({ length: n }, (_, i) => ({
+    slug: `doc-${i}`,
+    title: `문서 ${i}`,
+    lastActivatedAt: i,
+  }));
+}
+
+function renderStrip(tabs: DocTab[], activeSlug: string) {
+  const t = ((key: string, values?: Record<string, unknown>) => {
+    if (key === "tabs.closeAria") return `${values?.title} 닫기`;
+    if (key === "tabs.stripAriaLabel") return "열린 문서";
+    return key;
+  }) as unknown as ReturnType<typeof useTranslations<"docsVault">>;
+  return render(
+    <NextIntlClientProvider locale="ko" messages={koMessages}>
+      <DocsVaultTabStrip
+        tabs={tabs}
+        activeSlug={activeSlug}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        t={t}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+// nav 의 스크롤 메트릭을 지정 — jsdom 은 전부 0 이라 직접 목킹한다.
+function mockScrollMetrics(
+  nav: HTMLElement,
+  { scrollLeft, clientWidth, scrollWidth }: { scrollLeft: number; clientWidth: number; scrollWidth: number },
+) {
+  Object.defineProperty(nav, "clientWidth", { configurable: true, value: clientWidth });
+  Object.defineProperty(nav, "scrollWidth", { configurable: true, value: scrollWidth });
+  Object.defineProperty(nav, "scrollLeft", { configurable: true, writable: true, value: scrollLeft });
+}
+
+describe("DocsVaultTabStrip — 오버플로 엣지 페이드 신호", () => {
+  it("탭이 안 넘치면 페이드 마스크가 없다", () => {
+    const { container } = renderStrip(makeTabs(2), "doc-0");
+    const nav = container.querySelector("nav")!;
+    mockScrollMetrics(nav, { scrollLeft: 0, clientWidth: 800, scrollWidth: 300 });
+    fireEvent.scroll(nav);
+    expect(nav.getAttribute("data-edge-overflow")).toBeNull();
+  });
+
+  it("오른쪽에 숨은 탭이 있으면 오른쪽 페이드만 켠다", () => {
+    const { container } = renderStrip(makeTabs(20), "doc-0");
+    const nav = container.querySelector("nav")!;
+    mockScrollMetrics(nav, { scrollLeft: 0, clientWidth: 300, scrollWidth: 2000 });
+    fireEvent.scroll(nav);
+    expect(nav.getAttribute("data-edge-overflow")).toBe("right");
+    expect(nav.style.maskImage).toContain("transparent 100%");
+  });
+
+  it("가운데로 스크롤하면 양쪽 페이드를 켠다", () => {
+    const { container } = renderStrip(makeTabs(20), "doc-10");
+    const nav = container.querySelector("nav")!;
+    mockScrollMetrics(nav, { scrollLeft: 500, clientWidth: 300, scrollWidth: 2000 });
+    fireEvent.scroll(nav);
+    expect(nav.getAttribute("data-edge-overflow")).toBe("both");
+  });
+
+  it("끝까지 스크롤하면 왼쪽 페이드만 켠다", () => {
+    const { container } = renderStrip(makeTabs(20), "doc-19");
+    const nav = container.querySelector("nav")!;
+    mockScrollMetrics(nav, { scrollLeft: 1700, clientWidth: 300, scrollWidth: 2000 });
+    fireEvent.scroll(nav);
+    expect(nav.getAttribute("data-edge-overflow")).toBe("left");
+  });
+});

--- a/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { useTranslations } from "next-intl";
 import { FileText, X } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
@@ -48,6 +48,38 @@ export function DocsVaultTabStrip({
   t,
 }: DocsVaultTabStripProps) {
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
+  const stripRef = useRef<HTMLElement | null>(null);
+  // 열린 문서 워킹셋이 스트립 폭을 넘칠 때, 숨은 탭이 있는 쪽에만 엣지
+  // 페이드를 켠다 — 넘침 어포던스 0(조용한 은닉) 결함 정정. mask 알파만
+  // 쓰므로 색/glow/모션 0, reduced-motion 무관.
+  const [edgeOverflow, setEdgeOverflow] = useState({ left: false, right: false });
+
+  const recomputeEdges = useCallback(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const maxScroll = strip.scrollWidth - strip.clientWidth;
+    const left = strip.scrollLeft > 1;
+    const right = strip.scrollLeft < maxScroll - 1;
+    setEdgeOverflow((prev) =>
+      prev.left === left && prev.right === right ? prev : { left, right },
+    );
+  }, []);
+
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    recomputeEdges();
+    strip.addEventListener("scroll", recomputeEdges, { passive: true });
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(recomputeEdges)
+        : null;
+    resizeObserver?.observe(strip);
+    return () => {
+      strip.removeEventListener("scroll", recomputeEdges);
+      resizeObserver?.disconnect();
+    };
+  }, [recomputeEdges, tabs.length]);
 
   useEffect(() => {
     // JS 스크롤 애니메이션은 globals.css 의 reduced-motion base layer 가
@@ -85,10 +117,31 @@ export function DocsVaultTabStrip({
 
   if (tabs.length === 0) return null;
 
+  // 숨은 콘텐츠가 있는 엣지에만 투명 페이드. 양쪽/한쪽/없음 4상태.
+  const fade = "var(--docs-tab-edge-fade)";
+  const maskImage = edgeOverflow.left && edgeOverflow.right
+    ? `linear-gradient(to right, transparent 0, black ${fade}, black calc(100% - ${fade}), transparent 100%)`
+    : edgeOverflow.right
+      ? `linear-gradient(to right, black calc(100% - ${fade}), transparent 100%)`
+      : edgeOverflow.left
+        ? `linear-gradient(to right, transparent 0, black ${fade})`
+        : undefined;
+
   return (
     <nav
+      ref={stripRef}
       aria-label={t("tabs.stripAriaLabel")}
+      data-edge-overflow={
+        edgeOverflow.left && edgeOverflow.right
+          ? "both"
+          : edgeOverflow.right
+            ? "right"
+            : edgeOverflow.left
+              ? "left"
+              : undefined
+      }
       className="docs-vault-tab-strip flex h-full min-w-0 flex-1 items-stretch overflow-x-auto"
+      style={maskImage ? { maskImage, WebkitMaskImage: maskImage } : undefined}
     >
       {tabs.map((tab) => {
         const active = tab.slug === activeSlug;


### PR DESCRIPTION
## Summary
열린 문서 탭이 스트립 폭을 넘쳐도 '더 있음' 시각 어포던스가 없어 워킹셋이 조용히 은닉됐다(페르소나·디자인 감사 4렌즈 독립 지적, 소유자 미결 처방 #1). 스크롤 상태 기반으로 숨은 탭이 있는 엣지에만 `mask-image` 페이드를 켠다.

- 양쪽/오른쪽/왼쪽/없음 4상태, `--docs-tab-edge-fade` 토큰
- 색·glow·모션 0(mask 알파만) → 헌장 무충돌, reduced-motion 무관
- `<lg` 터치 표면 스크롤 어포던스와 무충돌(mask 는 pointer 이벤트 미간섭)

## Test plan
- DocsVaultTabStrip.test.tsx 4상태 회귀 신규 · docs-vault 142 passed · tsc ✅