### PR TITLE
feat: 지도에서 노드를 만드는 자리를 빈 캔버스 우클릭으로 옮긴다

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2437,8 +2437,19 @@ pub fn run() {
                                     return true;
                                   };
                                   const openComposer = (attempt = 0) => {
-                                    const toggle = document.querySelector('[data-testid="topology-create-node-toggle"]');
+                                    /*
+                                     * 상단 「+ 개념」 필은 2026-08-03 에 제거됐다
+                                     * (빈 캔버스 우클릭이 그 자리를 대신한다).
+                                     * 프로브는 우클릭을 흉내 내지 않고 **딥링크**
+                                     * (`?create=concept`)로 연다 — 그 경로는
+                                     * `createNodeIntent` 로 이미 계약돼 있고,
+                                     * 캔버스 좌표에 의존하지 않아 창 크기와 무관하게
+                                     * 재현된다.
+                                     */
                                     const panel = document.querySelector('[data-testid="topology-create-node-panel"]');
+                                    if (!visible(panel)) {
+                                      requestCreateRouteIntent();
+                                    }
                                     if (visible(panel)) {
                                       if (!result.shortcutsAttempted) {
                                         result.shortcutsAttempted = true;
@@ -3102,7 +3113,6 @@ pub fn run() {
                               const topologySearchActionLaneStyle = topologySearchActionLane
                                 ? getComputedStyle(topologySearchActionLane)
                                 : null;
-                              const topologyTopCreateButton = document.querySelector('[data-testid="topology-create-node-toggle"]');
                               const topologySigmaControlsStack =
                                 document.querySelector('[data-testid="topology-sigma-controls-stack"]');
                               const topologySigmaControlsStackRect =
@@ -4914,8 +4924,6 @@ pub fn run() {
                                     topologySearchActionLaneRect?.width || 0,
                                   topologySearchActionLaneHeight:
                                     topologySearchActionLaneRect?.height || 0,
-                                  topologyTopCreateLabel:
-                                    topologyTopCreateButton?.textContent?.trim() || "",
                                   topologySigmaControlsStackVisible:
                                     Boolean(
                                       topologySigmaControlsStackRect &&

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -3667,53 +3667,21 @@ export function HomePage() {
                       {t('controls.docsLabel')}
                     </ChromeChip>
                     </Tooltip>
-                    {canCreateNode ? (
-                      <Tooltip content={t('createNode.toggleTooltip')} side="bottom" withProvider={false}>
-                        <button
-                          type="button"
-                          ref={createNodeToggleRef}
-                          onClick={() => {
-                            if (createNodeOpen) {
-                              closeCreateNode();
-                            } else {
-                              openCreateNode();
-                            }
-                          }}
-                          aria-expanded={createNodeOpen}
-                          aria-label={t('createNode.toggleAria')}
-                          data-testid="topology-create-node-toggle"
-                          data-utility-action-token-contract="accent-surface-family"
-                          data-utility-action-surface-token="--topology-utility-lane-accent-surface"
-                          data-utility-action-border-token="--topology-utility-lane-accent-border"
-                          data-utility-action-shadow-token="--topology-utility-lane-shadow"
-                          data-utility-action-focus-ring-token="--topology-utility-lane-focus-ring"
-                          // 높이/radius/compact 폭은 ChromeChip 기준(44px·10px)으로
-                          // 수렴 — 같은 열의 "작업공간" 칩과 나란히 있어
-                          // --topology-utility-lane-height(32~36px clamp) 를
-                          // 쓰면 과도기 높이 불일치가 났다(feat/chrome-finish).
-                          // #13 정합 (2026-07-25) — 옆 ChromeChip 들과 같은
-                          // 타이포/아이콘 규격으로 수렴: 높이 --chrome-tile-size,
-                          // radius --chrome-radius, text-label, 아이콘 size-3.5.
-                          // accent surface(인디고) 만 primary 로 남긴다.
-                          className={`inline-flex h-[var(--chrome-tile-size)] items-center justify-center gap-2 rounded-[var(--chrome-radius)] border border-[color:var(--topology-utility-lane-accent-border)] bg-[color:var(--topology-utility-lane-accent-surface)] text-label tracking-label font-[var(--font-weight-signature)] text-[color:var(--color-indigo-accent)] shadow-[var(--topology-utility-lane-shadow)] transition-[background-color,border-color] duration-[var(--motion-fast)] ease-[var(--motion-ease)] hover:bg-[color:var(--topology-utility-lane-accent-hover-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--topology-utility-lane-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-canvas)] motion-reduce:transition-none [&>svg]:size-3.5 [&>svg]:shrink-0 ${
-                            topologyUtilityChromeCompact
-                              ? "w-[var(--chrome-tile-size)] px-0"
-                              : "px-3.5"
-                          }`}
-                        >
-                          <Plus aria-hidden />
-                          {/* <xl 아이콘-only — 레인 라벨 사다리(겹침 소탕
-                              2026-07-23). aria-label + 툴팁이 뜻을 보존한다. */}
-                          <span
-                            className={
-                              topologyUtilityChromeCompact ? "sr-only" : "max-xl:hidden"
-                            }
-                          >
-                            {t('createNode.toggleLabel')}
-                          </span>
-                        </button>
-                      </Tooltip>
-                    ) : null}
+                    {/*
+                      ⚠️ **「+ 개념」 크롬 필을 뺐다** (2026-08-03, 소유자 지시).
+                      *"이거좀 이상해 없어져도 될듯?"*
+
+                      이 필은 「노드가 이미 있는 지도에서, 아무것도 안 고른 채
+                      새 개념을 만들 때」의 **유일한** 문이었다 — 빈 지도의 두
+                      진입점(시작 체크리스트 · 빈 상태)은 지도가 차면 사라지기
+                      때문이다. 그래서 그냥 지우면 populated 지도에서 만들 길이
+                      통째로 없어진다.
+
+                      그 자리를 **빈 캔버스 우클릭**이 대신한다(`onContextMenuPane`).
+                      빈 자리 우클릭은 어느 도구에서나 «여기에 새로 만들기»의
+                      관용구이고, 무엇보다 **클릭한 좌표가 곧 새 노드의 자리**라
+                      상단 고정 버튼보다 뜻이 분명하다. 상시 잉크도 0이 된다.
+                    */}
                     {/* 기록 <lg 진입점. `lg+` 는 레일 목적지가 담당하고
                         레일이 사라지는 `<lg` 에서는 이 크롬 타일이 같은
                         목적지로 보낸다 — 브레이크포인트가 달라도 **같은
@@ -4383,6 +4351,12 @@ export function HomePage() {
                     onGraphStatsChange={handleTopologyGraphStatsChange}
                     onZoomTierChange={setMapZoomTier}
                     onContextMenuNode={handleContextMenuNode}
+                    /*
+                     * 빈 캔버스 우클릭 = 「여기에 개념 만들기」 — 상단에서 뺀
+                     * 크롬 필의 자리를 대신한다. 쓰기 가능한 볼트일 때만 건다:
+                     * 못 쓰는 볼트에서 메뉴가 뜨면 그건 죽은 문이다.
+                     */
+                    onContextMenuPane={canCreateNode ? () => openCreateNode() : undefined}
                     minimal={localGraphRoot !== null}
                     agentFocusNodeId={agentFocusNodeId}
                     spotlightIds={spotlightIds}

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -115,6 +115,8 @@ export interface TopologyMapV2Props {
    * unchanged (browser default menu everywhere, same as before this slice).
    */
   onContextMenuNode?: (slug: string, position: { x: number; y: number }) => void;
+  /** 빈 캔버스 우클릭 — 「여기에 개념 만들기」. 생략하면 종전대로 no-op. */
+  onContextMenuPane?: (position: { x: number; y: number }) => void;
   /**
    * 밀도 게이트 (fable 설계) — 사용자가 펼친 부모 slug Set(URL `?open=`).
    * 임계(12) 초과 자식을 가진 부모는 기본 접힘(클러스터 칩)이고 여기 담긴
@@ -282,7 +284,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -356,6 +358,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       onGraphStatsChange,
       onZoomTierChange,
       onContextMenuNode,
+      onContextMenuPane,
       agentFocusNodeId,
       spotlightIds,
       expandedParents,

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.contextmenu.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.contextmenu.test.ts
@@ -98,3 +98,47 @@ describe("createTopologyPointerHandlers — handleContextMenu (W2-B)", () => {
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
 });
+
+describe("createTopologyPointerHandlers — 빈 캔버스 우클릭 (2026-08-03)", () => {
+  /*
+   * 상단 「+ 개념」 크롬 필을 지우면서 이 자리가 **populated 지도에서 노드를
+   * 만드는 유일한 문**이 됐다. 빈 지도의 두 진입점(시작 체크리스트 · 빈 상태)은
+   * 지도가 차는 순간 사라지기 때문이다 — 이 배선이 끊기면 노드가 있는 볼트에서
+   * 지도로는 아무것도 못 만든다.
+   */
+  it("빈 자리에서는 만들기를 부르고 브라우저 기본 메뉴를 막는다", () => {
+    vi.mocked(hitTestWorld).mockReturnValue(null);
+    const onContextMenuPane = vi.fn();
+    const { handleContextMenu } = createTopologyPointerHandlers(
+      buildRefs({ onContextMenuPane }),
+    );
+
+    const event = fakeContextMenuEvent(300, 420);
+    handleContextMenu(event);
+
+    expect(onContextMenuPane).toHaveBeenCalledWith({ x: 300, y: 420 });
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("노드를 맞히면 빈 자리 콜백은 안 부른다 — 두 자리가 섞이면 안 된다", () => {
+    vi.mocked(hitTestWorld).mockReturnValue("capabilities/mcp-server");
+    const onContextMenuNode = vi.fn();
+    const onContextMenuPane = vi.fn();
+    const { handleContextMenu } = createTopologyPointerHandlers(
+      buildRefs({ onContextMenuNode, onContextMenuPane }),
+    );
+
+    handleContextMenu(fakeContextMenuEvent(10, 20));
+
+    expect(onContextMenuNode).toHaveBeenCalledTimes(1);
+    expect(onContextMenuPane).not.toHaveBeenCalled();
+  });
+
+  it("소비처가 없으면 종전대로 no-op — 브라우저 기본 메뉴가 살아 있다", () => {
+    vi.mocked(hitTestWorld).mockReturnValue(null);
+    const { handleContextMenu } = createTopologyPointerHandlers(buildRefs({}));
+    const event = fakeContextMenuEvent(10, 20);
+    handleContextMenu(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
+++ b/src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts
@@ -273,6 +273,16 @@ export interface PointerHandlerRefs {
    * only — see that handler's own doc).
    */
   onContextMenuNode?: (slug: string, position: { x: number; y: number }) => void;
+  /**
+   * **빈 캔버스 우클릭** — 노드가 없는 자리에서 부른다 (2026-08-03).
+   *
+   * 종전엔 이 자리가 그냥 무시됐다(`if (!hitNodeId) return;`). 그런데 빈
+   * 캔버스 우클릭은 어느 도구에서나 «여기에 새로 만들기»의 관용구이고, 무엇보다
+   * **클릭한 좌표가 곧 새 노드의 자리**라 상단 크롬 버튼보다 뜻이 분명하다.
+   *
+   * 생략하면 종전처럼 no-op — 브라우저 기본 메뉴도 그대로 뜬다.
+   */
+  onContextMenuPane?: (position: { x: number; y: number }) => void;
 }
 
 export interface TopologyPointerHandlers {
@@ -351,6 +361,7 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
     onHoverEdge,
     onPaneClick,
     onContextMenuNode,
+    onContextMenuPane,
     onToggleCluster,
     onHoverCluster,
     onExpandEgoNeighbors,
@@ -1227,11 +1238,18 @@ export function createTopologyPointerHandlers(refs: PointerHandlerRefs): Topolog
   const handleContextMenu = (e: ReactMouseEvent<HTMLCanvasElement>) => {
     const tokens = readTopologyV2TokensOrNull();
     const world = worldRef.current;
-    if (!tokens || !world || !onContextMenuNode) return;
+    if (!tokens || !world || (!onContextMenuNode && !onContextMenuPane)) return;
     const rect = currentRect(e.currentTarget);
     const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
     const hitNodeId = hitVisibleNode(world, cameraRef.current, tokens, point.x, point.y);
-    if (!hitNodeId) return;
+    if (!hitNodeId) {
+      // 빈 자리 — 「여기에 개념 만들기」. 소비처가 없으면 종전대로 no-op.
+      if (!onContextMenuPane) return;
+      e.preventDefault();
+      onContextMenuPane({ x: e.clientX, y: e.clientY });
+      return;
+    }
+    if (!onContextMenuNode) return;
     e.preventDefault();
     onContextMenuNode(hitNodeId, { x: e.clientX, y: e.clientY });
   };

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -200,6 +200,8 @@ export interface UseTopologyLoopArgs {
   onZoomTierChange?: (tier: ZoomTier) => void;
   /** W2-B node right-click context menu — see `topology-pointer-handlers.ts#createTopologyPointerHandlers`'s `onContextMenuNode` doc. */
   onContextMenuNode?: (slug: string, position: { x: number; y: number }) => void;
+  /** 빈 캔버스 우클릭 — 「여기에 개념 만들기」. */
+  onContextMenuPane?: (position: { x: number; y: number }) => void;
   /**
    * W6 agent visibility — the graph node id matching the agent heartbeat's
    * current focus (already resolved to `kind:slug` form upstream, or `null`
@@ -338,7 +340,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -3233,6 +3235,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     onHoverEdge,
     onPaneClick,
     onContextMenuNode,
+    onContextMenuPane,
     onToggleCluster,
     onHoverCluster,
     // S2 파트 3a — `이웃 +N` 칩 클릭 → 다음 이웃 배치 점등(세션 임시). 클릭


### PR DESCRIPTION
## Summary

상단 「+ 개념」 크롬 필을 지우고, 그 일을 **빈 캔버스 우클릭**으로 옮겼다.

**먼저 세어 봤다** — 노드 만들기 진입점은 넷인데 셋은 지도가 비었을 때만 뜬다(시작 체크리스트 · 빈 상태 · 딥링크). 그래서 이 필의 진짜 근거는 「노드가 이미 있는 지도에서, 아무것도 안 고른 채 만들 때」 하나뿐이었다. (앞서 제가 「빈 볼트의 첫 노드」를 근거로 든 것은 틀렸다 — 체크리스트가 이미 덮는다.)

빈 자리 우클릭은 어느 도구에서나 «여기에 새로 만들기»의 관용구이고, **클릭한 좌표가 곧 새 노드의 자리**라 상단 고정 버튼보다 뜻이 분명하다. 상시 잉크도 0이 된다.

**WebView 프로브도 같이 고쳤다** — 프로브가 지운 버튼의 testid 를 조회하고 있었고 `webview-probe-selectors` 계약이 그걸 잡았다. 우클릭을 흉내 내는 대신 이미 있던 `requestCreateRouteIntent`(`?create=concept`)로 옮겼다.

## Test plan

- `pnpm exec tsc --noEmit` · `pnpm lint` (error 0) · `cargo check`
- `pnpm exec vitest run` — 609 파일 / 5,893 통과
- 새 게이트 셋(빈 자리 호출 · 노드와 안 섞임 · 소비처 없으면 no-op), 배선을 끊어 붉어지는 것 확인

⚠️ **우클릭 자체는 사람 확인이 필요하다** — AppleScript 의 ctrl+click 이 Tauri WebView 에 `contextmenu` 로 전달되지 않아 자동 검증이 안 된다. 핸들러 층까지는 잠갔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)