### PR TITLE
fix: 소유자 5건 + sonnet 최종검수 D1~D3 (평문·위치명시·EN오버플로·투어겹침·브레드크럼·발췌·Esc·복사토스트)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -330,7 +330,7 @@
     "openTitle": "Open vault folder",
     "openBody": "Pick an existing markdown folder and enter the workspace.",
     "justStartTitle": "Just start",
-    "justStartBody": "Creates a folder in Documents automatically — no picker. Your AI agent can read and write it too.",
+    "justStartBody": "Creates it in your Documents › Ontology Atlas folder — no picker. Your AI agent can read and write it too.",
     "justStartBusy": "Creating…",
     "justStartToast": "Created at {path} — your AI agent can see this folder too.",
     "createTitle": "Create a new vault",
@@ -340,7 +340,7 @@
     "busy": "Opening folder…",
     "scaffolding": "Writing starter structure…",
     "errorFallback": "Could not open the folder. Try again.",
-    "trustLine": "Local-first · markdown is the source of truth · 0 backend"
+    "trustLine": "Stored only on your computer · plain markdown files · no server"
   },
   "firstRunStarter": {
     "brand": "Ontology Atlas",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2531,7 +2531,8 @@
     "copyCodexCommandDone": "Copied · paste in terminal",
     "deeplinkWebNote": "One-click for Cursor and VS Code needs the folder path.",
     "deeplinkWebNoteCta": "Automatic in the macOS app",
-    "serverLine": "There's no server to leave running. Your agent starts it when needed and it shuts down when done — no always-on process, no open port. That's why your data never leaves this computer."
+    "serverLine": "There's no server to leave running. Your agent starts it when needed and it shuts down when done — no always-on process, no open port. That's why your data never leaves this computer.",
+    "copiedToast": "Config copied — paste it into your tool to connect."
   },
   "atlasGit": {
     "tileLabel": "Footprints",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -330,7 +330,7 @@
     "openTitle": "볼트 폴더 열기",
     "openBody": "기존 마크다운 폴더를 선택해 워크스페이스로 들어갑니다.",
     "justStartTitle": "그냥 시작하기",
-    "justStartBody": "폴더 선택 없이 문서 폴더 안에 자동으로 만들어요 — AI 에이전트도 이 폴더를 읽고 쓸 수 있어요.",
+    "justStartBody": "내 문서(Documents) › Ontology Atlas 폴더에 바로 만들어요 — 폴더 선택 없이. AI 에이전트도 이 폴더를 읽고 쓸 수 있어요.",
     "justStartBusy": "만드는 중…",
     "justStartToast": "{path} 에 만들었어요 — 에이전트도 이 폴더를 볼 수 있어요.",
     "createTitle": "새 볼트 만들기",
@@ -340,7 +340,7 @@
     "busy": "폴더 여는 중…",
     "scaffolding": "시작 구조 작성 중…",
     "errorFallback": "폴더를 열지 못했습니다. 다시 시도해 주세요.",
-    "trustLine": "Local-first · 마크다운이 진실원 · 백엔드 0"
+    "trustLine": "내 컴퓨터에만 저장돼요 · 파일은 평범한 마크다운 · 서버 없음"
   },
   "firstRunStarter": {
     "brand": "Ontology Atlas",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2531,7 +2531,8 @@
     "copyCodexCommandDone": "복사됨 · 터미널에 붙여넣기",
     "deeplinkWebNote": "Cursor·VS Code 원클릭은 폴더 경로가 필요해요.",
     "deeplinkWebNoteCta": "macOS 앱에서 자동으로",
-    "serverLine": "따로 켜둘 서버가 없어요. 에이전트가 필요할 때 직접 실행하고, 끝나면 함께 꺼져요. 항상 도는 프로그램도 열린 포트도 없어요 — 데이터가 이 컴퓨터를 떠나지 않는 이유예요."
+    "serverLine": "따로 켜둘 서버가 없어요. 에이전트가 필요할 때 직접 실행하고, 끝나면 함께 꺼져요. 항상 도는 프로그램도 열린 포트도 없어요 — 데이터가 이 컴퓨터를 떠나지 않는 이유예요.",
+    "copiedToast": "설정을 복사했어요 — 도구에 붙여넣으면 연결돼요."
   },
   "atlasGit": {
     "tileLabel": "발자취",

--- a/src/features/docs-vault-local/ui/AgentClientButtons.tsx
+++ b/src/features/docs-vault-local/ui/AgentClientButtons.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { ArrowUpRight, Check, Copy, Loader2, Terminal } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { copyText } from "@/shared/lib/copy-text";
+import { useToast } from "@/shared/ui";
 
 /**
  * 클라이언트별 원클릭 연결 버튼 묶음 (#12, Phase 4). 지도 시트와 설정 패널이
@@ -49,6 +50,7 @@ export function AgentClientButtons({
   needsManualPath,
 }: AgentClientButtonsProps) {
   const t = useTranslations("agentConnect");
+  const toast = useToast();
   const [feedback, setFeedback] = useState<Record<ClientId, Feedback>>({
     claudeCode: mcpJsonReady ? "done" : "idle",
     cursor: "idle",
@@ -73,7 +75,12 @@ export function AgentClientButtons({
   async function copyAndConfirm(id: ClientId, value: string) {
     const ok = await copyText(value);
     setState(id, ok ? "copied" : "failed");
-    if (ok) window.setTimeout(() => setState(id, "idle"), 2000);
+    // 인라인 라벨 전환(2초)에 더해 캐노니컬 토스트로 확실히 확인시킨다 —
+    // sonnet 최종 검수 D3 (공방 저장 흐름과 동일한 확인 문법).
+    if (ok) {
+      toast.show(t("copiedToast"), "success");
+      window.setTimeout(() => setState(id, "idle"), 2000);
+    }
   }
 
   return (

--- a/src/features/guided-tour/model/auto-start-guard.test.ts
+++ b/src/features/guided-tour/model/auto-start-guard.test.ts
@@ -14,6 +14,15 @@ describe("canAutoStartGuidedTour (stacked-transient guard)", () => {
     expect(canAutoStartGuidedTour(document)).toBe(false);
   });
 
+  it("blocks auto start while a blocking edit composer (개념 추가) is open (#96)", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    // CreateNodeForm/OntologyBootstrapForm declare modality via
+    // data-surface-role, not role=dialog — the tour must still defer.
+    document.body.innerHTML =
+      '<section data-surface-role="blocking-edit-surface" data-testid="create-node-form"></section>';
+    expect(canAutoStartGuidedTour(document)).toBe(false);
+  });
+
   it("blocks auto start while document focus is away (OS folder picker / background tab)", () => {
     vi.spyOn(document, "hasFocus").mockReturnValue(false);
     expect(canAutoStartGuidedTour(document)).toBe(false);

--- a/src/features/guided-tour/model/auto-start-guard.ts
+++ b/src/features/guided-tour/model/auto-start-guard.ts
@@ -20,5 +20,13 @@ export function canAutoStartGuidedTour(doc: Document = document): boolean {
   if (doc.querySelector('[role="dialog"][aria-modal="true"]') !== null) {
     return false;
   }
+  // #96 — blocking edit composer (개념 추가 · 부트스트랩 등)는 `role=dialog`
+  // 대신 `data-surface-role="blocking-edit-surface"` (dimmed map 위 solid
+  // panel) 로 modality 를 선언한다. 이 마커도 모달 등급이므로 그 위에 투어
+  // 오버레이를 겹쳐 쏘면 안 된다 — 실측: "개념 추가" 열린 상태에서 900ms 자동
+  // 투어가 1단계 카드로 그 위에 떴다(stacked-transient 위반).
+  if (doc.querySelector('[data-surface-role="blocking-edit-surface"]') !== null) {
+    return false;
+  }
   return doc.hasFocus();
 }

--- a/src/shared/lib/parse-frontmatter.test.ts
+++ b/src/shared/lib/parse-frontmatter.test.ts
@@ -150,9 +150,23 @@ describe('buildExcerpt — markdown is flattened to readable prose', () => {
     expect(excerpt).not.toMatch(/^\s*-\s/);
   });
 
-  it('respects the max length', () => {
-    expect(buildExcerpt('x'.repeat(500)).length).toBe(320);
-    expect(buildExcerpt('x'.repeat(500), 50).length).toBe(50);
+  it('respects the max length (잘릴 땐 말줄임표 포함 max+1 이내)', () => {
+    // 공백 없는 초장문(잘라도 어절 경계 없음) → max 에서 자르고 … 부착.
+    expect(buildExcerpt('x'.repeat(500)).length).toBeLessThanOrEqual(321);
+    expect(buildExcerpt('x'.repeat(500)).endsWith('…')).toBe(true);
+    expect(buildExcerpt('x'.repeat(500), 50).length).toBeLessThanOrEqual(51);
+  });
+
+  it('단어 중간에서 뚝 끊지 않고 어절 경계에서 자르고 말줄임표를 붙인다 (sonnet 검수 D1)', () => {
+    const prose = '이 프로젝트의 ontology 는 비즈니스 핵심과 구현 근거를 잇는다 '.repeat(20);
+    const out = buildExcerpt(prose, 60);
+    expect(out.endsWith('…')).toBe(true);
+    // 마지막 조각이 완전한 어절이어야 함(공백 뒤 절단 없음)
+    const body = out.slice(0, -1);
+    expect(prose.includes(body)).toBe(true);
+    expect(body.endsWith(' ')).toBe(false);
+    // 짧은 입력은 그대로
+    expect(buildExcerpt('짧은 문장', 320)).toBe('짧은 문장');
   });
 });
 

--- a/src/shared/lib/parse-frontmatter.ts
+++ b/src/shared/lib/parse-frontmatter.ts
@@ -189,7 +189,13 @@ export function buildExcerpt(body: string, max = 320): string {
     .replace(/(?:·\s*){2,}/g, '· ') // collapse middot runs left by empty cells
     .replace(/^[\s·]+|[\s·]+$/g, '') // trim leading/trailing middots
     .trim();
-  return stripped.slice(0, max);
+  if (stripped.length <= max) return stripped;
+  // 단어 중간에서 뚝 끊기지 않게: max 이내 마지막 공백에서 자르고 말줄임표.
+  // (한국어는 공백 단위 어절이라 어절 경계, 영문은 단어 경계가 된다.)
+  const cut = stripped.slice(0, max);
+  const lastSpace = cut.lastIndexOf(' ');
+  const safe = lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return `${safe.replace(/[\s·,.:;]+$/g, '')}…`;
 }
 
 export interface LinkContext {

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -14,6 +14,7 @@ import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { AnimatePresence } from 'framer-motion';
 import {
+  ArrowLeft,
   Bot,
   ClipboardCheck,
   FileText,
@@ -50,7 +51,7 @@ import {
   getTauriVaultRootPath,
   isTauriVaultRuntime,
 } from '@/shared/lib/tauri-vault-fs';
-import { HexMark, SimilarNodeWarning, Tooltip, useToast } from '@/shared/ui';
+import { SimilarNodeWarning, Tooltip, useToast } from '@/shared/ui';
 import {
   findSimilarNodeByTitle,
   type SimilarNodeMatch,
@@ -1550,42 +1551,13 @@ function DocsVaultContent() {
           행으로 그리드를 채운다 — <lg 는 기존 2행 wrap + 모바일 drawer 를
           그대로 유지(90px 폭 뷰포트에서 단일 행이 가로 스크롤을 만들기
           때문 — local-vault-picker.spec.ts 의 zero-overflow 계약). */}
-      <div data-chrome-grid="76" className="flex-none">
-      {/* Crumbs row — engraved vault census (docs-vault-final spec §상단 헤더). */}
-      <nav
-        aria-label={t('header.breadcrumbAriaLabel')}
-        className="flex h-8 flex-none items-center gap-2 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-3 text-label text-[color:var(--color-text-tertiary)] md:px-4"
-      >
-        <Link
-          href={workspaceHref}
-          aria-label={
-            insightsReturnTab
-              ? t('header.backToReviewAriaLabel')
-              : t('header.backToWorkspaceAriaLabel')
-          }
-          className="transition-colors hover:text-[color:var(--color-text-primary)]"
-        >
-          {insightsReturnTab
-            ? t('header.reviewBack')
-            : t('header.crumbBack')}
-        </Link>
-        <span className="text-[color:var(--color-text-quaternary)]" aria-hidden>
-          /
-        </span>
-        {/* H6 — 육각 운율. sr-only h1 표면이라 브레드크럼 현재-구간 라벨이
-            시각 정체성 앵커다. 무채(tertiary) 6px 급 아웃라인 헥사로 브랜드
-            형태 언어를 심되 앰버 예산은 건드리지 않는다. */}
-        <span className="inline-flex min-w-0 items-center gap-1.5">
-          <HexMark size={10} className="shrink-0 text-[color:var(--color-text-quaternary)]" />
-          <span className="truncate text-[color:var(--color-text-secondary)]">{t('header.title')}</span>
-        </span>
-        {/* 그래프 census(개념/관계 총계)는 이 행에서 삭제됐다 — 문서를 읽는
-            표면에서 총계는 어떤 읽기 판단도 바꾸지 못하는 비행동 잉크였고,
-            같은 수치가 문서함 점검 모달의 그래프 행에 맥락(둘러보기 CTA)과
-            함께 이미 있다(zone-r 점검 타일 1클릭). 한 화면에 문서 155개 /
-            목록 53개 / 개념·관계 총계 3종 계수 체계가 겹치던 것도 함께 해소.
-            census 는 그래프가 주인공인 지도(/topology) 크롬이 계속 소유한다. */}
-      </nav>
+      <div data-chrome-grid="44" className="flex-none">
+      {/* #97 — 브레드크럼 행("워크스페이스 / 문서함") 삭제. 좌측 내비 레일이
+          이미 "문서함" 을 하이라이트해 "여기가 어디" 를 답하고, "지도로" 복귀도
+          레일의 map 목적지(→ /topology)가 소유하므로 이 행의 뒤로가기 링크는
+          중복 내비였다. 세로 공간(32px)을 회수하고, 레일이 못 하는 유일한
+          기능 — insights 리뷰에서 넘어온 문맥 복귀 — 만 헤더 zone-l 로 이관한다
+          (아래 insightsReturnTab 백 칩). "문서함" 정체성은 sr-only h1 로 유지. */}
       {/* 헤더 3존 [zone-l identity] [zone-c 탭 예약, 슬라이스 B] [zone-r
           tools] — implementation-contract.md §1. macOS 다운로드 버튼은
           여기서 완전히 삭제(읽기 전용 샘플 배너 1곳 + /download 만 소유,
@@ -1628,6 +1600,20 @@ function DocsVaultContent() {
               : "lg:w-[calc(var(--docs-list-width)-1.5rem)]",
           )}
         >
+          {/* #97 — 삭제된 브레드크럼에서 유일하게 살릴 기능: insights 리뷰에서
+              넘어온 문맥 복귀. 레일의 map 목적지가 커버 못 하는 경로라 헤더로
+              이관한다. 일반 진입(비-insights)에서는 렌더하지 않는다 — 지도
+              복귀는 좌측 레일이 소유. */}
+          {insightsReturnTab ? (
+            <Link
+              href={workspaceHref}
+              aria-label={t('header.backToReviewAriaLabel')}
+              className="inline-flex h-8 flex-none items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-divider)] px-2 text-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]"
+            >
+              <ArrowLeft size={14} aria-hidden />
+              <span className="hidden sm:inline">{t('header.reviewBack')}</span>
+            </Link>
+          ) : null}
           <button
             type="button"
             onClick={() => setSourceTreeOpen(true)}

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -1665,7 +1665,12 @@ function LaneRender({
             left: layout.socket.x,
             top: layout.socket.y,
             width: layout.socket.w,
-            height: layout.socket.h,
+            // #94/#95 — grow to wrapped text instead of clipping. The layout
+            // height is Korean-tuned; longer English questions/eyebrows wrap to
+            // more lines, so the dashed box must expand (minHeight) rather than
+            // let the text bleed past its border. `justify-center` keeps short
+            // (Korean) content vertically centered in the base height.
+            minHeight: layout.socket.h,
             ...stageStyle,
             border: view.recommended
               ? "2px dashed var(--color-indigo-a46)"
@@ -1684,19 +1689,23 @@ function LaneRender({
               ◈ {labels.guideBadge}
             </span>
           ) : view.expected ? (
-            <span className="inline-flex items-center gap-1.5 text-label text-[color:var(--color-text-quaternary)]">
-              <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--color-amber-signal-a60)]" /> {view.emptyHint}
+            <span className="flex w-full items-start gap-1.5 text-label text-[color:var(--color-text-quaternary)]">
+              <span className="mt-[3px] h-1.5 w-1.5 flex-none rounded-full bg-[color:var(--color-amber-signal-a60)]" />
+              <span className="min-w-0 [overflow-wrap:anywhere]">{view.emptyHint}</span>
             </span>
           ) : (
-            <span className="text-label text-[color:var(--color-text-quaternary)]">{view.emptyHint}</span>
+            <span className="block w-full text-label text-[color:var(--color-text-quaternary)] [overflow-wrap:anywhere]">{view.emptyHint}</span>
           )}
           {/* #6 — question is text-body(12.5); `text-callout` was an unregistered
               ramp step that silently rendered at the root 16px (the "billboard"
-              defect). max-w keeps a long question wrapping at a sane ~18-22ch
-              measure so the socket reads as a quiet slot. */}
-          <span className="flex max-w-[19ch] items-start gap-1.5 text-body font-medium text-[color:var(--color-text-secondary)] [word-break:keep-all]">
+              defect). #94/#95 — keep-all stays (nice Korean 어절 wrapping) but
+              add overflow-wrap:anywhere so long English words break instead of
+              spilling past the dashed border, and widen the measure to the box
+              so English wraps to fewer lines. The box height grows (minHeight)
+              to hold the wrap. */}
+          <span className="flex max-w-full items-start gap-1.5 text-body font-medium text-[color:var(--color-text-secondary)] [word-break:keep-all] [overflow-wrap:anywhere]">
             <span className="mt-px flex-none text-[color:var(--color-text-quaternary)]">＋</span>
-            <span>{view.question}</span>
+            <span className="min-w-0">{view.question}</span>
           </span>
         </button>
       ) : null}
@@ -1963,7 +1972,11 @@ function laneHeadPos(view: CompassBearingView, layout: LaneLayout): React.CSSPro
   if (view.bearing === "right") return { left: layout.sats[0]?.x ?? 0, top: (layout.sats[0]?.y ?? CY) - 20 };
   if (view.bearing === "left") return { left: layout.sats[0]?.x ?? 0, top: (layout.sats[0]?.y ?? CY) - 20 };
   if (view.bearing === "up") return { left: CX - 60, top: (layout.sats[0]?.y ?? 0) - 20 };
-  return { left: CX - 60, top: (layout.sats[layout.sats.length - 1]?.y ?? 0) + SAT.h + 6 };
+  // #94/#95 — DOWN lane head sat BELOW the last satellite (+6), landing on top
+  // of the fold chip ("+90 more", +12) → collision. Mirror the UP lane: place
+  // the header ABOVE the topmost DOWN satellite (in the clear gap between the
+  // card and the stack) so it never overlaps the fold/add-chip cluster below.
+  return { left: CX - 60, top: (layout.sats[0]?.y ?? 0) - 20 };
 }
 
 // ── Inline anchored picker (dark canonical) ──────────────────────────────────

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -733,6 +733,19 @@ export function StudioCompass(props: StudioCompassProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [openEdit]);
 
+  // Esc = "계속 편집"(안전한 쪽)으로 그만하기 확인 팝오버를 닫는다 — sonnet
+  // 최종 검수 D2 (포커스 위치와 무관하게 동작해야 하므로 전역 리스너).
+  useEffect(() => {
+    if (!confirmExit) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      event.preventDefault();
+      setConfirmExit(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [confirmExit]);
+
   const saveAllowed = props.canSave !== false;
   const effectiveSummary = saveAllowed ? (props.summary ?? null) : null;
   const previewAvailable = saveAllowed && Boolean(props.deltaPreview?.hasDelta);
@@ -796,6 +809,13 @@ export function StudioCompass(props: StudioCompassProps) {
               data-testid="studio-exit-confirm"
               className="absolute right-0 top-[calc(100%+8px)] z-[10] w-[248px] rounded-[12px] border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)] p-3.5"
               style={{ boxShadow: "0 12px 34px rgba(0,0,0,.5)" }}
+              onKeyDown={(e) => {
+                // Esc = "계속 편집" (안전한 쪽) — sonnet 최종 검수 D2.
+                if (e.key === "Escape") {
+                  e.stopPropagation();
+                  setConfirmExit(false);
+                }
+              }}
             >
               <p className="text-caption text-[color:var(--color-text-secondary)] [word-break:keep-all]">
                 {labels.exitConfirmTitle}


### PR DESCRIPTION
## Summary
소유자 실보고 5건 + sonnet 최종 전수 검수 발견 D1~D3 일괄 수정.

**소유자 5건**
- #92 은어 태그라인 → "내 컴퓨터에만 저장돼요 · 파일은 평범한 마크다운 · 서버 없음"
- #93 "그냥 시작하기" 위치 명시 → 코드 추적 결과 실위치 `내 문서 › Ontology Atlas` — 문구 반영(생성 후 실제 경로 토스트는 기존 존재 확인)
- #94/95 EN 오버플로 → 소켓 고정 height→minHeight 성장 + eyebrow wrap + DOWN 라벨을 스택 위로(접기 칩 충돌 해소). **EN 전 라벨 스윕 통과**
- #96 투어가 모달 위 겹침 → 가드가 `data-surface-role="blocking-edit-surface"` 도 모달로 인식(red→green 테스트)
- #97 문서함 브레드크럼 행 제거 → 기능 확인 후(뒤로 링크는 레일 중복) 유일 기능(insights 복귀)만 헤더 이관, 32px 회수

**sonnet 검수 D1~D3**
- D1 발췌 320자 단어 중간 절단(프로젝트 lede 노출) → 어절 경계 + 말줄임(기존 버그, 재설계로 표면화)
- D2 그만하기 확인 팝오버 Esc 무반응 → 전역 리스너로 '계속 편집' 닫기
- D3 에이전트 연결 복사 무확인 → 캐노니컬 success 토스트(공방과 동일 문법)
- D4 간헐 aria-hidden 경고는 재현 불가 — 관찰 기록만

**sonnet 최종 판정**: pass-with-issues → 본 PR로 D1~D3 해소. 크래시/헌장 위반/콘솔 에러 0, 정비 전 출하 주장 실확인(verify 32툴 green·설정 피커 픽셀 검증·원클릭 클립보드 실검증 포함)

## Test plan
- tsc clean · studio+vault-local+frontmatter+docs 516+335 pass · i18n parity ✓
- 미검증(정직): 로컬 vault 실디스크 쓰기(FS API 자동화 불가 — 소유자 실사용 확인 권장) · Cursor/VS Code 딥링크 실발사

🤖 Generated with [Claude Code](https://claude.com/claude-code)
