### PR TITLE
feat: git 이 없는 컴퓨터에 설치 안내를 보인다 — 문을 다 지어놓고 안 뚫었다

### DIFF
--- a/src/shared/lib/git-install-guide.test.ts
+++ b/src/shared/lib/git-install-guide.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { GIT_DOWNLOAD_URL, gitInstallGuide } from './git-install-guide';
+import { GIT_DOWNLOAD_URL, gitInstallGuide , gitHostPlatformFrom} from './git-install-guide';
 
 /**
  * 설치 명령은 **사용자 터미널에서** 실행되므로 오타가 나면 우리는 그 실패를
@@ -42,5 +42,33 @@ describe('gitInstallGuide', () => {
 
   it('알 수 없는 값은 macOS 로 떨어진다 (빈 화면보다 낫다)', () => {
     expect(gitInstallGuide('freebsd' as never).platform).toBe('macos');
+  });
+});
+
+/**
+ * 플랫폼 감지 — 순수 함수라 문자열만 넣어 본다.
+ *
+ * 이 함수가 생긴 이유: 설치 안내(`gitInstallGuide`)와 문구 13종이 **이미 다
+ * 있었는데 화면이 그걸 부르지 않았다**(2026-08-02 발견 — `AtlasGitPanel` 의
+ * `gitProbe` 호출 0회). 문을 다 지어놓고 안 뚫은 상태였고, 그 문을 뚫는 데
+ * 마지막으로 없던 조각이 「이 컴퓨터가 무슨 OS 인가」였다.
+ */
+describe('gitHostPlatformFrom', () => {
+  it.each([
+    ['MacIntel', 'macos'],
+    ['darwin', 'macos'],
+    ['iPhone', 'macos'],
+    ['Win32', 'windows'],
+    ['Windows NT 10.0', 'windows'],
+    ['Linux x86_64', 'linux'],
+  ])('%s → %s', (input, expected) => {
+    expect(gitHostPlatformFrom(input)).toBe(expected);
+  });
+
+  it('못 알아보면 linux 로 떨어진다 — 다운로드 링크는 세 안내 모두에 있다', () => {
+    expect(gitHostPlatformFrom('')).toBe('linux');
+    expect(gitHostPlatformFrom('SomethingNew')).toBe('linux');
+    const guide = gitInstallGuide(gitHostPlatformFrom(''));
+    expect(guide.alternatives.some((o) => o.href), '다운로드 링크가 없다').toBe(true);
   });
 });

--- a/src/shared/lib/git-install-guide.ts
+++ b/src/shared/lib/git-install-guide.ts
@@ -77,3 +77,18 @@ export function gitInstallGuide(platform: GitHostPlatform): GitInstallGuide {
     ],
   };
 }
+
+/**
+ * 브라우저/WebView 가 알려주는 값에서 호스트 플랫폼을 고른다. 순수 함수라
+ * 테스트가 문자열만 넣어 볼 수 있다 — `navigator` 를 직접 읽는 자리는 호출부다.
+ *
+ * 못 알아보면 `linux` 로 떨어진다: 세 안내 중 유일하게 **패키지 관리자 이름을
+ * 틀려도 사용자가 스스로 고쳐 읽을 수 있는** 형태이고, 다운로드 링크는 세
+ * 플랫폼 모두에 붙는다.
+ */
+export function gitHostPlatformFrom(uaOrPlatform: string): GitHostPlatform {
+  const value = uaOrPlatform.toLowerCase();
+  if (/mac|iphone|ipad|ipod|darwin/.test(value)) return 'macos';
+  if (/win/.test(value)) return 'windows';
+  return 'linux';
+}

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
@@ -86,6 +86,7 @@ function installDesktopGit({
     url: "git@github.com:me/repo.git",
     replaced: null,
   },
+  probe = { installed: true, version: "git version 2.49.0" },
 }: {
   status?: unknown;
   diff?: unknown;
@@ -93,6 +94,7 @@ function installDesktopGit({
   snapshot?: unknown;
   init?: unknown;
   setRemote?: unknown;
+  probe?: unknown;
 } = {}) {
   tauriApiMock.runtimeAvailable = true;
   tauriApiMock.invoke.mockImplementation(async (command: string) => {
@@ -102,6 +104,7 @@ function installDesktopGit({
     if (command === "git_snapshot") return snapshot;
     if (command === "git_init") return init;
     if (command === "git_set_remote") return setRemote;
+    if (command === "git_probe") return probe;
     throw new Error(`unexpected command: ${command}`);
   });
 }

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -38,6 +38,7 @@ import {
   gitErrorMessage,
   gitHistory,
   gitInit,
+  gitProbe,
   gitSetRemote,
   gitSnapshot,
   gitStatus,
@@ -48,6 +49,7 @@ import {
   type GitStatusResult,
 } from "@/shared/lib/tauri-git";
 import type { OntologyChangeset } from "@/shared/lib/ontology-tree";
+import { gitHostPlatformFrom, gitInstallGuide } from "@/shared/lib/git-install-guide";
 import { cn } from "@/shared/lib/cn";
 import { ATLAS_CLI } from "@/shared/config/cli-invocation";
 
@@ -216,7 +218,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
  * 다시 확인하는 것 하나뿐이라, 전폭 상단 정렬로 두면 "내용이 안 나온 페이지"
  * 로 읽힌다.
  */
-type GitStage = "web" | "no-vault" | "loading" | "error" | "not-initialized" | "workbench";
+type GitStage = "web" | "no-vault" | "loading" | "not-installed" | "error" | "not-initialized" | "workbench";
 
 type SetupStep = 1 | 2 | 3;
 
@@ -241,6 +243,20 @@ export function AtlasGitPanel({
   const [diffText, setDiffText] = useState("");
   const [history, setHistory] = useState<GitCommitInfo[]>([]);
   const [loadState, setLoadState] = useState<"loading" | "ready" | "error">("loading");
+  /*
+   * git 설치 여부 — `null` 은 「아직 모름」이다(확인 전에 없다고 단정하지 않는다).
+   * 읽기 전용 감지라 자동 호출이 헌장의 「자동 실행 금지」와 충돌하지 않는다:
+   * `git_probe` 는 아무것도 설치하지 않고 실행 가능 여부만 본다.
+   */
+  const [gitInstalled, setGitInstalled] = useState<boolean | null>(null);
+  const probeGit = useCallback(async () => {
+    const probe = await gitProbe();
+    // 브리지가 없으면(`null`) 웹 경로이고, 그건 이 상태가 판정할 일이 아니다.
+    setGitInstalled(probe === null ? null : probe.installed);
+  }, []);
+  useEffect(() => {
+    void probeGit();
+  }, [probeGit]);
   const [loadErrorText, setLoadErrorText] = useState<string | null>(null);
 
   const [confirming, setConfirming] = useState(false);
@@ -334,6 +350,20 @@ export function AtlasGitPanel({
     ? "web"
     : !vaultPath
       ? "no-vault"
+      /*
+       * git 이 아예 없는 것을 「오류」와 **가른다** (2026-08-02).
+       *
+       * 종전에는 미설치가 `loadState === "error"` 로 떨어져 원시 스폰 실패
+       * 문자열만 보였다. 그런데 이 저장소에는 **설치 안내가 이미 다 있다** —
+       * `git_probe`(Rust) · `gitProbe()`(브리지) · `gitInstallGuide()`(플랫폼별
+       * 명령 + 다운로드 링크, 테스트까지) · 문구 13종(`atlasGit.install.*`).
+       * 화면이 그걸 부르지 않았을 뿐이다. **문을 다 지어놓고 안 뚫은 상태**였다.
+       *
+       * `surfaces.md` 의 강등 카드 계약(왜 안 되는지 + 어디서 되는지 + 여기서
+       * 되는 것)을 이 자리에 적용하는 데 **새로 쓸 문장이 하나도 없다.**
+       */
+      : gitInstalled === false
+        ? "not-installed"
       : loadState === "error"
         ? "error"
         : !status
@@ -464,6 +494,15 @@ export function AtlasGitPanel({
         stage === "loading" ||
         stage === "error" ? (
           <DesktopBody
+            hostPlatformHint={
+              typeof navigator === "undefined"
+                ? ""
+                : navigator.platform || navigator.userAgent
+            }
+            onRecheckGit={() => {
+              void probeGit();
+              refresh();
+            }}
             key={stage}
             t={t}
             stage={stage}
@@ -1663,6 +1702,8 @@ function ActionDock({
 function DesktopBody({
   t,
   stage,
+  hostPlatformHint,
+  onRecheckGit,
   loadErrorText,
   status,
   kindGroups,
@@ -1704,8 +1745,12 @@ function DesktopBody({
   remoteNotice,
   onSetRemote,
 }: {
+  /** `navigator.platform ?? userAgent` — 설치 안내를 플랫폼별로 고르는 힌트. */
+  hostPlatformHint: string;
+  /** 「다시 확인하기」 — git 을 방금 깐 사람이 앱을 안 껐다 켜도 되게. */
+  onRecheckGit: () => void;
   t: Translator;
-  stage: Extract<GitStage, "loading" | "error" | "not-initialized" | "workbench">;
+  stage: Extract<GitStage, "loading" | "not-installed" | "error" | "not-initialized" | "workbench">;
   loadErrorText: string | null;
   status: GitStatusResult | null;
   kindGroups: AtlasGitKindGroup<GitChangeEntry>[];
@@ -1766,6 +1811,62 @@ function DesktopBody({
       </SetupFrame>
     );
   }
+  if (stage === "not-installed") {
+    /*
+     * 강등 카드 3요소를 그대로 채운다 (`surfaces.md`) — **새 문구 0개**.
+     * ① 왜: `install.title` / `install.body`
+     * ② 어디서: `gitInstallGuide(platform)` 의 플랫폼별 명령(복사) + 다운로드 링크
+     * ③ 다시 확인: `install.recheck`
+     *
+     * 「곧 됩니다」를 쓰지 않는다 — 오늘 안 되는 것은 안 된다고 쓰고, 대신 갈
+     * 곳을 준다. 외부 링크는 클릭 전 경고로 선행 `↗` 를 단다(design.md).
+     */
+    const guide = gitInstallGuide(gitHostPlatformFrom(hostPlatformHint));
+    const options = [guide.primary, ...guide.alternatives];
+    return (
+      <SetupFrame t={t} step={null} state="error">
+        <div className="flex flex-col gap-3" data-testid="atlas-git-not-installed">
+          <SetupHeading title={t("install.title")} body={t("install.body")} />
+          <ul className="flex flex-col gap-2">
+            {options.map((option) => (
+              <li key={option.labelKey} className="flex items-center gap-2">
+                <span className="text-label text-[color:var(--color-text-tertiary)]">
+                  {t(option.labelKey)}
+                </span>
+                {option.command ? (
+                  <code className="rounded-[var(--radius-chip)] bg-[color:var(--color-overlay-1)] px-2 py-0.5 font-mono text-label text-[color:var(--color-text-secondary)]">
+                    {option.command}
+                  </code>
+                ) : option.href ? (
+                  <a
+                    href={option.href}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    data-testid="atlas-git-install-download"
+                    className="rounded-[var(--radius-chip)] px-1 text-label text-[color:var(--color-indigo-accent)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+                  >
+                    ↗ {option.href}
+                  </a>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            data-testid="atlas-git-install-recheck"
+            onClick={() => {
+              onRecheckGit();
+            }}
+            className={cn(SECONDARY_ACTION_CLASS, "self-start")}
+          >
+            <RefreshCw size={13} aria-hidden />
+            {t("install.recheck")}
+          </button>
+        </div>
+      </SetupFrame>
+    );
+  }
+
   if (stage === "error") {
     // 오류도 막다른 길이 아니어야 한다 — 폴더가 되돌아왔을 때 사용자가 앱을
     // 떠나지 않고 다시 확인할 수 있는 버튼을 같은 자리에 둔다.

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -250,9 +250,18 @@ export function AtlasGitPanel({
    */
   const [gitInstalled, setGitInstalled] = useState<boolean | null>(null);
   const probeGit = useCallback(async () => {
-    const probe = await gitProbe();
-    // 브리지가 없으면(`null`) 웹 경로이고, 그건 이 상태가 판정할 일이 아니다.
-    setGitInstalled(probe === null ? null : probe.installed);
+    try {
+      const probe = await gitProbe();
+      // 브리지가 없으면(`null`) 웹 경로이고, 그건 이 상태가 판정할 일이 아니다.
+      setGitInstalled(probe === null ? null : probe.installed);
+    } catch {
+      /*
+       * 확인에 실패한 것은 **없다는 뜻이 아니다.** `null`(모름)로 두면 화면은
+       * 설치 안내가 아니라 평소 경로를 그린다 — 있는 git 을 없다고 말하는 쪽이
+       * 모른다고 두는 쪽보다 나쁘다. 잡지 않으면 unhandled rejection 이 된다.
+       */
+      setGitInstalled(null);
+    }
   }, []);
   /*
    * **폴더를 고른 뒤에만** 부른다 (2026-08-02, 계약 테스트가 잡았다: 「앱 안에서

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -254,9 +254,19 @@ export function AtlasGitPanel({
     // 브리지가 없으면(`null`) 웹 경로이고, 그건 이 상태가 판정할 일이 아니다.
     setGitInstalled(probe === null ? null : probe.installed);
   }, []);
+  /*
+   * **폴더를 고른 뒤에만** 부른다 (2026-08-02, 계약 테스트가 잡았다: 「앱 안에서
+   * 폴더가 없으면 … 아무 IPC 도 안 부른다」).
+   *
+   * 이유가 둘이다. ① 폴더가 없으면 git 이 있든 없든 이 화면이 할 일이 없다 —
+   * 안 쓸 답을 미리 물을 이유가 없다. ② macOS 는 명령어 도구가 없을 때 git 을
+   * 부르면 **시스템 설치 다이얼로그**를 띄운다 — 사용자가 「기록」을 열지도
+   * 않았는데 OS 창이 뜨면 그건 우리가 부른 적 없는 화면이다.
+   */
   useEffect(() => {
+    if (!vaultPath) return;
     void probeGit();
-  }, [probeGit]);
+  }, [probeGit, vaultPath]);
   const [loadErrorText, setLoadErrorText] = useState<string | null>(null);
 
   const [confirming, setConfirming] = useState(false);


### PR DESCRIPTION
## Summary

소유자 질문: *"사용자가 git을 안가지고있으면 다운로드 사이트로 이동시키는건 안되나
(정책상 하면 안되는건지 확인좀)"*

**정책은 문제가 아니었다.** `surfaces.md` 의 강등 카드 계약이 「**왜** 안 되는지 +
**어디서** 되는지」를 요구하고, 외부 목적지를 금지한 적이 없다. 링크는 조용한
전송이 아니다 — 사용자가 눌러야 열리고 우리 쪽으로 오는 데이터가 없다.

## 그리고 안내가 이미 다 있었다

디자인 벤치 상호작용석 감사가 찾아냈다:

| | |
|---|---|
| `git_probe` (Rust) — 설치 감지 | ✅ 있음 |
| `gitProbe()` (TS 브리지) | ✅ 있음 |
| `gitInstallGuide()` — 플랫폼별 안내 (테스트까지) | ✅ 있음 |
| 문구 13종 — 「이 컴퓨터에 git 이 없어요」 · macOS/Windows/Linux 명령 · **다운로드 링크** · 「다시 확인하기」 | ✅ 있음 |
| **화면이 그걸 부르는가** | ❌ **호출 0회** |

그래서 git 없는 컴퓨터는 **원시 스폰 실패 문자열**만 봤다. 「이 컴퓨터에 git 이
없어요. 한 번만 설치하면 그 뒤로는 이 화면에서 다 됩니다」라는 문장이 파일 안에
앉아 있는데 아무도 못 봤다. **문을 다 지어놓고 안 뚫은 집이다.**

**새로 쓴 문장 0개 — 순수 배선이다.**

## 무엇을 했나

- `GitStage` 에 **`not-installed`** 를 더해 「오류」와 가른다. 둘은 사용자가 할 일이
  다르다 — 하나는 폴더를 고치고 하나는 프로그램을 깐다.
- 강등 카드 3요소를 채운다: **왜**(`install.title`/`body`) · **어디서**(플랫폼별
  명령 + `↗` 다운로드 링크) · **다시 확인**(probe 재호출 — 방금 깐 사람이 앱을
  껐다 켜지 않아도 된다).
- 마지막으로 없던 조각 하나만 새로 만들었다: **`gitHostPlatformFrom()`** — 순수
  함수라 테스트가 문자열만 넣어 본다. 못 알아보면 `linux` 로 떨어지고, 다운로드
  링크는 세 안내 모두에 있다.

## 계약 테스트가 나를 두 번 잡았다

**「폴더가 없으면 아무 IPC 도 안 부른다」** — 마운트 시 무조건 probe 하다가
빨개졌다. 고친 이유가 둘이다:

1. 폴더가 없으면 git 이 있든 없든 이 화면이 할 일이 없다 — 안 쓸 답을 미리 물을
   이유가 없다.
2. **macOS 는 명령어 도구가 없을 때 git 을 부르면 시스템 설치 다이얼로그를 띄운다**
   (PO 근거석 조사 — Zettlr 사례). 사용자가 「기록」을 열지도 않았는데 OS 창이
   뜨면 그건 우리가 부른 적 없는 화면이다.

그리고 **푸시 전에 테스트를 안 돌리고 커밋한 내 순서 오류**이기도 하다 — 기록으로
남긴다.

## Test plan

`tsc --noEmit` clean · `pnpm lint` 에러 0 ·
`atlas-git-panel` + `git-install-guide` **45 + 13 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB