### PR TITLE
fix: 디자인 시스템 감사 — 실증된 게이트 구멍 셋을 닫고, 못 닫은 넷을 보고한다

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -746,7 +746,21 @@ const eslintConfig = defineConfig([
     files: ['src/shared/lib/footprint-glyph.ts'],
     rules: {
       'no-restricted-syntax': [
-        'warn',
+        /*
+         * ⚠️ **`error` 다 — 종전엔 `warn` 이었고 그건 게이트가 아니었다.**
+         *
+         * 예외는 이미 아래 `.filter(…shadowBlur)` 한 줄이 정확히 낸다. 그런데
+         * 레벨까지 `warn` 으로 내려 두면 **남은 셀렉터 전부**(arbitrary 크기 ·
+         * accent 틴트 · scale/gradient)가 이 파일에서만 무력해진다. 게다가
+         * `pnpm lint` 는 `--max-warnings` 가 없어 경고가 몇 개든 exit 0 이다.
+         *
+         * 2026-08-04 감사 실측: 이 파일에 `text-[13px] rounded-[7px]` 를 심고
+         * `pnpm lint` 를 돌리니 «94 problems (0 errors, 94 warnings)» 로
+         * **통과했다.** 예외 하나를 여느라 문 전체를 열어 둔 것이다.
+         *
+         * 켜기 전 전수: 이 파일의 위반은 **0** 이라 승격 비용이 0이다.
+         */
+        'error',
         ...scaleGradientSelectors.filter((rule) => !rule.selector.includes('shadowBlur')),
         ...arbitrarySizeSelectors,
         ...accentTintPairingSelectors,

--- a/scripts/check-no-raw-color.mjs
+++ b/scripts/check-no-raw-color.mjs
@@ -98,8 +98,27 @@ export const ALLOWLIST = new Set([
   "entities/ontology-class/model/tone.ts",
 ]);
 
+/**
+ * **디렉터리째 면제는 이 저장소의 규격이 아니다** — 면제는 «파일 단위 + 사유
+ * 주석»이고, 그것이 `ALLOWLIST` 다.
+ *
+ * 종전엔 `topology-map-v2`(캔버스 엔진) 전체를 건너뛰었다. 이유는 정당했다 —
+ * canvas `fillStyle` 은 `var()` 를 못 먹는다. 하지만 **디렉터리 하나를 통째로
+ * 면제하면 그 안에서 무엇이 자라는지 아무도 모른다**: 59개 파일이 이 검사를
+ * 한 번도 받은 적이 없었고, 게이트가 «깨끗해서 0» 인지 «안 봐서 0» 인지 구별할
+ * 방법이 없었다.
+ *
+ * ⚠️ **켜기 전 전수 측정**(`/gate-probe` · `design-system-audit` §4): 이 스킵을
+ * 걷어낸 뒤 그 디렉터리의 위반은 **0** 이다(2026-08-04 실측 — 비-테스트 파일의
+ * rgba 리터럴은 `rgba(3,3,4)` 2건과 `rgba(236,236,240)` 2건뿐이고 넷 다 어느
+ * `HUE_FAMILIES` 에도 없다). 그래서 이 변경은 픽셀도 0, 위반도 0이고, 막는 것은
+ * **앞으로의 재유입**뿐이다.
+ *
+ * 캔버스가 정말 raw 리터럴을 요구하는 파일이 생기면 `ALLOWLIST` 에 **파일 하나
+ * + 그 파일 상단 docstring 의 사유**로 등재한다 — `tone.ts` 가 그 선례다.
+ */
 function shouldSkipDir(name) {
-  return name === "node_modules" || name === "topology-map-v2";
+  return name === "node_modules";
 }
 
 function isTargetFile(name) {

--- a/scripts/check-no-raw-color.test.mjs
+++ b/scripts/check-no-raw-color.test.mjs
@@ -124,12 +124,25 @@ test("skips .test. files", () => {
   );
 });
 
-test("skips the topology-map-v2 canvas engine directory", () => {
+/*
+ * 종전 이 자리에는 «topology-map-v2 디렉터리를 건너뛴다» 는 테스트가 있었다.
+ * 그 디렉터리째 면제를 2026-08-04 감사가 걷어냈다 (`check-no-raw-color.mjs` 의
+ * `shouldSkipDir` 주석 — 걷어낸 시점의 그 디렉터리 위반 전수는 0 이다).
+ * 면제는 이제 파일 단위 `ALLOWLIST` 로만 존재한다.
+ *
+ * **이 테스트는 반대 방향을 못박는다** — 디렉터리 스킵이 되살아나면 여기가
+ * 빨개진다. 이 단언이 없으면 「깨끗해서 0」과 「안 봐서 0」이 다시 같은 초록이
+ * 된다.
+ */
+test("scans the topology-map-v2 canvas engine directory — no directory-wide exemption", () => {
   withTempSrc({}, (dir) => {
     const nested = join(dir, "widgets", "topology-map-v2", "lib");
     mkdirSync(nested, { recursive: true });
     writeFileSync(join(nested, "colors.ts"), `const c = "rgba(94,106,210,0.24)";\n`, "utf8");
-    assert.deepEqual(findRawColorLiterals(dir), []);
+    const found = findRawColorLiterals(dir);
+    assert.equal(found.length, 1, "캔버스 디렉터리가 다시 통째로 면제됐다");
+    assert.equal(found[0].family, "indigo");
+    assert.match(found[0].file, /topology-map-v2/);
   });
 });
 

--- a/src/features/docs-vault-local/ui/StepRow.tsx
+++ b/src/features/docs-vault-local/ui/StepRow.tsx
@@ -13,11 +13,16 @@
  * 그 한 겹이 설정 패널에서 **보더 4단 중첩**을 만들었다:
  *
  * ```
- * app-settings-popover       1px rgba(255,255,255,0.06)  r12
- *  └ section (인디고 패널)    1px rgba(139,151,255,0.22)  r6
- *     └ agent-setup-step-N   1px rgba(255,255,255,0.06)  r6   ← 이 겹
- *        └ agent-client-…    1px rgba(139,151,255,0.54)  r6
+ * app-settings-popover       1px --color-border-soft        r12
+ *  └ section (인디고 패널)    1px --color-indigo-line-a22    r6
+ *     └ agent-setup-step-N   1px --color-border-soft        r6   ← 이 겹
+ *        └ agent-client-…    1px --color-indigo-line-a54    r6
  * ```
+ *
+ * ⚠️ 이 도해는 **토큰 이름으로 적는다** — 값을 적으면 토큰이 움직였을 때 산문만
+ * 조용히 낡고, 게다가 `check-no-raw-color` 가 주석 속 리터럴을 위반으로 세서
+ * 게이트가 붉은 채로 굳는다(2026-08-04 감사 실측: 이 두 줄이 그 게이트의
+ * 유일한 위반이었고, 그 게이트는 CI 에 안 걸려 있어 아무도 몰랐다).
  *
  * 카드 크롬을 뺀 쪽으로 합치면 3단이 되고, 「2단계가 내용 한 줄인데 카드
  * 크롬을 다 갖는다」는 결함도 함께 사라진다 — 보더/배경이 없으면 「내용 0줄


### PR DESCRIPTION
## Summary

`/design-system-audit` 전수 감사. 질문은 「이번 변경이 규격에 맞나」가 아니라
**「시스템이 강제되고 있나」**였고, 답을 **결함 주입**으로 냈다 — 각 게이트에
위반을 심고 빨개지는지 보고 원복했다.

**「전부 통과」로 끝나지 않았다.** 오늘 주장된 게이트 여덟 중 **셋이 공회전**하고
있었고, 실물 계측에서 **어떤 래칫도 못 보는 AA 미달 1건**을 새로 찾았다.

### 닫은 문 (이 PR) — 픽셀 변화 0

| 구멍 | 무엇을 못 봤나 | 실증 | 처방 |
|---|---|---|---|
| `check-no-raw-color` 가 **붉은 채 굳어 있었다** | `StepRow.tsx` 도해가 토큰 «값»을 산문에 적어 그 두 줄이 유일한 위반. 게이트는 CI·훅·`checks:changed` **어디에도 안 걸려 있어** 아무도 몰랐다 | `node scripts/check-no-raw-color.mjs` → exit 1 (main 에서) | 도해를 토큰 «이름»으로. 게이트 0 |
| 같은 게이트가 `topology-map-v2` 를 **디렉터리째 면제** | 59개 파일이 한 번도 검사받은 적 없음 — 「깨끗해서 0」과 「안 봐서 0」이 구별 불가 | 승격 후 프로브 주입 → 빨강 | 스킵 제거. 켜기 전 전수 = **0**. 면제는 파일 단위 `ALLOWLIST` + 사유만 |
| 발자국 예외 블록이 램프 룰 **전체를 `warn`** 으로 강등 | `pnpm lint` 에 `--max-warnings` 가 없어 경고는 아무것도 실패시키지 않는다 | 그 파일에 `text-[13px] rounded-[7px]` 주입 → **«0 errors, 94 warnings» 로 통과** | `error` 승격(위반 전수 0). `shadowBlur` 예외는 프로브로 보존 확인 |

스킵을 못박던 테스트는 **반대 방향으로 뒤집었다** — 스킵이 되살아나면 빨개진다.

### 못 닫은 문 — 「체계」 소집 사항 (이 PR 범위 밖)

| 구멍 | 실증 | 규모 |
|---|---|---|
| **`surface-motion-ratchet` 에 탐지 단계가 없다** | 새 `ProbePanel.tsx`(기제 0)를 만들어도 **초록**. `stillHardCut()` 은 **등록부만** 순회하는데 등록부가 비어 있다 — 「하드컷 0」은 제품이 아니라 **빈 목록**에 대한 참이다 | 코드베이스를 훑는 단계 자체가 없음. 접미사 휴리스틱으로 세면 20개 중 8개가 후보지만 **1건 실측(`VaultAgentSetupPanel`)은 부모가 퇴장을 주고 있었다**(opacity 1→0, ~120ms) — 즉 8은 결함 수가 아니라 «부모 인식 탐지기로 판정해야 할 후보 수» |
| **`control-adoption-ratchet` 은 `<button>` 만 센다** | 손으로 쓴 `<Link>` 컨트롤을 심어도 **초록** | 컨트롤 모양(`px/py/h` + `rounded/border`)을 가진 비-button 원소 **77개**(Link 39 · a 11 · input 15 · textarea 5 · select 3 · label 2 · summary 2). 값 층에 `shape:'link'` 가 **이미 있다** → 「등재」가 아니라 부채 |
| **`named-offramp-utility-ratchet` 은 `.tsx` 만 센다** | `.ts` 에 `text-sm rounded-2xl` 을 심어도 **초록** | 오늘 실부채 **0**(`.ts` 히트 2건은 전부 산문 주석). 구조적 구멍이지 현행 결함 아님 |
| **`check-no-raw-color` 는 손으로 적은 RGB 삼중항 34개 denylist** | 새 드리프트 값은 **구조적으로 안 보인다** | 어느 패밀리에도 없는 raw 값 **13종 / 30건**. 인디고 계열만 4종 드리프트: `rgba(113,112,255)`×3 · `rgba(210,218,255)`×3 · `rgba(159,170,235)`×2 · `rgba(208,214,224)` — 헌장은 «인디고 하나»다. `documentation.md` 가 금지한 «손으로 등재하는 금지어 사전» 형태 |

### 새로 찾은 결함 — 어떤 게이트도 못 보는 자리

**에이전트 연결 패널의 단계 번호 배지가 AA 미달이다.**

```
--color-indigo-accent  rgb(113,112,255)  on  --color-indigo-a16 합성  rgb(28,30,48)
11px · font-weight 500 · 24×24 @ (497,112)
대비 4.27:1   (WCAG 1.4.3 요구 4.5:1)
elementFromPoint → 자기 자신 (실제로 화면에 보인다 · 오탐 아님)
나침 라우트 10곳에서 도달 가능
```

**왜 래칫이 못 봤나** — `contrast-ratchet` 은 17 라우트를 **초기 상태로만** 연다
(`domcontentloaded` 후 클릭 0). 팝오버·드로어·시트·다이얼로그 **20개 표면이
열린 상태로는 한 번도 측정된 적이 없다.** 이 결함은 2026-08-03 이 이미 고친
것과 **같은 계열**(인디고 면 위 인디고 잉크 4.42:1)인데, 열어야 보이는 자리라
살아남았다.

토큰 값 판정이 필요해 **고치지 않았다** — 「체계」/소유자 사항.

### 실측으로 확인한 «진짜 0» (안 잰 0 과 구별)

측정 후 0인 항목은 0이라고 적는다.

| 항목 | 결과 |
|---|---|
| AA 미달 — 17 라우트 × **모바일 390 / 태블릿 834 / 랩탑 1512** | **0건** (초기 상태) |
| AA 미달 — 뷰포트 클립 제거(문서 전체, 스크롤 아래 포함) | **0건** |
| 렌더된 램프 이탈 반경 | 16px×2(`ontology-studio`) · 18px×1 — 전부 `type-ramp-coverage` **장부 안** |
| 렌더된 램프 이탈 크기 | 10px×7 · 9px×1 · 28px×1 — 전부 장부 안 |
| arbitrary 값 총 부채 | **176건 / 8 디렉터리** (`type-ramp-coverage` 장부, 못 자람) |
| `topology-map-v2` 안의 금지 hue | **0건** (그래서 스킵 제거 비용 0) |

⚠️ 오탐 방지: 모든 계측은 `elementFromPoint` 로 **실제 가시성**을 확인했고,
「8개 하드컷」은 실측으로 **후보로 강등**했다.

### 소유자 판단이 필요한 것

1. `pnpm check:tokens` 를 CI 에 배선할까 — 지금은 어디에서도 안 돈다(이 PR 이후 0건이라 배선 비용 0).
2. `pnpm lint` 에 `--max-warnings` — 현행 경고 92건(전부 react-hooks)이라 별도 라운드.
3. 위 AA 미달 4.27:1 의 잉크 판정.

## Test plan

- `pnpm exec tsc --noEmit` — 통과
- `pnpm lint` — 0 errors (92 warnings, 변화 없음)
- `pnpm test:contracts` — **108 파일 / 1261 테스트 통과**
- `node --test scripts/check-no-raw-color.test.mjs` — 9/9 통과
- `node scripts/check-no-raw-color.mjs` — exit 0 (main 에서는 exit 1 이었다)
- `pnpm build` — 통과
- `PLAYWRIGHT_STATIC=1 playwright test a11y-ratchet contrast-ratchet` — **2 passed**
- 게이트 프로브(주입 → 빨강 → 원복): 새 raw color · 램프 위반 in warn 파일 · shadowBlur 예외 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
