### PR TITLE
docs: mcp 의존성 설치를 두 빠른 시작에 등재한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,16 @@ Markdown frontmatter is the graph. The git repo is the source of truth. No backe
 
 ```bash
 pnpm install && pnpm dev          # localhost:3000 — pick a markdown folder and you're in
+pnpm --dir mcp install            # mcp/ carries its own lockfile — root install skips it
 pnpm checks:changed               # start here: the focused checks for what you touched
 ```
+
+**Re-run the `--dir mcp` line after any pull that touches `mcp/package.json`.**
+It is the only way `mcp/node_modules` reaches the version that file names, and a
+stale one fails in the worst shape available: the web build stays green, `init`
+still scaffolds, and every CLI/MCP path that spawns the server dies with
+`ERR_MODULE_NOT_FOUND`. The SDK v1→v2 bump did exactly that (2026-08-03). CI
+installs it as its own step, so green CI is no evidence your checkout is current.
 
 **There is no setup step.** No `.env`, no auth provider, no backend, no seed data —
 if a task seems to need one, the design is wrong (Round 10 removed the optional

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ environments without a supported installed app.
 # Keep the tool outside the project you are describing.
 git clone https://github.com/wlsdks/ontology-atlas ~/tools/ontology-atlas
 cd ~/tools/ontology-atlas && pnpm install
+pnpm --dir mcp install   # mcp/ carries its own lockfile — the line above skips it
 ATLAS=~/tools/ontology-atlas/cli/src/index.mjs
 
 cd /path/to/your/repo
@@ -604,6 +605,14 @@ node $ATLAS index . --vault ./ontology --apply
 # 3. The compact packet a person or coding agent starts from.
 node $ATLAS agent-brief ./ontology
 ```
+
+Both installs are load-bearing, and so is repeating the second one. `mcp/` is
+not in the root pnpm workspace, so the first `pnpm install` never reaches it and
+a `git pull` that bumps `mcp/package.json` leaves it behind. A stale
+`mcp/node_modules` does not fail loudly, and it does not fail first: step 1
+scaffolds happily, because `init` only writes files. Step 2 and everything after
+it exit with `ERR_MODULE_NOT_FOUND` instead, because those spawn the MCP server
+to answer. Re-run the `--dir mcp` line after every pull.
 
 Restart your agent in your repository and the 33 MCP tools register from the
 generated config. `node $ATLAS mcp-verify ./ontology` proves the actual server


### PR DESCRIPTION
## Summary

`mcp/` 는 루트 pnpm 워크스페이스에 없고 자기 락파일을 따로 가진다. 그래서
`pnpm install` 은 그곳을 건드리지 않는데, `AGENTS.md` 와 `README.md` 의 빠른
시작 모두 그 한 줄만 적고 있었다. SDK v1→v2 이후 이 저장소의 실제 체크아웃에서
CLI/MCP 표면이 죽어 있었다 (`overview`, `health` 가 `ERR_MODULE_NOT_FOUND`).

두 곳에 `pnpm --dir mcp install` 을 넣고, **왜 늦게 알아채는지**를 같이 적었다.
CI 는 이미 별도 단계로 설치하므로(`checks.yml:235` 등) CI 는 초록인 채 로컬만
깨진다 — 초록 CI 가 내 체크아웃의 최신성을 증명하지 못한다는 점을 문안에 명시했다.

### 실측으로 정정한 것

처음엔 "위의 모든 CLI 명령이 죽는다"고 쓰려 했으나, `mcp/node_modules` 를 치우고
빈 디렉터리에서 직접 돌려 확인한 결과 그렇지 않았다:

| 명령 | mcp 의존성 없을 때 |
|---|---|
| `init ./ontology` | ✅ 성공 — 파일만 쓴다 |
| `index . --vault ./ontology` | ❌ `ERR_MODULE_NOT_FOUND` |
| `agent-brief ./ontology` | ❌ `ERR_MODULE_NOT_FOUND` |

`init` 이 성공한다는 사실이 이 고장의 핵심이다. 1단계가 되니까 설치가 됐다고
믿고, 서버를 띄우는 2단계에서 죽는다. 문안을 이 사실에 맞춰 다시 썼다.

`--frozen-lockfile`(CI 용) 대신 평범한 install 을 골랐다. 로컬에서는 이쪽이
낡은 패키지를 잘라낸다 — 실제로 `+2 -91` 이 나오며 v1 SDK 잔해를 치웠다.

## Test plan

`pnpm checks:changed` 가 지목한 세 개 전부:

- `pnpm agents:check` — ✅ AGENTS.md **30125 / 32768 bytes**, drift 4종 ok
- `pnpm docs:links` — ✅ 366개 마크다운, 깨진 참조 0
- `pnpm test:dogfood:script-refs` — ✅ 1/1
- `pnpm test:mcp:docs` — ✅ 12/12

문서 전용 변경이라 라우트·공개 계약 변화가 없어 `decisions:check` 대상이 아니다.

> ⚠️ AGENTS.md 여유가 **2643B (8.1%)** 로 10% 아래다. 다음에 이 파일에 무언가
> 더할 때는 뺄 것을 먼저 정해야 한다 — Codex 는 상한 초과분을 경고 없이 문장
> 중간에서 자른다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275