### PR TITLE
fix: 볼트 연결 상태에서 재현한 3건 — Esc 사다리 · 배지 모순 · 릴리스 태그 두 출처

### DIFF
--- a/src/views/download/lib/pending-release-tag.test.ts
+++ b/src/views/download/lib/pending-release-tag.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveDisplayReleaseTag } from "./pending-release-tag";
+
+describe("표시할 릴리스 태그 — 게시된 것만 생성 파일이 말한다", () => {
+  it("게시됐으면 실제로 나간 태그를 말한다", () => {
+    expect(
+      resolveDisplayReleaseTag({
+        published: true,
+        publishedTag: "v1.0.0-rc.2",
+        releaseVersion: "1.0.0-rc.3",
+      }),
+    ).toBe("v1.0.0-rc.2");
+  });
+
+  /**
+   * 결함의 정확한 재현 — 버전은 rc.3 인데 생성 파일은 rc.2 에 머물러 있고
+   * 아직 아무것도 게시되지 않은 구간. 이때 화면은 rc.3 이라고 말해야 한다.
+   * 종전에는 제목이 rc.3, 본문이 rc.2 로 **한 화면에서 갈렸다**.
+   */
+  it("아직 안 나갔으면 지금 저장소의 버전을 말한다", () => {
+    expect(
+      resolveDisplayReleaseTag({
+        published: false,
+        publishedTag: "v1.0.0-rc.2",
+        releaseVersion: "1.0.0-rc.3",
+      }),
+    ).toBe("v1.0.0-rc.3");
+  });
+
+  it("미게시 표시는 제목과 본문이 같은 값을 쓴다", () => {
+    const args = { published: false, publishedTag: "v0.0.0", releaseVersion: "1.2.3" } as const;
+    expect(resolveDisplayReleaseTag(args)).toBe(resolveDisplayReleaseTag(args));
+    expect(resolveDisplayReleaseTag(args)).toBe("v1.2.3");
+  });
+});

--- a/src/views/download/lib/pending-release-tag.ts
+++ b/src/views/download/lib/pending-release-tag.ts
@@ -1,0 +1,27 @@
+/**
+ * 아직 게시되지 않은 릴리스가 **자기를 뭐라고 부를 것인가**.
+ *
+ * 2026-07-28 QA 실측: `/download` 한 화면에 `v1.0.0-rc.3`(제목)과
+ * `v1.0.0-rc.2 는 아직 게시 전입니다`(본문)가 **동시에** 떠 있었다.
+ *
+ * 원인은 두 출처였다. 제목은 게시 여부로 갈라 미게시면 `RELEASE_VERSION`
+ * (= `package.json`)을 쓰는데, 본문은 **게시 여부와 무관하게** 생성 파일
+ * (`macos-release.generated.ts`)의 `tag` 를 썼다. 그 생성 파일은 릴리스가
+ * 실제로 나갈 때만 갱신되므로, 버전을 올리고 아직 안 내보낸 구간에서는
+ * **한 세대 전 태그**가 그대로 남는다.
+ *
+ * 규칙: **게시된 것만 생성 파일이 말한다.** 아직 안 나간 것의 이름은 지금
+ * 저장소가 스스로 아는 값(`RELEASE_VERSION`)에서 나온다 — 그래야 버전을
+ * 올리는 것만으로 화면이 따라오고, 두 문장이 갈라질 자리가 없다.
+ */
+export function resolveDisplayReleaseTag({
+  published,
+  publishedTag,
+  releaseVersion,
+}: {
+  published: boolean;
+  publishedTag: string;
+  releaseVersion: string;
+}): string {
+  return published ? publishedTag : `v${releaseVersion}`;
+}

--- a/src/views/download/ui/DownloadPage.test.tsx
+++ b/src/views/download/ui/DownloadPage.test.tsx
@@ -109,12 +109,27 @@ describe('DownloadPage', () => {
   });
 
   describe('before a release is published', () => {
-    it('says the build is not out yet instead of rendering placeholder facts', () => {
+    /**
+     * 미게시 상태의 태그는 **지금 저장소의 버전**에서 나온다.
+     *
+     * 2026-07-28 실측: 한 화면에 `v1.0.0-rc.3`(제목)과 `v1.0.0-rc.2 는 아직
+     * 게시 전입니다`(본문)가 동시에 떠 있었다. 제목은 게시 여부로 갈라
+     * `RELEASE_VERSION` 을 쓰는데 본문은 **게시 여부와 무관하게** 생성 파일의
+     * `tag` 를 썼고, 그 파일은 릴리스가 실제로 나갈 때만 갱신되므로 버전을
+     * 올린 뒤 아직 안 내보낸 구간에서 한 세대 전 태그가 남는다.
+     *
+     * 그래서 이 테스트는 **픽스처의 태그(`v1.0.0`)를 기대하지 않는다** — 그걸
+     * 기대하는 것이 곧 옛 결함을 계약으로 굳히는 일이었다.
+     */
+    it('names the current repo version — not the stale generated tag — while unpublished', () => {
       renderDownloadPage();
 
-      expect(screen.getByTestId('download-macos-pending')).toHaveTextContent(
-        /v1\.0\.0 has not been published yet/i,
+      const pending = screen.getByTestId('download-macos-pending');
+      expect(pending).toHaveTextContent(
+        new RegExp(`v${RELEASE_VERSION.replace(/\./g, '\\.')} has not been published yet`, 'i'),
       );
+      // 픽스처의 생성 태그는 미게시 상태에서 화면에 나오지 않는다.
+      expect(pending).not.toHaveTextContent(/v1\.0\.0 has not been/i);
       // A size and a checksum are per-release facts. With no release there is
       // no honest value for either, so neither row exists at all.
       expect(screen.queryByTestId('download-checksum-aarch64')).not.toBeInTheDocument();

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowLeft, Check, Clipboard, Download, ExternalLink, Orbit, ShieldCheck } from 'lucide-react';
+import { resolveDisplayReleaseTag } from "../lib/pending-release-tag";
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import { cn } from '@/shared/lib/cn';
@@ -210,6 +211,12 @@ function MacosDecision({
   published: boolean;
   primaryAsset: ReturnType<typeof macosAssetFor>;
 }) {
+  // 제목과 본문이 **같은 값**을 쓴다 — 갈라지던 자리다(`lib/pending-release-tag`).
+  const displayTag = resolveDisplayReleaseTag({
+    published,
+    publishedTag: MACOS_RELEASE.tag,
+    releaseVersion: RELEASE_VERSION,
+  });
   const t = useTranslations('download');
 
   return (
@@ -235,7 +242,7 @@ function MacosDecision({
           {t('factFormatLabel')} DMG
         </span>
         <span className={`ml-auto text-label leading-label ${numeralClass}`}>
-          {published ? t('macosPublishedBadge', { tag: MACOS_RELEASE.tag }) : `v${RELEASE_VERSION}`}
+          {published ? t('macosPublishedBadge', { tag: displayTag }) : displayTag}
         </span>
       </div>
 
@@ -249,7 +256,7 @@ function MacosDecision({
           data-testid="download-macos-pending"
           className="mt-3 break-keep text-body leading-body text-[color:var(--color-text-secondary)]"
         >
-          {t('macosPendingBody', { tag: MACOS_RELEASE.tag })}
+          {t('macosPendingBody', { tag: displayTag })}
         </p>
       )}
     </section>

--- a/src/views/home/lib/topology-esc-ladder.test.ts
+++ b/src/views/home/lib/topology-esc-ladder.test.ts
@@ -8,6 +8,7 @@ const BASE: TopologyEscLadderInput = {
   contextMenuOpen: false,
   tourOpen: false,
   createNodeOpen: false,
+  bootstrapOpen: false,
   searchOpen: false,
   fullDetailOpen: false,
   selectedRelationActive: false,
@@ -269,5 +270,39 @@ describe("resolveTopologyEscLadderAction", () => {
       hasLocalGraphRoot: true,
     });
     expect(step3).toBe("pop-local-graph");
+  });
+});
+
+/**
+ * 부트스트랩 패널이 **사다리에 칸이 없어서** Escape 가 아무 일도 하지 않았다
+ * (2026-07-28 볼트 연결 재현).
+ *
+ * 앱은 자기 단축키 시트에 "Esc — 열린 표면을 한 단계씩 닫습니다" 라고 적어
+ * 두고 있고 다른 모든 다이얼로그가 그렇게 동작한다. 이 하나만 안 닫히는 것은
+ * **앱이 키를 무시하는 것**으로 읽힌다.
+ */
+describe("부트스트랩 패널 — 블로킹 표면이 먼저 답한다", () => {
+  it("열려 있으면 Escape 가 그것을 닫는다", () => {
+    expect(
+      resolveTopologyEscLadderAction({ ...BASE, bootstrapOpen: true }),
+    ).toBe("close-bootstrap");
+  });
+
+  // 덮여 있는 것을 두고 그 아래 선택을 푸는 것은 사용자가 부른 일이 아니다.
+  it("아래에 선택이 있어도 패널이 먼저다", () => {
+    expect(
+      resolveTopologyEscLadderAction({
+        ...BASE,
+        bootstrapOpen: true,
+        hasSelection: true,
+        nodePopoverOpen: true,
+      }),
+    ).toBe("close-bootstrap");
+  });
+
+  it("닫혀 있으면 아래 칸이 정상적으로 답한다", () => {
+    expect(
+      resolveTopologyEscLadderAction({ ...BASE, bootstrapOpen: false, hasSelection: true }),
+    ).toBe("deselect");
   });
 });

--- a/src/views/home/lib/topology-esc-ladder.ts
+++ b/src/views/home/lib/topology-esc-ladder.ts
@@ -56,6 +56,19 @@ export interface TopologyEscLadderInput {
    *  closes itself on Escape while it holds focus; this covers the case
    *  where focus has moved outside it while it's still blocking the page). */
   createNodeOpen: boolean;
+  /**
+   * 「내 문서로 지도 만들기」 부트스트랩 패널(`ontology-bootstrap-panel`).
+   *
+   * 이 사다리에 **칸이 아예 없어서** Escape 가 아무 일도 하지 않았다
+   * (2026-07-28 볼트 연결 재현: 패널을 열고 Esc 를 눌러도 `aria-modal` 이
+   * 그대로 남는다). 앱은 자기 단축키 시트에 "Esc — 열린 표면을 한 단계씩
+   * 닫습니다" 라고 적어 두고 있고 다른 모든 다이얼로그는 그렇게 동작하므로,
+   * 이 하나만 안 닫히는 것은 **앱이 키를 무시하는 것**으로 읽힌다.
+   *
+   * `aria-modal` 블로킹 표면이라 아래 칸들보다 먼저 답해야 한다 — 덮여 있는
+   * 것을 두고 그 아래 선택을 푸는 것은 사용자가 부른 일이 아니다.
+   */
+  bootstrapOpen: boolean;
   /** Global search / ontology palette open (`MountedGlobalSearch` → Radix
    *  `Dialog`, which already closes itself on Escape). If this is true the
    *  ladder must return "none" and let the palette's own handler own the
@@ -92,6 +105,7 @@ export type TopologyEscLadderAction =
   | "close-context-menu"
   | "close-tour"
   | "close-create-node"
+  | "close-bootstrap"
   | "close-full-detail"
   | "close-relation-lens"
   | "close-node-popover"
@@ -121,6 +135,7 @@ export function resolveTopologyEscLadderAction(
   if (input.contextMenuOpen) return "close-context-menu";
   if (input.tourOpen) return "close-tour";
   if (input.createNodeOpen) return "close-create-node";
+  if (input.bootstrapOpen) return "close-bootstrap";
   // The palette (Radix Dialog) already closes itself on Escape — returning
   // "none" here means the window ladder does nothing this keypress, so only
   // the palette closes. Without this tier, the ladder would fall through to

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2312,6 +2312,7 @@ export function HomePage() {
         contextMenuOpen: contextMenuNode !== null,
         tourOpen: tour.open,
         createNodeOpen,
+        bootstrapOpen,
         searchOpen: ontologySearchOpen,
         fullDetailOpen,
         selectedRelationActive,
@@ -2342,6 +2343,9 @@ export function HomePage() {
           break;
         case "close-create-node":
           closeCreateNode();
+          break;
+        case "close-bootstrap":
+          setBootstrapOpen(false);
           break;
         case "close-full-detail":
           setFullDetailSlug(null);

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -242,6 +242,8 @@ export function OntologyInsightsPage() {
   const nodes = insight?.nodes ?? EMPTY_NODES;
   const edges = insight?.edges ?? EMPTY_EDGES;
   const totalNodes = nodes.length;
+  /** 탭 본문이 그려지는가 — 빈 상태로 갈리면 배지도 숫자를 말하지 않는다. */
+  const hasConcepts = (insight?.nodes.length ?? 0) > 0;
   const totalEdges = edges.length;
 
   const kindDist = useMemo(() => computeKindDistribution(nodes), [nodes]);
@@ -907,12 +909,22 @@ export function OntologyInsightsPage() {
               // 예전엔 do-next 통계 신호만 세고 CLI-parity 신호(분리된 섬 ·
               // 누락된 연결)를 빠뜨려, 수리 큐가 1건을 보여주는데 배지는 0
               // 이라고 말하는 모순이 났다.
-              count: INSIGHTS_TAB_BADGE[key]({
-                verdictTotal: insightsVerdict.total,
-                totalNodes,
-                totalEdges,
-                crossDomainEdges: domainCoupling.crossDomainEdgeCount,
-              }),
+              // 개념이 0이면 이 페이지는 탭 본문 대신 빈 상태를 그린다. 그때
+              // 배지가 숫자를 말하면 **화면이 자기 자신과 모순**된다 —
+              // 2026-07-28 볼트 연결 재현: 「할 일 14」 배지 아래 본문은
+              // "아직 온톨로지 개념이 없습니다" 였다. 위 주석이 기록한
+              // 과거 사고(큐 1건인데 배지 0)의 정확한 반대 방향이다.
+              //
+              // 배지는 "그 탭이 답하는 질문의 규모" 인데, 답할 탭 본문이
+              // 아예 안 그려지면 그 규모는 0 이다.
+              count: hasConcepts
+                ? INSIGHTS_TAB_BADGE[key]({
+                    verdictTotal: insightsVerdict.total,
+                    totalNodes,
+                    totalEdges,
+                    crossDomainEdges: domainCoupling.crossDomainEdgeCount,
+                  })
+                : 0,
               // 라벨 없는 숫자가 무엇을 세는지 — hover/보조기술에만 뜨는 한 마디.
               countTitle: key === "freshness" ? undefined : t(`tabCountTitle.${key}`),
             }))}


### PR DESCRIPTION
## Summary

미확정 5건을 **볼트를 실제로 연결해** 재현했다 — OPFS 스텁 픽커 + 프론트매터 없는 노트 15개(QA 가 보고한 "My Notes, 15 docs, 0 concepts" 상태 그대로). 셋은 사실이었고 둘은 아니었다.

### ② 부트스트랩 패널이 Escape 를 무시했다 (확정 → 수정)

「내 문서로 지도 만들기」 패널이 Escape 사다리에 **칸이 아예 없었다**. 앱은 자기 단축키 시트에 "Esc — 열린 표면을 한 단계씩 닫습니다"라고 적어 두고 다른 모든 다이얼로그가 그렇게 동작하므로, 이 하나만 안 닫히는 것은 **앱이 키를 무시하는 것**으로 읽힌다.

`aria-modal` 블로킹 표면이라 아래 칸들(노드 선택 해제 등)보다 **먼저** 답하게 넣었다 — 덮여 있는 것을 두고 그 아래 선택을 푸는 것은 사용자가 부른 일이 아니다.

### ④ 배지가 본문과 모순됐다 (확정 → 수정)

「할 일 14」 배지 아래 본문이 "아직 온톨로지 개념이 없습니다"였다. 개념이 0이면 이 페이지는 탭 본문 대신 빈 상태를 그리는데, 배지는 그와 무관하게 계산되고 있었다.

같은 파일의 주석이 **과거의 정확한 반대 방향 사고**를 기록하고 있다("수리 큐가 1건을 보여주는데 배지는 0"). 배지는 "그 탭이 답하는 질문의 규모"인데, 답할 탭 본문이 아예 안 그려지면 그 규모는 0 이다.

### ⑤ 릴리스 태그가 두 출처였다 (확정 → 수정)

한 화면에 \`v1.0.0-rc.3\`(제목)과 \`v1.0.0-rc.2 는 아직 게시 전입니다\`(본문)가 동시에 떠 있었다. 제목은 게시 여부로 갈라 \`RELEASE_VERSION\` 을 쓰는데 본문은 **게시 여부와 무관하게** 생성 파일의 \`tag\` 를 썼고, 그 파일은 릴리스가 실제로 나갈 때만 갱신되므로 버전을 올린 뒤 아직 안 내보낸 구간에서 한 세대 전 태그가 남는다.

규칙으로 승격: **게시된 것만 생성 파일이 말한다.** 아직 안 나간 것의 이름은 지금 저장소가 스스로 아는 값에서 나온다.

기존 테스트가 옛 결함을 계약으로 굳히고 있어(픽스처의 생성 태그를 본문에서 기대) 새 계약으로 다시 썼다.

## 재현되지 않은 둘 (수정하지 않음)

- **탭 전부 닫으면 본문 잔존** — 볼트 연결 상태에서도 어긋나지 않았다(닫은 뒤 탭 1 · article 없음 · 주소에 slug 없음). 설계된 폴백이 도는 것이고 모순이 아니다.
- **INDEX 「블록 가져오기」 무반응** — 실제로는 **반응한다**(클릭 후 DOM 208,596 → 211,735자). QA 가 무반응으로 본 것은 ② 때문이다 — 안 닫히는 모달이 화면을 덮고 있어 그 버튼에 닿지 못했다. **결함 하나가 다른 결함을 결함처럼 보이게 만든 사례**다.

## Test plan

- \`pnpm test:run\` — 4,809 passed | 3 todo
- \`pnpm lint\` — 0 errors / 144 warnings (baseline 유지)
- \`pnpm exec tsc --noEmit\` — 통과
- 회귀 테스트 추가: Esc 사다리 3건(\`topology-esc-ladder.test.ts\`) · 태그 단일 출처(\`pending-release-tag.test.ts\` 신규 + \`DownloadPage.test.tsx\` 계약 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD