### PR TITLE
feat: 공방에 에이전트 도크를 여는 문을 준다 — 닫으면 못 여는 함정이었다

### DIFF
--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -126,13 +126,20 @@ function normalize(s: string): string {
 function StudioStage({
   practiceSaved,
   onPracticeSaved,
+  agentDock,
 }: {
   /** 실습 저장이 이미 끝났나 — 안내 띠를 접고 마무리에 자리를 넘긴다. */
   practiceSaved: boolean;
   /** 쓰기가 성공한 **그 순간** 되돌리기 표를 바깥으로 올린다. */
   onPracticeSaved: (artifact: PracticeArtifact) => void;
+  /**
+   * 오른쪽 도크의 여닫기 — 껍질이 소유한 상태를 무대 헤더의 버튼과 잇는다.
+   * `null` 이면 도크가 설 수 없는 자리라 버튼도 그리지 않는다.
+   */
+  agentDock: { open: boolean; toggle: () => void } | null;
 }) {
   const t = useTranslations("ontologyStudio");
+  const tAgentPanel = useTranslations("vaultAgentPanel");
   const locale = useLocale();
   // C12③ — the secondary display-name locale is the OTHER of the two app locales.
   const secondaryLocale = locale === "en" ? "ko" : "en";
@@ -219,6 +226,8 @@ function StudioStage({
   const labels: StudioCompassLabels = useMemo(
     () => ({
       searchPlaceholder: t("searchPlaceholder"),
+      // 지도 칩과 **같은 키** — 이름이 바뀌면 두 표면이 함께 바뀐다.
+      agentDock: tAgentPanel("title"),
       exit: insightsReturnTab ? t("returnToReview") : t("exit"),
       moreRelations: t("moreRelations"),
       flowEyebrow: t("flowEyebrow"),
@@ -307,7 +316,7 @@ function StudioStage({
       previewLegendMoved: t("preview.legendMoved"),
       previewLegendRemoved: t("preview.legendRemoved"),
     }),
-    [t, isCreate, flowHint, insightsReturnTab],
+    [t, tAgentPanel, isCreate, flowHint, insightsReturnTab],
   );
 
   // Plain-language record summary vocab — one bag serving both ko + en and both
@@ -918,6 +927,8 @@ function StudioStage({
         }
         onSave={applyCreate}
         onExit={exit}
+        agentDockOpen={agentDock?.open}
+        onToggleAgentDock={agentDock?.toggle}
         searchNodes={candidates}
         onOpenNode={openNode}
         moreRelationsSoon={t("moreRelationsSoon")}
@@ -1348,6 +1359,8 @@ function StudioStage({
       canSave={changes.length > 0}
       onSave={commit}
       onExit={exit}
+      agentDockOpen={agentDock?.open}
+      onToggleAgentDock={agentDock?.toggle}
       onCreateNew={(ctx) => {
         // C2 — carry the socket's relation + typed query into CREATE so the new
         // node lands with the A --relation--> new link + a name prefill.
@@ -1421,6 +1434,15 @@ export function OntologyStudioPage() {
   const closeDock = useCallback(() => {
     dockTouchedRef.current = true;
     setDockOpenState(false);
+  }, []);
+  /**
+   * 무대 헤더의 문. **닫은 뒤 다시 열 수 있어야** 도크가 함정이 아니다 —
+   * 이 문이 없던 동안 공방에서 한 번 닫으면 그 세션에서 되돌릴 방법이 없었다
+   * (2026-07-29 설치 앱 실측).
+   */
+  const toggleDock = useCallback(() => {
+    dockTouchedRef.current = true;
+    setDockOpenState((open) => !open);
   }, []);
 
   const vaultPath = localVault.handle ? getTauriVaultRootPath(localVault.handle) ?? null : null;
@@ -1501,6 +1523,7 @@ export function OntologyStudioPage() {
         <StudioStage
           practiceSaved={practiceArtifact !== null}
           onPracticeSaved={setPracticeArtifact}
+          agentDock={dockUsable ? { open: dockOpen, toggle: toggleDock } : null}
         />
       </div>
       {/* 오른쪽 에이전트 도크 — 지도와 **같은 위젯, 같은 자리**. 공방에서만

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -8,6 +8,7 @@ import { buildDeltaPreview, type DeltaPreviewLayout } from "../lib/build-delta-p
 
 const labels: StudioCompassLabels = {
   searchPlaceholder: "search",
+  agentDock: "에이전트",
   exit: "stop",
   moreRelations: "more",
   flowEyebrow: "completeness",
@@ -124,6 +125,7 @@ const CANDIDATE: CreateCandidate = {
 function renderEnhance(
   onFill = vi.fn(),
   initialFocus?: "heading" | "create-name",
+  dock?: { agentDockOpen?: boolean; onToggleAgentDock?: () => void },
 ) {
   const bearings: CompassBearingView[] = [
     bearing("isA", "up", { recommended: true }),
@@ -149,6 +151,7 @@ function renderEnhance(
       onSave={vi.fn()}
       onExit={vi.fn()}
       initialFocus={initialFocus}
+      {...dock}
     />,
   );
   return onFill;
@@ -1552,5 +1555,34 @@ describe("StudioCompass — 소켓 피커 Esc 계약", () => {
     const onFill = renderPickerOpen();
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onFill).not.toHaveBeenCalled();
+  });
+
+  /**
+   * **닫을 수 있으면 다시 열 수 있어야 한다.** 2026-07-29 설치 앱 실측: 공방에
+   * 도크는 붙었는데 여는 문이 없어서, 한 번 닫으면 그 세션에서 되돌릴 방법이
+   * 없었다 — 축소가 아니라 함정이다.
+   */
+  it("gives the dock a door that can reopen it", () => {
+    const toggle = vi.fn();
+    renderEnhance(vi.fn(), undefined, { agentDockOpen: false, onToggleAgentDock: toggle });
+
+    const button = screen.getByTestId("studio-agent-dock-toggle");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(button);
+    expect(toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the door pressed while the dock stands open", () => {
+    renderEnhance(vi.fn(), undefined, { agentDockOpen: true, onToggleAgentDock: vi.fn() });
+    expect(screen.getByTestId("studio-agent-dock-toggle")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  /**
+   * **설 수 없는 자리에는 문을 그리지 않는다** — 웹이나 좁은 폭에서 열리지 않을
+   * 버튼은 강등이 아니라 죽은 어포던스다.
+   */
+  it("draws no door where the dock cannot stand", () => {
+    renderEnhance();
+    expect(screen.queryByTestId("studio-agent-dock-toggle")).not.toBeInTheDocument();
   });
 });

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   Eye,
   FilePen,
+  MessageCircle,
   MoreHorizontal,
   Plus,
   Search,
@@ -90,6 +91,8 @@ export interface CompassKindOption {
 export interface StudioCompassLabels {
   searchPlaceholder: string;
   exit: string;
+  /** 오른쪽 에이전트 도크 토글의 이름 — 지도 칩과 **같은 i18n 키**를 읽는다. */
+  agentDock: string;
   moreRelations: string;
   flowEyebrow: string;
   /** (filled, total) → e.g. "4방향 중 2 채움 · 반쯤 왔어요". */
@@ -234,6 +237,12 @@ export interface StudioCompassProps {
   onFill: (relation: StudioRelation, candidate: CreateCandidate) => void;
   onSave: () => void;
   onExit: () => void;
+  /**
+   * 오른쪽 에이전트 도크 여닫기. **없으면 버튼을 그리지 않는다** — 웹이나
+   * 좁은 폭처럼 도크가 설 수 없는 자리에 열리지 않는 문을 두지 않는다.
+   */
+  agentDockOpen?: boolean;
+  onToggleAgentDock?: () => void;
   /**
    * Picker "찾는 게 없어요 · 새로 만들기" bridge — opt-in, enhance mode routes to
    * create. C2: the picker passes the socket's relation + typed query so CREATE
@@ -547,6 +556,8 @@ export function StudioCompass(props: StudioCompassProps) {
     onFill,
     onSave,
     onExit,
+    agentDockOpen,
+    onToggleAgentDock,
   } = props;
 
   const [openRelation, setOpenRelation] = useState<StudioRelation | null>(null);
@@ -977,6 +988,29 @@ export function StudioCompass(props: StudioCompassProps) {
             >
               <FilePen size={13} aria-hidden className="text-[color:var(--color-text-quaternary)]" />
               {labels.draftsOpen(drafts.length)}
+            </button>
+          ) : null}
+          {/* 「에이전트」 — 지도의 유틸 레인 칩과 **같은 일, 같은 이름, 같은
+              아이콘**이다(`vaultAgentPanel.title` 단일 키). 공방에 이 문이
+              없으면 도크를 한 번 닫은 사람은 그 세션에서 다시 열 방법이 없다
+              — 2026-07-29 설치 앱 실측에서 나온 함정. 여기 규격은 지도의
+              ChromeChip 이 아니라 **이 헤더의 버튼 규격**을 따른다(같은 줄에
+              선 「그만하기」와 높이·모서리·테두리를 맞춘다). */}
+          {onToggleAgentDock ? (
+            <button
+              type="button"
+              onClick={onToggleAgentDock}
+              aria-pressed={agentDockOpen}
+              data-testid="studio-agent-dock-toggle"
+              className={cn(
+                "flex h-8 items-center gap-1.5 rounded-lg border px-3 text-label transition-colors",
+                agentDockOpen
+                  ? "border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-a12)] text-[color:var(--color-indigo-accent)]"
+                  : "border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]",
+              )}
+            >
+              <MessageCircle size={13} aria-hidden />
+              {labels.agentDock}
             </button>
           ) : null}
           <button


### PR DESCRIPTION
## Summary

2026-07-29 설치 앱 실측에서 나온 결함. 도크는 지도와 공방 **양쪽에** 붙는데
여는 컨트롤은 지도에만 있었다. 공방에서 한 번 닫으면 그 세션에서 다시 열 방법이
없다 — **축소가 아니라 함정이다.**

## 지도와 같은 문, 이 헤더의 규격으로

이름과 아이콘은 지도 유틸 레인 칩과 **같다** — `vaultAgentPanel.title` 단일 키를
읽고 같은 말풍선 아이콘을 쓴다. 이름이 바뀌면 두 표면이 함께 바뀐다.

규격만 이 헤더를 따른다. 지도의 `ChromeChip` 을 가져오면 같은 줄에 선
「그만하기」와 높이·모서리·테두리가 어긋나므로 옆 버튼과 같은 규격으로 그린다
(새 컴포넌트 0, 새 토큰 0).

## 설 수 없는 자리에는 그리지 않는다

`onToggleAgentDock` 이 없으면 버튼 자체를 렌더하지 않는다. 웹(다리 없음)과
`<1444px`(도크가 무대를 자기 최소 폭 아래로 누르는 폭)에서는 도크가 설 수 없고,
**열리지 않을 버튼은 강등이 아니라 죽은 어포던스**다.

## 설치 앱 실측

```
닫힘 → 「에이전트」 클릭 → 열림 (무대가 좁아지고 도크가 자리를 받음)
     → 다시 클릭 → 닫힘 (무대가 전체 폭 복귀)
     → 다시 클릭 → 열림
```

키가 없는 컴퓨터라 도크는 "쓰려면 AI 서비스 키가 한 번 필요해요 · 설정에서 키
등록" 으로 정직하게 잠긴 상태를 보였다 — 문은 열리고 안이 정직하다.

**측정 방법에 대한 기록**: 도크 열림을 오른쪽 영역 **밝기 평균**으로 재려다 두 번
틀렸다(투어 딤이 낀 프레임과 섞였다). 무대는 도트 그리드라 분산이 있고 패널은
균일면이라 분산이 0 이다 — 평균이 아니라 그걸로 갈라야 했다. 결국 판단은
스크린샷이 했다. **틀린 계기는 없는 계기보다 나쁘다.**

## Test plan

- `pnpm test:run` — 4,880 (신규 3: 문이 여닫힘 · 눌림 상태 · 설 수 없으면 없음)
- `pnpm lint` — 0 errors / 150 warnings (baseline 불변)
- `pnpm exec tsc --noEmit`
- `playwright` — 107건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD