### PR TITLE
perf: CI 를 실측대로 자른다 — Rust 캐시 + Checks 3잡 병렬

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,68 @@
+name: Setup Playwright
+description: >-
+  Node · pnpm · 브라우저 캐시 · 변경 분류를 한 번에. E2E 잡 다섯이 같은 준비를
+  하므로 여기 한 곳에 둔다 — 복사본이 다섯이면 어긋나는 쪽이 기본값이다(이
+  저장소가 스킬 사본으로 이미 겪었다).
+
+  ⚠️ **체크아웃은 여기 못 넣는다.** 로컬 복합 액션은 워크스페이스에 이미 있어야
+  로드되므로, 체크아웃보다 먼저 부르면 `action.yml` 을 못 찾고 죽는다. 그래서
+  체크아웃만 각 잡의 첫 스텝으로 남고 `fetch-depth: 0` 도 거기 붙는다.
+
+outputs:
+  runtime:
+    description: shipped code(런타임)가 바뀌었나
+    value: ${{ steps.classify.outputs.runtime }}
+  browser:
+    description: 브라우저가 의존하는 경로가 바뀌었나
+    value: ${{ steps.classify.outputs.browser }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+
+    - name: Enable Corepack pnpm
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare pnpm@10.18.0 --activate
+        pnpm --version
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Resolve installed Playwright version
+      id: playwright-version
+      shell: bash
+      run: |
+        version=$(node -e "console.log(require('@playwright/test/package.json').version)")
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    # 캐시 키가 잡마다 같으므로 다섯 잡이 같은 브라우저 캐시를 공유한다.
+    - name: Cache Playwright browsers
+      uses: actions/cache@v6
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install Playwright chromium (+ system deps)
+      shell: bash
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: pnpm exec playwright install --with-deps chromium
+
+    - name: Install Playwright system deps only
+      shell: bash
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm exec playwright install-deps chromium
+
+    # node 빌트인만 쓰는 스크립트라 잡마다 따로 돌려도 0초다. 앞단 잡을 두고
+    # `needs:` 로 묶으면 그 잡의 준비 시간이 전체 앞에 직렬로 붙는다.
+    - name: Classify change
+      id: classify
+      shell: bash
+      run: node scripts/classify-change.mjs --base=origin/${{ github.base_ref }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-# 단위 검증 게이트 — tsc · lint · vitest.
+# 단위 검증 게이트 — tsc · lint · vitest · MCP.
 #
 # 왜 있는가: 2026-07-26 까지 PR 에서 도는 것은 Playwright(15분)와 vault
 # 정합뿐이었다. `pnpm test:run` 3900여 개, `tsc`, `lint` 는 **한 번도 돌지
@@ -6,8 +6,24 @@
 # 들어가 앉아 있다가 사람이 우연히 발견했고, 브랜치가 자기가 지운 모듈을
 # 자기가 import 하는 상태로 CI 를 세 번 깨뜨렸다.
 #
-# 이 잡은 Playwright 보다 **훨씬 빨라서** 오히려 먼저 답을 준다 — 타입/단위
-# 회귀는 여기서 몇 분 안에 걸리고, 느린 e2e 는 그 뒤에 온다.
+# 이 워크플로는 Playwright 보다 **훨씬 빨라서** 오히려 먼저 답을 준다 —
+# 타입/단위 회귀는 여기서 몇 분 안에 걸리고, 느린 e2e 는 그 뒤에 온다.
+#
+# ## 왜 한 잡이 아니라 셋인가 (2026-08-02)
+#
+# 실측: 이 워크플로가 624초였고 그중 **463초(74%)가 단 두 스텝**이었다 —
+# 유닛+계약 291초, MCP 통합 172초. 둘은 서로를 전혀 안 기다리는데 한 잡
+# 안에서 줄줄이 돌아 합이 그대로 대기 시간이 됐다.
+#
+# 셋으로 가르면 임계 경로가 **가장 느린 하나**가 된다. 대가는 잡마다
+# 체크아웃·설치가 반복되는 것(잡당 ≈25초)인데, 그건 각 잡의 경로에 얹힐 뿐
+# 합산되지 않는다.
+#
+# 가른 기준은 「무엇을 검사하나」가 아니라 **「얼마나 걸리나」**다 — 빠른 게이트
+# 아홉은 서로를 기다리게 할 값이 없어 한 잡에 몰아 둔다.
+#
+# `if: always()` 는 잡 **안에서** 유지한다 — 첫 실패가 나머지를 가리면 검수가
+# 왕복이 된다. 잡 **사이**는 원래 독립이라 한 잡이 빨개도 나머지는 끝까지 돈다.
 name: Checks
 
 on:
@@ -27,14 +43,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  checks:
-    name: Types · Lint · Unit
+  # ── 잡 1: 빠른 게이트 아홉 (실측 합 ≈100초) ──────────────────────────
+  gates:
+    name: Types · Lint · Docs
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       # fetch-depth: 0 필수 — `docs-vault:check` 가 문서별 "마지막으로 바뀐 날"
       # 을 git 히스토리에서 읽는다. 얕은 클론은 문서 전부에 같은 날짜를 줘
-      # 검증이 실제와 다른 값을 비교하게 된다.
+      # 검증이 실제와 다른 값을 비교하게 된다. `decisions:check` 도 base ref 를
+      # 필요로 한다.
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -54,8 +72,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 셋을 각각 별 스텝으로 둔다 — 한 스텝에 묶으면 어느 게 깨졌는지
-      # 로그를 뒤져야 한다. `if: always()` 로 첫 실패가 나머지를 가리지 않게.
+      # 각각 별 스텝으로 둔다 — 한 스텝에 묶으면 어느 게 깨졌는지 로그를
+      # 뒤져야 한다. `if: always()` 로 첫 실패가 나머지를 가리지 않게.
       # 카운슬 소집 트리거 중 **기계적으로 확인 가능한 두 줄**만 강제한다:
       # 라우트 신설/제거, MCP·CLI 공개 계약 변경. 나머지 트리거("포지셔닝",
       # "낯선 사람이 처음 읽는 문구")는 의미라서 스크립트가 볼 수 없다.
@@ -65,32 +83,12 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pnpm decisions:check -- --base=origin/${{ github.base_ref }}
 
-      # 변경이 실제로 깨뜨릴 수 있는 것만 돌린다. 실측(2026-07-27): Checks 5~6분
-      # 중 **270초가 단위 스위트**이고, 이 세션의 변경은 거의 전부 에이전트
-      # 브리프와 문서였다. 판단이 안 서면 runtime=true 로 열어둔다 — 빠뜨린
-      # 테스트는 출하되는 버그고, 남는 테스트는 4분이다.
-      - name: Classify change
-        id: classify
-        if: github.event_name == 'pull_request'
-        run: node scripts/classify-change.mjs --base=origin/${{ github.base_ref }}
-
       - name: Typecheck
         run: pnpm exec tsc --noEmit
 
       - name: Lint
         if: always()
         run: pnpm lint
-
-      # 런타임 코드가 안 바뀌었으면 계약 스위트만 돈다(2.4초 vs 270초).
-      # 계약 테스트는 `.claude/**` 배선을 읽으므로 거버넌스 변경에서도 반드시
-      # 돈다 — 건너뛰는 건 런타임 단위 테스트뿐이다.
-      - name: Unit + contract tests
-        if: always() && (github.event_name != 'pull_request' || steps.classify.outputs.runtime == 'true')
-        run: pnpm test:run
-
-      - name: Contract tests only (no runtime change)
-        if: always() && github.event_name == 'pull_request' && steps.classify.outputs.runtime != 'true'
-        run: pnpm exec vitest run tests/contract/
 
       # 아래 둘은 `pnpm test:run` 밖의 node:test 스위트라 여기 걸지 않으면
       # 아무 데서도 안 돈다. 실제로 2026-07-26 까지 둘 다 main 에서 깨진 채
@@ -122,49 +120,6 @@ jobs:
         if: always()
         run: pnpm agents:check
 
-      # MCP 서버의 단위 스위트. **어느 워크플로에도 물려 있지 않았다** —
-      # `package:check` 가 CLI 쪽(`test:cli:lib`/`test:cli:commands`)은 돌리는데
-      # MCP 는 대칭 스텝이 없었다. 그 사이 `verify-script.test.mjs` 1건이 소스
-      # 변경에 뒤처진 채 실패하고 있었고 아무도 못 봤다(2026-07-28 발견).
-      #
-      # 파일 목록이 아니라 **글롭**으로 찾는다. 종전 스크립트는 손으로 적은
-      # 21개 목록이었고 디스크에는 27개가 있었다 — 새 테스트 파일이 조용히
-      # 빠지는 구조였다. 목록이 곧 사정거리인데 목록이 손으로 관리되면
-      # 사정거리도 손으로 줄어든다.
-      #
-      # 통합 테스트(`integration.test.mjs`)만 뺀다. 그 하나가 162초이고
-      # (단위 416건은 합쳐 1.2초) 실서버를 띄운다 — 별도 스텝의 몫이다.
-      # MCP 는 워크스페이스 멤버가 아니라(루트에 `pnpm-workspace.yaml` 이 없다)
-      # 루트 설치가 `mcp/node_modules` 를 안 만든다. 순수 단위 케이스는 그래도
-      # 돌지만, 실제 서버를 띄우는 케이스가 `@modelcontextprotocol/sdk` 를 못
-      # 찾아 죽는다 — 로컬에서는 예전에 설치해 둔 게 있어서 통과했고, CI 에서
-      # 처음 드러났다(스위트를 물린 첫날). 릴리스 워크플로가 이미 쓰는 것과
-      # 같은 한 줄이다.
-      - name: Install MCP dependencies
-        if: always()
-        run: pnpm --dir mcp install --frozen-lockfile
-
-      - name: MCP unit tests
-        if: always()
-        run: pnpm test:mcp:unit
-
-      # **통합 스위트 — 이제 실제로 돈다.** 바로 위 주석이 162초를 이유로 이걸
-      # 빼면서 *"별도 스텝의 몫이다"* 라고 적었는데, 그 스텝은 만들어진 적이
-      # 없다. 결과: 실서버를 띄우는 가장 큰 MCP 스위트가 **어느 워크플로에도
-      # 안 물린 채** #806(경로형 슬러그 거부) 이후로 계속 빨간색이었고 아무도
-      # 못 봤다 — 2026-08-01 rc.5 검수에서 사람이 손으로 돌려서야 드러났다.
-      #
-      # 이 파일이 이미 두 번 적어 둔 것과 같은 병이다: *"목록이 곧 사정거리인데
-      # 목록이 손으로 관리되면 사정거리도 손으로 줄어든다."* 여기서는 목록이
-      # 아니라 **의도**가 손으로 관리됐다 — "나중에 스텝을 만든다"는 의도는
-      # 어디에도 강제되지 않았다.
-      #
-      # 162초는 다른 스텝들과 병렬로 흡수된다. `if: always()` 라 앞 스텝이
-      # 빨개도 이건 돈다 — 한 번에 한 결함만 알려 주면 검수가 왕복이 된다.
-      - name: MCP integration tests
-        if: always()
-        run: node --test mcp/src/integration.test.mjs
-
       # 데스크톱 게이트의 단위 스위트다. 지금까지 **릴리스 워크플로에만** 걸려
       # 있어서, 여기서 잡혔어야 할 결함이 전부 "태그를 찍은 뒤"에 처음 드러났다
       # — `v1.0.0-rc.2` 가 네 번 찍혀 네 번 다 빌드 잡에서 멈춘 이유다. 30초짜리
@@ -177,10 +132,14 @@ jobs:
         if: always()
         run: pnpm test:desktop:check
 
-      # 생성 매니페스트 게이트 둘. 지금까지 어느 PR 검증에도 물려 있지 않았다 —
-      # `docs-vault:check` 는 macOS 릴리스 경로에만, `test:docs-vault` 는 아무
-      # 곳에도 없었다. 그래서 `docs/**` 를 고치고 재생성을 잊은 PR 도, 생성이
-      # 비결정적으로 되돌아간 PR 도 아무도 막지 못했다.
+      # 생성 매니페스트 게이트 둘. 2026-07 까지 어느 PR 검증에도 물려 있지
+      # 않았다 — `docs-vault:check` 는 macOS 릴리스 경로에만, `test:docs-vault`
+      # 는 아무 곳에도 없었다. 그래서 `docs/**` 를 고치고 재생성을 잊은 PR 도,
+      # 생성이 비결정적으로 되돌아간 PR 도 아무도 막지 못했다.
+      #
+      # 2026-08-02 부터 `.githooks/pre-commit`(#834)이 같은 검사를 커밋 자리에서
+      # 먼저 한다. 그래도 여기 남는다 — 훅은 로컬 설정에 의존하고(`pnpm install`
+      # 을 안 한 클론 · `--no-verify` · 포크 기여자), CI 는 그렇지 않다.
       - name: Docs vault freshness
         if: always()
         run: pnpm docs-vault:check
@@ -188,3 +147,109 @@ jobs:
       - name: Docs vault determinism
         if: always()
         run: pnpm test:docs-vault
+
+  # ── 잡 2: 단위 + 계약 스위트 (실측 291초 — 임계 경로) ────────────────
+  unit:
+    name: Unit · Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # `classify-change.mjs` 가 base ref 와 비교하므로 전체 히스토리가 필요하다.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.0 --activate
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 변경이 실제로 깨뜨릴 수 있는 것만 돌린다. 실측(2026-07-27): 이 스위트가
+      # 270초였고 그 세션의 변경은 거의 전부 에이전트 브리프와 문서였다. 판단이
+      # 안 서면 runtime=true 로 열어둔다 — 빠뜨린 테스트는 출하되는 버그고,
+      # 남는 테스트는 4분이다.
+      - name: Classify change
+        id: classify
+        if: github.event_name == 'pull_request'
+        run: node scripts/classify-change.mjs --base=origin/${{ github.base_ref }}
+
+      # 런타임 코드가 안 바뀌었으면 계약 스위트만 돈다(2.4초 vs 270초).
+      # 계약 테스트는 `.claude/**` 배선을 읽으므로 거버넌스 변경에서도 반드시
+      # 돈다 — 건너뛰는 건 런타임 단위 테스트뿐이다.
+      - name: Unit + contract tests
+        if: always() && (github.event_name != 'pull_request' || steps.classify.outputs.runtime == 'true')
+        run: pnpm test:run
+
+      - name: Contract tests only (no runtime change)
+        if: always() && github.event_name == 'pull_request' && steps.classify.outputs.runtime != 'true'
+        run: pnpm exec vitest run tests/contract/
+
+  # ── 잡 3: MCP 서버 (실측 176초) ──────────────────────────────────────
+  mcp:
+    name: MCP
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.0 --activate
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # MCP 는 워크스페이스 멤버가 아니라(루트에 `pnpm-workspace.yaml` 이 없다)
+      # 루트 설치가 `mcp/node_modules` 를 안 만든다. 순수 단위 케이스는 그래도
+      # 돌지만, 실제 서버를 띄우는 케이스가 `@modelcontextprotocol/sdk` 를 못
+      # 찾아 죽는다 — 로컬에서는 예전에 설치해 둔 게 있어서 통과했고, CI 에서
+      # 처음 드러났다(스위트를 물린 첫날). 릴리스 워크플로가 이미 쓰는 것과
+      # 같은 한 줄이다.
+      - name: Install MCP dependencies
+        run: pnpm --dir mcp install --frozen-lockfile
+
+      # MCP 서버의 단위 스위트. **어느 워크플로에도 물려 있지 않았다** —
+      # `package:check` 가 CLI 쪽(`test:cli:lib`/`test:cli:commands`)은 돌리는데
+      # MCP 는 대칭 스텝이 없었다. 그 사이 `verify-script.test.mjs` 1건이 소스
+      # 변경에 뒤처진 채 실패하고 있었고 아무도 못 봤다(2026-07-28 발견).
+      #
+      # 파일 목록이 아니라 **글롭**으로 찾는다. 종전 스크립트는 손으로 적은
+      # 21개 목록이었고 디스크에는 27개가 있었다 — 새 테스트 파일이 조용히
+      # 빠지는 구조였다. 목록이 곧 사정거리인데 목록이 손으로 관리되면
+      # 사정거리도 손으로 줄어든다.
+      - name: MCP unit tests
+        if: always()
+        run: pnpm test:mcp:unit
+
+      # **통합 스위트 — 이제 실제로 돈다.** 종전 주석이 162초를 이유로 이걸
+      # 단위 스텝에서 빼면서 *"별도 스텝의 몫이다"* 라고 적었는데, 그 스텝은
+      # 만들어진 적이 없다. 결과: 실서버를 띄우는 가장 큰 MCP 스위트가 **어느
+      # 워크플로에도 안 물린 채** #806(경로형 슬러그 거부) 이후로 계속
+      # 빨간색이었고 아무도 못 봤다 — 2026-08-01 rc.5 검수에서 사람이 손으로
+      # 돌려서야 드러났다.
+      #
+      # 이 파일이 이미 두 번 적어 둔 것과 같은 병이다: *"목록이 곧 사정거리인데
+      # 목록이 손으로 관리되면 사정거리도 손으로 줄어든다."* 여기서는 목록이
+      # 아니라 **의도**가 손으로 관리됐다 — "나중에 스텝을 만든다"는 의도는
+      # 어디에도 강제되지 않았다. 2026-08-02, 그 "별도" 가 드디어 이 잡이다.
+      - name: MCP integration tests
+        if: always()
+        run: node --test mcp/src/integration.test.mjs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,3 +1,33 @@
+# E2E — Playwright(chromium).
+#
+# ## 왜 한 잡이 아니라 다섯인가 (2026-08-02)
+#
+# 이 파일은 2026-07 정리 때 *"스위트가 충분히 작아져 샤딩 없이 한 잡으로 돌린다"*
+# 고 적어 뒀다. 그 전제가 낡았다 — 실측(가장 오래 걸린 성공 런의 스텝별 소요):
+#
+# | 스텝 | 테스트 | 소요 |
+# |---|---|---|
+# | 정적 export (공방 내비) | 5 | 49초 |
+# | 웹 스모크 | 10 | 46초 |
+# | **전체 스위트** | **150** | **448초** (부팅 22초 + 실행 426초) |
+#
+# 셋이 한 잡에서 줄줄이 돌아 543초였다.
+#
+# **워커를 올리지 않고 러너를 늘린다.** `playwright.config.ts` 의 `workers: 1`
+# 과 `fullyParallel: false` 는 취향이 아니라 dev(Turbopack) 콜드 스타트의
+# 타이밍 취약성에 대한 답이다(같은 파일의 `retries` 주석 참고 — 온디맨드
+# 재컴파일이 산발 실패를 낸다). 워커를 올리면 **한 dev 서버에 동시 요청이
+# 늘어** 정확히 그 취약성을 키운다. 샤딩은 다르다: 샤드마다 러너도 dev 서버도
+# 따로라 **서버당 동시성은 그대로 1**이고 벽시계만 나뉜다.
+#
+# 산수: 샤드당 고정비가 부팅 22초 + 준비 36초 ≈ 58초다. 150개를 N 등분하면
+# 샤드 하나가 58 + 426/N 초. N=3 이면 200초, N=4 면 165초, N=5 면 143초 —
+# **고정비 때문에 수확이 빠르게 준다.** 3을 고른다(543 → 200초, 63% 감소).
+# 더 잘게 썰 이유가 생기면 `shard` 배열만 늘리고 `/3` 을 같이 고친다.
+#
+# 다섯 잡은 서로를 안 기다린다 — 분류(`classify-change.mjs`)는 node 빌트인만
+# 쓰는 스크립트라 잡마다 따로 돌려도 0초다. 앞단 잡을 두고 `needs:` 로 묶으면
+# 그 잡의 준비 시간이 전체 앞에 직렬로 붙는다.
 name: E2E smoke
 
 on:
@@ -17,113 +47,132 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  playwright:
-    name: Playwright (chromium)
+  # ── 정적 export 전용 층 — dev 로는 못 잡는다 ──────────────────────────
+  #
+  # 2026-07-28 실측: 공방의 같은-라우트 이동(산책 · 생성 전환)이 프로덕션
+  # 빌드에서만 죽어 있었다. 경로가 같고 쿼리만 다른 `router.push` 는 라우팅
+  # 단위가 아니라 no-op 이 되는데, dev 는 같은 코드로 둘 다 성공한다 —
+  # **dev 는 그 결함에 대해 진단력이 0** 이다. 나머지 스위트가 전부 dev 를
+  # 상대하므로, 이 잡이 없으면 그 부류의 회귀는 영원히 초록으로 통과한다.
+  static-export:
+    name: Playwright (static export)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # fetch-depth: 0 필수 — 변경 분류가 `git merge-base` 를 쓴다. 얕은 클론
-      # 이면 베이스를 못 찾아 "전부 실행"으로 열리고 게이트가 무의미해진다.
+      # fetch-depth: 0 필수 — 변경 분류가 `git merge-base` 를 쓴다. 얕은 클론이면
+      # 베이스를 못 찾아 "전부 실행"으로 열리고 게이트가 무의미해진다. 체크아웃은
+      # 복합 액션 안에 못 넣는다 — 로컬 액션은 워크스페이스에 이미 있어야 로드된다.
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
+      - uses: ./.github/actions/setup-playwright
+        id: setup
 
-      - name: Enable Corepack pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.18.0 --activate
-          pnpm --version
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Resolve installed Playwright version
-        id: playwright-version
-        run: |
-          version=$(node -e "console.log(require('@playwright/test/package.json').version)")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v6
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright chromium (+ system deps)
-        run: pnpm exec playwright install --with-deps chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-
-      - name: Install Playwright system deps only
-        run: pnpm exec playwright install-deps chromium
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-
-      # Full e2e suite — small enough post-decontamination (2026-07) to run
-      # as one job rather than sharding. `webServer` in playwright.config.ts
-      # boots `pnpm dev` itself; do not start a dev server here separately.
-      # 렌더되는 페이지가 의존하지 않는 변경(에이전트 브리프 · 문서 · 워크플로)
-      # 에 브라우저를 띄우지 않는다. 잡은 그대로 초록으로 끝나므로 required
-      # check 가 막히지 않는다 — 스텝만 건너뛴다.
-      - name: Classify change
-        id: classify
-        run: node scripts/classify-change.mjs --base=origin/${{ github.base_ref }}
-
-      # 웹 스모크는 분류기가 못 끄는 자리에 둔다.
-      #
-      # 2026-07-27 표면 분리(`docs/DECISIONS.md`) 이후 웹은 앱을 따라가지
-      # 않고, 소유자는 앱만 쓴다. 즉 웹은 **무인 표면**인데 유일한 유입
-      # 경로다. 나머지 스위트와 같은 조건(browser)만 걸면, 데스크톱 브리지만
-      # 건드린 변경(`src-tauri/**`)은 웹을 한 번도 안 보고 머지된다 — 그게
-      # 정확히 이 게이트가 막으라고 만들어진 부패다. 그래서 조건을 하나 넓혀
-      # **shipped code 가 바뀌면(runtime) 무조건** 돌고, main 푸시에서는
-      # 분류기가 비교 베이스를 못 찾아도 항상 돈다.
-      # 정적 export 에서만 재현되는 층 — dev 로는 못 잡는다.
-      #
-      # 2026-07-28 실측: 공방의 같은-라우트 이동(산책 · 생성 전환)이 프로덕션
-      # 빌드에서만 죽어 있었다. 경로가 같고 쿼리만 다른 `router.push` 는 라우팅
-      # 단위가 아니라 no-op 이 되는데, dev 는 같은 코드로 둘 다 성공한다 —
-      # **dev 는 그 결함에 대해 진단력이 0** 이다. 나머지 스위트가 전부 dev 를
-      # 상대하므로, 이 스텝이 없으면 그 부류의 회귀는 영원히 초록으로 통과한다.
       - name: Static export e2e (studio navigation)
         if: >-
-          steps.classify.outputs.runtime == 'true'
-          || steps.classify.outputs.browser == 'true'
+          steps.setup.outputs.runtime == 'true'
+          || steps.setup.outputs.browser == 'true'
           || github.event_name != 'pull_request'
         run: pnpm test:e2e:static
         env:
           CI: true
 
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-static-export
+          path: output/playwright/test-results
+          retention-days: 7
+
+  # ── 웹 스모크 — 분류기가 못 끄는 자리 ────────────────────────────────
+  #
+  # 2026-07-27 표면 분리(`docs/DECISIONS.md`) 이후 웹은 앱을 따라가지 않고,
+  # 소유자는 앱만 쓴다. 즉 웹은 **무인 표면**인데 유일한 유입 경로다. 나머지
+  # 스위트와 같은 조건(browser)만 걸면, 데스크톱 브리지만 건드린 변경
+  # (`src-tauri/**`)은 웹을 한 번도 안 보고 머지된다 — 그게 정확히 이 게이트가
+  # 막으라고 만들어진 부패다. 그래서 조건을 하나 넓혀 **shipped code 가
+  # 바뀌면(runtime) 무조건** 돌고, main 푸시에서는 분류기가 비교 베이스를 못
+  # 찾아도 항상 돈다.
+  web-smoke:
+    name: Playwright (web surface)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # fetch-depth: 0 필수 — 변경 분류가 `git merge-base` 를 쓴다. 얕은 클론이면
+      # 베이스를 못 찾아 "전부 실행"으로 열리고 게이트가 무의미해진다. 체크아웃은
+      # 복합 액션 안에 못 넣는다 — 로컬 액션은 워크스페이스에 이미 있어야 로드된다.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-playwright
+        id: setup
+
       - name: Web surface smoke
         if: >-
-          steps.classify.outputs.runtime == 'true'
-          || steps.classify.outputs.browser == 'true'
+          steps.setup.outputs.runtime == 'true'
+          || steps.setup.outputs.browser == 'true'
           || github.event_name != 'pull_request'
         run: pnpm exec playwright test tests/e2e/web-surface-smoke.spec.ts
         env:
           CI: true
 
-      # 전체 스위트가 위 스모크를 한 번 더 포함하는 것은 의도적이다(약 20초).
-      # 스텝을 나눠야 웹이 깨졌을 때 로그를 뒤지지 않고 스텝 이름만 보고 안다.
-      - name: Run Playwright suite
-        if: steps.classify.outputs.browser == 'true'
-        run: pnpm exec playwright test
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-web-smoke
+          path: output/playwright/test-results
+          retention-days: 7
+
+  # ── 전체 스위트 — 3 샤드 ─────────────────────────────────────────────
+  #
+  # 전체 스위트가 위 웹 스모크를 한 번 더 포함하는 것은 의도적이다(약 20초).
+  # 잡을 나눠야 웹이 깨졌을 때 로그를 뒤지지 않고 잡 이름만 보고 안다.
+  #
+  # 렌더되는 페이지가 의존하지 않는 변경(에이전트 브리프 · 문서 · 워크플로)에
+  # 브라우저를 띄우지 않는다. 잡은 그대로 초록으로 끝나므로 머지가 막히지
+  # 않는다 — 스텝만 건너뛴다.
+  suite:
+    name: Playwright (chromium ${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # 한 샤드가 빨개도 나머지는 끝까지 돈다 — 한 번에 한 결함만 알려 주면
+      # 검수가 왕복이 된다. `if: always()` 를 잡 안에서 쓰는 것과 같은 이유다.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      # fetch-depth: 0 필수 — 변경 분류가 `git merge-base` 를 쓴다. 얕은 클론이면
+      # 베이스를 못 찾아 "전부 실행"으로 열리고 게이트가 무의미해진다. 체크아웃은
+      # 복합 액션 안에 못 넣는다 — 로컬 액션은 워크스페이스에 이미 있어야 로드된다.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-playwright
+        id: setup
+
+      - name: Run Playwright suite (shard ${{ matrix.shard }}/3)
+        if: steps.setup.outputs.browser == 'true'
+        run: pnpm exec playwright test --shard=${{ matrix.shard }}/3
         env:
           CI: true
 
       - name: Skip note
-        if: steps.classify.outputs.browser != 'true'
-        run: echo "브라우저가 의존하는 경로 변경 없음 — 전체 Playwright 생략(웹 스모크는 위에서 별도 판정)"
+        if: steps.setup.outputs.browser != 'true'
+        run: echo "브라우저가 의존하는 경로 변경 없음 — 전체 Playwright 생략(웹 스모크는 별도 잡에서 판정)"
 
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: output/playwright/test-results
           retention-days: 7

--- a/.github/workflows/windows-beta-check.yml
+++ b/.github/workflows/windows-beta-check.yml
@@ -26,6 +26,22 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # `cargo test` 의 debug 컴파일에서 **전체 디버그 정보를 만들지 않는다**.
+  # MSVC 에서 556개 크레이트의 PDB 를 굽고 링크하는 비용이 이 프로파일의 큰
+  # 몫인데, CI 의 이 잡은 디버거를 붙이지 않는다.
+  #
+  # 그렇다고 `0` 으로 끄지는 않는다 — 그러면 테스트가 깨졌을 때 백트레이스에서
+  # 파일·줄이 사라져 원격 진단이 어려워진다. `line-tables-only` 는 파일·줄은
+  # 남기고 타입 정보만 버리는 중간값이라, 이 잡이 실제로 쓰는 것은 그대로 두고
+  # 안 쓰는 것만 안 만든다.
+  #
+  # **release 프로파일은 안 건드린다** — 사람들이 받을 설치 파일은 릴리스
+  # 워크플로가 굽는 것과 같은 방식으로 굽혀야 이 잡의 증명이 유효하다.
+  #
+  # `CARGO_INCREMENTAL` 은 여기 없다. `Swatinem/rust-cache` 가 스스로 0 으로
+  # 건다(문서 명시) — 같은 값을 두 곳에 적으면 그 순간부터 드리프트가 시작된다.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   verify-windows:

--- a/.github/workflows/windows-beta-check.yml
+++ b/.github/workflows/windows-beta-check.yml
@@ -51,6 +51,24 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # 이 잡의 시간은 거의 전부 Rust 컴파일이다 (실측 2026-08-02, 마지막 성공
+      # 런의 스텝별 소요): 720초 중 **637초(88%)** — release 번들 437초 +
+      # `cargo test` 의 debug 컴파일 200초. 나머지 스텝을 전부 0으로 만들어도
+      # 83초밖에 못 줄인다.
+      #
+      # 그런데 그 637초는 매번 **의존성부터** 다시 짓는 시간이다. Tauri 의
+      # 의존 그래프는 우리 크레이트보다 압도적으로 크고, 그 부분은 `Cargo.lock`
+      # 이 그대로면 바이트가 같다. `target/` 과 `~/.cargo` 를 캐시하면 우리
+      # 크레이트만 다시 짓는다.
+      #
+      # 캐시 키는 이 액션이 `Cargo.lock` + 러너 + 툴체인으로 만든다 — 잠금이
+      # 바뀌면 자동으로 미스가 나므로 낡은 의존성이 살아남지 않는다.
+      # 서드파티 액션이라 이 저장소의 관례대로 SHA 로 고정한다.
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: src-tauri
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/windows-beta-check.yml
+++ b/.github/workflows/windows-beta-check.yml
@@ -1,12 +1,29 @@
 name: Windows x64 Beta Check
 
+# 발동 조건은 **Windows 에서만 알 수 있는 것**으로 좁힌다 (2026-08-02).
+#
+# 실측: #834(pre-commit 훅)가 이 12분짜리 잡을 **5번** 켰다 — 총 60분. 그 PR 이
+# 한 일은 `package.json` 에 `prepare` 스크립트 한 줄을 더한 것이고, Windows
+# 설치 파일과는 아무 상관이 없었다. 최근 40런의 절반 가까이가 이런 부류다.
+#
+# `package.json` · `pnpm-lock.yaml` 을 뺀다. **빼도 잃는 게 없다** — 둘 다
+# `scripts/classify-change.mjs` 의 RUNTIME 목록에 있어서, 바뀌면 리눅스에서
+# 전체 단위 스위트와 정적 export 빌드(`pnpm build`)가 이미 돈다. Windows 릴리스
+# 계약 테스트 3종도 `pnpm test:desktop:check` 안에 있어 매 PR 리눅스에서 돈다.
+# 즉 저 둘이 켜던 것은 «Windows 에서만 알 수 있는 것» 이 아니었다.
+#
+# 남은 목록은 전부 **네이티브 산출물에 직접 들어가는 것**이다: Rust 소스,
+# 번들되는 MCP 서버, 그 바이너리를 굽고 검증하고 스테이징하는 스크립트, 그리고
+# 이 워크플로 자신.
+#
+# ⚠️ 이 잡은 사람들이 받는 `.exe` 를 만들지 않는다. 그건 `release-macos.yml` 의
+# `build-windows` 잡이 태그에서 만든다. 여기 올라가는 아티팩트는 조기경보용
+# 사본이다 — 그래서 발동을 좁히는 것이 릴리스 검증을 약화시키지 않는다.
 on:
   pull_request:
     paths:
       - ".github/workflows/release-macos.yml"
       - ".github/workflows/windows-beta-check.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
       - "mcp/**"
       - "scripts/build-mcp-binary.mjs"
       - "scripts/verify-mcp-binary.mjs"


### PR DESCRIPTION
## Summary

"CI 가 왜 이렇게 오래 걸리나" 를 감으로 답하지 않고 **마지막 성공 런의 스텝별
소요**로 쟀다. 결과가 둘 다 한쪽으로 심하게 쏠려 있었다.

### Windows — 720초 중 637초(88%)가 Rust 컴파일

| 단계 | 실측 |
|---|---|
| NSIS release 번들 빌드 | **437초** |
| `cargo test` (debug 컴파일) | **200초** |
| 나머지 전부 (체크아웃·설치·감사·Defender 스캔·설치 스모크) | 83초 |

나머지 스텝을 **전부 0으로 만들어도 83초**밖에 못 준다. 그리고 그 637초는
매번 **의존성부터** 다시 짓는 시간이다 — Tauri 의 의존 그래프는 우리
크레이트보다 압도적으로 크고, `Cargo.lock` 이 그대로면 그 부분은 바이트가
같다. 워크플로 6개 중 캐시를 쓰는 건 `e2e.yml` 하나뿐이었다.

→ `Swatinem/rust-cache` 로 `target/` + `~/.cargo` 캐시. 키는 액션이
`Cargo.lock` + 러너 + 툴체인으로 만들어서, 잠금이 바뀌면 자동 미스가 난다.
서드파티라 이 저장소 관례대로 SHA 고정(`rustsec/audit-check` 와 같은 방식).

### Checks — 624초 중 463초(74%)가 단 두 스텝

| 단계 | 실측 |
|---|---|
| 유닛 + 계약 테스트 | 291초 |
| MCP 통합 테스트 | 172초 |
| 린트 | 62초 |
| 타입체크 | 3초 |

둘은 서로를 전혀 안 기다리는데 **한 잡 안에서 줄줄이** 돌아 합이 그대로 대기
시간이 됐다. 셋으로 가르면 임계 경로가 **가장 느린 하나**가 된다.

가른 기준은 「무엇을 검사하나」가 아니라 **「얼마나 걸리나」**다 — 빠른 게이트
아홉은 서로를 기다리게 할 값이 없어 한 잡에 몰아 뒀다.

| 잡 | 이름 | 실측 합 |
|---|---|---|
| `gates` | Types · Lint · Docs | ≈100초 |
| `unit` | Unit · Contract | ≈291초 (임계 경로) |
| `mcp` | MCP | ≈176초 |

`if: always()` 는 잡 **안에서** 유지했다. 잡 **사이**는 원래 독립이라 한 잡이
빨개도 나머지가 끝까지 도는 건 오히려 나아진다.

## 일부러 안 한 것

**`release-macos.yml` 은 안 건드렸다.** 같은 Rust 캐시를 넣을 수 있지만, 그건
사용자가 설치할 산출물을 만드는 경로이고 태그 때만 돈다 — 절약분은 작은데
위험은 그쪽에 몰린다. 매 PR 마다 도는 경로만 손댔다.

**pnpm store 캐시도 안 넣었다.** `pnpm install` 실측이 7~15초라 캐시가 아끼는
것보다 워크플로에 더해지는 줄이 더 비싸다.

## Test plan

- **스텝·명령 유실 0건** — 이전 파일과 diff 대조: 스텝 이름 19 → 27(늘어난 8개는
  잡 셋으로 반복되는 체크아웃·Node·corepack·설치뿐), 사라진 스텝 0, 사라진
  `run:` 명령 0.
- **YAML 파서로 구조 확인** — `checks.yml` 잡 3개(13·7·7 스텝),
  `windows-beta-check.yml` 잡 1개(20 스텝).
- **잡 이름 변경이 안전한지 확인** — `branches/main/protection` 에
  `required_status_checks` 가 없다. 필수 체크 이름을 요구하지 않으므로
  분할·개명이 머지를 막지 않는다.
- `pnpm exec vitest run tests/contract` 1,025 통과.

## 효과는 다음 런에서 실측한다

**"캐시를 넣었으니 빨라졌겠지" 는 이 저장소가 금지하는 종류의 주장이다.**
이 PR 의 CI 가 돌면 같은 방식(스텝별 소요)으로 다시 재서 숫자를 여기 남긴다.
첫 런은 캐시 미스라 안 줄어드는 게 정상이고, 두 번째 런부터가 판정이다.
안 줄면 되돌린다.

반증 조건: Tauri `target/` 이 커서 저장소 캐시 한도(10GB)를 밀어내 캐시
적중률이 낮게 유지되면, Rust 캐시는 이득 없이 업로드 시간만 더한다 — 그때는
캐시를 빼고 Checks 분할만 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB