### PR TITLE
fix: 오버레이 동시 개방 차단 — 블로킹 표면 하나가 키보드를 소유한다 (#62)

### DIFF
--- a/src/views/home/lib/blocking-surface.test.ts
+++ b/src/views/home/lib/blocking-surface.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSuppressGlobalShortcuts } from "./blocking-surface";
+
+describe("shouldSuppressGlobalShortcuts", () => {
+  it("아무 블로킹 표면도 없으면 전역 단축키가 산다", () => {
+    expect(shouldSuppressGlobalShortcuts({ createNodeOpen: false, tourOpen: false })).toBe(false);
+  });
+
+  it("개념 추가 컴포저가 열려 있으면 단축키를 삼킨다 (기존 계약)", () => {
+    expect(shouldSuppressGlobalShortcuts({ createNodeOpen: true, tourOpen: false })).toBe(true);
+  });
+
+  // opus5 검수 실측 회귀: 투어가 열린 채 `?` 를 누르면 단축키 모달이 투어 카드
+  // 위에 겹쳐 떴다 — role="dialog" 두 개 동시 개방. 투어도 자체 blocker/포커스
+  // 트랩을 가진 블로킹 표면이므로 같은 규칙을 받는다.
+  it("가이드 투어가 열려 있어도 단축키를 삼킨다 — 두 오버레이 동시 개방 차단", () => {
+    expect(shouldSuppressGlobalShortcuts({ createNodeOpen: false, tourOpen: true })).toBe(true);
+  });
+
+  it("둘 다 열려 있어도 마찬가지", () => {
+    expect(shouldSuppressGlobalShortcuts({ createNodeOpen: true, tourOpen: true })).toBe(true);
+  });
+});

--- a/src/views/home/lib/blocking-surface.ts
+++ b/src/views/home/lib/blocking-surface.ts
@@ -1,0 +1,37 @@
+/**
+ * 지도 화면의 "블로킹 표면이 키보드를 소유한다" 계약 (#62).
+ *
+ * 왜 필요한가: 전역 단축키(⌘K 팔레트 · `?` 단축키 · `D` 문서함 드로어 · ⌘O
+ * 폴더 열기)는 각자 `if (createNodeOpen) return;` 이라는 임시 가드를 달고
+ * 있었다. 개념 추가 컴포저만 막고 **가이드 투어는 빠져 있어서**, 투어가 열린
+ * 상태에서 `?` 를 누르면 단축키 모달이 투어 카드 위에 겹쳐 떴다 —
+ * `role="dialog"` 두 개가 동시에 살아 있고, 어느 쪽이 포커스를 소유하는지
+ * 아무도 모르는 상태 (opus5 검수 2026-07-25 실측).
+ *
+ * 디자인 규칙(`.claude/rules/design.md`)은 "transient surface 는 unrelated
+ * surface 를 닫거나 demote 해야 한다" 이므로, 상충하는 오버레이 2개가 동시에
+ * 서 있으면 결함이다. 가드를 표면마다 손으로 나열하는 대신 **하나의 술어**로
+ * 모은다 — 새 블로킹 표면이 생기면 여기 한 곳만 고치면 되고, 빠뜨리면 이
+ * 파일의 테스트가 잡는다.
+ *
+ * `openX 가 나머지를 닫는다` 는 반대 방향 계약(`openCreateNode` ·
+ * `openGuidedTour`)과 짝을 이룬다: 열 때는 나머지를 닫고, 열려 있는 동안은
+ * 키보드를 독점한다.
+ */
+
+export interface BlockingSurfaceState {
+  /** 개념 추가 컴포저 — 지도를 dim 하고 상호작용을 막는 모달. */
+  createNodeOpen: boolean;
+  /** 가이드 투어 — 자체 scrim/blocker + 포커스 트랩을 가진 순차 안내. */
+  tourOpen: boolean;
+}
+
+/**
+ * 지금 전역 단축키를 무시해야 하는가.
+ *
+ * true 면 ⌘K / `?` / `D` / ⌘O 는 아무 것도 하지 않는다. 사용자는 열려 있는
+ * 표면을 Esc 로 먼저 닫고 나서 쓴다 — 모달이 키보드를 소유한다는 흔한 계약.
+ */
+export function shouldSuppressGlobalShortcuts(state: BlockingSurfaceState): boolean {
+  return state.createNodeOpen || state.tourOpen;
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -158,6 +158,7 @@ import {
 } from "../lib/topology-render-state";
 import { resolveTopologySelectedOntologyNode } from "../lib/resolve-topology-selected-node";
 import { resolveDeeplinkMissDecision } from "../lib/deeplink-miss-notice";
+import { shouldSuppressGlobalShortcuts } from "../lib/blocking-surface";
 import { resolveAgentFocusNodeId } from "../lib/resolve-agent-focus-node";
 import { resolveTopologyNodeEditTarget } from "../lib/topology-node-edit";
 import { computeCanonicalCensus } from "@/shared/lib/ontology-tree/canonical-census";
@@ -2025,6 +2026,15 @@ export function HomePage() {
     }
   }, [docsDrawerOpen]);
 
+  // #62 — 블로킹 표면이 열려 있는 동안 전역 단축키는 죽는다. 예전엔 표면마다
+  // `if (createNodeOpen) return;` 을 손으로 달아서 **투어가 빠져 있었고**,
+  // 투어 위에 `?` 단축키 모달이 겹쳐 뜨는 상태가 실제로 재현됐다. 이제 술어
+  // 하나(`blocking-surface`)로 모아 새 표면이 생겨도 한 곳만 고치면 된다.
+  const shortcutsSuppressed = shouldSuppressGlobalShortcuts({
+    createNodeOpen,
+    tourOpen: tour.open,
+  });
+
   // 공용 useTypingShortcuts로 글로벌 키 단축키 통합.
   // ⌘K 와 ⇧⌘K 는 이제 동일한 팔레트(ontology 노드 + 프로젝트 통합 검색)를
   // 연다 — persona-P1: 예전엔 ⌘K 만 프로젝트 전용 SearchPalette 를 열어
@@ -2035,28 +2045,28 @@ export function HomePage() {
     {
       combo: { key: "k", meta: true, shift: true },
       onFire: () => {
-        if (createNodeOpen) return;
+        if (shortcutsSuppressed) return;
         setOntologySearchOpen((v) => !v);
       },
     },
     {
       combo: { key: "k", meta: true },
       onFire: () => {
-        if (createNodeOpen) return;
+        if (shortcutsSuppressed) return;
         setOntologySearchOpen((v) => !v);
       },
     },
     {
       combo: { key: "?" },
       onFire: () => {
-        if (createNodeOpen) return;
+        if (shortcutsSuppressed) return;
         setShortcutsOpen((v) => !v);
       },
     },
     {
       combo: { key: "d" },
       onFire: () => {
-        if (createNodeOpen) return;
+        if (shortcutsSuppressed) return;
         setDocsDrawerOpen((v) => !v);
       },
     },
@@ -2067,7 +2077,7 @@ export function HomePage() {
       // 게이트가 꺼져 무동작.
       combo: { key: "o", meta: true },
       onFire: () => {
-        if (createNodeOpen) return;
+        if (shortcutsSuppressed) return;
         if (!sampleModeSettled) return;
         void vault.open();
       },

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -1309,3 +1309,76 @@ describe("StudioCompass — 작업중 목록 (drafts)", () => {
     expect(preview.closest("header")).not.toBeNull();
   });
 });
+
+// #62 — 무대 위 임시 표면 상호 배타. 디자인 규칙: "transient surface 는
+// unrelated surface 를 닫거나 demote 해야 한다". opus5 검수에서 '+90 더 보기'
+// 접힘 목록 위에 소켓 피커가 그대로 쌓여 둘 다 살아 있는 상태가 실측됐다.
+describe("StudioCompass — 임시 표면 상호 배타 (#62)", () => {
+  function renderStacking() {
+    const many = Array.from({ length: 6 }, (_, i) => ({
+      id: `el:${i}`,
+      title: `Element ${i}`,
+      kind: "element",
+      ref: `elements/e${i}`,
+    }));
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "MCP Server", definition: "def" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down", { filled: true, neighbors: many }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={1}
+        writable
+        candidatesFor={() => [CANDIDATE]}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        focalId="capability:mcp"
+        drafts={[{ focalId: "capability:mcp", title: "MCP Server", count: 1 }]}
+        onOpenDraft={vi.fn()}
+        onDiscardDraft={vi.fn()}
+      />,
+    );
+  }
+
+  it("소켓 피커를 열면 접힘 목록이 닫힌다 — 둘이 겹쳐 서지 않는다", () => {
+    renderStacking();
+
+    // 접힘 목록을 먼저 연다.
+    fireEvent.click(screen.getByTestId("studio-lane-more-down"));
+    expect(screen.getByTestId("studio-lane-list-down")).toBeInTheDocument();
+
+    // 그 상태에서 빈 소켓의 피커를 연다.
+    fireEvent.click(screen.getByTestId("studio-socket-up"));
+    expect(screen.getByTestId("studio-picker")).toBeInTheDocument();
+    expect(screen.queryByTestId("studio-lane-list-down")).not.toBeInTheDocument();
+  });
+
+  it("접힘 목록을 열면 피커가 닫힌다 (반대 방향도 대칭)", () => {
+    renderStacking();
+
+    fireEvent.click(screen.getByTestId("studio-socket-up"));
+    expect(screen.getByTestId("studio-picker")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("studio-lane-more-down"));
+    expect(screen.getByTestId("studio-lane-list-down")).toBeInTheDocument();
+    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+  });
+
+  it("작업중 패널을 열면 피커·접힘 목록이 함께 닫힌다", () => {
+    renderStacking();
+
+    fireEvent.click(screen.getByTestId("studio-socket-up"));
+    expect(screen.getByTestId("studio-picker")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("studio-drafts-open"));
+    expect(screen.getByTestId("studio-drafts-panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+  });
+});

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -686,7 +686,14 @@ export function StudioCompass(props: StudioCompassProps) {
   const similarHit =
     openRelation && similarFor ? similarFor(openRelation, query) : null;
 
+  // #62 — 무대 위 임시 표면은 서로 배타적이다. 예전엔 '+90 더 보기' 접힘
+  // 목록이 열린 채 소켓 피커가 그 위에 그대로 쌓여, 아래 목록이 반쯤 가린
+  // 상태로 둘 다 살아 있었다(opus5 검수 스크린샷). 피커를 열 때 접힘 목록·
+  // 관계 편집 카드·작업중 패널을 함께 닫는다.
   const openPicker = (relation: StudioRelation) => {
+    setOpenFold(null);
+    setOpenEdit(null);
+    setDraftsOpen(false);
     setOpenRelation((cur) => (cur === relation ? null : relation));
     setQuery("");
   };
@@ -835,7 +842,13 @@ export function StudioCompass(props: StudioCompassProps) {
               data-testid="studio-drafts-open"
               aria-expanded={draftsOpen}
               aria-label={labels.draftsOpenAria(drafts.length)}
-              onClick={() => setDraftsOpen((v) => !v)}
+              onClick={() => {
+                // #62 — 작업중 패널도 무대 위 임시 표면을 밀어낸다.
+                setOpenRelation(null);
+                setOpenFold(null);
+                setOpenEdit(null);
+                setDraftsOpen((v) => !v);
+              }}
               className={cn(
                 "flex h-[30px] items-center gap-1.5 rounded-lg border px-3 text-caption transition-colors",
                 draftsOpen
@@ -1012,7 +1025,13 @@ export function StudioCompass(props: StudioCompassProps) {
               onHoverBearing={setHoveredBearing}
               arrivalId={arrivedFrom}
               arrivalLit={arrivalLit}
-              onToggleFold={() => setOpenFold((cur) => (cur === view.bearing ? null : view.bearing))}
+              onToggleFold={() => {
+                // #62 — 접힘 목록도 같은 배타 규칙을 받는다.
+                setOpenRelation(null);
+                setOpenEdit(null);
+                setDraftsOpen(false);
+                setOpenFold((cur) => (cur === view.bearing ? null : view.bearing));
+              }}
               foldOpen={openFold === view.bearing}
               onCloseFold={() => setOpenFold(null)}
               onEditNeighbor={


### PR DESCRIPTION
## Summary

opus5 검수에서 실측한 **오버레이 충돌 2건**:

1. **지도** — 가이드 투어가 열린 채 `?` 를 누르면 단축키 모달이 투어 카드 위에 그대로 떴다. `role="dialog"` **두 개가 동시에 살아 있고**, 어느 쪽이 포커스를 소유하는지 모르는 상태.
2. **공방** — `+90 더 보기` 접힘 목록 위에 소켓 피커가 쌓여, 아래 목록이 반쯤 가린 채 둘 다 열려 있었다.

디자인 규칙(`.claude/rules/design.md`)은 *"transient surface 는 unrelated surface 를 닫거나 demote 해야 한다"* 이므로 둘 다 결함이다.

### 왜 생겼나

전역 단축키 가드가 표면마다 `if (createNodeOpen) return;` 로 **손으로 나열**돼 있었고, 가이드 투어가 그 목록에서 빠져 있었다. 투어는 자체 blocker + 포커스 트랩을 가진 블로킹 표면인데도 키보드를 놓치고 있었다.

### 고친 것

- **`blocking-surface`** — 전역 단축키(⌘K · `?` · `D` · ⌘O)를 삼킬지 판단하는 **술어 하나**로 모았다. 새 블로킹 표면이 생기면 이 파일 한 곳만 고치면 되고, 빠뜨리면 테스트가 잡는다.
- **공방 임시 표면 상호 배타** — 소켓 피커 · 접힘 목록 · 관계 편집 카드 · 작업중 패널 중 하나를 열면 나머지가 닫힌다. `openX 가 나머지를 닫는다` 는 지도의 기존 관례(`openCreateNode` / `openGuidedTour`)와 같은 문법으로 맞췄다.

## Test plan

- `pnpm exec vitest run src/views/home src/views/ontology-studio` — **452/452**
- `pnpm exec tsc --noEmit` — clean
- `pnpm desktop:check` — exit 0
- 회귀 테스트 **7건 신규**: 단축키 억제 술어 4(투어 열림 포함) + 공방 배타 3(피커↔접힘, 접힘↔피커, 작업중↔둘 다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr