### PR TITLE
fix: 공방 검색이 canonical title 까지 본다 (#66)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -162,7 +162,8 @@
       "reasonTitleSimilar": "Similar name",
       "reasonAdjacent": "Neighbor of a neighbor",
       "browseBack": "← Domains",
-      "browseNoDomain": "No domain"
+      "browseNoDomain": "No domain",
+      "browseEmpty": "No nodes to link yet — start with “Create new” below"
     },
     "fillSaved": "Linked and saved ‘{title}’.",
     "fillCopied": "Copied the MCP command — paste it into your agent to run.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -162,7 +162,8 @@
       "reasonTitleSimilar": "이름 비슷",
       "reasonAdjacent": "이웃의 이웃",
       "browseBack": "← 도메인",
-      "browseNoDomain": "도메인 없음"
+      "browseNoDomain": "도메인 없음",
+      "browseEmpty": "이 문서함엔 아직 이을 노드가 없어요 — 아래 ‘새로 만들기’ 로 시작해요"
     },
     "fillSaved": "‘{title}’ 를 이어 저장했어요.",
     "fillCopied": "MCP 명령을 복사했어요 — 에이전트에 붙여넣어 실행하세요.",

--- a/src/views/ontology-studio/lib/build-create-node.ts
+++ b/src/views/ontology-studio/lib/build-create-node.ts
@@ -64,7 +64,14 @@ export const RELATION_EDGE_TYPE: Record<Exclude<CreateRelationType, "isA">, stri
 export interface CreateCandidate {
   /** Graph node id, e.g. `capability:mcp-server`. */
   id: string;
+  /** 화면에 보이는 이름 — 현재 로케일의 표시 이름(`display ?? title`). */
   title: string;
+  /**
+   * frontmatter 의 canonical `title` — 검색/매칭의 단일 진실원(AGENTS.md).
+   * 표시 이름은 화면용 레이어라 매칭 범위를 줄여서는 안 된다(#66). 구 후보와의
+   * 하위 호환을 위해 optional.
+   */
+  canonicalTitle?: string;
   kind: string;
   /** Folder-prefixed ref the derivation resolves, e.g. `capabilities/mcp-server`. */
   ref: string;
@@ -115,7 +122,15 @@ export function candidateFromNode(node: {
   const prefix = `${node.kind}:`;
   const tail = node.id.startsWith(prefix) ? node.id.slice(prefix.length) : slugify(node.id);
   const ref = `${vaultFolderForKind(node.kind)}/${tail || slugify(node.title)}`;
-  return { id: node.id, title: node.display ?? node.title, kind: node.kind, ref };
+  return {
+    id: node.id,
+    title: node.display ?? node.title,
+    // 표시 이름과 별개로 원문을 함께 싣는다 — 예전엔 여기서 버려져 `display_ko`
+    // 가 달린 노드를 원문 title 로 검색할 수 없었다(#66).
+    canonicalTitle: node.title,
+    kind: node.kind,
+    ref,
+  };
 }
 
 /** Whether `kind` expects a parent domain (capability / element). */

--- a/src/views/ontology-studio/lib/match-candidate.test.ts
+++ b/src/views/ontology-studio/lib/match-candidate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import type { CreateCandidate } from "./build-create-node";
+import { candidateMatches, normalizeForMatch } from "./match-candidate";
+
+const LOCALIZED: CreateCandidate = {
+  id: "element:example-element",
+  // 화면에 보이는 이름(현재 로케일).
+  title: "예시 구성요소",
+  // frontmatter 의 단일 진실원.
+  canonicalTitle: "Example element",
+  kind: "element",
+  ref: "elements/example-element",
+};
+
+describe("normalizeForMatch", () => {
+  it("대소문자·앞뒤 공백·연속 공백을 접는다", () => {
+    expect(normalizeForMatch("  Example   ELEMENT ")).toBe("example element");
+  });
+
+  it("NFD 로 들어온 한글을 NFC 로 모은다 — 로컬 vault 파일명/클립보드 대비", () => {
+    const nfd = "예시".normalize("NFD");
+    expect(normalizeForMatch(nfd)).toBe("예시");
+  });
+});
+
+describe("candidateMatches", () => {
+  it("빈 검색어는 모두 통과 — 발견-우선 목록을 가리지 않는다", () => {
+    expect(candidateMatches(LOCALIZED, "")).toBe(true);
+    expect(candidateMatches(LOCALIZED, "   ")).toBe(true);
+  });
+
+  // #66 의 핵심: 예전엔 표시 이름만 봐서 원문으로는 못 찾았다.
+  it("canonical title 로 찾는다 — 표시 이름이 다른 언어여도", () => {
+    expect(candidateMatches(LOCALIZED, "Example element")).toBe(true);
+    expect(candidateMatches(LOCALIZED, "example ELEMENT")).toBe(true);
+  });
+
+  it("표시 이름으로도 찾는다 — 기존 동작 유지", () => {
+    expect(candidateMatches(LOCALIZED, "예시")).toBe(true);
+  });
+
+  it("ref 슬러그로도 찾는다", () => {
+    expect(candidateMatches(LOCALIZED, "elements/example")).toBe(true);
+  });
+
+  it("한글 NFD 입력도 찾는다", () => {
+    expect(candidateMatches(LOCALIZED, "예시 구성요소".normalize("NFD"))).toBe(true);
+  });
+
+  it("아무 데도 없는 말은 안 찾는다", () => {
+    expect(candidateMatches(LOCALIZED, "환불")).toBe(false);
+  });
+
+  it("canonicalTitle 이 없는(구) 후보도 표시 이름/ref 로 동작한다", () => {
+    const legacy = { ...LOCALIZED, canonicalTitle: undefined } as unknown as CreateCandidate;
+    expect(candidateMatches(legacy, "예시")).toBe(true);
+    expect(candidateMatches(legacy, "Example element")).toBe(false);
+  });
+});

--- a/src/views/ontology-studio/lib/match-candidate.ts
+++ b/src/views/ontology-studio/lib/match-candidate.ts
@@ -1,0 +1,30 @@
+import type { CreateCandidate } from "./build-create-node";
+
+/**
+ * 공방 소켓 피커의 후보 매칭 (#66).
+ *
+ * 결함: `candidateFromNode` 가 `title: node.display ?? node.title` 로 **canonical
+ * title 을 버렸고**, 피커 필터는 그 display 와 `ref` 만 봤다. 그래서
+ * `display_ko: 예시 구성요소` 가 달린 노드는 원문 `Example element` 로 검색해도
+ * 나오지 않았다 — ref 슬러그(`elements/example-element`)에는 공백이 없어 부분
+ * 일치도 실패한다 (opus5 검수 2026-07-25 · codex 감사 P2).
+ *
+ * AGENTS.md 계약: "title 은 검색/매칭의 단일 진실원". 표시 이름은 화면용 레이어일
+ * 뿐 매칭 범위를 **줄여서는 안 된다**. 그래서 후보는 표시 이름과 canonical title
+ * 을 함께 들고, 매칭은 둘 다(+ ref) 를 본다.
+ *
+ * 정규화: NFC → 소문자 → 앞뒤 공백 제거 → 연속 공백 1칸. 한글은 자소 분리(NFD)
+ * 로 들어오는 입력이 있어 NFC 정규화가 필요하다(로컬 vault 파일명 · macOS 클립보드).
+ */
+
+export function normalizeForMatch(value: string): string {
+  return value.normalize("NFC").toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+/** 이 후보가 검색어와 일치하는가. 빈 검색어는 모두 통과. */
+export function candidateMatches(candidate: CreateCandidate, query: string): boolean {
+  const q = normalizeForMatch(query);
+  if (q === "") return true;
+  const haystacks = [candidate.title, candidate.canonicalTitle, candidate.ref];
+  return haystacks.some((text) => text && normalizeForMatch(text).includes(q));
+}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -54,6 +54,7 @@ import { buildDeltaPreview } from "../lib/build-delta-preview";
 import { resolveStudioFocalId } from "../lib/resolve-studio-focal";
 import { studioHasDeepLinkIntent } from "../lib/entry-choice";
 import { allowedKindsFor } from "../lib/allowed-kinds";
+import { candidateMatches } from "../lib/match-candidate";
 import {
   clearStudioDraft,
   readStudioDraft,
@@ -192,6 +193,7 @@ export function OntologyStudioPage() {
       pickerSub: t("picker.sub"),
       pickerPlaceholder: t("picker.placeholder"),
       pickerEmpty: t("picker.empty"),
+      pickerBrowseEmpty: t("picker.browseEmpty"),
       pickerKind: (kindLabelText) => kindLabelText,
       pickerCreateNew: t("picker.createNew"),
       suggestHeading: t("picker.suggestHeading"),
@@ -321,11 +323,13 @@ export function OntologyStudioPage() {
       exclude: ReadonlySet<string>,
     ): CreateCandidate[] => {
       const allow = allowedKindsFor(relation, focalKind);
-      const q = query.trim().toLowerCase();
       return candidates
         .filter((c) => allow.has(c.kind))
         .filter((c) => !exclude.has(c.id))
-        .filter((c) => (q ? c.title.toLowerCase().includes(q) || c.ref.toLowerCase().includes(q) : true))
+        // #66 — 표시 이름뿐 아니라 canonical title 과 ref 까지 정규화해 본다.
+        // 예전엔 `c.title`(= display) 만 봐서 `display_ko` 가 달린 노드를 원문
+        // 이름으로 검색할 수 없었다.
+        .filter((c) => candidateMatches(c, query))
         .slice(0, 8);
     },
     [candidates],

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -28,6 +28,7 @@ const labels: StudioCompassLabels = {
   pickerSub: "sub",
   pickerPlaceholder: "search nodes",
   pickerEmpty: "empty",
+  pickerBrowseEmpty: "nothing to link yet",
   pickerKind: (k) => k,
   pickerCreateNew: "create new",
   suggestHeading: "Suggested",
@@ -1380,5 +1381,46 @@ describe("StudioCompass — 임시 표면 상호 배타 (#62)", () => {
     fireEvent.click(screen.getByTestId("studio-drafts-open"));
     expect(screen.getByTestId("studio-drafts-panel")).toBeInTheDocument();
     expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+  });
+});
+
+// #66 — 검색 전 빈 상태는 "맞는 노드가 없어요" 가 아니다. 아직 아무것도 찾지
+// 않았는데 없다고 단정하면 거짓말이고, 사용자는 다음에 뭘 할지 모른다.
+describe("StudioCompass — 피커 빈 상태 구분 (#66)", () => {
+  const EMPTY_DISCOVERY: PickerDiscovery = { suggestions: [], domains: [], nodesByDomain: {} };
+
+  function renderPicker(over: Partial<Parameters<typeof StudioCompass>[0]> = {}) {
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "MCP Server", definition: "def" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right"),
+          bearing("contains", "down"),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={0}
+        writable
+        candidatesFor={() => []}
+        discoveryFor={() => EMPTY_DISCOVERY}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+        {...over}
+      />,
+    );
+  }
+
+  it("검색 전인데 이을 후보가 없으면 다음 행동을 안내한다 — '없어요' 로 끝내지 않는다", () => {
+    renderPicker();
+    fireEvent.click(screen.getByTestId("studio-socket-up"));
+
+    expect(screen.getByTestId("studio-picker-browse-empty")).toHaveTextContent(
+      "nothing to link yet",
+    );
+    expect(screen.queryByText("empty")).not.toBeInTheDocument();
   });
 });

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -14,6 +14,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
+import { candidateMatches } from "../lib/match-candidate";
 import { usePrefersReducedMotion } from "@/shared/lib/use-prefers-reduced-motion";
 import { Select } from "@/shared/ui";
 import type {
@@ -116,7 +117,9 @@ export interface StudioCompassLabels {
   pickerTitle: (question: string) => string;
   pickerSub: string;
   pickerPlaceholder: string;
-  pickerEmpty: string;
+  pickerEmpty: string; // 검색했는데 결과가 없을 때
+  /** 검색 전(빈 질의)인데 둘러볼 후보조차 없을 때 — "없다" 가 아니라 "시작하는 법". */
+  pickerBrowseEmpty: string;
   pickerKind: (kindLabel: string) => string;
   pickerCreateNew: string;
   // ── Slice 3 — 발견 표면 (browse + 추천) ──
@@ -2195,7 +2198,14 @@ function InlinePicker({
       <div className="overflow-y-auto p-1.5" style={{ maxHeight: listMax }} data-testid="studio-picker-body">
         {discovery ? (
           discovery.suggestions.length === 0 && discovery.domains.length === 0 ? (
-            <div className="px-3 py-3 text-center text-label text-[color:var(--color-text-quaternary)]">{labels.pickerEmpty}</div>
+            // #66 — 아직 검색하지 않았는데 "맞는 노드가 없어요" 는 거짓말이다.
+            // 검색 전 빈 상태는 다음 행동(새로 만들기)을 알려준다.
+            <div
+              data-testid="studio-picker-browse-empty"
+              className="px-3 py-3 text-center text-label leading-[1.6] text-[color:var(--color-text-quaternary)] [word-break:keep-all]"
+            >
+              {labels.pickerBrowseEmpty}
+            </div>
           ) : (
             <>
               {/* 추천 — up to 5 likely candidates, each with a muted reason. */}
@@ -2352,9 +2362,10 @@ function NodeSearch({
     );
   }
 
-  const q = query.trim().toLowerCase();
+
   const rows = nodes
-    .filter((n) => (q ? n.title.toLowerCase().includes(q) || n.ref.toLowerCase().includes(q) : true))
+    // #66 — 표시 이름 · canonical title · ref 를 함께 본다(정규화 포함).
+    .filter((n) => candidateMatches(n, query))
     .filter((n) => n.title !== currentName)
     .slice(0, 8);
 


### PR DESCRIPTION
## Summary

`candidateFromNode` 가 `title: node.display ?? node.title` 로 **canonical title 을 버렸고**, 피커 필터는 그 표시 이름과 `ref` 만 봤다. 그래서 `display_ko: 예시 구성요소` 가 달린 노드는 원문 `Example element` 로 검색해도 나오지 않았다 — ref 슬러그(`elements/example-element`)에는 공백이 없어 부분 일치도 실패한다.

AGENTS.md 계약: **"title 은 검색/매칭의 단일 진실원"**. 표시 이름은 화면용 레이어일 뿐 매칭 범위를 줄여서는 안 된다.

### 고친 것

- **`CreateCandidate.canonicalTitle`** — 표시 이름과 별개로 원문을 함께 싣는다.
- **`match-candidate`** — 표시 이름 · canonical title · ref 를 정규화해 매칭. NFC → 소문자 → 앞뒤 공백 → 연속 공백 1칸. 한글 NFD 입력(로컬 vault 파일명 · macOS 클립보드) 대비.
- **필터가 두 곳에 있었다** (컴포넌트 + 페이지 `makeCandidatesFor`). 실제로 걸러내던 쪽은 페이지였고, 컴포넌트만 고쳤을 때 브라우저에서 여전히 안 나와서 잡았다. 둘 다 같은 매처로 통일.
- **검색 전 빈 상태**를 "맞는 노드가 없어요" 와 분리. 아직 아무것도 찾지 않았는데 없다고 단정하는 건 거짓말이고 다음 행동도 안 알려준다 — 이제 `새로 만들기` 로 시작하라고 말한다.

## Test plan

- `pnpm exec vitest run src/views/ontology-studio` — **180/180**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — error 0
- 회귀 테스트 **10건 신규**: 정규화 2 + 매칭 7(canonical / 표시 / ref / NFD / 미스 / 구 후보 호환) + 빈 상태 1
- **실브라우저**: `MCP  SERVER`(대문자 + 연속 공백) 입력 → `MCP Server` 매칭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr