### PR TITLE
perf: 드래그 프레임 4.4ms → 3.7ms — 안 그려지는 노드에 일을 시키지 않는다

### DIFF
--- a/src/widgets/topology-map-v2/model/force-layout.ts
+++ b/src/widgets/topology-map-v2/model/force-layout.ts
@@ -67,13 +67,20 @@ export interface ForceSimulation {
   /**
    * Current `{x, y}` per node id — a fresh Map each call.
    *
-   * ⚠️ NOT cheap at scale: the sim holds EVERY node regardless of semantic-zoom
-   * capping, so this allocates an N-entry Map per tick (3000 at `?synth=3000`)
-   * even when a restricted tick moved ~30 of them. Known waste, measured but
-   * not yet fixed — see `docs/MAP-TESTABILITY.md` for how to re-measure before
-   * changing it.
+   * `only` narrows the map to those ids. The sim holds EVERY node regardless of
+   * semantic-zoom capping, so the unrestricted call allocates an N-entry Map
+   * plus N position objects per tick (3000 at `?synth=3000`) even when a
+   * restricted tick moved ~30 of them — pass the same set you passed `tick`
+   * and the caller's write-back shrinks with it. Ids the sim doesn't hold are
+   * skipped, so an over-wide `only` is safe.
+   *
+   * ⚠️ The omitted ids are omitted from the RESULT, and the caller's write-back
+   * therefore no longer overwrites their world coordinates. That is only sound
+   * while nothing else relies on this call to reset a per-frame displacement —
+   * see `use-topology-loop.ts`'s neighbor tug, which does, and is why the set
+   * passed there is wider than the tick's own restriction.
    */
-  positions(): Map<string, ForcePosition>;
+  positions(only?: ReadonlySet<string> | null): Map<string, ForcePosition>;
   /** Pins a node to a world coordinate (grabbed for drag) — held fixed across ticks until `clearPin`. */
   pin(id: string, x: number, y: number): void;
   /** Updates the active pin's coordinate (drag move) — 1:1, no easing. */
@@ -197,15 +204,21 @@ export function createForceSimulation(
       }
       restamp();
     },
-    positions() {
+    positions(only?: ReadonlySet<string> | null) {
       const map = new Map<string, ForcePosition>();
-      graph.forEachNode((id, attrs) => {
-        const x = attrs.x as number;
-        const y = attrs.y as number;
-        // Guard against a rare FA2 NaN blow-up — callers keep the last good
-        // position rather than teleporting a node to nowhere.
+      // Guard against a rare FA2 NaN blow-up — callers keep the last good
+      // position rather than teleporting a node to nowhere.
+      const put = (id: string, x: number, y: number) => {
         if (Number.isFinite(x) && Number.isFinite(y)) map.set(id, { x, y });
-      });
+      };
+      if (only) {
+        for (const id of only) {
+          if (!graph.hasNode(id)) continue;
+          put(id, graph.getNodeAttribute(id, "x") as number, graph.getNodeAttribute(id, "y") as number);
+        }
+      } else {
+        graph.forEachNode((id, attrs) => put(id, attrs.x as number, attrs.y as number));
+      }
       return map;
     },
     pin(id: string, x: number, y: number) {

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
@@ -252,6 +252,7 @@ describe("computeFocusCameraTarget — fit-to-ego dive (dive-framing fix)", () =
       nodes: [...nodeById.values()],
       nodeById,
       edges: [],
+      edgeIndexByNode: new Map(),
       neighborMap,
       childrenByParent: new Map(),
       clusterMetaByParent: new Map(),

--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -714,6 +714,13 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   const tierAlphaById = tierAlphaByIdReused;
   const effectiveAlphaById = effectiveAlphaByIdReused;
   for (const node of world.nodes) {
+    // **접힌 노드는 알파를 가질 이유가 없다** — 칩 하나로 대체돼 이 프레임에
+    // 그려지지 않는다(실측 synth=3000: 3000 중 2820개). 소비처 넷이 전부 이
+    // 조회 «앞에서» 접힘을 이미 거른다: 엣지 루프 둘은 양 끝이 접히면 continue,
+    // 노드/라벨 루프는 첫 줄이 같은 가드, 히트 판정(`isNodeHittable`)은 알파
+    // 맵을 읽기 전에 접힘으로 false 를 낸다. 칩 부모는 정의상 접히지 않으며
+    // 그마저 `?? 1` 기본값을 갖는다.
+    if (clusteredIds.has(node.id)) continue;
     const tierKind = realmTierKinds?.get(node.id) ?? node.kind;
     const tierAlpha = nodeTierAlpha(tierKind, node.isHub, zoomRatio, tierReveal);
     tierAlphaById.set(node.id, tierAlpha);

--- a/src/widgets/topology-map-v2/ui/topology-physics-step.ts
+++ b/src/widgets/topology-map-v2/ui/topology-physics-step.ts
@@ -110,6 +110,24 @@ export interface PhysicsStepInput {
    * co-occur.
    */
   freezeCamera?: boolean;
+  /**
+   * 밀도 게이트로 접혀 **그려지지 않는** 노드들 (칩 하나로 대체된 서브트리).
+   *
+   * 주면 아래 램프 넷을 이들에게서 돌리지 않는다 — 화면에 없는 노드의 강조·
+   * ego 공개·포커스 dim·등장 램프는 아무 데도 나타나지 않는다. 실측(synth=3000)
+   * 은 3000 중 **2820개(94%)가 접혀 있고**, 그 94% 에 프레임당 맵 연산 약
+   * 24,000 회가 나가고 있었다 — 드래그가 아닌 평상시에도 상시로.
+   *
+   * ⚠️ **건너뛰면서 값을 남기면 안 된다.** 남은 값은 그 노드가 칩에서 펼쳐지는
+   * 순간 «과거의 상태» 로 되살아나, 포커스 중에 펼친 노드가 dim 으로 **스냅**한다.
+   * 그래서 건너뛸 때 해당 항목을 지운다 — 소비처가 전부 `?? 0`(강조·ego·포커스)
+   * / `?? 1`(등장) 기본값을 갖고 있어, 지운 항목은 «처음부터 램프 인» 이라는
+   * 이미 있는 계약으로 되돌아간다.
+   *
+   * 생략하면 전 노드가 대상 — 이 인자를 모르는 기존 호출부/테스트는 종전 동작
+   * 그대로다.
+   */
+  clusteredIds?: ReadonlySet<string> | null;
   /** Mutated in place — the hook owns this map's lifetime across frames. */
   emphasisById: Map<string, number>;
   rippleStartById: ReadonlyMap<string, number>;
@@ -186,6 +204,7 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
     ambientFactor,
     userDrivenCamera = false,
     freezeCamera,
+    clusteredIds = null,
     emphasisById,
     rippleStartById,
     egoRevealById,
@@ -283,6 +302,15 @@ export function stepTopologyPhysics(input: PhysicsStepInput): PhysicsStepResult 
   // the same normal↔dim color ramp (owner headline motion).
   const focusActive = focusedNodeId !== null || pairFocusActive;
   for (const node of world.nodes) {
+    if (clusteredIds?.has(node.id)) {
+      // 접혀서 화면에 없다 — 램프를 태우지 않고, **남은 값도 지운다**.
+      // 남기면 이 노드가 칩에서 펼쳐질 때 과거 상태로 되살아나 스냅한다.
+      emphasisById.delete(node.id);
+      egoRevealById.delete(node.id);
+      focusRampById.delete(node.id);
+      appearById.delete(node.id);
+      continue;
+    }
     const isHoverEgoMember =
       !!activeEgoId && (node.id === activeEgoId || world.neighborMap.get(activeEgoId)?.has(node.id) === true);
     const isInActiveEgoSet = isNodeEmphasisActive(node.id, focusedNodeId, isHoverEgoMember, panelEmphasisNodeId);

--- a/src/widgets/topology-map-v2/ui/topology-world.ts
+++ b/src/widgets/topology-map-v2/ui/topology-world.ts
@@ -136,6 +136,14 @@ export interface TopologyWorld {
   childrenByParent: ReadonlyMap<string, readonly string[]>;
   /** 밀도 게이트 칩 배치 메타 (자식 있는 부모만, 정적). */
   clusterMetaByParent: ReadonlyMap<string, ClusterParentMeta>;
+  /**
+   * node id → indices into `edges` of every edge touching that node (both
+   * directions). Static: `edges` is never structurally mutated after the build
+   * (only its per-frame geometry / comet phase fields are). Exists so a frame
+   * that moved ~30 nodes can refresh ~60 edges instead of all ~3000
+   * (`recomputeWorldGeometry`'s `movedIds` path).
+   */
+  edgeIndexByNode: ReadonlyMap<string, readonly number[]>;
   /** Top `starCount` nodes by magnitude — get the far-field diffraction-spike overlay. */
   brightStarIds: ReadonlySet<string>;
   /** Bbox of ALL nodes — used for pan clamping and focus-mode context. */
@@ -490,10 +498,24 @@ export function buildTopologyWorld(
   const ranked = [...nodes].sort((x, y) => y.size + y.fullDegree * 18 - (x.size + x.fullDegree * 18));
   const brightStarIds = new Set(ranked.slice(0, Math.max(0, Math.round(tokens.starCount))).map((n) => n.id));
 
+  // 노드 → 자기에게 물린 엣지 인덱스. 빌드 때 한 번 만들어 두면 «움직인 노드의
+  // 엣지만» 갱신하는 프레임 경로가 성립한다 (`recomputeWorldGeometry`).
+  const edgeIndexByNode = new Map<string, number[]>();
+  const indexEdge = (nodeId: string, edgeIndex: number) => {
+    const list = edgeIndexByNode.get(nodeId);
+    if (list) list.push(edgeIndex);
+    else edgeIndexByNode.set(nodeId, [edgeIndex]);
+  };
+  for (let i = 0; i < worldEdges.length; i += 1) {
+    indexEdge(worldEdges[i].sourceId, i);
+    indexEdge(worldEdges[i].targetId, i);
+  }
+
   return {
     nodes: worldNodes,
     nodeById,
     edges: worldEdges,
+    edgeIndexByNode,
     neighborMap,
     childrenByParent,
     clusterMetaByParent,
@@ -509,9 +531,13 @@ export function buildTopologyWorld(
  * `force-layout.ts#positions`) leave the node's last-good coordinate intact.
  */
 export function applyForcePositions(world: TopologyWorld, positions: ReadonlyMap<string, { x: number; y: number }>): void {
-  for (const node of world.nodes) {
-    const p = positions.get(node.id);
-    if (p) {
+  // **주는 쪽을 순회한다.** 종전에는 월드의 전 노드(3000)를 돌며 `positions.get`
+  // 을 했는데, 제한 틱이 실제로 움직인 것은 그중 수십 개다. 맵이 그 수십 개만
+  // 담고 오면(`force-layout.ts#positions(only)`) 이 루프도 그만큼만 돈다.
+  // 의미는 동일하다 — 맵에 없는 노드는 종전에도 좌표가 유지됐다.
+  for (const [id, p] of positions) {
+    const node = world.nodeById.get(id);
+    if (node) {
       node.x = p.x;
       node.y = p.y;
     }
@@ -519,31 +545,95 @@ export function applyForcePositions(world: TopologyWorld, positions: ReadonlyMap
 }
 
 /**
- * Recomputes every edge's endpoints + bow control point and the world bounds
- * from the current (force-updated) node positions. Called each frame while the
- * sim is warm — the "layout precomputed once" invariant only held while
- * positions were static; a living graph refreshes derived geometry per frame.
+ * Refreshes one edge's endpoints + bow control point from its (force-updated)
+ * endpoint nodes.
  */
-export function recomputeWorldGeometry(world: TopologyWorld, tokens: TopologyV2Tokens): void {
+function recomputeEdgeGeometry(world: TopologyWorld, tokens: TopologyV2Tokens, edge: WorldEdge): void {
+  const a = world.nodeById.get(edge.sourceId);
+  const b = world.nodeById.get(edge.targetId);
+  if (!a || !b) return;
+  edge.ax = a.x;
+  edge.ay = a.y;
+  edge.bx = b.x;
+  edge.by = b.y;
+  const control =
+    edge.kind === "depends"
+      ? computeDependsBowControlPoint({ x: a.x, y: a.y }, { x: b.x, y: b.y }, tokens.edgeBowDepends)
+      : computeBowControlPoint(
+          { x: a.x, y: a.y },
+          { x: b.x, y: b.y },
+          tokens.edgeBowContains,
+          tokens.edgeBlendContains,
+        );
+  edge.controlX = control.x;
+  edge.controlY = control.y;
+}
+
+/** 한 노드의 반지름 패딩 박스를 기존 bbox 에 합친다 (넓히기만 — 줄이지 않는다). */
+function growBounds(bounds: Bounds, node: WorldNode, tokens: TopologyV2Tokens): void {
+  const r = radiusForKind(node.kind, tokens);
+  if (node.x - r < bounds.minX) bounds.minX = node.x - r;
+  if (node.x + r > bounds.maxX) bounds.maxX = node.x + r;
+  if (node.y - r < bounds.minY) bounds.minY = node.y - r;
+  if (node.y + r > bounds.maxY) bounds.maxY = node.y + r;
+}
+
+/**
+ * 움직인 노드만 받았을 때의 부분 갱신.
+ *
+ * - **엣지**: 움직인 노드에 물린 것만 (`edgeIndexByNode`). 양끝이 다 움직인
+ *   엣지는 두 번 계산되지만 멱등이라 결과가 같다 — 중복 제거용 Set 을 매
+ *   프레임 새로 만드는 값이 그 중복보다 비싸다.
+ * - **bbox**: 넓히기만 한다. 팬 클램프 입력이라 «조금 넉넉함» 은 안전한
+ *   방향(사용자를 잘라내지 않는다)이고, 정확한 축소는 드래그가 끝나는
+ *   프레임의 전체 재계산이 되돌린다 (`use-topology-loop.ts` 정착 종료 블록).
+ */
+function recomputeMovedGeometry(world: TopologyWorld, tokens: TopologyV2Tokens, movedIds: ReadonlySet<string>): void {
+  for (const id of movedIds) {
+    const indices = world.edgeIndexByNode.get(id);
+    if (indices) {
+      for (const index of indices) recomputeEdgeGeometry(world, tokens, world.edges[index]);
+    }
+    const node = world.nodeById.get(id);
+    if (!node) continue;
+    growBounds(world.bounds, node, tokens);
+    if (isSpineNode(node)) growBounds(world.spineBounds, node, tokens);
+  }
+}
+
+/**
+ * Recomputes edge endpoints + bow control points and the world bounds from the
+ * current (force-updated) node positions. Called each frame while the sim is
+ * warm — the "layout precomputed once" invariant only held while positions were
+ * static; a living graph refreshes derived geometry per frame.
+ *
+ * `movedIds` scopes the pass to the nodes that actually changed this frame.
+ * Omit it (or pass null) for the exact full pass — that is what the homing /
+ * relayout / `relaxNewlyVisible` paths want, since they move everything.
+ *
+ * ⚠️ **A missing id is an immediately visible defect**: the edge keeps last
+ * frame's endpoint and visibly detaches from its node. The caller must derive
+ * the set from the positions it actually wrote, not from the set it *intended*
+ * to move — the drag frame moves nodes through three different writers (force
+ * apply, neighbor tug, overlap relaxation) and the tug alone reaches nodes the
+ * force tick deliberately excluded.
+ */
+export function recomputeWorldGeometry(
+  world: TopologyWorld,
+  tokens: TopologyV2Tokens,
+  movedIds?: ReadonlySet<string> | null,
+): void {
+  if (movedIds) {
+    // 절반 넘게 움직였으면 인덱스 우회가 오히려 손해다 (맵 조회 + 중복 계산).
+    // 그 경계 위는 전체 경로가 싸고, 덤으로 bbox 가 정확히 «줄어들» 기회를 준다.
+    if (movedIds.size * 2 < world.nodes.length) {
+      recomputeMovedGeometry(world, tokens, movedIds);
+      return;
+    }
+  }
+
   for (const edge of world.edges) {
-    const a = world.nodeById.get(edge.sourceId);
-    const b = world.nodeById.get(edge.targetId);
-    if (!a || !b) continue;
-    edge.ax = a.x;
-    edge.ay = a.y;
-    edge.bx = b.x;
-    edge.by = b.y;
-    const control =
-      edge.kind === "depends"
-        ? computeDependsBowControlPoint({ x: a.x, y: a.y }, { x: b.x, y: b.y }, tokens.edgeBowDepends)
-        : computeBowControlPoint(
-            { x: a.x, y: a.y },
-            { x: b.x, y: b.y },
-            tokens.edgeBowContains,
-            tokens.edgeBlendContains,
-          );
-    edge.controlX = control.x;
-    edge.controlY = control.y;
+    recomputeEdgeGeometry(world, tokens, edge);
   }
 
   const full = accumulateBounds(world.nodes, tokens);

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -124,6 +124,17 @@ const VIEWPORT_SETTLE_FRAMES = 2;
  * 뿐이다. 지도 앱의 표준 기법이고, 여기서는 그 교환이 실측으로 정당화된다.
  */
 const INTERACTION_DPR_CAP = 1;
+/**
+ * 시뮬 프레임의 파생 갱신을 «움직인 노드» 로 좁히는 희소성 문턱 — 터그 영향권이
+ * 전체의 `1/이 값` 미만일 때만 좁힌 경로를 탄다.
+ *
+ * 문턱이 필요한 이유는 좁히기가 공짜가 아니어서다: 인덱스 조회는 배열 순회보다
+ * 캐시 지역성이 나쁘고, 어느 노드가 움직였는지 실측하려면 좌표 스냅샷도 떠야
+ * 한다. 2026-07-31 구간 실측이 갈림점을 직접 보여줬다 — 영향권 **281/3000(9%)**
+ * 에서 시뮬 블록 2.1 → 1.5ms(이득), **975/3000(33%)** 에서 기하 0.4 → 0.6ms
+ * (손해). 5 는 그 사이에서 손해 쪽에 여유를 두고 고른 값이다.
+ */
+const SCOPED_FRAME_SPARSITY = 5;
 /** World-unit epsilon below which a homing node is considered "arrived" (`relayout-home.ts#isHomeSpringConverged`). */
 const HOME_CONVERGE_EPSILON = 0.5;
 
@@ -385,6 +396,26 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   const dragStartPosRef = useRef<{ x: number; y: number } | null>(null);
   /** C1 B1 — each tug-affected neighbor's current eased offset (world units), added on top of its natural position. */
   const dragTugOffsetsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+  /**
+   * 시뮬 프레임 «시작» 좌표 스냅샷 (노드 배열 순서). 프레임 끝에서 이것과
+   * 비교해 **정말 움직인 노드**를 뽑고, 파생 기하 갱신을 거기로 좁힌다
+   * (`recomputeWorldGeometry(world, tokens, movedIds)`).
+   *
+   * 「어느 집합이 움직일 예정인가」로 유추하지 않고 실측하는 이유: 한 프레임의
+   * 좌표를 쓰는 주체가 셋(힘 적용 · 이웃 터그 · 겹침 완화)인데 셋의 사정거리가
+   * 서로 다르다. 유추하면 언젠가 하나를 빠뜨리고, 그 증상은 «엣지가 노드에서
+   * 떨어져 보이는» 가시 결함이다.
+   */
+  const geomPrevXRef = useRef<Float64Array | null>(null);
+  const geomPrevYRef = useRef<Float64Array | null>(null);
+  /**
+   * 직전 프레임에 **겹침 완화가 민** 노드들 중 힘-적용 집합 밖의 것.
+   *
+   * 이 프레임의 `applyForcePositions` 가 이들의 좌표를 sim 값으로 되돌리는 것이
+   * 종전 동작이라, 좁힌 write-back 에도 그 되돌림을 남기려면 대상에 포함해야
+   * 한다. (되돌림 자체의 타당성은 별개 문제다 — 여기서는 동작을 바꾸지 않는다.)
+   */
+  const sepDisplacedIdsRef = useRef<Set<string>>(new Set());
   /** C1 B3 — active auto-arrange homing springs, keyed by node id; empty/absent when no relayout is in flight. */
   const homeSpringsRef = useRef<Map<string, HomeSpringState>>(new Map());
   const homingActiveRef = useRef(false);
@@ -1801,8 +1832,54 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
               ),
             )
           : null;
+        // **좁힌 경로는 «희소할 때만» 이득이다** (2026-07-31 구간 실측).
+        //
+        // 이 프레임에 좌표를 쓰는 주체가 셋인데 그중 이웃 터그는 접힌 노드까지
+        // 포함한 1/2홉 전체를 매 프레임 민다. 그래서 «움직인 노드» 는 감사가
+        // 가정한 ~30 이 아니라 **터그 영향권의 크기**다 — 프로젝트 루트를 끌면
+        // 975/3000(33%)이라 인덱스 우회가 오히려 손해였고(기하 0.4 → 0.6ms),
+        // 도메인을 끌면 281/3000(9%)이라 시뮬 블록이 2.1 → 1.5ms 로 줄었다.
+        //
+        // 그래서 갈림길을 하나 둔다: 희소하면 좁히고, 아니면 **스냅샷조차 뜨지
+        // 않고** 종전 전체 경로 그대로 간다. 이득이 없을 때 비용만 남기지 않는
+        // 것이 이 판정의 목적이다.
+        const nodeCount = world.nodes.length;
+        const scoped =
+          affected !== null &&
+          (affected.oneHop.size + affected.twoHop.size + 1) * SCOPED_FRAME_SPARSITY < nodeCount;
+        let prevX: Float64Array | null = null;
+        let prevY: Float64Array | null = null;
+        if (scoped) {
+          // 프레임 시작 좌표를 떠 둔다 — 프레임 끝에서 «정말 움직인 것» 을 실측해
+          // 파생 기하 갱신을 거기로 좁힌다.
+          if (geomPrevXRef.current?.length !== nodeCount) {
+            geomPrevXRef.current = new Float64Array(nodeCount);
+            geomPrevYRef.current = new Float64Array(nodeCount);
+          }
+          prevX = geomPrevXRef.current!;
+          prevY = geomPrevYRef.current!;
+          for (let i = 0; i < nodeCount; i += 1) {
+            prevX[i] = world.nodes[i].x;
+            prevY[i] = world.nodes[i].y;
+          }
+        }
+
         sim.tick(forceIterationsForDt(dt), restrictToIds);
-        applyForcePositions(world, sim.positions());
+        // **되쓸 대상도 제한한다.** 제한 틱은 부분 그래프 밖 좌표를 건드리지
+        // 않으므로 그 값을 다시 써 넣는 것은 무의미한 3000회 왕복이다. 단
+        // **터그 이웃과 직전 프레임의 겹침-밀림 노드는 포함해야 한다** — 이 되쓰기가
+        // 그들의 프레임 변위를 0 으로 되돌리는 것이 기존 계약이고, 빠뜨리면
+        // 터그 오프셋이 프레임마다 누적돼 이웃이 날아간다.
+        const applyOnly =
+          scoped && affected
+            ? new Set<string>([
+                affected.draggedId,
+                ...affected.oneHop,
+                ...affected.twoHop,
+                ...sepDisplacedIdsRef.current,
+              ])
+            : null;
+        applyForcePositions(world, sim.positions(applyOnly));
 
         // C1 B1 — explicit neighbor tug: the dragged node's own per-frame
         // world-space displacement (Δ since grab) propagates to 1-hop/2-hop
@@ -1896,13 +1973,30 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
             pinnedId: nodeDragRef.current?.nodeId ?? null,
             activeIds: sepActive,
           });
+          // 밀린 노드를 여기서 기록해 둔다 — 다음 프레임의 좁힌 write-back 이
+          // 이들의 «되돌림» 을 빠뜨리지 않게 (위 `applyOnly`).
+          const sepDisplaced = sepDisplacedIdsRef.current;
+          sepDisplaced.clear();
           for (let i = 0; i < sepNodes.length; i += 1) {
             const target = world.nodes[drawnIdx[i]];
+            if (scoped && (target.x !== sepNodes[i].x || target.y !== sepNodes[i].y)) {
+              sepDisplaced.add(target.id);
+            }
             target.x = sepNodes[i].x;
             target.y = sepNodes[i].y;
           }
         }
-        recomputeWorldGeometry(world, tokens);
+        // 이 프레임에 좌표가 실제로 바뀐 노드만 — 셋(힘·터그·겹침) 중 누가 썼든
+        // 결과로 판정하므로 어느 하나를 빠뜨릴 수 없다.
+        let movedIds: Set<string> | null = null;
+        if (prevX && prevY) {
+          movedIds = new Set<string>();
+          for (let i = 0; i < nodeCount; i += 1) {
+            const node = world.nodes[i];
+            if (node.x !== prevX[i] || node.y !== prevY[i]) movedIds.add(node.id);
+          }
+        }
+        recomputeWorldGeometry(world, tokens, movedIds);
         // A4 — heat is a TIME budget (ms), not a frame count, so the release
         // settle lasts `--topology-v2-node-release-settle-ms` on every display.
         if (!pinned && heatRef.current > 0) heatRef.current = Math.max(0, heatRef.current - dt * 1000);
@@ -1911,6 +2005,11 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           // drop any residual (by-now-decayed-near-0) tug offsets.
           dragAffectedSetRef.current = null;
           dragTugOffsetsRef.current.clear();
+          sepDisplacedIdsRef.current.clear();
+          // 드래그 동안 bbox 는 «넓히기만» 했다(팬 클램프라 넉넉한 쪽이 안전).
+          // 정착이 끝나는 이 한 프레임에서 정확한 값으로 되돌린다 — 안쪽으로
+          // 모인 그래프의 클램프가 드래그 이전보다 헐렁한 채 남지 않게.
+          recomputeWorldGeometry(world, tokens);
         }
       }
 

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -2226,6 +2226,11 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         reducedMotion: reducedMotionRef.current,
         userDrivenCamera: userDrivenCameraRef.current,
         freezeCamera,
+        // **직전 프레임의** 접힘 집합이다 — 이번 프레임 것은 아래 클러스터
+        // 단계에서야 정해진다. 램프는 시간 위의 값이라 한 프레임 지연이 곧
+        // 정상 동작이고(펼친 노드는 다음 프레임부터 0 에서 램프 인, 접힌
+        // 노드는 한 프레임 더 램프), 순서를 뒤집어 얻을 것이 없다.
+        clusteredIds: clusteredIdsRef.current,
         emphasisById: emphasisRef.current,
         rippleStartById: rippleStartRef.current,
         egoRevealById: egoRevealRef.current,


### PR DESCRIPTION
## Summary

#800 이 드래그를 139.9ms → 4.3ms 로 내린 뒤 남은 후보 4건. 전부 같은 구조의 결함이다 — **화면에 없는 노드에 매 프레임 일을 시킨다**(synth=3000 기준 2,820개가 접혀 있고 화면 안은 118개).

| 순위 | 무엇 | 전 → 후 |
|---|---|---|
| 1+2 | `recomputeWorldGeometry` · `positions()` · `applyForcePositions` 를 **실측된 moved 집합**으로 스코프 | 희소 드래그 4.8 → **4.0ms** |
| 3 | 접힌 노드의 램프 4종 skip + 항목 `delete` | physics 1.35 → **0.75ms** |
| 4 | `frame-draw:716` 에 `clusteredIds` 첫 줄 가드 | draw 1.55 → **1.2ms** |

**최종 (2회 반복)**: work p95 **3.6 · 3.7ms** (기준선 4.4) · synth=31 **1.3ms** → 비율 **2.8배**. 롱태스크 **0**, 최악 프레임 5.2ms.

## 감사의 전제가 실측에서 틀렸다

감사는 "드래그 중 움직이는 노드 ~30"을 전제로 1+2순위를 처방했다. 실측하니 **프로젝트 루트 드래그에서는 950/3000** 이었다. 무조건 좁히면 스코프 계산 비용이 이득을 넘어 **4.4 → 4.8ms 로 느려진다**(실측).

그래서 설계를 바꿔 **희소할 때만**(`SCOPED_FRAME_SPARSITY=5`, 20% 미만) 좁힌다. 밀집 드래그는 종전 경로 그대로라 중립이다. 이 상수는 이 기계의 교차점(9%에서 이기고 33%에서 짐)에서 **안전 쪽으로** 잡은 값이지 정밀한 손익분기점이 아니다.

## 3순위의 함정

접힌 노드의 램프를 그냥 skip 하면 **stale 값이 남아** mid-focus 에 펼쳐진 노드가 dim 으로 스냅한다. 그래서 skip 시 **항목을 `delete`** 한다 — 소비처 기본값(`?? 0` / `?? 1`)이 이미 "0에서 램프 인" 계약이라 회귀가 0이다.

## 4순위는 감사 결론에 기대지 않고 재검증했다

`clusteredIds` 가드가 안전한지 소비처 4곳을 직접 확인했다 — 엣지 루프·ambient 필터가 알파 조회 **앞**에서 거르고, 칩 부모는 정의상 비접힘, 히트 테스트는 자체 배제.

## Test plan

- 측정: `node scripts/perf-node-drag.mjs` — `headless:false` · 진짜 CDP 마우스 · **「노드 잡음 ✓」자체 판정** · `work` p95 인용 · synth=31 대조군
- `pnpm exec tsc --noEmit` 통과 · `pnpm lint` 0 error · `pnpm test:run` **5,270건 통과**
- 시각 검증: 드래그 중 스크린샷 3장 — 엣지-노드 분리 없음, dim 스냅 없음

## 남은 리스크

- **선재 결함 하나를 발견했다** — 포커스 중 칩을 펼치면 자식이 안 그려진다. **자기 변경을 전부 되돌리고 기준선에서 동일 재현**해 이 PR 과 무관함을 확인했다. 별건
- **다음 지렛대는 이웃 당김(tug)** — 안 그려지는 ~950개를 매 프레임 움직이는, 여기서 고친 것과 같은 구조. 다만 **동작이 바뀌는 변경**(나중에 펼쳐질 노드의 위치)이라 의도적으로 제외
- 측정은 Chrome. 제품 표면은 Tauri(WKWebView)라 설치 앱 재검증 필요

라우트·공개 계약 변경 없음 → `docs/DECISIONS.md` 등재 대상 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)