### PR TITLE
fix: AI 연결 행 위계·정렬 + 접힌 행의 초안 키 수명

### DIFF
--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2593,7 +2593,7 @@
       "stored": "등록됨 ···· {last4}",
       "verify": "연결 확인",
       "verifying": "확인 중…",
-      "verifyScope": "전송: 인증 확인용 최소 요청 → {host} · 볼트 데이터 0자 · 감사 기록됨",
+      "verifyScope": "전송: 인증 확인용 최소 요청 → {host} · 볼트 데이터 0자 · 기록됨",
       "verified": "연결됨 · 방금",
       "verifyDenied": "키가 거부됐어요 ({status})",
       "verifyFailed": "확인하지 못했어요: {message}",

--- a/src/widgets/app-settings-menu/ui/AiConnectionPanel.test.tsx
+++ b/src/widgets/app-settings-menu/ui/AiConnectionPanel.test.tsx
@@ -133,6 +133,25 @@ describe('AiConnectionPanel unregistered rows', () => {
     expect(screen.queryByTestId('ai-key-input-anthropic')).toBeNull();
   });
 
+  it('drops an unsaved draft when another row takes the open slot', () => {
+    // 접기가 만든 새 노출 창 — 행은 접혀도 컴포넌트는 살아 있으므로, 붙여넣었다가
+    // 그만둔 키가 화면에서만 사라진 채 상태에 남을 수 있다. 사용자는 포기했다고
+    // 믿는데 남아 있으면 "저장 전까지만 화면에 있다" 는 계약이 깨진다.
+    renderPanel(makeConnection());
+    fireEvent.click(screen.getByTestId('ai-register-anthropic'));
+    fireEvent.change(screen.getByTestId('ai-key-input-anthropic'), {
+      target: { value: 'sk-ant-abandoned' },
+    });
+
+    fireEvent.click(screen.getByTestId('ai-register-gemini'));
+    expect(document.body.innerHTML).not.toContain('sk-ant-abandoned');
+
+    fireEvent.click(screen.getByTestId('ai-register-anthropic'));
+    expect(
+      (screen.getByTestId('ai-key-input-anthropic') as HTMLInputElement).value,
+    ).toBe('');
+  });
+
   it('collapses the row again once the key lands — no lingering open field', async () => {
     // 저장·삭제 직후에도 입력칸이 열려 있으면 화면이 "하나 더 넣으라" 고
     // 재촉하는 것처럼 읽힌다.

--- a/src/widgets/app-settings-menu/ui/AiConnectionPanel.tsx
+++ b/src/widgets/app-settings-menu/ui/AiConnectionPanel.tsx
@@ -181,8 +181,6 @@ function ProviderCard({
 }) {
   const t = useTranslations('settings.ai');
   const toast = useToast();
-  const [draftKey, setDraftKey] = useState('');
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [verify, setVerify] = useState<VerifyState>({ kind: 'idle' });
   const [clearArmed, setClearArmed] = useState(false);
@@ -197,23 +195,6 @@ function ProviderCard({
 
   const label = t(AI_PROVIDER_LABEL_KEY[provider]);
   const stored = status?.stored === true;
-
-  const handleSave = async () => {
-    if (!draftKey.trim() || saving) return;
-    setSaving(true);
-    setError(null);
-    try {
-      const next = await secretSet(provider, draftKey);
-      // 저장 성공 즉시 프런트 상태에서 키를 지운다 — 전체 키가 이 화면에
-      // 남아 있을 수 있는 유일한 순간을 여기서 끝낸다.
-      setDraftKey('');
-      if (next) onStatusChange(provider, next);
-    } catch (err) {
-      setError(secretErrorMessage(err));
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const handleVerify = async () => {
     if (!vaultRootPath || verify.kind === 'checking') return;
@@ -262,10 +243,14 @@ function ProviderCard({
   if (!stored && !expanded) {
     return (
       <div
-        className="flex items-center justify-between gap-3 px-3 py-2.5"
+        className="flex h-8 items-center justify-between gap-3 px-3 py-2.5"
         data-testid={`ai-provider-${provider}`}
       >
-        <p className="text-label text-[color:var(--color-text-tertiary)]">{label}</p>
+        {/* 벤더 이름은 정체성이지 상태가 아니다 — 등록 여부와 무관하게 같은
+            잉크로 그린다. 미등록이라는 사실은 뒤따르는 슬롯이 [키 등록] 버튼이냐
+            끝 4자냐로 이미 오해 없이 말한다. 이름까지 어둡히면 같은 사실을 두 번
+            부호화하면서, 이 화면의 1차 과업("내 벤더 찾기")만 어려워진다. */}
+        <p className="text-label text-[color:var(--color-text-secondary)]">{label}</p>
         <button
           type="button"
           data-testid={`ai-register-${provider}`}
@@ -280,7 +265,10 @@ function ProviderCard({
 
   return (
     <div className="grid gap-2 px-3 py-2.5" data-testid={`ai-provider-${provider}`}>
-      <div className="flex items-center justify-between gap-3">
+      {/* 접힌 행과 **같은 32px 헤더 밴드** — 이름 열과 뒤따르는 슬롯의 광학
+          중심이 행 상태와 무관하게 맞는다. 밴드가 없으면 등록 행의 이름만 8px
+          위로 떠서, 등록·미등록이 섞인 흔한 상태에서 세로 열이 삐뚤어진다. */}
+      <div className="flex h-8 items-center justify-between gap-3">
         <p className="text-label text-[color:var(--color-text-secondary)]">{label}</p>
         {stored ? (
           <span className="font-mono text-caption text-[color:var(--color-text-tertiary)]">
@@ -315,34 +303,12 @@ function ProviderCard({
           </button>
         </div>
       ) : (
-        <div className="flex items-center gap-2">
-          <input
-            type="password"
-            autoComplete="off"
-            spellCheck={false}
-            // 사용자가 방금 [키 등록]을 눌러 이 칸을 연 참이다 — 한 번 더
-            // 클릭하게 만들지 않는다.
-            autoFocus
-            value={draftKey}
-            aria-label={t('keyLabel', { provider: label })}
-            placeholder={t('keyPlaceholder')}
-            data-testid={`ai-key-input-${provider}`}
-            onChange={(event) => setDraftKey(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') void handleSave();
-            }}
-            className="h-8 min-w-0 flex-1 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-2 font-mono text-caption text-[color:var(--color-text-primary)] transition-colors placeholder:text-[color:var(--color-text-quaternary)] focus-visible:border-[color:var(--color-indigo-line-a45)] focus-visible:outline-none"
-          />
-          <button
-            type="button"
-            data-testid={`ai-save-${provider}`}
-            onClick={() => void handleSave()}
-            disabled={!draftKey.trim() || saving}
-            className="inline-flex h-8 shrink-0 items-center rounded-md border border-[color:var(--color-indigo-line-a32)] px-2.5 text-label text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-line-a13)] disabled:opacity-60"
-          >
-            {saving ? t('saving') : t('save')}
-          </button>
-        </div>
+        <KeyDraftForm
+          provider={provider}
+          label={label}
+          onSaved={(next) => onStatusChange(provider, next)}
+          onError={setError}
+        />
       )}
 
       <ProviderCaption
@@ -353,6 +319,83 @@ function ProviderCard({
         verify={verify}
         vaultKnown={vaultRootPath !== null}
       />
+    </div>
+  );
+}
+
+/**
+ * 붙여넣는 칸 — **펼쳐진 동안만 존재하는 컴포넌트다.**
+ *
+ * 초안 키를 부모가 아니라 여기서 들고 있는 것이 요점이다. 행이 접히면 이
+ * 컴포넌트가 언마운트되면서 초안도 **함께 사라진다** — 지우는 코드가 따로 있는
+ * 게 아니라, 남을 자리 자체가 없다.
+ *
+ * 왜 굳이 이렇게 하나: 행 접기는 "화면에서 사라졌으니 없어졌겠지" 라는 믿음을
+ * 만든다. 초안을 부모가 들고 있으면 그 믿음이 틀리게 된다 — 붙여넣었다가 다른
+ * 행으로 옮겨 그만둔 키가 시트가 닫힐 때까지 메모리에 남는다. 수명을 가시성에
+ * 묶어 두면 "붙여넣은 키는 저장 전까지만 화면에 있다" 는 이 패널의 계약이
+ * 규율이 아니라 구조가 된다.
+ */
+function KeyDraftForm({
+  provider,
+  label,
+  onSaved,
+  onError,
+}: {
+  provider: SecretProvider;
+  label: string;
+  onSaved: (next: SecretStatus) => void;
+  onError: (message: string | null) => void;
+}) {
+  const t = useTranslations('settings.ai');
+  const [draftKey, setDraftKey] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!draftKey.trim() || saving) return;
+    setSaving(true);
+    onError(null);
+    try {
+      const next = await secretSet(provider, draftKey);
+      // 저장 성공 즉시 프런트 상태에서 키를 지운다 — 전체 키가 이 화면에
+      // 남아 있을 수 있는 유일한 순간을 여기서 끝낸다.
+      setDraftKey('');
+      if (next) onSaved(next);
+    } catch (err) {
+      onError(secretErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="password"
+        autoComplete="off"
+        spellCheck={false}
+        // 사용자가 방금 [키 등록]을 눌러 이 칸을 연 참이다 — 한 번 더
+        // 클릭하게 만들지 않는다.
+        autoFocus
+        value={draftKey}
+        aria-label={t('keyLabel', { provider: label })}
+        placeholder={t('keyPlaceholder')}
+        data-testid={`ai-key-input-${provider}`}
+        onChange={(event) => setDraftKey(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') void handleSave();
+        }}
+        className="h-8 min-w-0 flex-1 rounded-md border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-2 font-mono text-caption text-[color:var(--color-text-primary)] transition-colors placeholder:text-[color:var(--color-text-quaternary)] focus-visible:border-[color:var(--color-indigo-line-a45)] focus-visible:outline-none"
+      />
+      <button
+        type="button"
+        data-testid={`ai-save-${provider}`}
+        onClick={() => void handleSave()}
+        disabled={!draftKey.trim() || saving}
+        className="inline-flex h-8 shrink-0 items-center rounded-md border border-[color:var(--color-indigo-line-a32)] px-2.5 text-label text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] hover:bg-[color:var(--color-indigo-line-a13)] disabled:opacity-60"
+      >
+        {saving ? t('saving') : t('save')}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

#677 (AI 연결 Gemini) 의 **디자인 가디언 검수 후속**이다. #677 이 머지되는 동안
검수가 끝나 세 건이 나왔고, 그중 하나는 행 접기가 만든 **실제 노출 창**이다.

가디언 판정: **조건부 승인** — "행 접기 방향은 옳고 금지 패턴은 깨끗하다.
다만 첫 실행 화면의 잉크 위계가 무너졌고, 접힌 행이 미저장 키를 조용히 들고 있다."

### 1. 첫 화면에 `--color-text-secondary` 가 0개가 됐다

접기 전에는 미등록 행이 항상 펼쳐져 있어 벤더 이름이 secondary(#d0d6e0, 13.4:1)
였다. 접힌 행을 tertiary(#8a8f98, 6.0:1)로 그리면서 **콘텐츠 영역 전체의 잉크
천장이 tertiary 로 내려앉았다** — principle·벤더 이름 3개·`Finder에서 열기` 가
전부 tertiary, 나머지는 quaternary, 인디고 0개.

하필 같은 화면에 `emptyConsumer`("볼트에 질문하는 기능은 준비 중이에요")가 있어
그 오독을 확증해 준다: **화면 전체가 아직 안 되는 기능처럼 읽힌다.**

벤더 이름은 **정체성이지 상태가 아니다.** 미등록이라는 사실은 뒤따르는 슬롯이
`[키 등록]` 버튼이냐 `등록됨 ···· abcd` 냐로 이미 오해 없이 말한다. 이름까지
어둡히면 같은 사실을 두 번 부호화하면서, 이 화면의 1차 과업("내 벤더 찾기")만
어려워진다.

→ 접힌 행 이름 `tertiary` → `secondary`. 규칙이 단순해진다: **이름 = 항상
secondary, 후행 슬롯 = 항상 tertiary.**

인디고는 그대로 둔다 — 벤더는 서로 peer 이고 어느 것도 primary 가 아니므로
`[키 등록]` 을 인디고로 올리면 3개의 경쟁하는 primary 가 된다.

### 2. 이름 열이 행마다 8px 튀었다

| 행 | 라벨 광학 중심 |
|---|---|
| 접힌 행 (`py-2.5` + `h-8` 버튼 `items-center`) | 10 + 16 = **26px** |
| 등록/펼친 행 (`py-2.5` + 라벨 높이만) | 10 + 8 = **18px** |

등록 1 + 미등록 2 라는 흔한 상태에서 이름 열과 후행 열이 함께 어긋난다.

→ 두 갈래에 **같은 32px 헤더 밴드**(`h-8`). 모든 행에서 이름·후행 슬롯 중심이
26px 에 맞는다.

**높이 차 자체는 결함이 아니다** — 상태가 다르면 담는 내용이 실제로 다르므로
정직한 차이다(`DESIGN-SYSTEM.md` "Dimensional regularity" 가 잡는 건 내용 길이가
*우연히* 정하는 높이다).

### 3. 접힌 행이 저장 안 한 키를 들고 있었다 — 접기가 만든 노출 창

`ProviderCard` 는 다른 행이 펼쳐져도 **언마운트되지 않는다**(`key={provider}`,
위치 동일). 그래서:

1. Anthropic `[키 등록]` → 키를 붙여넣는다 (저장 안 함)
2. 마음이 바뀌어 Gemini `[키 등록]` 클릭 → Anthropic 행이 접힌다
3. **`draftKey` 에 전체 키가 그대로 남는다** — 시트가 닫힐 때까지

DOM 에는 없으니 기존 단언은 통과한다. 하지만 접기는 "화면에서 사라졌으니
없어졌겠지" 라는 믿음을 만들고, 그 믿음이 틀리게 된 것이다. 이 파일이 스스로
적어 둔 계약("전체 키가 이 화면에 남아 있을 수 있는 유일한 순간을 여기서
끝낸다")을 접기가 조용히 연장했다.

**지우는 effect 를 붙이지 않았다.** 대신 초안의 **수명을 가시성에 묶었다** —
입력칸을 `KeyDraftForm` 으로 분리해 펼쳐진 동안만 존재하게 했다. 행이 접히면
컴포넌트가 언마운트되면서 초안도 함께 사라진다. **지우는 코드가 있는 게 아니라
남을 자리가 없다.** 계약이 규율이 아니라 구조가 된다.

(첫 시도는 `useEffect` 로 초안을 비우는 것이었는데 `react-hooks/set-state-in-effect`
경고가 붙었다. 그 경고가 가리킨 방향이 맞았다 — 반응적으로 지우는 것보다 수명을
묶는 쪽이 더 강한 보장이다.)

### 4. 문구: `감사 기록됨` → `기록됨`

설계서 §D-3 이 명시한 ko 문구가 `· 기록됨` 인데 구현이 기존 `감사 기록됨` 을
유지했다. 이 패널의 사용자향 어휘는 이미 평문 "기록" 이다(`보낸 기록`, `기록`).
`감사` 는 내부어이고, EN 은 이미 `logged` 라 한/영 레지스터도 어긋나 있었다.

## 가디언이 백로그로 넘긴 것 (이 PR 에 넣지 않음)

- **호스트 mono 승격** — `api.anthropic.com` 이 헌장 ⑥ 주장의 증거물인데 비례활자
  quaternary 로 산문에 섞여 있다. `t.rich` 로 `font-mono` + tertiary 승격이
  처방이지만, 테스트의 `useTranslations` mock 이 `.rich` 를 갖고 있지 않아 mock
  개편이 따라붙는다. 별도 커밋.
- **포커스 링 + `aria-expanded`** — `[키 등록]` 에 `focus-visible` 이 없다. 다만
  기존 `[연결 확인]`/`[저장]`/`[지우기]` 도 같이 빠져 있어 **패널 전체 한 번에**
  처리가 맞다.

가디언이 승인한 것: 화살표(`→ {host}`)는 **데이터다** — 지우면 문장이 깨지므로
`{source} → {target}` 허용 문법. 금지 패턴 스윕 전 항목 0건.

## Test plan

| 명령 | 결과 |
|---|---|
| `pnpm exec tsc --noEmit` | 통과 |
| `pnpm test:run` (전체) | **4038 passed / 3 todo** |
| `pnpm exec vitest run src/widgets/app-settings-menu src/shared/lib tests/contract` | 90 파일 · 973 통과 |
| `cargo test` (src-tauri) | 64 통과 · 0 실패 |
| `pnpm lint` | **145 warnings / 0 errors — 베이스라인 그대로** |

새 회귀 테스트: `drops an unsaved draft when another row takes the open slot` —
붙여넣고 → 다른 행 펼침 → 되돌아왔을 때 빈 칸.

### 설치 앱 실측 (`/Applications` 교체 설치 + Orca computer-use)

- **미등록 3행** — 벤더 이름 3개가 주변 캡션보다 뚜렷하게 밝다(잉크 천장 복구 확인).
- **등록 1 + 미등록 2 혼합** — `Anthropic / 등록됨 ····` 과 `OpenAI / [키 등록]`,
  `Google Gemini / [키 등록]` 의 이름 열·후행 열이 한 줄에 정렬된다(8px 지터 해소).
- 캡션 실물: `전송: 인증 확인용 최소 요청 → api.anthropic.com · 볼트 데이터 0자 · 기록됨`
- 테스트로 만든 키체인 항목은 삭제 완료.

### 못 한 검증

- 3번(초안 폐기)은 **단위 테스트로만** 덮었다. 설치 앱에서 재현하려면 붙여넣기 →
  다른 행 → 되돌아오기를 합성 클릭으로 이어야 하는데, Orca 가 매 클릭마다 새
  스냅샷을 요구하면서 element index 가 무효화된다(#677 의 2단 삭제와 같은 한계).
- 진짜 Gemini 키로 성공(200) 경로는 여전히 미검증 — 유효한 키가 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ieq1ffxPJhxvSjDUHMMYr