### PR TITLE
chore: 릴리스 전에 임시 검증 마커를 걷는다

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3515,47 +3515,6 @@ pub fn run() {
                                     window.localStorage.getItem("ontology-atlas:verify-fixture-vault") || "",
                                   verificationFixtureVaultError:
                                     window.__ontologyAtlasVerifyFixtureVaultError || "",
-                                  // 스킬 사본 판정의 **데스크톱 능력 실측** (2026-07-29).
-                                  // manifest walker 가 dot 디렉터리를 걸러 `.claude/skills`
-                                  // 는 웹에서 원리적으로 안 보이는데, 데스크톱 브리지는
-                                  // 볼 수 있는가. 브라우저 증명이 증명이 아닌 자리라
-                                  // 설치 앱에서만 참이 되는 값이다.
-                                  //
-                                  // 앱이 쓰고 하네스가 읽는다 — 이 저장소의 다른 마커
-                                  // 수십 개와 같은 방식이다. `window.__TAURI__` 를
-                                  // 전역 노출시키는 설정 변경(제품 표면)을 검증 하나를
-                                  // 위해 하지 않는다.
-                                  skillTreeProbe:
-                                    document.querySelector("[data-skill-parity]")?.getAttribute("data-skill-parity") || "",
-                                  // 공방 실습 · 에이전트 도크 실측 (2026-07-29).
-                                  // 둘 다 **제품이 이미 갖고 있는** 속성/테스트
-                                  // 아이디를 읽을 뿐이라 하네스 쪽 변경만이다 —
-                                  // `bodyText` 가 240자로 잘려 화면 아래쪽 상태를
-                                  // 못 보는 사각지대를 이 두 줄이 덮는다.
-                                  studioPracticeStep:
-                                    document.querySelector("[data-testid=\"studio-practice-rail\"]")?.getAttribute("data-step") || "",
-                                  studioPracticeCleanupOpen:
-                                    Boolean(document.querySelector("[data-testid=\"studio-practice-cleanup\"]")),
-                                  agentDockPresent:
-                                    Boolean(document.querySelector("[data-testid=\"vault-agent-panel\"]")),
-                                  // 바깥에서 클릭하려면 좌표가 필요하다 — WebView 안의
-                                  // 위치는 바깥 자동화가 알 방법이 없다. CSS 픽셀이라
-                                  // 창 원점 기준으로 환산해 쓴다.
-                                  clickTargets: (() => {
-                                    const out = {};
-                                    for (const id of ["studio-save", "studio-practice-delete", "studio-practice-keep", "studio-create-name"]) {
-                                      const el = document.querySelector(`[data-testid="${id}"]`);
-                                      if (!el) continue;
-                                      const r = el.getBoundingClientRect();
-                                      if (r.width === 0 && r.height === 0) continue;
-                                      out[id] = [Math.round(r.x + r.width / 2), Math.round(r.y + r.height / 2)];
-                                    }
-                                    return out;
-                                  })(),
-                                  agentDockWidth:
-                                    Math.round(
-                                      document.querySelector("[data-testid=\"vault-agent-panel\"]")?.getBoundingClientRect().width || 0
-                                    ),
                                   ontologyNav: links.some((link) => link.href.includes("/ontology") || /온톨로지|Ontology/.test(link.text)),
                                   sourceVaultNav: links.some((link) => link.href.includes("/docs") || /저장소|문서함|Source Vault|Documents/.test(link.text)),
                                   agentBriefCopy: buttons.some((text) => /브리핑 복사|Copy brief/.test(text)) && /agent_brief/.test(bodyText),


### PR DESCRIPTION
rc.3 태그를 밀기 전 정리. 이번 세션에서 설치 앱 실측을 하려고 WebView 검증
하네스에 넣었던 마커 여섯을 뺀다:

`skillTreeProbe` · `studioPracticeStep` · `studioPracticeCleanupOpen` ·
`agentDockPresent` · `agentDockWidth` · `clickTargets`

## 사실 하나

이 마커 루프는 `ONTOLOGY_ATLAS_VERIFY_WEBVIEW` 환경변수 뒤에 게이트돼 있어
**사용자 세션에서는 한 번도 실행되지 않는다** — 바이너리에 문자열만 남았다.
그래도 릴리스에 싣지 않기로 했다(소유자 판단): 실행되지 않는 코드라도 그것을
읽는 다음 사람에게는 "왜 여기 있나" 를 설명해야 한다.

## 무엇을 잃는가 (정직하게)

`skillTreeProbe` 는 #767 과 원장 2026-07-29 항목이 인용하는 **설치 앱 실측의
기제**였다(앱 `11/3` = CLI `agent-files` 판정과 일치). 이 커밋 이후 같은 실측을
다시 하려면 그 줄을 되살려야 한다 — 커밋 하나짜리 되돌리기이고, 그 사실을
적어 두는 것이 그때의 비용을 줄인다.

나머지 다섯은 이번 실측을 위한 임시 계기였다. 상시로 둘 이유가 없다.

## Test plan

- `cargo check --release` — 통과
- `pnpm exec tsc --noEmit` — 통과
- `pnpm test:run` — 4,895
- `pnpm lint` — 0 errors / 150 warnings (baseline 불변)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsRd6dwCyZ9dKGU8jRTRD