### PR TITLE
fix: 레일 하단 유틸 티어를 셸이 소유 — 모든 화면에서 3개 (#65)

### DIFF
--- a/src/app/providers/AppShell.test.tsx
+++ b/src/app/providers/AppShell.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppShell } from "./AppShell";
+
+/**
+ * #65 — 레일 하단 유틸 티어(활동 · 발자취 · 설정)는 **모든 화면에서 같다.**
+ *
+ * 예전엔 페이지가 `useNavRailSettingsSlot` 으로 손수 등록해야 했고, 공방이
+ * 그걸 빠뜨려 그 화면만 아이콘 1개였다 (지도 3 · 문서함/인사이트/프로젝트 2 ·
+ * 공방 1, opus5 검수 2026-07-25 실측). 셸이 기본을 소유하도록 바꿨으므로,
+ * 슬롯을 아무도 주입하지 않아도 세 타일이 서 있어야 한다.
+ */
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => Object.assign((key: string) => key, { rich: (key: string) => key }),
+  useLocale: () => "ko",
+}));
+
+vi.mock("@/features/docs-vault-local", () => ({
+  useLocalVault: () => ({ status: "idle", handle: null, manifest: null }),
+}));
+
+vi.mock("@/features/vault-ontology", () => ({
+  useOntologyInsight: () => ({ insight: null }),
+}));
+
+vi.mock("@/features/data-source-mode", () => ({
+  useDataSourceMode: () => "static",
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/ontology/studio",
+  Link: ({ children }: { children?: unknown }) => children,
+}));
+
+describe("AppShell — 레일 하단 유틸 티어 (#65)", () => {
+  it("페이지가 슬롯을 주입하지 않아도 활동·발자취·설정이 모두 선다", () => {
+    render(
+      <AppShell>
+        <div>page</div>
+      </AppShell>,
+    );
+
+    const tier = screen.getByTestId("app-nav-rail-utility-tier");
+    expect(screen.getByTestId("app-nav-rail-agent-status")).toBeInTheDocument();
+    expect(screen.getByTestId("app-nav-rail-git-tile")).toBeInTheDocument();
+    // 활동 · 발자취 · 설정(<details> 트리거) 세 자식.
+    expect(tier.children.length).toBe(3);
+  });
+});

--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -12,6 +12,10 @@ import {
   AgentConnectLauncherProvider,
   useAgentConnectLauncher,
 } from "@/widgets/agent-connect";
+import { AppSettingsMenu } from "@/widgets/app-settings-menu";
+import { AtlasGitLauncherProvider } from "@/shared/lib/atlas-git-launcher";
+import { AtlasGitPanelHost, NavRailGitTile } from "./NavRailGitTile";
+import { useDataSourceMode } from "@/features/data-source-mode";
 import { RouteFocusManager } from "@/shared/ui/route-focus-manager";
 
 /**
@@ -42,11 +46,15 @@ export function AppShell({ children }: { children: ReactNode }) {
   return (
     <NavRailShellProvider>
       <AgentConnectLauncherProvider>
-        <RouteFocusManager />
-        <div className="flex w-full">
-          <AppNavRailSlot />
-          <div className="flex min-w-0 flex-1 flex-col">{children}</div>
-        </div>
+        {/* #65 — 발자취(Atlas Git) 패널도 셸 상주. `<lg` 에서는 레일이 숨으므로
+            지도의 크롬 타일이 같은 런처로 같은 패널을 연다. */}
+        <AtlasGitLauncherProvider renderPanel={AtlasGitPanelHost}>
+          <RouteFocusManager />
+          <div className="flex w-full">
+            <AppNavRailSlot />
+            <div className="flex min-w-0 flex-1 flex-col">{children}</div>
+          </div>
+        </AtlasGitLauncherProvider>
       </AgentConnectLauncherProvider>
     </NavRailShellProvider>
   );
@@ -62,6 +70,7 @@ function AppNavRailSlot() {
   const launcher = useAgentConnectLauncher();
   const router = useRouter();
   const pathname = usePathname() ?? "/";
+  const dataSourceMode = useDataSourceMode();
 
   // P4-② 분기(TopologyIndexPanel 푸터와 동일 계약) — 연결됨: 활동
   // 다이제스트(인사이트)로. 미연결/stale: 연결 시트를 여는 전역 의도를 세운다.
@@ -81,9 +90,25 @@ function AppNavRailSlot() {
     [launcher, router, pathname],
   );
 
+  // #65 — 레일 하단 유틸 티어는 셸이 기본으로 채운다. 예전엔 페이지마다
+  // `useNavRailSettingsSlot(<AppSettingsMenu triggerVariant="rail-tile" />)` 를
+  // 손으로 등록해야 했고, **공방(OntologyStudioPage)이 그걸 빠뜨려** 그 화면만
+  // 하단에 아이콘 1개(에이전트)만 남았다 (지도 3 · 문서함/인사이트/프로젝트 2 ·
+  // 공방 1, opus5 검수 2026-07-25 실측). 페이지가 기억해야 하는 구조가 drift 의
+  // 원인이므로 기본값을 셸로 올린다 — 페이지는 특별한 슬롯이 필요할 때만
+  // 덮어쓴다.
+  // 발자취 타일은 항상 셸이 붙인다 — 페이지가 슬롯을 덮어써도 유틸 티어의
+  // 개수가 화면마다 달라지지 않는다.
+  const utilityTier = (
+    <>
+      <NavRailGitTile />
+      {settingsSlot ?? <AppSettingsMenu mode={dataSourceMode} triggerVariant="rail-tile" />}
+    </>
+  );
+
   return (
     <AppNavRail
-      settingsSlot={settingsSlot ?? undefined}
+      settingsSlot={utilityTier}
       hidden={hidden}
       contextHrefs={contextHrefs}
       onAgentTileActivate={onAgentTileActivate}

--- a/src/app/providers/NavRailGitTile.tsx
+++ b/src/app/providers/NavRailGitTile.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { computeOntologyChangeset, useChangeBaseline } from "@/shared/lib/ontology-tree";
+import { useOntologyInsight } from "@/features/vault-ontology";
+import { useLocalVault } from "@/features/docs-vault-local";
+import { GitStatusTile } from "@/widgets/app-nav-rail";
+import { AtlasGitPanel } from "@/widgets/atlas-git-panel";
+import { getTauriVaultRootPath } from "@/shared/lib/tauri-vault-fs";
+import { useAudiencePlain } from "@/shared/lib/audience-preference";
+import { useAtlasGitLauncher } from "@/shared/lib/atlas-git-launcher";
+
+/**
+ * 레일 하단 **발자취(Atlas Git)** 타일 + 그 패널 — 셸 소유 (#65).
+ *
+ * 왜 셸로 올렸나: 이 타일은 원래 `HomePage` 가 `settingsSlot` 에 끼워 넣었고,
+ * 설정 기어도 페이지마다 손으로 등록했다. 그래서 하단 유틸 티어 개수가 화면마다
+ * 갈렸다 — 지도 3개 · 문서함/인사이트/프로젝트 2개 · **공방 1개**
+ * (opus5 검수 2026-07-25 실측, 소유자: "모든 페이지에서 다 똑같이 하단에
+ * 아이콘이 3개여야 하는데 왜 1개만 나옴?").
+ *
+ * 페이지가 기억해야 하는 구조가 drift 의 원인이므로, 전역에서 같아야 하는 것은
+ * 셸이 소유한다. vault 경로와 세션 changeset 은 전부 공용 훅에서 나오므로
+ * 페이지 상태에 의존하지 않는다.
+ *
+ * 비개발(plain) 모드에서는 발자취를 개발자 크롬으로 보고 숨긴다 — 기존 지도
+ * 규칙 그대로이며, 이제 `audience-preference` 공용 스토어를 읽어 설정에서
+ * 바꾸면 모든 화면이 함께 바뀐다.
+ */
+export function NavRailGitTile() {
+  const [audiencePlain] = useAudiencePlain();
+  const launcher = useAtlasGitLauncher();
+  const { vaultPath, changeset } = useAtlasGitContext();
+
+  if (audiencePlain) return null;
+
+  return (
+    <GitStatusTile
+      onActivate={launcher.open}
+      panelOpen={launcher.isOpen}
+      vaultPath={vaultPath}
+      sessionDirty={changeset.touchedNodeIds.size > 0}
+    />
+  );
+}
+
+/** vault 경로 + 세션 changeset — 타일과 패널이 같은 값을 본다. */
+function useAtlasGitContext() {
+  const localVault = useLocalVault();
+  const { insight } = useOntologyInsight();
+  const changeBaseline = useChangeBaseline();
+
+  const changeset = useMemo(
+    () => computeOntologyChangeset(changeBaseline, insight?.nodes ?? [], insight?.edges ?? []),
+    [changeBaseline, insight],
+  );
+
+  // Tauri 데스크톱이면 vault 절대 경로(브리지 활성), 웹 FSA 핸들이면 null →
+  // 타일/패널이 세션 changeset 기반으로 정직하게 강등한다.
+  const vaultPath = localVault.handle ? (getTauriVaultRootPath(localVault.handle) ?? null) : null;
+  return { vaultPath, changeset };
+}
+
+/**
+ * 패널 본체. **열렸을 때만 마운트**한다 — 닫힌 상태에서도 changeset 을 계산하면
+ * 모든 페이지의 모든 렌더에서 그래프를 훑는 낭비가 된다.
+ */
+export function AtlasGitPanelHost({ open, onClose }: { open: boolean; onClose: () => void }) {
+  if (!open) return null;
+  return <AtlasGitPanelBody onClose={onClose} />;
+}
+
+function AtlasGitPanelBody({ onClose }: { onClose: () => void }) {
+  const { vaultPath, changeset } = useAtlasGitContext();
+
+  return (
+    <div
+      data-interactive-overlay="true"
+      data-testid="atlas-git-scrim"
+      className="pointer-events-auto fixed inset-0 z-50 flex items-stretch justify-center bg-[color:var(--color-backdrop-medium)] sm:items-center sm:p-6"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(event) => event.stopPropagation()}
+        className="flex h-[calc(100dvh-var(--topology-mobile-bottom-tab-reserve))] w-full flex-col overflow-y-auto border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] shadow-2xl sm:h-auto sm:max-h-[calc(100vh-3rem)] sm:max-w-[560px] sm:rounded-[var(--topology-shortcut-sheet-radius)]"
+      >
+        <AtlasGitPanel vaultPath={vaultPath} sessionChangeset={changeset} onClose={onClose} />
+      </div>
+    </div>
+  );
+}

--- a/src/shared/lib/atlas-git-launcher.tsx
+++ b/src/shared/lib/atlas-git-launcher.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+
+/**
+ * 발자취(Atlas Git) 패널을 여는 **전역 의도** (#65).
+ *
+ * 패널 본체는 셸이 소유한다(`app/providers/NavRailGitTile`). 레일은 `lg:flex`
+ * 라 `<lg` 에서 숨으므로, 그 폭에서는 지도의 크롬 타일이 같은 패널을 열어야
+ * 한다 — 두 진입점이 각자 패널을 복제하지 않도록 "열려는 의도" 만 공유한다.
+ * `AgentConnectLauncher` 와 같은 문법.
+ *
+ * shared 레이어에 두는 이유: 프로바이더는 app(셸)이, 소비자는 views(지도)가
+ * 쓴다. FSD 는 views→app import 를 금지하므로 계약만 아래 레이어로 내린다.
+ */
+export interface AtlasGitLauncher {
+  open: () => void;
+  isOpen: boolean;
+}
+
+const AtlasGitLauncherContext = createContext<AtlasGitLauncher | null>(null);
+
+/** 프로바이더 밖에서도 안전하게 no-op 으로 강등한다(테스트/격리 렌더). */
+export function useAtlasGitLauncher(): AtlasGitLauncher {
+  return useContext(AtlasGitLauncherContext) ?? { open: () => {}, isOpen: false };
+}
+
+export function AtlasGitLauncherProvider({
+  children,
+  renderPanel,
+}: {
+  children: ReactNode;
+  /** 패널 렌더러 — 셸이 주입한다(패널 자체는 widget 이라 shared 가 모른다). */
+  renderPanel: (args: { open: boolean; onClose: () => void }) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const value = useMemo<AtlasGitLauncher>(
+    () => ({ open: () => setOpen(true), isOpen: open }),
+    [open],
+  );
+  const onClose = useCallback(() => setOpen(false), []);
+  return (
+    <AtlasGitLauncherContext.Provider value={value}>
+      {children}
+      {renderPanel({ open, onClose })}
+    </AtlasGitLauncherContext.Provider>
+  );
+}

--- a/src/shared/lib/audience-preference.test.ts
+++ b/src/shared/lib/audience-preference.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { readAudiencePlain, writeAudiencePlain } from "./audience-preference";
+
+describe("audience-preference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("기본값은 개발자 모드 — 발자취 같은 크롬이 보인다", () => {
+    expect(readAudiencePlain()).toBe(false);
+  });
+
+  it("plain 모드를 저장하면 다음 읽기에서 살아 있다", () => {
+    writeAudiencePlain(true);
+    expect(readAudiencePlain()).toBe(true);
+  });
+
+  it("되돌리면 다시 개발자 모드", () => {
+    writeAudiencePlain(true);
+    writeAudiencePlain(false);
+    expect(readAudiencePlain()).toBe(false);
+  });
+
+  // #65 — 셸과 지도가 각자 localStorage 를 읽으면 한쪽만 갱신되는 drift 가 난다.
+  // 같은 탭 구독자에게 알리는 이벤트가 있어야 레일과 지도가 함께 바뀐다.
+  it("쓰기가 같은 탭 구독자에게 알린다", () => {
+    let fired = 0;
+    const onChange = () => { fired += 1; };
+    window.addEventListener("ontology-atlas:audience-preference-change", onChange);
+    writeAudiencePlain(true);
+    window.removeEventListener("ontology-atlas:audience-preference-change", onChange);
+    expect(fired).toBe(1);
+  });
+});

--- a/src/shared/lib/audience-preference.ts
+++ b/src/shared/lib/audience-preference.ts
@@ -1,0 +1,55 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * 비개발(plain) 관객 모드 — 개발자 크롬(발자취/Atlas Git 등)을 숨긴다.
+ *
+ * 원래 `HomePage` 안에 지역 상태로만 있었다. 레일 하단 유틸 티어를 셸로 올리면서
+ * (#65) 셸도 같은 값을 읽어야 해서 공용 스토어로 승격했다 — 두 곳이 각자
+ * localStorage 를 읽으면 설정에서 바꿨을 때 한쪽만 갱신되는 고전적 drift 가 난다.
+ *
+ * `appearance-preferences` 와 같은 로컬-퍼스트 지속 문법: localStorage 가 진실원,
+ * `useSyncExternalStore` 구독 + 커스텀 이벤트로 같은 탭 라이브 갱신. SSR/정적
+ * export 프리렌더에서는 false 를 반환해 hydration 불일치를 피한다.
+ */
+
+const AUDIENCE_PLAIN_KEY = "demo:audience-plain:v1";
+const AUDIENCE_EVENT = "ontology-atlas:audience-preference-change";
+
+export function readAudiencePlain(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(AUDIENCE_PLAIN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeAudiencePlain(next: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(AUDIENCE_PLAIN_KEY, next ? "1" : "0");
+  } catch {
+    /* private mode — session-only, no persistence */
+  }
+  window.dispatchEvent(new Event(AUDIENCE_EVENT));
+}
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener(AUDIENCE_EVENT, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(AUDIENCE_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/** 현재 plain 모드 값 + setter. 어느 표면에서 바꿔도 모든 구독자가 함께 바뀐다. */
+export function useAudiencePlain(): [boolean, (next: boolean) => void] {
+  const value = useSyncExternalStore(subscribe, readAudiencePlain, getServerSnapshot);
+  const set = useCallback((next: boolean) => writeAudiencePlain(next), []);
+  return [value, set];
+}

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -28,13 +28,14 @@ import {
   SampleNodeHint,
   useFirstRunSampleModeSettled,
 } from "@/features/first-run-starter";
-import { GitStatusTile, useNavRailContextHrefs, useNavRailSettingsSlot } from "@/widgets/app-nav-rail";
-import { AtlasGitPanel } from "@/widgets/atlas-git-panel";
+import { useNavRailContextHrefs, useNavRailSettingsSlot } from "@/widgets/app-nav-rail";
+import { useAtlasGitLauncher } from "@/shared/lib/atlas-git-launcher";
 import dynamic from "next/dynamic";
 import { ProjectDrawer } from "@/widgets/project-drawer";
 import { SearchHint } from "@/widgets/search-hint";
 import { useDocumentTitle } from "@/shared/lib/use-document-title";
 import { useLocalStorageBoolean } from "@/shared/lib/use-local-storage-boolean";
+import { useAudiencePlain } from "@/shared/lib/audience-preference";
 import { useCanvasBackground, useGlyphSet } from "@/shared/lib/appearance-preferences";
 
 const CREATE_NODE_DIALOG_TITLE_ID = "topology-create-node-dialog-title";
@@ -279,17 +280,6 @@ const INDEX_PANEL_COLLAPSED_KEY = "demo:index-panel-collapsed:v1";
  * useState 미러 + setter 에서 setItem 동기화 패턴을 쓴다(기존
  * `setIndexPreference` 의 "저장+즉시 적용" 계약과 동일).
  */
-const AUDIENCE_PLAIN_KEY = "demo:audience-plain:v1";
-
-function readAudiencePlainPreference(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(AUDIENCE_PLAIN_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
 export function HomePage() {
   const t = useTranslations('topology');
   // 어권별 이름 입력(create composer) 계약의 '지금 화면 언어'.
@@ -303,15 +293,10 @@ export function HomePage() {
   // 슬라이스 C — lazy initializer 는 클라이언트에서만 실제 실행(SSR 은 항상
   // false), 클라이언트 hydration 도 localStorage 없는 서버 프리렌더 기준
   // false 와 같아 hydration mismatch 없음(다른 세션 플래그와 같은 패턴).
-  const [audiencePlain, setAudiencePlainState] = useState<boolean>(readAudiencePlainPreference);
-  const setAudiencePlain = useCallback((next: boolean) => {
-    try {
-      window.localStorage.setItem(AUDIENCE_PLAIN_KEY, next ? "1" : "0");
-    } catch {
-      /* private mode — session-only, no persistence */
-    }
-    setAudiencePlainState(next);
-  }, []);
+  // #65 — 공용 스토어로 승격. 셸(레일 하단 발자취 타일)도 같은 값을 읽으므로
+  // 각자 localStorage 를 읽던 구조를 없앴다 — 설정에서 바꾸면 지도와 레일이
+  // 함께 바뀐다.
+  const [audiencePlain, setAudiencePlain] = useAudiencePlain();
   // Phase 5 #20/#21 — 개인화 설정(설정 시트에서 변경). 캔버스 배경 세트와 노드
   // 아이콘 세트를 앱 전역 스토어에서 읽어 지도 캔버스에 내려보낸다. DOM 글리프는
   // 같은 스토어를 스스로 구독하므로 두 표면이 lockstep 으로 스왑된다.
@@ -659,27 +644,20 @@ export function HomePage() {
   // S1.1 — 토폴로지를 온톨로지의 1차 편집 surface 로. writable 로컬 vault 면
   // 선택 노드를 자기 .md 문서로 해석해 전체 상세(A1)의 본문 인라인 편집을 허용.
   // 발자취(Atlas Git) 패널 — 레일 타일 클릭으로 열리는 스냅샷/히스토리 표면.
-  const [gitPanelOpen, setGitPanelOpen] = useState(false);
+  // #65 — 발자취 패널은 셸 소유. `<lg` 크롬 타일은 같은 런처로 그 패널을 연다.
+  const atlasGit = useAtlasGitLauncher();
   // Tauri 데스크톱이면 vault 절대 경로(브리지 활성), 웹 FSA 핸들이면 null →
   // 타일/패널이 세션 changeset 기반으로 정직하게 강등한다.
   const gitVaultPath = vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null;
   const handoffSource: "loaded-vault" | "read-only-sample" =
     vault.status === "loaded" ? "loaded-vault" : "read-only-sample";
-  // 레일 하단 설정 슬롯 — 발자취 타일 + 설정 기어를 한 fragment 로 등록.
-  // (perf/persistent-shell: 레일은 layout 상주, 이 페이지가 슬롯만 주입.)
+  // 레일 하단 설정 슬롯 — 지도 전용 화면 상태(screenControls)를 실어야 해서
+  // 이 페이지만 셸 기본 슬롯을 덮어쓴다. 발자취 타일은 #65 에서 셸(AppShell)로
+  // 올라갔다 — 페이지마다 등록해야 하는 구조가 하단 유틸 티어를 1/2/3 개로
+  // 갈라놓은 원인이었다.
   const navRailSettingsSlot = useMemo(
     () => (
       <>
-        {/* 슬라이스 C — 비개발(plain) 모드는 발자취(Atlas Git) 타일을 개발자
-            크롬으로 간주해 숨긴다. */}
-        {audiencePlain ? null : (
-          <GitStatusTile
-            onActivate={() => setGitPanelOpen(true)}
-            panelOpen={gitPanelOpen}
-            vaultPath={gitVaultPath}
-            sessionDirty={ontologyChangeset.touchedNodeIds.size > 0}
-          />
-        )}
         {/* 설정 통합 2026-07-24 — 구 "지도 설정" 팝오버(TopologyV2SettingsGear)
             폐지. 톱니는 이제 단일 설정 시트(AppSettingsMenu)를 연다. 지도
             전용 화면 상태(보기 모드·INDEX 기본 상태)는 screenControls 로
@@ -703,7 +681,6 @@ export function HomePage() {
       handleChangeIndexDefaultCollapsed,
       audiencePlain,
       setAudiencePlain,
-      gitPanelOpen,
       gitVaultPath,
       ontologyChangeset,
       vault.status,
@@ -2943,11 +2920,11 @@ export function HomePage() {
                     {audiencePlain ? null : (
                       <button
                         type="button"
-                        onClick={() => setGitPanelOpen(true)}
+                        onClick={atlasGit.open}
                         aria-label={tAtlasGit('tileLabel')}
                         title={tAtlasGit('tileLabel')}
                         aria-haspopup="dialog"
-                        aria-expanded={gitPanelOpen}
+                        aria-expanded={atlasGit.isOpen}
                         data-testid="topology-footprint-lg-tile"
                         className="relative lg:hidden flex size-[var(--chrome-tile-size)] items-center justify-center rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[color:var(--chrome-surface)] text-[color:var(--color-text-tertiary)] shadow-[var(--chrome-shadow)] transition-colors hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)]"
                       >
@@ -4070,27 +4047,6 @@ export function HomePage() {
         {/* 발자취(Atlas Git) 시트 — 레일 타일이 연다. AgentConnectSheet 와
             같은 scrim+중앙 카드 모달 골격(같은 토큰, modality 증명 — 스크림
             클릭 닫기). 패널 내용/조회는 위젯 자기완결. */}
-        {gitPanelOpen ? (
-          <div
-            data-interactive-overlay="true"
-            data-testid="atlas-git-scrim"
-            className="pointer-events-auto fixed inset-0 z-50 flex items-stretch justify-center bg-[color:var(--color-backdrop-medium)] sm:items-center sm:p-6"
-            onClick={() => setGitPanelOpen(false)}
-          >
-            <div
-              role="dialog"
-              aria-modal="true"
-              onClick={(event) => event.stopPropagation()}
-              className="flex h-[calc(100dvh-var(--topology-mobile-bottom-tab-reserve))] w-full flex-col overflow-y-auto border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] shadow-2xl sm:h-auto sm:max-h-[calc(100vh-3rem)] sm:max-w-[560px] sm:rounded-[var(--topology-shortcut-sheet-radius)]"
-            >
-              <AtlasGitPanel
-                vaultPath={gitVaultPath}
-                sessionChangeset={ontologyChangeset}
-                onClose={() => setGitPanelOpen(false)}
-              />
-            </div>
-          </div>
-        ) : null}
         <AgentConnectSheet
           open={agentConnect.open}
           onClose={() => {

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -237,7 +237,12 @@ export function AppNavRail({
         </ul>
       </nav>
 
-      <div className="mt-auto flex w-full flex-col items-center gap-1 pt-2">
+      {/* #65 — 하단 유틸 티어. 이 안의 구성(활동 · 발자취 · 설정)은 모든 화면에서
+          같아야 한다 — 셸(AppShell)이 소유하며 페이지가 등록하지 않는다. */}
+      <div
+        data-testid="app-nav-rail-utility-tier"
+        className="mt-auto flex w-full flex-col items-center gap-1 pt-2"
+      >
         {/* 에이전트 타일 — 클릭 가능. 연결됨: 활동 다이제스트(인사이트)로,
             미연결/stale: 연결 시트를 연다(P4-② 분기, AppShell 이 라우팅).
             aria: 미연결일 때만 dialog 를 여므로 그때만 haspopup/expanded. */}


### PR DESCRIPTION
## Summary

소유자 실보고: *"모든 페이지에서 다 똑같이 하단에 아이콘이 3개여야 하는데 왜 1개만 나옴? 이건 모든 페이지 봐줘야할듯."*

### 실측

| 화면 | 하단 유틸 타일 |
|---|---|
| 지도 | 3 (활동 · 발자취 · 설정) |
| 문서함 · 인사이트 · 프로젝트 | 2 (활동 · 설정) |
| **공방** | **1 (활동만)** |

원인은 페이지가 `useNavRailSettingsSlot` 으로 **손수 등록**하는 구조 — 공방이 등록을 빠뜨렸고, 발자취 타일은 애초에 지도 전용이었다. **페이지가 기억해야 하는 것은 언젠가 잊힌다.**

### 고친 것

- **셸(`AppShell`)이 유틸 티어를 소유**한다. 페이지는 특별한 슬롯이 필요할 때만 덮어쓰고(지도의 `screenControls`), 발자취는 항상 셸이 붙인다.
- **`audience-preference`** — plain 모드를 공용 스토어로 승격. 셸과 지도가 각자 localStorage 를 읽던 구조라, 설정에서 바꾸면 한쪽만 갱신되는 drift 가 났다.
- **`atlas-git-launcher`** (shared) — 발자취 패널을 여는 전역 의도. `<lg` 에서는 레일이 숨으므로 지도의 크롬 타일이 **같은 패널**을 연다(패널 복제 없음). 프로바이더는 app, 소비자는 views 라 계약만 shared 로 내렸다(FSD).
- 패널 본체는 **열렸을 때만 마운트**한다 — 닫힌 채로 changeset 을 계산하면 모든 페이지의 모든 렌더에서 그래프를 훑는 낭비가 된다.

## Test plan

- **실브라우저 5개 라우트 전부 3개 확인** (`/topology` `/docs` `/ontology/studio` `/ontology/insights` `/projects` → `app-nav-rail-agent-status` + `app-nav-rail-git-tile` + 설정 `<details>`)
- `pnpm exec vitest run src/app src/views/home src/widgets/app-nav-rail src/shared/lib` — **859/859**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — **error 0** (FSD 경계 포함)
- 회귀 테스트 **5건 신규**: 공용 스토어 4 + 셸 티어 1(슬롯 미주입 화면에서도 3개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr