### PR TITLE
fix: 에이전트 턴이 화면에서 자기 화면을 부정하던 여섯 자리

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3329,7 +3329,7 @@
     "uncited": "Read this turn:",
     "footerDetail": "{chars} characters went out this turn — mostly system guidance and tool descriptions.",
     "reground": {
-      "title": "Ask it to read first"
+      "title": "Stopped at round {round}/{cap} — have it read first"
     }
   },
   "skillParity": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -3230,9 +3230,9 @@
     "placeholderFirst": "Write what you want done",
     "thinking": "Thinking",
     "thinkingSeconds": "Thinking · {seconds}s",
-    "unsupported": "Answered without reading anything. Do not take it as fact.",
+    "unsupported": "Answered without reading the vault this turn. Do not take it as fact.",
     "charsLabel": "{chars} chars",
-    "footer": "{provider} · {chars} chars this turn · {rounds} recorded",
+    "footer": "{provider} · {rounds} recorded",
     "boundary": "Work that needs your source code is better done by the AI in your own terminal. Here the agent only reads your document folder.",
     "handoffSummary": "Continue in your terminal",
     "handoffNote": "Copy this and paste it into your own terminal. You run it — this app never types commands for you.",
@@ -3292,7 +3292,8 @@
       "rejected": "The key was rejected. Check it in settings.",
       "auditBlocked": "Nothing was sent, because the record could not be written.",
       "providerRefused": "This request was declined.",
-      "failed": "Something went wrong."
+      "failed": "Something went wrong.",
+      "noToolCall": "Stopped at round {round}/{cap} without calling a single tool."
     },
     "degraded": {
       "webTitle": "Available in the desktop app only",
@@ -3324,6 +3325,11 @@
     },
     "retry": {
       "title": "Try again"
+    },
+    "uncited": "Read this turn:",
+    "footerDetail": "{chars} characters went out this turn — mostly system guidance and tool descriptions.",
+    "reground": {
+      "title": "Ask it to read first"
     }
   },
   "skillParity": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3329,7 +3329,7 @@
     "uncited": "이 턴에 읽은 자료:",
     "footerDetail": "이 턴에 오간 글 {chars}자 — 대부분 시스템 안내와 도구 설명이에요.",
     "reground": {
-      "title": "읽고 다시 답하게 하려면"
+      "title": "{round}/{cap}번째에서 멈췄어요 — 읽고 다시 답하게 하기"
     }
   },
   "skillParity": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3230,9 +3230,9 @@
     "placeholderFirst": "무엇을 시킬지 여기에 적어요",
     "thinking": "생각 중",
     "thinkingSeconds": "생각 중 · {seconds}초",
-    "unsupported": "읽은 근거 없이 답했어요. 그대로 믿지 마세요.",
+    "unsupported": "이 턴에는 볼트를 읽지 않고 답했어요. 그대로 믿지 마세요.",
     "charsLabel": "{chars}자",
-    "footer": "{provider} · 이 턴 {chars}자 · 기록 {rounds}건",
+    "footer": "{provider} · 기록 {rounds}건",
     "boundary": "코드까지 봐야 하는 일은 내 컴퓨터의 터미널에서 여는 AI 가 나아요. 여기서는 문서 폴더만 봐요.",
     "handoffSummary": "터미널에서 이어가기",
     "handoffNote": "아래를 복사해 내 컴퓨터의 터미널에 붙여넣어요. 실행은 사용자가 해요 — 앱은 명령을 대신 치지 않아요.",
@@ -3292,7 +3292,8 @@
       "rejected": "키가 거부됐어요. 설정에서 확인해 주세요.",
       "auditBlocked": "기록을 남길 수 없어 보내지 않았어요.",
       "providerRefused": "이 요청은 거절됐어요.",
-      "failed": "실패했어요."
+      "failed": "실패했어요.",
+      "noToolCall": "{round}/{cap}번째에서 도구를 한 번도 안 부르고 멈췄어요."
     },
     "degraded": {
       "webTitle": "데스크톱 앱에서만 쓸 수 있어요",
@@ -3324,6 +3325,11 @@
     },
     "retry": {
       "title": "다시 해볼까요"
+    },
+    "uncited": "이 턴에 읽은 자료:",
+    "footerDetail": "이 턴에 오간 글 {chars}자 — 대부분 시스템 안내와 도구 설명이에요.",
+    "reground": {
+      "title": "읽고 다시 답하게 하려면"
     }
   },
   "skillParity": {

--- a/src/features/vault-agent/index.ts
+++ b/src/features/vault-agent/index.ts
@@ -10,6 +10,14 @@ export type { AgentLoopDeps, StartTurnInput, TurnRunResult } from './model/agent
 export { extractCitations } from './model/citation';
 export type { CitationResult } from './model/citation';
 export {
+  COMPOSER_MAX_ROWS,
+  COMPOSER_MIN_ROWS,
+  composerGrowth,
+  composerTopIsHidden,
+  snapScrollTop,
+} from './model/composer-growth';
+export type { ComposerGrowth, ComposerMetrics } from './model/composer-growth';
+export {
   FIRST_WORDS_MAX_CHIPS,
   buildFirstWords,
   nodeIntent,
@@ -69,6 +77,7 @@ export {
 export type {
   AgentEvent,
   AgentProposal,
+  AnswerGrounding,
   AgentTurn,
   AgentTurnStatus,
   CitedParagraph,

--- a/src/features/vault-agent/model/agent-loop.test.ts
+++ b/src/features/vault-agent/model/agent-loop.test.ts
@@ -11,6 +11,7 @@ import { AGENT_ROUND_CAP } from './types';
 
 const NOTICES: AgentLoopDeps['notices'] = {
   roundCap: '여기까지 하고 정리할게요',
+  noToolCall: ({ round, cap }) => `${round}/${cap}번째에서 도구를 한 번도 안 부르고 멈췄어요`,
   aborted: '여기까지 읽었어요',
   networkFailed: '연결에 실패했어요',
   rateLimited: '지금은 호출 한도예요',
@@ -246,7 +247,7 @@ describe('runTurn', () => {
     ]);
   });
 
-  it('인용 0 인 답은 강등 표시가 붙는다', async () => {
+  it('아무것도 안 읽고 나온 답은 unread 로 표시된다', async () => {
     const send = vi.fn<Send>(async () =>
       echo({ content: [{ type: 'text', text: '그냥 제 생각인데요' }], stop_reason: 'end_turn' }),
     );
@@ -256,6 +257,43 @@ describe('runTurn', () => {
       { signal: new AbortController().signal },
     );
     const assistant = result.turn.events.find((event) => event.kind === 'assistant');
-    expect(assistant).toMatchObject({ demoted: true });
+    expect(assistant).toMatchObject({ grounding: 'unread' });
+  });
+
+  /**
+   * 2026-08-02 — 이 분기는 아무 알림 없이 `status: 'done'` 으로 접수됐다.
+   * 상한 도달은 `round-cap` 을 띄우는데 조기 종료는 조용해서, 화면이 정상
+   * 완료와 구별되지 않았다(실측 감사 로그의 `agent ok tools=[]` 턴들).
+   */
+  it('도구를 한 번도 안 부르고 멈춘 턴은 상한 도달과 대칭인 알림을 남긴다', async () => {
+    const send = vi.fn<Send>(async () =>
+      echo({ content: [{ type: 'text', text: '아마 그럴 거예요' }], stop_reason: 'end_turn' }),
+    );
+    const result = await runTurn(
+      deps({ send }),
+      startTurn({ text: 'x', screenContext: EMPTY_SCREEN_CONTEXT }),
+      { signal: new AbortController().signal },
+    );
+    const notice = result.turn.events.find((event) => event.kind === 'notice');
+    expect(notice).toMatchObject({ code: 'no-tool-call' });
+    expect(notice).toMatchObject({ text: `1/${AGENT_ROUND_CAP}번째에서 도구를 한 번도 안 부르고 멈췄어요` });
+  });
+
+  it('도구를 쓴 뒤 마무리하는 정상 종료에는 그 알림이 붙지 않는다', async () => {
+    // ①에 붙이면 모든 정상 턴에 벽지가 하나 는다.
+    const send = vi
+      .fn<Send>()
+      .mockResolvedValueOnce(echo(TOOL_CALL))
+      .mockResolvedValueOnce(echo(TEXT_ONLY));
+    const result = await runTurn(
+      deps({ send }),
+      startTurn({ text: 'x', screenContext: EMPTY_SCREEN_CONTEXT }),
+      { signal: new AbortController().signal },
+    );
+    expect(
+      result.turn.events.filter(
+        (event) => event.kind === 'notice' && event.code === 'no-tool-call',
+      ),
+    ).toHaveLength(0);
   });
 });

--- a/src/features/vault-agent/model/agent-loop.ts
+++ b/src/features/vault-agent/model/agent-loop.ts
@@ -58,6 +58,12 @@ export interface AgentLoopDeps {
   /** 상한 도달·중단·오류 문구는 화면 언어로 온다 — 모델이 짓지 않는다. */
   notices: {
     roundCap: string;
+    /**
+     * 도구를 한 번도 안 부르고 멈춘 턴의 한 줄. 라운드 수를 실어 보내는
+     * 이유는 상한 도달 문구와 **대칭**이 되게 하기 위해서다 — 둘 다
+     * "몇 번째에서 멈췄나" 를 말한다.
+     */
+    noToolCall: (args: { round: number; cap: number }) => string;
     aborted: string;
     networkFailed: string;
     rateLimited: string;
@@ -227,6 +233,24 @@ export async function runTurn(
 
     if (parsed.toolCalls.length === 0) {
       pushAssistant(parsed.text);
+      /**
+       * **도구를 한 번도 안 부르고 끝난 턴은 조용히 죽으면 안 된다.**
+       *
+       * 이 분기는 두 가지를 동시에 받는다: ① 도구를 쓰고 나서 마무리하는
+       * 정상 종료(그때 `toolRefs` 는 차 있다) ② 볼트를 아예 안 열고 멈춘 턴.
+       * ②는 상한 도달과 똑같이 "여기서 멈췄다" 인데 `round-cap` 과 달리
+       * 아무 알림도 없어서, 화면이 정상 완료와 구별되지 않았다. 실측 감사
+       * 로그에 `agent ok tools=[]` 로 남은 그 턴들이다.
+       *
+       * 알림은 ②에만 붙인다 — ①에 붙이면 모든 정상 턴에 벽지가 하나 는다.
+       */
+      if (toolRefs.length === 0) {
+        events.push({
+          kind: 'notice',
+          code: 'no-tool-call',
+          text: deps.notices.noToolCall({ round: rounds, cap: AGENT_ROUND_CAP }),
+        });
+      }
       status = 'done';
       emit();
       return { turn: snapshot(), readSlugs, writeIntents };
@@ -329,7 +353,10 @@ export async function runTurn(
     events.push({
       kind: 'assistant',
       paragraphs: cited.paragraphs,
-      demoted: cited.demoted,
+      grounding: cited.grounding,
+      // 화면이 인용 표기 없이도 근거를 그릴 수 있게, 이 시점의 읽은 목록을
+      // 그대로 실어 보낸다 (모델 순응에 기대지 않는 보정의 재료).
+      sources: [...readSlugs],
       nextStep,
     });
   }

--- a/src/features/vault-agent/model/citation.test.ts
+++ b/src/features/vault-agent/model/citation.test.ts
@@ -12,7 +12,7 @@ describe('인용 강제', () => {
       'capabilities/payment',
       'capabilities/refund',
     ]);
-    expect(result.demoted).toBe(false);
+    expect(result.grounding).toBe('grounded');
   });
 
   it('읽은 적 없는 이름은 인용이 아니라 지어낸 것이다', () => {
@@ -22,7 +22,8 @@ describe('인용 강제', () => {
     ]);
     expect(result.paragraphs[0].citations).toEqual([]);
     expect(result.droppedCitations).toEqual(['capabilities/imaginary']);
-    expect(result.demoted).toBe(true);
+    // 읽기는 했으니 `unread` 가 아니다 — 표기만 무효다.
+    expect(result.grounding).toBe('uncited');
   });
 
   it('마지막 조각만 적어도 읽은 slug 로 되찾는다', () => {
@@ -30,9 +31,33 @@ describe('인용 강제', () => {
     expect(result.paragraphs[0].citations).toEqual(['capabilities/payment']);
   });
 
-  it('인용이 하나도 없으면 렌더가 강등된다', () => {
+  /**
+   * 2026-08-02 — 구 구현은 이 둘을 **같은 값**(`demoted: true`)으로 접었다.
+   * 실제로는 다음 행동이 다르다: 하나는 되돌아갈 길이 필요하고, 다른 하나는
+   * 화면이 읽은 목록으로 보정하면 끝난다.
+   */
+  it('읽었는데 표기만 없으면 uncited — 강등이 아니라 보정 대상이다', () => {
     const result = extractCitations('제 생각에는 이렇습니다.', ['capabilities/payment']);
-    expect(result.demoted).toBe(true);
+    expect(result.grounding).toBe('uncited');
+  });
+
+  it('이 턴에 읽은 것이 하나도 없을 때만 unread', () => {
+    const result = extractCitations('제 생각에는 이렇습니다.', []);
+    expect(result.grounding).toBe('unread');
+  });
+
+  it('모델이 쓴 인라인 마크다운 표기는 화면에 글자로 남지 않는다', () => {
+    const result = extractCitations(
+      '**증거가 없는 기능(`capability`):**\n\n`capabilities/checkout` 을 보세요.',
+      ['capabilities/checkout'],
+    );
+    expect(result.paragraphs[0].text).toBe('증거가 없는 기능(capability):');
+    expect(result.paragraphs[1].text).toBe('capabilities/checkout 을 보세요.');
+  });
+
+  it('코드 펜스 안의 백틱은 경계라서 건드리지 않는다', () => {
+    const result = extractCitations('```\nkind: capability\n```', []);
+    expect(result.paragraphs[0].text).toBe('```\nkind: capability\n```');
   });
 
   it('빈 문단은 버리고 문단 단위를 지킨다', () => {

--- a/src/features/vault-agent/model/citation.ts
+++ b/src/features/vault-agent/model/citation.ts
@@ -1,21 +1,37 @@
-import type { CitedParagraph } from './types';
+import type { AnswerGrounding, CitedParagraph } from './types';
 
 /**
  * 인용 강제 — 답을 렌더하기 전에 `[[slug]]` 인용을 검증한다.
  *
- * 규칙 둘:
- * ① 인용이 하나도 없는 답은 **강등**해서 그린다. 근거 없이 말한 문장을
- *    근거 있는 문장과 똑같이 그리면 화면이 거짓말을 한다.
- * ② **이 턴에 실제로 읽지 않은 slug 는 인용이 아니다.** 모델이 지어낸
+ * 규칙 셋:
+ * ① **이 턴에 실제로 읽지 않은 slug 는 인용이 아니다.** 모델이 지어낸
  *    이름을 칩으로 만들면 누르는 순간 빈 곳으로 데려간다.
+ * ② 근거의 판정은 **두 갈래**다 — 아래 참조.
+ * ③ 모델이 쓴 마크다운 표기(`**굵게**` · 인라인 코드)는 화면에 글자로
+ *    남지 않는다. 정보를 안 나르는 글자다.
+ *
+ * ## 왜 "인용 0" 하나로 판정하면 안 되나 (2026-08-02)
+ *
+ * 이 파일은 오래 `demoted: total === 0` 하나만 봤다. 인용 **표기**의 개수이지
+ * 도구 호출과는 아무 상관이 없는 값이다. 실측 턴에서 도구를 4번 부르고
+ * 1,370자를 읽어 화면에 「읽음: capabilities/checkout 635자」까지 찍어 놓고,
+ * 네 줄 아래에서 「읽은 근거 없이 답했어요」가 떴다 — 모델이 `[[…]]` 대신
+ * 백틱으로 이름을 적었기 때문이다. 화면이 자기 화면을 부정한 것이다.
+ *
+ * 그래서 갈래를 나눈다. 둘은 **다음 행동이 다르다**:
+ *
+ * - `unread` — 이 턴에 읽은 것이 하나도 없다. 근거가 없는 게 맞으니 강등하고,
+ *   되돌아갈 길(다시 읽고 답하기)을 준다.
+ * - `uncited` — 읽었는데 표기만 없다. 이건 고칠 문제가 아니라 **정확한
+ *   자기 서술**이라 컨트롤을 붙이지 않는다. 화면이 읽은 목록을 「참고한 자료」
+ *   칩으로 기계적으로 보정한다 — 모델 순응에 기대지 않는다.
  */
 
 const CITATION_PATTERN = /\[\[([^[\]]+)\]\]/g;
 
 export interface CitationResult {
   paragraphs: CitedParagraph[];
-  /** 인용 0 — 렌더 강등. */
-  demoted: boolean;
+  grounding: AnswerGrounding;
   /** 읽은 적 없어 무효 처리된 이름들. 화면이 조용히 지우지 않고 알린다. */
   droppedCitations: string[];
 }
@@ -31,7 +47,7 @@ export function extractCitations(text: string, readSlugs: readonly string[]): Ci
   const dropped = new Set<string>();
   const paragraphs: CitedParagraph[] = [];
 
-  for (const block of text.split(/\n{2,}/)) {
+  for (const block of stripInlineMarkup(text).split(/\n{2,}/)) {
     const trimmed = block.trim();
     if (!trimmed) continue;
     const citations: string[] = [];
@@ -50,7 +66,35 @@ export function extractCitations(text: string, readSlugs: readonly string[]): Ci
   const total = paragraphs.reduce((sum, paragraph) => sum + paragraph.citations.length, 0);
   return {
     paragraphs,
-    demoted: total === 0,
+    grounding: total > 0 ? 'grounded' : allowed.size > 0 ? 'uncited' : 'unread',
     droppedCitations: [...dropped],
   };
+}
+
+const BOLD_PATTERN = /\*\*([^*\n]+)\*\*/g;
+const INLINE_CODE_PATTERN = /`([^`\n]+)`/g;
+
+/**
+ * 모델이 쓴 인라인 마크다운 표기를 **글자 단위로 지운다** (렌더하지 않는다).
+ *
+ * 화면에 `**증거가 없는 기능(\`capability\`):**` 이 문자 그대로 찍히고 있었다.
+ * 별표와 백틱은 이 표면에서 아무 정보도 나르지 않는다 — 대화 본문의 강조
+ * 문법은 인용 칩이고, 그건 `[[…]]` 가 이미 맡고 있다.
+ *
+ * 코드 펜스(``` ) 안은 건드리지 않는다. 거기서는 백틱이 경계라서 지우면
+ * 내용이 무너진다.
+ */
+function stripInlineMarkup(text: string): string {
+  let inFence = false;
+  return text
+    .split('\n')
+    .map((line) => {
+      if (line.trimStart().startsWith('```')) {
+        inFence = !inFence;
+        return line;
+      }
+      if (inFence) return line;
+      return line.replace(BOLD_PATTERN, '$1').replace(INLINE_CODE_PATTERN, '$1');
+    })
+    .join('\n');
 }

--- a/src/features/vault-agent/model/composer-growth.test.ts
+++ b/src/features/vault-agent/model/composer-growth.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPOSER_MAX_ROWS,
+  COMPOSER_MIN_ROWS,
+  composerGrowth,
+  composerTopIsHidden,
+  snapScrollTop,
+} from './composer-growth';
+
+/**
+ * 실측 치수(1512×806, 다크, Pretendard 12.5px/20px):
+ * padding 8+8 · border 1+1 · line-height 20 → 2줄 상자 = 58px.
+ */
+const BASE = { lineHeight: 20, paddingBlock: 16, borderBlock: 2 };
+const rowsToContent = (rows: number) => rows * BASE.lineHeight + BASE.paddingBlock;
+
+describe('composerGrowth', () => {
+  it('한 줄짜리 글도 최소 2줄 상자를 지킨다', () => {
+    const growth = composerGrowth({ ...BASE, contentHeight: rowsToContent(1) });
+    expect(growth).toEqual({ height: 58, rows: COMPOSER_MIN_ROWS, overflowing: false });
+  });
+
+  it('세 줄이면 상자가 세 줄로 자란다 (구 고정 높이에서 잘리던 그 문장)', () => {
+    const growth = composerGrowth({ ...BASE, contentHeight: rowsToContent(3) });
+    expect(growth).toEqual({ height: 78, rows: 3, overflowing: false });
+  });
+
+  it('상한은 6줄이고, 그 위는 상자가 아니라 안쪽 스크롤이 받는다', () => {
+    const at = composerGrowth({ ...BASE, contentHeight: rowsToContent(6) });
+    expect(at).toEqual({ height: 138, rows: COMPOSER_MAX_ROWS, overflowing: false });
+
+    const over = composerGrowth({ ...BASE, contentHeight: rowsToContent(9) });
+    expect(over).toEqual({ height: 138, rows: COMPOSER_MAX_ROWS, overflowing: true });
+  });
+
+  it('어떤 줄 수에서도 높이는 정수 줄 + 크롬이다 — 반 줄이 생길 자리가 없다', () => {
+    for (let rows = 1; rows <= 12; rows += 1) {
+      const growth = composerGrowth({ ...BASE, contentHeight: rowsToContent(rows) });
+      expect(growth).not.toBeNull();
+      const text = growth!.height - BASE.paddingBlock - BASE.borderBlock;
+      expect(text % BASE.lineHeight).toBe(0);
+    }
+  });
+
+  it('잴 수 없는 상태(SSR·jsdom·폰트 로드 전)에서는 아무 값도 만들지 않는다', () => {
+    expect(composerGrowth({ ...BASE, lineHeight: Number.NaN, contentHeight: 76 })).toBeNull();
+    expect(composerGrowth({ ...BASE, contentHeight: 0 })).toBeNull();
+    expect(composerGrowth({ ...BASE, lineHeight: 0, contentHeight: 76 })).toBeNull();
+  });
+});
+
+describe('snapScrollTop', () => {
+  it('격자 밖 값은 가장 가까운 줄 경계로 붙는다', () => {
+    // 실측 결함: 한 프레임에 9px 이동 → 줄 높이 20 의 배수가 아니라 글리프가
+    // 반으로 잘렸다. 9 는 첫 줄에 더 가까우므로 첫 줄로 되돌아간다.
+    expect(snapScrollTop(9, 20)).toBe(0);
+    expect(snapScrollTop(13, 20)).toBe(20);
+    expect(snapScrollTop(31, 20)).toBe(40);
+  });
+
+  it('이미 격자 위인 값은 움직이지 않는다', () => {
+    expect(snapScrollTop(0, 20)).toBe(0);
+    expect(snapScrollTop(40, 20)).toBe(40);
+  });
+
+  it('줄 높이를 모르면 손대지 않는다', () => {
+    expect(snapScrollTop(9, 0)).toBe(9);
+    expect(snapScrollTop(9, Number.NaN)).toBe(9);
+  });
+});
+
+describe('composerTopIsHidden', () => {
+  it('상한에 닿았어도 맨 위에 있으면 가려진 것이 없다', () => {
+    expect(composerTopIsHidden(true, 0)).toBe(false);
+  });
+
+  it('상한에 닿고 실제로 밀려 올라갔을 때만 참', () => {
+    expect(composerTopIsHidden(true, 20)).toBe(true);
+  });
+
+  it('자라는 중(상한 미도달)에는 어떤 스크롤 값에서도 신호가 없다', () => {
+    expect(composerTopIsHidden(false, 20)).toBe(false);
+  });
+});

--- a/src/features/vault-agent/model/composer-growth.ts
+++ b/src/features/vault-agent/model/composer-growth.ts
@@ -1,0 +1,99 @@
+/**
+ * 컴포저의 **높이와 스크롤 정렬** — 순수 산수 한 벌.
+ *
+ * ## 왜 높이가 계산이어야 하나
+ *
+ * 입력칸은 `rows={2}` 고정이었다. 세 줄짜리 문장이 들어오면 상자는 그대로인 채
+ * 안쪽만 스크롤했고, 그때 브라우저가 놓는 `scrollTop` 은 줄 격자와 무관한
+ * 값이라 **윗변에 글리프가 반으로 잘린 줄**이 걸렸다. 실측(1512×806, 다크):
+ * `line-height 20px` · `padding 8+8` · `border 1+1` → `clientHeight 56`,
+ * 3줄이면 `scrollHeight 76`, 최대 스크롤 20px. 20 은 줄 높이의 배수인데도
+ * 글은 패딩 8px 뒤에서 시작하므로 첫 줄의 아래 8px 만 남는다.
+ *
+ * 그래서 높이를 **줄 수로** 정한다: `rows * lineHeight + padding + border`.
+ * 상자가 항상 정수 줄이면 잘릴 자리가 없다. 자람의 상한(6줄)에서만 안쪽
+ * 스크롤이 생기고, 그때부터는 사용자가 미는 스크롤이다.
+ *
+ * ## 왜 순수 함수인가
+ *
+ * DOM 측정(`getComputedStyle` · 미러의 `scrollHeight`)은 호출자가 하고, 판정은
+ * 여기서 한다. 그래야 "9px 이 아니라 20px 의 배수" 같은 불변식을 jsdom 없이
+ * 단위 테스트로 못 박을 수 있다 — 이건 모션이 아니라 **정렬**이라
+ * reduced-motion 에서도 살아 있어야 하는 규칙이다.
+ */
+
+/** 아직 아무 말도 안 한 사람에게 내미는 최소 크기. */
+export const COMPOSER_MIN_ROWS = 2;
+/**
+ * 자람의 상한. 여기를 넘으면 입력칸이 대화를 밀어내기 시작하므로, 그 위는
+ * 상자를 키우는 대신 안쪽 스크롤로 넘긴다.
+ */
+export const COMPOSER_MAX_ROWS = 6;
+
+export interface ComposerMetrics {
+  /** 계산된 줄 높이(px). */
+  lineHeight: number;
+  /** padding-top + padding-bottom. */
+  paddingBlock: number;
+  /** border-top + border-bottom (`box-sizing: border-box` 라 높이에 포함된다). */
+  borderBlock: number;
+  /**
+   * 오프스크린 미러의 `scrollHeight` — 패딩을 포함하고 보더는 제외한 값.
+   *
+   * **보이는 입력칸을 재지 않는 이유**: `style.height=''` → 리플로우 →
+   * 재설정 패턴은 매 프레임 높이를 0 으로 되돌렸다가 다시 놓으므로 자람이
+   * 부드러운 전이가 아니라 계단이 된다.
+   */
+  contentHeight: number;
+}
+
+export interface ComposerGrowth {
+  /** 입력칸에 그대로 써 넣을 높이(px). 항상 정수 줄 + 크롬. */
+  height: number;
+  /** 상자가 담는 줄 수 (MIN..MAX). */
+  rows: number;
+  /** 상한에 닿아 **안쪽 스크롤이 실제로 생겼는가**. */
+  overflowing: boolean;
+}
+
+/**
+ * 측정값 → 높이. 재료가 아직 없으면(SSR·jsdom·폰트 로드 전) `null` 이고,
+ * 호출자는 그때 아무것도 하지 않는다 — 0px 로 접히는 것보다 손대지 않는 편이
+ * 언제나 낫다.
+ */
+export function composerGrowth(metrics: ComposerMetrics): ComposerGrowth | null {
+  const { lineHeight, paddingBlock, borderBlock, contentHeight } = metrics;
+  if (!Number.isFinite(lineHeight) || lineHeight <= 0) return null;
+  if (!Number.isFinite(paddingBlock) || !Number.isFinite(borderBlock)) return null;
+  if (!Number.isFinite(contentHeight) || contentHeight <= 0) return null;
+
+  const textHeight = contentHeight - paddingBlock;
+  const wanted = Math.max(1, Math.round(textHeight / lineHeight));
+  const rows = Math.min(Math.max(wanted, COMPOSER_MIN_ROWS), COMPOSER_MAX_ROWS);
+  return {
+    height: rows * lineHeight + paddingBlock + borderBlock,
+    rows,
+    overflowing: wanted > COMPOSER_MAX_ROWS,
+  };
+}
+
+/**
+ * 스크롤 위치를 줄 격자에 붙인다. 상자가 줄어들거나(글을 지웠다) 커진 뒤
+ * 브라우저가 남겨 놓는 `scrollTop` 은 격자와 무관한 값이라, 그대로 두면 다음
+ * 프레임에 반 줄이 윗변에 걸린다.
+ */
+export function snapScrollTop(scrollTop: number, lineHeight: number): number {
+  if (!Number.isFinite(scrollTop) || !Number.isFinite(lineHeight) || lineHeight <= 0) {
+    return scrollTop;
+  }
+  return Math.round(scrollTop / lineHeight) * lineHeight;
+}
+
+/**
+ * 상단 페이드를 켤 조건 — **상한에 닿았고 실제로 위가 가려졌을 때만.**
+ * 자라는 동안에는 아무것도 가려지지 않으므로 신호도 없다(없는 넘침을
+ * 광고하지 않는다).
+ */
+export function composerTopIsHidden(overflowing: boolean, scrollTop: number): boolean {
+  return overflowing && Number.isFinite(scrollTop) && scrollTop > 0;
+}

--- a/src/features/vault-agent/model/types.ts
+++ b/src/features/vault-agent/model/types.ts
@@ -7,6 +7,18 @@
  * 같은 철학).
  */
 
+/**
+ * 이 답이 무엇에 기대고 있는가. 화면의 문구·컨트롤이 여기서 갈린다.
+ * 판정은 `citation.ts` 가 하고, 갈래의 뜻은 그 파일의 머리주석에 있다.
+ */
+export type AnswerGrounding =
+  /** `[[slug]]` 인용이 하나 이상 — 문장이 스스로 근거를 가리킨다. */
+  | 'grounded'
+  /** 이 턴에 읽기는 했는데 인용 표기가 없다. 화면이 읽은 목록으로 보정한다. */
+  | 'uncited'
+  /** 이 턴에 읽은 것이 없다. 근거 없이 말한 답이다. */
+  | 'unread';
+
 /** 이 왕복에 실린 도구 호출 한 건의 실측 기록. */
 export interface ToolCallRecord {
   /** 벤더가 준 id. Gemini 는 주지 않아 실행기가 합성한다. */
@@ -116,6 +128,15 @@ export type NoticeCode =
   | 'rate-limited'
   | 'rejected'
   | 'round-cap'
+  /**
+   * **도구를 한 번도 안 부르고 멈춘 턴** (2026-08-02).
+   *
+   * 라운드 상한 분기는 `round-cap` 을 명시적으로 띄우는데, 조기 종료 분기는
+   * 아무 알림도 없이 `status: 'done'` 으로 접수됐다 — 화면은 정상 완료와
+   * 똑같이 입력칸을 되돌려 줬고, 사용자는 볼트를 아예 안 본 답을 읽은 답과
+   * 구별할 수 없었다. 두 분기가 대칭이 되도록 이 코드가 있다.
+   */
+  | 'no-tool-call'
   | 'aborted'
   | 'audit-blocked'
   | 'provider-refused'
@@ -128,7 +149,18 @@ export type AgentEvent =
   | {
       kind: 'assistant';
       paragraphs: CitedParagraph[];
-      demoted: boolean;
+      /**
+       * 이 답이 무엇에 기대고 있는가 — `citation.ts` 의 두 갈래 판정.
+       * 구 `demoted: boolean` 은 인용 **표기** 개수만 보느라, 볼트를 읽고
+       * 답한 턴에도 「읽은 근거 없이 답했어요」를 띄웠다.
+       */
+      grounding: AnswerGrounding;
+      /**
+       * 이 턴에 실제로 읽은 노드들. `uncited` 갈래에서 화면이 「참고한 자료」
+       * 칩으로 **기계적으로 보정**하는 재료다 — 모델이 표기를 지켰는지에
+       * 기대지 않는다.
+       */
+      sources?: string[];
       /**
        * 같은 응답의 마지막 줄에서 떼어낸 **다음 한 걸음**. 추가 호출로 얻은
        * 것이 아니라 이 턴이 이미 말한 것이다. 칩 하나가 되고, 칩은 프리필이지

--- a/src/widgets/vault-agent-panel/model/use-vault-agent.ts
+++ b/src/widgets/vault-agent-panel/model/use-vault-agent.ts
@@ -45,6 +45,8 @@ export interface AgentSessionSummary {
 
 export interface VaultAgentNotices {
   roundCap: string;
+  /** 도구를 한 번도 안 부르고 멈춘 턴 — 상한 도달과 대칭인 한 줄. */
+  noToolCall: (args: { round: number; cap: number }) => string;
   aborted: string;
   networkFailed: string;
   rateLimited: string;

--- a/src/widgets/vault-agent-panel/ui/AgentTranscript.test.tsx
+++ b/src/widgets/vault-agent-panel/ui/AgentTranscript.test.tsx
@@ -19,7 +19,7 @@ const labels: AgentTranscriptLabels = {
   footerDetail: ({ chars }) => `이 턴에 오간 글 ${chars}자`,
   nextStepTitle: '다음 한 걸음',
   retryTitle: '다시 해볼까요',
-  regroundTitle: '읽고 다시 답하게 하려면',
+  regroundTitle: ({ round, cap }) => `${round}/${cap}번째에서 멈췄어요 — 읽고 다시 답하게 하기`,
 };
 
 function turn(overrides: Partial<AgentTurn> = {}): AgentTurn {
@@ -161,11 +161,62 @@ describe('AgentTranscript', () => {
     expect(screen.queryByTestId('agent-retry')).not.toBeInTheDocument();
   });
 
+  /**
+   * 2026-08-02 합집합 정정 — 처음 구현은 강등 문장 + `no-tool-call` 알림 줄 +
+   * 칩 제목으로 **한 턴에 경고를 셋** 세웠다(상호작용석의 칩 처방과 작업대석의
+   * 알림 처방을 둘 다 실은 결과). 셋이 되는 순간 그 경고들은 벽지가 된다 —
+   * 이 파일이 이미 2026-07-27 에 배운 것과 같은 실패다. 알림은 칩 제목이
+   * 흡수하고, **타입 코드는 데이터에 그대로 남는다.**
+   */
+  const noToolCallTurn = () =>
+    turn({
+      roundsUsed: 1,
+      events: [
+        ...turn().events,
+        {
+          kind: 'assistant',
+          paragraphs: [{ text: '아마 그럴 거예요.', citations: [] }],
+          grounding: 'unread',
+        },
+        { kind: 'notice', code: 'no-tool-call', text: '1/6번째에서 도구를 한 번도 안 부르고 멈췄어요.' },
+      ],
+    });
+
   it('아무것도 안 읽은 턴에는 되돌아갈 길이 붙는다 — 새 배너가 아니라 같은 칩 슬롯', () => {
-    const { onPrefill } = renderTranscript(
+    const { onPrefill } = renderTranscript(noToolCallTurn());
+    expect(screen.getByTestId('agent-retry-title')).toHaveTextContent(
+      '1/6번째에서 멈췄어요 — 읽고 다시 답하게 하기',
+    );
+    fireEvent.click(screen.getByTestId('agent-retry-chip'));
+    expect(onPrefill).toHaveBeenCalledWith('이 개념에 빠진 연결 이어줘');
+  });
+
+  it('경고 줄은 한 턴에 둘까지다 — 알림은 칩 제목이 흡수한다', () => {
+    const fixture = noToolCallTurn();
+    // 데이터에는 남는다: 흡수는 렌더의 일이지 사실을 지우는 것이 아니다.
+    expect(
+      fixture.events.filter((event) => event.kind === 'notice' && event.code === 'no-tool-call'),
+    ).toHaveLength(1);
+
+    renderTranscript(fixture);
+    const warningLines = [
+      ...screen.queryAllByTestId('agent-answer-unsupported'),
+      ...screen.queryAllByTestId('agent-notice'),
+      ...screen.queryAllByTestId('agent-retry-title'),
+    ];
+    expect(warningLines.map((node) => node.dataset.testid)).toEqual([
+      'agent-answer-unsupported',
+      'agent-retry-title',
+    ]);
+  });
+
+  it('흡수할 칩이 안 서면 알림은 그대로 남는다 — 사실이 사라지지 않는다', () => {
+    // 원 질문이 없는 턴(칩이 앉힐 문장이 없다). 흡수는 흡수하는 쪽이 실제로
+    // 있을 때만 성립한다.
+    renderTranscript(
       turn({
+        roundsUsed: 1,
         events: [
-          ...turn().events,
           {
             kind: 'assistant',
             paragraphs: [{ text: '아마 그럴 거예요.', citations: [] }],
@@ -175,9 +226,11 @@ describe('AgentTranscript', () => {
         ],
       }),
     );
-    expect(screen.getByTestId('agent-retry')).toHaveTextContent('읽고 다시 답하게 하려면');
-    fireEvent.click(screen.getByTestId('agent-retry-chip'));
-    expect(onPrefill).toHaveBeenCalledWith('이 개념에 빠진 연결 이어줘');
+    expect(screen.queryByTestId('agent-retry')).not.toBeInTheDocument();
+    expect(screen.getByTestId('agent-notice')).toHaveAttribute(
+      'data-notice-code',
+      'no-tool-call',
+    );
   });
 
   it('강등 판정은 턴의 결론에만 붙는다 — 중간 서술은 주장이 아니다', () => {

--- a/src/widgets/vault-agent-panel/ui/AgentTranscript.test.tsx
+++ b/src/widgets/vault-agent-panel/ui/AgentTranscript.test.tsx
@@ -1,4 +1,4 @@
-// 대화 본문의 세 계약: 진행 표시는 실제 사건만 · 인용 0 은 강등 · 칩은 지도로.
+// 대화 본문의 세 계약: 진행 표시는 실제 사건만 · 근거 판정은 두 갈래 · 칩은 지도로.
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -10,13 +10,16 @@ const labels: AgentTranscriptLabels = {
   you: '나:',
   lookingAt: (title) => `화면: ${title} 을(를) 보는 중`,
   wholeMap: '화면: 지도 전체를 보는 중',
-  unsupported: '읽은 근거 없이 답했어요.',
+  unsupported: '이 턴에는 볼트를 읽지 않고 답했어요.',
+  uncited: '이 턴에 읽은 자료:',
   charsLabel: (chars) => `${chars}자`,
   thinking: '생각 중',
   thinkingSeconds: (seconds) => `생각 중 · ${seconds}초`,
-  footer: ({ provider, chars, rounds }) => `${provider} · ${chars}자 · ${rounds}건`,
+  footer: ({ provider, rounds }) => `${provider} · ${rounds}건`,
+  footerDetail: ({ chars }) => `이 턴에 오간 글 ${chars}자`,
   nextStepTitle: '다음 한 걸음',
   retryTitle: '다시 해볼까요',
+  regroundTitle: '읽고 다시 답하게 하려면',
 };
 
 function turn(overrides: Partial<AgentTurn> = {}): AgentTurn {
@@ -108,12 +111,16 @@ describe('AgentTranscript', () => {
     expect(screen.getByTestId('agent-pending')).toHaveTextContent('생각 중 · 7초');
   });
 
-  it('인용 0 인 답은 강등해서 그린다', () => {
+  it('아무것도 안 읽고 나온 답은 강등해서 그린다', () => {
     renderTranscript(
       turn({
         events: [
           ...turn().events,
-          { kind: 'assistant', paragraphs: [{ text: '제 생각에는요', citations: [] }], demoted: true },
+          {
+            kind: 'assistant',
+            paragraphs: [{ text: '제 생각에는요', citations: [] }],
+            grounding: 'unread',
+          },
         ],
       }),
     );
@@ -121,7 +128,59 @@ describe('AgentTranscript', () => {
     expect(screen.getByTestId('agent-answer-unsupported')).toBeInTheDocument();
   });
 
-  it('강등 경고는 턴의 결론에만 붙는다 — 중간 서술은 주장이 아니다', () => {
+  /**
+   * 2026-08-02 회귀 차단 — 실측 턴에서 도구를 4번 부르고 1,336자를 읽어
+   * 화면에 「읽음: capabilities/checkout 635자」까지 찍어 놓고, 네 줄 아래에서
+   * 「읽은 근거 없이 답했어요」가 떴다. 화면이 자기 화면을 부정한 것이다.
+   */
+  it('읽었는데 표기만 없는 답은 강등하지 않고 읽은 목록으로 보정한다', () => {
+    const { onFocusNode } = renderTranscript(
+      turn({
+        events: [
+          ...turn().events,
+          {
+            kind: 'assistant',
+            paragraphs: [{ text: 'capabilities/checkout 은 결제의 시작점이에요.', citations: [] }],
+            grounding: 'uncited',
+            sources: ['capabilities/checkout', 'capabilities/refund'],
+          },
+        ],
+      }),
+    );
+    expect(screen.getByTestId('agent-answer')).toHaveAttribute('data-demoted', 'false');
+    expect(screen.queryByTestId('agent-answer-unsupported')).not.toBeInTheDocument();
+    const chips = screen.getAllByTestId('agent-citation-chip');
+    expect(chips.map((chip) => chip.dataset.citationSlug)).toEqual([
+      'capabilities/checkout',
+      'capabilities/refund',
+    ]);
+    // 보정 칩도 인용 칩과 **같은 경로**를 탄다 — 같은 동작이 다르게 보이면 결함.
+    fireEvent.click(chips[0]);
+    expect(onFocusNode).toHaveBeenCalledWith('capabilities/checkout');
+    // 컨트롤은 붙이지 않는다: 이건 고칠 문제가 아니라 정확한 자기 서술이다.
+    expect(screen.queryByTestId('agent-retry')).not.toBeInTheDocument();
+  });
+
+  it('아무것도 안 읽은 턴에는 되돌아갈 길이 붙는다 — 새 배너가 아니라 같은 칩 슬롯', () => {
+    const { onPrefill } = renderTranscript(
+      turn({
+        events: [
+          ...turn().events,
+          {
+            kind: 'assistant',
+            paragraphs: [{ text: '아마 그럴 거예요.', citations: [] }],
+            grounding: 'unread',
+          },
+          { kind: 'notice', code: 'no-tool-call', text: '1/6번째에서 도구를 한 번도 안 부르고 멈췄어요.' },
+        ],
+      }),
+    );
+    expect(screen.getByTestId('agent-retry')).toHaveTextContent('읽고 다시 답하게 하려면');
+    fireEvent.click(screen.getByTestId('agent-retry-chip'));
+    expect(onPrefill).toHaveBeenCalledWith('이 개념에 빠진 연결 이어줘');
+  });
+
+  it('강등 판정은 턴의 결론에만 붙는다 — 중간 서술은 주장이 아니다', () => {
     // 구 렌더는 도구를 부르기 전 "먼저 읽어볼게요" 같은 서술에도 같은 경고를
     // 붙여 한 턴에 3회 반복됐다(2026-07-27 실측). 반복되는 최고 경고는 벽지가
     // 된다 — 경고가 값을 하려면 그 턴의 **결론**에만 서야 한다.
@@ -132,7 +191,7 @@ describe('AgentTranscript', () => {
           {
             kind: 'assistant',
             paragraphs: [{ text: '먼저 이 개념의 문서를 읽어볼게요.', citations: [] }],
-            demoted: true,
+            grounding: 'unread',
           },
           {
             kind: 'toolLine',
@@ -149,7 +208,7 @@ describe('AgentTranscript', () => {
           {
             kind: 'assistant',
             paragraphs: [{ text: '제 생각에는요', citations: [] }],
-            demoted: true,
+            grounding: 'unread',
           },
         ],
       }),
@@ -195,7 +254,7 @@ describe('AgentTranscript', () => {
           ...turn().events,
           {
             kind: 'assistant',
-            demoted: false,
+            grounding: 'grounded',
             paragraphs: [
               {
                 text: '[[capabilities/payment]] 에 연결이 빠졌어요.',
@@ -218,7 +277,7 @@ describe('AgentTranscript', () => {
           ...turn().events,
           {
             kind: 'assistant',
-            demoted: true,
+            grounding: 'unread',
             paragraphs: [{ text: '[[capabilities/ghost]] 를 보세요.', citations: [] }],
           },
         ],
@@ -242,7 +301,7 @@ describe('AgentTranscript', () => {
           {
             kind: 'assistant',
             paragraphs: [{ text: '정의를 이렇게 제안해요.', citations: [] }],
-            demoted: true,
+            grounding: 'unread',
             nextStep: '「환불」과 「정산」 사이 연결을 살펴줘',
           },
         ],
@@ -257,7 +316,7 @@ describe('AgentTranscript', () => {
     renderTranscript(
       turn({
         events: [
-          { kind: 'assistant', paragraphs: [{ text: '답.', citations: [] }], demoted: true },
+          { kind: 'assistant', paragraphs: [{ text: '답.', citations: [] }], grounding: 'unread' },
         ],
       }),
     );

--- a/src/widgets/vault-agent-panel/ui/AgentTranscript.tsx
+++ b/src/widgets/vault-agent-panel/ui/AgentTranscript.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment } from 'react';
 
+import { AGENT_ROUND_CAP } from '@/features/vault-agent';
 import type { AgentEvent, AgentTurn, CitedParagraph } from '@/features/vault-agent';
 
 import { AgentToolLine } from './AgentToolLine';
@@ -24,8 +25,14 @@ export interface AgentTranscriptLabels {
   nextStepTitle: string;
   /** 실패한 턴의 되돌아갈 길 — 같은 말을 입력칸에 다시 앉힌다(전송 아님). */
   retryTitle: string;
-  /** `unread` 갈래의 되돌아갈 길 — 같은 슬롯, 다른 문구. */
-  regroundTitle: string;
+  /**
+   * `unread` 갈래의 되돌아갈 길 — 같은 슬롯, 다른 문구.
+   *
+   * **멈춘 이유(라운드)를 이 한 줄이 함께 나른다.** 「도구를 한 번도 안
+   * 부르고 멈췄어요」를 별도 알림 줄로 세우면 한 턴에 경고가 셋이 되고,
+   * 셋이 되는 순간 그 경고들은 벽지가 된다.
+   */
+  regroundTitle: (args: { round: number; cap: number }) => string;
 }
 
 /**
@@ -36,6 +43,14 @@ export interface AgentTranscriptLabels {
  * "호출 한도예요" 가 화면에서 가장 조용한 문장이었다. 멎은 이유는 그 턴에서
  * 가장 중요한 사실이다(Tufte — 잉크는 데이터에).
  */
+/**
+ * 되돌아갈 칩이 **제목으로 흡수하는** 알림 코드. 데이터에는 남고 화면에서만
+ * 접힌다 — 같은 사실을 두 줄로 말하지 않기 위한 것이지, 사실을 지우는 것이
+ * 아니다(타입 코드는 인계·기록의 근거로 계속 읽힌다).
+ */
+const ABSORBED_BY_RECOVERY: ReadonlySet<string> = new Set(['no-tool-call']);
+const EMPTY_CODES: ReadonlySet<string> = new Set();
+
 const BLOCKING_NOTICES: ReadonlySet<string> = new Set([
   'network-failed',
   'rate-limited',
@@ -97,7 +112,23 @@ export function AgentTranscript({
           conclusion?.kind === 'assistant' && conclusion.grounding === 'unread';
         // 같은 자리, 같은 문법. 이유가 둘이라 문구만 갈린다.
         const recoveryTitle =
-          turn.status === 'failed' ? labels.retryTitle : unread ? labels.regroundTitle : null;
+          turn.status === 'failed'
+            ? labels.retryTitle
+            : unread
+              ? labels.regroundTitle({ round: turn.roundsUsed, cap: AGENT_ROUND_CAP })
+              : null;
+        const showsRecovery = Boolean(recoveryTitle && asked);
+        /**
+         * **알림 줄을 칩이 흡수한다.** `no-tool-call` 은 데이터 층에 그대로
+         * 남아 있고(다음 사람이 프로그램으로 읽을 수 있어야 한다), 화면에서만
+         * 되돌아갈 칩의 제목으로 접힌다 — 같은 사실을 두 줄로 말하지 않는다.
+         *
+         * 칩이 안 서는 경우(원 질문을 잃은 턴)에는 **알림이 그대로 남는다**.
+         * 흡수는 흡수하는 쪽이 실제로 있을 때만 성립한다.
+         */
+        const absorbedCodes: ReadonlySet<string> = showsRecovery
+          ? ABSORBED_BY_RECOVERY
+          : EMPTY_CODES;
         return (
         <section key={turn.id} data-testid="agent-turn" data-turn-status={turn.status}>
           {turn.events.map((event, index) => (
@@ -109,6 +140,7 @@ export function AgentTranscript({
                 onPrefill,
                 renderProposal,
                 index === lastAssistant,
+                absorbedCodes,
               )}
             </Fragment>
           ))}
@@ -137,9 +169,12 @@ export function AgentTranscript({
               같은 슬롯을 **볼트를 아예 안 본 턴**도 쓴다. 새 배너를 세우지
               않는 이유: 이미 있는 칩 하나를 채우는 것으로 끝나고, 사용자가
               배울 상호작용도 그대로 하나다. */}
-          {recoveryTitle && asked ? (
+          {showsRecovery && asked ? (
             <div data-testid="agent-retry" className="mt-2 flex flex-col gap-1.5">
-              <p className="text-label tracking-label text-[color:var(--color-text-quaternary)]">
+              <p
+                data-testid="agent-retry-title"
+                className="text-label tracking-label text-[color:var(--color-text-quaternary)]"
+              >
                 {recoveryTitle}
               </p>
               <button
@@ -187,6 +222,8 @@ function renderEvent(
   renderProposal: (event: Extract<AgentEvent, { kind: 'proposal' }>) => React.ReactNode,
   /** 이 턴의 마지막 답인가 — 강등 경고는 결론에만 붙는다. */
   isConclusion: boolean,
+  /** 되돌아갈 칩이 제목으로 흡수한 알림 코드 — 화면에서만 접힌다. */
+  absorbedCodes: ReadonlySet<string>,
 ) {
   switch (event.kind) {
     case 'user':
@@ -297,6 +334,8 @@ function renderEvent(
       return renderProposal(event);
 
     case 'notice': {
+      // 되돌아갈 칩이 제목으로 이미 말한 사실은 줄을 하나 더 쓰지 않는다.
+      if (absorbedCodes.has(event.code)) return null;
       // 멎은 이유는 그 턴에서 가장 중요한 사실이라 본문 무게로 그린다.
       // 진행 보고(중단·상한)는 종전대로 조용하다.
       const blocking = BLOCKING_NOTICES.has(event.code);

--- a/src/widgets/vault-agent-panel/ui/AgentTranscript.tsx
+++ b/src/widgets/vault-agent-panel/ui/AgentTranscript.tsx
@@ -10,14 +10,22 @@ export interface AgentTranscriptLabels {
   you: string;
   lookingAt: (title: string) => string;
   wholeMap: string;
+  /** `unread` 갈래 — 이 턴에 읽은 것이 하나도 없다. */
   unsupported: string;
+  /** `uncited` 갈래 — 읽었는데 인용 표기만 없다. 강등이 아니라 보정이다. */
+  uncited: string;
   charsLabel: (chars: number) => string;
   thinking: string;
   thinkingSeconds: (seconds: number) => string;
-  footer: (args: { provider: string; chars: number; rounds: number }) => string;
+  /** 1행 라벨 — 사람 언어. 원값(글자수)은 `footerDetail` 로 내려간다. */
+  footer: (args: { provider: string; rounds: number }) => string;
+  /** hover 로만 오는 원값. 데이터를 지우는 게 아니라 렌더만 내린다. */
+  footerDetail: (args: { chars: number }) => string;
   nextStepTitle: string;
   /** 실패한 턴의 되돌아갈 길 — 같은 말을 입력칸에 다시 앉힌다(전송 아님). */
   retryTitle: string;
+  /** `unread` 갈래의 되돌아갈 길 — 같은 슬롯, 다른 문구. */
+  regroundTitle: string;
 }
 
 /**
@@ -79,6 +87,17 @@ export function AgentTranscript({
         /** 실패한 턴에서 다시 시도할 원문 — 이 턴을 연 사용자 본인의 말. */
         const askedEvent = turn.events.find((event) => event.kind === 'user');
         const asked = askedEvent?.kind === 'user' ? askedEvent.text : null;
+        /**
+         * 결론이 **아무것도 안 읽고 나온 답**인가. 그때만 되돌아갈 길을 준다 —
+         * 「읽었는데 표기를 안 했다」 는 고칠 문제가 아니라 정확한 자기
+         * 서술이라, 거기에 컨트롤을 붙이면 없는 문제를 있는 것처럼 만든다.
+         */
+        const conclusion = lastAssistant >= 0 ? turn.events[lastAssistant] : null;
+        const unread =
+          conclusion?.kind === 'assistant' && conclusion.grounding === 'unread';
+        // 같은 자리, 같은 문법. 이유가 둘이라 문구만 갈린다.
+        const recoveryTitle =
+          turn.status === 'failed' ? labels.retryTitle : unread ? labels.regroundTitle : null;
         return (
         <section key={turn.id} data-testid="agent-turn" data-turn-status={turn.status}>
           {turn.events.map((event, index) => (
@@ -113,11 +132,15 @@ export function AgentTranscript({
           {/* 멎은 턴에는 **되돌아갈 길**을 준다. 이유만 말하고 길을 안 주면
               그 자리가 막다른 골목이 된다. 「다음 한 걸음」과 같은 문법이라
               새 상호작용을 배우지 않아도 된다 — 누르면 같은 말이 입력칸에
-              앉을 뿐, 전송은 언제나 [보내기]다. */}
-          {turn.status === 'failed' && asked ? (
+              앉을 뿐, 전송은 언제나 [보내기]다.
+
+              같은 슬롯을 **볼트를 아예 안 본 턴**도 쓴다. 새 배너를 세우지
+              않는 이유: 이미 있는 칩 하나를 채우는 것으로 끝나고, 사용자가
+              배울 상호작용도 그대로 하나다. */}
+          {recoveryTitle && asked ? (
             <div data-testid="agent-retry" className="mt-2 flex flex-col gap-1.5">
               <p className="text-label tracking-label text-[color:var(--color-text-quaternary)]">
-                {labels.retryTitle}
+                {recoveryTitle}
               </p>
               <button
                 type="button"
@@ -130,17 +153,23 @@ export function AgentTranscript({
             </div>
           ) : null}
 
-          {/* 푸터는 상시 1행 예약 — 답이 와도 위 내용이 밀리지 않는다. */}
+          {/* 푸터는 상시 1행 예약 — 답이 와도 위 내용이 밀리지 않는다.
+
+              **글자수는 여기서 hover 로 내려갔다** (2026-08-02). 한 라운드의
+              고정비가 18,934자(시스템 안내 8,500 + 도구 스키마 10,122)라
+              「이 턴 40,036자」는 사용자 데이터의 크기가 아니다 — 같은 화면의
+              읽기 줄 합계는 1,336자였고, 총량은 그것의 30배이며 대부분 도구
+              스키마다. 상시 노출되면 화면에서 가장 큰 숫자가 가장 뜻 없는
+              숫자가 된다. 데이터(`sentChars`)는 그대로 있고 렌더만 내렸다. */}
           <p
             data-testid="agent-turn-footer"
+            title={
+              turn.auditCount > 0 ? labels.footerDetail({ chars: turn.sentChars }) : undefined
+            }
             className="mt-2 h-5 truncate text-label tracking-label text-[color:var(--color-text-quaternary)]"
           >
             {turn.auditCount > 0
-              ? labels.footer({
-                  provider: providerLabel,
-                  chars: turn.sentChars,
-                  rounds: turn.auditCount,
-                })
+              ? labels.footer({ provider: providerLabel, rounds: turn.auditCount })
               : ''}
           </p>
         </section>
@@ -192,22 +221,29 @@ function renderEvent(
       );
 
     case 'assistant': {
-      // 강등은 **결론에만**. 중간 서술은 볼트에 대한 주장이 아니다.
-      const demoted = event.demoted && isConclusion;
+      // 판정은 **결론에만**. 중간 서술은 볼트에 대한 주장이 아니다.
+      const grounding = isConclusion ? event.grounding : 'grounded';
+      /** 아무것도 안 읽고 나온 답 — 근거 있는 문장과 같은 무게로 그릴 수 없다. */
+      const unread = grounding === 'unread';
+      /**
+       * 읽었는데 표기만 없는 답. **강등하지 않는다** — 근거는 실제로 있고,
+       * 화면이 그 목록을 칩으로 보정한다. 여기에 파선 테두리를 두면 화면이
+       * 자기가 방금 그린 「읽음」 줄을 부정하게 된다.
+       */
+      const sources = grounding === 'uncited' ? (event.sources ?? []) : [];
       return (
         <div
           data-testid="agent-answer"
-          data-demoted={demoted ? 'true' : 'false'}
+          data-grounding={grounding}
+          data-demoted={unread ? 'true' : 'false'}
           className={[
             'mb-2 flex flex-col gap-2',
-            // 인용 없는 답은 강등해서 그린다 — 근거 있는 문장과 같은 무게로
-            // 그리면 화면이 거짓말을 한다.
-            demoted
+            unread
               ? 'border-l border-dashed border-[color:var(--color-border-strong)] pl-3'
               : '',
           ].join(' ')}
         >
-          {demoted ? (
+          {unread ? (
             <p
               data-testid="agent-answer-unsupported"
               className="text-label tracking-label text-[color:var(--color-text-quaternary)]"
@@ -218,6 +254,20 @@ function renderEvent(
           {event.paragraphs.map((paragraph, index) => (
             <CitedText key={index} paragraph={paragraph} onFocusNode={onFocusNode} />
           ))}
+          {/* 표기가 없어도 근거는 있었다 — 읽은 목록을 그대로 칩으로 놓는다.
+              인용 칩과 **같은 컴포넌트**라 누르면 같은 곳으로 간다(지도 ego
+              포커스). 새 상호작용 0. */}
+          {sources.length > 0 ? (
+            <p
+              data-testid="agent-answer-sources"
+              className="flex flex-wrap items-center gap-1 text-label tracking-label text-[color:var(--color-text-quaternary)]"
+            >
+              <span className="mr-0.5">{labels.uncited}</span>
+              {sources.map((slug) => (
+                <ConceptChip key={slug} slug={slug} onFocusNode={onFocusNode} />
+              ))}
+            </p>
+          ) : null}
           {/* 다음 한 걸음 — 반영을 먼저 보이고, 그 다음에 권한다. 순서가 곧
               서사이므로 이 줄은 답 **뒤에** 오고, 등장은 짧은 페이드 하나다
               (숫자 굴림·강조 펄스 같은 장식은 없다). */}
@@ -273,6 +323,39 @@ function renderEvent(
 
 const CITATION_PATTERN = /\[\[([^[\]]+)\]\]/g;
 
+/**
+ * 개념 하나로 가는 칩. 본문 안의 `[[slug]]` 인용과, 표기가 없을 때 화면이
+ * 보정으로 놓는 「참고한 자료」가 **같은 컨트롤**을 쓴다 — 같은 동작이 다르게
+ * 보이면 그것이 결함이다.
+ */
+function ConceptChip({
+  slug,
+  label,
+  onFocusNode,
+}: {
+  slug: string;
+  label?: string;
+  onFocusNode: (slug: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid="agent-citation-chip"
+      data-citation-slug={slug}
+      onClick={() => onFocusNode(slug)}
+      className="mx-0.5 inline-flex max-w-full items-center rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-px align-baseline text-label tracking-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-accent)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)]"
+    >
+      <span className="truncate">{label ?? tailOfSlug(slug)}</span>
+    </button>
+  );
+}
+
+/** 칩에는 이름만 앉힌다 — 경로 전체는 한 줄을 다 먹고 정보를 더 주지 않는다. */
+function tailOfSlug(slug: string): string {
+  const index = slug.lastIndexOf('/');
+  return index >= 0 ? slug.slice(index + 1) : slug;
+}
+
 /** `[[slug]]` 을 칩으로 — 누르면 지도가 그 개념으로 이동한다. */
 function CitedText({
   paragraph,
@@ -292,16 +375,7 @@ function CitedText({
       paragraph.citations.find((slug) => slug === raw || slug.endsWith(`/${raw}`)) ?? null;
     if (resolved) {
       parts.push(
-        <button
-          key={`chip-${key++}`}
-          type="button"
-          data-testid="agent-citation-chip"
-          data-citation-slug={resolved}
-          onClick={() => onFocusNode(resolved)}
-          className="mx-0.5 inline-flex max-w-full items-center rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-1.5 py-px align-baseline text-label tracking-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-accent)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)]"
-        >
-          <span className="truncate">{raw}</span>
-        </button>,
+        <ConceptChip key={`chip-${key++}`} slug={resolved} label={raw} onFocusNode={onFocusNode} />,
       );
     } else {
       // 읽은 적 없는 이름은 칩이 아니다 — 누르면 빈 곳으로 데려간다.

--- a/src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx
+++ b/src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 import { X } from 'lucide-react';
 
 import type { VaultManifest } from '@/entities/docs-vault';
 import type { KnowledgeProjectInsight } from '@/entities/knowledge-graph';
-import { buildFirstWords, type ScreenContextSnapshot } from '@/features/vault-agent';
+import {
+  buildFirstWords,
+  COMPOSER_MIN_ROWS,
+  composerGrowth,
+  composerTopIsHidden,
+  snapScrollTop,
+  type ScreenContextSnapshot,
+} from '@/features/vault-agent';
 import { useVaultConceptFacts } from '@/features/vault-ontology';
 import {
   hostOfBaseUrl,
@@ -102,6 +109,15 @@ export function VaultAgentPanel({
    */
   const [meta, setMeta] = useState<'prompt' | 'handoff' | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  /**
+   * 자람을 재는 **오프스크린 미러**. 보이는 입력칸의 높이를 `''` 로 되돌려
+   * `scrollHeight` 를 읽는 흔한 패턴은 매 프레임 상자를 0 으로 접었다 펴므로
+   * 자람이 전이가 아니라 계단이 된다. 미러는 같은 타이포·같은 폭이라 같은
+   * 값을 주고, 보이는 상자는 한 번도 되돌려지지 않는다.
+   */
+  const mirrorRef = useRef<HTMLTextAreaElement>(null);
+  /** 상한(6줄)에 닿아 **실제로 위가 가려졌는가** — 그때만 상단 페이드. */
+  const [composerHidesTop, setComposerHidesTop] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const bridgeAvailable = isLlmChatBridgeAvailable();
@@ -208,6 +224,7 @@ export function VaultAgentPanel({
     snapshotLabel: t('snapshotLabel'),
     notices: {
       roundCap: t('notice.roundCap'),
+      noToolCall: ({ round, cap }) => t('notice.noToolCall', { round, cap }),
       aborted: t('notice.aborted'),
       networkFailed: t('notice.networkFailed'),
       rateLimited: t('notice.rateLimited'),
@@ -266,17 +283,47 @@ export function VaultAgentPanel({
   }, [open, vaultPath, appliedTally]);
 
   /**
-   * 칩 → 프리필. **누른 그 프레임**에 문장이 앉고 전체 선택 + 포커스 —
-   * 한 타로 덮어쓸 수 있다. 전송은 언제나 [보내기]다.
+   * 프리필된 문장을 **처음부터 읽히게** 놓는다 — 캐럿은 문장 끝(이어서
+   * 쓸 자리), 시야는 첫 줄.
+   *
+   * 구 구현은 `input.select()` 였다. 전체 선택은 "다음 타건이 이 문장을
+   * 지운다" 는 뜻인데, 사용자는 방금 이 문장을 **고르려고** 눌렀다 — 의도와
+   * 반대다. 게다가 select 는 선택 끝(마지막 줄)으로 스크롤해서, 2줄 고정
+   * 상자에 3줄이 들어온 순간 한 프레임에 `scrollTop` 을 9px 로 밀어 넣었다.
+   * 줄 높이가 20px 이라 9는 배수가 아니고, 그래서 윗변에 글리프가 반으로
+   * 잘린 줄이 걸렸다(실측: 420프레임 중 f231, 16.7ms).
+   *
+   * `scrollTop` 은 언제나 줄 격자에 붙인다. 이건 모션이 아니라 **정렬**이라
+   * reduced-motion 에서도 그대로 산다.
    */
-  const prefill = useCallback((text: string) => {
-    setDraft(text);
-    const input = inputRef.current;
-    if (!input) return;
+  const seatDraft = useCallback((input: HTMLTextAreaElement) => {
     input.focus();
+    const end = input.value.length;
     // jsdom·구형 WebView 에 없을 수 있는 API 는 있을 때만 부른다.
-    if (typeof input.select === 'function') input.select();
+    if (typeof input.setSelectionRange === 'function') input.setSelectionRange(end, end);
+    const lineHeight = Number.parseFloat(window.getComputedStyle(input).lineHeight);
+    input.scrollTop = snapScrollTop(0, lineHeight);
   }, []);
+
+  /**
+   * 칩 → 프리필. **누른 그 프레임**에 문장이 앉는다. 전송은 언제나 [보내기]다.
+   *
+   * 자리 앉히기는 `requestAnimationFrame` 뒤로 미룬다 — `setDraft` 직후에는
+   * React 가 아직 값을 써 넣지 않아 캐럿이 옛 값(빈 문자열) 기준으로 잡힌다.
+   */
+  const prefill = useCallback(
+    (text: string) => {
+      setDraft(text);
+      const input = inputRef.current;
+      if (!input) return;
+      input.focus();
+      window.requestAnimationFrame(() => {
+        const current = inputRef.current;
+        if (current) seatDraft(current);
+      });
+    },
+    [seatDraft],
+  );
 
   /**
    * 바깥에서 건너온 첫 마디(S7).
@@ -294,14 +341,51 @@ export function VaultAgentPanel({
     setSeenPrefillNonce(prefillNonce);
     setDraft(prefillText);
   }
-  // 포커스·전체 선택은 DOM 조작이라 렌더 뒤에 한다 — 한 타로 덮어쓸 수 있게.
+  // 포커스·캐럿은 DOM 조작이라 렌더 뒤에 한다 — 그때는 값이 이미 들어와 있다.
   useEffect(() => {
     if (seenPrefillNonce === null) return;
     const input = inputRef.current;
     if (!input) return;
-    input.focus();
-    if (typeof input.select === 'function') input.select();
-  }, [seenPrefillNonce]);
+    seatDraft(input);
+  }, [seenPrefillNonce, seatDraft]);
+
+  /**
+   * 컴포저 자람 — 2줄에서 시작해 6줄까지 **내용을 따라** 자란다.
+   *
+   * 구 구현은 `rows={2}` 고정이라 세 줄짜리 문장이 들어와도 상자가 그대로였고
+   * (420프레임 전체에서 높이 58px 고정, 프레임간 픽셀 diff 평균 0.013),
+   * 사용자는 자기가 방금 고른 문장의 3분의 1만 볼 수 있었다.
+   *
+   * 높이는 `transform` 이 아니라 **실제 `height`** 로 간다 — 형제(보내기
+   * 버튼·곁가지 줄)가 같이 자리를 내줘야 "이 칸이 자랐다" 로 읽히고,
+   * transform 은 자리를 안 만든다. 곡선은 표면 이동 램프(`--motion-base`)
+   * 하나이고 스프링은 쓰지 않는다: 재타기팅이 없는데 baseline 을 넘어서면
+   * 읽는 중에 글자가 흔들린다.
+   */
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    const mirror = mirrorRef.current;
+    if (!input || !mirror) return;
+    mirror.value = draft;
+    const style = window.getComputedStyle(input);
+    const lineHeight = Number.parseFloat(style.lineHeight);
+    const growth = composerGrowth({
+      lineHeight,
+      paddingBlock:
+        Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom),
+      borderBlock:
+        Number.parseFloat(style.borderTopWidth) + Number.parseFloat(style.borderBottomWidth),
+      contentHeight: mirror.scrollHeight,
+    });
+    // 잴 수 없는 상태(SSR·jsdom·폰트 로드 전)에서는 손대지 않는다 — 0px 로
+    // 접히는 것보다 `rows` 기본값이 언제나 낫다.
+    if (!growth) return;
+    input.style.height = `${growth.height}px`;
+    input.scrollTop = snapScrollTop(input.scrollTop, lineHeight);
+    setComposerHidesTop(composerTopIsHidden(growth.overflowing, input.scrollTop));
+    // `scopeAccepted`/`provider` 는 입력칸이 **마운트되는** 순간이다 — 그때
+    // 한 번 재야 첫 그림부터 맞는 높이로 선다.
+  }, [draft, open, scopeAccepted, provider]);
 
   // 새 내용은 아래로만 자란다 — 스크롤 앵커 하단 고정.
   useEffect(() => {
@@ -501,15 +585,17 @@ export function VaultAgentPanel({
                 labels={{
                   nextStepTitle: t('nextStep.title'),
                   retryTitle: t('retry.title'),
+                  regroundTitle: t('reground.title'),
                   you: t('you'),
                   lookingAt: (title) => t('screenContext.lookingAt', { title, josa: josa(title, 'object') }),
                   wholeMap: t('screenContext.wholeMap'),
                   unsupported: t('unsupported'),
+                  uncited: t('uncited'),
                   charsLabel: (chars) => t('charsLabel', { chars }),
                   thinking: t('thinking'),
                   thinkingSeconds: (seconds) => t('thinkingSeconds', { seconds }),
-                  footer: ({ provider: name, chars, rounds }) =>
-                    t('footer', { provider: name, chars, rounds }),
+                  footer: ({ provider: name, rounds }) => t('footer', { provider: name, rounds }),
+                  footerDetail: ({ chars }) => t('footerDetail', { chars }),
                 }}
                 renderProposal={() => null}
               />
@@ -599,13 +685,36 @@ export function VaultAgentPanel({
             key={stage}
             className="agent-panel-stage-swap shrink-0 border-t border-[color:var(--color-border-soft)] p-2.5"
           >
+            {/* 버튼은 `items-end` — 텍스트 입력의 주 행동은 아래에 고정한다
+                (Apple HIG: 직접 조작의 목적지는 움직이지 않는다). 칸이 자라면
+                버튼이 그 아래 끝을 따라가므로 세로 정렬도 함께 맞는다. */}
             <div className="flex items-end gap-2">
+              <div className="relative min-w-0 flex-1">
               <textarea
                 ref={inputRef}
                 data-testid="vault-agent-input"
+                data-composer-hides-top={composerHidesTop ? 'true' : 'false'}
                 value={draft}
-                rows={2}
+                rows={COMPOSER_MIN_ROWS}
                 disabled={agent.running}
+                onScroll={(event) => {
+                  const input = event.currentTarget;
+                  setComposerHidesTop(
+                    input.scrollHeight > input.clientHeight && input.scrollTop > 0,
+                  );
+                }}
+                style={{
+                  // 자람은 **표면 이동**이다 — 앱 공통 램프를 그대로 탄다.
+                  // 새 토큰 0 · 새 duration 0.
+                  transitionProperty: 'height',
+                  transitionDuration: 'var(--motion-base)',
+                  transitionTimingFunction: 'var(--motion-ease)',
+                  // 넘침 신호는 상한에 닿아 **위가 실제로 가려졌을 때만**.
+                  // 자라는 동안에는 없는 넘침을 광고하지 않는다.
+                  maskImage: composerHidesTop
+                    ? 'linear-gradient(to bottom, transparent 0, #000 var(--leading-body))'
+                    : undefined,
+                }}
                 // 아직 아무 말도 안 한 사람에게 "이어서 말하기" 는 이어갈 것이
                 // 없는 문장이다. 첫 마디용 자리표시는 잠긴 상태의 띠가 쓰는
                 // 문구와 **같은 키**라, 키가 들어오는 순간 같은 자리에 같은
@@ -620,8 +729,25 @@ export function VaultAgentPanel({
                     submit();
                   }
                 }}
-                className="min-w-0 flex-1 resize-none rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2.5 py-2 text-body leading-body text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] disabled:opacity-60"
+                className={`${COMPOSER_BOX_CLASS} block w-full text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] disabled:opacity-60`}
               />
+              {/* 자람을 재는 미러. **같은 클래스 = 같은 타이포·같은 폭**이라
+                  같은 줄 나눔이 나온다. 화면 밖으로 치우지 않고 같은 자리에
+                  두는 이유: 폭(패딩·보더 포함)이 실제 칸과 같아야 줄 수가 같다.
+
+                  `invisible`(visibility: hidden)이지 `opacity-0` 이 아니다 —
+                  투명한 원소는 여전히 그려지는 원소라 겹침 감사에 잡히고,
+                  캐럿·선택이 칠해질 여지도 남는다. 레이아웃은 그대로 도니
+                  `scrollHeight` 는 똑같이 나온다. */}
+              <textarea
+                ref={mirrorRef}
+                aria-hidden="true"
+                tabIndex={-1}
+                readOnly
+                data-testid="vault-agent-input-mirror"
+                className={`${COMPOSER_BOX_CLASS} pointer-events-none invisible absolute left-0 top-0 h-0 w-full overflow-hidden`}
+              />
+              </div>
               {agent.running ? (
                 <button
                   type="button"
@@ -702,6 +828,14 @@ export function VaultAgentPanel({
     </aside>
   );
 }
+
+/**
+ * 입력칸과 미러가 **함께** 쓰는 상자 규격. 하나의 문자열이라 둘의 타이포가
+ * 갈라질 자리가 없다 — 갈라지면 미러가 다른 줄 수를 재고 상자가 틀린 높이로
+ * 선다(값이 두 곳에 적히면 이미 드리프트가 시작된 것).
+ */
+const COMPOSER_BOX_CLASS =
+  'resize-none rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] px-2.5 py-2 text-body leading-body';
 
 /**
  * 곁가지를 여는 한 줄짜리 컨트롤. 테두리도 배경도 없다 — 이 줄이 입력칸과

--- a/src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx
+++ b/src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx
@@ -585,7 +585,7 @@ export function VaultAgentPanel({
                 labels={{
                   nextStepTitle: t('nextStep.title'),
                   retryTitle: t('retry.title'),
-                  regroundTitle: t('reground.title'),
+                  regroundTitle: ({ round, cap }) => t('reground.title', { round, cap }),
                   you: t('you'),
                   lookingAt: (title) => t('screenContext.lookingAt', { title, josa: josa(title, 'object') }),
                   wholeMap: t('screenContext.wholeMap'),

--- a/tests/contract/reduced-motion-equivalent.contract.test.ts
+++ b/tests/contract/reduced-motion-equivalent.contract.test.ts
@@ -175,6 +175,52 @@ describe('reduced-motion 동등물 계약', () => {
   });
 
   /**
+   * 2026-08-02 컴포저 자람 — **일부러 `EQUIVALENT_CLASSES` 에 넣지 않는다.**
+   *
+   * 동등물이 필요한 것은 불투명도처럼 전정계를 안 건드리면서 **정보를 나르는**
+   * 축이다. 입력칸이 두 줄에서 세 줄로 자라는 것은 그런 축이 아니라 컷아웃
+   * 링과 같은 **진짜 이동**이라, 감속 사용자에게는 `swap` 이 아니라 **즉시
+   * 도착**이 정답이다 — 전역 kill 규칙(`transition-duration: 0.01ms`)이 그
+   * 답을 이미 주고 있으므로 carve-out 을 만들면 오히려 되돌리는 셈이 된다.
+   *
+   * 그래서 이 자리에서 지키는 것은 둘이다: ① 시간이 램프 토큰이라 전역 규칙이
+   * 닿는다 ② 아무도 이 표면에 carve-out 을 슬쩍 넣지 않는다. 등록부 밖에
+   * 있어도 결정이 기록되고 검사되게 하는 형식이다(컷아웃 링은 주석으로만
+   * 남아 있어 다음 사람이 되돌릴 수 있었다).
+   */
+  describe('컴포저 자람 — 감속에서는 즉시 도착', () => {
+    const PANEL = 'src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx';
+
+    it('자람의 시간은 표면 이동 램프 토큰이다 (리터럴 ms 0)', () => {
+      const src = TS(PANEL);
+      expect(src).toContain("transitionProperty: 'height'");
+      expect(src).toContain("transitionDuration: 'var(--motion-base)'");
+      expect(src).toContain("transitionTimingFunction: 'var(--motion-ease)'");
+      expect(
+        /transitionDuration:\s*['"`]\s*\d/.test(src),
+        '컴포저 자람이 리터럴 ms 로 시간을 적었다 — 램프를 탄다',
+      ).toBe(false);
+    });
+
+    it('감속 경로에 carve-out 이 없다 — 있으면 잘려야 할 이동이 되살아난다', () => {
+      const carved = allRules.filter((rule) =>
+        /vault-agent-input|agent-composer/.test(rule.selector),
+      );
+      expect(
+        carved.map((rule) => rule.selector),
+        '컴포저에 reduced-motion 동등물이 생겼다 — 이 축은 잘리는 것이 맞다',
+      ).toEqual([]);
+    });
+
+    it('전역 kill 규칙이 transition 까지 덮는다 (그게 이 결정의 전제다)', () => {
+      const global = allRules.find((r) =>
+        /\*,?\s*\*::before/.test(r.selector.replace(/\s+/g, ' ')),
+      );
+      expect(global!.body).toMatch(/transition-duration:\s*0\.01ms/);
+    });
+  });
+
+  /**
    * D8 (2026-07-28) — 토스트는 벤더(sonner)가 자기 `@media
    * (prefers-reduced-motion)` 에서 `transition: none !important` 로 전부 끈다.
    * 실측 결과 **둘 중 나쁜 쪽만** 남았다: 알림의 도착이라는 정보 모션(불투명도)은


### PR DESCRIPTION
## Summary

에이전트 패널의 한 턴이 **화면에서 자기 화면을 부정하고** 있었다. 스크립트된 로컬 러너로 재현한 여섯 자리를 고친다 (1512×806, 다크, 볼트 4노드).

| | 무엇이 | 전 | 후 |
|---|---|---|---|
| ① | 프리필된 문장의 첫 줄이 윗변에 반으로 잘림 | `scrollTop 20` · 첫 줄 12px 잘림 · 전체 선택 | `scrollTop 0` · 캐럿 문장 끝 · `scrollHeight === clientHeight`(잘림 0) |
| ② | 입력칸이 안 자람 | 58px 고정 (`rows={2}`) | 58 → 78 → 118 → 138(6행 상한) |
| ③ | 읽고도 「읽은 근거 없이 답했어요」 | `demoted: true` (도구 4회·1,336자 읽은 턴) | `grounding: 'uncited'` + 「이 턴에 읽은 자료」 칩 |
| ④ | 도구 0회 턴이 조용히 죽음 | notice 0건 | `no-tool-call`(데이터) + 되돌아갈 칩이 그 사실을 제목으로 흡수 |
| ⑤ | 「이 턴 40036자」 상시 노출 | 1행 라벨 | `title` 로 강등, 라벨은 「기록 2건」 |
| ⑥ | 원시 마크다운이 글자로 | `**증거가 없는 기능(\`capability\`):**` | `증거가 없는 기능(capability):` |

**왜 ③이 두 갈래인가.** 「아예 안 읽었다」와 「읽었는데 표기를 안 했다」는 **다음 행동이 다르다.** 앞은 되돌아갈 길이 필요하고(같은 칩 슬롯 재사용, 새 배너 0), 뒤는 고칠 문제가 아니라 정확한 자기 서술이라 컨트롤을 붙이지 않고 화면이 읽은 목록으로 기계적으로 보정한다.

**한 턴의 경고는 둘까지다** (2026-08-02 합집합 정정, chief 규칙 적용). 첫 구현은 상호작용석의 칩 처방과 작업대석의 알림 처방을 **둘 다** 실어 강등 문장 + 알림 줄 + 칩 제목으로 셋이 됐다. 알림이 말하던 라운드를 칩 제목이 싣고 줄 하나를 접는다 — **타입 코드 `no-tool-call` 은 events 에 그대로 남는다**(흡수는 렌더의 일이지 사실을 지우는 것이 아니다). 흡수하는 칩이 안 서면 알림은 그대로 남는다.

**새 토큰 0 · 새 duration 0 · 새 hue 0.** 자람은 앱 공통 이동 램프(`--motion-base` + `--motion-ease`)를 인라인으로 탄다 (패널 폭 전이가 이미 쓰는 문법). 넘침 페이드는 상한에 닿고 **위가 실제로 가려졌을 때만** — 자라는 동안에는 없는 넘침을 광고하지 않는다.

`app/globals.css` · `docs/DECISIONS.md` 는 손대지 않았다 (PR 2/2 · chief 소유).

## Test plan

`pnpm checks:changed -- <바꾼 15개 경로>` 가 추천한 것 전부:

- `pnpm exec vitest run` × 5 (agent-loop · citation · composer-growth · AgentTranscript · VaultAgentPanel) — 67 passed
- `pnpm test:contracts` — 88 files / 1001 passed
- `pnpm exec tsc --noEmit` — clean
- `pnpm test:i18n:messages` — 16 passed
- `pnpm exec eslint src/features/vault-agent src/widgets/vault-agent-panel` — 0 warnings

**게이트 프로브** (되돌려서 빨개지는지 확인 — 6/6 red):

| 되돌린 결함 | 잡은 게이트 |
|---|---|
| `snapScrollTop` 항등 | `composer-growth.test.ts` ×1 |
| 6행 상한 제거 | `composer-growth.test.ts` ×1 |
| grounding 단일 판정 복귀 | `citation.test.ts` + `AgentTranscript.test.tsx` ×2 |
| 마크다운 스트립 제거 | `citation.test.ts` ×1 |
| `no-tool-call` 알림 제거 | `agent-loop.test.ts` ×1 |
| 자람 duration 리터럴 ms | `reduced-motion-equivalent.contract.test.ts` ×1 |
| 알림 흡수 되돌리기(경고 3줄) | `AgentTranscript.test.tsx` ×1 |
| 흡수를 무조건화(칩 없어도 사실 소실) | `AgentTranscript.test.tsx` ×1 |

**되돌릴 조건 (falsifier)** — 「참고한 자료」 칩에 개수 상한을 두지 않은 결정: *한 턴에 10개 이상 노드를 읽어 칩 줄이 답 본문보다 길어지는 화면이 관측되면 「N개 더」 접기를 넣는다.* 데이터 없이 접기 규칙부터 만드는 건 순서 역전이라 지금은 넣지 않는다.

**감사 재측정** (적용 후): 패널 안 rect 교차 **0건**, 도구 행 높이 24/24/24, 칩 20/20, 푸터 20/20/20.

**reduced-motion**: 컴포저 자람은 **일부러 등록부(`EQUIVALENT_CLASSES`) 밖**이다. 컷아웃 링과 같은 진짜 이동 축이라 감속에서는 swap 이 아니라 즉시 도착이 정답이고, 전역 kill 규칙이 그 답을 이미 준다. 그 결정이 주석으로만 남지 않도록 계약 테스트 3건으로 못 박았다(램프 토큰 사용 · carve-out 0 · 전역 규칙이 transition 을 덮음).

## Before / after

<details><summary>패널 전체 (다크, 1512×806)</summary>

전: 「읽음: capabilities/checkout 635자」 세 줄 바로 아래 「읽은 근거 없이 답했어요」 · 원시 마크다운 · 「이 턴 40036자」 · 도구 0회 턴에 알림 0
후: 「이 턴에 읽은 자료: [checkout] [refund]」 칩 · 평문 · 「기록 2건」 · 「1/6번째에서 도구를 한 번도 안 부르고 멈췄어요」 + 「읽고 다시 답하게 하려면」

</details>

<details><summary>컴포저 기하</summary>

전: 3줄 문장이 2행 상자에서 첫 줄 12px 잘린 채 전체 선택
후: 3행으로 자라 세 줄 모두 온전, 캐럿은 문장 끝

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB

