### PR TITLE
fix: 이름을 댄 릴리스는 프리릴리스라도 검증한다 — RC 초안이 영영 확인 불가였다

### DIFF
--- a/scripts/check-desktop-readiness.mjs
+++ b/scripts/check-desktop-readiness.mjs
@@ -617,7 +617,12 @@ if (
   downloadReleaseVerifier.includes("do not match the tag version") &&
   downloadReleaseVerifier.includes("allowDraft") &&
   downloadReleaseVerifier.includes("per_page=100") &&
-  downloadReleaseVerifier.includes("release?.tag_name !== options.tag") &&
+  // 폴백은 **태그로** 초안을 찾는다. 그리고 프리릴리스 여부로 다시 거르지
+  // 않는다 — 호출자가 이름을 댔으면 무엇을 원하는지 이미 말했고, 거기서 한 번
+  // 더 거르면 RC 초안을 영영 검증할 수 없다(2026-07-27 v1.0.0-rc.1 실측).
+  downloadReleaseVerifier.includes("export function isRequestedDraft") &&
+  downloadReleaseVerifier.includes("release?.tag_name === tag && release?.draft === true") &&
+  downloadReleaseVerifier.includes("if (!options.tag && release.prerelease && !options.allowPrerelease)") &&
   downloadReleaseVerifier.includes("unsupported macOS DMG asset names") &&
   downloadReleaseVerifier.includes("function isAnyDmgAsset") &&
   downloadReleaseVerifier.includes('asset.name.endsWith(".dmg")') &&

--- a/scripts/check-macos-download-release.mjs
+++ b/scripts/check-macos-download-release.mjs
@@ -257,6 +257,24 @@ function isChecksumFor(asset, dmgName) {
   );
 }
 
+/**
+ * 이름을 대고 찾은 draft 인가.
+ *
+ * 프리릴리스 여부로 거르지 **않는다**. `allowPrerelease` 는 태그 없이 "지금
+ * 릴리스" 를 **고를 때** 프리릴리스가 뽑히지 않게 하는 장치이고, 호출자가
+ * `--tag=v1.0.0-rc.1` 이라고 이름을 댄 순간 그 장치는 할 일이 없다 — 무엇을
+ * 원하는지 이미 말했다.
+ *
+ * 직접 조회(`releases/tags/<tag>`)에는 이 필터가 없다. 즉 같은 질문에 두 경로가
+ * 다르게 답하고 있었고, 그 비대칭이 결함이었다. RC 초안은 draft 라 404 로
+ * 떨어져 이 폴백을 타는데, 거기서 프리릴리스라는 이유로 다시 걸러져 "태그를 못
+ * 찾았다" 는 엉뚱한 메시지로 끝났다.
+ * (2026-07-27 v1.0.0-rc.1 에서 실측 — 정식 태그로는 드러나지 않는다.)
+ */
+export function isRequestedDraft(release, tag) {
+  return release?.tag_name === tag && release?.draft === true;
+}
+
 async function findRelease(options) {
   const base = `${apiBase()}/repos/${options.repo}`;
   if (options.tag) {
@@ -271,12 +289,7 @@ async function findRelease(options) {
       if (!Array.isArray(releases)) {
         fail("GitHub releases response was not an array.");
       }
-      const draftRelease = releases.find((release) => {
-        if (release?.tag_name !== options.tag) return false;
-        if (!release?.draft) return false;
-        if (!options.allowPrerelease && release?.prerelease) return false;
-        return true;
-      });
+      const draftRelease = releases.find((release) => isRequestedDraft(release, options.tag));
       if (draftRelease) {
         return draftRelease;
       }
@@ -400,7 +413,14 @@ if (!release) {
 if (release.draft && !options.allowDraft) {
   fail(`release ${release.tag_name ?? "(unknown tag)"} is a draft and is not downloadable from the hosted landing page.`);
 }
-if (release.prerelease && !options.allowPrerelease) {
+// 이름을 대지 않았을 때만 프리릴리스를 막는다.
+//
+// 태그 없이 부르면 이 스크립트는 "지금 공개된 릴리스" 를 **고르고**, 그 자리에
+// RC 가 뽑히면 안 된다 — 랜딩 페이지가 광고할 대상이 아니기 때문이다. 그러나
+// 호출자가 `--tag=v1.0.0-rc.1` 이라고 이름을 댔다면 무엇을 검증하려는지 이미
+// 말했고, 그걸 프리릴리스라는 이유로 거절하면 **RC 를 영영 검증할 수 없다.**
+// 릴리스 워크플로가 자기 태그의 초안을 확인하는 경로가 정확히 이것이다.
+if (!options.tag && release.prerelease && !options.allowPrerelease) {
   fail(`release ${release.tag_name ?? "(unknown tag)"} is a prerelease; pass --allow-prerelease to accept it.`);
 }
 

--- a/scripts/check-macos-download-release.test.mjs
+++ b/scripts/check-macos-download-release.test.mjs
@@ -494,3 +494,50 @@ test("download release verifier reports rate limits without a stack trace", asyn
     );
   });
 });
+
+/**
+ * 2026-07-27 v1.0.0-rc.1 이 CI 에서 실패한 그 상황 그대로다.
+ *
+ * RC 초안은 draft 라 `releases/tags/<tag>` 가 404 를 준다. 그러면 목록 폴백을
+ * 타는데, 거기서만 "프리릴리스면 거부" 를 한 번 더 걸고 있었다 — 직접 조회
+ * 경로에는 없는 필터다. 그래서 이름을 대고 찾았는데도 걸러졌고, 에러 메시지는
+ * 엉뚱하게 "태그를 못 찾았다" 였다.
+ *
+ * 정식 태그로는 드러나지 않는다. 프리릴리스를 처음 내는 날에만 나타난다.
+ */
+test("download release verifier finds a prerelease draft that was requested by tag", async () => {
+  const rcTag = "v1.0.0-rc.1";
+  // DMG 이름의 버전은 태그와 맞아야 한다 — 이 테스트는 그 대조가 `-rc.1` 을
+  // 포함한 버전에서도 성립하는지까지 함께 검사한다.
+  const rcNames = ["ontology-atlas_1.0.0-rc.1_aarch64.dmg", "ontology-atlas_1.0.0-rc.1_x64.dmg"];
+  await withServer((req, res) => {
+    // draft 는 태그 직접 조회에서 404 다 — GitHub 의 실제 동작.
+    if (req.url === `/repos/wlsdks/ontology-atlas/releases/tags/${rcTag}`) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Not Found" }));
+      return;
+    }
+    if (req.url === "/repos/wlsdks/ontology-atlas/releases?per_page=100") {
+      const payload = releasePayload(`http://${req.headers.host}`, validChecksum, rcNames, rcTag);
+      payload[0].draft = true;
+      payload[0].prerelease = true;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+      return;
+    }
+    makeHandler({ tagName: rcTag, names: rcNames })(req, res);
+  }, async (baseUrl) => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["scripts/check-macos-download-release.mjs", `--tag=${rcTag}`, "--allow-draft"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, OATLAS_GITHUB_API_BASE: baseUrl, GITHUB_TOKEN: "test-token" },
+      },
+    );
+
+    // --allow-prerelease 를 주지 않았는데도 통과해야 한다. 이름을 댔기 때문이다.
+    assert.match(stdout, /draft macOS download assets/);
+  });
+});


### PR DESCRIPTION
## Summary

**RC 를 낸 보람이 여기 있다.** `v1.0.0-rc.1` 이 실제 결함을 잡았고, 이건 정식
태그로는 **원리적으로 드러나지 않는다.**

빌드는 두 아키텍처 다 성공했고 초안도 만들어졌다. 프리릴리스 배지도 정확히
붙었다(#719 가 의도한 대로). 그런데 그 초안을 확인하는 단계에서 죽었고, 메시지는
엉뚱했다:

```
release tag v1.0.0-rc.1 was not found for wlsdks/ontology-atlas
```

**초안은 실재했다.** `--tag` 으로 이름을 댔는데도 못 찾은 이유는 프리릴리스
필터가 두 군데서 한 번씩 더 걸렸기 때문이다.

| | 어디 | 무슨 일 |
|---|---|---|
| ① | 조회 폴백 | draft 는 `releases/tags/<tag>` 가 404 → 목록 폴백을 타는데, **거기서만** 프리릴리스를 거부했다. 바로 위 직접 조회에는 없는 필터다 |
| ② | 검증 본문 | ①을 통과해도 다시 막았다 |

①이 특히 나쁘다 — **같은 질문에 두 경로가 다르게 답하고 있었다.** 그 비대칭이
결함이고, 에러 메시지가 "못 찾았다" 로 나온 것도 그래서다.

## 왜 이 필터가 원래는 옳은가

`allowPrerelease` 는 태그 **없이** "지금 공개된 릴리스" 를 **고를 때** RC 가
뽑히지 않게 하는 장치다. 랜딩 페이지가 광고할 대상이 아니므로 그건 옳다.

그러나 호출자가 `--tag=v1.0.0-rc.1` 이라고 **이름을 댄 순간** 그 장치는 할 일이
없다 — 무엇을 검증하려는지 이미 말했다. 그래서 두 곳 모두 "태그를 안 준 경우"
로 좁혔다. 릴리스 워크플로가 자기 태그의 초안을 확인하는 경로가 정확히 이것이다.

## Test plan

| 게이트 | 결과 |
|---|---|
| `node --test scripts/check-macos-download-release.test.mjs` | **21 pass** (기존 20 + 신규 1) |
| `pnpm test:desktop:check` | **221 pass / 0 fail** |
| `pnpm desktop:check` | PASS |
| `pnpm test:run` | 496 files passed |
| `pnpm exec tsc --noEmit` | PASS |
| `pnpm lint` | 145 — 베이스라인과 동일 |

회귀 테스트는 **CI 가 실패한 상황을 그대로 재현한다** — draft 는 태그 직접
조회에서 404, 목록에는 `draft: true, prerelease: true` 로 존재. `--allow-prerelease`
없이 통과해야 한다. DMG 파일명 버전 대조가 `-rc.1` 에서도 성립하는지까지 함께 본다.

**두 수정을 각각 되돌려 테스트가 실제로 잡는 것을 확인했다** (되돌리면 20/1 실패,
복구하면 21/0).

> `check-desktop-readiness.mjs` 가 리팩터로 사라진 리터럴 문자열을 단언하고
> 있었다. 지우지 않고 **새 함수와 좁혀진 조건을 가리키도록** 갱신했다 — 그
> 게이트의 의도(폴백은 태그로 매칭한다)는 그대로 지킨다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DP7YyGTinSVvcUyMb2d8q