### PR TITLE
feat: 프로젝트 빠른 편집이 나가는 길을 갖는다

### DIFF
--- a/src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx
+++ b/src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx
@@ -10,7 +10,7 @@ import {
   type ProjectFrontmatterPatch,
   useProjectMutations,
 } from "@/features/project-data-source";
-import { Button } from "@/shared/ui";
+import { Button, Surface } from "@/shared/ui";
 
 interface Props {
   project: Project;
@@ -200,146 +200,163 @@ export function ProjectQuickEditPanel({
         {open ? t("closeLabel") : t("openLabel")}
       </Button>
 
-      {open ? (
-        <div className="fixed inset-0 z-50">
-          <button
-            type="button"
-            aria-label={t("ariaCloseOverlay")}
-            className="absolute inset-0 bg-[var(--color-scrim-a58)]"
-            onClick={() => setOpen(false)}
-          />
-          <section
-            role="dialog"
-            aria-modal="true"
-            aria-label={t("ariaDialog")}
-            className="absolute right-0 top-0 flex h-full w-full max-w-[30rem] flex-col border-l border-[color:var(--color-divider)] bg-[color:rgba(11,12,14,0.98)] shadow-[var(--shadow-elevation-dock-side)]"
-          >
-            <div className="flex items-start justify-between gap-4 border-b border-[color:var(--color-border-soft)] px-5 py-5">
-              <div>
-                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
-                  {t("headerEyebrow")}
-                </p>
-                <p className="mt-2 text-body-lg leading-6 text-[color:var(--color-text-secondary)]">
-                  {t("headerSubtitle")}
-                </p>
-              </div>
+      {/* 나가는 길을 갖는다 — 종전엔 `{open ? … : null}` 이라 딤과 서랍이 함께
+          **1프레임에** 나타나고 사라졌다(등장도 퇴장도 없음). `Surface` 가 퇴장
+          창(`EXIT_WINDOW_MS`) · 퇴장 클래스(`topology-chrome-out`) · `inert` 를
+          지므로 여기서 새로 챙길 것이 없다. 새 토큰/duration/색 0개 —
+          크롬 모션 패밀리를 그대로 탄다.
+
+          `origin` 은 **트리거 방향**이다. 이 서랍을 여는 버튼은 히어로 우상단에
+          있고 서랍도 오른쪽에서 산다 — 중앙에서 태어나면 누른 자리와 태어난
+          자리가 어긋난다(모션석 반려 사유).
+
+          폼 값은 이 컴포넌트가 소유한다(`values`/`baseline`/`notice`). 그래서
+          퇴장 창 동안 붙들 **외부 모델이 없다** — 사라지는 표면이 빈 상자가
+          되지 않는다(HomePage 엣지 패널이 `useHeldValue` 를 쓴 이유는 모델이
+          부모 소유였기 때문이다). */}
+      <Surface
+        open={open}
+        origin="top right"
+        data-testid="public-quick-edit-surface"
+        className="fixed inset-0 z-50"
+      >
+        <button
+          type="button"
+          aria-label={t("ariaCloseOverlay")}
+          className="absolute inset-0 bg-[var(--color-scrim-a58)]"
+          onClick={() => setOpen(false)}
+        />
+        <section
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("ariaDialog")}
+          className="absolute right-0 top-0 flex h-full w-full max-w-[30rem] flex-col border-l border-[color:var(--color-divider)] bg-[color:rgba(11,12,14,0.98)] shadow-[var(--shadow-elevation-dock-side)]"
+        >
+          <div className="flex items-start justify-between gap-4 border-b border-[color:var(--color-border-soft)] px-5 py-5">
+            <div>
+              <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+                {t("headerEyebrow")}
+              </p>
+              <p className="mt-2 text-body-lg leading-6 text-[color:var(--color-text-secondary)]">
+                {t("headerSubtitle")}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 px-0"
+              onClick={() => setOpen(false)}
+            >
+              <X size={16} aria-hidden="true" />
+            </Button>
+          </div>
+
+          <div className="flex-1 space-y-4 overflow-y-auto px-5 py-5">
+            <label className="block">
+              <FieldLabel>{t("fieldName")}</FieldLabel>
+              <input
+                data-testid="public-quick-edit-name"
+                name="projectName"
+                autoComplete="off"
+                value={values.name}
+                onChange={(event) => handleChange("name", event.target.value)}
+                className={FIELD_INPUT_CLASS}
+                placeholder={t("fieldNamePlaceholder")}
+              />
+            </label>
+
+            <label className="block">
+              <FieldLabel>{t("fieldDescription")}</FieldLabel>
+              <textarea
+                data-testid="public-quick-edit-description"
+                name="projectDescription"
+                autoComplete="off"
+                value={values.description}
+                onChange={(event) => handleChange("description", event.target.value)}
+                rows={3}
+                className="mt-1.5 w-full rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-3 py-2 text-body leading-relaxed text-[color:var(--color-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[color:var(--color-text-quaternary)] focus:border-[color:var(--color-indigo-accent)] focus:ring-2 focus:ring-[color:var(--color-indigo-a24)]"
+                placeholder={t("fieldDescriptionPlaceholder")}
+              />
+            </label>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <FieldLabel optional={t("optionalHint")}>{t("fieldOwner")}</FieldLabel>
+                <input
+                  data-testid="public-quick-edit-owner"
+                  name="projectOwner"
+                  autoComplete="off"
+                  value={values.owner}
+                  onChange={(event) => handleChange("owner", event.target.value)}
+                  className={FIELD_INPUT_CLASS}
+                  placeholder={t("fieldOwnerPlaceholder")}
+                />
+              </label>
+
+              <label className="block">
+                <FieldLabel optional={t("optionalHint")}>{t("fieldTags")}</FieldLabel>
+                <input
+                  data-testid="public-quick-edit-tags"
+                  name="projectTags"
+                  autoComplete="off"
+                  value={values.tags}
+                  onChange={(event) => handleChange("tags", event.target.value)}
+                  className={FIELD_INPUT_CLASS}
+                  placeholder={t("fieldTagsPlaceholder")}
+                />
+              </label>
+            </div>
+
+            {error ? (
+              <p className="text-body text-[color:var(--color-status-danger)]">{error}</p>
+            ) : null}
+
+            {notice ? (
+              <p role="status" className="text-body text-[color:var(--color-text-primary)]">
+                {notice}
+              </p>
+            ) : null}
+          </div>
+
+          {/* #9 — footer: 주 액션 하나(변경 적용) + quiet 되돌리기 우측 정렬,
+              전체 편집/문서 등록은 링크형 3차 액션으로 아래에 조용히. */}
+          <div className="space-y-3 border-t border-[color:var(--color-border-soft)] px-5 py-4">
+            <div className="flex items-center justify-end gap-2">
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="h-9 w-9 px-0"
-                onClick={() => setOpen(false)}
+                onClick={handleReset}
+                disabled={!hasChanges || pending}
               >
-                <X size={16} aria-hidden="true" />
+                {t("reset")}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void handleSubmit()}
+                disabled={!hasChanges || pending}
+              >
+                {pending ? t("applying") : t("apply")}
               </Button>
             </div>
-
-            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-5">
-              <label className="block">
-                <FieldLabel>{t("fieldName")}</FieldLabel>
-                <input
-                  data-testid="public-quick-edit-name"
-                  name="projectName"
-                  autoComplete="off"
-                  value={values.name}
-                  onChange={(event) => handleChange("name", event.target.value)}
-                  className={FIELD_INPUT_CLASS}
-                  placeholder={t("fieldNamePlaceholder")}
-                />
-              </label>
-
-              <label className="block">
-                <FieldLabel>{t("fieldDescription")}</FieldLabel>
-                <textarea
-                  data-testid="public-quick-edit-description"
-                  name="projectDescription"
-                  autoComplete="off"
-                  value={values.description}
-                  onChange={(event) => handleChange("description", event.target.value)}
-                  rows={3}
-                  className="mt-1.5 w-full rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] px-3 py-2 text-body leading-relaxed text-[color:var(--color-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[color:var(--color-text-quaternary)] focus:border-[color:var(--color-indigo-accent)] focus:ring-2 focus:ring-[color:var(--color-indigo-a24)]"
-                  placeholder={t("fieldDescriptionPlaceholder")}
-                />
-              </label>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <label className="block">
-                  <FieldLabel optional={t("optionalHint")}>{t("fieldOwner")}</FieldLabel>
-                  <input
-                    data-testid="public-quick-edit-owner"
-                    name="projectOwner"
-                    autoComplete="off"
-                    value={values.owner}
-                    onChange={(event) => handleChange("owner", event.target.value)}
-                    className={FIELD_INPUT_CLASS}
-                    placeholder={t("fieldOwnerPlaceholder")}
-                  />
-                </label>
-
-                <label className="block">
-                  <FieldLabel optional={t("optionalHint")}>{t("fieldTags")}</FieldLabel>
-                  <input
-                    data-testid="public-quick-edit-tags"
-                    name="projectTags"
-                    autoComplete="off"
-                    value={values.tags}
-                    onChange={(event) => handleChange("tags", event.target.value)}
-                    className={FIELD_INPUT_CLASS}
-                    placeholder={t("fieldTagsPlaceholder")}
-                  />
-                </label>
+            {documentNewHref || settingsHref ? (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                {documentNewHref ? (
+                  <Link href={documentNewHref} className={TERTIARY_LINK_CLASS}>
+                    {t("openDocument")}
+                  </Link>
+                ) : null}
+                {settingsHref ? (
+                  <Link href={settingsHref} className={TERTIARY_LINK_CLASS}>
+                    {t("openSettings")}
+                  </Link>
+                ) : null}
               </div>
-
-              {error ? (
-                <p className="text-body text-[color:var(--color-status-danger)]">{error}</p>
-              ) : null}
-
-              {notice ? (
-                <p role="status" className="text-body text-[color:var(--color-text-primary)]">
-                  {notice}
-                </p>
-              ) : null}
-            </div>
-
-            {/* #9 — footer: 주 액션 하나(변경 적용) + quiet 되돌리기 우측 정렬,
-                전체 편집/문서 등록은 링크형 3차 액션으로 아래에 조용히. */}
-            <div className="space-y-3 border-t border-[color:var(--color-border-soft)] px-5 py-4">
-              <div className="flex items-center justify-end gap-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleReset}
-                  disabled={!hasChanges || pending}
-                >
-                  {t("reset")}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => void handleSubmit()}
-                  disabled={!hasChanges || pending}
-                >
-                  {pending ? t("applying") : t("apply")}
-                </Button>
-              </div>
-              {documentNewHref || settingsHref ? (
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
-                  {documentNewHref ? (
-                    <Link href={documentNewHref} className={TERTIARY_LINK_CLASS}>
-                      {t("openDocument")}
-                    </Link>
-                  ) : null}
-                  {settingsHref ? (
-                    <Link href={settingsHref} className={TERTIARY_LINK_CLASS}>
-                      {t("openSettings")}
-                    </Link>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          </section>
-        </div>
-      ) : null}
+            ) : null}
+          </div>
+        </section>
+      </Surface>
     </>
   );
 }

--- a/tests/contract/surface-motion-ratchet.contract.test.ts
+++ b/tests/contract/surface-motion-ratchet.contract.test.ts
@@ -57,7 +57,6 @@ import { describe, expect, it } from 'vitest';
  */
 const HARD_CUT_REGISTRY: ReadonlyArray<readonly [file: string, why: string]> = [
   ['src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx', '노드 클릭으로 뜬다 — 이 앱에서 가장 자주 열리는 표면'],
-  ['src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx', 'ProjectDetailPage 의 삼항으로 뜬다'],
   ['src/widgets/vault-agent-panel/ui/VaultAgentPanel.tsx', 'HomePage 의 삼항으로 뜬다'],
 ];
 


### PR DESCRIPTION
## Summary

`ProjectQuickEditPanel` 의 서랍은 `{open ? … : null}` 이었다 — 딤과 패널이 함께 **1프레임에** 나타나고 사라졌다. 사용자가 누른 목적물이 0프레임을 받는 구조라, 하드컷 등록부(`tests/contract/surface-motion-ratchet.contract.test.ts`)가 이 파일을 부채로 들고 있었다.

`<Surface open={open}>` 로 전환한다. 퇴장 창(`EXIT_WINDOW_MS` 140ms) · 퇴장 클래스(`topology-chrome-out`) · `inert` 가 프리미티브에 딸려 오므로 소비처에서 새로 챙길 것이 없다. **새 토큰 · 새 duration · 새 색 0개** — 크롬 모션 패밀리를 그대로 탄다.

- `origin="top right"` — 트리거(히어로 우상단)와 서랍(오른쪽)의 방향. 중앙에서 태어나면 누른 자리와 태어난 자리가 어긋난다.
- `useHeldValue` 는 **쓰지 않았다.** 폼 값(`values`/`baseline`/`notice`)을 이 컴포넌트가 소유하므로 퇴장 창 동안 붙들 외부 모델이 없다(HomePage 엣지 패널이 그 훅을 쓴 이유는 모델이 부모 소유였기 때문이다). 실측이 확인한다 — `exiting` 전 구간에서 입력 필드 4개가 그대로 있었고 빈 상자가 되지 않았다.
- 부채를 갚았으므로 `HARD_CUT_REGISTRY` 에서 줄을 지웠다 (3 → 2).

## Test plan

**실측** — `pnpm build` 후 `node scripts/serve-static-export.mjs --port=4199`, Playwright(Chromium 1440×900)로 OPFS 스텁 픽커로 볼트를 열어 `canEdit=true` 를 만든 뒤 `/ko/project/storefront/` 에서 패널을 열고 닫으며 rAF 샘플링:

| 시점 | `data-surface-state` | `inert` | animation | opacity |
|---|---|---|---|---|
| 열기 0–25ms | (없음) | — | — | — |
| 열기 32ms | `entered` | false | `topologyChromeIn 180ms` + `panelCrossfadeIn 120ms` | 0.00 |
| 열기 65ms | `entered` | false | 동일 | 0.47 |
| 열기 148ms | `entered` | false | 동일 | 1.00 |
| 닫기 18ms | `entered` | false | in | 1.00 |
| 닫기 29ms | `exiting` | **true** | `topologyChromeOut 120.6ms` + `overlayFadeOut 120ms` | 1.00 |
| 닫기 68ms | `exiting` | true | 동일 | 0.39 |
| 닫기 135ms | `exiting` | true | 동일 | 0.00 |
| 닫기 168ms | (사라짐) | — | — | — |

퇴장 창 실측 139ms ≈ `EXIT_WINDOW_MS`(140). `transform-origin` = `1440px 0px`(우상단). `exiting` 전 구간에서 `input/textarea` 4개 유지.

**검사**

- `pnpm exec tsc --noEmit` — 통과
- `pnpm lint` — 0 errors / 92 warnings (`main` 베이스라인도 92 — 증가 0)
- `pnpm exec vitest run src/features/project-quick-edit src/views/project-detail tests/contract/surface-motion-ratchet.contract.test.ts` — 13 files / 86 tests 통과
- `pnpm checks:changed` 권고분: `pnpm test:contracts` — 103 files / 1188 tests 통과
- `pnpm build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275