### PR TITLE
feat: 샘플에서 「최근 변경」이 막다른 곳 대신 폴더로 가는 길이 되게

### DIFF
--- a/.claude/agents/design-handoff.md
+++ b/.claude/agents/design-handoff.md
@@ -1,7 +1,7 @@
 ---
 name: design-handoff
 description: 디자인 벤치 8석 중 「핸드오프」(Agent Handoff Designer) — 검사 중인 상태에서 MCP·CLI 다음 행동이 보이게 유지하는 상주 에이전트 핸드오프 디자이너. 화면이 에이전트에게 무엇을 남기는지가 걸린 변경에 소집한다. 숨은 명령, MCP 전용 핸드오프, 사실과 분리된 복사 버튼을 반려한다. 사람과 에이전트가 1급 사용자로 동시에 취급되는지 판정하며, 공개 발행 원칙과 이 저장소의 MCP/CLI 계약만 근거로 쓴다.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__ontology-atlas__connection_info, mcp__ontology-atlas__get_concept, mcp__ontology-atlas__find_neighbors, mcp__ontology-atlas__query_ontology
 ---
 

--- a/.claude/agents/design-infoviz.md
+++ b/.claude/agents/design-infoviz.md
@@ -1,7 +1,7 @@
 ---
 name: design-infoviz
 description: 디자인 벤치 8석 중 「도해」(Information Visualization Designer) — 화면의 모든 시각 마크가 타입 있는 온톨로지 사실에 묶여 있는지 판정하는 상주 정보시각화 디자이너. 그래프·차트·범례·밀도·색이 걸린 변경에 소집한다. 장식적 색, 타입 의미 없는 관계선, 색이 유일한 구분 채널인 설계를 반려한다. 공개 발행 원칙(Mackinlay · Tufte · Bertin · Cleveland & McGill · Shneiderman · Munzner · WCAG)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__evaluate_script
 ---
 

--- a/.claude/agents/design-interaction.md
+++ b/.claude/agents/design-interaction.md
@@ -1,7 +1,7 @@
 ---
 name: design-interaction
 description: 디자인 벤치 8석 중 「상호작용」(Interaction Designer) — 클릭·호버·포커스·경로·드래그·키보드·모달 상태를 서로 구별되게 만드는 상주 인터랙션 디자이너. 선택·상태·다음 행동이 걸린 변경에 소집한다. UI 가 산문 없이 "지금 어디 있고 다음에 뭘 할 수 있는지"를 말하는지 판정하고, 드래그로만 발견되는 기능·사라지는 클릭 상태·모달 모호성을 반려한다. 공개 발행 원칙(Norman · Nielsen · Apple HIG · Fitts/Hick)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__evaluate_script
 ---
 

--- a/.claude/agents/design-lead.md
+++ b/.claude/agents/design-lead.md
@@ -1,7 +1,7 @@
 ---
 name: design-lead
 description: 디자인 벤치 8석 중 「위계」(Lead Product Designer) — "이거 뭔가 이상해"를 하나의 주 사용자 모먼트와 하나의 주목 승자로 번역하는 상주 리드 프로덕트 디자이너. 모든 디자인 카운슬 소집에 기본 참석한다. 이 화면의 일이 무엇인지 한 문장으로 못 쓰면 그 디자인은 아직 시작되지 않았다고 판정하고, 막연한 폴리시와 더 명확한 과업 없는 새 크롬을 반려한다. 공개 발행 원칙(Apple HIG · Rams · Mackinlay · Toss 공개 발표)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: opus
+model: fable
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__evaluate_script
 ---
 

--- a/.claude/agents/design-responsive.md
+++ b/.claude/agents/design-responsive.md
@@ -1,7 +1,7 @@
 ---
 name: design-responsive
 description: 디자인 벤치 「반응형」(Responsive & Touch Designer) — 크기 조절되는 뷰포트에서 재는 모든 것을 소유하는 상주 반응형·터치 디자이너. 브레이크포인트·패널 접힘·터치 타깃·safe-area·확대/reflow·태블릿 레이아웃이 걸린 변경에 소집한다. 소집되면 `/responsive-sweep` 매트릭스 실측을 반드시 실행한다 — rect 없는 판정은 무효. 폰을 늘린 태블릿 레이아웃과 근거 없는 분할 뷰를 모두 반려한다. 공개 발행 원칙(WCAG · Apple HIG · Material · NN/g)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__resize_page
 ---
 

--- a/.claude/agents/design-system.md
+++ b/.claude/agents/design-system.md
@@ -1,7 +1,7 @@
 ---
 name: design-system
 description: 디자인 벤치 8석 중 「체계」(Design Systems Engineer) — 결정을 취향이 아니라 토큰·제약·마커·테스트로 바꾸는 상주 디자인 시스템 엔지니어. 모든 디자인 카운슬 소집에 기본 참석한다(이 자리는 빠질 수 없다). 새 값이 필요하면 램프에 등록하고 같은 PR 에 lint 룰까지 넣게 만들고, 일회성 사이즈·검증 안 된 반응형·룰 없는 규격을 반려한다. 공개 발행 원칙(Carbon · Fluent · W3C Design Tokens · Apple HIG)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: sonnet
+model: fable
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
 ---
 

--- a/.claude/agents/design-workbench.md
+++ b/.claude/agents/design-workbench.md
@@ -1,7 +1,7 @@
 ---
 name: design-workbench
 description: 디자인 벤치 8석 중 「작업대」(macOS Workbench Designer) — 14인치 첫 뷰포트·창 안정성·앱 종료 동작을 지키는 상주 macOS 워크벤치 디자이너. 데스크톱 앱 UX·창 크롬·패널·반응형이 걸린 변경에 소집한다. 브라우저 전용 증명, 비좁은 풀스크린, 크래시/재열기 대화상자를 반려하고 설치된 앱에서 직접 확인한다. 공개 발행 원칙(Apple HIG macOS · WCAG)만 인용하고 타사 자산은 절대 모방하지 않는다.
-model: sonnet
+model: opus
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__evaluate_script
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -2494,6 +2494,13 @@
       "ctaScaffold": "Create for me",
       "ctaScaffoldBusy": "Creating…",
       "scaffoldToast": "Created {concepts} ontology concepts and {configs} agent config files"
+    },
+    "recentChangesNeedsVault": {
+      "eyebrow": "Recent changes",
+      "title": "Open your folder to turn this on",
+      "body": "You're looking at the sample map. Its dates are when this app last touched the sample, which has nothing to do with you. Open your folder and the map will point out what changed and when.",
+      "action": "Open my folder",
+      "close": "Close"
     }
   },
   "fullDetailA1": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2494,6 +2494,13 @@
       "ctaScaffold": "만들어 주기",
       "ctaScaffoldBusy": "만드는 중…",
       "scaffoldToast": "온톨로지 개념 {concepts}개 · 에이전트 설정 파일 {configs}개를 만들었어요"
+    },
+    "recentChangesNeedsVault": {
+      "eyebrow": "최근 변경",
+      "title": "내 폴더를 열면 켜져요",
+      "body": "지금 보는 건 예시 지도예요. 여기 날짜는 이 앱이 예시를 마지막으로 손본 시각이라 당신과 관계가 없어요. 내 폴더를 열면 무엇이 언제 바뀌었는지 지도 위에서 바로 짚어드려요.",
+      "action": "내 폴더 열기",
+      "close": "닫기"
     }
   },
   "fullDetailA1": {

--- a/src/features/vault-ontology/index.ts
+++ b/src/features/vault-ontology/index.ts
@@ -10,4 +10,5 @@ export {
 export { useAdaptiveRecentChanges } from './model/use-recent-changes';
 export { OntologyLiveBaselineInit } from './ui/OntologyLiveBaselineInit';
 export { LiveActivityIndicator } from './ui/LiveActivityIndicator';
+export { RecentChangesNeedsVaultDialog } from './ui/RecentChangesNeedsVaultDialog';
 export { formatActivityAge } from './lib/format-activity-age';

--- a/src/features/vault-ontology/ui/RecentChangesNeedsVaultDialog.tsx
+++ b/src/features/vault-ontology/ui/RecentChangesNeedsVaultDialog.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { FolderOpen, History, X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { MOTION } from '@/shared/motion';
+
+export interface RecentChangesNeedsVaultDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** 「내 폴더 열기」 — 첫 실행 카드가 쓰는 것과 **같은** 핸들러여야 한다. */
+  onOpenVault: () => void;
+}
+
+/**
+ * 「최근 변경」을 샘플에서 눌렀을 때 — **막다른 곳 대신 길을 준다.**
+ *
+ * ## 왜 여기만 팝업인가
+ *
+ * 2026-08-02 판단은 「아무것도 없다」를 말하려고 모달을 여는 것을 기각했다. 그건
+ * 누른 사람에게 일을 두 번 시키는 것이고 이 저장소가 `popup soup` 로 금지한
+ * 부류다. **그 판단은 여전히 유효하다** — 내 폴더를 연 사람에게 최근 변경이
+ * 0이면 그건 진짜로 보여줄 게 없는 것이라 비활성 + 툴팁 그대로다.
+ *
+ * 샘플은 다르다. 여기서 0인 이유는 「아직 안 바꿨다」가 아니라 **샘플의 날짜가
+ * 이 저장소가 픽스처를 마지막으로 건드린 시각이라 사용자와 무관**하다는 것이다.
+ * 즉 폴더를 열기 전에는 이 기능이 원리적으로 뜻을 못 가진다 — 기다린다고
+ * 켜지지 않는다. 사유가 「없음」이 아니라 「다음 행동」이면 그때는 다음 행동을
+ * 줘야 하고, 그게 `surfaces.md` 의 강등 계약(왜 + 어디서)이자 웹 스모크가
+ * 요구하는 **죽은 CTA 0** 이다.
+ *
+ * 소유자 지시(2026-08-03): *"칩 누르면 뭔가 화면에서 팝업 띄워줘야 하지 않을까?
+ * … 화면 중앙에 예쁜 팝업 띄워서 폴더 세팅 유도하던지?"*
+ *
+ * ## 골격은 새로 만들지 않았다
+ *
+ * scrim + 중앙 카드 + 토큰 + `MOTION.base` — `AgentConnectSheet` 와 같은 계약이다
+ * (`design.md`: 모달은 dim/scrim 또는 차단된 상호작용을 **증명**해야 한다).
+ * Esc 로 닫히고 포커스는 트리거로 돌아간다.
+ */
+export function RecentChangesNeedsVaultDialog({
+  open,
+  onClose,
+  onOpenVault,
+}: RecentChangesNeedsVaultDialogProps) {
+  const t = useTranslations('topology.recentChangesNeedsVault');
+  const primaryRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    // 열리면 **다음 행동**에 포커스가 간다 — 이 표면의 일이 그것 하나라서다.
+    primaryRef.current?.focus();
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          data-interactive-overlay="true"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={MOTION.base}
+          onClick={onClose}
+          data-testid="recent-changes-needs-vault-scrim"
+          className="pointer-events-auto fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--color-backdrop-medium)] p-6"
+        >
+          <motion.section
+            initial={{ opacity: 0, y: 12, scale: 0.985 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.985 }}
+            transition={MOTION.base}
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t('title')}
+            data-testid="recent-changes-needs-vault-dialog"
+            className="w-full max-w-[420px] rounded-[var(--radius-panel)] border border-[color:var(--color-divider)] bg-[color:var(--color-panel)] shadow-[var(--shadow-elevation-3)]"
+          >
+            <header className="flex items-start justify-between gap-3 border-b border-[color:var(--color-border-soft)] px-5 py-4">
+              <div>
+                <p className="flex items-center gap-1.5 font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-indigo-accent)]">
+                  <History size={11} aria-hidden />
+                  {t('eyebrow')}
+                </p>
+                <p className="mt-1.5 text-body-lg text-[color:var(--color-text-primary)]">{t('title')}</p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label={t('close')}
+                data-testid="recent-changes-needs-vault-close"
+                className="shrink-0 rounded p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              >
+                <X size={15} aria-hidden />
+              </button>
+            </header>
+
+            <div className="px-5 py-4">
+              <p className="text-body text-[color:var(--color-text-secondary)]">{t('body')}</p>
+              <button
+                ref={primaryRef}
+                type="button"
+                onClick={() => {
+                  onClose();
+                  onOpenVault();
+                }}
+                data-testid="recent-changes-needs-vault-open"
+                className="mt-4 inline-flex h-10 w-full items-center justify-center gap-2 rounded-[var(--radius-card)] border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-brand)] px-4 text-body text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+              >
+                <FolderOpen size={14} aria-hidden />
+                {t('action')}
+              </button>
+              {/*
+                두 번째 행동을 안 준다. 이 표면의 일은 하나이고, 두 번째 버튼은
+                「닫기」인데 그건 헤더의 X 와 scrim 이 이미 두 경로로 준다.
+              */}
+            </div>
+          </motion.section>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/features/vault-ontology/ui/RecentChangesNeedsVaultDialog.tsx
+++ b/src/features/vault-ontology/ui/RecentChangesNeedsVaultDialog.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { MOTION } from '@/shared/motion';
+import { Button, controlClass } from '@/shared/ui';
 
 export interface RecentChangesNeedsVaultDialogProps {
   open: boolean;
@@ -100,7 +101,12 @@ export function RecentChangesNeedsVaultDialog({
                 onClick={onClose}
                 aria-label={t('close')}
                 data-testid="recent-changes-needs-vault-close"
-                className="shrink-0 rounded p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className={controlClass({
+                  shape: 'icon',
+                  size: 'sm',
+                  tone: 'muted',
+                  className: 'hover:text-[color:var(--color-text-primary)]',
+                })}
               >
                 <X size={15} aria-hidden />
               </button>
@@ -108,19 +114,24 @@ export function RecentChangesNeedsVaultDialog({
 
             <div className="px-5 py-4">
               <p className="text-body text-[color:var(--color-text-secondary)]">{t('body')}</p>
-              <button
+              {/*
+                여기가 `<Button>` 이 덮는 **바로 그 한 모양**이다 — 전수 419개 중
+                표준 버튼 높이(h-10/11)는 1개였고, 새로 짓는 주 행동이 그 자리다.
+                손으로 쓰지 않는 이유는 규율이 아니라 계기다: 채택 래칫이 이
+                파일의 손 className 두 개를 커밋 전에 잡았다.
+              */}
+              <Button
                 ref={primaryRef}
-                type="button"
                 onClick={() => {
                   onClose();
                   onOpenVault();
                 }}
                 data-testid="recent-changes-needs-vault-open"
-                className="mt-4 inline-flex h-10 w-full items-center justify-center gap-2 rounded-[var(--radius-card)] border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-brand)] px-4 text-body text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-panel)]"
+                className="mt-4 w-full"
               >
                 <FolderOpen size={14} aria-hidden />
                 {t('action')}
-              </button>
+              </Button>
               {/*
                 두 번째 행동을 안 준다. 이 표면의 일은 하나이고, 두 번째 버튼은
                 「닫기」인데 그건 헤더의 X 와 scrim 이 이미 두 경로로 준다.

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -21,7 +21,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Compass, FolderOpen, HelpCircle, History as HistoryIcon, MessageCircle, Plus, X } from "lucide-react";
 import { useTypingShortcuts } from "@/shared/lib/use-typing-shortcut";
 import { useProjects } from "@/features/project-data-source";
-import { useAdaptiveRecentChanges, useOntologyInsight, useVaultConceptFacts, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
+import { RecentChangesNeedsVaultDialog, useAdaptiveRecentChanges, useOntologyInsight, useVaultConceptFacts, useVaultDocFreshnessIndex } from "@/features/vault-ontology";
 import {
   useAgentServer,
   useLocalVault,
@@ -641,12 +641,30 @@ export function HomePage() {
   const recentChanges = useAdaptiveRecentChanges(
     spotlightOn && recentWindow !== "auto" ? recentWindow : undefined,
   );
+  /*
+   * 샘플에서 이 칩을 누르면 **막다른 곳 대신 길**을 준다 (2026-08-03 소유자 지시:
+   * *"칩 누르면 뭔가 화면에서 팝업 띄워줘야 하지 않을까? … 화면 중앙에 예쁜 팝업
+   * 띄워서 폴더 세팅 유도하던지?"*).
+   *
+   * **두 빈 상태를 가른다.** 내 폴더를 연 사람에게 최근 변경이 0이면 그건 진짜로
+   * 보여줄 게 없는 것이라 비활성 + 툴팁 그대로다 — 「아무것도 없다」를 말하려고
+   * 모달을 여는 것은 여전히 기각이다(2026-08-02, popup soup). 샘플은 다르다:
+   * 여기서 0인 이유는 **샘플의 날짜가 이 저장소가 픽스처를 마지막으로 건드린
+   * 시각**이라 사용자와 무관하다는 것이고, 기다린다고 켜지지 않는다. 사유가
+   * 「없음」이 아니라 「다음 행동」이면 다음 행동을 줘야 한다.
+   */
+  const [recentNeedsVaultOpen, setRecentNeedsVaultOpen] = useState(false);
+  const spotlightNeedsVault = vault.status !== 'loaded';
   const handleToggleSpotlight = useCallback(() => {
+    if (spotlightNeedsVault) {
+      setRecentNeedsVaultOpen(true);
+      return;
+    }
     setRouteState((current) => ({
       ...current,
       recentWindow: current.recentWindow === null ? "auto" : null,
     }));
-  }, [setRouteState]);
+  }, [spotlightNeedsVault, setRouteState]);
   // 소유자 지시 (Image #14): "전체 변경점을 보여주는 거면 아예 zoom out 을
   // 크게" — 렌즈가 켜지는 순간 카메라를 전체 fit 으로 물러나 변경 지점
   // 전부(자동 전개 포함)가 한 화면에 들어오게 한다. off→on 전이에서만 1회
@@ -3627,7 +3645,14 @@ export function HomePage() {
                          * 켜져 있는 동안은 **끌 수 있어야** 하므로, 꺼져 있고
                          * 강조가 0일 때만 비활성이다.
                          */
-                        disabled={!spotlightOn && recentChanges.recentNodeIds.size === 0}
+                        /*
+                         * 샘플에서는 **비활성이 아니다** — 누르면 폴더 안내가 열린다.
+                         * 비활성은 「내 폴더를 열었는데 최근 변경이 0」일 때만이고,
+                         * 그때는 정말로 보여줄 게 없다.
+                         */
+                        disabled={
+                          !spotlightNeedsVault && !spotlightOn && recentChanges.recentNodeIds.size === 0
+                        }
                         aria-pressed={spotlightOn}
                         aria-label={t('controls.spotlightAriaLabel')}
                         data-testid="topology-spotlight-toggle"
@@ -4683,6 +4708,15 @@ export function HomePage() {
                 open={unsupportedGuideOpen}
                 unsupported
                 onClose={() => setUnsupportedGuideOpen(false)}
+              />
+
+              {/* 샘플에서 「최근 변경」을 눌렀을 때 — 막다른 곳 대신 폴더로 가는 길.
+                  `requestVaultOpen` 을 그대로 쓴다: 첫 실행 카드의 「내 폴더 열기」와
+                  **같은 핸들러**여야 미지원 브라우저 분기도 한 번만 존재한다. */}
+              <RecentChangesNeedsVaultDialog
+                open={recentNeedsVaultOpen}
+                onClose={() => setRecentNeedsVaultOpen(false)}
+                onOpenVault={requestVaultOpen}
               />
 
             </>

--- a/tests/contract/design-council.contract.test.ts
+++ b/tests/contract/design-council.contract.test.ts
@@ -41,21 +41,37 @@ const DECIDER_AGENT = 'design-guardian';
 const ALWAYS_ATTENDING = ['design-lead', 'design-system'];
 
 /**
- * Tier is a decision, not a default. Judgment seats get the stronger model;
- * measurement seats are scaffolded enough that a cheaper one suffices. No haiku
- * anywhere — a council is a judgment body, and a haiku seat produces checklist
- * parroting that reads like a verdict, which is worse than an absent one.
+ * 티어는 기본값이 아니라 결정이다. haiku 는 어디에도 없다 — 카운슬은 판정 기구이고
+ * haiku 자리는 평결처럼 읽히는 체크리스트 앵무새를 낸다(부재보다 나쁘다).
+ *
+ * **2026-08-03 개정 — 소유자 지시** *"다 opus가 해도됨! 가장 높은 결정 필요한건
+ * fable로"*. 그 지시는 PO 5석에만 적용되고 디자인 벤치는 8석 중 6석이 sonnet 으로
+ * 남아 있었다. 같은 규칙으로 맞춘다.
+ *
+ * **fable 은 「항상 참석하는 두 자리」다.** 스킬이 *위계와 체계는 빠질 수 없다* 고
+ * 못박은 그 둘이고, 이유가 티어와 같다 — 「위계」는 **무엇이 주목을 이기는가**를
+ * 정하고 나머지 판정이 전부 그 뒤에 온다. 「체계」는 결정을 **토큰·lint·계약
+ * 테스트**로 굳혀서 되돌리기가 가장 비싸다. PO 가 5석 중 2석에 fable 을 둔 것과
+ * 같은 비율이고 같은 논거다.
+ *
+ * ⚠️ **단일 계열로 되돌리지 않는다.** PO 쪽 실측이 여기에도 적용된다 — 원장 7회 ·
+ * 좌석 판정 35건에서 평균 쌍별 일치율 65.7%(우연 기대 36.8%). 한 계열로 통일하면
+ * 여덟 자리가 아니라 「여덟 번 다르게 프롬프트한 심판 하나」다
+ * (Verga et al. arXiv:2404.18796 · Panickssery et al. NeurIPS 2024).
  */
 const TIERS: Record<string, string> = {
-  'design-lead': 'opus',
+  'design-lead': 'fable',
+  'design-system': 'fable',
   'design-motion': 'opus',
-  'design-system': 'sonnet',
-  'design-interaction': 'sonnet',
-  'design-infoviz': 'sonnet',
-  'design-workbench': 'sonnet',
-  'design-responsive': 'sonnet',
-  'design-handoff': 'sonnet',
+  'design-interaction': 'opus',
+  'design-infoviz': 'opus',
+  'design-workbench': 'opus',
+  'design-responsive': 'opus',
+  'design-handoff': 'opus',
 };
+
+/** 계열이 최소 둘 — 위 ⚠️. 없으면 다음 사람이 「일관성」을 이유로 통일해 버린다. */
+const MIN_MODEL_FAMILIES = 2;
 
 /** Measuring seats must run their instrument; the skill has to say so. */
 const INSTRUMENTS = ['motion-verify', 'responsive-sweep', 'design-audit'];
@@ -378,6 +394,16 @@ describe('발산 단계 — /design-directions', () => {
    * 나머지 갈래가 허수아비가 되고, 그 순간 발산은 변경을 정당화하는 의식이 된다
    * — 카운슬을 만든 이유와 같은 실패다.
    */
+  it('벤치가 한 모델 계열로 수렴하지 않는다', () => {
+    // 이 단언이 없으면 다음 사람이 「일관성」을 이유로 한 줄씩 통일해 이질성이
+    // 조용히 사라진다 — PO 카운슬에서 실제로 그렇게 될 뻔했다.
+    expect(
+      new Set(Object.values(TIERS)).size,
+      '여덟 자리가 한 계열이면 배심원 여덟이 아니라 여덟 번 다르게 프롬프트한 심판 하나다 ' +
+        '(실측: 좌석 판정 35건 평균 쌍별 일치율 65.7% · Verga et al. arXiv:2404.18796)',
+    ).toBeGreaterThanOrEqual(MIN_MODEL_FAMILIES);
+  });
+
   it('갈래를 그리는 자리가 짓는 자리와 분리돼 있다', () => {
     const skill = read(DIRECTIONS_SKILL).replace(/\s+/g, ' ');
     expect(skill, '발산 소유자를 chief 로 명시해야 한다').toMatch(

--- a/tests/e2e/recent-changes-needs-vault.spec.ts
+++ b/tests/e2e/recent-changes-needs-vault.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * 「최근 변경」이 샘플에서 **막다른 곳이 아니어야 한다.**
+ *
+ * ## 왜 이 스펙이 있나
+ *
+ * 2026-08-03 소유자 실보고: *"일반 화면에서 '최근 변경' 누르니까 아무런 반응이
+ * 없는데?"*. 원인이 둘이었다 — ① 비활성인데 비활성처럼 안 보였고(그건
+ * `tests/contract/disabled-affordance.contract.test.ts` 가 맡는다), ② 샘플에서는
+ * 애초에 **비활성이면 안 됐다.**
+ *
+ * 샘플에서 최근 변경이 0인 이유는 「아직 안 바꿨다」가 아니라 **샘플의 날짜가 이
+ * 저장소가 픽스처를 마지막으로 건드린 시각**이라는 것이다. 기다린다고 켜지지
+ * 않는다 — 폴더를 열어야 뜻을 갖는다. 사유가 「없음」이 아니라 「다음 행동」이면
+ * 다음 행동을 줘야 하고, 그게 `surfaces.md` 의 강등 계약(왜 + 어디서)이자 웹
+ * 스모크가 요구하는 **죽은 CTA 0** 이다.
+ *
+ * jsdom 이 아니라 e2e 인 이유: 모달성(scrim)·중앙 배치·포커스·Esc 는 **렌더된
+ * 화면에서만** 참인지 알 수 있다.
+ */
+
+test.describe('최근 변경 — 샘플에서 폴더로 가는 길', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto('/ko/topology/?guides=off', { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2500);
+  });
+
+  test('샘플에서는 눌린다 — 비활성으로 막지 않는다', async ({ page }) => {
+    const chip = page.getByTestId('topology-spotlight-toggle');
+    await expect(chip).toBeEnabled();
+  });
+
+  test('누르면 안내가 열리고, 다음 행동이 하나 있다', async ({ page }) => {
+    await page.getByTestId('topology-spotlight-toggle').click();
+    const dialog = page.getByTestId('recent-changes-needs-vault-dialog');
+    await expect(dialog).toBeVisible();
+
+    // 「왜」와 「어디서」가 둘 다 있어야 한다 — 하나만 있으면 사과문이거나 명령이다.
+    await expect(dialog).toContainText('폴더');
+    await expect(page.getByTestId('recent-changes-needs-vault-open')).toBeVisible();
+  });
+
+  test('모달이 모달임을 증명한다 — scrim 이 뒤를 막는다', async ({ page }) => {
+    // `design.md`: 모달은 dim/scrim 또는 차단된 상호작용을 **증명**해야 한다.
+    await page.getByTestId('topology-spotlight-toggle').click();
+    const scrim = page.getByTestId('recent-changes-needs-vault-scrim');
+    await expect(scrim).toBeVisible();
+    const alpha = await scrim.evaluate((el) => {
+      const m = /rgba?\(([^)]+)\)/.exec(getComputedStyle(el).backgroundColor);
+      const parts = m ? m[1].split(',').map(Number) : [];
+      return parts.length > 3 ? parts[3] : 1;
+    });
+    expect(alpha, 'scrim 이 투명하면 모달이 아니라 떠 있는 카드다').toBeGreaterThan(0.2);
+  });
+
+  test('열리면 포커스가 다음 행동에 간다', async ({ page }) => {
+    await page.getByTestId('topology-spotlight-toggle').click();
+    await expect(page.getByTestId('recent-changes-needs-vault-open')).toBeFocused();
+  });
+
+  test('Esc 와 scrim 클릭 둘 다로 닫힌다', async ({ page }) => {
+    const chip = page.getByTestId('topology-spotlight-toggle');
+    const dialog = page.getByTestId('recent-changes-needs-vault-dialog');
+
+    await chip.click();
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+
+    await chip.click();
+    await expect(dialog).toBeVisible();
+    // scrim 의 가장자리를 누른다 — 카드 위가 아니라.
+    await page.mouse.click(40, 40);
+    await expect(dialog).toBeHidden();
+  });
+
+  test('지도를 바꾸지 않는다 — 렌즈는 폴더가 있어야 켜진다', async ({ page }) => {
+    // 안내를 여는 것이 렌즈를 켜 버리면, 아무것도 강조 못 하는 렌즈가 켜진 채
+    // 남아 「켜져 있는데 아무 일도 안 일어난다」가 된다.
+    const before = page.url();
+    await page.getByTestId('topology-spotlight-toggle').click();
+    await expect(page.getByTestId('recent-changes-needs-vault-dialog')).toBeVisible();
+    expect(page.url(), '`?recent=` 가 붙으면 안 된다').toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

소유자 실보고: *"'최근 변경' 누르니까 아무런 반응이 없는데?"* → *"칩 누르면 뭔가 화면에서 팝업 띄워줘야 하지 않을까? … 화면 중앙에 예쁜 팝업 띄워서 폴더 세팅 유도하던지?"*

**두 빈 상태를 갈랐다.** 내 폴더를 연 사람에게 최근 변경이 0이면 진짜로 보여줄 게 없으므로 비활성 + 툴팁 그대로다 — 「아무것도 없다」를 말하려고 모달을 여는 2026-08-02 기각은 유효하다. **샘플은 다르다**: 여기서 0인 이유는 샘플의 날짜가 이 저장소가 픽스처를 마지막으로 건드린 시각이라 사용자와 무관하다는 것이고, 기다린다고 켜지지 않는다. 사유가 「없음」이 아니라 「다음 행동」이면 다음 행동을 줘야 한다 (`surfaces.md` 강등 계약: 왜 + 어디서 · 죽은 CTA 0).

골격은 새로 만들지 않았다 — scrim + 중앙 카드 + 토큰 + `MOTION.base` 로 `AgentConnectSheet` 와 같은 계약. 폴더 열기는 첫 실행 카드와 **같은 핸들러**(`requestVaultOpen`)라 미지원 브라우저 분기가 한 번만 존재한다.

**디자인 벤치 티어도 함께 맞췄다.** *"다 opus가 해도됨! 가장 높은 결정 필요한건 fable로"* 지시가 PO 5석에만 적용되고 디자인은 8석 중 6석이 sonnet 이었다. fable 은 스킬이 「빠질 수 없다」고 못박은 두 자리(위계·체계) — 위계는 무엇이 주목을 이기는가를 정해 나머지 판정이 그 뒤에 오고, 체계는 결정을 토큰·lint·계약 테스트로 굳혀 되돌리기가 가장 비싸다. PO 가 5석 중 2석에 fable 을 둔 것과 같은 비율·같은 논거이고, 단일 계열 수렴을 막는 단언도 같은 형태로 넣었다.

## Test plan

- `pnpm exec tsc --noEmit` 통과 · `pnpm lint` 96 warnings / 0 errors (신규 0)
- `pnpm test:contracts` 1162/1162
- `pnpm exec playwright test tests/e2e/recent-changes-needs-vault.spec.ts` 6/6

**실측** (1512×900 정적 빌드): 칩 `enabled` · 카드 중심 x=756 (뷰포트 중심 일치) · scrim `rgba(8,9,10,0.6)` · 포커스가 다음 행동에 · Esc 로 닫힘.

**게이트 프로브**

| 프로브 | 결과 |
|---|---|
| 샘플에서도 비활성으로 되돌린다 (원래 결함) | ✗ 6 실패 |
| 안내가 렌즈까지 켜 버린다 | ✗ 1 실패 |
| 복원 | ✓ 6/6 |

그리고 **채택 래칫이 이 PR 의 코드를 먼저 잡았다** — 새 다이얼로그의 버튼 둘이 손 className 이라 「417 → 419 로 늘었다」로 막혔고, `controlClass({shape:'icon'})` 와 `<Button>` 으로 바꿔 통과시켰다. 게이트가 남이 아니라 만든 사람에게 걸린 사례다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275