### PR TITLE
ci: 아티팩트 보관 기간을 하루로 제한한다

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -87,6 +87,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: out
+          retention-days: 1
 
   deploy:
     needs: build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           name: playwright-report-static-export
           path: output/playwright/test-results
-          retention-days: 7
+          retention-days: 1
 
   # ── 웹 스모크 — 분류기가 못 끄는 자리 ────────────────────────────────
   #
@@ -127,7 +127,7 @@ jobs:
         with:
           name: playwright-report-web-smoke
           path: output/playwright/test-results
-          retention-days: 7
+          retention-days: 1
 
   # ── 전체 스위트 — 3 샤드 ─────────────────────────────────────────────
   #
@@ -175,4 +175,4 @@ jobs:
         with:
           name: playwright-report-shard-${{ matrix.shard }}
           path: output/playwright/test-results
-          retention-days: 7
+          retention-days: 1

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -212,6 +212,7 @@ jobs:
           # 경로는 **하나**다. 여럿이면 루트가 최소공통조상으로 정해진다.
           path: release-upload
           if-no-files-found: error
+          retention-days: 1
 
       - name: Cleanup Apple signing keychain
         if: ${{ always() && steps.signing.outputs.signed == 'true' }}
@@ -354,6 +355,7 @@ jobs:
           name: ontology-atlas-windows-x64
           path: release-upload
           if-no-files-found: error
+          retention-days: 1
 
   # Staging and publishing are separate jobs so a human can install the exact
   # bytes that will go public before they do. The draft release is assembled

--- a/.github/workflows/windows-beta-check.yml
+++ b/.github/workflows/windows-beta-check.yml
@@ -200,3 +200,4 @@ jobs:
           name: ontology-atlas-windows-x64-pr-${{ github.event.pull_request.number || github.run_number }}
           path: release-upload
           if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## 변경
- 저장소의 모든 Actions 업로드 아티팩트를 1일 뒤 만료하도록 명시합니다.
- Playwright 실패 보고서, Pages 배포 아티팩트, Windows beta, macOS/Windows 릴리스 스테이징 아티팩트를 포함합니다.
- GitHub Release에 공개된 설치 파일은 workflow artifact와 별개이며 영향을 받지 않습니다.

## 저장소 설정
- Artifact and log retention도 90일에서 1일로 변경하고 API로 확인했습니다.

## 검증
- `pnpm checks:changed -- .github/workflows/e2e.yml .github/workflows/windows-beta-check.yml .github/workflows/deploy-pages.yml .github/workflows/release-macos.yml`
- `pnpm test:mcp:docs`
- `pnpm test:desktop:check`
- `pnpm desktop:check`
- `pnpm test:mcp:package`
- `pnpm package:check`
- workflow 계약 18개
- YAML parse + `git diff --check`