### PR TITLE
fix: 레일 활성 표시가 가로로 두 번 밀리던 것 (소유자 제보)

### DIFF
--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -321,7 +321,12 @@ export function AppNavRail({
             data-testid="app-nav-rail-active-indicator"
             data-placed={indicator ? "true" : "false"}
             className={cn(
-              "pointer-events-none absolute left-1/2 z-0 -translate-x-1/2 rounded-card bg-[color:var(--color-indigo-a14)] shadow-[inset_0_0_0_1px_var(--color-indigo-line-a22)]",
+              // 가로 중앙 정렬은 **인라인 transform 하나가** 한다. Tailwind v4 의
+              // 이동 유틸리티는 `transform` 이 아니라 **`translate` 표준 속성**을
+              // 쓰기 때문에, 클래스로 `-translate-x-1/2` 를 주고 인라인으로
+              // `transform: translate(-50%, …)` 을 주면 **둘 다 적용돼 두 번**
+              // 밀린다(실측: 타일보다 19px 왼쪽 → 레일 밖으로 잘림).
+              "pointer-events-none absolute left-1/2 z-0 rounded-card bg-[color:var(--color-indigo-a14)] shadow-[inset_0_0_0_1px_var(--color-indigo-line-a22)]",
               // 첫 배치는 전이가 아니다 — 처음 그려질 때 0 에서 미끄러져
               // 들어오면 "이동" 이 아니라 "등장" 이 되고, 사용자가 부르지
               // 않은 모션이 된다(`use-row-disclosure` 가 배운 것과 같다).

--- a/tests/e2e/rail-active-indicator.spec.ts
+++ b/tests/e2e/rail-active-indicator.spec.ts
@@ -47,6 +47,11 @@ async function readIndicator(page: Page) {
       count: document.querySelectorAll('[data-testid="app-nav-rail-active-indicator"]').length,
       offsetY: Math.round(i.top - t.top),
       offsetHeight: Math.round(i.height - t.height),
+      // **가로축도 잰다.** 이 게이트는 처음에 Y 와 높이만 봤고, 그래서 지표가
+      // 타일보다 19px 왼쪽으로 밀려 레일 밖으로 잘려 나가는 것을 통과시켰다
+      // (소유자 실사용 제보 2026-07-28). 겹침은 네 변 전부의 문제다.
+      offsetX: Math.round(i.left - t.left),
+      offsetWidth: Math.round(i.width - t.width),
       duration: style.transitionDuration,
       easing: style.transitionTimingFunction,
     };
@@ -63,6 +68,8 @@ test.describe("레일 활성 표시 — 같은 것이 옮겨간다", () => {
     expect(start!.count, "지표가 여럿이면 '옮겨간다' 는 주장이 거짓이다").toBe(1);
     expect(start!.offsetY).toBe(0);
     expect(start!.offsetHeight).toBe(0);
+    expect(start!.offsetX).toBe(0);
+    expect(start!.offsetWidth).toBe(0);
 
     for (const destination of DESTINATIONS) {
       await page.getByTestId(`app-nav-rail-item-${destination.id}`).click();
@@ -76,6 +83,8 @@ test.describe("레일 활성 표시 — 같은 것이 옮겨간다", () => {
       const settled = await readIndicator(page);
       expect(settled!.count, `${destination.id}: 지표가 늘었다`).toBe(1);
       expect(settled!.offsetHeight, `${destination.id}: 높이가 타일과 다르다`).toBe(0);
+      expect(settled!.offsetX, `${destination.id}: 가로로 밀렸다`).toBe(0);
+      expect(settled!.offsetWidth, `${destination.id}: 폭이 타일과 다르다`).toBe(0);
     }
   });
 


### PR DESCRIPTION
## Summary

소유자 실사용 제보: *"선택했을때 이상한거 나오는데.. 지도보면? 이런거 없는게 나을듯 가로로 길게 뭔 이상한거"*

**제 회귀입니다** (#753 에서 들어갔습니다).

실측: 지표가 활성 타일보다 **19px 왼쪽**. 폭·높이·세로는 정확했는데 가로만 틀려서, 레일 왼쪽 경계에서 잘려 나가고 남은 오른쪽 반쪽이 **가로로 늘어진 덩어리**로 보였습니다.

| | 전 | 후 |
|---|---|---|
| `offsetX` (지표 − 타일) | **−19px** | 0 |
| `offsetWidth` | 0 | 0 |
| `offsetY` / `offsetHeight` | 0 / 0 | 0 / 0 |

## 원인 — Tailwind v4 는 `transform` 이 아니라 `translate` 를 쓴다

가운데 정렬을 **두 곳**에서 하고 있었습니다: 클래스의 `-translate-x-1/2` 와 인라인 `transform: translate(-50%, …)`. 인라인이 이길 거라 기대했지만 **Tailwind v4 의 이동 유틸리티는 표준 `translate` 속성**을 씁니다 — 서로 다른 CSS 속성이라 둘 다 적용되고 −50% 가 두 번 걸립니다(31.5 − 19 − 19 = −6.5px).

정렬은 인라인 transform 하나가 하도록 고쳤습니다.

## 게이트가 왜 통과시켰나

제가 만든 게이트가 **Y 와 높이만** 재고 있었습니다. 겹침은 네 변 전부의 문제인데 두 변만 본 것이고, 그래서 "정확히 겹친다" 는 이름을 달고 가로 19px 어긋남을 통과시켰습니다.

가로축(`offsetX`·`offsetWidth`)을 더했고, **클래스를 되돌려 그 검사가 실제로 터지는 것을 확인**했습니다.

## 남은 판단은 소유자 몫입니다

*"이런거 없는게 나을듯"* 이라고 하셨는데, 그건 **깨진 상태를 보고 하신 말씀**일 수 있습니다. 이 PR 은 깨진 것을 고쳐 원래 의도한 모양(타일과 정확히 겹치는 지표가 180ms 로 이동)으로 되돌립니다. 고친 것을 보시고도 여전히 없는 편이 낫다면 말씀해 주세요 — 지표를 걷어내는 것은 되돌리기 쉽습니다.

## Test plan

- `playwright rail-active-indicator.spec` — 2/2 (네 목적지 전부 offsetX/Y/W/H = 0)
- **프로브**: 클래스를 되돌리면 그 검사가 실패하는 것 확인
- `pnpm lint` — 144 warning · 0 error · `pnpm exec vitest run src/widgets/app-nav-rail` — 39 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD