### PR TITLE
ci: 단위 검증 게이트 — tsc · lint · vitest (PR 에서 한 번도 안 돌던 것)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,63 @@
+# 단위 검증 게이트 — tsc · lint · vitest.
+#
+# 왜 있는가: 2026-07-26 까지 PR 에서 도는 것은 Playwright(15분)와 vault
+# 정합뿐이었다. `pnpm test:run` 3900여 개, `tsc`, `lint` 는 **한 번도 돌지
+# 않았다.** 그래서 `ProjectSelectorPage.test.tsx` 의 낡은 기대값이 main 에
+# 들어가 앉아 있다가 사람이 우연히 발견했고, 브랜치가 자기가 지운 모듈을
+# 자기가 import 하는 상태로 CI 를 세 번 깨뜨렸다.
+#
+# 이 잡은 Playwright 보다 **훨씬 빨라서** 오히려 먼저 답을 준다 — 타입/단위
+# 회귀는 여기서 몇 분 안에 걸리고, 느린 e2e 는 그 뒤에 온다.
+name: Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  checks:
+    name: Types · Lint · Unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.0 --activate
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 셋을 각각 별 스텝으로 둔다 — 한 스텝에 묶으면 어느 게 깨졌는지
+      # 로그를 뒤져야 한다. `if: always()` 로 첫 실패가 나머지를 가리지 않게.
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: Lint
+        if: always()
+        run: pnpm lint
+
+      - name: Unit + contract tests
+        if: always()
+        run: pnpm test:run

--- a/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
@@ -180,7 +180,7 @@ describe("ProjectSelectorPage", () => {
     expect(
       within(card).getByRole("link", { name: "Open ontology-atlas details" }),
     ).toHaveAttribute("href", "/project/fallback/?slug=ontology-atlas");
-    expect(within(card).getByRole("link", { name: "View in topology →" })).toHaveAttribute(
+    expect(within(card).getByRole("link", { name: "View in topology" })).toHaveAttribute(
       "href",
       expect.stringContaining("ontology-atlas"),
     );


### PR DESCRIPTION
## Summary

**PR 에서 `pnpm test:run`·`tsc`·`lint` 가 한 번도 돌지 않고 있었다.** 도는 건 Playwright(15분)와 vault 정합뿐이었다.

오늘 그 대가를 세 번 치렀다:

1. `ProjectSelectorPage.test.tsx` 가 장식 화살표를 걷어내기 전 라벨을 기대한 채 **main 에 들어가 앉아 있었다** — 사람이 우연히 발견할 때까지 아무도 몰랐다. 이 PR 에서 함께 고친다.
2. 브랜치가 **자기가 지운 모듈을 자기가 import** 하는 상태로 CI 를 세 번 깨뜨렸다. `tsc` 한 번이면 즉시 걸렸을 일을 15분짜리 e2e 18건 실패로 알았다.
3. 리베이스 직후 같은 사고가 다음 브랜치에서 또 났다.

## 설계

- `Typecheck` · `Lint` · `Unit + contract` 를 **각각 별 스텝**으로 — 한 스텝에 묶으면 어느 게 깨졌는지 로그를 뒤져야 한다.
- `if: always()` — 첫 실패가 나머지를 가리지 않는다.
- Playwright 보다 훨씬 빨라 **먼저 답을 준다.** 타입/단위 회귀는 몇 분 안에, 느린 e2e 는 그 뒤에.

## 켜기 전에 main 이 통과하는지 확인했다

게이트가 첫날부터 빨간불이면 아무도 안 본다.

| 관문 | 결과 |
|---|---|
| `tsc --noEmit` | 0 에러 |
| `pnpm lint` | **145 warnings / 0 errors** (베이스라인) |
| `pnpm test:run` | **3903 통과 / 440 파일** |

## Test plan

위 셋을 `origin/main` + 이 커밋 기준으로 로컬 실행해 통과 확인. 워크플로 자체는 이 PR 의 CI 실행이 곧 증명이다.