### PR TITLE
fix: 전 화면 디자인 감사 — 68 렌더 실측, 사다리 밖 컨트롤 1건 정정

### DIFF
--- a/src/views/ontology-studio/ui/StudioTooNarrow.tsx
+++ b/src/views/ontology-studio/ui/StudioTooNarrow.tsx
@@ -50,18 +50,32 @@ export function StudioTooNarrow() {
         tone="solid"
         align="center"
         action={
+          /*
+           * 높이는 **선언**이지 패딩의 부산물이 아니다.
+           *
+           * 2026-08-04 실측: 이 두 CTA 가 `py-1.5` 산수로 **30px** 로 렌더되고
+           * 있었다 — `docs/DESIGN-SYSTEM.md` 「컨트롤 높이 사다리」가 어휘
+           * (24·28·32·36·40·44) 밖이라고 이름까지 지목한 값이고, 값 층이
+           * `card/sm` 30→32 · `card/md` 34→36 으로 걷어낸 바로 그 부산물이다.
+           * 이 화면은 손으로 쓴 컨트롤이라 그 라운드의 사정거리 밖에 있었다.
+           *
+           * `<lg` 강등 화면의 **유일한 두 컨트롤**이라 더 그렇다 — 여기서
+           * 나가는 길이 이 라우트의 전부인데 그 길만 사다리 밖이었다.
+           * `min-h-8`(32px = `--control-h-md`)로 바닥을 선언하면 반경·인셋·
+           * 타입은 그대로고 움직이는 픽셀은 높이 2px 뿐이다.
+           */
           <div className="flex flex-wrap items-center justify-center gap-2">
             <Link
               href="/topology/"
               data-testid="studio-too-narrow-map"
-              className="rounded-card border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex min-h-8 items-center rounded-card border border-[color:var(--color-border-strong)] px-3 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
             >
               {t("openMap")}
             </Link>
             <Link
               href="/download/"
               data-testid="studio-too-narrow-get-app"
-              className="rounded-card border border-[color:var(--color-border-strong)] px-3 py-1.5 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
+              className="inline-flex min-h-8 items-center rounded-card border border-[color:var(--color-border-strong)] px-3 text-label font-semibold text-[color:var(--color-text-secondary)] transition-colors hover:text-[color:var(--color-text-primary)]"
             >
               {t("getApp")}
             </Link>


### PR DESCRIPTION
## Summary

`/design-audit` 을 **17 라우트 전부 × 2 뷰포트(1512×900 · 390×844) × 볼트 유/무
= 68 렌더**에 돌렸다. 눈으로 본 게 아니라 rect 교집합 · `elementFromPoint` ·
반복 세트 치수 편차 · computed style 대 램프 · 실제 스크롤 컨테이너 끝 여백을
쟀다. 지난 이틀에 픽셀이 크게 움직였으므로(컨트롤 294건 값 층 이동 · 반경/글자
24건 램프 진입 · 잉크 상향 · 등장/퇴장) **합쳐진 화면**을 통으로 재는 것이 목적.

### 고친 것 — 1건

**`src/views/ontology-studio/ui/StudioTooNarrow.tsx`** — `<lg` 강등 화면의 두
탈출구가 `py-1.5` 산수로 **30px** 로 렌더되고 있었다. 사다리(24·28·32·36·40·44)
밖이고, `docs/DESIGN-SYSTEM.md` 가 30·34 를 「이 앱의 높이 어휘 어디에도 없는
값」이라고 이름까지 지목한 그 값이다. 값 층 라운드가 `card/sm` 30→32 ·
`card/md` 34→36 으로 걷어낸 부산물과 같은 부류인데, 이 둘은 손으로 쓴 컨트롤이라
사정거리 밖이었다.

`min-h-8`(32px = `--control-h-md`)로 바닥을 **선언**한다. 반경 9px · 인셋 px-3 ·
타입 `text-label` 그대로 — 움직인 픽셀은 높이 2px 하나다.

| | before | after |
|---|---:|---:|
| `studio-too-narrow-map` (390 · 1023) | 30px | **32px** |
| `studio-too-narrow-get-app` (390 · 1023) | 30px | **32px** |
| 그 화면의 컨트롤 높이 종류 | 1종(30) | 1종(32) |

### 넘긴 것 — 「체계」 소집 4건 (규격 변경이라 감사가 단독으로 안 고친다)

1. **오버레이 반경이 여섯 값이다.** 실측(1512, 각 표면을 실제로 열어서):
   설정 팝오버 **12** · 문서 팔레트 **9** · 문서 퀵드로어 **9** · 단축키 시트
   **22** · 볼트 안내 시트 **22** · 검색 팔레트 **22** · 공방 진입 카드 **16** ·
   퀵액션/제스처 힌트 **18** · 히어로 **20**. 마지막 라운드가 드로어 한 열에서
   고친 「16/18/20 이 세 가지 일을 하며 거의 같아 보이던 평평함」이 **한 층 위
   오버레이 단에 그대로 살아 있다**. 값의 출처도 갈라져 있다 — 토큰 2개
   (`--topology-shortcut-sheet-radius` 22 · `--topology-search-sheet-radius` 16)
   + eslint-disable 4개. 그중 `StudioEntryChoice.tsx:167` 의 사유는 문자 그대로
   **"램프 밖 16px, 등재 대기"** 이고 등재는 오지 않았다. 보더 알파도 0.06/0.08
   이 임의로 갈린다.
2. **행간 램프만 게이트가 없다.** 타입·반경은 2026-08-03/04 에 이름 유틸리티
   래칫이 섰는데 `leading-*` 은 패밀리가 하나도 없고, eslint 도 `leading-[N]`
   (arbitrary)만 본다. 소스 census: `leading-relaxed` **71** · `leading-snug`
   **17** · `leading-none` **9** · `leading-tight` **8** = **105곳**. 화면에서
   실제로 나온 램프 밖 행간: 22.75 / 20.3125 / 17.875 / 15.125 / 28.75 / 9.5px
   (8개 라우트 + 볼트 안내 시트). `text-sm`/`rounded-md` 268건이 통째로 램프를
   우회하던 것과 **같은 모양의 구멍**이다 — 세 램프 중 하나만 안 덮였다.
3. **`border-white/35` 1건** — `FirstRunStarterModule.tsx:459` 의 `⌘O` kbd 캡.
   앱 전체에서 유일한 raw 색 유틸리티(hex 룰은 `-[#hex]` 만 본다). 흰색 알파
   0.35 짜리 보더 토큰이 없어 값-충실 치환이 불가능 — 토큰 신설이냐 기존
   `--color-border-strong`(0.14)로 내리느냐가 판정 사항.
4. **단축키 시트 행 17개 중 2개가 40px**(나머지 24px) — 라벨이 두 줄로 감긴다
   (「지도 이동(빈 공간) 또는 노드 위치 이동(스프링 반사)」 · 「컨텍스트 메뉴 —
   문서 열기 · 관계 편집 · …」). 치수 규칙성의 대상이지만 처방이 클램프면 단축키
   설명의 의미가 잘린다 — 문안 축약이냐 2행 예약이냐가 판정 사항.

### 오탐으로 기각한 것 (재고 나서 반증했다 — 다음 감사가 되풀이하지 않게 기록)

- `/ko/changelog/` 의 `<em>`×`<strong>` 「겹침 2건」 → **줄상자 교집합 0**.
  여러 줄에 걸친 인라인의 `getBoundingClientRect()` 가 union 이라 겹쳐 보였을 뿐.
- `project-save`/`project-cancel`/`project-save-return`/`project-mobile-preview-toggle`/
  `project-selector-activity-row` 「하단 탭바에 가림」 → 스크롤 top 에서 접힌
  것뿐. 스크롤 끝에서 전부 도달 가능(gap +95 ~ +120px).
- `topology-cluster-hint` 「탭바와 1px 겹침」 → **1×1px sr-only 라이브 영역**.
- `topology-index-row` 「높이 20 vs 37.5」 → 행 종류가 다르다(프로젝트 행 vs
  「역량 N · 요소 N」 부제를 든 도메인 행).
- 마크다운 `li` 16px 「루트 상속」 → 자기 텍스트 없는 내비 `<li>` 껍데기.
- 1차 스크롤 끝 측정의 −274.9px 등 → **document 가 실제 스크롤러가 아니었다**
  (본문은 안쪽 `overflow-y-auto` 컨테이너).

## 실측표 — 전 라우트 (결함 0인 칸이 대부분이다)

| 검사 | 결과 |
|---|---|
| 겹침 (rect 교집합, 실제 도색 원소만) | **0건** / 68 렌더 |
| 도달 가능성 (`elementFromPoint`) | **0건** — 후보 6건 전부 스크롤로 도달 |
| 치수 편차 (반복 세트) | 라우트단 0건 · 단축키 시트 2행(위 4번) |
| 타입 램프 이탈 | 등재 부채 밖 **0건** (`project-edit` 26 · `ontology-studio` 45 · `entities/project` 33 은 `type-ramp-coverage` 원장에 있음) |
| 반경 램프 이탈 | 전부 등재 예외/원장 — 단 `StudioEntryChoice` 는 사유가 "등재 대기" |
| 색 토큰 이탈 | **1건** (`border-white/35`) |
| 행간 램프 이탈 | 105 소스 · 8 라우트 (게이트 없음, 위 2번) |
| 스크롤 끝 여백 (390, 실제 스크롤러) | 16 라우트 전부 양수 — 최소 `/ko/` **+39.3px**, 다음 `/ko/docs/` +67 |
| 컨트롤 높이 종류 / 화면 | 최대 6종, 사다리 밖은 이번 1건뿐(나머지는 인라인 면제·미디어 표면) |
| 드로어 반경 (16→12 라운드 착지 확인) | 6 / 9 / 12 + 등재된 시트 단 18 · 20 — **16 은 사라졌다** |

**증거 스크린샷**: 68 + 오버레이 7 + 드로어 4, DPR 1, `prefers-reduced-motion: reduce`,
`?guides=off` — `/private/tmp/.../scratchpad/da/shots/`.

## Test plan

- `pnpm exec tsc --noEmit` ✓
- `pnpm exec eslint src/views/ontology-studio/ui/StudioTooNarrow.tsx` ✓
- `pnpm build` ✓ → 정적 export 서빙 후 실측
- `playwright a11y-ratchet` ✓ (17 라우트 기준선 0 유지)
- `playwright contrast-ratchet` ✓ (17 라우트 기준선 0 유지)
- `playwright responsive-overflow-audit` 45종 ✓ · `touch-target-contract` 3종 ✓
- 재측정: 고친 뒤 같은 계기로 `/ko/ontology/studio/` 4조합 재주행 — 겹침 0 ·
  도달 불가 0 · 신규 이탈 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275