### PR TITLE
fix: 번들 MCP 서버의 의존이 러너에 안 깔려 있었다

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # `mcp/` 는 pnpm 워크스페이스 멤버가 아니라 자체 `node_modules` 를 쓴다
+      # (npm 에 따로 내보내던 패키지의 잔재). 루트 install 이 그걸 안 깔아서
+      # 사람 머신에서만 있고 러너에는 없다 — `v1.0.0-rc.2` 가 사이드카를 굽다가
+      # `@modelcontextprotocol/sdk` 를 못 찾고 멈췄다. 의존은 정확 핀 하나뿐이다.
+      - name: Install bundled MCP server dependencies
+        run: pnpm --dir mcp install
+
       - name: Desktop readiness
         run: pnpm desktop:check
 

--- a/tests/contract/release-sidecar-order.contract.test.ts
+++ b/tests/contract/release-sidecar-order.contract.test.ts
@@ -63,6 +63,21 @@ describe("release workflow — 사이드카 순서 (v1.0.0-rc.2 회귀)", () => 
     expect(bunAt).toBeLessThan(workflow.indexOf(SIDECAR_STEP));
   });
 
+  /**
+   * `mcp/` 는 pnpm 워크스페이스 멤버가 아니라 자체 `node_modules` 를 쓴다 —
+   * 루트 `pnpm install` 이 그걸 안 깐다. 사람 머신에는 예전에 한 번 깔아 둔
+   * 것이 남아 있어 로컬 컴파일이 통과하고, 러너에서만 `@modelcontextprotocol/sdk`
+   * 를 못 찾는다.
+   *
+   * 도구(bun)와 순서를 다 잠근 뒤에도 **컴파일 대상의 의존**이 비어 있으면
+   * 같은 자리에서 멈춘다. 세 조건을 다 잠가야 이 단계가 실제로 통과한다.
+   */
+  it("bundled MCP 의존 설치가 사이드카 빌드보다 앞선다", () => {
+    const depsAt = workflow.indexOf("pnpm --dir mcp install");
+    expect(depsAt, "번들 MCP 서버 의존 설치 단계가 없다").toBeGreaterThan(-1);
+    expect(depsAt).toBeLessThan(workflow.indexOf(SIDECAR_STEP));
+  });
+
   it("사이드카 빌드가 cargo 를 돌리는 모든 단계보다 앞선다", () => {
     const sidecarAt = workflow.indexOf(SIDECAR_STEP);
     expect(sidecarAt).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

bun 이 사이드카를 굽다가 멈췄다:

```
error: Could not resolve: "@modelcontextprotocol/sdk/server/index.js"
```

`mcp/` 는 **pnpm 워크스페이스 멤버가 아니라 자체 `node_modules`** 를 쓴다 — npm 으로 따로 내보내던 패키지의 잔재다. 루트 `pnpm install --frozen-lockfile` 이 그걸 안 깔아서, **사람 머신에는 예전에 깔아 둔 것이 남아 있고 러너에는 없다.**

`pnpm --dir mcp install` 단계 추가. 의존은 정확 핀 하나뿐(`@modelcontextprotocol/sdk@1.29.0`)이다.

## 세 조건을 다 잠가야 이 단계가 통과한다

| # | 조건 | 잠근 PR |
|---|---|---|
| 1 | 사이드카를 **먼저** 부른다 | #744 |
| 2 | 부를 **도구(bun)** 가 있다 | #745 |
| 3 | 컴파일 **대상의 의존**이 있다 | 이 PR |

하나씩 고칠 때마다 **바로 다음 칸에서 멈췄다.** 계약에 셋째도 넣었다.

**프로브**: 의존 설치 단계를 지우면 실패, 되돌리면 통과 — 실행 확인 (5 passed / 1 failed).

## Test plan

- `pnpm test:run tests/contract/release-sidecar-order.contract.test.ts` — 5 passed
- 프로브 — 1 failed, 되돌린 뒤 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)