### PR TITLE
fix: 공방 retype→끊기 연쇄가 원래 방위 관계를 못 지우던 결함 (sonnet 검증)

### DIFF
--- a/src/views/ontology-studio/lib/build-studio-changes.test.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.test.ts
@@ -53,6 +53,22 @@ describe("reduceStudioChanges", () => {
     expect(s).toEqual([{ op: "retype", from: "relates", to: "contains", target: B }]);
   });
 
+  it("retype-then-remove collapses to a remove at the TRUE original bearing (sonnet 검증 결함 1)", () => {
+    // 기대는 곳(dependsOn)에 실재하는 관계를 '비슷한 것'으로 옮겨둔 뒤 끊으면,
+    // 실제로 기록돼 있는 dependsOn 을 끊어야 한다 — 옮긴 후 방위(relates)로
+    // 끊으면 실재하지 않는 엣지를 지우려는 no-op 쓰기가 된다.
+    let s = reduceStudioChanges([], { type: "retype", from: "dependsOn", to: "relates", target: A });
+    s = reduceStudioChanges(s, { type: "remove", relation: "relates", target: A });
+    expect(s).toEqual([{ op: "remove", relation: "dependsOn", target: A }]);
+  });
+
+  it("chained-retype-then-remove still removes at the TRUE original bearing", () => {
+    let s = reduceStudioChanges([], { type: "retype", from: "dependsOn", to: "relates", target: A });
+    s = reduceStudioChanges(s, { type: "retype", from: "relates", to: "contains", target: A });
+    s = reduceStudioChanges(s, { type: "remove", relation: "contains", target: A });
+    expect(s).toEqual([{ op: "remove", relation: "dependsOn", target: A }]);
+  });
+
   it("retype back to the original bearing cancels the change", () => {
     let s = reduceStudioChanges([], { type: "retype", from: "relates", to: "dependsOn", target: B });
     s = reduceStudioChanges(s, { type: "retype", from: "dependsOn", to: "relates", target: B });

--- a/src/views/ontology-studio/lib/build-studio-changes.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.ts
@@ -72,7 +72,12 @@ export function reduceStudioChanges(
       // Removing a freshly-added (not-yet-saved) link just cancels the add.
       if (existing?.op === "add") return withoutTarget(prev, action.target.id);
       const rest = withoutTarget(prev, action.target.id);
-      return [...rest, { op: "remove", relation: action.relation, target: action.target }];
+      // 옮겨둔(아직 저장 전) 노드를 끊으면 실제로 기록돼 있는 건 원래 방위의
+      // 관계 하나뿐이다 — retype 를 접고 TRUE original bearing 을 끊는다.
+      // 현재(옮긴 후) 방위로 끊으면 실재하지 않는 엣지를 지우려는 잘못된
+      // 쓰기(디스크 no-op / 잘못된 remove_relation 패킷)가 된다.
+      const relation = existing?.op === "retype" ? existing.from : action.relation;
+      return [...rest, { op: "remove", relation, target: action.target }];
     }
     case "retype": {
       const existing = findForTarget(prev, action.target.id);


### PR DESCRIPTION
## Summary
sonnet 독립 검증(공방 아크 #618~624 전수)이 찾은 High 결함 수정.

**결함**: retype(방위 이동) 후 같은 위성을 끊으면 reducer 가 이전 retype 를 무시하고 현재(옮긴 후) 방위로 remove 를 기록 → 실재하지 않는 엣지 대상 쓰기(디스크 silent no-op / 잘못된 `remove_relation` 타입 패킷)인데 UI 는 성공처럼 보임. 원래 관계는 영영 안 지워짐.

**수정**: remove 케이스도 retype 와 동일하게 이전 retype 의 TRUE original bearing 으로 접어 기록. 회귀 테스트 2건(retype→remove·연쇄 retype→remove) 추가 — 기존엔 이 조합 커버리지가 없었음(sonnet 확인).

## Test plan
- studio 102 pass(신규 2) · tsc clean
- 라이브 재현→수정 확증: 기대는 곳 MCP Server 를 '비슷한 것'으로 옮긴 뒤 끊기 → (전) 원래 레인에 가짜 저장 대기로 재등장+related_to 패킷 → (후) 재등장 없음 + 요약 "'기대는 곳: MCP Server' 끊기" 정확

## sonnet 검증 전체 판정
pass-with-issues → 본 수정으로 해소. 그 외 전 기능(딥링크·검색·산책 가드·발견 피커·델타 미리보기·만들기·en 로케일·헌장) 정상 확인, 콘솔 에러 0. 잔여 관찰(비결함): create 모드 피커에 발견 뷰 없음(신규 노드라 그래프 위치 없음 — 의도 범위), 근접중복 가드는 advisory(서버측 dup-slug 방어는 mcp add_concept 소관), a11y form-field id 경고(기존).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
