### PR TITLE
fix: 인사이트 판정 모델 단일화 — 같은 데이터에 두 말 하지 않게 (#63)

### DIFF
--- a/src/views/ontology-insights/lib/insights-verdict.test.ts
+++ b/src/views/ontology-insights/lib/insights-verdict.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { buildInsightsVerdict, type InsightsSignalCounts } from "./insights-verdict";
+
+const NONE: InsightsSignalCounts = {
+  islands: 0,
+  missingContainment: 0,
+  cycles: 0,
+  neglectedHubs: 0,
+  orphans: 0,
+  promotions: 0,
+};
+
+describe("buildInsightsVerdict", () => {
+  it("신호가 하나도 없을 때만 '건강함' — CLI 판정도 healthy", () => {
+    expect(buildInsightsVerdict(NONE)).toEqual({
+      blocking: 0,
+      advisory: 0,
+      total: 0,
+      healthy: true,
+      status: "healthy",
+    });
+  });
+
+  // opus5 검수 실측 모순: 스타터 볼트에서 신호가 '누락된 연결 1건' 뿐이었는데
+  // `할 일 0` + "그래프가 건강합니다" + `누락된 연결 1` 이 동시에 떴다.
+  // 같은 데이터에 MCP health 는 needs_attention 을 반환했다.
+  it("누락된 연결 1건이면 할 일도 1 · 건강하지 않음 · CLI 와 같은 needs_attention", () => {
+    const verdict = buildInsightsVerdict({ ...NONE, missingContainment: 1 });
+
+    expect(verdict.total).toBe(1);
+    expect(verdict.healthy).toBe(false);
+    expect(verdict.status).toBe("needs_attention");
+  });
+
+  it("분리된 섬도 차단 신호다", () => {
+    const verdict = buildInsightsVerdict({ ...NONE, islands: 3 });
+
+    expect(verdict.blocking).toBe(3);
+    expect(verdict.status).toBe("needs_attention");
+  });
+
+  it("의존 순환도 차단 신호다 — 구조적 결함", () => {
+    expect(buildInsightsVerdict({ ...NONE, cycles: 2 }).status).toBe("needs_attention");
+  });
+
+  it("권장 사항만 있으면 CLI 판정은 healthy 지만 화면은 '건강합니다' 라고 말하지 않는다", () => {
+    const verdict = buildInsightsVerdict({ ...NONE, neglectedHubs: 2, orphans: 1, promotions: 4 });
+
+    expect(verdict.blocking).toBe(0);
+    expect(verdict.advisory).toBe(7);
+    expect(verdict.status).toBe("healthy");
+    // 바로 아래 큐가 7건을 보여주는데 "손볼 것이 없어요" 라고 하면 자기모순.
+    expect(verdict.healthy).toBe(false);
+  });
+
+  it("배지 총합은 차단 + 권장 — 숫자를 숨겨 모순을 피하지 않는다", () => {
+    const verdict = buildInsightsVerdict({
+      islands: 1,
+      missingContainment: 2,
+      cycles: 1,
+      neglectedHubs: 3,
+      orphans: 0,
+      promotions: 5,
+    });
+
+    expect(verdict.blocking).toBe(4);
+    expect(verdict.advisory).toBe(8);
+    expect(verdict.total).toBe(12);
+  });
+});

--- a/src/views/ontology-insights/lib/insights-verdict.ts
+++ b/src/views/ontology-insights/lib/insights-verdict.ts
@@ -1,0 +1,74 @@
+/**
+ * 인사이트 화면의 **단일 판정 모델** (#63).
+ *
+ * 왜 필요한가: 같은 볼트를 두고 한 화면이 서로 모순된 말을 했다.
+ *
+ * - `할 일` 탭 배지는 `do-next-queue` 만 셌다 — 방치된 허브 · 고아 · 승격 후보
+ *   + 의존 순환. 통계적 신호다.
+ * - `수리 큐` 는 CLI-parity 인 `vault-health` 를 셌다 — 분리된 섬 · 누락된 연결.
+ *   `ontology-atlas health` 가 `needs_attention` 으로 뒤집는 바로 그 신호다.
+ * - 빈 상태 문구는 do-next 만 보고 "지금은 손볼 것이 없어요 — 그래프가
+ *   건강합니다" 라고 단정했다.
+ *
+ * 그래서 스타터 볼트처럼 신호가 '누락된 연결 1건' 뿐이면 `할 일 0` +
+ * "그래프가 건강합니다" + `누락된 연결 1` 이 **동시에** 떴고, 같은 데이터에
+ * MCP `health` 는 `needs_attention` 을 반환했다 (opus5 검수 2026-07-25).
+ * C1(#631)이 수리 큐만 CLI 와 맞추고 할 일/건강 문구는 옛 모델에 남긴 결과다.
+ *
+ * 이 모듈은 두 신호군을 하나의 판정으로 합친다. 숫자를 숨겨 모순을 피하지
+ * 않는다 — 둘 다 세되, **무엇이 차단(blocking)이고 무엇이 권장(advisory)인지**
+ * 구분해서 "건강함" 이 실제로 0일 때만 나오게 한다.
+ */
+
+export interface InsightsSignalCounts {
+  /** CLI 가 needs_attention 으로 뒤집는 신호 — 분리된 섬. */
+  islands: number;
+  /** CLI 가 needs_attention 으로 뒤집는 신호 — 소속 도메인 누락. */
+  missingContainment: number;
+  /** 의존 순환 — 구조적 결함이라 차단으로 센다. */
+  cycles: number;
+  /** 오래 안 만진 허브 — 통계적 권장. */
+  neglectedHubs: number;
+  /** 아무 데도 안 붙은 노드 — 통계적 권장. */
+  orphans: number;
+  /** 여러 곳에서 참조되는 노드 — 상위 개념 승격 권장. */
+  promotions: number;
+}
+
+export interface InsightsVerdict {
+  /**
+   * 그래프를 "고쳐야 하는" 신호 수 — CLI 가 needs_attention 으로 판정하는
+   * 것들. 이 값이 0 이 아니면 어떤 표면도 "건강합니다" 라고 말하면 안 된다.
+   */
+  blocking: number;
+  /** 해두면 좋은 권장 사항 수. 차단이 아니다. */
+  advisory: number;
+  /** 배지에 쓰는 총합 — 사용자가 보는 "할 일" 은 둘을 합친 수다. */
+  total: number;
+  /**
+   * `건강함` 을 주장해도 되는가. **차단·권장이 모두 0일 때만** true —
+   * 권장이 남아 있는데 "건강합니다" 라고 하면, 바로 아래 수리 큐가 1건을
+   * 보여주는 순간 화면이 자기모순에 빠진다.
+   */
+  healthy: boolean;
+  /**
+   * CLI(`ontology-atlas health` / MCP `health`)와 같은 판정 문자열.
+   * UI 와 에이전트가 같은 단어를 쓰는지 계약 테스트로 잡을 수 있게 노출한다.
+   */
+  status: "healthy" | "needs_attention";
+}
+
+export function buildInsightsVerdict(counts: InsightsSignalCounts): InsightsVerdict {
+  const blocking = counts.islands + counts.missingContainment + counts.cycles;
+  const advisory = counts.neglectedHubs + counts.orphans + counts.promotions;
+  return {
+    blocking,
+    advisory,
+    total: blocking + advisory,
+    healthy: blocking === 0 && advisory === 0,
+    // CLI 는 섬/누락 연결/순환에서만 needs_attention 으로 뒤집는다 — 권장
+    // 사항은 통계적 제안이라 판정을 바꾸지 않는다. 그래서 `status` 는 blocking
+    // 만 보고, `healthy`(화면이 "건강합니다" 라고 말해도 되는가)는 둘 다 본다.
+    status: blocking === 0 ? "healthy" : "needs_attention",
+  };
+}

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -46,6 +46,7 @@ import {
 } from "../lib/insights-tab-state";
 import { computeDomainCapacityRows } from "../lib/domain-capacity";
 import { buildDoNextQueue, withDoNextVerification } from "../lib/do-next-queue";
+import { buildInsightsVerdict } from "../lib/insights-verdict";
 import { pickTodaysTouchUps, type TouchUpItem } from "../lib/todays-touch-ups";
 import { countRecentEntries } from "@/shared/lib/agent-activity-log";
 import { findDependencyCycles, type DependencyCycle } from "../lib/dependency-cycles";
@@ -382,6 +383,21 @@ export function OntologyInsightsPage() {
         return t("doNext.touchUpWhyPromotion");
     }
   };
+  // #63 — 이 화면의 단일 판정. 탭 배지 · 빈 상태 문구 · 건강 주장이 모두
+  // 여기서 나와야 같은 데이터에 서로 다른 말을 하지 않는다.
+  const insightsVerdict = useMemo(
+    () =>
+      buildInsightsVerdict({
+        islands: healthRepair.islandCount,
+        missingContainment: healthRepair.missingContainmentCount,
+        cycles: dependencyCycles.totalCycles,
+        neglectedHubs: doNextQueue.counts.neglectedHub,
+        orphans: doNextQueue.counts.orphan,
+        promotions: doNextQueue.counts.promotion,
+      }),
+    [healthRepair, dependencyCycles.totalCycles, doNextQueue.counts],
+  );
+
   const doNextTouchUps: DoNextTouchUp[] = pickTodaysTouchUps(doNextQueue, dependencyCycles, {
     totalNodes,
     cycleTitle: cycleNodeTitle,
@@ -573,10 +589,11 @@ export function OntologyInsightsPage() {
               label: t(`tab.${key}`),
               count:
                 key === "do-next"
-                  ? doNextQueue.counts.neglectedHub +
-                    doNextQueue.counts.orphan +
-                    doNextQueue.counts.promotion +
-                    dependencyCycles.totalCycles
+                  // #63 — 배지는 단일 판정 모델(`insights-verdict`)에서 나온다.
+                  // 예전엔 do-next 통계 신호만 세고 CLI-parity 신호(분리된 섬 ·
+                  // 누락된 연결)를 빠뜨려, 수리 큐가 1건을 보여주는데 배지는 0
+                  // 이라고 말하는 모순이 났다.
+                  ? insightsVerdict.total
                   : key === "structure"
                     ? totalNodes
                     : `${FRESHNESS_WINDOW_WEEKS}${t("weeksUnit")}`,

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.test.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.test.tsx
@@ -578,3 +578,44 @@ describe("DoNextTab — 오늘의 손질 밴드 (③)", () => {
     expect(trigger).toHaveFocus();
   });
 });
+
+// #63 — 판정 모델 단일화. opus5 검수 실측 모순: 신호가 '누락된 연결 1건' 뿐인
+// 볼트에서 `할 일 0` + "그래프가 건강합니다" + `누락된 연결 1` 이 동시에 떴고,
+// 같은 데이터에 MCP health 는 needs_attention 을 반환했다.
+describe("DoNextTab — 건강 주장은 CLI-parity 신호까지 0일 때만 (#63)", () => {
+  const emptyQueue: DoNextQueue = {
+    rows: [],
+    activeRowIds: [],
+    counts: { neglectedHub: 0, orphan: 0, promotion: 0 },
+  };
+
+  function renderWith(healthQueue: typeof emptyHealthQueue) {
+    render(
+      <DoNextTab
+        queue={emptyQueue}
+        cycles={noCycles}
+        agentReadiness={{ ready: 0, preflight: 0, review: 0 }}
+        healthQueue={healthQueue}
+        mapHref={(id) => `/ontology/?node=${encodeURIComponent(id)}`}
+        builderHref={(id) => `/ontology/edit/?node=${encodeURIComponent(id)}`}
+        {...cycleProps}
+        labels={labels}
+      />,
+    );
+  }
+
+  it("모든 신호가 0이면 '손볼 것 없음' 문구가 나온다", () => {
+    renderWith(emptyHealthQueue);
+    expect(screen.getByText(labels.emptyQueue)).toBeInTheDocument();
+  });
+
+  it("누락된 연결이 1건이면 '손볼 것 없음' 이라고 말하지 않는다", () => {
+    renderWith({ ...emptyHealthQueue, missingContainmentCount: 1 });
+    expect(screen.queryByText(labels.emptyQueue)).not.toBeInTheDocument();
+  });
+
+  it("분리된 섬이 있어도 마찬가지", () => {
+    renderWith({ ...emptyHealthQueue, islandCount: 2 });
+    expect(screen.queryByText(labels.emptyQueue)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -706,7 +706,13 @@ export function DoNextTab({
     totalCycles: Math.max(0, cycles.totalCycles - removedVisibleCycleCount),
   };
   const hasCycles = visibleCycles.cycles.length > 0;
-  const queueEmpty = queue.rows.length === 0 && !hasCycles;
+  // #63 — "지금은 손볼 것이 없어요 — 그래프가 건강합니다" 는 CLI-parity 신호
+  // (분리된 섬 · 누락된 연결)까지 0일 때만 나온다. 예전엔 do-next 행만 보고
+  // 단정해서, 바로 아래 수리 큐가 `누락된 연결 1` 을 보여주는 화면에서도
+  // "건강합니다" 라고 말했다 (opus5 검수 실측 모순).
+  const hasClipParityIssues =
+    healthQueue.islandCount > 0 || healthQueue.missingContainmentCount > 0;
+  const queueEmpty = queue.rows.length === 0 && !hasCycles && !hasClipParityIssues;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-[var(--card-gap)]">


### PR DESCRIPTION
## Summary

opus5 검수 실측 모순: 신호가 **'누락된 연결 1건' 뿐인 볼트**에서

- `할 일` **0**
- "지금은 손볼 것이 없어요 — **그래프가 건강합니다**"
- `누락된 연결` **1**

이 **동시에** 떴다. 같은 데이터에 MCP `health` 는 `needs_attention` 을 반환했다.

### 원인 — 한 화면에 판정 모델이 둘

| 표면 | 세던 것 |
|---|---|
| `할 일` 배지 | do-next 통계 신호(방치 허브 · 고아 · 승격) + 순환 |
| `수리 큐` | CLI-parity `vault-health`(분리된 섬 · 누락된 연결) |
| 빈 상태 문구 | do-next 행만 보고 단정 |

C1(#631)이 **수리 큐만** CLI 와 맞추고 할 일/건강 문구는 옛 모델에 남긴 결과다.

### 고친 것

- **`insights-verdict`** — 두 신호군을 하나의 판정으로 합친다. **숫자를 숨겨 모순을 피하지 않는다**: 둘 다 세되 **차단(blocking)** 과 **권장(advisory)** 을 구분한다.
  - `status` — CLI 와 같은 규칙(차단만 `needs_attention`)
  - `healthy` — 화면이 "건강합니다" 라고 말해도 되는가. **차단·권장 모두 0일 때만** true. 권장이 남았는데 "건강합니다" 라고 하면 바로 아래 큐가 자기모순을 만든다.
- **탭 배지**가 이 판정의 `total` 을 쓴다 — 수리 큐가 1건인데 배지가 0인 상태가 **구조적으로 불가능**해졌다.
- **빈 상태 문구**가 CLI-parity 신호까지 0일 때만 나온다.

## Test plan

- `pnpm exec vitest run src/views/ontology-insights` — **106/106**
- `pnpm exec tsc --noEmit` — clean
- 회귀 테스트 **9건 신규**: 판정 6(0건 / 누락연결 1 / 섬 / 순환 / 권장만 / 총합) + 빈 상태 모순 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr