### PR TITLE
fix: 경계 페이지 넷을 램프 위로 · 프로젝트에서 실시간 표시를 뺀다

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -74,7 +74,7 @@ export default async function LocaleLayout({
           app/layout.tsx as hardcoded Korean; moved here so it's translated. */}
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:border focus:border-[color:rgba(113,112,255,0.5)] focus:bg-[color:var(--color-panel)] focus:px-3 focus:py-2 focus:text-[13px] focus:text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[color:rgba(94,106,210,0.46)]"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-[var(--radius-chip)] focus:border focus:border-[color:var(--color-indigo-a50)] focus:bg-[color:var(--color-panel)] focus:px-3 focus:py-2 focus:text-body focus:text-[color:var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--color-indigo-a46)]"
       >
         {tNav('skipToContent')}
       </a>

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -51,40 +51,40 @@ export default function LocaleNotFound() {
       id="main"
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10"
     >
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[var(--shadow-elevation-2)]">
+      <div className="w-full max-w-[440px] rounded-[var(--radius-panel)] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[var(--shadow-elevation-2)]">
         <div className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
+          <span className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-chip)] border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
             <Compass size={16} />
           </span>
-          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {t("label")}
           </p>
         </div>
-        <h1 className="mt-4 text-[22px] leading-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+        <h1 className="mt-4 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {t("title")}
         </h1>
-        <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
+        <p className="mt-3 text-body leading-relaxed text-[color:var(--color-text-secondary)]">
           {t("body")}
         </p>
         <div className="mt-5 flex flex-col gap-2">
           <button
             type="button"
             onClick={openSearchOnHome}
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
           >
             <Search size={14} />
             {t("findByProject")}
           </button>
           <Link
             href="/"
-            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t("home")}
           </Link>
           <button
             type="button"
             onClick={goBack}
-            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             <ArrowLeft size={13} />
             {t("previous")}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -21,24 +21,24 @@ export default function RouteError({ error, reset }: Props) {
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10">
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
+      <div className="w-full max-w-[440px] rounded-[var(--radius-panel)] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
         <div className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:rgba(244,183,49,0.35)] bg-[color:rgba(244,183,49,0.08)] text-[color:var(--color-status-warning)]">
+          <span className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-chip)] border border-[color:var(--color-amber-source-a35)] bg-[color:var(--color-amber-source-a08)] text-[color:var(--color-status-warning)]">
             <AlertTriangle size={16} />
           </span>
-          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             Unexpected error
           </p>
         </div>
-        <h1 className="mt-4 text-[22px] leading-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+        <h1 className="mt-4 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           Something went wrong while rendering this screen.
         </h1>
-        <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
+        <p className="mt-3 text-body leading-relaxed text-[color:var(--color-text-secondary)]">
           It might be a temporary issue. Try again or return to the topology
           home. If it persists, please report it with the error ID below.
         </p>
         {error.digest && (
-          <p className="mt-3 font-mono text-[10px] text-[color:var(--color-text-quaternary)]">
+          <p className="mt-3 font-mono text-caption text-[color:var(--color-text-quaternary)]">
             Error ID: <span className="tabular-nums">{error.digest}</span>
           </p>
         )}
@@ -46,14 +46,14 @@ export default function RouteError({ error, reset }: Props) {
           <button
             type="button"
             onClick={reset}
-            className="inline-flex h-10 items-center gap-2 rounded-full border border-[color:rgba(94,106,210,0.38)] bg-[color:rgba(94,106,210,0.14)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:rgba(94,106,210,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a14)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
           >
             <RefreshCw size={14} />
             Try again
           </button>
           <Link
             href="/"
-            className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+            className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
           >
             Topology home
           </Link>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -24,19 +24,19 @@ export default function GlobalError({ error, reset }: Props) {
     <html lang="en">
       <body className="bg-[color:var(--color-canvas)] text-[color:var(--color-text-primary)]">
         <main className="flex min-h-screen items-center justify-center px-6 py-10">
-          <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
-            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <div className="w-full max-w-[440px] rounded-[var(--radius-panel)] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-6">
+            <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
               Critical error
             </p>
-            <h1 className="mt-3 text-[22px] leading-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)]">
+            <h1 className="mt-3 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)]">
               Something went wrong while booting the app.
             </h1>
-            <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
+            <p className="mt-3 text-body leading-relaxed text-[color:var(--color-text-secondary)]">
               Browser cache, extensions, or network issues may be at play.
               Please refresh the page or return to the home screen.
             </p>
             {error.digest && (
-              <p className="mt-3 font-mono text-[10px] text-[color:var(--color-text-quaternary)]">
+              <p className="mt-3 font-mono text-caption text-[color:var(--color-text-quaternary)]">
                 Error ID: <span className="tabular-nums">{error.digest}</span>
               </p>
             )}
@@ -44,13 +44,13 @@ export default function GlobalError({ error, reset }: Props) {
               <button
                 type="button"
                 onClick={reset}
-                className="inline-flex h-10 items-center gap-2 rounded-full border border-[color:rgba(94,106,210,0.38)] bg-[color:rgba(94,106,210,0.14)] px-4 text-[13px] font-[var(--font-weight-signature)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:rgba(94,106,210,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-[color:var(--color-indigo-a38)] bg-[color:var(--color-indigo-a14)] px-4 text-body font-[var(--font-weight-signature)] transition-colors hover:border-[color:var(--color-indigo-brand)] hover:bg-[color:var(--color-indigo-a20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
               >
                 Try again
               </button>
               <Link
                 href="/"
-                className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+                className="inline-flex h-10 items-center rounded-full border border-[color:var(--color-divider)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
               >
                 Home
               </Link>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -72,40 +72,40 @@ export default function NotFound() {
       id="main"
       className="flex min-h-screen items-center justify-center bg-[color:var(--color-canvas)] px-6 py-10"
     >
-      <div className="w-full max-w-[440px] rounded-[22px] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[var(--shadow-elevation-2)]">
+      <div className="w-full max-w-[440px] rounded-[var(--radius-panel)] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] p-7 shadow-[var(--shadow-elevation-2)]">
         <div className="flex items-center gap-2">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
+          <span className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-chip)] border border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]">
             <Compass size={16} />
           </span>
-          <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
             {t.label}
           </p>
         </div>
-        <h1 className="mt-4 text-[22px] leading-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+        <h1 className="mt-4 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {t.title}
         </h1>
-        <p className="mt-3 text-[13px] leading-6 text-[color:var(--color-text-secondary)]">
+        <p className="mt-3 text-body leading-relaxed text-[color:var(--color-text-secondary)]">
           {t.body}
         </p>
         <div className="mt-5 flex flex-col gap-2">
           <button
             type="button"
             onClick={openSearchOnHome}
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-[13px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgba(94,106,210,0.5)]"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[color:var(--color-indigo-brand)] px-4 text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)]"
           >
             <Search size={14} />
             {t.findByProject}
           </button>
           <Link
             href={`/${locale}/`}
-            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-[13px] text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center rounded-full border border-[color:var(--color-divider)] px-4 text-body text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t.home}
           </Link>
           <button
             type="button"
             onClick={goBack}
-            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-[12px] text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+            className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             <ArrowLeft size={13} />
             {t.previous}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -330,6 +330,14 @@ export const codexMigratedGlobs = [
   // `pnpm exec eslint <file>` 에서 **error 0 / warning 0** 을 보고했다. 룰이
   // 틀린 게 아니라 이 디렉토리들을 안 보고 있었다(침묵하는 통과). 진입 경로
   // 4곳의 이탈을 0으로 만들고 여기 승격한다 — 이제 error 로 막힌다.
+  /*
+   * 2026-08-03 — 경계 페이지 넷(`error` · `global-error` · `not-found` ×2)이
+   * 거의 같은 JSX 를 복제하면서 램프 이탈 22줄까지 그대로 복제하고 있었다.
+   * `app/**` 이 이 목록 밖이라 `pnpm exec eslint` 가 **error 0 / warning 0**
+   * 을 보고했다 — 룰이 틀린 게 아니라 이 경로를 안 보고 있었다. 이탈을 0으로
+   * 만들고 승격한다.
+   */
+  'app/**/*.{ts,tsx}',
   'src/features/first-run-starter/**/*.{ts,tsx}',
   'src/features/docs-vault-local/**/*.{ts,tsx}',
   'src/features/locale-switch/**/*.{ts,tsx}',

--- a/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.test.tsx
@@ -132,10 +132,16 @@ describe("ProjectSelectorPage", () => {
   // 레일 자체가 아니라, 페이지가 여전히 소유하는 settings/agent-status
   // 클러스터만 단언한다 — 레일 persistence 자체는 Playwright(프로덕션 정적
   // 서빙에서 rail DOM identity 유지)로 검증한다.
-  it("mounts the settings/agent-status cluster instead of OperationsNav", () => {
+  it("설정은 남고, 실시간 표시는 여기 없다", () => {
+    /*
+     * 「실시간 · 변경 N」은 **지도의 물건**이다 — 무엇이 바뀌었는지를 노드 위에
+     * 그려 주는 화면에서만 그 수가 다음 행동으로 이어진다. 목록 화면에서는 갈
+     * 곳이 없는 채로 우상단의 가장 센 잉크를 가져가고 자기 줄까지 예약해
+     * 아래 내용을 밀어냈다(소유자 실보고 2026-08-03).
+     */
     renderPage();
     expect(screen.getByTestId("app-settings-trigger-stub")).toBeInTheDocument();
-    expect(screen.getByTestId("live-activity-indicator-stub")).toBeInTheDocument();
+    expect(screen.queryByTestId("live-activity-indicator-stub")).toBeNull();
   });
 
   it("renders the workspace census (concepts/relations) from the unified formula", () => {

--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -10,7 +10,7 @@ import {
   type Project,
 } from "@/entities/project";
 import { useProjects } from "@/features/project-data-source";
-import { LiveActivityIndicator, useOntologyInsight } from "@/features/vault-ontology";
+import { useOntologyInsight } from "@/features/vault-ontology";
 import { useDataSourceMode } from "@/features/data-source-mode";
 import { useLocalVault } from "@/features/docs-vault-local";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
@@ -106,13 +106,20 @@ export function ProjectSelectorPage() {
     <div className="flex min-h-full w-full">
       {/* 레일은 perf/persistent-shell 이후 layout(AppShell) 상주. */}
       <main id="main" tabIndex={-1} className="min-w-0 flex-1 bg-[color:var(--color-canvas)] max-lg:pb-[calc(var(--topology-mobile-bottom-tab-reserve)+24px)]">
-        <div className="flex items-center justify-end gap-2 px-4 pt-3 md:px-6">
-          <LiveActivityIndicator agentActivityStatus={vault.agentActivityStatus} />
-          {/* #15 — 설정은 lg+ 에선 나브레일 하단 톱니. 레일이 숨는 <lg 에서만
-              chrome-tile 로 노출. */}
-          <div className="lg:hidden">
-            <AppSettingsMenu mode={dataSourceMode} triggerVariant="chrome-tile" />
-          </div>
+        {/*
+         * ⚠️ **실시간 표시를 여기서 뺐다** (2026-08-03, 소유자 지적).
+         *
+         * 「실시간 · 추적 중 · 변경 8」은 **지도의 물건**이다 — 무엇이 바뀌었는지
+         * 를 노드 위에 그려 주기 때문에 거기서는 그 수가 다음 행동으로 이어진다.
+         * 프로젝트 목록은 훑는 화면이라 그 수가 갈 곳이 없고, 대신 **화면에서
+         * 가장 센 잉크를 우상단에서 가져가고** 자기 줄까지 예약해 아래 내용을
+         * 통째로 밀어냈다(실측: lg+ 에서 이 줄의 유일한 내용이 그 칩이다).
+         *
+         * 그래서 줄 자체도 `lg:hidden` 이다 — 레일이 설정을 지는 폭에서는 이
+         * 줄에 남는 것이 없고, 빈 줄이 자리를 지키면 그건 여백이 아니라 결함이다.
+         */}
+        <div className="flex items-center justify-end gap-2 px-4 pt-3 md:px-6 lg:hidden">
+          <AppSettingsMenu mode={dataSourceMode} triggerVariant="chrome-tile" />
         </div>
         <div className="mx-auto px-5 py-6 md:px-10 md:py-10" style={{ maxWidth: PAGE_MAX_WIDTH }}>
         <nav className="mb-5 flex flex-wrap items-center gap-2.5 text-body text-[color:var(--color-text-tertiary)]">

--- a/tests/contract/type-ramp-coverage.contract.test.ts
+++ b/tests/contract/type-ramp-coverage.contract.test.ts
@@ -86,13 +86,8 @@ const UNCOVERED_DEBT: ReadonlyArray<readonly [string, number]> = [
   ["src/features/vault-ontology", 27],
   ["src/views/project-detail", 23],
   ["src/views/first-run", 14],
-  ["app/[locale]/not-found.tsx", 7],
-  ["app/error.tsx", 7],
-  ["app/global-error.tsx", 7],
-  ["app/not-found.tsx", 7],
   ["src/views/project-editor", 2],
   ["src/views/root-entry", 6],
-  ["app/[locale]/layout.tsx", 1],
 ];
 
 const ROOTS = ["src", "app"] as const;


### PR DESCRIPTION
## Summary

디자인 시스템 전수조사(3인 병렬)의 1차 적용분.

- **경계 페이지 넷이 lint 사각지대** — `error`/`global-error`/`not-found`×2 가 같은 JSX 를 복제하며 램프 이탈 22줄까지 복제하고 있었고, `pnpm exec eslint` 는 error 0 / warning 0 을 보고했다. `app/**` 이 `codexMigratedGlobs` 밖이라 **이 경로를 안 보고 있었던 것**. 전부 램프로 올리고 승격했다(새 토큰 0).
- **프로젝트 화면의 실시간 표시 제거** — 지도의 물건이 목록 화면에서 우상단 최강 잉크를 가져가고 자기 줄까지 예약해 내용을 밀어냈다. lg+ 에서는 그 줄의 유일한 내용이었다.
- **데스크톱 준비 게이트가 따옴표를 재고 있었다** — 목적지 정규식으로 바꿨고, 링크를 딴 데로 돌리면 붉어지는 것을 확인했다.

## 남은 것 (후속 PR)

감사가 **게이트 구멍 넷**을 더 찾았다 — 값보다 이쪽이 원인이다:

1. lint 셀렉터가 **대괄호 문법만** 본다 → `text-sm`/`rounded-md` 같은 Tailwind 기본 스텝 268건이 램프를 통째로 우회
2. `src/widgets/topology-map-v2/**`·`src/views/home/**` 이 `warn` 이고 `pnpm lint` 에 `--max-warnings` 가 없다 → 80건이 아무것도 실패시키지 않음
3. `check-no-raw-color.mjs` 가 `topology-map-v2` 를 디렉터리째 건너뛴다
4. `rgba()` 리터럴이 hex 금지 룰의 문법을 우회

## Test plan

- `pnpm exec tsc --noEmit` · `pnpm lint` (error 0, 경고 baseline 유지)
- `pnpm exec vitest run` — 608 파일 / 5,891 통과
- 준비 게이트 프로브: 링크를 딴 곳으로 돌리면 16/1 로 붉어짐 → 복구 후 17/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)