### PR TITLE
feat: 검색 콘솔 등록과 페이지 단 SEO — description · canonical · hreflang · SoftwareApplication

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -49,6 +49,15 @@ jobs:
         run: pnpm build
         env:
           NEXT_PUBLIC_BASE_PATH: /ontology-atlas
+          # 검색 콘솔 소유권 확인 코드 — 저장소 Variables 에서 받는다
+          # (Settings → Secrets and variables → Actions → Variables).
+          #
+          # 비밀이 아니라 **공개 태그로 나가는 값**이라 Secrets 가 아니라
+          # Variables 가 맞다. 다만 이 저장소의 사실도 아니어서 하드코딩하지
+          # 않는다 — 포크한 사람의 사이트에 우리 코드가 박히면 그쪽 콘솔
+          # 등록이 막힌다. 미설정이면 `app/layout.tsx` 가 태그 자체를 안 낸다.
+          NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ vars.GOOGLE_SITE_VERIFICATION }}
+          NEXT_PUBLIC_BING_SITE_VERIFICATION: ${{ vars.BING_SITE_VERIFICATION }}
       - name: Adapt static PWA manifest to base path
         run: |
           test -f out/manifest.webmanifest

--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -30,6 +30,19 @@ export default async function Page({ params }: { params: Promise<{ locale: strin
   // release runbook in `docs/DESKTOP-MACOS.md` owns the operator checklist.
   return (
     <>
+      <DownloadPage />
+      {/*
+       * ⚠️ **페이지 루트 뒤에 온다 — 앞이 아니다.**
+       *
+       * 셸 본문 슬롯의 `firstElementChild` 가 페이지 루트라는 것이
+       * `tests/e2e/scroll-end-gap.spec.ts` 의 측정 전제다. 이 `<script>` 를
+       * 앞에 두면 그게 첫 자식이 되고, 높이 0 이라 "페이지 루트가 압축됐다
+       * (박스 0 < 내용 1589)" 로 게이트가 정확히 잡아낸다(실측: CI 2폭 실패).
+       *
+       * 스펙의 가정이 옳다 — 슬롯의 첫 자식이 페이지다. 그러니 비시각
+       * 형제는 뒤에 선다. JSON-LD 는 문서 어디에 있든 검색엔진이 읽으므로
+       * 순서 비용이 0이다.
+       */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -38,7 +51,6 @@ export default async function Page({ params }: { params: Promise<{ locale: strin
           ),
         }}
       />
-      <DownloadPage />
     </>
   );
 }

--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { DownloadPage } from '@/views/download';
+import { DownloadPage, downloadStructuredData } from '@/views/download';
+import { buildPageMetadata } from '@/shared/lib/page-metadata';
 
 export async function generateMetadata({
   params,
@@ -9,15 +10,35 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'metadata' });
-  return { title: t('pages.download') };
+  return buildPageMetadata({
+    locale,
+    path: 'download',
+    title: t('pages.download'),
+    description: t('descriptions.download'),
+  });
 }
 
-export default function Page() {
+export default async function Page({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata' });
+
   // The owner-only first-release checklist (blocked-on-PR/secrets/tag status
   // plus a copyable CI audit command) was removed for the public launch: it
   // spoke about the build pipeline, not about whether a visitor can install
   // the app. What the page may claim now derives from whether a release is
   // actually published — see `views/download/lib/release-state.ts`. The
   // release runbook in `docs/DESKTOP-MACOS.md` owns the operator checklist.
-  return <DownloadPage />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            downloadStructuredData(locale, t('descriptions.download')),
+          ),
+        }}
+      />
+      <DownloadPage />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,6 +34,25 @@ export const metadata: Metadata = {
   description: 'AI-native codebase ontology workbench. Humans and AI agents author the same vault. Markdown frontmatter is the graph.',
   keywords: ['Ontology Atlas', 'ontology-atlas', 'ontology', 'knowledge graph', 'markdown', 'frontmatter', 'AI agent', 'MCP', 'topology'],
   authors: [{ name: 'ontology-atlas contributors' }],
+  /**
+   * 검색 콘솔 소유권 확인 — **값은 환경변수로 받는다.**
+   *
+   * GitHub Pages 프로젝트 사이트(`user.github.io/repo/`)는 DNS 확인을 쓸 수
+   * 없다(그 도메인이 우리 것이 아니다). 그래서 남는 방법은 둘이고, 이 메타
+   * 태그가 그중 파일을 저장소에 커밋하지 않아도 되는 쪽이다.
+   *
+   * 코드는 **비밀이 아니지만 이 저장소의 사실도 아니다** — 포크한 사람의
+   * 사이트에 우리 확인 코드가 박혀 나가면 그쪽 콘솔 등록이 막힌다. 그래서
+   * 하드코딩하지 않고 빌드 환경에서 주입한다. 미설정이면 태그 자체가 안 나간다.
+   */
+  verification: {
+    ...(process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+      ? { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }
+      : {}),
+    ...(process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION
+      ? { other: { 'msvalidate.01': process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION } }
+      : {}),
+  },
   openGraph: {
     type: 'website',
     locale: 'en_US',

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,6 +11,12 @@
       "ontologyStudio": "Ontology Workshop",
       "ontologyInsights": "Graph Insights",
       "projectNew": "New project"
+    },
+    "descriptions": {
+      "home": "Code survives; context does not. Ontology Atlas keeps your project's context — what depends on what, and why it was built this way — in one markdown folder. Prose you read, structure your AI agents read and write over MCP. Local-first, no backend, open source.",
+      "download": "Free macOS app. Open a markdown folder on your own disk as a project map, and connect Claude Code, Codex or Cursor over MCP. Signed and notarized by Apple, nothing sent to a server, MIT licensed.",
+      "topology": "See your project's domains, capabilities, elements and their dependencies as one map. Markdown frontmatter is the graph, and the files stay on your own disk.",
+      "docs": "Read and edit the markdown folder directly. Change the frontmatter and the map follows."
     }
   },
   "notFound": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -11,6 +11,12 @@
       "ontologyStudio": "온톨로지 공방",
       "ontologyInsights": "그래프 인사이트",
       "projectNew": "새 프로젝트"
+    },
+    "descriptions": {
+      "home": "코드는 남고 맥락은 사라집니다. Ontology Atlas 는 프로젝트의 맥락 — 무엇이 무엇에 기대는지, 왜 이렇게 만들었는지 — 을 마크다운 폴더 하나에 담습니다. 사람이 읽는 글이자 AI 에이전트가 MCP 로 읽고 쓰는 구조. 로컬 우선, 백엔드 없음, 오픈소스.",
+      "download": "macOS 앱 무료 다운로드. 내 디스크의 마크다운 폴더를 열어 프로젝트 지도로 보고, Claude Code · Codex · Cursor 를 MCP 로 연결합니다. Apple 서명·공증 완료, 서버 전송 없음, MIT 오픈소스.",
+      "topology": "프로젝트의 도메인 · 역량 · 구성요소와 그 의존 관계를 한 화면의 지도로 봅니다. 마크다운 frontmatter 가 곧 그래프이고, 파일은 내 디스크에만 있습니다.",
+      "docs": "마크다운 폴더를 그대로 읽고 고치는 문서함. frontmatter 를 고치면 지도가 따라 바뀝니다."
     }
   },
   "notFound": {

--- a/src/shared/lib/page-metadata.ts
+++ b/src/shared/lib/page-metadata.ts
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next';
+import { SITE_URL } from '@/shared/config';
+import { routing } from '@/i18n/routing';
+
+/**
+ * 페이지 단 메타데이터 — 검색엔진이 이 사이트를 **찾고 고르는** 층.
+ *
+ * ## 왜 이게 필요했나
+ *
+ * 루트 레이아웃은 이미 갖출 것을 갖췄다(`metadataBase` · OG · Twitter ·
+ * `WebSite` JSON-LD · hreflang 사이트맵 · robots). 그런데 **개별 페이지는
+ * 대부분 `title` 하나만** 달고 있었다. 그러면 셋이 무너진다:
+ *
+ * - **description 부재** → 검색 결과의 스니펫을 구글이 본문에서 임의로
+ *   긁어 만든다. 이 사이트는 본문 대부분이 캔버스(회화 픽셀)라 긁을 산문이
+ *   거의 없다 — 스니펫이 비거나 UI 라벨 조각이 된다.
+ * - **canonical 부재** → `/ko/download` 와 `/ko/download/` 처럼 같은 문서로
+ *   가는 여러 경로가 서로 경쟁한다.
+ * - **hreflang 부재** → 사이트맵에는 있는데 문서 자체엔 없어서, 검색엔진이
+ *   ko/en 중 어느 쪽을 누구에게 줄지 판단할 근거가 페이지에 없다.
+ *
+ * ## 절대 경로여야 한다
+ *
+ * `metadataBase` 가 있어도 `alternates` 는 basePath(`/ontology-atlas`)를 자동
+ * 프리픽스하지 않는다 — 이 저장소가 `app/layout.tsx` 주석에 이미 못박아 둔
+ * 함정이다. 그래서 여기서 `SITE_URL` 로 직접 조립한다.
+ */
+export interface PageMetadataInput {
+  locale: string;
+  /** 로케일 접두 뒤의 경로. 루트는 빈 문자열. 예: `download` · `ontology/insights` */
+  path: string;
+  title: string;
+  description: string;
+  /** OG 이미지 경로를 페이지가 따로 가질 때만. 생략 시 루트 레이아웃 것을 상속. */
+  ogImage?: string;
+}
+
+function absolute(locale: string, path: string): string {
+  const tail = path ? `/${path}` : '';
+  return `${SITE_URL}/${locale}${tail}`;
+}
+
+export function buildPageMetadata({
+  locale,
+  path,
+  title,
+  description,
+  ogImage,
+}: PageMetadataInput): Metadata {
+  const canonical = absolute(locale, path);
+
+  /**
+   * 모든 로케일을 서로에게 알린다 + `x-default`. 후자가 없으면 검색엔진이
+   * "어느 언어도 아닌 사용자"(예: 프랑스어 브라우저)에게 무엇을 줄지 스스로
+   * 고르는데, 그 선택은 우리 것이 아니다.
+   */
+  const languages: Record<string, string> = { 'x-default': absolute(routing.defaultLocale, path) };
+  for (const l of routing.locales) languages[l] = absolute(l, path);
+
+  return {
+    title,
+    description,
+    alternates: { canonical, languages },
+    openGraph: {
+      type: 'website',
+      url: canonical,
+      title,
+      description,
+      locale,
+      ...(ogImage ? { images: [{ url: ogImage }] } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}

--- a/src/views/download/index.ts
+++ b/src/views/download/index.ts
@@ -1,1 +1,2 @@
 export { DownloadPage } from './ui/DownloadPage';
+export { downloadStructuredData } from './lib/structured-data';

--- a/src/views/download/lib/structured-data.ts
+++ b/src/views/download/lib/structured-data.ts
@@ -1,0 +1,51 @@
+import { SITE_URL } from '@/shared/config';
+import { RELEASE_MIN_MACOS } from './release-facts';
+import { MACOS_RELEASE } from './release-state';
+
+/**
+ * `SoftwareApplication` 구조화 데이터 — 앱 다운로드 페이지가 검색 결과에서
+ * **리치 결과**(가격 · 운영체제 · 카테고리 · 버전)를 받을 수 있는 유일한
+ * 스키마다. 루트 레이아웃의 `WebSite` 스키마는 사이트를 설명하지 앱을
+ * 설명하지 않으므로, 이 페이지에는 자기 것이 따로 필요하다.
+ *
+ * ⚠️ **릴리스가 게시됐을 때만 버전·다운로드 URL·크기를 싣는다.**
+ *
+ * 구조화 데이터는 화면보다 **더 엄격한** 정직성을 요구한다 — 화면의 거짓은
+ * 사람이 보고 웃고 끝나지만, 여기 거짓은 검색엔진이 색인해 두고 우리가 모르는
+ * 채로 남는다(그리고 구글은 사실과 다른 구조화 데이터에 수동 조치를 내린다).
+ * 게시 전에 자리표시자를 넣지 않는 것이 이 페이지 전체가 지켜 온 계약
+ * (`release-state.ts` 의 게시 여부 단일 상태)이고, 여기서도 같은 규율을 쓴다.
+ *
+ * `offers.price: "0"` 은 마케팅 문구가 아니라 사실이다 — MIT 오픈소스이고
+ * 결제 표면이 존재하지 않는다. `isAccessibleForFree` 도 같은 근거.
+ */
+export function downloadStructuredData(locale: string, description: string) {
+  const published = MACOS_RELEASE.published && MACOS_RELEASE.assets.length > 0;
+  const primary =
+    MACOS_RELEASE.assets.find((asset) => asset.arch === 'aarch64') ?? MACOS_RELEASE.assets[0];
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Ontology Atlas',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: RELEASE_MIN_MACOS,
+    description,
+    url: `${SITE_URL}/${locale}/download`,
+    inLanguage: locale,
+    license: 'https://opensource.org/licenses/MIT',
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    ...(published && primary
+      ? {
+          softwareVersion: MACOS_RELEASE.tag.replace(/^v/, ''),
+          downloadUrl: primary.downloadUrl,
+          ...(MACOS_RELEASE.publishedAt ? { datePublished: MACOS_RELEASE.publishedAt } : {}),
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
## Summary

프로젝트명으로 검색하면 GitHub 저장소만 나오고 **사이트는 안 나온다**(실측). 기반(robots · hreflang 사이트맵 · `metadataBase` · OG · `WebSite` JSON-LD)은 이미 갖춰져 있었으나 **개별 페이지가 대부분 `title` 하나만** 달고 있었다.

그러면 셋이 무너진다:

- **description 부재** → 검색 결과 스니펫을 구글이 본문에서 긁는데, **이 사이트 본문은 대부분 캔버스(회화 픽셀)라 긁을 산문이 거의 없다.** 스니펫이 비거나 UI 라벨 조각이 된다 — 이 사이트에 특히 치명적인 이유다.
- **canonical 부재** → 같은 문서로 가는 여러 경로가 서로 경쟁한다.
- **hreflang 이 사이트맵에만 있고 문서엔 없음** → 검색엔진이 ko/en 중 어느 쪽을 누구에게 줄지 판단할 근거가 페이지에 없다.

## 변경

**`src/shared/lib/page-metadata.ts` (신설)** — title · description · canonical · hreflang(`x-default` 포함) · OG · Twitter 를 한 번에 만든다. `alternates` 는 `metadataBase` 가 있어도 basePath(`/ontology-atlas`)를 자동 프리픽스하지 않으므로 `SITE_URL` 로 직접 조립한다 — 이 저장소가 `app/layout.tsx` 주석에 이미 못박아 둔 함정이다.

**`/download` 에 `SoftwareApplication` 구조화 데이터** — 앱 페이지가 리치 결과(가격 · OS · 버전)를 받는 유일한 스키마다. 루트의 `WebSite` 스키마는 사이트를 설명하지 앱을 설명하지 않는다.

> ⚠️ **게시된 릴리스가 있을 때만** 버전 · 다운로드 URL 을 싣는다. 구조화 데이터는 화면보다 **더 엄격한** 정직성을 요구한다 — 화면의 거짓은 사람이 보고 웃고 끝나지만, 여기 거짓은 검색엔진이 색인해 두고 우리가 모르는 채로 남는다. `release-state.ts` 의 게시 여부 단일 상태 계약을 그대로 따른다.

**검색 콘솔 소유권 확인 배선** — GitHub Pages 프로젝트 사이트는 DNS 확인을 쓸 수 없어(그 도메인이 우리 것이 아니다) URL 접두어 속성 + HTML 메타 태그가 유일하게 편한 경로다.

값은 저장소 **Variables** 로 받는다(`GOOGLE_SITE_VERIFICATION` · `BING_SITE_VERIFICATION`). Secrets 가 아닌 이유: 어차피 공개 태그로 나가므로 비밀이 아니다. 그럼에도 하드코딩하지 않는 이유는 따로다 — **포크한 사람의 사이트에 우리 확인 코드가 박히면 그쪽 콘솔 등록이 막힌다.** 미설정이면 태그 자체가 안 나간다.

## Test plan

- `pnpm exec tsc --noEmit` 통과
- `pnpm exec vitest run src/views/download tests/contract/` — 56 파일 / 636 통과
- `pnpm test:i18n:messages` — 16/16
- `pnpm lint` — 0 errors (총계 148 = 이 브랜치 base 인 main 자체 기준선, 변경 파일 5개의 경고는 0건)
- `pnpm build` 정적 export 통과 후 **산출물에서 직접 확인**:
  - `<meta name="google-site-verification" content="…">` (실제 토큰으로 빌드해 방출 확인)
  - `rel="canonical" href="https://wlsdks.github.io/ontology-atlas/ko/download/"`
  - `rel="alternate"` hreflang 3종 (`x-default` · `en` · `ko`)
  - `"@type":"SoftwareApplication"`

## 남은 리스크

- **확인이 되어도 색인은 즉시가 아니다** — 보통 며칠~몇 주. sitemap 제출이 그 시간을 줄인다.
- **순위는 별개 문제다.** `user.github.io/repo/` 는 경로 단위라 자체 도메인 권위가 없다. 이 PR 전체보다 **커스텀 도메인 하나가 더 크다** — 비용이 드는 결정이라 여기서 하지 않는다.
- 저장소 Variables 가 없으면 이 배선은 **조용히** 아무 일도 안 한다. 확인 클릭 전에 배포된 페이지에서 태그를 직접 보는 것이 안전장치다:
  ```
  curl -s https://wlsdks.github.io/ontology-atlas/ | grep google-site-verification
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBf17p8tJkayGY7bHXAJqX