### PR TITLE
fix: 관문 크롬 칩에 터치 히트 영역을 되돌린다

### DIFF
--- a/src/widgets/gateway-chrome/ui/GatewayNav.tsx
+++ b/src/widgets/gateway-chrome/ui/GatewayNav.tsx
@@ -201,7 +201,11 @@ function GatewayNavLink({
       data-testid={`gateway-nav-${href.slice(1)}`}
       aria-current={active ? 'page' : undefined}
       className={cn(
-        'inline-flex h-8 items-center whitespace-nowrap rounded-chip border px-2.5',
+        // ⚠️ `touch-hit-expand` 는 **칩이 되면서 더 필요해졌다.** 맨 글자였을
+        // 때부터 달려 있던 것을 칩으로 바꾸며 떨어뜨렸고, 터치 계약이 32px 높이를
+        // 잡았다(coarse 포인터 44px). 보이는 상자는 그대로 두고 히트 영역만
+        // 의사요소로 넓히므로 이 줄의 레이아웃은 1px 도 안 바뀐다.
+        'touch-hit-expand inline-flex h-8 items-center whitespace-nowrap rounded-chip border px-2.5',
         'text-body leading-body transition-colors',
         // ⚠️ **쉴 때부터 테두리를 준다.** 처음엔 비활성을 `border-transparent`
         // 로 두고 호버에서만 칩이 나타나게 했는데, 그러면 소유자가 짚은 상태


### PR DESCRIPTION
## Summary

`touch-target-contract` 가 `gateway-nav-guide`(55×32) · `gateway-nav-changelog`
(69×32)를 44px 미만으로 잡았다. coarse 포인터 계약은 44px 인데 칩 높이가 32 다.

맨 글자였을 때는 `touch-hit-expand` 가 달려 있었는데, 칩으로 바꾸면서 클래스
문자열을 새로 쓰다가 **그 한 조각을 떨궜다.** 보이는 상자가 20 → 32 로 커졌으니
좋아졌다고 착각하기 쉽지만 44 에는 여전히 못 미친다.

`touch-hit-expand` 는 의사요소로 히트 영역만 넓혀 **보이는 레이아웃은 1px 도 안
바뀐다** — 되돌리는 데 대가가 없다.

## ⚠️ #797 은 빨간 채로 머지됐다 (내 절차 실수)

확인 루프가 "체크가 **끝났는가**" 까지만 보고 "무엇으로 끝났는가" 를 안 봤고, 그
뒤 머지가 조건 없이 실행됐다. `Types · Lint · Unit` 만 초록인 것을 통과로 읽은
셈이다. 완료(`COMPLETED`)와 성공(`SUCCESS`)은 다른 단어이고 머지 조건은 뒤쪽이다.

이 PR 이 그 red 를 main 에서 걷어낸다.

## Test plan

- `pnpm exec playwright test tests/e2e/touch-target-contract.spec.ts` — **3 passed**
  (빨갰던 관문 케이스 포함)
- `pnpm exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB