### PR TITLE
fix: "예시 비즈니스 보기" 가 절반만 적용되던 결함 — 번들 볼트 단일 진입점

### DIFF
--- a/src/entities/docs-vault/index.ts
+++ b/src/entities/docs-vault/index.ts
@@ -13,6 +13,10 @@ export { default as vaultContent } from './data/content.json';
 // 빌드한다.
 export { default as sampleStorefrontManifest } from './data/sample-storefront.manifest.json';
 export {
+  resolveStaticVaultSource,
+  type StaticVaultSource,
+} from './lib/static-vault-source';
+export {
   pinnedDocsStorageKey,
   recentDocsStorageKey,
   vaultScopeKey,

--- a/src/entities/docs-vault/lib/static-vault-source.ts
+++ b/src/entities/docs-vault/lib/static-vault-source.ts
@@ -1,0 +1,55 @@
+import type { SampleSource } from '@/shared/lib/sample-source';
+import sampleStorefrontContent from '../data/sample-storefront.content.json';
+import sampleStorefrontManifest from '../data/sample-storefront.manifest.json';
+import vaultContent from '../data/content.json';
+import vaultManifest from '../data/manifest.json';
+import type { VaultManifest } from '../model/types';
+
+/**
+ * static 모드(vault 미선택)에서 **지금 진실원인 번들 볼트 한 벌**.
+ *
+ * ## 왜 리졸버가 필요한가
+ *
+ * 실측 결함(2026-07-26): `demo:sample-source:v1 = storefront` 인 상태로 프로젝트
+ * 상세를 열면 **한 화면에 두 볼트가 섞였다** — 제목·본문은 dogfood 의
+ * `ontology-atlas`, 그래프는 storefront(31노드). 그 결과 히어로 지표가 전부 0,
+ * 구성 탭은 빈 상태, 헤더만 "31 CONCEPTS · 61 RELATIONS" 를 외쳤다. 사용자에게
+ * 이건 "고장" 으로 읽힌다.
+ *
+ * 원인은 단순했다. 샘플 선택을 존중하는 소비자가 2곳(`useOntologyInsight` ·
+ * `useVaultHealth`)뿐이고 나머지 9곳이 dogfood 매니페스트를 **직접 import**
+ * 했다. 같은 질문("지금 어떤 볼트인가")에 답이 두 개면 언젠가 갈라진다 —
+ * 아키텍처 규율의 "단일 진실원" 이 정확히 이걸 막으려는 규칙이다.
+ *
+ * 그래서 매니페스트와 본문을 **짝으로** 돌려준다. 하나만 바꾸는 실수를
+ * 타입 차원에서 불가능하게 만드는 게 이 함수의 존재 이유다(예전 결함은
+ * 정확히 "매니페스트는 storefront, 본문은 dogfood" 였다).
+ *
+ * local 모드(사용자 vault 로드됨)에서는 이 값이 아예 소비되지 않는다 —
+ * 사용자 디스크가 항상 우선.
+ */
+export interface StaticVaultSource {
+  source: SampleSource;
+  manifest: VaultManifest;
+  /** slug → 원문 마크다운. 매니페스트와 항상 같은 볼트에서 온다. */
+  content: Record<string, string>;
+}
+
+// JSON import 는 union 필드를 string 으로 추론한다. 빌드 시점에 스키마가
+// 고정이라 runtime 검증 대신 cast (기존 소비자들이 각자 하던 cast 를 여기로
+// 모은 것 — 그 자체가 중복이었다).
+const DOGFOOD: StaticVaultSource = {
+  source: 'dogfood',
+  manifest: vaultManifest as VaultManifest,
+  content: vaultContent as Record<string, string>,
+};
+
+const STOREFRONT: StaticVaultSource = {
+  source: 'storefront',
+  manifest: sampleStorefrontManifest as VaultManifest,
+  content: sampleStorefrontContent as Record<string, string>,
+};
+
+export function resolveStaticVaultSource(source: SampleSource): StaticVaultSource {
+  return source === 'storefront' ? STOREFRONT : DOGFOOD;
+}

--- a/src/features/project-data-source/model/use-project-body.ts
+++ b/src/features/project-data-source/model/use-project-body.ts
@@ -3,16 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useLocalVault } from '@/features/docs-vault-local';
-import {
-  extractProjectBody,
-  findProjectVaultDoc,
-  vaultContent as staticVaultContentRaw,
-  vaultManifest as staticVaultManifestRaw,
-  type VaultManifest,
-} from '@/entities/docs-vault';
-
-const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
-const staticVaultContent = staticVaultContentRaw as Record<string, string>;
+import { useStaticVaultSource } from '@/features/vault-sample-source';
+import { extractProjectBody, findProjectVaultDoc } from '@/entities/docs-vault';
 
 export interface UseProjectBodyState {
   /** project.md 의 실제 마크다운 본문. 없거나 아직 못 읽었으면 null. */
@@ -33,6 +25,10 @@ export interface UseProjectBodyState {
 export function useProjectBody(slug: string | null): UseProjectBodyState {
   const mode = useDataSourceMode();
   const vault = useLocalVault();
+  // 매니페스트와 본문을 **짝으로** 받는다 — 예전 결함이 정확히 "매니페스트는
+  // storefront, 본문은 dogfood" 였다. 모듈 상수 한 벌을 그대로 돌려주므로
+  // 참조가 안정적이라 effect 의존성에 넣어도 재실행 루프가 없다.
+  const staticSource = useStaticVaultSource();
   const [resolved, setResolved] = useState<{ slug: string; body: string | null } | null>(
     null,
   );
@@ -50,8 +46,8 @@ export function useProjectBody(slug: string | null): UseProjectBodyState {
     }
 
     if (mode === 'static') {
-      const doc = findProjectVaultDoc(staticVaultManifest, slug);
-      const body = doc ? extractProjectBody(staticVaultContent[doc.slug]) ?? null : null;
+      const doc = findProjectVaultDoc(staticSource.manifest, slug);
+      const body = doc ? extractProjectBody(staticSource.content[doc.slug]) ?? null : null;
       window.queueMicrotask(() => {
         if (!cancelled) setResolved({ slug, body });
       });
@@ -82,7 +78,7 @@ export function useProjectBody(slug: string | null): UseProjectBodyState {
     return () => {
       cancelled = true;
     };
-  }, [slug, mode, vault.manifest, vault.fileHandles]);
+  }, [slug, mode, vault.manifest, vault.fileHandles, staticSource]);
 
   return { body: resolved && resolved.slug === slug ? resolved.body : null };
 }

--- a/src/features/project-data-source/model/use-projects.ts
+++ b/src/features/project-data-source/model/use-projects.ts
@@ -3,15 +3,8 @@
 import { useMemo } from 'react';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useLocalVault } from '@/features/docs-vault-local';
-import {
-  deriveProjectsFromVault,
-  vaultManifest as staticVaultManifestRaw,
-  type VaultManifest,
-} from '@/entities/docs-vault';
-
-// JSON import 가 mode 같은 union 필드를 string 으로 추론. 빌드 시점에 schema
-// 가 안정적이라 runtime 검증 대신 cast.
-const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
+import { useStaticVaultSource } from '@/features/vault-sample-source';
+import { deriveProjectsFromVault } from '@/entities/docs-vault';
 import type { Project } from '@/entities/project';
 
 /**
@@ -19,8 +12,9 @@ import type { Project } from '@/entities/project';
  *
  * - **local**: vault manifest 의 `projects/*.md` frontmatter 를 동기 매핑.
  *   사용자가 vault 에 .md 추가하면 즉시 list 에 반영.
- * - **static**: 빌드 타임 `docs/ontology/` 매니페스트 (dogfood). vault 미선택
- *   사용자도 이 OSS 자체의 ontology 를 즉시 본다 — "0 마찰 진입" 의 read 구현.
+ * - **static**: 빌드 타임 번들 매니페스트. vault 미선택 사용자도 ontology 를
+ *   즉시 본다 — "0 마찰 진입" 의 read 구현. 어느 번들 볼트인지는 사용자의
+ *   "예시 비즈니스" 선택이 정하므로 매니페스트를 직접 import 하지 않는다.
  */
 export interface UseProjectsState {
   projects: Project[];
@@ -32,6 +26,9 @@ export interface UseProjectsState {
 export function useProjects(): UseProjectsState {
   const mode = useDataSourceMode();
   const vault = useLocalVault();
+  // 번들 볼트는 모듈 상수 두 벌 중 하나를 그대로 돌려주므로 참조가 안정적이다
+  // — 의존성 배열에 넣어도 리렌더마다 재계산되지 않는다.
+  const staticSource = useStaticVaultSource();
 
   const localProjects = useMemo(() => {
     if (mode !== 'local' || !vault.manifest) return [];
@@ -40,8 +37,8 @@ export function useProjects(): UseProjectsState {
 
   const staticProjects = useMemo(() => {
     if (mode !== 'static') return [];
-    return deriveProjectsFromVault(staticVaultManifest);
-  }, [mode]);
+    return deriveProjectsFromVault(staticSource.manifest);
+  }, [mode, staticSource.manifest]);
 
   if (mode === 'local') {
     return {

--- a/src/features/vault-ontology/model/use-ontology-insight.ts
+++ b/src/features/vault-ontology/model/use-ontology-insight.ts
@@ -11,9 +11,7 @@ import {
 } from '@/entities/knowledge-graph';
 import {
   deriveOntologyFromVault,
-  vaultManifest as staticVaultManifestRaw,
-  sampleStorefrontManifest as storefrontVaultManifestRaw,
-  type VaultManifest,
+  resolveStaticVaultSource,
   type VaultOntologyDerivation,
 } from '@/entities/docs-vault';
 import { isContainmentRelation } from '@/shared/lib/ontology-tree';
@@ -26,17 +24,17 @@ import { useVaultOntology } from './use-vault-ontology';
 const VAULT_SENTINEL_DATE = new Date(0);
 const VAULT_SENTINEL_AUTHOR = 'vault-frontmatter';
 
-// 빌드타임 dogfood 매니페스트 — JSON import. mode === 'static' 일 때
-// 진실원. local 모드와는 별 path.
-const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
-const STATIC_DERIVATION: VaultOntologyDerivation =
-  deriveOntologyFromVault(staticVaultManifest);
-
-// P0 공감형 샘플 vault — "예시 비즈니스 보기" 선택 시 진실원(dogfood 와 같은
-// 빌드타임 JSON import 라 module-load 1 회 derive + 메모이즈).
-const storefrontVaultManifest = storefrontVaultManifestRaw as VaultManifest;
-const STOREFRONT_DERIVATION: VaultOntologyDerivation =
-  deriveOntologyFromVault(storefrontVaultManifest);
+// 번들 샘플 볼트 — mode === 'static' 일 때 진실원. local 모드와는 별 path.
+// 매니페스트는 리졸버를 통해서만 받는다: JSON 을 직접 import 하면 매니페스트와
+// 본문이 서로 다른 볼트에서 오는 사고가 다시 열린다(단일 진입점 계약,
+// tests/contract/static-vault-source.contract.test.ts).
+// 둘 다 빌드타임 JSON 이라 module-load 1 회만 derive 하고 재사용한다.
+const STATIC_DERIVATION: VaultOntologyDerivation = deriveOntologyFromVault(
+  resolveStaticVaultSource('dogfood').manifest,
+);
+const STOREFRONT_DERIVATION: VaultOntologyDerivation = deriveOntologyFromVault(
+  resolveStaticVaultSource('storefront').manifest,
+);
 
 export function derivationToInsight(
   d: VaultOntologyDerivation,

--- a/src/features/vault-ontology/model/use-vault-doc-freshness.ts
+++ b/src/features/vault-ontology/model/use-vault-doc-freshness.ts
@@ -3,9 +3,8 @@
 import { useMemo } from 'react';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useLocalVault } from '@/features/docs-vault-local';
-import { vaultManifest as staticVaultManifestRaw, type VaultManifest } from '@/entities/docs-vault';
-
-const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
+import { useStaticVaultSource } from '@/features/vault-sample-source';
+import type { VaultManifest } from '@/entities/docs-vault';
 
 export function manifestToFreshnessIndex(manifest: VaultManifest): Map<string, string> {
   const map = new Map<string, string>();
@@ -15,7 +14,6 @@ export function manifestToFreshnessIndex(manifest: VaultManifest): Map<string, s
   return map;
 }
 
-const STATIC_FRESHNESS_INDEX = manifestToFreshnessIndex(staticVaultManifest);
 const EMPTY_FRESHNESS_INDEX: Map<string, string> = new Map();
 
 /**
@@ -32,10 +30,14 @@ const EMPTY_FRESHNESS_INDEX: Map<string, string> = new Map();
 export function useVaultDocFreshnessIndex(): ReadonlyMap<string, string> {
   const mode = useDataSourceMode();
   const vault = useLocalVault();
+  // 번들 볼트가 둘(dogfood · storefront)이라 index 를 모듈 로드 시점에 못 굳힌다.
+  // 대신 모듈 상수 매니페스트를 그대로 받으므로 참조가 안정적이고, 표본을
+  // 바꿀 때만 memo 가 다시 돈다.
+  const staticSource = useStaticVaultSource();
 
   return useMemo(() => {
-    if (mode === 'static') return STATIC_FRESHNESS_INDEX;
+    if (mode === 'static') return manifestToFreshnessIndex(staticSource.manifest);
     if (vault.status !== 'loaded' || !vault.manifest) return EMPTY_FRESHNESS_INDEX;
     return manifestToFreshnessIndex(vault.manifest);
-  }, [mode, vault.status, vault.manifest]);
+  }, [mode, vault.status, vault.manifest, staticSource.manifest]);
 }

--- a/src/features/vault-ontology/model/use-vault-health.ts
+++ b/src/features/vault-ontology/model/use-vault-health.ts
@@ -4,11 +4,7 @@ import { useMemo } from 'react';
 import { useDataSourceMode } from '@/features/data-source-mode';
 import { useSampleSource } from '@/features/vault-sample-source';
 import { useLocalVault } from '@/features/docs-vault-local';
-import {
-  vaultManifest as staticVaultManifestRaw,
-  sampleStorefrontManifest as storefrontVaultManifestRaw,
-  type VaultManifest,
-} from '@/entities/docs-vault';
+import { resolveStaticVaultSource, type VaultManifest } from '@/entities/docs-vault';
 import {
   computeVaultHealth,
   type VaultHealthResult,
@@ -22,8 +18,10 @@ import {
  * derived graph. Mirrors the mode selection of `useOntologyInsight` so the
  * verdict is computed against whatever vault the rest of the page shows.
  */
-const staticManifest = staticVaultManifestRaw as VaultManifest;
-const storefrontManifest = storefrontVaultManifestRaw as VaultManifest;
+// 매니페스트는 리졸버를 통해서만 받는다 — JSON 직접 import 는 샘플 선택을
+// 우회할 수 있는 두 번째 진입점이 된다(tests/contract/static-vault-source.contract.test.ts).
+const staticManifest = resolveStaticVaultSource('dogfood').manifest;
+const storefrontManifest = resolveStaticVaultSource('storefront').manifest;
 
 const staticHealthCache = new WeakMap<VaultManifest, VaultHealthResult>();
 function manifestHealth(manifest: VaultManifest): VaultHealthResult {

--- a/src/features/vault-sample-source/index.ts
+++ b/src/features/vault-sample-source/index.ts
@@ -1,2 +1,4 @@
 export { useSampleSource } from './model/use-sample-source';
+export { useStaticVaultSource } from './model/use-static-vault-source';
+export type { StaticVaultSource } from '@/entities/docs-vault';
 export type { SampleSource } from '@/shared/lib/sample-source';

--- a/src/features/vault-sample-source/model/use-static-vault-source.ts
+++ b/src/features/vault-sample-source/model/use-static-vault-source.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import {
+  resolveStaticVaultSource,
+  type StaticVaultSource,
+} from '@/entities/docs-vault';
+import { useSampleSource } from './use-sample-source';
+
+/**
+ * static 모드에서 **지금 봐야 할 번들 볼트**(매니페스트 + 본문 한 벌).
+ *
+ * 화면 코드가 `vaultManifest` / `vaultContent` 를 직접 import 하면 사용자의
+ * "예시 비즈니스 보기" 선택을 조용히 무시하게 된다 — 2026-07-26 실측에서
+ * 9개 표면이 그랬다(프로젝트 목록·상세 본문·문서함·검색 팔레트·문서 드로어
+ * 등). 그래서 진입점을 이 훅 하나로 모은다. 자세한 배경은
+ * `entities/docs-vault/lib/static-vault-source.ts`.
+ *
+ * local 모드에서는 호출부가 이 값을 버리면 된다 — 사용자 vault 가 우선이라
+ * 여기서 분기하지 않는다(모드 판단은 각 호출부의 책임이고, 이 훅은 "static
+ * 이면 어느 볼트인가" 라는 한 질문에만 답한다).
+ */
+export function useStaticVaultSource(): StaticVaultSource {
+  const [sampleSource] = useSampleSource();
+  return resolveStaticVaultSource(sampleSource);
+}

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -79,9 +79,9 @@ import {
   buildNewNodeDoc,
   buildOntologyDeeplinkForDoc,
   deriveOntologyFromVault,
-  vaultManifest,
   type VaultManifest,
 } from '@/entities/docs-vault';
+import { useStaticVaultSource } from '@/features/vault-sample-source';
 import { DocsVaultBacklinks } from '@/widgets/docs-vault/ui/DocsVaultBacklinks';
 import { DocsVaultEditor } from '@/widgets/docs-vault/ui/DocsVaultEditor';
 import { DocsVaultUnifiedPalette } from '@/widgets/docs-vault/ui/DocsVaultUnifiedPalette';
@@ -100,8 +100,6 @@ import {
   pushRecentDoc,
   RECENT_DOCS_STORAGE_PREFIX,
 } from '@/widgets/docs-vault/lib/recent-docs';
-
-const serverManifest = vaultManifest as VaultManifest;
 
 const subscribeDesktopRuntime = () => () => undefined;
 const readDesktopRuntime = () => isTauriVaultRuntime();
@@ -535,10 +533,14 @@ function DocsVaultContent() {
     Boolean(localVault.manifest);
 
   // 현재 활성 매니페스트 — source 에 따라 분기. 로컬은 loaded 이전엔 null.
+  // static 폴백은 사용자가 고른 샘플(도그푸드 / 예시 쇼핑몰)을 따른다 —
+  // 번들 매니페스트를 직접 읽으면 "예시 비즈니스 보기" 선택이 문서함에서만
+  // 조용히 무시돼 지도와 다른 볼트를 보여주게 된다.
+  const staticVault = useStaticVaultSource();
   const manifest: VaultManifest =
     isLocalSourceLoaded && localVault.manifest
       ? localVault.manifest
-      : serverManifest;
+      : staticVault.manifest;
   const ontologyDerivation = useMemo(
     () => deriveOntologyFromVault(manifest),
     [manifest],

--- a/src/views/project-selector/lib/use-vault-docs.ts
+++ b/src/views/project-selector/lib/use-vault-docs.ts
@@ -3,24 +3,28 @@
 import { useMemo } from "react";
 import { useLocalVault } from "@/features/docs-vault-local";
 import { useDataSourceMode } from "@/features/data-source-mode";
-import { vaultManifest as staticVaultManifestRaw, type VaultDoc, type VaultManifest } from "@/entities/docs-vault";
-
-const staticVaultManifest = staticVaultManifestRaw as VaultManifest;
+import { useStaticVaultSource } from "@/features/vault-sample-source";
+import type { VaultDoc } from "@/entities/docs-vault";
 
 /**
  * Mode-aware vault doc list — the same `local` (user's disk) vs `static`
- * (build-time dogfood manifest) truth-source priority as `useOntologyInsight`
+ * (번들 샘플 볼트) truth-source priority as `useOntologyInsight`
  * / `useProjects`, but exposing `VaultDoc[]` directly for callers that need
  * real per-file `updatedAt`/`mtime` (the /projects "recent activity" strip —
  * `KnowledgeGraphNode.lastApprovedAt` is a sentinel in vault mode and can't
  * rank recency, see `recent-activity.ts`).
+ *
+ * static 쪽 매니페스트는 반드시 `useStaticVaultSource()` 로 받는다 — dogfood
+ * 매니페스트를 직접 import 하면 사용자의 "예시 비즈니스 보기" 선택이 이
+ * 목록에서만 조용히 무시된다.
  */
 export function useVaultDocs(): readonly VaultDoc[] {
   const mode = useDataSourceMode();
   const vault = useLocalVault();
+  const { manifest: staticManifest } = useStaticVaultSource();
 
   return useMemo(() => {
-    if (mode === "static") return staticVaultManifest.docs;
+    if (mode === "static") return staticManifest.docs;
     return vault.manifest?.docs ?? [];
-  }, [mode, vault.manifest]);
+  }, [mode, staticManifest, vault.manifest]);
 }

--- a/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
+++ b/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
@@ -22,11 +22,11 @@ import {
   findRelatedDocs,
   pinnedDocsStorageKey,
   recentDocsStorageKey,
-  vaultManifest,
   vaultScopeKey,
   type VaultManifest,
   type VaultTreeNode,
 } from "@/entities/docs-vault";
+import { useStaticVaultSource } from "@/features/vault-sample-source";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { useLocalVault } from "@/features/docs-vault-local";
 import {
@@ -293,14 +293,17 @@ export function DocsQuickDrawer({
   // `:server` 로 고정돼 다른 볼트의 목록이 섞였다 (opus5 검수 2026-07-25).
   //
   // 이제 /docs 와 같은 규칙을 쓴다: 로컬 볼트가 로드돼 있으면 그 manifest 와
-  // 그 볼트 범위의 고정/최근을, 아니면 번들(도그푸드 샘플)을 본다.
+  // 그 볼트 범위의 고정/최근을, 아니면 사용자가 고른 번들 샘플(도그푸드 /
+  // 예시 쇼핑몰)을 본다 — 번들을 직접 읽으면 샘플 선택이 여기서만 무시된다.
   const mode = useDataSourceMode();
   const localVault = useLocalVault();
+  const staticVault = useStaticVaultSource();
   const isLocalLoaded =
     mode === "local" && localVault.status === "loaded" && Boolean(localVault.manifest);
-  const activeManifest = (isLocalLoaded && localVault.manifest
-    ? localVault.manifest
-    : vaultManifest) as VaultManifest;
+  const activeManifest: VaultManifest =
+    isLocalLoaded && localVault.manifest
+      ? localVault.manifest
+      : staticVault.manifest;
   const scope = vaultScopeKey({
     isLocalLoaded,
     handleName: localVault.handle?.name ?? null,

--- a/src/widgets/docs-vault/lib/use-docs-body-index.ts
+++ b/src/widgets/docs-vault/lib/use-docs-body-index.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { vaultContent, type VaultDoc } from '@/entities/docs-vault';
+import { type VaultDoc } from '@/entities/docs-vault';
+import { useStaticVaultSource } from '@/features/vault-sample-source';
 import {
   buildBodyEntry,
   docBodyCacheKey,
@@ -46,6 +47,10 @@ export function useDocsBodyIndex({
 }: Options): { bodyIndex: DocsBodyIndex; indexing: boolean } {
   const [bodyIndex, setBodyIndex] = useState<DocsBodyIndex>(() => new Map());
   const [indexing, setIndexing] = useState(false);
+  // static 볼트의 번들 본문 — 검색 결과가 목록(매니페스트)과 같은 볼트를
+  // 가리키게 하려면 본문도 같은 샘플에서 와야 한다. 번들 content.json 을
+  // 직접 읽으면 "예시 비즈니스 보기" 에서 도그푸드 본문이 검색된다.
+  const { content: bundledContent } = useStaticVaultSource();
   /** slug → entry 캐시. docs 배열이 갈려도 key 가 같으면 재사용. */
   const cacheRef = useRef<Map<string, DocsBodyEntry>>(new Map());
   /** 실패한 key — 같은 mtime 에 대한 재시도 폭주 방지 (변경되면 재시도). */
@@ -82,7 +87,7 @@ export function useDocsBodyIndex({
       getDocContent ??
       ((slug: string) =>
         fetchServerDocContent(slug, {
-          bundledContent: vaultContent as Record<string, string>,
+          bundledContent,
           locationHref:
             typeof window === 'undefined' ? undefined : window.location.href,
         }));
@@ -121,7 +126,7 @@ export function useDocsBodyIndex({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [docs, getDocContent, startDelayMs]);
+  }, [bundledContent, docs, getDocContent, startDelayMs]);
 
   return { bodyIndex, indexing };
 }

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
@@ -9,9 +9,9 @@ import { useTranslations } from 'next-intl';
 import { ExternalLink, Hash } from 'lucide-react';
 import {
   buildDocsVaultHref,
-  vaultContent,
   type VaultDoc,
 } from '@/entities/docs-vault';
+import { useStaticVaultSource } from '@/features/vault-sample-source';
 import { splitHighlightSegments } from '@/shared/lib/highlight-match';
 import { useCopyFeedback } from '@/shared/lib/use-copy-feedback';
 import { fetchServerDocContent } from '../lib/server-doc-content';
@@ -64,6 +64,10 @@ export function DocsVaultViewer({
   const t = useTranslations('vaultWidgets.viewer');
   const [raw, setRaw] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // static 볼트의 번들 본문 — 매니페스트를 고른 것과 **같은 볼트**에서 와야
+  // 한다. 예전 결함이 정확히 이 어긋남이었다(매니페스트는 예시 쇼핑몰,
+  // 본문은 도그푸드라 제목과 내용이 다른 문서를 가리켰다).
+  const { content: bundledContent } = useStaticVaultSource();
 
   // raw 로드되고 highlightQuery 있으면 첫 매치로 자동 스크롤 — md-highlight
   // class 가 부여된 첫 mark 를 찾아 scrollIntoView.
@@ -85,7 +89,7 @@ export function DocsVaultViewer({
     const fetcher = getDocContent
       ? getDocContent(doc.slug)
       : fetchServerDocContent(doc.slug, {
-          bundledContent: vaultContent as Record<string, string>,
+          bundledContent,
           locationHref:
             typeof window === 'undefined' ? undefined : window.location.href,
         });
@@ -116,7 +120,7 @@ export function DocsVaultViewer({
     return () => {
       cancelled = true;
     };
-  }, [doc.slug, getDocContent]);
+  }, [bundledContent, doc.slug, getDocContent]);
 
   // 문자열 노드에 highlightQuery 매치를 <mark> 로 래핑. useMemo 내부에서
   // 의존성 추적하기 좋게 pure 함수로 분리, 클로저 대신 인자로 query 전달.

--- a/src/widgets/project-drawer/ui/ProjectDrawer.tsx
+++ b/src/widgets/project-drawer/ui/ProjectDrawer.tsx
@@ -13,12 +13,8 @@ import {
 import { MOTION, SPRING } from "@/shared/motion";
 import { ArrowUpRight, BookOpen, ChevronDown, X } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
-import {
-  buildDocsVaultHref,
-  findRelatedDocs,
-  vaultManifest,
-  type VaultManifest,
-} from "@/entities/docs-vault";
+import { buildDocsVaultHref, findRelatedDocs } from "@/entities/docs-vault";
+import { useStaticVaultSource } from "@/features/vault-sample-source";
 import { formatDate } from "@/shared/lib/format-date";
 import {
   formatProjectIntegrityIssue,
@@ -275,18 +271,20 @@ export function ProjectDrawer({
   // 관련 문서 — Source Vault에서 이 프로젝트를 인용하는 md top 5.
   // 권한 없으면 섹션 자체 숨김 (게스트/로그인 안 된 사용자에게 admin 문서
   // 링크 새는 것 방지).
+  // 매니페스트를 직접 import 하면 "예시 비즈니스 보기" 선택과 무관하게 늘
+  // dogfood 문서가 나와, 화면의 다른 부분과 다른 볼트를 가리키게 된다.
+  const { manifest: staticManifest } = useStaticVaultSource();
   const relatedDocs = useMemo(() => {
     if (!project) return [];
-    const manifest = vaultManifest as VaultManifest;
     return findRelatedDocs(
-      manifest.docs,
+      staticManifest.docs,
       {
         projectSlug: project.slug,
         projectName: project.name,
       },
       5,
     );
-  }, [project]);
+  }, [project, staticManifest]);
   const relationshipSummary = project
     ? (() => {
         if (project.isHub && referencedBy.length > 0) {

--- a/src/widgets/search-palette/ui/SearchPalette.tsx
+++ b/src/widgets/search-palette/ui/SearchPalette.tsx
@@ -10,12 +10,8 @@ import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED } from '@/shared/motion';
 import { useBodyScrollLock } from '@/shared/lib/use-body-scroll-lock';
 import type { Project } from '@/entities/project';
 import { useTaxonomy } from '@/features/taxonomy';
-import {
-  buildDocsVaultHref,
-  vaultManifest,
-  type VaultDoc,
-  type VaultManifest,
-} from '@/entities/docs-vault';
+import { buildDocsVaultHref, type VaultDoc } from '@/entities/docs-vault';
+import { useStaticVaultSource } from '@/features/vault-sample-source';
 import { searchProjects } from '../model/fuzzy-search';
 
 // Source Vault 매칭 — 가볍게 title/excerpt/slug includes. ⌘K 팔레트는
@@ -205,11 +201,14 @@ function SearchPaletteDialog({
   }, [filteredProjects, query]);
 
   // Vault 문서 매칭 — 쿼리 있을 때 top 3.
+  // 매니페스트를 직접 import 하면 "예시 비즈니스 보기" 선택을 무시하고 늘
+  // dogfood 를 뒤진다 — 팔레트가 화면에 안 보이는 볼트를 검색하는 셈이다.
+  // 훅은 훅 규칙상 useMemo 밖에서 부르고 값만 의존성으로 넘긴다.
+  const { manifest: staticManifest } = useStaticVaultSource();
   const docResults = useMemo(() => {
     if (!query.trim()) return [];
-    const manifest = vaultManifest as VaultManifest;
-    return matchVaultDocs(query, manifest.docs);
-  }, [query]);
+    return matchVaultDocs(query, staticManifest.docs);
+  }, [query, staticManifest]);
   const rows = useMemo<PaletteRow[]>(
     () => [
       ...docResults.map((doc) => ({ kind: 'doc' as const, doc })),

--- a/tests/contract/static-vault-source.contract.test.ts
+++ b/tests/contract/static-vault-source.contract.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * 단일 진실원 가드 — static 모드(사용자 vault 미선택)에서 "지금 어떤 번들
+ * 볼트인가" 라는 질문의 답은 **한 곳**에서만 나와야 한다.
+ *
+ * 실측 결함(2026-07-26): 샘플 선택(`dogfood` / `storefront`)을 존중하는
+ * 소비자가 2곳뿐이었고 나머지는 dogfood 매니페스트를 직접 import 해서,
+ * 사용자가 예시 쇼핑몰을 골라도 검색 팔레트·프로젝트 드로어·문서 목록은
+ * dogfood 를 뒤졌다. 한 화면에 두 볼트가 섞여 "고장" 으로 읽혔다.
+ *
+ * 그래서 진입점을 `resolveStaticVaultSource` / `useStaticVaultSource` 로
+ * 좁히고, 그 규율이 다시 무너지지 않도록 여기서 코드를 직접 스캔한다.
+ *
+ * 구현 주의: 외부 프로세스(ripgrep 등)에 의존하지 않는다. 도구가 없으면
+ * 조용히 0건을 돌려주고 "위반 없음" 으로 오판하기 때문이다. node:fs 로 직접
+ * 순회하고, 스캔 파일 수를 함께 단언해 파서가 죽으면 가드가 먼저 터지게 한다.
+ */
+
+const SRC_DIR = path.join(process.cwd(), 'src');
+
+/** 유일한 허용 구역 — 리졸버가 사는 엔티티. 여기서만 원본 JSON 을 만진다. */
+const ALLOWED_PREFIX = path.join('src', 'entities', 'docs-vault');
+
+/** 번들 볼트 원본 데이터의 export 이름. 화면 코드가 직접 쓰면 안 된다. */
+const FORBIDDEN_BINDINGS = [
+  'vaultManifest',
+  'vaultContent',
+  'sampleStorefrontManifest',
+  'sampleStorefrontContent',
+];
+
+/** `import ... from '...'` 을 여러 줄에 걸쳐도 통째로 집는다. */
+const IMPORT_STATEMENT = /import\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"]/g;
+
+/** 엔티티를 우회해 JSON 을 직접 집는 경로 (`.../docs-vault/data/manifest.json`). */
+const RAW_DATA_SPECIFIER = /docs-vault\/data\/[\w.-]+\.json$/;
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      collectSourceFiles(full, acc);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    if (/\.(test|spec)\.tsx?$/.test(entry.name)) continue;
+    acc.push(full);
+  }
+  return acc;
+}
+
+function findViolations(source: string): string[] {
+  const hits: string[] = [];
+  for (const match of source.matchAll(IMPORT_STATEMENT)) {
+    const clause = match[1];
+    const specifier = match[2];
+    if (RAW_DATA_SPECIFIER.test(specifier)) {
+      hits.push(specifier);
+      continue;
+    }
+    for (const binding of FORBIDDEN_BINDINGS) {
+      if (new RegExp(`\\b${binding}\\b`).test(clause)) hits.push(binding);
+    }
+  }
+  return [...new Set(hits)];
+}
+
+describe('static 볼트 단일 진입점 계약', () => {
+  it('entities/docs-vault 바깥에서는 번들 볼트 원본을 직접 import 하지 않는다', () => {
+    const files = collectSourceFiles(SRC_DIR);
+
+    // 가드가 살아있음을 스스로 증명한다 — 순회가 깨져 0건을 읽으면 위반도
+    // 0건이 되어 조용히 통과한다. 그 실패를 여기서 먼저 잡는다.
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = path.relative(process.cwd(), file);
+      if (rel.startsWith(ALLOWED_PREFIX)) continue;
+      const violations = findViolations(readFileSync(file, 'utf8'));
+      if (violations.length > 0) offenders.push(`${rel} → ${violations.join(', ')}`);
+    }
+
+    expect(
+      offenders,
+      [
+        '번들 볼트 원본(dogfood / storefront 매니페스트·본문)을 직접 import 하면',
+        '사용자의 "예시 비즈니스 보기" 선택이 그 표면에서만 조용히 무시된다.',
+        '대신 화면 코드는 useStaticVaultSource() 를, 훅이 아닌 코드는',
+        'resolveStaticVaultSource(source) 를 써서 매니페스트와 본문을 짝으로 받는다.',
+        '위반 파일:',
+        ...offenders,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`demo:sample-source:v1 = storefront` 인 상태로 프로젝트 상세를 열면 **한 화면에 두 볼트가 섞였다.** 제목·본문은 dogfood 의 `ontology-atlas`, 그래프는 storefront(31 문서). 그 결과 히어로 지표가 전부 0, 구성 탭은 빈 상태, 헤더만 "31 CONCEPTS · 61 RELATIONS" 를 외쳤다. 사용자에게는 그냥 고장이다.

**원인은 같은 질문("지금 어떤 볼트인가")에 답이 두 개였던 것.** 샘플 선택을 존중하는 소비자는 2곳뿐이고, 나머지 9곳이 dogfood 매니페스트를 직접 import 했다 — 프로젝트 목록·상세 본문·문서 신선도·문서함·본문 인덱스·검색 팔레트·문서 드로어·프로젝트 드로어·프로젝트 선택기.

"예시 비즈니스" 는 비개발자를 위한 공감 진입로인데, 정작 거기 들어가면 절반이 이 프로젝트 자신을 보여줬다.

### 수정

`resolveStaticVaultSource(source)` 가 매니페스트와 본문을 **짝으로** 돌려준다 — 하나만 바꾸는 실수를 타입 차원에서 불가능하게. 예전 결함이 정확히 그 어긋남이었다. `useStaticVaultSource()` 훅이 유일한 화면 진입점이 된다.

### 재발 방지

`tests/contract/static-vault-source.contract.test.ts` — `entities/docs-vault` 바깥의 어떤 파일도 번들 매니페스트/본문을 직접 import 하지 못한다. 배럴 우회(`docs-vault/data/*.json` 직접 지정)도 막는다.

게이트가 조용히 죽는 걸 막으려고 둘을 넣었다: 외부 `rg` 프로세스에 의존하지 않고(없으면 0건을 "위반 없음" 으로 오판한다) `node:fs` 로 직접 순회하며, **스캔한 파일 수가 100을 넘는지 단언한다** — 순회가 깨지면 위반 0건이 아니라 그 단언이 먼저 터진다.

> 스택 PR — base 는 #663.

## Test plan

- `pnpm exec tsc --noEmit`
- `pnpm test:run` — 3847 통과
- `pnpm lint` — 145 warnings / 0 errors (베이스라인 유지)
- 게이트 실효성: 일부러 위반 2종(배럴 import · JSON 직접 지정)을 넣어 실패와 파일 경로 지목 확인 후 복구
- 브라우저: storefront 선택 시 프로젝트 목록이 "온라인 쇼핑몰" 로 전환