### PR TITLE
feat: 기록 화면이 시안의 2단 작업대가 된다 — 탭을 없애고 시간축 하나로

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3245,7 +3245,9 @@
     "bearingDependsOn": "Depends on",
     "bearingUsedBy": "Used by",
     "dockNoRemote": "Still only on this machine — connect a remote repository to read it elsewhere and keep a backup.",
-    "dockConnectRemote": "Connect a remote"
+    "dockConnectRemote": "Connect a remote",
+    "pendingNow": "now",
+    "pendingHint": "Commit to add it to the history"
   },
   "agentFiles": {
     "header": "Agent files",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3245,7 +3245,9 @@
     "bearingDependsOn": "기대는 곳",
     "bearingUsedBy": "이곳을 쓰는 곳",
     "dockNoRemote": "아직 이 컴퓨터에만 쌓여요 — 원격 저장소를 연결하면 다른 기기에서도 보고 백업돼요.",
-    "dockConnectRemote": "원격 저장소 연결"
+    "dockConnectRemote": "원격 저장소 연결",
+    "pendingNow": "지금",
+    "pendingHint": "커밋하면 이력이 됩니다"
   },
   "agentFiles": {
     "header": "에이전트 파일",

--- a/scripts/perf-graph.mjs
+++ b/scripts/perf-graph.mjs
@@ -13,6 +13,7 @@
 //   node scripts/perf-graph.mjs --check --runs=5
 //   node scripts/perf-graph.mjs --json
 
+import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 
 import { compileOntology } from "../mcp/src/ontology-compiler.mjs";
@@ -72,8 +73,14 @@ function parseSize(value, flag) {
   return size;
 }
 
+/*
+ * 컴파일러가 노드마다 불변 `uid` 를 요구한다(2026-08-02 정체성 규칙). 벤치
+ * 픽스처는 손으로 쓴 것이 아니라 여기서 만들어지므로, 실제 볼트가 쓰는 것과
+ * 같은 방식(`randomUUID`)으로 만들어 준다 — 안 그러면 벤치가 컴파일 단계에서
+ * 죽고, 재는 대상(질의 성능)에 닿지도 못한다.
+ */
 function doc(slug, frontmatter, mtime = 1) {
-  return { slug, frontmatter: { slug, ...frontmatter }, body: "", mtime };
+  return { slug, frontmatter: { uid: randomUUID(), slug, ...frontmatter }, body: "", mtime };
 }
 
 function generateDocs(n) {

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.test.tsx
@@ -175,7 +175,6 @@ describe("AtlasGitPanel — 데스크톱(Tauri)", () => {
     expect(groups).toHaveTextContent("capabilities/foo");
 
     // #85 — 이력은 증거 pane 의 두 번째 탭이다(좌: 무엇을 남길까 / 우: 증거).
-    fireEvent.click(screen.getByTestId("atlas-git-history-tab"));
     const step = screen.getByTestId("atlas-git-history-item");
     // 2026-07-27 — 걸음 요약은 **사람 말**로 읽힌다. 커밋 제목
     // `ontology snapshot: +1 concept (…)` 은 우리가 만든 문자열이고, 그걸
@@ -188,7 +187,7 @@ describe("AtlasGitPanel — 데스크톱(Tauri)", () => {
 
     // 다만 원문은 사라지지 않는다 — 펼치면 감사 흔적으로 그대로 있다.
     fireEvent.click(step);
-    expect(screen.getByTestId("atlas-git-history-detail")).toHaveTextContent(
+    expect(await screen.findByTestId("atlas-git-history-detail")).toHaveTextContent(
       "ontology snapshot: +1 concept (capabilities/foo)",
     );
   });
@@ -356,25 +355,41 @@ describe("AtlasGitPanel — 데스크톱(Tauri)", () => {
     expect(screen.queryByTestId("atlas-git-remote-setup")).not.toBeInTheDocument();
   });
 
-  it("바뀐 줄이 증거 pane 기본 탭으로 열려 있다 (#85)", async () => {
+  /*
+   * 탭이 사라졌다(2026-08-02). 「변경 내용 / 커밋 이력」은 사실 *안 된 것 vs
+   * 된 것* 이라 목록의 위치가 이미 말한다 — 맨 위가 미커밋, 아래가 커밋.
+   * 그래서 이 테스트는 이제 **기본 선택**을 잡는다: 커밋할 게 있으면 그것이
+   * 열려 있고 변경 내용이 바로 보인다.
+   */
+  it("커밋할 게 있으면 그 변경이 기본으로 열려 있다 — 탭을 눌러 찾지 않는다", async () => {
     installDesktopGit();
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" />);
 
-    // 토글이 아니라 탭이다 — 증거는 숨겨두는 게 아니라 목록 옆에 늘 있다.
     expect(await screen.findByTestId("atlas-git-diff-pre")).toHaveTextContent("+new line");
-    fireEvent.click(screen.getByTestId("atlas-git-history-tab"));
-    expect(screen.queryByTestId("atlas-git-diff-pre")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("atlas-git-diff-toggle"));
-    expect(screen.getByTestId("atlas-git-diff-pre")).toHaveTextContent("+new line");
+    // 미커밋 줄이 목록 맨 위에 있고, 그것이 골라져 있다.
+    const pending = screen.getByTestId("atlas-git-pending-row");
+    expect(pending).toHaveAttribute("aria-pressed", "true");
+    // 탭 버튼은 더 이상 존재하지 않는다.
+    expect(screen.queryByTestId("atlas-git-diff-toggle")).toBeNull();
+    expect(screen.queryByTestId("atlas-git-history-tab")).toBeNull();
+  });
+
+  it("커밋 이력이 탭 뒤에 숨지 않는다 — 목록에 늘 있다", async () => {
+    installDesktopGit();
+    renderPanel(<AtlasGitPanel vaultPath="/repo/vault" />);
+    const steps = await screen.findByTestId("atlas-git-steps");
+    expect(steps).toHaveTextContent("abc1234");
   });
 
   it("expands a history item to its full hash + iso time on click", async () => {
     installDesktopGit();
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" />);
 
-    fireEvent.click(await screen.findByTestId("atlas-git-history-tab"));
+    await screen.findByTestId("atlas-git-steps");
     fireEvent.click(screen.getByTestId("atlas-git-history-item"));
-    expect(screen.getByTestId("atlas-git-history-detail")).toHaveTextContent("abc1234def5678");
+    expect(await screen.findByTestId("atlas-git-history-detail")).toHaveTextContent(
+      "abc1234def5678",
+    );
   });
 
   it("목적지에는 닫기가 없다 — 제목은 페이지 헤드라인이다", async () => {
@@ -539,11 +554,13 @@ describe("AtlasGitPanel — 작업대 빈 상태", () => {
     expect(screen.queryByTestId("atlas-git-evidence")).not.toBeInTheDocument();
   });
 
-  it("남길 것이 있으면 두 열이 되고, 증거 열은 보여줄 것이 있을 때만 온다", async () => {
-    // 소유자 스크린샷의 그 순간: 새로 만든 문서 하나 + 첫 걸음 전 → 바뀐 줄도
-    // 지난 걸음도 없다. 구 화면은 그래도 2열을 선언해 오른쪽에 한 줄
-    // ("새로 만든 문서라 비교할 예전 내용이 없어요")만 띄우고 세로 구분선을
-    // 화면 끝까지 그었다.
+  it("새로 만든 문서만 바뀐 순간에도 변경 목록이 살아 있다", async () => {
+    /*
+     * 소유자 스크린샷의 그 순간: 새로 만든 문서 하나 + 첫 커밋 전 → 비교할
+     * 예전 내용이 없어 diff 가 0줄이다. 2단 전환에서 변경 목록이 오른쪽 열로
+     * 옮겨갔으므로, 열의 존재 조건이 `diff 가 있는가` 로 남아 있으면 이
+     * 순간에 판단 대상이 **통째로 사라진다**. 그 회귀를 잡는다.
+     */
     installDesktopGit({
       status: { ...STATUS_WITH_CHANGES, changedCount: 1 },
       diff: { count: 1, files: [DIFF_WITH_CHANGES.files[0]], diff: "" },
@@ -553,7 +570,6 @@ describe("AtlasGitPanel — 작업대 빈 상태", () => {
 
     const workbench = await screen.findByTestId("atlas-git-workbench");
     expect(workbench).toHaveAttribute("data-shape", "decide");
-    expect(screen.queryByTestId("atlas-git-evidence")).not.toBeInTheDocument();
     // 판단 대상은 그대로 있다.
     expect(screen.getByTestId("atlas-git-change-groups")).toHaveTextContent("capabilities/foo");
   });
@@ -781,7 +797,7 @@ describe("AtlasGitPanel — 걸음의 주어는 개념이다", () => {
   it("걸음 행이 커밋 제목이 아니라 개념 이름을 주어로 그린다", async () => {
     installDesktopGit({ history: HISTORY_WITH_FILES });
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" graph={GRAPH} />);
-    fireEvent.click(await screen.findByTestId("atlas-git-history-tab"));
+    await screen.findByTestId("atlas-git-steps");
     const step = screen.getByTestId("atlas-git-history-item");
     expect(step).toHaveTextContent("첫 실행 안내");
     // 원문은 사라지지 않는다 — 아래 줄에서 그 걸음을 구별해 준다.
@@ -806,7 +822,7 @@ describe("AtlasGitPanel — 걸음의 주어는 개념이다", () => {
       ],
     });
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" graph={GRAPH} />);
-    fireEvent.click(await screen.findByTestId("atlas-git-history-tab"));
+    await screen.findByTestId("atlas-git-steps");
     expect(screen.getByTestId("atlas-git-history-item")).not.toHaveTextContent("첫 실행 안내");
   });
 });
@@ -884,7 +900,7 @@ describe("AtlasGitPanel — 고른 개념의 성질과 이웃", () => {
   it("걸음을 펼치면 그 개념의 성질과 이웃이 그 자리에 뜬다", async () => {
     installDesktopGit({ history: HISTORY });
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" graph={EGO_GRAPH} />);
-    fireEvent.click(await screen.findByTestId("atlas-git-history-tab"));
+    await screen.findByTestId("atlas-git-steps");
     fireEvent.click(screen.getByTestId("atlas-git-history-item"));
     const ego = await screen.findByTestId("atlas-git-concept-ego");
     expect(ego).toHaveTextContent("첫 실행 안내");
@@ -895,7 +911,7 @@ describe("AtlasGitPanel — 고른 개념의 성질과 이웃", () => {
   it("그래프가 없으면 (웹·미로드) 카드를 아예 안 그린다 — 빈 상자를 두지 않는다", async () => {
     installDesktopGit({ history: HISTORY });
     renderPanel(<AtlasGitPanel vaultPath="/repo/vault" />);
-    fireEvent.click(await screen.findByTestId("atlas-git-history-tab"));
+    await screen.findByTestId("atlas-git-steps");
     fireEvent.click(screen.getByTestId("atlas-git-history-item"));
     expect(screen.queryByTestId("atlas-git-concept-ego")).toBeNull();
   });

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -55,7 +55,7 @@ import { gitHostPlatformFrom, gitInstallGuide } from "@/shared/lib/git-install-g
 import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
 import type { KnowledgeGraphEdge, KnowledgeGraphNode } from "@/entities/knowledge-graph";
 import { buildConceptEgo, matchNodeId, type ConceptEgo } from "../model/build-concept-ego";
-import { ConceptEgoCard } from "./ConceptEgoCard";
+import { CommitDetail } from "./CommitDetail";
 import { cn } from "@/shared/lib/cn";
 import { ATLAS_CLI } from "@/shared/config/cli-invocation";
 
@@ -1816,48 +1816,17 @@ function StepList({
               </span>
             </button>
             {expanded ? (
-              <div
-                className="git-fade-in flex flex-col gap-0.5 pb-1.5 pl-1.5"
-                data-testid="atlas-git-history-detail"
-              >
-                <p className="font-mono text-caption break-all text-[color:var(--color-text-quaternary)]">
-                  {t("historyItemDetail", { hash: commit.hash, isoTime: commit.isoTime })}
-                </p>
-                {/* 원문 — 터미널·저장소 페이지에서 다시 마주칠 문자열이다. */}
-                <p className="font-mono text-caption break-all text-[color:var(--color-text-quaternary)]">
-                  {commit.subject}
-                </p>
-                {stepConcepts.length > 0 ? (
-                  <div className="mt-2 flex flex-col gap-2">
-                    {/* 개념이 둘 이상이면 **무엇을 볼지 고르는 축**이 필요하다.
-                        「첫 개념만」은 나머지를 볼 길이 없고, 전부 펼치면
-                        overview-first 를 어긴다 — 칩이 그 선택기다. */}
-                    {stepConcepts.length > 1 ? (
-                      <div className="flex flex-wrap gap-1.5">
-                        {stepConcepts.map((concept) => (
-                          <button
-                            key={concept.id}
-                            type="button"
-                            data-testid="atlas-git-concept-chip"
-                            aria-pressed={focusedConceptId === concept.id}
-                            onClick={() => setFocusedConceptId(concept.id)}
-                            className="inline-flex min-h-6 items-center gap-1.5 rounded-[var(--radius-chip)] border border-[color:var(--color-border-soft)] px-2 py-0.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] aria-pressed:border-[color:var(--color-indigo-a46)] aria-pressed:bg-[color:var(--color-indigo-a16)] aria-pressed:text-[color:var(--color-text-primary)]"
-                          >
-                            <TopologyV2KindGlyph kind={concept.kind} size={11} />
-                            {concept.label}
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
-                    <ConceptEgoCard
-                      ego={egoFor(focusedConceptId ?? stepConcepts[0].id)}
-                      t={t}
-                      kindLabel={kindLabel}
-                      onSelect={setFocusedConceptId}
-                    />
-                  </div>
-                ) : null}
-              </div>
+              <CommitDetail
+                t={t}
+                hash={commit.hash}
+                isoTime={commit.isoTime}
+                subject={commit.subject}
+                concepts={stepConcepts}
+                focusedConceptId={focusedConceptId}
+                setFocusedConceptId={setFocusedConceptId}
+                egoFor={egoFor}
+                kindLabel={kindLabel}
+              />
             ) : null}
           </li>
         );

--- a/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
+++ b/src/widgets/atlas-git-panel/ui/AtlasGitPanel.tsx
@@ -234,6 +234,12 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
  * 다시 확인하는 것 하나뿐이라, 전폭 상단 정렬로 두면 "내용이 안 나온 페이지"
  * 로 읽힌다.
  */
+/**
+ * 작업대에서 지금 보고 있는 것. `pending` = 아직 커밋 안 한 변경,
+ * `commit` = 그 해시의 커밋.
+ */
+export type WorkbenchSelection = { kind: "pending" } | { kind: "commit"; hash: string };
+
 type GitStage = "web" | "no-vault" | "loading" | "not-installed" | "error" | "not-initialized" | "workbench";
 
 type SetupStep = 1 | 2 | 3;
@@ -355,7 +361,17 @@ export function AtlasGitPanel({
    * 변경이 있어도 비교할 예전 내용이 없어서, 변경 수로 판정하면 사용자가
    * 요청하지도 않은 빈 칸에 착지한다(소유자 스크린샷의 그 한 줄).
    */
-  const [evidenceTabChoice, setEvidenceTabChoice] = useState<"diff" | "history" | null>(null);
+  /*
+   * 작업대의 선택 — **탭을 대신하는 축**이다.
+   *
+   * 종전에는 오른쪽 열이 「변경 내용 / 커밋 이력」 탭으로 갈렸는데, 그 둘은
+   * 사실 *"아직 커밋 안 된 것 vs 된 것"* 이라 **목록의 위치**가 이미 말한다
+   * (맨 위가 안 된 것, 아래가 된 것 — 시간순이니 자연스럽다). 탭이 있으면
+   * 커밋 이력이 그 뒤에 숨어서, 실제로 소유자가 새 화면을 못 봤다.
+   *
+   * `null` = 아직 안 골랐음 → 아래 `selection` 이 상태를 보고 정한다.
+   */
+  const [selectionChoice, setSelectionChoice] = useState<WorkbenchSelection | null>(null);
   const [expandedHash, setExpandedHash] = useState<string | null>(null);
 
   /**
@@ -425,7 +441,19 @@ export function AtlasGitPanel({
   // 행별 줄 증감이 둘 다 이 값을 봐야 하는데, 자식에서 두 번 계산하면
   // 화면의 두 곳이 서로 다른 사실을 말할 수 있다.
   const diffFiles = useMemo(() => parseUnifiedDiff(diffText), [diffText]);
-  const evidenceTab = evidenceTabChoice ?? (diffFiles.length > 0 ? "diff" : "history");
+  /*
+   * 고르기 전 기본값: 아직 커밋 안 한 변경이 있으면 그것, 없으면 최근 커밋.
+   * 판정 기준이 "변경 수" 가 아니라 **파싱된 diff 파일 수** 인 이유는 종전
+   * 탭 판정과 같다 — 새로 만든 문서만 바뀐 순간에는 변경이 있어도 비교할
+   * 예전 내용이 없어서, 변경 수로 판정하면 요청하지도 않은 빈 칸에 착지한다.
+   */
+  const selection: WorkbenchSelection =
+    selectionChoice ??
+    (diffFiles.length > 0
+      ? { kind: "pending" }
+      : history.length > 0
+        ? { kind: "commit", hash: history[0].hash }
+        : { kind: "pending" });
 
   const stage: GitStage = !bridgeAvailable
     ? "web"
@@ -462,9 +490,12 @@ export function AtlasGitPanel({
       setSnapshotResult(result);
       setConfirming(false);
       setPushOptIn(false);
-      // 사용자의 명시 선택을 지운다 — 남긴 직후 화면은 `recall` 모양으로
-      // 넘어가고(지난 걸음이 본문), 변경이 남아 있으면 계속 `바뀐 줄`이다.
-      setEvidenceTabChoice(null);
+      /*
+       * 사용자의 명시 선택을 지운다 — 커밋 직후 화면은 기본값으로 돌아간다.
+       * 남은 변경이 있으면 계속 「아직 커밋 안 한 변경」, 없으면 방금 만든
+       * 커밋이 열린다. 방금 한 일의 결과를 보여주는 쪽이 옳다.
+       */
+      setSelectionChoice(null);
       setSelectedPath(null);
       await refresh();
     } catch (err) {
@@ -652,8 +683,8 @@ export function AtlasGitPanel({
             snapshotError={snapshotError}
             confirmSnapshot={confirmSnapshot}
             onRetry={refresh}
-            evidenceTab={evidenceTab}
-            setEvidenceTab={setEvidenceTabChoice}
+            selection={selection}
+            setSelection={setSelectionChoice}
             diffFiles={diffFiles}
             history={history}
             expandedHash={expandedHash}
@@ -1711,6 +1742,9 @@ function StepList({
   expandedHash,
   setExpandedHash,
   settledHash,
+  pendingCount,
+  selection,
+  setSelection,
 }: {
   t: Translator;
   history: GitCommitInfo[];
@@ -1729,6 +1763,13 @@ function StepList({
   setExpandedHash: (v: string | null) => void;
   /** 방금 남긴 커밋의 해시 — 그 한 줄만 확정 램프로 정착시킨다. */
   settledHash?: string | null;
+  /**
+   * 아직 커밋 안 한 변경 수. 0 이면 그 줄을 안 그린다 — 없는 것을 자리로
+   * 남겨 두면 목록이 "무언가 비어 있다" 로 읽힌다.
+   */
+  pendingCount: number;
+  selection: WorkbenchSelection;
+  setSelection: (v: WorkbenchSelection) => void;
 }) {
   if (history.length === 0) {
     return (
@@ -1743,6 +1784,37 @@ function StepList({
 
   return (
     <ul data-testid="atlas-git-steps" className="flex flex-col">
+      {/*
+        아직 커밋 안 한 변경도 **변경 묶음**이라는 점에서 커밋과 같다. 다른
+        것은 아직 이름이 안 붙었다는 것뿐이라, 같은 행 문법을 쓰고 구별은
+        선 스타일(점선)과 시각(「지금」)이 진다. 새 색은 안 쓴다.
+      */}
+      {pendingCount > 0 ? (
+        <li>
+          <button
+            type="button"
+            data-testid="atlas-git-pending-row"
+            aria-pressed={selection.kind === "pending"}
+            onClick={() => setSelection({ kind: "pending" })}
+            className="flex h-[var(--git-step-h)] w-full items-center gap-3 rounded-[var(--radius-chip)] border-l-2 border-l-dashed border-l-[color:var(--color-indigo-a46)] pr-1.5 pl-1.5 text-left transition-colors hover:bg-[color:var(--color-overlay-1)] aria-pressed:border-l-[color:var(--color-indigo-brand)] aria-pressed:bg-[color:var(--color-overlay-2)]"
+          >
+            <span className="w-20 shrink-0 truncate text-label text-[color:var(--color-text-tertiary)]">
+              {t("pendingNow")}
+            </span>
+            <span className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-body font-medium text-[color:var(--color-text-primary)]">
+                {t("changesTitle")}
+              </span>
+              <span className="truncate text-label text-[color:var(--color-text-quaternary)]">
+                {t("pendingHint")}
+              </span>
+            </span>
+            <span className="shrink-0 tabular-nums text-label text-[color:var(--color-text-tertiary)]">
+              {pendingCount}
+            </span>
+          </button>
+        </li>
+      ) : null}
       {history.map((commit, index) => {
         const summary = describeSnapshotSubject(commit.subject);
         const parts = [
@@ -1759,7 +1831,7 @@ function StepList({
         const stepConcepts = concepts.get(commit.hash) ?? [];
         const names = summary.slugs.join(", ");
         const trail = summary.overflow > 0 ? t("moreSlugs", { count: summary.overflow }) : "";
-        const expanded = expandedHash === commit.hash;
+        const expanded = selection.kind === "commit" && selection.hash === commit.hash;
         return (
           <li
             key={commit.hash}
@@ -1773,7 +1845,7 @@ function StepList({
               data-testid="atlas-git-history-item"
               aria-expanded={expanded}
               title={t("stepSelectHint")}
-              onClick={() => setExpandedHash(expanded ? null : commit.hash)}
+              onClick={() => setSelection({ kind: "commit", hash: commit.hash })}
               className="flex h-[var(--git-step-h)] w-full items-center gap-3 rounded-[var(--radius-chip)] border-l-2 border-l-transparent pr-1.5 pl-1.5 text-left transition-colors hover:bg-[color:var(--color-overlay-1)] aria-expanded:border-l-[color:var(--color-indigo-brand)] aria-expanded:bg-[color:var(--color-overlay-2)]"
             >
               <span className="w-20 shrink-0 truncate text-label text-[color:var(--color-text-quaternary)]">
@@ -1815,19 +1887,6 @@ function StepList({
                 {commit.shortHash}
               </span>
             </button>
-            {expanded ? (
-              <CommitDetail
-                t={t}
-                hash={commit.hash}
-                isoTime={commit.isoTime}
-                subject={commit.subject}
-                concepts={stepConcepts}
-                focusedConceptId={focusedConceptId}
-                setFocusedConceptId={setFocusedConceptId}
-                egoFor={egoFor}
-                kindLabel={kindLabel}
-              />
-            ) : null}
           </li>
         );
       })}
@@ -2047,8 +2106,8 @@ function DesktopBody({
   snapshotError,
   confirmSnapshot,
   onRetry,
-  evidenceTab,
-  setEvidenceTab,
+  selection,
+  setSelection,
   diffFiles,
   history,
   expandedHash,
@@ -2103,8 +2162,8 @@ function DesktopBody({
   snapshotError: string | null;
   confirmSnapshot: () => void;
   onRetry: () => void;
-  evidenceTab: "diff" | "history";
-  setEvidenceTab: (v: "diff" | "history") => void;
+  selection: WorkbenchSelection;
+  setSelection: (v: WorkbenchSelection) => void;
   diffFiles: AtlasGitDiffFile[];
   history: GitCommitInfo[];
   expandedHash: string | null;
@@ -2394,9 +2453,12 @@ function DesktopBody({
               kindLabel={kindLabel}
               focusedConceptId={focusedConceptId}
               setFocusedConceptId={setFocusedConceptId}
-              expandedHash={expandedHash}
-              setExpandedHash={setExpandedHash}
+              expandedHash={null}
+              setExpandedHash={() => {}}
               settledHash={settledHash}
+              pendingCount={0}
+              selection={selection}
+              setSelection={setSelection}
             />
           </div>
           {dock}
@@ -2409,7 +2471,15 @@ function DesktopBody({
   // 증거 열 최소 폭이 `--git-evidence-min`(600px)인 이유: 11px mono 80칼럼
   // ≈ 528px + gutter + padding. 시안 v1 의 420px 는 모든 줄을 잘랐고 **잘린
   // diff 는 증거가 아니다**. `lg` 미만은 세로로 쌓인다(증거가 목록 아래).
-  const showEvidence = diffFiles.length > 0 || history.length > 0;
+  /*
+   * 오른쪽 열은 이제 「증거」가 아니라 **고른 것의 상세**다. 그래서 존재
+   * 조건도 바뀐다 — 종전에는 "보여줄 diff 나 이력이 있는가" 였는데, 지금은
+   * 변경 목록도 이 열에 살기 때문에 **커밋할 것이 있으면** 열이 있어야 한다.
+   *
+   * 구 규칙(`diffFiles.length > 0`)을 그대로 두면 새로 만든 문서만 바뀐
+   * 순간(비교할 예전 내용이 없어 diff 가 0줄)에 변경 목록이 통째로 사라진다.
+   */
+  const showEvidence = statusCounts.total > 0 || diffFiles.length > 0 || history.length > 0;
 
   return (
     <div
@@ -2440,20 +2510,30 @@ function DesktopBody({
               "mx-auto w-full max-w-[var(--git-single-measure)]",
         )}
       >
+        {/*
+          왼쪽은 **시간축 하나**다. 맨 위가 아직 커밋 안 한 변경, 그 아래가
+          커밋 이력 — 시간순이라 "안 된 것 / 된 것" 이 위치로 이미 갈린다.
+          그래서 탭이 필요 없다(구 「변경 내용 / 커밋 이력」 탭 제거).
+        */}
         <div className="flex min-w-0 flex-col gap-3 xl:min-h-0">
           {remotePanel}
-          <ChangeList
-            t={t}
-            kindGroups={kindGroups}
-            otherChanges={otherChanges}
-            statusCounts={statusCounts}
-            deltaByPath={deltaByPath}
-            selectedPath={selectedPath}
-            setSelectedPath={setSelectedPath}
-            othersOpen={othersOpen}
-            setOthersOpen={setOthersOpen}
-            stagedOutsideCount={status?.stagedOutsideVault.length ?? 0}
-          />
+          <div className="min-h-0 xl:flex-1 xl:overflow-y-auto">
+            <StepList
+              t={t}
+              history={history}
+              concepts={concepts}
+              egoFor={egoFor}
+              kindLabel={kindLabel}
+              focusedConceptId={focusedConceptId}
+              setFocusedConceptId={setFocusedConceptId}
+              expandedHash={null}
+              setExpandedHash={() => {}}
+              settledHash={settledHash}
+              pendingCount={statusCounts.total}
+              selection={selection}
+              setSelection={setSelection}
+            />
+          </div>
           {dock}
         </div>
 
@@ -2462,58 +2542,63 @@ function DesktopBody({
             data-testid="atlas-git-evidence"
             className="flex min-w-0 flex-col gap-2 xl:min-h-0 xl:border-l xl:border-[color:var(--color-divider)] xl:pl-5"
           >
-            <div className="flex shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-1">
-              <div className="flex items-center gap-1.5">
-                <EvidenceTab
-                  active={evidenceTab === "diff"}
-                  testId="atlas-git-diff-toggle"
-                  onClick={() => setEvidenceTab("diff")}
-                >
-                  {t("diffTab")}
-                </EvidenceTab>
-                <EvidenceTab
-                  active={evidenceTab === "history"}
-                  testId="atlas-git-history-tab"
-                  onClick={() => setEvidenceTab("history")}
-                >
-                  {t("stepsTab")}
-                </EvidenceTab>
-              </div>
-              {/* 무엇의 증거인지 — 고른 것이 없으면 "전체" 라고 말한다. */}
-              {evidenceTab === "diff" ? (
-                <span className="min-w-0 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
-                  {selectedPath ?? t("diffAllLabel")}
-                </span>
-              ) : null}
-            </div>
-
-            {evidenceTab === "diff" ? (
-              shownDiffFiles.length > 0 ? (
-                <DiffView
+            {/*
+              오른쪽은 **왼쪽에서 고른 것 하나**를 그린다. 탭이 아니라 선택이
+              무엇을 보여줄지 정한다 — 구조가 "지금 무엇을 보고 있나" 를 스스로
+              말하므로 탭 라벨을 읽어 알아낼 필요가 없다.
+            */}
+            {selection.kind === "pending" ? (
+              <>
+                <div className="flex shrink-0 flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                  <SectionLabel>{t("changesTitle")}</SectionLabel>
+                  <span className="min-w-0 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
+                    {selectedPath ?? t("diffAllLabel")}
+                  </span>
+                </div>
+                <ChangeList
                   t={t}
-                  files={shownDiffFiles}
-                  showFileHeads={!selectedPath && shownDiffFiles.length > 1}
+                  kindGroups={kindGroups}
+                  otherChanges={otherChanges}
+                  statusCounts={statusCounts}
+                  deltaByPath={deltaByPath}
+                  selectedPath={selectedPath}
+                  setSelectedPath={setSelectedPath}
+                  othersOpen={othersOpen}
+                  setOthersOpen={setOthersOpen}
+                  stagedOutsideCount={status?.stagedOutsideVault.length ?? 0}
                 />
-              ) : (
-                <p className="git-fade-in text-label leading-relaxed text-[color:var(--color-text-quaternary)]">
-                  {t("diffEmpty")}
-                </p>
-              )
+                {shownDiffFiles.length > 0 ? (
+                  <DiffView
+                    t={t}
+                    files={shownDiffFiles}
+                    showFileHeads={!selectedPath && shownDiffFiles.length > 1}
+                  />
+                ) : (
+                  <p className="git-fade-in text-label leading-relaxed text-[color:var(--color-text-quaternary)]">
+                    {t("diffEmpty")}
+                  </p>
+                )}
+              </>
             ) : (
-              <div className="git-fade-in overflow-y-auto max-xl:max-h-[var(--git-evidence-stack-max)] xl:min-h-0 xl:flex-1">
-                <StepList
-                  t={t}
-                  history={history}
-                  concepts={concepts}
-                  egoFor={egoFor}
-                  kindLabel={kindLabel}
-                  focusedConceptId={focusedConceptId}
-                  setFocusedConceptId={setFocusedConceptId}
-                  expandedHash={expandedHash}
-                  setExpandedHash={setExpandedHash}
-                  settledHash={settledHash}
-                />
-              </div>
+              (() => {
+                const picked = history.find((c) => c.hash === selection.hash);
+                if (!picked) return null;
+                return (
+                  <div className="git-fade-in overflow-y-auto xl:min-h-0 xl:flex-1">
+                    <CommitDetail
+                      t={t}
+                      hash={picked.hash}
+                      isoTime={picked.isoTime}
+                      subject={picked.subject}
+                      concepts={concepts.get(picked.hash) ?? []}
+                      focusedConceptId={focusedConceptId}
+                      setFocusedConceptId={setFocusedConceptId}
+                      egoFor={egoFor}
+                      kindLabel={kindLabel}
+                    />
+                  </div>
+                );
+              })()
             )}
           </div>
         ) : null}

--- a/src/widgets/atlas-git-panel/ui/CommitDetail.tsx
+++ b/src/widgets/atlas-git-panel/ui/CommitDetail.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
+import type { ConceptEgo } from "../model/build-concept-ego";
+import { ConceptEgoCard } from "./ConceptEgoCard";
+
+/**
+ * 한 커밋이 **무엇을 바꿨나** — 해시·원문 + 바뀐 개념 + 고른 개념의 성질/이웃.
+ *
+ * `StepList` 의 펼침 영역 안에 인라인으로 살던 것을 뺐다. 2단 작업대에서는
+ * 이 내용이 **오른쪽 열**로 가야 하는데, 목록 행 안에 있으면 옮길 수가 없다.
+ * 지금은 추출만 하고 자리는 그대로다 — 옮기는 것은 다음 슬라이스다.
+ */
+export interface CommitConcept {
+  id: string;
+  label: string;
+  kind: string;
+}
+
+export function CommitDetail({
+  t,
+  hash,
+  isoTime,
+  subject,
+  concepts,
+  focusedConceptId,
+  setFocusedConceptId,
+  egoFor,
+  kindLabel,
+}: {
+  t: (key: string, values?: Record<string, string | number>) => string;
+  hash: string;
+  isoTime: string;
+  subject: string;
+  concepts: readonly CommitConcept[];
+  focusedConceptId: string | null;
+  setFocusedConceptId: (id: string) => void;
+  egoFor: (nodeId: string) => ConceptEgo | null;
+  kindLabel: (kind: string) => string;
+}) {
+  const focused = focusedConceptId ?? concepts[0]?.id ?? null;
+  return (
+    <div
+      className="git-fade-in flex flex-col gap-0.5 pb-1.5 pl-1.5"
+      data-testid="atlas-git-history-detail"
+    >
+      <p className="font-mono text-caption break-all text-[color:var(--color-text-quaternary)]">
+        {t("historyItemDetail", { hash, isoTime })}
+      </p>
+      {/* 원문 — 터미널·저장소 페이지에서 다시 마주칠 문자열이다. */}
+      <p className="font-mono text-caption break-all text-[color:var(--color-text-quaternary)]">
+        {subject}
+      </p>
+      {concepts.length > 0 ? (
+        <div className="mt-2 flex flex-col gap-2">
+          {/* 개념이 둘 이상이면 **무엇을 볼지 고르는 축**이 필요하다.
+              「첫 개념만」은 나머지를 볼 길이 없고, 전부 펼치면 overview-first
+              를 어긴다 — 칩이 그 선택기다. */}
+          {concepts.length > 1 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {concepts.map((concept) => (
+                <button
+                  key={concept.id}
+                  type="button"
+                  data-testid="atlas-git-concept-chip"
+                  aria-pressed={focused === concept.id}
+                  onClick={() => setFocusedConceptId(concept.id)}
+                  className="inline-flex min-h-6 items-center gap-1.5 rounded-[var(--radius-chip)] border border-[color:var(--color-border-soft)] px-2 py-0.5 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] aria-pressed:border-[color:var(--color-indigo-a46)] aria-pressed:bg-[color:var(--color-indigo-a16)] aria-pressed:text-[color:var(--color-text-primary)]"
+                >
+                  <TopologyV2KindGlyph kind={concept.kind} size={11} />
+                  {concept.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {focused ? (
+            <ConceptEgoCard
+              ego={egoFor(focused)}
+              t={t}
+              kindLabel={kindLabel}
+              onSelect={setFocusedConceptId}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

소유자가 두 탭(「바뀐 줄」·「지난 걸음」)을 보고 *"이건 또 뭐야"* 라고 물었다. 그게 판정이다 — 이름이 무엇인지 안 말하고, **커밋 이력이 탭 뒤에 숨어서** 새로 만든 화면을 아무도 못 봤다.

두 탭은 사실 **「안 된 것 vs 된 것」**이었고, 그건 목록의 **위치**가 이미 말한다.

- **왼쪽 = 시간축 하나** — 맨 위 미커밋 줄(점선 인디고 · 「지금」), 아래 커밋 이력
- **오른쪽 = 고른 것의 상세** — 미커밋이면 변경 목록 + 변경 내용, 커밋이면 개념 + ego 그림
- `evidenceTab` → `selection` (`pending | {hash}`)

시안: `docs/prototypes/git-workbench-2026-08-02.html#dirty`

## 옮기다 낸 구멍 하나 (게이트가 잡음)

변경 목록이 오른쪽 열로 갔는데 열의 존재 조건이 `diff 가 있는가` 로 남아, **새로 만든 문서만 바뀐 순간**(diff 0줄)에 판단 대상이 통째로 사라졌다. 조건을 `커밋할 것이 있는가` 로 고치고 회귀를 테스트로 고정.

## Test plan

- 패널 **51개** (신규: 기본 선택 · 탭 부재 · 이력이 목록에 상주 · 새 문서만 바뀐 순간)
- 계약 **1,066개** · `tsc` · i18n 16개 · lint 그대로

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeS3wQjp2pnHriZHxhpLB