### PR TITLE
refactor: 지도 두 위젯의 컨트롤 17개를 값·행동 층 위로 올린다

### DIFF
--- a/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyIndexPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { ChevronLeft, Search } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { controlClass } from "@/shared/ui";
 import {
   filterTreeByNodeIds,
   filterTreeByQuery,
@@ -651,7 +652,12 @@ export function TopologyIndexPanel({
           type="button"
           onClick={onPromoteUncatalogedDocs}
           data-testid="topology-index-uncataloged-docs"
-          className="mt-2 flex shrink-0 items-center gap-2 rounded-[var(--chrome-radius-inner)] border border-[color:var(--topology-v2-panel-border)] px-2 py-1.5 text-left text-label transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]"
+          className={controlClass({
+            shape: "card",
+            size: "sm",
+            className:
+              "mt-2 shrink-0 text-left border-[color:var(--topology-v2-panel-border)] hover:bg-[color:var(--topology-v2-panel-row-hover)]",
+          })}
         >
           <span className="min-w-0 flex-1 truncate text-[color:var(--topology-v2-panel-text-tertiary)]">
             {labels.uncatalogedDocsLabel}
@@ -742,7 +748,12 @@ export function TopologyIndexPanel({
               onClick={onOpenAgentConnect ?? undefined}
               disabled={!onOpenAgentConnect}
               data-testid="topology-index-agent-connect"
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-[var(--chrome-radius-inner)] px-0.5 text-left transition-colors enabled:cursor-pointer enabled:hover:bg-[color:var(--topology-v2-panel-row-hover)] enabled:hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+              className={controlClass({
+                shape: "link",
+                size: "md",
+                className:
+                  "shrink-0 enabled:cursor-pointer enabled:hover:bg-[color:var(--topology-v2-panel-row-hover)] enabled:hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
+              })}
             >
               {/* C11 — 미연결 상태: power-on(인디고) 점 + "AI가 함께 갱신 중"
                   진행형이 heartbeat 없이도 활동을 암시했다. 중립 muted 점 +

--- a/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
+++ b/src/widgets/topology-index-panel/ui/TopologyRealmLedger.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/shared/lib/ontology-tree";
 import { RealmBlockExportAction } from "@/features/ontology-blocks";
 import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
+import { controlClass } from "@/shared/ui";
 import {
   flattenVisibleRowIds,
   nextRovingId,
@@ -201,7 +202,13 @@ export function TopologyRealmLedger({
             onClick={onExit}
             aria-label={labels.exitAria}
             data-testid="topology-realm-exit"
-            className="shrink-0 rounded-[var(--chrome-radius-inner)] px-1 py-0.5 text-label text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+            className={controlClass({
+              shape: "link",
+              size: "md",
+              tone: "muted",
+              className:
+                "shrink-0 text-[color:var(--topology-v2-panel-text-quaternary)] hover:text-[color:var(--topology-v2-panel-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
+            })}
           >
             {labels.exit}
           </button>
@@ -346,7 +353,12 @@ export function TopologyRealmLedger({
                       aria-label={labels.boundaryJumpAria}
                       title={labels.boundaryJump}
                       data-testid="topology-realm-boundary-jump"
-                      className="inline-flex shrink-0 items-center gap-1 rounded-[var(--chrome-radius-inner)] px-1.5 py-0.5 text-label text-[color:var(--color-indigo-accent)] opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset group-hover:opacity-100 motion-reduce:transition-none"
+                      className={controlClass({
+                        shape: "link",
+                        size: "md",
+                        className:
+                          "shrink-0 text-[color:var(--color-indigo-accent)] opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset group-hover:opacity-100 motion-reduce:transition-none",
+                      })}
                     >
                       <CornerUpRight size={11} aria-hidden="true" />
                       {labels.boundaryJump}

--- a/src/widgets/topology-map-v2/ui/TopologyV2ContextMenu.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2ContextMenu.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { Copy, FileText, GitBranch, Maximize2, Route } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { controlClass, RowButton } from "@/shared/ui";
 
 /**
  * W2-B — node right-click context menu (`use-topology-loop.ts`'s
@@ -75,8 +76,17 @@ export function clampContextMenuPosition(
   };
 }
 
-const MENU_ITEM_CLASS =
-  "flex w-full items-center gap-2 rounded-[var(--topology-v2-panel-row-radius)] px-2.5 py-1.5 text-left text-body text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)]";
+/**
+ * 이 메뉴 항목의 **한 자리에만 참인 것** — 지도 패널 스코프 토큰(모서리·잉크·
+ * 호버 표면)뿐이다. 모양·크기·정렬은 아래 `controlClass({ shape: "row" })` 가
+ * 낸다. `row` 는 램프에 모서리가 없어서(패널 밖 행은 각지게 산다) 반경만
+ * 여기서 얹는다 — 값은 `--topology-v2-panel-row-radius` 와 같은 `--radius-chip`
+ * 이라 전역 램프 유틸리티로 적는다.
+ */
+const MENU_ITEM_LOCAL =
+  "rounded-chip text-[color:var(--topology-v2-panel-text-secondary)] hover:bg-[color:var(--topology-v2-panel-row-hover)]";
+/** `<Link>`/`<span>` 형제용 — `<RowButton>` 이 내는 것과 바이트 동일해야 한다. */
+const MENU_ITEM_CLASS = controlClass({ shape: "row", size: "md", className: MENU_ITEM_LOCAL });
 const MENU_ITEM_DISABLED_CLASS = "pointer-events-none opacity-40";
 
 export function TopologyV2ContextMenu({
@@ -168,37 +178,37 @@ export function TopologyV2ContextMenu({
         <GitBranch size={14} aria-hidden="true" />
         {labels.actionEditRelations}
       </Link>
-      <button
-        type="button"
+      <RowButton
         role="menuitem"
+        size="md"
         onClick={onCopyHandoff}
         data-testid="topology-v2-context-menu-handoff"
-        className={MENU_ITEM_CLASS}
+        className={MENU_ITEM_LOCAL}
       >
         <Copy size={14} aria-hidden="true" />
         {labels.actionCopyHandoff}
-      </button>
-      <button
-        type="button"
+      </RowButton>
+      <RowButton
         role="menuitem"
+        size="md"
         onClick={onSetPathSource}
         data-testid="topology-v2-context-menu-path"
-        className={MENU_ITEM_CLASS}
+        className={MENU_ITEM_LOCAL}
       >
         <Route size={14} aria-hidden="true" />
         {labels.actionPath}
-      </button>
+      </RowButton>
       <div className="my-0.5 border-t border-[color:var(--topology-v2-panel-divider)]" />
-      <button
-        type="button"
+      <RowButton
         role="menuitem"
+        size="md"
         onClick={onOpenFullDetail}
         data-testid="topology-v2-context-menu-full-detail"
-        className={MENU_ITEM_CLASS}
+        className={MENU_ITEM_LOCAL}
       >
         <Maximize2 size={14} aria-hidden="true" />
         {labels.openFullDetail}
-      </button>
+      </RowButton>
     </div>
   );
 }

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -37,7 +37,7 @@ import {
   type V2DatasheetConnection,
   type V2EvidenceRow,
 } from "./topology-v2-datasheet";
-import { LastEditSubjectRow, MtimeConflictBadge } from "@/shared/ui";
+import { controlClass, IconButton, LastEditSubjectRow, MtimeConflictBadge, RowButton } from "@/shared/ui";
 import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
 import { Tooltip } from "@/shared/ui/tooltip";
 
@@ -703,7 +703,12 @@ export function TopologyV2DetailPanel({
           type="button"
           onClick={() => setShowAllContains((v) => !v)}
           data-testid="topology-v2-contains-summary-toggle"
-          className="ml-auto shrink-0 text-label text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)] active:text-[color:var(--topology-v2-panel-text-primary)]"
+          className={controlClass({
+            shape: "link",
+            size: "md",
+            className:
+              "ml-auto shrink-0 text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-secondary)] active:text-[color:var(--topology-v2-panel-text-primary)]",
+          })}
         >
           {showAllContains ? labels.containsShowSummary : labels.containsShowAll}
         </button>
@@ -753,17 +758,17 @@ export function TopologyV2DetailPanel({
               // 시안: 행의 왼쪽 마크는 캔버스와 같은 kind 글리프(무엇인지) —
               // 관계 타입은 그룹 자체(담는 것/기대는 곳)가 이미 인코딩한다.
               <li key={`${group}:${row.id}`}>
-                <button
-                  type="button"
+                <RowButton
+                  size="md"
                   onClick={() => onSelectConnection(row.id)}
                   data-datasheet-connection={row.id}
-                  className="flex min-h-[33px] w-full items-center gap-2.5 rounded-[var(--topology-v2-panel-row-radius)] px-2 py-1.5 text-left transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]"
+                  className="rounded-chip hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]"
                 >
                   <TopologyV2KindGlyph kind={row.kind} />
                   <span className="min-w-0 flex-1 truncate text-body text-[color:var(--topology-v2-panel-text-secondary)]">
                     {row.title}
                   </span>
-                </button>
+                </RowButton>
               </li>
             ))}
           </ul>
@@ -811,7 +816,14 @@ export function TopologyV2DetailPanel({
                 href={buildDocsVaultHref({ slug: row.id })}
                 data-datasheet-evidence={row.id}
                 title={row.id}
-                className="flex min-h-[33px] w-full items-center gap-2.5 rounded-[var(--topology-v2-panel-row-radius)] px-2 py-1.5 transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]"
+                // 연결 행(`RowButton`)과 **같은 램프 스텝**이어야 한다 — 한 패널
+                // 안에서 행 높이가 갈리면 「치수 규칙성」이 깨진다.
+                className={controlClass({
+                  shape: "row",
+                  size: "md",
+                  className:
+                    "rounded-chip hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]",
+                })}
               >
                 <FileText
                   size={14}
@@ -906,15 +918,15 @@ export function TopologyV2DetailPanel({
             <TopologyV2KindGlyph kind={kind} size={12} />
             {labels.kindLabel}
           </span>
-          <button
-            type="button"
+          <IconButton
+            label={labels.close}
+            size="sm"
             onClick={onClose}
-            aria-label={labels.close}
             data-testid="topology-v2-detail-panel-close"
-            className="-mr-1 shrink-0 rounded-[var(--topology-v2-panel-row-radius)] p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)] active:bg-[color:var(--topology-v2-panel-row-active)]"
+            className="-mr-1 text-[color:var(--topology-v2-panel-text-tertiary)] hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)] active:bg-[color:var(--topology-v2-panel-row-active)]"
           >
             <X size={15} />
-          </button>
+          </IconButton>
         </div>
         {showSourcePath && sourceTitle && sourceTitle !== title ? (
           <div
@@ -955,7 +967,12 @@ export function TopologyV2DetailPanel({
                 onClick={() => onSelectConnection(domain.id)}
                 aria-label={`${labels.domainLabel} ${domain.title}`}
                 data-testid="topology-v2-detail-panel-domain"
-                className="flex min-w-0 items-center gap-1.5 rounded-card border border-[color:var(--topology-v2-panel-domain-border)] bg-[color:var(--topology-v2-panel-domain-surface)] py-1.5 pl-2.5 pr-2 text-left transition-colors hover:border-[color:var(--topology-v2-panel-domain-border-hover)] hover:bg-[color:var(--topology-v2-panel-domain-surface-hover)]"
+                className={controlClass({
+                  shape: "card",
+                  size: "sm",
+                  className:
+                    "min-w-0 text-left border-[color:var(--topology-v2-panel-domain-border)] bg-[color:var(--topology-v2-panel-domain-surface)] hover:border-[color:var(--topology-v2-panel-domain-border-hover)] hover:bg-[color:var(--topology-v2-panel-domain-surface-hover)]",
+                })}
               >
                 <span className="shrink-0 text-label text-[color:var(--topology-v2-panel-text-tertiary)]">
                   {labels.domainLabel}
@@ -1270,7 +1287,12 @@ export function TopologyV2DetailPanel({
               type="button"
               onClick={() => setShowProjectRelations((value) => !value)}
               aria-expanded={showProjectRelations}
-              className="ml-auto shrink-0 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)] active:text-[color:var(--topology-v2-panel-text-primary)]"
+              className={controlClass({
+                shape: "link",
+                size: "md",
+                className:
+                  "ml-auto shrink-0 text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-secondary)] active:text-[color:var(--topology-v2-panel-text-primary)]",
+              })}
             >
               {showProjectRelations
                 ? labels.sourceRelationsHide ?? labels.containsShowSummary
@@ -1326,8 +1348,18 @@ export function TopologyV2DetailPanel({
             onClick={onOpenFullDetail}
             data-testid="topology-v2-detail-panel-open-full-detail"
             className={showProjectSource
-              ? "shrink-0 rounded-[var(--topology-v2-panel-row-radius)] px-1.5 py-[7px] text-body leading-body text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-secondary)]"
-              : "shrink-0 rounded-card border border-[color:var(--topology-v2-panel-primary-border)] bg-[color:var(--topology-v2-panel-primary-surface)] px-3 py-[7px] text-label leading-label font-semibold text-[color:var(--topology-v2-panel-primary-text)] transition-colors hover:border-[color:var(--topology-v2-panel-primary-border-hover)] hover:bg-[color:var(--topology-v2-panel-primary-surface-hover)]"}
+              ? controlClass({
+                  shape: "link",
+                  size: "lg",
+                  className:
+                    "shrink-0 text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-secondary)]",
+                })
+              : controlClass({
+                  shape: "card",
+                  size: "sm",
+                  className:
+                    "shrink-0 font-semibold border-[color:var(--topology-v2-panel-primary-border)] bg-[color:var(--topology-v2-panel-primary-surface)] text-[color:var(--topology-v2-panel-primary-text)] hover:border-[color:var(--topology-v2-panel-primary-border-hover)] hover:bg-[color:var(--topology-v2-panel-primary-surface-hover)]",
+                })}
           >
             {labels.openFullDetail}
           </button>
@@ -1340,7 +1372,12 @@ export function TopologyV2DetailPanel({
               disabled={projectSourceBusy}
               aria-busy={projectSourceBusy}
               data-testid="topology-v2-project-source-action"
-              className="shrink-0 rounded-[var(--topology-v2-panel-row-radius)] border border-[color:var(--topology-v2-panel-primary-border)] bg-[color:var(--topology-v2-panel-primary-surface)] px-3 py-[7px] text-body font-semibold text-[color:var(--topology-v2-panel-primary-text)] transition-colors hover:border-[color:var(--topology-v2-panel-primary-border-hover)] hover:bg-[color:var(--topology-v2-panel-primary-surface-hover)] disabled:cursor-wait disabled:opacity-60"
+              className={controlClass({
+                shape: "chip",
+                size: "lg",
+                className:
+                  "shrink-0 font-semibold border-[color:var(--topology-v2-panel-primary-border)] bg-[color:var(--topology-v2-panel-primary-surface)] text-[color:var(--topology-v2-panel-primary-text)] hover:border-[color:var(--topology-v2-panel-primary-border-hover)] hover:bg-[color:var(--topology-v2-panel-primary-surface-hover)] disabled:cursor-wait",
+              })}
             >
               {projectSourceBusy ? labels.sourceBusy ?? labels.sourceAction : labels.sourceAction}
             </button>
@@ -1382,16 +1419,15 @@ function CodeLocationRow({
       >
         {truncateMiddlePath(path)}
       </span>
-      <button
-        type="button"
+      <IconButton
+        label={state === "copied" ? copiedLabel : copyLabel}
+        size="sm"
         onClick={() => void copy(path)}
-        aria-label={state === "copied" ? copiedLabel : copyLabel}
-        title={state === "copied" ? copiedLabel : copyLabel}
         data-testid="topology-v2-detail-panel-code-location-copy"
-        className="shrink-0 rounded-[var(--topology-v2-panel-row-radius)] p-1 text-[color:var(--topology-v2-panel-text-quaternary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
+        className="text-[color:var(--topology-v2-panel-text-quaternary)] hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-secondary)]"
       >
         {state === "copied" ? <Check size={11} aria-hidden /> : <Clipboard size={11} aria-hidden />}
-      </button>
+      </IconButton>
     </li>
   );
 }

--- a/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2EdgePanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { IconButton, RowButton } from "@/shared/ui";
 
 /**
  * P3b — 엣지 팝오버. 노드 데이터시트와 같은 재질(panel 토큰)로, 관계
@@ -94,15 +95,15 @@ export function TopologyV2EdgePanel({
         <p className="font-mono text-label uppercase tracking-[0.14em] text-[color:var(--topology-v2-panel-text-tertiary)]">
           {labels.kicker} · {typeLabel}
         </p>
-        <button
-          type="button"
+        <IconButton
+          label={labels.close}
+          size="sm"
           onClick={onClose}
-          aria-label={labels.close}
           data-testid="topology-v2-edge-panel-close"
-          className="-mr-1 -mt-1 rounded p-1 text-[color:var(--topology-v2-panel-text-tertiary)] transition-colors hover:text-[color:var(--topology-v2-panel-text-primary)]"
+          className="-mr-1 -mt-1 text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
         >
           <X size={13} aria-hidden />
-        </button>
+        </IconButton>
       </div>
 
       {/* 문장이 주인공 — 의미의 평문화 */}
@@ -127,14 +128,14 @@ export function TopologyV2EdgePanel({
           { id: fromId, title: fromTitle },
           { id: toId, title: toTitle },
         ].map((n) => (
-          <button
+          <RowButton
             key={n.id}
-            type="button"
+            size="md"
             onClick={() => onSelectNode(n.id)}
-            className="rounded-[var(--topology-v2-panel-row-radius)] px-1.5 py-1 text-left text-body text-[color:var(--topology-v2-panel-text-secondary)] transition-colors hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
+            className="rounded-chip text-[color:var(--topology-v2-panel-text-secondary)] hover:bg-[color:var(--topology-v2-panel-row-hover)] hover:text-[color:var(--topology-v2-panel-text-primary)]"
           >
             {n.title}
-          </button>
+          </RowButton>
         ))}
       </div>
 

--- a/tests/contract/control-adoption-ratchet.contract.test.ts
+++ b/tests/contract/control-adoption-ratchet.contract.test.ts
@@ -53,8 +53,9 @@ const ROOTS = ['src', 'app'];
  * |---:|---|
  * | 417 | 2026-08-03 최초 실측 |
  * | **406** | 설정 시트(`src/widgets/app-settings-menu/**`) 11개 — 칩 6 · 아이콘 2 · 행 1 · 링크형 1 (+ 그중 하나는 눌림 상태를 `active` 로 넘김) |
+ * | **389** | 지도 두 위젯(`topology-map-v2` · `topology-index-panel`) 31개 중 17개 — 행 8 · 링크형 5 · 아이콘 3 · 카드 2 · 칩 1. 남긴 14개는 여섯 분류에 **없는** 모양(세로 액션 타일 5 · 세그먼트 탭 3 · 창 선택 칩 · 세로 엣지 탭 · 캔버스 앵커 원형 버튼 · 트리 셰브론)이거나, 램프의 최소 인셋(8px)이 이 패널의 4px 인셋과 어긋나 헤더가 자기 행들과 어긋나는 자리(2)다 |
  */
-const BASELINE_HAND_WRITTEN_CONTROLS = 406;
+const BASELINE_HAND_WRITTEN_CONTROLS = 389;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {


### PR DESCRIPTION
## Summary

지도 패널(`topology-map-v2` · `topology-index-panel`)의 생 `<button>` **31개**는
전부 손으로 쓴 className 이었다. 그래서 새 컨트롤을 만들 때 베낄 정본이 없고,
같은 역할의 컨트롤이 자리마다 다른 치수를 갖는다. 실측 중 그 대가가 드러났다 —
연결 행(`<button>`)과 근거 문서 행(`<Link>`)은 **클래스 문자열이 바이트 동일한
쌍둥이**였는데, 한쪽만 고치면 아무 게이트도 없이 갈라지는 구조였다.

31개 중 **17개**를 `controlClass()` / `Chip`·`IconButton`·`RowButton` 로 옮긴다.
`<Link>` 쌍둥이 1개도 같은 스텝으로 맞춘다(래칫 집계 대상은 아니지만 안 맞추면
한 패널 안에서 행 높이가 36 / 33 으로 갈린다 — 이 저장소가 「치수 규칙성」으로
금지한 그 패턴).

| 모양 | 개수 | 어디 |
|---|---:|---|
| `row` | 8 | 컨텍스트 메뉴 3 · 연결 행 · 근거 문서 행 · 엣지 패널 이웃 2 |
| `link` | 5 | 요약 토글 2 · 푸터 고스트 · 영역 나가기 · 경계 점프 · 에이전트 연결 |
| `icon` | 3 | 팝오버 닫기 · 엣지 패널 닫기 · 코드 경로 복사 |
| `card` | 2 | 도메인 칩 · 「지도에 없는 문서」 행 |
| `chip` | 1 | 프로젝트 소스 액션 |

**색은 한 값도 안 바꿨다.** `--topology-v2-panel-*` 스코프 잉크(4단 텍스트
사다리는 `#17171c` 위 AA 를 위해 손으로 조정된 값이다)는 `className` 으로 그대로
얹었고, 램프가 결정한 것은 모양·크기·반경·정렬뿐이다. 새 토큰 0 · 새 값 0 ·
새 색 0.

## 픽셀 변화 (before/after — 정적 export 실측, `?e2e=1`)

| 컨트롤 | before | after |
|---|---|---|
| 컨텍스트 메뉴 항목 ×5 | 190×**32** · pad 6/10 · r6 | 190×**36** · pad **8**/10 · r6 |
| 메뉴 전체 박스 | 200×185 | 200×**205** (정적 추정치 210 안) |
| 연결 행 ×N | 322×**33** · pad 6/8 · gap **10** | 322×**36** · pad **8**/**10** · gap **8** |
| 근거 문서 행(`<Link>`) | 322×33 · pad 6/8 | 322×**36** — 연결 행과 **동일** |
| 글리프 인셋 | 8px | **10px** (텍스트 시작점은 33px 로 불변 → `pl-[34px]` 그대로 유효) |
| 팝오버 닫기 | 23×23 · pad 4 | **24×24** · pad 0 (`h-6 w-6`) |
| 엣지 패널 닫기 | 21×21 · r**4**(램프 밖) | **24×24** · r**6** |
| 엣지 패널 이웃 ×2 | 266×**28** · pad 4/6 | 266×**36** · pad **8**/**10** |
| 코드 경로 복사 | 19×19 | **24×24** |
| 도메인 칩 | 95.1×34 · pl 10 / pr **8** | 97.1×34 · pl 10 / pr **10** |
| 푸터 「자세히 보기」 | 76.2×**32** · pad 7/12 | 72.2×**30** · pad **6**/**10** |
| 영역 나가기 | 48.8×**20** · pad 2/4 | 40.8×**16** · pad **0** |
| 경계 점프 ×6 | 89.6×**20** · pad 2/6 | 77.6×**16** · pad **0** |
| 요약 토글 ×2 | (패딩 없음) | **변화 없음** — `link` 는 상자를 안 만든다 |
| 액션 타일 ×5 · 세그먼트 탭 ×3 · 창 선택 칩 | — | **손 안 댐** |

가장 큰 효과: 팝오버의 **모든 행이 36px 한 종으로 수렴**한다(실측 —
`distinctHeights: [36]`, `distinctGlyphInsets: [10]`). 종전엔 손으로 쓴
`min-h-[33px]` 와 `gap-2.5` 였다.

## 안 옮기고 남긴 14개 — 우회가 아니라 분류 밖

| 남긴 것 | 왜 |
|---|---|
| 세로 액션 타일 ×5 (`ACTION_TILE_CLASS`) | 아이콘 위·라벨 아래의 **세로** 타일. 모양 여섯(`card` 포함)은 전부 가로다 |
| 세그먼트 탭 ×3 | `chip` 은 보더가 필수인데, 이 탭들은 **이미 보더가 있는 컨테이너 안**이라 상자 속 상자가 된다 |
| 창 선택 칩 | 2026-08-02 소유자 2회 반복으로 24px·11px·7px·48px 균일폭이 확정된 자리 |
| 세로 엣지 탭 · 캔버스 앵커 원형 버튼 · 트리 셰브론 | 각각 `writing-mode` 세로 · 매 프레임 투영되는 원형 · `transition-transform` 히트 컬럼 |
| INDEX 접기 헤더 · 영역 경계 토글 | `row` 램프의 **최소 인셋이 8px** 인데 이 패널은 4px(`px-1`/`px-0.5`) 위에 서 있다. 옮기면 헤더만 4~6px 밀려 자기 행들과 어긋난다 |

앞의 넷은 **일곱째 모양이 필요하다는 신호**이고, 마지막 둘은 **`row` 에 4px
스텝이 없다는 신호**다. 둘 다 전수를 다시 세라는 뜻이지 우회하라는 뜻이
아니므로 래칫 주석에 등재했다.

## Test plan

- `pnpm exec tsc --noEmit` — 통과
- `pnpm lint` — **0 errors**, warning 92 (baseline 92, 증가 없음)
- `pnpm exec vitest run src/widgets/topology-map-v2 src/widgets/topology-index-panel` — 66 files / 914 passed
- `pnpm test:contracts` — 103 files / 1188 passed. `control-adoption-ratchet` 기준선 **406 → 389** (main #873 이 417→406 을 이미 내렸고, 그 위에 17개)
- `pnpm build` 후 `scripts/serve-static-export.mjs` 로 띄워 지도에서 노드 클릭 →
  팝오버 · 우클릭 → 컨텍스트 메뉴 · 엣지 클릭 → 엣지 패널 · 영역 전개 →
  영역 원장까지 열어 rect/computed style 실측(위 표) + 스크린샷

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
