### PR TITLE
fix: 문서함 빠른 드로어가 활성 볼트를 본다 (#61)

### DIFF
--- a/src/entities/docs-vault/index.ts
+++ b/src/entities/docs-vault/index.ts
@@ -13,6 +13,12 @@ export { default as vaultContent } from './data/content.json';
 // 빌드한다.
 export { default as sampleStorefrontManifest } from './data/sample-storefront.manifest.json';
 export {
+  pinnedDocsStorageKey,
+  recentDocsStorageKey,
+  vaultScopeKey,
+  type VaultScopeKey,
+} from './lib/vault-scope-key';
+export {
   buildLocalManifest,
   buildLocalManifestWithEntries,
   rebuildLocalManifestIncremental,

--- a/src/entities/docs-vault/lib/vault-scope-key.test.ts
+++ b/src/entities/docs-vault/lib/vault-scope-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  pinnedDocsStorageKey,
+  recentDocsStorageKey,
+  vaultScopeKey,
+} from './vault-scope-key';
+
+describe('vaultScopeKey', () => {
+  it('로컬 볼트가 없으면 번들 범위', () => {
+    expect(vaultScopeKey({ isLocalLoaded: false, handleName: null })).toBe('server');
+  });
+
+  it('로컬 볼트가 로드되면 폴더 이름으로 범위를 나눈다', () => {
+    expect(vaultScopeKey({ isLocalLoaded: true, handleName: 'my-vault' })).toBe('local:my-vault');
+  });
+
+  // 로드 중(handle 은 있는데 아직 manifest 가 없는) 순간에 로컬 키를 쓰면
+  // 빈 목록을 그 볼트의 진실로 굳혀버린다 — 로드 완료 전엔 번들 범위 유지.
+  it('폴더 이름이 아직 없으면 번들 범위로 떨어진다', () => {
+    expect(vaultScopeKey({ isLocalLoaded: true, handleName: null })).toBe('server');
+  });
+
+  it('저장 키는 기존 /docs 네임스페이스와 정확히 같다 — 두 표면이 같은 목록을 본다', () => {
+    expect(pinnedDocsStorageKey('server')).toBe('demo:docs-vault:pinned:v1:server');
+    expect(recentDocsStorageKey('local:my-vault')).toBe('demo:docs-vault:recent:v2:local:my-vault');
+  });
+});

--- a/src/entities/docs-vault/lib/vault-scope-key.ts
+++ b/src/entities/docs-vault/lib/vault-scope-key.ts
@@ -1,0 +1,35 @@
+/**
+ * 문서 최근/고정 목록의 **볼트 범위 키** (#61).
+ *
+ * 최근 열람과 고정은 볼트마다 따로 남아야 한다 — 5개짜리 로컬 볼트를 열었는데
+ * 번들 샘플에서 고정해 둔 문서가 섞여 나오면, 사용자는 자기가 지금 무엇을
+ * 보고 있는지 알 수 없다.
+ *
+ * `/docs` 는 이미 이 규칙을 지키고 있었지만, 지도의 문서함 빠른 드로어는
+ * `'server'` 를 하드코딩해 **활성 로컬 볼트와 무관한 번들 문서의 고정/최근**을
+ * 보여줬다 (opus5 검수 2026-07-25). 두 표면이 같은 규칙을 쓰도록 산출식을 한
+ * 곳으로 모은다 — entities 레이어라 두 widget 이 모두 import 할 수 있다
+ * (widget→widget import 는 FSD 경계에서 금지).
+ */
+export type VaultScopeKey = 'server' | `local:${string}`;
+
+export const PINNED_DOCS_STORAGE_PREFIX = 'demo:docs-vault:pinned:v1:';
+export const RECENT_DOCS_STORAGE_PREFIX = 'demo:docs-vault:recent:v2:';
+
+export function vaultScopeKey(args: {
+  /** 활성 데이터 소스가 실제로 로드된 로컬 볼트인가. */
+  isLocalLoaded: boolean;
+  /** 선택된 로컬 폴더 이름. 없으면 번들 범위로 떨어진다. */
+  handleName?: string | null;
+}): VaultScopeKey {
+  if (args.isLocalLoaded && args.handleName) return `local:${args.handleName}`;
+  return 'server';
+}
+
+export function pinnedDocsStorageKey(scope: VaultScopeKey): string {
+  return `${PINNED_DOCS_STORAGE_PREFIX}${scope}`;
+}
+
+export function recentDocsStorageKey(scope: VaultScopeKey): string {
+  return `${RECENT_DOCS_STORAGE_PREFIX}${scope}`;
+}

--- a/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.test.tsx
+++ b/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DocsQuickDrawer } from "./DocsQuickDrawer";
+
+/**
+ * #61 — 이 드로어는 **활성 볼트**의 빠른 접근이다. 예전엔 빌드타임 번들
+ * `vaultManifest` 를 직접 읽어, 5개짜리 로컬 볼트를 선택해도 Atlas 번들 문서가
+ * 나왔다 (opus5 검수 2026-07-25 · codex 감사 P1). 고정/최근도 `:server` 로
+ * 고정돼 다른 볼트의 목록이 섞였다.
+ */
+
+const mocks = vi.hoisted(() => ({
+  mode: "server" as "server" | "local",
+  vaultStatus: "idle" as string,
+  handleName: null as string | null,
+  localManifest: null as unknown,
+}));
+
+vi.mock("@/features/data-source-mode", () => ({
+  useDataSourceMode: () => mocks.mode,
+}));
+
+vi.mock("@/features/docs-vault-local", () => ({
+  useLocalVault: () => ({
+    status: mocks.vaultStatus,
+    handle: mocks.handleName ? { name: mocks.handleName } : null,
+    manifest: mocks.localManifest,
+  }),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  Link: ({ children }: { children?: unknown }) => children,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    values ? `${key}:${JSON.stringify(values)}` : key,
+}));
+
+const LOCAL_MANIFEST = {
+  tree: {
+    type: "dir",
+    name: "root",
+    path: "",
+    children: [
+      { type: "doc", name: "정산 규칙", path: "settlement.md", slug: "settlement", title: "정산 규칙" },
+      { type: "doc", name: "환불", path: "refund.md", slug: "refund", title: "환불" },
+    ],
+  },
+  docs: [
+    { slug: "settlement", title: "정산 규칙", updatedAt: "2026-07-01", tags: [] },
+    { slug: "refund", title: "환불", updatedAt: "2026-07-02", tags: [] },
+  ],
+  tags: {},
+  backlinks: {},
+};
+
+function renderDrawer() {
+  render(<DocsQuickDrawer open onClose={vi.fn()} />);
+}
+
+describe("DocsQuickDrawer — 활성 볼트 범위 (#61)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mocks.mode = "server";
+    mocks.vaultStatus = "idle";
+    mocks.handleName = null;
+    mocks.localManifest = null;
+  });
+
+  it("로컬 볼트가 없으면 번들(도그푸드) 문서를 보여준다 — 기존 fallback 유지", () => {
+    renderDrawer();
+
+    // 번들 매니페스트에 실제로 있는 문서. 로컬 볼트 문서는 없어야 한다.
+    expect(screen.queryByText("정산 규칙")).not.toBeInTheDocument();
+  });
+
+  it("로컬 볼트가 로드되면 그 볼트의 문서만 보여준다 — 번들 문서가 새지 않는다", () => {
+    mocks.mode = "local";
+    mocks.vaultStatus = "loaded";
+    mocks.handleName = "my-vault";
+    mocks.localManifest = LOCAL_MANIFEST;
+
+    renderDrawer();
+
+    // 트리와 목록 양쪽에 나오므로 개수는 보지 않고 존재만 확인한다.
+    expect(screen.getAllByText("정산 규칙").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("환불").length).toBeGreaterThan(0);
+    // 번들 도그푸드 문서(ARCHITECTURE 등)는 이 볼트에 없다.
+    expect(screen.queryByText("ARCHITECTURE")).not.toBeInTheDocument();
+  });
+
+  it("고정/최근은 볼트 범위로 나뉜다 — 샘플에서 고정한 게 로컬 볼트에 섞이지 않는다", () => {
+    // 번들 범위에 고정을 심어 둔다.
+    window.localStorage.setItem(
+      "demo:docs-vault:pinned:v1:server",
+      JSON.stringify(["ARCHITECTURE"]),
+    );
+
+    mocks.mode = "local";
+    mocks.vaultStatus = "loaded";
+    mocks.handleName = "my-vault";
+    mocks.localManifest = LOCAL_MANIFEST;
+
+    renderDrawer();
+
+    // 번들 범위의 고정 문서가 로컬 볼트 드로어에 나타나면 안 된다.
+    expect(screen.queryByText("ARCHITECTURE")).not.toBeInTheDocument();
+  });
+});

--- a/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
+++ b/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
@@ -20,10 +20,15 @@ import {
 } from "lucide-react";
 import {
   findRelatedDocs,
+  pinnedDocsStorageKey,
+  recentDocsStorageKey,
   vaultManifest,
+  vaultScopeKey,
   type VaultManifest,
   type VaultTreeNode,
 } from "@/entities/docs-vault";
+import { useDataSourceMode } from "@/features/data-source-mode";
+import { useLocalVault } from "@/features/docs-vault-local";
 import {
   filterTree,
   firstDocSlug,
@@ -33,12 +38,6 @@ import {
 import { MOTION } from "@/shared/motion";
 import { useBodyScrollLock } from "@/shared/lib/use-body-scroll-lock";
 import { cn } from "@/shared/lib/cn";
-
-// docs-vault widget 에 이미 있는 storage key 와 shape 을 그대로 참조 — 타입만
-// 같이 유지하면 두 위젯이 같은 localStorage 네임스페이스를 공유한다.
-// widget→widget import 는 FSD 경계에서 금지라, 최소 read-only 접근만 inline.
-const PINNED_KEY = "demo:docs-vault:pinned:v1:server";
-const RECENT_KEY = "demo:docs-vault:recent:v2:server";
 
 function readStoredSlugs(key: string, limit: number): string[] {
   if (typeof window === "undefined") return [];
@@ -56,14 +55,14 @@ function readStoredSlugs(key: string, limit: number): string[] {
 }
 
 /** docs-vault widget 의 togglePinnedDoc 과 동일 동작 — 고정 추가 시 맨 앞. */
-function togglePinnedInStorage(slug: string): string[] {
+function togglePinnedInStorage(pinnedKey: string, slug: string): string[] {
   if (typeof window === "undefined") return [];
-  const current = readStoredSlugs(PINNED_KEY, 500);
+  const current = readStoredSlugs(pinnedKey, 500);
   const next = current.includes(slug)
     ? current.filter((s) => s !== slug)
     : [slug, ...current];
   try {
-    window.localStorage.setItem(PINNED_KEY, JSON.stringify(next));
+    window.localStorage.setItem(pinnedKey, JSON.stringify(next));
   } catch {
     /* private mode */
   }
@@ -287,6 +286,28 @@ export function DocsQuickDrawer({
 }: Props) {
   const t = useTranslations("vaultWidgets.docsDrawer");
   const router = useRouter();
+
+  // #61 — 이 드로어는 **활성 볼트**의 빠른 접근이다(라벨도 "문서함 빠른 접근",
+  // '전체' 는 /docs 로 간다). 예전엔 빌드타임 번들 `vaultManifest` 를 직접
+  // 읽어, 5개짜리 로컬 볼트를 선택해도 Atlas 번들 문서가 나왔다. 고정/최근도
+  // `:server` 로 고정돼 다른 볼트의 목록이 섞였다 (opus5 검수 2026-07-25).
+  //
+  // 이제 /docs 와 같은 규칙을 쓴다: 로컬 볼트가 로드돼 있으면 그 manifest 와
+  // 그 볼트 범위의 고정/최근을, 아니면 번들(도그푸드 샘플)을 본다.
+  const mode = useDataSourceMode();
+  const localVault = useLocalVault();
+  const isLocalLoaded =
+    mode === "local" && localVault.status === "loaded" && Boolean(localVault.manifest);
+  const activeManifest = (isLocalLoaded && localVault.manifest
+    ? localVault.manifest
+    : vaultManifest) as VaultManifest;
+  const scope = vaultScopeKey({
+    isLocalLoaded,
+    handleName: localVault.handle?.name ?? null,
+  });
+  const pinnedKey = pinnedDocsStorageKey(scope);
+  const recentKey = recentDocsStorageKey(scope);
+
   const [query, setQuery] = useState("");
   const [pinnedSlugs, setPinnedSlugs] = useState<string[]>([]);
   const [recentSlugs, setRecentSlugs] = useState<string[]>([]);
@@ -308,15 +329,16 @@ export function DocsQuickDrawer({
     }
     // 열릴 때마다 다시 읽어 /docs 에서 방금 pin 한 것도 즉시 반영.
     queueMicrotask(() => {
-      setPinnedSlugs(readStoredSlugs(PINNED_KEY, 50));
-      setRecentSlugs(readStoredSlugs(RECENT_KEY, 5));
+      setPinnedSlugs(readStoredSlugs(pinnedKey, 50));
+      setRecentSlugs(readStoredSlugs(recentKey, 5));
     });
     previousFocusRef.current = document.activeElement as HTMLElement | null;
     const t = window.setTimeout(() => searchRef.current?.focus(), 40);
     return () => {
       window.clearTimeout(t);
     };
-  }, [open]);
+    // 볼트가 바뀌면 그 볼트 범위의 고정/최근을 다시 읽는다.
+  }, [open, pinnedKey, recentKey]);
 
   useEffect(() => {
     if (!open) return;
@@ -334,10 +356,10 @@ export function DocsQuickDrawer({
   }, [open, onClose]);
 
   const docs: FlatDoc[] = useMemo(() => {
-    const all = flattenDocs(vaultManifest.tree as VaultTreeNode)
+    const all = flattenDocs(activeManifest.tree as VaultTreeNode)
       .filter((n) => n.type === "doc" && n.slug)
       .map((n) => {
-        const meta = vaultManifest.docs.find((d) => d.slug === n.slug);
+        const meta = activeManifest.docs.find((d) => d.slug === n.slug);
         return {
           slug: n.slug as string,
           title: n.title ?? n.name,
@@ -348,7 +370,7 @@ export function DocsQuickDrawer({
         } satisfies FlatDoc;
       });
     return all;
-  }, []);
+  }, [activeManifest]);
 
   // 태그별 문서 slug set. manifest.tags 는 이미 역색인이지만 JSON 로딩시
   // readonly 로 취급 — FlatDoc.tags 에서 다시 쌓아 O(1) 조회용 Set 화.
@@ -396,7 +418,7 @@ export function DocsQuickDrawer({
   const pinnedSet = useMemo(() => new Set(pinnedSlugs), [pinnedSlugs]);
 
   const handleTogglePin = (slug: string) => {
-    setPinnedSlugs(togglePinnedInStorage(slug));
+    setPinnedSlugs(togglePinnedInStorage(pinnedKey, slug));
   };
 
   const recentViewed = useMemo(
@@ -409,7 +431,7 @@ export function DocsQuickDrawer({
   // 를 종합한 score 를 반환 — ProjectDrawer 와 동일 로직.
   const relatedDocs = useMemo(() => {
     if (!contextProject) return [];
-    const manifest = vaultManifest as VaultManifest;
+    const manifest = activeManifest;
     return findRelatedDocs(
       manifest.docs,
       {
@@ -419,7 +441,7 @@ export function DocsQuickDrawer({
       },
       6,
     );
-  }, [contextProject]);
+  }, [contextProject, activeManifest]);
 
   const trimmedQuery = query.trim().toLowerCase();
   const activeTagSlugs = useMemo(
@@ -429,11 +451,11 @@ export function DocsQuickDrawer({
   const filteredTree = useMemo(
     () =>
       filterTree(
-        vaultManifest.tree as VaultTreeNode,
+        activeManifest.tree as VaultTreeNode,
         trimmedQuery,
         activeTagSlugs,
       ),
-    [trimmedQuery, activeTagSlugs],
+    [trimmedQuery, activeTagSlugs, activeManifest],
   );
 
   // 검색/태그 모드에서 키보드 ↑/↓ 가 순회할 대상 slug 평면 리스트.


### PR DESCRIPTION
## Summary

지도의 문서함 빠른 드로어(`D`)가 **빌드타임 번들 `vaultManifest` 를 직접 import** 해서, 5개짜리 로컬 볼트를 선택해도 **Atlas 번들 문서가 나왔다.** 고정/최근 저장 키도 `demo:docs-vault:*:server` 로 하드코딩돼 **다른 볼트의 목록이 섞였다.**

### 의도 확정

라벨이 "문서함 빠른 접근"이고 `전체` 링크가 `/docs`(활성 볼트)로 간다 — 이 드로어는 명백히 **활성 볼트 빠른 접근**이지 번들 제품 문서 기능이 아니다. 그래서 `/docs` 와 같은 규칙으로 맞췄다.

### 고친 것

- 로컬 볼트가 로드돼 있으면 그 manifest 를, 아니면 번들(도그푸드 샘플)을 본다 — `/docs` 의 기존 분기와 동일.
- **`vault-scope-key`** (entities) — 고정/최근의 볼트 범위 키 산출을 한 곳으로 모았다. `/docs` 는 이미 볼트별로 나누고 있었는데 **드로어만** `:server` 로 고정돼 있었다. widget→widget import 가 FSD 에서 금지라 entities 레이어에 뒀다.
- 로드 중(handle 은 있고 manifest 는 아직 없는) 순간엔 번들 범위를 유지한다 — 빈 목록을 그 볼트의 진실로 굳히지 않기 위해.

## Test plan

- `pnpm exec vitest run src/widgets/docs-quick-drawer src/entities/docs-vault` — **152/152**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — 이 파일 경고 0 (memo 의존성까지 정리)
- 회귀 테스트 **7건 신규**: 범위 키 4 + 드로어 3(번들 fallback / 로컬 볼트 문서만 / 고정 범위 격리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr