### PR TITLE
refactor: 뷰 라운드 — 인사이트 컨트롤 10개를 램프로, 269 → 259

### DIFF
--- a/src/views/ontology-insights/ui/parts/QueueRowActions.tsx
+++ b/src/views/ontology-insights/ui/parts/QueueRowActions.tsx
@@ -5,6 +5,7 @@ import { useCopyFeedback } from "@/shared/lib/use-copy-feedback";
 import { Check, Copy, FileText, GitBranch, MessageCircle, MoreHorizontal } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { copyText } from "@/shared/lib/copy-text";
+import { controlClass } from "@/shared/ui/control-class";
 
 /**
  * 「할 일」 큐 행의 행동 — 주 액션(지도)만 밖에 두고 나머지는 케밥 안으로.
@@ -97,9 +98,19 @@ export function HandoffCopyButton({
           if (candidate) onReviewStart?.(candidate);
           await copyHandoff(payload);
         }}
-        className={`inline-flex items-center gap-1 rounded-chip border border-[color:var(--color-border-soft)] text-label text-[color:var(--color-text-tertiary)] transition-colors hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)] ${
-          compact ? "min-h-7 px-2" : "min-h-8 px-2.5"
-        }`}
+        /**
+         * `compact` 는 이제 **높이 축**만 고른다. 한 줄 행에 얹히는 자리는
+         * 램프 기본(패딩이 높이를 정한다 = 30px), 홀로 서는 자리는
+         * `fixedHeight`(크롬 계약의 32px). 손으로 쓰던 28/32 중 28은 램프에
+         * 스텝이 없어 30으로 올라간다 — 그게 이 정규화의 값이다.
+         */
+        className={controlClass({
+          shape: "chip",
+          size: "md",
+          fixedHeight: !compact,
+          className:
+            "hover:border-[color:var(--color-indigo-a46)] hover:text-[color:var(--color-text-primary)]",
+        })}
       >
         {copied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
         {copyState === "failed"
@@ -172,8 +183,21 @@ export function RowActionMenu({
     };
   }, [open]);
 
-  const menuItemClass =
-    "flex items-center gap-2 rounded-chip px-2.5 py-1.5 text-left text-label text-[color:var(--color-text-secondary)] transition-colors hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]";
+  /**
+   * 메뉴 한 항목 = 목록의 한 줄 → `row`. `<Link>` 와 `<button>` 이 같은
+   * 문자열을 쓰므로 상수 하나로 묶는다(둘이 갈리면 메뉴 안에서 항목마다
+   * 높이가 달라진다). 램프가 안 내는 호버 잉크만 여기 남는다.
+   *
+   * `row` 가 `w-full` 을 싣지만 이 메뉴는 이미 `flex-col`(= stretch)이라
+   * 폭은 바뀌지 않는다.
+   */
+  const menuItemClass = controlClass({
+    shape: "row",
+    size: "sm",
+    tone: "secondary",
+    className:
+      "hover:bg-[color:var(--color-overlay-2)] hover:text-[color:var(--color-text-primary)]",
+  });
 
   return (
     <div ref={containerRef} className="relative">

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -26,6 +26,26 @@ import {
 import type { MeaningGapKind } from "@/entities/knowledge-graph";
 import { MeaningGapSection, type MeaningGapLabels } from "./MeaningGapSection";
 import { InsightsSectionTitle } from "../parts/InsightsSectionTitle";
+import { controlClass } from "@/shared/ui/control-class";
+
+/**
+ * 「접어 둔 나머지」를 여는 **조용한 토글**의 완성 클래스.
+ *
+ * 이 탭에 두 자리(중복 나머지 · 수리 큐 나머지)가 있고, 같은 문법이
+ * 「연결」 탭 영향 랭킹과 「신선도」 탭 근거 계층에도 있다 — 같은 종류의
+ * 절단은 같게 보여야 하므로 값이 갈리면 안 된다. 모양·크기·색은 램프가
+ * 내고(`row`/`sm`/`default` = 28px · text-label · 3차), 여기 남는 것은
+ * 램프가 일부러 안 내는 **호버 잉크**와 이 자리의 **음수 마진**뿐이다.
+ *
+ * `-mx-2` 는 램프 인셋(`px-2`)과 짝이다 — 글자 x 좌표를 형제 행들과
+ * 맞춘 채 히트 영역만 좌우로 넓힌다.
+ */
+const QUIET_REST_TOGGLE = controlClass({
+  shape: "row",
+  size: "sm",
+  className:
+    "-mx-2 mt-1 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]",
+});
 
 /**
  * 탭1 "할 일" (S5, 전략 verdict B 채택) — 인사이트의 기본 탭. "무엇이
@@ -559,7 +579,7 @@ function DuplicateSection({
           aria-expanded={restOpen}
           data-testid="do-next-duplicate-rest-toggle"
           onClick={() => setRestOpen((open) => !open)}
-          className="-mx-1.5 mt-1 flex min-h-7 w-full items-center gap-1.5 rounded-chip px-1.5 text-left text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+          className={QUIET_REST_TOGGLE}
         >
           {restOpen ? (
             <ChevronDown aria-hidden size={13} className="flex-none" />
@@ -1205,7 +1225,7 @@ export function DoNextTab({
                     aria-expanded={repairTargetsOpen}
                     data-testid="insights-repair-queue-rest-toggle"
                     onClick={() => setRepairTargetsOpen((open) => !open)}
-                    className="-mx-1.5 mt-1 flex min-h-7 w-full items-center gap-1.5 rounded-chip px-1.5 text-left text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+                    className={QUIET_REST_TOGGLE}
                   >
                     {repairTargetsOpen ? (
                       <ChevronDown aria-hidden size={13} className="flex-none" />

--- a/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/FreshnessTab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { formatDate } from "@/shared/lib/format-date";
 import { EvidenceOnlyBadge, TopologyV2KindGlyph } from "@/shared/ui";
+import { controlClass } from "@/shared/ui/control-class";
 import { RecentNodeRow } from "@/widgets/recent-node-row";
 import type { DomainFreshnessRow, RecentUpdateRow } from "../../lib/freshness";
 import { InsightsSectionTitle } from "../parts/InsightsSectionTitle";
@@ -220,7 +221,15 @@ export function FreshnessTab({
               aria-expanded={evidenceOpen}
               data-testid="insights-freshness-evidence-toggle"
               onClick={() => setEvidenceOpen((open) => !open)}
-              className="-mx-1.5 flex min-h-7 w-full items-center gap-1.5 rounded-chip px-1.5 text-left text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+              // 「할 일」·「연결」 탭의 조용한 토글과 **같은 램프 호출**이다 —
+              // 같은 종류의 절단은 같게 보여야 한다. 남는 것은 램프가 일부러
+              // 안 내는 호버 잉크와 인셋(`px-2`)의 짝인 음수 마진뿐이다.
+              className={controlClass({
+                shape: "row",
+                size: "sm",
+                className:
+                  "-mx-2 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]",
+              })}
             >
               {evidenceOpen ? (
                 <ChevronDown aria-hidden size={13} className="flex-none" />

--- a/src/views/ontology-insights/ui/tabs/ImpactRankingCard.tsx
+++ b/src/views/ontology-insights/ui/tabs/ImpactRankingCard.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronRight, Radar } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { cn } from "@/shared/lib/cn";
 import { EmptyState, EvidenceOnlyBadge, TopologyV2KindGlyph } from "@/shared/ui";
+import { controlClass } from "@/shared/ui/control-class";
 import type { ImpactRankingRow } from "../../lib/impact-ranking";
 import { InsightsBar } from "../parts/InsightsBar";
 import { InsightsSectionTitle } from "../parts/InsightsSectionTitle";
@@ -151,9 +152,15 @@ export function ImpactRankingCard({
             aria-expanded={evidenceOpen}
             data-testid="insights-impact-evidence-toggle"
             onClick={() => setEvidenceOpen((open) => !open)}
-            // 같은 탭의 다른 작은 컨트롤(행별 인계 복사)과 같은 min-h-7 —
-            // 25px 짜리 글자 폭 히트영역은 이 카드에서 유일한 조작점이라 좁다.
-            className="-mx-1.5 flex min-h-7 w-full items-center gap-1.5 rounded-chip px-1.5 text-left text-label text-[color:var(--color-text-tertiary)] transition-colors hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+            // 25px 짜리 글자 폭 히트영역은 이 카드에서 유일한 조작점이라 좁다 —
+            // 램프의 `row`/`sm` 이 같은 28px 를 내면서 인셋을 6 → 8 로 넓힌다.
+            // 「할 일」·「신선도」 탭의 조용한 토글과 같은 호출이다.
+            className={controlClass({
+              shape: "row",
+              size: "sm",
+              className:
+                "-mx-2 hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]",
+            })}
           >
             {evidenceOpen ? (
               <ChevronDown aria-hidden size={13} className="flex-none" />

--- a/src/views/ontology-insights/ui/tabs/MeaningGapSection.tsx
+++ b/src/views/ontology-insights/ui/tabs/MeaningGapSection.tsx
@@ -6,6 +6,7 @@ import { Link } from "@/i18n/navigation";
 import { useRowDisclosure } from "@/shared/lib/use-row-disclosure";
 import { MtimeConflictBadge } from "@/shared/ui/mtime-conflict-badge";
 import { TopologyV2KindGlyph } from "@/shared/ui/topology-v2-kind-glyph";
+import { controlClass } from "@/shared/ui/control-class";
 import type { MeaningGapKind } from "@/entities/knowledge-graph";
 import type { DomainChoice, MeaningGapRow } from "../../lib/meaning-gap-rows";
 import {
@@ -36,6 +37,21 @@ import { InsightsSectionTitle } from "../parts/InsightsSectionTitle";
  * - **모션은 목록 행 펼침 문법 하나만 쓴다**(`.ai-row-disclosure`,
  *   `app/globals.css`) — 아래로만 자라고, 나가는 길이 들어온 길과 같다.
  */
+
+/**
+ * 이 섹션 인디고 칩들의 **잉크** — 값 층(`controlClass`)이 일부러 안 내는 층.
+ *
+ * 램프의 `tone` 은 **글자색만** 낸다(`control-class.ts`). 테두리·배경 틴트와
+ * 호버는 아직 램프에 없으므로 소비처가 갖는다. 같은 문자열이 세 자리에 흩어져
+ * 있었고, 손으로 세 번 쓰면 언젠가 한 벌이 갈린다 — 상수로 묶어 그 갈림을
+ * 없앤다. 값은 **한 글자도 새로 만들지 않았다**(기존 `--color-indigo-line-*`).
+ */
+const ACCENT_CHIP_IDLE =
+  "border-[color:var(--color-indigo-line-a22)] hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]";
+const ACCENT_CHIP_OPEN =
+  "border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)]";
+const ACCENT_CHIP_FILLED =
+  "font-medium border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)] hover:border-[color:var(--color-indigo-line-a45)]";
 
 export interface MeaningGapLabels extends QueueRowActionLabels {
   sectionTitle: string;
@@ -353,11 +369,17 @@ function MeaningGapRowView({
               data-testid="meaning-gap-write-toggle"
               aria-expanded={open}
               onClick={() => (open ? requestClose() : onOpen())}
-              className={`inline-flex min-h-8 items-center gap-1 rounded-chip border px-2.5 text-label transition-colors ${
-                open
-                  ? "border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)] text-[color:var(--color-indigo-accent)]"
-                  : "border-[color:var(--color-indigo-line-a22)] text-[color:var(--color-indigo-accent)] hover:border-[color:var(--color-indigo-line-a42)] hover:bg-[color:var(--color-indigo-line-a13)]"
-              }`}
+              /* 이 칩은 **열림 여부와 무관하게 강조**다 — 선택(`active`)이 아니라
+                 disclosure 라서 램프의 눌림 잉크가 아니라 `tone: 'accent'` 를
+                 쓴다. 높이는 `fixedHeight` 로 32px 를 그대로 지킨다(램프 기본
+                 패딩은 30px 을 내고, 이 행은 옆 컨트롤들과 한 줄에 선다). */
+              className={controlClass({
+                shape: "chip",
+                size: "md",
+                tone: "accent",
+                fixedHeight: true,
+                className: open ? ACCENT_CHIP_OPEN : ACCENT_CHIP_IDLE,
+              })}
             >
               <Pencil size={11} aria-hidden />
               {open ? labels.writeHereClose : labels.writeHere}
@@ -460,11 +482,19 @@ function MeaningGapRowView({
                               onClick={() =>
                                 onPatch({ value: choice.value, cancelArmed: false })
                               }
-                              className={`inline-flex min-h-8 items-center rounded-chip border px-2.5 text-label transition-colors ${
-                                active
-                                  ? "border-[color:var(--color-indigo-line-a45)] bg-[color:var(--color-indigo-line-a13)] text-[color:var(--color-indigo-accent)]"
-                                  : "border-[color:var(--color-border-soft)] text-[color:var(--color-text-tertiary)] hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
-                              }`}
+                              /* 여기는 **선택**이다(`aria-pressed` 와 짝) —
+                                 그래서 잉크를 손으로 쓰지 않고 램프의 `active`
+                                 를 쓴다. 눌림은 이 앱 전역에서 한 벌이어야
+                                 하고, 그 한 벌을 소유하는 곳이 값 층이다. */
+                              className={controlClass({
+                                shape: "chip",
+                                size: "md",
+                                active,
+                                fixedHeight: true,
+                                className: active
+                                  ? ""
+                                  : "hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]",
+                              })}
                             >
                               {choice.label}
                             </button>
@@ -488,7 +518,15 @@ function MeaningGapRowView({
                       data-testid="meaning-gap-save"
                       onClick={() => onSave(ui.value.trim())}
                       disabled={!canSave}
-                      className="inline-flex min-h-8 items-center rounded-chip border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-indigo-line-a13)] px-2.5 text-label font-medium text-[color:var(--color-indigo-accent)] transition-colors hover:border-[color:var(--color-indigo-line-a45)] disabled:opacity-50"
+                      /* 비활성 어포던스도 램프가 가져간다 — 손으로 쓴
+                         `disabled:opacity-50` 은 커서도 호버도 안 껐다. */
+                      className={controlClass({
+                        shape: "chip",
+                        size: "md",
+                        tone: "accent",
+                        fixedHeight: true,
+                        className: ACCENT_CHIP_FILLED,
+                      })}
                     >
                       {saving ? labels.saving : labels.save}
                     </button>
@@ -497,7 +535,12 @@ function MeaningGapRowView({
                       data-testid="meaning-gap-cancel"
                       onClick={requestClose}
                       disabled={saving}
-                      className="inline-flex min-h-8 items-center rounded-chip border border-[color:var(--color-border-soft)] px-2.5 text-label text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-primary)] disabled:opacity-50"
+                      className={controlClass({
+                        shape: "chip",
+                        size: "md",
+                        fixedHeight: true,
+                        className: "hover:text-[color:var(--color-text-primary)]",
+                      })}
                     >
                       {labels.cancel}
                     </button>

--- a/tests/contract/control-adoption-ratchet.contract.test.ts
+++ b/tests/contract/control-adoption-ratchet.contract.test.ts
@@ -57,6 +57,7 @@ const ROOTS = ['src', 'app'];
  * | **303** | 문서함 · 빠른 서랍 · 공방(`views/docs-vault` · `widgets/docs-vault` · `widgets/docs-quick-drawer` · `views/ontology-studio`) 121개 중 86개 — 행 27 · 아이콘 24 · 칩 21 · 링크형 13 · pill 4 · 카드 2. 남긴 35개는 넷으로 갈린다: ① **크롬 토큰 계약**(`--chrome-tile-size` · `--docs-header-tile-size` · `--overlay-close-size`)을 지는 자리 4 — 램프가 아니라 크롬이 규격이다 ② **나침 무대의 절대배치 기하**(소켓 · 레인 접기 · 더 잇기 · 고정 높이 30/32 툴바) 15 — 이 표면의 문법이 따로 있고 `studio-navigation` 스펙이 그 치수를 계약으로 잡는다 ③ **한 벌로 읽혀야 하는 세트**(첫 실행 선택 행 4 + 최근 볼트 grid 행 1, 다중행 `items-start` 라 `row`(단행 `items-center`)에 안 맞는다) 11 ④ **문장·바 속 인라인 컨트롤** 5 — `link` 이 `min-h-11`(WCAG 2.5.8)을 실으면서 글줄 안에서는 줄 상자를 44px 로 밀어 올린다(실측 21.3 → 44). 시각 크기와 히트 영역이 다른 축이라는 상류 판단은 옳고, 다만 그 해법이 «문장 속» 이라는 세 번째 축을 아직 안 본다 |
  *
  * | **269** | 위 두 라운드가 「자리가 없어서」 남긴 48개의 회수 — 값 층의 구멍 넷을 메운(`a1f956ce9`) 직후다. 설정 시트 29(칩 24 · 타일 2 · 링크형 3) + 지도 액션 타일 5. `tone` 의 새 넷(secondary 6 · accent 11 · success 2 · warning 2 · danger 1)이 22개를, `shape: 'tile'` 이 7개를, `link` 의 `min-h-11` 이 3개를 열었다 |
+ * | **259** | 뷰 라운드 — `src/views/{ontology-insights,download,first-run,git,project-*,gateway-doc,root-entry}` 18개 중 10개. 행 6(조용한 「나머지 보기」 토글 4 + 케밥 메뉴 항목 1 + 그 항목을 쓰는 `<Link>` 3) · 칩 5(의미 공백 쓰기 토글 · 도메인 선택 · 저장 · 취소 · 인계 복사). **여기서 처음으로 `row`/`sm` 이 손으로 쓰던 높이와 정확히 같았다** — `py-1.5`+`--leading-label`(16px) = 28px = `min-h-7`. 램프가 오늘 화면을 맞힌 첫 자리다 |
  *
  * ## 남은 것을 왜 안 옮겼나 — 이 목록이 다음 라운드의 입력이다
  *
@@ -75,6 +76,26 @@ const ROOTS = ['src', 'app'];
  * 나머지 6(세그먼트 탭 3 · 창 선택 칩 · 세로 엣지 탭 · 캔버스 앵커 원형 버튼 ·
  * 트리 셰브론)은 일곱 모양 어디에도 없다.
  *
+ * 뷰 라운드가 남긴 8개(2026-08-03)는 **값 층의 새 구멍 셋**을 가리킨다:
+ *
+ * 1. **보더 있는 아이콘 정사각이 없다** — `icon` 은 정의상 보더가 없다
+ *    (`「link`/`row`/`icon` 은 보더가 없다」). 그런데 큐 행의 케밥 트리거는
+ *    `h-8 w-8` + `border` 다. 보더를 `className` 으로 넣으면 **모양을 넘기는
+ *    것**이라 층이 무력해진다(1 — `QueueRowActions` 케밥).
+ * 2. **28px 칩 스텝이 없다** — 칩 램프는 24(sm)/30(md)/32(fixedHeight)를 내는데
+ *    저장소에는 `rounded-chip` + `h-7`/`min-h-7` 이 18곳 있다. 이번에 옮긴
+ *    인계 복사 칩의 compact 도 28 → 30 으로 올라갔다. `row` 는 28 을 정확히
+ *    내는데 칩은 못 낸다 — 축이 갈린 것이지 값이 틀린 게 아니다
+ *    (1 — `/download` 체크섬 복사. 관문 표면이라 4px 을 옮기지 않았다).
+ * 3. **`card` 가 단행(`items-center`) 고정이다** — 아이콘 + 제목 + 설명 두 줄인
+ *    선택 카드는 `items-start` 여야 한다. 첫 실행 3개가 여기서 걸린다
+ *    (3 — `FirstRunPage`). 앞 라운드의 「한 벌로 읽혀야 하는 세트」와 같은 구멍이
+ *    두 번째로 나왔으니 다음 라운드는 이걸 먼저 본다.
+ *
+ * 나머지 3(에이전트 복사 칩의 `font-mono` + `active:translate-y` 방언 ·
+ * 데모 영상 위 전면 오버레이 재생 버튼 · 도메인 결합 히트맵의 `role="gridcell"`)
+ * 은 일곱 모양 어디에도 없다.
+ *
  * ## 이 수가 **과다 계상**이라는 것 — 알고 두는 한계
  *
  * 세는 것은 여는 태그 안의 **리터럴** `controlClass(` 다. 그래서 램프를 통과한
@@ -83,7 +104,7 @@ const ROOTS = ['src', 'app'];
  * **공유 상수로 뽑는 옳은 리팩터에 벌점을 준다.** 그래서 이 라운드는 잉크만
  * 상수로 공유하고 램프 호출은 자리마다 인라인으로 썼다.
  */
-const BASELINE_HAND_WRITTEN_CONTROLS = 269;
+const BASELINE_HAND_WRITTEN_CONTROLS = 259;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {


### PR DESCRIPTION
## Summary

`src/views` (home · docs-vault · 공방 제외) 의 손 className `<button>` **18개 중 10개**를 `controlClass()` 로 옮겼다. 래칫 기준선 **269 → 259**.

모양/톤 분포: `row` 6 (조용한 「나머지 보기」 토글 4 + 케밥 메뉴 항목 1, 그 항목을 공유하는 `<Link>` 3 포함) · `chip` 5 (쓰기 토글 · 도메인 선택 · 저장 · 취소 · 인계 복사). 톤은 `default` 6 · `accent` 2 · `secondary` 1 · `active` 1.

**이 라운드가 처음 확인한 것**: 앞선 네 라운드의 전환은 전부 「픽셀이 바뀐다」로 시작했는데, 조용한 토글 4개는 `row`/`sm` 이 **정확히 같은 28px** 를 냈다 — `py-1.5`(6+6) + `--leading-label`(16) = 28 = 손으로 쓰던 `min-h-7`. 인셋만 6 → 8 로 넓어지고 짝인 음수 마진을 `-mx-1.5` → `-mx-2` 로 같이 옮겨 **글자 x 좌표는 1px 도 안 움직인다.**

## 픽셀 변화 (실측 — 빌드된 CSS · 렌더된 DOM · `getComputedStyle`)

| 컨트롤 | 높이 | 좌우 인셋 | gap | 그 외 |
|---|---|---|---|---|
| 조용한 나머지 토글 ×4 | 28 → **28** | 6 → 8 (마진 −6 → −8 로 상쇄) | 6 → 6 | 색·타입·반경 동일 |
| 케밥 메뉴 항목 ×4 | 28 → **28** | 10 → 8 | 8 → 6 | 폭 150 → **150** (`w-full` 은 `flex-col` 안에서 무효 — 실측) |
| 의미공백 쓰기 토글 | 32 → **32** | 10 → 10 | 4 → 6 | 잉크 동일 |
| 도메인 선택 칩(선택) | 32 → **32** | 10 → 10 | — | **잉크가 램프의 눌림으로**: 글자 `#7170FF` → `#F7F8F8`, 배경 `line-a13` → `indigo-a16`, 테두리 `line-a45` → `pale-a28` |
| 취소 칩 | 32 → **32** | 10 → 10 | — | 테두리 α .06 → .08(`--color-divider`), 비활성 α .50 → **.55 + 커서·호버 차단** |
| 저장 칩 | 32 → **32** | 10 → 10 | — | 위와 같은 비활성 어포던스 |
| 인계 복사 칩 full | 32 → **32** | 10 → 10 | 4 → 6 | 테두리 α .06 → .08 |
| 인계 복사 칩 compact | 28 → **30** | 8 → 10 | 4 → 6 | 램프에 28px 칩 스텝이 없다 |

새 토큰·값·색·모양 **0개**. `className` 에 남은 것은 램프가 일부러 안 내는 호버 잉크와 이 자리의 음수 마진뿐이다.

## 왜 잉크를 어떤 자리는 넘기고 어떤 자리는 안 넘겼나

`aria-pressed` 와 짝인 **선택**(도메인 칩)은 램프의 `active` 를 쓴다 — 눌림은 앱 전역에서 한 벌이어야 하고 그 한 벌의 주인이 값 층이다. 쓰기 토글은 열림 여부와 무관하게 **강조**(disclosure)라 `tone: 'accent'` 이고, 램프가 아직 안 내는 테두리·배경 틴트만 상수 셋으로 묶었다(같은 문자열이 세 자리에 흩어져 있었다 — `VaultAgentSetupPanel` 의 `NEUTRAL_COPY_CHIP` 선례).

## 남긴 8개가 가리키는 값 층의 새 구멍 셋

1. **보더 있는 아이콘 정사각이 없다** — `icon` 은 정의상 보더가 없는데(`「link`/`row`/`icon` 은 보더가 없다」) 큐 행 케밥 트리거는 `h-8 w-8` + `border` 다. 보더를 `className` 으로 넣으면 **모양을 넘기는 것**이라 층이 무력해진다 (1).
2. **28px 칩 스텝이 없다** — 칩 램프는 24(sm)/30(md)/32(fixedHeight)를 내는데 저장소에 `rounded-chip` + `h-7`/`min-h-7` 이 **18곳** 있다. `row` 는 28 을 정확히 내므로 값이 틀린 게 아니라 축이 갈렸다. `/download` 체크섬 복사는 관문 표면이라 4px 을 옮기지 않고 남겼다 (1).
3. **`card` 가 단행 `items-center` 고정이다** — 아이콘 + 제목 + 설명 두 줄인 첫 실행 선택 카드는 `items-start` 여야 한다 (3 — `FirstRunPage`). 앞 라운드의 「한 벌로 읽혀야 하는 세트」와 **같은 구멍이 두 번째로** 나왔으니 다음 라운드는 이걸 먼저 본다.

나머지 3(에이전트 복사 칩의 `font-mono` + `active:translate-y` 방언 · 데모 영상 위 전면 오버레이 재생 버튼 · 도메인 결합 히트맵의 `role="gridcell"`)은 일곱 모양 어디에도 없다. 셋 다 래칫 주석에 등재했다.

## Test plan

격리 워크트리(`/Users/stark/dev/.wt-views`, `origin/main` = `e10499225`)에서:

- `pnpm exec tsc --noEmit` — 통과 (출력 0)
- `pnpm lint` — **0 errors, 92 warnings**. `origin/main` 기준선을 같은 워크트리에서 직접 재측정했고 **동일**(0 errors / 92 warnings)
- `pnpm exec vitest run src/views` — 154 files / 1308 tests 통과
- `pnpm exec vitest run src/views/ontology-insights` — 25 files / 189 tests 통과
- `pnpm test:contracts` — 103 files / 1194 tests 통과 (`control-adoption-ratchet` 포함, 기준선 259 로 하향)
- `pnpm build` — 정적 export 성공. 포트 4193 정적 서버로 `/ko/projects` · `/ko/git` · `/ko/download` 200 · 가로 오버플로 0
- **픽셀 실측**: 빌드된 CSS 를 로드한 하니스에서 before/after 클래스 문자열을 나란히 렌더해 `getBoundingClientRect` + `getComputedStyle` 로 위 표를 얻었다. 케밥 메뉴는 실제 컨테이너(`absolute` · `flex-col` · `min-w-[10rem]`) 를 복제해 폭 불변(150 → 150)을 확인했다
- `/download` 는 **손대지 않았다** — 체크섬 복사 버튼 실측 28px · 9.5px 그대로이고 `DownloadPage.test.tsx` 도 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275