### PR TITLE
fix: 단축키 시트를 문맥 탭으로 — 과밀·하단 잘림 해소 (#67)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1489,6 +1489,10 @@
     --topology-shortcut-sheet-floating-width: 45rem;
     --topology-shortcut-sheet-radius: 22px;
     --topology-shortcut-sheet-close-size: 32px;
+    /* #67 — 스크롤 가능 신호(scroll edge). 목록이 잘려 보일 때 "여기서 끝" 이
+       아니라 "아래 더 있다" 로 읽히게 하는 아래쪽 페이드. 패널색 → 투명 한
+       단계뿐이라 장식 그라디언트가 아니며, 움직이지 않는다. */
+    --topology-shortcut-sheet-scroll-fade: 28px;
     --topology-bottom-tab-min-height: 56px;
     --topology-bottom-tab-surface: #08090a;
     --topology-bottom-tab-border: rgba(255, 255, 255, 0.09);

--- a/messages/en.json
+++ b/messages/en.json
@@ -755,6 +755,14 @@
         "focus": "focus",
         "modeToggle": "Planner/Dev",
         "queryCommandPrefix": "> "
+      },
+      "scope": {
+        "ariaLabel": "Shortcut scope",
+        "current": "This screen",
+        "topology": "Map",
+        "docs": "Docs",
+        "all": "All",
+        "emptyCurrent": "This screen has no dedicated shortcuts — the global ones above still work"
       }
     },
     "hero": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -755,6 +755,14 @@
         "focus": "focus",
         "modeToggle": "기획자/개발자",
         "queryCommandPrefix": "> "
+      },
+      "scope": {
+        "ariaLabel": "단축키 범위",
+        "current": "지금 화면",
+        "topology": "지도",
+        "docs": "문서함",
+        "all": "전체",
+        "emptyCurrent": "이 화면에는 전용 단축키가 없어요 — 위 전역 단축키를 쓰면 돼요"
       }
     },
     "hero": {

--- a/src/widgets/shortcut-sheet/lib/shortcut-scope.test.ts
+++ b/src/widgets/shortcut-sheet/lib/shortcut-scope.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sectionVisible,
+  sectionVisibleForCurrent,
+  surfaceForPathname,
+} from "./shortcut-scope";
+
+describe("surfaceForPathname", () => {
+  it("루트와 /topology 는 지도 표면", () => {
+    expect(surfaceForPathname("/")).toBe("topology");
+    expect(surfaceForPathname("/topology")).toBe("topology");
+    expect(surfaceForPathname("/ko/topology/")).toBe("topology");
+  });
+
+  it("/docs 는 문서함 표면", () => {
+    expect(surfaceForPathname("/docs")).toBe("docs");
+    expect(surfaceForPathname("/en/docs/")).toBe("docs");
+  });
+
+  // 공방/인사이트/프로젝트는 전용 단축키가 없다 — 없는 걸 있다고 하지 않는다.
+  it("전용 단축키가 없는 화면은 전역만", () => {
+    expect(surfaceForPathname("/ko/ontology/studio/")).toBe("global");
+    expect(surfaceForPathname("/ko/projects/")).toBe("global");
+  });
+});
+
+describe("sectionVisible", () => {
+  it("'전체' 탭은 모두 보여준다 — 분류로 정보를 잃지 않는다", () => {
+    expect(sectionVisible("all", "topology")).toBe(true);
+    expect(sectionVisible("all", "docs")).toBe(true);
+    expect(sectionVisible("all", "global")).toBe(true);
+  });
+
+  it("전역 단축키는 어느 탭에서도 남는다 — 지금 누를 수 있는 키가 사라지면 안 된다", () => {
+    expect(sectionVisible("topology", "global")).toBe(true);
+    expect(sectionVisible("docs", "global")).toBe(true);
+  });
+
+  it("표면 탭은 그 표면만", () => {
+    expect(sectionVisible("topology", "topology")).toBe(true);
+    expect(sectionVisible("topology", "docs")).toBe(false);
+    expect(sectionVisible("docs", "topology")).toBe(false);
+  });
+});
+
+describe("sectionVisibleForCurrent", () => {
+  it("지도에서는 전역 + 지도", () => {
+    expect(sectionVisibleForCurrent("topology", "global")).toBe(true);
+    expect(sectionVisibleForCurrent("topology", "topology")).toBe(true);
+    expect(sectionVisibleForCurrent("topology", "docs")).toBe(false);
+  });
+
+  it("전용 단축키가 없는 화면에서는 전역만", () => {
+    expect(sectionVisibleForCurrent("global", "global")).toBe(true);
+    expect(sectionVisibleForCurrent("global", "topology")).toBe(false);
+    expect(sectionVisibleForCurrent("global", "docs")).toBe(false);
+  });
+});

--- a/src/widgets/shortcut-sheet/lib/shortcut-scope.ts
+++ b/src/widgets/shortcut-sheet/lib/shortcut-scope.ts
@@ -1,0 +1,53 @@
+/**
+ * 단축키 시트의 **문맥 범위** (#67).
+ *
+ * 결함: 8개 섹션 40여 행을 2열로 한 번에 쏟아, 1512×900 에서 다이얼로그가
+ * 852px(뷰포트의 95%)를 먹고 하단이 잘려 보였다. 스크롤 가능 여부 신호도 없었다
+ * (opus5 검수 2026-07-25 실측 · codex 감사 P2).
+ *
+ * 해법은 **숨기기가 아니라 분류**다 — 단축키를 지우면 발견 가능성이 사라지므로,
+ * 지금 화면에서 실제로 쓸 수 있는 것을 먼저 보여주고 나머지는 탭 뒤에 둔다.
+ * `전체` 탭은 종전처럼 모두 보여주므로 잃는 정보가 없다.
+ */
+
+export type ShortcutSurface = "global" | "topology" | "docs";
+
+/** 시트 탭. `current` 는 지금 화면 + 전역, `all` 은 종전 전체 목록. */
+export type ShortcutScope = "current" | "topology" | "docs" | "all";
+
+export const SHORTCUT_SCOPES: readonly ShortcutScope[] = ["current", "topology", "docs", "all"];
+
+/**
+ * 지금 보고 있는 라우트의 표면. locale prefix 는 벗겨서 판정한다.
+ * 공방/인사이트/프로젝트처럼 전용 단축키가 없는 화면은 `global` —
+ * "지금 화면" 탭이 전역 단축키만 보여주는 것이 정직하다.
+ */
+export function surfaceForPathname(pathname: string): ShortcutSurface {
+  const normalized = pathname.replace(/^\/(?:en|ko)(?=\/|$)/, "") || "/";
+  if (normalized === "/" || normalized.startsWith("/topology")) return "topology";
+  if (normalized.startsWith("/docs")) return "docs";
+  return "global";
+}
+
+/**
+ * 이 범위에서 이 섹션을 보여줄 것인가.
+ * `current` 는 지금 화면 표면을 알아야 하므로 `sectionVisibleForCurrent` 를 쓴다.
+ */
+export function sectionVisible(
+  scope: Exclude<ShortcutScope, "current">,
+  surface: ShortcutSurface,
+): boolean {
+  if (scope === "all") return true;
+  // 전역 단축키(⌘K · ? · Esc)는 어느 탭에서도 유효하므로 항상 남긴다 —
+  // 탭을 바꿨다고 "지금 누를 수 있는 키" 가 사라지면 안 된다.
+  if (surface === "global") return true;
+  return scope === surface;
+}
+
+/** `current` 탭에서 보여줄 섹션 판정 — 지금 화면의 표면 + 전역. */
+export function sectionVisibleForCurrent(
+  currentSurface: ShortcutSurface,
+  surface: ShortcutSurface,
+): boolean {
+  return surface === "global" || surface === currentSurface;
+}

--- a/src/widgets/shortcut-sheet/ui/ShortcutSheet.test.tsx
+++ b/src/widgets/shortcut-sheet/ui/ShortcutSheet.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/i18n/navigation", () => ({
+  usePathname: () => "/topology",
+}));
 import enMessages from "../../../../messages/en.json";
 import { ShortcutSheet } from "./ShortcutSheet";
 
@@ -62,5 +66,61 @@ describe("ShortcutSheet — kind glossary (P1a-2)", () => {
     expect(
       screen.getByText("A piece of code or a doc that implements it"),
     ).toBeInTheDocument();
+  });
+});
+
+
+// #67 — 40여 행을 2열로 한 번에 쏟아 1512×900 에서 다이얼로그가 뷰포트의 95%
+// (852px)를 먹고 하단이 잘렸다. 해법은 **숨기기가 아니라 분류** — `전체` 탭이
+// 종전 목록을 그대로 유지하므로 발견 가능성을 잃지 않는다.
+describe("ShortcutSheet — 문맥 탭 (#67)", () => {
+  it("기본은 '지금 화면' — 지도에서는 문서함 섹션이 나오지 않는다", () => {
+    renderSheet();
+
+    expect(screen.getByTestId("shortcut-sheet-scope-current")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    // 지도 표면 + 전역은 보인다.
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.topology)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.navigation)).toBeInTheDocument();
+    // 문서함 전용 섹션은 이 탭에 없다.
+    expect(
+      screen.queryByText(enMessages.searchWidgets.shortcuts.sections.docsPalette),
+    ).not.toBeInTheDocument();
+  });
+
+  it("'전체' 탭은 모든 섹션을 되살린다 — 단축키를 숨겨 과밀을 회피하지 않는다", () => {
+    renderSheet();
+    fireEvent.click(screen.getByTestId("shortcut-sheet-scope-all"));
+
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.docsPalette)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.docsGraph)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.topology)).toBeInTheDocument();
+  });
+
+  it("문서함 탭에서도 전역 단축키는 남는다 — 지금 누를 수 있는 키가 사라지면 안 된다", () => {
+    renderSheet();
+    fireEvent.click(screen.getByTestId("shortcut-sheet-scope-docs"));
+
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.navigation)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.searchWidgets.shortcuts.sections.docsPalette)).toBeInTheDocument();
+    expect(
+      screen.queryByText(enMessages.searchWidgets.shortcuts.sections.topology),
+    ).not.toBeInTheDocument();
+  });
+
+  it("탭 바와 닫기 버튼은 스크롤 영역 밖에 고정된다", () => {
+    renderSheet();
+    const tabs = screen.getByTestId("shortcut-sheet-scope-tabs");
+    const scroll = screen.getByTestId("shortcut-sheet-scroll");
+
+    expect(scroll.contains(tabs)).toBe(false);
+    expect(scroll.contains(screen.getByTestId("shortcut-sheet-close"))).toBe(false);
+  });
+
+  it("스크롤 여지를 알리는 아래쪽 페이드가 있다", () => {
+    renderSheet();
+    expect(screen.getByTestId("shortcut-sheet-scroll-fade")).toBeInTheDocument();
   });
 });

--- a/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
+++ b/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 import { MOTION } from "@/shared/motion";
 import { useBodyScrollLock } from "@/shared/lib/use-body-scroll-lock";
+import { usePathname } from "@/i18n/navigation";
+import { cn } from "@/shared/lib/cn";
+import {
+  SHORTCUT_SCOPES,
+  sectionVisible,
+  sectionVisibleForCurrent,
+  surfaceForPathname,
+  type ShortcutScope,
+  type ShortcutSurface,
+} from "../lib/shortcut-scope";
 
 interface Props {
   open: boolean;
@@ -21,6 +31,8 @@ interface ShortcutRow {
 
 interface ShortcutSection {
   titleKey: string;
+  /** 이 섹션이 유효한 표면 — 문맥 탭 분류의 진실원(#67). */
+  surface: ShortcutSurface;
   rows: ShortcutRow[];
 }
 
@@ -37,6 +49,7 @@ const GLOSSARY_TERMS = ["domain", "capability", "element"] as const;
 const SECTIONS: ShortcutSection[] = [
   {
     titleKey: "navigation",
+    surface: "global",
     rows: [
       { keys: ["⌘", "K"], labelKey: "openProjectPalette" },
       { keys: ["⇧", "⌘", "K"], labelKey: "openGlobalPalette" },
@@ -54,6 +67,7 @@ const SECTIONS: ShortcutSection[] = [
     // 드래그(팬/노드 이동) · 휠 줌 · ⌘K 검색 · Esc 사다리 · 우클릭 메뉴(W2-B,
     // now real).
     titleKey: "topology",
+    surface: "topology",
     rows: [
       { keys: [k("click")], labelKey: "clickSelect" },
       { keys: [k("drag")], labelKey: "dragPan" },
@@ -65,6 +79,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "searchPalette",
+    surface: "global",
     rows: [
       { keys: ["↑", "↓"], labelKey: "moveBetweenResults" },
       { keys: ["↵"], labelKey: "openSelectedProject" },
@@ -73,6 +88,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "hubRail",
+    surface: "topology",
     rows: [
       { keys: ["↑", "↓"], labelKey: "prevHub" },
       { keys: ["Home"], labelKey: "firstHub" },
@@ -81,6 +97,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "docsPalette",
+    surface: "docs",
     rows: [
       { keys: ["⌘", "K"], labelKey: "openPaletteSearchCmdTag" },
       { keys: ["⌘", "P"], labelKey: "openPaletteAlias" },
@@ -97,6 +114,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "docsGraph",
+    surface: "docs",
     rows: [
       { keys: [k("click")], labelKey: "clickGraphNode" },
       { keys: [k("drag")], labelKey: "dragGraphNode" },
@@ -107,6 +125,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "docsSource",
+    surface: "docs",
     rows: [
       { keys: [k("server")], labelKey: "serverBundle" },
       { keys: [k("local")], labelKey: "localVault" },
@@ -116,6 +135,7 @@ const SECTIONS: ShortcutSection[] = [
   },
   {
     titleKey: "docsActions",
+    surface: "docs",
     rows: [
       { keys: ["⭐"], labelKey: "pinDoc" },
       { keys: ["🔗"], labelKey: "copyDocUrl" },
@@ -130,10 +150,34 @@ const SECTIONS: ShortcutSection[] = [
 
 export function ShortcutSheet({ open, onClose }: Props) {
   const t = useTranslations("searchWidgets.shortcuts");
+  const pathname = usePathname() ?? "/";
+  const currentSurface = surfaceForPathname(pathname);
+  // #67 — 문맥 탭. 기본은 "지금 화면" — 40여 행을 한 번에 쏟는 대신 지금 실제로
+  // 누를 수 있는 것부터 보여준다. `전체` 탭이 종전 목록을 그대로 유지하므로
+  // 단축키를 숨겨서 과밀을 회피하는 것이 아니다.
+  const [scope, setScope] = useState<ShortcutScope>("current");
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useBodyScrollLock(open);
+
+  const visibleSections = useMemo(
+    () =>
+      SECTIONS.filter((section) =>
+        scope === "current"
+          ? sectionVisibleForCurrent(currentSurface, section.surface)
+          : sectionVisible(scope, section.surface),
+      ),
+    [scope, currentSurface],
+  );
+  /** 지금 화면 탭인데 전역 섹션밖에 없을 때 — 그 사실을 조용히 알려준다. */
+  const currentHasOwnSections =
+    scope !== "current" || visibleSections.some((s) => s.surface !== "global");
+
+  useEffect(() => {
+    if (!open) return;
+    setScope("current");
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -242,11 +286,42 @@ export function ShortcutSheet({ open, onClose }: Props) {
               </button>
             </header>
 
-            <div className="flex-1 overflow-y-auto">
+            {/* #67 — 문맥 탭. 헤더와 함께 고정(shrink-0)이라 스크롤해도 항상
+                보인다: 지금 어느 범위를 보고 있고 어디로 갈 수 있는지. */}
+            <div
+              role="tablist"
+              aria-label={t("scope.ariaLabel")}
+              data-testid="shortcut-sheet-scope-tabs"
+              className="flex shrink-0 items-center gap-1 border-b border-[color:var(--color-border-soft)] px-5 py-2.5"
+            >
+              {SHORTCUT_SCOPES.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  role="tab"
+                  aria-selected={scope === key}
+                  data-testid={`shortcut-sheet-scope-${key}`}
+                  onClick={() => setScope(key)}
+                  className={cn(
+                    "h-[var(--control-h-sm)] rounded-md px-2.5 text-label transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]",
+                    scope === key
+                      ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--color-text-primary)]"
+                      : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-secondary)]",
+                  )}
+                >
+                  {t(`scope.${key}`)}
+                </button>
+              ))}
+            </div>
+
+            {/* #67 — 목록 영역. 스크롤이 남았을 때 아래쪽에 한 단계 페이드를
+                깔아 "여기서 끝" 이 아니라 "더 있다" 로 읽히게 한다. */}
+            <div className="relative min-h-0 flex-1">
+              <div className="h-full overflow-y-auto" data-testid="shortcut-sheet-scroll">
               {/* sm+ 는 2-column grid 로 펼쳐 세로 길이 줄임. 작은 뷰포트는
                   단일 컬럼 + 내부 스크롤로 넘침 방지. */}
               <div className="grid grid-cols-1 gap-x-6 divide-y divide-[color:var(--color-overlay-2)] sm:grid-cols-2 sm:divide-x sm:divide-y-0">
-                {SECTIONS.map((section, idx) => (
+                {visibleSections.map((section, idx) => (
                   <section
                     key={section.titleKey}
                     className={
@@ -286,6 +361,24 @@ export function ShortcutSheet({ open, onClose }: Props) {
                   </section>
                 ))}
               </div>
+                {!currentHasOwnSections ? (
+                  <p
+                    data-testid="shortcut-sheet-current-empty"
+                    className="px-5 pb-4 text-label leading-[1.6] text-[color:var(--color-text-quaternary)] [word-break:keep-all]"
+                  >
+                    {t("scope.emptyCurrent")}
+                  </p>
+                ) : null}
+              </div>
+              <div
+                aria-hidden
+                data-testid="shortcut-sheet-scroll-fade"
+                className="pointer-events-none absolute inset-x-0 bottom-0 h-[var(--topology-shortcut-sheet-scroll-fade)]"
+                style={{
+                  background:
+                    "linear-gradient(to top, var(--color-panel), transparent)",
+                }}
+              />
             </div>
 
             <footer className="shrink-0 border-t border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-5 py-3">


### PR DESCRIPTION
## Summary

1512×900 에서 다이얼로그가 **852px(뷰포트의 95%)** 를 먹고, 8개 섹션 40여 행을 2열로 한 번에 쏟아 하단이 잘려 보였다. 스크롤 가능 여부 신호도 없었다.

**해법은 숨기기가 아니라 분류** — 단축키를 지우면 발견 가능성이 사라진다.

- **`shortcut-scope`** — 섹션마다 유효한 표면(`global`/`topology`/`docs`)을 태깅하고, 라우트에서 지금 화면의 표면을 판정한다.
- **문맥 탭 4개**: `지금 화면`(기본) · `지도` · `문서함` · `전체`.
  - 전역 단축키(⌘K · `?` · Esc)는 **어느 탭에서도 남는다** — 탭을 바꿨다고 지금 누를 수 있는 키가 사라지면 안 된다.
  - **`전체` 탭은 종전 목록 그대로** — 잃는 정보가 없다.
- 탭 바와 닫기 버튼은 **스크롤 영역 밖에 고정**(`shrink-0`). 스크롤 여지는 패널색 → 투명 **한 단계 페이드**로 알린다(`--topology-shortcut-sheet-scroll-fade`). 움직이지 않고 색 하나만 쓰므로 장식 그라디언트가 아니다.
- 전용 단축키가 없는 화면(공방·인사이트·프로젝트)에서는 그 사실을 조용히 적는다 — 없는 걸 있는 척하지 않는다.

### 실측 (1512 지도)

| | before | after |
|---|---|---|
| 다이얼로그 높이 | 852px (뷰포트 95%) | **641px (79%)** |
| 첫 화면 섹션 수 | 8 | **4** (탐색·지형도·검색 팔레트·허브 레일) |
| 하단 잘림 | 있음 | 없음 |
| 스크롤 신호 | 없음 | edge fade |

## Test plan

- `pnpm exec vitest run src/widgets src/views/home` — **1443/1443**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — error 0
- 회귀 테스트 **13건 신규**: 범위 판정 8 + 시트 탭 5(기본 탭 / 전체 복원 / 전역 유지 / 고정 크롬 / 페이드)
- **실브라우저 1512**: 탭 전환·스크롤·높이 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr