### PR TITLE
refactor: 프리미티브·뷰 라운드 — 4개를 램프로, 31개는 세어서 남긴다 (148 → 144)

### DIFF
--- a/src/shared/ui/link-list-editor.tsx
+++ b/src/shared/ui/link-list-editor.tsx
@@ -3,6 +3,7 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { Plus, X } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
+import { controlClass } from "./control-class";
 
 export interface LinkItem {
   label: string;
@@ -168,14 +169,34 @@ export function LinkListEditor({
               <button
                 type="button"
                 onClick={commit}
-                className="rounded-chip border border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a16)] px-2 py-1 text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)] hover:bg-[color:var(--color-indigo-a24)]"
+                /*
+                 * 손으로 쓰던 `rounded-chip`/`px-2 py-1`/`text-caption` 이
+                 * 램프의 `chip`/`sm` 과 **바이트 단위로 같다** — 상자 치수는
+                 * 한 픽셀도 안 바뀐다. 인디고 틴트(보더·바탕·호버)는 「이
+                 * 자리의 주 행동」이라 `tone: 'accent'` 가 잉크를 내고 나머지
+                 * 알파는 소비처가 얹는다(값 층은 호버를 안 낸다).
+                 */
+                className={controlClass({
+                  shape: "chip",
+                  size: "sm",
+                  tone: "accent",
+                  className:
+                    "border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a16)] uppercase tracking-[0.12em] hover:bg-[color:var(--color-indigo-a24)]",
+                })}
               >
                 {commitLabel}
               </button>
               <button
                 type="button"
                 onClick={cancel}
-                className="rounded-chip border border-[color:var(--color-divider)] px-2 py-1 text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-tertiary)] hover:text-[color:var(--color-text-primary)]"
+                /* `chip`/`sm` 의 기본 톤이 그대로 `text-tertiary` + 보더
+                   `--color-divider` 다 — 값이 하나도 안 바뀐다. */
+                className={controlClass({
+                  shape: "chip",
+                  size: "sm",
+                  className:
+                    "uppercase tracking-[0.12em] hover:text-[color:var(--color-text-primary)]",
+                })}
               >
                 {cancelLabel}
               </button>

--- a/src/shared/ui/similar-node-warning.tsx
+++ b/src/shared/ui/similar-node-warning.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { MOTION } from "@/shared/motion";
 import { cn } from "@/shared/lib/cn";
+import { controlClass } from "./control-class";
 
 export interface SimilarNodeWarningProps {
   /** 이미 보간된 메시지 — 예: `비슷한 노드가 이미 있어요 — 사용자 인증 흐름`.
@@ -56,7 +57,19 @@ export function SimilarNodeWarning({
       <button
         type="button"
         onClick={onOpen}
-        className="shrink-0 font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] underline decoration-[color:var(--color-border-strong)] underline-offset-2 transition-colors hover:text-[color:var(--color-indigo-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+        /*
+         * 문장 속 컨트롤이다 — `inline: true` 가 `min-h-11`(WCAG 2.5.8 이
+         * 인라인을 면제한다)을 빼서 이 경고 줄(`text-label`/16px)이 44px 로
+         * 밀려 올라가지 않게 한다. 크기 기본값 `md` 가 부모와 같은 `text-label`
+         * 이라 상자 치수는 바뀌지 않는다.
+         */
+        className={controlClass({
+          shape: "link",
+          tone: "strong",
+          inline: true,
+          className:
+            "shrink-0 font-[var(--font-weight-signature)] underline decoration-[color:var(--color-border-strong)] underline-offset-2 hover:text-[color:var(--color-indigo-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
+        })}
       >
         {openLabel}
       </button>
@@ -66,7 +79,12 @@ export function SimilarNodeWarning({
       <button
         type="button"
         onClick={onCreateAnyway}
-        className="shrink-0 text-[color:var(--color-text-tertiary)] underline decoration-[color:var(--color-border-soft)] underline-offset-2 transition-colors hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset"
+        className={controlClass({
+          shape: "link",
+          inline: true,
+          className:
+            "shrink-0 underline decoration-[color:var(--color-border-soft)] underline-offset-2 hover:text-[color:var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-indigo-a46)] focus-visible:ring-inset",
+        })}
       >
         {createAnywayLabel}
       </button>

--- a/tests/contract/control-adoption-ratchet.contract.test.ts
+++ b/tests/contract/control-adoption-ratchet.contract.test.ts
@@ -62,6 +62,42 @@ const ROOTS = ['src', 'app'];
  * | **210** | 지도 뷰(`src/views/home/**`) 31개 중 17개 — 아이콘 9 · pill 4 · 칩 1 · 링크형 1(그 외 2는 인디고 강조 아이콘/pill). 남긴 14개는 다섯으로 갈린다: ① **컨트롤이 아닌 것** 3 — `absolute inset-0` 전면 백드롭은 스크림이지 눌리는 원소가 아니다 ② **크롬 토큰 계약** 2 — 투어·단축키 타일은 `--chrome-tile-size`/`--chrome-radius` 를 진다 ③ **말줄임이 필요한 텍스트 컨트롤** 3 — 모양 일곱이 전부 flex 계열이라 `text-overflow: ellipsis` 가 통하지 않는다(실측: `inline-block` 은 `…`, `inline-flex` 는 하드 클립) — **메움 ✅**: `truncate` 축이 display 를 `block` 으로 바꾸고 `truncate` 를 싣는다. 유틸리티만 얹어선 못 고치는 것이라 **모양의 일**이지 소비처의 일이 아니다 ④ **패딩을 가진 텍스트 링크** 3 — `link` 는 패딩이 0이라 `px-1 py-0.5`/`px-2 py-1` 히트 영역이 사라진다 ⑤ **램프에 스텝이 없는 것** 3 — 20px 아이콘 · 40px(`--control-h-lg`) 인디고 pill · 2줄 세로 목록 행 |
  * | **173** | 위젯 라운드 — `src/widgets/**` 중 이미 정규화된 다섯(설정 시트 · 지도 둘 · 문서함 · 빠른 서랍)을 뺀 84개에서 37개. 칩 21 · pill 4 · 아이콘 4 · 카드 5 · 행 2 · 링크형 1. 새 축 0개로 옮겼고, **남긴 47개가 값 층의 다음 구멍 목록**이다(아래). **210 − 37 = 173 이 전수 재측정으로 정확히 맞았다** — 앞선 두 정렬(227 − 37 = 190)과 마찬가지로, 이 라운드가 features·지도 뷰 라운드와 파일을 하나도 안 겹친다는 뜻이다. 세 라운드의 합산이 성립한다 |
  * | **148** | 값 층 라운드 — 옮긴 25개는 새 표면이 아니라 **원장이 반복해서 센 구멍**을 메운 결과다. 세그먼트/고스트 12(지도 INDEX 렌즈 3 · 블록 가져오기 4 · 에이전트 범위 2 · 단축키 스코프 · 투어 뒤로 · 발자국 프리셋) · 패널 잉크 7(첫 실행 4 · 전체 상세 3) · 채운 인디고 3 · 말줄임 3. **새 축 셋 + 여덟째 모양 하나**로 열었고, 그 넷 전부가 원장에 두 번 이상 적혀 있던 것이다 |
+ * | **144** | 프리미티브·뷰 라운드(`shared/ui` 18 · `views/{docs-vault,first-run,ontology-insights}` 17 = 35) 중 **4개**. 링크형 2(근접중복 경고의 두 선택지 — `inline` 축이 열어 준 첫 자리) · 칩 2(링크 편집기의 확인·취소). **이 라운드는 옮긴 수보다 «왜 31개가 안 움직였나»가 산출물이다** — 셋 중 하나이고 셋 다 아래에 수를 세어 적었다 |
+ *
+ * ## 프리미티브·뷰 라운드(2026-08-03)가 남긴 31개 — 세 부류, 그리고 전수
+ *
+ * ⚠️ **이 라운드는 옮긴 수가 적은 것이 결과다.** `src/shared/ui` 는 시스템
+ * **자신의 집**이라 여기 있는 손 className `<button>` 은 대부분 값 층의
+ * 소비처가 아니라 **값 층과 같은 층의 계약**(크롬 토큰 · 프리미티브 자신)이다.
+ * 억지로 옮기면 계약을 깨거나 색·치수를 `className` 으로 넘겨 층을 무력화한다.
+ *
+ * | 부류 | 남은 수 | 무엇인가 |
+ * |---|---:|---|
+ * | **값 층과 같은 층** | 6 | `button.tsx`(값 층 자신) · `select.tsx` 트리거(`--control-h-*` 계약 + `rounded-card` + `w-full`) · `chrome-chip`/`chrome-tile`(`--chrome-tile-size` 44px 계약) · `DocsHeaderTile`(`--docs-header-tile-size`) · `tab-bar`(밑줄 탭 — 반경 0 · `items-baseline` · `pb-[11px]`) |
+ * | **이미 원장에 적힌 구멍** | 21 | 아래 census 참조 |
+ * | **렌더되지 않는 죽은 프리미티브** | 4 | `link-list-editor` 2(X 글리프 · `rounded-2xl` 추가 버튼) · `chip-list-editor` 2 — **둘 다 프로덕션 소비처 0**(아래) |
+ *
+ * ### 이번에 **전수로 센** 구멍 넷 — 다음 라운드의 입력
+ *
+ * 규칙 4(「몇 개가 막혔나 세라」)를 이 라운드가 저장소 전수로 실행했다. 감이
+ * 아니라 수다:
+ *
+ * | 구멍 | 전수 | 어디 |
+ * |---|---:|---|
+ * | **`sm` 아래 한 칸이 없다**(`px-1`/`px-1.5` 인셋) — 원장 features 라운드 구멍 4의 재측정 | **14** (9파일) | `LiveActivityIndicator` 4 · `TopologyTrailChip` 3 · `AgentActivityChip` · `RealmBlockExportAction` · `DocsSidebarBody` 필터 지우기 · `full-detail-a1` 2 · `TopologyRealmLedger` · `AgentTranscript`. **이 라운드에서 가장 큰 구멍이고, 세 라운드 연속으로 나왔다** |
+ * | **원형 아이콘 컨트롤이 없다** — `icon` 은 `rounded-chip` 고정 | **6** (4파일) | `node-explanation-edit` 3 · `info-hint` · `TopologyTrailChip` · `TopologyMapV2`(원장의 「캔버스 앵커 원형 버튼」). 24px 원을 6px 사각으로 바꾸는 것은 정규화가 아니라 **정체성 변경**이라 「체계」 소집 없이 혼자 정하지 않았다 |
+ * | **보더 있는 아이콘 정사각이 없다** — 원장 뷰 라운드 구멍 1의 재측정 | **2** | `QueueRowActions` 케밥 · `HubRail`. 수가 둘뿐이라 **아직 축이 아니다** — 규칙 4대로 수를 적어 두고 넘긴다 |
+ * | **`rounded-2xl`(16px)이 반경 램프 밖** | **2** | `link-list-editor` · `DocsVaultBacklinks`. 램프는 chip 6 / card 9 / panel 12 뿐이라 16px 은 어느 스텝도 아니다 |
+ *
+ * ### 💀 렌더되지 않는 프리미티브 둘 — 삭제 후보(소유자 판단)
+ *
+ * `LinkListEditor`·`ChipListEditor` 는 `shared/ui/index.ts` 가 export 하고
+ * 단위 테스트도 있는데 **프로덕션 소비처가 0**이다(전수 grep). 이 저장소는
+ * 같은 실패를 이미 겪었다 — `control-class.ts` 머리말의 `Card`/`Badge`/
+ * `DetailCard` 셋이고, 그때의 답은 **삭제**였다. 두 컴포넌트는 그때와 같은
+ * 증상까지 갖고 있다: 램프 밖 값(`rounded-2xl` 16px)을 쓴다. 이 라운드는
+ * 램프에 정확히 맞는 둘만 옮기고 삭제는 제안만 한다 — 공개 export 를 지우는
+ * 것은 리팩터가 아니라 API 변경이라서다.
  *
  * ## features 라운드(2026-08-03)가 찾은 구멍 — 값 층의 다음 입력
  *
@@ -197,7 +233,7 @@ const ROOTS = ['src', 'app'];
  * **공유 상수로 뽑는 옳은 리팩터에 벌점을 준다.** 그래서 이 라운드는 잉크만
  * 상수로 공유하고 램프 호출은 자리마다 인라인으로 썼다.
  */
-const BASELINE_HAND_WRITTEN_CONTROLS = 148;
+const BASELINE_HAND_WRITTEN_CONTROLS = 144;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {


### PR DESCRIPTION
## Summary

`src/shared/ui`(18) · `src/views/{docs-vault,first-run,ontology-insights}`(17)
= **35개**의 손 className `<button>` 을 하나씩 판정했다. **옮긴 것은 4개다.**

**적게 옮긴 것이 이 라운드의 결과다.** `shared/ui` 는 시스템 자신의 집이라,
여기 있는 손 className 은 대개 값 층의 *소비처*가 아니라 **값 층과 같은 층의
계약**이다 — `button.tsx` 는 값 층 자신이고, `select.tsx` 트리거는
`--control-h-*` 를, `chrome-chip`/`chrome-tile`/`DocsHeaderTile` 은 크롬
토큰(44px / `--docs-header-tile-size`)을 진다. 억지로 옮기면 계약을 깨거나,
색·치수를 `className` 으로 넘겨 층을 무력화한다.

그래서 규칙 0(「새 값을 만들기 전에 이미 있는지 먼저 찾아라」)을 뒤집어
물었다: **이 자리가 값 층의 소비처인가, 아니면 값 층과 같은 층인가.**

새 토큰 · 새 값 · 새 색 · 새 모양 · 새 축 **0개**. 래칫 **148 → 144**.

## 픽셀 변화 — 다섯 원소 전부 0

실측 방법: 빌드한 정적 사이트(포트 4182)에서 **옛 클래스 문자열과 새 클래스
문자열을 같은 CSS 아래 나란히 렌더**해 `getBoundingClientRect()` +
`getComputedStyle()` 을 비교했다. 값 층의 변경은 결국 «어떤 문자열이 나오는가»
이므로, 그 두 문자열을 같은 캐스케이드에 놓고 재는 것이 판정이다.

| 자리 | 무엇으로 | before | after | Δ |
|---|---|---|---|---|
| 근접중복 경고 「그 노드 열기」 | `link` / `strong` / `inline` | 53.70×16.00 · 11px/16px · `rgb(247,248,248)` · pad 0 | 53.70×16.00 · 11px/16px · `rgb(247,248,248)` · pad 0 | **0** |
| 근접중복 경고 「그래도 새로 만들기」 | `link` / `inline` | 82.44×16.00 · 11px/16px · `rgb(138,143,152)` · pad 0 | 82.44×16.00 · 11px/16px · `rgb(138,143,152)` · pad 0 | **0** |
| 링크 편집기 확인(Add) | `chip` / `sm` / `accent` | 42.06×24.00 · 9.5px/14px · `rgb(113,112,255)` · bg `rgba(94,106,210,.16)` · border 1px `rgb(94,106,210)` · pad 4/8 | 동일 | **0** |
| 링크 편집기 취소(Cancel) | `chip` / `sm` | 63.63×24.00 · 9.5px/14px · `rgb(138,143,152)` · border 1px `rgba(255,255,255,.08)` · pad 4/8 | 동일 | **0** |
| (담는 경고 상자) | — | 34.00 높이 | 34.00 높이 | **0** |

폭 · 높이 · `font-size` · `line-height` · `color` · `background-color` ·
`border-width` · `border-color` · `padding` · `min-height` **열 항목이 다섯
원소 모두에서 일치**했다. 계산값 차이는 둘뿐이고 둘 다 화면에 안 나타난다:

- `display: block → flex` — 둘 다 flex 컨테이너의 자식이라 블록화 결과가 같다
- 보더도 바탕도 없는 `link` 두 개의 `border-radius: 0 → 6px` — 그릴 모서리가
  없어 포커스 링 코너에만 영향

![before/after](https://github.com/user-attachments/assets/placeholder)

*(스크린샷: 위가 손 className, 아래가 `controlClass()`. 육안으로 구별되지 않는다.)*

## `inline` 축의 첫 실사용

이 경고 줄은 `text-label`/16px 인데 `link` 의 기본값은 `min-h-11`(44px)이라
그냥 옮기면 줄 상자가 **세 배**가 된다. 값 층 라운드가 만든 `inline` 축이
정확히 그것을 막았다 — 축이 실제로 자리를 열었다는 첫 증거다. 원장의
「문장·바 속 인라인 컨트롤」 항목이 이 자리를 가리키고 있었다.

## 남긴 31개 — 셋으로 갈리고, 넷은 **전수를 셌다**

| 부류 | 수 | 무엇인가 |
|---|---:|---|
| 값 층과 **같은 층** | 6 | `button.tsx`(값 층 자신) · `select.tsx` 트리거(`--control-h-*` + `rounded-card` + `w-full`) · `chrome-chip`·`chrome-tile`(44px `--chrome-tile-size` 계약) · `DocsHeaderTile` · `tab-bar`(밑줄 탭 — 반경 0 · `items-baseline` · `pb-[11px]`) |
| 이미 원장에 적힌 구멍 | 21 | 아래 전수 참조 |
| **렌더되지 않는** 프리미티브 | 4 | `link-list-editor` 2 · `chip-list-editor` 2 |

### 규칙 4 실행 — 「몇 개가 막혀 있나」를 저장소 전수로 셌다

감으로 축을 더하지 않기 위해, 이 라운드가 막힌 자리를 **수로** 남긴다:

| 구멍 | 전수 | 어디 |
|---|---:|---|
| **`sm` 아래 한 칸이 없다** (`px-1`/`px-1.5` 인셋) | **14** (9파일) | `LiveActivityIndicator` 4 · `TopologyTrailChip` 3 · `AgentActivityChip` · `RealmBlockExportAction` · `DocsSidebarBody` 필터 지우기 · `full-detail-a1` 2 · `TopologyRealmLedger` · `AgentTranscript`. **세 라운드 연속으로 나왔고 이 라운드 최대 구멍이다** |
| **원형 아이콘 컨트롤이 없다** (`icon` 은 `rounded-chip` 고정) | **6** (4파일) | `node-explanation-edit` 3 · `info-hint` · `TopologyTrailChip` · `TopologyMapV2`(원장의 「캔버스 앵커 원형 버튼」). 24px 원을 6px 사각으로 바꾸는 것은 정규화가 아니라 **정체성 변경**이라 「체계」 소집 없이 혼자 정하지 않았다(규칙 3) |
| **보더 있는 아이콘 정사각이 없다** | **2** | `QueueRowActions` 케밥 · `HubRail`. 둘뿐이라 **아직 축이 아니다** — 규칙 4대로 수만 적어 넘긴다 |
| **`rounded-2xl`(16px)이 반경 램프 밖** | **2** | `link-list-editor` · `DocsVaultBacklinks`. 램프는 chip 6 / card 9 / panel 12 뿐 |

그 밖에 개별 사유로 남은 것: 첫 실행 카드 3 · `DesktopVaultWelcome` 5(둘 다
원장이 이미 「축 하나로 안 열린다 = 사용처 0인 축이 된다」로 판정) ·
`DocsSidebarBody` 섹션 헤더(비대칭 `pt-3`/`pb-1.5` — `row` 는 대칭 `py` 만
낸다) · `BackToTopButton`(44px 크롬) · `CopyAgentTextButton`(mono 방언 +
`min-h-9`) · `DomainCouplingCard`(데이터 마크) · `DocsVaultTabStrip`(에디터 탭)
· `DocFrontmatterBlock` 인라인 참조(`inline` 축은 열렸으나 잉크
`--color-indigo-pale-a90` 이 톤 램프 밖).

## 💀 렌더되지 않는 프리미티브 둘 — 삭제 후보 (소유자 판단)

`LinkListEditor`·`ChipListEditor` 는 `shared/ui/index.ts` 가 export 하고
단위 테스트도 15개 있는데 **프로덕션 소비처가 0**이다(전수 grep).

이 저장소는 같은 실패를 이미 겪었다 — `control-class.ts` 머리말의
`Card`/`Badge`/`DetailCard` 셋이고, 그때의 답은 **삭제**였다. 증상까지
같다: 램프 밖 값(`rounded-2xl` 16px)을 쓴다.

이 PR 은 램프에 정확히 맞는 둘만 옮기고 **삭제는 제안만 한다** — 공개
export 를 지우는 것은 리팩터가 아니라 API 변경이라서다.

## Test plan

- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm lint` — **0 errors, 92 warnings** (예산 96 이내, baseline 대비 증가 0)
- `pnpm test:contracts` — 103 files / 1211 tests pass (래칫 144 포함)
- `pnpm exec vitest run src/shared src/views/docs-vault` — 142 files / 1255 tests pass
- `pnpm checks:changed` 가 지목한 직접 형제 테스트 2종 — 15 tests pass
- `pnpm build` — 성공, 정적 서버(4182)에서 위 표의 rect/computed style 실측
- 최신 `origin/main`(`eedc7a14c`, `fixedHeight` 축 제거) 을 **merge** 한 뒤
  다시 세고 다시 쟀다 — 네 클래스 문자열이 병합 전과 **바이트 동일**했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
