### PR TITLE
fix: 실습 중에는 첫 방문 투어가 뜨지 않는다 — 하고 있는 사람에게 설명하지 않는다

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3527,6 +3527,35 @@ pub fn run() {
                                   // 위해 하지 않는다.
                                   skillTreeProbe:
                                     document.querySelector("[data-skill-parity]")?.getAttribute("data-skill-parity") || "",
+                                  // 공방 실습 · 에이전트 도크 실측 (2026-07-29).
+                                  // 둘 다 **제품이 이미 갖고 있는** 속성/테스트
+                                  // 아이디를 읽을 뿐이라 하네스 쪽 변경만이다 —
+                                  // `bodyText` 가 240자로 잘려 화면 아래쪽 상태를
+                                  // 못 보는 사각지대를 이 두 줄이 덮는다.
+                                  studioPracticeStep:
+                                    document.querySelector("[data-testid=\"studio-practice-rail\"]")?.getAttribute("data-step") || "",
+                                  studioPracticeCleanupOpen:
+                                    Boolean(document.querySelector("[data-testid=\"studio-practice-cleanup\"]")),
+                                  agentDockPresent:
+                                    Boolean(document.querySelector("[data-testid=\"vault-agent-panel\"]")),
+                                  // 바깥에서 클릭하려면 좌표가 필요하다 — WebView 안의
+                                  // 위치는 바깥 자동화가 알 방법이 없다. CSS 픽셀이라
+                                  // 창 원점 기준으로 환산해 쓴다.
+                                  clickTargets: (() => {
+                                    const out = {};
+                                    for (const id of ["studio-save", "studio-practice-delete", "studio-practice-keep", "studio-create-name"]) {
+                                      const el = document.querySelector(`[data-testid="${id}"]`);
+                                      if (!el) continue;
+                                      const r = el.getBoundingClientRect();
+                                      if (r.width === 0 && r.height === 0) continue;
+                                      out[id] = [Math.round(r.x + r.width / 2), Math.round(r.y + r.height / 2)];
+                                    }
+                                    return out;
+                                  })(),
+                                  agentDockWidth:
+                                    Math.round(
+                                      document.querySelector("[data-testid=\"vault-agent-panel\"]")?.getBoundingClientRect().width || 0
+                                    ),
                                   ontologyNav: links.some((link) => link.href.includes("/ontology") || /온톨로지|Ontology/.test(link.text)),
                                   sourceVaultNav: links.some((link) => link.href.includes("/docs") || /저장소|문서함|Source Vault|Documents/.test(link.text)),
                                   agentBriefCopy: buttons.some((text) => /브리핑 복사|Copy brief/.test(text)) && /agent_brief/.test(bodyText),

--- a/src/features/guided-tour/model/auto-start-guard.test.ts
+++ b/src/features/guided-tour/model/auto-start-guard.test.ts
@@ -61,4 +61,16 @@ describe("canAutoStartGuidedTour (stacked-transient guard)", () => {
     document.body.innerHTML = '<div data-interactive-overlay="true"></div>';
     expect(canAutoStartGuidedTour(document)).toBe(true);
   });
+
+  /**
+   * **하고 있는 사람에게 설명하지 않는다.** 2026-07-29 설치 앱 실측: 공방
+   * 실습을 시작하자 900ms 뒤 첫 방문 투어가 그 위에 떠 실습의 1단계
+   * ("이름을 지어 보세요")를 물리적으로 막았다. 실습 띠는 모달이 아니라
+   * 비차단 띠라 modality 조건 어디에도 안 걸렸다.
+   */
+  it("does not explain a surface the user is already working through", () => {
+    document.body.innerHTML =
+      '<div data-testid="studio-practice-rail" data-surface-role="hands-on-guide"></div>';
+    expect(canAutoStartGuidedTour(document)).toBe(false);
+  });
 });

--- a/src/features/guided-tour/model/auto-start-guard.ts
+++ b/src/features/guided-tour/model/auto-start-guard.ts
@@ -40,5 +40,16 @@ export function canAutoStartGuidedTour(doc: Document = document): boolean {
   if (doc.querySelector('[data-surface-role="degraded-surface"]') !== null) {
     return false;
   }
+  // 2026-07-29 설치 앱 실측 — **하고 있는 사람에게 설명하지 않는다.**
+  // 공방 실습(`?practice=1`)을 시작하자 900ms 뒤 첫 방문 투어가 그 위에 떴고,
+  // 실습의 1단계("이름을 지어 보세요")를 물리적으로 막았다. 실습 띠는 모달이
+  // 아니라 비차단 띠라 위의 어떤 조건에도 안 걸렸다.
+  //
+  // 두 안내가 같은 순간에 서로 다른 "지금 이걸 하세요" 를 말하면, 사용자는
+  // 둘 다 못 한다. 손이 이미 움직이고 있는 실습이 소개보다 우선한다 — 소개는
+  // 실습을 그만두면 다음 방문에 그대로 기다린다(기록을 남기지 않으므로).
+  if (doc.querySelector('[data-surface-role="hands-on-guide"]') !== null) {
+    return false;
+  }
   return doc.hasFocus();
 }

--- a/src/views/ontology-studio/ui/StudioPracticeRail.tsx
+++ b/src/views/ontology-studio/ui/StudioPracticeRail.tsx
@@ -47,6 +47,13 @@ export function StudioPracticeRail({
     <div
       data-testid="studio-practice-rail"
       data-step={step}
+      /**
+       * 손이 이미 움직이고 있다는 선언 — 첫 방문 투어가 이 위에 겹쳐 뜨지
+       * 않게 한다(`auto-start-guard`). 실습 띠는 모달이 아니라 비차단 띠라
+       * modality 마커로는 잡히지 않고, 실제로 설치 앱에서 투어가 실습의
+       * 1단계를 덮었다(2026-07-29 실측).
+       */
+      data-surface-role="hands-on-guide"
       className="pointer-events-auto mx-auto flex w-full max-w-[640px] items-center gap-3 rounded-panel border border-[color:var(--color-indigo-a46)] bg-[color:var(--color-indigo-a06)] px-4 py-2.5"
     >
       <span


### PR DESCRIPTION
## Summary

설치 앱에서 공방 실습을 **끝까지 실제로 돌려 보다** 나온 결함.

`?practice=1` 로 실습을 시작하면 900ms 뒤 첫 방문 투어("글끼리 이어 붙이는
작업대예요")가 그 위에 떴다. 실습의 1단계는 "만들 개념의 이름을 지어 보세요"
인데, **투어 모달이 이름 칸을 물리적으로 덮어** 그 단계를 할 수 없었다.

두 안내가 같은 순간에 서로 다른 "지금 이걸 하세요" 를 말하면 사용자는 **둘 다
못 한다.**

## 왜 기존 가드에 안 걸렸나

`canAutoStartGuidedTour` 는 modality 등급 표면만 본다 — `role=dialog` ·
`blocking-edit-surface` · `degraded-surface`. 실습 띠는 **일부러** 모달이 아니라
무대를 가리지 않는 비차단 띠라(안내와 대상이 같은 화면에 있어야 가르쳐진다)
세 조건 어디에도 해당하지 않았다.

가드가 본 것은 "무엇이 화면을 막고 있나" 였는데, 필요한 판정은 **"사용자의 손이
이미 움직이고 있나"** 였다.

## 고침

가드 어휘(`data-surface-role`)를 그대로 써서 한 단을 더한다: **`hands-on-guide`
가 서 있으면 소개는 뜨지 않는다.** 소개는 기록을 남기지 않으므로 실습을 그만두면
다음 방문에 그대로 기다린다.

## 설치 앱 실측 — 전/후

```
이전:  실습 1/4 위에 투어 카드 1/2 가 겹침 — 이름 칸 도달 불가
이후:  실습 띠만. 이름 칸이 바로 열려 있음("예: 결제 취소")
```

## 실측 하네스

이번 검증이 가능하려면 바깥에서 WebView 안을 볼 수 있어야 했다. 하네스
(`src-tauri`)에 읽기 전용 마커를 더한다 — **제품이 이미 갖고 있는 속성과 테스트
아이디를 읽을 뿐**이다:

- `studioPracticeStep` · `studioPracticeCleanupOpen` — `bodyText` 가 240자로 잘려
  화면 아래쪽 상태를 못 보는 사각지대를 덮는다
- `agentDockPresent` · `agentDockWidth` — 도크가 어느 표면에 붙었고 열렸는지
- `clickTargets` — 바깥 자동화는 WebView 안의 좌표를 알 방법이 없다

## 같은 실행에서 확인된 것 (결함 아님)

| 단계 | 결과 |
|---|---|
| 진입 선택 | 「처음이신가요? 하나 같이 만들어 봅니다」 뜸 |
| 안내 띠 | 이름을 넣자 **1/4 → 2/4** — 상태를 따라감 |
| 저장 | 디스크에 **진짜 파일** (`capabilities/*.md`) |
| 마무리 | 「해 보셨습니다」 + 파일 이름 + 「지우기/남겨 두기」 + 에이전트 안내 |
| 지우기 | **디스크에서 실제 삭제** (capabilities 0개로 복귀) |
| 에이전트 도크 | 지도와 공방 **양쪽에** 마운트됨 |

## Test plan

- `pnpm test:run` — 4,877 (신규 1: 가드 회귀)
- `pnpm lint` — 0 errors / 150 warnings (baseline 불변)
- `pnpm exec tsc --noEmit`
- `playwright` — 107건
- 설치 앱 실측 — 위 전/후 표

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD