### PR TITLE
feat: 설정에 「알림」 절 — 「화면」이 지고 있던 두 번째 주제를 떼어낸다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -162,6 +162,7 @@
         "background": "Map background",
         "expand": "Expansion",
         "footprint": "Footprints",
+        "notify": "Notifications",
         "workspace": "Workspace",
         "agent": "Connect my agents",
         "ai": "In-app agent"
@@ -530,7 +531,7 @@
     "contextStorefrontBold": "A sample map of how an online store connects products, orders, customers, delivery, and marketing.",
     "contextStorefrontRest": "Pick your markdown folder and the same map switches to your data.",
     "sampleScale": "Sample size — {concepts} concepts · {relations} relations · {domains} domains",
-    "sampleRelationExample": "For example, a relation like \u201cOrders \u2192 Fulfillment\u201d.",
+    "sampleRelationExample": "For example, a relation like “Orders → Fulfillment”.",
     "agentClause": "AI agents like Claude Code read and write the same folder.",
     "openLabel": "Open my markdown folder",
     "openBusy": "Opening folder…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -162,6 +162,7 @@
         "background": "지도 배경",
         "expand": "확장",
         "footprint": "발자국",
+        "notify": "알림",
         "workspace": "작업 공간",
         "agent": "내 에이전트 연결",
         "ai": "앱 안 에이전트"

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.test.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.test.tsx
@@ -568,7 +568,7 @@ describe('AppSettingsMenu appearance pickers (#20/#21)', () => {
     const baseline = sizeClasses();
     expect(baseline, '고정 높이가 없다 — 내용이 창 크기를 정하고 있다').toMatch(/h-\[\d+px\]/);
     expect(baseline, '고정 폭이 없다').toMatch(/w-\[\d+px\]/);
-    for (const item of ['background', 'expand', 'footprint', 'workspace', 'agent', 'ai']) {
+    for (const item of ['background', 'expand', 'footprint', 'notify', 'workspace', 'agent', 'ai']) {
       fireEvent.click(screen.getByTestId(`app-settings-nav-${item}`));
       expect(sizeClasses(), `${item} 절에서 창 크기가 바뀐다`).toBe(baseline);
     }
@@ -578,13 +578,13 @@ describe('AppSettingsMenu appearance pickers (#20/#21)', () => {
    * LNB 는 **묶음**을 가진다. 다섯 항목이 왜 그 순서인지를 말하는 것이 묶음의
    * 일이고, 그게 없으면 목록이 그냥 다섯 줄이다.
    */
-  it('LNB 는 두 묶음으로 나뉘고 4·3 으로 갈린다', () => {
+  it('LNB 는 두 묶음으로 나뉘고 5·3 으로 갈린다', () => {
     openSheet();
     const nav = screen.getByTestId('app-settings-nav');
     // 문구가 아니라 **구조**로 잠근다 — 라벨을 다듬을 때마다 깨지면 안 된다.
     const groups = [...nav.children];
     expect(groups.length, '묶음이 둘이 아니다').toBe(2);
-    expect(groups.map((g) => g.querySelectorAll('button').length)).toEqual([4, 3]);
+    expect(groups.map((g) => g.querySelectorAll('button').length)).toEqual([5, 3]);
     for (const g of groups) {
       expect(g.querySelector('p'), '묶음에 제목이 없다 — 그러면 그냥 일곱 줄이다').not.toBeNull();
     }
@@ -596,16 +596,51 @@ describe('AppSettingsMenu appearance pickers (#20/#21)', () => {
    */
   it('LNB 항목마다 아이콘이 하나씩 있다', () => {
     openSheet();
-    for (const item of ['screen', 'background', 'expand', 'footprint', 'workspace', 'agent', 'ai']) {
+    for (const item of ['screen', 'background', 'expand', 'footprint', 'notify', 'workspace', 'agent', 'ai']) {
       const svgs = screen.getByTestId(`app-settings-nav-${item}`).querySelectorAll('svg');
       expect(svgs.length, `${item} 항목에 아이콘이 없다`).toBe(1);
     }
   });
 
-  it('LNB 일곱 절을 모두 싣는다', () => {
+  it('LNB 여덟 절을 모두 싣는다', () => {
     openSheet();
-    for (const item of ['screen', 'background', 'expand', 'footprint', 'workspace', 'agent', 'ai']) {
+    for (const item of ['screen', 'background', 'expand', 'footprint', 'notify', 'workspace', 'agent', 'ai']) {
       expect(screen.getByTestId(`app-settings-nav-${item}`)).toBeInTheDocument();
+    }
+  });
+
+  /**
+   * 「알림」 셋은 **「화면」으로 돌아가지 않는다** (2026-08-02, 소유자 지적).
+   *
+   * 이 셋은 원래 「화면」 절 바닥에 얹혀 있었고, 그 자리를 정당화한 주석까지
+   * 있었다 — 즉 **의도적으로 거기 있었다.** 그래서 되돌아갈 길이 넓다: 다음에
+   * 알림 관련 행을 하나 더 만드는 사람이 「화면」에 붙이면 아무 검사도 안
+   * 걸린다(양쪽 다 정당한 컴포넌트 배치라 lint 가 볼 리터럴이 없다).
+   *
+   * 그래서 **두 방향을 함께** 잠근다: 알림 컨트롤이 「알림」 절에 있을 것, 그리고
+   * 「화면」 절에는 없을 것. 한쪽만 잠그면 복제(양쪽에 다 있는 상태)를 통과시킨다.
+   */
+  it('알림 컨트롤은 「알림」 절에 있고 「화면」 절에는 없다', () => {
+    const NOTIFY_CONTROLS = [
+      'app-settings-agent-status',
+      'app-settings-agent-notifications',
+      'app-settings-agent-notification-kinds',
+    ];
+    openSheet();
+
+    // 첫 화면(=「화면」 절)에는 하나도 없다.
+    expect(screen.getByTestId('app-settings-pane-screen')).toBeInTheDocument();
+    for (const testId of NOTIFY_CONTROLS) {
+      expect(
+        screen.queryByTestId(testId),
+        `${testId} 가 「화면」 절에 남아 있다 — 알림은 자기 절로 빠졌다`,
+      ).toBeNull();
+    }
+
+    fireEvent.click(screen.getByTestId('app-settings-nav-notify'));
+    expect(screen.getByTestId('app-settings-pane-notify')).toBeInTheDocument();
+    for (const testId of NOTIFY_CONTROLS) {
+      expect(screen.getByTestId(testId), `${testId} 가 「알림」 절에 없다`).toBeInTheDocument();
     }
   });
 

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { usePanelPresence } from '@/shared/lib/use-presence';
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import {
+  Bell,
   Bot,
   ChevronRight,
   Copy,
@@ -129,7 +130,10 @@ const SETTINGS_GROUPS = [
   // 하나 넣어주면 될듯"*): 앞의 둘은 지도가 무엇으로 그려지는가(바닥·글리프)고
   // 「확장」은 그 위에서 무엇이 열리는가다. 발자국은 다 그린 뒤 남는 흔적이라
   // 맨 뒤가 맞다.
-  { key: 'look', items: ['screen', 'background', 'expand', 'footprint'] },
+  // 「알림」이 발자국 **뒤**인 이유: 앞의 넷은 지도가 어떻게 그려지는가(바닥 ·
+  // 글리프 · 펼침 · 흔적)의 순서이고, 알림은 그 위에 앱이 말을 얹는 층이라
+  // 마지막이다. 「이어진 것」으로 내리지 않는 이유는 렌더 분기 주석에.
+  { key: 'look', items: ['screen', 'background', 'expand', 'footprint', 'notify'] },
   // 「내 에이전트 연결」·「앱 안 에이전트」가 여기 **나란히** 있는 이유: 둘은
   // 같은 절의 두 요약 행이 아니라 서로 다른 목적지다. 하나는 밖의 도구가 이
   // 폴더를 읽게 하는 **설정 파일**이고, 하나는 앱 안에서 말을 거는 **키**다.
@@ -148,6 +152,10 @@ const SECTION_ICON: Record<SettingsSection, typeof Monitor> = {
   // 안 섞인다(아이콘은 장식이 아니라 훑기 채널이다, 위 주석).
   expand: Expand,
   footprint: Footprints,
+  // 종 — 이 목록에서 유일한 «울리는» 실루엣이다. 말풍선(ai)과 헷갈릴 자리가
+  // 아닌 이유: 말풍선은 «내가 말을 건다», 종은 «앱이 나를 부른다» 이고 외곽선도
+  // 사각 대 삼각이라 훑기에서 갈린다.
+  notify: Bell,
   workspace: HardDrive,
   // 밖의 도구 = 로봇, 앱 안의 대화 = 말풍선. 실루엣이 갈려야 훑기 채널이 선다
   // (이름의 첫 글자를 가른 것과 같은 이유다).
@@ -782,11 +790,29 @@ export function AppSettingsMenu({
                   />
                 ) : null}
                   </SettingsGroup>
-                  {/* 「작업 중 표시」·「알림」 — 이 칸인 이유: 둘 다 **화면이 무엇을
-                      말하는가**의 설정이다(에이전트를 어떻게 연결하는가가 아니다.
-                      그건 「AI 에이전트」 칸의 일이다). 기본은 둘 다 켜짐. */}
-                  <AgentActivitySettings />
                   </>
+                ) : section === 'notify' ? (
+                  /*
+                   * 「알림」이 자기 칸을 갖는 이유 (2026-08-02, 소유자 지적).
+                   *
+                   * 이 셋은 어제까지 「화면」 절의 **바닥**에 있었고, 그 자리를
+                   * 정당화한 주석은 *"둘 다 화면이 무엇을 말하는가의 설정이다"*
+                   * 였다. 그 문장은 맞다 — 그리고 그게 바로 **자기 절이어야 하는
+                   * 근거**다. 「화면」의 나머지 여섯(언어 · 뷰 모드 · INDEX 기본 ·
+                   * 글리프 세트 · 가이드 둘)은 «지도를 어떻게 그리는가»이고, 이
+                   * 셋은 «앱이 나에게 무엇을 알리는가»다.
+                   *
+                   * 부피로도 그렇다 — 실측: 「화면」이 컨트롤 여섯에 더해 이 셋
+                   * (행 3개 + 칩 6개)을 함께 지고 있었다. 「받을 알림」 6칩은 접힌
+                   * 세부가 아니라 **주 컨트롤**이라, 한 절의 절반을 다른 주제가
+                   * 차지하고 있던 셈이다. 빼내도 「화면」에는 여섯이 남는다.
+                   *
+                   * 「이어진 것」이 아니라 「보이는 것」에 두는 이유: 「작업 중
+                   * 표시」는 문자 그대로 **지도 위에** 뜨고, 알림도 앱이 나에게
+                   * 보여주는 것이다. 「이어진 것」은 «밖의 무엇과 연결되는가»의
+                   * 자리라 성격이 다르다.
+                   */
+                  <AgentActivitySettings />
                 ) : section === 'background' ? (
                   <>
                   <CanvasBackgroundPicker />


### PR DESCRIPTION
## Summary

소유자 지적(2026-08-02): *"이런것도 아예 설정 LNB로 빠져야하는거 아닌가?"*

「작업 중 표시」·「알림」·「받을 알림」 셋이 「화면」 절 **바닥**에 있었다. 그
자리를 정당화한 주석까지 코드에 있었다 — *"둘 다 화면이 무엇을 말하는가의
설정이다"*. **그 문장은 맞고, 그게 바로 자기 절이어야 하는 근거다.**

| 계열 | 내용 |
|---|---|
| 지도를 어떻게 그리는가 (6) | 언어 · 뷰 모드 · INDEX 기본 · 글리프 세트 · 가이드 자동 시작 · 가이드 다시보기 |
| **앱이 나에게 무엇을 알리는가 (3+6)** | 작업 중 표시 · 알림 · 받을 알림(6갈래 칩) |

부피로도 그렇다 — 컨트롤 여섯이 지던 절에 행 3개 + 칩 6개가 얹혀 있었다.
「받을 알림」 6칩은 **접힌 세부가 아니라 주 컨트롤**이라, 한 절의 절반을 다른
주제가 차지하고 있었다. 빼내도 「화면」에 여섯이 남아 비지 않는다.

**「이어진 것」이 아니라 「보이는 것」에 둔 이유**: 「작업 중 표시」는 문자
그대로 **지도 위에** 뜨고, 알림도 앱이 나에게 보여주는 것이다. 「이어진 것」은
«밖의 무엇과 연결되는가»의 자리라 성격이 다르다. 발자국 **뒤**인 이유는 앞의
넷이 «지도가 어떻게 그려지는가»(바닥 · 글리프 · 펼침 · 흔적)의 순서이고, 알림은
그 위에 앱이 말을 얹는 층이라서다.

**새 토큰 0개.** 항목은 기존 LNB 규격(`px-3 py-2` · `text-body-lg` · 아이콘
16px)을 그대로 탄다. 아이콘은 종 — 이 목록에서 유일한 «울리는» 실루엣이고,
말풍선(앱 안 에이전트)과는 «내가 말을 건다» 대 «앱이 나를 부른다» 로 갈린다.

## 실측 (dev, 1512×917 다크)

| | 값 |
|---|---|
| 「알림」 항목 높이 | **38px** (다른 일곱과 동일) |
| 글자 / 아이콘 | **14px / 16px** (동일) |
| 인셋 | **8px / 12px** (동일) |
| 여덟 항목에서 목록 넘침 | **없음** (`scrollHeight ≤ clientHeight`) |
| 「화면」 절 잔여 컨트롤 | **6개** |
| 「알림」 절 컨트롤 | **3행 + 칩 6개** |

렌더된 LNB: 보이는 것 [화면 · 지도 배경 · 확장 · 발자국 · **알림**] · 이어진 것
[작업 공간 · 내 에이전트 연결 · 앱 안 에이전트]

## 게이트

새 계약 하나: **「알림 컨트롤은 「알림」 절에 있고 「화면」 절에는 없다」**

두 방향을 **함께** 잠근다. 한쪽만 잠그면 복제(양쪽에 다 있는 상태)를
통과시킨다. 되돌아갈 길이 넓어서 필요하다 — 이 셋은 원래 「화면」에 **의도적으로**
있었고, 다음에 알림 행을 하나 더 만드는 사람이 「화면」에 붙이면 lint 는 볼
리터럴이 없다(양쪽 다 정당한 컴포넌트 배치다).

| 프로브 | 결과 |
|---|---|
| 알림을 「화면」으로 되돌린다 | ✅ red |
| 「알림」 절에서 빼기만 한다 | ✅ red |
| 복원 | ✅ 51 passed |

기존 게이트 셋도 새 절에 맞춰 갱신했다(LNB 묶음 4·3 → **5·3**, 절 목록 7 → 8,
창 크기 불변 검사에 `notify` 추가). **그 갱신 자체가 이 변경이 게이트에 실제로
걸린다는 증거다** — 고치지 않았으면 빨간 채로 남았다.

## Test plan

`pnpm checks:changed` 가 추천한 전부 — 5/5 통과:

- `pnpm exec vitest run src/widgets/app-settings-menu/ui/AppSettingsMenu.test.tsx` (51)
- `pnpm test:desktop:runtime`
- `pnpm desktop:check`
- `pnpm exec tsc --noEmit`
- `pnpm test:i18n:messages`

ko/en 두 카탈로그에 `section.notify` 를 함께 넣었다(한쪽만 채우면 다른 언어
사용자에게 키가 그대로 노출된다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB