### PR TITLE
fix: 도메인 결합 밀집 행의 WCAG 2.5.8 위반 — 데이터가 있어야 보이던 자리를 계기에 넣는다

### DIFF
--- a/src/views/ontology-insights/ui/tabs/DomainCouplingCard.tsx
+++ b/src/views/ontology-insights/ui/tabs/DomainCouplingCard.tsx
@@ -403,7 +403,23 @@ function SelectedPairDetail({
           </span>
         ))}
       </div>
-      <div className="flex flex-col gap-1">
+      {/* 세로 간격 10px(`gap-2.5`) — WCAG 2.5.8(AA) 의 spacing 예외를 위한 값이다.
+          이 줄의 링크는 `text-label`(11px/16px) 이라 자연 높이가 16px 이고,
+          24px 본칙에 미달한다. 예외를 타려면 **지름 24 원이 이웃 타깃과 안 만나야**
+          하므로 중심 간 거리가 24px 이상이어야 하는데, `gap-1`(4px) 에서는
+          16+4 = **20.0px** 였다(실측 2026-08-04, 1512×900 정적 export).
+          10px 이면 26.0px 이 되어 예외를 넘긴다.
+
+          높이를 24px 로 올리는 갈래(본칙 충족)를 쓰지 않은 이유 둘: ① 행 높이가
+          바뀌면 이 카드가 예약해 둔 상세 슬롯이 클릭마다 24px 씩 더 뛴다(간격만
+          늘리면 12px). ② 링크의 높이 바닥은 값 층(`control-class`)에서 따로
+          재설계 중이라, 여기서 한 자리만 먼저 정하면 두 규격이 갈린다.
+
+          ⚠️ `.touch-hit-expand` 로 히트만 넓히는 우회는 **금지**다. 행 피치
+          26px 에 44px 확장은 이웃과 18px 겹치고, DOM 순서상 뒤 행이 앞 행의
+          탭을 훔친다 — 「작아서 못 누름」이 「눌렀는데 다른 게 열림」이 된다.
+          게이트: `tests/e2e/dense-row-target-size.spec.ts`. */}
+      <div className="flex flex-col gap-2.5">
         {pair.examples.map((example) => (
           <div
             key={example.id}

--- a/tests/e2e/dense-row-target-size.spec.ts
+++ b/tests/e2e/dense-row-target-size.spec.ts
@@ -1,0 +1,261 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+import { stubDirectoryPicker } from "./vault-picker-stub";
+
+/**
+ * 밀집 행의 타깃 크기 — **데이터가 있어야만 존재하는 자리**를 WCAG 2.5.8 로 잰다.
+ *
+ * ## 왜 접근성 래칫이 이 위반을 한 번도 못 봤나
+ *
+ * `a11y-ratchet` 은 17 라우트를 열고 axe 를 돌린다. 그 게이트의 `target-size`
+ * 기준선은 **0** 이고 실제로 0 이었다 — 그런데 그건 위반이 없어서가 아니라
+ * **그 자리가 렌더된 적이 없어서**다. 「경계」 탭의 도메인 결합 상세(짝을 이룬
+ * 예시 링크 줄)는 두 조건을 모두 만족해야 화면에 나온다:
+ *
+ *   ① 볼트에 **교차 도메인 엣지**가 있어야 격자에 누를 수 있는 칸이 생기고,
+ *   ② 사람이 그 칸을 **눌러야** 상세가 펼쳐진다.
+ *
+ * 기본 샘플 볼트에는 ①이 없다. 그래서 axe 는 그 DOM 을 한 번도 본 적이 없고,
+ * 게이트는 **빈 집합 위에서 초록**이었다. 이건 이 한 자리의 문제가 아니라
+ * 부류의 문제다 — *데이터에 의존해 눈이 감기는 게이트*.
+ *
+ * 그래서 이 스펙은 위반을 **재현**한다: OPFS 스텁 픽커로 교차 도메인 엣지가
+ * 있는 볼트를 물리고, 칸을 눌러 그 행을 실제로 그린 다음 rect 를 잰다.
+ *
+ * ## 무엇을 재는가 — WCAG 2.5.8 Target Size (Minimum), AA
+ *
+ * 통과 조건은 둘 중 하나다(둘 다 실패해야 위반):
+ *   - **본칙**: 타깃이 24×24 CSS px 이상이다.
+ *   - **Spacing 예외**: 타깃 중심의 지름 24 원이 다른 어떤 타깃의 원과도 만나지
+ *     않는다 → 중심 간 거리 ≥ 24.
+ * (Inline 예외는 문장 흐름 안의 링크에만 붙는다. 목록 행은 자기 줄을 차지하는
+ * 블록이라 해당 없음 — 실측에서도 `display: block` 이었다.)
+ *
+ * ## 히트 확장(`.touch-hit-expand`)으로는 못 고친다
+ *
+ * 행 피치가 21px 인 자리에 44px 히트 영역을 붙이면 이웃과 16px 겹치고, DOM
+ * 순서상 **뒤 행이 앞 행의 탭을 훔친다.** 「작아서 못 누름」이 「눌렀는데 다른
+ * 게 열림」이 되는 것은 개선이 아니다. 그래서 이 자리의 처방은 값 층(행 간격)
+ * 이고, 이 스펙은 보이는 rect 를 잰다.
+ */
+
+const MIN_TARGET = 24;
+
+/** 교차 도메인 엣지가 있는 볼트 — 이게 없으면 검사 대상 DOM 이 태어나지 않는다. */
+const CROSS_DOMAIN_VAULT: Record<string, string> = {
+  "project.md": [
+    "---",
+    "kind: project",
+    "slug: coupling-platform",
+    "title: Coupling Platform",
+    "contains:",
+    "  - coupling-orders",
+    "  - coupling-settlement",
+    "---",
+    "",
+    "# Coupling Platform",
+    "",
+    "교차 도메인 엣지를 가진 최소 볼트 — 밀집 행 재현용.",
+    "",
+  ].join("\n"),
+  "domains/orders.md": [
+    "---",
+    "kind: domain",
+    "slug: coupling-orders",
+    "title: Orders",
+    "contains:",
+    "  - coupling-checkout",
+    "  - coupling-cart-pricing",
+    "  - coupling-order-history",
+    "---",
+    "",
+    "# Orders",
+    "",
+    "주문 도메인.",
+    "",
+  ].join("\n"),
+  "domains/settlement.md": [
+    "---",
+    "kind: domain",
+    "slug: coupling-settlement",
+    "title: Settlement",
+    "contains:",
+    "  - coupling-invoice",
+    "  - coupling-payout-ledger",
+    "  - coupling-tax-report",
+    "---",
+    "",
+    "# Settlement",
+    "",
+    "정산 도메인.",
+    "",
+  ].join("\n"),
+  // 주문 → 정산 세 갈래. `insights.ts` 가 쌍마다 예시를 3개까지 모으므로
+  // 이 셋이 그대로 세로로 쌓인 세 줄이 된다 — 재현하려는 밀집 행이 그것이다.
+  "capabilities/checkout.md": capability("coupling-checkout", "Checkout", "coupling-orders", [
+    "coupling-invoice",
+  ]),
+  "capabilities/cart-pricing.md": capability(
+    "coupling-cart-pricing",
+    "Cart pricing",
+    "coupling-orders",
+    ["coupling-payout-ledger"],
+  ),
+  "capabilities/order-history.md": capability(
+    "coupling-order-history",
+    "Order history",
+    "coupling-orders",
+    ["coupling-tax-report"],
+  ),
+  "capabilities/invoice.md": capability("coupling-invoice", "Invoice", "coupling-settlement", []),
+  "capabilities/payout-ledger.md": capability(
+    "coupling-payout-ledger",
+    "Payout ledger",
+    "coupling-settlement",
+    [],
+  ),
+  "capabilities/tax-report.md": capability(
+    "coupling-tax-report",
+    "Tax report",
+    "coupling-settlement",
+    [],
+  ),
+};
+
+/**
+ * `relates` 를 쓰는 이유 — 웹 파생기(`derive-ontology-from-vault`)가 역량의
+ * 교차 엣지로 읽는 키가 그것이다. `depends_on` 은 스키마의 역량 키지만 이
+ * 파생기가 읽는 것은 `dependencies`(프로젝트 키)라, 역량에 `depends_on` 을
+ * 적으면 **엣지가 조용히 0개**가 된다(실측: 관계 8 = 컨테인먼트뿐, 격자 없음).
+ * 이 스펙의 주제가 아니므로 여기서는 실제로 엣지가 되는 키를 쓴다.
+ */
+function capability(slug: string, title: string, domain: string, relates: string[]): string {
+  return [
+    "---",
+    "kind: capability",
+    `slug: ${slug}`,
+    `title: ${title}`,
+    `domain: ${domain}`,
+    ...(relates.length ? ["relates:", ...relates.map((d) => `  - ${d}`)] : []),
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    `${title} 역량.`,
+    "",
+  ].join("\n");
+}
+
+interface Target {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  isExampleLink: boolean;
+}
+
+/** 볼트를 물리고 「경계」 탭의 상세를 펼친 뒤, 그 화면의 타깃 전수를 돌려준다. */
+async function openCouplingDetail(page: Page): Promise<Target[]> {
+  await stubDirectoryPicker(page, CROSS_DOMAIN_VAULT);
+  await seedFirstRunSeen(page);
+
+  await page.goto("/ko/topology/?guides=off");
+  await page.waitForLoadState("networkidle");
+  await page.getByTestId("first-run-starter-open").click();
+  await expect(page.getByTestId("vault-guide-sheet")).toBeVisible();
+  await page.getByTestId("vault-guide-pick-existing").click();
+  await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 20_000 });
+
+  await page.goto("/ko/ontology/insights/?tab=boundaries&guides=off");
+  await page.waitForLoadState("networkidle");
+
+  // 콜드스타트 카드가 떴다면 볼트가 안 실린 것이다 — 아래 단언이 그 자리에서 터진다.
+  await expect(page.getByTestId("domain-coupling-grid")).toBeVisible({ timeout: 20_000 });
+  await page.getByTestId("domain-coupling-cell").first().click();
+  await expect(page.getByTestId("domain-coupling-pair")).toBeVisible();
+
+  return page.evaluate(() => {
+    const panel =
+      document.querySelector('[id^="insights-tabpanel"]') ?? document.body;
+    const visible = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      return r.width > 0 && r.height > 0 && cs.visibility !== "hidden";
+    };
+    return Array.from(panel.querySelectorAll('a[href], button:not([disabled])'))
+      .filter(visible)
+      .map((el) => {
+        const r = el.getBoundingClientRect();
+        return {
+          id:
+            el.getAttribute("data-testid") ||
+            (el.textContent || "").trim().slice(0, 24) ||
+            el.tagName,
+          x: r.x,
+          y: r.y,
+          w: r.width,
+          h: r.height,
+          isExampleLink:
+            el.getAttribute("data-testid") === "domain-coupling-example-link",
+        };
+      });
+  });
+}
+
+const centerDistance = (a: Target, b: Target) =>
+  Math.hypot(a.x + a.w / 2 - (b.x + b.w / 2), a.y + a.h / 2 - (b.y + b.h / 2));
+
+test.describe("밀집 행 타깃 크기 (WCAG 2.5.8 AA)", () => {
+  test("도메인 결합 상세의 예시 링크가 24px 본칙 또는 간격 예외를 만족한다", async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.setViewportSize({ width: 1512, height: 900 });
+    const targets = await openCouplingDetail(page);
+    const examples = targets.filter((t) => t.isExampleLink);
+
+    // ★ 빈 집합 위에서 놀지 않는다는 증거 ① — 잴 것이 실제로 렌더됐는가.
+    //   이 게이트가 태어난 이유가 «그 행이 안 뜨면 조용히 통과» 였다.
+    expect(
+      examples.length,
+      "예시 링크가 없다 — 볼트가 안 실렸거나 칸이 안 펼쳐졌다. 위반이 없는 게 아니라 미측정이다.",
+    ).toBeGreaterThanOrEqual(4);
+
+    // ★ 증거 ② — 그중 **세로로 겹쳐 쌓인 이웃**이 실제로 있는가. 밀집 행이
+    //   한 줄로 펴지면(예: 예시가 1건뿐인 볼트) 이 검사는 아무것도 안 본다.
+    const stacked = examples.some((a) =>
+      examples.some(
+        (b) =>
+          a !== b &&
+          Math.abs(a.x - b.x) < 1 &&
+          Math.abs(a.y - b.y) > 1 &&
+          Math.abs(a.y - b.y) < 60,
+      ),
+    );
+    expect(stacked, "세로로 쌓인 예시 링크 이웃이 없다 — 밀집 행을 재고 있지 않다.").toBe(true);
+
+    const violations = examples
+      .map((target) => {
+        if (target.w >= MIN_TARGET && target.h >= MIN_TARGET) return null;
+        const nearest = targets
+          .filter((other) => other !== target)
+          .reduce<{ other: Target; d: number } | null>((best, other) => {
+            const d = centerDistance(target, other);
+            return !best || d < best.d ? { other, d } : best;
+          }, null);
+        if (nearest && nearest.d >= MIN_TARGET) return null;
+        return (
+          `  "${target.id}" ${target.w.toFixed(1)}×${target.h.toFixed(1)}px · ` +
+          `가장 가까운 타깃("${nearest?.other.id ?? "-"}") 중심 거리 ` +
+          `${nearest?.d.toFixed(1) ?? "-"}px (필요 ≥ ${MIN_TARGET})`
+        );
+      })
+      .filter((line): line is string => line !== null);
+
+    expect(
+      violations,
+      `WCAG 2.5.8 미달 — 24×24 본칙도, 중심 거리 ${MIN_TARGET}px 간격 예외도 못 넘겼다.\n` +
+        `히트 확장(.touch-hit-expand)으로 덮지 말 것 — 행 피치보다 큰 확장은 뒤 행이 ` +
+        `앞 행의 탭을 훔친다.\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/e2e/vault-picker-stub.ts
+++ b/tests/e2e/vault-picker-stub.ts
@@ -1,0 +1,57 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * `showDirectoryPicker` 를 OPFS 핸들로 스텁한다.
+ *
+ * File System Access API 는 OS 창을 열기 때문에 자동화가 클릭할 수 없다.
+ * OPFS(`navigator.storage.getDirectory()`) 핸들은 **진짜**
+ * `FileSystemDirectoryHandle` 이라 `createWritable` 을 포함한 앱의 볼트
+ * 읽기/쓰기 경로가 그대로 돈다 — 즉 이 스텁은 픽커 창만 대신하고 그
+ * 이후 여정은 전부 실제 코드로 검증된다.
+ *
+ * **왜 spec 밖의 모듈인가** (2026-08-04): 이 스텁은 웹 스모크 ② 안에서
+ * 태어났지만, 그 자리에 갇혀 있는 동안 **데이터에 의존하는 결함을 재현할
+ * 유일한 수단**이 한 spec 의 사유물이었다. 샘플 볼트에 없는 모양
+ * (교차 도메인 엣지 등)을 그리는 화면은 어떤 게이트도 본 적이 없다 —
+ * 두 번째 소비처가 생긴 지금이 승격 시점이다.
+ *
+ * @param seed 폴더 안에 미리 넣어 둘 마크다운 (경로 → 내용)
+ */
+export async function stubDirectoryPicker(page: Page, seed: Record<string, string>) {
+  await page.addInitScript((files: Record<string, string>) => {
+    const grant = async () => "granted" as const;
+    // 픽커가 돌려주는 핸들과 그 하위 핸들 전부가 권한 질의에 답해야 한다 —
+    // 앱은 IndexedDB 복원 경로에서 `queryPermission` 을 부른다.
+    const patch = (handle: FileSystemDirectoryHandle): FileSystemDirectoryHandle => {
+      const target = handle as FileSystemDirectoryHandle & {
+        queryPermission?: () => Promise<"granted">;
+        requestPermission?: () => Promise<"granted">;
+      };
+      target.queryPermission ??= grant;
+      target.requestPermission ??= grant;
+      const inner = target.getDirectoryHandle.bind(target);
+      target.getDirectoryHandle = async (name: string, options?: FileSystemGetDirectoryOptions) =>
+        patch(await inner(name, options));
+      return target;
+    };
+
+    (window as unknown as { showDirectoryPicker: () => Promise<FileSystemDirectoryHandle> })
+      .showDirectoryPicker = async () => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle(`stub-vault-${Date.now()}`, { create: true });
+      for (const [path, body] of Object.entries(files)) {
+        const segments = path.split("/");
+        const name = segments.pop() as string;
+        let cursor = dir;
+        for (const segment of segments) {
+          cursor = await cursor.getDirectoryHandle(segment, { create: true });
+        }
+        const file = await cursor.getFileHandle(name, { create: true });
+        const writable = await file.createWritable();
+        await writable.write(body);
+        await writable.close();
+      }
+      return patch(dir);
+    };
+  }, seed);
+}

--- a/tests/e2e/web-surface-smoke.spec.ts
+++ b/tests/e2e/web-surface-smoke.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { stubDirectoryPicker } from "./vault-picker-stub";
 
 /**
  * 웹 표면 스모크 — 무인 표면의 유일한 눈.
@@ -32,56 +33,6 @@ async function gotoSettled(page: Page, url: string) {
   await seedFirstRunSeen(page);
   await page.goto(url);
   await page.waitForLoadState("networkidle");
-}
-
-/**
- * `showDirectoryPicker` 를 OPFS 핸들로 스텁한다.
- *
- * File System Access API 는 OS 창을 열기 때문에 자동화가 클릭할 수 없다.
- * OPFS(`navigator.storage.getDirectory()`) 핸들은 **진짜**
- * `FileSystemDirectoryHandle` 이라 `createWritable` 을 포함한 앱의 볼트
- * 읽기/쓰기 경로가 그대로 돈다 — 즉 이 스텁은 픽커 창만 대신하고 그
- * 이후 여정은 전부 실제 코드로 검증된다.
- *
- * @param seed 폴더 안에 미리 넣어 둘 마크다운 (경로 → 내용)
- */
-async function stubDirectoryPicker(page: Page, seed: Record<string, string>) {
-  await page.addInitScript((files: Record<string, string>) => {
-    const grant = async () => "granted" as const;
-    // 픽커가 돌려주는 핸들과 그 하위 핸들 전부가 권한 질의에 답해야 한다 —
-    // 앱은 IndexedDB 복원 경로에서 `queryPermission` 을 부른다.
-    const patch = (handle: FileSystemDirectoryHandle): FileSystemDirectoryHandle => {
-      const target = handle as FileSystemDirectoryHandle & {
-        queryPermission?: () => Promise<"granted">;
-        requestPermission?: () => Promise<"granted">;
-      };
-      target.queryPermission ??= grant;
-      target.requestPermission ??= grant;
-      const inner = target.getDirectoryHandle.bind(target);
-      target.getDirectoryHandle = async (name: string, options?: FileSystemGetDirectoryOptions) =>
-        patch(await inner(name, options));
-      return target;
-    };
-
-    (window as unknown as { showDirectoryPicker: () => Promise<FileSystemDirectoryHandle> })
-      .showDirectoryPicker = async () => {
-      const root = await navigator.storage.getDirectory();
-      const dir = await root.getDirectoryHandle(`smoke-vault-${Date.now()}`, { create: true });
-      for (const [path, body] of Object.entries(files)) {
-        const segments = path.split("/");
-        const name = segments.pop() as string;
-        let cursor = dir;
-        for (const segment of segments) {
-          cursor = await cursor.getDirectoryHandle(segment, { create: true });
-        }
-        const file = await cursor.getFileHandle(name, { create: true });
-        const writable = await file.createWritable();
-        await writable.write(body);
-        await writable.close();
-      }
-      return patch(dir);
-    };
-  }, seed);
 }
 
 /** 사람이 고를 법한 최소 볼트 — 프로젝트 하나 + 도메인 하나 + 역량 하나. */


### PR DESCRIPTION
## Summary

「경계」 탭 도메인 결합 상세의 **예시 링크 줄**이 WCAG 2.5.8(AA) 를 어기고 있었다. 값 하나를 고쳤지만 이 PR 의 무게는 **게이트** 쪽에 있다.

### 위반 — 고치기 전 실측 (1512×900, 빌드된 정적 export)

| | 값 |
|---|---|
| 링크 rect | 16.0 × 34.8~68.0px · `display: block` · 11px/16px |
| 세로 이웃 중심 거리(피치) | **20.0px** · 20.0px |
| 가장 가까운 타깃까지 중심 거리 | 20.7 / 20.7 / 21.8px |

24×24 본칙 미달 + 지름 24 원이 서로 교차해 spacing 예외도 탈락. Inline 예외는 목록 행이라 붙지 않는다(`display: block` 실측).

### 고른 갈래 — **B(세로 간격만)**, `gap-1`(4px) → `gap-2.5`(10px)

| | 피치 | 행 높이 | 슬롯 증가 |
|---|---|---|---|
| A. 높이 24 바닥 | 28px | 16 → 24 | +24px |
| **B. 간격만** | **26.0px** | 16 (불변) | **+12px** |

B 를 고른 이유 셋:

1. **이 카드는 상세 슬롯을 예약해 둔 자리다**(`min-h-[76px]`, "칸을 누를 때마다 카드 높이가 뛰면 방금 비교하던 격자가 눈 밑에서 움직인다"). 실측상 3행 상세는 이미 예약치를 넘어 84px 이라 클릭마다 슬롯이 자란다 — A 는 그 증가를 24px 로, B 는 12px 로 만든다.
2. **링크의 높이 바닥은 값 층에서 병렬로 재설계 중**이다. 여기서 한 자리만 먼저 24를 정하면 두 규격이 갈린다.
3. 페이지 스크롤은 안 늘었다(문서 900 = 뷰포트 900, 전후 동일). 섹션 321 → 333px.

**`.touch-hit-expand` 는 쓰지 않았다.** 피치 26px 자리에 44px 확장은 이웃과 18px 겹치고, DOM 순서상 뒤 행이 앞 행의 탭을 훔친다 — 「작아서 못 누름」이 「눌렀는데 다른 게 열림」이 되는 건 개선이 아니다. 근거를 코드 주석에 남겼다.

### 고친 뒤 실측

피치 **26.0px** × 2 · 링크 rect 불변(16.0 × 34.8~68.0) · 위반 0.

## 진짜 산출물 — 이 부류가 다시 안 새게 하는 게이트

`a11y-ratchet` 의 `target-size` 기준선은 0 이고 실제로 0 이었다. **위반이 없어서가 아니라 그 자리가 렌더된 적이 없어서**다:

1. 볼트에 **교차 도메인 엣지**가 있어야 격자에 누를 수 있는 칸이 생기고,
2. 사람이 그 칸을 **눌러야** 상세가 펼쳐진다.

기본 샘플 볼트에는 ①이 없다 → axe 는 그 DOM 을 한 번도 못 봤고, 게이트는 **빈 집합 위에서 초록**이었다. 한 자리의 문제가 아니라 *데이터에 의존해 눈이 감기는 게이트* 라는 부류의 문제다.

`tests/e2e/dense-row-target-size.spec.ts` 를 추가했다 — OPFS 스텁 픽커로 교차 도메인 엣지가 있는 볼트를 물리고, 칸을 눌러 그 행을 실제로 그린 뒤 WCAG 2.5.8 을 그대로 계산한다(본칙 24×24 **또는** 중심 거리 ≥ 24). 스텁 픽커는 웹 스모크 ② 안에 갇혀 있던 것을 `tests/e2e/vault-picker-stub.ts` 로 승격했다 — 데이터 의존 결함을 재현할 유일한 수단이 한 spec 의 사유물이면 안 된다.

### 프로브 3종 — 이 게이트는 실제로 빨개진다

| 일부러 만든 상태 | 결과 |
|---|---|
| 고치기 전 값(`gap-1`, 피치 20.0) | **빨강** — 위반 3, 20.7/20.7/21.8px 로 지목 |
| 한 단만 되돌림(`gap-1.5`, 피치 22.0) | **빨강** — 22.6/22.6/23.7px. 클래스 이름이 아니라 **거리**를 잰다는 증거 |
| 픽스처의 교차 엣지를 1건으로 줄여 밀집 행이 안 쌓이게 | **빨강** — 「예시 링크가 없다 … 위반이 없는 게 아니라 미측정이다」. 빈 집합 위에서 조용히 통과하지 않는다 |

수정 후 초록. 프로브는 전부 원복했다.

## 보고만 — 다른 밀집 세로 스택 전수

**후보 35곳 / 26 파일.** 정적 휴리스틱 센서스다(`flex-col` + `gap-0.5|1|1.5` 컨테이너 중 40줄 창 안에 링크·버튼과 `text-label|caption` 이 함께 있는 자리). 렌더해 잰 값이 아니라 **위반 수가 아니라 확인해야 할 자리 수**이고, 컨테이너 안 타깃이 하나뿐이거나 간격이 블록 사이인 자리가 섞여 있다. `link` 바닥 재설계와 겹치므로 이 PR 에서는 손대지 않았다.

## Test plan

빌드된 정적 export 를 자체 포트(3187)에 물려 실행:

- `pnpm exec playwright test tests/e2e/dense-row-target-size.spec.ts` ✓ (신규)
- 기준선 넷: `a11y-ratchet` ✓ · `contrast-ratchet` ✓ · `a11y-open-surfaces` ✓ (2) · `surface-motion-ratchet`(vitest 계약) ✓
- `pnpm exec playwright test tests/e2e/web-surface-smoke.spec.ts` ✓ 10/10 (스텁 픽커 모듈 승격 회귀)
- `pnpm exec vitest run DomainCouplingCard.test.tsx surface-motion-ratchet.contract.test.ts` ✓ 20/20
- `pnpm exec tsc --noEmit` ✓ · `pnpm exec eslint <touched>` ✓ · `pnpm build` ✓ · `pnpm decisions:check` ✓ (트리거 없음)

`pnpm checks:changed` 가 권한 넷을 그대로 돌렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
