### PR TITLE
refactor: 문서함·서랍·공방 컨트롤 86개를 값·행동 층 위로 올린다

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -136,7 +136,6 @@
   --color-indigo-line-a90: rgba(139, 151, 255, 0.9);
 
   --color-danger-a12: rgba(229, 72, 77, 0.12);
-  --color-danger-a42: rgba(229, 72, 77, 0.42);
   --color-danger-text-strong: rgba(236, 116, 116, 0.95);
 
   /* 저장 연결 상태(getBuilderSourceStatus) amber — 위 amber-muted(197,122,43)
@@ -1755,7 +1754,6 @@
     --color-indigo-line-a54: rgba(139, 151, 255, 0.54);
     --color-indigo-line-a90: rgba(139, 151, 255, 0.9);
     --color-danger-a12: rgba(229, 72, 77, 0.12);
-    --color-danger-a42: rgba(229, 72, 77, 0.42);
     --color-danger-text-strong: rgba(236, 116, 116, 0.95);
     --color-amber-source-a07: rgba(244, 183, 49, 0.07);
     --color-amber-source-a30: rgba(244, 183, 49, 0.3);

--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -50,7 +50,15 @@ import {
   getTauriVaultRootPath,
   isTauriVaultRuntime,
 } from '@/shared/lib/tauri-vault-fs';
-import { RouteLoadingFallback, SimilarNodeWarning, Tooltip, useToast } from '@/shared/ui';
+import {
+  Chip,
+  IconButton,
+  RouteLoadingFallback,
+  SimilarNodeWarning,
+  Tooltip,
+  controlClass,
+  useToast,
+} from '@/shared/ui';
 import {
   findSimilarNodeByTitle,
   type SimilarNodeMatch,
@@ -1848,22 +1856,29 @@ function DocsVaultContent() {
             <Link
               href={workspaceHref}
               aria-label={t('header.backToReviewAriaLabel')}
-              className="inline-flex h-8 flex-none items-center justify-center gap-1.5 rounded-chip border border-[color:var(--color-divider)] px-2 text-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]"
+              // 이 Link 는 바로 아래 「트리 열기」 칩과 나란히 선다. `<button>` 이
+              // 아니라 래칫에는 안 잡히지만, 한쪽만 정규화하면 둘의 높이가 갈린다.
+              className={controlClass({
+                shape: 'chip',
+                size: 'lg',
+                className:
+                  'flex-none justify-center hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]',
+              })}
             >
               <ArrowLeft size={14} aria-hidden />
               <span className="hidden sm:inline">{t('header.reviewBack')}</span>
             </Link>
           ) : null}
-          <button
-            type="button"
+          <Chip
+            size="lg"
             onClick={() => setSourceTreeOpen(true)}
-            className="inline-flex h-8 flex-none items-center justify-center gap-1.5 rounded-chip border border-[color:var(--color-divider)] px-2 text-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] lg:hidden"
+            className="flex-none justify-center hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)] lg:hidden"
             aria-label={t('header.openTreeAriaLabel')}
             title={t('header.openTreeTitle')}
           >
             <Menu size={14} aria-hidden />
             <span className="hidden sm:inline">{t('header.openTreeTitle')}</span>
-          </button>
+          </Chip>
           <DocsHeaderTile
             icon={<PanelLeft size={16} aria-hidden />}
             title={docListCollapsed ? t('header.docListExpand') : t('header.docListCollapse')}
@@ -1939,20 +1954,16 @@ function DocsVaultContent() {
             role="radiogroup"
             aria-label={t('header.sourceAriaLabel')}
           >
-            <button
-              type="button"
+            <Chip
               role="radio"
               aria-checked={source === 'server'}
+              active={source === 'server'}
               onClick={() => handleSourceChange('server')}
-              className={`inline-flex min-h-8 items-center gap-1 rounded-chip px-3 transition-colors ${
-                source === 'server'
-                  ? 'bg-[color:var(--color-indigo-a16)] text-[color:var(--color-text-primary)]'
-                  : 'text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]'
-              }`}
+              className="hover:text-[color:var(--color-text-primary)]"
             >
               <Package size={11} aria-hidden />
               {t('advanced.sourceServer')}
-            </button>
+            </Chip>
             <Tooltip
               content={
                 localVault.status === 'unsupported'
@@ -1961,10 +1972,10 @@ function DocsVaultContent() {
               }
               withProvider={false}
             >
-              <button
-                type="button"
+              <Chip
                 role="radio"
                 aria-checked={source === 'local'}
+                active={source === 'local'}
                 disabled={localSourceDisabled}
                 aria-describedby={
                   localSourceDisabled
@@ -1972,15 +1983,11 @@ function DocsVaultContent() {
                     : undefined
                 }
                 onClick={() => handleSourceChange('local')}
-                className={`inline-flex min-h-8 items-center gap-1 rounded-chip px-3 transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
-                  source === 'local'
-                    ? 'bg-[color:var(--color-indigo-a16)] text-[color:var(--color-text-primary)]'
-                    : 'text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]'
-                }`}
+                className="hover:text-[color:var(--color-text-primary)]"
               >
                 <HardDrive size={11} aria-hidden />
                 {t('advanced.sourceLocal')}
-              </button>
+              </Chip>
             </Tooltip>
             {/* unsupported 상태일 때 sr-only hint 노출 — 시각적으론 disabled
                 opacity 와 tooltip 만으로 신호. 스크린리더 사용자는 disabled
@@ -2071,7 +2078,11 @@ function DocsVaultContent() {
                 ? localVault.requestPermission()
                 : void openLocalVault()
             }
-            className="rounded-sm border border-[color:var(--color-danger-a32)] px-2 py-0.5 text-label transition-colors hover:bg-[color:var(--color-danger-a12)]"
+            className={controlClass({
+              shape: 'chip',
+              tone: 'danger',
+              className: 'hover:bg-[color:var(--color-danger-a12)]',
+            })}
           >
             {t('vaultStatus.openPicker')}
           </button>
@@ -2146,14 +2157,13 @@ function DocsVaultContent() {
                 <span className="font-mono text-caption uppercase tracking-[0.14em] text-[color:var(--color-text-quaternary)]">
                   {t('mobileDrawer.title')}
                 </span>
-                <button
-                  type="button"
+                <IconButton
+                  label={t('mobileDrawer.closeAriaLabel')}
                   onClick={() => setSourceTreeOpen(false)}
-                  className="flex h-7 w-7 items-center justify-center rounded-sm text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
-                  aria-label={t('mobileDrawer.closeAriaLabel')}
+                  className="hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
                 >
                   <X size={14} aria-hidden />
-                </button>
+                </IconButton>
               </div>
               <div className="flex flex-1 flex-col overflow-auto">
                 {sidebarBody}
@@ -2243,32 +2253,26 @@ function DocsVaultContent() {
                     aria-label={`${t('editorHeader.previewTab')} / ${t('editorHeader.editTab')}`}
                     className="inline-flex flex-none items-stretch gap-0.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-canvas)] p-0.5 shadow-[inset_0_1px_2px_var(--color-shadow-a35)]"
                   >
-                    <button
-                      type="button"
+                    <Chip
                       role="tab"
                       aria-selected={!editing}
+                      active={!editing}
+                      tone={!editing ? 'strong' : 'muted'}
                       onClick={() => setEditing(false)}
-                      className={`rounded-sm px-2.5 py-1 font-mono text-label transition-colors ${
-                        !editing
-                          ? 'border border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]'
-                          : 'border border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]'
-                      }`}
+                      className="font-mono hover:text-[color:var(--color-text-secondary)]"
                     >
                       {t('editorHeader.previewTab')}
-                    </button>
-                    <button
-                      type="button"
+                    </Chip>
+                    <Chip
                       role="tab"
                       aria-selected={editing}
+                      active={editing}
+                      tone={editing ? 'strong' : 'muted'}
                       onClick={() => setEditing(true)}
-                      className={`rounded-sm px-2.5 py-1 font-mono text-label transition-colors ${
-                        editing
-                          ? 'border border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]'
-                          : 'border border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]'
-                      }`}
+                      className="font-mono hover:text-[color:var(--color-text-secondary)]"
                     >
                       {t('editorHeader.editTab')}
-                    </button>
+                    </Chip>
                   </div>
                 ) : null}
                 <span className="flex-none font-mono text-label text-[color:var(--color-text-quaternary)]">

--- a/src/views/docs-vault/ui/parts/DesktopVaultWelcome.tsx
+++ b/src/views/docs-vault/ui/parts/DesktopVaultWelcome.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from "next-intl";
 import type { LocalFsHandleRecord } from "@/entities/local-fs-handle";
 import { AGENT_GRAPH_DB_RUNTIME_GATE_CHECK_COUNT } from "@/shared/lib/ontology-tree";
 import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
-import { StaggeredFadeIn } from "@/shared/ui";
+import { Chip, StaggeredFadeIn } from "@/shared/ui";
 import { DOGFOOD_VAULT_PATH } from "../../lib/dogfood-vault-path";
 
 const DOGFOOD_VERIFICATION_LOOP = [
@@ -113,24 +113,24 @@ export function DesktopVaultWelcome({
                 <code className="min-w-0 flex-1 truncate rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-label text-[color:var(--color-text-secondary)]">
                   {DOGFOOD_VAULT_PATH}
                 </code>
-                <button
-                  type="button"
+                <Chip
+                  tone="accent"
                   onClick={() => void copyDogfoodPath(DOGFOOD_VAULT_PATH)}
                   aria-label={dogfoodPathCopyAriaLabel}
-                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-chip border border-[color:var(--color-indigo-line-a22)] bg-[color:var(--color-indigo-line-a06)] px-2.5 py-1.5 font-mono text-caption text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]"
+                  className="shrink-0 justify-center font-mono hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]"
                 >
                   {dogfoodPathCopied ? <Check size={12} aria-hidden /> : <Clipboard size={12} aria-hidden />}
                   {t("desktopWelcome.copyDogfoodPath")}
-                </button>
-                <button
-                  type="button"
+                </Chip>
+                <Chip
+                  tone="secondary"
                   onClick={() => void copyDogfoodLoop(DOGFOOD_VERIFICATION_LOOP)}
                   aria-label={dogfoodLoopCopyAriaLabel}
-                  className="inline-flex min-h-8 shrink-0 items-center justify-center gap-1.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a32)] hover:text-[color:var(--color-text-primary)]"
+                  className="shrink-0 justify-center font-mono hover:border-[color:var(--color-indigo-a32)] hover:text-[color:var(--color-text-primary)]"
                 >
                   {dogfoodLoopCopied ? <Check size={12} aria-hidden /> : <Terminal size={12} aria-hidden />}
                   {t("desktopWelcome.copyDogfoodLoop")}
-                </button>
+                </Chip>
               </div>
             ) : null}
           </section>

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -14,7 +14,13 @@ import {
   type VaultIssueCode,
 } from "@/shared/lib/validate-vault-document";
 import { mapVaultIssueCodeToPlainMessage } from "@/shared/lib/vault-issue-plain-message";
-import { CompactCopyButton, LastEditSubjectRow, MtimeConflictBadge } from "@/shared/ui";
+import {
+  CompactCopyButton,
+  IconButton,
+  LastEditSubjectRow,
+  MtimeConflictBadge,
+  controlClass,
+} from "@/shared/ui";
 import { hasDocMtimeConflict, resolveDocLastEditSubject } from "../../lib/resolve-doc-edit-subject";
 
 /**
@@ -431,7 +437,11 @@ export function DocFrontmatterBlock({
                               type="button"
                               onClick={() => onNavigate!(target)}
                               data-testid={`doc-frontmatter-ref-${tok}`}
-                              className="rounded-sm text-[color:var(--color-indigo-pale-a90)] underline decoration-[color:var(--color-indigo-line-a35)] underline-offset-2 transition-colors hover:text-[color:var(--color-text-primary)] hover:decoration-[color:var(--color-indigo-line-a45)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[color:var(--color-indigo-line-a45)]"
+                              // 인라인 참조/문장 속 컨트롤이다 — `link` 은 이제 `min-h-11`(44px, WCAG 2.5.8)을 싣는데,
+                              // 글줄 안에서는 그 높이가 줄 상자를 통째로 밀어 올린다(실측 21.3 → 44px).
+                              // 시각 크기와 히트 영역이 다른 축이라는 상류 판단은 옳지만, 그 해법이
+                              // 문장 속 컨트롤에는 안 맞는다 — 값 층에 «인라인» 축이 하나 더 필요하다.
+                              className="rounded-chip text-[color:var(--color-indigo-pale-a90)] underline decoration-[color:var(--color-indigo-line-a35)] underline-offset-2 transition-colors hover:text-[color:var(--color-text-primary)] hover:decoration-[color:var(--color-indigo-line-a45)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[color:var(--color-indigo-line-a45)]"
                             >
                               {tok}
                             </button>
@@ -536,7 +546,11 @@ export function DocFrontmatterBlock({
                   type="button"
                   onClick={() => void handleSave()}
                   disabled={saving}
-                  className="rounded-sm border border-[color:var(--color-indigo-a42)] bg-[color:var(--color-indigo-a10)] px-2.5 py-1 text-label text-[color:var(--color-text-primary)] transition-colors hover:bg-[color:var(--color-indigo-a16)] disabled:opacity-60"
+                  className={controlClass({
+                    shape: "chip",
+                    tone: "accent",
+                    className: "hover:bg-[color:var(--color-indigo-a16)]",
+                  })}
                 >
                   {saving ? t("editSaving") : t("editSave")}
                 </button>
@@ -544,7 +558,11 @@ export function DocFrontmatterBlock({
                   type="button"
                   onClick={() => setEditing(false)}
                   disabled={saving}
-                  className="text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                  className={controlClass({
+                    shape: "link",
+                    tone: "muted",
+                    className: "hover:text-[color:var(--color-text-secondary)]",
+                  })}
                 >
                   {t("editCancel")}
                 </button>
@@ -554,7 +572,11 @@ export function DocFrontmatterBlock({
             <button
               type="button"
               onClick={startEditing}
-              className="mt-2 inline-flex items-center gap-1.5 font-sans text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              className={controlClass({
+                shape: "link",
+                className:
+                  "mt-2 font-sans hover:text-[color:var(--color-text-primary)]",
+              })}
             >
               <Pencil size={11} aria-hidden />
               {t("editAction")}
@@ -615,7 +637,11 @@ export function DocFrontmatterBlock({
             aria-expanded={exampleOpen}
             aria-controls="doc-frontmatter-example"
             data-testid="doc-frontmatter-example-toggle"
-            className="flex items-center gap-1 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+            className={controlClass({
+              shape: "link",
+              tone: "muted",
+              className: "hover:text-[color:var(--color-text-secondary)]",
+            })}
           >
             <ChevronRight
               size={11}
@@ -676,16 +702,17 @@ function CodeLocationRow({
       >
         {truncateMiddlePath(path)}
       </span>
-      <button
-        type="button"
+      <IconButton
+        label={copyAriaLabel}
+        size="sm"
+        tone="muted"
         onClick={() => void copy(path)}
-        aria-label={copyAriaLabel}
         title={state === "copied" ? copiedLabel : copyLabel}
         data-testid="doc-frontmatter-code-location-copy"
-        className="shrink-0 rounded-sm p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
+        className="hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
       >
         {state === "copied" ? <Check size={11} aria-hidden /> : <Clipboard size={11} aria-hidden />}
-      </button>
+      </IconButton>
     </li>
   );
 }

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
@@ -32,7 +32,7 @@ import {
   type DocsTreeSort,
 } from "@/widgets/docs-vault/lib/tree-order";
 import { resolveLocaleDisplayName } from "@/shared/lib/locale-display-name";
-import { Tooltip } from "@/shared/ui";
+import { IconButton, RowButton, Tooltip, controlClass } from "@/shared/ui";
 
 /**
  * DocsVaultPage 의 사이드바 본문 — machined 파일 트리 (docs-vault-final spec).
@@ -124,21 +124,18 @@ function RailIconButton({
 }) {
   return (
     <Tooltip content={label}>
-      <button
-        type="button"
+      <IconButton
+        label={label}
+        size="lg"
+        active={active}
         onClick={onClick}
         disabled={disabled}
-        aria-label={label}
         aria-pressed={active}
         data-testid={testId}
-        className={`inline-flex h-8 w-8 flex-none items-center justify-center rounded-chip border transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
-          active
-            ? "border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-a16)] text-[color:var(--color-indigo-pale-a95)]"
-            : "border-[color:var(--color-overlay-2)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a35)] hover:text-[color:var(--color-text-primary)]"
-        }`}
+        className="flex-none hover:text-[color:var(--color-text-primary)]"
       >
         {icon}
-      </button>
+      </IconButton>
     </Tooltip>
   );
 }
@@ -160,17 +157,14 @@ function OrderOption({
   testId: string;
 }) {
   return (
-    <button
-      type="button"
+    <RowButton
+      size="sm"
+      active={checked}
       role="menuitemradio"
       aria-checked={checked}
       data-testid={testId}
       onClick={onSelect}
-      className={`flex w-full items-center gap-2 rounded-sm px-1.5 py-1.5 text-left text-label transition-colors ${
-        checked
-          ? "text-[color:var(--color-indigo-pale-a95)]"
-          : "text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
-      }`}
+      className="hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
     >
       <Check
         size={11}
@@ -178,7 +172,7 @@ function OrderOption({
         className={`flex-none ${checked ? "opacity-100" : "opacity-0"}`}
       />
       <span className="min-w-0 flex-1 truncate">{label}</span>
-    </button>
+    </RowButton>
   );
 }
 
@@ -425,14 +419,15 @@ export function DocsSidebarBody({
             autoComplete="off"
           />
           {treeQuery ? (
-            <button
-              type="button"
+            <IconButton
+              label={t("clearSearch")}
+              size="sm"
+              tone="muted"
               onClick={() => setTreeQuery("")}
-              className="rounded-sm p-0.5 text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
-              aria-label={t("clearSearch")}
+              className="hover:text-[color:var(--color-text-primary)]"
             >
               <X size={11} aria-hidden />
-            </button>
+            </IconButton>
           ) : null}
         </label>
       ) : null}
@@ -447,7 +442,9 @@ export function DocsSidebarBody({
               setTreeQuery("");
               onTagSelect(null);
             }}
-            className="flex-none rounded-sm px-1.5 py-0.5 transition-colors hover:text-[color:var(--color-text-primary)]"
+            // 이 필터 바는 `py-1`(28px)이다 — `link` 의 44px 최소 높이가 바를
+            // 그만큼 부풀린다. 문장/바 속 컨트롤에는 이 모양이 아직 안 맞는다.
+            className="flex-none rounded-chip px-1.5 py-0.5 transition-colors hover:text-[color:var(--color-text-primary)]"
           >
             {t("clearFilter")}
           </button>
@@ -492,21 +489,17 @@ export function DocsSidebarBody({
                       const active = selectedSlug === doc.slug;
                       return (
                         <li key={doc.slug}>
-                          <button
-                            type="button"
+                          <RowButton
+                            active={active}
                             onClick={() => onSelect(doc.slug)}
-                            className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors ${
-                              active
-                                ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
-                                : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
-                            }`}
+                            className="group relative hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
                           >
                             <FileText size={11} className="flex-none opacity-60" aria-hidden />
                             {/* 트리·검색·지도와 같은 이름 규칙. */}
                             <span className="min-w-0 flex-1 truncate">
                               {resolveLocaleDisplayName(doc.frontmatter, locale, doc.title)}
                             </span>
-                          </button>
+                          </RowButton>
                         </li>
                       );
                     })}
@@ -555,16 +548,12 @@ export function DocsSidebarBody({
                   .join("\n");
                 return (
                   <li key={record.path}>
-                    <button
-                      type="button"
+                    <RowButton
+                      active={active}
                       onClick={() => onSelect(record.slug)}
                       title={driftTitle || undefined}
                       aria-current={active ? "true" : undefined}
-                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors ${
-                        active
-                          ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
-                          : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
-                      }`}
+                      className="group relative hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
                     >
                       <FileText size={11} className="flex-none opacity-60" aria-hidden />
                       <span className="min-w-0 flex-1 truncate">{record.path}</span>
@@ -579,7 +568,7 @@ export function DocsSidebarBody({
                           {tAgentFiles("driftBadge")}
                         </span>
                       ) : null}
-                    </button>
+                    </RowButton>
                   </li>
                 );
               })}
@@ -598,14 +587,10 @@ export function DocsSidebarBody({
                 return (
                   <li key={slug} className="group">
                     <div className="relative flex items-stretch">
-                      <button
-                        type="button"
+                      <RowButton
+                        active={active}
                         onClick={() => onSelect(slug)}
-                        className={`flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1 pr-7 text-left text-body transition-colors ${
-                          active
-                            ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
-                            : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
-                        }`}
+                        className="min-w-0 flex-1 pr-7 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
                       >
                         <Star
                           size={11}
@@ -616,19 +601,20 @@ export function DocsSidebarBody({
                         <span className="truncate">
                           {resolveLocaleDisplayName(d.frontmatter, locale, d.title)}
                         </span>
-                      </button>
+                      </RowButton>
                       <Tooltip content={t("unpinTooltip")} withProvider={false}>
-                        <button
-                          type="button"
+                        <IconButton
+                          label={t("unpinTooltip")}
+                          size="sm"
+                          tone="muted"
                           onClick={(e) => {
                             e.stopPropagation();
                             onTogglePin(slug);
                           }}
-                          aria-label={t("unpinTooltip")}
-                          className="absolute right-1 top-1/2 -translate-y-1/2 rounded-sm p-1 text-[color:var(--color-text-quaternary)] opacity-0 transition-opacity hover:text-[color:var(--color-text-primary)] group-hover:opacity-100"
+                          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity hover:text-[color:var(--color-text-primary)] group-hover:opacity-100"
                         >
                           <PinOff size={10} aria-hidden />
-                        </button>
+                        </IconButton>
                       </Tooltip>
                     </div>
                   </li>
@@ -663,14 +649,10 @@ export function DocsSidebarBody({
                 const active = selectedSlug === slug;
                 return (
                   <li key={slug}>
-                    <button
-                      type="button"
+                    <RowButton
+                      active={active}
                       onClick={() => onSelect(slug)}
-                      className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-colors ${
-                        active
-                          ? "bg-[color:var(--color-indigo-a14)] text-[color:var(--color-text-primary)]"
-                          : "text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
-                      }`}
+                      className="group relative hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
                     >
                       <FileText
                         size={11}
@@ -680,7 +662,7 @@ export function DocsSidebarBody({
                       <span className="truncate">
                         {resolveLocaleDisplayName(d.frontmatter, locale, d.title)}
                       </span>
-                    </button>
+                    </RowButton>
                   </li>
                 );
               })}
@@ -713,11 +695,12 @@ export function DocsSidebarBody({
                     type="button"
                     onClick={() => onTagSelect(active ? null : tag)}
                     aria-pressed={active}
-                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-label transition-colors ${
-                      active
-                        ? "bg-[color:var(--color-indigo-a16)] text-[color:var(--color-indigo-pale-a95)]"
-                        : "bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-text-primary)]"
-                    }`}
+                    className={controlClass({
+                      shape: "pill",
+                      active,
+                      className:
+                        "gap-1 hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-text-primary)]",
+                    })}
                     title={t("tagTitle", { tag, count: slugs.length })}
                   >
                     {active ? <X size={9} aria-hidden /> : null}

--- a/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultAuditModal.tsx
@@ -7,7 +7,7 @@ import { Bot, Check, Clipboard, GitCompareArrows, HardDrive, Network, X } from "
 import { MOTION } from "@/shared/motion";
 import { Link } from "@/i18n/navigation";
 import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
-import { useToast } from "@/shared/ui";
+import { IconButton, controlClass, useToast } from "@/shared/ui";
 import {
   AGENT_GRAPH_DB_RUNTIME_GATE_CHECK_COUNT,
   AGENT_GRAPH_DB_RUNTIME_GATE_COMMAND,
@@ -255,15 +255,14 @@ export function DocsVaultAuditModal({
                   {t("sourceContract.modalSubtitle")}
                 </p>
               </div>
-              <button
-                type="button"
+              <IconButton
+                label={t("header.contractToggleHide")}
                 onClick={onClose}
                 title={t("sourceContract.closeTitle")}
-                aria-label={t("header.contractToggleHide")}
-                className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-[var(--chrome-radius-inner)] border border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+                className="flex-none hover:text-[color:var(--color-text-primary)]"
               >
                 <X size={14} aria-hidden />
-              </button>
+              </IconButton>
             </div>
 
             {cells.map((cell) => {
@@ -316,7 +315,12 @@ export function DocsVaultAuditModal({
                         type="button"
                         aria-label={cell.copyAriaLabel}
                         onClick={() => void handleCopyGate(cell.copyText, cell.copySuccess)}
-                        className="inline-flex h-6 min-w-0 items-center gap-1 rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+                        className={controlClass({
+                          shape: "chip",
+                          size: "sm",
+                          className:
+                            "min-w-0 gap-1 font-mono uppercase tracking-[0.06em] hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]",
+                        })}
                       >
                         {copiedGate ? <Check size={10} aria-hidden /> : <Clipboard size={10} aria-hidden />}
                         <span className="truncate">{cell.copyCta}</span>
@@ -389,7 +393,12 @@ export function DocsVaultAuditModal({
                       type="button"
                       data-testid="docs-audit-skill-parity-copy"
                       onClick={() => onCopySkillParityHandoff(disagreeing)}
-                      className="inline-flex h-6 min-w-0 items-center gap-1 rounded-sm border border-[color:var(--color-indigo-line-a20)] bg-[color:var(--color-indigo-a06)] px-1.5 font-mono text-caption uppercase tracking-[0.06em] text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+                      className={controlClass({
+                          shape: "chip",
+                          size: "sm",
+                          className:
+                            "min-w-0 gap-1 font-mono uppercase tracking-[0.06em] hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]",
+                        })}
                     >
                       <Clipboard size={10} aria-hidden />
                       <span className="truncate">{tSkillParity("copyHandoff")}</span>

--- a/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultTabStrip.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import type { useTranslations } from "next-intl";
 import { FileText, X } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
+import { IconButton } from "@/shared/ui";
 import type { DocTab } from "../../lib/doc-tabs";
 
 export interface DocsVaultTabStripProps {
@@ -195,9 +196,9 @@ export function DocsVaultTabStrip({
               <FileText size={14} aria-hidden className="flex-none" />
               <span className="min-w-0 flex-1 truncate text-left">{tab.title}</span>
             </button>
-            <button
-              type="button"
-              aria-label={t("tabs.closeAria", { title: tab.title })}
+            <IconButton
+              size="sm"
+              label={t("tabs.closeAria", { title: tab.title })}
               onClick={(event) => {
                 event.stopPropagation();
                 // 키보드 activation(click.detail=0)으로 ×를 누르면 해당 버튼은
@@ -210,14 +211,14 @@ export function DocsVaultTabStrip({
                 onClose(tab.slug);
               }}
               className={cn(
-                "my-auto mr-1.5 flex h-5 w-5 flex-none items-center justify-center rounded-sm text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)]",
+                "my-auto mr-1.5 flex-none hover:bg-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)]",
                 active
                   ? "opacity-100"
                   : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
               )}
             >
               <X size={14} aria-hidden />
-            </button>
+            </IconButton>
             {active ? (
               <span
                 aria-hidden

--- a/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from "react";
 import { ChevronDown, HardDrive } from "lucide-react";
 import type { useTranslations } from "next-intl";
+import { Chip, RowButton } from "@/shared/ui";
 
 export interface DocsVaultVaultChipProps {
   /** vault 짧은 이름 — local=폴더명, server=샘플 라벨. */
@@ -43,13 +44,12 @@ export function DocsVaultVaultChip({
 }: DocsVaultVaultChipProps) {
   return (
     <div ref={menuRef} className="relative min-w-0 flex-none">
-      <button
-        type="button"
+      <Chip
         onClick={onToggle}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t("vaultChip.menuAriaLabel")}
-        className="inline-flex h-7 min-w-0 max-w-[200px] flex-none items-center gap-1.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 font-mono text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+        className="min-w-0 max-w-[200px] flex-none font-mono hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
       >
         <HardDrive size={12} aria-hidden className="flex-none" />
         <span className="hidden min-w-0 truncate text-[color:var(--color-text-secondary)] sm:inline">
@@ -63,7 +63,7 @@ export function DocsVaultVaultChip({
           aria-hidden
           className={`flex-none transition-transform ${open ? "rotate-180" : ""}`}
         />
-      </button>
+      </Chip>
       {open ? (
         <div
           role="menu"
@@ -82,14 +82,14 @@ export function DocsVaultVaultChip({
               {t("header.localBadge")}
             </p>
           ) : null}
-          <button
-            type="button"
+          <RowButton
+            size="sm"
             role="menuitem"
             onClick={onSwap}
-            className="mt-1 flex w-full items-center rounded-sm px-1.5 py-1.5 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+            className="mt-1 hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
           >
             {t("header.vaultPillSwap")}
-          </button>
+          </RowButton>
           {toolsMovedHint ? (
             <p className="mt-1 border-t border-[color:var(--color-border-soft)] px-1.5 pt-1.5 text-caption leading-4 text-[color:var(--color-text-tertiary)]">
               {toolsMovedHint}

--- a/src/views/docs-vault/ui/parts/EmptyState.tsx
+++ b/src/views/docs-vault/ui/parts/EmptyState.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/i18n/navigation";
 import { Bot, Network, PanelLeftOpen } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { controlClass } from "@/shared/ui";
 
 /**
  * 문서 미선택 상태 — 항상 보이는 트리를 없앤 뒤의 Source Vault 시작점.
@@ -33,7 +34,13 @@ export function EmptyState({
           <button
             type="button"
             onClick={onOpenTree}
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-chip border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-a10)] px-3 text-body font-medium text-[color:rgba(220,225,255,0.94)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)]"
+            className={controlClass({
+              shape: "chip",
+              size: "lg",
+              active: true,
+              className:
+                "justify-center gap-2 font-medium hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a16)]",
+            })}
           >
             <PanelLeftOpen size={14} aria-hidden />
             {t("openTree")}
@@ -41,14 +48,26 @@ export function EmptyState({
           <button
             type="button"
             onClick={onOpenAgentWorkflow}
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-chip border border-[color:var(--color-border-soft)] px-3 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+            className={controlClass({
+              shape: "chip",
+              size: "lg",
+              tone: "secondary",
+              className:
+                "justify-center gap-2 hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]",
+            })}
           >
             <Bot size={14} aria-hidden />
             {t("openAgent")}
           </button>
           <Link
             href="/topology/"
-            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-chip border border-[color:var(--color-border-soft)] px-3 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+            className={controlClass({
+              shape: "chip",
+              size: "lg",
+              tone: "secondary",
+              className:
+                "justify-center gap-2 hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]",
+            })}
           >
             <Network size={14} aria-hidden />
             {t("openTopology")}

--- a/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
+++ b/src/views/docs-vault/ui/parts/NewDocKindDialog.tsx
@@ -5,7 +5,7 @@ import { motion, useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { useOntologyKindLabel } from "@/entities/ontology-class";
 import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED, SCRIM_FADE, SCRIM_FADE_REDUCED } from "@/shared/motion";
-import { TopologyV2KindGlyph } from "@/shared/ui";
+import { TopologyV2KindGlyph, controlClass } from "@/shared/ui";
 
 /**
  * P5c — "새 문서" 가 generic `title:` 템플릿 대신 kind 선택을 먼저 받는다.
@@ -131,7 +131,11 @@ export function NewDocKindDialog({
               <button
                 type="button"
                 onClick={() => onSelect(kind)}
-                className="flex w-full items-center gap-2 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2 text-left transition-colors hover:border-[color:var(--color-border-strong)]"
+                className={controlClass({
+                  shape: "card",
+                  className:
+                    "w-full text-left hover:border-[color:var(--color-border-strong)]",
+                })}
               >
                 <TopologyV2KindGlyph kind={kind} size={16} />
                 <span className="text-body text-[color:var(--color-text-secondary)]">
@@ -144,7 +148,11 @@ export function NewDocKindDialog({
         <button
           type="button"
           onClick={onClose}
-          className="mt-3 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+          className={controlClass({
+            shape: "link",
+            tone: "muted",
+            className: "mt-3 hover:text-[color:var(--color-text-secondary)]",
+          })}
         >
           {t("cancel")}
         </button>

--- a/src/views/docs-vault/ui/parts/SampleNotice.tsx
+++ b/src/views/docs-vault/ui/parts/SampleNotice.tsx
@@ -1,6 +1,7 @@
 import { Download, FolderOpen } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import { controlClass } from "@/shared/ui";
 
 export interface SampleNoticeProps {
   /** P1b — 게이트는 런타임이 아니라 능력: FSA 지원이면 웹에서도 폴더 열기. */
@@ -38,7 +39,13 @@ export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticePr
         <button
           type="button"
           onClick={onOpenFolder}
-          className="inline-flex flex-none items-center gap-1.5 rounded-chip border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a18)] px-2.5 py-1.5 text-body font-medium text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a24)]"
+          className={controlClass({
+            shape: "chip",
+            size: "lg",
+            active: true,
+            className:
+              "flex-none font-medium hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a24)]",
+          })}
         >
           <FolderOpen size={12} aria-hidden />
           {t("sampleNotice.openFolderCta")}

--- a/src/views/docs-vault/ui/parts/SampleWelcomeNote.tsx
+++ b/src/views/docs-vault/ui/parts/SampleWelcomeNote.tsx
@@ -1,5 +1,6 @@
 import { FolderOpen, X } from "lucide-react";
 import { useLocale } from "next-intl";
+import { IconButton, controlClass } from "@/shared/ui";
 
 export interface SampleWelcomeNoteProps {
   /** P1b — FSA 지원이면 웹에서도 폴더 열기(SampleNotice 와 동일 능력 계약). */
@@ -51,14 +52,15 @@ export function SampleWelcomeNote({
       data-testid="docs-vault-sample-welcome-note"
       className="relative flex flex-none flex-col gap-2 border-b border-l-2 border-b-[color:var(--color-divider)] border-l-[color:var(--color-indigo-brand)] bg-[color:var(--color-elevated)] px-6 py-4 md:px-10"
     >
-      <button
-        type="button"
+      <IconButton
+        label={copy.dismissAria}
+        size="sm"
+        tone="muted"
         onClick={onDismiss}
-        aria-label={copy.dismissAria}
-        className="absolute right-3 top-3 rounded-sm p-1 text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+        className="absolute right-3 top-3 hover:text-[color:var(--color-text-primary)]"
       >
         <X size={13} aria-hidden />
-      </button>
+      </IconButton>
       <p className="max-w-[560px] pr-6 text-body leading-body text-[color:var(--color-text-secondary)]">
         <span className="block font-semibold text-[color:var(--color-text-primary)]">
           {copy.title}
@@ -69,7 +71,13 @@ export function SampleWelcomeNote({
         <button
           type="button"
           onClick={onOpenFolder}
-          className="inline-flex w-fit flex-none items-center gap-1.5 rounded-chip border border-[color:var(--color-indigo-line-a42)] bg-[color:var(--color-indigo-a18)] px-2.5 py-1.5 text-body font-medium text-[color:var(--color-text-primary)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a24)]"
+          className={controlClass({
+          shape: "chip",
+          size: "lg",
+          active: true,
+          className:
+            "w-fit flex-none font-medium hover:border-[color:var(--color-indigo-line-a54)] hover:bg-[color:var(--color-indigo-a24)]",
+        })}
         >
           <FolderOpen size={12} aria-hidden />
           {copy.openFolderCta}

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -24,7 +24,7 @@ import type { ScreenContextSnapshot } from "@/features/vault-agent";
 import { VaultAgentPanel } from "@/widgets/vault-agent-panel";
 import { STUDIO_AGENT_DOCK_MIN_VIEWPORT_PX } from "../lib/studio-agent-dock";
 import { josa } from "@/shared/lib/ko-josa";
-import { EmptyState, useToast } from "@/shared/ui";
+import { EmptyState, controlClass, useToast } from "@/shared/ui";
 import {
   buildStudioItem,
   selectDefaultStudioNodeId,
@@ -1140,14 +1140,22 @@ function StudioStage({
               <button
                 type="button"
                 onClick={exit}
-                className="rounded-card border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className={controlClass({
+                  shape: "card",
+                  className:
+                    "font-semibold hover:text-[color:var(--color-text-primary)]",
+                })}
               >
                 {t("notFound.openMap")}
               </button>
               <button
                 type="button"
                 onClick={enterCreate}
-                className="rounded-card border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+                className={controlClass({
+                  shape: "card",
+                  className:
+                    "font-semibold hover:text-[color:var(--color-text-primary)]",
+                })}
               >
                 {t("notFound.create")}
               </button>
@@ -1174,7 +1182,11 @@ function StudioStage({
             <button
               type="button"
               onClick={enterCreate}
-              className="rounded-card border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              className={controlClass({
+                  shape: "card",
+                  className:
+                    "font-semibold hover:text-[color:var(--color-text-primary)]",
+                })}
             >
               {t("empty.create")}
             </button>

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/shared/lib/cn";
 import { candidateMatches } from "../lib/match-candidate";
 import { studioBoardScale } from "../lib/board-scale";
 import { usePrefersReducedMotion } from "@/shared/lib/use-prefers-reduced-motion";
-import { Select } from "@/shared/ui";
+import { IconButton, RowButton, Select, controlClass } from "@/shared/ui";
 import type {
   StudioBearing,
   StudioRelation,
@@ -1347,15 +1347,16 @@ export function StudioCompass(props: StudioCompassProps) {
                   <span aria-hidden className="mt-1.5 h-1 w-1 flex-none rounded-full bg-[color:var(--color-indigo-brand)]" />
                   <span className="min-w-0 flex-1 [word-break:keep-all]">{line}</span>
                   {props.onUndoChange ? (
-                    <button
-                      type="button"
+                    <IconButton
+                      size="sm"
+                      tone="muted"
                       data-testid={`studio-summary-undo-${i}`}
-                      aria-label={labels.summaryUndo}
+                      label={labels.summaryUndo}
                       onClick={() => props.onUndoChange?.(i)}
-                      className="flex-none text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                      className="flex-none hover:text-[color:var(--color-text-secondary)]"
                     >
                       <X size={12} aria-hidden />
-                    </button>
+                    </IconButton>
                   ) : null}
                 </li>
               ))}
@@ -1458,14 +1459,15 @@ export function StudioCompass(props: StudioCompassProps) {
                 {labels.draftsHint}
               </p>
             </div>
-            <button
-              type="button"
+            <IconButton
+              size="sm"
+              tone="muted"
               onClick={() => setDraftsOpen(false)}
-              aria-label={labels.draftsCloseAria}
-              className="-mr-1 flex h-6 w-6 flex-none items-center justify-center rounded-chip text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+              label={labels.draftsCloseAria}
+              className="-mr-1 flex-none hover:text-[color:var(--color-text-secondary)]"
             >
               <X size={13} aria-hidden />
-            </button>
+            </IconButton>
           </div>
           <ul className="mt-2.5 min-h-0 flex-1 overflow-y-auto px-2 pb-2">
             {drafts.map((draft) => {
@@ -1495,16 +1497,16 @@ export function StudioCompass(props: StudioCompassProps) {
                       </button>
                     ) : null}
                     {props.onDiscardDraft ? (
-                      <button
-                        type="button"
+                      <IconButton
+                        tone="muted"
                         data-testid={`studio-draft-discard-${draft.focalId}`}
                         onClick={() => props.onDiscardDraft?.(draft.focalId)}
-                        aria-label={labels.draftsDiscardAria(draft.title)}
+                        label={labels.draftsDiscardAria(draft.title)}
                         title={labels.draftsDiscard}
-                        className="flex h-7 w-7 flex-none items-center justify-center rounded-chip text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-danger-a12)] hover:text-[color:var(--color-danger-text)]"
+                        className="flex-none hover:bg-[color:var(--color-danger-a12)] hover:text-[color:var(--color-danger-text)]"
                       >
                         <X size={12} aria-hidden />
-                      </button>
+                      </IconButton>
                     ) : null}
                   </div>
                 </li>
@@ -1714,7 +1716,11 @@ function CenterCard(
               type="button"
               data-testid="studio-def-more"
               onClick={() => setDefExpanded((v) => !v)}
-              className="mt-1 text-label font-medium text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+              className={controlClass({
+                shape: "link",
+                tone: "muted",
+                className: "mt-1 font-medium hover:text-[color:var(--color-text-secondary)]",
+              })}
             >
               {defExpanded ? props.labels.defLess : props.labels.defMore}
             </button>
@@ -1757,7 +1763,8 @@ function CenterCard(
             <button
               type="button"
               onClick={() => props.onOpenSimilar?.(props.createSimilarHit!.slug)}
-              className="font-semibold text-[color:var(--color-indigo-text-soft)]"
+              // 문장 속 컨트롤 — `link` 의 `min-h-11` 이 힌트 줄을 44px 로 밀어 올린다.
+              className="rounded-chip font-semibold text-[color:var(--color-indigo-text-soft)]"
             >
               {props.labels.createSimilarOpen}
             </button>
@@ -1767,6 +1774,7 @@ function CenterCard(
                 <button
                   type="button"
                   onClick={() => props.onDismissSimilar?.()}
+                  // 같은 줄의 형제라 위와 같은 이유로 남긴다.
                   className="text-[color:var(--color-text-quaternary)]"
                 >
                   {props.labels.createSimilarAnyway}
@@ -1910,16 +1918,17 @@ function LaneRender({
               </span>
             </Tag>
             {onEditNeighbor ? (
-              <button
-                type="button"
+              <IconButton
+                size="sm"
+                tone="muted"
                 data-testid={`studio-edit-${view.bearing}`}
-                aria-label={labels.edit}
+                label={labels.edit}
                 title={labels.edit}
                 onClick={() => onEditNeighbor(sat)}
-                className="absolute right-1.5 top-1.5 grid h-5 w-5 place-items-center rounded-chip text-[color:var(--color-text-quaternary)] opacity-70 transition-opacity transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] group-hover:opacity-100 motion-reduce:transition-none"
+                className="absolute right-1.5 top-1.5 opacity-70 transition-opacity hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] group-hover:opacity-100 motion-reduce:transition-none"
               >
                 <MoreHorizontal size={14} aria-hidden />
-              </button>
+              </IconButton>
             ) : null}
             {/* arrival orientation (#3) — where you walked from. Indigo border
                 emphasis (color/opacity only, no glow), holds ~1.5s then fades. */}
@@ -2112,14 +2121,15 @@ function LaneOverflowList({
         <span className="min-w-0 truncate text-caption font-semibold text-[color:var(--color-text-secondary)] [word-break:keep-all]">
           {labels.foldTitle(view.laneLabel, view.neighbors.length)}
         </span>
-        <button
-          type="button"
-          aria-label={labels.close}
+        <IconButton
+          size="sm"
+          tone="muted"
+          label={labels.close}
           onClick={onClose}
-          className="ml-auto flex-none text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]"
+          className="ml-auto flex-none hover:text-[color:var(--color-text-secondary)]"
         >
           <X size={13} aria-hidden />
-        </button>
+        </IconButton>
       </div>
       <div className="max-h-[260px] overflow-y-auto p-1.5">
         {view.neighbors.map((sat) => {
@@ -2140,16 +2150,17 @@ function LaneOverflowList({
                 </span>
               </Tag>
               {onEditNeighbor ? (
-                <button
-                  type="button"
+                <IconButton
+                  size="sm"
+                  tone="muted"
                   data-testid={`studio-lane-edit-${sat.id}`}
-                  aria-label={labels.edit}
+                  label={labels.edit}
                   title={labels.edit}
                   onClick={() => onEditNeighbor(sat)}
-                  className="mr-1.5 grid h-6 w-6 flex-none place-items-center rounded-chip text-[color:var(--color-text-quaternary)] opacity-70 transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] group-hover:opacity-100"
+                  className="mr-1.5 flex-none opacity-70 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] group-hover:opacity-100"
                 >
                   <MoreHorizontal size={14} aria-hidden />
-                </button>
+                </IconButton>
               ) : null}
             </div>
           );
@@ -2221,14 +2232,15 @@ function InlineEditCard({
         <span className="min-w-0 flex-1 truncate text-caption font-semibold text-[color:var(--color-text-secondary)] [word-break:keep-all]">
           {labels.editTitle}
         </span>
-        <button
-          type="button"
-          aria-label={labels.close}
+        <IconButton
+          size="sm"
+          tone="muted"
+          label={labels.close}
           onClick={onClose}
-          className="flex-none text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]"
+          className="flex-none hover:text-[color:var(--color-text-secondary)]"
         >
           <X size={13} aria-hidden />
-        </button>
+        </IconButton>
       </div>
       <div className="flex items-center gap-2 px-3.5 pt-2.5">
         <KindGlyph kind={neighbor.kind} />
@@ -2244,16 +2256,15 @@ function InlineEditCard({
           </div>
           <div className="flex flex-col gap-1 px-2 pb-1.5">
             {otherRelations.map((to) => (
-              <button
+              <RowButton
                 key={to}
-                type="button"
                 data-testid={`studio-edit-retype-${to}`}
                 onClick={() => onRetype(to)}
-                className="flex items-center gap-2 rounded-[8px] px-2.5 py-2 text-left text-body text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-indigo-a08)] hover:text-[color:var(--color-text-primary)]"
+                className="hover:bg-[color:var(--color-indigo-a08)] hover:text-[color:var(--color-text-primary)]"
               >
                 <span className="text-[color:var(--color-text-quaternary)]">→</span>
                 {labels.editMoveTo(bearingLabelFor(to))}
-              </button>
+              </RowButton>
             ))}
           </div>
           <div className="border-t border-[color:var(--color-divider)] p-2">
@@ -2265,7 +2276,10 @@ function InlineEditCard({
                 <button
                   type="button"
                   onClick={() => setConfirmDelete(false)}
-                  className="flex-none rounded-chip px-2 py-1 text-label text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-secondary)]"
+                  className={controlClass({
+                    shape: "link",
+                    className: "flex-none hover:text-[color:var(--color-text-secondary)]",
+                  })}
                 >
                   {labels.editDeleteCancel}
                 </button>
@@ -2273,21 +2287,25 @@ function InlineEditCard({
                   type="button"
                   data-testid="studio-edit-delete-confirm"
                   onClick={onRemove}
-                  className="flex-none rounded-chip border border-[color:var(--color-danger-a42)] bg-[color:var(--color-danger-a12)] px-2 py-1 text-label font-semibold text-[color:var(--color-danger-text)] transition-colors hover:bg-[color:var(--color-danger-a32)]"
+                  className={controlClass({
+                    shape: "chip",
+                    tone: "danger",
+                    className:
+                      "flex-none font-semibold hover:bg-[color:var(--color-danger-a32)]",
+                  })}
                 >
                   {labels.editDeleteYes}
                 </button>
               </div>
             ) : (
-              <button
-                type="button"
+              <RowButton
                 data-testid="studio-edit-delete"
                 onClick={() => setConfirmDelete(true)}
-                className="flex w-full items-center gap-2 rounded-[8px] px-2.5 py-2 text-left text-body text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
+                className="hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
               >
                 <X size={13} aria-hidden className="text-[color:var(--color-text-quaternary)]" />
                 {labels.editDelete}
-              </button>
+              </RowButton>
             )}
           </div>
         </>
@@ -2300,7 +2318,12 @@ function InlineEditCard({
             type="button"
             data-testid="studio-edit-open-other"
             onClick={onOpenOther}
-            className="mt-2.5 flex items-center gap-1.5 rounded-card border border-[color:var(--color-border-soft)] px-2.5 py-1.5 text-label font-medium text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]"
+            className={controlClass({
+              shape: "card",
+              size: "sm",
+              className:
+                "mt-2.5 font-medium hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]",
+            })}
           >
             {labels.editElsewhereGo}
           </button>
@@ -2483,14 +2506,15 @@ function InlinePicker({
       <div className="flex items-baseline gap-2 border-b border-[color:var(--color-divider)] px-3.5 py-2.5">
         <span className="text-caption font-semibold text-[color:var(--color-text-secondary)]">{labels.pickerTitle(question)}</span>
         <span className="text-label text-[color:var(--color-text-quaternary)]">{labels.pickerSub}</span>
-        <button
-          type="button"
-          aria-label={labels.close}
+        <IconButton
+          size="sm"
+          tone="muted"
+          label={labels.close}
           onClick={onClose}
-          className="ml-auto text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]"
+          className="ml-auto hover:text-[color:var(--color-text-secondary)]"
         >
           <X size={13} aria-hidden />
-        </button>
+        </IconButton>
       </div>
       <div className="flex items-center gap-2 border-b border-[color:var(--color-divider)] px-3 py-2">
         <Search size={13} aria-hidden className="flex-none text-[color:var(--color-text-quaternary)]" />
@@ -2530,7 +2554,11 @@ function InlinePicker({
                       type="button"
                       data-testid={`studio-suggest-row-${s.candidate.id}`}
                       onClick={() => onPick(s.candidate)}
-                      className="flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left transition-colors hover:bg-[color:var(--color-indigo-a08)]"
+                      className={controlClass({
+                        shape: "row",
+                        className:
+                          "hover:bg-[color:var(--color-indigo-a08)]",
+                      })}
                     >
                       <KindGlyph kind={s.candidate.kind} />
                       <span className="min-w-0 truncate text-body text-[color:var(--color-text-primary)]">{s.candidate.title}</span>
@@ -2550,7 +2578,11 @@ function InlinePicker({
                       type="button"
                       data-testid={`studio-browse-domain-${d.key}`}
                       onClick={() => setBrowseKey(d.key)}
-                      className="flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left transition-colors hover:bg-[color:var(--color-indigo-a08)]"
+                      className={controlClass({
+                        shape: "row",
+                        className:
+                          "hover:bg-[color:var(--color-indigo-a08)]",
+                      })}
                     >
                       <span className="min-w-0 truncate text-body text-[color:var(--color-text-secondary)]">
                         {d.title ?? labels.browseNoDomain}
@@ -2567,7 +2599,12 @@ function InlinePicker({
                       type="button"
                       data-testid="studio-browse-back"
                       onClick={() => setBrowseKey(null)}
-                      className="flex w-full items-center gap-1.5 rounded-[8px] px-2.5 py-1.5 text-left text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+                      className={controlClass({
+                        shape: "row",
+                        size: "sm",
+                        className:
+                          "hover:text-[color:var(--color-text-secondary)]",
+                      })}
                     >
                       {labels.browseBack}
                     </button>
@@ -2577,7 +2614,11 @@ function InlinePicker({
                         type="button"
                         data-testid={`studio-browse-node-${c.id}`}
                         onClick={() => onPick(c)}
-                        className="flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left transition-colors hover:bg-[color:var(--color-indigo-a08)]"
+                        className={controlClass({
+                        shape: "row",
+                        className:
+                          "hover:bg-[color:var(--color-indigo-a08)]",
+                      })}
                       >
                         <KindGlyph kind={c.kind} />
                         <span className="min-w-0 truncate text-body text-[color:var(--color-text-primary)]">{c.title}</span>
@@ -2598,7 +2639,11 @@ function InlinePicker({
               type="button"
               data-testid={`studio-picker-row-${c.id}`}
               onClick={() => onPick(c)}
-              className="flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left transition-colors hover:bg-[color:var(--color-indigo-a08)]"
+              className={controlClass({
+                        shape: "row",
+                        className:
+                          "hover:bg-[color:var(--color-indigo-a08)]",
+                      })}
             >
               <KindGlyph kind={c.kind} />
               <span className="truncate text-body text-[color:var(--color-text-primary)]">{c.title}</span>
@@ -2620,7 +2665,8 @@ function InlinePicker({
               type="button"
               data-testid="studio-picker-similar-accept"
               onClick={() => onPick(similarHit)}
-              className="font-semibold text-[color:var(--color-indigo-text-soft)]"
+              // 문장 속 컨트롤 — `link` 의 `min-h-11` 이 힌트 줄을 44px 로 밀어 올린다.
+              className="rounded-chip font-semibold text-[color:var(--color-indigo-text-soft)]"
             >
               {labels.similarAccept}
             </button>
@@ -2732,7 +2778,11 @@ function NodeSearch({
                   type="button"
                   data-testid={`studio-node-search-row-${n.id}`}
                   onClick={() => pick(n.id)}
-                  className="flex w-full items-center gap-2.5 rounded-[8px] px-2.5 py-2 text-left transition-colors hover:bg-[color:var(--color-indigo-a08)]"
+                  className={controlClass({
+                        shape: "row",
+                        className:
+                          "hover:bg-[color:var(--color-indigo-a08)]",
+                      })}
                 >
                   <KindGlyph kind={n.kind} />
                   <span className="min-w-0 truncate text-body text-[color:var(--color-text-primary)] [word-break:keep-all]">{n.title}</span>
@@ -2931,15 +2981,16 @@ function DeltaPreviewModal({
           <span className="min-w-0 flex-1 truncate text-body-lg font-semibold text-[color:var(--color-text-primary)] [word-break:keep-all]">
             {labels.previewTitle}
           </span>
-          <button
-            type="button"
+          <IconButton
+            size="sm"
+            tone="muted"
             data-testid="studio-preview-close"
-            aria-label={labels.previewCloseAria}
+            label={labels.previewCloseAria}
             onClick={onClose}
-            className="flex-none text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+            className="flex-none hover:text-[color:var(--color-text-secondary)]"
           >
             <X size={15} aria-hidden />
-          </button>
+          </IconButton>
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/src/views/ontology-studio/ui/StudioEntryChoice.tsx
+++ b/src/views/ontology-studio/ui/StudioEntryChoice.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { controlClass } from "@/shared/ui";
 
 /**
  * 공방 진입 선택 모먼트 (#1, 2026-07-25) — `/ontology/studio` 를 딥링크
@@ -104,7 +105,12 @@ export function StudioEntryChoice({
         type="button"
         data-testid="studio-entry-practice"
         onClick={onPractice}
-        className="studio-stage-in mt-5 rounded-card px-3 py-1.5 text-caption text-[color:var(--color-text-tertiary)] underline underline-offset-4 transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+        className={controlClass({
+          shape: "link",
+          size: "sm",
+          className:
+            "studio-stage-in mt-5 underline underline-offset-4 hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]",
+        })}
         style={{ ["--studio-stagger" as string]: "120ms" }}
       >
         {labels.practice}
@@ -114,7 +120,12 @@ export function StudioEntryChoice({
         type="button"
         data-testid="studio-entry-exit"
         onClick={onExit}
-        className="studio-stage-in mt-3 rounded-card px-3 py-1.5 text-label text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+        className={controlClass({
+          shape: "link",
+          tone: "muted",
+          className:
+            "studio-stage-in mt-3 hover:text-[color:var(--color-text-secondary)]",
+        })}
         style={{ ["--studio-stagger" as string]: "160ms" }}
       >
         {labels.exit}

--- a/src/views/ontology-studio/ui/StudioMaterializeDialog.tsx
+++ b/src/views/ontology-studio/ui/StudioMaterializeDialog.tsx
@@ -6,6 +6,7 @@ import { FileText, X } from "lucide-react";
 import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED, SCRIM_FADE, SCRIM_FADE_REDUCED } from "@/shared/motion";
 import type { CreateNodeKind } from "../lib/build-create-node";
 import type { StudioWriteTarget } from "../lib/resolve-write-target";
+import { controlClass } from "@/shared/ui";
 
 /**
  * "이 개념은 아직 문서가 없어요" — 문서를 만들어도 되는지 묻는 동의 표면.
@@ -188,11 +189,12 @@ export function StudioMaterializeDialog({
                       data-testid={`studio-materialize-kind-${option}`}
                       aria-pressed={on}
                       onClick={() => setKind(option)}
-                      className={
-                        on
-                          ? `flex h-8 flex-1 items-center justify-center rounded-chip border border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-a16)] text-body tracking-body font-semibold text-[color:var(--color-indigo-text-soft)] transition-colors ${FOCUS_RING}`
-                          : `flex h-8 flex-1 items-center justify-center rounded-chip border border-[color:var(--color-border-soft)] text-body tracking-body text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] ${FOCUS_RING}`
-                      }
+                      className={controlClass({
+                        shape: "chip",
+                        size: "lg",
+                        active: on,
+                        className: `flex-1 justify-center tracking-body hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-secondary)] ${FOCUS_RING}`,
+                      })}
                     >
                       {labels.kindOptionLabel(option)}
                     </button>
@@ -217,7 +219,11 @@ export function StudioMaterializeDialog({
             type="button"
             data-testid="studio-materialize-cancel"
             onClick={onCancel}
-            className={`flex h-8 items-center rounded-chip border border-[color:var(--color-border-soft)] px-3.5 text-body tracking-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] ${FOCUS_RING}`}
+            className={controlClass({
+              shape: "chip",
+              size: "lg",
+              className: `tracking-body hover:border-[color:var(--color-border-strong)] ${FOCUS_RING}`,
+            })}
           >
             {labels.cancel}
           </button>

--- a/src/views/ontology-studio/ui/StudioPracticeCleanup.tsx
+++ b/src/views/ontology-studio/ui/StudioPracticeCleanup.tsx
@@ -5,6 +5,7 @@ import { motion, useReducedMotion } from "framer-motion";
 import { FileText, Sparkles } from "lucide-react";
 import { OVERLAY_SPRING, OVERLAY_SPRING_REDUCED, SCRIM_FADE, SCRIM_FADE_REDUCED } from "@/shared/motion";
 import type { PracticeCleanupPlan } from "../lib/studio-practice-guide";
+import { controlClass } from "@/shared/ui";
 
 /**
  * 실습 마무리 — **"이거 지울까요?"** 를 묻는 자리.
@@ -236,7 +237,12 @@ export function StudioPracticeCleanup({
                   type="button"
                   data-testid="studio-practice-agent"
                   onClick={onAgentAction}
-                  className="rounded-chip font-medium text-[color:var(--color-indigo-text-soft)] underline underline-offset-2 transition-colors hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+                  className={controlClass({
+            shape: "link",
+            tone: "accent",
+            className:
+              "font-medium underline underline-offset-2 hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]",
+          })}
                 >
                   {labels.agentAction}
                 </button>

--- a/src/views/ontology-studio/ui/StudioPracticeRail.tsx
+++ b/src/views/ontology-studio/ui/StudioPracticeRail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { practiceStepIndex, PRACTICE_STEP_ORDER, type PracticeStep } from "../lib/studio-practice-guide";
+import { controlClass } from "@/shared/ui";
 
 /**
  * 실습 안내 띠 — 나침 무대 **위에 얹는 한 줄**이다.
@@ -107,7 +108,11 @@ export function StudioPracticeRail({
         type="button"
         data-testid="studio-practice-quit"
         onClick={onQuit}
-        className="flex-none touch-hit-expand rounded-chip px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]"
+        className={controlClass({
+          shape: "link",
+          className:
+            "flex-none px-2 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)]",
+        })}
       >
         {labels.quit}
       </button>

--- a/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
+++ b/src/widgets/docs-quick-drawer/ui/DocsQuickDrawer.tsx
@@ -39,6 +39,7 @@ import { MOTION } from "@/shared/motion";
 import { useBodyScrollLock } from "@/shared/lib/use-body-scroll-lock";
 import { cn } from "@/shared/lib/cn";
 import { resolveLocaleDisplayName } from "@/shared/lib/locale-display-name";
+import { IconButton, RowButton, controlClass } from "@/shared/ui";
 
 function readStoredSlugs(key: string, limit: number): string[] {
   if (typeof window === "undefined") return [];
@@ -168,10 +169,11 @@ function TreeBranch({
   return (
     <div>
       {depth > 0 ? (
-        <button
-          type="button"
+        <RowButton
+          size="sm"
+          tone="muted"
           onClick={() => setOpen((v) => !v)}
-          className="flex w-full items-center gap-1.5 rounded-card px-2 py-1.5 text-left font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-1)]"
+          className="rounded-card font-mono uppercase tracking-[0.08em] hover:bg-[color:var(--color-overlay-1)]"
           style={{ paddingLeft: `${depth * 12 + 4}px` }}
           aria-expanded={effectiveOpen}
         >
@@ -185,7 +187,7 @@ function TreeBranch({
           <span className="ml-auto font-mono text-caption text-[color:var(--color-text-quaternary)]">
             {node.children.filter((c) => c.type === "doc" || (c.children?.length ?? 0) > 0).length}
           </span>
-        </button>
+        </RowButton>
       ) : null}
       {effectiveOpen
         ? node.children.map((child) => (
@@ -241,28 +243,29 @@ function DocRow({
             </span>
           ) : null}
         </Link>
-        <button
-          type="button"
+        <IconButton
+          size="sm"
+          tone="muted"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
             onTogglePin(doc.slug);
           }}
-          aria-label={
+          label={
             pinned
               ? t("togglePinOff", { title: doc.title })
               : t("togglePinOn", { title: doc.title })
           }
           title={pinned ? t("pinTooltipOn") : t("pinTooltipOff")}
           className={cn(
-            "mr-1 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-opacity",
+            "mr-1 transition-opacity",
             pinned
               ? "text-[color:var(--color-indigo-accent)] opacity-100"
-              : "text-[color:var(--color-text-quaternary)] opacity-0 hover:text-[color:var(--color-indigo-accent)] group-hover:opacity-100 focus-visible:opacity-100",
+              : "opacity-0 hover:text-[color:var(--color-indigo-accent)] group-hover:opacity-100 focus-visible:opacity-100",
           )}
         >
           <Star size={12} fill={pinned ? "currentColor" : "none"} />
-        </button>
+        </IconButton>
       </div>
       {hasExcerpt && (
         // hover 시에만 렌더되는 본문 첫 단락 프리뷰. 터치 기기 (hover: none)
@@ -544,14 +547,14 @@ export function DocsQuickDrawer({
                     <BookOpen size={11} />
                     {t("openAllLabel")}
                   </Link>
-                  <button
-                    type="button"
+                  <IconButton
+                    label={t("closeAriaLabel")}
+                    size="lg"
                     onClick={onClose}
-                    aria-label={t("closeAriaLabel")}
-                    className="flex h-8 w-8 items-center justify-center rounded-chip text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-strong)]"
+                    className="hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-strong)]"
                   >
                     <X size={14} />
-                  </button>
+                  </IconButton>
                 </div>
               </div>
 
@@ -593,14 +596,15 @@ export function DocsQuickDrawer({
                   aria-label={t("filterAriaLabel")}
                 />
                 {query ? (
-                  <button
-                    type="button"
+                  <IconButton
+                    label={t("filterClearAriaLabel")}
+                    size="sm"
+                    tone="muted"
                     onClick={() => setQuery("")}
-                    aria-label={t("filterClearAriaLabel")}
-                    className="text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-primary)]"
+                    className="hover:text-[color:var(--color-text-primary)]"
                   >
                     <X size={13} aria-hidden />
-                  </button>
+                  </IconButton>
                 ) : null}
               </form>
 
@@ -614,7 +618,12 @@ export function DocsQuickDrawer({
                     <button
                       type="button"
                       onClick={() => setActiveTag(null)}
-                      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] bg-[color:var(--color-overlay-1)] px-2 py-1 text-caption text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]"
+                      className={controlClass({
+                        shape: "pill",
+                        size: "sm",
+                        className:
+                          "shrink-0 gap-1 hover:border-[color:var(--color-border-strong)] hover:text-[color:var(--color-text-primary)]",
+                      })}
                       aria-label={t("tagClearAriaLabel")}
                     >
                       <X size={10} />
@@ -631,12 +640,13 @@ export function DocsQuickDrawer({
                           setActiveTag((current) => (current === tag ? null : tag))
                         }
                         aria-pressed={selected}
-                        className={cn(
-                          "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-1 text-caption transition-colors",
-                          selected
-                            ? "border-[color:var(--color-indigo-a55)] bg-[color:var(--color-indigo-a16)] text-[color:var(--color-text-primary)]"
-                            : "border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-a34)] hover:text-[color:var(--color-text-primary)]",
-                        )}
+                        className={controlClass({
+                          shape: "pill",
+                          size: "sm",
+                          active: selected,
+                          className:
+                            "shrink-0 gap-1 hover:border-[color:var(--color-indigo-a34)] hover:text-[color:var(--color-text-primary)]",
+                        })}
                       >
                         <Hash size={9} />
                         <span className="max-w-[96px] truncate">{tag}</span>
@@ -781,7 +791,11 @@ export function DocsQuickDrawer({
                             setActiveTag(null);
                             searchRef.current?.focus();
                           }}
-                          className="inline-flex items-center gap-1 rounded-full border border-[color:var(--color-overlay-3)] px-2.5 py-1 text-label text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]"
+                          className={controlClass({
+                            shape: "pill",
+                            className:
+                              "gap-1 hover:border-[color:var(--color-indigo-a40)] hover:text-[color:var(--color-text-primary)]",
+                          })}
                         >
                           {t("clearFilters")}
                         </button>

--- a/src/widgets/docs-vault/ui/DocsVaultBacklinks.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultBacklinks.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@/entities/docs-vault';
 import { TopologyV2KindGlyph, isTopologyV2RenderableKind } from '@/shared/ui/topology-v2-kind-glyph';
 import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
+import { Chip, IconButton } from '@/shared/ui';
 
 interface Props {
   entries: VaultBacklinkEntry[];
@@ -52,11 +53,12 @@ export function DocsVaultBacklinks({
           const kind = doc.frontmatter?.kind;
           const kindStr = typeof kind === 'string' ? kind : '';
           return (
-            <button
+            <Chip
               key={entry.fromSlug}
-              type="button"
+              size="lg"
+              tone="secondary"
               onClick={() => onNavigate(doc.slug)}
-              className="inline-flex flex-none items-center gap-1.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1 text-body text-[color:var(--color-text-secondary)] transition-colors hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
+              className="flex-none hover:border-[color:var(--color-indigo-line-a40)] hover:text-[color:var(--color-text-primary)]"
             >
               {kindStr && isTopologyV2RenderableKind(kindStr) ? (
                 <TopologyV2KindGlyph kind={kindStr} size={11} />
@@ -66,7 +68,7 @@ export function DocsVaultBacklinks({
               <span className="max-w-[160px] truncate">
                 {resolveLocaleDisplayName(doc.frontmatter, locale, doc.title)}
               </span>
-            </button>
+            </Chip>
           );
         })}
       </div>
@@ -109,15 +111,16 @@ function BacklinkItem({
   return (
     <li className="rounded-sm border border-transparent transition-colors hover:border-[color:var(--color-overlay-2)]">
       <div className="flex items-stretch">
-        <button
-          type="button"
+        <IconButton
+          label={open ? t('collapse') : t('expand')}
+          size="sm"
+          tone="muted"
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
-          aria-label={open ? t('collapse') : t('expand')}
-          className="flex w-5 flex-none items-center justify-center text-[color:var(--color-text-quaternary)] transition-colors hover:text-[color:var(--color-text-secondary)]"
+          className="hover:text-[color:var(--color-text-secondary)]"
         >
           {open ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
-        </button>
+        </IconButton>
         <button
           type="button"
           onClick={() => onNavigate(doc.slug)}

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -24,6 +24,7 @@ import {
   X,
 } from 'lucide-react';
 import type { VaultDoc } from '@/entities/docs-vault';
+import { Chip, IconButton, RowButton } from '@/shared/ui';
 
 interface Props {
   doc: VaultDoc;
@@ -486,13 +487,12 @@ export function DocsVaultEditor({
         <div className="font-mono text-label text-[color:var(--color-text-quaternary)]">
           {error}
         </div>
-        <button
-          type="button"
+        <Chip
           onClick={requestClose}
-          className="mt-2 rounded-sm border border-[color:var(--color-divider)] px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
+          className="mt-2 hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
         >
           {t('close')}
-        </button>
+        </Chip>
       </div>
     );
   }
@@ -613,14 +613,10 @@ export function DocsVaultEditor({
           </span>
         </span>
         <div className="ml-auto flex items-center gap-1.5">
-          <button
-            type="button"
+          <Chip
+            active={preview}
             onClick={() => setPreview((v) => !v)}
-            className={`inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-label transition-colors ${
-              preview
-                ? 'border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-a08)] text-[color:var(--color-indigo-pale-a92)]'
-                : 'border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]'
-            }`}
+            className="hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
             aria-pressed={preview}
             title={t('previewTooltip')}
           >
@@ -630,12 +626,13 @@ export function DocsVaultEditor({
               <Eye size={11} aria-hidden />
             )}
             {t('preview')}
-          </button>
-          <button
-            type="button"
+          </Chip>
+          <Chip
+            active
+            tone="accent"
             onClick={() => void doSave()}
             disabled={saving || !dirty}
-            className="inline-flex items-center gap-1.5 rounded-sm border border-[color:var(--color-indigo-line-a35)] bg-[color:var(--color-indigo-a14)] px-2 py-1 text-label text-[color:var(--color-indigo-pale-a95)] transition-colors hover:border-[color:var(--color-indigo-line-a54)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="hover:border-[color:var(--color-indigo-line-a54)]"
             title={t('saveTooltip')}
           >
             {saving ? (
@@ -649,17 +646,16 @@ export function DocsVaultEditor({
                 {t('save')}
               </>
             )}
-          </button>
-          <button
-            type="button"
+          </Chip>
+          <Chip
             onClick={requestClose}
             disabled={saving}
-            className="inline-flex items-center gap-1 rounded-sm border border-transparent px-2 py-1 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="hover:border-[color:var(--color-overlay-3)] hover:text-[color:var(--color-text-primary)]"
             title={dirty ? t('closeUnsavedTooltip') : t('closeTooltip')}
           >
             <X size={11} aria-hidden />
             {dirty ? t('cancel') : t('closeAction')}
-          </button>
+          </Chip>
         </div>
       </div>
       {error ? (
@@ -807,19 +803,15 @@ export function DocsVaultEditor({
               <ul className="max-h-[220px] overflow-auto py-0.5">
                 {acMatches.map((d, idx) => (
                   <li key={d.slug}>
-                    <button
-                      type="button"
+                    <RowButton
+                      active={idx === autocomplete.active}
                       onMouseEnter={() =>
                         setAutocomplete((ac) =>
                           ac ? { ...ac, active: idx } : ac,
                         )
                       }
                       onClick={() => applyWikilink(d.slug)}
-                      className={`flex w-full items-center gap-2 px-2 py-1 text-left transition-colors ${
-                        idx === autocomplete.active
-                          ? 'bg-[color:var(--color-indigo-a14)]'
-                          : 'hover:bg-[color:var(--color-overlay-1)]'
-                      }`}
+                      className="hover:bg-[color:var(--color-overlay-1)]"
                     >
                       <span className="truncate text-body text-[color:var(--color-text-primary)]">
                         {d.title}
@@ -827,7 +819,7 @@ export function DocsVaultEditor({
                       <span className="ml-auto truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
                         {d.slug}
                       </span>
-                    </button>
+                    </RowButton>
                   </li>
                 ))}
               </ul>
@@ -931,14 +923,12 @@ function ToolbarButton({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
+    <IconButton
+      label={label}
       onClick={onClick}
-      title={label}
-      aria-label={label}
-      className="flex h-7 w-7 items-center justify-center rounded-sm transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+      className="hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
     >
       {icon}
-    </button>
+    </IconButton>
   );
 }

--- a/src/widgets/docs-vault/ui/DocsVaultTree.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultTree.tsx
@@ -18,6 +18,7 @@ import {
   type DocsTreeSort,
 } from '../lib/tree-order';
 import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
+import { RowButton } from '@/shared/ui';
 
 interface Props {
   tree: VaultTreeNode;
@@ -147,15 +148,11 @@ function TreeNode({
     if (!matchesQuery(node, query)) return null;
     const active = selectedSlug === node.slug;
     return (
-      <button
-        type="button"
+      <RowButton
+        active={active}
         onClick={() => onSelect(node.slug!)}
         aria-current={active ? 'page' : undefined}
-        className={`group relative flex w-full items-center gap-2 rounded-sm px-2 py-1 text-left text-body transition-[background-color,color,transform] motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-inset ${
-          active
-            ? 'bg-[color:var(--color-indigo-a12)] text-[color:var(--color-text-primary)]'
-            : 'text-[color:var(--color-text-tertiary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]'
-        }`}
+        className="group relative transition-[background-color,color,transform] motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a50)] focus-visible:ring-inset"
         style={{ paddingLeft: `${16 + depth * 12}px` }}
       >
         {active ? (
@@ -175,7 +172,7 @@ function TreeNode({
             node.title ?? node.name,
           )}
         </span>
-      </button>
+      </RowButton>
     );
   }
 
@@ -183,11 +180,11 @@ function TreeNode({
   const docCount = countDocs(node);
   return (
     <div>
-      <button
-        type="button"
+      <RowButton
+        tone="muted"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        className="flex w-full items-center gap-1.5 rounded-sm px-2 py-1 text-left text-body font-medium text-[color:var(--color-text-quaternary)] transition-[background-color,color,transform] motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
+        className="font-medium transition-[background-color,color,transform] motion-safe:hover:-translate-y-px motion-safe:active:translate-y-0 motion-safe:active:scale-[0.99] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-secondary)]"
         style={{ paddingLeft: `${16 + depth * 12}px` }}
       >
         {open ? (
@@ -205,7 +202,7 @@ function TreeNode({
             {docCount}
           </span>
         ) : null}
-      </button>
+      </RowButton>
       {(open || activeTagSlugs || query) && node.children ? (
         <div>
           {sortDocsTreeNodes(node.children, order).map((child) => (

--- a/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultUnifiedPalette.tsx
@@ -16,7 +16,7 @@ import {
   X,
 } from 'lucide-react';
 import { buildDocsVaultHref, type VaultDoc } from '@/entities/docs-vault';
-import { LiveAnnouncer } from '@/shared/ui';
+import { IconButton, LiveAnnouncer, controlClass } from '@/shared/ui';
 import { searchDocs, type DocsSearchMatch } from '../lib/search';
 import type { DocsBodyIndex } from '../lib/body-index';
 import { githubBlobUrl } from '../lib/resolve-doc-link';
@@ -531,14 +531,15 @@ export function DocsVaultUnifiedPalette({
             }
             className="min-w-0 flex-1 bg-transparent text-body text-[color:var(--color-text-primary)] placeholder:text-[color:var(--color-text-quaternary)] focus:outline-none"
           />
-          <button
-            type="button"
+          <IconButton
+            label={t('closeAriaLabel')}
+            size="sm"
+            tone="muted"
             onClick={onClose}
-            aria-label={t('closeAriaLabel')}
-            className="flex h-6 w-6 items-center justify-center rounded-sm text-[color:var(--color-text-quaternary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
+            className="hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]"
           >
             <X size={12} />
-          </button>
+          </IconButton>
         </div>
         <ul
           ref={listRef}
@@ -666,11 +667,14 @@ function ResultRow({
   onClose: () => void;
   getDocHref: (slug: string) => string;
 }) {
-  const base = `group relative flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors ${
-    active
-      ? 'bg-[color:var(--color-indigo-a14)]'
-      : 'hover:bg-[color:var(--color-overlay-1)]'
-  }`;
+  // 같은 행이 문서면 <Link>, 아니면 <button> 으로 난다 — 둘 다 같은 값 층을
+  // 통과해야 팔레트 안에서 행 높이가 갈리지 않는다.
+  const base = controlClass({
+    shape: 'row',
+    active,
+    className:
+      'group relative hover:bg-[color:var(--color-overlay-1)]',
+  });
   const inner = (
     <>
       {active ? (
@@ -727,7 +731,12 @@ function ResultRow({
         row.onRun();
         onClose();
       }}
-      className={base}
+      className={controlClass({
+        shape: 'row',
+        active,
+        className:
+          'group relative hover:bg-[color:var(--color-overlay-1)]',
+      })}
     >
       {inner}
     </button>

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
@@ -12,6 +12,7 @@ import {
   type VaultDoc,
 } from '@/entities/docs-vault';
 import { useStaticVaultSource } from '@/features/vault-sample-source';
+import { IconButton } from '@/shared/ui';
 import { splitHighlightSegments } from '@/shared/lib/highlight-match';
 import { useCopyFeedback } from '@/shared/lib/use-copy-feedback';
 import { fetchServerDocContent } from '../lib/server-doc-content';
@@ -778,20 +779,22 @@ function HeadingAnchor({
     await copy(url.toString());
   };
   return (
-    <button
-      type="button"
+    <IconButton
+      label={copied ? t('anchorCopiedAria') : t('anchorCopyAria')}
+      size="lg"
+      tone="muted"
+      active={copied}
       onClick={onClick}
-      aria-label={copied ? t('anchorCopiedAria') : t('anchorCopyAria')}
       title={copied ? t('anchorCopiedTitle') : t('anchorCopyTitle')}
-      className={`absolute right-0 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-chip transition-[background-color,color,opacity] sm:-left-9 sm:right-auto ${
+      className={`absolute right-0 top-1/2 -translate-y-1/2 transition-[background-color,color,opacity] sm:-left-9 sm:right-auto ${
         copied
-          ? 'text-[color:var(--color-indigo-line-a90)] opacity-100'
-          : 'text-[color:var(--color-text-quaternary)] opacity-100 hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-indigo-line-a90)] sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100'
+          ? 'opacity-100'
+          : 'opacity-100 hover:bg-[color:var(--color-indigo-line-a06)] hover:text-[color:var(--color-indigo-line-a90)] sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100'
       }`}
       contentEditable={false}
     >
       <Hash size={11} aria-hidden />
-    </button>
+    </IconButton>
   );
 }
 

--- a/tests/contract/control-adoption-ratchet.contract.test.ts
+++ b/tests/contract/control-adoption-ratchet.contract.test.ts
@@ -54,8 +54,9 @@ const ROOTS = ['src', 'app'];
  * | 417 | 2026-08-03 최초 실측 |
  * | **406** | 설정 시트(`src/widgets/app-settings-menu/**`) 11개 — 칩 6 · 아이콘 2 · 행 1 · 링크형 1 (+ 그중 하나는 눌림 상태를 `active` 로 넘김) |
  * | **389** | 지도 두 위젯(`topology-map-v2` · `topology-index-panel`) 31개 중 17개 — 행 8 · 링크형 5 · 아이콘 3 · 카드 2 · 칩 1. 남긴 14개는 여섯 분류에 **없는** 모양(세로 액션 타일 5 · 세그먼트 탭 3 · 창 선택 칩 · 세로 엣지 탭 · 캔버스 앵커 원형 버튼 · 트리 셰브론)이거나, 램프의 최소 인셋(8px)이 이 패널의 4px 인셋과 어긋나 헤더가 자기 행들과 어긋나는 자리(2)다 |
+ * | **303** | 문서함 · 빠른 서랍 · 공방(`views/docs-vault` · `widgets/docs-vault` · `widgets/docs-quick-drawer` · `views/ontology-studio`) 121개 중 86개 — 행 27 · 아이콘 24 · 칩 21 · 링크형 13 · pill 4 · 카드 2. 남긴 35개는 넷으로 갈린다: ① **크롬 토큰 계약**(`--chrome-tile-size` · `--docs-header-tile-size` · `--overlay-close-size`)을 지는 자리 4 — 램프가 아니라 크롬이 규격이다 ② **나침 무대의 절대배치 기하**(소켓 · 레인 접기 · 더 잇기 · 고정 높이 30/32 툴바) 15 — 이 표면의 문법이 따로 있고 `studio-navigation` 스펙이 그 치수를 계약으로 잡는다 ③ **한 벌로 읽혀야 하는 세트**(첫 실행 선택 행 4 + 최근 볼트 grid 행 1, 다중행 `items-start` 라 `row`(단행 `items-center`)에 안 맞는다) 11 ④ **문장·바 속 인라인 컨트롤** 5 — `link` 이 `min-h-11`(WCAG 2.5.8)을 실으면서 글줄 안에서는 줄 상자를 44px 로 밀어 올린다(실측 21.3 → 44). 시각 크기와 히트 영역이 다른 축이라는 상류 판단은 옳고, 다만 그 해법이 «문장 속» 이라는 세 번째 축을 아직 안 본다 |
  */
-const BASELINE_HAND_WRITTEN_CONTROLS = 389;
+const BASELINE_HAND_WRITTEN_CONTROLS = 303;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {

--- a/tests/e2e/a11y-ratchet.spec.ts
+++ b/tests/e2e/a11y-ratchet.spec.ts
@@ -53,14 +53,18 @@ const ROUTES = [
  * |---|---|---|
  * | `color-contrast` | 12 | 인디고 면 위 흰 글자 4.42:1 · `text-quaternary` 4.31:1 등. `scripts/measure-contrast.mjs` 가 독립적으로 같은 결함군을 지목한다 |
  * | `aria-required-children` | 1 | `role="tablist"` 가 `role="tab"` 자식을 안 갖는다 |
- * | `target-size` | 1 | WCAG 2.2 §2.5.8 — 24px 미만이고 여백도 부족 |
+ * | ~~`target-size`~~ | ~~1~~ → **0** | WCAG 2.2 §2.5.8 — 24px 미만이고 여백도 부족.
+ *   2026-08-03 문서함/서랍 컨트롤 정규화로 사라졌다: `p-1`/`p-0.5` 로 크기를
+ *   내용에 맡기던 아이콘 컨트롤들이 `IconButton`(24/28/32 고정)으로 넘어가면서
+ *   가장 작은 것이 24px 바닥을 갖게 됐다. **값 층이 바닥을 소유하면 자리마다
+ *   빠뜨릴 수 없다** — 이 항목이 그 증거다 |
  *
  * **이 숫자는 내려가기만 한다.**
  */
 const BASELINE: Readonly<Record<string, number>> = {
   "color-contrast": 12,
   "aria-required-children": 1,
-  "target-size": 1,
+  "target-size": 0,
 };
 
 test("접근성 래칫 — 새 룰 위반 0, 기존 개수는 늘지 않는다", async ({ page }) => {


### PR DESCRIPTION
## Summary

문서함(`views/docs-vault` · `widgets/docs-vault`) · 빠른 서랍(`widgets/docs-quick-drawer`) · 공방(`views/ontology-studio`)의 생 `<button>` **121개 중 86개**를 `Chip` / `IconButton` / `RowButton` / `controlClass()` 위로 올렸다.

모양별: 행 25 · 아이콘 24 · 칩 21 · 링크형 10 · pill 4 · 카드 2.

**왜 지금 이게 문제였나.** 같은 목록 행이 파일마다 `rounded-sm` · `rounded-[8px]` · 반경 없음으로 갈렸고, 공방 고르기 팝오버의 행 14개는 `text-*` 가 아예 없어 **루트 16px** 로 렌더되고 있었다 — 클래스가 없으면 리터럴도 안 남아서 어떤 값 lint 도 이걸 못 본다(`design.md` 가 말하는 «미정의 스텝은 침묵한다» 그대로). 옮긴 뒤 그 14개는 **36px · px10 · py8 · gap8 · r6 · 12.5px 로 전부 동일**하다.

## 픽셀 변화 (실측 · 1440×900 정적 export, `/ko/docs` · `/ko/ontology/studio`)

| 컨트롤 | before | after |
|---|---|---|
| 문서 트리·목록 행 (4곳) | h 28 · py 4 · r 4 | **h 36 · py 8 · r 6** |
| 공방 고르기 팝오버 행 (14개) | r 8 · gap 10 · **fs 16(램프 밖)** | **r 6 · gap 8 · fs 12.5** |
| 사이드바 레일 아이콘 토글 (6개) | 24×24 + 1px 보더 | 24×24 · **보더 0**(`icon` 은 보더가 없다) |
| 레일 토글 활성 | 인디고 보더+`indigo-a16` | `overlay-2` + 1차 텍스트 |
| 탭 닫기 × | 20×20 · r 4 | **24×24 · r 6** (WCAG 2.5.8 통과) |
| 소스 세그먼트 (샘플/로컬) | h 32 · px 12 · 보더 0 | **h 30 · px 10 · 보더 1px** |
| 볼트 칩 | h 28 · px 8 | **h 30 · px 10** |
| 백링크 칩 | h 30 · px 10 | **h 34 · px 12** (색은 `tone="secondary"` 로 유지) |
| 규격 예시 토글 | h 16 | **h 44** (`link` 최소 높이) |
| 공방 진입 보조 링크 2개 | h 26 / 28 | **h 44** |

대비 실측 `node scripts/measure-contrast.mjs` — 두 라우트 **미달 0건** (전/후 동일).

## 게이트

- **컨트롤 래칫 389 → 303.** 전수를 다시 세서 내렸고, 「내려온 기록」 표에 한 줄 추가.
- **접근성 래칫 `target-size` 1 → 0.** `p-1`/`p-0.5` 로 크기를 내용에 맡기던 아이콘 컨트롤이 `IconButton`(24/28/32 고정)으로 넘어가며 사라졌다. 값 층이 바닥을 소유하면 자리마다 빠뜨릴 수 없다.
- **`--color-danger-a42` 삭제.** danger 톤으로 옮기며 소비처가 0이 됐고 `unused-token-ratchet` 이 그 자리에서 잡았다. 죽은 토큰은 규격이 아니라 오정보다.

## 값 층에 남은 구멍 하나 — 「인라인」 축

`link` 이 실은 `min-h-11`(WCAG 2.5.8)은 **문장 속 컨트롤**에서 줄 상자를 통째로 밀어 올린다 — frontmatter 참조를 옮겼더니 **21.3 → 44px** 였다(실측). 시각 크기와 히트 영역이 다른 축이라는 상류 판단은 옳고, 다만 그 해법이 «글줄 안» 이라는 세 번째 축을 아직 안 본다. 해당 5개(frontmatter 참조 · 공방 유사노드 힌트 3 · 사이드바 필터 바)는 **남기고 사유를 코드에 적었다**.

## 남긴 35개 — 우연이 아니라 분류다

| 사유 | 개수 |
|---|---:|
| 나침 무대의 절대배치 기하 (소켓 · 레인 접기 · 더 잇기 · 고정 높이 30/32 툴바) | 18 |
| 한 벌로 읽혀야 하는 다중행 세트 (첫 실행 선택 4 + 최근 볼트 grid 1) | 5 |
| 문장·바 속 인라인 컨트롤 (위 참조) | 5 |
| 크롬 토큰 계약 (`--chrome-tile-size` · `--docs-header-tile-size` · `--overlay-close-size`) | 4 |
| 기타 (탭 본체의 비대칭 인셋 등) | 3 |

공방 툴바는 `studio-navigation.spec.ts` 의 「공방 크롬이 스케일 계약을 지킨다」가 그 치수를 이미 계약으로 잡고 있어 건드리지 않았다.

## Test plan

- `pnpm exec tsc --noEmit` ✅
- `pnpm lint` ✅ 0 errors · 92 warnings (**main 과 동일** — 전/후 각각 측정해 대조)
- `pnpm exec vitest run src/views/docs-vault src/widgets/docs-vault src/views/ontology-studio src/widgets/docs-quick-drawer` ✅ 60 files · 595 tests
- `pnpm test:contracts` ✅ 103 files · 1191 tests (`control-adoption-ratchet` · `unused-token-ratchet` 포함)
- `pnpm desktop:check` ✅
- `pnpm build` → `node scripts/serve-static-export.mjs --port=4196` 위에서:
  - `pnpm exec playwright test a11y-ratchet · studio-navigation · studio-fill-arrival · web-surface-smoke · touch-target-contract` ✅ 20 passed
  - `node scripts/measure-contrast.mjs` ✅ 미달 0
  - rect·computed style 전/후 대조 (위 표)
- `pnpm checks:changed` 가 권한 목록 전부 실행

정적 export 로 띄워 확인한 이유: 공방은 dev 서버에서 안 드러나는 라우팅 결함 전례가 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275