### PR TITLE
docs: README 재검 P1 2건 — 곧 낡을 시제와 잘린 트랜스크립트 꼬리

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ The theory and prior art behind that position are cited in
 
 *Last updated 2026-07-28.*
 
-- **No public release exists yet.** There is nothing on
-  [GitHub Releases](https://github.com/wlsdks/ontology-atlas/releases) at the
-  time of writing. Everything below runs from a source checkout.
+- **Check [GitHub Releases](https://github.com/wlsdks/ontology-atlas/releases)
+  for a build.** If that page is empty, or only lists release candidates,
+  everything below runs from a source checkout. The screenshots here were
+  captured from a local build, before the first signed release.
 - **The release pipeline is credentialed to sign with a Developer ID
   certificate and notarize with Apple**, and update packages are signed with a
   separate project key the app verifies before replacing anything — see
@@ -277,6 +278,7 @@ next impact capabilities/order-cancel — impact rows are candidates, not proof;
 inspect backlinks and node detail before refactor decisions
   ontology-atlas node capabilities/order-cancel [vault] --limit 20
   ontology-atlas backlinks capabilities/payment-authorize [vault]
+  ontology-atlas reachability capabilities/payment-authorize [vault] --plan --depth 2 --direction both --limit 20
 ```
 
 *Verbatim. The node titles are Korean because this example vault is written in
@@ -501,8 +503,10 @@ git diff 로 판단합니다. 백엔드·로그인·텔레메트리가 없고 va
   자리에서 연결까지 확인합니다.
 - **npm 발행 계획은 폐기됐습니다** (2026-07-27). 소스 체크아웃에서 CLI 와 MCP
   서버를 바로 실행합니다.
-- **아직 공개 릴리스가 없습니다.** 서명·공증 자격증명은 갖춰졌지만 그 경로로
-  나간 빌드가 아직 없습니다. 이 README 의 화면들은 로컬 빌드 앱에서 찍었습니다.
+- **받을 수 있는 빌드가 있는지는
+  [GitHub Releases](https://github.com/wlsdks/ontology-atlas/releases)에서
+  확인하세요.** 비어 있거나 릴리스 후보만 있으면 소스 체크아웃으로 씁니다.
+  이 README 의 화면들은 첫 서명 릴리스 이전에 로컬 빌드 앱에서 찍었습니다.
 - [라이브 데모](https://wlsdks.github.io/ontology-atlas/)에서 이 저장소 자신의
   온톨로지(97 노드)를 설치 없이 볼 수 있습니다.
 - 연결은 [MCP 가이드](mcp/README.md), 전체 명령은 [CLI 가이드](cli/README.md),


### PR DESCRIPTION
## Summary

README 전면 재검(`.qa-scratch/readme-review-2026-07-28.md`)이 **P0 0건 · 출하 가능** 판정을 냈지만 P1 둘을 남겼다. 둘 다 **릴리스 직전이라 지금 고치는 게 싸다**.

**① 시제가 곧 낡는다** — "No public release exists yet" 는 오늘은 참이지만 `v1.0.0-rc.2` 가 나가는 순간 README 가 Releases 페이지와 **정면으로 모순**된다. 릴리스마다 고쳐야 하는 문장 대신, 읽는 사람이 그 페이지를 **직접 보게 하는** 형태로 바꿨다 — 지금도 참이고 나간 뒤에도 참이다. 로컬 빌드 캡처 고지는 유지.

**② "Verbatim" 인데 꼬리가 잘렸다** — 실행해서 대조하니 실제 출력의 마지막 `reachability` 힌트 한 줄이 표시 없이 빠져 있었다. 그대로라 부른 블록의 유일한 부정확이라 원문을 복원했다.

한국어 절도 같은 기준으로 맞췄다.

## Test plan

- `pnpm package:check` — pass (README 6-표면 절 · `workspace-brief` 문구 계약 포함)
- `pnpm test:run tests/contract` — pass
- `pnpm exec tsc --noEmit` — clean
- `pnpm docs-vault:build` 재생성 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)