### PR TITLE
refactor: 설정 시트 컨트롤 11개를 값·행동 층 위로 올린다

### DIFF
--- a/src/widgets/app-settings-menu/ui/AiConnectionPanel.tsx
+++ b/src/widgets/app-settings-menu/ui/AiConnectionPanel.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/shared/lib/local-endpoint';
 import type { LlmAuditEntry } from '@/shared/lib/llm-audit-log';
 import { openTauriVaultInFinder } from '@/shared/lib/tauri-vault-fs';
+import { Chip } from '@/shared/ui/controls';
 import { Select } from '@/shared/ui/select';
 import { useToast } from '@/shared/ui/toast';
 import { cn } from '@/shared/lib/cn';
@@ -70,6 +71,14 @@ import type { AiConnectionState } from '../model/use-ai-connection';
  */
 
 const CLEAR_ARM_MS = 3000;
+
+/**
+ * 중립 칩의 **호버·포커스**. 값 층(`controlClass`)이 일부러 안 내는 층이라
+ * (빈도가 모션 예산을 깎으므로 호버 색은 소비처가 정한다) 여기 한 번만 적고
+ * 네 자리가 같은 문자열을 쓴다 — 손으로 네 번 쓰면 언젠가 한 벌이 갈린다.
+ */
+const NEUTRAL_CHIP_HOVER =
+  'shrink-0 hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset';
 
 /** 감사 기록 파일의 볼트 상대 경로 — 경로만 mono, 곁의 한국어는 본문 서체. */
 const LLM_AUDIT_RELATIVE_PATH = '.ontology-atlas/llm-audit.jsonl';
@@ -448,8 +457,7 @@ function ProviderCard({
             <span className="font-mono">···· {status?.last4 ?? ''}</span>
           </span>
         ) : (
-          <button
-            type="button"
+          <Chip
             data-testid={`ai-register-${provider}`}
             // `aria-expanded` 를 달았으면 다시 눌렀을 때 접혀야 한다 — 안 접히면
             // 스크린 리더에게 한 약속이 거짓말이 된다. 그래서 이 버튼도 [취소]·
@@ -458,16 +466,18 @@ function ProviderCard({
             aria-expanded={expanded}
             // 펼친 동안에도 사라지지 않고 **눌린 상태**로 남는다. 사라지면
             // 카드가 어디서 나왔는지 가리키는 것이 화면에서 없어져, 접힐 때
-            // 돌아갈 자리도 같이 사라진다.
+            // 돌아갈 자리도 같이 사라진다. 눌림은 이제 값 층의 `active` 가 낸다 —
+            // 손으로 쓴 인디고 3종 대신 램프의 눌림 한 벌이다.
+            active={expanded}
             className={cn(
-              'inline-flex h-8 shrink-0 items-center rounded-chip border px-2.5 text-label transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset',
+              'shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset',
               expanded
-                ? 'border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)] text-[color:var(--color-indigo-accent)]'
-                : 'border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-indigo-accent)]',
+                ? null
+                : 'hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-indigo-accent)]',
             )}
           >
             {t('keyRegister')}
-          </button>
+          </Chip>
         )}
       </div>
 
@@ -667,20 +677,20 @@ function LocalEndpointCard({
             <span className="truncate font-mono">{settings.model}</span>
           </span>
         ) : (
-          <button
-            type="button"
+          <Chip
             data-testid="ai-register-local"
             onClick={expanded ? onCancel : onExpand}
             aria-expanded={expanded}
+            active={expanded}
             className={cn(
-              'inline-flex h-8 shrink-0 items-center rounded-chip border px-2.5 text-label transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset',
+              'shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset',
               expanded
-                ? 'border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)] text-[color:var(--color-indigo-accent)]'
-                : 'border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-indigo-accent)]',
+                ? null
+                : 'hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-indigo-accent)]',
             )}
           >
             {t('localConnect')}
-          </button>
+          </Chip>
         )}
       </div>
 
@@ -710,14 +720,13 @@ function LocalEndpointCard({
                 className="h-8 min-w-0 flex-1 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] px-2 font-mono text-caption text-[color:var(--color-text-primary)] transition-colors placeholder:font-sans placeholder:text-[color:var(--color-text-quaternary)] focus-visible:border-[color:var(--color-indigo-line-a45)] focus-visible:outline-none"
               />
               {!connected ? (
-                <button
-                  type="button"
+                <Chip
                   data-testid="ai-cancel-local"
                   onClick={onCancel}
-                  className="inline-flex h-8 shrink-0 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+                  className={NEUTRAL_CHIP_HOVER}
                 >
                   {t('cancel')}
-                </button>
+                </Chip>
               ) : null}
               <button
                 type="button"
@@ -756,14 +765,13 @@ function LocalEndpointCard({
                   data-testid="ai-local-model"
                 />
                 {connected ? (
-                  <button
-                    type="button"
+                  <Chip
                     data-testid="ai-local-disconnect"
                     onClick={handleDisconnect}
-                    className="inline-flex h-8 shrink-0 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+                    className={NEUTRAL_CHIP_HOVER}
                   >
                     {t('localDisconnect')}
-                  </button>
+                  </Chip>
                 ) : null}
               </div>
             ) : connected ? (
@@ -771,14 +779,13 @@ function LocalEndpointCard({
                 <span className="min-w-0 flex-1 truncate font-mono text-caption text-[color:var(--color-text-tertiary)]">
                   {settings.model}
                 </span>
-                <button
-                  type="button"
+                <Chip
                   data-testid="ai-local-disconnect"
                   onClick={handleDisconnect}
-                  className="inline-flex h-8 shrink-0 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+                  className={NEUTRAL_CHIP_HOVER}
                 >
                   {t('localDisconnect')}
-                </button>
+                </Chip>
               </div>
             ) : null}
 
@@ -979,14 +986,13 @@ function KeyDraftForm({
       {/* 저장 왼쪽의 중립 컨트롤 — 눌러 보고 마음이 바뀐 사람의 출구다.
           Esc 로도 같은 일이 일어나지만 그건 보이지 않는다. 되돌릴 길이 화면에
           없는 펼침은 함정이라, 발견 가능한 컨트롤이 있어야 계약이 성립한다. */}
-      <button
-        type="button"
+      <Chip
         data-testid={`ai-cancel-${provider}`}
         onClick={onCancel}
-        className="inline-flex h-8 shrink-0 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+        className={NEUTRAL_CHIP_HOVER}
       >
         {t('cancel')}
-      </button>
+      </Chip>
       <button
         type="button"
         data-testid={`ai-save-${provider}`}

--- a/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
+++ b/src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx
@@ -33,6 +33,7 @@ import { summarizeVaultValidation } from '@/shared/lib/validate-vault-document';
 import { useCopyFeedback } from '@/shared/lib/use-copy-feedback';
 import { useDialogFocusTrap } from '@/shared/lib/use-dialog-focus-trap';
 import { cn } from '@/shared/lib/cn';
+import { Chip, IconButton, RowButton } from '@/shared/ui/controls';
 import { subscribeSettingsViewIntent } from '@/shared/lib/settings-view-intent';
 
 import {
@@ -628,14 +629,18 @@ export function AppSettingsMenu({
                 {t('title')}
               </h2>
             </div>
-            <button
-              type="button"
-              aria-label={t('closeLabel')}
+            {/* 정사각 아이콘 컨트롤이라 `IconButton` 이 제자리다 — 접근 이름은
+                타입이 강제하고, 크기(h-7 w-7)·톤(3차)은 램프가 낸다. 테두리가
+                빠진 것은 이 전환의 대가다: 실측 36개의 아이콘 컨트롤에서 뽑은
+                모양에 테두리가 없다(`control-class.ts`). 호버·포커스는 규율대로
+                소비처가 낸다. */}
+            <IconButton
+              label={t('closeLabel')}
               onClick={() => closePanel()}
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-chip border border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+              className="hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
             >
               <X size={13} aria-hidden />
-            </button>
+            </IconButton>
           </div>
 
           {
@@ -935,19 +940,19 @@ export function AppSettingsMenu({
                     caption={vaultRootPath}
                     control={
                       <>
-                        <button
-                          type="button"
+                        <Chip
+                          size="lg"
                           data-testid="app-settings-copy-vault-path"
                           onClick={() => void copy(vaultRootPath)}
                           aria-label={tPicker('copyPathAriaLabel', { path: vaultRootPath })}
-                          className="inline-flex h-8 shrink-0 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]"
+                          className="shrink-0 hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)]"
                         >
                           {copyState === 'copied'
                             ? tPicker('copyPathCopied')
                             : copyState === 'failed'
                               ? tPicker('copyPathFailed')
                               : tPicker('copyPathTooltip')}
-                        </button>
+                        </Chip>
                         <button
                           type="button"
                           data-testid="app-settings-reveal-vault-path"
@@ -972,13 +977,17 @@ export function AppSettingsMenu({
                         className="flex min-h-11 items-center gap-2 px-3 py-1.5"
                         data-testid="app-settings-recent-vault"
                       >
-                        <button
-                          type="button"
+                        {/* 목록의 한 줄 전체가 눌리는 것 = `row`(실측 39).
+                            `disabled:opacity-60` 을 지운 이유는 값 층이 이미
+                            비활성 어포던스를 싣기 때문이다 — 두 벌이면 하나는
+                            언젠가 빠진다. */}
+                        <RowButton
+                          size="sm"
                           onClick={() => void localVault.openRecent(record)}
                           disabled={vaultBusy}
                           aria-label={t('workspaceRecentOpenAria', { name: record.name })}
                           title={record.desktopRootPath ?? record.name}
-                          className="flex min-w-0 flex-1 items-center gap-2 rounded-chip px-1 py-1 text-left transition-colors hover:bg-[color:var(--color-overlay-2)] disabled:opacity-60"
+                          className="min-w-0 flex-1 hover:bg-[color:var(--color-overlay-2)]"
                         >
                           <HardDrive
                             size={12}
@@ -995,15 +1004,16 @@ export function AppSettingsMenu({
                               </span>
                             ) : null}
                           </span>
-                        </button>
-                        <button
-                          type="button"
+                        </RowButton>
+                        <IconButton
+                          size="sm"
+                          tone="muted"
                           onClick={() => void localVault.forgetRecent(record)}
-                          aria-label={t('workspaceRecentForgetAria', { name: record.name })}
-                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-danger-a10)] hover:text-[color:var(--color-status-danger)]"
+                          label={t('workspaceRecentForgetAria', { name: record.name })}
+                          className="hover:bg-[color:var(--color-danger-a10)] hover:text-[color:var(--color-status-danger)]"
                         >
                           <X size={12} aria-hidden />
-                        </button>
+                        </IconButton>
                       </div>
                     ))
                   : null}

--- a/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
+++ b/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
@@ -29,6 +29,7 @@ import { formatAgentPostChangeSyncPacket } from '@/shared/lib/ontology-tree';
 import type { VaultManifest } from '@/entities/docs-vault';
 import type { AgentClientId } from '@/features/docs-vault-local';
 import { copyText } from '@/shared/lib/copy-text';
+import { controlClass } from '@/shared/ui/control-class';
 import { getTauriVaultRootPath } from '@/shared/lib/tauri-vault-fs';
 import type { LocalFsHandleRecord } from '@/entities/local-fs-handle';
 import type { AgentServerAvailability } from '@/shared/config';
@@ -853,14 +854,22 @@ export function VaultAgentSetupPanel({
             ) : null}
           </div>
 
-          {/* 고급 · 자세한 검증 — 연결 파일 상태·수리·모드·게이트·CLI·복사 패킷 */}
+          {/* 고급 · 자세한 검증 — 연결 파일 상태·수리·모드·게이트·CLI·복사 패킷.
+              토글은 글자만으로 눌리는 것 = `link`(실측 85). 서체·자간·자리잡기만
+              이 한 자리의 것이라 className 에 남고, 크기·색은 램프가 낸다. */}
           {publicPackagesReady ? (
             <button
             type="button"
             onClick={() => setAdvancedOpen((v) => !v)}
             aria-expanded={advancedOpen}
             data-testid="agent-setup-advanced-toggle"
-            className="mt-3 flex items-center gap-1.5 self-start font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+            className={controlClass({
+              shape: 'link',
+              size: 'sm',
+              tone: 'muted',
+              className:
+                'mt-3 self-start font-mono uppercase tracking-[0.12em] hover:text-[color:var(--color-text-secondary)]',
+            })}
           >
             <ChevronDown
               size={11}

--- a/tests/contract/control-adoption-ratchet.contract.test.ts
+++ b/tests/contract/control-adoption-ratchet.contract.test.ts
@@ -46,8 +46,15 @@ const ROOTS = ['src', 'app'];
  * 전수는 419였고 그중 **className 자체가 없는 2건**은 제외했다 — 손으로 쓴 규격이
  * 아니라 래퍼라서다. 이 2를 뺀 **417**이 기준선이고, 이 정정은 래칫이 스스로
  * 잡았다(첫 실행이 «419 → 417 로 줄었다» 로 빨개졌다).
+ *
+ * ## 내려온 기록 — 이 표가 곧 정규화의 진도다
+ *
+ * | 값 | 무엇이 옮겨졌나 |
+ * |---:|---|
+ * | 417 | 2026-08-03 최초 실측 |
+ * | **406** | 설정 시트(`src/widgets/app-settings-menu/**`) 11개 — 칩 6 · 아이콘 2 · 행 1 · 링크형 1 (+ 그중 하나는 눌림 상태를 `active` 로 넘김) |
  */
-const BASELINE_HAND_WRITTEN_CONTROLS = 417;
+const BASELINE_HAND_WRITTEN_CONTROLS = 406;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {


### PR DESCRIPTION
## Summary

프로덕션 생 `<button>` 417개 중 **설정 시트(`src/widgets/app-settings-menu/**`) 몫 11개**를
`controlClass()` / `Chip`·`IconButton`·`RowButton` 으로 옮겼다. 범위는 이 디렉터리로 한정했고
새 토큰·새 값은 0개다.

**이건 리팩터가 아니라 정규화다 — 픽셀이 바뀐다.** 칩 크기 조합 50종을 3단 램프로 접는 일이라서,
전환 전후로 rect·computed style 을 실측해 아래 표에 남겼다.

| 모양 | 개수 | 어디 |
|---|---:|---|
| `chip` | 6 | `ai-register-*`(2, 눌림은 `active` 로) · `ai-cancel-*`(2) · `ai-local-disconnect`(2) |
| `chip` | 1 | `app-settings-copy-vault-path` (size `lg`) |
| `icon` | 2 | 시트 닫기(md) · 최근 볼트 잊기(sm) |
| `row` | 1 | 최근 볼트 열기 |
| `link` | 1 | `agent-setup-advanced-toggle` |

## 픽셀이 바뀐 것 — before / after 실측

측정 환경: `pnpm build` → `node scripts/serve-static-export.mjs --port=4198`, 1512×806, 다크.
「시트 닫기」는 **실제 시트에서** 잰 값이고, 나머지는 데스크톱 브리지/볼트가 있어야 나타나는
컨트롤이라 **같은 페이지·같은 CSS 안에 before/after 문자열을 나란히 삽입해** 잰 값이다.

| 컨트롤 | 항목 | before | after |
|---|---|---|---|
| 시트 닫기 (icon md) | 테두리 | `1px rgba(255,255,255,.06)` | **없음** |
| | 크기 | 28×28 | 28×28 (동일) |
| 볼트 경로 복사 (chip lg) | 높이 | 32px | **34px** |
| | 폭 | 68.35px | **72.35px** |
| | 패딩 | `0 / 10px` | **`6px / 12px`** |
| | 테두리색 | `border-soft (.06)` | **`divider (.08)`** |
| | gap | 없음 | **6px** |
| AI [키 등록] · [취소] · [연결 끊기] (chip md) | 높이 | 32px | **30px** |
| | 패딩 | `0 / 10px` | **`6px / 10px`** |
| | 테두리색 | `border-soft (.06)` | **`divider (.08)`** |
| | gap | 없음 | **6px** |
| AI [키 등록] **눌림** (chip md active) | 글자 | `indigo-accent` | **`text-primary`** |
| | 배경 | `indigo-line-a13` | **`indigo-a16`** |
| | 테두리 | `indigo-line-a32` | **`indigo-pale-a28`** |
| 최근 볼트 잊기 (icon sm) | 반경 | 4px (`rounded-sm`) | **6px (`rounded-chip`)** |
| | 크기 | 24×24 | 24×24 (동일) |
| 최근 볼트 열기 (row sm) | 높이 | 44px | **48px** (감싼 행 56 → 60) |
| | 패딩 | `4px / 4px` | **`6px / 8px`** |
| | **반경** | 6px | **0px** ← `row` 모양은 반경을 안 싣는다 |
| | gap | 8px | **6px** |
| 고급 토글 (link sm) | 반경 | 0px | 6px (배경이 없어 보이지 않음) |
| | gap | 6px | **4px** |
| | 크기·글자 | 변화 없음 | 변화 없음 |

가장 큰 변화 둘: **row 의 반경 손실**(호버 하이라이트가 각지게 된다)과 **chip md 의 2px 축소**.
둘 다 값 층이 실측 419개에서 뽑은 규격이므로 이 PR 에서 손으로 되돌리지 않았다 — 되돌려야
한다면 고칠 곳은 소비처가 아니라 `control-class.ts` 다.

## 옮기지 않은 34개와 그 이유 — 이게 이 PR 의 진짜 산출물

억지로 넣지 않았다. **시스템에 자리가 없다**는 것이 반복해서 나온 이유다:

| 남긴 것 | 개수 | 왜 |
|---|---:|---|
| `text-secondary` 기반 컨트롤 (안내 다시 보기 · 확장/발자국 세부 토글 · 설정 패킷 복사 4종) | 7 | **톤 램프가 3단**(3차·4차·1차)인데 이 시트는 4단을 쓴다. 어느 톤을 골라도 위계가 조용히 바뀐다 |
| 인디고 강조 행동 (폴더 열기 · Finder · 검증 · 저장 · 수리 · 패킷 복사 등) | 11 | `tone` 에 **강조 자리가 없다**. className 으로 색을 넘기면 값 층이 있으나 마나다 |
| 신호 톤 (권한 amber · 지우기 danger · JSON 게이트 success · CLI amber) | 4 | 헌장상 `controlClass` 는 인디고 외 hue 를 못 낸다. 신호 톤은 값 층 밖이다 |
| 「초기화」 2종 · 감사 열기 | 3 | `link` 는 패딩을 안 싣는다 → 높이 24px → 16px. 이 시트가 자기 계약(`settings-sheet-type-dialect`)에서 인용한 **WCAG 2.5.8** 최소 타깃 아래로 내려간다 |
| `Choice` 라디오 칩 · `SegmentSwitch` · 알림 칩 · LNB 항목 | 4(문법) | 2026-08-02 소유자 판정을 `settings-sheet-type-dialect.contract.test.ts` 가 **문자열로 못박고 있다**. 게이트가 지키는 값을 되돌리지 않는다 |
| 배경 스와치 · 글리프 세트 카드 | 2 | 세로로 쌓는 카드라 `card`(가로 정렬)가 아니다. **일곱째 모양을 감으로 만들지 않는다** |
| 발자국 프리셋 세그먼트 | 3 | 테두리 없는 세그먼트. `chip` 을 쓰면 칸마다 상자가 생긴다 |

즉 이 시트에서 채택을 막은 것은 **모양(shape)이 아니라 톤(tone)** 이다. 여섯 모양은 잘 맞았다.

## 부수 효과 둘

- 최근 볼트 열기의 손 `disabled:opacity-60` 이 값 층의 비활성 어포던스로 대체됐다. 두 벌이면
  하나는 언젠가 빠진다(`ChromeChip`/`ChromeTile` 이 실제로 그랬다).
- [키 등록] 눌림이 손으로 쓴 인디고 3종 대신 램프의 `active` 한 벌이 됐다.

## 래칫

`BASELINE_HAND_WRITTEN_CONTROLS` **417 → 406**. 안 내리면 그 11칸이 되돌아갈 여유로 남는다.
내려온 기록 표도 같은 파일에 남겼다.

> ⚠️ 브랜치 이름: `refactor/settings-controls-normalize` 는 이미 원격에 **무관한 커밋**
> (`444ffe6ec` 「경로를 지도에 그린다」)으로 존재해서 `-v2` 를 썼다.

## Test plan

전부 `origin/main` 에서 딴 격리 워크트리에서 실행 (공유 체크아웃에 다른 작업이 진행 중이라).

- `pnpm exec tsc --noEmit` — 통과
- `eslint` — **0 errors / 92 warnings**, `origin/main` 기준선(92)과 동일
- `pnpm exec vitest run src/widgets/app-settings-menu` — 125 passed
- `pnpm test:contracts` — 103 files / 1188 passed (`control-adoption-ratchet` · `settings-sheet-type-dialect` 포함)
- `pnpm test:desktop:runtime` — 87 passed · `pnpm desktop:check` — ready
- `pnpm build` → `serve-static-export --port=4198` → 설정 시트 열어 rect·computed style 실측 + 스크린샷
- `pnpm checks:changed` 가 권한 항목 전부 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
