### PR TITLE
fix: 볼트 순회에 경계를 준다 — 저장소 루트를 열면 앱이 죽던 것

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1750,7 +1750,9 @@
       "agentCopyGateSuccess": "Workspace graph check copied.",
       "copyFailed": "Copy failed",
       "modalSubtitle": "See this vault's files, graph, and AI check gate at a glance",
-      "closeTitle": "Close (Esc)"
+      "closeTitle": "Close (Esc)",
+      "filesTruncated": "The folder was too large to read fully — pick a narrower document folder.",
+      "filesPruned": "Skipped {count} build/dependency folder(s) ({names})."
     },
     "advanced": {
       "sourceServer": "Sample",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1750,7 +1750,9 @@
       "agentCopyGateSuccess": "문서함 그래프 점검을 복사했습니다.",
       "copyFailed": "복사 실패",
       "modalSubtitle": "이 vault 의 파일 · 그래프 · AI 검증 게이트를 한눈에 확인",
-      "closeTitle": "닫기 (Esc)"
+      "closeTitle": "닫기 (Esc)",
+      "filesTruncated": "폴더가 너무 커서 일부만 읽었습니다 — 문서 폴더를 더 좁게 골라 주세요.",
+      "filesPruned": "빌드·의존성 폴더 {count}개는 건너뛰었습니다({names})."
     },
     "advanced": {
       "sourceServer": "샘플",

--- a/src/entities/docs-vault/lib/build-local-manifest.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.ts
@@ -88,34 +88,107 @@ interface WalkEntry {
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i;
 
+/**
+ * 순회의 경계 — **볼트는 문서 폴더지 임의의 디렉터리가 아니다.**
+ *
+ * 2026-07-29 실측: 설치 앱에서 볼트로 **저장소 루트**를 고르면 WebView 가
+ * 죽었다("This page couldn't load"). 순회가 무제한이라 `src-tauri/target`
+ * 까지 내려가 디렉터리 984개 · 마크다운 965개(9.4MB)를 IPC 로 실어 나른다 —
+ * 정상 볼트(23 · 97)의 16배다.
+ *
+ * 이게 아픈 이유는 **스킬 사본 판정처럼 볼트가 저장소 루트여야 의미 있는
+ * 기능이 있고, 그 조합이 정확히 그 사용자의 첫 시도**라는 점이다.
+ */
+
+/**
+ * 이름만으로 확실한 것. `node_modules` 안에 사용자의 온톨로지가 있을 확률은
+ * 0이고, 이름이 겹칠 일도 없다. **목록을 늘리지 않는다** — `build`·`dist`·
+ * `out` 같은 이름은 문서 폴더에도 정당하게 존재할 수 있어서, 이름으로 자르면
+ * 남의 문서를 조용히 버린다.
+ */
+const PRUNE_BY_NAME = new Set(['node_modules']);
+
+/**
+ * 캐시 디렉터리의 **공개 규약** — 디렉터리가 스스로 "나는 캐시다" 라고 선언한다
+ * (bford.info/cachedir, Cargo·Bazel 등이 따른다). 이름 목록과 달리 관리할
+ * 것이 없고 오탐이 원리적으로 없다: 사용자가 자기 문서 폴더에 이 파일을 넣을
+ * 이유가 없다.
+ */
+const CACHE_DIR_TAG = 'CACHEDIR.TAG';
+
+/** 정상 볼트의 20배 남짓. 넘으면 자르고 **자른 사실을 말한다**. */
+export const VAULT_WALK_MAX_ENTRIES = 4000;
+/** 문서 폴더의 현실적 상한. 넘는 깊이는 대개 남의 트리에 들어간 것이다. */
+export const VAULT_WALK_MAX_DEPTH = 12;
+
+export interface WalkResult {
+  entries: WalkEntry[];
+  /**
+   * 상한에 걸려 **일부만 봤는가.** 침묵하는 절단은 "전부 봤다" 로 읽히므로
+   * 호출부까지 올려 보낸다 — 이 저장소가 게이트에서 반복해 배운 규율이다.
+   */
+  truncated: boolean;
+  /** 캐시/의존성으로 판정해 통째로 건너뛴 디렉터리의 상대 경로. */
+  prunedDirs: string[];
+}
+
+async function walkInto(
+  root: FileSystemDirectoryHandle,
+  prefix: string,
+  depth: number,
+  acc: WalkResult,
+): Promise<void> {
+  if (acc.truncated) return;
+  if (depth > VAULT_WALK_MAX_DEPTH) {
+    acc.truncated = true;
+    return;
+  }
+
+  // 목록을 **먼저 모은다.** 캐시 표식은 이 목록 안에 이미 들어 있으므로
+  // `getFileHandle` 로 따로 물어볼 이유가 없다 — 그렇게 하면 디렉터리마다
+  // IPC 왕복이 하나씩 늘고, 그건 지금 고치고 있는 비용과 같은 종류다.
+  const children: Array<[string, FileSystemHandle]> = [];
+  for await (const entry of root.entries()) children.push(entry);
+
+  if (children.some(([name]) => name === CACHE_DIR_TAG)) {
+    acc.prunedDirs.push(prefix || '.');
+    return;
+  }
+
+  for (const [name, handle] of children) {
+    if (acc.entries.length >= VAULT_WALK_MAX_ENTRIES) {
+      acc.truncated = true;
+      return;
+    }
+    if (name.startsWith('.')) continue;
+    const relative = prefix ? `${prefix}/${name}` : name;
+    if (handle.kind === 'directory') {
+      if (PRUNE_BY_NAME.has(name)) {
+        acc.prunedDirs.push(relative);
+        continue;
+      }
+      await walkInto(handle as FileSystemDirectoryHandle, relative, depth + 1, acc);
+    } else if (name.endsWith('.md')) {
+      acc.entries.push({ handle: handle as FileSystemFileHandle, relativePath: relative, kind: 'md' });
+    } else if (IMAGE_EXT.test(name)) {
+      acc.entries.push({ handle: handle as FileSystemFileHandle, relativePath: relative, kind: 'image' });
+    }
+  }
+}
+
+export async function walkVault(root: FileSystemDirectoryHandle): Promise<WalkResult> {
+  const acc: WalkResult = { entries: [], truncated: false, prunedDirs: [] };
+  await walkInto(root, '', 0, acc);
+  return acc;
+}
+
 async function walk(
   root: FileSystemDirectoryHandle,
   prefix = '',
 ): Promise<WalkEntry[]> {
-  const out: WalkEntry[] = [];
-  for await (const [name, handle] of root.entries()) {
-    if (name.startsWith('.')) continue;
-    if (handle.kind === 'directory') {
-      const nested = await walk(
-        handle as FileSystemDirectoryHandle,
-        prefix ? `${prefix}/${name}` : name,
-      );
-      out.push(...nested);
-    } else if (name.endsWith('.md')) {
-      out.push({
-        handle: handle as FileSystemFileHandle,
-        relativePath: prefix ? `${prefix}/${name}` : name,
-        kind: 'md',
-      });
-    } else if (IMAGE_EXT.test(name)) {
-      out.push({
-        handle: handle as FileSystemFileHandle,
-        relativePath: prefix ? `${prefix}/${name}` : name,
-        kind: 'image',
-      });
-    }
-  }
-  return out;
+  const acc: WalkResult = { entries: [], truncated: false, prunedDirs: [] };
+  await walkInto(root, prefix, 0, acc);
+  return acc.entries;
 }
 
 function insertIntoTree(root: VaultTreeNode, slug: string, title: string) {
@@ -273,6 +346,7 @@ function buildMdEntry(
 function aggregateBuild(
   entries: BuiltVaultEntry[],
   rootName: string,
+  walkInfo?: { truncated: boolean; prunedDirs: string[] },
 ): LocalVaultBuild {
   const docs: VaultDoc[] = [];
   const fileHandles = new Map<string, FileSystemFileHandle>();
@@ -366,6 +440,10 @@ function aggregateBuild(
   const manifest: VaultManifest = {
     version: '2026-04-23',
     generatedAt: new Date().toISOString(),
+    // 상한에 걸리지 않았으면 필드 자체를 두지 않는다 — `false`/`[]` 를 늘 실으면
+    // 매니페스트를 비교하는 코드(증분 빌드 · 스냅샷)에 의미 없는 차이가 생긴다.
+    ...(walkInfo?.truncated ? { walkTruncated: true } : {}),
+    ...(walkInfo?.prunedDirs.length ? { prunedDirs: walkInfo.prunedDirs } : {}),
     docs,
     backlinksDetail,
     tags,
@@ -382,8 +460,15 @@ function aggregateBuild(
 /** 디렉터리를 walk 하며 모든 .md 본문을 읽어 BuiltVaultEntry[] 로. (전체 I/O) */
 async function collectEntries(
   root: FileSystemDirectoryHandle,
+  /** 순회의 경계 사실을 매니페스트까지 실어 나르는 자리 — 침묵하지 않기 위해. */
+  walkInfo?: { truncated: boolean; prunedDirs: string[] },
 ): Promise<BuiltVaultEntry[]> {
-  const files = await walk(root);
+  const walked = await walkVault(root);
+  if (walkInfo) {
+    walkInfo.truncated = walked.truncated;
+    walkInfo.prunedDirs = walked.prunedDirs;
+  }
+  const files = walked.entries;
   const entries: BuiltVaultEntry[] = [];
   for (const entry of files) {
     const file = await entry.handle.getFile();
@@ -409,8 +494,9 @@ async function collectEntries(
 export async function buildLocalManifestWithEntries(
   root: FileSystemDirectoryHandle,
 ): Promise<{ build: LocalVaultBuild; entries: BuiltVaultEntry[] }> {
-  const entries = await collectEntries(root);
-  return { build: aggregateBuild(entries, root.name), entries };
+  const walkInfo = { truncated: false, prunedDirs: [] as string[] };
+  const entries = await collectEntries(root, walkInfo);
+  return { build: aggregateBuild(entries, root.name, walkInfo), entries };
 }
 
 /**
@@ -420,7 +506,9 @@ export async function buildLocalManifestWithEntries(
 export async function buildLocalManifest(
   root: FileSystemDirectoryHandle,
 ): Promise<LocalVaultBuild> {
-  return aggregateBuild(await collectEntries(root), root.name);
+  const walkInfo = { truncated: false, prunedDirs: [] as string[] };
+  const entries = await collectEntries(root, walkInfo);
+  return aggregateBuild(entries, root.name, walkInfo);
 }
 
 /**

--- a/src/entities/docs-vault/lib/walk-vault.test.ts
+++ b/src/entities/docs-vault/lib/walk-vault.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VAULT_WALK_MAX_DEPTH,
+  VAULT_WALK_MAX_ENTRIES,
+  walkVault,
+} from './build-local-manifest';
+
+/**
+ * 볼트 순회의 **경계** — 2026-07-29 실측 회귀.
+ *
+ * 설치 앱에서 볼트로 저장소 루트를 고르면 WebView 가 죽었다. 순회가 무제한이라
+ * `src-tauri/target` 까지 내려가 디렉터리 984개 · 마크다운 965개(9.4MB)를 IPC 로
+ * 실어 날랐다 — 정상 볼트(23 · 97)의 16배다.
+ *
+ * **ms 가 아니라 횟수로 잠근다.** 성능 예산은 기계마다 달라 플레이크가 되지만
+ * "캐시 디렉터리는 한 번도 안 들어간다" 는 어느 기계에서나 참이다.
+ */
+
+type Entry = readonly [string, FakeFile | FakeDir];
+
+class FakeFile {
+  readonly kind = 'file' as const;
+  constructor(readonly name: string) {}
+}
+
+class FakeDir {
+  readonly kind = 'directory' as const;
+  /** 이 디렉터리 안으로 실제로 들어갔는가 — 프룬 증명의 핵심. */
+  visited = false;
+  constructor(
+    readonly name: string,
+    private readonly children: Entry[],
+  ) {}
+  async *entries(): AsyncGenerator<Entry> {
+    this.visited = true;
+    for (const child of this.children) yield child;
+  }
+  async getFileHandle(name: string): Promise<FakeFile> {
+    const hit = this.children.find(([childName]) => childName === name);
+    if (!hit || hit[1].kind !== 'file') throw new Error('NotFoundError');
+    return hit[1];
+  }
+}
+
+function dir(name: string, children: Array<FakeFile | FakeDir>): FakeDir {
+  return new FakeDir(
+    name,
+    children.map((child) => [child.name, child] as Entry),
+  );
+}
+const file = (name: string) => new FakeFile(name);
+
+const run = (root: FakeDir) => walkVault(root as unknown as FileSystemDirectoryHandle);
+
+describe('walkVault — 경계', () => {
+  it('collects markdown and images from an ordinary vault', async () => {
+    const result = await run(
+      dir('vault', [file('a.md'), file('cover.png'), file('notes.txt'), dir('sub', [file('b.md')])]),
+    );
+    expect(result.entries.map((e) => e.relativePath).sort()).toEqual([
+      'a.md',
+      'cover.png',
+      'sub/b.md',
+    ]);
+    expect(result.truncated).toBe(false);
+    expect(result.prunedDirs).toEqual([]);
+  });
+
+  /**
+   * `CACHEDIR.TAG` 는 캐시 디렉터리의 **공개 규약**이다 — 디렉터리가 스스로
+   * "나는 캐시다" 라고 선언한다(Cargo 가 `target/` 에 쓴다). 이름 목록과 달리
+   * 관리할 것이 없고 오탐이 원리적으로 없다.
+   */
+  it('never descends into a directory that declares itself a cache', async () => {
+    const target = dir('target', [file('CACHEDIR.TAG'), file('vendored.md')]);
+    const result = await run(dir('repo', [file('README.md'), target]));
+
+    // 표식은 **그 디렉터리의 목록 안에** 있으므로 한 번은 목록을 받는다 —
+    // 그러나 그 안의 어떤 항목도 수집되지 않고 하위로도 내려가지 않는다.
+    expect(result.entries.map((e) => e.relativePath)).toEqual(['README.md']);
+    expect(result.prunedDirs).toEqual(['target']);
+  });
+
+  it('never descends into node_modules', async () => {
+    const deps = dir('node_modules', [file('readme.md')]);
+    const result = await run(dir('repo', [file('a.md'), deps]));
+
+    expect(deps.visited).toBe(false);
+    expect(result.prunedDirs).toEqual(['node_modules']);
+  });
+
+  /**
+   * 이름으로 자르는 목록을 **늘리지 않는다.** `build`·`dist`·`out` 같은 이름은
+   * 문서 폴더에도 정당하게 존재할 수 있고, 이름으로 자르면 남의 문서를 조용히
+   * 버린다 — 크래시를 고치려다 데이터를 잃는 쪽이 더 나쁘다.
+   */
+  it('keeps ordinary folders whose names merely look like build output', async () => {
+    const build = dir('build', [file('process.md')]);
+    const result = await run(dir('vault', [build]));
+
+    expect(build.visited).toBe(true);
+    expect(result.entries.map((e) => e.relativePath)).toEqual(['build/process.md']);
+    expect(result.prunedDirs).toEqual([]);
+  });
+
+  it('stops at the entry cap and says it stopped', async () => {
+    const many = Array.from({ length: VAULT_WALK_MAX_ENTRIES + 50 }, (_, i) => file(`n${i}.md`));
+    const result = await run(dir('vault', many));
+
+    expect(result.entries.length).toBeLessThanOrEqual(VAULT_WALK_MAX_ENTRIES);
+    // **침묵하는 절단은 "전부 봤다" 로 읽힌다.**
+    expect(result.truncated).toBe(true);
+  });
+
+  it('stops at the depth cap and says it stopped', async () => {
+    let deepest = dir('leaf', [file('deep.md')]);
+    for (let i = 0; i < VAULT_WALK_MAX_DEPTH + 2; i += 1) {
+      deepest = dir(`d${i}`, [deepest]);
+    }
+    const result = await run(deepest);
+
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/src/entities/docs-vault/model/types.ts
+++ b/src/entities/docs-vault/model/types.ts
@@ -46,6 +46,15 @@ export interface VaultBacklinkEntry {
 export interface VaultManifest {
   version: string;
   generatedAt: string;
+  /**
+   * 순회가 상한에 걸려 **일부만 봤는가.** 침묵하는 절단은 "전부 봤다" 로
+   * 읽히므로 매니페스트가 이 사실을 들고 다닌다 — 화면이 "문서 N개" 라고
+   * 말할 때 그 N 이 전부인지 아닌지를 같은 자리에서 알 수 있어야 한다.
+   * 빌드타임 매니페스트에는 없는 개념이라 optional.
+   */
+  walkTruncated?: boolean;
+  /** 캐시/의존성으로 판정해 통째로 건너뛴 디렉터리 — 왜 빠졌는지의 근거. */
+  prunedDirs?: string[];
   docs: VaultDoc[];
   backlinksDetail: Record<string, VaultBacklinkEntry[]>;
   tags: Record<string, string[]>;

--- a/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
@@ -127,7 +127,21 @@ export function DocsVaultAuditModal({
       icon: HardDrive,
       label: t("sourceContract.filesLabel"),
       value: sourceLabel,
-      body: t("sourceContract.filesBody"),
+      // **침묵하는 절단은 "전부 봤다" 로 읽힌다.** 순회가 상한에 걸렸거나
+      // 캐시 디렉터리를 건너뛰었으면, 사용자가 문서 수를 읽는 **그 자리**에서
+      // 함께 말한다 — 다른 화면에 적어 두면 이 숫자를 믿는 사람은 못 본다.
+      body: [
+        t("sourceContract.filesBody"),
+        manifest.walkTruncated ? t("sourceContract.filesTruncated") : "",
+        manifest.prunedDirs?.length
+          ? t("sourceContract.filesPruned", {
+              count: manifest.prunedDirs.length,
+              names: manifest.prunedDirs.slice(0, 3).join(" · "),
+            })
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" "),
       chip: t("sourceContract.filesChip"),
       href: "/docs/",
       cta: t("sourceContract.filesCta"),


### PR DESCRIPTION
## Summary

#767 실측에서 나온 별건. 설치 앱에서 볼트로 **저장소 루트**를 고르면 WebView 가
죽었다("This page couldn't load"). 아픈 이유는 **스킬 사본 판정처럼 볼트가
저장소 루트여야 의미 있는 기능이 있고, 그 조합이 정확히 그 사용자의 첫
시도**라는 점이다 — 그 검증조차 작은 픽스처 볼트로 우회해야 했다.

## 원인 — 순회에 경계가 없었다

`walk` 은 dot 디렉터리만 걸렀다. 깊이도, 개수도, 캐시/의존성 제외도 없었다.

| | 정상 볼트(`docs/ontology`) | 저장소 루트 |
|---|---|---|
| 디렉터리 목록 | 23 | **984** |
| 마크다운 읽기 | 97 | **965** (9.4MB) |

각각이 Tauri IPC 왕복이라 1,949회. 지배적인 몫은 `src-tauri/target`(파일 10,137개).

## 고침 — 이름 목록이 아니라 규약으로 자른다

**`CACHEDIR.TAG`** 를 신호로 쓴다. 캐시 디렉터리의 공개 규약(bford.info/cachedir)
이고 Cargo·Bazel 등이 따른다 — 디렉터리가 **스스로** "나는 캐시다" 라고 선언한다.
이름 목록과 달리 관리할 것이 없고 오탐이 원리적으로 없다.

**이름으로 자르는 것은 `node_modules` 하나뿐이다.** `build`·`dist`·`out` 을
목록에 넣고 싶은 유혹이 있지만 그 이름들은 **문서 폴더에도 정당하게 존재**할 수
있다 — 크래시를 고치려다 남의 문서를 조용히 버리는 쪽이 더 나쁘다. 계약 테스트가
`build/` 폴더가 살아남는 것을 잠근다.

**그리고 상한을 둔다**(항목 4,000 · 깊이 12). 볼트는 문서 폴더지 임의의
디렉터리가 아니고, 규약을 안 따르는 도구는 언제나 있다.

표식은 **이미 받는 목록 안에서** 찾는다 — `getFileHandle` 로 따로 물으면
디렉터리마다 IPC 왕복이 하나씩 늘고, 그건 지금 고치는 비용과 같은 종류다.

## 절단은 침묵하지 않는다

`walkTruncated` · `prunedDirs` 를 매니페스트가 들고 다니고, 「문서함 점검」의
**문서 수를 읽는 바로 그 자리**에서 말한다. 다른 화면에 적으면 그 숫자를 믿는
사람은 못 본다.

초안에서 이 값을 계산해 놓고 `walk()` 이 버리고 있었다 — 주석에는 "호출부까지
올려 보낸다"고 써 놓고서. **내가 금지한 침묵을 내가 하고 있었다.**

## 설치 앱 실측 — 크래시 전/후

```
이전:  "This page couldn't load"
이후:  문서 551개 · skillTreeProbe "11/3"
```

프룬 후 984→411 디렉터리 · 965→551 마크다운. **스킬 사본 판정이 이제 실제
저장소 루트에서 동작한다** — 그 기능이 의도한 바로 그 시나리오다.

## Test plan

- `pnpm test:run` — 4,876 통과 (신규 6: 경계 계약 — 캐시 프룬 · node_modules 프룬 · `build/` 생존 · 개수 상한 · 깊이 상한 · 정상 볼트)
- `pnpm lint` — 0 errors / 150 warnings (baseline 불변)
- `pnpm exec tsc --noEmit`
- `playwright` — 107건 (빌드된 export)
- 설치 앱 실측 — 위 표

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD