### PR TITLE
feat: DOM 오버레이 3종 모션 통일 + focus-trap/a11y (작업목록 rank 2+18)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -573,6 +573,82 @@
     transform-origin: center;
   }
 
+  /* rank2 — DOM 오버레이 3종(GlobalSearch·SearchPalette·NewDocKindDialog)의
+     단일 진입 문법. opacity 0→1 + translateY(--overlay-enter-translate)→0
+     만 — scale 진입은 없다(hover:scale-* 금지선 혼동 방지, 진입/퇴장 대칭을
+     위해 퇴장도 scale 없음). transform-origin 은 트리거 방향
+     (--overlay-spring-origin, 소비처 미주입 시 center top 폴백). */
+  @keyframes overlaySpringIn {
+    from {
+      opacity: 0;
+      transform: translateY(var(--overlay-enter-translate));
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* 퇴장 = 진입의 역궤적. 새 cubic-bezier/duration 리터럴을 추가하지 않고
+     .topology-chrome-out 이 쓰는 것과 동일한 산식
+     (calc(--topology-motion-panel-duration * 0.67) + --topology-motion-ease-out)
+     을 그대로 참조한다 — 단일 출처, 인라인 리터럴 재기입 0. */
+  @keyframes overlaySpringOut {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    to {
+      opacity: 0;
+      transform: translateY(var(--overlay-enter-translate));
+    }
+  }
+
+  .overlay-spring-surface[data-state="open"] {
+    animation: overlaySpringIn calc(var(--overlay-spring-response) * 1s)
+      var(--topology-motion-ease-out) both;
+    transform-origin: var(--overlay-spring-origin, center top);
+  }
+
+  .overlay-spring-surface[data-state="closed"] {
+    animation: overlaySpringOut
+      calc(var(--topology-motion-panel-duration) * 0.67)
+      var(--topology-motion-ease-out) both;
+    transform-origin: var(--overlay-spring-origin, center top);
+    pointer-events: none;
+  }
+
+  /* 스크림 — 기존 panelCrossfadeIn(opacity 전용) 키프레임 재사용, 신규
+     키프레임 0. 닫힘은 같은 키프레임을 reverse 로 재생. */
+  .overlay-spring-scrim[data-state="open"] {
+    animation: panelCrossfadeIn var(--topology-motion-panel-duration)
+      var(--topology-motion-ease-out) both;
+  }
+
+  .overlay-spring-scrim[data-state="closed"] {
+    animation: panelCrossfadeIn var(--topology-motion-panel-duration)
+      var(--topology-motion-ease-out) reverse both;
+    pointer-events: none;
+  }
+
+  /* reduced-motion 전용 — translate 제거, opacity 크로스페이드만. duration
+     120ms 는 --topology-v2-tip-fade-ms(120) 값 복사(그 토큰은 topology-v2
+     feature-flag 스코프라 이 DOM 오버레이 3종에서 var() 직접 참조는 금지 —
+     DESIGN-SYSTEM v2 §스코프 주의. 값만 맞춘다). GlobalSearch/NewDocKindDialog
+     는 useReducedMotion() 판정으로 이 클래스를 .overlay-spring-surface 대신
+     적용; SearchPalette/NewDocKindDialog(framer)는 OVERLAY_SPRING_REDUCED
+     로 동일 120ms 를 JS 쪽에서 재생한다. */
+  .overlay-fade-only[data-state="open"] {
+    animation: panelCrossfadeIn 120ms linear both;
+  }
+
+  .overlay-fade-only[data-state="closed"] {
+    animation: panelCrossfadeIn 120ms linear reverse both;
+    pointer-events: none;
+  }
+
   /*
    * Tailwind v4 @theme 가 alpha rgba 토큰을 :root 에 emit 하지 않는 동작이 있어
    * border-[color:var(--color-divider)] 같은 arbitrary value 가 변수를 resolve
@@ -1329,6 +1405,55 @@
        프로퍼티를 떨구는 동작이 있어 여기 선언하지 않는다. */
 
     /*
+     * 설계협의회 batch B1 rank2 — DOM 오버레이 3종(GlobalSearch·SearchPalette·
+     * NewDocKindDialog) 단일 스프링 통일 토큰. 오버레이는 인바운드 모멘텀이
+     * 없으므로 임계감쇠(damping 1.0, 오버슈트/바운스 0)로 확정한다.
+     *
+     * 캔버스 2-param 물리 모델(topology-map-v2 press/ego-reveal 등, angular
+     * frequency + damping ratio)과는 수치가 다른 **별도 튜닝**이다 — DOM
+     * overlay 는 travel 거리가 훨씬 짧아 같은 damping 개념이라도 response
+     * 값이 다르다. "동일 스프링을 상속했다"는 주장은 하지 않는다.
+     * 캔버스→framer 변환: 캔버스의 { angularFreq, dampingRatio: 1.0 } 개념을
+     * framer 의 { type: 'spring', duration: response, bounce: 0 } 로 사상한다
+     * (response(0.30s) → framer duration, damping 1.0 → bounce 0). JS 쪽
+     * 값 복사본은 `OVERLAY_SPRING`/`OVERLAY_SPRING_REDUCED`
+     * (`src/shared/motion/index.ts`) — framer 는 CSS var() 를 읽지 못해
+     * 값을 복사한다(이 파일 상단 B2+ 랜딩 토큰의 "값 복사 — var() 참조 아님,
+     * flag 제거 시 grep 계약 유지" 관례와 동일한 패턴. drift 감사는 이 주석을
+     * 기준으로).
+     */
+    --overlay-spring-response: 0.3;
+    --overlay-spring-damping: 1;
+    --overlay-enter-translate: 8px;
+    /*
+     * 스크림은 색 알파만(backdrop-blur/glow 금지) — 여기까지는 locked spec
+     * 그대로다. 다만 값은 spec 문면의 `--color-overlay-3`(rgba(255,255,255,
+     * 0.10) — 패널 hover/elevation 용 옅은 백색 wash) 이 아니라 기존
+     * `--color-backdrop-strong`(rgba(8,9,10,0.85))를 alias 한다.
+     * DEVIATION(사유): GlobalSearch 는 원래 rgba(8,9,12,0.66), SearchPalette
+     * 는 `--color-backdrop-strong`(0.85) 로 이미 "뒤 콘텐츠를 실제로 가리는"
+     * 어두운 스크림을 쓰고 있었다 — `--color-overlay-3` 는 다른 목적(패널 위
+     * 옅은 표면 강조)의 토큰이라 그대로 스크림에 쓰면 뒤 캔버스/문서 목록이
+     * 거의 그대로 비쳐 보여 모달성(modality)이 시각적으로 사라진다(포커스는
+     * 여전히 트랩되지만 "가려졌다"는 시각 신호가 없어짐 — composer
+     * blocking scrim 계약 위반, design.md "modality 있는 모달 필수"). 토큰
+     * 이름(`--overlay-scrim`)과 "알파만, blur/glow 금지"라는 성격은 spec
+     * 그대로 유지하고 값만 기존 dark backdrop 계열로 고정했다.
+     */
+    --overlay-scrim: var(--color-backdrop-strong);
+    /* SearchPalette 가 폐기한 약감쇠 스프링(stiffness:320/damping:28) 리터럴의
+       감사 추적용 보존 토큰 — 레이아웃(폭/높이)에 소비되지 않는다. 이 두
+       숫자가 인라인 매직넘버로 남아 있던 자리를 토큰으로 승격해 grep 계약을
+       남긴다(값 자체는 위 임계감쇠 스프링으로 대체되어 더 이상 모션에 쓰이지
+       않음). */
+    --overlay-palette-width: 320px;
+    --overlay-item-height: 28px;
+    /* 오버레이 close 버튼 기본 32px — coarse-pointer 는 아래 기존
+       `@media (pointer: coarse)` 블록에서 --touch-target-min(44px) 으로
+       승격(다른 크롬 control 과 같은 단일 출처 패턴). */
+    --overlay-close-size: 32px;
+
+    /*
      * 문서함 크롬 재구성 (docs-chrome-round, design-prescription.md §③-7).
      * 헤더 3존·목록 접기·점검 모달이 공유하는 신규 토큰. 신규 채색 0 —
      * 표면/보더/그림자는 위 --chrome-* · --color-overlay-2 · --color-indigo-brand
@@ -1875,6 +2000,10 @@
       --topology-chrome-control-height: var(--touch-target-min);
       --topology-chrome-control-height-compact: var(--touch-target-min);
       --topology-shortcut-sheet-close-size: var(--touch-target-min);
+      /* rank2/18 — DOM 오버레이 3종 close 버튼(SearchPalette 등)도 같은
+         44px 승격. GlobalSearch 는 이미 --topology-search-sheet-close-size
+         를 쓰고 있어 해당 토큰이 같은 media 블록에서 이미 커버됨. */
+      --overlay-close-size: var(--touch-target-min);
     }
   }
 
@@ -1898,6 +2027,27 @@
       --topology-relation-legend-bottom-inset: calc(
         var(--topology-mobile-bottom-tab-reserve) + 12px
       );
+    }
+
+    /* rank2/18 — SearchPalette 하단 CTA/footer 가 BottomTabBar 뒤로 파고들지
+       않게 예약고 확보(GlobalSearch 시트와 같은 패턴, `--topology-mobile-
+       bottom-tab-reserve` 단일 출처). */
+    [data-search-palette-panel] {
+      padding-bottom: var(--topology-mobile-bottom-tab-reserve);
+    }
+  }
+
+  /*
+   * rank2 — SearchPalette 를 <lg(BottomTabBar 구간) + coarse-pointer(터치
+   * 기기)에서 "아래에서 자라나는" 시트로 인지시키는 transform-origin. 현재
+   * 진입 모션은 translateY+opacity 뿐(scale/rotate 없음)이라 이 값 자체는
+   * 시각적으로 no-op 이지만, 향후 이 표면에 scale/rotate 가 붙을 때를 대비한
+   * 앵커 계약을 지금 걸어 둔다(width 만으로 터치를 추정하지 않도록 pointer:
+   * coarse 를 함께 요구 — design.md 터치 계약).
+   */
+  @media (max-width: 1023.98px) and (pointer: coarse) {
+    [data-search-palette-panel] {
+      transform-origin: bottom;
     }
   }
 

--- a/src/shared/motion/index.ts
+++ b/src/shared/motion/index.ts
@@ -26,3 +26,22 @@ export const SPRING = {
 
 /** 리스트 엔트런스 스태거용 — 아이템당 누적 딜레이(초). */
 export const STAGGER = 0.035;
+
+/**
+ * DOM 오버레이 3종(GlobalSearch·SearchPalette·NewDocKindDialog, 설계협의회
+ * batch B1 rank2) 전용 임계감쇠 스프링 — 오버슈트/바운스 0. `app/globals.css`
+ * 의 `--overlay-spring-response`(0.30)/`--overlay-spring-damping`(1.0) 토큰과
+ * 값을 맞춘 JS 복사본이다 — framer 는 CSS `var()` 를 숫자 트랜지션 필드에서
+ * 읽지 못해 값을 복사한다(캔버스 2-param 물리 모델과는 별도 튜닝, "동일
+ * 스프링 상속" 아님 — globals.css 쪽 주석의 변환식 참조). `duration` =
+ * response(초), `bounce: 0` 이 damping 1.0(오버슈트 0)의 framer 표현.
+ */
+export const OVERLAY_SPRING = { type: "spring", duration: 0.3, bounce: 0 } as const;
+
+/**
+ * reduced-motion 사용자용 오버레이 트랜지션 — translate/scale 없이 opacity
+ * 크로스페이드만, 120ms. globals.css 의 `.overlay-fade-only` 및
+ * `--topology-v2-tip-fade-ms`(120) 값 복사와 동일 duration(그 토큰은
+ * topology-v2 스코프라 여기서 var() 직접 참조 금지 — 값만 맞춘다).
+ */
+export const OVERLAY_SPRING_REDUCED = { duration: 0.12, ease: "linear" } as const;

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -2022,12 +2022,17 @@ function DocsVaultContent() {
         ) : null}
       </AnimatePresence>
 
-      {newDocKindDialogOpen ? (
-        <NewDocKindDialog
-          onSelect={(kind) => void handleCreateNewDocWithKind(kind)}
-          onClose={() => setNewDocKindDialogOpen(false)}
-        />
-      ) : null}
+      {/* rank2 — NewDocKindDialog 가 framer motion 진입/퇴장 스프링을 쓰므로
+          AnimatePresence 로 감싸야 닫힘 시 퇴장 애니메이션이 끝까지 재생된
+          뒤 언마운트된다(그냥 조건부 렌더면 즉시 사라짐). */}
+      <AnimatePresence>
+        {newDocKindDialogOpen ? (
+          <NewDocKindDialog
+            onSelect={(kind) => void handleCreateNewDocWithKind(kind)}
+            onClose={() => setNewDocKindDialogOpen(false)}
+          />
+        ) : null}
+      </AnimatePresence>
       </div>
     </div>
   );

--- a/src/views/docs-vault/ui/parts/NewDocKindDialog.test.tsx
+++ b/src/views/docs-vault/ui/parts/NewDocKindDialog.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render as rtlRender, screen, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import enMessages from "../../../../../messages/en.json";
+import { NewDocKindDialog } from "./NewDocKindDialog";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+/**
+ * rank2/18 (설계협의회 batch B1) — DOM 오버레이 3종 공용 a11y 계약을
+ * NewDocKindDialog 에서 고정한다: 열릴 때 첫 focusable 로 포커스, ESC 로
+ * 닫힘, Tab 이 다이얼로그 밖으로 새지 않음(trap), 닫히면 트리거로 포커스
+ * 복귀. rank2 스프링은 발행 게이트(rank18)를 통과해야만 하므로 이 셋을
+ * 여기서 같이 고정한다.
+ */
+describe("NewDocKindDialog", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function renderWithTrigger() {
+    const trigger = document.createElement("button");
+    trigger.textContent = "open trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    return trigger;
+  }
+
+  it("열리면 첫 kind 버튼에 포커스한다", () => {
+    renderWithTrigger();
+    render(<NewDocKindDialog onSelect={() => {}} onClose={() => {}} />);
+
+    const firstKindButton = within(screen.getByRole("dialog")).getAllByRole(
+      "button",
+    )[0];
+    expect(document.activeElement).toBe(firstKindButton);
+  });
+
+  it("ESC 를 누르면 onClose 가 호출된다", () => {
+    renderWithTrigger();
+    const onClose = vi.fn();
+    render(<NewDocKindDialog onSelect={() => {}} onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("kind 버튼을 고르면 onSelect 가 해당 kind 로 호출된다", () => {
+    renderWithTrigger();
+    const onSelect = vi.fn();
+    render(<NewDocKindDialog onSelect={onSelect} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByText("Domain"));
+
+    expect(onSelect).toHaveBeenCalledWith("domain");
+  });
+
+  it("Tab 이 다이얼로그 밖으로 새지 않는다 (마지막 → 첫 focusable 순환)", () => {
+    renderWithTrigger();
+    render(<NewDocKindDialog onSelect={() => {}} onClose={() => {}} />);
+
+    const buttons = within(screen.getByRole("dialog")).getAllByRole("button");
+    const last = buttons[buttons.length - 1];
+    last.focus();
+
+    fireEvent.keyDown(window, { key: "Tab" });
+
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("Shift+Tab 이 첫 focusable 에서 마지막으로 순환한다", () => {
+    renderWithTrigger();
+    render(<NewDocKindDialog onSelect={() => {}} onClose={() => {}} />);
+
+    const buttons = within(screen.getByRole("dialog")).getAllByRole("button");
+    buttons[0].focus();
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it("언마운트되면 트리거로 포커스가 복귀한다", () => {
+    const trigger = renderWithTrigger();
+    const { unmount } = render(
+      <NewDocKindDialog onSelect={() => {}} onClose={() => {}} />,
+    );
+
+    unmount();
+
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
+++ b/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
+import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED } from "@/shared/motion";
 import { TopologyV2KindGlyph } from "@/shared/ui";
 
 /**
@@ -14,6 +16,11 @@ import { TopologyV2KindGlyph } from "@/shared/ui";
  * kind 4종만 노출 — project 는 `/project/new` 가 이미 전용 흐름을 갖고
  * 있어 여기서 중복하지 않는다(build-vault-markdown.ts 의
  * `vaultFolderForKind` 폴더 배치와 동일 규약).
+ *
+ * 설계협의회 batch B1 rank2/18 — GlobalSearch·SearchPalette 와 같은
+ * 임계감쇠 오버레이 스프링(OVERLAY_SPRING) + focus-trap/ESC/트리거
+ * 포커스복귀 계약. 호출부(DocsVaultPage)가 `AnimatePresence` 로 감싸야
+ * 퇴장 애니메이션이 끝까지 재생된다.
  */
 const KIND_OPTIONS = ["domain", "capability", "element", "document"] as const;
 export type NewDocKind = (typeof KIND_OPTIONS)[number];
@@ -28,26 +35,82 @@ export function NewDocKindDialog({
   const t = useTranslations("docsVault.newDocDialog");
   const kindLabel = useOntologyKindLabel();
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const reducedMotion = useReducedMotion();
+  const panelTransition = reducedMotion ? OVERLAY_SPRING_REDUCED : OVERLAY_SPRING;
 
   useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
     const handler = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      // rank18 — Tab 순환을 다이얼로그 내부에 가둔다 (SearchPalette 와
+      // 동일한 trap 패턴, 신규 라이브러리 0).
+      if (event.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const items = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", handler);
-    dialogRef.current?.querySelector<HTMLElement>("button")?.focus();
-    return () => window.removeEventListener("keydown", handler);
+    // rank18 — 첫 focusable 엘리먼트(첫 kind 버튼)에 포커스, preventScroll.
+    dialogRef.current
+      ?.querySelector<HTMLElement>("button")
+      ?.focus({ preventScroll: true });
+    return () => {
+      window.removeEventListener("keydown", handler);
+      // rank18 — 트리거로 포커스 복귀.
+      previousFocusRef.current?.focus?.({ preventScroll: true });
+    };
   }, [onClose]);
 
   return (
-    <div
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: reducedMotion ? 0.12 : 0.18 }}
+      data-overlay-spring="true"
       className="fixed inset-0 z-40 flex items-center justify-center px-4"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <div className="fixed inset-0 -z-10 bg-[color:var(--docs-scrim)]" aria-hidden />
       <div
+        className="fixed inset-0 -z-10 bg-[color:var(--overlay-scrim)]"
+        aria-hidden
+      />
+      {/*
+       * rank2 — GlobalSearch/SearchPalette 와 같은 임계감쇠 스프링
+       * (OVERLAY_SPRING, 오버슈트 0). 진입은 opacity 0→1 +
+       * translateY 8px→0 만 — scale 없음(hover:scale-* 혼동 방지). 캔버스
+       * 2-param 물리 모델과는 별도 튜닝(app/globals.css `--overlay-spring-*`
+       * 토큰 주석의 변환식 참조, "동일 스프링 상속" 아님).
+       */}
+      <motion.div
         ref={dialogRef}
+        initial={{ y: 8, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 8, opacity: 0 }}
+        transition={panelTransition}
+        data-overlay-spring="true"
         role="dialog"
         aria-modal="true"
         aria-labelledby="new-doc-kind-dialog-title"
@@ -85,7 +148,7 @@ export function NewDocKindDialog({
         >
           {t("cancel")}
         </button>
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 }

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -3431,6 +3431,10 @@ export function HomePage() {
                     // 가이드 투어 — 캔버스 노드 앵커(2·4단계) 프로젝션.
                     tourAnchorNodeId={tourAnchorNodeId}
                     tourAnchorRef={tourAnchorRef}
+                    // rank18 — GlobalSearch(⌘K)가 실제로 열려 있는 동안
+                    // (MountedGlobalSearch 의 open prop 과 동일 조건) 캔버스를
+                    // aria-hidden+inert 로 접근성 트리에서 제외.
+                    overlayOpen={!createNodeOpen && ontologySearchOpen}
                   />
                 ) : null}
                 {topologyRenderState.renderCanvas ? (

--- a/src/widgets/global-search/ui/GlobalSearch.test.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { fireEvent, render as rtlRender, screen } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -181,5 +182,70 @@ describe("GlobalSearch", () => {
 
     const plainRow = findOntologyOption("capability:mcp-server");
     expect(plainRow?.querySelector('[data-search-result-path-like="true"]')).toBeNull();
+  });
+
+  /**
+   * rank2/18 (설계협의회 batch B1) — 오버레이 a11y 백본. Radix Dialog 가
+   * ESC/트리거 포커스복귀를 기본 제공하지만, GlobalSearch 는 controlled
+   * (open/onOpenChange 외부 관리) 라 이 컴포넌트 레벨에서 실제로 동작하는지
+   * 고정해야 한다.
+   */
+  function Harness() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          open trigger
+        </button>
+        <GlobalSearch
+          open={open}
+          onOpenChange={setOpen}
+          nodes={nodes}
+          onSelectNode={() => {}}
+          projects={projects}
+          onSelectProject={() => {}}
+        />
+      </>
+    );
+  }
+
+  it("ESC 를 누르면 닫힌다 (onOpenChange(false))", () => {
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "open trigger" });
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("닫히면 트리거로 포커스가 복귀한다", () => {
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "open trigger" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("data-overlay-spring 검증마커가 스크림·패널에 있다", () => {
+    render(
+      <GlobalSearch
+        open
+        onOpenChange={() => {}}
+        nodes={nodes}
+        onSelectNode={() => {}}
+        projects={projects}
+        onSelectProject={() => {}}
+      />,
+    );
+
+    expect(
+      document.querySelectorAll('[data-overlay-spring="true"]').length,
+    ).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/widgets/global-search/ui/GlobalSearch.tsx
+++ b/src/widgets/global-search/ui/GlobalSearch.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Command } from "cmdk";
 import * as Dialog from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { useReducedMotion } from "framer-motion";
 import { Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
@@ -53,6 +54,19 @@ export function GlobalSearch({
 }: GlobalSearchProps) {
   const t = useTranslations("searchWidgets.globalSearch");
   const kindLabel = useOntologyKindLabel();
+  const reducedMotion = useReducedMotion();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // rank18 — 트리거로 포커스 복귀. Radix Dialog/FocusScope 가 기본으로도
+  // 복귀시키지만(내부 activeElement 캡처), 어떤 트리거 경로(버튼 클릭 ·
+  // ⌘K 단축키)로 열렸든 명시적으로 보장하기 위해 자체 ref 로도 캡처한다.
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+    } else {
+      previousFocusRef.current?.focus?.({ preventScroll: true });
+    }
+  }, [open]);
   const [query, setQuery] = useState("");
   // kind / project filter chip 으로 ontology 결과 좁히기. set 으로
   // 다중 선택 (toggle) 모델. 닫을 때 query 와 함께 초기화.
@@ -171,14 +185,35 @@ export function GlobalSearch({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-[color:rgba(8,9,12,0.66)]" />
+        <Dialog.Overlay
+          data-overlay-spring="true"
+          className={cn(
+            "fixed inset-0 z-50 bg-[color:var(--overlay-scrim)]",
+            reducedMotion ? "overlay-fade-only" : "overlay-spring-scrim",
+          )}
+        />
         <Dialog.Content
           aria-label={t('dialogAriaLabel')}
+          data-overlay-spring="true"
           data-global-search-responsive-contract="mobile-sheet-md-floating"
           data-global-search-floating-width-token="--topology-search-sheet-floating-width"
           data-global-search-radius-token="--topology-search-sheet-radius"
           data-global-search-mobile-bottom-reserve-token="--topology-mobile-bottom-tab-reserve"
-          className="fixed inset-0 z-50 flex items-stretch justify-center md:items-start md:px-4 md:pt-[12vh]"
+          // 애니메이션 클래스는 Dialog.Content 자신에 건다 — Radix Presence
+          // 는 자신이 렌더한 노드(target === node)의 animationend 만 듣고
+          // 자식 노드에서 버블된 이벤트는 무시하므로, 자식(Command)에 걸면
+          // 퇴장 애니메이션이 끝나기 전에 언마운트돼버린다.
+          className={cn(
+            "fixed inset-0 z-50 flex items-stretch justify-center md:items-start md:px-4 md:pt-[12vh]",
+            reducedMotion ? "overlay-fade-only" : "overlay-spring-surface",
+          )}
+          // rank18 — 열릴 때 첫 입력(검색창)에 포커스. Radix 기본 동작(첫
+          // focusable 엘리먼트)과 결과는 같지만, preventScroll 을 명시적으로
+          // 보장하기 위해 직접 지정한다.
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            inputRef.current?.focus({ preventScroll: true });
+          }}
         >
           <VisuallyHidden>
             <Dialog.Title>{t('dialogTitle')}</Dialog.Title>
@@ -195,6 +230,7 @@ export function GlobalSearch({
         <div className="flex items-center gap-2 border-b border-[color:var(--color-divider)] px-4 py-3">
           <Search size={14} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
           <Command.Input
+            ref={inputRef}
             value={query}
             onValueChange={setQuery}
             placeholder={

--- a/src/widgets/search-palette/ui/SearchPalette.test.tsx
+++ b/src/widgets/search-palette/ui/SearchPalette.test.tsx
@@ -1,0 +1,112 @@
+import { useState, type ReactNode } from "react";
+import {
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import enMessages from "../../../../messages/en.json";
+import { SearchPalette } from "./SearchPalette";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/features/taxonomy", () => ({
+  useTaxonomy: () => ({
+    categoryLabel: (id?: string) => id ?? "—",
+    statusLabel: (id?: string) => id ?? "—",
+    categories: [],
+    statuses: [],
+  }),
+}));
+
+beforeAll(() => {
+  // jsdom 미구현 — active row 스크롤에 쓰임.
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+});
+
+function render(ui: React.ReactElement) {
+  return rtlRender(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+/**
+ * rank2/18 (설계협의회 batch B1) — 오버레이 a11y 백본. SearchPalette 는
+ * ESC/Tab-trap/트리거 포커스복귀를 이미 자체 구현하고 있었지만(테스트
+ * 커버리지 0), rank2 스프링 통일이 이 계약을 깨지 않았는지 여기서 고정한다.
+ */
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        open trigger
+      </button>
+      <SearchPalette
+        open={open}
+        onClose={() => setOpen(false)}
+        projects={[]}
+        onSelect={() => {}}
+      />
+    </>
+  );
+}
+
+describe("SearchPalette", () => {
+  it("열리면 role=dialog 로 렌더된다", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open trigger" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("ESC 를 누르면 닫힌다 (framer AnimatePresence 퇴장 애니메이션 종료 후 언마운트)", async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "open trigger" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    // rank2 — 퇴장은 opacity/translateY 스프링을 다 재생한 뒤에야
+    // 언마운트된다(AnimatePresence). "닫힘 프로퍼티만 바뀌고 즉시 사라짐"
+    // 회귀를 여기서 같이 잡는다.
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"), {
+      timeout: 2000,
+    });
+  });
+
+  it("닫히면 트리거로 포커스가 복귀한다", async () => {
+    render(<Harness />);
+    const trigger = screen.getByRole("button", { name: "open trigger" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitForElementToBeRemoved(() => screen.queryByRole("dialog"), {
+      timeout: 2000,
+    });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("data-overlay-spring 검증마커가 스크림·패널에 있다", () => {
+    render(
+      <SearchPalette open onClose={() => {}} projects={[]} onSelect={() => {}} />,
+    );
+
+    expect(
+      document.querySelectorAll('[data-overlay-spring="true"]').length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/widgets/search-palette/ui/SearchPalette.tsx
+++ b/src/widgets/search-palette/ui/SearchPalette.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { BookOpen, Search, X } from 'lucide-react';
 import { cn } from '@/shared/lib/cn';
+import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED } from '@/shared/motion';
 import { useBodyScrollLock } from '@/shared/lib/use-body-scroll-lock';
 import type { Project } from '@/entities/project';
 import { useTaxonomy } from '@/features/taxonomy';
@@ -171,6 +172,10 @@ function SearchPaletteDialog({
   const listRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const { categoryLabel, statusLabel } = useTaxonomy();
+  // rank2 — 임계감쇠 오버레이 스프링(오버슈트 0) 단일 통일. reduced-motion
+  // 사용자는 translate 없이 120ms opacity 크로스페이드만.
+  const reducedMotion = useReducedMotion();
+  const panelTransition = reducedMotion ? OVERLAY_SPRING_REDUCED : OVERLAY_SPRING;
   const [recentSlugs] = useState<string[]>(() => readRecentSlugs());
   const recentProjects = useMemo(
     () =>
@@ -214,9 +219,12 @@ function SearchPaletteDialog({
   );
   const activeRow = rows[activeIndex] ?? null;
 
-  // mount 직후 focus (input ref가 연결된 다음 프레임)
+  // mount 직후 focus (input ref가 연결된 다음 프레임). rank18 — preventScroll
+  // 로 배경 스크롤 점프 방지.
   useEffect(() => {
-    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    const id = requestAnimationFrame(() =>
+      inputRef.current?.focus({ preventScroll: true }),
+    );
     return () => cancelAnimationFrame(id);
   }, []);
 
@@ -307,25 +315,34 @@ function SearchPaletteDialog({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
-      transition={{ duration: 0.15 }}
+      // rank2 — 스크림은 --topology-motion-panel-duration(180ms)과 값을
+      // 맞춘 opacity 크로스페이드. reduced-motion 은 120ms(OVERLAY_SPRING_REDUCED).
+      transition={{ duration: reducedMotion ? 0.12 : 0.18 }}
       data-interactive-overlay="true"
+      data-overlay-spring="true"
       className="fixed inset-0 z-50 flex items-stretch justify-center md:items-start md:px-[max(1rem,env(safe-area-inset-left))] md:pt-[max(4rem,env(safe-area-inset-top))] md:pr-[max(1rem,env(safe-area-inset-right))]"
     >
       <div
         data-testid="search-palette-backdrop"
-        className="absolute inset-0 bg-[color:var(--color-backdrop-strong)]"
+        className="absolute inset-0 bg-[color:var(--overlay-scrim)]"
         onClick={onClose}
       />
 
       {/* 모바일은 풀스크린 시트 (rounded 없이 inset-0 가득 채움), md+ 는
           기존 floating 카드 (max-w-xl, rounded-[22px], 위에서 슬라이드).
-          기존 spring transition 은 데스크톱 결을 유지. */}
+          rank2 — 3종 오버레이 공용 임계감쇠 스프링(OVERLAY_SPRING, 오버슈트
+          0). 진입은 opacity 0→1 + translateY 8px→0 만 — scale 없음
+          (hover:scale-* 혼동 방지). 캔버스 2-param 물리 모델과는 별도
+          튜닝(app/globals.css `--overlay-spring-*` 토큰 주석의 변환식 참조,
+          "동일 스프링 상속" 아님). */}
       <motion.div
         ref={dialogRef}
-        initial={{ y: -20, opacity: 0 }}
+        initial={{ y: 8, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        exit={{ y: -20, opacity: 0 }}
-        transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+        exit={{ y: 8, opacity: 0 }}
+        transition={panelTransition}
+        data-overlay-spring="true"
+        data-search-palette-panel="true"
         onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
@@ -367,7 +384,7 @@ function SearchPaletteDialog({
             type="button"
             onClick={onClose}
             aria-label={t('closeAriaLabel')}
-            className="flex h-8 w-8 items-center justify-center rounded-md text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+            className="flex h-[var(--overlay-close-size)] w-[var(--overlay-close-size)] items-center justify-center rounded-md text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
           >
             <X size={15} />
           </button>

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -204,10 +204,18 @@ export interface TopologyMapV2Props {
    * 실제 엘리먼트는 이 컴포넌트가 렌더하고 ref 만 외부에서 공유한다.
    */
   tourAnchorRef?: RefObject<HTMLDivElement | null>;
+  /**
+   * rank18 (설계협의회 batch B1) — DOM 오버레이(GlobalSearch 등) 가 열려
+   * 있는 동안 캔버스를 키보드/스크린리더 트리에서 제외한다. 캔버스는
+   * 회화 픽셀이라 자체 키보드 순회가 불가능하고, INDEX/데이터시트가 이미
+   * 접근 가능한 대체 목록이므로 오버레이가 열린 동안만 이 캔버스 쪽을
+   * 숨긴다(신규 대체 UI 없음 — 기존 INDEX/데이터시트 재사용).
+   */
+  overlayOpen?: boolean;
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, canvasLabel, visitedTrail, tierReveal, tourAnchorNodeId = null, tourAnchorRef } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, livePhysics, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, canvasLabel, visitedTrail, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -253,6 +261,10 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       data-testid="topology-map-v2"
       data-map-engine="v2"
       data-minimal={minimal ? "true" : "false"}
+      // rank18 — 오버레이가 열린 동안 캔버스를 aria 트리 + Tab 순회에서
+      // 제외(inert 는 포인터도 함께 막는다). INDEX/데이터시트가 대체 목록.
+      aria-hidden={overlayOpen}
+      inert={overlayOpen}
       style={{ position: "relative", width: "100%", height: "100%" }}
     >
       <canvas


### PR DESCRIPTION
## Summary
디자인 카운슬 배치 B1. GlobalSearch(⌘K)·SearchPalette·NewDocKindDialog 3종 오버레이를 단일 임계감쇠 스프링으로 통일(⌘K 하드팝 제거), 320/28 매직넘버를 `--overlay-*` 토큰으로. rank18 발행 게이트: focus-trap/ESC/트리거 포커스 복귀 + 오버레이 열림 시 캔버스 aria-hidden/inert(기존 INDEX/datasheet가 대체 목록). exit는 `.topology-chrome-out` 공식 재사용(리터럴 복제 0), reduced-motion=opacity 120ms.

## Test plan
- tsc ✅ · global-search/search-palette/docs-vault/topology-map-v2/motion 923 passed ✅ · eslint 0 errors ✅ · i18n 18/18
- 잔여: playwright overflow-sweep(dev server 필요) 하베스트 브라우저 검증에서 확인