### PR TITLE
fix: 모니터 이동 시 DPR 변화 감지 + 모든 노드가 화면 밖일 때만 안전 보정 (#71)

### DIFF
--- a/src/widgets/topology-map-v2/ui/topology-camera-math.offscreen.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.offscreen.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { hasAnyNodeOnScreen } from "./topology-camera-math";
+import type { CameraAxes } from "../engine/camera";
+
+const cam = (x: number, y: number, scale: number): CameraAxes => ({
+  x: { value: x, velocity: 0 },
+  y: { value: y, velocity: 0 },
+  scale: { value: scale, velocity: 0 },
+});
+
+describe("hasAnyNodeOnScreen (#71)", () => {
+  const NODES = [
+    { x: 0, y: 0 },
+    { x: 100, y: 40 },
+  ];
+
+  it("카메라가 노드 위에 있으면 보인다", () => {
+    expect(hasAnyNodeOnScreen(cam(0, 0, 1), 1512, 900, NODES)).toBe(true);
+  });
+
+  it("카메라가 아주 멀리 가면 전부 화면 밖 — 빈 지도로 보이는 상태", () => {
+    expect(hasAnyNodeOnScreen(cam(100000, 100000, 1), 1512, 900, NODES)).toBe(false);
+  });
+
+  it("하나라도 걸쳐 있으면 보정하지 않는다 — 사용자의 줌·위치 의도를 지우지 않는다", () => {
+    // 두 번째 노드만 화면 안쪽에 남게 카메라를 옮긴다.
+    expect(hasAnyNodeOnScreen(cam(100, 40, 1), 200, 200, NODES)).toBe(true);
+  });
+
+  it("가장자리 여유 안쪽이면 '보인다' — 경계에서 카메라가 튀지 않게", () => {
+    // 노드를 오른쪽 경계 바로 바깥(+10px)에 두고 margin 24 를 준다.
+    const width = 200;
+    const justOutside = [{ x: width / 2 + 10, y: 0 }];
+    expect(hasAnyNodeOnScreen(cam(0, 0, 1), width, 200, justOutside, 24)).toBe(true);
+  });
+
+  it("노드가 없으면 사라진 것도 아니다", () => {
+    expect(hasAnyNodeOnScreen(cam(9999, 9999, 1), 1512, 900, [])).toBe(true);
+  });
+
+  it("레이아웃 전(뷰포트 0)에는 판단하지 않는다", () => {
+    expect(hasAnyNodeOnScreen(cam(9999, 9999, 1), 0, 0, NODES)).toBe(true);
+  });
+});

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -391,3 +391,41 @@ export function computeClusterFitTarget(
   const scale = Math.min(effectiveMax, focusZoomInCeiling, Math.max(overviewEntryScale, fitScale));
   return { tx: centerX, ty: centerY, tscale: scale };
 }
+
+/**
+ * 카메라가 모든 노드를 화면 밖으로 밀어냈는가 (#71).
+ *
+ * 왜 필요한가: 창을 다른 모니터로 옮기거나 크게 리사이즈하면 뷰포트와 DPR 이
+ * 함께 바뀌는데, 카메라는 그대로다. 그 조합에서 노드가 전부 뷰포트 밖으로
+ * 나가면 사용자에게는 **빈 지도**로 보인다 — '지도 전체 맞추기' 를 눌러야만
+ * 돌아온다(codex 감사 P1 실보고).
+ *
+ * 안전망의 규율:
+ * - **매 resize 마다 강제 전체 맞추기는 하지 않는다.** 사용자가 잡아둔 줌·위치는
+ *   의도이고, 그걸 지우는 건 다른 종류의 결함이다.
+ * - 오직 "화면 안에 노드가 하나도 없다" 는 명백한 상태에서만 보정한다.
+ * - 여유(margin)를 둬 가장자리에 살짝 걸친 노드는 '보인다' 로 센다 — 경계에서
+ *   깜빡이며 카메라가 튀는 것을 막는다.
+ */
+export function hasAnyNodeOnScreen(
+  camera: CameraAxes,
+  viewportWidth: number,
+  viewportHeight: number,
+  nodes: ReadonlyArray<{ x: number; y: number }>,
+  marginPx = 24,
+): boolean {
+  if (nodes.length === 0) return true; // 노드가 없으면 '사라진' 것도 아니다.
+  if (viewportWidth <= 0 || viewportHeight <= 0) return true; // 아직 레이아웃 전.
+  for (const node of nodes) {
+    const p = worldToScreen(camera, viewportWidth, viewportHeight, node.x, node.y);
+    if (
+      p.x >= -marginPx &&
+      p.x <= viewportWidth + marginPx &&
+      p.y >= -marginPx &&
+      p.y <= viewportHeight + marginPx
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -25,7 +25,7 @@ import { buildGridPattern } from "../render/grid";
 import { buildConstellationPattern, buildContourPattern, readCanvasBgTokens } from "../render/background-patterns";
 import { buildDustPoints, buildRealmCosmosPoints, computeStarDustCount, type DustPoint } from "../render/starfield";
 import type { CanvasBackground, GlyphSet } from "@/shared/lib/appearance-preferences";
-import { computeClusterFitTarget, computeFocusCameraTarget, computeOverviewCameraTarget, computeOverviewFitScale, worldToScreen } from "./topology-camera-math";
+import { computeClusterFitTarget, computeFocusCameraTarget, computeOverviewCameraTarget, computeOverviewFitScale, hasAnyNodeOnScreen, worldToScreen } from "./topology-camera-math";
 import { drawTopologyFrame } from "./topology-frame-draw";
 import { computeTopologyClusterState } from "./topology-cluster-state";
 import type { ClusterChip } from "../model/density-gate";
@@ -708,6 +708,25 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     return () => query.removeEventListener?.("change", onChange);
   }, []);
 
+  /**
+   * #71 안전망 — 리사이즈/모니터 이동 뒤 **노드가 하나도 화면에 없으면** 전체
+   * 맞추기로 되돌린다.
+   *
+   * 규율: 매 resize 마다 강제로 맞추지 않는다. 사용자가 잡아둔 줌·위치는 의도이고
+   * 그걸 지우는 건 다른 종류의 결함이다. 오직 "빈 지도로 보이는" 명백한 상태
+   * (`hasAnyNodeOnScreen === false`)에서만 개입한다. 튐을 막기 위해 스프링
+   * 타깃만 옮기고 값은 건드리지 않는다 — reduced-motion 은 카메라 트윈 계약이
+   * 이미 존중한다.
+   */
+  const rescueCameraIfEverythingOffscreen = (tokens: TopologyV2Tokens) => {
+    const world = worldRef.current;
+    const { width, height } = viewportRef.current;
+    if (!world || width <= 0 || height <= 0) return;
+    if (hasAnyNodeOnScreen(cameraRef.current, width, height, world.nodes)) return;
+    const target = computeOverviewCameraTarget(world.spineBounds, width, height, tokens, world.nodes.length);
+    cameraTargetRef.current = { tx: target.tx, ty: target.ty, tscale: target.tscale };
+  };
+
   const trySnapInitialCamera = (tokens: TopologyV2Tokens) => {
     if (hasInitializedRef.current) return;
     const world = worldRef.current;
@@ -847,6 +866,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         computeStarDustCount(rect.width, rect.height, tokens.dustAreaPerPoint) * 2,
       );
       trySnapInitialCamera(tokens);
+      rescueCameraIfEverythingOffscreen(tokens);
     };
 
     applyResize();
@@ -857,7 +877,30 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     }
     const observer = new ResizeObserver(applyResize);
     observer.observe(container);
-    return () => observer.disconnect();
+
+    // #71 — `ResizeObserver` 는 **크기** 변화만 본다. 창을 다른 모니터로 옮기면
+    // CSS 크기는 그대로인데 `devicePixelRatio` 만 바뀌고, 그러면 캔버스 백킹
+    // 크기가 옛 DPR 로 남아 그려지는 내용이 어긋난다. DPR 변화를 따로 듣는다.
+    // `matchMedia(resolution)` 은 현재 DPR 에서 벗어나는 순간 한 번 발화하므로
+    // 매번 새 질의로 다시 건다.
+    let dprQuery: MediaQueryList | null = null;
+    const onDprChange = () => {
+      applyResize();
+      watchDpr();
+    };
+    const watchDpr = () => {
+      if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+      dprQuery?.removeEventListener?.("change", onDprChange);
+      const dpr = window.devicePixelRatio || 1;
+      dprQuery = window.matchMedia(`(resolution: ${dpr}dppx)`);
+      dprQuery.addEventListener?.("change", onDprChange);
+    };
+    watchDpr();
+
+    return () => {
+      observer.disconnect();
+      dprQuery?.removeEventListener?.("change", onDprChange);
+    };
   }, []);
 
   // --- relayoutToken / fitViewToken — both mean "spring back to the full overview fit" ---


### PR DESCRIPTION
## Summary

codex 감사 P1: 창을 외장 1920 으로 옮기고 리사이즈하면 카메라가 갱신되지 않아 **빈 지도처럼** 보이고, `지도 전체 맞추기` 를 눌러야 노드가 돌아온다.

> **이 증상 자체는 재현하지 못했습니다.** 외장 모니터와 설치 앱이 필요하고, 브라우저에서는 DPR 변화를 강제할 수 없습니다. 대신 **코드에서 확인된 두 구멍**을 막았습니다.

### ① `ResizeObserver` 는 크기 변화만 본다

창을 다른 모니터로 옮기면 **CSS 크기는 그대로인데 `devicePixelRatio` 만 바뀐다.** 그러면 `applyResize` 가 **아예 안 불려** 캔버스 백킹 크기가 옛 DPR 로 남는다 — 그려지는 내용이 어긋나는 경로다.

→ `matchMedia('(resolution: Ndppx)')` 로 DPR 변화를 따로 듣고 재적용. 현재 DPR 에서 벗어날 때 한 번 발화하므로 매번 새 질의로 다시 건다.

### ② 리사이즈 후 카메라를 아무도 보정하지 않는다

→ **`hasAnyNodeOnScreen`** — *"노드가 하나도 화면에 없다"* 는 **명백한 상태에서만** 전체 맞추기로 되돌린다.

규율(태스크 요구사항 그대로):
- **매 resize 강제 맞추기는 하지 않는다** — 사용자가 잡아둔 줌·위치는 의도이고, 그걸 지우는 건 다른 종류의 결함이다.
- 가장자리 여유(24px)로 경계에서 카메라가 튀지 않게.
- 스프링 **값이 아니라 타깃만** 옮겨 reduced-motion 계약을 그대로 탄다.

## Test plan

- `pnpm exec vitest run src/widgets/topology-map-v2` — **754/754**
- `pnpm exec vitest run src/widgets` — **1167/1167**
- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — error 0
- 회귀 테스트 **6건 신규**: 정상 / 원거리 전부밖 / 일부 걸침 / 여유 경계 / 노드 0 / 뷰포트 0

## 남은 리스크

**원 증상의 실제 해소는 설치 앱 + 외장 모니터에서 소유자가 확인해야 합니다.** 이 PR 은 확인된 구멍을 막은 것이지, 증상 재현·해소를 증명한 것이 아닙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr