### PR TITLE
fix: 사전 안내 시트에 브라우저 허용 확인창 예고 추가

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3138,6 +3138,7 @@
     "bulletAnyFolder": "Any markdown folder works — no special format required.",
     "bulletLocal": "Files never leave this computer. Nothing is uploaded.",
     "bulletStarter": "Pick an empty folder and we scaffold starter docs for you.",
+    "bulletPermission": "After you pick, the browser asks to Allow — approve it and your files still stay on this computer.",
     "actionPickExisting": "Choose existing folder",
     "actionCreateNew": "Start fresh with an empty folder",
     "actionCancel": "Not now"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3138,6 +3138,7 @@
     "bulletAnyFolder": "아무 마크다운 폴더나 괜찮아요 — 특별한 형식이 없어도 돼요.",
     "bulletLocal": "파일은 이 컴퓨터를 떠나지 않아요. 서버 전송이 없어요.",
     "bulletStarter": "빈 폴더를 고르면 시작 문서를 자동으로 만들어 드려요.",
+    "bulletPermission": "고르고 나면 브라우저가 '허용'을 물어요 — 허용해야 지도가 켜지고, 파일은 여전히 내 컴퓨터 안에만 있어요.",
     "actionPickExisting": "기존 폴더 선택",
     "actionCreateNew": "빈 폴더로 새로 시작",
     "actionCancel": "다음에"

--- a/src/features/docs-vault-local/ui/VaultOpenGuideSheet.test.tsx
+++ b/src/features/docs-vault-local/ui/VaultOpenGuideSheet.test.tsx
@@ -24,6 +24,7 @@ describe("VaultOpenGuideSheet", () => {
     expect(screen.getByText("bulletAnyFolder")).toBeInTheDocument();
     expect(screen.getByText("bulletLocal")).toBeInTheDocument();
     expect(screen.getByText("bulletStarter")).toBeInTheDocument();
+    expect(screen.getByText("bulletPermission")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("vault-guide-pick-existing"));
     expect(onPick).toHaveBeenCalledTimes(1);

--- a/src/features/docs-vault-local/ui/VaultOpenGuideSheet.tsx
+++ b/src/features/docs-vault-local/ui/VaultOpenGuideSheet.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useTranslations } from "next-intl";
-import { FolderOpen, HardDrive, Sparkles, X } from "lucide-react";
+import { FolderOpen, HardDrive, ShieldCheck, Sparkles, X } from "lucide-react";
 import { MOTION } from "@/shared/motion";
 import { useBodyScrollLock } from "@/shared/lib/use-body-scroll-lock";
 
@@ -30,6 +30,10 @@ const BULLETS = [
   { icon: FolderOpen, key: "bulletAnyFolder" },
   { icon: HardDrive, key: "bulletLocal" },
   { icon: Sparkles, key: "bulletStarter" },
+  // 소유자 실사용 지적 (2026-07-24) — 폴더 선택 직후 브라우저의 표준
+  // 허용 확인창("이 사이트에서 파일을 보고…")을 예고하지 않아 처음 보면
+  // 우리 팝업/이상 동작으로 오인했다. 미리 한 줄로 안심시킨다.
+  { icon: ShieldCheck, key: "bulletPermission" },
 ] as const;
 
 export function VaultOpenGuideSheet({


### PR DESCRIPTION
## Summary
실사용 중 폴더 선택 직후 Chrome 표준 허용 확인창이 예고 없이 떠 오인을 유발 — 사전 안내 시트에 4번째 안심 줄("고르고 나면 브라우저가 '허용'을 물어요…")을 추가한다.

## Test plan
- `pnpm test src/features/docs-vault-local` ✅ · `pnpm exec tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)