### PR TITLE
fix: 볼트 변경 알림이 정보를 나르게 — 폴더 경로 대신 종류 + 사람 이름

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2499,13 +2499,18 @@
       "validationTooltip": "{errors, plural, =0 {{warnings} frontmatter warning(s) — run pnpm vault:validate for detail} other {{errors} frontmatter error(s){warnings, plural, =0 {} other {, {warnings} warning(s)}} — some nodes are missing from the graph. Run pnpm vault:validate for detail}}"
     },
     "vaultDiffToaster": {
-      "added": "Added: {slug}",
-      "edited": "Edited: {slug}",
-      "digestAdded": "{count} added",
-      "digestModified": "{count} edited",
+      "added": "Added — {name}",
+      "addedKind": "{kind} added — {name}",
+      "edited": "Edited — {name}",
+      "editedKind": "{kind} edited — {name}",
+      "digestAdded": "{breakdown} added",
+      "digestModified": "{breakdown} edited",
       "digestRemoved": "{count} removed",
-      "digestJoin": " · ",
-      "digestPrefix": "Folder changed — "
+      "digestKindItem": "{kind} {count}",
+      "digestKindOther": "{count} other",
+      "digestKindPlain": "{count}",
+      "digestKindJoin": " · ",
+      "digestJoin": ", "
     },
     "starterCta": {
       "errorFallback": "Failed to create starter",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2501,7 +2501,11 @@
     "vaultDiffToaster": {
       "added": "Added: {slug}",
       "edited": "Edited: {slug}",
-      "overflow": "+{count} more node(s)"
+      "digestAdded": "{count} added",
+      "digestModified": "{count} edited",
+      "digestRemoved": "{count} removed",
+      "digestJoin": " · ",
+      "digestPrefix": "Folder changed — "
     },
     "starterCta": {
       "errorFallback": "Failed to create starter",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2501,7 +2501,11 @@
     "vaultDiffToaster": {
       "added": "추가됨: {slug}",
       "edited": "편집됨: {slug}",
-      "overflow": "+{count}개 더"
+      "digestAdded": "추가 {count}",
+      "digestModified": "편집 {count}",
+      "digestRemoved": "삭제 {count}",
+      "digestJoin": " · ",
+      "digestPrefix": "폴더가 바뀌었어요 — "
     },
     "starterCta": {
       "errorFallback": "시작 시드 만들기 실패",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2499,13 +2499,18 @@
       "validationTooltip": "{errors, plural, =0 {frontmatter 경고 {warnings} 건 — pnpm vault:validate 로 상세} other {frontmatter 오류 {errors} 건{warnings, plural, =0 {} other {, 경고 {warnings} 건}} — 일부 노드가 graph 에서 빠졌습니다. pnpm vault:validate 로 상세}}"
     },
     "vaultDiffToaster": {
-      "added": "추가됨: {slug}",
-      "edited": "편집됨: {slug}",
-      "digestAdded": "추가 {count}",
-      "digestModified": "편집 {count}",
-      "digestRemoved": "삭제 {count}",
-      "digestJoin": " · ",
-      "digestPrefix": "폴더가 바뀌었어요 — "
+      "added": "추가 — {name}",
+      "addedKind": "{kind} 추가 — {name}",
+      "edited": "편집 — {name}",
+      "editedKind": "{kind} 편집 — {name}",
+      "digestAdded": "{breakdown} 추가",
+      "digestModified": "{breakdown} 편집",
+      "digestRemoved": "{count}개 삭제",
+      "digestKindItem": "{kind} {count}",
+      "digestKindOther": "그 외 {count}",
+      "digestKindPlain": "{count}개",
+      "digestKindJoin": " · ",
+      "digestJoin": ", "
     },
     "starterCta": {
       "errorFallback": "시작 시드 만들기 실패",

--- a/src/entities/ontology-class/model/use-kind-label.ts
+++ b/src/entities/ontology-class/model/use-kind-label.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 
 // vault-readme: scaffold 한 vault root 의 README.md 가 갖는 sentinel kind.
@@ -25,11 +26,13 @@ function isKnown(kind: string): kind is KnownKind {
  * tree chips, ego graph, search results, builder palette, inspector,
  * insights breakdown. The pure `getOntologyKindLabel` is kept for vault
  * data / non-i18n contexts (tests, build scripts).
+ *
+ * The returned function is **referentially stable** for a given locale — some
+ * callers put it in a `useEffect` dependency array (`VaultDiffToaster`, which
+ * labels vault-change toasts). A fresh closure per render would re-run those
+ * effects on every render.
  */
 export function useOntologyKindLabel() {
   const t = useTranslations('kinds');
-  return (kind: string): string => {
-    if (isKnown(kind)) return t(kind);
-    return kind;
-  };
+  return useCallback((kind: string): string => (isKnown(kind) ? t(kind) : kind), [t]);
 }

--- a/src/features/docs-vault-local/lib/diff-manifest.test.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { diffVaultManifest, planVaultDiffToasts } from './diff-manifest';
+import {
+  diffVaultManifest,
+  planVaultDiffToasts,
+  toVaultDiffNode,
+  type VaultDiffNode,
+} from './diff-manifest';
+
+/** 테스트용 축약 — 이름만 주고 종류는 선택. */
+function node(name: string, kind?: string, slug = `capabilities/${name}`): VaultDiffNode {
+  return { slug, kind, name };
+}
 
 describe('diffVaultManifest', () => {
   it('첫 mount 와 동일 → added/modified 모두 빈 배열', () => {
@@ -114,23 +124,76 @@ describe('diffVaultManifest', () => {
   });
 });
 
+/**
+ * **슬러그는 화면에 나가지 않는다** (2026-08-01 소유자 지시). 이 describe 가
+ * 그 계약이다 — 되돌리면 여기서 걸린다.
+ */
+describe('toVaultDiffNode', () => {
+  it('display_<locale> 이 있으면 그 이름을 쓴다 — 폴더 경로도 슬러그도 아니다', () => {
+    const result = toVaultDiffNode(
+      {
+        slug: 'capabilities/payment-authorization',
+        title: 'Payment authorization',
+        frontmatter: {
+          kind: 'capability',
+          display_ko: '결제 승인',
+          display_en: 'Payment authorization',
+        },
+      },
+      'ko',
+    );
+    expect(result).toEqual({
+      slug: 'capabilities/payment-authorization',
+      kind: 'capability',
+      name: '결제 승인',
+    });
+    expect(result.name).not.toContain('/');
+    expect(result.name).not.toContain('payment-authorization');
+  });
+
+  it('display_<locale> 이 없으면 title — 그래도 슬러그는 안 쓴다', () => {
+    expect(
+      toVaultDiffNode(
+        {
+          slug: 'domains/refunds',
+          title: '환불',
+          frontmatter: { kind: 'domain' },
+        },
+        'ko',
+      ).name,
+    ).toBe('환불');
+  });
+
+  it('최후 수단이라도 폴더 경로는 붙지 않는다 — 슬러그의 마지막 조각만', () => {
+    // title 도 display_* 도 없는 손편집 .md. 이름을 지어낼 수는 없지만
+    // `capabilities/` 라는 개발자 폴더 이름은 어떤 경우에도 화면에 안 나간다.
+    const result = toVaultDiffNode({ slug: 'capabilities/orphan' }, 'ko');
+    expect(result.name).toBe('orphan');
+    expect(result.name).not.toContain('/');
+  });
+
+  it('frontmatter 에 kind 가 없으면 undefined — 지어내지 않는다', () => {
+    expect(toVaultDiffNode({ slug: 'notes/memo', title: '메모' }, 'ko').kind).toBeUndefined();
+    expect(
+      toVaultDiffNode({ slug: 'notes/memo', title: '메모', frontmatter: { kind: '  ' } }, 'ko').kind,
+    ).toBeUndefined();
+  });
+});
+
 describe('planVaultDiffToasts', () => {
   it('변화가 없으면 toast 계획도 비어 있다', () => {
     expect(planVaultDiffToasts({ added: [], modified: [] })).toEqual([]);
   });
 
   // N10 — 문구는 더 이상 여기서 완성 문자열로 만들지 않는다(영문 하드코딩
-  // "Added: <slug>" ko 리터럴 새는 것 방지). kind/slug/count 만 반환하고,
+  // "Added: <slug>" ko 리터럴 새는 것 방지). 구조만 반환하고,
   // 실제 로케일 문구 조립은 `VaultDiffToaster` 가 `useTranslations` 로 한다.
-  it('added 와 modified 를 kind/slug + variant 구조로 변환한다', () => {
-    expect(
-      planVaultDiffToasts({
-        added: ['capabilities/new'],
-        modified: ['domains/existing'],
-      }),
-    ).toEqual([
-      { kind: 'added', slug: 'capabilities/new', variant: 'info' },
-      { kind: 'edited', slug: 'domains/existing', variant: 'success' },
+  it('added 와 modified 를 노드 + variant 구조로 변환한다', () => {
+    const added = node('new', 'capability');
+    const modified = node('existing', 'domain', 'domains/existing');
+    expect(planVaultDiffToasts({ added: [added], modified: [modified] })).toEqual([
+      { kind: 'added', node: added, variant: 'info' },
+      { kind: 'edited', node: modified, variant: 'success' },
     ]);
   });
 
@@ -142,27 +205,105 @@ describe('planVaultDiffToasts', () => {
    */
   it('preview 를 넘으면 한 장으로 접고, 합계가 아니라 세 갈래로 센다', () => {
     expect(
-      planVaultDiffToasts({ added: ['a', 'b'], modified: ['c', 'd'] }, 3),
+      planVaultDiffToasts(
+        {
+          added: [node('a', 'capability'), node('b', 'capability')],
+          modified: [node('c', 'domain'), node('d', 'domain')],
+        },
+        3,
+      ),
     ).toEqual([
-      { kind: 'digest', counts: { added: 2, modified: 2, removed: 0 }, variant: 'info' },
+      {
+        kind: 'digest',
+        counts: {
+          added: { total: 2, byKind: [{ kind: 'capability', count: 2 }] },
+          modified: { total: 2, byKind: [{ kind: 'domain', count: 2 }] },
+          removed: 0,
+        },
+        variant: 'info',
+      },
     ]);
   });
 
-  it('삭제가 섞이면 개수가 작아도 다이제스트로 간다 — 지워진 슬러그는 열 수 없다', () => {
-    expect(planVaultDiffToasts({ added: ['a'], modified: [], removed: 1 }, 3)).toEqual([
-      { kind: 'digest', counts: { added: 1, modified: 0, removed: 1 }, variant: 'info' },
+  /**
+   * 「15개 추가」보다 「역량 3 · 요소 12 추가」가 낫다 — 다이제스트가 개수만
+   * 말하면 사용자는 무엇이 늘었는지 모른 채 숫자만 본다.
+   */
+  it('다이제스트는 종류별로 센다 — 많은 순, 동수면 이름 순', () => {
+    const [digest] = planVaultDiffToasts(
+      {
+        added: [
+          node('e1', 'element'),
+          node('c1', 'capability'),
+          node('e2', 'element'),
+          node('c2', 'capability'),
+          node('e3', 'element'),
+          node('d1', 'domain'),
+        ],
+        modified: [],
+      },
+      3,
+    );
+    expect(digest.counts?.added).toEqual({
+      total: 6,
+      byKind: [
+        { kind: 'element', count: 3 },
+        { kind: 'capability', count: 2 },
+        { kind: 'domain', count: 1 },
+      ],
+    });
+  });
+
+  it('kind 를 못 얻은 몫은 지어내지 않고 마지막 한 행으로 모은다', () => {
+    const [digest] = planVaultDiffToasts(
+      {
+        added: [node('a', 'capability'), node('b'), node('c'), node('d', 'capability')],
+        modified: [],
+      },
+      3,
+    );
+    expect(digest.counts?.added).toEqual({
+      total: 4,
+      byKind: [{ kind: 'capability', count: 2 }, { count: 2 }],
+    });
+  });
+
+  it('삭제가 섞이면 개수가 작아도 다이제스트로 간다 — 지워진 문서는 이름을 읽을 곳이 없다', () => {
+    expect(
+      planVaultDiffToasts({ added: [node('a', 'capability')], modified: [], removed: 1 }, 3),
+    ).toEqual([
+      {
+        kind: 'digest',
+        counts: {
+          added: { total: 1, byKind: [{ kind: 'capability', count: 1 }] },
+          modified: { total: 0, byKind: [] },
+          removed: 1,
+        },
+        variant: 'info',
+      },
     ]);
   });
 
   it('삭제만 있어도 보고한다 — 종전엔 이 버스트가 통째로 침묵했다', () => {
     expect(planVaultDiffToasts({ added: [], modified: [], removed: 3 })).toEqual([
-      { kind: 'digest', counts: { added: 0, modified: 0, removed: 3 }, variant: 'info' },
+      {
+        kind: 'digest',
+        counts: {
+          added: { total: 0, byKind: [] },
+          modified: { total: 0, byKind: [] },
+          removed: 3,
+        },
+        variant: 'info',
+      },
     ]);
   });
 
   it('preview limit 0 이면 한 건이라도 다이제스트로 접는다', () => {
-    expect(planVaultDiffToasts({ added: ['a'], modified: ['b'] }, 0)).toEqual([
-      { kind: 'digest', counts: { added: 1, modified: 1, removed: 0 }, variant: 'info' },
-    ]);
+    const plan = planVaultDiffToasts(
+      { added: [node('a', 'capability')], modified: [node('b', 'domain')] },
+      0,
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0].kind).toBe('digest');
   });
 });

--- a/src/features/docs-vault-local/lib/diff-manifest.test.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.test.ts
@@ -134,49 +134,35 @@ describe('planVaultDiffToasts', () => {
     ]);
   });
 
-  it('preview limit 안에서는 added 를 먼저 보여주고 남은 칸에 modified 를 보여준다', () => {
+  /**
+   * **부채꼴은 폐기됐다** (2026-08-01). 종전엔 앞 3개를 슬러그로 내고 나머지를
+   * `+N개 더` 라는 별도 토스트로 냈는데, 토스트는 각자 만료하므로 앞의 것이
+   * 먼저 사라지면 **참조 대상을 잃은 숫자만 남았다** — 소유자가 화면에서 그
+   * 상태를 잡았다(「+4개 더」 한 장). 34개 쓰기면 잔해가 「+31개 더」다.
+   */
+  it('preview 를 넘으면 한 장으로 접고, 합계가 아니라 세 갈래로 센다', () => {
     expect(
-      planVaultDiffToasts(
-        {
-          added: ['a', 'b'],
-          modified: ['c', 'd'],
-        },
-        3,
-      ),
+      planVaultDiffToasts({ added: ['a', 'b'], modified: ['c', 'd'] }, 3),
     ).toEqual([
-      { kind: 'added', slug: 'a', variant: 'info' },
-      { kind: 'added', slug: 'b', variant: 'info' },
-      { kind: 'edited', slug: 'c', variant: 'success' },
-      { kind: 'overflow', count: 1, variant: 'info' },
+      { kind: 'digest', counts: { added: 2, modified: 2, removed: 0 }, variant: 'info' },
     ]);
   });
 
-  it('added 만으로 preview 가 차면 modified 는 overflow 로만 집계한다', () => {
-    expect(
-      planVaultDiffToasts(
-        {
-          added: ['a', 'b', 'c', 'd'],
-          modified: ['e'],
-        },
-        3,
-      ),
-    ).toEqual([
-      { kind: 'added', slug: 'a', variant: 'info' },
-      { kind: 'added', slug: 'b', variant: 'info' },
-      { kind: 'added', slug: 'c', variant: 'info' },
-      { kind: 'overflow', count: 2, variant: 'info' },
+  it('삭제가 섞이면 개수가 작아도 다이제스트로 간다 — 지워진 슬러그는 열 수 없다', () => {
+    expect(planVaultDiffToasts({ added: ['a'], modified: [], removed: 1 }, 3)).toEqual([
+      { kind: 'digest', counts: { added: 1, modified: 0, removed: 1 }, variant: 'info' },
     ]);
   });
 
-  it('preview limit 0 은 개별 항목 없이 전체 overflow 만 보여준다', () => {
-    expect(
-      planVaultDiffToasts(
-        {
-          added: ['a'],
-          modified: ['b'],
-        },
-        0,
-      ),
-    ).toEqual([{ kind: 'overflow', count: 2, variant: 'info' }]);
+  it('삭제만 있어도 보고한다 — 종전엔 이 버스트가 통째로 침묵했다', () => {
+    expect(planVaultDiffToasts({ added: [], modified: [], removed: 3 })).toEqual([
+      { kind: 'digest', counts: { added: 0, modified: 0, removed: 3 }, variant: 'info' },
+    ]);
+  });
+
+  it('preview limit 0 이면 한 건이라도 다이제스트로 접는다', () => {
+    expect(planVaultDiffToasts({ added: ['a'], modified: ['b'] }, 0)).toEqual([
+      { kind: 'digest', counts: { added: 1, modified: 1, removed: 0 }, variant: 'info' },
+    ]);
   });
 });

--- a/src/features/docs-vault-local/lib/diff-manifest.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.ts
@@ -39,39 +39,60 @@ export function diffVaultManifest(
  * (`VaultDiffToaster`, React 컴포넌트)가 `t('featuresMisc.vaultDiffToaster.*')`
  * 로 한다 — "Added: domains/refunds" 같은 하드코딩 영문 리터럴이 다시 새지 않게.
  */
-export type VaultDiffToastKind = 'added' | 'edited' | 'overflow';
+export type VaultDiffToastKind = 'added' | 'edited' | 'removed' | 'digest';
 
 export type VaultDiffToast = {
   kind: VaultDiffToastKind;
   slug?: string;
-  count?: number;
+  /** digest 전용 — 세 갈래를 각각 센다. 합계 하나로 접지 않는다. */
+  counts?: { added: number; modified: number; removed: number };
   variant: 'info' | 'success';
 };
 
+/**
+ * **가장 오래 남는 것이 가장 많이 말해야 한다** (2026-08-01 판정).
+ *
+ * 종전 판은 앞 3개를 슬러그로 내고 나머지를 `+N개 더` 라는 **별도 토스트**로
+ * 냈다. 토스트는 각자 만료하므로 앞의 것이 먼저 사라지면 **참조 대상을 잃은
+ * 숫자만 화면에 남는다** — 소유자가 화면에서 그 상태를 잡았다(「+4개 더」 한 장).
+ * 에이전트가 한 번에 34개를 쓰면 그 잔해는 「+31개 더」가 된다.
+ *
+ * 그래서 부채꼴을 버리고 **버스트당 한 장**으로 간다. 몇 개냐가 아니라 **무엇이
+ * 달라졌느냐**를 말해야 하므로 합계로 접지 않고 추가·편집·삭제를 각각 센다.
+ * 합계가 작을 때(≤ `previewLimit`)는 이름이 숫자보다 낫다 — 그대로 슬러그를 낸다.
+ *
+ * ## 삭제 수를 여기서 계산하지 않는 이유
+ *
+ * 매니페스트는 슬러그 집합이라, **rename 이 「삭제 1 + 추가 1」로 보인다**
+ * (2026-08-01 실측: `appointment-booking` → `appointment-booking-renamed` 이
+ * 정확히 그 모양이었고, 역참조를 가진 파일들이 덤으로 「편집」으로 잡혔다).
+ * merge 도 같다. 그래서 삭제만은 **호출자가 `.ontology-atlas/activity.jsonl` 의
+ * `delete_concept` 항목에서 세어 넘긴다** — 도구 이름은 의도를 알고, 슬러그
+ * 집합은 모른다.
+ */
 export function planVaultDiffToasts(
-  diff: { added: string[]; modified: string[] },
+  diff: { added: string[]; modified: string[]; removed?: number },
   previewLimit = 3,
 ): VaultDiffToast[] {
   const limit = Math.max(0, previewLimit);
-  const planned: VaultDiffToast[] = [];
-  let shown = 0;
+  const removed = Math.max(0, diff.removed ?? 0);
+  const total = diff.added.length + diff.modified.length + removed;
+  if (total === 0) return [];
 
-  for (const slug of diff.added) {
-    if (shown >= limit) break;
-    planned.push({ kind: 'added', slug, variant: 'info' });
-    shown += 1;
+  // 작은 변화는 이름이 숫자보다 낫다. 단 삭제가 섞이면 이름을 댈 수 없으므로
+  // (지워진 문서의 슬러그는 화면에서 열 수 없다) 그때는 다이제스트로 간다.
+  if (total <= limit && removed === 0) {
+    return [
+      ...diff.added.map((slug): VaultDiffToast => ({ kind: 'added', slug, variant: 'info' })),
+      ...diff.modified.map((slug): VaultDiffToast => ({ kind: 'edited', slug, variant: 'success' })),
+    ];
   }
 
-  for (const slug of diff.modified) {
-    if (shown >= limit) break;
-    planned.push({ kind: 'edited', slug, variant: 'success' });
-    shown += 1;
-  }
-
-  const overflow = Math.max(0, diff.added.length + diff.modified.length - limit);
-  if (overflow > 0) {
-    planned.push({ kind: 'overflow', count: overflow, variant: 'info' });
-  }
-
-  return planned;
+  return [
+    {
+      kind: 'digest',
+      counts: { added: diff.added.length, modified: diff.modified.length, removed },
+      variant: 'info',
+    },
+  ];
 }

--- a/src/features/docs-vault-local/lib/diff-manifest.ts
+++ b/src/features/docs-vault-local/lib/diff-manifest.ts
@@ -1,3 +1,5 @@
+import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
+
 /**
  * R14 #157 + #158 — vault polling 결과를 *added* / *modified* 두 부류로
  * 분류하는 pure helper. VaultDiffToaster 가 React 외 dependency 없이 호출.
@@ -35,19 +37,110 @@ export function diffVaultManifest(
 /**
  * 토스트 문구를 여기서 완성 문자열로 만들지 않는 이유(N10 — 영어 토스트 ko 수리) —
  * 이 파일은 React 밖의 pure helper라 next-intl `useTranslations` 에 닿지 않는다.
- * 그래서 kind + slug/count 만 구조화해서 넘기고, 실제 로케일 문구 조립은 호출자
+ * 그래서 kind + 이름/개수 만 구조화해서 넘기고, 실제 로케일 문구 조립은 호출자
  * (`VaultDiffToaster`, React 컴포넌트)가 `t('featuresMisc.vaultDiffToaster.*')`
  * 로 한다 — "Added: domains/refunds" 같은 하드코딩 영문 리터럴이 다시 새지 않게.
  */
 export type VaultDiffToastKind = 'added' | 'edited' | 'removed' | 'digest';
 
+/**
+ * **토스트가 슬러그를 말하지 않는 계약**(2026-08-01 소유자 지시).
+ *
+ * 종전엔 `편집됨: capabilities/payment-authorization` 이라고 썼다. 그 한 줄이
+ * 사용자에게 주는 정보는 0에 가깝다 — `capabilities/` 는 개발자 폴더 이름이고,
+ * `payment-authorization` 은 파일 이름이지 사람이 그 개념을 부르는 이름이 아니다
+ * (볼트 노드는 `display_ko`/`display_en` 을 갖고 지도·INDEX·팝오버는 이미 그걸
+ * 그린다 — 토스트만 원시 슬러그를 쓰고 있었다).
+ *
+ * 그래서 이 타입이 화면으로 나가는 세 조각을 고정한다:
+ *   - `kind` — 「역량 / 도메인 / 요소 / 프로젝트」 평문으로 옮길 원본 kind.
+ *     **매니페스트에 없으면 `undefined` 로 둔다. 지어내지 않는다.**
+ *   - `name` — 사람이 부르는 이름. `display_<locale>` → `title` → 슬러그 꼬리.
+ *     **폴더 경로는 어떤 경우에도 여기 들어오지 않는다** (`toVaultDiffNode` 가
+ *     마지막 조각만 취한다).
+ *   - `slug` — 화면 밖 용도(딥링크·중복 제거)로만 남긴다.
+ */
+export type VaultDiffNode = {
+  slug: string;
+  kind?: string;
+  name: string;
+};
+
+/** 한 갈래(추가/편집) 안에서 종류별로 센 결과. `kind` 없는 행은 종류를 모르는 몫. */
+export type VaultDiffKindCount = { kind?: string; count: number };
+
+export type VaultDiffActionCount = {
+  total: number;
+  /** 총합이 0이면 빈 배열. 총합이 0이 아니면 최소 한 행이 있다. */
+  byKind: VaultDiffKindCount[];
+};
+
+/**
+ * digest 전용 — 세 갈래를 각각 센다. 합계 하나로 접지 않는다.
+ *
+ * 추가·편집은 매니페스트에서 종류를 읽을 수 있으므로 종류별로 쪼갠다
+ * (「역량 3 · 요소 12 추가」가 「15개 추가」보다 낫다). **삭제는 숫자뿐이다** —
+ * 지워진 문서는 매니페스트에서 사라져 kind 를 읽을 곳이 없고, 개수 자체도
+ * 활동 로그의 `delete_concept` 에서 온다(아래 주석 참고).
+ */
+export type VaultDiffDigestCounts = {
+  added: VaultDiffActionCount;
+  modified: VaultDiffActionCount;
+  removed: number;
+};
+
 export type VaultDiffToast = {
   kind: VaultDiffToastKind;
-  slug?: string;
-  /** digest 전용 — 세 갈래를 각각 센다. 합계 하나로 접지 않는다. */
-  counts?: { added: number; modified: number; removed: number };
+  node?: VaultDiffNode;
+  counts?: VaultDiffDigestCounts;
   variant: 'info' | 'success';
 };
+
+/**
+ * 매니페스트 행 → 화면에 낼 수 있는 조각. **슬러그가 화면으로 새는 유일한
+ * 경로를 여기 하나로 모은다.**
+ *
+ * 이름 우선순위: `display_<locale>` → `title` → 슬러그의 **마지막 조각**.
+ * 셋째는 최후 수단이고, 그때도 `capabilities/` 같은 폴더 이름은 붙지 않는다.
+ * (실전에서 셋째까지 내려가는 일은 드물다 — 매니페스트의 `title` 자체가 이미
+ * frontmatter title → 첫 H1 → 슬러그 꼬리 순으로 채워진다.)
+ */
+export function toVaultDiffNode(
+  doc: {
+    slug: string;
+    title?: string;
+    frontmatter?: Record<string, unknown> | null;
+  },
+  locale?: string,
+): VaultDiffNode {
+  const tail = doc.slug.split('/').pop() || doc.slug;
+  const title = typeof doc.title === 'string' ? doc.title.trim() : '';
+  const name = resolveLocaleDisplayName(doc.frontmatter, locale, title || tail);
+  const rawKind = doc.frontmatter?.kind;
+  const kind = typeof rawKind === 'string' && rawKind.trim() ? rawKind.trim() : undefined;
+  return { slug: doc.slug, kind, name: name.trim() || tail };
+}
+
+/**
+ * 종류별 집계. 종류를 모르는 몫은 **마지막 한 행으로 모은다** — 섞어 세면
+ * 「역량 3」이 실제로는 4였는지 알 수 없게 되고, 버리면 합계가 안 맞는다.
+ */
+function countByKind(nodes: VaultDiffNode[]): VaultDiffActionCount {
+  const byKind = new Map<string, number>();
+  let untyped = 0;
+  for (const node of nodes) {
+    if (!node.kind) {
+      untyped += 1;
+      continue;
+    }
+    byKind.set(node.kind, (byKind.get(node.kind) ?? 0) + 1);
+  }
+  const rows: VaultDiffKindCount[] = [...byKind.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([kind, count]) => ({ kind, count }));
+  if (untyped > 0) rows.push({ count: untyped });
+  return { total: nodes.length, byKind: rows };
+}
 
 /**
  * **가장 오래 남는 것이 가장 많이 말해야 한다** (2026-08-01 판정).
@@ -71,7 +164,7 @@ export type VaultDiffToast = {
  * 집합은 모른다.
  */
 export function planVaultDiffToasts(
-  diff: { added: string[]; modified: string[]; removed?: number },
+  diff: { added: VaultDiffNode[]; modified: VaultDiffNode[]; removed?: number },
   previewLimit = 3,
 ): VaultDiffToast[] {
   const limit = Math.max(0, previewLimit);
@@ -80,18 +173,23 @@ export function planVaultDiffToasts(
   if (total === 0) return [];
 
   // 작은 변화는 이름이 숫자보다 낫다. 단 삭제가 섞이면 이름을 댈 수 없으므로
-  // (지워진 문서의 슬러그는 화면에서 열 수 없다) 그때는 다이제스트로 간다.
+  // (지워진 문서는 매니페스트에서 사라져 이름을 읽을 곳이 없다) 그때는
+  // 다이제스트로 간다.
   if (total <= limit && removed === 0) {
     return [
-      ...diff.added.map((slug): VaultDiffToast => ({ kind: 'added', slug, variant: 'info' })),
-      ...diff.modified.map((slug): VaultDiffToast => ({ kind: 'edited', slug, variant: 'success' })),
+      ...diff.added.map((node): VaultDiffToast => ({ kind: 'added', node, variant: 'info' })),
+      ...diff.modified.map((node): VaultDiffToast => ({ kind: 'edited', node, variant: 'success' })),
     ];
   }
 
   return [
     {
       kind: 'digest',
-      counts: { added: diff.added.length, modified: diff.modified.length, removed },
+      counts: {
+        added: countByKind(diff.added),
+        modified: countByKind(diff.modified),
+        removed,
+      },
       variant: 'info',
     },
   ];

--- a/src/features/docs-vault-local/model/VaultDiffToaster.test.tsx
+++ b/src/features/docs-vault-local/model/VaultDiffToaster.test.tsx
@@ -27,21 +27,51 @@ vi.mock('@/shared/ui/toast', () => ({
   useToast: () => ({ show: toastMocks.show }),
 }));
 
-// N10 — VaultDiffToaster 는 이제 `featuresMisc.vaultDiffToaster.*` 로 문구를
-// 조립한다(diff-manifest.ts 는 kind/slug/count 만 반환). 실제 en 메시지 문구
-// 그대로 mock 해 en 로케일 사용자가 실제로 보는 문자열을 검증한다.
+// N10 — VaultDiffToaster 는 `featuresMisc.vaultDiffToaster.*` 로 문구를
+// 조립한다(diff-manifest.ts 는 구조만 반환). **실제 ko 메시지 문자열을 그대로**
+// 여기 넣는다 — 문구가 슬러그를 다시 노출하면 이 mock 을 통과한 결과 문자열에
+// 그대로 나타나므로 아래 계약 테스트가 잡는다.
+const KO_MESSAGES: Record<string, string> = {
+  'vaultDiffToaster.added': '추가 — {name}',
+  'vaultDiffToaster.addedKind': '{kind} 추가 — {name}',
+  'vaultDiffToaster.edited': '편집 — {name}',
+  'vaultDiffToaster.editedKind': '{kind} 편집 — {name}',
+  'vaultDiffToaster.digestAdded': '{breakdown} 추가',
+  'vaultDiffToaster.digestModified': '{breakdown} 편집',
+  'vaultDiffToaster.digestRemoved': '{count}개 삭제',
+  'vaultDiffToaster.digestKindItem': '{kind} {count}',
+  'vaultDiffToaster.digestKindOther': '그 외 {count}',
+  'vaultDiffToaster.digestKindPlain': '{count}개',
+  'vaultDiffToaster.digestKindJoin': ' · ',
+  'vaultDiffToaster.digestJoin': ', ',
+  'kinds.project': '프로젝트',
+  'kinds.domain': '도메인',
+  'kinds.capability': '역량',
+  'kinds.element': '요소',
+  'kinds.document': '문서',
+  'kinds.unknown': '기타',
+  'kinds.vault-readme': '저장소 안내',
+};
+
 vi.mock('next-intl', () => ({
-  useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
-    if (key === 'added') return `Added: ${vars?.slug}`;
-    if (key === 'edited') return `Edited: ${vars?.slug}`;
-    if (key === 'overflow') return `+${vars?.count} more node(s)`;
-    return key;
+  useLocale: () => 'ko',
+  useTranslations: (namespace: string) => (key: string, vars?: Record<string, unknown>) => {
+    const template = KO_MESSAGES[`${namespace.split('.').pop()}.${key}`];
+    if (!template) return key;
+    return template.replace(/\{(\w+)\}/g, (_, name: string) => String(vars?.[name] ?? ''));
   },
 }));
 
 import { VaultDiffToaster } from './VaultDiffToaster';
 
-function manifestWith(docs: Array<{ slug: string; mtime?: number }>) {
+type TestDoc = {
+  slug: string;
+  mtime?: number;
+  title?: string;
+  frontmatter?: Record<string, unknown>;
+};
+
+function manifestWith(docs: TestDoc[]) {
   return {
     version: '1',
     generatedAt: '',
@@ -50,6 +80,12 @@ function manifestWith(docs: Array<{ slug: string; mtime?: number }>) {
     tags: {},
     tree: { name: 'root', path: '', type: 'dir' as const },
   };
+}
+
+/** 마지막으로 화면에 나간 문자열. */
+function lastMessage(): string {
+  const calls = toastMocks.show.mock.calls;
+  return String(calls[calls.length - 1]?.[0] ?? '');
 }
 
 afterEach(() => {
@@ -88,7 +124,7 @@ describe('VaultDiffToaster', () => {
     });
     rerender(<VaultDiffToaster />);
 
-    expect(toastMocks.show).toHaveBeenCalledWith('Added: b', 'info');
+    expect(toastMocks.show).toHaveBeenCalledWith('추가 — b', 'info');
   });
 
   it('mtime 만 증가한 기존 slug 는 modified(success) 토스트를 띄운다', () => {
@@ -106,7 +142,7 @@ describe('VaultDiffToaster', () => {
     });
     rerender(<VaultDiffToaster />);
 
-    expect(toastMocks.show).toHaveBeenCalledWith('Edited: a', 'success');
+    expect(toastMocks.show).toHaveBeenCalledWith('편집 — a', 'success');
   });
 
   it('status 가 loaded 가 아니면(loading/permission-needed 등) diff 판정을 하지 않는다', () => {
@@ -155,6 +191,105 @@ describe('VaultDiffToaster', () => {
     rerender(<VaultDiffToaster />);
 
     expect(toastMocks.show).toHaveBeenCalledTimes(1);
-    expect(toastMocks.show).toHaveBeenCalledWith('Added: d', 'info');
+    expect(toastMocks.show).toHaveBeenCalledWith('추가 — d', 'info');
+  });
+
+  /**
+   * **알림은 정보를 날라야 한다** (2026-08-01 소유자 지시). 소유자가 화면에서
+   * 잡은 실물은 `✓ 편집됨: capabilities/payment-authorization` 이었다 —
+   * `capabilities/` 는 개발자 폴더 이름이고, 슬러그는 사람이 그 개념을 부르는
+   * 이름이 아니다. 아래 셋이 그 되돌림을 막는 계약이다.
+   */
+  describe('문구 계약 — 슬러그가 아니라 종류 + 사람 이름', () => {
+    function burst(second: TestDoc[], first: TestDoc[] = [{ slug: 'seed', mtime: 1 }]) {
+      localVaultMocks.useLocalVault.mockReturnValue({
+        status: 'loaded',
+        manifest: manifestWith(first),
+        consumeSelfWrittenSlugs: () => new Set(),
+      });
+      const { rerender } = render(<VaultDiffToaster />);
+      localVaultMocks.useLocalVault.mockReturnValue({
+        status: 'loaded',
+        manifest: manifestWith([...first, ...second]),
+        consumeSelfWrittenSlugs: () => new Set(),
+      });
+      rerender(<VaultDiffToaster />);
+    }
+
+    const paymentAuthorization: TestDoc = {
+      slug: 'capabilities/payment-authorization',
+      mtime: 2000,
+      title: 'Payment authorization',
+      frontmatter: {
+        kind: 'capability',
+        display_ko: '결제 승인',
+        display_en: 'Payment authorization',
+      },
+    };
+
+    it('종류를 평문으로, 이름은 display_<locale> 로 — 폴더 경로도 슬러그도 안 나간다', () => {
+      burst([paymentAuthorization]);
+
+      expect(lastMessage()).toBe('역량 추가 — 결제 승인');
+      expect(lastMessage()).not.toContain('capabilities/');
+      expect(lastMessage()).not.toContain('payment-authorization');
+      expect(lastMessage()).not.toContain('/');
+    });
+
+    it('편집도 종류를 말한다 — 「편집됨」만으로는 무엇이 바뀐지 알 수 없다', () => {
+      const before: TestDoc = { ...paymentAuthorization, mtime: 1000 };
+      localVaultMocks.useLocalVault.mockReturnValue({
+        status: 'loaded',
+        manifest: manifestWith([before]),
+        consumeSelfWrittenSlugs: () => new Set(),
+      });
+      const { rerender } = render(<VaultDiffToaster />);
+      localVaultMocks.useLocalVault.mockReturnValue({
+        status: 'loaded',
+        manifest: manifestWith([paymentAuthorization]),
+        consumeSelfWrittenSlugs: () => new Set(),
+      });
+      rerender(<VaultDiffToaster />);
+
+      expect(lastMessage()).toBe('역량 편집 — 결제 승인');
+    });
+
+    it('다이제스트도 종류별로 센다 — 「15개 추가」가 아니라 「역량 3 · 요소 12 추가」', () => {
+      const many: TestDoc[] = [
+        ...Array.from({ length: 3 }, (_, i) => ({
+          slug: `capabilities/c${i}`,
+          mtime: 2000,
+          title: `역량 ${i}`,
+          frontmatter: { kind: 'capability' },
+        })),
+        ...Array.from({ length: 12 }, (_, i) => ({
+          slug: `elements/e${i}`,
+          mtime: 2000,
+          title: `요소 ${i}`,
+          frontmatter: { kind: 'element' },
+        })),
+      ];
+      burst(many);
+
+      expect(lastMessage()).toBe('요소 12 · 역량 3 추가');
+      expect(lastMessage()).not.toContain('capabilities/');
+      expect(lastMessage()).not.toContain('elements/');
+    });
+
+    it('kind 를 못 얻으면 종류를 지어내지 않는다 — 단건은 종류 없이, 묶음은 「그 외 N」', () => {
+      burst([{ slug: 'notes/memo', mtime: 2000, title: '회의 메모' }]);
+      expect(lastMessage()).toBe('추가 — 회의 메모');
+
+      toastMocks.show.mockClear();
+      burst([
+        { slug: 'capabilities/c1', mtime: 2000, title: '역량 1', frontmatter: { kind: 'capability' } },
+        { slug: 'notes/n1', mtime: 2000, title: '메모 1' },
+        { slug: 'notes/n2', mtime: 2000, title: '메모 2' },
+        { slug: 'notes/n3', mtime: 2000, title: '메모 3' },
+      ]);
+      // 종류 미상은 개수와 무관하게 늘 맨 끝이다 — 「그 외」가 앞에 서면
+      // 아는 것보다 모르는 것이 먼저 읽힌다.
+      expect(lastMessage()).toBe('역량 1 · 그 외 3 추가');
+    });
   });
 });

--- a/src/features/docs-vault-local/model/VaultDiffToaster.tsx
+++ b/src/features/docs-vault-local/model/VaultDiffToaster.tsx
@@ -31,10 +31,12 @@ import { useLocalVault } from './LocalVaultProvider';
  * toast 띄우면 noise).
  */
 export function VaultDiffToaster() {
-  const { status, manifest, consumeSelfWrittenSlugs } = useLocalVault();
+  const { status, manifest, consumeSelfWrittenSlugs, agentActivityLog } = useLocalVault();
   const toast = useToast();
   const t = useTranslations('featuresMisc.vaultDiffToaster');
   const prevMapRef = useRef<Map<string, number | null> | null>(null);
+  /** 직전 diff 를 본 시각 — 이 창 안의 `delete_concept` 만 이번 버스트의 것이다. */
+  const prevSeenAtRef = useRef<number>(Date.now());
 
   useEffect(() => {
     if (status !== 'loaded' || !manifest) return;
@@ -62,14 +64,44 @@ export function VaultDiffToaster() {
     const externalAdded = added.filter((slug) => !selfWritten.has(slug));
     const externalModified = modified.filter((slug) => !selfWritten.has(slug));
 
-    if (externalAdded.length === 0 && externalModified.length === 0) return;
+    // 삭제는 매니페스트로 못 센다 — rename/merge 가 「삭제 + 추가」로 보이기
+    // 때문이다(diff-manifest.ts 주석의 실측). 도구 이름은 의도를 알고 있으므로
+    // 이 버스트 창 안의 `delete_concept` 만 센다.
+    const removed = countRecentDeletes(agentActivityLog, prevSeenAtRef.current);
+    prevSeenAtRef.current = Date.now();
 
-    for (const planned of planVaultDiffToasts({ added: externalAdded, modified: externalModified })) {
+    if (externalAdded.length === 0 && externalModified.length === 0 && removed === 0) return;
+
+    for (const planned of planVaultDiffToasts({
+      added: externalAdded,
+      modified: externalModified,
+      removed,
+    })) {
       toast.show(formatVaultDiffToastMessage(planned, t), planned.variant);
     }
-  }, [status, manifest, toast, t, consumeSelfWrittenSlugs]);
+  }, [status, manifest, toast, t, consumeSelfWrittenSlugs, agentActivityLog]);
 
   return null;
+}
+
+/**
+ * 이 버스트 창(`since` 이후)에 기록된 `delete_concept` 수.
+ *
+ * 활동 로그는 MCP 쓰기 성공 직후 서버가 append 하는 감사 로그라, 도구 이름이
+ * 곧 의도다 — 매니페스트 슬러그 diff 와 달리 rename 을 삭제로 오독하지 않는다.
+ */
+function countRecentDeletes(
+  entries: { at: string; tool: string }[] | undefined,
+  since: number,
+): number {
+  if (!entries?.length) return 0;
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.tool !== 'delete_concept') continue;
+    const at = Date.parse(entry.at);
+    if (Number.isFinite(at) && at >= since) count += 1;
+  }
+  return count;
 }
 
 function formatVaultDiffToastMessage(
@@ -81,8 +113,15 @@ function formatVaultDiffToastMessage(
       return t('added', { slug: planned.slug ?? '' });
     case 'edited':
       return t('edited', { slug: planned.slug ?? '' });
-    case 'overflow':
-      return t('overflow', { count: planned.count ?? 0 });
+    case 'digest': {
+      const c = planned.counts ?? { added: 0, modified: 0, removed: 0 };
+      // 0인 갈래는 그리지 않는다 — 「삭제 0」은 정보가 아니라 소음이다.
+      const parts: string[] = [];
+      if (c.added > 0) parts.push(t('digestAdded', { count: c.added }));
+      if (c.modified > 0) parts.push(t('digestModified', { count: c.modified }));
+      if (c.removed > 0) parts.push(t('digestRemoved', { count: c.removed }));
+      return `${t('digestPrefix')}${parts.join(t('digestJoin'))}`;
+    }
     default:
       return '';
   }

--- a/src/features/docs-vault-local/model/VaultDiffToaster.tsx
+++ b/src/features/docs-vault-local/model/VaultDiffToaster.tsx
@@ -1,18 +1,25 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
+import { useOntologyKindLabel } from '@/entities/ontology-class';
 import { useToast } from '@/shared/ui/toast';
-import { diffVaultManifest, planVaultDiffToasts, type VaultDiffToast } from '../lib/diff-manifest';
+import {
+  diffVaultManifest,
+  planVaultDiffToasts,
+  toVaultDiffNode,
+  type VaultDiffActionCount,
+  type VaultDiffToast,
+} from '../lib/diff-manifest';
 import { useLocalVault } from './LocalVaultProvider';
 
 /**
  * R13 #71 + #72 — vault polling 결과 *시각적 알림*. polling 으로 detect 한
  * 변화를 어떤 페이지에서든 toast 로 알림.
  *
- * #71 added detection: 새로운 slug 등장 → "추가됨: <slug>" info toast.
- * #72 modified detection: slug 같지만 mtime 변화 → "편집됨: <slug>"
- *   success toast. 사용자 / AI agent 가 IDE 에서 .md 편집한 경우.
+ * #71 added detection: 새로운 slug 등장 → info toast.
+ * #72 modified detection: slug 같지만 mtime 변화 → success toast.
+ *   사용자 / AI agent 가 IDE 에서 .md 편집한 경우.
  *
  * 동작:
  *   - LocalVaultProvider 안에 mount, manifest.docs 의 (slug, mtime) Map 추적
@@ -20,11 +27,24 @@ import { useLocalVault } from './LocalVaultProvider';
  *   - 이후 diff:
  *     · slug 신규 → added
  *     · slug 동일 + mtime 새로움 → modified
- *   - added/modified 합쳐 처음 3 명시 + "+N more"
+ *   - 버스트당 한 장(부채꼴 폐기 — `diff-manifest.ts` 주석)
  *   - 문구는 `featuresMisc.vaultDiffToaster.*` 로 로케일별 조립 — `diffVaultManifest`/
- *     `planVaultDiffToasts` 는 kind/slug/count 만 반환하는 pure helper라 여기서
+ *     `planVaultDiffToasts` 는 구조만 반환하는 pure helper라 여기서
  *     `useTranslations` 로 문자열을 완성한다(N10 — "Added: domains/refunds" 영문
  *     리터럴 ko 수리).
+ *
+ * ## 알림은 정보를 날라야 한다 (2026-08-01 소유자 지시)
+ *
+ * 종전 문구는 `편집됨: capabilities/payment-authorization` 이었다. 네 가지가
+ * 동시에 빠져 있었다 — ① `capabilities/` 는 화면에 쓸 말이 아닌 개발자 폴더
+ * 이름, ② 슬러그는 사람이 그 개념을 부르는 이름이 아님(`display_<locale>` 이
+ * 있는데 토스트만 안 씀), ③ 무엇이 일어났는지 종류를 말하지 않음,
+ * ④ 「편집됨」은 사건이 있었다는 말이지 정보가 아님.
+ *
+ * 그래서 화면에 나가는 것은 **「역량 편집 — 결제 승인」** 처럼 *종류(평문) +
+ * 사건 + 사람 이름* 셋이다. 여러 건이면 종류별로 세어 「역량 3 · 요소 12 추가」.
+ * **kind 를 못 얻으면 지어내지 않는다** — 종류 없이 「추가 — 이름」으로 쓰고,
+ * 다이제스트에서는 「그 외 N」으로 정직하게 센다.
  *
  * 삭제 detection 은 일단 제외 — 사용자 명시 액션 후 toast 가 더 가치 있음
  * (delete_concept 같은 명령 자체가 toast 띄우면 됨, polling 결과로 다시
@@ -34,21 +54,34 @@ export function VaultDiffToaster() {
   const { status, manifest, consumeSelfWrittenSlugs, agentActivityLog } = useLocalVault();
   const toast = useToast();
   const t = useTranslations('featuresMisc.vaultDiffToaster');
+  const kindLabel = useOntologyKindLabel();
+  const locale = useLocale();
   const prevMapRef = useRef<Map<string, number | null> | null>(null);
-  /** 직전 diff 를 본 시각 — 이 창 안의 `delete_concept` 만 이번 버스트의 것이다. */
-  const prevSeenAtRef = useRef<number>(Date.now());
+  /**
+   * 직전 diff 를 본 시각 — 이 창 안의 `delete_concept` 만 이번 버스트의 것이다.
+   * 렌더 중에 `Date.now()` 를 부르면 순수하지 않으므로(`react-hooks/purity`)
+   * 첫 baseline 저장 때 effect 안에서 채운다.
+   */
+  const prevSeenAtRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (status !== 'loaded' || !manifest) return;
 
-    type DocLite = { slug: string; mtime?: number };
+    type DocLite = {
+      slug: string;
+      mtime?: number;
+      title?: string;
+      frontmatter?: Record<string, unknown>;
+    };
+    const docs: DocLite[] = manifest.docs;
     const currentMap = new Map<string, number | null>(
-      manifest.docs.map((d: DocLite) => [d.slug, d.mtime ?? null]),
+      docs.map((d) => [d.slug, d.mtime ?? null]),
     );
 
     // 첫 load — baseline 저장만 하고 끝
     if (prevMapRef.current === null) {
       prevMapRef.current = currentMap;
+      prevSeenAtRef.current = Date.now();
       return;
     }
 
@@ -67,19 +100,24 @@ export function VaultDiffToaster() {
     // 삭제는 매니페스트로 못 센다 — rename/merge 가 「삭제 + 추가」로 보이기
     // 때문이다(diff-manifest.ts 주석의 실측). 도구 이름은 의도를 알고 있으므로
     // 이 버스트 창 안의 `delete_concept` 만 센다.
-    const removed = countRecentDeletes(agentActivityLog, prevSeenAtRef.current);
+    const removed = countRecentDeletes(agentActivityLog, prevSeenAtRef.current ?? 0);
     prevSeenAtRef.current = Date.now();
 
     if (externalAdded.length === 0 && externalModified.length === 0 && removed === 0) return;
 
+    // 슬러그를 그대로 넘기지 않는다 — 여기서 매니페스트 행(kind + display_*/title)
+    // 으로 바꿔야 화면이 폴더 경로 대신 「역량 · 결제 승인」을 말할 수 있다.
+    const docBySlug = new Map(docs.map((d) => [d.slug, d]));
+    const toNode = (slug: string) => toVaultDiffNode(docBySlug.get(slug) ?? { slug }, locale);
+
     for (const planned of planVaultDiffToasts({
-      added: externalAdded,
-      modified: externalModified,
+      added: externalAdded.map(toNode),
+      modified: externalModified.map(toNode),
       removed,
     })) {
-      toast.show(formatVaultDiffToastMessage(planned, t), planned.variant);
+      toast.show(formatVaultDiffToastMessage(planned, t, kindLabel), planned.variant);
     }
-  }, [status, manifest, toast, t, consumeSelfWrittenSlugs, agentActivityLog]);
+  }, [status, manifest, toast, t, kindLabel, locale, consumeSelfWrittenSlugs, agentActivityLog]);
 
   return null;
 }
@@ -104,25 +142,60 @@ function countRecentDeletes(
   return count;
 }
 
+type Translate = ReturnType<typeof useTranslations>;
+type KindLabel = (kind: string) => string;
+
 function formatVaultDiffToastMessage(
   planned: VaultDiffToast,
-  t: ReturnType<typeof useTranslations>,
+  t: Translate,
+  kindLabel: KindLabel,
 ): string {
   switch (planned.kind) {
     case 'added':
-      return t('added', { slug: planned.slug ?? '' });
-    case 'edited':
-      return t('edited', { slug: planned.slug ?? '' });
+    case 'edited': {
+      const node = planned.node;
+      if (!node) return '';
+      // 종류를 아는 경우에만 종류를 말한다 — 모르면 「추가 — 이름」으로 끝낸다.
+      return node.kind
+        ? t(planned.kind === 'added' ? 'addedKind' : 'editedKind', {
+            kind: kindLabel(node.kind),
+            name: node.name,
+          })
+        : t(planned.kind, { name: node.name });
+    }
     case 'digest': {
-      const c = planned.counts ?? { added: 0, modified: 0, removed: 0 };
+      const c = planned.counts;
+      if (!c) return '';
       // 0인 갈래는 그리지 않는다 — 「삭제 0」은 정보가 아니라 소음이다.
       const parts: string[] = [];
-      if (c.added > 0) parts.push(t('digestAdded', { count: c.added }));
-      if (c.modified > 0) parts.push(t('digestModified', { count: c.modified }));
+      if (c.added.total > 0) {
+        parts.push(t('digestAdded', { breakdown: formatBreakdown(c.added, t, kindLabel) }));
+      }
+      if (c.modified.total > 0) {
+        parts.push(t('digestModified', { breakdown: formatBreakdown(c.modified, t, kindLabel) }));
+      }
       if (c.removed > 0) parts.push(t('digestRemoved', { count: c.removed }));
-      return `${t('digestPrefix')}${parts.join(t('digestJoin'))}`;
+      return parts.join(t('digestJoin'));
     }
     default:
       return '';
   }
+}
+
+/**
+ * 「역량 3 · 요소 12」. 종류를 하나도 못 읽었으면 숫자만 낸다 — 전부 미상인데
+ * 「그 외 5」라고 쓰면 있지도 않은 다른 몫을 암시한다.
+ */
+function formatBreakdown(count: VaultDiffActionCount, t: Translate, kindLabel: KindLabel): string {
+  const rows = count.byKind;
+  if (rows.length === 1 && !rows[0].kind) {
+    return t('digestKindPlain', { count: rows[0].count });
+  }
+  return rows
+    .map((row) =>
+      row.kind
+        ? t('digestKindItem', { kind: kindLabel(row.kind), count: row.count })
+        : t('digestKindOther', { count: row.count }),
+    )
+    .join(t('digestKindJoin'));
 }

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -116,8 +116,12 @@ export function ProjectSelectorPage() {
         </div>
         <div className="mx-auto px-5 py-6 md:px-10 md:py-10" style={{ maxWidth: PAGE_MAX_WIDTH }}>
         <nav className="mb-5 flex flex-wrap items-center gap-2.5 text-body text-[color:var(--color-text-tertiary)]">
+          {/* 「← 지도」는 **지도로 간다**. 2026-07-30 에 `/` 가 지도에서 관문으로
+              바뀐 뒤(원장 「root-first-open」 뒤집기) 이 링크만 안 고쳐져서,
+              지도라고 적힌 버튼이 다운로드 화면으로 보내고 있었다. */}
           <Link
-            href="/"
+            href="/topology"
+            data-testid="projects-back-to-map"
             className="text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t("crumbBack")}

--- a/tests/contract/map-destination-route.contract.test.ts
+++ b/tests/contract/map-destination-route.contract.test.ts
@@ -159,3 +159,115 @@ describe("지도를 약속하는 링크의 목적지", () => {
     expect(hrefForTestid(probe, "probe-absent")).toEqual([]);
   });
 });
+
+/**
+ * **등록을 기억해야 작동하는 게이트는, 기억 못 한 것에 대해 존재하지 않는다.**
+ *
+ * 위 시험은 `MAP_DESTINED` 허용목록을 돈다. 그건 "이 컨트롤은 지도로 간다" 를
+ * 정확히 지키지만, **목록에 없는 컨트롤은 구조적으로 시야 밖**이다. 그래서
+ * 2026-08-01 실측에서 `/projects` 의 「← 지도」가 `/`(관문)로 가고 있었는데도
+ * 이 파일 전체가 초록이었다 — 그 링크에는 testid 자체가 없었다.
+ *
+ * 이 시험은 조준을 뒤집는다. **누가 등록했는지가 아니라 라벨이 무엇을
+ * 약속하는지**로 찾는다: i18n 값이 「지도」/「Map」 그 자체인 키를 모으고,
+ * 그 키를 렌더하는 링크의 href 를 본다. 새 링크를 만들면서 이 게이트에
+ * 등록하는 것을 잊어도, 라벨이 지도를 약속하는 한 잡힌다.
+ *
+ * 사정거리를 **라벨이 곧 「지도」인 것**으로 좁힌 이유: 「지도에서 보기」처럼
+ * 문장 안에 지도가 든 것까지 넣으면 링크가 아닌 안내 문구까지 걸려 소음이
+ * 된다. 실제로 깨진 부류가 정확히 이 좁은 부류였고, 넓히는 것은 위반이
+ * 관측될 때 하면 된다.
+ */
+const MAP_LABEL = /^[\s←→]*(?:지도|map)[\s←→]*$/i;
+
+/** i18n 값이 「지도」 그 자체인 leaf 키들 — `t("<leaf>")` 가 쓰는 이름이다. */
+function mapLabelKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const file of ["messages/ko.json", "messages/en.json"]) {
+    const walk = (node: unknown) => {
+      if (!node || typeof node !== "object") return;
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        if (typeof value === "string") {
+          if (MAP_LABEL.test(value)) keys.add(key);
+        } else {
+          walk(value);
+        }
+      }
+    };
+    walk(JSON.parse(readFileSync(join(process.cwd(), file), "utf8")));
+  }
+  return keys;
+}
+
+/**
+ * `t("key")` 를 렌더하는 원소가 속한 **가장 가까운 href 보유 여는 태그**의 href.
+ *
+ * 라벨은 `<Link href=…>{t("key")}</Link>` 처럼 자식 자리에 있고, 때로 한 겹 더
+ * 감싸인다(`<span>{t("key")}</span>`). 그래서 뒤로 걸어 올라가며 href 를 가진
+ * 첫 태그를 찾는다. 링크가 아니면(href 없음) 대상이 아니므로 건너뛴다.
+ */
+function hrefForLabelKey(source: string, key: string): string[] {
+  const found: string[] = [];
+  for (const marker of [`t("${key}")`, `t('${key}')`]) {
+    let cursor = source.indexOf(marker);
+    while (cursor !== -1) {
+      let at = cursor;
+      for (let hop = 0; hop < 6; hop += 1) {
+        const open = source.lastIndexOf("<", at);
+        if (open === -1) break;
+        const close = source.indexOf(">", open);
+        const tag = source.slice(open, close === -1 ? source.length : close);
+        // 닫는 태그를 만났다 = 앞선 **형제** 원소를 지나친 것이다. 더 올라가면
+        // 남의 링크 href 를 자기 것으로 주워온다(프로브가 이걸 잡았다).
+        if (tag.startsWith("</")) break;
+        const match = /href=(?:"([^"]*)"|\{`([^`]*)`\}|\{"([^"]*)"\})/.exec(tag);
+        if (match) {
+          found.push(match[1] ?? match[2] ?? match[3] ?? "");
+          break;
+        }
+        at = open - 1;
+      }
+      cursor = source.indexOf(marker, cursor + marker.length);
+    }
+  }
+  return found;
+}
+
+describe("라벨이 「지도」인 링크는 등록 없이도 감시된다", () => {
+  const source = collectSources();
+  const keys = [...mapLabelKeys()].sort();
+
+  it("i18n 에서 지도 라벨 키를 실제로 찾는다 (탐지기 무장 확인)", () => {
+    // 0개면 이 시험 전체가 공회전한다 — 조용한 무력화를 여기서 막는다.
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  it("그 라벨을 렌더하는 링크는 전부 지도로 간다", () => {
+    const violations: string[] = [];
+    for (const key of keys) {
+      for (const href of hrefForLabelKey(source, key)) {
+        // 로케일 prefix 는 `@/i18n/navigation` 이 붙이므로 소스에는 없다.
+        if (href.replace(/\/$/, "") !== MAP_ROUTE) {
+          violations.push(`t("${key}") → "${href}"`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `라벨이 「지도」인데 ${MAP_ROUTE} 가 아닌 곳으로 가는 링크가 있다. ` +
+        `\`/\` 는 2026-07-30 부터 관문(마케팅)이라, 지도라고 적어 놓고 그리로 ` +
+        `보내면 사용자는 방금 떠난 화면으로 되돌아온다.`,
+    ).toEqual([]);
+  });
+
+  it("추출기가 감싸인 라벨의 href 도 읽는다 (탐지기 무장 확인)", () => {
+    const probe = `
+      <Link href="/topology"><span>{t("crumbBack")}</span></Link>
+      <Link href="/">{t("someOther")}</Link>
+      <p>{t("crumbBack")}</p>
+    `;
+    expect(hrefForLabelKey(probe, "crumbBack")).toEqual(["/topology"]);
+    expect(hrefForLabelKey(probe, "someOther")).toEqual(["/"]);
+    expect(hrefForLabelKey(probe, "absent")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

소유자가 화면에서 잡은 실물:

```
✓ 편집됨: capabilities/payment-authorization
```

이 한 줄이 주는 정보가 0에 가깝다 — `capabilities/` 는 개발자 폴더 이름이고,
슬러그는 사람이 그 개념을 부르는 이름이 아니며(`display_ko`/`display_en` 이
있는데 토스트만 안 썼다), 「편집됨」은 사건이 있었다는 말이지 정보가 아니다.

화면에 나가는 것을 *종류(평문) + 사건 + 사람 이름* 셋으로 바꿨다.

| | 이전 | 이후 (ko) | 이후 (en) |
|---|---|---|---|
| 단건 추가 | `추가됨: capabilities/payment-authorization` | `역량 추가 — 결제 승인` | `Capability added — Payment authorization` |
| 단건 편집 | `편집됨: capabilities/payment-authorization` | `역량 편집 — 결제 승인` | `Capability edited — Payment authorization` |
| 다이제스트 | `폴더가 바뀌었어요 — 추가 15 · 편집 2` | `요소 12 · 역량 3 추가, 도메인 2 편집` | `Element 12 · Capability 3 added, Domain 2 edited` |
| 삭제 포함 | `… · 삭제 1` | `역량 1 추가, 1개 삭제` | `Capability 1 added, 1 removed` |

**없는 정보는 지어내지 않는다.** 매니페스트에서 `kind` 를 못 읽으면 종류를
빼고 `추가 — 회의 메모`, 다이제스트에서는 `역량 1 · 그 외 3 추가`. 삭제는
문서가 매니페스트에서 사라져 종류를 읽을 곳이 없으므로 숫자만 낸다.

로직(다이제스트 접기 · 삭제 집계)은 손대지 않았다 — 말하는 내용만 바꿨다.

### 되돌림 방지

`toVaultDiffNode` 가 화면 이름을 만드는 유일한 경로다. `display_<locale>` →
`title` → **슬러그의 마지막 조각** 순이라, 최후 수단에서도 폴더 경로가 화면에
닿지 못한다. 계약 테스트 둘이 실제 ko 문구로 조립한 결과 문자열에
`capabilities/` · 원시 슬러그 · `/` 가 없음을 못박는다.

### 곁가지 둘

- `useOntologyKindLabel` 이 매 렌더 새 클로저를 돌려줘 effect 의존성에 넣으면
  매 렌더 재실행됐다 → `useCallback` 으로 고정.
- `useRef(Date.now())` 가 렌더 중 비순수 호출이라 `react-hooks/purity` 를
  깨고 있었다(HEAD 에서도 깨져 있었다) → baseline 저장 시점에 effect 안에서
  채우게 옮겼다.

## Test plan

- `pnpm exec tsc --noEmit` — 통과
- `pnpm exec vitest run src/features/docs-vault-local src/entities/ontology-class` — 26 files / 201 tests 통과
- `pnpm exec vitest run tests/contract` — 통과
- `pnpm test:run` — 573 files / 5375 tests 통과
- `pnpm exec eslint src/features/docs-vault-local src/entities/ontology-class` — 0 problems

UI 변경이 토스트 **문구**뿐이라(토큰·레이아웃·모션 무변경) 스크린샷 대신 실제
ko 메시지로 조립한 결과 문자열을 단위 테스트에 못박았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)