### PR TITLE
fix: opus5 검수 — 유령 관계 리듀서 결함 + 건강도 사이클 열거 성능 절벽

### DIFF
--- a/src/entities/knowledge-graph/lib/vault-health.ts
+++ b/src/entities/knowledge-graph/lib/vault-health.ts
@@ -334,6 +334,42 @@ function dependencyCycleCount(graph: CompiledGraph): number {
   const cycleKeys = new Set<string>();
   const sortedSlugs = graph.nodes.map((n) => n.slug).sort((a, b) => a.localeCompare(b));
 
+  // 역방향 인접 — "여기서 start 로 몇 걸음에 돌아갈 수 있나"를 재려고 만든다.
+  const inByType = new Map<string, string[]>();
+  for (const [from, targets] of outByType) {
+    for (const to of targets) {
+      if (!inByType.has(to)) inByType.set(to, []);
+      inByType.get(to)!.push(from);
+    }
+  }
+
+  /**
+   * start 로 MAX_DEPTH 이내에 되돌아올 수 있는 노드와 그 최단 거리(간선 수).
+   * 이 안에 없는 노드로 뻗는 가지는 **절대 사이클을 못 닫으므로** 탐색에서
+   * 잘라낸다 — 결과 집합은 그대로이고(정확성 보존) 죽은 경로 탐색만 사라진다.
+   *
+   * WHY: 브라우저(인사이트 화면)가 이 계산을 메인 스레드에서 돌린다. 가지치기
+   * 전 실측 — 2000노드 × 평균 4의존(강연결이지만 길이 ≤8 사이클은 0)에서
+   * 6.3초 블로킹. 가지치기 후 두 자릿수 ms. MCP 엔진과의 카운트 동일성은
+   * `tests/contract/vault-health.contract.test.ts` 가 계속 강제한다.
+   */
+  const reverseDistances = (start: string): Map<string, number> => {
+    const dist = new Map<string, number>();
+    let frontier = [start];
+    for (let step = 1; step <= MAX_DEPTH && frontier.length > 0; step += 1) {
+      const next: string[] = [];
+      for (const node of frontier) {
+        for (const prev of inByType.get(node) ?? []) {
+          if (dist.has(prev) || prev === start) continue;
+          dist.set(prev, step);
+          next.push(prev);
+        }
+      }
+      frontier = next;
+    }
+    return dist;
+  };
+
   const normalizeCycle = (path: string[]): string => {
     // path is a closed walk start..start; drop trailing repeat, rotate to min.
     const ring = path.slice(0, -1);
@@ -345,7 +381,13 @@ function dependencyCycleCount(graph: CompiledGraph): number {
     return rotated.join('\0');
   };
 
-  const dfs = (start: string, current: string, path: string[], visited: Set<string>) => {
+  const dfs = (
+    start: string,
+    current: string,
+    path: string[],
+    visited: Set<string>,
+    backDist: Map<string, number>,
+  ) => {
     if (path.length > MAX_DEPTH) return;
     for (const next of outByType.get(current) ?? []) {
       if (next === start && path.length > 1) {
@@ -353,14 +395,20 @@ function dependencyCycleCount(graph: CompiledGraph): number {
         continue;
       }
       if (visited.has(next) || path.length >= MAX_DEPTH) continue;
+      // next 를 밟은 뒤 start 까지 남은 예산 안에 못 돌아오면 이 가지는 사이클을
+      // 만들 수 없다 → 자른다. (사이클 노드 수 = path.length + backDist ≤ MAX_DEPTH)
+      const back = backDist.get(next);
+      if (back === undefined || path.length + back > MAX_DEPTH) continue;
       visited.add(next);
-      dfs(start, next, [...path, next], visited);
+      dfs(start, next, [...path, next], visited, backDist);
       visited.delete(next);
     }
   };
 
   for (const slug of sortedSlugs) {
-    dfs(slug, slug, [slug], new Set([slug]));
+    const backDist = reverseDistances(slug);
+    if (backDist.size === 0) continue; // 아무도 start 로 못 돌아옴 → 사이클 불가
+    dfs(slug, slug, [slug], new Set([slug]), backDist);
   }
   return cycleKeys.size;
 }

--- a/src/views/ontology-studio/lib/build-studio-changes.test.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.test.ts
@@ -53,6 +53,28 @@ describe("reduceStudioChanges", () => {
     expect(s).toEqual([{ op: "retype", from: "relates", to: "contains", target: B }]);
   });
 
+  it("remove-then-add(다른 방위)는 retype 로 접힌다 — 원래 관계가 디스크에 남지 않게 (opus5 검수)", () => {
+    // 재현: 기대는 곳의 A 를 끊고(pending remove) → 투영에서 사라진 A 를
+    // 담는 것 피커에서 다시 고르면(add), 예전 reducer 는 remove 를 버려
+    // dependsOn: A 가 디스크에 그대로 남고 contains: A 만 추가돼 유령 관계가 됐다.
+    let s = reduceStudioChanges([], { type: "remove", relation: "dependsOn", target: A });
+    s = reduceStudioChanges(s, { type: "add", relation: "contains", target: A });
+    expect(s).toEqual([{ op: "retype", from: "dependsOn", to: "contains", target: A }]);
+  });
+
+  it("remove-then-add(같은 방위)는 서로 상쇄돼 기록이 남지 않는다 (opus5 검수)", () => {
+    let s = reduceStudioChanges([], { type: "remove", relation: "relates", target: B });
+    s = reduceStudioChanges(s, { type: "add", relation: "relates", target: B });
+    expect(s).toEqual([]);
+  });
+
+  it("retype→remove→add 연쇄도 TRUE original bearing 을 기준으로 접힌다 (opus5 검수)", () => {
+    let s = reduceStudioChanges([], { type: "retype", from: "dependsOn", to: "relates", target: A });
+    s = reduceStudioChanges(s, { type: "remove", relation: "relates", target: A });
+    s = reduceStudioChanges(s, { type: "add", relation: "contains", target: A });
+    expect(s).toEqual([{ op: "retype", from: "dependsOn", to: "contains", target: A }]);
+  });
+
   it("retype-then-remove collapses to a remove at the TRUE original bearing (sonnet 검증 결함 1)", () => {
     // 기대는 곳(dependsOn)에 실재하는 관계를 '비슷한 것'으로 옮겨둔 뒤 끊으면,
     // 실제로 기록돼 있는 dependsOn 을 끊어야 한다 — 옮긴 후 방위(relates)로

--- a/src/views/ontology-studio/lib/build-studio-changes.ts
+++ b/src/views/ontology-studio/lib/build-studio-changes.ts
@@ -64,7 +64,19 @@ export function reduceStudioChanges(
     case "undo":
       return prev.filter((_, i) => i !== action.index);
     case "add": {
+      const existing = findForTarget(prev, action.target.id);
       const rest = withoutTarget(prev, action.target.id);
+      // 끊어둔(아직 저장 전) 노드를 다른 방위에 다시 이으면 실제로 필요한 건
+      // "옮기기" 한 건이다 — remove 를 버리고 add 만 남기면 원래 방위의 관계가
+      // 디스크에 그대로 남아 유령 관계가 된다(opus5 검수). 같은 방위로 되돌리면
+      // 상쇄. `remove` 는 이미 TRUE original bearing 을 들고 있다.
+      if (existing?.op === "remove") {
+        if (existing.relation === action.relation) return rest;
+        return [
+          ...rest,
+          { op: "retype", from: existing.relation, to: action.relation, target: action.target },
+        ];
+      }
       return [...rest, { op: "add", relation: action.relation, target: action.target }];
     }
     case "remove": {

--- a/tests/fixtures/vault-health-cases.mjs
+++ b/tests/fixtures/vault-health-cases.mjs
@@ -113,4 +113,38 @@ export const VAULT_HEALTH_CASES = [
       },
     ],
   },
+  {
+    // opus5 검수 — 사이클 열거 가지치기(역방향 도달성)가 결과를 바꾸지 않는지
+    // 강하게 잡는 케이스: 길이 4 순환 + 그와 두 노드를 공유하는 길이 3 순환 +
+    // 아무 데도 못 돌아오는 긴 사슬(가지치기가 잘라야 하는 죽은 경로).
+    name: 'overlapping cycles + dead chain → engine and app agree on the count',
+    docs: [
+      {
+        slug: 'domains/core',
+        frontmatter: {
+          kind: 'domain',
+          title: 'Core',
+          capabilities: [
+            'capabilities/a',
+            'capabilities/b',
+            'capabilities/c',
+            'capabilities/d',
+            'capabilities/e',
+            'capabilities/f',
+            'capabilities/g',
+          ],
+        },
+      },
+      // 4-cycle: a → b → c → d → a
+      { slug: 'capabilities/a', frontmatter: { kind: 'capability', title: 'A', domain: 'domains/core', depends_on: ['capabilities/b'] } },
+      { slug: 'capabilities/b', frontmatter: { kind: 'capability', title: 'B', domain: 'domains/core', depends_on: ['capabilities/c'] } },
+      { slug: 'capabilities/c', frontmatter: { kind: 'capability', title: 'C', domain: 'domains/core', depends_on: ['capabilities/d', 'capabilities/a'] } },
+      // c → a 는 3-cycle (a → b → c → a) 도 만든다 — 두 순환이 노드를 공유.
+      { slug: 'capabilities/d', frontmatter: { kind: 'capability', title: 'D', domain: 'domains/core', depends_on: ['capabilities/a'] } },
+      // 죽은 사슬: e → f → g (돌아오는 간선 없음)
+      { slug: 'capabilities/e', frontmatter: { kind: 'capability', title: 'E', domain: 'domains/core', depends_on: ['capabilities/f'] } },
+      { slug: 'capabilities/f', frontmatter: { kind: 'capability', title: 'F', domain: 'domains/core', depends_on: ['capabilities/g'] } },
+      { slug: 'capabilities/g', frontmatter: { kind: 'capability', title: 'G', domain: 'domains/core' } },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

opus5 독립 검수 중 **머지된 코드에 남아 있던 결함 2건**을 발견해 잡았다.

### 1. 유령 관계 (데이터 정합 · High)

공방에서 관계를 **끊고(저장 전) 같은 노드를 다른 방위에 다시 이으면** 대기 중이던 `remove` 가 버려지고 `add` 만 남았다. 저장하면 원래 방위의 관계가 디스크에 그대로 남아 **UI 가 보여주지 않는 유령 관계**가 된다.

도달 가능성: 피커의 중복 제외(`excludeFor`)가 *투영된* 이웃 기준이라 끊어둔 노드가 즉시 다시 후보로 올라온다. 실제 UI 에서 재현 확인함.

수정: `remove` 뒤 `add` 는 `retype` 한 건으로 접는다(같은 방위로 되돌리면 상쇄). `remove` 가 이미 TRUE original bearing 을 들고 있어 `retype→remove→add` 연쇄도 원래 방위 기준으로 접힌다.

이는 sonnet 검수가 잡았던 #625 (`retype→remove` 가 사후 방위를 기록) 의 **거울상**이다.

**검증 (실 UI)**: `기대는 것` 의 MCP Server 를 끊고 `상위개념` 소켓에서 다시 선택 → 요약이 `'MCP Server' 를 '상위개념' 으로 이동` · 1가지 · 파일 1개 수정 으로 표시.

### 2. 건강도 사이클 열거 성능 절벽 (반응성 · Medium-High)

`computeVaultHealth` 의 사이클 DFS 가 **2000노드·평균 4의존에서 메인스레드를 6.3초 블로킹**했다(실측). 원인은 시작 노드로 되돌아올 수 없는 죽은 경로를 깊이 한계까지 파고드는 것.

- Johnson 식 rank 가지치기: 7068ms (효과 없음 — 비용이 rank 가 아니라 dead-end 탐색이었다)
- **역방향 도달 거리 가지치기**: 시작 노드로의 역 BFS 거리를 먼저 재고, 남은 예산 안에 못 돌아오는 분기를 잘라낸다 → **24ms** (263배)

결과 불변을 강하게 잡기 위해 app↔MCP 엔진 동수 계약 테스트에 **겹치는 순환(4-cycle + 노드 공유 3-cycle) + 죽은 사슬** fixture 추가 (6/6 통과).

## Test plan

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/views/ontology-studio tests/contract/vault-health.contract.test.ts src/entities/knowledge-graph` — **215 passed (16 files)**
- 회귀 테스트 3건 신규: `remove-then-add(다른 방위)는 retype 로 접힌다` · `remove-then-add(같은 방위)는 서로 상쇄` · `retype→remove→add 연쇄도 TRUE original bearing 기준`
- 계약 fixture 1건 신규: `overlapping cycles + dead chain → engine and app agree on the count`
- 실 브라우저 확인 (`/ko/ontology/studio/?node=capability:cli-developer-entry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr