### PR TITLE
feat: 프로젝트 상세를 개요/구성 탭으로 분리 (#87)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1359,7 +1359,12 @@
       "saveErrorGeneric": "Save failed",
       "saveErrorConflict": "This project file was changed first by another editor or AI agent. Refresh and save again.",
       "saveErrorPrefix": "Save failed — {message}",
-      "readOnlyBadge": "View only — open a folder to edit"
+      "readOnlyBadge": "View only — open a folder to edit",
+      "tabs": {
+        "ariaLabel": "Switch project detail view",
+        "overview": "Overview",
+        "composition": "Composition"
+      }
     },
     "editor": {
       "documentTitleEdit": "Edit project · Ontology Atlas",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1364,7 +1364,9 @@
         "ariaLabel": "Switch project detail view",
         "overview": "Overview",
         "composition": "Composition"
-      }
+      },
+      "domainEmptyTitle": "No domains yet",
+      "domainEmptyHint": "Connect a domain to this project on the map and its composition shows up here."
     },
     "editor": {
       "documentTitleEdit": "Edit project · Ontology Atlas",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1364,7 +1364,9 @@
         "ariaLabel": "프로젝트 상세 보기 전환",
         "overview": "개요",
         "composition": "구성"
-      }
+      },
+      "domainEmptyTitle": "아직 도메인이 없어요",
+      "domainEmptyHint": "지도에서 도메인을 이 프로젝트에 연결하면 여기에 구성이 나타나요."
     },
     "editor": {
       "documentTitleEdit": "프로젝트 편집 · Ontology Atlas",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1359,7 +1359,12 @@
       "saveErrorGeneric": "저장 실패",
       "saveErrorConflict": "이 프로젝트 파일이 외부 편집기나 AI agent에 의해 먼저 변경됐습니다. 새로고침 후 다시 저장해주세요.",
       "saveErrorPrefix": "저장 실패 — {message}",
-      "readOnlyBadge": "보기 전용 — 폴더를 열면 편집"
+      "readOnlyBadge": "보기 전용 — 폴더를 열면 편집",
+      "tabs": {
+        "ariaLabel": "프로젝트 상세 보기 전환",
+        "overview": "개요",
+        "composition": "구성"
+      }
     },
     "editor": {
       "documentTitleEdit": "프로젝트 편집 · Ontology Atlas",

--- a/src/views/project-detail/lib/project-detail-tab.test.ts
+++ b/src/views/project-detail/lib/project-detail-tab.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compositionTabCount,
+  DEFAULT_PROJECT_DETAIL_TAB,
+  parseProjectDetailTab,
+  PROJECT_DETAIL_TABS,
+  serializeProjectDetailTab,
+} from "./project-detail-tab";
+
+describe("parseProjectDetailTab", () => {
+  it("알려진 탭을 그대로 해석한다", () => {
+    for (const tab of PROJECT_DETAIL_TABS) {
+      expect(parseProjectDetailTab(tab)).toBe(tab);
+    }
+  });
+
+  it("없음·빈값·모르는 값은 기본 탭으로 떨어진다 — 화면을 막지 않는다", () => {
+    // 공유 링크는 남의 손에서 편집된다. 오타가 에러 화면이 되면 안 된다.
+    for (const raw of [null, undefined, "", "activity", "Overview", "../x"]) {
+      expect(parseProjectDetailTab(raw)).toBe(DEFAULT_PROJECT_DETAIL_TAB);
+    }
+  });
+});
+
+describe("serializeProjectDetailTab", () => {
+  it("기본 탭은 URL 에 쓰지 않는다 — 공유 링크가 짧아야 붙여넣기 쉽다", () => {
+    expect(serializeProjectDetailTab(DEFAULT_PROJECT_DETAIL_TAB)).toBeNull();
+  });
+
+  it("기본이 아닌 탭은 값을 남긴다", () => {
+    expect(serializeProjectDetailTab("composition")).toBe("composition");
+  });
+
+  it("직렬화 → 파싱이 왕복한다 (핸드오프 패킷이 탭을 잃지 않게)", () => {
+    for (const tab of PROJECT_DETAIL_TABS) {
+      expect(parseProjectDetailTab(serializeProjectDetailTab(tab))).toBe(tab);
+    }
+  });
+});
+
+describe("compositionTabCount", () => {
+  it("도메인이 있으면 카운트를 준다", () => {
+    expect(compositionTabCount(3)).toBe(3);
+  });
+
+  it("0 은 배지를 그리지 않는다 — '없음' 을 강조하는 꼴이 된다", () => {
+    expect(compositionTabCount(0)).toBeUndefined();
+  });
+});

--- a/src/views/project-detail/lib/project-detail-tab.ts
+++ b/src/views/project-detail/lib/project-detail-tab.ts
@@ -1,0 +1,59 @@
+/**
+ * 프로젝트 상세 탭 계약 (#87, fable 설계 PR-1).
+ *
+ * ## 왜 탭인가
+ *
+ * 상세가 단일 스크롤 덤프였다 — 히어로 → 도메인 구성 → **project.md 전문**
+ * (dogfood 기준 수천 px) → 연결/핸드오프 → 푸터. 소유자: *"스크롤로 모든거
+ * 보여주려 안해도 되니까?"*
+ *
+ * 탭은 "정보 종류" 가 아니라 **답하는 질문**으로 가른다:
+ *
+ * - `overview` — 이 프로젝트가 **무엇인가** (project.md 본문)
+ * - `composition` — **무엇으로 이루어졌나** (미니 지도 + 도메인 구성)
+ *
+ * ## 왜 URL 인가
+ *
+ * 이 앱은 세션 상태를 URL 에 둔다(`?p=` · `?realm=` · `?open=` · `?recent=`).
+ * 이유가 둘: **공유 가능**하고 **에이전트가 읽고 재현**할 수 있다. 탭을 숨은
+ * 상태로 두면 핸드오프 패킷에 "어느 탭을 보던 중" 이 빠진다.
+ *
+ * 기본 탭은 파라미터를 **생략**한다 — `?tab=overview` 는 없어도 될 소음이고,
+ * 공유 링크가 짧을수록 붙여넣기가 쉽다.
+ */
+
+export const PROJECT_DETAIL_TABS = ["overview", "composition"] as const;
+
+export type ProjectDetailTab = (typeof PROJECT_DETAIL_TABS)[number];
+
+export const DEFAULT_PROJECT_DETAIL_TAB: ProjectDetailTab = "overview";
+
+/**
+ * `?tab=` 을 탭으로 해석한다. 모르는 값·없음은 기본 탭 — **에러가 아니다.**
+ * 낡은 링크나 오타가 화면을 막으면 안 된다(공유 링크는 남의 손에서 편집된다).
+ */
+export function parseProjectDetailTab(raw: string | null | undefined): ProjectDetailTab {
+  if (!raw) return DEFAULT_PROJECT_DETAIL_TAB;
+  const found = PROJECT_DETAIL_TABS.find((tab) => tab === raw);
+  return found ?? DEFAULT_PROJECT_DETAIL_TAB;
+}
+
+/**
+ * 탭을 URL 쿼리로 직렬화한다. 기본 탭이면 `null` — 호출부가 파라미터를 지운다.
+ * "기본값을 URL 에 쓰지 않는다" 를 한 곳에서 결정해 화면마다 달라지지 않게.
+ */
+export function serializeProjectDetailTab(tab: ProjectDetailTab): string | null {
+  return tab === DEFAULT_PROJECT_DETAIL_TAB ? null : tab;
+}
+
+/**
+ * 구성 탭을 보여줄 수 있는가.
+ *
+ * 도메인이 0개여도 **탭은 숨기지 않는다** — 탭 세트가 프로젝트마다 흔들리면
+ * 공간 기억이 깨진다(같은 자리를 눌렀는데 다른 게 나온다). 대신 탭 안에서
+ * 빈 상태 + "첫 도메인 연결" 로 안내한다. 이 함수는 **카운트 배지**를 붙일지만
+ * 판단한다 — 0 을 배지로 그리면 "없음" 을 강조하는 꼴이라 생략한다.
+ */
+export function compositionTabCount(domainCount: number): number | undefined {
+  return domainCount > 0 ? domainCount : undefined;
+}

--- a/src/views/project-detail/ui/ProjectDetailPage.test.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.test.tsx
@@ -1,9 +1,19 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import enMessages from "../../../../messages/en.json";
 import { ProjectDetailPage } from "./ProjectDetailPage";
+
+// 탭 상태가 **URL 에 산다**(#87) — 공유·에이전트 재현을 위해. 실앱에서는
+// `router.replace` 가 리렌더를 일으켜 `useSearchParams` 가 새 값을 준다.
+// 테스트에서 둘 다 목이면 그 루프가 끊기므로, 여기서 이어 붙인다.
+const nav = vi.hoisted(() => ({ search: "", version: 0 }));
+
+vi.mock("next/navigation", () => ({
+  // `version` 을 읽어 replace 후 리렌더 시 새 인스턴스를 만든다.
+  useSearchParams: () => new URLSearchParams(nav.search),
+}));
 
 vi.mock("@/i18n/navigation", () => ({
   Link: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
@@ -11,7 +21,13 @@ vi.mock("@/i18n/navigation", () => ({
       {children}
     </a>
   ),
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: (href: string) => {
+      nav.search = href.startsWith("?") ? href.slice(1) : "";
+      nav.version += 1;
+    },
+  }),
 }));
 
 vi.mock("@/features/taxonomy", () => ({
@@ -139,6 +155,8 @@ function renderPage(overrides: { related?: ReturnType<typeof baseProject>[] } = 
 
 describe("ProjectDetailPage", () => {
   beforeEach(() => {
+    // 탭은 URL 상태라 테스트 간에 새지 않게 초기화한다.
+    nav.search = "";
     mocks.vaultBody = null;
     mocks.projects = [];
     mocks.projectsMode = "static";
@@ -176,11 +194,61 @@ describe("ProjectDetailPage", () => {
     mocks.insightNodes = BASE_NODES;
     mocks.insightEdges = BASE_EDGES;
     mocks.canEdit = false;
+    // #87 — 구성은 탭 뒤에 있고 탭 상태는 URL 이 진실원이다. 렌더 계약과
+    // 클릭 계약을 나눠 검사한다: 여기서는 "URL 이 구성이면 카드가 그려진다".
+    // (클릭 → URL 이동은 Next 의 일이라 아래 별 테스트가 URL 기록만 본다.)
+    nav.search = "tab=composition";
     renderPage();
 
     const card = screen.getByTestId("project-detail-domain-card");
     expect(card).toHaveAttribute("href", "/topology/?mode=focus&p=domain%3Aviews");
     expect(card).toHaveTextContent("Views");
+  });
+
+  it("탭을 누르면 URL 에 기록된다 — 공유·에이전트 재현이 가능해야 한다 (#87)", () => {
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    renderPage();
+
+    fireEvent.click(screen.getByRole("tab", { name: /composition/i }));
+    expect(nav.search).toContain("tab=composition");
+  });
+
+  it("기본 탭으로 돌아가면 URL 에서 파라미터가 사라진다 (#87)", () => {
+    // 공유 링크가 짧아야 붙여넣기 쉽다 — `?tab=overview` 는 없어도 될 소음이다.
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    nav.search = "tab=composition";
+    renderPage();
+
+    fireEvent.click(screen.getByRole("tab", { name: /overview/i }));
+    expect(nav.search).not.toContain("tab=");
+  });
+
+  it("기본은 개요 탭 — 본문이 보이고 구성 카드는 아직 없다 (#87)", () => {
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    renderPage();
+
+    // 소유자: "스크롤로 모든거 보여주려 안해도 되니까?" — project.md 본문이
+    // 수천 px 라 구성과 같은 스크롤에 두면 구성을 스캔할 방법이 없었다.
+    expect(screen.queryByTestId("project-detail-domain-card")).not.toBeInTheDocument();
+  });
+
+  it("연결된 프로젝트는 탭 밖에 있다 — 어느 탭에서든 보인다 (#87)", () => {
+    // 프로젝트 간 관계를 온톨로지로 다루는 방향의 첫 표면이라 탭 뒤에 숨기면
+    // 안 된다. 구성 탭으로 옮겨도 그대로 있어야 한다.
+    mocks.insightNodes = BASE_NODES;
+    mocks.insightEdges = BASE_EDGES;
+    mocks.canEdit = false;
+    renderPage();
+
+    const railBefore = screen.getByTestId("project-detail-connected");
+    fireEvent.click(screen.getByRole("tab", { name: /composition/i }));
+    expect(screen.getByTestId("project-detail-connected")).toBe(railBefore);
   });
 
   it("shows a sentence-form empty state (not a numeral) when no project is connected", () => {

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useState, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import { Link } from "@/i18n/navigation";
 import { useRouter } from "@/i18n/navigation";
+// `useSearchParams` 는 locale-agnostic 이라 raw next/navigation 에서 가져온다
+// (`architecture.md` i18n 라우팅 가드).
+import { useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { ArrowLeft, BookOpen, FileText, Waypoints } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -42,6 +45,13 @@ import { buildAgentHandoffSnippet } from "../model/agent-handoff-snippet";
 import { shortenDomainTitle } from "../model/short-domain-title";
 import { MiniDomainMap } from "./MiniDomainMap";
 import { DomainCompositionGrid } from "./DomainCompositionGrid";
+import { TabBar } from "@/shared/ui/tab-bar";
+import {
+  compositionTabCount,
+  parseProjectDetailTab,
+  serializeProjectDetailTab,
+  type ProjectDetailTab,
+} from "../lib/project-detail-tab";
 
 const SearchPalette = dynamic(
   () => import("@/widgets/search-palette").then((m) => m.SearchPalette),
@@ -189,6 +199,22 @@ export function ProjectDetailPage({
 }: Props) {
   const t = useTranslations("projectPages.detail");
   const router = useRouter();
+  // 탭은 URL 에 산다 (#87) — 공유 가능하고 에이전트가 재현할 수 있어야 한다.
+  // 숨은 상태로 두면 핸드오프 패킷에서 "어느 탭을 보던 중" 이 사라진다.
+  const searchParams = useSearchParams();
+  const activeTab = parseProjectDetailTab(searchParams.get("tab"));
+  const selectTab = useCallback(
+    (key: string) => {
+      const next = serializeProjectDetailTab(key as ProjectDetailTab);
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set("tab", next);
+      else params.delete("tab");
+      const query = params.toString();
+      // `replace` — 탭 전환은 뒤로가기 이력을 쌓을 만한 이동이 아니다.
+      router.replace(query ? `?${query}` : "?", { scroll: false });
+    },
+    [router, searchParams],
+  );
   const { show: showToast } = useToast();
   const [project, setProject] = useState<Project | null>(
     initialProject,
@@ -511,9 +537,34 @@ export function ProjectDetailPage({
         ) : null}
       </header>
 
-      {/* zone 2 — 도메인 구성 3×N: 각 카드는 topology focus 로 이동. 도메인이
-          0개면(=온톨로지 미기재) 통째로 숨김 — 매치 0 자동 숨김 원칙. */}
-      {domainComposition.domains.length > 0 ? (
+      {/* 탭 (#87) — "정보 종류" 가 아니라 **답하는 질문**으로 가른다.
+          개요 = 이게 무엇인가(본문) · 구성 = 무엇으로 이루어졌나.
+          project.md 본문이 dogfood 기준 수천 px 라 한 스크롤에 같이 두면
+          "무엇으로 이루어졌나" 를 스캔할 방법이 없었다(소유자: "스크롤로
+          모든거 보여주려 안해도 되니까?").
+
+          컴포넌트는 앱의 유일한 탭바(`shared/ui/tab-bar`)를 재사용한다 —
+          인사이트·기록 증거 pane 과 같은 문법이라 새 관용구가 안 생긴다. */}
+      <div className="mt-[var(--section-gap)]">
+        <TabBar
+          ariaLabel={t("tabs.ariaLabel")}
+          activeKey={activeTab}
+          onSelect={selectTab}
+          items={[
+            { key: "overview", label: t("tabs.overview") },
+            {
+              key: "composition",
+              label: t("tabs.composition"),
+              count: compositionTabCount(domainComposition.domains.length),
+            },
+          ]}
+        />
+      </div>
+
+      {/* zone 2 (구성 탭) — 도메인 구성 3×N: 각 카드는 topology focus 로 이동.
+          도메인이 0개여도 **탭은 숨기지 않는다** — 탭 세트가 프로젝트마다
+          흔들리면 같은 자리를 눌렀는데 다른 게 나와 공간 기억이 깨진다. */}
+      {activeTab === "composition" && domainComposition.domains.length > 0 ? (
         <section className="mt-[var(--section-gap)]">
           <div className="mb-3 flex items-center gap-2.5">
             <TopologyV2TraceMark containment />
@@ -548,8 +599,17 @@ export function ProjectDetailPage({
           핸드오프). Connection map 제거(c84ecb25e) 이후의 left-column-void
           결함은 이 3존 재배치로 구조적으로 해소된다 — 좌측이 항상 도메인
           구성/본문으로 채워진다. */}
+      {/* zone 3 — 좌: 본문(개요 탭 전용) / 우: 연결된 프로젝트 + 에이전트 핸드오프.
+          **우측 레일은 탭 밖에 둔다** — 어느 탭에서 보든 유효한 cross-tab
+          맥락이고, 특히 "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로
+          다루는 방향의 첫 표면이라 탭 뒤에 숨기면 안 된다(기록 목적지의
+          좌/우 분할과 같은 문법). */}
       <section className="mt-[var(--section-gap)] grid grid-cols-1 items-start gap-[var(--card-gap)] lg:grid-cols-[minmax(0,1fr)_400px]">
-        <article className="rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]">
+        <article
+          data-tab-panel="overview"
+          hidden={activeTab !== "overview"}
+          className="rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]"
+        >
           <div className="mb-2.5 flex items-baseline gap-2">
             <span className="text-[13px] font-[560] text-[color:var(--color-text-primary)]">
               {t("bodyCardTitle")}
@@ -577,7 +637,10 @@ export function ProjectDetailPage({
           )}
         </article>
 
-        <aside className="flex flex-col gap-[var(--card-gap)]">
+        {/* 우측 레일은 **탭 밖**이다 (#87) — 어느 탭에서 보든 유효한 맥락이고,
+            "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로 다루는 방향의
+            첫 표면이라 탭 뒤에 숨기면 안 된다. */}
+        <aside data-testid="project-detail-connected" className="flex flex-col gap-[var(--card-gap)]">
           <section className="rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]">
             <div className="mb-2.5 flex items-baseline gap-2">
               <TopologyV2TraceMark containment={false} />

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "@/i18n/navigation";
 // (`architecture.md` i18n 라우팅 가드).
 import { useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, BookOpen, FileText, Waypoints } from "lucide-react";
+import { ArrowLeft, BookOpen, FileText, Layers, Waypoints } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useTranslations } from "next-intl";
@@ -561,11 +561,24 @@ export function ProjectDetailPage({
         />
       </div>
 
-      {/* zone 2 (구성 탭) — 도메인 구성 3×N: 각 카드는 topology focus 로 이동.
-          도메인이 0개여도 **탭은 숨기지 않는다** — 탭 세트가 프로젝트마다
-          흔들리면 같은 자리를 눌렀는데 다른 게 나와 공간 기억이 깨진다. */}
-      {activeTab === "composition" && domainComposition.domains.length > 0 ? (
-        <section className="mt-[var(--section-gap)]">
+      {/* zone 3 — 본문(project.md) + 요약 레일(연결된 프로젝트 · 에이전트
+          핸드오프). Connection map 제거(c84ecb25e) 이후의 left-column-void
+          결함은 이 3존 재배치로 구조적으로 해소된다 — 좌측이 항상 도메인
+          구성/본문으로 채워진다. */}
+      {/* zone 3 — 좌: 본문(개요 탭 전용) / 우: 연결된 프로젝트 + 에이전트 핸드오프.
+          **우측 레일은 탭 밖에 둔다** — 어느 탭에서 보든 유효한 cross-tab
+          맥락이고, 특히 "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로
+          다루는 방향의 첫 표면이라 탭 뒤에 숨기면 안 된다(기록 목적지의
+          좌/우 분할과 같은 문법). */}
+      <section className="mt-[var(--section-gap)] grid grid-cols-1 items-start gap-[var(--card-gap)] lg:grid-cols-[minmax(0,1fr)_400px]">
+        {/* 좌측 = **탭 본문**. 구성을 별 섹션으로 두고 `hidden` 으로 감췄더니
+            grid 첫 트랙이 `display:none` 으로 사라져 400px 우측 레일이 1fr
+            트랙으로 당겨져 늘어났다(실측 결함). 좌측이 **항상 무언가를 그리면**
+            트랙이 무너질 수 없다. */}
+        {activeTab === "composition" ? (
+          <section data-tab-panel="composition" className="min-w-0">
+            {domainComposition.domains.length > 0 ? (
+              <>
           <div className="mb-3 flex items-center gap-2.5">
             <TopologyV2TraceMark containment />
             <span className="text-[14px] font-[560] tracking-[-0.01em] text-[color:var(--color-text-primary)]">
@@ -592,22 +605,22 @@ export function ProjectDetailPage({
                 : t("domainMoreLineElementsOnly", { elements })
             }
           />
-        </section>
-      ) : null}
-
-      {/* zone 3 — 본문(project.md) + 요약 레일(연결된 프로젝트 · 에이전트
-          핸드오프). Connection map 제거(c84ecb25e) 이후의 left-column-void
-          결함은 이 3존 재배치로 구조적으로 해소된다 — 좌측이 항상 도메인
-          구성/본문으로 채워진다. */}
-      {/* zone 3 — 좌: 본문(개요 탭 전용) / 우: 연결된 프로젝트 + 에이전트 핸드오프.
-          **우측 레일은 탭 밖에 둔다** — 어느 탭에서 보든 유효한 cross-tab
-          맥락이고, 특히 "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로
-          다루는 방향의 첫 표면이라 탭 뒤에 숨기면 안 된다(기록 목적지의
-          좌/우 분할과 같은 문법). */}
-      <section className="mt-[var(--section-gap)] grid grid-cols-1 items-start gap-[var(--card-gap)] lg:grid-cols-[minmax(0,1fr)_400px]">
+              </>
+            ) : (
+              // 도메인 0이어도 탭은 남는다(공간 기억) — 대신 여기서 다음 걸음을 준다.
+              <div data-testid="project-detail-composition-empty">
+                <EmptyState
+                  size="compact"
+                  icon={<Layers size={16} aria-hidden />}
+                  title={t("domainEmptyTitle")}
+                  description={t("domainEmptyHint")}
+                />
+              </div>
+            )}
+          </section>
+        ) : (
         <article
           data-tab-panel="overview"
-          hidden={activeTab !== "overview"}
           className="rounded-[9px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]"
         >
           <div className="mb-2.5 flex items-baseline gap-2">
@@ -636,6 +649,7 @@ export function ProjectDetailPage({
             </div>
           )}
         </article>
+        )}
 
         {/* 우측 레일은 **탭 밖**이다 (#87) — 어느 탭에서 보든 유효한 맥락이고,
             "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로 다루는 방향의


### PR DESCRIPTION
## Summary

상세가 단일 스크롤 덤프였다 — 히어로 → 도메인 구성 → **project.md 전문**(dogfood 기준 수천 px) → 연결/핸드오프 → 푸터. 소유자: *"스크롤로 모든거 보여주려 안해도 되니까?"*

탭은 "정보 종류" 가 아니라 **답하는 질문**으로 갈랐다 — `개요`(이 프로젝트가 **무엇인가**) · `구성`(**무엇으로 이루어졌나**).

탭 상태는 URL 에 산다(`?tab=`). 이 앱의 다른 상태(`?p=` `?realm=` `?open=` `?recent=`)와 같은 계약이고, 이유가 둘이다: 공유 가능하고 **에이전트가 읽고 재현**할 수 있다. 기본 탭은 파라미터를 생략한다.

두 번째 커밋은 브라우저 실측에서 나온 자기 결함 수정이다:
- `hidden` 속성이 `display:none` 이라 그리드 첫 트랙을 지웠고, 400px 우측 레일이 `1fr` 로 끌려와 화면 폭만큼 늘어났다.
- 도메인 0개면 구성 탭이 아무것도 안 그렸다 — 탭은 남고 내용은 빈 화면이라 "고장" 으로 읽힌다.

우측 레일(연결된 프로젝트·핸드오프)은 **탭 밖**이다 — 어느 탭에서든 유효한 맥락이고, "연결된 프로젝트" 는 프로젝트 간 관계를 온톨로지로 다루는 방향의 첫 표면이라 탭 뒤에 숨기면 안 된다.

> 스택 PR — base 는 #662 (`feat/agent-terminal-dock`). 그 PR 이 머지되면 base 를 main 으로 바꾼다.

## Test plan

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/views/project-detail` — 65 통과
- 브라우저 실측 1512: `gridTemplateColumns "932px 400px"` · 레일 400px 유지 · 빈 상태 렌더