### PR TITLE
fix: 접근성 래칫 부채 6건을 갚고 게이트가 실제로 빨개지는지 증명한다

### DIFF
--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -27,8 +27,16 @@ const buttonVariants = cva(
         // 눈에 띄는 컨트롤의 색을 무채색으로 바꾸는 것은 취향 판단이라 소유자
         // 몫이다. 착색 그림자는 광원이 둘이라는 뜻이므로, 정리하기로 하면
         // `--shadow-control-press` 로 흡수하면 된다.
+        //
+        // 잉크는 `--color-text-on-accent`(#ffffff) 다 — **`--color-text-primary`
+        // 가 아니다.** 채운 인디고(`#5e6ad2`) 위에서 `#f7f8f8` 은 합성 대비
+        // **4.42:1** 로 WCAG 1.4.3 AA(4.5) 밑이고, `#ffffff` 는 **4.70:1** 로
+        // 통과한다. 이 토큰은 2026-08-03 에 「채운 인디고 위의 잉크」 라는
+        // 이름으로 이미 만들어져 `control-class.ts` 의 `accentSolid` 가 쓰고
+        // 있었는데, 이 프리미티브만 이관에서 빠져 있었다 — 관문의 주 CTA 가
+        // 앱에서 가장 눈에 띄는 컨트롤인데 유일하게 AA 미달이던 이유다.
         primary:
-          'bg-[color:var(--color-indigo-brand)] text-[color:var(--color-text-primary)] shadow-[inset_0_1px_0_var(--color-border-strong),0_10px_24px_var(--color-indigo-a22)] hover:border-[color:var(--color-indigo-pale-a28)] hover:bg-[color:var(--color-indigo-hover)] active:shadow-[inset_0_1px_0_var(--color-divider),0_6px_14px_var(--color-indigo-a20)]',
+          'bg-[color:var(--color-indigo-brand)] text-[color:var(--color-text-on-accent)] shadow-[inset_0_1px_0_var(--color-border-strong),0_10px_24px_var(--color-indigo-a22)] hover:border-[color:var(--color-indigo-pale-a28)] hover:bg-[color:var(--color-indigo-hover)] active:shadow-[inset_0_1px_0_var(--color-divider),0_6px_14px_var(--color-indigo-a20)]',
         ghost:
           'bg-transparent text-[color:var(--color-text-primary)] hover:border-[color:var(--color-border-soft)] hover:bg-[color:var(--color-overlay-2)] active:bg-[color:var(--color-border-soft)] active:shadow-[var(--shadow-control-press)]',
         outline:

--- a/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
+++ b/src/views/docs-vault/ui/parts/DocsSidebarBody.tsx
@@ -285,23 +285,39 @@ export function DocsSidebarBody({
       {/* #22 — 옵시디언식 단일 아이콘 행: 전체/가이드/지도 문서 뷰 전환 +
           검색 토글 + 새 문서. 큰 헤더·세그먼트·상시 검색창을 걷어내 밀도를
           낮춘다. active 는 인디고, hover 툴팁이 평문으로 뜻을 설명한다. */}
-      <div
-        role="tablist"
-        aria-label={t("collectionAriaLabel")}
-        className="flex flex-none items-center gap-1 border-b border-[color:var(--color-overlay-2)] px-2 py-2"
-      >
-        {collectionOptions.map((option) => (
-          <RailIconButton
-            key={option}
-            testId={`docs-sidebar-collection-${option}`}
-            icon={collectionIcons[option]}
-            label={t(`collection.${option}.tooltip`, {
-              count: collectionCounts[option],
-            })}
-            active={collection === option}
-            onClick={() => onCollectionChange(option)}
-          />
-        ))}
+      {/*
+        a11y: 이 줄은 `role="tablist"` 가 **아니다**. 2026-08-03 axe 전수에서
+        `aria-required-children`(WCAG 4.1.2) 위반 1건이 여기였다 — 줄 안에
+        컬렉션 3개 말고 검색 토글 · 정렬 메뉴 · 새 문서가 같이 있어서
+        `tablist` 가 허용하지 않는 자식(`button[aria-label]`)을 이고 있었다.
+
+        고침은 **자식을 `role="tab"` 으로 바꾸는 쪽이 아니라 role 을 반납하는
+        쪽**이다. 형제인 `DocsVaultTabStrip` 이 같은 이유로 이미 그렇게 적어
+        뒀다: `tabpanel`·`aria-controls`·roving tabindex 가 없는데 role 만
+        빌리면 AT 는 «탭 n/N» 과 화살표키 이동을 약속하고 아무 일도 일어나지
+        않는다. 여기 세 버튼은 아래 트리를 **거르는 토글**이고 진실원은
+        `collection` 상태다 — 정직한 계약은 `group` + `aria-pressed` 다.
+        `toolbar` 도 안 쓴다: 그건 다시 화살표키 이동 약속이다.
+      */}
+      <div className="flex flex-none items-center gap-1 border-b border-[color:var(--color-overlay-2)] px-2 py-2">
+        <div
+          role="group"
+          aria-label={t("collectionAriaLabel")}
+          className="flex flex-none items-center gap-1"
+        >
+          {collectionOptions.map((option) => (
+            <RailIconButton
+              key={option}
+              testId={`docs-sidebar-collection-${option}`}
+              icon={collectionIcons[option]}
+              label={t(`collection.${option}.tooltip`, {
+                count: collectionCounts[option],
+              })}
+              active={collection === option}
+              onClick={() => onCollectionChange(option)}
+            />
+          ))}
+        </div>
         <span aria-hidden className="mx-0.5 h-5 w-px bg-[color:var(--color-overlay-2)]" />
         <RailIconButton
           testId="docs-sidebar-search-toggle"

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -602,11 +602,17 @@ function AssetSize({ bytes, onFill = false }: { bytes: number; onFill?: boolean 
       className={cn(
         'hidden font-mono text-label leading-label sm:inline',
         // 채운 버튼 위에서는 **약화도 하지 않는다**. `opacity-80` 을 얹어 봤더니
-        // 합성 대비가 3.45:1 로 떨어졌다(11px 텍스트, 실측 2026-07-29) — 라벨
-        // 자신이 4.42:1 인 표면이라 여기서 한 단만 낮춰도 바로 밑으로 뚫린다.
-        // 크기와 라벨을 가르는 것은 이미 mono 페이스와 간격이 한다.
+        // 합성 대비가 3.45:1 로 떨어졌다(11px 텍스트, 실측 2026-07-29) — 한 단만
+        // 낮춰도 바로 밑으로 뚫린다. 크기와 라벨을 가르는 것은 이미 mono
+        // 페이스와 간격이 한다.
+        //
+        // 잉크는 라벨과 **같은 토큰**이어야 한다. 2026-08-03 까지 이 자리는
+        // `--color-text-primary` 였고 채운 인디고 위에서 4.42:1 이라 AA 미달
+        // 이었다(위 주석의 «라벨 자신이 4.42:1» 이 그 값이다). 라벨이
+        // `--color-text-on-accent`(4.70:1)로 올라갔으므로 크기 배지도 같이
+        // 간다 — 한 버튼 안에서 잉크가 둘로 갈리면 그게 다음 회귀다.
         onFill
-          ? 'text-[color:var(--color-text-primary)]'
+          ? 'text-[color:var(--color-text-on-accent)]'
           : 'text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]',
       )}
     >

--- a/tests/e2e/a11y-ratchet.spec.ts
+++ b/tests/e2e/a11y-ratchet.spec.ts
@@ -14,16 +14,31 @@ import { expect, test } from "@playwright/test";
  * ## 왜 「위반 0」이 아니라 래칫인가
  *
  * `/gate-probe`: **룰을 켜기 전에 위반을 전수 측정한다.** 안 치운 채 0 을 요구하면
- * 그 게이트는 첫날부터 빨갛고, 빨간 게이트는 곧 꺼지거나 무시된다. 그리고 오늘의
- * 14건 중 12건은 **헌장 색이 걸린 사안**이라 이 파일이 단독으로 못 고친다 —
- * 처방은 `/design-council` 의 「체계」·「도해」로 간다.
+ * 그 게이트는 첫날부터 빨갛고, 빨간 게이트는 곧 꺼지거나 무시된다.
  *
- * 그래서 계약은 둘이다:
- *   1. **새 룰 위반 0** — 목록에 없는 룰이 하나라도 뜨면 실패. 새 결함은 못 들어온다.
- *   2. **개수는 늘 수 없다** — 기준선은 상한이고, 고치면 이 파일의 숫자를 내린다.
+ * 처음 등재한 14건 중 **6건이 갚였다** — `target-size` 1(컨트롤 정규화),
+ * `aria-required-children` 1(role 반납), `color-contrast` 4(채운 인디고 위
+ * 잉크 토큰). 남은 8건은 **토큰 값 한 개**라 이 파일이 단독으로 못 고친다 —
+ * 처방은 `/design-council` 의 「체계」로 간다(아래 `BASELINE` 주석).
+ *
+ * 그래서 계약은 셋이다:
+ *   1. **채집이 살아 있다** — 라우트마다 axe 가 내용에 적용한 룰이 바닥 위여야
+ *      한다. 세 룰 중 둘이 이미 0이라, 이게 없으면 «빈 화면»과 «위반 없음»이
+ *      같은 초록이 된다.
+ *   2. **새 룰 위반 0** — 목록에 없는 룰이 하나라도 뜨면 실패. 새 결함은 못 들어온다.
+ *   3. **개수는 늘 수 없다** — 기준선은 상한이고, 고치면 이 파일의 숫자를 내린다.
  *
  * 기준선을 **올리는 것은 diff 에 남는 사람의 결정**이다. 그게 이 형태의 요점이다 —
  * 조용히 늘어나는 것만 막고, 의도적으로 늘리는 것은 리뷰가 본다.
+ *
+ * ## 이 게이트는 실제로 빨개진다 (2026-08-03 프로브 4종)
+ *
+ * | 일부러 만든 결함 | 결과 |
+ * |---|---|
+ * | CTA 잉크를 `--color-text-primary` 로 되돌림 | `color-contrast` 8 → 12 실패 |
+ * | 사이드바 줄에 `role="tablist"` 복원 | `aria-required-children` 0 → 1 실패 |
+ * | 고친 채 `BASELINE` 만 9로 둠 | 여유 단언 실패(기준선 9 · 실측 8) |
+ * | 빈 문서만 서빙하는 서버에 물림 | 채집 단언 실패(통과 룰 4 < 15) |
  *
  * 센서스를 다시 뜨려면: `node scripts/measure-a11y.mjs`(빌드 + 정적 서버 필요).
  */
@@ -51,45 +66,126 @@ const ROUTES = [
  *
  * | 룰 | 원소 | 무엇인가 |
  * |---|---|---|
- * | `color-contrast` | 12 | 인디고 면 위 흰 글자 4.42:1 · `text-quaternary` 4.31:1 등. `scripts/measure-contrast.mjs` 가 독립적으로 같은 결함군을 지목한다 |
- * | `aria-required-children` | 1 | `role="tablist"` 가 `role="tab"` 자식을 안 갖는다 |
+ * | `color-contrast` | 12 → **8** | 아래 절 참고. 남은 8은 **토큰 한 개**다 |
+ * | ~~`aria-required-children`~~ | ~~1~~ → **0** | 문서함 사이드바 상단 줄이
+ *   `role="tablist"` 였는데 그 안에 컬렉션 3개 말고 검색·정렬·새 문서가 같이
+ *   있었다. 고침은 **자식을 `tab` 으로 바꾸는 쪽이 아니라 role 을 반납하는
+ *   쪽**이다 — `tabpanel`·`aria-controls`·roving tabindex 없이 role 만 빌리면
+ *   AT 에게 지키지 못할 약속을 한다. 형제 `DocsVaultTabStrip` 이 같은 판단을
+ *   먼저 적어 뒀고 이제 둘이 같은 계약을 쓴다 |
  * | ~~`target-size`~~ | ~~1~~ → **0** | WCAG 2.2 §2.5.8 — 24px 미만이고 여백도 부족.
  *   2026-08-03 문서함/서랍 컨트롤 정규화로 사라졌다: `p-1`/`p-0.5` 로 크기를
  *   내용에 맡기던 아이콘 컨트롤들이 `IconButton`(24/28/32 고정)으로 넘어가면서
  *   가장 작은 것이 24px 바닥을 갖게 됐다. **값 층이 바닥을 소유하면 자리마다
  *   빠뜨릴 수 없다** — 이 항목이 그 증거다 |
  *
+ * ## `color-contrast` 12 → 8 — 무엇이 갚였고 무엇이 남았나
+ *
+ * **갚은 4건**: 관문/다운로드의 주 CTA(`/ko/` ×2 · `/ko/download/` ×2). 채운
+ * 인디고(`#5e6ad2`) 위의 잉크가 `--color-text-primary`(#f7f8f8, **4.42:1**)
+ * 였다. `--color-text-on-accent`(#ffffff, **4.70:1**)로 옮겼다 — 이 토큰은
+ * 2026-08-03 에 「채운 인디고 위의 잉크」 라는 이름으로 이미 만들어져
+ * `control-class.ts` 가 쓰고 있었고, `button.tsx` 의 `primary` 만 이관에서
+ * 빠져 있었다. 새 값 0개.
+ *
+ * **남은 8건은 전부 `--color-text-quaternary`(#787c84) 한 토큰이다.**
+ * 자리: `/ko/ontology/insights/` 4 · `/ko/projects/` 4.
+ *
+ * | 바탕 | 현재 | 필요 |
+ * |---|---:|---:|
+ * | `--color-canvas` #08090a | 4.76 | — |
+ * | `--color-panel` #0f1011 | 4.55 | — |
+ * | panel + `--color-overlay-1` #151617 | **4.33** | 4.5 |
+ * | `--color-elevated` #191a1b | **4.16** | 4.5 |
+ *
+ * 즉 이 잉크는 **캔버스/패널에서만 AA 를 넘고, 한 단 올라선 표면에서 뚫린다.**
+ * 소비처는 652곳이라 자리별 치환은 오늘 보이는 8곳만 지우고 644곳을 장전된
+ * 채로 남긴다 — 그건 수를 내리는 것이지 고치는 것이 아니다. 값 하나를
+ * **`#82828a`** 로 올리면 네 바탕 전부 통과하고(5.23 / 5.00 / 4.75 / 4.57)
+ * tertiary(#8a8f98)와의 명도 순서도 보존된다. 무채 명도만 움직이므로 새 hue 는
+ * 없다 — 지도 패널의 같은 이름 잉크(`--topology-v2-panel-text-quaternary`)가
+ * 2026-07 에 `#55555d` → `#82828a` 로 **정확히 같은 사유로** 이미 올라갔다.
+ * 그 처방은 `app/globals.css` 의 램프라 「체계」석의 자리다(`design.md`
+ * "규격을 바꾸려면 「체계」를 부른다").
+ *
  * **이 숫자는 내려가기만 한다.**
  */
 const BASELINE: Readonly<Record<string, number>> = {
-  "color-contrast": 12,
-  "aria-required-children": 1,
+  "color-contrast": 8,
+  "aria-required-children": 0,
   "target-size": 0,
 };
+
+/**
+ * 탐지기가 놀고 있지 않다는 증거 — **기준선이 0에 가까워질수록 필요해진다.**
+ *
+ * axe 를 못 실었거나 페이지가 빈 채로 떠도 «위반 0» 은 나온다. 그건 통과가
+ * 아니라 **미측정**이고, 아래 단언 셋은 그 둘을 구별하지 못한다
+ * (`target-size` 와 `aria-required-children` 이 이미 0이라 그 자리에서는 어떤
+ * 신호도 안 나온다).
+ *
+ * ⚠️ **세는 대상을 틀리면 이 가드도 장식이 된다.** 처음엔 «평가된 룰 수»
+ * (violations+passes+incomplete+inapplicable)를 세려 했는데, 실측해 보니 실제
+ * 라우트가 **64** 이고 빈 문서도 **63** 이었다 — `inapplicable` 이 총계를
+ * 지배해서 빈 화면과 진짜 화면이 구별되지 않는다. 그건 켜도 절대 안 빨개지는
+ * 가드다.
+ *
+ * 가르는 것은 `passes` 다: **실제 내용에 적용돼 통과한 룰**의 수. 실측
+ * 2026-08-03 — `/ko/` 26 · `/ko/topology/` 27 · `/ko/projects/` 26 ·
+ * `/ko/docs/` 25 vs **빈 문서 2**. 바닥 15는 그 사이의 빈 구간이다.
+ */
+const MIN_RULES_PASSED_PER_ROUTE = 15;
 
 test("접근성 래칫 — 새 룰 위반 0, 기존 개수는 늘지 않는다", async ({ page }) => {
   await page.setViewportSize({ width: 1512, height: 900 });
   const counts = new Map<string, number>();
   const samples = new Map<string, string>();
+  const thinRuns: string[] = [];
 
   for (const route of ROUTES) {
     await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
     // 지도는 물리 시뮬이 수렴해야 화면이 정해진다 — 수렴 전에 재면 중간 상태를 잰다.
     await page.waitForTimeout(2500);
     await page.addScriptTag({ path: AXE_PATH });
-    const violations = await page.evaluate(async (tags) => {
-      const run = await (window as unknown as { axe: { run: (ctx: Document, opts: unknown) => Promise<{ violations: Array<{ id: string; nodes: Array<{ target: string[] }> }> }> } }).axe.run(
+    const result = await page.evaluate(async (tags) => {
+      type Run = {
+        violations: Array<{ id: string; nodes: Array<{ target: string[] }> }>;
+        passes: Array<unknown>;
+        incomplete: Array<unknown>;
+        inapplicable: Array<unknown>;
+      };
+      const run = await (window as unknown as { axe: { run: (ctx: Document, opts: unknown) => Promise<Run> } }).axe.run(
         document,
         { runOnly: { type: "tag", values: tags }, resultTypes: ["violations"] },
       );
-      return run.violations.map((v) => ({ id: v.id, count: v.nodes.length, sample: v.nodes[0]?.target?.join(" ") ?? "" }));
+      return {
+        // `resultTypes` 는 **노드 상세**만 줄인다 — 배열의 길이는 그대로다.
+        // 그래서 «내용에 실제로 적용된 룰» 수를 추가 비용 없이 셀 수 있다.
+        rulesPassed: run.passes.length,
+        violations: run.violations.map((v) => ({
+          id: v.id,
+          count: v.nodes.length,
+          sample: v.nodes[0]?.target?.join(" ") ?? "",
+        })),
+      };
     }, WCAG_TAGS);
 
-    for (const v of violations) {
+    if (result.rulesPassed < MIN_RULES_PASSED_PER_ROUTE) {
+      thinRuns.push(`  ${route}: 내용에 적용돼 통과한 룰 ${result.rulesPassed}`);
+    }
+    for (const v of result.violations) {
       counts.set(v.id, (counts.get(v.id) ?? 0) + v.count);
       if (!samples.has(v.id)) samples.set(v.id, `${route} → ${v.sample}`);
     }
   }
+
+  // ★ 「위반 0」과 「아무것도 안 쟀다」를 가른다. 이게 없으면 아래 단언 셋은
+  //   빈 집합 위에서 전부 초록이고, 그건 게이트가 없는 것과 같다.
+  expect(
+    thinRuns,
+    `axe 가 라우트당 ${MIN_RULES_PASSED_PER_ROUTE}개 룰도 내용에 적용하지 못했다 — ` +
+      `위반이 없는 게 아니라 화면이 안 떴거나 채집이 깨진 것이다.\n${thinRuns.join("\n")}`,
+  ).toEqual([]);
 
   const unknown = [...counts.keys()].filter((id) => !(id in BASELINE)).sort();
   expect(

--- a/tests/e2e/contrast-ratchet.spec.ts
+++ b/tests/e2e/contrast-ratchet.spec.ts
@@ -28,19 +28,24 @@ const { judgeText } = require('../../scripts/lib/contrast.mjs');
 const ROUTES = ['/ko/', '/ko/topology/', '/ko/docs/', '/ko/ontology/studio/', '/ko/projects/'];
 
 /**
- * 2026-08-03 전수 (1512×900, 위 5개 라우트, 조합 110):
+ * 2026-08-03 전수 (1512×900, 위 5개 라우트, 조합 109):
  *
  * | 라우트 | 미달 | 무엇 |
  * |---|---:|---|
- * | `/ko` | 2 | 주 CTA 인디고 면 위 흰 글자 **4.42:1** (요구 4.5) |
- * | `/ko/projects` | 2 | `--color-text-quaternary` **4.31:1** |
+ * | ~~`/ko`~~ | ~~2~~ → **0** | 주 CTA 의 인디고 면 위 잉크가 `--color-text-primary`(#f7f8f8, **4.42:1**)였다. 그 표면 전용으로 이미 있던 `--color-text-on-accent`(#ffffff, **4.70:1**)로 옮겼다 — `button.tsx` 의 `primary` 변형과 `DownloadPage` 의 크기 배지 두 곳. 새 값 0개 |
+ * | `/ko/projects` | 2 | `--color-text-quaternary`(#787c84) **4.31:1** |
  * | 지도 · 문서함 · 공방 | 0 | |
  *
- * 넷 다 **헌장 색이 걸린 사안**이라 계기를 켠 쪽이 단독으로 못 고친다 — 처방은
- * 디자인 게이트(「체계」·「도해」)로 간다. 그래서 0이 아니라 래칫이다.
+ * 남은 둘은 **토큰 한 개**다. 이 잉크는 캔버스(4.76)/패널(4.55)에서만 AA 를
+ * 넘고 한 단 올라선 표면 — 패널+`--color-overlay-1`(**4.33**) ·
+ * `--color-elevated`(**4.16**) — 에서 뚫린다. 소비처 652곳이라 자리별 치환은
+ * 오늘 보이는 곳만 지우고 나머지를 장전된 채 남긴다. 값 하나(`#82828a`)를
+ * 올리면 네 바탕 전부 통과하고 명도 순서도 보존되지만, 그건 `app/globals.css`
+ * 의 램프라 「체계」석의 자리다. 그래서 0이 아니라 래칫이다.
+ * 자리별 실측과 근거는 `tests/e2e/a11y-ratchet.spec.ts` 의 `BASELINE` 주석.
  * **이 수는 내려가기만 한다.**
  */
-const BASELINE_FAILING_COMBINATIONS = 4;
+const BASELINE_FAILING_COMBINATIONS = 2;
 
 /** 페이지에서 색·폰트만 꺼내 온다. 판정은 순수 함수가 한다. */
 const COLLECT = `(() => {


### PR DESCRIPTION
## Summary

접근성 래칫 둘의 기준선을 **등록된 수가 아니라 실측한 수**로 내렸다. 기준선은
남겨 두면 「고칠 예정」이 아니라 **「나빠질 여유」**다.

| 게이트 | before | after |
|---|---:|---:|
| `a11y-ratchet` `color-contrast` | 12 | **8** |
| `a11y-ratchet` `aria-required-children` | 1 | **0** |
| `a11y-ratchet` `target-size` | 0 | 0 |
| `contrast-ratchet` 미달 조합 | 4 | **2** |

### 자리별 before → after

| # | 라우트 | 원소 | 전경 on 배경 | before | after |
|---|---|---|---|---:|---:|
| 1 | `/ko/` | 주 CTA `a[data-testid=download-primary-cta]` | `#f7f8f8` on `#5e6ad2` | 4.42 | **4.70** |
| 2 | `/ko/` | CTA 안 크기 배지 `50.4 MB` | `#f7f8f8` on `#5e6ad2` | 4.42 | **4.70** |
| 3 | `/ko/download/` | 주 CTA (같은 컴포넌트) | `#f7f8f8` on `#5e6ad2` | 4.42 | **4.70** |
| 4 | `/ko/download/` | CTA 안 크기 배지 | `#f7f8f8` on `#5e6ad2` | 4.42 | **4.70** |
| 5 | `/ko/docs/` | 사이드바 상단 `div[role=tablist]` | — | `aria-required-children` 위반 | **role 반납, 위반 0** |

1~4는 `--color-text-primary` → **`--color-text-on-accent`**(`#ffffff`). **새 값
0개** — 이 토큰은 2026-08-03 에 「채운 인디고 위의 잉크」라는 이름으로 이미
만들어져 `control-class.ts` 의 `accentSolid` 가 쓰고 있었고, `button.tsx` 의
`primary` 변형만 이관에서 빠져 있었다. 무채/인디고 헌장 안이고 새 hue 없음.

5는 **자식을 `role="tab"` 으로 바꾸지 않았다.** 그 줄에는 컬렉션 3개 말고
검색 토글·정렬 메뉴·새 문서가 같이 있고, `tabpanel`·`aria-controls`·roving
tabindex 가 없다. 형제 `DocsVaultTabStrip` 이 이미 같은 이유로 tab role 을
안 쓴다고 적어 뒀다 — 이제 둘이 같은 계약을 쓴다. 세 컬렉션 버튼은
`role="group"` + `aria-pressed` 로 정직하게 묶었다.

### 게이트가 공회전하지 않는다 (`/gate-probe` 4종)

기준선이 0에 가까워지면 「늘지 않는다」 검사가 빈 집합 위에서 놀 수 있다.
넷 다 일부러 결함을 만들어 **빨개지는 것을 확인하고 원복**했다.

| 일부러 만든 결함 | 결과 |
|---|---|
| CTA 잉크를 `--color-text-primary` 로 되돌림 | `color-contrast` 8 → 12 실패 · 조합 2 → 4 실패 |
| 사이드바 줄에 `role="tablist"` 복원 | `aria-required-children` 0 → 1 실패 |
| 고친 채 `BASELINE` 만 9로 둠 | 여유 단언 실패 (기준선 9 · 실측 8) |
| 빈 문서만 서빙하는 서버에 물림 | 채집 단언 실패 (통과 룰 4 < 15) · 대비 스펙도 «한 개도 못 쟀다» 로 실패 |

**상주 프로브를 남겼다.** 네 번째가 잡은 것이 이 PR 의 숨은 결함이다 —
`target-size` 와 `aria-required-children` 이 둘 다 0이 되면서 **「빈 화면」과
「위반 없음」이 같은 초록**이 될 수 있었다. 처음 세려던 «평가된 룰 수»는
실측해 보니 **실제 화면 64 · 빈 문서 63** 이라 켜도 절대 안 빨개지는
장식이었다. 가르는 것은 `passes` 였다: 실제 화면 25~27 vs **빈 문서 2**.
바닥 15로 상주시켰다.

### 못 내린 것과 원리적 이유

**`color-contrast` 8건이 남았다. 8건 전부 `--color-text-quaternary`(#787c84)
토큰 **하나**다** (`/ko/ontology/insights/` 4 · `/ko/projects/` 4).

| 바탕 | 현재 대비 | 판정 |
|---|---:|---|
| `--color-canvas` `#08090a` | 4.76 | 통과 |
| `--color-panel` `#0f1011` | 4.55 | 통과 |
| panel + `--color-overlay-1` `#151617` | **4.33** | 미달 |
| `--color-elevated` `#191a1b` | **4.16** | 미달 |

이 잉크는 **캔버스/패널에서만 AA 를 넘고 한 단 올라선 표면에서 뚫린다.**

**자리별로 못 고치는 이유**: 소비처가 **652곳**이다. 오늘 8곳만 tertiary 로
바꾸면 그 8곳은 사라지지만 **644곳이 장전된 채 남는다** — 그건 수를 내리는
것이지 고치는 것이 아니고, 이 래칫이 정확히 그 행위를 막으려고 있는 것이다.

**「체계」로 넘길 토큰 (1건)**

- 파일: `app/globals.css:32`
- `--color-text-quaternary: #787c84` → **`#82828a`**
- 그 값이면 네 바탕 전부 통과: 5.23 / 5.00 / **4.75** / **4.57**
- tertiary(`#8a8f98`, 휘도 0.2732)와의 명도 순서 보존 (제안값 0.2255 > 현재 0.2007)
- 무채 명도만 움직이므로 **새 hue 0개** — 헌장 안
- **선례가 같은 저장소에 있다**: 지도 패널의 같은 이름 잉크
  `--topology-v2-panel-text-quaternary` 가 2026-07 에 `#55555d`(~2.5:1) →
  **`#82828a`**(~4.7:1) 로 **정확히 같은 사유**(«AA 크게 미달, 접근성 감사
  H3 P1»)로 이미 올라갔다. 전역 quaternary 만 그 정정을 못 받았다.

`app/globals.css` 의 램프는 `design.md` 「규격을 바꾸려면 「체계」를 부른다」
목록에 있고, 지금 「체계」가 그 파일과 `control-class.ts` 를 작업 중이라
이 PR 은 손대지 않았다. 그 한 줄이 들어오면 `color-contrast` 8 → 0 ·
미달 조합 2 → 0 이 되고, 래칫의 여유 단언이 **기준선을 안 내리면 그 PR 을
빨갛게 만든다** — 자동으로 이어진다.

## Test plan

- `pnpm checks:changed` 권고 전부:
  - `pnpm exec playwright test tests/e2e/a11y-ratchet.spec.ts tests/e2e/contrast-ratchet.spec.ts` — **2 passed**
  - `pnpm exec vitest run src/shared/ui/button.test.tsx src/views/docs-vault/ui/parts/DocsSidebarBody.test.tsx src/views/download/ui/DownloadPage.test.tsx` — **53 passed**
  - `pnpm exec tsc --noEmit` — 통과
- `pnpm test:contracts` — **1219 passed (104 files)**
- `pnpm lint` — **0 errors, 92 warnings** (main 96 대비 증가 0, 변경 파일 경고 0)
- 프로브 4종 — 위 표대로 전부 빨개진 뒤 원복 확인

디자인 변경(주 CTA 잉크 `#f7f8f8` → `#ffffff`)은 **육안 델타가 사실상 0**이고
움직인 것은 합성 대비 4.42 → 4.70 이다. 그래서 증거는 스크린샷이 아니라
위 자리별 수치이고(이 저장소 `/design-audit` 규율 — «재지 않으면 처방할 수
없다»), 렌더 확인용 캡처는 `/ko/download/` CTA 에서 따로 받았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
