### PR TITLE
feat: 온톨로지 스튜디오 CREATE(만들기) 모드 + 쓰기 경로 (Slice 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,9 +142,13 @@ scripts/                   vault tooling (R11) + perf baseline (R11) + dogfood w
 /docs                      vault picker / editor / unified palette
 /ontology                  thin redirect → /topology?index=expanded (B3 허브가 곧 지도 — the old tree/ego hub is retired)
 /ontology/edit             ERD canvas builder (xyflow → vault md export)
-/ontology/studio           immersive "강화(enhancement) screen" — one node as a game item you
-                           complete by socketing relation "gems" (sanctioned scoped design
-                           exception: glow/gradient/aura via `--studio-*` tokens only)
+/ontology/studio           immersive game-styled surface (sanctioned scoped design
+                           exception: glow/gradient/aura via `--studio-*` tokens only) with two
+                           modes off one route: ENHANCE (default) = one node as a game item you
+                           complete by socketing relation "gems"; CREATE (`?mode=create`) =
+                           assemble a brand-new node — kind/name/domain/definition + relation
+                           cards with a node picker, near-dup guard, live preview, then apply
+                           direct-to-disk (loaded local vault) or as a copyable MCP command packet
 /ontology/insights         graph insights (kind census · hubs · relation breakdown)
 /download                  macOS desktop app download (DMG)
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 ---
 
+## 2026-07-24 — 온톨로지 스튜디오 Slice 2 — CREATE(만들기) 모드
+
+같은 `/ontology/studio` 라우트에 `?mode=create` 로 진입하는 **새 노드 만들기**
+표면 추가 (enhance 는 default 유지). 왼쪽 신원 폼(종류·이름·소속 도메인·정의 +
+근접 중복 가드 `SimilarNodeWarning`), 오른쪽 관계 카드 4종(상위 개념 is-a ·
+기대는 곳 · 담는 것 · 비슷한 것)을 노드 피커 버튼으로 하나씩 조립, 완성도
+게이지 + "지금까지 이런 모양" 미니 프리뷰. **두 적용 경로**: ① 직접 적용 —
+쓰기 가능한 로컬 vault 가 열려 있을 때 `createDoc` 로 `.md` 를 디스크에 씀
+(기존 `/docs`·빌더와 같은 write infra 재사용: `buildNewNodeDoc` 계열) ② 에이전트에게
+맡기기 — `add_concept` + `add_relation` MCP 명령 패킷을 클립보드로 복사(읽기
+전용/샘플 모드의 유일한 활성 경로). frontmatter 관계 키는 런타임 파생이 읽는
+키(`contains`/`dependencies`/`relates`)로 써 지도에 즉시 반영, is-a 는 `broader:`·
+정의는 `definition:` 로 additive(전체 검증은 S3). 게임 에너지는 스튜디오
+스코프 예외(`--studio-*`) 유지. 빌더(`/ontology/edit`) 은 아직 유지(S4 에서 정리).
+
 ## 2026-07-24 — 온톨로지 스튜디오 (게임 "강화 화면") Slice 1 — 읽기 전용 표면
 
 새 라우트 `/ontology/studio` + 레일 LNB "스튜디오" 항목. 노드 하나를 게임

--- a/messages/en.json
+++ b/messages/en.json
@@ -165,7 +165,74 @@
     "agent": "Hand to agent",
     "nextSlice": "Writing opens in the next slice — this view is read-only for now.",
     "emptyTitle": "No node to enhance yet",
-    "emptyBody": "Pick a vault or open the sample data and a node will appear here."
+    "emptyBody": "Pick a vault or open the sample data and a node will appear here.",
+    "create": {
+      "entry": "＋ New node",
+      "mode": "＋ Create",
+      "title": "Create a new node",
+      "close": "Close Esc",
+      "kindLabel": "Kind",
+      "nameLabel": "Name",
+      "namePlaceholder": "New node name — e.g. Cancel payment",
+      "domainLabel": "Parent domain",
+      "domainNone": "No domain",
+      "definitionLabel": "Definition · one line",
+      "definitionPlaceholder": "What this node does, in one line — a clear definition/boundary is what stops duplicates.",
+      "gaugeLabel": "Completeness",
+      "gaugeNote": "{filled} of 6 filled — wire the rest one button at a time on the right.",
+      "assembleTitle": "Assemble relations",
+      "assembleSubtitle": "Where this node attaches · one connection per button",
+      "progress": "{filled}/{total} filled",
+      "relation": {
+        "isA": {
+          "title": "Parent concept",
+          "type": "is-a",
+          "hint": "\"What kind of thing is this?\" — pick one parent to open the axis",
+          "add": "Link a parent"
+        },
+        "dependsOn": {
+          "title": "Depends on",
+          "type": "depends",
+          "hint": "The nodes this one relies on to work",
+          "add": "Add link"
+        },
+        "contains": {
+          "title": "Contains",
+          "type": "contains",
+          "hint": "The elements that implement this node (files · schemas · APIs)",
+          "add": "Add element"
+        },
+        "relates": {
+          "title": "Related",
+          "type": "relates",
+          "hint": "Link it if it substitutes or complements another node",
+          "add": "Add link"
+        }
+      },
+      "isaTag": "new axis",
+      "optionalTag": "optional",
+      "emptyCard": "Nothing yet — wire it with the button",
+      "pickerPlaceholder": "Search existing nodes…",
+      "pickerEmpty": "No matching node",
+      "pickerHint": "Click to attach",
+      "previewLabel": "So far\nit looks like",
+      "previewGhostIsa": "＋ Wire a relation and it appears here",
+      "similarMessage": "A similar node already exists — {title} ({kind} · {domain})",
+      "similarOpen": "Open that node",
+      "similarCreateAnyway": "Create new anyway",
+      "ledgerCount": "things assembled",
+      "pendingNode": "Create node ({kind})",
+      "pendingRelation": "{relation} → {target}",
+      "applyDirect": "Apply directly",
+      "applyDirectSub": "Write to your folder",
+      "applyDirectDisabled": "Open a vault to write",
+      "applyAgent": "Hand to agent",
+      "applyAgentSub": "Copy MCP commands",
+      "appliedDirect": "Created node \"{title}\" in your folder.",
+      "applyFailed": "Couldn't create it — {message}",
+      "copiedAgent": "Copied the MCP commands — paste them to your agent to run.",
+      "copyFailed": "Copy was blocked — please try again."
+    }
   },
   "liveActivity": {
     "live": "Live",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -165,7 +165,74 @@
     "agent": "에이전트에게 맡기기",
     "nextSlice": "쓰기는 다음 슬라이스에서 열립니다 — 지금은 읽기 전용이에요.",
     "emptyTitle": "강화할 노드가 아직 없어요",
-    "emptyBody": "vault 를 선택하거나 예시 데이터를 열면 강화할 노드가 나타납니다."
+    "emptyBody": "vault 를 선택하거나 예시 데이터를 열면 강화할 노드가 나타납니다.",
+    "create": {
+      "entry": "＋ 노드 만들기",
+      "mode": "＋ 만들기",
+      "title": "새 노드 만들기",
+      "close": "닫기 Esc",
+      "kindLabel": "종류",
+      "nameLabel": "이름",
+      "namePlaceholder": "새 노드 이름 — 예: 결제 취소",
+      "domainLabel": "소속 도메인",
+      "domainNone": "도메인 없음",
+      "definitionLabel": "정의 · 한 줄",
+      "definitionPlaceholder": "이 노드가 하는 일을 한 줄로 — 정의·경계가 중복을 막는 핵심이에요.",
+      "gaugeLabel": "완성도",
+      "gaugeNote": "6가지 중 {filled}가지 채움 — 오른쪽에서 버튼으로 하나씩 이어요.",
+      "assembleTitle": "관계 조립",
+      "assembleSubtitle": "이 노드가 어디에 붙는지 · 버튼으로 하나씩 이어요",
+      "progress": "{filled}/{total} 채움",
+      "relation": {
+        "isA": {
+          "title": "상위 개념",
+          "type": "is-a",
+          "hint": "\"이 노드는 무엇의 한 종류인가?\" — 상위를 하나 고르면 축이 생겨요",
+          "add": "상위 개념 잇기"
+        },
+        "dependsOn": {
+          "title": "기대는 곳",
+          "type": "depends",
+          "hint": "이 노드가 동작하려고 기대는 다른 노드",
+          "add": "연결 추가"
+        },
+        "contains": {
+          "title": "담는 것",
+          "type": "contains",
+          "hint": "이 노드를 구현하는 요소(파일·스키마·API)",
+          "add": "요소 담기"
+        },
+        "relates": {
+          "title": "비슷한 것",
+          "type": "relates",
+          "hint": "대체·보완 관계라면 이어요",
+          "add": "연결 추가"
+        }
+      },
+      "isaTag": "새 축",
+      "optionalTag": "선택",
+      "emptyCard": "아직 없음 — 버튼으로 이어요",
+      "pickerPlaceholder": "기존 노드 검색…",
+      "pickerEmpty": "맞는 노드가 없어요",
+      "pickerHint": "클릭해서 붙이기",
+      "previewLabel": "지금까지\n이런 모양",
+      "previewGhostIsa": "＋ 관계를 이으면 여기 나타나요",
+      "similarMessage": "비슷한 노드가 이미 있어요 — {title} ({kind} · {domain})",
+      "similarOpen": "그 노드 열기",
+      "similarCreateAnyway": "그래도 새로 만들기",
+      "ledgerCount": "가지 만들어짐",
+      "pendingNode": "노드 생성 ({kind})",
+      "pendingRelation": "{relation} → {target}",
+      "applyDirect": "직접 적용",
+      "applyDirectSub": "내 폴더에 쓰기",
+      "applyDirectDisabled": "vault 를 열어야 써요",
+      "applyAgent": "에이전트에게 맡기기",
+      "applyAgentSub": "MCP 명령 복사",
+      "appliedDirect": "\"{title}\" 노드를 내 폴더에 만들었어요.",
+      "applyFailed": "만들지 못했어요 — {message}",
+      "copiedAgent": "MCP 명령을 복사했어요 — 에이전트에 붙여넣어 실행하세요.",
+      "copyFailed": "복사가 막혔어요 — 다시 시도해 주세요."
+    }
   },
   "liveActivity": {
     "live": "실시간",

--- a/src/views/ontology-studio/lib/build-create-node.test.ts
+++ b/src/views/ontology-studio/lib/build-create-node.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCreateNodeDoc,
+  buildCreateNodeSlug,
+  buildMcpPacket,
+  candidateFromNode,
+  computeCreateCompleteness,
+  groupRelationRefs,
+  type CreateDraft,
+  type PendingRelation,
+} from "./build-create-node";
+
+const orderCancel = candidateFromNode({ id: "capability:order-cancel", kind: "capability", title: "주문 취소" });
+const gateway = candidateFromNode({ id: "element:gateway", kind: "element", title: "src/payment/gateway.ts" });
+const payment = candidateFromNode({ id: "capability:payment", kind: "capability", title: "결제 처리" });
+
+function draft(overrides: Partial<CreateDraft> = {}): CreateDraft {
+  return {
+    kind: "capability",
+    title: "결제 취소",
+    domainValue: "payments",
+    definition: "결제 후 사용자가 주문을 취소하면 승인을 취소한다",
+    relations: [],
+    ...overrides,
+  };
+}
+
+describe("candidateFromNode", () => {
+  it("computes the folder-prefixed ref the derivation resolves", () => {
+    expect(orderCancel.ref).toBe("capabilities/order-cancel");
+    expect(gateway.ref).toBe("elements/gateway");
+  });
+  it("prefers the display title", () => {
+    const c = candidateFromNode({ id: "domain:auth", kind: "domain", title: "auth", display: "인증" });
+    expect(c.title).toBe("인증");
+    expect(c.ref).toBe("domains/auth");
+  });
+});
+
+describe("buildCreateNodeSlug", () => {
+  it("slugs into the kind folder, preserving Korean", () => {
+    expect(buildCreateNodeSlug({ kind: "capability", title: "결제 취소" })).toBe("capabilities/결제-취소");
+  });
+  it("returns null when the title has no slug-able characters", () => {
+    expect(buildCreateNodeSlug({ kind: "capability", title: "!!!" })).toBeNull();
+  });
+});
+
+describe("groupRelationRefs", () => {
+  it("groups by frontmatter key in card order and dedupes", () => {
+    const relations: PendingRelation[] = [
+      { type: "dependsOn", candidate: orderCancel },
+      { type: "dependsOn", candidate: orderCancel }, // dup
+      { type: "contains", candidate: gateway },
+      { type: "isA", candidate: payment },
+    ];
+    expect(groupRelationRefs(relations)).toEqual([
+      { key: "broader", refs: ["capabilities/payment"] },
+      { key: "dependencies", refs: ["capabilities/order-cancel"] },
+      { key: "contains", refs: ["elements/gateway"] },
+    ]);
+  });
+});
+
+describe("buildCreateNodeDoc", () => {
+  it("serializes the assembled node with runtime-read relation keys", () => {
+    const { slug, markdown } = buildCreateNodeDoc(
+      draft({
+        relations: [
+          { type: "dependsOn", candidate: orderCancel },
+          { type: "contains", candidate: gateway },
+          { type: "isA", candidate: payment },
+        ],
+      }),
+    );
+    expect(slug).toBe("capabilities/결제-취소");
+    expect(markdown).toContain("kind: capability");
+    expect(markdown).toContain("domain: payments");
+    expect(markdown).toContain("title: 결제 취소");
+    // dependsOn writes `dependencies` (dogfood + runtime convention, not depends_on)
+    expect(markdown).toContain("dependencies: [capabilities/order-cancel]");
+    expect(markdown).toContain("contains: [elements/gateway]");
+    // is_a is additive as `broader:` (S3 wires validation)
+    expect(markdown).toContain("broader: [capabilities/payment]");
+    expect(markdown).toContain("definition: 결제 후");
+    expect(markdown).toContain("# 결제 취소");
+  });
+
+  it("omits domain for project/domain kinds", () => {
+    const { markdown } = buildCreateNodeDoc(draft({ kind: "domain", title: "결제", domainValue: null }));
+    expect(markdown).not.toContain("domain:");
+  });
+
+  it("throws on an empty title", () => {
+    expect(() => buildCreateNodeDoc(draft({ title: "   " }))).toThrow();
+  });
+});
+
+describe("buildMcpPacket", () => {
+  it("reflects the assembled node and its relations as add_concept + add_relation", () => {
+    const packet = buildMcpPacket(
+      draft({
+        relations: [
+          { type: "dependsOn", candidate: orderCancel },
+          { type: "isA", candidate: payment },
+        ],
+      }),
+    );
+    expect(packet).toContain('add_concept(slug: "capabilities/결제-취소", kind: "capability", title: "결제 취소", domain: "payments", definition: "결제 후');
+    expect(packet).toContain('add_relation(from: "capabilities/결제-취소", to: "capabilities/order-cancel", type: "depends_on")');
+    expect(packet).toContain('add_relation(from: "capabilities/결제-취소", to: "capabilities/payment", type: "is_a")');
+  });
+});
+
+describe("computeCreateCompleteness", () => {
+  it("is 33% with name + one relation (2 of 6 checkpoints)", () => {
+    const c = computeCreateCompleteness(
+      draft({ definition: "", relations: [{ type: "dependsOn", candidate: orderCancel }] }),
+    );
+    expect(c.filledCount).toBe(2);
+    expect(c.percent).toBe(33);
+    expect(c.pips[0]).toBe("on"); // name
+    expect(c.pips[1]).toBe("next"); // definition is the next gap
+  });
+  it("reaches 100% when every checkpoint is filled", () => {
+    const c = computeCreateCompleteness(
+      draft({
+        relations: [
+          { type: "isA", candidate: payment },
+          { type: "dependsOn", candidate: orderCancel },
+          { type: "contains", candidate: gateway },
+          { type: "relates", candidate: payment },
+        ],
+      }),
+    );
+    expect(c.percent).toBe(100);
+    expect(c.pips.every((p) => p === "on")).toBe(true);
+  });
+});

--- a/src/views/ontology-studio/lib/build-create-node.ts
+++ b/src/views/ontology-studio/lib/build-create-node.ts
@@ -1,0 +1,237 @@
+/**
+ * Studio CREATE (만들기) mode — pure, deterministic model for assembling a
+ * brand-new ontology node and its typed relations, then serializing that draft
+ * two ways: (1) a vault `.md` document for the DIRECT-APPLY path (written to the
+ * user's disk via `createDoc`), and (2) a copyable MCP command packet for the
+ * DELEGATE path (`에이전트에게 맡기기`).
+ *
+ * Slice 2 of the Ontology Studio track. Enhance (Slice 1) reads ONE existing
+ * node; Create ASSEMBLES a new one by clicking relation cards. The two apply
+ * routes keep the single source of truth intact — the vault (or the agent that
+ * runs the packet) is always the writer; this module only produces strings.
+ *
+ * Frontmatter relation keys are the ones the RUNTIME derivation
+ * (`deriveOntologyFromVault`) actually reads so a direct-applied node shows up
+ * on the map immediately:
+ *   - contains   → `contains`
+ *   - dependsOn  → `dependencies`  (matches the dogfood vault convention +
+ *                  runtime derive — schema.mjs's `depends_on` alias is a known
+ *                  drift; the validator accepts both)
+ *   - relates    → `relates`
+ *   - isA        → `broader`       (S3 additive — the runtime does not derive an
+ *                  is_a edge yet; the key is written so S3 can wire validation)
+ * The definition is written as `definition:` (S3 additive — full validation lands
+ * in S3; today it is an inert, portable frontmatter fact).
+ */
+
+import { slugify } from "@/shared/lib/slugify";
+import { vaultFolderForKind } from "@/entities/docs-vault";
+
+/** The four node kinds a user can assemble in Create mode (project → element). */
+export const CREATE_NODE_KINDS = ["project", "domain", "capability", "element"] as const;
+export type CreateNodeKind = (typeof CREATE_NODE_KINDS)[number];
+
+/**
+ * Relation cards, in display order: is_a (the new axis) first, then the three
+ * relations the enhance surface already renders as gems.
+ */
+export const CREATE_RELATION_TYPES = ["isA", "dependsOn", "contains", "relates"] as const;
+export type CreateRelationType = (typeof CREATE_RELATION_TYPES)[number];
+
+/** Relation type → the frontmatter array key the runtime derivation reads. */
+export const RELATION_FRONTMATTER_KEY: Record<CreateRelationType, string> = {
+  contains: "contains",
+  dependsOn: "dependencies",
+  relates: "relates",
+  isA: "broader",
+};
+
+/** Relation type → the MCP `add_relation` edge type (for the agent packet). */
+export const RELATION_EDGE_TYPE: Record<CreateRelationType, string> = {
+  contains: "contains",
+  dependsOn: "depends_on",
+  relates: "related_to",
+  isA: "is_a",
+};
+
+/** A pickable existing node — the frontmatter-writable `ref` is precomputed. */
+export interface CreateCandidate {
+  /** Graph node id, e.g. `capability:mcp-server`. */
+  id: string;
+  title: string;
+  kind: string;
+  /** Folder-prefixed ref the derivation resolves, e.g. `capabilities/mcp-server`. */
+  ref: string;
+}
+
+export interface PendingRelation {
+  type: CreateRelationType;
+  candidate: CreateCandidate;
+}
+
+export interface CreateDraft {
+  kind: CreateNodeKind;
+  title: string;
+  /** Parent domain tail-slug (e.g. `views`) — null for project/domain kinds. */
+  domainValue: string | null;
+  definition: string;
+  relations: PendingRelation[];
+}
+
+/**
+ * Turn an insight graph node (`id = kind:tail`) into a pickable candidate with a
+ * folder-prefixed `ref` the vault derivation can resolve. Falls back to
+ * slugifying the id tail when the id is not `kind:tail` shaped.
+ */
+export function candidateFromNode(node: {
+  id: string;
+  kind: string;
+  title: string;
+  display?: string;
+}): CreateCandidate {
+  const prefix = `${node.kind}:`;
+  const tail = node.id.startsWith(prefix) ? node.id.slice(prefix.length) : slugify(node.id);
+  const ref = `${vaultFolderForKind(node.kind)}/${tail || slugify(node.title)}`;
+  return { id: node.id, title: node.display ?? node.title, kind: node.kind, ref };
+}
+
+/** Whether `kind` expects a parent domain (capability / element). */
+export function kindExpectsDomain(kind: CreateNodeKind): boolean {
+  return kind === "capability" || kind === "element";
+}
+
+/** The vault slug the new node will occupy, or null when the title is unusable. */
+export function buildCreateNodeSlug(draft: Pick<CreateDraft, "kind" | "title">): string | null {
+  const tail = slugify(draft.title);
+  if (!tail) return null;
+  return `${vaultFolderForKind(draft.kind)}/${tail}`;
+}
+
+function quoteYamlScalar(v: string): string {
+  return /[:#[\]{}"',&|*!%@`]/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v;
+}
+
+/** Dedupe pending relations by (type, candidate.id) preserving first-seen order. */
+function dedupeRelations(relations: readonly PendingRelation[]): PendingRelation[] {
+  const seen = new Set<string>();
+  const out: PendingRelation[] = [];
+  for (const rel of relations) {
+    const key = `${rel.type}:${rel.candidate.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(rel);
+  }
+  return out;
+}
+
+/** Group deduped relation refs by their frontmatter key, in card order. */
+export function groupRelationRefs(relations: readonly PendingRelation[]): Array<{
+  key: string;
+  refs: string[];
+}> {
+  const deduped = dedupeRelations(relations);
+  const out: Array<{ key: string; refs: string[] }> = [];
+  for (const type of CREATE_RELATION_TYPES) {
+    const refs = deduped.filter((r) => r.type === type).map((r) => r.candidate.ref);
+    if (refs.length > 0) out.push({ key: RELATION_FRONTMATTER_KEY[type], refs });
+  }
+  return out;
+}
+
+/**
+ * Serialize the draft into a vault `.md` document (slug + markdown). Reuses the
+ * shared `buildNewNodeDoc` base serialization (identical to /docs + the builder)
+ * and injects the definition + relation-array keys before the closing `---`, so
+ * the base frontmatter (slug/kind/domain/title) stays byte-identical.
+ */
+export function buildCreateNodeDoc(draft: CreateDraft): { slug: string; markdown: string } {
+  const title = draft.title.trim();
+  if (!title) throw new Error("title must not be empty");
+  const slug = buildCreateNodeSlug({ kind: draft.kind, title });
+  if (!slug) throw new Error("title produced an empty slug");
+
+  const extra: string[] = [];
+  const definition = draft.definition.trim();
+  if (definition) extra.push(`definition: ${quoteYamlScalar(definition)}`);
+  for (const { key, refs } of groupRelationRefs(draft.relations)) {
+    extra.push(`${key}: [${refs.join(", ")}]`);
+  }
+
+  const lines: string[] = ["---", `slug: ${slug}`, `kind: ${draft.kind}`];
+  const domain = draft.domainValue?.trim();
+  if (domain && kindExpectsDomain(draft.kind)) lines.push(`domain: ${quoteYamlScalar(domain)}`);
+  lines.push(`title: ${quoteYamlScalar(title)}`);
+  lines.push(...extra);
+  lines.push("---", "", `# ${title}`, "");
+  if (definition) lines.push(definition, "");
+
+  return { slug, markdown: lines.join("\n") };
+}
+
+/**
+ * Build the copyable MCP command packet for the DELEGATE path. This is the ONLY
+ * active write route in read-only / sample mode — the agent runs these calls
+ * against the vault it is registered on.
+ */
+export function buildMcpPacket(draft: CreateDraft): string {
+  const title = draft.title.trim();
+  const slug = buildCreateNodeSlug({ kind: draft.kind, title }) ?? `${draft.kind}s/new-node`;
+  const q = (v: string) => `"${v.replace(/"/g, '\\"')}"`;
+
+  const conceptArgs = [`slug: ${q(slug)}`, `kind: ${q(draft.kind)}`, `title: ${q(title)}`];
+  const domain = draft.domainValue?.trim();
+  if (domain && kindExpectsDomain(draft.kind)) conceptArgs.push(`domain: ${q(domain)}`);
+  const definition = draft.definition.trim();
+  if (definition) conceptArgs.push(`definition: ${q(definition)}`);
+
+  const lines: string[] = [`add_concept(${conceptArgs.join(", ")})`];
+  for (const rel of dedupeRelations(draft.relations)) {
+    lines.push(
+      `add_relation(from: ${q(slug)}, to: ${q(rel.candidate.ref)}, type: ${q(RELATION_EDGE_TYPE[rel.type])})`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Six completeness checkpoints (name · definition · is_a · depends · contains ·
+ * relates) drive the rising gauge. Deterministic so the gauge and the pips never
+ * disagree. Percent = round(filled / 6 · 100).
+ */
+export const CREATE_CHECKPOINTS = 6;
+
+export interface CreateCompleteness {
+  percent: number;
+  filledCount: number;
+  total: number;
+  /** One state per checkpoint: the first unfilled after the filled ones is `next`. */
+  pips: Array<"on" | "next" | "off">;
+}
+
+export function computeCreateCompleteness(draft: CreateDraft): CreateCompleteness {
+  const has = (type: CreateRelationType) => draft.relations.some((r) => r.type === type);
+  const checks = [
+    draft.title.trim().length > 0,
+    draft.definition.trim().length > 0,
+    has("isA"),
+    has("dependsOn"),
+    has("contains"),
+    has("relates"),
+  ];
+  const filledCount = checks.filter(Boolean).length;
+  let nextAssigned = false;
+  const pips = checks.map((filled) => {
+    if (filled) return "on" as const;
+    if (!nextAssigned) {
+      nextAssigned = true;
+      return "next" as const;
+    }
+    return "off" as const;
+  });
+  return {
+    percent: Math.round((filledCount / CREATE_CHECKPOINTS) * 100),
+    filledCount,
+    total: CREATE_CHECKPOINTS,
+    pips,
+  };
+}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -3,23 +3,35 @@
 import { useCallback, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
 import { useOntologyInsight } from "@/features/vault-ontology";
+import { useDataSourceMode } from "@/features/data-source-mode";
+import { useLocalVault } from "@/features/docs-vault-local";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
+import type { SimilarNodeCandidate } from "@/shared/lib/similar-node-title";
 import { EmptyState, useToast } from "@/shared/ui";
 import { buildStudioItem, selectDefaultStudioNodeId } from "../lib/build-studio-item";
+import {
+  buildCreateNodeDoc,
+  buildMcpPacket,
+  candidateFromNode,
+  type CreateCandidate,
+  type CreateDraft,
+} from "../lib/build-create-node";
 import { StudioArena, type StudioArenaLabels } from "./StudioArena";
+import { StudioCreateArena, type StudioCreateLabels } from "./StudioCreateArena";
 
 /**
- * `/ontology/studio` — the Ontology Studio "강화(enhancement) screen". Slice 1
- * is READ-ONLY: it reads a node's real relations from the derived ontology
- * (`useOntologyInsight` — the SAME source as the map/insights) and renders it
- * as a game item with equipped relation gems, enhancement sockets, and a
- * deterministic completeness score. The 강화하기 / 넣기 / 에이전트 buttons render
- * with the right affordance but only surface a "next slice" notice — no writes.
+ * `/ontology/studio` — the Ontology Studio. Two modes off one route
+ * (static-export compatible, switched by `?mode=`):
  *
- * Node selection: `?node=<id>` deeplink wins; otherwise the most-connected
- * capability in the active vault (or the built-in dogfood/storefront sample) is
- * chosen deterministically.
+ * - **enhance** (default, Slice 1) — read one node's real relations as a game
+ *   item you complete by socketing relation gems. `?node=<id>` deeplinks;
+ *   otherwise the most-connected capability is chosen deterministically.
+ * - **create** (`?mode=create`, Slice 2) — ASSEMBLE a brand-new node by
+ *   clicking relation cards, then apply two ways: 직접 적용 (write the .md to a
+ *   loaded local vault via `createDoc`) or 에이전트에게 맡기기 (copy an MCP
+ *   command packet — the only active route in read-only / sample mode).
  */
 
 // Static particle seeds — deterministic so SSR (static export) and the client
@@ -41,69 +53,240 @@ const PARTICLE_SEEDS = [
   { left: 90, top: 66, dur: 6.3, delay: 0.7, opacity: 0.46 },
 ] as const;
 
+const STUDIO_BASE = "/ontology/studio";
+const CREATE_HREF = `${STUDIO_BASE}?mode=create`;
+
 export function OntologyStudioPage() {
   const t = useTranslations("ontologyStudio");
   const searchParams = useSearchParams();
+  const router = useRouter();
   const { insight } = useOntologyInsight();
+  const mode = useDataSourceMode();
+  const localVault = useLocalVault();
   const kindLabel = useOntologyKindLabel();
   const toast = useToast();
 
+  const isCreate = searchParams.get("mode") === "create";
   const requestedNode = searchParams.get("node");
 
+  const nodes = useMemo(() => insight?.nodes ?? [], [insight]);
+  const edges = useMemo(() => insight?.edges ?? [], [insight]);
+
+  // ── ENHANCE mode data ──────────────────────────────────────────────────
   const item = useMemo(() => {
-    const nodes = insight?.nodes ?? [];
-    const edges = insight?.edges ?? [];
     if (nodes.length === 0) return null;
     const targetId =
       (requestedNode && nodes.some((n) => n.id === requestedNode) ? requestedNode : null) ??
       selectDefaultStudioNodeId(nodes, edges);
     if (!targetId) return null;
     return buildStudioItem(targetId, nodes, edges);
-  }, [insight, requestedNode]);
+  }, [nodes, edges, requestedNode]);
+
+  // ── CREATE mode data ───────────────────────────────────────────────────
+  const writable = mode === "local" && localVault.status === "loaded";
+
+  const domains = useMemo(
+    () =>
+      nodes
+        .filter((n) => n.kind === "domain")
+        .map((n) => ({ value: n.id.replace(/^domain:/, ""), title: n.display ?? n.title })),
+    [nodes],
+  );
+  const candidates = useMemo<CreateCandidate[]>(() => nodes.map((n) => candidateFromNode(n)), [nodes]);
+  const similarCandidates = useMemo<SimilarNodeCandidate[]>(
+    () => candidates.map((c) => ({ slug: c.ref, title: c.title, kind: c.kind })),
+    [candidates],
+  );
+  const refToNodeId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of candidates) map.set(c.ref, c.id);
+    return map;
+  }, [candidates]);
 
   const onDeferredAction = useCallback(() => {
     toast.show(t("nextSlice"), "info");
   }, [toast, t]);
 
-  const labels: StudioArenaLabels = useMemo(
-    () => ({
-      mode: t("mode"),
-      close: t("close"),
-      statsTitle: t("statsTitle"),
-      socketsTitle: t("socketsTitle"),
-      axis: {
-        definition: t("axis.definition"),
-        evidence: t("axis.evidence"),
-        contains: t("axis.contains"),
-        dependsOn: t("axis.dependsOn"),
-        relates: t("axis.relates"),
-        isA: t("axis.isA"),
-      },
-      statConfirmed: t("statConfirmed"),
-      statMissing: t("statMissing"),
-      level: (from, to) => t("level", { from, to }),
-      levelMax: (level) => t("levelMax", { level }),
-      gaugeLead: t("gaugeLead"),
-      gaugeTrail: t("gaugeTrail"),
-      gaugeMax: (percent) => t("gaugeMax", { percent }),
-      isaTag: t("isaTag"),
-      isaPrompt: (title) => t("isaPrompt", { title }),
-      relationMeta: (count) => t("relationMeta", { count }),
-      relatesPick: t("relatesPick"),
-      relatesEmptyHint: t("relatesEmptyHint"),
-      add: t("add"),
-      readOnlyNote: t("readOnlyNote"),
-      enhance: t("enhance"),
-      enhanceSub: t("enhanceSub"),
-      agent: t("agent"),
-    }),
-    [t],
+  const enterCreate = useCallback(() => router.push(CREATE_HREF), [router]);
+  const exitCreate = useCallback(() => router.push(STUDIO_BASE), [router]);
+
+  const applyDirect = useCallback(
+    async (draft: CreateDraft) => {
+      try {
+        const { slug, markdown } = buildCreateNodeDoc(draft);
+        await localVault.createDoc(slug, markdown);
+        toast.show(t("create.appliedDirect", { title: draft.title.trim() }), "success");
+        // Hand the fresh node to enhance so the user can keep completing it.
+        const tail = slug.split("/").at(-1) ?? "";
+        router.push(`${STUDIO_BASE}?node=${encodeURIComponent(`${draft.kind}:${tail}`)}`);
+      } catch (err) {
+        toast.show(
+          t("create.applyFailed", { message: err instanceof Error ? err.message : String(err) }),
+          "error",
+        );
+      }
+    },
+    [localVault, toast, t, router],
   );
+
+  const applyAgent = useCallback(
+    async (draft: CreateDraft) => {
+      const packet = buildMcpPacket(draft);
+      try {
+        await navigator.clipboard.writeText(packet);
+        toast.show(t("create.copiedAgent"), "success");
+      } catch {
+        // Clipboard blocked (permissions / insecure context) — still confirm the
+        // packet was built; the user can re-trigger once focus/permission allows.
+        toast.show(t("create.copyFailed"), "info");
+      }
+    },
+    [toast, t],
+  );
+
+  const openSimilar = useCallback(
+    (slug: string) => {
+      const nodeId = refToNodeId.get(slug);
+      if (nodeId) router.push(`${STUDIO_BASE}?node=${encodeURIComponent(nodeId)}`);
+    },
+    [refToNodeId, router],
+  );
+
+  // ── CREATE surface ─────────────────────────────────────────────────────
+  if (isCreate) {
+    const createLabels: StudioCreateLabels = {
+      mode: t("create.mode"),
+      title: t("create.title"),
+      close: t("create.close"),
+      kindLabelHead: t("create.kindLabel"),
+      nameLabel: t("create.nameLabel"),
+      namePlaceholder: t("create.namePlaceholder"),
+      domainLabel: t("create.domainLabel"),
+      domainNone: t("create.domainNone"),
+      definitionLabel: t("create.definitionLabel"),
+      definitionPlaceholder: t("create.definitionPlaceholder"),
+      gaugeLabel: t("create.gaugeLabel"),
+      gaugeNote: (filled, total) => t("create.gaugeNote", { filled, total }),
+      assembleTitle: t("create.assembleTitle"),
+      assembleSubtitle: t("create.assembleSubtitle"),
+      progress: (filled, total) => t("create.progress", { filled, total }),
+      relation: {
+        isA: {
+          title: t("create.relation.isA.title"),
+          type: t("create.relation.isA.type"),
+          hint: t("create.relation.isA.hint"),
+          add: t("create.relation.isA.add"),
+        },
+        dependsOn: {
+          title: t("create.relation.dependsOn.title"),
+          type: t("create.relation.dependsOn.type"),
+          hint: t("create.relation.dependsOn.hint"),
+          add: t("create.relation.dependsOn.add"),
+        },
+        contains: {
+          title: t("create.relation.contains.title"),
+          type: t("create.relation.contains.type"),
+          hint: t("create.relation.contains.hint"),
+          add: t("create.relation.contains.add"),
+        },
+        relates: {
+          title: t("create.relation.relates.title"),
+          type: t("create.relation.relates.type"),
+          hint: t("create.relation.relates.hint"),
+          add: t("create.relation.relates.add"),
+        },
+      },
+      isaTag: t("create.isaTag"),
+      optionalTag: t("create.optionalTag"),
+      emptyCard: t("create.emptyCard"),
+      pickerPlaceholder: t("create.pickerPlaceholder"),
+      pickerEmpty: t("create.pickerEmpty"),
+      pickerHint: t("create.pickerHint"),
+      previewLabel: t("create.previewLabel"),
+      previewGhostIsa: t("create.previewGhostIsa"),
+      similarMessage: (title, kLabel, dLabel) =>
+        t("create.similarMessage", { title, kind: kLabel, domain: dLabel }),
+      similarOpen: t("create.similarOpen"),
+      similarCreateAnyway: t("create.similarCreateAnyway"),
+      ledgerCount: (count) => t("create.ledgerCount", { count }),
+      pendingNode: (kLabel) => t("create.pendingNode", { kind: kLabel }),
+      pendingRelation: (relationLabel, target) =>
+        t("create.pendingRelation", { relation: relationLabel, target }),
+      applyDirect: t("create.applyDirect"),
+      applyDirectSub: t("create.applyDirectSub"),
+      applyDirectDisabled: t("create.applyDirectDisabled"),
+      applyAgent: t("create.applyAgent"),
+      applyAgentSub: t("create.applyAgentSub"),
+    };
+
+    return (
+      <StudioCreateArena
+        labels={createLabels}
+        kindLabel={kindLabel}
+        domains={domains}
+        candidates={candidates}
+        similarCandidates={similarCandidates}
+        writable={writable}
+        onApplyDirect={applyDirect}
+        onApplyAgent={applyAgent}
+        onOpenSimilar={openSimilar}
+        onExit={exitCreate}
+        particleSeeds={PARTICLE_SEEDS}
+      />
+    );
+  }
+
+  // ── ENHANCE surface ────────────────────────────────────────────────────
+  const labels: StudioArenaLabels = {
+    mode: t("mode"),
+    close: t("close"),
+    statsTitle: t("statsTitle"),
+    socketsTitle: t("socketsTitle"),
+    axis: {
+      definition: t("axis.definition"),
+      evidence: t("axis.evidence"),
+      contains: t("axis.contains"),
+      dependsOn: t("axis.dependsOn"),
+      relates: t("axis.relates"),
+      isA: t("axis.isA"),
+    },
+    statConfirmed: t("statConfirmed"),
+    statMissing: t("statMissing"),
+    level: (from, to) => t("level", { from, to }),
+    levelMax: (level) => t("levelMax", { level }),
+    gaugeLead: t("gaugeLead"),
+    gaugeTrail: t("gaugeTrail"),
+    gaugeMax: (percent) => t("gaugeMax", { percent }),
+    isaTag: t("isaTag"),
+    isaPrompt: (title) => t("isaPrompt", { title }),
+    relationMeta: (count) => t("relationMeta", { count }),
+    relatesPick: t("relatesPick"),
+    relatesEmptyHint: t("relatesEmptyHint"),
+    add: t("add"),
+    readOnlyNote: t("readOnlyNote"),
+    enhance: t("enhance"),
+    enhanceSub: t("enhanceSub"),
+    agent: t("agent"),
+  };
 
   if (!item) {
     return (
       <div className="flex h-[100dvh] items-center justify-center bg-[color:var(--color-canvas)] p-6">
-        <EmptyState title={t("emptyTitle")} description={t("emptyBody")} tone="solid" align="center" />
+        <EmptyState
+          title={t("emptyTitle")}
+          description={t("emptyBody")}
+          tone="solid"
+          align="center"
+          action={
+            <button
+              type="button"
+              onClick={enterCreate}
+              className="rounded-lg border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            >
+              {t("create.entry")}
+            </button>
+          }
+        />
       </div>
     );
   }
@@ -115,6 +298,8 @@ export function OntologyStudioPage() {
       kindLabel={kindLabel}
       onDeferredAction={onDeferredAction}
       particleSeeds={PARTICLE_SEEDS}
+      onCreate={enterCreate}
+      createLabel={t("create.entry")}
     />
   );
 }

--- a/src/views/ontology-studio/ui/StudioArena.tsx
+++ b/src/views/ontology-studio/ui/StudioArena.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { Bot, Zap } from "lucide-react";
+import { Bot, Plus, Zap } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
 import type { StudioGem, StudioGemKind, StudioItem } from "../lib/build-studio-item";
 
@@ -88,6 +88,9 @@ export interface StudioArenaProps {
   onDeferredAction: () => void;
   /** Static particle positions (avoids `Math.random` in render → SSR-stable). */
   particleSeeds: ReadonlyArray<{ left: number; top: number; dur: number; delay: number; opacity: number }>;
+  /** Slice 2 — enter CREATE (만들기) mode. Omitted → the entry is not rendered. */
+  onCreate?: () => void;
+  createLabel?: string;
 }
 
 export function StudioArena({
@@ -96,6 +99,8 @@ export function StudioArena({
   kindLabel,
   onDeferredAction,
   particleSeeds,
+  onCreate,
+  createLabel,
 }: StudioArenaProps) {
   const { node, stats, score, projectedScore } = item;
   const maxed = score.level >= score.pips.length;
@@ -170,9 +175,28 @@ export function StudioArena({
             {labels.mode}
           </span>
         </div>
+        {onCreate ? (
+          <button
+            type="button"
+            onClick={onCreate}
+            data-testid="studio-create-entry"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-label font-semibold transition-colors"
+            style={{
+              color: "var(--studio-indigo-bright)",
+              borderColor: "var(--studio-indigo-a45)",
+              background: "var(--studio-indigo-a10)",
+            }}
+          >
+            <Plus size={13} aria-hidden />
+            {createLabel}
+          </button>
+        ) : null}
         <span
           data-testid="studio-close"
-          className="ml-auto rounded-lg border border-[color:var(--color-border-soft)] px-2.5 py-1.5 text-label text-[color:var(--color-text-quaternary)]"
+          className={cn(
+            "rounded-lg border border-[color:var(--color-border-soft)] px-2.5 py-1.5 text-label text-[color:var(--color-text-quaternary)]",
+            !onCreate && "ml-auto",
+          )}
         >
           {labels.close}
         </span>

--- a/src/views/ontology-studio/ui/StudioCreateArena.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCreateArena.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { candidateFromNode, type CreateCandidate, type CreateDraft } from "../lib/build-create-node";
+import { StudioCreateArena, type StudioCreateLabels } from "./StudioCreateArena";
+
+const candidates: CreateCandidate[] = [
+  candidateFromNode({ id: "capability:order-cancel", kind: "capability", title: "주문 취소" }),
+  candidateFromNode({ id: "capability:refund", kind: "capability", title: "환불 처리" }),
+  candidateFromNode({ id: "element:gateway", kind: "element", title: "src/payment/gateway.ts" }),
+];
+
+const labels: StudioCreateLabels = {
+  mode: "＋ 만들기",
+  title: "새 노드 만들기",
+  close: "닫기",
+  kindLabelHead: "종류",
+  nameLabel: "이름",
+  namePlaceholder: "이름",
+  domainLabel: "소속 도메인",
+  domainNone: "도메인 없음",
+  definitionLabel: "정의",
+  definitionPlaceholder: "정의",
+  gaugeLabel: "완성도",
+  gaugeNote: (f, t) => `${f}/${t}`,
+  assembleTitle: "관계 조립",
+  assembleSubtitle: "sub",
+  progress: (f, t) => `${f}/${t} 채움`,
+  relation: {
+    isA: { title: "상위 개념", type: "is-a", hint: "h", add: "상위 잇기" },
+    dependsOn: { title: "기대는 곳", type: "depends", hint: "h", add: "연결 추가" },
+    contains: { title: "담는 것", type: "contains", hint: "h", add: "요소 담기" },
+    relates: { title: "비슷한 것", type: "relates", hint: "h", add: "연결 추가" },
+  },
+  isaTag: "새 축",
+  optionalTag: "선택",
+  emptyCard: "아직 없음",
+  pickerPlaceholder: "검색",
+  pickerEmpty: "없음",
+  pickerHint: "클릭",
+  previewLabel: "지금까지",
+  previewGhostIsa: "ghost",
+  similarMessage: (title, kind, domain) => `비슷한 노드 — ${title} (${kind} · ${domain})`,
+  similarOpen: "그 노드 열기",
+  similarCreateAnyway: "그래도 새로 만들기",
+  ledgerCount: () => "가지",
+  pendingNode: (k) => `노드 (${k})`,
+  pendingRelation: (r, tg) => `${r} → ${tg}`,
+  applyDirect: "직접 적용",
+  applyDirectSub: "쓰기",
+  applyDirectDisabled: "vault 열기",
+  applyAgent: "에이전트에게 맡기기",
+  applyAgentSub: "복사",
+};
+
+const kindLabel = (k: string) =>
+  ({ capability: "역량", domain: "도메인", element: "요소", project: "프로젝트" })[k] ?? k;
+
+function setup(overrides: Partial<React.ComponentProps<typeof StudioCreateArena>> = {}) {
+  const onApplyDirect = vi.fn();
+  const onApplyAgent = vi.fn();
+  const onOpenSimilar = vi.fn();
+  const onExit = vi.fn();
+  render(
+    <StudioCreateArena
+      labels={labels}
+      kindLabel={kindLabel}
+      domains={[{ value: "payments", title: "결제" }]}
+      candidates={candidates}
+      similarCandidates={candidates.map((c) => ({ slug: c.ref, title: c.title, kind: c.kind }))}
+      writable={false}
+      onApplyDirect={onApplyDirect}
+      onApplyAgent={onApplyAgent}
+      onOpenSimilar={onOpenSimilar}
+      onExit={onExit}
+      particleSeeds={[]}
+      {...overrides}
+    />,
+  );
+  return { onApplyDirect, onApplyAgent, onOpenSimilar, onExit };
+}
+
+function type(title: string) {
+  fireEvent.change(screen.getByTestId("studio-create-title"), { target: { value: title } });
+}
+
+describe("StudioCreateArena", () => {
+  it("adds a pending relation through the node picker", () => {
+    setup();
+    fireEvent.click(screen.getByTestId("studio-create-add-dependsOn"));
+    // element gateway is a valid dependsOn candidate; order-cancel too
+    fireEvent.click(screen.getByTestId("studio-create-picker-row-capability:order-cancel"));
+    const card = screen.getByTestId("studio-create-card-dependsOn");
+    expect(card).toHaveAttribute("data-count", "1");
+    expect(within(card).getByText("주문 취소")).toBeInTheDocument();
+  });
+
+  it("removes a pending relation via its chip", () => {
+    setup();
+    fireEvent.click(screen.getByTestId("studio-create-add-contains"));
+    fireEvent.click(screen.getByTestId("studio-create-picker-row-element:gateway"));
+    const card = screen.getByTestId("studio-create-card-contains");
+    expect(card).toHaveAttribute("data-count", "1");
+    fireEvent.click(within(card).getByTestId("studio-create-chip-remove"));
+    expect(screen.getByTestId("studio-create-card-contains")).toHaveAttribute("data-count", "0");
+  });
+
+  it("fires the near-dup guard when the typed title matches an existing node/kind", () => {
+    const { onOpenSimilar } = setup();
+    type("환불 처리"); // exact title match, kind capability (default)
+    const warn = screen.getByTestId("studio-create-similar");
+    expect(warn).toHaveTextContent("환불 처리");
+    fireEvent.click(within(warn).getByText("그 노드 열기"));
+    expect(onOpenSimilar).toHaveBeenCalledWith("capabilities/refund");
+  });
+
+  it("agent apply is enabled once a title is set and passes the assembled draft", () => {
+    const { onApplyAgent } = setup();
+    const agentBtn = screen.getByTestId("studio-create-apply-agent");
+    expect(agentBtn).toBeDisabled();
+    type("결제 취소");
+    fireEvent.click(screen.getByTestId("studio-create-add-dependsOn"));
+    fireEvent.click(screen.getByTestId("studio-create-picker-row-capability:order-cancel"));
+    expect(agentBtn).not.toBeDisabled();
+    fireEvent.click(agentBtn);
+    const draft = onApplyAgent.mock.calls[0][0] as CreateDraft;
+    expect(draft.title).toBe("결제 취소");
+    expect(draft.relations).toHaveLength(1);
+    expect(draft.relations[0]).toMatchObject({ type: "dependsOn" });
+    expect(draft.relations[0].candidate.ref).toBe("capabilities/order-cancel");
+  });
+
+  it("direct apply stays disabled in read-only / sample mode even with a title", () => {
+    const { onApplyDirect } = setup({ writable: false });
+    type("결제 취소");
+    expect(screen.getByTestId("studio-create-apply-direct")).toBeDisabled();
+    expect(onApplyDirect).not.toHaveBeenCalled();
+  });
+
+  it("direct apply is enabled with a writable vault and passes the draft", () => {
+    const { onApplyDirect } = setup({ writable: true });
+    type("결제 취소");
+    const btn = screen.getByTestId("studio-create-apply-direct");
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    expect(onApplyDirect).toHaveBeenCalledTimes(1);
+    expect((onApplyDirect.mock.calls[0][0] as CreateDraft).title).toBe("결제 취소");
+  });
+});

--- a/src/views/ontology-studio/ui/StudioCreateArena.tsx
+++ b/src/views/ontology-studio/ui/StudioCreateArena.tsx
@@ -1,0 +1,663 @@
+"use client";
+
+import { useMemo, useState, type CSSProperties } from "react";
+import { Bot, Check, Plus, Search, X } from "lucide-react";
+import { cn } from "@/shared/lib/cn";
+import { SimilarNodeWarning } from "@/shared/ui";
+import {
+  findSimilarNodeByTitle,
+  type SimilarNodeCandidate,
+} from "@/shared/lib/similar-node-title";
+import {
+  CREATE_NODE_KINDS,
+  CREATE_RELATION_TYPES,
+  buildCreateNodeSlug,
+  computeCreateCompleteness,
+  kindExpectsDomain,
+  type CreateCandidate,
+  type CreateDraft,
+  type CreateNodeKind,
+  type CreateRelationType,
+  type PendingRelation,
+} from "../lib/build-create-node";
+
+/**
+ * Studio CREATE (만들기) — the assemble-by-clicking surface for a brand-new
+ * ontology node. Enhance (Slice 1) mutates a live item; Create ASSEMBLES: a
+ * left identity form (kind · name · domain · definition + near-dup guard) and
+ * right relation cards you fill one connection at a time with a node picker,
+ * with a rising completeness gauge and a mini "지금까지 이런 모양" preview.
+ *
+ * Two apply routes (owner: "직접+위임 둘 다"):
+ *   - 직접 적용  → `onApplyDirect(draft)` writes the node .md to the local vault
+ *                 (only when a writable local vault is loaded).
+ *   - 에이전트에게 맡기기 → `onApplyAgent(draft)` copies an MCP command packet —
+ *                 the ONLY active path in read-only / sample mode.
+ *
+ * SCOPED CHARTER EXCEPTION: game visuals (gems, glow) come only from
+ * `--studio-*` tokens under `.studio-stage`. Presentational: every string is a
+ * resolved label so it renders in isolation and is unit-testable.
+ */
+
+export interface StudioCreateLabels {
+  mode: string;
+  title: string;
+  close: string;
+  kindLabelHead: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  domainLabel: string;
+  domainNone: string;
+  definitionLabel: string;
+  definitionPlaceholder: string;
+  gaugeLabel: string;
+  gaugeNote: (filled: number, total: number) => string;
+  assembleTitle: string;
+  assembleSubtitle: string;
+  progress: (filled: number, total: number) => string;
+  relation: Record<CreateRelationType, { title: string; type: string; hint: string; add: string }>;
+  isaTag: string;
+  optionalTag: string;
+  emptyCard: string;
+  pickerPlaceholder: string;
+  pickerEmpty: string;
+  pickerHint: string;
+  previewLabel: string;
+  previewGhostIsa: string;
+  similarMessage: (title: string, kindLabel: string, domainLabel: string) => string;
+  similarOpen: string;
+  similarCreateAnyway: string;
+  ledgerCount: (count: number) => string;
+  pendingNode: (kindLabel: string) => string;
+  pendingRelation: (relationLabel: string, target: string) => string;
+  applyDirect: string;
+  applyDirectSub: string;
+  applyDirectDisabled: string;
+  applyAgent: string;
+  applyAgentSub: string;
+}
+
+const GEM_CLASS: Record<CreateRelationType, string> = {
+  dependsOn: "studio-gem--dep",
+  contains: "studio-gem--con",
+  relates: "studio-gem--rel",
+  isA: "studio-gem--isa",
+};
+
+const OPTIONAL_TYPES = new Set<CreateRelationType>(["relates"]);
+
+/** Which existing-node kinds each relation card offers as picker candidates. */
+const CANDIDATE_KINDS: Record<CreateRelationType, ReadonlySet<string> | null> = {
+  isA: new Set(["capability", "domain", "project"]),
+  dependsOn: new Set(["capability", "element"]),
+  contains: new Set(["capability", "element"]),
+  relates: null, // any non-container
+};
+
+export interface StudioCreateArenaProps {
+  labels: StudioCreateLabels;
+  kindLabel: (kind: string) => string;
+  /** Existing `kind: domain` nodes → `{ value: tail-slug, title }`. */
+  domains: ReadonlyArray<{ value: string; title: string }>;
+  /** All pickable existing nodes (frontmatter-ref precomputed). */
+  candidates: ReadonlyArray<CreateCandidate>;
+  /** Near-dup candidates (title/kind) — reuses the shared similar-node guard. */
+  similarCandidates: ReadonlyArray<SimilarNodeCandidate>;
+  /** True only when a writable local vault is loaded — gates 직접 적용. */
+  writable: boolean;
+  onApplyDirect: (draft: CreateDraft) => void;
+  onApplyAgent: (draft: CreateDraft) => void;
+  onOpenSimilar: (slug: string) => void;
+  onExit: () => void;
+  particleSeeds: ReadonlyArray<{ left: number; top: number; dur: number; delay: number; opacity: number }>;
+}
+
+export function StudioCreateArena({
+  labels,
+  kindLabel,
+  domains,
+  candidates,
+  similarCandidates,
+  writable,
+  onApplyDirect,
+  onApplyAgent,
+  onOpenSimilar,
+  onExit,
+  particleSeeds,
+}: StudioCreateArenaProps) {
+  const [kind, setKind] = useState<CreateNodeKind>("capability");
+  const [title, setTitle] = useState("");
+  const [domainValue, setDomainValue] = useState<string | null>(null);
+  const [definition, setDefinition] = useState("");
+  const [relations, setRelations] = useState<PendingRelation[]>([]);
+  const [pickerFor, setPickerFor] = useState<CreateRelationType | null>(null);
+  const [pickerQuery, setPickerQuery] = useState("");
+  const [similarDismissed, setSimilarDismissed] = useState(false);
+
+  const draft: CreateDraft = useMemo(
+    () => ({ kind, title, domainValue, definition, relations }),
+    [kind, title, domainValue, definition, relations],
+  );
+  const completeness = useMemo(() => computeCreateCompleteness(draft), [draft]);
+  const slug = buildCreateNodeSlug({ kind, title });
+  const canApply = Boolean(title.trim()) && slug !== null;
+
+  const similar = useMemo(() => {
+    if (similarDismissed || !title.trim()) return null;
+    return findSimilarNodeByTitle(title, kind, similarCandidates);
+  }, [title, kind, similarCandidates, similarDismissed]);
+
+  const changeKind = (next: CreateNodeKind) => {
+    setKind(next);
+    if (!kindExpectsDomain(next)) setDomainValue(null);
+    setSimilarDismissed(false);
+  };
+
+  const addRelation = (type: CreateRelationType, candidate: CreateCandidate) => {
+    setRelations((prev) =>
+      prev.some((r) => r.type === type && r.candidate.id === candidate.id)
+        ? prev
+        : [...prev, { type, candidate }],
+    );
+    setPickerFor(null);
+    setPickerQuery("");
+  };
+  const removeRelation = (type: CreateRelationType, id: string) => {
+    setRelations((prev) => prev.filter((r) => !(r.type === type && r.candidate.id === id)));
+  };
+  const togglePicker = (type: CreateRelationType) => {
+    setPickerFor((cur) => (cur === type ? null : type));
+    setPickerQuery("");
+  };
+
+  const relationsByType = (type: CreateRelationType) => relations.filter((r) => r.type === type);
+
+  const pickerCandidates = useMemo(() => {
+    if (!pickerFor) return [];
+    const allow = CANDIDATE_KINDS[pickerFor];
+    const q = pickerQuery.trim().toLowerCase();
+    const taken = new Set(relations.map((r) => `${r.type}:${r.candidate.id}`));
+    return candidates
+      .filter((c) => (allow ? allow.has(c.kind) : c.kind !== "project" && c.kind !== "domain"))
+      .filter((c) => !taken.has(`${pickerFor}:${c.id}`))
+      .filter((c) => (q ? c.title.toLowerCase().includes(q) || c.ref.toLowerCase().includes(q) : true))
+      .slice(0, 8);
+  }, [pickerFor, pickerQuery, candidates, relations]);
+
+  return (
+    <div
+      className="studio-stage relative grid h-[100dvh] min-h-0 grid-rows-[54px_1fr_82px] overflow-hidden"
+      data-testid="studio-create-stage"
+    >
+      <div className="studio-bg" aria-hidden />
+      <div className="studio-rays studio-anim-spin" aria-hidden />
+      <div className="pointer-events-none absolute inset-0 z-[1] overflow-hidden" aria-hidden>
+        {particleSeeds.map((p, i) => (
+          <span
+            key={i}
+            className="studio-particle studio-anim-rise"
+            style={{
+              left: `${p.left}%`,
+              top: `${p.top}%`,
+              animationDuration: `${p.dur}s`,
+              animationDelay: `${p.delay}s`,
+              opacity: p.opacity,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Header — breadcrumb + 만들기 mode badge + close. */}
+      <header className="relative z-[5] flex items-center gap-4 border-b border-[color:var(--color-divider)] px-[22px]">
+        <div className="flex items-center gap-2.5 text-label text-[color:var(--color-text-tertiary)]">
+          <span className="font-semibold text-[color:var(--color-text-secondary)]">{labels.title}</span>
+          <span
+            className="ml-1 rounded-md border px-2 py-1 text-caption font-bold uppercase tracking-[0.14em]"
+            style={{
+              color: "var(--studio-indigo-bright)",
+              background: "var(--studio-indigo-a20)",
+              borderColor: "var(--studio-indigo-a45)",
+            }}
+          >
+            {labels.mode}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onExit}
+          data-testid="studio-create-close"
+          className="ml-auto rounded-lg border border-[color:var(--color-border-soft)] px-2.5 py-1.5 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+        >
+          {labels.close}
+        </button>
+      </header>
+
+      {/* Body — left identity form · right relation assembly. */}
+      <div className="relative z-[3] grid min-h-0 grid-cols-1 lg:grid-cols-[376px_1fr]">
+        {/* Left — identity + near-dup + gauge. */}
+        <aside className="flex min-h-0 flex-col overflow-y-auto border-r border-[color:var(--color-divider)] bg-[color:var(--color-panel)]">
+          <div className="flex flex-col gap-3.5 border-b border-[color:var(--color-divider)] p-5">
+            <Field label={labels.kindLabelHead}>
+              <div
+                role="group"
+                aria-label={labels.kindLabelHead}
+                className="flex gap-1 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] p-[3px]"
+              >
+                {CREATE_NODE_KINDS.map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    data-testid={`studio-create-kind-${k}`}
+                    aria-pressed={kind === k}
+                    onClick={() => changeKind(k)}
+                    className={cn(
+                      "flex-1 rounded-[5px] py-1.5 text-label transition-colors",
+                      kind === k
+                        ? "text-[color:var(--color-text-primary)]"
+                        : "text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-secondary)]",
+                    )}
+                    style={kind === k ? { background: "var(--studio-indigo-a20)" } : undefined}
+                  >
+                    {kindLabel(k)}
+                  </button>
+                ))}
+              </div>
+            </Field>
+
+            <Field label={labels.nameLabel}>
+              <input
+                data-testid="studio-create-title"
+                value={title}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setSimilarDismissed(false);
+                }}
+                placeholder={labels.namePlaceholder}
+                className="w-full rounded-[9px] border bg-[color:var(--color-overlay-1)] px-3 py-2.5 text-body-lg font-semibold tracking-[-0.02em] text-[color:var(--color-text-primary)] outline-none placeholder:text-[color:var(--color-text-quaternary)] placeholder:font-normal"
+                style={{ borderColor: "var(--studio-indigo-a45)" }}
+              />
+            </Field>
+
+            {kindExpectsDomain(kind) ? (
+              <Field label={labels.domainLabel}>
+                <select
+                  data-testid="studio-create-domain"
+                  value={domainValue ?? ""}
+                  onChange={(e) => setDomainValue(e.target.value || null)}
+                  className="w-full rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5 text-label text-[color:var(--color-text-secondary)] outline-none"
+                >
+                  <option value="">{labels.domainNone}</option>
+                  {domains.map((d) => (
+                    <option key={d.value} value={d.value}>
+                      {d.title}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+            ) : null}
+
+            {similar ? (
+              <div data-testid="studio-create-similar">
+                <SimilarNodeWarning
+                  message={labels.similarMessage(similar.title, kindLabel(similar.kind), similar.slug)}
+                  openLabel={labels.similarOpen}
+                  createAnywayLabel={labels.similarCreateAnyway}
+                  onOpen={() => onOpenSimilar(similar.slug)}
+                  onCreateAnyway={() => setSimilarDismissed(true)}
+                />
+              </div>
+            ) : null}
+
+            <Field label={labels.definitionLabel}>
+              <textarea
+                data-testid="studio-create-definition"
+                value={definition}
+                onChange={(e) => setDefinition(e.target.value)}
+                placeholder={labels.definitionPlaceholder}
+                rows={3}
+                className="w-full resize-none rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5 text-label leading-[1.55] text-[color:var(--color-text-secondary)] outline-none placeholder:text-[color:var(--color-text-quaternary)]"
+              />
+            </Field>
+          </div>
+
+          {/* Completeness gauge. */}
+          <div className="mt-auto flex flex-col gap-2.5 border-t border-[color:var(--color-divider)] p-5" data-testid="studio-create-gauge">
+            <div className="flex items-baseline gap-2">
+              <span className="text-caption font-bold uppercase tracking-[0.05em] text-[color:var(--color-text-quaternary)]">
+                {labels.gaugeLabel}
+              </span>
+              <span
+                className="ml-auto text-display font-semibold tabular-nums tracking-[-0.02em]"
+                style={{ color: "var(--studio-gold-bright)", textShadow: "0 0 12px var(--studio-gold-a45)" }}
+              >
+                {completeness.percent}%
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-[color:var(--color-overlay-2)]">
+              <span
+                className="block h-full rounded-full transition-[width] duration-300"
+                style={{ width: `${completeness.percent}%`, background: "var(--studio-indigo)" }}
+              />
+            </div>
+            <span className="text-label leading-[1.5] text-[color:var(--color-text-tertiary)]">
+              {labels.gaugeNote(completeness.filledCount, completeness.total)}
+            </span>
+          </div>
+        </aside>
+
+        {/* Right — relation assembly. */}
+        <section className="flex min-h-0 flex-col overflow-y-auto bg-[color:var(--color-canvas)]">
+          <div className="sticky top-0 z-[5] flex items-baseline gap-3 border-b border-[color:var(--color-divider)] bg-[color:var(--color-canvas)] px-6 py-3.5">
+            <span className="text-title font-semibold tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              {labels.assembleTitle}
+            </span>
+            <span className="text-label text-[color:var(--color-text-quaternary)]">{labels.assembleSubtitle}</span>
+            <div className="ml-auto flex items-center gap-2">
+              <div className="flex gap-1">
+                {completeness.pips.map((p, i) => (
+                  <span
+                    key={i}
+                    className={cn(
+                      "studio-pip",
+                      p === "on" && "studio-pip--on",
+                      p === "next" && "studio-pip--next studio-anim-pip",
+                    )}
+                  />
+                ))}
+              </div>
+              <span className="text-label tabular-nums text-[color:var(--color-text-tertiary)]">
+                {labels.progress(completeness.filledCount, completeness.total)}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 content-start gap-3.5 p-6 xl:grid-cols-2">
+            {CREATE_RELATION_TYPES.map((type) => {
+              const rels = relationsByType(type);
+              const isIsa = type === "isA";
+              const optional = OPTIONAL_TYPES.has(type);
+              const meta = labels.relation[type];
+              const open = pickerFor === type;
+              return (
+                <div
+                  key={type}
+                  data-testid={`studio-create-card-${type}`}
+                  data-count={rels.length}
+                  className={cn(
+                    "relative flex flex-col gap-2.5 rounded-[13px] border p-[14px]",
+                    isIsa && "xl:col-span-2",
+                  )}
+                  style={{
+                    background: "var(--color-panel)",
+                    borderColor: open
+                      ? "var(--studio-gold-a45)"
+                      : rels.length > 0
+                        ? "var(--studio-indigo-a45)"
+                        : "var(--color-border-soft)",
+                  }}
+                >
+                  <div className="flex items-start gap-2.5">
+                    <span
+                      className={cn("studio-gem h-8 w-7 flex-none text-[11px]", GEM_CLASS[type])}
+                      aria-hidden
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="flex flex-wrap items-center gap-1.5 text-body font-semibold text-[color:var(--color-text-primary)]">
+                        {meta.title}
+                        <span
+                          className="rounded bg-[color:var(--color-overlay-2)] px-1.5 py-px font-mono text-[9px] uppercase tracking-[0.04em] text-[color:var(--color-text-quaternary)]"
+                        >
+                          {meta.type}
+                        </span>
+                        {isIsa ? (
+                          <span
+                            className="rounded px-1.5 py-px text-[9px] font-bold"
+                            style={{ color: "var(--studio-gold-bright)", background: "var(--studio-gold-a20)" }}
+                          >
+                            {labels.isaTag}
+                          </span>
+                        ) : optional ? (
+                          <span className="rounded bg-[color:var(--color-overlay-2)] px-1.5 py-px text-[9px] font-bold text-[color:var(--color-text-quaternary)]">
+                            {labels.optionalTag}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="text-caption leading-[1.45] text-[color:var(--color-text-quaternary)]">
+                        {meta.hint}
+                      </span>
+                    </div>
+                    <span className="flex-none font-mono text-caption text-[color:var(--color-text-quaternary)]">
+                      {rels.length}
+                    </span>
+                  </div>
+
+                  {rels.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {rels.map((r) => (
+                        <span
+                          key={r.candidate.id}
+                          data-testid={`studio-create-chip-${type}-${r.candidate.id}`}
+                          className="inline-flex items-center gap-1.5 rounded-[7px] border px-2 py-1 text-label text-[color:var(--color-text-secondary)]"
+                          style={{ background: "var(--studio-indigo-a10)", borderColor: "var(--studio-indigo-a45)" }}
+                        >
+                          <span className={cn("studio-gem h-3 w-2.5 flex-none", GEM_CLASS[type])} aria-hidden />
+                          {r.candidate.title}
+                          <button
+                            type="button"
+                            aria-label="remove"
+                            data-testid="studio-create-chip-remove"
+                            onClick={() => removeRelation(type, r.candidate.id)}
+                            className="text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                          >
+                            <X size={12} aria-hidden />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  ) : !open ? (
+                    <div className="rounded-lg border border-dashed border-[color:var(--color-border-soft)] px-2.5 py-2 text-center text-label text-[color:var(--color-text-quaternary)]">
+                      {labels.emptyCard}
+                    </div>
+                  ) : null}
+
+                  {open ? (
+                    <NodePicker
+                      query={pickerQuery}
+                      onQuery={setPickerQuery}
+                      candidates={pickerCandidates}
+                      kindLabel={kindLabel}
+                      placeholder={labels.pickerPlaceholder}
+                      emptyLabel={labels.pickerEmpty}
+                      hint={labels.pickerHint}
+                      onPick={(c) => addRelation(type, c)}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      data-testid={`studio-create-add-${type}`}
+                      onClick={() => togglePicker(type)}
+                      className="inline-flex items-center gap-2 self-start rounded-lg border border-dashed px-3 py-1.5 text-label font-semibold transition-colors"
+                      style={{
+                        color: isIsa ? "var(--studio-gold-bright)" : "var(--studio-indigo-bright)",
+                        borderColor: isIsa ? "var(--studio-gold-a45)" : "var(--studio-indigo-a45)",
+                        background: isIsa ? "var(--studio-gold-a20)" : "var(--studio-indigo-a10)",
+                      }}
+                    >
+                      <Plus size={13} aria-hidden />
+                      {meta.add}
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* 지금까지 이런 모양 — compact preview of the assembled node. */}
+            <div
+              className="flex items-center gap-4 rounded-[12px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-3.5 xl:col-span-2"
+              data-testid="studio-create-preview"
+            >
+              <span className="flex-none text-caption font-bold uppercase leading-[1.3] tracking-[0.05em] text-[color:var(--color-text-quaternary)]">
+                {labels.previewLabel}
+              </span>
+              <div className="flex flex-1 flex-wrap items-center gap-2">
+                <span
+                  className="inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-primary)]"
+                  style={{ borderColor: "var(--studio-gold-a45)", background: "var(--color-elevated)" }}
+                >
+                  <span className="studio-gem studio-gem--isa h-3.5 w-3 flex-none" aria-hidden />
+                  {title.trim() || labels.namePlaceholder}
+                </span>
+                {relations.map((r) => (
+                  <span
+                    key={`${r.type}:${r.candidate.id}`}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1 text-label text-[color:var(--color-text-tertiary)]"
+                  >
+                    <span aria-hidden className="text-[color:var(--color-text-quaternary)]">
+                      {labels.relation[r.type].type} →
+                    </span>
+                    <span className={cn("studio-gem h-3 w-2.5 flex-none", GEM_CLASS[r.type])} aria-hidden />
+                    {r.candidate.title}
+                  </span>
+                ))}
+                {relations.length === 0 ? (
+                  <span className="rounded-lg border border-dashed border-[color:var(--color-border-soft)] px-2.5 py-1 text-caption text-[color:var(--color-text-quaternary)]">
+                    {labels.previewGhostIsa}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* Footer — pending ledger + two apply routes. */}
+      <footer className="relative z-[5] flex items-center gap-4 border-t border-[color:var(--color-divider)] px-[22px]">
+        <div className="flex min-w-0 items-center gap-3 text-label text-[color:var(--color-text-tertiary)]">
+          <span className="text-body-lg font-bold tabular-nums text-[color:var(--color-text-primary)]">
+            {relations.length + (canApply ? 1 : 0)}
+          </span>
+          <span>{labels.ledgerCount(relations.length + (canApply ? 1 : 0))}</span>
+          <div className="hidden items-center gap-1.5 overflow-hidden md:flex">
+            {canApply ? (
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-caption text-[color:var(--color-text-tertiary)]">
+                <span style={{ color: "var(--studio-emerald)" }}>＋</span>
+                {labels.pendingNode(kindLabel(kind))}
+              </span>
+            ) : null}
+            {relations.slice(0, 3).map((r) => (
+              <span
+                key={`${r.type}:${r.candidate.id}`}
+                className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-caption text-[color:var(--color-text-tertiary)]"
+              >
+                <span style={{ color: "var(--studio-indigo-bright)" }}>＋</span>
+                {labels.pendingRelation(labels.relation[r.type].title, r.candidate.title)}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="ml-auto flex items-center gap-3">
+          <button
+            type="button"
+            data-testid="studio-create-apply-agent"
+            disabled={!canApply}
+            onClick={() => onApplyAgent(draft)}
+            className="inline-flex items-center gap-2 rounded-[10px] border border-[color:var(--color-border-strong)] px-4 py-2.5 text-body text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)] disabled:opacity-40 disabled:hover:text-[color:var(--color-text-secondary)]"
+          >
+            <Bot size={15} aria-hidden />
+            <span className="flex flex-col items-start leading-tight">
+              <span>{labels.applyAgent}</span>
+              <span className="text-caption text-[color:var(--color-text-quaternary)]">{labels.applyAgentSub}</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            data-testid="studio-create-apply-direct"
+            disabled={!canApply || !writable}
+            onClick={() => onApplyDirect(draft)}
+            title={!writable ? labels.applyDirectDisabled : undefined}
+            className="studio-enhance inline-flex items-center gap-2.5 rounded-[12px] px-6 py-3 text-body font-extrabold tracking-[0.02em] text-white transition-transform hover:-translate-y-px disabled:translate-y-0 disabled:opacity-40"
+          >
+            <Check size={16} aria-hidden />
+            <span className="flex flex-col items-start leading-tight">
+              <span>{labels.applyDirect}</span>
+              <span className="text-caption font-semibold" style={{ color: "rgba(255,255,255,0.72)" }}>
+                {writable ? labels.applyDirectSub : labels.applyDirectDisabled}
+              </span>
+            </span>
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-caption font-bold uppercase tracking-[0.05em] text-[color:var(--color-text-quaternary)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function NodePicker({
+  query,
+  onQuery,
+  candidates,
+  kindLabel,
+  placeholder,
+  emptyLabel,
+  hint,
+  onPick,
+}: {
+  query: string;
+  onQuery: (q: string) => void;
+  candidates: ReadonlyArray<CreateCandidate>;
+  kindLabel: (kind: string) => string;
+  placeholder: string;
+  emptyLabel: string;
+  hint: string;
+  onPick: (c: CreateCandidate) => void;
+}) {
+  return (
+    <div
+      data-testid="studio-create-picker"
+      className="overflow-hidden rounded-[10px] border bg-[color:var(--color-elevated)]"
+      style={{ borderColor: "var(--color-border-strong)", boxShadow: "0 16px 40px rgba(0,0,0,0.55)" } as CSSProperties}
+    >
+      <div className="flex items-center gap-2 border-b border-[color:var(--color-divider)] px-2.5 py-2">
+        <Search size={13} aria-hidden className="flex-none text-[color:var(--color-text-quaternary)]" />
+        <input
+          autoFocus
+          data-testid="studio-create-picker-input"
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          placeholder={placeholder}
+          className="w-full bg-transparent text-label text-[color:var(--color-text-secondary)] outline-none placeholder:text-[color:var(--color-text-quaternary)]"
+        />
+      </div>
+      {candidates.length === 0 ? (
+        <div className="px-3 py-3 text-center text-label text-[color:var(--color-text-quaternary)]">{emptyLabel}</div>
+      ) : (
+        candidates.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            data-testid={`studio-create-picker-row-${c.id}`}
+            onClick={() => onPick(c)}
+            className="flex w-full items-center gap-2.5 border-b border-[color:var(--color-border-soft)] px-3 py-2 text-left text-label text-[color:var(--color-text-secondary)] transition-colors last:border-b-0 hover:bg-[color:var(--color-overlay-1)]"
+          >
+            <span className="font-medium text-[color:var(--color-text-secondary)]">{c.title}</span>
+            <span className="ml-auto text-caption text-[color:var(--color-text-quaternary)]">{kindLabel(c.kind)}</span>
+          </button>
+        ))
+      )}
+      <div className="bg-[color:var(--color-overlay-1)] px-3 py-1.5 text-caption text-[color:var(--color-text-quaternary)]">
+        {hint}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
스튜디오에 **만들기(Create) 모드** — 소유자가 "제일 중요한 추가". `/ontology/studio?mode=create`. 빈 노드 조립 폼(종류·이름·도메인·정의 + 관계 카드 "+" 버튼 + 노드 피커 + 근접중복 + 미리보기) + 쓰기 경로 2종.

- **직접 적용** → `useLocalVault().createDoc`(기존 /docs·빌더 경로 재사용) — 쓰기 vault일 때만
- **에이전트에게 맡기기** → `add_concept`+`add_relation` MCP 패킷 클립보드 — 읽기전용·샘플의 유일 경로
- 근접중복 `findSimilarNodeByTitle` 재사용, 후보/도메인 `useOntologyInsight`에서
- ENHANCE와 명확히 구분(조립 폼 vs 살아있는 아이템), `--studio-*` 미학 공유

## Test plan
- tsc ✅ · ontology-studio 40 ✅ · i18n 18/18 ✅ · build 정적 export ✅ · 브라우저(조립 폼 렌더, 콘솔 0)
- 참고: 비주얼은 다음 재앵커(지도 렌더 재사용)에서 통일. 쓰기 로직 재작업 0.