### PR TITLE
fix: README 언어 절 제목이 도메인 후보로 세어지던 것을 막는다

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -796,7 +796,7 @@ A successful run looks like this:
 ✓ find_backlinks — project (2 backlinks)
 ✓ query_concepts — 1 query result / 1 total query result
 ✓ query_concepts limited — 1 query result / 97 total query results (limited true)
-✓ analyze_repo_structure — fsd (6 domain candidates, 16 capability candidates, 41 element candidates)
+✓ analyze_repo_structure — fsd (5 domain candidates, 16 capability candidates, 41 element candidates)
 ✓ infer_imports — 1181 files scanned, 772 module edges (elements/src/views/home->elements/src/entities/knowledge-graph x32 (static:31/dynamic:1), elements/src/views/ontology-insights->elements/src/entities/knowledge-graph x29 (static:29), +770 more)
 ✓ index_project — 64 concept candidates, 772 import relations, validation 0 problem files
 ✓ find_neighbors — src/widgets/bottom-tab-bar (4/4 edges, limited false)

--- a/mcp/src/analyze.mjs
+++ b/mcp/src/analyze.mjs
@@ -930,6 +930,14 @@ function detectDomainsFromReadme(rootPath) {
           /^(why|what|how|when|where|who)\b/i.test(normalizedTitle) ||
           // language-guide / translation section headers
           /가이드|\bguide\b/i.test(normalizedTitle) ||
+          // bare language-name headers ("## 한국어", "## English") — a
+          // translated-README section, same noise class as "## 한국어 가이드".
+          // Measured 2026-07-30: the repo's own "## 한국어" section counted as
+          // a 6th domain candidate and drifted the verify census when the
+          // section moved.
+          /^(한국어|한글|english|日本語|中文|简体中文|繁體中文|español|français|deutsch|português|русский|italiano|türkçe)$/i.test(
+            normalizedTitle,
+          ) ||
           // sentence-like headers (clause separator or long phrase)
           title.includes(',') ||
           wordCount > 5

--- a/mcp/src/analyze.test.mjs
+++ b/mcp/src/analyze.test.mjs
@@ -198,6 +198,8 @@ test('Narrative / language-guide / sentence README H2s skipped from domains', ()
         '## Three views plus MCP, one vault', // sentence (comma)
         '## 한국어 가이드', // language guide
         '## English Guide', // language guide
+        '## 한국어', // bare language-name header — translated-README section
+        '## English', // bare language-name header — translated-README section
         '## Providers and local path', // operational setup section
         '## Provider Management', // real domain — kept
         '## Providers and local marketplace', // real domain — kept


### PR DESCRIPTION
## Summary
- `pnpm package:check` 의 verify census 게이트 실패(머지 블로커, PR #783 CI) 원인 진단 + 수선.
- **측정된 원인**: `analyze_repo_structure` 의 도메인 휴리스틱이 README H2 를 후보로 세는데, 언어-가이드 필터(`/가이드|\bguide\b/`)가 `## 한국어 가이드` 는 거르면서 **맨 언어명 헤더(`## 한국어`)는 통과**시켰다. `slugify` 가 한글을 보존해 이 절이 6번째 도메인 후보였고, #783 이 그 절을 지우자 census 가 6→5 로 움직여 `mcp/README.md` 예시(6)와 어긋났다. 6이 참이던 마지막 지점 = `## 한국어` 절이 살아있는 main(`eff4a1f12`)까지.
- 수선: 맨 언어명 헤더(한국어·English·日本語 등)를 기존 언어-가이드 필터 부류에 등재(번역-README 절은 소유 경계가 아니라 문서 구조 — 기존 필터 주석이 이미 규정한 부류, 사정거리만 짧았다). `mcp/README.md` census 예시를 실측 5 로 갱신. 이 수는 이제 `## 한국어` 절 유무와 무관해 main·#783 양쪽에서 동일하다.
- 게이트: `mcp/src/analyze.test.mjs` 의 스킵 테스트에 맨 언어명 케이스 2건 추가.

## Test plan
- `node --test mcp/src/analyze.test.mjs` 23/23 통과
- `pnpm package:check` 58/58 통과
- 프로브: 필터를 일부러 무력화 → census 게이트 6≠5 빨감 → 복원 → 초록 (탐지기 생존)
- `pnpm exec tsc --noEmit` 통과 · `pnpm lint` 149 warnings (baseline 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)