### PR TITLE
perf: 볼트 지문을 Rust 한 번에 받는다 — 포커스마다 17.7MB 를 나르고 있었다

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -688,6 +688,137 @@ fn list_vault_directory(
     Ok(out)
 }
 
+/// 볼트 지문 한 항목 — 경로와 mtime **만**. 본문은 담지 않는다.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultStamp {
+    relative_path: String,
+    /// `TauriTextFile::last_modified` 와 같은 표현 — 이 볼트에서 mtime 의 타입은 하나다.
+    last_modified: u128,
+}
+
+/// `vault_fingerprint` 의 결과. 절단·가지치기를 **숨기지 않고** 함께 돌려준다.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VaultFingerprint {
+    entries: Vec<VaultStamp>,
+    truncated: bool,
+    pruned_dirs: Vec<String>,
+}
+
+/// TS `VAULT_WALK_MAX_DEPTH` 와 **같은 값이어야 한다** (계약 테스트가 본다).
+const VAULT_WALK_MAX_DEPTH: usize = 12;
+/// TS `VAULT_WALK_MAX_ENTRIES` 와 같은 값.
+const VAULT_WALK_MAX_ENTRIES: usize = 4000;
+/// TS `PRUNE_BY_NAME` 과 같은 목록.
+const VAULT_PRUNE_DIR_NAMES: &[&str] = &["node_modules"];
+/// TS `CACHE_DIR_TAG` 와 같은 값.
+const VAULT_CACHE_DIR_TAG: &str = "CACHEDIR.TAG";
+/// TS `IMAGE_EXT` 와 같은 확장자 집합(소문자 비교).
+const VAULT_IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "bmp"];
+
+fn vault_entry_is_tracked(name: &str) -> bool {
+    if name.ends_with(".md") {
+        return true;
+    }
+    match name.rsplit_once('.') {
+        Some((_, ext)) => VAULT_IMAGE_EXTS.contains(&ext.to_ascii_lowercase().as_str()),
+        None => false,
+    }
+}
+
+fn walk_vault_stamps(
+    dir: &Path,
+    prefix: &str,
+    depth: usize,
+    acc: &mut VaultFingerprint,
+) -> Result<(), String> {
+    if acc.truncated {
+        return Ok(());
+    }
+    if depth > VAULT_WALK_MAX_DEPTH {
+        acc.truncated = true;
+        return Ok(());
+    }
+
+    // 목록을 먼저 모은다 — 캐시 표식 판정이 이 목록 안에서 끝난다.
+    let mut children: Vec<(String, bool)> = Vec::new();
+    for entry in fs::read_dir(dir).map_err(|err| err.to_string())? {
+        let entry = entry.map_err(|err| err.to_string())?;
+        let file_type = entry.file_type().map_err(|err| err.to_string())?;
+        if !file_type.is_dir() && !file_type.is_file() {
+            continue;
+        }
+        children.push((
+            entry.file_name().to_string_lossy().to_string(),
+            file_type.is_dir(),
+        ));
+    }
+
+    if children.iter().any(|(name, _)| name == VAULT_CACHE_DIR_TAG) {
+        acc.pruned_dirs
+            .push(if prefix.is_empty() { ".".into() } else { prefix.into() });
+        return Ok(());
+    }
+
+    for (name, is_dir) in children {
+        if acc.entries.len() >= VAULT_WALK_MAX_ENTRIES {
+            acc.truncated = true;
+            return Ok(());
+        }
+        if name.starts_with('.') {
+            continue;
+        }
+        let relative = if prefix.is_empty() {
+            name.clone()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        if is_dir {
+            if VAULT_PRUNE_DIR_NAMES.contains(&name.as_str()) {
+                acc.pruned_dirs.push(relative);
+                continue;
+            }
+            walk_vault_stamps(&dir.join(&name), &relative, depth + 1, acc)?;
+        } else if vault_entry_is_tracked(&name) {
+            let last_modified = metadata_mtime_ms(&dir.join(&name))?;
+            acc.entries.push(VaultStamp {
+                relative_path: relative,
+                last_modified,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// 볼트를 훑어 **경로와 mtime 만** 돌려준다.
+///
+/// ## 왜 이 명령이 필요한가 (2026-07-31)
+///
+/// 지문 계산이 `read_vault_text_file` 을 파일마다 불렀다 — 그 명령은 **본문
+/// 전체 + mtime** 을 돌려주므로, 쓰이는 것이 숫자 하나인데 볼트 전체가 IPC 를
+/// 건너왔다. 이 저장소 자신을 볼트로 열면 `docs/` 가 **261 파일 · 17.7MB** 이고,
+/// 그 경로는 창에 포커스가 돌아올 때마다 돈다.
+///
+/// 왕복도 파일마다 하나씩이었다(디렉터리마다 `list_vault_directory` 하나 추가).
+/// 이제 **한 번**이고, 페이로드는 경로+숫자뿐이다.
+///
+/// ⚠️ **walk 규칙은 TS 쪽과 한 글자도 달라선 안 된다.** 다르면 지문이 달라지고,
+/// 앱은 "바뀐 게 없는데 매번 재빌드" 하거나 "바뀌었는데 안 알아챈다". 상수는 위에
+/// 모아 두었고 `tests/contract/vault-walk-rules.contract.test.ts` 가 두 소스를
+/// 맞대어 본다.
+#[tauri::command]
+fn vault_fingerprint(root_path: String) -> Result<VaultFingerprint, String> {
+    let root = resolve_existing_inside(&root_path, "")?;
+    let mut acc = VaultFingerprint {
+        entries: Vec::new(),
+        truncated: false,
+        pruned_dirs: Vec::new(),
+    };
+    walk_vault_stamps(&root, "", 0, &mut acc)?;
+    Ok(acc)
+}
+
 #[tauri::command]
 fn read_vault_text_file(root_path: String, relative_path: String) -> Result<TauriTextFile, String> {
     let path = resolve_existing_inside(&root_path, &relative_path)?;
@@ -6356,6 +6487,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             pick_vault_directory,
             list_vault_directory,
+            vault_fingerprint,
             read_vault_text_file,
             read_vault_binary_file,
             write_vault_text_file,

--- a/src/entities/docs-vault/lib/build-local-manifest.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.ts
@@ -6,6 +6,7 @@ import {
   parseFrontmatter,
   type LinkContext,
 } from '@/shared/lib/parse-frontmatter';
+import { nativeVaultFingerprint } from '@/shared/lib/tauri-vault-fs';
 import type {
   VaultBacklinkEntry,
   VaultDoc,
@@ -257,6 +258,26 @@ function fingerprintFromEntries(
 export async function computeLocalVaultFingerprint(
   root: FileSystemDirectoryHandle,
 ): Promise<string> {
+  /*
+   * **앱에서는 네이티브 한 번으로 끝낸다** (2026-07-31).
+   *
+   * 아래 웹 경로는 파일마다 `getFile()` 을 부르는데, Tauri 에서 그건
+   * `read_vault_text_file` IPC 왕복이고 그 명령은 **본문 전체 + mtime** 을
+   * 돌려준다. 쓰이는 것은 숫자 하나인데 볼트 전체가 다리를 건넜다 — 이
+   * 저장소 자신을 볼트로 열면 `docs/` 가 261 파일 · 17.7MB 이고, 이 함수는
+   * 창에 포커스가 돌아올 때마다 돈다.
+   *
+   * `vault_fingerprint` 는 Rust 가 훑어 **경로와 mtime 만** 한 번에 준다.
+   * 웹에는 이런 일괄 API 가 없어 `null` 이 오고, 그러면 아래 경로로 떨어진다 —
+   * `surfaces.md` 의 브리지 관례(없으면 `null`, 화면/동작은 정직하게 강등)
+   * 그대로다.
+   */
+  const nativeRoot = (root as { rootPath?: unknown }).rootPath;
+  if (typeof nativeRoot === 'string' && nativeRoot) {
+    const native = await nativeVaultFingerprint(nativeRoot);
+    if (native) return fingerprintFromEntries(native.entries);
+  }
+
   const files = await walk(root);
   const stamps = await Promise.all(
     files.map(async (entry) => {

--- a/src/shared/lib/tauri-vault-fs.ts
+++ b/src/shared/lib/tauri-vault-fs.ts
@@ -121,6 +121,21 @@ class TauriFileHandle {
   }
 }
 
+/**
+ * 볼트 지문 — **경로와 mtime 만** 네이티브에서 한 번에 받는다.
+ *
+ * 웹에는 없다(FSA 에 이런 일괄 API 가 없다). `isTauri()` 가 아니면 `null` 을
+ * 돌려주고 호출부가 기존 경로로 떨어진다 — `surfaces.md` 의 브리지 관례
+ * (`getInvoke()` → 아니면 `null` → 화면 정직 강등) 그대로다.
+ */
+export async function nativeVaultFingerprint(
+  rootPath: string,
+): Promise<{ entries: Array<{ relativePath: string; lastModified: number }>; truncated: boolean; prunedDirs: string[] } | null> {
+  const invoke = getInvoke();
+  if (!invoke) return null;
+  return invoke('vault_fingerprint', { rootPath });
+}
+
 class TauriDirectoryHandle {
   readonly kind = 'directory';
   readonly name: string;

--- a/tests/contract/vault-walk-rules.contract.test.ts
+++ b/tests/contract/vault-walk-rules.contract.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  VAULT_WALK_MAX_DEPTH,
+  VAULT_WALK_MAX_ENTRIES,
+} from '@/entities/docs-vault/lib/build-local-manifest';
+
+const repoRoot = resolve(__dirname, '../..');
+const rustSource = readFileSync(resolve(repoRoot, 'src-tauri/src/lib.rs'), 'utf8');
+const tsSource = readFileSync(
+  resolve(repoRoot, 'src/entities/docs-vault/lib/build-local-manifest.ts'),
+  'utf8',
+);
+
+/**
+ * **두 walker 가 같은 규칙을 써야 한다.**
+ *
+ * 2026-07-31 에 `vault_fingerprint`(Rust) 를 추가하면서 볼트를 훑는 곳이 둘이
+ * 됐다 — TS 의 `walk()`(웹 · 실제 빌드)와 Rust 의 `walk_vault_stamps`(앱의 지문).
+ * 둘이 같은 파일 집합을 세지 않으면 **지문이 달라지고**, 그 결함은 이렇게 나온다:
+ *
+ * - Rust 가 더 많이 세면 → 바뀐 게 없는데 앱이 **매번 전체 재빌드**
+ * - Rust 가 덜 세면 → 파일이 바뀌었는데 **안 알아챈다**
+ *
+ * 둘 다 조용하다. 화면에 에러가 안 뜨고, 타입도 lint 도 통과한다. 그래서 여기서
+ * 두 소스의 **규칙 상수**를 직접 맞대어 본다 — 한쪽만 고치면 여기서 먼저 터진다.
+ *
+ * ⚠️ 이 게이트는 상수의 **일치**만 본다. 순회 로직 자체가 갈라지는 것은 못 잡는다.
+ * 그건 설치 앱에서 같은 볼트로 두 지문을 비교해야 알 수 있고, 그 검증은 데스크톱
+ * 실측의 몫이다(`surfaces.md`).
+ */
+describe('볼트 walk 규칙 — TS 와 Rust 가 같아야 한다', () => {
+  it('깊이 상한이 같다', () => {
+    expect(VAULT_WALK_MAX_DEPTH).toBe(12);
+    expect(rustSource).toMatch(/const VAULT_WALK_MAX_DEPTH: usize = 12;/);
+  });
+
+  it('항목 수 상한이 같다', () => {
+    expect(VAULT_WALK_MAX_ENTRIES).toBe(4000);
+    expect(rustSource).toMatch(/const VAULT_WALK_MAX_ENTRIES: usize = 4000;/);
+  });
+
+  it('가지치기 디렉터리 목록이 같다', () => {
+    expect(tsSource).toMatch(/PRUNE_BY_NAME = new Set\(\['node_modules'\]\)/);
+    expect(rustSource).toMatch(/VAULT_PRUNE_DIR_NAMES: &\[&str\] = &\["node_modules"\];/);
+  });
+
+  it('캐시 표식 파일명이 같다', () => {
+    expect(tsSource).toMatch(/CACHE_DIR_TAG = 'CACHEDIR\.TAG'/);
+    expect(rustSource).toMatch(/VAULT_CACHE_DIR_TAG: &str = "CACHEDIR\.TAG";/);
+  });
+
+  /**
+   * 이미지 확장자는 TS 가 정규식, Rust 가 목록이라 문자열 비교가 안 된다.
+   * 그래서 **같은 집합인지**를 각자에서 뽑아 비교한다.
+   */
+  it('이미지 확장자 집합이 같다', () => {
+    const tsMatch = /IMAGE_EXT = \/\\\.\(([^)]+)\)\$\/i/.exec(tsSource);
+    expect(tsMatch, 'TS 쪽 IMAGE_EXT 를 못 읽었다 — 정규식 모양이 바뀌었나').toBeTruthy();
+    // `png|jpe?g|gif|…` → 확장자 집합. `jpe?g` 는 jpg·jpeg 둘 다다.
+    const tsExts = new Set(
+      tsMatch![1]!.split('|').flatMap((token) => (token === 'jpe?g' ? ['jpg', 'jpeg'] : [token])),
+    );
+
+    const rustMatch = /VAULT_IMAGE_EXTS: &\[&str\] = &\[([^\]]+)\]/.exec(rustSource);
+    expect(rustMatch, 'Rust 쪽 VAULT_IMAGE_EXTS 를 못 읽었다').toBeTruthy();
+    const rustExts = new Set(
+      rustMatch![1]!.split(',').map((s) => s.trim().replace(/"/g, '')).filter(Boolean),
+    );
+
+    expect([...rustExts].sort()).toEqual([...tsExts].sort());
+  });
+
+  it('숨김 파일(.으로 시작)을 둘 다 건너뛴다', () => {
+    expect(tsSource).toMatch(/name\.startsWith\('\.'\)/);
+    expect(rustSource).toMatch(/name\.starts_with\('\.'\)/);
+  });
+
+  it('Rust 지문은 본문을 담지 않는다 — 그것이 이 명령의 존재 이유다', () => {
+    const stamp = /struct VaultStamp \{[\s\S]*?\n\}/.exec(rustSource)?.[0] ?? '';
+    expect(stamp).toBeTruthy();
+    expect(stamp).toMatch(/relative_path/);
+    expect(stamp).toMatch(/last_modified/);
+    expect(stamp, '지문에 본문이 들어가면 IPC 절약이 사라진다').not.toMatch(/\btext\b|\bbytes\b/);
+  });
+});


### PR DESCRIPTION
## Summary

창에 포커스가 돌아올 때마다 **볼트 전체를 IPC 로 나르고 mtime 만 쓰고 있었습니다.**

```
이 저장소를 볼트로 열면   docs/ 261 파일 · 17.7MB 가 다리를 건넘
실제로 쓰는 것            숫자 261개
```

`computeLocalVaultFingerprint` 가 파일마다 `getFile()` 을 부르는데, 앱에서 그건 `read_vault_text_file` IPC 왕복이고 그 명령은 **본문 전체 + mtime** 을 돌려줍니다.

새 `vault_fingerprint` 명령이 Rust 쪽에서 한 번 훑어 `(상대경로, mtime)` 만 돌려줍니다. **절단·가지치기도 숨기지 않고 함께** 줍니다 — 조용한 절단은 "전부 봤다"로 읽히고, 이 저장소가 게이트마다 배운 규율입니다.

웹에는 이런 일괄 API 가 없으므로 브리지가 `null` 을 주고 기존 경로로 떨어집니다 — `surfaces.md` 의 관례(`getInvoke()` → 없으면 `null` → 정직한 강등) 그대로입니다.

## 배경

2026-07-31 에 만들어졌으나 머지되지 않고 남아 있던 브랜치입니다. 오늘 최신 `main` 위로 리베이스했고 **충돌 없이 붙었습니다**. (구 브랜치 `perf/vault-fingerprint-rust` 는 이 PR 머지 후 정리합니다.)

## Test plan

- `pnpm exec vitest run tests/contract` — **938 passed** (신규 계약 테스트 7건 포함)
- `pnpm exec tsc --noEmit` — clean
- ⚠️ `cargo test --lib` 은 로컬에서 못 돌렸습니다 — `src-tauri/binaries`(= `mcp:build-binary` 산출물)가 없으면 빌드 스크립트가 실패합니다. CI 에서 확인이 필요합니다.
- ⚠️ **설치 앱 실측이 아직 없습니다.** 데스크톱 능력이므로 머지 후 실측이 필요합니다 — 특히 포커스 복귀 시 왕복 수와 페이로드 크기.