### PR TITLE
docs: README MCP 공개 계약 복원

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ This is normally a paragraph of setup instructions. Here it is a button.
 
 Claude Code, Cursor, VS Code and Codex each get a button. Any other MCP client
 can copy the snippet from **Advanced · detailed checks**.
+The bundled server exposes **33 tools — 19 read + 14 write**; the
+[agent guide](mcp/README.md) documents every tool and its contract.
 
 ### 3. Read the map
 


### PR DESCRIPTION
## 변경
- README 에 현재 MCP 계약 33 tools 표기 복원
- 19 read + 14 write 분리와 MCP 에이전트 가이드 링크 추가

## 검증
- `pnpm exec vitest run src/shared/lib/launch-docs-current.test.ts`
- `pnpm docs:links`
- `pnpm test:dogfood:script-refs`
- `pnpm test:mcp:docs`
- `pnpm checks:changed -- README.md`