### PR TITLE
feat: 상세 패널 편집 주체(사람/AI) + 충돌 배지 (작업목록 rank 7)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3057,5 +3057,20 @@
       "skill-copy-diverged": "Duplicated skill copies diverged between .claude/skills and .agents/skills",
       "skill-copy-file-missing": "A skill file exists in only one of the duplicated skill trees"
     }
+  },
+  "editProvenance": {
+    "prefix": "Last edited",
+    "subjectAgent": "AI agent",
+    "subjectHuman": "me",
+    "conflictMessage": "This document changed elsewhere — check before you overwrite",
+    "age": {
+      "justNow": "just now",
+      "minutesAgo": "{count}m ago",
+      "hoursAgo": "{count}h ago",
+      "yesterday": "yesterday",
+      "daysAgo": "{count}d ago",
+      "weeksAgo": "{count}w ago",
+      "monthsAgo": "{count}mo ago"
+    }
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3057,5 +3057,20 @@
       "skill-copy-diverged": "복제된 스킬 사본(.claude/skills ↔ .agents/skills)이 서로 달라졌어요",
       "skill-copy-file-missing": "복제 스킬 트리의 한쪽에만 있는 파일이 있어요"
     }
+  },
+  "editProvenance": {
+    "prefix": "마지막 편집",
+    "subjectAgent": "AI 에이전트",
+    "subjectHuman": "나",
+    "conflictMessage": "이 문서가 다른 곳에서 바뀌었어요 — 덮어쓰기 전에 확인하세요",
+    "age": {
+      "justNow": "방금",
+      "minutesAgo": "{count}분 전",
+      "hoursAgo": "{count}시간 전",
+      "yesterday": "어제",
+      "daysAgo": "{count}일 전",
+      "weeksAgo": "{count}주 전",
+      "monthsAgo": "{count}개월 전"
+    }
   }
 }

--- a/src/features/docs-vault-local/index.ts
+++ b/src/features/docs-vault-local/index.ts
@@ -1,5 +1,11 @@
 export { LocalVaultProvider, useLocalVault } from './model/LocalVaultProvider';
 export { VaultConflictError } from './model/use-local-vault';
+export type {
+  AgentActivityFocus,
+  AgentActivityHeartbeat,
+  AgentActivityState,
+  AgentActivityStatus,
+} from './model/agent-activity-status';
 export { shouldClearCreateIntent, shouldScaffoldAfterOpen } from './model/vault-create-flow';
 export {
   useVaultCreateFlow,

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -858,8 +858,22 @@ export function useLocalVaultInternal() {
   // "추가됨/편집됨" 으로 재보고하지 않도록 (부트스트랩 토스트 4연발 마찰).
   // 소비 시점에 비워지는 1회성 장부: 외부(에이전트/IDE) 변경만 토스트로 남는다.
   const selfWrittenSlugsRef = useRef<Set<string>>(new Set());
+  // rank7 (design-council B5) — "마지막 편집 · 나" 사실의 유일한 실데이터
+  // 출처. `selfWrittenSlugsRef` 와 달리 소비해도 비워지지 않는 영속 기록
+  // (slug → 마지막 자기 쓰기 시각 ms). mtime 만으로는 "누가" 바꿨는지 알 수
+  // 없다(git checkout·다른 에디터·heartbeat 없는 에이전트 세션도 mtime 을
+  // 바꾼다) — 이 세션이 실제로 로컬 vault 쓰기 API 를 거쳐 이 slug 를 쓴
+  // 사실만 기록해, 그 신뢰 가능한 부분만 "나" 로 표시한다(추측 0).
+  const [selfEditTimestamps, setSelfEditTimestamps] = useState<ReadonlyMap<string, number>>(
+    () => new Map(),
+  );
   const markSelfWrite = useCallback((slug: string) => {
     selfWrittenSlugsRef.current.add(slug);
+    setSelfEditTimestamps((prev) => {
+      const next = new Map(prev);
+      next.set(slug, Date.now());
+      return next;
+    });
   }, []);
   const consumeSelfWrittenSlugs = useCallback((): ReadonlySet<string> => {
     const consumed = selfWrittenSlugsRef.current;
@@ -1213,5 +1227,6 @@ export function useLocalVaultInternal() {
     ensureAgentConfigs,
     updateFrontmatter,
     consumeSelfWrittenSlugs,
+    selfEditTimestamps,
   };
 }

--- a/src/shared/lib/edit-age.test.ts
+++ b/src/shared/lib/edit-age.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { computeEditAge } from "./edit-age";
+
+describe("computeEditAge", () => {
+  const now = Date.parse("2026-07-24T12:00:00.000Z");
+
+  it("returns justNow under a minute", () => {
+    expect(computeEditAge(now - 30_000, now)).toEqual({ key: "justNow", count: 0 });
+  });
+
+  it("returns minutesAgo under an hour", () => {
+    expect(computeEditAge(now - 3 * 60_000, now)).toEqual({ key: "minutesAgo", count: 3 });
+    expect(computeEditAge(now - 59 * 60_000, now)).toEqual({ key: "minutesAgo", count: 59 });
+  });
+
+  it("returns hoursAgo under a day", () => {
+    expect(computeEditAge(now - 2 * 3_600_000, now)).toEqual({ key: "hoursAgo", count: 2 });
+    expect(computeEditAge(now - 23 * 3_600_000, now)).toEqual({ key: "hoursAgo", count: 23 });
+  });
+
+  it("returns yesterday at exactly one day", () => {
+    expect(computeEditAge(now - 24 * 3_600_000, now)).toEqual({ key: "yesterday", count: 1 });
+  });
+
+  it("returns daysAgo under a week", () => {
+    expect(computeEditAge(now - 3 * 24 * 3_600_000, now)).toEqual({ key: "daysAgo", count: 3 });
+  });
+
+  it("returns weeksAgo under a month", () => {
+    expect(computeEditAge(now - 14 * 24 * 3_600_000, now)).toEqual({ key: "weeksAgo", count: 2 });
+  });
+
+  it("returns monthsAgo past a month", () => {
+    expect(computeEditAge(now - 90 * 24 * 3_600_000, now)).toEqual({ key: "monthsAgo", count: 3 });
+  });
+
+  it("clamps future timestamps to justNow instead of negative counts", () => {
+    expect(computeEditAge(now + 60_000, now)).toEqual({ key: "justNow", count: 0 });
+  });
+});

--- a/src/shared/lib/edit-age.ts
+++ b/src/shared/lib/edit-age.ts
@@ -1,0 +1,42 @@
+/**
+ * rank7 (design-council B5) — minute-granularity "ago" ladder for
+ * edit-provenance timestamps (agent heartbeats and same-session self-edits
+ * both resolve to minutes/seconds). The day-granularity `computeUpdatedAgo`
+ * ladder used elsewhere for vault-doc freshness (`views/home/lib/format-
+ * updated-ago.ts`) collapses every within-a-day edit to "오늘" — fine for
+ * "when was this doc last touched at all", too coarse for "AI agent · 3분
+ * 전". This ladder covers minutes/hours, then falls back to the same
+ * day/week/month buckets so long-idle facts still read naturally.
+ */
+
+export type EditAgeKey =
+  | "justNow"
+  | "minutesAgo"
+  | "hoursAgo"
+  | "yesterday"
+  | "daysAgo"
+  | "weeksAgo"
+  | "monthsAgo";
+
+export interface EditAge {
+  key: EditAgeKey;
+  count: number;
+}
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function computeEditAge(atMs: number, nowMs: number): EditAge {
+  const diffMs = Math.max(0, nowMs - atMs);
+  const minutes = Math.floor(diffMs / MINUTE_MS);
+  if (minutes < 1) return { key: "justNow", count: 0 };
+  if (minutes < 60) return { key: "minutesAgo", count: minutes };
+  const hours = Math.floor(diffMs / HOUR_MS);
+  if (hours < 24) return { key: "hoursAgo", count: hours };
+  const days = Math.floor(diffMs / DAY_MS);
+  if (days === 1) return { key: "yesterday", count: 1 };
+  if (days < 7) return { key: "daysAgo", count: days };
+  if (days < 30) return { key: "weeksAgo", count: Math.floor(days / 7) };
+  return { key: "monthsAgo", count: Math.floor(days / 30) };
+}

--- a/src/shared/lib/last-edit-subject.test.ts
+++ b/src/shared/lib/last-edit-subject.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { pickLastEditSubject } from "./last-edit-subject";
+
+describe("pickLastEditSubject", () => {
+  it("returns null when no candidate has evidence", () => {
+    expect(
+      pickLastEditSubject([
+        { kind: "agent", atMs: null },
+        { kind: "human", atMs: null },
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns the only candidate with evidence", () => {
+    expect(
+      pickLastEditSubject([
+        { kind: "agent", atMs: 100 },
+        { kind: "human", atMs: null },
+      ]),
+    ).toEqual({ kind: "agent", atMs: 100 });
+  });
+
+  it("picks the most recent of two real candidates — human newer", () => {
+    expect(
+      pickLastEditSubject([
+        { kind: "agent", atMs: 100 },
+        { kind: "human", atMs: 200 },
+      ]),
+    ).toEqual({ kind: "human", atMs: 200 });
+  });
+
+  it("picks the most recent of two real candidates — agent newer", () => {
+    expect(
+      pickLastEditSubject([
+        { kind: "agent", atMs: 300 },
+        { kind: "human", atMs: 200 },
+      ]),
+    ).toEqual({ kind: "agent", atMs: 300 });
+  });
+
+  it("ignores non-finite atMs values (defensive — never fabricate)", () => {
+    expect(
+      pickLastEditSubject([
+        { kind: "agent", atMs: Number.NaN },
+        { kind: "human", atMs: null },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/src/shared/lib/last-edit-subject.ts
+++ b/src/shared/lib/last-edit-subject.ts
@@ -1,0 +1,34 @@
+/**
+ * rank7 (design-council B5) — "마지막 편집 · 사람/AI" 사실의 중립 선택기.
+ * 사람/AI 는 hue 가 아니라 glyph+라벨로만 구분한다는 결정 원칙을 코드
+ * 레벨에서도 지킨다: 이 함수는 어느 kind 도 우대하지 않고, 오직 각
+ * 후보의 `atMs`(실측 근거가 있을 때만 non-null — 호출자 책임) 중 가장
+ * 최근 것을 고른다. 모든 후보가 `atMs: null` 이면(= 실데이터 근거 0)
+ * null 을 반환 — 절대 추측해서 하나를 지어내지 않는다.
+ */
+
+export type LastEditSubjectKind = "agent" | "human";
+
+export interface LastEditSubjectFact {
+  kind: LastEditSubjectKind;
+  atMs: number;
+}
+
+export interface LastEditSubjectCandidate {
+  kind: LastEditSubjectKind;
+  /** null = 이 kind 에 대한 실데이터 근거가 없음(추측 금지). */
+  atMs: number | null;
+}
+
+export function pickLastEditSubject(
+  candidates: readonly LastEditSubjectCandidate[],
+): LastEditSubjectFact | null {
+  let best: LastEditSubjectFact | null = null;
+  for (const candidate of candidates) {
+    if (candidate.atMs == null || !Number.isFinite(candidate.atMs)) continue;
+    if (!best || candidate.atMs > best.atMs) {
+      best = { kind: candidate.kind, atMs: candidate.atMs };
+    }
+  }
+  return best;
+}

--- a/src/shared/lib/mtime-conflict.test.ts
+++ b/src/shared/lib/mtime-conflict.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { hasUnaccountedMtimeChange } from "./mtime-conflict";
+
+describe("hasUnaccountedMtimeChange", () => {
+  it("is false when baseline or current is missing", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: null,
+        current: 100,
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(false);
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: 100,
+        current: undefined,
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when baseline equals current (no real change)", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: 100,
+        current: 100,
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(false);
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: "2026-07-24T00:00:00.000Z",
+        current: "2026-07-24T00:00:00.000Z",
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when values differ and there is no self-edit record", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: 100,
+        current: 200,
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the change is accounted for by a self-edit at/after baseline capture", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: 100,
+        current: 200,
+        selfEditAtMs: 150,
+        baselineCapturedAtMs: 120,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when the self-edit predates the baseline capture (a later, unexplained change happened)", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: 100,
+        current: 200,
+        selfEditAtMs: 50,
+        baselineCapturedAtMs: 120,
+      }),
+    ).toBe(true);
+  });
+
+  it("works with ISO freshness strings as well as numeric mtimes", () => {
+    expect(
+      hasUnaccountedMtimeChange({
+        baseline: "2026-07-24T00:00:00.000Z",
+        current: "2026-07-24T01:00:00.000Z",
+        selfEditAtMs: null,
+        baselineCapturedAtMs: 0,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/shared/lib/mtime-conflict.ts
+++ b/src/shared/lib/mtime-conflict.ts
@@ -1,0 +1,30 @@
+/**
+ * rank7 (design-council B5) — expected_mtime 충돌 배지의 유일한 진실
+ * 판정. `patch_concept`/`updateFrontmatter`/`saveDoc` 가 이미 쓰는
+ * expected_mtime 계약(`assertExpectedMtime`, `use-local-vault.ts`)과 같은
+ * 질문을 저장 *이전에* 조용히 물어본다: "내가 이 문서를 열었을 때의
+ * baseline 과 지금 알려진 값이 다른가, 그리고 그 차이가 내 자신의 최근
+ * 쓰기로 설명되는가?" 두 값이 다르면서 자기 쓰기로 설명 안 되는 경우만
+ * true — 실제 mismatch 가 없으면(예: 그냥 시간이 흘렀을 뿐) 절대 켜지지
+ * 않는다(신호 인플레이션 금지, 소유회 결정 원문 guardianRisk).
+ *
+ * `baseline`/`current` 는 doc.mtime(number, R11 #15) 또는 vault-doc
+ * freshness ISO(string, docFreshnessIndex) 어느 쪽이든 받는다 — 두
+ * surface(문서함 vs 토폴로지 패널)가 서로 다른 표현을 쓰지만 "같았다/
+ * 달라졌다" 비교의 의미는 동일하므로 하나의 판정 함수를 공유한다.
+ */
+export function hasUnaccountedMtimeChange(params: {
+  baseline: number | string | null | undefined;
+  current: number | string | null | undefined;
+  /** 이 문서/노드에 대한 이번 세션의 실제 자기 쓰기 기록(`markSelfWrite`).
+   *  근거 없으면 undefined/null. */
+  selfEditAtMs: number | null | undefined;
+  /** baseline 을 캡처한 시각(ms) — 그 이후의 자기 쓰기만 "설명됨"으로 친다. */
+  baselineCapturedAtMs: number;
+}): boolean {
+  const { baseline, current, selfEditAtMs, baselineCapturedAtMs } = params;
+  if (baseline == null || current == null) return false;
+  if (baseline === current) return false;
+  if (typeof selfEditAtMs === "number" && selfEditAtMs >= baselineCapturedAtMs) return false;
+  return true;
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -36,3 +36,9 @@ export { BrandMark, BRAND_MARK_AMBER, type BrandMarkProps } from './brand-mark';
 export { HexMark, type HexMarkProps } from './hex-mark';
 export { CompactCopyButton, type CompactCopyButtonProps } from './compact-copy-button';
 export { SimilarNodeWarning, type SimilarNodeWarningProps } from './similar-node-warning';
+export {
+  LastEditSubjectRow,
+  type LastEditSubjectKind,
+  type LastEditSubjectRowProps,
+} from './last-edit-subject-row';
+export { MtimeConflictBadge, type MtimeConflictBadgeProps } from './mtime-conflict-badge';

--- a/src/shared/ui/last-edit-subject-row.test.tsx
+++ b/src/shared/ui/last-edit-subject-row.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LastEditSubjectRow } from "./last-edit-subject-row";
+
+describe("LastEditSubjectRow", () => {
+  it("renders the agent subject with prefix/subject/age text", () => {
+    render(
+      <LastEditSubjectRow
+        kind="agent"
+        prefixLabel="마지막 편집"
+        subjectLabel="AI 에이전트"
+        ageLabel="3분 전"
+      />,
+    );
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "agent");
+    expect(row).toHaveTextContent("마지막 편집");
+    expect(row).toHaveTextContent("AI 에이전트");
+    expect(row).toHaveTextContent("3분 전");
+  });
+
+  it("renders the human subject with a different kind marker, same structure", () => {
+    render(
+      <LastEditSubjectRow kind="human" prefixLabel="Last edited" subjectLabel="me" ageLabel="yesterday" />,
+    );
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "human");
+    expect(row).toHaveTextContent("Last edited");
+    expect(row).toHaveTextContent("me");
+    expect(row).toHaveTextContent("yesterday");
+  });
+});

--- a/src/shared/ui/last-edit-subject-row.tsx
+++ b/src/shared/ui/last-edit-subject-row.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Bot, User } from "lucide-react";
+
+export type LastEditSubjectKind = "agent" | "human";
+
+export interface LastEditSubjectRowProps {
+  kind: LastEditSubjectKind;
+  /** "마지막 편집" — caller resolves via i18n. */
+  prefixLabel: string;
+  /** "AI 에이전트" | "나" — caller resolves via i18n. */
+  subjectLabel: string;
+  /** "3분 전" — caller resolves via `computeEditAge` + i18n (tabular-nums). */
+  ageLabel: string;
+  className?: string;
+}
+
+/**
+ * rank7 (design-council B5) — last-edit provenance row, shared by
+ * `DocFrontmatterBlock`, `TopologyV2DetailPanel`, and `FullDetailA1`.
+ *
+ * Human vs AI is distinguished ONLY by a lucide glyph (User/Bot) + plain
+ * label — never by hue. The product identity is "agent-native,
+ * human-sovereign": both subjects are equal, neutral facts, so this
+ * component paints them with the exact same text color and no new color
+ * channel. Static, no motion — a plain fact, not a status change.
+ *
+ * Every string is resolved by the caller from a REAL data source
+ * (`resolveDocLastEditSubject` in docs-vault, `resolveNodeLastEditSubject`
+ * in home) — this component has no opinion about vault state and never
+ * fabricates a subject. If the caller has no evidence, it renders nothing
+ * instead of mounting this row.
+ */
+export function LastEditSubjectRow({
+  kind,
+  prefixLabel,
+  subjectLabel,
+  ageLabel,
+  className,
+}: LastEditSubjectRowProps) {
+  const Glyph = kind === "agent" ? Bot : User;
+  return (
+    <p
+      data-testid="last-edit-subject-row"
+      data-edit-subject-kind={kind}
+      className={[
+        "flex items-center gap-1.5 text-label text-[color:var(--color-text-tertiary)]",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <Glyph size={13} aria-hidden="true" className="shrink-0" />
+      <span className="min-w-0 truncate">
+        {prefixLabel}
+        <span aria-hidden="true"> · </span>
+        {subjectLabel}
+        <span aria-hidden="true"> · </span>
+        <span className="tabular-nums">{ageLabel}</span>
+      </span>
+    </p>
+  );
+}

--- a/src/shared/ui/mtime-conflict-badge.test.tsx
+++ b/src/shared/ui/mtime-conflict-badge.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MtimeConflictBadge } from "./mtime-conflict-badge";
+
+describe("MtimeConflictBadge", () => {
+  it("renders the given message with a status role", () => {
+    render(<MtimeConflictBadge message="이 문서가 다른 곳에서 바뀌었어요 — 덮어쓰기 전에 확인하세요" />);
+    const badge = screen.getByTestId("mtime-conflict-badge");
+    expect(badge).toHaveAttribute("role", "status");
+    expect(badge).toHaveTextContent("덮어쓰기 전에 확인하세요");
+  });
+});

--- a/src/shared/ui/mtime-conflict-badge.tsx
+++ b/src/shared/ui/mtime-conflict-badge.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+export interface MtimeConflictBadgeProps {
+  message: string;
+  className?: string;
+}
+
+/**
+ * rank7 (design-council B5) — expected_mtime conflict badge, shared by
+ * `DocFrontmatterBlock`, `TopologyV2DetailPanel`, and `FullDetailA1`.
+ *
+ * Rendered ONLY by the caller when a real mtime mismatch was detected
+ * (`hasUnaccountedMtimeChange`) — this component has no vault knowledge, it
+ * just paints the warning once told to. amber signal ladder (never
+ * red/error — a "check before you overwrite" heads-up, not a failure).
+ * Entrance reuses the existing `atlasStatusIn` keyframe (opacity 0→1 +
+ * translateY 4px→0, 180ms) already used for the builder's draft-status
+ * callout — no new keyframe/duration literal. `prefers-reduced-motion` is
+ * handled by the global base-layer rule (animation-duration 0.01ms) like
+ * every other entrance in this app.
+ */
+export function MtimeConflictBadge({ message, className }: MtimeConflictBadgeProps) {
+  return (
+    <p
+      data-testid="mtime-conflict-badge"
+      role="status"
+      className={[
+        "rounded-sm border border-[color:var(--color-amber-signal-a30)] bg-[color:var(--color-amber-signal-a07)] px-2 py-1.5 text-label leading-4 text-[color:var(--color-text-primary)]",
+        "motion-safe:animate-[atlasStatusIn_180ms_ease-out]",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {message}
+    </p>
+  );
+}

--- a/src/views/docs-vault/lib/resolve-doc-edit-subject.test.ts
+++ b/src/views/docs-vault/lib/resolve-doc-edit-subject.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
+import { hasDocMtimeConflict, resolveDocLastEditSubject } from "./resolve-doc-edit-subject";
+
+function emptyStatus(): AgentActivityStatus {
+  return {
+    sourcePath: ".ontology-atlas/agent-activity.json",
+    exists: false,
+    valid: false,
+    stale: false,
+    ageMs: null,
+    heartbeat: null,
+    reviewMode: "none",
+    reviewTarget: { kind: "none", ontologySlug: null, files: [], label: "none" },
+    proof: { count: 0, sources: { mcp: 0, source: 0, verification: 0 }, label: "" },
+    refreshRequest: {
+      required: false,
+      reason: null,
+      previousAgent: null,
+      previousState: null,
+      previousFocus: null,
+      previousOntologySlug: null,
+      previousFiles: [],
+      previousAgeMs: null,
+      command: null,
+      message: null,
+    },
+    errorMessage: null,
+  };
+}
+
+function freshHeartbeatStatus(overrides: {
+  updatedAt: string;
+  ontologySlug?: string | null;
+  files?: string[];
+}): AgentActivityStatus {
+  return {
+    ...emptyStatus(),
+    exists: true,
+    valid: true,
+    stale: false,
+    ageMs: 1000,
+    heartbeat: {
+      agent: "claude-code",
+      state: "editing",
+      focus: {
+        summary: "working",
+        ontologySlug: overrides.ontologySlug ?? null,
+        files: overrides.files ?? [],
+      },
+      plan: [],
+      evidence: { mcp: [], source: [], codegraph: [], verification: [] },
+      updatedAt: overrides.updatedAt,
+    },
+  };
+}
+
+describe("resolveDocLastEditSubject", () => {
+  const doc = { slug: "capabilities/foo", path: "docs/ontology/capabilities/foo.md" };
+
+  it("returns null when there is no heartbeat and no self-edit record", () => {
+    expect(
+      resolveDocLastEditSubject({
+        doc,
+        agentActivityStatus: emptyStatus(),
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns agent when a fresh heartbeat's ontologySlug matches the doc slug", () => {
+    const status = freshHeartbeatStatus({
+      updatedAt: "2026-07-24T12:00:00.000Z",
+      ontologySlug: "capabilities/foo",
+    });
+    const result = resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps: new Map() });
+    expect(result?.kind).toBe("agent");
+    expect(result?.atMs).toBe(Date.parse("2026-07-24T12:00:00.000Z"));
+  });
+
+  it("returns agent via bare-slug suffix match (folder-prefixed vs bare)", () => {
+    const status = freshHeartbeatStatus({ updatedAt: "2026-07-24T12:00:00.000Z", ontologySlug: "foo" });
+    const result = resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps: new Map() });
+    expect(result?.kind).toBe("agent");
+  });
+
+  it("returns agent when focus.files includes the doc path", () => {
+    const status = freshHeartbeatStatus({
+      updatedAt: "2026-07-24T12:00:00.000Z",
+      files: ["docs/ontology/capabilities/foo.md"],
+    });
+    const result = resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps: new Map() });
+    expect(result?.kind).toBe("agent");
+  });
+
+  it("ignores a heartbeat that does not name this doc", () => {
+    const status = freshHeartbeatStatus({
+      updatedAt: "2026-07-24T12:00:00.000Z",
+      ontologySlug: "capabilities/other",
+    });
+    expect(
+      resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps: new Map() }),
+    ).toBeNull();
+  });
+
+  it("ignores a stale heartbeat even if it names this doc", () => {
+    const status: AgentActivityStatus = {
+      ...freshHeartbeatStatus({ updatedAt: "2026-07-24T12:00:00.000Z", ontologySlug: "capabilities/foo" }),
+      stale: true,
+    };
+    expect(
+      resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps: new Map() }),
+    ).toBeNull();
+  });
+
+  it("returns human when this session self-wrote this exact slug", () => {
+    const selfEditTimestamps = new Map([["capabilities/foo", 500]]);
+    const result = resolveDocLastEditSubject({
+      doc,
+      agentActivityStatus: emptyStatus(),
+      selfEditTimestamps,
+    });
+    expect(result).toEqual({ kind: "human", atMs: 500 });
+  });
+
+  it("prefers whichever of agent/human is more recent", () => {
+    const status = freshHeartbeatStatus({
+      updatedAt: new Date(1000).toISOString(),
+      ontologySlug: "capabilities/foo",
+    });
+    const selfEditTimestamps = new Map([["capabilities/foo", 5000]]);
+    const result = resolveDocLastEditSubject({ doc, agentActivityStatus: status, selfEditTimestamps });
+    expect(result?.kind).toBe("human");
+  });
+});
+
+describe("hasDocMtimeConflict", () => {
+  const doc = { slug: "capabilities/foo", mtime: 2000 };
+
+  it("is false when mtime has not changed since baseline", () => {
+    expect(
+      hasDocMtimeConflict({
+        doc,
+        baselineMtime: 2000,
+        baselineCapturedAtMs: 0,
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when mtime changed and no self-edit record explains it (real external change)", () => {
+    expect(
+      hasDocMtimeConflict({
+        doc,
+        baselineMtime: 1000,
+        baselineCapturedAtMs: 0,
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when the change is explained by this session's own save", () => {
+    expect(
+      hasDocMtimeConflict({
+        doc,
+        baselineMtime: 1000,
+        baselineCapturedAtMs: 50,
+        selfEditTimestamps: new Map([["capabilities/foo", 100]]),
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/views/docs-vault/lib/resolve-doc-edit-subject.ts
+++ b/src/views/docs-vault/lib/resolve-doc-edit-subject.ts
@@ -1,0 +1,84 @@
+import type { AgentActivityFocus, AgentActivityStatus } from "@/features/docs-vault-local";
+import { pickLastEditSubject, type LastEditSubjectFact } from "@/shared/lib/last-edit-subject";
+import { hasUnaccountedMtimeChange } from "@/shared/lib/mtime-conflict";
+
+/**
+ * rank7 (design-council B5) — resolves `DocFrontmatterBlock`'s "마지막
+ * 편집 · 사람/AI" fact from the ONLY two real data sources this surface has:
+ *
+ * - **AI agent**: a fresh (valid, non-stale) activity heartbeat whose
+ *   `focus` names THIS doc — `ontologySlug` may be a folder-prefixed vault
+ *   path ("capabilities/foo"), a bare slug ("foo"), or already canonical,
+ *   matched the same permissive bare-slug-suffix way
+ *   `resolveAgentFocusNodeId` (home) matches graph node ids, just against
+ *   the doc's own slug/path instead of a graph id.
+ * - **Human**: `selfEditTimestamps` — the real record of THIS browser
+ *   session actually writing this exact slug through the local vault (see
+ *   `markSelfWrite` in `use-local-vault.ts`). Never inferred from mtime
+ *   alone — an mtime change could come from a git checkout, another
+ *   editor, or a different AI agent session with no heartbeat, none of
+ *   which is "me".
+ *
+ * When neither source has evidence for this doc, returns null — the caller
+ * renders nothing rather than guessing a subject.
+ */
+export function resolveDocLastEditSubject(params: {
+  doc: { slug: string; path: string };
+  /** null — 호출자가 heartbeat 출처를 아예 못 받은 표면(서버/샘플 볼트).
+   *  agent 후보는 자동으로 근거 없음 처리, human 후보는 그대로 평가한다. */
+  agentActivityStatus: AgentActivityStatus | null;
+  selfEditTimestamps: ReadonlyMap<string, number>;
+}): LastEditSubjectFact | null {
+  const { doc, agentActivityStatus, selfEditTimestamps } = params;
+  const heartbeat = agentActivityStatus?.heartbeat ?? null;
+  const hasFreshHeartbeat = Boolean(
+    heartbeat && agentActivityStatus?.valid && !agentActivityStatus?.stale,
+  );
+  const agentMatches = hasFreshHeartbeat && heartbeat ? doesHeartbeatFocusMatchDoc(heartbeat.focus, doc) : false;
+  const agentAtMs = agentMatches && heartbeat ? Date.parse(heartbeat.updatedAt) : Number.NaN;
+  const selfEditAtMs = selfEditTimestamps.get(doc.slug) ?? null;
+
+  return pickLastEditSubject([
+    { kind: "agent", atMs: Number.isFinite(agentAtMs) ? agentAtMs : null },
+    { kind: "human", atMs: selfEditAtMs },
+  ]);
+}
+
+function doesHeartbeatFocusMatchDoc(
+  focus: AgentActivityFocus,
+  doc: { slug: string; path: string },
+): boolean {
+  const bareSlug = doc.slug.split("/").pop() ?? doc.slug;
+  if (focus.ontologySlug) {
+    const candidate = focus.ontologySlug;
+    if (candidate === doc.slug || candidate === bareSlug) return true;
+    if (candidate.endsWith(`/${bareSlug}`)) return true;
+  }
+  if (focus.files.length > 0) {
+    return focus.files.some(
+      (file) => file === doc.path || file.endsWith(`/${doc.path}`) || doc.path.endsWith(file),
+    );
+  }
+  return false;
+}
+
+/**
+ * expected_mtime 충돌 배지 — `doc.mtime`(R11 #15) 이 `baselineMtime`(문서를
+ * 연 시점의 값) 과 달라졌고, 그 차이가 이번 세션의 자기 쓰기로 설명되지
+ * 않을 때만 true. 판정 자체는 `hasUnaccountedMtimeChange`(shared) 재사용 —
+ * 토폴로지 패널의 freshness-ISO 버전과 같은 규칙.
+ */
+export function hasDocMtimeConflict(params: {
+  doc: { slug: string; mtime?: number };
+  baselineMtime: number | undefined;
+  baselineCapturedAtMs: number;
+  selfEditTimestamps: ReadonlyMap<string, number>;
+}): boolean {
+  const { doc, baselineMtime, baselineCapturedAtMs, selfEditTimestamps } = params;
+  return hasUnaccountedMtimeChange({
+    baseline: baselineMtime,
+    current: doc.mtime,
+    selfEditAtMs: selfEditTimestamps.get(doc.slug) ?? null,
+    baselineCapturedAtMs,
+  });
+}

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -1935,6 +1935,14 @@ function DocsVaultContent() {
                             onPatch={handlePatchDocFrontmatter}
                             onNavigate={handleSelect}
                             resolveRef={(token) => refSlugResolver.get(token) ?? null}
+                            // rank7 (design-council B5) — 마지막 편집 주체/
+                            // 충돌 배지의 실데이터 출처. 둘 다 로컬 vault
+                            // 싱글턴(`LocalVaultProvider`)이 실제로 관측한
+                            // 값만 — 서버/샘플 볼트에선 heartbeat/자기쓰기
+                            // 기록이 없으므로 컴포넌트가 알아서 아무것도
+                            // 렌더하지 않는다.
+                            agentActivityStatus={localVault.agentActivityStatus}
+                            selfEditTimestamps={localVault.selfEditTimestamps}
                           />
                         ) : null}
                         <DocMetaBar doc={selectedDoc} />

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import enMessages from "../../../../../messages/en.json";
 import koMessages from "../../../../../messages/ko.json";
 import type { VaultDoc } from "@/entities/docs-vault";
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
 import { DocFrontmatterBlock } from "./DocFrontmatterBlock";
 
 const doc: VaultDoc = {
@@ -276,5 +277,145 @@ describe("DocFrontmatterBlock — 코드 위치 (code location) section", () => 
     const copyButtons = screen.getAllByTestId("doc-frontmatter-code-location-copy");
     fireEvent.click(copyButtons[0]);
     expect(writeText).toHaveBeenCalledWith("mcp/src/index.js");
+  });
+});
+
+// rank7 (design-council B5) — last-edit provenance + expected_mtime conflict.
+describe("DocFrontmatterBlock — last-edit provenance", () => {
+  function emptyAgentActivityStatus(): AgentActivityStatus {
+    return {
+      sourcePath: ".ontology-atlas/agent-activity.json",
+      exists: false,
+      valid: false,
+      stale: false,
+      ageMs: null,
+      heartbeat: null,
+      reviewMode: "none",
+      reviewTarget: { kind: "none", ontologySlug: null, files: [], label: "none" },
+      proof: { count: 0, sources: { mcp: 0, source: 0, verification: 0 }, label: "" },
+      refreshRequest: {
+        required: false,
+        reason: null,
+        previousAgent: null,
+        previousState: null,
+        previousFocus: null,
+        previousOntologySlug: null,
+        previousFiles: [],
+        previousAgeMs: null,
+        command: null,
+        message: null,
+      },
+      errorMessage: null,
+    };
+  }
+
+  function freshHeartbeatStatus(): AgentActivityStatus {
+    return {
+      ...emptyAgentActivityStatus(),
+      exists: true,
+      valid: true,
+      stale: false,
+      ageMs: 1000,
+      heartbeat: {
+        agent: "claude-code",
+        state: "editing",
+        focus: {
+          summary: "working",
+          ontologySlug: "capabilities/cli-developer-entry",
+          files: [],
+        },
+        plan: [],
+        evidence: { mcp: [], source: [], codegraph: [], verification: [] },
+        updatedAt: new Date(Date.now() - 3 * 60_000).toISOString(),
+      },
+    };
+  }
+
+  it("renders no subject row when neither a heartbeat nor a self-edit record exists (no fabrication)", () => {
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={doc} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("last-edit-subject-row")).not.toBeInTheDocument();
+  });
+
+  it("renders the AI agent subject when a fresh heartbeat names this doc", () => {
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={doc} agentActivityStatus={freshHeartbeatStatus()} />
+      </NextIntlClientProvider>,
+    );
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "agent");
+    expect(row).toHaveTextContent("AI 에이전트");
+  });
+
+  it("renders the human subject when this session self-wrote this exact doc", () => {
+    const selfEditTimestamps = new Map([[doc.slug, Date.now() - 60_000]]);
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock
+          doc={doc}
+          agentActivityStatus={emptyAgentActivityStatus()}
+          selfEditTimestamps={selfEditTimestamps}
+        />
+      </NextIntlClientProvider>,
+    );
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "human");
+    expect(row).toHaveTextContent("나");
+  });
+
+  it("renders no conflict badge when the doc's mtime has not changed since it was opened", () => {
+    render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={{ ...doc, mtime: 1000 }} agentActivityStatus={emptyAgentActivityStatus()} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("mtime-conflict-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders the conflict badge when the doc's mtime changes externally after it was opened", () => {
+    const changingDoc = { ...doc, mtime: 1000 };
+    const { rerender } = render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={changingDoc} agentActivityStatus={emptyAgentActivityStatus()} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("mtime-conflict-badge")).not.toBeInTheDocument();
+
+    // simulate the background poller picking up an EXTERNAL edit (no
+    // self-edit record for this slug) while the panel stays mounted.
+    rerender(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock doc={{ ...changingDoc, mtime: 2000 }} agentActivityStatus={emptyAgentActivityStatus()} />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.getByTestId("mtime-conflict-badge")).toBeInTheDocument();
+  });
+
+  it("does not flag a conflict when the mtime change is explained by this session's own save", () => {
+    const changingDoc = { ...doc, mtime: 1000 };
+    const selfEditTimestamps = new Map([[doc.slug, Date.now() + 10_000]]);
+    const { rerender } = render(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock
+          doc={changingDoc}
+          agentActivityStatus={emptyAgentActivityStatus()}
+          selfEditTimestamps={new Map()}
+        />
+      </NextIntlClientProvider>,
+    );
+    rerender(
+      <NextIntlClientProvider locale="ko" messages={koMessages}>
+        <DocFrontmatterBlock
+          doc={{ ...changingDoc, mtime: 2000 }}
+          agentActivityStatus={emptyAgentActivityStatus()}
+          selfEditTimestamps={selfEditTimestamps}
+        />
+      </NextIntlClientProvider>,
+    );
+    expect(screen.queryByTestId("mtime-conflict-badge")).not.toBeInTheDocument();
   });
 });

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -1,8 +1,10 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronRight, Clipboard, Pencil } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { buildNewNodeDoc, type VaultDoc } from "@/entities/docs-vault";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
+import { computeEditAge } from "@/shared/lib/edit-age";
 import { looksLikeCodePath } from "@/shared/lib/humanize-code-path-title";
 import { truncateMiddlePath } from "@/shared/lib/truncate-middle-path";
 import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
@@ -12,7 +14,8 @@ import {
   type VaultIssueCode,
 } from "@/shared/lib/validate-vault-document";
 import { mapVaultIssueCodeToPlainMessage } from "@/shared/lib/vault-issue-plain-message";
-import { CompactCopyButton } from "@/shared/ui";
+import { CompactCopyButton, LastEditSubjectRow, MtimeConflictBadge } from "@/shared/ui";
+import { hasDocMtimeConflict, resolveDocLastEditSubject } from "../../lib/resolve-doc-edit-subject";
 
 /**
  * Engraved frontmatter visualization — "frontmatter 가 곧 그래프" made literal
@@ -41,6 +44,10 @@ import { CompactCopyButton } from "@/shared/ui";
  * `updateFrontmatter` conflict-guarded path the builder's relation preflight
  * already uses (`OntologyEditPage.tsx`) — one write path, two surfaces.
  */
+
+// rank7 — 안정된 빈 Map 참조. props 로 안 넘어온 경우 매 렌더 새 Map 을
+// 만들지 않도록(useMemo dep 안정성).
+const EMPTY_SELF_EDIT_TIMESTAMPS: ReadonlyMap<string, number> = new Map();
 
 const GRAPH_KEYS = [
   "kind",
@@ -128,6 +135,14 @@ export interface DocFrontmatterBlockProps {
   /** 맨슬러그(frontmatter 참조 표기)를 실제 네비게이션 슬러그로 해소.
    *  null 이면 vault 에 없는 참조라 링크로 만들지 않는다. */
   resolveRef?: (token: string) => string | null;
+  /** rank7 (design-council B5) — "마지막 편집 · AI 에이전트" 사실의 실데이터
+   *  출처. 없으면(서버/샘플 볼트) AI 주체 행은 절대 렌더되지 않는다. */
+  agentActivityStatus?: AgentActivityStatus | null;
+  /** rank7 — "마지막 편집 · 나" 및 충돌 배지의 실데이터 출처. 이번 브라우저
+   *  세션이 실제로 vault 쓰기 API 를 거쳐 쓴 slug 의 기록
+   *  (`useLocalVault().selfEditTimestamps`). 없으면(서버/샘플 볼트) 둘 다
+   *  절대 렌더되지 않는다. */
+  selfEditTimestamps?: ReadonlyMap<string, number>;
 }
 
 export function DocFrontmatterBlock({
@@ -137,13 +152,56 @@ export function DocFrontmatterBlock({
   onPatch,
   onNavigate,
   resolveRef,
+  agentActivityStatus = null,
+  selfEditTimestamps,
 }: DocFrontmatterBlockProps) {
   const t = useTranslations("docsVault.frontmatterBlock");
+  const tProvenance = useTranslations("editProvenance");
   const kindLabel = useOntologyKindLabel();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // rank7 — 이 문서를 "연" 시점의 mtime baseline + "지금" 스냅샷(렌더
+  // purity — `useState(() => Date.now())` 지연 초기화는 이 앱의 기존
+  // `updatedAgoNowMs` 계약과 같은 패턴, `Date.now()` 를 렌더 중 직접
+  // 호출하지 않는다). 캐러가 `key={doc.slug}` 로 문서 전환마다 이 컴포넌트를
+  // remount 하므로(파일 상단 docstring 참고) 둘 다 매 새 문서마다 자연스럽게
+  // 새 baseline 으로 초기화된다.
+  const openedMtimeRef = useRef(doc.mtime);
+  const [viewOpenedAtMs] = useState(() => Date.now());
+  const resolvedSelfEditTimestamps = selfEditTimestamps ?? EMPTY_SELF_EDIT_TIMESTAMPS;
+  // rank7 — 실데이터 2종(heartbeat 매치 / 이번 세션 자기 쓰기)만 후보로
+  // 넣는다. 둘 다 근거 없으면 null → 아래 렌더에서 주체 행 자체가 없다
+  // (마케팅 칩 재탕 금지).
+  const lastEditSubjectFact = useMemo(
+    () =>
+      resolveDocLastEditSubject({
+        doc: { slug: doc.slug, path: doc.path },
+        agentActivityStatus,
+        selfEditTimestamps: resolvedSelfEditTimestamps,
+      }),
+    [doc.slug, doc.path, agentActivityStatus, resolvedSelfEditTimestamps],
+  );
+  const lastEditSubjectRow = (() => {
+    if (!lastEditSubjectFact) return null;
+    const age = computeEditAge(lastEditSubjectFact.atMs, viewOpenedAtMs);
+    return {
+      kind: lastEditSubjectFact.kind,
+      prefixLabel: tProvenance("prefix"),
+      subjectLabel: tProvenance(
+        lastEditSubjectFact.kind === "agent" ? "subjectAgent" : "subjectHuman",
+      ),
+      ageLabel: tProvenance(`age.${age.key}`, { count: age.count }),
+    };
+  })();
+  // rank7 — 실제 mtime mismatch 가 있을 때만 true(신호 인플레이션 금지).
+  const mtimeConflict = hasDocMtimeConflict({
+    doc: { slug: doc.slug, mtime: doc.mtime },
+    baselineMtime: openedMtimeRef.current,
+    baselineCapturedAtMs: viewOpenedAtMs,
+    selfEditTimestamps: resolvedSelfEditTimestamps,
+  });
   const currentKind = formatValue(doc.frontmatter?.kind);
   const currentDomain = formatValue(doc.frontmatter?.domain) ?? "";
   const currentTitle = formatValue(doc.frontmatter?.title) ?? doc.title;
@@ -498,6 +556,21 @@ export function DocFrontmatterBlock({
           {t("note")}
         </p>
       </details>
+      {lastEditSubjectRow ? (
+        <div className="mt-2 font-sans">
+          <LastEditSubjectRow
+            kind={lastEditSubjectRow.kind}
+            prefixLabel={lastEditSubjectRow.prefixLabel}
+            subjectLabel={lastEditSubjectRow.subjectLabel}
+            ageLabel={lastEditSubjectRow.ageLabel}
+          />
+        </div>
+      ) : null}
+      {mtimeConflict ? (
+        <div className="mt-2 font-sans">
+          <MtimeConflictBadge message={tProvenance("conflictMessage")} />
+        </div>
+      ) : null}
       {validationWarnings.length > 0 ? (
         <div
           data-testid="doc-frontmatter-validator-warnings"

--- a/src/views/home/lib/resolve-node-edit-subject.test.ts
+++ b/src/views/home/lib/resolve-node-edit-subject.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
+import { hasNodeMtimeConflict, resolveNodeLastEditSubject } from "./resolve-node-edit-subject";
+
+function emptyStatus(): AgentActivityStatus {
+  return {
+    sourcePath: ".ontology-atlas/agent-activity.json",
+    exists: false,
+    valid: false,
+    stale: false,
+    ageMs: null,
+    heartbeat: null,
+    reviewMode: "none",
+    reviewTarget: { kind: "none", ontologySlug: null, files: [], label: "none" },
+    proof: { count: 0, sources: { mcp: 0, source: 0, verification: 0 }, label: "" },
+    refreshRequest: {
+      required: false,
+      reason: null,
+      previousAgent: null,
+      previousState: null,
+      previousFocus: null,
+      previousOntologySlug: null,
+      previousFiles: [],
+      previousAgeMs: null,
+      command: null,
+      message: null,
+    },
+    errorMessage: null,
+  };
+}
+
+function freshHeartbeatStatus(updatedAt: string): AgentActivityStatus {
+  return {
+    ...emptyStatus(),
+    exists: true,
+    valid: true,
+    stale: false,
+    ageMs: 1000,
+    heartbeat: {
+      agent: "claude-code",
+      state: "editing",
+      focus: { summary: "working", ontologySlug: "capabilities/foo", files: [] },
+      plan: [],
+      evidence: { mcp: [], source: [], codegraph: [], verification: [] },
+      updatedAt,
+    },
+  };
+}
+
+describe("resolveNodeLastEditSubject", () => {
+  it("returns null with no heartbeat and no self-edit record", () => {
+    expect(
+      resolveNodeLastEditSubject({
+        nodeId: "capability:foo",
+        sourceSlug: "capabilities/foo",
+        agentActivityStatus: emptyStatus(),
+        agentFocusNodeId: null,
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns agent when the fresh heartbeat's resolved focus node matches this node id", () => {
+    const status = freshHeartbeatStatus("2026-07-24T12:00:00.000Z");
+    const result = resolveNodeLastEditSubject({
+      nodeId: "capability:foo",
+      sourceSlug: "capabilities/foo",
+      agentActivityStatus: status,
+      agentFocusNodeId: "capability:foo",
+      selfEditTimestamps: new Map(),
+    });
+    expect(result).toEqual({ kind: "agent", atMs: Date.parse("2026-07-24T12:00:00.000Z") });
+  });
+
+  it("ignores the heartbeat when the resolved focus node is a different node", () => {
+    const status = freshHeartbeatStatus("2026-07-24T12:00:00.000Z");
+    expect(
+      resolveNodeLastEditSubject({
+        nodeId: "capability:foo",
+        sourceSlug: "capabilities/foo",
+        agentActivityStatus: status,
+        agentFocusNodeId: "capability:bar",
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns human when the node's source slug has a self-edit record", () => {
+    const result = resolveNodeLastEditSubject({
+      nodeId: "capability:foo",
+      sourceSlug: "capabilities/foo",
+      agentActivityStatus: emptyStatus(),
+      agentFocusNodeId: null,
+      selfEditTimestamps: new Map([["capabilities/foo", 800]]),
+    });
+    expect(result).toEqual({ kind: "human", atMs: 800 });
+  });
+});
+
+describe("hasNodeMtimeConflict", () => {
+  it("is false when freshness has not changed", () => {
+    expect(
+      hasNodeMtimeConflict({
+        sourceSlug: "capabilities/foo",
+        baselineFreshnessIso: "2026-07-24T00:00:00.000Z",
+        currentFreshnessIso: "2026-07-24T00:00:00.000Z",
+        baselineCapturedAtMs: 0,
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when freshness changed with no self-edit record explaining it", () => {
+    expect(
+      hasNodeMtimeConflict({
+        sourceSlug: "capabilities/foo",
+        baselineFreshnessIso: "2026-07-24T00:00:00.000Z",
+        currentFreshnessIso: "2026-07-24T01:00:00.000Z",
+        baselineCapturedAtMs: 0,
+        selfEditTimestamps: new Map(),
+      }),
+    ).toBe(true);
+  });
+
+  it("is false when a same-session self-edit explains the change", () => {
+    expect(
+      hasNodeMtimeConflict({
+        sourceSlug: "capabilities/foo",
+        baselineFreshnessIso: "2026-07-24T00:00:00.000Z",
+        currentFreshnessIso: "2026-07-24T01:00:00.000Z",
+        baselineCapturedAtMs: 50,
+        selfEditTimestamps: new Map([["capabilities/foo", 100]]),
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/views/home/lib/resolve-node-edit-subject.ts
+++ b/src/views/home/lib/resolve-node-edit-subject.ts
@@ -1,0 +1,63 @@
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
+import { pickLastEditSubject, type LastEditSubjectFact } from "@/shared/lib/last-edit-subject";
+import { hasUnaccountedMtimeChange } from "@/shared/lib/mtime-conflict";
+
+/**
+ * rank7 (design-council B5) — resolves the "마지막 편집 · 사람/AI" fact for
+ * `TopologyV2DetailPanel`/`FullDetailA1`, the graph-node counterparts of
+ * `resolveDocLastEditSubject` (docs-vault). Same two real sources, adapted
+ * to the graph's own id shape:
+ *
+ * - **AI agent**: a fresh heartbeat whose focus resolves (via the existing
+ *   `resolveAgentFocusNodeId`, W6) to THIS node id — reused as a param
+ *   rather than re-derived here, so both P4b's "에이전트가 방금" badge and
+ *   this fact always agree on which node the agent is looking at.
+ * - **Human**: `selfEditTimestamps` keyed by vault slug (`sourceSlug`) —
+ *   the same cross-page self-write record `resolveDocLastEditSubject`
+ *   reads, shared via the `LocalVaultProvider` singleton so an edit made on
+ *   `/docs` shows up here too.
+ */
+export function resolveNodeLastEditSubject(params: {
+  nodeId: string;
+  sourceSlug: string | null;
+  agentActivityStatus: AgentActivityStatus;
+  agentFocusNodeId: string | null;
+  selfEditTimestamps: ReadonlyMap<string, number>;
+}): LastEditSubjectFact | null {
+  const { nodeId, sourceSlug, agentActivityStatus, agentFocusNodeId, selfEditTimestamps } = params;
+  const heartbeat = agentActivityStatus.heartbeat;
+  const hasFreshHeartbeat = Boolean(
+    heartbeat && agentActivityStatus.valid && !agentActivityStatus.stale,
+  );
+  const agentMatches = hasFreshHeartbeat && agentFocusNodeId === nodeId;
+  const agentAtMs = agentMatches && heartbeat ? Date.parse(heartbeat.updatedAt) : Number.NaN;
+  const selfEditAtMs = sourceSlug ? selfEditTimestamps.get(sourceSlug) ?? null : null;
+
+  return pickLastEditSubject([
+    { kind: "agent", atMs: Number.isFinite(agentAtMs) ? agentAtMs : null },
+    { kind: "human", atMs: selfEditAtMs },
+  ]);
+}
+
+/**
+ * expected_mtime 충돌 배지 — 이 노드의 근거 문서 freshness(ISO, mtime 파생)
+ * 가 패널을 연 시점의 baseline 과 달라졌고, 그 차이가 자기 쓰기로 설명되지
+ * 않을 때만 true. `hasUnaccountedMtimeChange`(shared) 재사용 — docs-vault
+ * 쪽의 numeric-mtime 버전과 같은 규칙.
+ */
+export function hasNodeMtimeConflict(params: {
+  sourceSlug: string | null;
+  baselineFreshnessIso: string | null;
+  currentFreshnessIso: string | null;
+  baselineCapturedAtMs: number;
+  selfEditTimestamps: ReadonlyMap<string, number>;
+}): boolean {
+  const { sourceSlug, baselineFreshnessIso, currentFreshnessIso, baselineCapturedAtMs, selfEditTimestamps } =
+    params;
+  return hasUnaccountedMtimeChange({
+    baseline: baselineFreshnessIso,
+    current: currentFreshnessIso,
+    selfEditAtMs: sourceSlug ? selfEditTimestamps.get(sourceSlug) ?? null : null,
+    baselineCapturedAtMs,
+  });
+}

--- a/src/views/home/model/use-node-datasheet-model.ts
+++ b/src/views/home/model/use-node-datasheet-model.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import {
   buildOntologyBuilderNodeHrefFromGraphId,
   deriveCodeLocations,
@@ -8,8 +8,12 @@ import {
   type KnowledgeGraphNode,
 } from "@/entities/knowledge-graph";
 import { buildDocsVaultHref } from "@/entities/docs-vault";
+import type { AgentActivityStatus } from "@/features/docs-vault-local";
+import { computeEditAge } from "@/shared/lib/edit-age";
+import type { LastEditSubjectKind } from "@/shared/lib/last-edit-subject";
 import { isWithinRecentWindow } from "@/shared/lib/ontology-tree";
 import { computeUpdatedAgo } from "../lib/format-updated-ago";
+import { hasNodeMtimeConflict, resolveNodeLastEditSubject } from "../lib/resolve-node-edit-subject";
 import { buildTopologyOntologyDrawerModel } from "../lib/topology-ontology-drawer";
 import { buildTopologyNodeFocus, type TopologyNodeFocusModel } from "../lib/topology-node-focus";
 import { buildNodeSignificance, type NodeSignificanceModel } from "../lib/topology-node-significance";
@@ -44,6 +48,18 @@ export interface UseNodeDatasheetModelArgs {
   updatedAgoNowMs: number;
   /** i18n — `nodeDatasheet.updated_<key>` 해석. */
   formatUpdatedLabel: (key: string, count: number) => string;
+  /** rank7 (design-council B5) — "마지막 편집" 주체/충돌 배지의 실데이터
+   *  출처. `emptyAgentActivityStatus()` 로 항상 defined (heartbeat 없으면
+   *  agent 후보가 자동으로 근거 없음 처리된다). */
+  agentActivityStatus: AgentActivityStatus;
+  /** W6 `resolveAgentFocusNodeId` 결과 재사용 — P4b 배지와 이 fact 가 항상
+   *  같은 노드를 가리키게(별도 재-매칭 로직 만들지 않음). */
+  agentFocusNodeId: string | null;
+  /** `useLocalVault().selfEditTimestamps` — 이번 세션이 실제로 쓴 slug 의
+   *  기록. "마지막 편집 · 나" 및 충돌 배지 둘 다의 유일한 human 근거. */
+  selfEditTimestamps: ReadonlyMap<string, number>;
+  /** i18n — `editProvenance.age.<key>` 해석. */
+  formatEditAgeLabel: (key: string, count: number) => string;
 }
 
 export interface NodeDatasheetDerivation {
@@ -76,6 +92,11 @@ export interface NodeDatasheetDerivation {
     handoffText: string;
     documentHref: string | null;
     builderEditHref: string;
+    /** rank7 — 실데이터 근거(heartbeat 매치 / 자기 쓰기 기록) 있을 때만
+     *  non-null. 사람/AI 는 `kind` 로만 구분(hue 0). */
+    lastEditSubject: { kind: LastEditSubjectKind; ageLabel: string } | null;
+    /** rank7 — 실제 mtime mismatch 있을 때만 true. */
+    mtimeConflict: boolean;
   } | null;
 }
 
@@ -86,6 +107,10 @@ export function useNodeDatasheetModel({
   docFreshnessIndex,
   updatedAgoNowMs,
   formatUpdatedLabel,
+  agentActivityStatus,
+  agentFocusNodeId,
+  selfEditTimestamps,
+  formatEditAgeLabel,
 }: UseNodeDatasheetModelArgs): NodeDatasheetDerivation {
   // drawer model 1회 빌드로 focus(팝오버 연결) + significance(평문 so-what)
   // 둘 다 파생 — 재계산 0, count drift 불가.
@@ -98,6 +123,28 @@ export function useNodeDatasheetModel({
     };
   }, [selectedOntologyNode, insight, authoredSignificance]);
   const nodeFocus = nodeFocusData?.focus ?? null;
+
+  // rank7 — 이 노드를 "연" (선택한) 시점의 freshness baseline. nodeId 가
+  // 바뀔 때만 재설정 — 같은 노드를 계속 보는 동안 폴링이 freshness 를
+  // 바꾸면 그게 바로 "연 뒤에 바뀐" 실제 신호다. ref 변경은 렌더를 새로
+  // 유발하지 않으므로 순수성 문제 없음(React 의 "렌더 중 파생 상태" 패턴).
+  // capturedAtMs 는 `updatedAgoNowMs`(세션 스냅샷, 렌더 purity — 파일 상단
+  // 계약 재사용) — 새 `Date.now()` 호출 0.
+  const editBaselineRef = useRef<{
+    nodeId: string;
+    freshnessIso: string | null;
+    capturedAtMs: number;
+  } | null>(null);
+  const currentNodeId = selectedOntologyNode?.id ?? null;
+  const currentSourceSlug = nodeFocus?.sourceSlug ?? null;
+  const currentFreshnessIso = currentSourceSlug ? docFreshnessIndex.get(currentSourceSlug) ?? null : null;
+  if (currentNodeId !== null && editBaselineRef.current?.nodeId !== currentNodeId) {
+    editBaselineRef.current = {
+      nodeId: currentNodeId,
+      freshnessIso: currentFreshnessIso,
+      capturedAtMs: updatedAgoNowMs,
+    };
+  }
 
   const v2DatasheetModel = useMemo(() => {
     if (!nodeFocus || !selectedOntologyNode || !insight) return null;
@@ -129,6 +176,36 @@ export function useNodeDatasheetModel({
     });
     const freshnessIso = nodeFocus.sourceSlug ? docFreshnessIndex.get(nodeFocus.sourceSlug) : undefined;
     const ago = freshnessIso ? computeUpdatedAgo(freshnessIso, updatedAgoNowMs) : null;
+
+    // rank7 (design-council B5) — 실데이터 2종(heartbeat 매치 / 자기 쓰기
+    // 기록)만 후보로 넣는다. 둘 다 근거 없으면 lastEditSubject 는 null.
+    const lastEditSubjectFact = resolveNodeLastEditSubject({
+      nodeId: selectedOntologyNode.id,
+      sourceSlug: nodeFocus.sourceSlug,
+      agentActivityStatus,
+      agentFocusNodeId,
+      selfEditTimestamps,
+    });
+    const lastEditSubject = lastEditSubjectFact
+      ? {
+          kind: lastEditSubjectFact.kind,
+          ageLabel: (() => {
+            const age = computeEditAge(lastEditSubjectFact.atMs, updatedAgoNowMs);
+            return formatEditAgeLabel(age.key, age.count);
+          })(),
+        }
+      : null;
+
+    const baseline = editBaselineRef.current;
+    const mtimeConflict = hasNodeMtimeConflict({
+      sourceSlug: nodeFocus.sourceSlug,
+      baselineFreshnessIso: baseline && baseline.nodeId === selectedOntologyNode.id ? baseline.freshnessIso : null,
+      currentFreshnessIso: freshnessIso ?? null,
+      baselineCapturedAtMs:
+        baseline && baseline.nodeId === selectedOntologyNode.id ? baseline.capturedAtMs : updatedAgoNowMs,
+      selfEditTimestamps,
+    });
+
     return {
       slug,
       nodeId: selectedOntologyNode.id,
@@ -156,8 +233,22 @@ export function useNodeDatasheetModel({
       // 빌더 딥링크는 canonical `<kind>:<slug>`(그래프 node id) 그대로 — 발신 문법
       // 통일(H5 계약 item 1). 예전 `?node=<vault slug>` 인라인 링크를 대체.
       builderEditHref: buildOntologyBuilderNodeHrefFromGraphId(selectedOntologyNode.id),
+      lastEditSubject,
+      mtimeConflict,
     };
-  }, [nodeFocus, selectedOntologyNode, insight, nodeFocusData, docFreshnessIndex, updatedAgoNowMs, formatUpdatedLabel]);
+  }, [
+    nodeFocus,
+    selectedOntologyNode,
+    insight,
+    nodeFocusData,
+    docFreshnessIndex,
+    updatedAgoNowMs,
+    formatUpdatedLabel,
+    agentActivityStatus,
+    agentFocusNodeId,
+    selfEditTimestamps,
+    formatEditAgeLabel,
+  ]);
 
   return { nodeFocus, significance: nodeFocusData?.significance ?? null, v2DatasheetModel };
 }

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1351,6 +1351,13 @@ export function HomePage() {
     (key: string, count: number) => t(`nodeDatasheet.updated_${key}`, { count }),
     [t],
   );
+  // rank7 (design-council B5) — 마지막 편집 주체/충돌 배지 카피. DocFrontmatterBlock
+  // 과 같은 `editProvenance` 네임스페이스를 재사용 — 사본 없음, drift 방지.
+  const tEditProvenance = useTranslations("editProvenance");
+  const formatEditAgeLabel = useCallback(
+    (key: string, count: number) => tEditProvenance(`age.${key}`, { count }),
+    [tEditProvenance],
+  );
   const { nodeFocus, v2DatasheetModel } = useNodeDatasheetModel({
     selectedOntologyNode,
     insight: ontologyInsight,
@@ -1358,6 +1365,10 @@ export function HomePage() {
     docFreshnessIndex,
     updatedAgoNowMs,
     formatUpdatedLabel,
+    agentActivityStatus,
+    agentFocusNodeId,
+    selfEditTimestamps: vault.selfEditTimestamps,
+    formatEditAgeLabel,
   });
   // 과제 ⑪ — LNB 컨텍스트 이월. 노드를 선택한 채 좌측 레일의 "문서함"으로
   // 이동하면 선택과 무관한 `/docs/` 기본 화면이 뜨던 문제 — 데이터시트가
@@ -1539,6 +1550,14 @@ export function HomePage() {
         kind: nodeFocus.kind,
         slug,
         fresh: changedSlugs.has(selectedOntologyNode.id),
+        // rank7 (design-council B5) — 같은 노드 선택에서 나온
+        // `v2DatasheetModel`(compact 패널)의 SAME fact 를 그대로 재사용 —
+        // 이 노드의 baseline/heartbeat 판정을 두 번 만들지 않는다(count
+        // drift 방지 원칙과 동일 이유).
+        lastEditSubject:
+          v2DatasheetModel?.nodeId === selectedOntologyNode.id ? v2DatasheetModel.lastEditSubject : null,
+        mtimeConflict:
+          v2DatasheetModel?.nodeId === selectedOntologyNode.id ? v2DatasheetModel.mtimeConflict : false,
       },
       groups,
       reach,
@@ -1563,6 +1582,7 @@ export function HomePage() {
     nodeEditTarget,
     vault.manifest,
     saveNodeExplanation,
+    v2DatasheetModel,
   ]);
   const selectedNodeFocusActive =
     Boolean(
@@ -3712,6 +3732,8 @@ export function HomePage() {
                 evidence={panelDatasheetModel.evidence}
                 codeLocations={panelDatasheetModel.codeLocations}
                 updatedAtLabel={panelDatasheetModel.updatedAtLabel}
+                lastEditSubject={panelDatasheetModel.lastEditSubject}
+                mtimeConflict={panelDatasheetModel.mtimeConflict}
                 handoffText={panelDatasheetModel.handoffText}
                 documentHref={panelDatasheetModel.documentHref}
                 builderEditHref={panelDatasheetModel.builderEditHref}
@@ -3752,6 +3774,12 @@ export function HomePage() {
                   codeLocationsLabel: t("nodeDatasheet.codeLocationsLabel"),
                   codeLocationsCopyLabel: t("nodeDatasheet.codeLocationsCopyLabel"),
                   codeLocationsCopiedLabel: t("nodeDatasheet.codeLocationsCopiedLabel"),
+                  // rank7 (design-council B5) — DocFrontmatterBlock 과 같은
+                  // `editProvenance` 네임스페이스(단일 출처, drift 방지).
+                  editSubjectPrefix: tEditProvenance("prefix"),
+                  editSubjectAgent: tEditProvenance("subjectAgent"),
+                  editSubjectHuman: tEditProvenance("subjectHuman"),
+                  editConflictMessage: tEditProvenance("conflictMessage"),
                   handoff: t("nodeDatasheet.handoff"),
                   close: t("controls.close"),
                   openFullDetail: t("nodeDatasheet.openFullDetail"),

--- a/src/widgets/full-detail-a1/ui/FullDetailA1.test.tsx
+++ b/src/widgets/full-detail-a1/ui/FullDetailA1.test.tsx
@@ -91,6 +91,21 @@ const messages = {
       saving: "저장 중…",
     },
   },
+  editProvenance: {
+    prefix: "마지막 편집",
+    subjectAgent: "AI 에이전트",
+    subjectHuman: "나",
+    conflictMessage: "이 문서가 다른 곳에서 바뀌었어요 — 덮어쓰기 전에 확인하세요",
+    age: {
+      justNow: "방금",
+      minutesAgo: "{count}분 전",
+      hoursAgo: "{count}시간 전",
+      yesterday: "어제",
+      daysAgo: "{count}일 전",
+      weeksAgo: "{count}주 전",
+      monthsAgo: "{count}개월 전",
+    },
+  },
 };
 
 function node(id: string, kind: string, title = id): KnowledgeGraphNode {
@@ -253,5 +268,65 @@ describe("FullDetailA1 — 코드 위치 (code location) section", () => {
     renderFullDetail({ codeLocations: ["mcp/src/index.js"] });
     fireEvent.click(screen.getByTestId("full-detail-a1-code-location-copy"));
     expect(writeText).toHaveBeenCalledWith("mcp/src/index.js");
+  });
+});
+
+// rank7 (design-council B5) — last-edit provenance + expected_mtime conflict.
+describe("FullDetailA1 — last-edit provenance", () => {
+  it("renders no subject row when the node carries no lastEditSubject fact", () => {
+    renderFullDetail();
+    expect(screen.queryByTestId("last-edit-subject-row")).not.toBeInTheDocument();
+  });
+
+  it("renders the AI agent subject row from a real, caller-resolved fact", () => {
+    renderFullDetail({
+      node: {
+        id: "domain:a",
+        title: "Domain A",
+        kind: "domain",
+        slug: "domains/a",
+        fresh: true,
+        lastEditSubject: { kind: "agent", ageLabel: "3분 전" },
+      },
+    });
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "agent");
+    expect(row).toHaveTextContent("AI 에이전트");
+    expect(row).toHaveTextContent("3분 전");
+  });
+
+  it("renders the human subject row from a real, caller-resolved fact", () => {
+    renderFullDetail({
+      node: {
+        id: "domain:a",
+        title: "Domain A",
+        kind: "domain",
+        slug: "domains/a",
+        fresh: true,
+        lastEditSubject: { kind: "human", ageLabel: "어제" },
+      },
+    });
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "human");
+    expect(row).toHaveTextContent("나");
+  });
+
+  it("renders no conflict badge when mtimeConflict is false/omitted", () => {
+    renderFullDetail();
+    expect(screen.queryByTestId("mtime-conflict-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders the conflict badge only when the caller resolved a real mtime mismatch", () => {
+    renderFullDetail({
+      node: {
+        id: "domain:a",
+        title: "Domain A",
+        kind: "domain",
+        slug: "domains/a",
+        fresh: true,
+        mtimeConflict: true,
+      },
+    });
+    expect(screen.getByTestId("mtime-conflict-badge")).toBeInTheDocument();
   });
 });

--- a/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
+++ b/src/widgets/full-detail-a1/ui/FullDetailA1.tsx
@@ -9,7 +9,7 @@ import { buildOntologyNodeHref } from "@/entities/knowledge-graph";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
 import { truncateMiddlePath } from "@/shared/lib/truncate-middle-path";
-import { useToast } from "@/shared/ui";
+import { LastEditSubjectRow, MtimeConflictBadge, useToast } from "@/shared/ui";
 import {
   NodeExplanationEdit,
   type NodeExplanationEditLabels,
@@ -51,6 +51,16 @@ export interface FullDetailA1Node {
    * agent-handoff call chain. */
   slug: string;
   fresh: boolean;
+  /**
+   * rank7 (design-council B5) — last-edit provenance, pre-resolved by the
+   * caller (reuses the SAME fact `TopologyV2DetailPanel` shows for this
+   * node, `resolveNodeLastEditSubject`) from real data only. `null`/omitted
+   * when neither an agent heartbeat nor a same-session self-write names
+   * this node — the row is not rendered.
+   */
+  lastEditSubject?: { kind: "agent" | "human"; ageLabel: string } | null;
+  /** rank7 — expected_mtime conflict badge, `true` only on a real mismatch. */
+  mtimeConflict?: boolean;
 }
 
 export interface FullDetailA1Breadcrumb {
@@ -102,6 +112,9 @@ export function FullDetailA1({
   className,
 }: FullDetailA1Props) {
   const t = useTranslations("fullDetailA1");
+  // rank7 (design-council B5) — DocFrontmatterBlock/TopologyV2DetailPanel 과
+  // 같은 `editProvenance` 네임스페이스(단일 출처, drift 방지).
+  const tProvenance = useTranslations("editProvenance");
   const getKindLabel = useOntologyKindLabel();
   const { show } = useToast();
   const copyLinkFeedback = useCopyFeedback();
@@ -227,6 +240,26 @@ export function FullDetailA1({
             <span className="text-[color:var(--topology-v2-panel-text-quaternary)]">·</span>
             <span>{node.fresh ? t("freshOn") : t("freshOff")}</span>
           </div>
+          {/* rank7 (design-council B5) — last-edit provenance + expected_mtime
+              conflict, gated on real data by the caller (reuses the SAME
+              fact as the compact topology panel — no separate judgment). */}
+          {node.lastEditSubject ? (
+            <div className="mt-1">
+              <LastEditSubjectRow
+                kind={node.lastEditSubject.kind}
+                prefixLabel={tProvenance("prefix")}
+                subjectLabel={tProvenance(
+                  node.lastEditSubject.kind === "agent" ? "subjectAgent" : "subjectHuman",
+                )}
+                ageLabel={node.lastEditSubject.ageLabel}
+              />
+            </div>
+          ) : null}
+          {node.mtimeConflict ? (
+            <div className="mt-1">
+              <MtimeConflictBadge message={tProvenance("conflictMessage")} />
+            </div>
+          ) : null}
         </div>
         <div className="mt-2.5 flex shrink-0 items-center gap-3">
           <span className="font-mono text-label text-[color:var(--topology-v2-panel-text-quaternary)]">

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -32,6 +32,10 @@ const labels = {
   codeLocationsLabel: "code location",
   codeLocationsCopyLabel: "copy",
   codeLocationsCopiedLabel: "copied",
+  editSubjectPrefix: "Last edited",
+  editSubjectAgent: "AI agent",
+  editSubjectHuman: "me",
+  editConflictMessage: "This document changed elsewhere — check before you overwrite",
   noConnections: "no relations recorded yet · relations are declared in frontmatter",
   handoff: "Copy next action",
   close: "Close",
@@ -60,6 +64,8 @@ function renderPanel(
     showHandoff?: boolean;
     showSourcePath?: boolean;
     codeLocations?: readonly string[];
+    lastEditSubject?: { kind: "agent" | "human"; ageLabel: string } | null;
+    mtimeConflict?: boolean;
   } = {},
 ) {
   render(
@@ -87,6 +93,8 @@ function renderPanel(
       }
       builderEditHref="/ontology/edit/?node=domains%2Fviews"
       labels={labels}
+      lastEditSubject={overrides.lastEditSubject ?? null}
+      mtimeConflict={overrides.mtimeConflict ?? false}
       onSelectConnection={overrides.onSelectConnection ?? (() => {})}
       onCopyHandoff={overrides.onCopyHandoff ?? (() => {})}
       onClose={() => {}}
@@ -692,5 +700,42 @@ describe("TopologyV2DetailPanel — W2-A action row", () => {
     expect(screen.queryByTestId("topology-v2-contains-summary")).not.toBeInTheDocument();
     expect(screen.queryByTestId("topology-v2-contains-summary-toggle")).not.toBeInTheDocument();
     expect(screen.getByText("leaf 0")).toBeInTheDocument();
+  });
+});
+
+// rank7 (design-council B5) — last-edit provenance + expected_mtime conflict.
+describe("TopologyV2DetailPanel — last-edit provenance", () => {
+  it("renders no subject row when lastEditSubject is null (no fabrication)", () => {
+    renderPanel();
+    expect(screen.queryByTestId("last-edit-subject-row")).not.toBeInTheDocument();
+  });
+
+  it("renders the AI agent subject row from a real, caller-resolved fact", () => {
+    renderPanel(undefined, undefined, {
+      lastEditSubject: { kind: "agent", ageLabel: "3m ago" },
+    });
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "agent");
+    expect(row).toHaveTextContent("AI agent");
+    expect(row).toHaveTextContent("3m ago");
+  });
+
+  it("renders the human subject row from a real, caller-resolved fact", () => {
+    renderPanel(undefined, undefined, {
+      lastEditSubject: { kind: "human", ageLabel: "yesterday" },
+    });
+    const row = screen.getByTestId("last-edit-subject-row");
+    expect(row).toHaveAttribute("data-edit-subject-kind", "human");
+    expect(row).toHaveTextContent("me");
+  });
+
+  it("renders no conflict badge when mtimeConflict is false (default)", () => {
+    renderPanel();
+    expect(screen.queryByTestId("mtime-conflict-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders the conflict badge only when the caller resolved a real mtime mismatch", () => {
+    renderPanel(undefined, undefined, { mtimeConflict: true });
+    expect(screen.getByTestId("mtime-conflict-badge")).toBeInTheDocument();
   });
 });

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -17,6 +17,7 @@ import {
   type V2EvidenceRow,
   type V2MetricValues,
 } from "./topology-v2-datasheet";
+import { LastEditSubjectRow, MtimeConflictBadge } from "@/shared/ui";
 import { TopologyV2KindGlyph, TopologyV2TraceMark } from "@/shared/ui/topology-v2-kind-glyph";
 import { Tooltip } from "@/shared/ui/tooltip";
 
@@ -148,6 +149,12 @@ export interface TopologyV2DetailPanelLabels {
   codeLocationsLabel: string;
   codeLocationsCopyLabel: string;
   codeLocationsCopiedLabel: string;
+  /** rank7 (design-council B5) — "마지막 편집" 주체 행 + expected_mtime
+   *  충돌 배지 카피. `editProvenance` i18n 네임스페이스 재사용(단일 출처). */
+  editSubjectPrefix: string;
+  editSubjectAgent: string;
+  editSubjectHuman: string;
+  editConflictMessage: string;
 }
 
 export interface TopologyV2DetailPanelProps {
@@ -198,6 +205,21 @@ export interface TopologyV2DetailPanelProps {
    * label passes through the same i18n path as every other string here.
    */
   updatedAtLabel?: string | null;
+  /**
+   * rank7 (design-council B5) — last-edit provenance, pre-resolved by the
+   * caller (`resolveNodeLastEditSubject`) from real data only (a fresh
+   * agent heartbeat attributed to this node, or a same-session self-write
+   * record). `null` when neither source has evidence — the row is not
+   * rendered (no fabrication). Human vs AI is the `kind` field only, never
+   * a color.
+   */
+  lastEditSubject?: { kind: "agent" | "human"; ageLabel: string } | null;
+  /**
+   * rank7 — expected_mtime conflict badge. `true` only on a REAL mismatch
+   * between the freshness this panel opened with and the freshness now
+   * known (`hasNodeMtimeConflict`) — never shown speculatively.
+   */
+  mtimeConflict?: boolean;
   /** Pre-built agent handoff payload; the view owns clipboard + toast. */
   handoffText: string;
   /**
@@ -295,6 +317,8 @@ export function TopologyV2DetailPanel({
   evidence,
   codeLocations,
   updatedAtLabel = null,
+  lastEditSubject = null,
+  mtimeConflict = false,
   handoffText,
   documentHref,
   builderEditHref,
@@ -659,6 +683,20 @@ export function TopologyV2DetailPanel({
           <X size={14} />
         </button>
       </div>
+
+      {/* rank7 (design-council B5) — last-edit provenance + expected_mtime
+          conflict, both gated on real data by the caller. Subject row is
+          static (no motion, a plain fact); conflict badge only mounts on a
+          real mismatch and fades in via the shared `atlasStatusIn` entrance. */}
+      {lastEditSubject ? (
+        <LastEditSubjectRow
+          kind={lastEditSubject.kind}
+          prefixLabel={labels.editSubjectPrefix}
+          subjectLabel={lastEditSubject.kind === "agent" ? labels.editSubjectAgent : labels.editSubjectHuman}
+          ageLabel={lastEditSubject.ageLabel}
+        />
+      ) : null}
+      {mtimeConflict ? <MtimeConflictBadge message={labels.editConflictMessage} /> : null}
 
       {/* One engraved metric line — no subtitle + boxes triplication.
           라벨(tertiary)과 값(metric-text)의 잉크를 분리 — 숫자가 데이터,


### PR DESCRIPTION
## Summary
디자인 카운슬 배치 B5. agent-native/human-sovereign 정체성 모먼트를 read 표면에 노출. DocFrontmatterBlock·TopologyV2DetailPanel·FullDetailA1에 **마지막 편집 주체**(사람/AI, lucide user/bot 글리프+평문, hue 0)와 **expected_mtime 충돌 배지**(실제 mismatch 시에만 amber). 실데이터만 재사용: agent activity heartbeat·자기 쓰기 타임스탬프(신규 selfEditTimestamps)·mtime 계약. 마케팅 'Updated with AI' 칩 대체.

## Test plan
- tsc ✅ · shared/docs-vault/topology-map-v2/full-detail-a1/home 1535 passed ✅ · i18n ✅ · shared/ui/index.ts 충돌(B2) 해소
- 주체 행 실데이터일 때만 렌더·부재 시 숨김, 충돌 배지 실 mismatch 에만 (테스트 커버)