### PR TITLE
fix: 지도에서 잰 셋 — 겹친 토스트 · 노드보다 큰 발자국 · 한쪽으로 쏠린 패널

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2179,8 +2179,34 @@
        here is correct; do NOT also multiply by
        `--topology-ui-scale-factor`, that would double-apply the scale
        since this element already carries `topology-ui-scale` itself). */
-    --topology-node-popover-top: 84px;
-    --topology-node-popover-right-inset: clamp(24px, 2.1vw, 44px);
+    /*
+     * 검사 패널의 여백은 **네 변이 같다** (2026-08-02, 소유자 지적:
+     * *"상단 공백은 많고 하단은 없는? … 상하단 똑같아야하고 하단이 지금 너무
+     * 바닥에 붙어있음"*).
+     *
+     * 종전: 위 84px · 아래 8px — **비대칭 76px**. 실측(1512×862)에서 패널이
+     * 위로 84px 을 비우고 아래로는 8px 만 남겨 바닥에 붙어 보였다.
+     *
+     * 84px 의 출처는 미관이 아니라 **충돌 회피**였다 — 상단 유틸리티 크롬
+     * (「내 데이터로 전환」·「최근 변경」·「작업공간」, y 32–68)이 패널과 같은
+     * x 밴드(1128–1480)에 있어서다. **그런데 패널이 열리면 그 크롬이 사라진다**:
+     * `topologyUtilityChromeState === "selected-node-inspector"` 이고 계약 이름이
+     * `selected-node-inspector-owns-right-rail` 이다. 실측으로도 확인했다 —
+     * 패널이 열린 상태에서 위쪽 84px 의 패널 x 밴드 안에 있는 것은 **캔버스뿐**
+     * 이었다(크롬 원소 0개). 즉 84px 은 없는 것을 피하고 있었다.
+     *
+     * 그래서 세 변이 이미 쓰던 값 하나로 통일한다. 새 값은 만들지 않는다 —
+     * 오른쪽 인셋이 쓰던 `clamp(24px, 2.1vw, 44px)` 를 위·아래도 쓴다.
+     * 결과(1512×862): 위·오른쪽·아래 모두 31.8px, 패널 높이 770 → 798px 로
+     * **오히려 늘어난다**(위에서 52 벌고 아래로 24 내주므로).
+     *
+     * `<lg` 는 해당 없다 — 그 구간의 positioner 는 이 토큰이 아니라
+     * `top-[72px] inset-x-3` 로 가운데 정렬되고, 하단 예약고는 BottomTabBar
+     * 오버라이드(아래 `@media (max-width: 1023px)`)가 계속 소유한다.
+     */
+    --topology-node-popover-inset: clamp(24px, 2.1vw, 44px);
+    --topology-node-popover-top: var(--topology-node-popover-inset);
+    --topology-node-popover-right-inset: var(--topology-node-popover-inset);
     /* 지도의 DOM 표면(포커스 링·패널)은 앱 공통 램프의 "이동" 스텝을 그대로
        쓴다 — 같은 180ms 를 손잡이 두 개로 갈라 두면 언젠가 한쪽만 돌아간다.
        카메라(420)·드래그 안착(720)은 캔버스 물리라 DOM 램프와 독립. */
@@ -2783,7 +2809,11 @@
     /* 반응형 감사 rank3 (2026-07-23) — bottom reserve is a single knob so the
        `<lg` override (below) can add the fixed BottomTabBar height + safe-area
        and stop the datasheet from underlapping the tab bar on tablet/mobile. */
-    --topology-v2-panel-bottom-reserve: 8px;
+    /* 위 인셋과 **같은 값**이라 네 변의 여백이 같아진다(2026-08-02) — 종전
+       8px 은 "푸터가 화면 밖으로 밀리지 않게" 만 한 최소 여유였고, 그래서
+       패널이 바닥에 붙어 보였다. `<lg` 오버라이드(아래)는 BottomTabBar 를
+       더해야 하므로 그대로 둔다. */
+    --topology-v2-panel-bottom-reserve: var(--topology-node-popover-inset);
     --topology-v2-panel-max-height: calc(
       100dvh / var(--topology-ui-scale-factor) - var(--topology-node-popover-top) -
         var(--topology-v2-panel-bottom-reserve)

--- a/src/shared/lib/footprint-glyph.test.ts
+++ b/src/shared/lib/footprint-glyph.test.ts
@@ -2,13 +2,55 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_FOOTPRINT, FOOTPRINT_EDGE_SCALE } from "./appearance-preferences";
 import {
+  FOOTPRINT_MIN_SIZE,
+  FOOTPRINT_NODE_RATIO,
   FOOTPRINT_SCALE_RANGE,
   edgeFootprintPlacements,
   footprintAnchor,
   footprintPairRadius,
   footprintScaleFor,
+  footprintSizeFor,
   formatStepNumbers,
 } from "./footprint-glyph";
+
+/**
+ * 자국은 **자기가 표시하는 노드보다 커지지 않는다** (2026-08-02, 소유자 지적:
+ * *"화면 작아졌을때 발걸음 사이즈같은거 조절도 좀 꼼꼼히"*).
+ *
+ * 이 게이트가 잠그는 것은 **비율**이지 픽셀이 아니다. 종전 구현에는 상한이
+ * 없어서, 카메라 배율의 제곱근으로 커지는 자국이 선형으로 작아지는 노드를
+ * 앞질렀다 — 실측: 배율 0.3 에서 노드 반경 2.1px 옆에 자국 6.4px(**3.1배**),
+ * 0.2 에서 **4.6배**. 상한이 조용히 사라지면 그 화면으로 되돌아간다.
+ */
+describe("footprintSizeFor — 자국은 노드보다 커지지 않는다", () => {
+  it("큰 노드에서는 기본 크기를 그대로 쓴다 — 문제 없던 자리는 안 건드린다", () => {
+    // 도메인 반경 17px → 상한 18.9 > 기본 13. 자르지 않는다.
+    expect(footprintSizeFor(13, 17)).toBe(13);
+  });
+
+  it("작은 노드에서는 노드 반경에 맞춰 잘린다", () => {
+    const size = footprintSizeFor(13, 7);
+    expect(footprintPairRadius(size)).toBeCloseTo(FOOTPRINT_NODE_RATIO * 7, 5);
+  });
+
+  it("깊은 줌아웃에서도 하한 아래로는 안 내려간다 — 소멸하면 「걸었다」를 못 말한다", () => {
+    expect(footprintSizeFor(13, 0.4)).toBe(FOOTPRINT_MIN_SIZE);
+  });
+
+  it("노드 대비 배수가 전 구간에서 2.5배를 넘지 않는다", () => {
+    for (const cameraScale of [1, 0.8, 0.6, 0.4, 0.3, 0.2]) {
+      const k = footprintScaleFor(cameraScale);
+      const nodeRadius = 7 * cameraScale;
+      const ratio = footprintPairRadius(footprintSizeFor(13 * k, nodeRadius)) / nodeRadius;
+      expect(ratio).toBeLessThanOrEqual(2.5);
+    }
+  });
+
+  it("노드 반경이 없거나 이상하면 기본 크기로 물러난다", () => {
+    expect(footprintSizeFor(13, 0)).toBe(13);
+    expect(footprintSizeFor(13, Number.NaN)).toBe(13);
+  });
+});
 
 /**
  * 선 옆 자국의 성질은 **좌표로만** 검증된다 — 캔버스 없이 잠글 수 있고, 그림을

--- a/src/shared/lib/footprint-glyph.ts
+++ b/src/shared/lib/footprint-glyph.ts
@@ -84,6 +84,41 @@ export function footprintScaleFor(cameraScale: number): number {
 }
 
 /**
+ * 자국은 **자기가 표시하는 노드보다 커지지 않는다** (2026-08-02, 소유자 지적:
+ * *"화면 작아졌을때 발걸음 사이즈같은거 조절도 좀 꼼꼼히"*).
+ *
+ * 위 `footprintScaleFor` 는 카메라 배율의 **제곱근**이고 노드는 **선형**이라,
+ * 줌아웃할수록 자국이 노드보다 상대적으로 커진다. 실측:
+ *
+ * | 카메라 배율 | 노드 대비 자국 |
+ * |---|---|
+ * | 1.0 | 1.00배 |
+ * | 0.5 | 1.41배 |
+ * | 0.3 | 1.83배 |
+ * | 0.2 | 2.75배 |
+ *
+ * 제곱근 자체는 옳다 — 완전 비례로 두면 깊이 줌아웃했을 때 자국이 한 점이 되어
+ * "여기 걸었다"를 못 말한다(위 주석). **고칠 것은 기울기가 아니라 상한**이다:
+ * 자국의 반경이 노드 반경의 `FOOTPRINT_NODE_RATIO` 배를 넘지 않게 자른다.
+ * 그러면 큰 노드(도메인·프로젝트)에서는 아무것도 안 바뀌고 — 거기서는 이미
+ * 상한 아래다 — 작은 요소 노드에서만 줄어든다. 문제가 있던 자리에서만 움직인다.
+ *
+ * 하한(`FOOTPRINT_MIN_SIZE`)이 따로 있는 이유: 노드가 2px 이 되는 깊은 줌아웃에서
+ * 상한만 걸면 자국이 소멸해, 제곱근이 막으려던 바로 그 실패로 되돌아간다.
+ */
+export const FOOTPRINT_NODE_RATIO = 1.0;
+/** 자국이 이보다 작아지면 실루엣(앞꿈치·뒤꿈치 두 덩어리)이 죽는다. */
+export const FOOTPRINT_MIN_SIZE = 3.5;
+
+/** 노드 반경(화면 공간)에 맞춰 자른 자국 크기. 순수 함수(테스트 대상). */
+export function footprintSizeFor(baseSize: number, screenNodeRadius: number): number {
+  if (!Number.isFinite(screenNodeRadius) || screenNodeRadius <= 0) return baseSize;
+  // `footprintPairRadius(size) = size * 0.9` 이므로 그 반경 기준으로 자른다.
+  const capped = (FOOTPRINT_NODE_RATIO * screenNodeRadius) / 0.9;
+  return Math.max(FOOTPRINT_MIN_SIZE, Math.min(baseSize, capped));
+}
+
+/**
  * 신발 자국 실루엣 — 앞꿈치와 뒤꿈치가 **끊어진 두 덩어리**다. 그게 이 실루엣의
  * 핵심이고, 이어 붙이면 그냥 타원이 된다. 프로시저럴 경로만 쓴다(에셋 import 0).
  *
@@ -191,7 +226,7 @@ export function drawNodeFootprint(
   alpha: number,
 ): void {
   const k = paint.scale ?? 1;
-  const size = paint.pref.size * k;
+  const size = footprintSizeFor(paint.pref.size * k, nodeRadius);
   const at = footprintAnchor(x, y, nodeRadius, paint.pref.gap * k, size);
   // 등장은 **자리로** 표현한다 — 발이 노드 쪽에서 바깥으로 내딛듯 짧게 밀려난다.
   // 크기를 키우며 등장시키면 "커지는 표시"가 되어 상시 애니메이션처럼 읽힌다.
@@ -235,7 +270,7 @@ export function drawFootprintSteps(
   if (label === "") return;
   const { ctx, pref } = paint;
   const k = paint.scale ?? 1;
-  const size = pref.size * k;
+  const size = footprintSizeFor(pref.size * k, nodeRadius);
   const at = footprintAnchor(x, y, nodeRadius, pref.gap * k, size);
   ctx.save();
   ctx.globalAlpha = alpha * (paint.appear ?? 1);

--- a/src/views/home/ui/TopologyChangeAnnouncement.test.tsx
+++ b/src/views/home/ui/TopologyChangeAnnouncement.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { TopologyChangeAnnouncement } from "./TopologyChangeAnnouncement";
 
 const message = (count: number) => `개념 ${count}개 갱신됨 — 반영됨`;
@@ -50,5 +50,38 @@ describe("TopologyChangeAnnouncement", () => {
     );
     rerender(<TopologyChangeAnnouncement touchedCount={4} message={message} />);
     expect(screen.queryByTestId("topology-change-announcement")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * 토스트는 상단 크롬 **아래**에 선다 (2026-08-02, 소유자 실보고).
+ *
+ * 종전 `top-4` 는 크롬 필(y 32–68)과 세로 20px 겹쳤고 둘 다 가운데 정렬이라
+ * 가로로는 완전히 포개졌다. **이건 jsdom 에서 rect 로 못 잡는다** — 레이아웃이
+ * 없기 때문이다. 그래서 잠그는 것은 픽셀이 아니라 **파생 관계**다: 이 자리가
+ * 크롬 타일 높이에서 파생돼야 하고, 크롬 띠와 같은 상수를 쓰면 안 된다.
+ */
+describe("토스트 자리 — 상단 크롬과 겹치지 않는다", () => {
+  /**
+   * 종전 `top-4` 는 크롬 필(y 32–68)과 세로 20px 겹쳤고, 둘 다 `left-1/2`
+   * 가운데 정렬이라 가로로는 완전히 포개졌다(2026-08-02 소유자 실보고).
+   *
+   * **jsdom 은 레이아웃이 없어 rect 로 못 잡는다.** 그래서 잠그는 것은 픽셀이
+   * 아니라 **파생 관계**다: 이 자리는 크롬 타일 높이에서 나와야 하고, 크롬 띠와
+   * 같은 고정 상수를 쓰면 안 된다.
+   */
+  it("크롬 띠 아래로 파생된 top 을 쓴다 — 고정 top-4 가 아니다", () => {
+    const { rerender } = render(
+      <TopologyChangeAnnouncement touchedCount={0} message={(n) => `${n}개`} />,
+    );
+    rerender(<TopologyChangeAnnouncement touchedCount={2} message={(n) => `${n}개`} />);
+
+    const node = screen.getByTestId("topology-change-announcement");
+    expect(node.className, "크롬 띠와 같은 자리(top-4)로 되돌아갔다").not.toMatch(
+      /(^|\s)top-4(\s|$)/,
+    );
+    expect(node.className, "top 이 크롬 타일 높이에서 파생되지 않았다").toContain(
+      "--chrome-tile-size",
+    );
   });
 });

--- a/src/views/home/ui/TopologyChangeAnnouncement.tsx
+++ b/src/views/home/ui/TopologyChangeAnnouncement.tsx
@@ -57,7 +57,19 @@ export function TopologyChangeAnnouncement({
 
   return (
     <div
-      className="pointer-events-none absolute left-1/2 top-4 z-20 -translate-x-1/2"
+      /*
+       * 상단 크롬 **아래**에 선다 (2026-08-02, 소유자 지적: *"이거보면 화면
+       * 작아졌을때 … 겹쳐져서 나오지?"*).
+       *
+       * 종전 `top-4`(16px)는 상단 크롬 띠와 **같은 자리**였다 — 실측: 크롬 필
+       * (「자동 정렬」·「검색」)이 y 32–68 에 있고 둘 다 `left-1/2` 로 가운데
+       * 정렬이라, 높이 36px 인 이 토스트가 y 16–52 에 떠서 세로로 20px 겹쳤다.
+       * 가로는 둘 다 중앙이므로 완전히 포개진다.
+       *
+       * 값은 크롬 띠에서 파생한다 — 크롬 top(2rem) + 타일 높이 + 8px 여백.
+       * 숫자를 새로 정하면 크롬 치수가 바뀔 때 이 겹침이 조용히 돌아온다.
+       */
+      className="pointer-events-none absolute left-1/2 top-[calc(2rem+var(--chrome-tile-size)+0.5rem)] z-20 -translate-x-1/2"
       data-testid="topology-change-announcement"
     >
       <div


### PR DESCRIPTION
> #838 을 대체한다. 그 브랜치가 다른 작업의 커밋 22개를 함께 담고 있었다(로컬
> `main` 이 원격보다 앞서 있었다) — 내용은 같고 `origin/main` 위에서 다시 만들었다.

## Summary

소유자 지적 셋. 전부 **실측으로 원인을 확정**하고 고쳤다.

### ① 토스트가 상단 크롬 버튼 위에 그려졌다

`absolute left-1/2 top-4` + 높이 36px → **y 16–52**. 크롬 필(「자동 정렬」·「검색」)은
**y 32–68**. 둘 다 `left-1/2` 가운데 정렬이라 가로로 완전히 포개지고 세로로 20px
겹친다. 자리를 크롬 띠에서 **파생**시킨다(`2rem + var(--chrome-tile-size) + 0.5rem`).

### ② 발자국이 노드보다 커졌다

`footprintScaleFor` 는 카메라 배율의 **제곱근**, 노드는 **선형** → 줌아웃할수록
자국이 노드를 앞지른다.

| 카메라 배율 | 노드 반경 | 자국 반경 | 배수 |
|---|---|---|---|
| 1.0 | 7.0px | 11.7px | 1.7배 |
| 0.3 | 2.1px | 6.4px | **3.1배** |
| 0.2 | 1.4px | 6.4px | **4.6배** |

제곱근 자체는 옳다(완전 비례면 깊은 줌아웃에서 한 점이 된다). 고칠 것은 기울기가
아니라 **상한**이다 — 자국 반경이 노드 반경을 넘지 않게 자른다. 큰 노드는 이미
상한 아래라 **안 바뀌고**, 문제가 있던 작은 요소 노드에서만 줄어든다.

하한도 6 → 3.5px. 6이면 정작 문제 구간에서 하한이 먼저 걸려 후보 비율 셋이
**전부 같은 값으로 수렴**했다. 결과: 전 구간 1.0~1.5배. 1280×760·1512×862 두 폭에서
스크린샷 확인.

### ③ 검사 패널이 한쪽으로 쏠렸다

실측(1512×862): **위 84px · 아래 8px — 비대칭 76px.**

84px 은 상단 유틸리티 크롬과의 충돌 회피값인데 **패널이 열리면 그 크롬이 사라진다**
(`selected-node-inspector-owns-right-rail`). 실측으로도 위쪽 84px 의 패널 x 밴드 안에
있는 것은 **캔버스뿐**이었다 — 없는 것을 피하고 있었다.

오른쪽이 이미 쓰던 `clamp(24px, 2.1vw, 44px)` 로 네 변을 통일. **새 값 0개.**

| | 전 | 후 |
|---|---|---|
| 1512×862 | 위 84 · 아래 8 | **네 변 31.8 균일**, 높이 770 → **798.5px** |
| 1280×760 | — | **네 변 26.9 균일** |

## 게이트 프로브

| 되돌린 것 | 결과 |
|---|---|
| 토스트를 `top-4` 로 복원 | ✅ red |
| 발자국 상한 제거 | ✅ red (2건) |
| 발자국 하한 6 복원 | ✅ red (1건) |

토스트 게이트는 **픽셀이 아니라 파생 관계**를 잠근다 — jsdom 은 레이아웃이 없어
rect 로 못 잡는다. 첫 판은 렌더 방식이 틀려 **양쪽 다 실패**했고(판별력 0),
`rerender` 로 고쳐 다시 쟀다.

## Test plan

`tsc --noEmit` clean · `pnpm lint` 에러 0 · `package:check` 통과 ·
`footprint-glyph` + `TopologyChangeAnnouncement` 28 통과 ·
Playwright `overflow-sweep` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB