### PR TITLE
fix: 공방 지지대가 레인 라벨을 관통하지 않게 + 완성도 인디케이터 가독성·모션 (#69)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2356,7 +2356,22 @@
   }
 
   /* 접근성: 모션 감소 선호 사용자 존중 */
-  @media (prefers-reduced-motion: reduce) {
+  /* #69 — 완성도 인디케이터 점. 채워지는 순간 색·반지름이 200ms 로 확정 전이해
+   "방금 하나 찼다" 가 움직임으로 읽힌다. glow 가 아니라 값(색·크기) 전이다. */
+.studio-rose-pip {
+  transition:
+    fill var(--motion-settle, 200ms) ease-out,
+    stroke var(--motion-settle, 200ms) ease-out,
+    r var(--motion-settle, 200ms) ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .studio-rose-pip {
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
     *,
     *::before,
     *::after {

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -1424,3 +1424,57 @@ describe("StudioCompass — 피커 빈 상태 구분 (#66)", () => {
     expect(screen.queryByText("empty")).not.toBeInTheDocument();
   });
 });
+
+// #69 — 지지대 축과 레인 라벨 · 완성도 인디케이터 가독성.
+// 소유자 실보고: "파란선에 글자가 겹쳐져서 뭔가 이상하지? 가로질러서?" /
+// "이것도 잘 안 보여.. 좀 더 잘보이게하고 그리고 반짝반짝 빛나면 좋을듯?"
+// (정정: 발광이 아니라 "적절히 표현 + 모션" — 헌장의 glow 금지는 그대로.)
+describe("StudioCompass — 지지대 축·완성도 인디케이터 (#69)", () => {
+  function renderCue() {
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "MCP Server", definition: "def" }}
+        bearings={[
+          bearing("isA", "up", { recommended: true }),
+          bearing("dependsOn", "right", {
+            filled: true,
+            neighbors: [{ id: "el:x", title: "Parser", kind: "element", ref: "elements/parser" }],
+          }),
+          bearing("contains", "down", {
+            filled: true,
+            neighbors: [{ id: "el:y", title: "Absorb", kind: "element", ref: "elements/absorb" }],
+          }),
+          bearing("relates", "left"),
+        ]}
+        filledBearings={2}
+        writable
+        candidatesFor={() => []}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+      />,
+    );
+  }
+
+  it("완성도 인디케이터가 4방위 점을 모두 그리고 전이 클래스를 단다", () => {
+    renderCue();
+    const cue = screen.getByTestId("studio-flow-cue");
+    const svg = cue.querySelector("svg");
+
+    expect(svg).not.toBeNull();
+    // 채운 방위는 강조 링 + 본체 2겹이라 점 개수는 4보다 많다.
+    expect(svg!.querySelectorAll(".studio-rose-pip").length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("인디케이터에 glow/halo 계열 그림자를 쓰지 않는다 (헌장)", () => {
+    renderCue();
+    const svg = screen.getByTestId("studio-flow-cue").querySelector("svg");
+    // glow 는 box-shadow `0 0 …` 또는 SVG filter(blur/glow)로 들어온다.
+    expect(svg!.outerHTML).not.toMatch(/box-shadow/i);
+    expect(svg!.outerHTML).not.toMatch(/filter=/i);
+    expect(svg!.outerHTML).not.toMatch(/feGaussianBlur/i);
+  });
+});

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -2038,15 +2038,23 @@ function clampY(y: number, h: number): number {
   return Math.min(Math.max(y, 8), Math.max(8, BOARD.h - h - 8));
 }
 
+/** 세로 레인 라벨이 지지대 축에서 비켜서는 간격(#69). */
+const LANE_HEAD_AXIS_GAP = 10;
+
 function laneHeadPos(view: CompassBearingView, layout: LaneLayout): React.CSSProperties {
   if (view.bearing === "right") return { left: layout.sats[0]?.x ?? 0, top: (layout.sats[0]?.y ?? CY) - 20 };
   if (view.bearing === "left") return { left: layout.sats[0]?.x ?? 0, top: (layout.sats[0]?.y ?? CY) - 20 };
-  if (view.bearing === "up") return { left: CX - 60, top: (layout.sats[0]?.y ?? 0) - 20 };
+  // #69 — 세로 레인(up/down)의 지지대는 `CX` 축을 타고 흐른다. 라벨을 CX 중앙에
+  // 놓으면 그 선이 글자를 **가로지른다**(소유자 실보고: "파란선에 글자가
+  // 겹쳐져서 뭔가 이상하지? 가로질러서?"). 선 뒤로 넣어도 글자 사이로 비쳐
+  // 읽히므로, 라벨을 축 오른쪽으로 비켜 세워 애초에 교차하지 않게 한다 —
+  // 선로 옆 표지판 문법.
+  if (view.bearing === "up") return { left: CX + LANE_HEAD_AXIS_GAP, top: (layout.sats[0]?.y ?? 0) - 20 };
   // #94/#95 — DOWN lane head sat BELOW the last satellite (+6), landing on top
   // of the fold chip ("+90 more", +12) → collision. Mirror the UP lane: place
   // the header ABOVE the topmost DOWN satellite (in the clear gap between the
   // card and the stack) so it never overlaps the fold/add-chip cluster below.
-  return { left: CX - 60, top: (layout.sats[0]?.y ?? 0) - 20 };
+  return { left: CX + LANE_HEAD_AXIS_GAP, top: (layout.sats[0]?.y ?? 0) - 20 };
 }
 
 // ── Inline anchored picker (dark canonical) ──────────────────────────────────
@@ -2436,28 +2444,58 @@ function NodeSearch({
 }
 
 // ── Mini compass rose (flow cue) — the four bearings at a glance ──────────────
+/**
+ * 완성도 인디케이터 (#69).
+ *
+ * 소유자 실보고: "이것도 잘 안 보여.. 좀 더 잘보이게하고(조금더 키워도 될지도?)
+ * 그리고 반짝반짝 빛나면 좋을듯?" — 발광이 아니라 **상태가 눈에 들어오고 변화가
+ * 움직임으로 읽히는 것**이 요구사항이다(소유자 정정). 그래서:
+ *
+ * - 크기를 40 → 52 로, 점 반지름을 2.6 → 3.6 으로 키운다.
+ * - 채움/빈 상태의 **값 차이를 벌린다** — 채운 점은 인디고 solid + 옅은 후광
+ *   링(같은 인디고 알파, glow 아님), 빈 점은 더 조용한 보더.
+ * - 채워지는 순간 200ms 로 색과 반지름이 확정 전이한다 — 결과가 움직임으로
+ *   확인된다. `prefers-reduced-motion` 은 전이를 끈다.
+ *
+ * 헌장 준수: glow pulse · neon · halo · `0 0 …` boxShadow 없음. 무채색 + 단일
+ * 인디고, 값(밝기·크기)으로만 구분한다.
+ */
 function MiniRose({ bearings }: { bearings: CompassBearingView[] }) {
   const by = (b: StudioBearing) => bearings.find((v) => v.bearing === b);
   const pip = (b: StudioBearing, cx: number, cy: number) => {
     const v = by(b);
-    if (v?.filled) return <circle cx={cx} cy={cy} r={2.6} fill="var(--color-indigo-brand)" />;
+    const common = {
+      cx,
+      cy,
+      className: "studio-rose-pip",
+    } as const;
+    if (v?.filled) {
+      return (
+        <>
+          {/* 채움 강조 — 같은 인디고의 옅은 알파 링. 발광이 아니라 값 대비. */}
+          <circle {...common} r={6} fill="var(--color-indigo-a16)" />
+          <circle {...common} r={3.6} fill="var(--color-indigo-brand)" />
+        </>
+      );
+    }
     if (v?.recommended)
       return (
         <>
-          <circle cx={cx} cy={cy} r={2.6} fill="none" stroke="var(--color-border-strong)" strokeWidth={1.5} />
-          <circle cx={cx} cy={cy} r={1} fill="var(--color-indigo-brand)" />
+          <circle {...common} r={3.6} fill="none" stroke="var(--color-indigo-line-a45)" strokeWidth={1.6} />
+          <circle {...common} r={1.4} fill="var(--color-indigo-brand)" />
         </>
       );
-    if (v?.expected) return <circle cx={cx} cy={cy} r={2.6} fill="none" stroke="var(--color-amber-muted-a62)" strokeWidth={1.5} />;
-    return <circle cx={cx} cy={cy} r={2.6} fill="none" stroke="var(--color-border-strong)" strokeWidth={1.5} />;
+    if (v?.expected)
+      return <circle {...common} r={3.6} fill="none" stroke="var(--color-amber-muted-a62)" strokeWidth={1.6} />;
+    return <circle {...common} r={3.6} fill="none" stroke="var(--color-border-soft)" strokeWidth={1.4} />;
   };
   return (
-    <svg width={40} height={40} viewBox="0 0 40 40" className="flex-none" aria-hidden>
-      <circle cx={20} cy={20} r={15} fill="none" stroke="var(--color-border-soft)" strokeWidth={1} strokeDasharray="1 3.6" />
-      {pip("up", 20, 5)}
-      {pip("right", 35, 20)}
-      {pip("down", 20, 35)}
-      {pip("left", 5, 20)}
+    <svg width={52} height={52} viewBox="0 0 52 52" className="flex-none" aria-hidden>
+      <circle cx={26} cy={26} r={19} fill="none" stroke="var(--color-border-soft)" strokeWidth={1} strokeDasharray="1 3.6" />
+      {pip("up", 26, 7)}
+      {pip("right", 45, 26)}
+      {pip("down", 26, 45)}
+      {pip("left", 7, 26)}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

소유자 실보고 2건.

### ① 지지대가 라벨을 가로지름

> "이런것도 지금 파란선에 글자가 겹쳐져서 뭔가 이상하지? 가로질러서?"

세로 레인(up/down)의 지지대는 `CX` 축을 타고 흐르는데 **레인 라벨이 그 축 한가운데** 있었다. 선을 뒤로 보내도 글자 사이로 비쳐 "가로지른다" 로 읽힌다.

→ 라벨을 축 오른쪽으로 10px 비켜 세워 **애초에 교차하지 않게** 했다(선로 옆 표지판 문법). 가로 레인은 이미 축에서 20px 위라 손대지 않았다.

### ② 완성도 인디케이터가 잘 안 보임

> "좀 더 잘보이게하고(조금더 키워도 될지도?) 그리고 반짝반짝 빛나면 좋을듯?"
> — 정정: **"발광하라는게 막 화려하게 하라는게 아니고.. 적절히 표현되도록 그리고 모션이 좀 있었으면 한거야."**

- 크기 **40 → 52**, 점 반지름 **2.6 → 3.6**
- 채운 방위는 인디고 solid + 같은 인디고의 **옅은 알파 링**(값 대비이지 발광 아님), 빈 방위는 더 조용한 보더 → **값 차이를 벌림**
- 채워지는 순간 색·반지름이 **200ms 확정 전이** — "방금 하나 찼다" 가 움직임으로 읽힌다. `prefers-reduced-motion` 은 전이를 끔.

**헌장 준수**: glow pulse · neon · halo · `0 0 …` boxShadow · SVG filter **없음**. 무채색 + 단일 인디고, 값(밝기·크기)으로만 구분. 회귀 테스트가 이를 잡는다.

## Test plan

- `pnpm exec vitest run src/views/ontology-studio` — **182/182**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — error 0
- `pnpm design:ontology` — **clean (144 파일)**
- 회귀 테스트 2건 신규: 4방위 점 + 전이 클래스 / glow 계열 금지
- **실브라우저**: 라벨이 축에서 비껴섬 확인, rose 52px 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr