### PR TITLE
fix: 펼친 단계가 화면에서 가장 흐린 줄이 되는 위계 뒤집힘 정정

### DIFF
--- a/src/widgets/app-settings-menu/ui/AgentSetupStep.test.tsx
+++ b/src/widgets/app-settings-menu/ui/AgentSetupStep.test.tsx
@@ -117,4 +117,47 @@ describe('AgentSetupStep — 흐름 안 접기 문법 계약', () => {
     const closedChevron = closedC.querySelector('button svg.transition-transform');
     expect((closedChevron as SVGElement).style.transform).toBe('rotate(-90deg)');
   });
+
+  /**
+   * ⑤ 위계 — **펼친 행은 흐린 잉크를 받지 않는다.**
+   *
+   * 되돌리면 여기가 빨개진다: `tone={state === 'todo' ? 'muted' : 'strong'}` 로
+   * 되돌리면 아직 안 온 단계를 펼쳤을 때 그 제목이 `quaternary` 로 떨어진다.
+   * 설치 앱 실측(2026-08-04, 1512×900): 3단계를 펼친 화면에서 펼친 행 제목
+   * rgb(130,130,137) < 접힌 1단계 제목 rgb(247,248,248) — 읽고 있는 줄이 가장
+   * 흐렸다.
+   */
+  const renderTodoStep = (open: boolean) =>
+    render(
+      <ol>
+        <AgentSetupStep
+          n={3}
+          title="연결 확인"
+          state="todo"
+          open={open}
+          onToggle={() => {}}
+          testId="probe-todo"
+        >
+          <button type="button">내용 컨트롤</button>
+        </AgentSetupStep>
+      </ol>,
+    );
+
+  it('⑤ 위계 — 안 온 단계라도 펼쳐 두면 흐린 잉크(quaternary)를 안 받는다', () => {
+    const closed = renderTodoStep(false);
+    expect(
+      closed.getByTestId('probe-todo-toggle').className,
+      '접힌 미래 단계가 물러나지 않는다 — 흐름의 사실이 지워졌다',
+    ).toContain('--color-text-quaternary');
+    closed.unmount();
+
+    const opened = renderTodoStep(true);
+    expect(
+      opened.getByTestId('probe-todo-toggle').className,
+      '펼친 행이 흐린 잉크를 받았다 — 읽고 있는 줄이 화면에서 가장 흐려진다',
+    ).not.toContain('--color-text-quaternary');
+    expect(opened.getByTestId('probe-todo-toggle').className).toContain(
+      '--color-text-primary',
+    );
+  });
 });

--- a/src/widgets/app-settings-menu/ui/AgentSetupStep.tsx
+++ b/src/widgets/app-settings-menu/ui/AgentSetupStep.tsx
@@ -110,7 +110,19 @@ export function AgentSetupStep({
     <li className="min-w-0" data-testid={testId} data-step-state={state}>
       <RowButton
         size="md"
-        tone={state === 'todo' ? 'muted' : 'strong'}
+        /*
+         * 물러나는 것은 **안 온 단계 중 접혀 있는 것**까지다 (2026-08-04 설치 앱
+         * 실측 정정). 종전 식은 `state === 'todo'` 만 봐서, 사용자가 아직 안 온
+         * 단계를 직접 열면 **펼친 행이 그 화면에서 가장 흐린 줄**이 됐다 —
+         * 앱에서 잰 값으로 3단계를 펼친 순간 그 제목이 `quaternary`
+         * rgb(130,130,137), 접힌 1단계 제목이 `primary` rgb(247,248,248) 이었다.
+         * 읽고 있는 것이 안 읽는 것보다 흐린 것은 위계가 뒤집힌 것이다.
+         *
+         * 배지는 그대로 흐름의 사실만 진다(위 `BADGE` 주석) — 여기서 바뀌는
+         * 것은 **펼침이 이미 가진 채널**(셰브론 회전)에 잉크를 한 단 얹는 것뿐이라
+         * 새 채널도 새 톤도 늘지 않는다.
+         */
+        tone={state === 'todo' && !open ? 'muted' : 'strong'}
         data-testid={`${testId}-toggle`}
         aria-expanded={open}
         aria-controls={bodyId}


### PR DESCRIPTION
## Summary

디자인 시스템 라운드 이후 전 라우트 + 조작 감사(`/design-audit`)에서 **수치로 확인된 결함 1건**을 고친다.

설치 앱(1512×900, 볼트 `docs/ontology`)에서 설정 → 「내 에이전트 연결」 → 3단계를
직접 눌러 펼치고 스크린샷 픽셀을 잰 값:

| 행 | 상태 | 제목 잉크 |
|---|---|---|
| 1단계 (접힘) | now | `--color-text-primary` rgb(247,248,248) |
| 2단계 (접힘) | todo | `--color-text-quaternary` rgb(130,130,137) |
| **3단계 (펼침)** | todo | **`--color-text-quaternary` rgb(130,130,137)** |

**읽고 있는 줄이 화면에서 가장 흐리다.** 원인은 `tone` 이 `state === 'todo'` 만
본 것 — 「안 온 단계는 물러난다」가 「지금 단계만 펼친다」를 전제하는데, 사용자가
아직 안 온 단계를 직접 열면 그 전제가 깨진다. 같은 충돌을 오늘 셰브론 회전으로
한 번 다뤘지만(`AgentSetupStep.tsx` BADGE 주석), 잉크는 그대로 흐름의 사실만
지고 있어 **가장 센 채널이 반대를 말하고 있었다**.

처방: `tone={state === 'todo' && !open ? 'muted' : 'strong'}`.
배지는 그대로 흐름의 사실만 진다 — 새 톤 0 · 새 채널 0 · 램프 변경 0.

## Test plan

- `pnpm test:run src/widgets/app-settings-menu/ui/AgentSetupStep.test.tsx` — 5 passed
- **게이트 프로브**: `tone` 을 옛 식으로 되돌리니 ⑤ 가 빨개졌다 (1 failed / 4 passed) → 되돌리면 잡힌다
- `pnpm exec eslint <changed>` — clean
- `pnpm exec tsc --noEmit` — clean
- `pnpm test:contracts` — 112 files / 1344 tests passed

## 아직 못 한 검증

이 탭은 **웹에 안 뜬다**(앱 전용). 고친 화면의 설치-앱 재캡처는 Tauri 재빌드가
필요해 이번 감사 범위 밖이다 — 그래서 위 ⑤ 계약을 남겨 다음 사람이 재빌드 없이도
회귀를 잡을 수 있게 했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275