### PR TITLE
fix: 사이드카를 굽는 bun 이 러너에 없었다

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # MCP 사이드카를 단일 바이너리로 굽는 컴파일러다(`bun build --compile`).
+      # 러너에 기본 설치돼 있지 않아 `v1.0.0-rc.2` 가 여기서 멈췄다 — 번들링을
+      # 들여올 때(#732) 이 설치 단계가 같이 안 들어왔다. 툴체인 설치는 위쪽에
+      # 모아 둔다.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/tests/contract/release-sidecar-order.contract.test.ts
+++ b/tests/contract/release-sidecar-order.contract.test.ts
@@ -50,6 +50,19 @@ describe("release workflow — 사이드카 순서 (v1.0.0-rc.2 회귀)", () => 
     expect(workflow).toContain(SIDECAR_STEP);
   });
 
+  /**
+   * 사이드카를 굽는 컴파일러(`bun build --compile`)가 러너에 기본으로 있지
+   * 않다. 번들링을 들여올 때(#732) 설치 단계가 같이 안 들어와서
+   * `v1.0.0-rc.2` 가 여기서 한 번 더 멈췄다 — 순서를 고친 **직후**에.
+   *
+   * 순서만 잠그면 "먼저 부르지만 부를 도구가 없는" 상태를 못 잡는다.
+   */
+  it("bun 설치가 사이드카 빌드보다 앞선다", () => {
+    const bunAt = workflow.indexOf("oven-sh/setup-bun");
+    expect(bunAt, "사이드카를 굽는 bun 설치 단계가 없다").toBeGreaterThan(-1);
+    expect(bunAt).toBeLessThan(workflow.indexOf(SIDECAR_STEP));
+  });
+
   it("사이드카 빌드가 cargo 를 돌리는 모든 단계보다 앞선다", () => {
     const sidecarAt = workflow.indexOf(SIDECAR_STEP);
     expect(sidecarAt).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

순서를 고치자마자(#744) **같은 자리에서 한 번 더** 멈췄다:

```
✖ bun is required to compile the bundled MCP binary.
```

MCP 사이드카는 `bun build --compile` 로 굽는데 **러너에 bun 이 기본 설치돼 있지 않다.** 번들링을 들여올 때(#732) 이 설치 단계가 같이 안 들어왔다.

`Setup Rust` 옆에 `oven-sh/setup-bun@v2` 추가 — 툴체인 설치는 위쪽에 모은다.

## 순서만 잠그면 부족했다

#744 가 "사이드카를 먼저 부른다"를 잠갔지만, **"부를 도구가 있다"** 는 안 잠갔다. 계약에 bun 설치가 사이드카 빌드보다 앞서는지도 넣었다.

**프로브**: bun 단계를 지우면 실패, 되돌리면 통과 — 실행 확인 (4 passed / 1 failed).

## 이 릴리스가 세 번 멈췄고 원인이 전부 같은 종류다

| 시도 | 멈춘 곳 | 원인 |
|---|---|---|
| 1 | `Desktop readiness` | 게이트가 어제의 문장을 요구 |
| 2 | `Native vault bridge tests` | 사이드카를 나중에 만듦 |
| 3 | `Build bundled MCP sidecar` | 굽는 도구가 없음 |

셋 다 **한 번도 실행된 적 없는 단계**였고, **로컬에서는 전부 통과한다** — 사람 머신에는 이미 다 있기 때문이다. 릴리스 워크플로는 태그를 찍어야만 도는데, 지금까지 성공한 적이 없어서 이 단계들이 처음 실행되고 있다.

## Test plan

- `pnpm test:run tests/contract/release-sidecar-order.contract.test.ts` — 4 passed
- 프로브(bun 단계 제거) — 1 failed, 되돌린 뒤 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)