### PR TITLE
chore: v1.0.0-rc.2 — 릴리스 후보를 다시 낸다

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2557,7 +2557,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/views/download/lib/release-facts.ts
+++ b/src/views/download/lib/release-facts.ts
@@ -38,7 +38,7 @@ export { CLI_COMMAND_COUNT } from "../../../../cli/src/lib/cli-commands.mjs";
  */
 export const MCP_TOOL_COUNT = 32;
 
-export const RELEASE_VERSION = "1.0.0-rc.1";
+export const RELEASE_VERSION = "1.0.0-rc.2";
 export const RELEASE_MIN_MACOS = "macOS 12";
 export const RELEASE_ARCHES = ["aarch64", "x64"] as const;
 export type ReleaseArch = (typeof RELEASE_ARCHES)[number];

--- a/src/views/download/model/macos-release.generated.ts
+++ b/src/views/download/model/macos-release.generated.ts
@@ -28,7 +28,7 @@ export interface MacosRelease {
 
 export const MACOS_RELEASE: MacosRelease = {
   published: false,
-  tag: 'v1.0.0-rc.1',
+  tag: 'v1.0.0-rc.2',
   publishedAt: null,
   releaseUrl: 'https://github.com/wlsdks/ontology-atlas/releases',
   assets: [],


### PR DESCRIPTION
## Summary

버전을 `1.0.0-rc.1` → `1.0.0-rc.2` 로 올린다. `v1.0.0-rc.1` 태그는 조립 단계가 세 번 실패한 옛 커밋을 가리키고, 그 뒤로 PR 18건이 들어갔다 — 같은 이름이 다른 내용을 가리키게 두지 않는다. GitHub Release 는 0건이라 슬롯은 비어 있다.

## 버전이 다섯 곳에 있다

`desktop:release-tag` 프리플라이트는 **넷만 본다**(`package.json` · `tauri.conf.json` · `Cargo.toml` · `Cargo.lock`). 다섯 번째는 `src/views/download/lib/release-facts.ts` 의 `RELEASE_VERSION` — 웹 번들이 서버 진입점(stdio JSON-RPC)을 못 끌어와 손으로 두는 값이다.

그래서 **프리플라이트가 초록인데 테스트가 빨간** 상태가 나왔다. 이번엔 테스트가 잡았지만, 프리플라이트를 믿고 태그를 밀면 놓친다. 후속으로 프리플라이트 사정거리를 넓힐지 판단이 필요하다.

`macos-release.generated.ts` 는 `pnpm download:release-facts -- --unpublished` 로 재생성 — `published: false` 인 정직한 출시 전 상태다.

## Test plan

- `pnpm exec tsc --noEmit` — clean
- `pnpm test:run` — **505 files / 4658 passed**
- `pnpm lint` — 0 errors / 142 warnings (베이스라인)
- `pnpm package:check` · `pnpm build` — pass
- `pnpm desktop:release-tag -- --tag=v1.0.0-rc.2` — pass

**미해결(이 PR 밖)**: `pnpm desktop:check` 가 `origin/main` 에서도 실패한다(문서 서술 게이트 2건). 이 변경과 무관하며 별도 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)