### PR TITLE
feat: 패널에서 이어서 새로 만들기 · 화면이 만든 노드에 human 스탬프

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2360,6 +2360,7 @@
       "agentHandoffAria": "Open AI work menu (copy project info, re-analyze, check latest status)",
       "segmentAll": "All",
       "segmentRecent": "Last {days}d · {count}",
+      "segmentHuman": "By a person · {count}",
       "segmentRecentAria": "Narrow the map to recently changed nodes",
       "windowChipAuto": "Auto",
       "windowChipDays": "{days}d",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2122,6 +2122,8 @@
       "actionsGroupLabel": "Node actions",
       "actionDocument": "Document",
       "actionMentionDocument": "Mentioned in",
+      "actionCreateLinked": "Create linked",
+      "actionCreateLinkedTip": "Creates a new capability inside this domain — without leaving the map",
       "actionEditRelations": "Edit relations",
       "actionCopyHandoff": "Copy handoff",
       "actionAskAgent": "Ask the agent",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2360,6 +2360,7 @@
       "agentHandoffAria": "AI 작업 메뉴 열기 (프로젝트 정보 복사 · 다시 분석 · 최신 상태 확인)",
       "segmentAll": "전체",
       "segmentRecent": "최근 {days}일 · {count}",
+      "segmentHuman": "사람이 쓴 것 {count}",
       "segmentRecentAria": "최근 변경 노드로 지도 좁히기",
       "windowChipAuto": "자동",
       "windowChipDays": "{days}일",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2122,6 +2122,8 @@
       "actionsGroupLabel": "선택한 항목에서 할 일",
       "actionDocument": "문서 열기",
       "actionMentionDocument": "언급 문서 열기",
+      "actionCreateLinked": "이어서 새로 만들기",
+      "actionCreateLinkedTip": "이 도메인 안에 새 역량을 만들어요 — 지도를 떠나지 않아요",
       "actionEditRelations": "관계 편집",
       "actionCopyHandoff": "AI에게 줄 항목 정보 복사",
       "actionAskAgent": "AI에게 물어보기",

--- a/src/entities/docs-vault/lib/build-vault-markdown.ts
+++ b/src/entities/docs-vault/lib/build-vault-markdown.ts
@@ -127,6 +127,15 @@ export function buildNewNodeDoc(args: {
   kind: string;
   domain?: string;
   localeLabels?: Record<string, string>;
+  /**
+   * 저작 출처 — 화면에서 **사람이 손으로 만든 노드**는 `human` 이다
+   * (2026-07-31 원장의 값 규약, 2026-08-03 배선).
+   *
+   * 스탬프는 **쓰기 시점에, 호출 경로가 증명하는 행위자에게만** 찍는다.
+   * 이 함수는 화면의 「개념 만들기」에서만 불리므로 그 경로가 사람을 증명한다.
+   * 생략하면 안 찍는다 — 부재는 unknown 이고, 그게 원장의 계약이다.
+   */
+  createdBy?: string;
 }): { slug: string; markdown: string } {
   const title = args.title.trim();
   if (!title) throw new Error("title must not be empty");
@@ -140,6 +149,7 @@ export function buildNewNodeDoc(args: {
     slug,
     domain: args.domain,
     localeLabels: args.localeLabels,
+    createdBy: args.createdBy,
   });
   return { slug, markdown };
 }

--- a/src/views/home/ui/CreateNodeForm.tsx
+++ b/src/views/home/ui/CreateNodeForm.tsx
@@ -51,6 +51,7 @@ export function CreateNodeForm({
   localeNames,
   labels,
   defaultKind = "capability",
+  defaultDomain = "",
   domainOptions = [],
 }: {
   onCreate: (input: {
@@ -63,6 +64,12 @@ export function CreateNodeForm({
   onCancel?: () => void;
   labels: CreateNodeFormLabels;
   defaultKind?: CreateNodeKind;
+  /**
+   * 미리 고른 도메인 (2026-08-03) — 지도의 도메인 노드에서 「이어서 새로
+   * 만들기」로 열면 그 도메인이 이미 골라져 있다. 사람이 방금 누른 노드를
+   * 다시 고르게 하는 것은 물어볼 필요 없는 것을 묻는 것이다.
+   */
+  defaultDomain?: string;
   /**
    * #8 평문화 — 기존 도메인 목록(값 = bare tail-slug, 라벨 = 표시 이름).
    * 자유 입력 slug 대신 이 목록 + "도메인 없음" 에서 고른다(비개발자가
@@ -83,7 +90,7 @@ export function CreateNodeForm({
 }) {
   const [title, setTitle] = useState("");
   const [kind, setKind] = useState<CreateNodeKind>(defaultKind);
-  const [domain, setDomain] = useState("");
+  const [domain, setDomain] = useState(defaultDomain);
   const [secondaryName, setSecondaryName] = useState("");
   const [creating, setCreating] = useState(false);
 

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1393,6 +1393,19 @@ export function HomePage() {
     ontologyLoaded: ontologyInsight !== null,
   });
   /** 지금 고른 노드의 그래프 원본 — 「이어서 새로 만들기」가 kind 를 본다. */
+  /**
+   * `created_by: human` 인 노드 집합 — INDEX 렌즈가 쓴다. 하나도 없으면 `null`
+   * 이라 세그먼트 자체가 안 뜬다(볼트에 없는 것을 거를 칸은 만들지 않는다).
+   */
+  const humanAuthoredLens = useMemo(() => {
+    const ids = new Set(
+      (ontologyInsight?.nodes ?? [])
+        .filter((node) => node.createdBy === "human")
+        .map((node) => node.id),
+    );
+    return ids.size > 0 ? { ids } : null;
+  }, [ontologyInsight]);
+
   const canvasSelectedGraphNode = useMemo(
     () =>
       canvasSelectedSlug
@@ -4095,6 +4108,12 @@ export function HomePage() {
                     onWindowChange={(next) =>
                       setRouteState((current) => ({ ...current, recentWindow: next }))
                     }
+                    /*
+                     * 「사람이 쓴 것」 렌즈 — 지도의 검수 대기 링과 같은 사실을
+                     * 세는 자리. 하나도 없으면 `null` 이라 세그먼트가 안 뜬다:
+                     * 빈 렌즈는 누르면 아무 일도 안 일어나는 죽은 컨트롤이다.
+                     */
+                    humanAuthored={humanAuthoredLens}
                     // P4c — "지도에 없는 문서 N개 · 올리기". `bootstrapPlan` 은
                     // vault 가 로드되기만 하면(빈 지도든 아니든) 항상 계산돼
                     // 있으므로 새 파생 없이 그 카운트를 그대로 노출한다 —
@@ -4167,6 +4186,9 @@ export function HomePage() {
                         days: recentChanges.windowDays,
                       }),
                       segmentRecentAria: t("index.segmentRecentAria"),
+                      segmentHuman: humanAuthoredLens
+                        ? t("index.segmentHuman", { count: humanAuthoredLens.ids.size })
+                        : undefined,
                       recentEmptyHint: t("index.recentEmptyHint", { days: recentChanges.windowDays }),
                       // 스포트라이트 창 프리셋 칩 라벨 (협의회 §②).
                       windowChipAuto: t("index.windowChipAuto"),

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1101,7 +1101,13 @@ export function HomePage() {
       localeLabels?: Record<string, string>;
     }) => {
       try {
-        const { slug, markdown } = buildNewNodeDoc(input);
+        /*
+         * **사람이 만든 노드**라고 적는다. 이 경로는 화면의 「개념 만들기」
+         * 하나뿐이라 호출 경로가 행위자를 증명한다 — 원장이 요구하는
+         * 「쓰기 시점 스탬프」의 조건이다. 이 한 줄이 없으면 방금 만든 노드가
+         * 지도에서 검수 대기 링을 못 받는다(2026-08-03 실측).
+         */
+        const { slug, markdown } = buildNewNodeDoc({ ...input, createdBy: "human" });
         await vault.createDoc(slug, markdown);
         toast.show(t("createNode.toastSaved", { slug }), "success");
         closeCreateNode();
@@ -1386,6 +1392,14 @@ export function HomePage() {
     projectsLoaded: projectsQuery.loaded,
     ontologyLoaded: ontologyInsight !== null,
   });
+  /** 지금 고른 노드의 그래프 원본 — 「이어서 새로 만들기」가 kind 를 본다. */
+  const canvasSelectedGraphNode = useMemo(
+    () =>
+      canvasSelectedSlug
+        ? (ontologyInsight?.nodes.find((n) => n.id === canvasSelectedSlug) ?? null)
+        : null,
+    [canvasSelectedSlug, ontologyInsight],
+  );
   const drawerProject = selectedProject;
 
   // S7 realm slug 해석(패널3-S7) — URL 의 `?realm=` 은 사용자가 손으로 bare
@@ -1793,6 +1807,11 @@ export function HomePage() {
   // 의도를 전달할 수 있게 컴포저 초기 kind 를 상태로 둔다. 일반 진입
   // (+ 개념 버튼 등)은 종전 기본값(역량) 유지.
   const [createNodeDefaultKind, setCreateNodeDefaultKind] = useState<CreateNodeKind>("capability");
+  /**
+   * 「이어서 새로 만들기」가 미리 고르는 도메인 — 지도의 도메인 노드에서 열면
+   * 그 도메인이 이미 골라져 있다. 빈 문자열이면 종전대로 「도메인 없음」.
+   */
+  const [createNodeSeedDomain, setCreateNodeSeedDomain] = useState("");
   const openCreateNode = useCallback(() => {
     setCreateNodeDefaultKind("capability");
     setOntologySearchOpen(false);
@@ -3843,6 +3862,7 @@ export function HomePage() {
                       primaryLocaleRequired: t('createNode.primaryLocaleRequired'),
                     }}
                     defaultKind={createNodeDefaultKind}
+                    defaultDomain={createNodeSeedDomain}
                     // 어권별 이름 — 지금 화면 언어가 필수 칸, 나머지가 선택
                     // 칸(소유자 지시 2026-07-24).
                     localeNames={{
@@ -4764,6 +4784,8 @@ export function HomePage() {
                   actionsGroupLabel: t("nodeDatasheet.actionsGroupLabel"),
                   actionDocument: t("nodeDatasheet.actionDocument"),
                   actionEditRelations: t("nodeDatasheet.actionEditRelations"),
+                  actionCreateLinked: t("nodeDatasheet.actionCreateLinked"),
+                  actionCreateLinkedTip: t("nodeDatasheet.actionCreateLinkedTip"),
                   actionCopyHandoff: t("nodeDatasheet.actionCopyHandoff"),
                   actionAskAgent: llmBridgeAvailable
                     ? t("nodeDatasheet.actionAskAgent")
@@ -4793,6 +4815,27 @@ export function HomePage() {
                 }}
                 onSelectConnection={(id) => handleSelect(id)}
                 onCopyHandoff={copyV2NodeHandoff}
+                /*
+                 * 「이어서 새로 만들기」 — **도메인 노드에서만** 넘긴다.
+                 *
+                 * 도메인→역량은 새 문서의 `domain:` 키 하나로 이어지므로 쓰기
+                 * 의미를 새로 만들 필요가 없다. 다른 조합(역량→요소 등)은 부모
+                 * 문서의 목록을 고쳐야 해서 «만들기»가 아니라 «남의 문서 수정»
+                 * 이 된다 — 그건 다른 일이고, 못 하는 자리에 문을 그리면 그게
+                 * 거짓 어포던스다.
+                 */
+                onCreateLinked={
+                  canCreateNode && canvasSelectedGraphNode?.kind === "domain"
+                    ? () => {
+                        const tail = canvasSelectedGraphNode.id.includes(":")
+                          ? canvasSelectedGraphNode.id.slice(canvasSelectedGraphNode.id.indexOf(":") + 1)
+                          : canvasSelectedGraphNode.id;
+                        setCreateNodeSeedDomain(tail);
+                        setCreateNodeDefaultKind("capability");
+                        openCreateNode();
+                      }
+                    : undefined
+                }
                 // 에이전트 표면이 없는 환경(웹)에서는 주입하지 않는다 — 타일도
                 // 함께 사라진다. 열리지 않을 문을 그리지 않는다.
                 onAskAgent={llmBridgeAvailable ? askAgentAboutSelectedNode : undefined}

--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -29,6 +29,14 @@ import {
   type TopologyIndexAgentHandoffLabels,
 } from "./TopologyIndexAgentHandoff";
 
+/**
+ * INDEX 의 렌즈 — 「전체」 · 「최근 변경」 · 「사람이 쓴 것」.
+ *
+ * 마지막 것은 지도의 검수 대기 링(`created_by: human`)과 **같은 사실**을 보는
+ * 두 번째 창구다: 지도는 «어디에 있나»를, 이 렌즈는 «전부 몇 개인가»를 답한다.
+ */
+export type IndexLens = "all" | "recent" | "human";
+
 export interface TopologyIndexPanelLabels {
   label: string;
   fold: string;
@@ -52,6 +60,8 @@ export interface TopologyIndexPanelLabels {
   segmentAll: string;
   /** P4a — 렌즈 세그먼트 "최근 변경 N"(호출자가 count 를 이미 포맷). */
   segmentRecent: string;
+  /** 「사람이 쓴 것 N」 — 없으면 그 칸을 안 그린다. */
+  segmentHuman?: string;
   segmentRecentAria: string;
   /** P4a — "최근 변경" 렌즈가 활성인데 결과가 0일 때. */
   recentEmptyHint: string;
@@ -137,6 +147,12 @@ export interface TopologyIndexPanelProps {
     /** P4b — fresh heartbeat 의 focus 와 일치하는 노드(있다면) 하나. */
     agentAttributedNodeId: string | null;
   } | null;
+  /**
+   * 「사람이 쓴 것」 렌즈의 대상 (`created_by: human`). 생략/`null` 이면 그
+   * 세그먼트를 **안 그린다** — 볼트에 그 값이 하나도 없으면 켤 것이 없고,
+   * 빈 렌즈는 누르면 아무 일도 안 일어나는 죽은 컨트롤이다.
+   */
+  humanAuthored?: { ids: ReadonlySet<string> } | null;
   /** P4c — vault 에 있지만 아직 kind 없는(=지도에 없는) 문서 수. */
   uncatalogedDocCount?: number;
   /** ④ 살아있는 지도 드리프트 — 먼지 앉은(dusty) 노드 수. 0 이면 행 숨김. */
@@ -155,8 +171,8 @@ export interface TopologyIndexPanelProps {
    * 구동해 두 표면의 창 불일치가 구조적으로 불가능해진다. 생략 시 기존 로컬
    * state 그대로(하위호환 — 다른 호출부/테스트 무영향).
    */
-  lens?: "all" | "recent";
-  onLensChange?: (lens: "all" | "recent") => void;
+  lens?: IndexLens;
+  onLensChange?: (lens: IndexLens) => void;
   /** 스포트라이트 창 — "auto"(적응 사다리) 또는 1/7/30 프리셋. 칩 활성 표시용. */
   recentWindow?: "auto" | 1 | 7 | 30;
   /** 프리셋 칩 클릭 → 창 전환(즉시 적용 — 팝업/확인 금지 계약). */
@@ -213,6 +229,7 @@ export function TopologyIndexPanel({
   footerGrowthText,
   agentHandoff,
   recentChanges = null,
+  humanAuthored = null,
   uncatalogedDocCount,
   dustyNodeCount,
   onPromoteUncatalogedDocs = null,
@@ -237,21 +254,30 @@ export function TopologyIndexPanel({
   // 때만 트리를 좁힌다.
   // 스포트라이트 (협의회 §⑤) — lensProp 제공 시 controlled(단일 진실원 =
   // URL `?recent=`), 아니면 종전 로컬 state.
-  const [lensLocal, setLensLocal] = useState<"all" | "recent">("all");
+  const [lensLocal, setLensLocal] = useState<IndexLens>("all");
   const lens = lensProp ?? lensLocal;
-  const setLens = (next: "all" | "recent") => {
+  const setLens = (next: IndexLens) => {
     if (onLensChange) onLensChange(next);
     else setLensLocal(next);
   };
   const trimmedQuery = query.trim();
   const isFiltering = trimmedQuery.length > 0;
   const lensActive = !isFiltering && lens === "recent" && recentChanges !== null;
+  /*
+   * 「사람이 쓴 것」 렌즈 (2026-08-03) — `created_by: human` 인 노드만.
+   *
+   * 검수 대기 링과 **같은 사실**을 보는 두 번째 창구다: 지도는 «어디에 있나»를,
+   * 이 렌즈는 «전부 몇 개인가»를 답한다. 프롭이 없으면 세그먼트 자체가 2칸으로
+   * 남아 종전 동작 그대로다 — 볼트에 그 값이 하나도 없으면 켤 것이 없다.
+   */
+  const humanLensActive = !isFiltering && lens === "human" && humanAuthored !== null;
 
   const visibleRoots = useMemo(() => {
     if (isFiltering) return filterTreeByQuery(treeResult.roots, trimmedQuery);
     if (lensActive && recentChanges) return filterTreeByNodeIds(treeResult.roots, recentChanges.ids);
+    if (humanLensActive && humanAuthored) return filterTreeByNodeIds(treeResult.roots, humanAuthored.ids);
     return treeResult.roots;
-  }, [treeResult.roots, isFiltering, trimmedQuery, lensActive, recentChanges]);
+  }, [treeResult.roots, isFiltering, trimmedQuery, lensActive, recentChanges, humanLensActive, humanAuthored]);
   const maxDomainDescendantCount = useMemo(() => {
     // 미터 분모도 같은 진실원에서 — census 가 있으면 BFS total 의 최댓값.
     if (domainCensus && domainCensus.size > 0) {
@@ -278,7 +304,7 @@ export function TopologyIndexPanel({
   // 검색과 마찬가지로 렌즈 활성 시에도 자동 펼침 — 좁혀진 조상 경로를 사용자가
   // 일일이 캐럿으로 열지 않게 한다(filterTreeByQuery 의 "auto-reveal matches"
   // 와 같은 UX 계약, filterTreeByNodeIds 결과에도 그대로 적용).
-  const isOpen = (nodeId: string) => isFiltering || lensActive || openIds.has(nodeId);
+  const isOpen = (nodeId: string) => isFiltering || lensActive || humanLensActive || openIds.has(nodeId);
 
   // H3 P0 — 로빙 tabindex. 화면에 실제로 보이는 행들을 위→아래 순서로 펴고
   // (검색/렌즈의 자동 펼침을 그대로 반영하는 `isOpen` 사용), 그 중 단 하나만
@@ -425,7 +451,9 @@ export function TopologyIndexPanel({
         <div
           role="tablist"
           aria-label={labels.segmentRecentAria}
-          className="mb-3 grid shrink-0 grid-cols-2 gap-1 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-overlay-1)] p-1"
+          className={`mb-3 grid shrink-0 gap-1 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--color-overlay-1)] p-1 ${
+            humanAuthored && labels.segmentHuman ? "grid-cols-3" : "grid-cols-2"
+          }`}
         >
           <button
             type="button"
@@ -455,6 +483,23 @@ export function TopologyIndexPanel({
           >
             {labels.segmentRecent}
           </button>
+          {/* 사람이 쓴 것 — 지도의 검수 대기 링과 **같은 사실**을 세는 자리. */}
+          {humanAuthored && labels.segmentHuman ? (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={humanLensActive}
+              data-testid="topology-index-segment-human"
+              onClick={() => setLens("human")}
+              className={`min-w-0 truncate rounded-[var(--chrome-radius-inner)] px-2 py-1 text-label transition-colors ${
+                humanLensActive
+                  ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--topology-v2-panel-text-primary)]"
+                  : "text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+              }`}
+            >
+              {labels.segmentHuman}
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -19,6 +19,7 @@ import {
   GitBranch,
   MessageCircle,
   Orbit,
+  Plus,
   Route,
   X,
 } from "lucide-react";
@@ -169,6 +170,8 @@ export interface TopologyV2DetailPanelLabels {
   actionsGroupLabel: string;
   actionDocument: string;
   actionEditRelations: string;
+  /** 이 개념에 **이어서 새 개념**을 만든다 — 지도를 떠나지 않는다. */
+  actionCreateLinked?: string;
   actionCopyHandoff: string;
   /**
    * S7 이음새 — 이 개념을 그대로 에이전트에게 말로 시키는 자리. optional 인
@@ -187,6 +190,7 @@ export interface TopologyV2DetailPanelLabels {
    */
   actionDocumentTip?: string;
   actionEditRelationsTip?: string;
+  actionCreateLinkedTip?: string;
   actionCopyHandoffTip?: string;
   actionAskAgentTip?: string;
   actionPathTip?: string;
@@ -304,6 +308,11 @@ export interface TopologyV2DetailPanelProps {
   labels: TopologyV2DetailPanelLabels;
   onSelectConnection: (id: string) => void;
   onCopyHandoff: (text: string) => void;
+  /**
+   * 「이어서 새로 만들기」 — 이 개념에 붙는 새 노드를 만든다. 없으면 타일 자체가
+   * 안 그려진다(못 하는 자리에 문을 그리지 않는다).
+   */
+  onCreateLinked?: () => void;
   /**
    * S7 이음새 — 「에이전트에게 말로 시키기」. 문장은 여기서 짓지 않는다:
    * 첫 마디 생성기(`buildFirstWords` 와 같은 함수)가 이 개념의 빈칸을 보고
@@ -587,6 +596,7 @@ export function TopologyV2DetailPanel({
   labels,
   onSelectConnection,
   onCopyHandoff,
+  onCreateLinked,
   onAskAgent,
   onClose,
   onSetPathSource,
@@ -1065,6 +1075,30 @@ export function TopologyV2DetailPanel({
                   <FileText size={16} aria-hidden="true" />
                   <span>{labels.actionDocument}</span>
                 </Link>,
+              )
+            : null}
+          {/*
+            **이어서 새로 만들기** — 「관계 편집」이 공방으로 나가는 것과 달리
+            이 자리는 지도에 남는다. 소유자 지시 2026-08-03: *"노드 클릭하면…
+            여기서 내가 하고싶은게 바로 신규노드 연결하기(생성하기)"*.
+
+            버튼 자리를 패널로 잡은 이유: 이미 「관계 편집」이 여기 있어 형제로
+            읽히고, 노드 주변 아이콘은 지도가 붐비는 데다 작은 표적이 된다.
+
+            핸들러가 없으면 타일 자체가 없다 — 못 하는 자리에 문을 그리지 않는다.
+          */}
+          {onCreateLinked && labels.actionCreateLinked
+            ? withActionTip(
+                labels.actionCreateLinkedTip,
+                <button
+                  type="button"
+                  onClick={onCreateLinked}
+                  data-testid="topology-v2-detail-panel-action-create-linked"
+                  className={ACTION_TILE_CLASS}
+                >
+                  <Plus size={16} aria-hidden="true" />
+                  <span>{labels.actionCreateLinked}</span>
+                </button>,
               )
             : null}
           {withActionTip(

--- a/tests/contract/create-linked-affordance.contract.test.ts
+++ b/tests/contract/create-linked-affordance.contract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * **못 하는 자리에 문을 그리지 않는다.**
+ *
+ * 「이어서 새로 만들기」는 도메인 노드에서만 뜬다. 도메인→역량은 새 문서의
+ * `domain:` 키 하나로 이어지므로 쓰기 의미를 새로 만들 필요가 없다. 다른
+ * 조합(역량→요소 등)은 **부모 문서의 목록을 고쳐야** 해서 「만들기」가 아니라
+ * 「남의 문서 수정」이 되고, 그건 다른 일이다.
+ *
+ * 이 게이트가 잠그는 것 셋: ① 도메인 조건 ② 도메인 미리 고르기(사람이 방금
+ * 누른 노드를 다시 고르게 하지 않는다) ③ 사람이 만든 노드에 `created_by` 스탬프
+ * (없으면 방금 만든 노드가 검수 대기 링을 못 받는다 — 2026-08-03 실측).
+ */
+const ROOT = process.cwd();
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+describe("「이어서 새로 만들기」 — 어포던스 계약", () => {
+  const home = read("src/views/home/ui/HomePage.tsx");
+
+  it("도메인 노드에서만 뜬다 — 다른 kind 는 이어 붙일 수가 없다", () => {
+    expect(home).toMatch(/canCreateNode && canvasSelectedGraphNode\?\.kind === "domain"/);
+    // 조건이 사라지면 못 이어지는 자리에도 타일이 뜬다.
+    expect(home).toMatch(/onCreateLinked=\{/);
+  });
+
+  it("고른 도메인이 미리 골라진다 — 방금 누른 노드를 다시 묻지 않는다", () => {
+    expect(home).toMatch(/setCreateNodeSeedDomain\(tail\)/);
+    expect(home).toMatch(/defaultDomain=\{createNodeSeedDomain\}/);
+    expect(read("src/views/home/ui/CreateNodeForm.tsx")).toMatch(
+      /useState\(defaultDomain\)/,
+    );
+  });
+
+  it("화면에서 만든 노드에 `human` 스탬프가 찍힌다", () => {
+    /*
+     * 스탬프는 **쓰기 시점에, 호출 경로가 증명하는 행위자에게만** 찍는다
+     * (2026-07-31 원장). 이 경로는 화면의 「개념 만들기」 하나뿐이라 그 조건을
+     * 만족한다. 빠지면 방금 만든 노드가 지도에서 검수 대기 링을 못 받는다.
+     */
+    expect(home).toMatch(/buildNewNodeDoc\(\{ \.\.\.input, createdBy: "human" \}\)/);
+    expect(read("src/entities/docs-vault/lib/build-vault-markdown.ts")).toMatch(
+      /createdBy: args\.createdBy,/,
+    );
+  });
+
+  it("타일은 핸들러가 있을 때만 그려진다 — 라벨만 있고 문이 없으면 안 된다", () => {
+    const panel = read("src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx");
+    expect(panel).toMatch(/onCreateLinked && labels\.actionCreateLinked/);
+  });
+});

--- a/tests/contract/create-linked-affordance.contract.test.ts
+++ b/tests/contract/create-linked-affordance.contract.test.ts
@@ -51,3 +51,26 @@ describe("「이어서 새로 만들기」 — 어포던스 계약", () => {
     expect(panel).toMatch(/onCreateLinked && labels\.actionCreateLinked/);
   });
 });
+
+describe("「사람이 쓴 것」 렌즈 — 지도의 링과 같은 사실", () => {
+  /*
+   * 검수 대기 링은 «어디에 있나»를, 이 렌즈는 «전부 몇 개인가»를 답한다. 둘이
+   * **같은 판정식**(`created_by === "human"`)을 써야 한 화면 안에서 수가 갈리지
+   * 않는다 — 지도가 셋을 붉게 그렸는데 렌즈가 다섯을 세면 사용자는 어느 쪽을
+   * 믿을지 모른다.
+   */
+  it("렌즈와 링이 같은 판정식을 쓴다", () => {
+    const home = read("src/views/home/ui/HomePage.tsx");
+    expect(home).toMatch(/node\.createdBy === "human"/);
+    expect(read("src/widgets/topology-map-v2/ui/topology-frame-draw.ts")).toMatch(
+      /node\.createdBy === "human"/,
+    );
+  });
+
+  it("하나도 없으면 세그먼트를 안 그린다 — 빈 렌즈는 죽은 컨트롤이다", () => {
+    const home = read("src/views/home/ui/HomePage.tsx");
+    expect(home).toMatch(/ids\.size > 0 \? \{ ids \} : null/);
+    const panel = read("src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx");
+    expect(panel).toMatch(/humanAuthored && labels\.segmentHuman/);
+  });
+});


### PR DESCRIPTION
## Summary

**① 「이어서 새로 만들기」** — 노드 패널 행동 줄. 「관계 편집」이 공방으로 나가는 것과 달리 이 자리는 지도에 남는다.

**도메인 노드에서만 뜬다.** 도메인→역량은 새 문서의 `domain:` 키 하나로 이어지므로 쓰기 의미를 새로 만들 필요가 없다. 다른 조합(역량→요소 등)은 부모 문서의 목록을 고쳐야 해서 「만들기」가 아니라 「남의 문서 수정」이 되고, 그건 다른 일이다 — 못 하는 자리에 문을 그리면 거짓 어포던스다.

고른 도메인은 미리 골라져 있다.

**② 화면에서 만든 노드에 `created_by: human` 스탬프** — #859 의 검수 대기 링이 정작 **방금 만든 노드에는 안 떴다**. `buildNewNodeDoc` 이 그 키를 안 쓰고 있었고, 공방은 이미 찍는데 지도 경로만 빠져 있었다.

## Test plan

- `pnpm exec tsc --noEmit` · `pnpm lint` (error 0)
- `pnpm exec vitest run` — 610 파일 / 5,897 통과
- 새 계약 `create-linked-affordance` 5종, 스탬프를 빼서 붉어지는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)