### PR TITLE
fix: desktop:check 가 어제의 문장을 요구해 릴리스를 막던 것

### DIFF
--- a/scripts/check-desktop-readiness.mjs
+++ b/scripts/check-desktop-readiness.mjs
@@ -806,7 +806,10 @@ if (
   featuresDoc.includes("lets you open your own local vault folder from the browser") &&
   productDirectionDoc.includes("Ontology Atlas") &&
   productDirectionDoc.includes("The Tauri bundle product name") &&
-  productDirectionDoc.includes("CLI · installed macOS app") &&
+  // 2026-07-28: npm 채널 폐기(#736)로 이 문장이 "설치 앱이 MCP 서버를 싣는다"
+  // 까지 말하게 바뀌었다. 옛 나열 순서를 요구하던 리터럴을 새 문장으로 옮긴다 —
+  // 게이트가 지키려는 것(설치 앱 + CLI 가 일상 표면)은 그대로다.
+  productDirectionDoc.includes("installed macOS app (carrying the MCP server) + CLI as the daily workbench") &&
   productDirectionDoc.includes("hosted website is the product introduction and download entry point") &&
   desktopDoc.includes("Ontology Atlas") &&
   desktopDoc.includes("current release") &&
@@ -835,8 +838,11 @@ if (
   developmentChecksDoc.includes("Firebase SDK, Firebase Admin, and Firebase CLI dependencies") &&
   developmentChecksDoc.includes("separate Hosting deploy toolchain") &&
   demoStoryboardDoc.includes("설치된 Ontology Atlas macOS 앱") &&
-  redditPostsDoc.includes("macOS desktop app that wraps the same Next.js static") &&
-  redditPostsDoc.includes("hosted website is only the product intro and download entry point")
+  // 2026-07-28: #736 이 npm 전제를 걷으며 이 문단을 다시 썼다. 앱이 같은 `.md`
+  // 를 네이티브 브리지로 읽고 쓴다는 사실과, 웹은 소개·다운로드 입구라는 역할
+  // 분담이 요구 사항이다 — 그걸 말하는 새 문장으로 옮긴다.
+  redditPostsDoc.includes("reads/writes the same `.md` files through a local native") &&
+  redditPostsDoc.includes("hosted website is the product intro and download")
 ) {
   pass("workflow, troubleshooting, publish, and launch docs route writable vault work through the desktop app");
 } else {


### PR DESCRIPTION
## Summary

**`v1.0.0-rc.2` 릴리스 빌드가 두 아키텍처 모두 `Desktop readiness` 에서 멈췄다.** 코드 문제가 아니라 **게이트가 옛 문자열 리터럴을 요구**하고 있었다 — npm 채널을 폐기하며(#736) 그 문단들을 다시 썼는데 게이트는 그 전 문장을 그대로 찾는다.

| 게이트가 찾던 것 | 지금 문서가 말하는 것 |
|---|---|
| `CLI · installed macOS app` | `installed macOS app (carrying the MCP server) + CLI as the daily workbench` |
| `macOS desktop app that wraps the same Next.js static` | `reads/writes the same .md files through a local native vault bridge` |
| `hosted website is **only** the product intro…` | `hosted website is the product intro and download entry point` |

**바뀐 문장이 오히려 더 많이 말한다** — 설치 앱이 MCP 서버를 싣는다는 사실, 네이티브 브리지로 같은 `.md` 를 읽고 쓴다는 사실. 게이트가 지키려는 것(설치 앱 + CLI 가 일상 표면 · 웹은 소개·다운로드 입구)은 그대로라 **리터럴만 옮겼다. 게이트를 무르게 하지 않았다.**

## 문서 게이트를 문장 복사본으로 만들면

문서를 고칠 때마다 게이트가 **거짓으로 빨개진다.** 오늘만 세 번째다 — 릴리스 자산 글롭(#729), 스타터 픽스처(#736), 그리고 이것. 옮긴 자리마다 **왜 바뀌었는지 주석**으로 남겼다.

## Test plan

- `pnpm desktop:check` — **pass** (before: 문서 서술 게이트 2건 실패)
- `pnpm test:desktop:check` — pass
- 이 실패는 `origin/main` 에서도 재현됐다 — 이 PR 이 처음 고치는 것이다

🤖 Generated with [Claude Code](https://claude.com/claude-code)