### PR TITLE
fix: codex C-B — 공방 워크플로 갭 4건 (더 잇기·문맥 보존 생성·focal 리졸버·kind 매트릭스)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -103,6 +103,8 @@
     "saveHint": "You can save now even before it's all filled",
     "foldMore": "more",
     "foldTitle": "{label} · {total}",
+    "addMore": "Add more to ‘{label}’",
+    "addMoreShort": "Add more",
     "defMore": "More",
     "defLess": "Less",
     "question": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -94,6 +94,7 @@
       "almost": "· almost done",
       "done": "· all filled"
     },
+    "domainMembership": "Already in ‘{domain}’",
     "framePrompt": "Complete what {name} is by linking it to nearby nodes",
     "guideBadge": "Start here",
     "bottomProgress": "{filled} of {total} filled",
@@ -213,6 +214,7 @@
     "create": {
       "framePrompt": "Decide what the new node is, then link it to nearby nodes",
       "namePlaceholder": "New node name — e.g. Payment cancel",
+      "secondaryName": "한국어 이름 (선택)",
       "domainNone": "No domain",
       "definitionPlaceholder": "One line on what this node does — definition & boundary prevent duplicates.",
       "similar": "A similar node already exists — {title} ({kind})",

--- a/messages/en.json
+++ b/messages/en.json
@@ -203,7 +203,8 @@
       "createHeadlineDomain": "New {kind} ‘{name}’ under the {domain} domain",
       "createHeadline": "New {kind} ‘{name}’",
       "createFileEffect": "1 file created · {count} relation line(s).",
-      "createCollapsed": "1 new node · {count} relation(s)"
+      "createCollapsed": "1 new node · {count} relation(s)",
+      "createOriginLine": "Links to ‘{name}’ ’s ‘{relation}’"
     },
     "empty": {
       "title": "No node to bring on stage yet",
@@ -215,6 +216,7 @@
       "framePrompt": "Decide what the new node is, then link it to nearby nodes",
       "namePlaceholder": "New node name — e.g. Payment cancel",
       "secondaryName": "한국어 이름 (선택)",
+      "originNote": "Will link as ‘{name}’ ’s ‘{bearing}’",
       "domainNone": "No domain",
       "definitionPlaceholder": "One line on what this node does — definition & boundary prevent duplicates.",
       "similar": "A similar node already exists — {title} ({kind})",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -203,7 +203,8 @@
       "createHeadlineDomain": "새 {kind} ‘{name}’ · {domain} 도메인 아래에 생성",
       "createHeadline": "새 {kind} ‘{name}’ 생성",
       "createFileEffect": "파일 1개 생성 · 관계 {count}줄 기록.",
-      "createCollapsed": "새 노드 1개 · 관계 {count}개"
+      "createCollapsed": "새 노드 1개 · 관계 {count}개",
+      "createOriginLine": "‘{name}’ 의 ‘{relation}’ 에 이어져요"
     },
     "empty": {
       "title": "무대에 올릴 노드가 아직 없어요",
@@ -215,6 +216,7 @@
       "framePrompt": "새 노드가 무엇인지 정하고, 주변 노드와 이어 완성해요",
       "namePlaceholder": "새 노드 이름 — 예: 결제 취소",
       "secondaryName": "영어 이름 (선택)",
+      "originNote": "‘{name}’ 의 ‘{bearing}’ 로 이어질 예정",
       "domainNone": "도메인 없음",
       "definitionPlaceholder": "이 노드가 하는 일을 한 줄로 — 정의·경계가 중복을 막아요.",
       "similar": "비슷한 노드가 이미 있어요 — {title} ({kind})",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -103,6 +103,8 @@
     "saveHint": "아직 다 안 채워도 지금 저장할 수 있어요",
     "foldMore": "더 보기",
     "foldTitle": "{label} · {total}",
+    "addMore": "‘{label}’ 에 더 잇기",
+    "addMoreShort": "더 잇기",
     "defMore": "더 보기",
     "defLess": "접기",
     "question": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -94,6 +94,7 @@
       "almost": "· 거의 다 됐어요",
       "done": "· 다 채웠어요"
     },
+    "domainMembership": "이미 ‘{domain}’ 소속이에요",
     "framePrompt": "‘{name}’의 의미를 주변 노드와 이어 완성해요",
     "guideBadge": "여기부터 채워요",
     "bottomProgress": "{total}개 중 {filled}개 채웠어요",
@@ -213,6 +214,7 @@
     "create": {
       "framePrompt": "새 노드가 무엇인지 정하고, 주변 노드와 이어 완성해요",
       "namePlaceholder": "새 노드 이름 — 예: 결제 취소",
+      "secondaryName": "영어 이름 (선택)",
       "domainNone": "도메인 없음",
       "definitionPlaceholder": "이 노드가 하는 일을 한 줄로 — 정의·경계가 중복을 막아요.",
       "similar": "비슷한 노드가 이미 있어요 — {title} ({kind})",

--- a/src/views/ontology-studio/lib/allowed-kinds.test.ts
+++ b/src/views/ontology-studio/lib/allowed-kinds.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { allowedKindsFor, kindAllowedFor } from "./allowed-kinds";
+
+/**
+ * C12 ① — 방위 × 초점 kind 후보 필터. 회귀: capability 의 `contains` 후보에
+ * domain 이 섞여 나왔다. 계층("한 단계 아래") 창을 강제하는지 검증한다.
+ */
+describe("allowedKindsFor — 계층 창", () => {
+  it("capability 의 contains 후보는 element 만 — domain 은 절대 아님 (회귀)", () => {
+    const set = allowedKindsFor("contains", "capability");
+    expect(set.has("element")).toBe(true);
+    expect(set.has("domain")).toBe(false);
+    expect(set.has("capability")).toBe(false);
+    expect(kindAllowedFor("contains", "capability", "domain")).toBe(false);
+  });
+
+  it("domain 의 contains 후보는 capability·element (한 단계 아래)", () => {
+    expect([...allowedKindsFor("contains", "domain")].sort()).toEqual(["capability", "element"]);
+  });
+
+  it("project 의 contains 후보는 domain", () => {
+    expect([...allowedKindsFor("contains", "project")]).toEqual(["domain"]);
+  });
+
+  it("isA 는 같거나 한 단계 위(컨테이너) — capability→{capability,domain}, element→{element,capability}", () => {
+    expect([...allowedKindsFor("isA", "capability")].sort()).toEqual(["capability", "domain"]);
+    expect([...allowedKindsFor("isA", "element")].sort()).toEqual(["capability", "element"]);
+    expect(allowedKindsFor("isA", "project").size).toBe(0);
+  });
+
+  it("dependsOn 은 초점 kind 무관 capability·element", () => {
+    for (const focal of ["project", "domain", "capability", "element"]) {
+      expect([...allowedKindsFor("dependsOn", focal)].sort()).toEqual(["capability", "element"]);
+    }
+  });
+
+  it("relates 는 컨테이너로 거슬러 올라가지 않는다 — capability→{capability,element}", () => {
+    const set = allowedKindsFor("relates", "capability");
+    expect(set.has("domain")).toBe(false);
+    expect(set.has("project")).toBe(false);
+    expect([...set].sort()).toEqual(["capability", "element"]);
+  });
+
+  it("초점 kind 미상이면 relation 별 합집합으로 폭넓게 허용", () => {
+    const union = allowedKindsFor("contains", null);
+    expect(union.has("domain")).toBe(true);
+    expect(union.has("capability")).toBe(true);
+    expect(union.has("element")).toBe(true);
+  });
+
+  it("core 밖 kind(document/unknown)는 어떤 소켓에도 안 든다", () => {
+    for (const rel of ["isA", "dependsOn", "contains", "relates"] as const) {
+      for (const focal of ["project", "domain", "capability", "element"]) {
+        expect(kindAllowedFor(rel, focal, "document")).toBe(false);
+        expect(kindAllowedFor(rel, focal, "unknown")).toBe(false);
+      }
+    }
+  });
+});

--- a/src/views/ontology-studio/lib/allowed-kinds.ts
+++ b/src/views/ontology-studio/lib/allowed-kinds.ts
@@ -1,0 +1,85 @@
+/**
+ * 방위(bearing/relation) × 초점 노드 kind → 그 소켓이 후보로 허용하는 기존 노드
+ * kind 집합 (C12 ①). 피커 검색 결과와 발견 표면(추천/둘러보기) BOTH 이 하나의
+ * 진실원으로 이 필터를 강제한다 — 예전에는 relation 만 보고(초점 kind 무시)
+ * `contains` 후보에 domain 이 섞여 나오는 등 계층에 안 맞는 후보가 노출됐다.
+ *
+ * 계층(위→아래): project(0) → domain(1) → capability(2) → element(3).
+ * 각 방위의 의미에 맞춰 "같은/한 단계 이웃" 창(window)으로 좁힌다:
+ *
+ *   isA (상위개념/broader)  — 자기와 같거나 한 단계 위(컨테이너) kind
+ *     project→∅ · domain→{domain} · capability→{capability,domain} ·
+ *     element→{element,capability}
+ *   dependsOn (기대는 곳)    — 런타임/행위 의존은 역량·요소로 수렴
+ *     (모든 초점)→{capability,element}
+ *   contains (담는 것)       — 한 단계 아래(자식) kind
+ *     project→{domain} · domain→{capability,element} · capability→{element} ·
+ *     element→{element}
+ *   relates (비슷한 것)      — 같은 kind + 한 단계 아래(대체/보완) — 컨테이너로
+ *     거슬러 올라가지 않는다(비슷함은 상향 포함이 아님)
+ *     project→{project} · domain→{domain} · capability→{capability,element} ·
+ *     element→{element,capability}
+ *
+ * `document`/`unknown` 같은 코어 밖 kind 는 어떤 창에도 들지 않아 자연히 제외된다
+ * (근거 문서/미해석 stub 을 관계 후보로 밀지 않는다). 항상 Set 을 반환하므로
+ * (null 폴백 없음) 피커·발견 표면 두 소비자가 동일 규칙을 적용한다.
+ */
+
+import type { StudioRelation } from "./build-studio-item";
+
+type KindSet = ReadonlySet<string>;
+
+const EMPTY: KindSet = new Set();
+
+/** relation → (초점 kind → 허용 kind 집합). 표에 없는 초점 kind 는 빈 집합. */
+const MATRIX: Record<StudioRelation, Record<string, KindSet>> = {
+  isA: {
+    project: EMPTY,
+    domain: new Set(["domain"]),
+    capability: new Set(["capability", "domain"]),
+    element: new Set(["element", "capability"]),
+  },
+  dependsOn: {
+    project: new Set(["capability", "element"]),
+    domain: new Set(["capability", "element"]),
+    capability: new Set(["capability", "element"]),
+    element: new Set(["capability", "element"]),
+  },
+  contains: {
+    project: new Set(["domain"]),
+    domain: new Set(["capability", "element"]),
+    capability: new Set(["element"]),
+    element: new Set(["element"]),
+  },
+  relates: {
+    project: new Set(["project"]),
+    domain: new Set(["domain"]),
+    capability: new Set(["capability", "element"]),
+    element: new Set(["element", "capability"]),
+  },
+};
+
+/**
+ * 이 소켓(방위 + 초점 kind)이 후보로 허용하는 기존 노드 kind 집합. 초점 kind 를
+ * 모르면(고립 렌더/테스트) relation 별 합집합으로 폭넓게 허용한다.
+ */
+export function allowedKindsFor(
+  relation: StudioRelation,
+  focalKind: string | null | undefined,
+): KindSet {
+  const perKind = MATRIX[relation];
+  if (focalKind && focalKind in perKind) return perKind[focalKind];
+  // 초점 kind 미상 → 그 relation 이 어느 초점에서든 허용하는 kind 의 합집합.
+  const union = new Set<string>();
+  for (const set of Object.values(perKind)) for (const k of set) union.add(k);
+  return union;
+}
+
+/** 후보 kind 가 이 소켓에 허용되는가 (피커·발견 표면 공용 술어). */
+export function kindAllowedFor(
+  relation: StudioRelation,
+  focalKind: string | null | undefined,
+  candidateKind: string,
+): boolean {
+  return allowedKindsFor(relation, focalKind).has(candidateKind);
+}

--- a/src/views/ontology-studio/lib/build-create-node.test.ts
+++ b/src/views/ontology-studio/lib/build-create-node.test.ts
@@ -34,6 +34,40 @@ function draft(overrides: Partial<CreateDraft> = {}): CreateDraft {
   };
 }
 
+describe("C12③ — per-locale display names", () => {
+  it("writes sorted display_<locale> keys under title in the vault doc", () => {
+    const { markdown } = buildCreateNodeDoc(
+      draft({ localeLabels: { en: "Payment cancel", ko: "결제 취소" } }),
+    );
+    // deterministic: en before ko (sorted), both right under title.
+    expect(markdown).toContain("display_en: Payment cancel");
+    expect(markdown).toContain("display_ko: 결제 취소");
+    expect(markdown.indexOf("display_en")).toBeLessThan(markdown.indexOf("display_ko"));
+    expect(markdown.indexOf("title:")).toBeLessThan(markdown.indexOf("display_en"));
+  });
+
+  it("omits display_* entirely when no locale names are given (unchanged today)", () => {
+    const { markdown } = buildCreateNodeDoc(draft());
+    expect(markdown).not.toContain("display_");
+  });
+
+  it("ignores blank / malformed locale entries", () => {
+    const { markdown } = buildCreateNodeDoc(
+      draft({ localeLabels: { ko: "  ", en: "Payment cancel", "en-US": "x" } }),
+    );
+    expect(markdown).toContain("display_en: Payment cancel");
+    expect(markdown).not.toContain("display_ko");
+    expect(markdown).not.toContain("en-US");
+  });
+
+  it("emits labels: { ... } in the MCP packet (add_concept locale-label input)", () => {
+    const packet = buildMcpPacket(draft({ localeLabels: { ko: "결제 취소", en: "Payment cancel" } }));
+    expect(packet).toContain('labels: { en: "Payment cancel", ko: "결제 취소" }');
+    // and none when absent.
+    expect(buildMcpPacket(draft())).not.toContain("labels:");
+  });
+});
+
 describe("candidateFromNode", () => {
   it("computes the folder-prefixed ref the derivation resolves", () => {
     expect(orderCancel.ref).toBe("capabilities/order-cancel");

--- a/src/views/ontology-studio/lib/build-create-node.test.ts
+++ b/src/views/ontology-studio/lib/build-create-node.test.ts
@@ -68,6 +68,37 @@ describe("C12③ — per-locale display names", () => {
   });
 });
 
+describe("C2 — CREATE-from-socket origin relation in ONE MCP packet", () => {
+  it("appends add_relation A→new for a non-is_a origin bearing", () => {
+    const packet = buildMcpPacket(draft({ relations: [] }), {
+      focalSlug: "capabilities/order-cancel",
+      relation: "contains",
+    });
+    const lines = packet.split("\n");
+    expect(lines[0]).toMatch(/^add_concept\(/);
+    // the origin line records the A→new edge (A contains the new node).
+    expect(packet).toContain(
+      'add_relation(from: "capabilities/order-cancel", to: "capabilities/결제-취소", type: "contains")',
+    );
+  });
+
+  it("patches A's broader for an is_a origin using the supplied post-add array", () => {
+    const packet = buildMcpPacket(draft(), {
+      focalSlug: "capabilities/order-cancel",
+      relation: "isA",
+      broaderRefsAfter: ["domains/payments", "capabilities/결제-취소"],
+    });
+    expect(packet).toContain(
+      'patch_concept(slug: "capabilities/order-cancel", frontmatter: { broader: ["domains/payments", "capabilities/결제-취소"] })',
+    );
+    expect(packet).not.toContain("is_a");
+  });
+
+  it("no origin → packet is unchanged (just the node + its own relations)", () => {
+    expect(buildMcpPacket(draft())).not.toContain("order-cancel");
+  });
+});
+
 describe("candidateFromNode", () => {
   it("computes the folder-prefixed ref the derivation resolves", () => {
     expect(orderCancel.ref).toBe("capabilities/order-cancel");

--- a/src/views/ontology-studio/lib/build-create-node.ts
+++ b/src/views/ontology-studio/lib/build-create-node.ts
@@ -82,6 +82,23 @@ export interface CreateDraft {
   domainValue: string | null;
   definition: string;
   relations: PendingRelation[];
+  /**
+   * C12③ — per-locale display names (locale → name), written as `display_<locale>`
+   * frontmatter (map/INDEX/popover render the screen-locale name; `title` stays
+   * the search/matching truth). Empty/absent → no `display_*` keys, same as today
+   * (other-locale viewers just see `title`). Keys are serialized in sorted order
+   * so the doc + MCP packet are deterministic.
+   */
+  localeLabels?: Record<string, string>;
+}
+
+/** Sorted, trimmed, non-empty `display_<locale>` entries from a draft. */
+function localeLabelEntries(draft: CreateDraft): Array<[string, string]> {
+  const raw = draft.localeLabels ?? {};
+  return Object.entries(raw)
+    .map(([locale, name]) => [locale.trim(), name.trim()] as [string, string])
+    .filter(([locale, name]) => /^[a-z]{2}$/.test(locale) && name !== "")
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 /**
@@ -171,6 +188,10 @@ export function buildCreateNodeDoc(draft: CreateDraft): { slug: string; markdown
   if (!slug) throw new Error("title produced an empty slug");
 
   const extra: string[] = [];
+  // C12③ — per-locale display names right under `title:`.
+  for (const [locale, name] of localeLabelEntries(draft)) {
+    extra.push(`display_${locale}: ${quoteYamlScalar(name)}`);
+  }
   const definition = draft.definition.trim();
   if (definition) extra.push(`definition: ${quoteYamlScalar(definition)}`);
   for (const { key, refs } of groupRelationRefs(draft.relations)) {
@@ -200,6 +221,13 @@ export function buildMcpPacket(draft: CreateDraft): string {
   const q = (v: string) => `"${v.replace(/"/g, '\\"')}"`;
 
   const conceptArgs = [`slug: ${q(slug)}`, `kind: ${q(draft.kind)}`, `title: ${q(title)}`];
+  // C12③ — per-locale display names as `labels: { ko, en }` (add_concept's
+  // documented locale-label input; mirrors the doc's `display_<locale>` keys).
+  const localeEntries = localeLabelEntries(draft);
+  if (localeEntries.length > 0) {
+    const pairs = localeEntries.map(([locale, name]) => `${locale}: ${q(name)}`);
+    conceptArgs.push(`labels: { ${pairs.join(", ")} }`);
+  }
   // C7 — canonical bare tail-slug `domain:` in the MCP packet too.
   const domain = canonicalizeDomainRef(draft.domainValue);
   if (domain && kindExpectsDomain(draft.kind)) conceptArgs.push(`domain: ${q(domain)}`);

--- a/src/views/ontology-studio/lib/build-create-node.ts
+++ b/src/views/ontology-studio/lib/build-create-node.ts
@@ -211,11 +211,26 @@ export function buildCreateNodeDoc(draft: CreateDraft): { slug: string; markdown
 }
 
 /**
+ * C2 — the ORIGIN relation for a CREATE-from-socket flow: the focal node A the
+ * user came from (A --relation--> the new node). Recorded IN THE SAME operation
+ * as the node create so "새로 만들기" from A's socket never drops the A→new link.
+ * `broaderRefsAfter` is A's full post-add `broader` array (is_a only, since MCP
+ * has no is_a edge — the caller supplies it from A's existing is_a neighbors).
+ */
+export interface CreateOrigin {
+  /** A's write-target doc slug (frontmatter lives here). */
+  focalSlug: string;
+  relation: CreateRelationType;
+  broaderRefsAfter?: readonly string[];
+}
+
+/**
  * Build the copyable MCP command packet for the DELEGATE path. This is the ONLY
  * active write route in read-only / sample mode — the agent runs these calls
- * against the vault it is registered on.
+ * against the vault it is registered on. With an `origin` (C2), the packet also
+ * records A --relation--> new node so the whole intent lands in ONE paste.
  */
-export function buildMcpPacket(draft: CreateDraft): string {
+export function buildMcpPacket(draft: CreateDraft, origin?: CreateOrigin): string {
   const title = draft.title.trim();
   const slug = buildCreateNodeSlug({ kind: draft.kind, title }) ?? `${draft.kind}s/new-node`;
   const q = (v: string) => `"${v.replace(/"/g, '\\"')}"`;
@@ -248,6 +263,24 @@ export function buildMcpPacket(draft: CreateDraft): string {
     lines.push(
       `add_relation(from: ${q(slug)}, to: ${q(rel.candidate.ref)}, type: ${q(RELATION_EDGE_TYPE[rel.type])})`,
     );
+  }
+  // C2 — the origin relation A --relation--> new node, in the same packet.
+  if (origin) {
+    if (origin.relation === "isA") {
+      // A is_a new → append new to A's broader (MCP has no is_a edge type).
+      const refs = origin.broaderRefsAfter ?? [slug];
+      lines.push(
+        `patch_concept(slug: ${q(origin.focalSlug)}, frontmatter: { broader: [${refs
+          .map((r) => q(r))
+          .join(", ")}] })`,
+      );
+    } else {
+      lines.push(
+        `add_relation(from: ${q(origin.focalSlug)}, to: ${q(slug)}, type: ${q(
+          RELATION_EDGE_TYPE[origin.relation],
+        )})`,
+      );
+    }
   }
   return lines.join("\n");
 }

--- a/src/views/ontology-studio/lib/build-studio-changes.test.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.test.ts
@@ -199,6 +199,7 @@ const koVocab: StudioSummaryVocab = {
     domain ? `${kind} '${name}' 가 ${domain} 도메인 아래 생겨요` : `${kind} '${name}' 가 생겨요`,
   createFileEffect: (n) => `파일 1개 생성 · 관계 ${n}줄 기록.`,
   createCollapsed: (n) => `새 노드 1개 · 관계 ${n}개`,
+  createOriginLine: (name, rel) => `'${name}' 의 '${rel}' 에 이어져요`,
   collapsedCount: (n) => `기록될 내용 ${n}가지`,
   empty: "기록할 변경이 없어요",
 };
@@ -213,6 +214,7 @@ const enVocab: StudioSummaryVocab = {
     domain ? `New ${kind} '${name}' under ${domain}` : `New ${kind} '${name}'`,
   createFileEffect: (n) => `1 file created · ${n} relation line(s).`,
   createCollapsed: (n) => `1 new node · ${n} relation(s)`,
+  createOriginLine: (name, rel) => `links to '${name}' '${rel}'`,
   collapsedCount: (n) => `${n} change(s) to record`,
   empty: "Nothing staged yet",
 };
@@ -278,5 +280,33 @@ describe("summarizeStudioChanges — create", () => {
     expect(s.headline).toBe("New capability 'Refund'");
     expect(s.fileEffect).toBe("1 file created · 0 relation line(s).");
     expect(s.collapsed).toBe("1 new node · 0 relation(s)");
+  });
+
+  it("C2: origin relation is listed FIRST and counts as a written line", () => {
+    const s = summarizeStudioChanges(
+      {
+        mode: "create",
+        kindLabel: "capability",
+        name: "결제 취소",
+        domainLabel: null,
+        changes: [{ op: "add", relation: "contains", target: C }],
+        origin: { focalName: "주문 취소", bearingLabel: "담는 것" },
+      },
+      koVocab,
+    );
+    // origin line first, then the draft's own relation lines.
+    expect(s.lines[0]).toBe("'주문 취소' 의 '담는 것' 에 이어져요");
+    expect(s.lines).toHaveLength(2);
+    expect(s.count).toBe(2); // origin + 1 draft relation both written
+    expect(s.fileEffect).toBe("파일 1개 생성 · 관계 2줄 기록.");
+  });
+
+  it("C2: no origin → summary unchanged (draft relations only)", () => {
+    const s = summarizeStudioChanges(
+      { mode: "create", kindLabel: "capability", name: "결제 취소", domainLabel: null, changes: [{ op: "add", relation: "contains", target: C }] },
+      koVocab,
+    );
+    expect(s.lines).toHaveLength(1);
+    expect(s.count).toBe(1);
   });
 });

--- a/src/views/ontology-studio/lib/build-studio-changes.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.ts
@@ -279,6 +279,12 @@ export interface StudioSummaryVocab {
   createFileEffect: (relationLines: number) => string;
   /** create collapsed one-liner, e.g. "새 노드 1개 · 관계 2개" */
   createCollapsed: (relationLines: number) => string;
+  /**
+   * C2 — origin relation line for a CREATE-from-socket flow, e.g.
+   * "‘CLI’ 의 ‘담는 것’ 에 이어져요". Optional: only the page's full vocab supplies
+   * it; a create summary without an origin omits it.
+   */
+  createOriginLine?: (focalName: string, bearingLabel: string) => string;
   /** collapsed one-liner, e.g. "기록될 내용 2가지" */
   collapsedCount: (count: number) => string;
   /** nothing staged yet */
@@ -302,6 +308,8 @@ export type StudioSummaryPlan =
       name: string;
       domainLabel: string | null;
       changes: readonly StudioChange[];
+      /** C2 — the focal A this new node is being created FROM, and the bearing. */
+      origin?: { focalName: string; bearingLabel: string };
     };
 
 function changeLine(change: StudioChange, vocab: StudioSummaryVocab): string {
@@ -322,9 +330,9 @@ export function summarizeStudioChanges(
   plan: StudioSummaryPlan,
   vocab: StudioSummaryVocab,
 ): StudioChangeSummary {
-  const lines = plan.changes.map((c) => changeLine(c, vocab));
-  const count = lines.length;
   if (plan.mode === "enhance") {
+    const lines = plan.changes.map((c) => changeLine(c, vocab));
+    const count = lines.length;
     return {
       count,
       headline: count === 0 ? vocab.empty : vocab.enhanceHeadline(plan.focalName, count),
@@ -334,7 +342,15 @@ export function summarizeStudioChanges(
       empty: count === 0,
     };
   }
-  // create — the node is always created; relation lines are additive.
+  // create — the node is always created; relation lines are additive. C2: the
+  // origin relation (A --bearing--> new) is one MORE written line, listed first.
+  const draftLines = plan.changes.map((c) => changeLine(c, vocab));
+  const originLine =
+    plan.origin && vocab.createOriginLine
+      ? vocab.createOriginLine(plan.origin.focalName, plan.origin.bearingLabel)
+      : null;
+  const lines = originLine ? [originLine, ...draftLines] : draftLines;
+  const count = lines.length;
   return {
     count,
     headline: vocab.createHeadline(plan.kindLabel, plan.name, plan.domainLabel),

--- a/src/views/ontology-studio/lib/resolve-studio-focal.test.ts
+++ b/src/views/ontology-studio/lib/resolve-studio-focal.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { resolveStudioFocalId } from "./resolve-studio-focal";
+import type { StudioSourceNode } from "./build-studio-item";
+
+/**
+ * C3 회귀 — 상단 검색 클릭이 focal 을 안 바꾸던 로컬 vault 조건.
+ *
+ * 로컬 vault 는 노드 id 가 항상 canonical `kind:slug` 라는 보장이 없다:
+ * `?node=` 는 folder-prefixed ref / bare tail / macOS 파일명발 NFD 형식으로도
+ * 도착한다. 예전 resolver 의 `n.id === requestedNode` 는 이 전부를 놓쳐 조용히
+ * 기본 노드로 되돌아갔다. 각 형식을 재현하고, 관용 resolver 가 canonical id 로
+ * 수렴하는지 검증한다.
+ */
+
+// 로컬 vault 형태 — 한국어 제목 + canonical id (파일명 슬러그 tail).
+const nodes: StudioSourceNode[] = [
+  { id: "capability:티켓-분류", title: "티켓 분류", kind: "capability" },
+  { id: "capability:응대-작성", title: "응대 작성", kind: "capability" },
+  { id: "element:분류-모델", title: "분류 모델", kind: "element" },
+  { id: "domain:문의-처리", title: "문의 처리", kind: "domain" },
+];
+
+// 예전 strict resolver (수정 전) — 회귀가 실재했음을 문서화하기 위한 대조군.
+const strictResolve = (req: string | null) =>
+  req && nodes.some((n) => n.id === req) ? req : null;
+
+describe("resolveStudioFocalId — id 형식 관용", () => {
+  it("canonical id 는 그대로 매칭한다 (스튜디오 상단 검색 경로)", () => {
+    expect(resolveStudioFocalId("capability:티켓-분류", nodes)).toBe("capability:티켓-분류");
+  });
+
+  it("folder-prefixed ref 를 canonical id 로 수렴한다 (라우트 메모리·딥링크 복원)", () => {
+    // 예전 resolver 는 실패했다 (회귀 재현) — 새 resolver 는 canonical 로 매칭.
+    expect(strictResolve("capabilities/티켓-분류")).toBeNull();
+    expect(resolveStudioFocalId("capabilities/티켓-분류", nodes)).toBe("capability:티켓-분류");
+    expect(resolveStudioFocalId("elements/분류-모델", nodes)).toBe("element:분류-모델");
+    expect(resolveStudioFocalId("domains/문의-처리", nodes)).toBe("domain:문의-처리");
+  });
+
+  it("NFD(분해형) 파일명 슬러그를 NFC 노드 id 로 폴딩해 매칭한다 (macOS)", () => {
+    const nfdReq = "capability:티켓-분류".normalize("NFD");
+    expect(nfdReq).not.toBe("capability:티켓-분류"); // 실제로 다른 바이트열
+    expect(strictResolve(nfdReq)).toBeNull(); // 회귀 재현
+    expect(resolveStudioFocalId(nfdReq, nodes)).toBe("capability:티켓-분류");
+    // folder-prefixed + NFD 동시
+    expect(resolveStudioFocalId("capabilities/티켓-분류".normalize("NFD"), nodes)).toBe(
+      "capability:티켓-분류",
+    );
+  });
+
+  it("bare tail slug 을 유일 매칭일 때만 수렴한다 (topology ?p= 핸드오프)", () => {
+    expect(strictResolve("티켓-분류")).toBeNull(); // 회귀 재현
+    expect(resolveStudioFocalId("티켓-분류", nodes)).toBe("capability:티켓-분류");
+  });
+
+  it("bare tail 이 2개 이상 노드와 겹치면 추측하지 않고 null (기본 노드 fallback)", () => {
+    const ambiguous: StudioSourceNode[] = [
+      { id: "capability:분류", title: "분류(역량)", kind: "capability" },
+      { id: "element:분류", title: "분류(요소)", kind: "element" },
+    ];
+    // canonical 은 유일 매칭이 되게, bare 는 모호하게.
+    expect(resolveStudioFocalId("capability:분류", ambiguous)).toBe("capability:분류");
+    expect(resolveStudioFocalId("분류", ambiguous)).toBeNull();
+  });
+
+  it("없는 노드·빈 입력은 null", () => {
+    expect(resolveStudioFocalId(null, nodes)).toBeNull();
+    expect(resolveStudioFocalId("", nodes)).toBeNull();
+    expect(resolveStudioFocalId("capability:없는거", nodes)).toBeNull();
+  });
+});

--- a/src/views/ontology-studio/lib/resolve-studio-focal.ts
+++ b/src/views/ontology-studio/lib/resolve-studio-focal.ts
@@ -1,0 +1,90 @@
+/**
+ * Resolve which node the 공방(Compass Stage) ENHANCE surface centers on from the
+ * `?node=<id>` deep-link — TOLERANTLY.
+ *
+ * WHY (C3, codex 로컬 vault 회귀): the studio focal resolver used a naive
+ * `nodes.some(n => n.id === requestedNode)`. That only holds when the `?node=`
+ * value is byte-identical to the derived node id (canonical `kind:slug`). The
+ * sample/dogfood vault's ids always are, so it worked there. A LOCAL vault does
+ * not guarantee that: `?node=` legitimately arrives in other id forms and the
+ * strict `===` misses every one of them, so the page silently fell back to the
+ * default node — the reported "검색 클릭이 focal 을 안 바꿈 (리스트만 닫히고
+ * focal 그대로)".
+ *
+ * The forms that legitimately reach `?node=`:
+ *   1. canonical            `capability:ticket`        (studio top-bar search)
+ *   2. folder-prefixed ref  `capabilities/ticket`      (route-memory restore,
+ *                            insights `evidenceIds` href, hand-built / stale link)
+ *   3. bare tail slug       `ticket`                   (topology `?p=` handoff)
+ *   4. Unicode NFD          `티켓-분류` (decomposed)     (macOS filename → doc.slug)
+ *
+ * `/topology`'s own resolver already tolerates 1–3; the studio never did. This
+ * closes the gap with the SAME entity-layer folder→kind normalizer the deep-link
+ * senders use (`translateOntologyDeeplinkToTopologyParam`), plus Unicode NFC
+ * folding so a decomposed filename slug matches a composed frontmatter one.
+ *
+ * Pure + synchronous so it is unit-tested independent of React and the router.
+ */
+
+import { translateOntologyDeeplinkToTopologyParam } from "@/entities/knowledge-graph";
+import type { StudioSourceNode } from "./build-studio-item";
+
+/** Unicode-fold (NFC) + trim so NFD filename slugs match NFC frontmatter ones. */
+function foldId(id: string): string {
+  return id.normalize("NFC").trim();
+}
+
+/** The comparable tail of an id — after the last `/` or `:` — NFC-folded. */
+function tailOf(id: string): string {
+  const folded = foldId(id);
+  const slash = folded.lastIndexOf("/");
+  const afterSlash = slash >= 0 ? folded.slice(slash + 1) : folded;
+  const colon = afterSlash.indexOf(":");
+  return colon >= 0 ? afterSlash.slice(colon + 1) : afterSlash;
+}
+
+/**
+ * Resolve `requestedNode` against the live graph, tolerant of id form. Returns
+ * the matching node id (the canonical graph id, so downstream `buildStudioItem`
+ * keeps working) or `null` when nothing matches. Deterministic: an exact id
+ * match wins, then canonicalized, then NFC-folded, then a unique bare-tail
+ * match. A tail that is ambiguous (matches 2+ nodes) is rejected rather than
+ * guessed — the caller falls back to its default node.
+ */
+export function resolveStudioFocalId(
+  requestedNode: string | null | undefined,
+  nodes: readonly StudioSourceNode[],
+): string | null {
+  if (!requestedNode) return null;
+  const raw = requestedNode.trim();
+  if (!raw) return null;
+
+  // 1. exact id (canonical `kind:slug` from the studio's own search).
+  for (const n of nodes) if (n.id === raw) return n.id;
+
+  // 2. folder-prefixed ref (`capabilities/foo`) → canonical, then exact match.
+  const canonical = translateOntologyDeeplinkToTopologyParam(raw);
+  if (canonical !== raw) {
+    for (const n of nodes) if (n.id === canonical) return n.id;
+  }
+
+  // 3. NFC fold — a decomposed (macOS filename) requested id vs a composed node
+  //    id, or vice versa. Compare the canonicalized forms folded.
+  const foldedReq = foldId(canonical);
+  for (const n of nodes) if (foldId(n.id) === foldedReq) return n.id;
+
+  // 4. bare tail — `?node=foo` (topology `?p=` handoff) or a tail-only link.
+  //    Only when it resolves to exactly ONE node (never guess between kinds).
+  const reqTail = tailOf(raw);
+  if (reqTail) {
+    let hit: string | null = null;
+    for (const n of nodes) {
+      if (tailOf(n.id) !== reqTail) continue;
+      if (hit !== null) return null; // ambiguous → let the caller default
+      hit = n.id;
+    }
+    if (hit) return hit;
+  }
+
+  return null;
+}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -50,6 +50,7 @@ import {
 import { buildPickerDiscovery } from "../lib/build-picker-discovery";
 import { buildDeltaPreview } from "../lib/build-delta-preview";
 import { resolveStudioFocalId } from "../lib/resolve-studio-focal";
+import { allowedKindsFor } from "../lib/allowed-kinds";
 import { StudioCompass, type CompassBearingView, type StudioCompassLabels } from "./StudioCompass";
 
 /**
@@ -65,14 +66,6 @@ const STUDIO_BASE = "/ontology/studio";
 const CREATE_HREF = `${STUDIO_BASE}?mode=create`;
 
 const CREATE_KINDS: CreateNodeKind[] = ["project", "domain", "capability", "element"];
-
-/** Which existing-node kinds each relation offers as picker candidates. */
-const CANDIDATE_KINDS: Record<StudioRelation, ReadonlySet<string> | null> = {
-  isA: new Set(["capability", "domain", "project"]),
-  dependsOn: new Set(["capability", "element"]),
-  contains: new Set(["capability", "element"]),
-  relates: null, // any non-container
-};
 
 const RELATIONS: StudioRelation[] = ["isA", "dependsOn", "contains", "relates"];
 const BEARING_OF: Record<StudioRelation, StudioBearing> = {
@@ -171,6 +164,8 @@ export function OntologyStudioPage() {
       saveHint: t("saveHint"),
       foldMore: () => t("foldMore"),
       foldTitle: (label, total) => t("foldTitle", { label, total }),
+      addMore: (label) => t("addMore", { label }),
+      addMoreShort: t("addMoreShort"),
       defMore: t("defMore"),
       defLess: t("defLess"),
       pickerTitle: (question) => question,
@@ -289,13 +284,19 @@ export function OntologyStudioPage() {
     [router, preserveReviewContext],
   );
 
-  // Candidate picker for a relation — allowed kinds, minus already-linked / self.
+  // Candidate picker for a relation — allowed kinds (per bearing × focal kind,
+  // C12 ①), minus already-linked / self.
   const makeCandidatesFor = useCallback(
-    (relation: StudioRelation, query: string, exclude: ReadonlySet<string>): CreateCandidate[] => {
-      const allow = CANDIDATE_KINDS[relation];
+    (
+      relation: StudioRelation,
+      focalKind: string | null,
+      query: string,
+      exclude: ReadonlySet<string>,
+    ): CreateCandidate[] => {
+      const allow = allowedKindsFor(relation, focalKind);
       const q = query.trim().toLowerCase();
       return candidates
-        .filter((c) => (allow ? allow.has(c.kind) : c.kind !== "project" && c.kind !== "domain"))
+        .filter((c) => allow.has(c.kind))
         .filter((c) => !exclude.has(c.id))
         .filter((c) => (q ? c.title.toLowerCase().includes(q) || c.ref.toLowerCase().includes(q) : true))
         .slice(0, 8);
@@ -305,16 +306,18 @@ export function OntologyStudioPage() {
 
   // Near-dup nudge in the picker — the user typed the exact name of an existing node.
   const makeSimilarFor = useCallback(
-    (relation: StudioRelation, query: string, exclude: ReadonlySet<string>): CreateCandidate | null => {
+    (
+      relation: StudioRelation,
+      focalKind: string | null,
+      query: string,
+      exclude: ReadonlySet<string>,
+    ): CreateCandidate | null => {
       const q = normalize(query);
       if (q.length < 2) return null;
-      const allow = CANDIDATE_KINDS[relation];
+      const allow = allowedKindsFor(relation, focalKind);
       return (
         candidates.find(
-          (c) =>
-            (allow ? allow.has(c.kind) : c.kind !== "project" && c.kind !== "domain") &&
-            !exclude.has(c.id) &&
-            normalize(c.title) === q,
+          (c) => allow.has(c.kind) && !exclude.has(c.id) && normalize(c.title) === q,
         ) ?? null
       );
     },
@@ -413,7 +416,7 @@ export function OntologyStudioPage() {
         nodes,
         edges,
         relation,
-        allowedKinds: CANDIDATE_KINDS[relation],
+        allowedKinds: allowedKindsFor(relation, enhanceItem?.node.kind ?? null),
         stagedTargetIds: enhanceProjection?.pendingTargetIds,
       }),
     [enhanceItem, nodes, edges, enhanceProjection],
@@ -538,8 +541,8 @@ export function OntologyStudioPage() {
         bearings={bearings}
         filledBearings={filledBearings}
         writable={writable}
-        candidatesFor={(relation, query) => makeCandidatesFor(relation, query, excludeFor(relation))}
-        similarFor={(relation, query) => makeSimilarFor(relation, query, excludeFor(relation))}
+        candidatesFor={(relation, query) => makeCandidatesFor(relation, kind, query, excludeFor(relation))}
+        similarFor={(relation, query) => makeSimilarFor(relation, kind, query, excludeFor(relation))}
         onFill={(relation, candidate) =>
           setRelations((prev) =>
             prev.some((r) => r.type === relation && r.candidate.id === candidate.id)
@@ -767,8 +770,12 @@ export function OntologyStudioPage() {
       bearings={bearings}
       filledBearings={filledBearings}
       writable={writable}
-      candidatesFor={(relation, query) => makeCandidatesFor(relation, query, excludeFor(relation))}
-      similarFor={(relation, query) => makeSimilarFor(relation, query, excludeFor(relation))}
+      candidatesFor={(relation, query) =>
+        makeCandidatesFor(relation, focalItem.node.kind, query, excludeFor(relation))
+      }
+      similarFor={(relation, query) =>
+        makeSimilarFor(relation, focalItem.node.kind, query, excludeFor(relation))
+      }
       discoveryFor={discoveryFor}
       onFill={(relation, candidate) =>
         stage({

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -26,6 +26,7 @@ import {
 } from "../lib/build-studio-item";
 import {
   buildCreateNodeDoc,
+  buildCreateNodeSlug,
   buildEditPacket,
   buildFillPacket,
   buildMcpPacket,
@@ -36,6 +37,7 @@ import {
   type CreateCandidate,
   type CreateDraft,
   type CreateNodeKind,
+  type CreateOrigin,
   type PendingRelation,
 } from "../lib/build-create-node";
 import {
@@ -256,6 +258,7 @@ export function OntologyStudioPage() {
           : t("summary.createHeadline", { kind: kindLabelText, name }),
       createFileEffect: (count) => t("summary.createFileEffect", { count }),
       createCollapsed: (count) => t("summary.createCollapsed", { count }),
+      createOriginLine: (name, relation) => t("summary.createOriginLine", { name, relation }),
       collapsedCount: (count) => t("summary.collapsed", { count }),
       empty: t("summary.empty"),
     }),
@@ -337,6 +340,49 @@ export function OntologyStudioPage() {
   const [similarDismissed, setSimilarDismissed] = useState(false);
   // C12③ — optional other-locale display name (primary name is the current locale).
   const [secondaryName, setSecondaryName] = useState("");
+
+  // C2 — CREATE opened from a socket carries the origin (A --relation--> new) and
+  // a name prefill via ?from & ?rel & ?name. Resolve A tolerantly; malformed /
+  // stale context is simply ignored (falls back to a blank CREATE).
+  const createContext = useMemo(() => {
+    if (!isCreate) return null;
+    const from = searchParams.get("from");
+    const rel = searchParams.get("rel");
+    if (!from || !rel || !(RELATIONS as string[]).includes(rel)) return null;
+    const originId = resolveStudioFocalId(from, nodes);
+    if (!originId) return null;
+    const originNode = nodes.find((n) => n.id === originId);
+    if (!originNode) return null;
+    return {
+      originId,
+      originLabel: originNode.display ?? originNode.title,
+      originKind: originNode.kind,
+      originSourceSlug: originNode.evidenceIds?.[0] ?? candidateFromNode(originNode).ref,
+      relation: rel as StudioRelation,
+      name: searchParams.get("name") ?? "",
+    };
+  }, [isCreate, searchParams, nodes]);
+
+  // Seed the CREATE draft from the origin context ONCE per context (React's
+  // "reset state during render when input changes" pattern — same as the enhance
+  // focal reset below). kind is pre-filtered to the bearing's allowed target kinds.
+  const [prevCreateCtxKey, setPrevCreateCtxKey] = useState<string | null>(null);
+  const createCtxKey = createContext
+    ? `${createContext.originId}|${createContext.relation}|${createContext.name}`
+    : null;
+  if (isCreate && createCtxKey !== prevCreateCtxKey) {
+    setPrevCreateCtxKey(createCtxKey);
+    if (createContext) {
+      setTitle(createContext.name);
+      const allowed = allowedKindsFor(createContext.relation, createContext.originKind);
+      setKind(CREATE_KINDS.find((k) => allowed.has(k)) ?? "capability");
+      setDomainValue(null);
+      setDefinition("");
+      setRelations([]);
+      setSecondaryName("");
+      setSimilarDismissed(false);
+    }
+  }
 
   // ─────────────────────────────── ENHANCE staged changes ────────────────
   // Which existing node the enhance stage is centered on (deeplink or default).
@@ -471,10 +517,25 @@ export function OntologyStudioPage() {
 
   const applyCreate = useCallback(async () => {
     if (!title.trim() || createSlugCollision) return;
+    const newRef = buildCreateNodeSlug({ kind, title: title.trim() });
     if (writable) {
       try {
         const { slug, markdown } = buildCreateNodeDoc(draft);
-        await localVault.createDoc(slug, markdown);
+        // C2 — create the node, then record A --relation--> new on A's own
+        // frontmatter. Batched: the node write skips refresh so the origin
+        // update triggers the single reload (both self-marked, one paint).
+        const recordOrigin = Boolean(createContext && newRef);
+        await localVault.createDoc(slug, markdown, { skipRefresh: recordOrigin });
+        if (createContext && newRef) {
+          const key = BEARING_FRONTMATTER_KEY[createContext.relation];
+          const originDoc = localVault.manifest?.docs.find(
+            (d) => d.slug === createContext.originSourceSlug,
+          );
+          const existing = originDoc ? asStringArray(originDoc.frontmatter[key]) : [];
+          await localVault.updateFrontmatter(createContext.originSourceSlug, {
+            [key]: Array.from(new Set([...existing, newRef])),
+          });
+        }
         toast.show(t("create.appliedDirect", { title: title.trim() }), "success");
         const tail = slug.split("/").at(-1) ?? "";
         openNode(`${kind}:${tail}`);
@@ -484,12 +545,30 @@ export function OntologyStudioPage() {
       return;
     }
     try {
-      await navigator.clipboard.writeText(buildMcpPacket(draft));
+      // C2 — read-only: ONE packet with add_concept + the A→new origin relation.
+      let origin: CreateOrigin | undefined;
+      if (createContext) {
+        const broaderRefsAfter =
+          createContext.relation === "isA"
+            ? [
+                ...(buildStudioItem(createContext.originId, nodes, edges)?.bearings.up.neighbors.map(
+                  (n) => n.ref,
+                ) ?? []),
+                ...(newRef ? [newRef] : []),
+              ]
+            : undefined;
+        origin = {
+          focalSlug: createContext.originSourceSlug,
+          relation: createContext.relation,
+          broaderRefsAfter,
+        };
+      }
+      await navigator.clipboard.writeText(buildMcpPacket(draft, origin));
       toast.show(t("create.copiedAgent"), "success");
     } catch {
       toast.show(t("create.copyFailed"), "info");
     }
-  }, [title, createSlugCollision, writable, draft, localVault, toast, t, kind, openNode]);
+  }, [title, createSlugCollision, writable, draft, localVault, toast, t, kind, openNode, createContext, nodes, edges]);
 
   if (isCreate) {
     const bearings: CompassBearingView[] = RELATIONS.map((relation) => {
@@ -525,9 +604,38 @@ export function OntologyStudioPage() {
       target: { id: r.candidate.id, title: r.candidate.title, kind: r.candidate.kind, ref: r.candidate.ref },
     }));
     const domainLabelText = domains.find((d) => d.value === domainValue)?.title ?? null;
+    // C2 — the origin (A --relation--> new) surfaces as a quiet context line and
+    // as the first line of the staged record summary.
+    const originSummary = createContext
+      ? { focalName: createContext.originLabel, bearingLabel: relationShort(createContext.relation) }
+      : undefined;
+    const createOriginNote = createContext
+      ? t("create.originNote", {
+          name: createContext.originLabel,
+          bearing: relationShort(createContext.relation),
+        })
+      : null;
     const createSummary = summarizeStudioChanges(
-      { mode: "create", kindLabel: kindLabel(kind), name: title.trim() || t("create.namePlaceholder"), domainLabel: domainLabelText, changes: createChanges },
+      {
+        mode: "create",
+        kindLabel: kindLabel(kind),
+        name: title.trim() || t("create.namePlaceholder"),
+        domainLabel: domainLabelText,
+        changes: createChanges,
+        origin: originSummary,
+      },
       summaryVocab,
+    );
+    // C2 — when opened from a socket, restrict the kind chooser to the bearing's
+    // allowed target kinds (isA/dependsOn/… × A's kind); fall back to all kinds
+    // if the window is empty so the chooser is never dead.
+    const allowedCreateKinds = createContext
+      ? CREATE_KINDS.filter((k) =>
+          allowedKindsFor(createContext.relation, createContext.originKind).has(k),
+        )
+      : CREATE_KINDS;
+    const createKindOptions = (allowedCreateKinds.length > 0 ? allowedCreateKinds : CREATE_KINDS).map(
+      (k) => ({ value: k, label: kindLabel(k) }),
     );
     // Slice 5 — the save-preview mini-graph for a brand-new node: the center is
     // itself the delta (isNew), every staged relation an indigo "added" strut.
@@ -586,7 +694,8 @@ export function OntologyStudioPage() {
             prev.map((r) => (r.type === from && r.candidate.id === neighbor.id ? { ...r, type: to } : r)),
           )
         }
-        createKinds={CREATE_KINDS.map((k) => ({ value: k, label: kindLabel(k) }))}
+        createOriginNote={createOriginNote}
+        createKinds={createKindOptions}
         createKind={kind}
         onCreateKind={(k) => {
           setKind(k);
@@ -818,7 +927,21 @@ export function OntologyStudioPage() {
       canSave={changes.length > 0}
       onSave={commit}
       onExit={exit}
-      onCreateNew={enterCreate}
+      onCreateNew={(ctx) => {
+        // C2 — carry the socket's relation + typed query into CREATE so the new
+        // node lands with the A --relation--> new link + a name prefill.
+        if (!ctx) {
+          enterCreate();
+          return;
+        }
+        const params = new URLSearchParams({
+          mode: "create",
+          from: focalItem.node.id,
+          rel: ctx.relation,
+        });
+        if (ctx.query.trim()) params.set("name", ctx.query.trim());
+        router.push(preserveReviewContext(`${STUDIO_BASE}?${params.toString()}`));
+      }}
       searchNodes={candidates}
       onOpenNode={openNode}
       onSaveAndOpenNode={commitThenOpen}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import {
   buildOntologyInsightsReturnHref,
@@ -87,6 +87,9 @@ function normalize(s: string): string {
 
 export function OntologyStudioPage() {
   const t = useTranslations("ontologyStudio");
+  const locale = useLocale();
+  // C12③ — the secondary display-name locale is the OTHER of the two app locales.
+  const secondaryLocale = locale === "en" ? "ko" : "en";
   const searchParams = useSearchParams();
   const router = useRouter();
   const { insight } = useOntologyInsight();
@@ -156,6 +159,7 @@ export function OntologyStudioPage() {
       moreRelations: t("moreRelations"),
       flowEyebrow: t("flowEyebrow"),
       flowCount: (filled, total) => `${t("flowCount", { filled, total })} ${flowHint(filled)}`,
+      domainMembership: (domain) => t("domainMembership", { domain }),
       framePrompt: (name) => (isCreate ? t("create.framePrompt") : t("framePrompt", { name })),
       guideBadge: t("guideBadge"),
       bottomProgress: (filled, total) =>
@@ -331,6 +335,8 @@ export function OntologyStudioPage() {
   const [definition, setDefinition] = useState("");
   const [relations, setRelations] = useState<PendingRelation[]>([]);
   const [similarDismissed, setSimilarDismissed] = useState(false);
+  // C12③ — optional other-locale display name (primary name is the current locale).
+  const [secondaryName, setSecondaryName] = useState("");
 
   // ─────────────────────────────── ENHANCE staged changes ────────────────
   // Which existing node the enhance stage is centered on (deeplink or default).
@@ -422,9 +428,19 @@ export function OntologyStudioPage() {
     [enhanceItem, nodes, edges, enhanceProjection],
   );
 
+  // C12③ — record BOTH locales' display names only when a secondary is supplied
+  // (a half-filled pair leaves other-locale viewers seeing the raw title, so we
+  // pair the current-locale title with the secondary name or write neither).
+  const localeLabels = useMemo(
+    () =>
+      secondaryName.trim()
+        ? { [locale]: title.trim(), [secondaryLocale]: secondaryName.trim() }
+        : undefined,
+    [secondaryName, locale, secondaryLocale, title],
+  );
   const draft: CreateDraft = useMemo(
-    () => ({ kind, title, domainValue, definition, relations }),
-    [kind, title, domainValue, definition, relations],
+    () => ({ kind, title, domainValue, definition, relations, localeLabels }),
+    [kind, title, domainValue, definition, relations, localeLabels],
   );
 
   const createSlugCollisionCandidate = useMemo(
@@ -585,6 +601,9 @@ export function OntologyStudioPage() {
         createDomainValue={domainValue}
         onCreateDomain={setDomainValue}
         onCreateDefinition={setDefinition}
+        createSecondaryName={secondaryName}
+        onCreateSecondaryName={setSecondaryName}
+        createSecondaryNamePlaceholder={t("create.secondaryName")}
         createSimilarHit={createSimilarHit}
         createSlugCollision={createSlugCollision}
         onOpenSimilar={openSimilarNode}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -49,6 +49,7 @@ import {
 } from "../lib/build-studio-changes";
 import { buildPickerDiscovery } from "../lib/build-picker-discovery";
 import { buildDeltaPreview } from "../lib/build-delta-preview";
+import { resolveStudioFocalId } from "../lib/resolve-studio-focal";
 import { StudioCompass, type CompassBearingView, type StudioCompassLabels } from "./StudioCompass";
 
 /**
@@ -334,10 +335,10 @@ export function OntologyStudioPage() {
   // create/enhance early return.
   const enhanceFocalId = useMemo(() => {
     if (nodes.length === 0) return null;
-    return (
-      (requestedNode && nodes.some((n) => n.id === requestedNode) ? requestedNode : null) ??
-      selectDefaultStudioNodeId(nodes, edges)
-    );
+    // C3 — resolve `?node=` tolerantly (canonical / folder-prefixed / bare tail /
+    // NFD). A raw `n.id === requestedNode` missed every non-canonical form a
+    // LOCAL vault produces, so a search click silently kept the default node.
+    return resolveStudioFocalId(requestedNode, nodes) ?? selectDefaultStudioNodeId(nodes, edges);
   }, [requestedNode, nodes, edges]);
 
   // Slice 2 — enhance is STAGED: fills / retypes / deletes accumulate here and

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -12,6 +12,7 @@ const labels: StudioCompassLabels = {
   moreRelations: "more",
   flowEyebrow: "completeness",
   flowCount: (f, t) => `${f}/${t} filled`,
+  domainMembership: (d) => `already in ${d}`,
   framePrompt: (n) => `complete ${n}`,
   guideBadge: "start here",
   bottomProgress: (f, t) => `${f} of ${t} filled`,
@@ -194,6 +195,37 @@ describe("StudioCompass — enhance", () => {
     // and it fills that bearing in place.
     fireEvent.click(screen.getByTestId("studio-picker-row-capability:server-interface"));
     expect(onFill).toHaveBeenCalledWith("dependsOn", CANDIDATE);
+  });
+
+  it("C12② — a domain-member focal shows the quiet '이미 소속' line so 0/4 isn't read as orphan", () => {
+    renderEnhance(); // focal domainLabel = "AI"
+    const line = screen.getByTestId("studio-domain-membership");
+    expect(line).toHaveTextContent("already in AI");
+  });
+
+  it("C12② — a focal with NO domain shows no membership line", () => {
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "Orphan", definition: "" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { expected: true }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        similarFor={() => null}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("studio-domain-membership")).not.toBeInTheDocument();
   });
 
   it("shows the near-dup suggestion and links it on accept", () => {
@@ -840,6 +872,67 @@ describe("StudioCompass — create", () => {
     expect(screen.getByTestId("studio-create-name")).toBeInTheDocument();
     // save is disabled until the node is named.
     expect(screen.getByTestId("studio-save")).toBeDisabled();
+  });
+
+  it("C12③ — renders ONE optional secondary-locale name input and echoes typing", () => {
+    const onSecondary = vi.fn();
+    render(
+      <StudioCompass
+        mode="create"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "결제 취소", definition: "" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { expected: true }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        canSave
+        createKinds={[{ value: "capability", label: "capability" }]}
+        createKind="capability"
+        createSecondaryName=""
+        onCreateSecondaryName={onSecondary}
+        createSecondaryNamePlaceholder="English name (optional)"
+      />,
+    );
+    const secondary = screen.getByTestId("studio-create-name-secondary");
+    expect(secondary).toHaveAttribute("placeholder", "English name (optional)");
+    fireEvent.change(secondary, { target: { value: "Payment cancel" } });
+    expect(onSecondary).toHaveBeenCalledWith("Payment cancel");
+  });
+
+  it("C12③ — omits the secondary name input when no handler is wired", () => {
+    render(
+      <StudioCompass
+        mode="create"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "", definition: "" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { expected: true }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        canSave={false}
+        createKinds={[{ value: "capability", label: "capability" }]}
+        createKind="capability"
+      />,
+    );
+    expect(screen.queryByTestId("studio-create-name-secondary")).not.toBeInTheDocument();
   });
 
   it("blocks an exact create-path collision and only offers the existing node", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -228,6 +228,38 @@ describe("StudioCompass — enhance", () => {
     expect(screen.queryByTestId("studio-domain-membership")).not.toBeInTheDocument();
   });
 
+  it("C2 — picker '새로 만들기' carries the socket relation + typed query", () => {
+    const onCreateNew = vi.fn();
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "MCP Server", definition: "" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { expected: true }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        similarFor={() => null}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        onCreateNew={onCreateNew}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("studio-socket-down")); // contains bearing
+    fireEvent.change(screen.getByTestId("studio-picker-input"), {
+      target: { value: "결제 취소" },
+    });
+    fireEvent.click(screen.getByTestId("studio-picker-create-new"));
+    expect(onCreateNew).toHaveBeenCalledWith({ relation: "contains", query: "결제 취소" });
+  });
+
   it("shows the near-dup suggestion and links it on accept", () => {
     const onFill = vi.fn();
     const bearings: CompassBearingView[] = [
@@ -906,6 +938,36 @@ describe("StudioCompass — create", () => {
     expect(secondary).toHaveAttribute("placeholder", "English name (optional)");
     fireEvent.change(secondary, { target: { value: "Payment cancel" } });
     expect(onSecondary).toHaveBeenCalledWith("Payment cancel");
+  });
+
+  it("C2 — a create-from-socket flow shows the quiet origin context note", () => {
+    render(
+      <StudioCompass
+        mode="create"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "결제 취소", definition: "" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { expected: true }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        canSave
+        createKinds={[{ value: "capability", label: "capability" }]}
+        createKind="capability"
+        createOriginNote="will continue 주문 취소 · 담는 것"
+      />,
+    );
+    expect(screen.getByTestId("studio-create-origin-note")).toHaveTextContent(
+      "will continue 주문 취소 · 담는 것",
+    );
   });
 
   it("C12③ — omits the secondary name input when no handler is wired", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -19,6 +19,8 @@ const labels: StudioCompassLabels = {
   saveHint: "hint",
   foldMore: () => "more",
   foldTitle: (label, total) => `${label} · ${total}`,
+  addMore: (label) => `add more to ${label}`,
+  addMoreShort: "add more",
   defMore: "more",
   defLess: "less",
   pickerTitle: (q) => q,
@@ -174,6 +176,24 @@ describe("StudioCompass — enhance", () => {
     expect(onFill).toHaveBeenCalledWith("isA", CANDIDATE);
     // picker closes after a fill.
     expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+  });
+
+  it("C4 — a FILLED lane exposes a '＋ 더 잇기' add chip that opens the same picker", () => {
+    const onFill = renderEnhance();
+    // The empty (recommended) lane has a socket, not an add chip.
+    expect(screen.queryByTestId("studio-add-more-up")).not.toBeInTheDocument();
+    // The filled `dependsOn` (right) lane has NO empty socket but DOES have the
+    // add chip — the only way to attach another relation on that bearing (C4).
+    expect(screen.queryByTestId("studio-socket-right")).not.toBeInTheDocument();
+    const addChip = screen.getByTestId("studio-add-more-right");
+    expect(addChip).toHaveAccessibleName("add more to lane-dependsOn");
+
+    fireEvent.click(addChip);
+    const picker = screen.getByTestId("studio-picker");
+    expect(picker).toHaveAttribute("data-relation", "dependsOn");
+    // and it fills that bearing in place.
+    fireEvent.click(screen.getByTestId("studio-picker-row-capability:server-interface"));
+    expect(onFill).toHaveBeenCalledWith("dependsOn", CANDIDATE);
   });
 
   it("shows the near-dup suggestion and links it on accept", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -87,6 +87,13 @@ export interface StudioCompassLabels {
   flowEyebrow: string;
   /** (filled, total) → e.g. "4방향 중 2 채움 · 반쯤 왔어요". */
   flowCount: (filled: number, total: number) => string;
+  /**
+   * C12② — quiet line under the flow cue when an ENHANCE focal already belongs
+   * to a domain. Domain membership is authored on the child's own `domain:` key
+   * (belonging, not this node's outgoing meaning), so it does NOT count toward
+   * the 4-bearing 완성도 — this line keeps 0/4 from reading as "orphan / 빈 껍데기".
+   */
+  domainMembership: (domain: string) => string;
   /** (name) → the one calm frame prompt. */
   framePrompt: (name: string) => string;
   guideBadge: string; // "여기부터 채워요"
@@ -219,6 +226,14 @@ export interface StudioCompassProps {
   createDomainValue?: string | null;
   onCreateDomain?: (value: string | null) => void;
   onCreateDefinition?: (def: string) => void;
+  /**
+   * C12③ — ONE optional secondary-locale display name (the primary name field is
+   * the current UI locale). Placeholder is locale-aware ("영어 이름 (선택)" on a
+   * ko UI, "한국어 이름 (선택)" on an en UI). Omit → no secondary field.
+   */
+  createSecondaryName?: string;
+  onCreateSecondaryName?: (name: string) => void;
+  createSecondaryNamePlaceholder?: string;
   createSimilarHit?: { title: string; kind: string; slug: string } | null;
   /** Exact deterministic path conflict — save cannot succeed until renamed. */
   createSlugCollision?: boolean;
@@ -740,6 +755,14 @@ export function StudioCompass(props: StudioCompassProps) {
             <span className="text-body text-[color:var(--color-text-secondary)]">
               {labels.flowCount(filledBearings, 4)}
             </span>
+            {mode === "enhance" && focal.domainLabel ? (
+              <span
+                data-testid="studio-domain-membership"
+                className="text-label text-[color:var(--color-text-quaternary)] [word-break:keep-all]"
+              >
+                {labels.domainMembership(focal.domainLabel)}
+              </span>
+            ) : null}
           </div>
         </div>
 
@@ -1194,6 +1217,18 @@ function CenterCard(
           {focal.name}
         </div>
       )}
+
+      {/* C12③ — quiet optional secondary-locale name (other-locale display). */}
+      {mode === "create" && props.onCreateSecondaryName ? (
+        <input
+          data-testid="studio-create-name-secondary"
+          value={props.createSecondaryName ?? ""}
+          onChange={(e) => props.onCreateSecondaryName?.(e.target.value)}
+          placeholder={props.createSecondaryNamePlaceholder}
+          aria-label={props.createSecondaryNamePlaceholder}
+          className="mt-2 w-full bg-transparent text-caption text-[color:var(--color-text-tertiary)] outline-none [word-break:keep-all] placeholder:text-[color:var(--color-text-quaternary)]"
+        />
+      ) : null}
 
       {mode === "create" && props.createDomains && props.createDomains.length > 0 ? (
         <div className="mt-3">

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -208,8 +208,17 @@ export interface StudioCompassProps {
   onFill: (relation: StudioRelation, candidate: CreateCandidate) => void;
   onSave: () => void;
   onExit: () => void;
-  /** Picker "찾는 게 없어요 · 새로 만들기" bridge — opt-in, enhance mode routes to create. */
-  onCreateNew?: () => void;
+  /**
+   * Picker "찾는 게 없어요 · 새로 만들기" bridge — opt-in, enhance mode routes to
+   * create. C2: the picker passes the socket's relation + typed query so CREATE
+   * opens carrying the origin (A --relation--> new) + a name prefill.
+   */
+  onCreateNew?: (ctx?: { relation: StudioRelation; query: string }) => void;
+  /**
+   * C2 — quiet create-mode context line ("‘A’ 의 ‘담는 것’ 으로 이어질 예정"),
+   * present only when CREATE was opened from a socket. Omit → no line.
+   */
+  createOriginNote?: string | null;
   /** All vault nodes, for the top-bar node search. Omit → static placeholder (isolated render/tests). */
   searchNodes?: CreateCandidate[];
   /** Load another node on the stage (top-bar search pick · satellite / fold-row click). */
@@ -767,8 +776,19 @@ export function StudioCompass(props: StudioCompassProps) {
         </div>
 
         {/* one calm frame prompt — top center */}
-        <div className="absolute left-1/2 top-4 z-[4] -translate-x-1/2 whitespace-nowrap text-center text-callout tracking-[-0.006em] text-[color:var(--color-text-secondary)]">
-          {labels.framePrompt(focal.name || "…")}
+        <div className="absolute left-1/2 top-4 z-[4] flex -translate-x-1/2 flex-col items-center gap-1 text-center">
+          <div className="whitespace-nowrap text-callout tracking-[-0.006em] text-[color:var(--color-text-secondary)]">
+            {labels.framePrompt(focal.name || "…")}
+          </div>
+          {/* C2 — quiet origin context: this new node continues A's bearing. */}
+          {mode === "create" && props.createOriginNote ? (
+            <div
+              data-testid="studio-create-origin-note"
+              className="max-w-[420px] text-label text-[color:var(--color-text-quaternary)] [word-break:keep-all]"
+            >
+              {props.createOriginNote}
+            </div>
+          ) : null}
         </div>
 
         {/* rare relations — top right. Not built yet: honest disabled "곧 제공"
@@ -1907,7 +1927,7 @@ function InlinePicker({
   onQuery: (q: string) => void;
   onPick: (c: CreateCandidate) => void;
   onClose: () => void;
-  onCreateNew?: () => void;
+  onCreateNew?: (ctx?: { relation: StudioRelation; query: string }) => void;
 }) {
   const W = 300;
   const { left, top, maxHeight } = placePicker(bearing, socket, cardLeft, cardRight);
@@ -2077,7 +2097,7 @@ function InlinePicker({
         <button
           type="button"
           data-testid="studio-picker-create-new"
-          onClick={onCreateNew}
+          onClick={() => onCreateNew?.({ relation, query })}
           className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[color:var(--color-border-strong)] py-2 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
         >
           <Plus size={13} aria-hidden className="text-[color:var(--color-text-tertiary)]" />

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -97,6 +97,10 @@ export interface StudioCompassLabels {
   foldMore: (n: number) => string;
   /** Lane overflow popover title, e.g. "이 노드가 품고 있는 것 · 92". */
   foldTitle: (label: string, total: number) => string;
+  /** C4 — filled-lane add chip. (laneLabel) → full aria/title, e.g. "이 노드가
+   * 품고 있는 것에 더 잇기". `addMoreShort` is the compact visible label. */
+  addMore: (laneLabel: string) => string;
+  addMoreShort: string;
   defMore: string;
   defLess: string;
   // picker
@@ -285,9 +289,18 @@ interface LaneLayout {
   sats: Array<{ sat: StudioSatellite; x: number; y: number }>;
   fold: { x: number; y: number; count: number } | null;
   socket: { x: number; y: number; w: number; h: number } | null;
+  /**
+   * FILLED lane only (C4) — a compact dashed "＋ 더 잇기" chip at the lane's
+   * outward end so a lane with satellites still has an entry point to add
+   * another relation on this bearing. Same picker anchor shape as `socket`.
+   */
+  addChip: { x: number; y: number; w: number; h: number } | null;
   struts: string[];
   anchor: { x: number; y: number }; // where the picker beak points
 }
+
+/** Compact add-chip footprint (C4) — narrower/shorter than an empty socket. */
+const ADD_CHIP = { w: SAT.w, h: 30 } as const;
 
 /** Vertically-centered top positions for `n` stacked satellites around `cy`. */
 function stackTops(cy: number, n: number, withFold: boolean): number[] {
@@ -322,6 +335,7 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
         sats: [],
         fold: null,
         socket: { x, y, w, h },
+        addChip: null,
         struts: [`M ${CX} ${cardTop} V ${y + h}`],
         anchor: { x: CX, y: y + h / 2 },
       };
@@ -335,6 +349,7 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
         sats: [],
         fold: null,
         socket: { x, y, w, h },
+        addChip: null,
         struts: [`M ${CX} ${cardBottom} V ${y}`],
         anchor: { x: CX, y: y + h / 2 },
       };
@@ -349,6 +364,7 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
         sats: [],
         fold: null,
         socket: { x, y, w, h },
+        addChip: null,
         struts: [`M ${cardRight} ${CY} H ${x}`],
         anchor: { x, y: CY },
       };
@@ -358,6 +374,7 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
       sats: [],
       fold: null,
       socket: { x, y, w, h },
+      addChip: null,
       struts: [`M ${cardLeft} ${CY} H ${x + w}`],
       anchor: { x: x + w, y: CY },
     };
@@ -379,14 +396,25 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
     if (busBottom - busTop > 0.5) struts.push(`M ${busX} ${busTop} V ${busBottom}`);
     for (const cyi of centers) struts.push(`M ${busX} ${cyi} H ${satMeetX}`);
     let fold: LaneLayout["fold"] = null;
+    let lastBottom = tops[tops.length - 1] + SAT.h;
     if (withFold) {
       const foldY = tops[tops.length - 1] + SAT.h + SAT.gap;
       fold = { x: satX, y: foldY, count: overflow };
       struts.push(`M ${busX} ${foldY + 15} H ${satMeetX}`);
       const newBottom = Math.max(busBottom, foldY + 15);
       struts[1] = `M ${busX} ${busTop} V ${newBottom}`;
+      lastBottom = foldY + 30;
     }
-    return { sats, fold, socket: null, struts, anchor: { x: isRight ? satX : satX + SAT.w, y: CY } };
+    // C4 — compact "＋ 더 잇기" chip below the stack (outward end).
+    const addChip = { x: satX, y: lastBottom + SAT.gap, w: ADD_CHIP.w, h: ADD_CHIP.h };
+    return {
+      sats,
+      fold,
+      socket: null,
+      addChip,
+      struts,
+      anchor: { x: isRight ? satX : satX + SAT.w, y: CY },
+    };
   }
 
   // up / down filled — vertical stack directly above/below the card.
@@ -403,10 +431,19 @@ function layoutLane(view: CompassBearingView, cardH: number): LaneLayout {
     const foldY = isDown ? y0 + visible.length * (SAT.h + SAT.gap) : y0 - (30 + SAT.gap);
     fold = { x: satX, y: foldY, count: overflow };
   }
+  // C4 — compact "＋ 더 잇기" chip at the outward end (below a DOWN stack, above
+  // an UP stack) so a filled vertical lane still has an add entry point.
+  const stackBottom = isDown
+    ? (fold ? fold.y + 30 : y0 + (visible.length - 1) * (SAT.h + SAT.gap) + SAT.h)
+    : (fold ? fold.y : y0); // up: topmost element top
+  const addChip = isDown
+    ? { x: satX, y: stackBottom + SAT.gap, w: ADD_CHIP.w, h: ADD_CHIP.h }
+    : { x: satX, y: stackBottom - SAT.gap - ADD_CHIP.h, w: ADD_CHIP.w, h: ADD_CHIP.h };
   return {
     sats,
     fold,
     socket: null,
+    addChip,
     struts,
     anchor: { x: CX, y: isDown ? y0 : y0 + SAT.h },
   };
@@ -511,6 +548,10 @@ export function StudioCompass(props: StudioCompassProps) {
         maxY = Math.max(maxY, s.y + SAT.h);
       }
       if (layout.fold) maxY = Math.max(maxY, layout.fold.y + 30);
+      if (layout.addChip) {
+        minY = Math.min(minY, layout.addChip.y);
+        maxY = Math.max(maxY, layout.addChip.y + layout.addChip.h);
+      }
     }
     return CY - (minY + maxY) / 2;
   }, [layouts, cardTop, cardBottom]);
@@ -824,11 +865,12 @@ export function StudioCompass(props: StudioCompassProps) {
             />
           ))}
 
-          {/* inline anchored picker */}
-          {openRelation && openLayout && openLayout.layout.socket ? (
+          {/* inline anchored picker — anchors to the empty socket OR (C4) to the
+              filled lane's "＋ 더 잇기" add chip (same {x,y,w,h} shape). */}
+          {openRelation && openLayout && (openLayout.layout.socket ?? openLayout.layout.addChip) ? (
             <InlinePicker
               key={openRelation}
-              socket={openLayout.layout.socket}
+              socket={(openLayout.layout.socket ?? openLayout.layout.addChip)!}
               bearing={openLayout.view.bearing}
               cardLeft={cardLeft}
               cardRight={cardRight}
@@ -1410,6 +1452,33 @@ function LaneRender({
           pendingNeighborIds={pendingNeighborIds}
           onClose={onCloseFold}
         />
+      ) : null}
+
+      {/* C4 — compact "＋ 더 잇기" chip on a FILLED lane: the entry point to add
+          another relation on this bearing once the empty socket is gone. Dashed =
+          addable (charter), quiet not shouting. Opens the SAME picker. */}
+      {layout.addChip ? (
+        <button
+          type="button"
+          data-testid={`studio-add-more-${view.bearing}`}
+          data-relation={view.relation}
+          aria-label={labels.addMore(view.laneLabel)}
+          title={labels.addMore(view.laneLabel)}
+          onClick={onOpen}
+          {...hoverProps}
+          className="group/add absolute z-[2] flex items-center justify-center gap-1.5 rounded-[9px] border border-dashed border-[color:var(--color-border-strong)] text-label text-[color:var(--color-text-quaternary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-secondary)]"
+          style={{
+            left: layout.addChip.x,
+            top: layout.addChip.y,
+            width: layout.addChip.w,
+            height: layout.addChip.h,
+          }}
+        >
+          <span aria-hidden className="text-[color:var(--color-text-tertiary)] transition-colors group-hover/add:text-[color:var(--color-indigo-text-soft)]">
+            ＋
+          </span>
+          {labels.addMoreShort}
+        </button>
       ) : null}
 
       {/* empty socket */}


### PR DESCRIPTION
## Summary
codex C-B — 공방 워크플로 갭 4건 (repro→root cause→fix→테스트 41 신규).

- **C4 채워진 방향 추가 진입점**: 레인 끝 파선 "＋ 더 잇기" 칩 → 같은 피커. 섬 발생 원인 해소 (강화·만들기 양쪽)
- **C2 새로 만들기 문맥 보존**: `?mode=create&from=&rel=&name=` — kind 사전 필터·이름 프리필·"'A' 의 '담는 것' 로 이어질 예정" 컨텍스트 라인. 저장 = 노드+원점 관계 **한 작업**(writable 배치 / 읽기전용 add_concept+add_relation 단일 패킷)
- **C3 로컬 vault 검색 무반응**: 원인 = focal 리졸버의 strict `===` — 폴더 프리픽스·bare tail·**NFD(맥 파일명)** 형태 미허용. `resolveStudioFocalId`(정확→canonical→NFC→유일 tail 매치, 모호 거부) + 한국어/형태별 회귀 테스트
- **C12**: 방위×kind 허용 매트릭스(문서화+테스트 — capability contains 에 domain 제외) · 완성도 판정 구현(소속은 4방위 미산입 + "이미 소속" 컨텍스트 라인으로 고아 오독 방지) · CREATE 보조 로케일 이름 1필드(display_ko/en + labels 패킷)

## Test plan
- tsc clean · studio+contract **417 pass** · eslint 0 · i18n parity 16/16
- 라이브: ＋ 더 잇기 칩·소속 컨텍스트 라인 확인(스크린샷)
- 참고: kind 매트릭스 세부(relates=동급+1하위 등)는 에이전트 판단 — 소유자 한번 보시면 좋음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
