### PR TITLE
feat: 퇴장 창 동안 내용을 붙드는 useHeldValue · Surface 의 data-* 통과

### DIFF
--- a/src/shared/lib/use-presence.ts
+++ b/src/shared/lib/use-presence.ts
@@ -146,3 +146,33 @@ export function useSwapHeight<T>(token: T) {
 
   return { hostRef, capture };
 }
+
+/**
+ * 퇴장 창 동안 **직전 값을 붙든다.**
+ *
+ * ## 왜 필요한가
+ *
+ * `<Surface open={Boolean(model)}>` 로 감싸면 표면은 퇴장 창 동안 남는다. 그런데
+ * **내용은 부모가 준다** — `model` 이 `null` 이 되는 순간 자식이 빈 채로 그려져,
+ * 표면은 예쁘게 사라지는데 그 안이 텅 빈다. 등장/퇴장을 붙이려던 것이 오히려
+ * 더 나쁜 화면이 된다.
+ *
+ * 그래서 값도 함께 붙들어야 한다. 이게 「부모의 렌더 게이트가 퇴장 창 동안 모델을
+ * 붙들어야 해서 기계적이지 않다」의 정체이고, 그래서 훅으로 만든다 — 표면마다
+ * 다시 발명하면 어느 하나는 틀린다.
+ *
+ * ## 왜 effect 가 아니라 렌더 중 조정인가
+ *
+ * `useEffect` 로 붙들면 **한 프레임 늦다** — 그 한 프레임 동안 자식이 `null` 을
+ * 받아 깜빡인다. 렌더 중 `setState` 는 React 가 문서에서 권하는 «prop 이 바뀔 때
+ * 상태 조정» 패턴이고, 화면에 칠하기 전에 즉시 다시 렌더하므로 깜빡임이 없다.
+ * 조건이 있어야 무한 루프가 안 난다 — 아래 `value !== held` 가 그것이다.
+ */
+export function useHeldValue<T>(value: T | null | undefined): T | null {
+  const [held, setHeld] = useState<T | null>(value ?? null);
+  if (value != null && value !== held) {
+    // 렌더 중 setState — React 가 즉시 재렌더하고 화면에는 한 번만 칠한다.
+    setHeld(value);
+  }
+  return value ?? held;
+}

--- a/src/shared/ui/surface.test.tsx
+++ b/src/shared/ui/surface.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EXIT_WINDOW_MS } from '@/shared/lib/use-presence';
+import { EXIT_WINDOW_MS, useHeldValue } from '@/shared/lib/use-presence';
 import { Surface } from './surface';
 
 /**
@@ -100,6 +100,20 @@ describe('Surface', () => {
     expect(screen.getByText('내용')).toHaveStyle({ transformOrigin: 'top right' });
   });
 
+  it('data-* 를 통과시킨다 — 밖에서 이 표면을 집을 수 있어야 한다', () => {
+    /*
+     * ⚠️ 이 단언이 없으면 **타입이 조용히 통과시킨다.** TypeScript 는 하이픈이 든
+     * JSX 속성을 검사하지 않아서, `Surface` 가 안 받아도 `tsc` 는 아무 말 없고
+     * 값만 버려진다. 2026-08-03 에 엣지 패널을 전환하면서 실제로 그럴 뻔했다.
+     */
+    render(
+      <Surface open data-testid="the-surface">
+        내용
+      </Surface>,
+    );
+    expect(screen.getByTestId('the-surface')).toBeInTheDocument();
+  });
+
   it('소비처 className 이 덧붙는다 — 모양은 소비처가 정한다', () => {
     render(
       <Surface open className="w-[300px]">
@@ -109,5 +123,54 @@ describe('Surface', () => {
     const el = screen.getByText('내용');
     expect(el).toHaveClass('w-[300px]');
     expect(el, '모션 문법은 그대로 남아야 한다').toHaveClass('topology-chrome-in');
+  });
+
+});
+
+describe('useHeldValue — 퇴장 창 동안 내용이 비지 않는다', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  function Holder({ model }: { model: string | null }) {
+    const held = useHeldValue(model);
+    return (
+      <Surface open={model !== null}>
+        <span data-testid="body">{held ?? '(비어 있음)'}</span>
+      </Surface>
+    );
+  }
+
+  it('값이 사라져도 퇴장 창 동안 직전 값을 그린다', () => {
+    // 이게 없으면 표면은 예쁘게 사라지는데 그 안이 텅 빈다 — 등장/퇴장을 붙이려던
+    // 것이 오히려 더 나쁜 화면이 된다.
+    const { rerender } = render(<Holder model="엣지 A→B" />);
+    expect(screen.getByTestId('body')).toHaveTextContent('엣지 A→B');
+
+    act(() => rerender(<Holder model={null} />));
+    expect(
+      screen.getByTestId('body'),
+      '퇴장 중에 내용이 비면 사라지는 표면이 빈 상자로 보인다',
+    ).toHaveTextContent('엣지 A→B');
+
+    act(() => void vi.advanceTimersByTime(EXIT_WINDOW_MS + 10));
+    expect(screen.queryByTestId('body')).toBeNull();
+  });
+
+  it('새 값이 오면 즉시 바뀐다 — 붙드는 것이 갱신을 막지 않는다', () => {
+    const { rerender } = render(<Holder model="첫째" />);
+    act(() => rerender(<Holder model="둘째" />));
+    expect(screen.getByTestId('body')).toHaveTextContent('둘째');
+  });
+
+  it('값이 바뀌는 동안 한 프레임도 비지 않는다', () => {
+    // effect 로 붙들면 한 프레임 늦어 그 사이 자식이 null 을 받는다.
+    // 렌더 중 조정이라 그 프레임이 존재하지 않는다.
+    const { rerender } = render(<Holder model="A" />);
+    act(() => rerender(<Holder model={null} />));
+    act(() => rerender(<Holder model="B" />));
+    expect(screen.getByTestId('body')).toHaveTextContent('B');
   });
 });

--- a/src/shared/ui/surface.tsx
+++ b/src/shared/ui/surface.tsx
@@ -64,6 +64,14 @@ export interface SurfaceProps {
   as?: 'div' | 'section' | 'aside';
   /** 퇴장이 **끝난 뒤** 한 번. 포커스 복귀처럼 언마운트에 붙는 일에 쓴다. */
   onExited?: () => void;
+  /**
+   * `data-*` 통과 — **밖에서 이 표면을 집을 수 있어야** 계기와 테스트가 산다.
+   *
+   * ⚠️ 이걸 안 받으면 **타입이 조용히 통과시킨다.** TypeScript 는 하이픈이 든 JSX
+   * 속성을 검사하지 않아서, `data-testid` 를 넘겨도 `tsc` 는 아무 말 없고 값은
+   * 그냥 버려진다. 2026-08-03 에 엣지 패널을 전환하면서 실제로 그럴 뻔했다.
+   */
+  [dataAttribute: `data-${string}`]: unknown;
 }
 
 export function Surface({
@@ -73,6 +81,7 @@ export function Surface({
   origin,
   as: Tag = 'div',
   onExited,
+  ...rest
 }: SurfaceProps) {
   const { mounted, exiting } = usePanelPresence(open);
   const wasMounted = useRef(mounted);
@@ -90,6 +99,7 @@ export function Surface({
       //   사용자는 「눌렀는데 엉뚱한 게 됐다」를 겪는다.
       // React 19 는 `inert` 를 불리언 속성으로 안다 — 빈 문자열을 넣으면 false 로
       // 읽혀 조용히 안 붙는다(이 테스트가 그걸 잡았다).
+      {...rest}
       inert={exiting}
       data-surface-state={exiting ? 'exiting' : 'entered'}
       style={origin ? { transformOrigin: origin } : undefined}


### PR DESCRIPTION
## Summary

하드컷 4건을 전환하려다 **선행 자산 두 개**가 먼저 필요했다. 그중 **검증된 것만** 낸다.

### `useHeldValue`

`<Surface open={Boolean(model)}>` 로 감싸면 표면은 퇴장 창 동안 남는데 **내용은 부모가 준다** — `model` 이 `null` 이 되는 순간 자식이 빈 채로 그려져, **표면은 예쁘게 사라지는데 그 안이 텅 빈다.** 등장/퇴장을 붙이려던 것이 오히려 더 나쁜 화면이 된다.

effect 가 아니라 **렌더 중 조정**인 이유: effect 로 붙들면 한 프레임 늦어 그 사이 자식이 `null` 을 받아 깜빡인다. 렌더 중 `setState` 는 React 가 권하는 «prop 이 바뀔 때 상태 조정» 패턴이고 화면에 칠하기 전에 즉시 재렌더한다.

### `Surface` 의 `data-*` 통과

**이걸 안 받으면 타입이 조용히 통과시킨다.** TypeScript 는 하이픈이 든 JSX 속성을 검사하지 않아서 `data-testid` 를 넘겨도 `tsc` 는 아무 말 없고 값은 그냥 버려진다. 밖에서 표면을 못 집으면 계기와 테스트가 죽는다.

## ⚠️ 왜 실제 전환은 안 들어왔나

엣지 패널을 전환해 놓고 브라우저에서 퇴장 프레임을 확인하려 했는데 **엣지를 스크립트로 선택할 수 없었다** — 곡선 중점 **101지점 × 오프셋 3종**을 클릭해도 `selection().edge` 가 계속 `null` 이었다. 캔버스 히트 판정을 밖에서 몰 방법이 없다.

검증 못 한 변경을 지도의 주 표면에 넣지 않는다(이 저장소 규율: **계기 없는 판정은 무효**). 전환은 되돌렸다.

**다음 라운드의 선행 과제**: `__atlasMap` 에 엣지 선택을 몰 수 있는 창구를 낸다. 그것 자체가 검사 가능성의 구멍이다 — 노드는 `nodes()` 로 좌표·`draggable` 을 얻어 몰 수 있는데 엣지는 못 몬다.

## Test plan

- `Surface` 12/12 — 퇴장 창 · 퇴장 클래스 · `inert` · 상태 노출 · `onExited` · `origin` · `data-*` 통과 · **`useHeldValue` 3종**
- `pnpm test:contracts` 1188/1188 · `pnpm exec tsc --noEmit` 통과
- `pnpm lint` 96 warnings / 0 errors (신규 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275