### PR TITLE
fix: 나침 무대 좌우 팔의 중심선 9px 어긋남 정정

### DIFF
--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -1923,6 +1923,13 @@ function LaneRender({
     view.recommended || view.expected
       ? "text-[color:var(--color-text-tertiary)]"
       : "text-[color:var(--color-text-quaternary)]";
+  /**
+   * 좌·우 소켓은 **중심선이 고정점**이다 — 점선 연결선이 상자의 세로 한가운데
+   * (CY)로 들어오기 때문이다(`layoutLane` 의 `struts`/`anchor`). 위·아래는
+   * 반대로 **카드에서 먼 쪽 모서리**가 고정점이라(연결선이 상자의 아래/위
+   * 모서리로 들어온다) 자랄 때 바깥으로 밀려야 한다.
+   */
+  const centerAnchored = view.bearing === "left" || view.bearing === "right";
   return (
     <>
       {/* lane head label for a filled lane */}
@@ -2090,13 +2097,27 @@ function LaneRender({
           )}
           style={{
             left: layout.socket.x,
-            top: layout.socket.y,
+            // 좌·우 소켓은 **중심선으로** 앉힌다 (2026-08-04). 나머지 둘은
+            // 바깥 모서리가 고정점이라 지금까지대로 top 으로 앉힌다.
+            top: centerAnchored
+              ? layout.socket.y + layout.socket.h / 2
+              : layout.socket.y,
+            // `translate` 는 `transform` 과 **다른 속성**이라 .studio-stage-in
+            // 의 transform 키프레임(6px 상승)과 겹쳐 쓸 수 있다 — transform 에
+            // 적으면 애니메이션이 덮어써서 중심 고정이 사라진다.
+            translate: centerAnchored ? "0 -50%" : undefined,
             width: layout.socket.w,
-            // #94/#95 — grow to wrapped text instead of clipping. The layout
-            // height is Korean-tuned; longer English questions/eyebrows wrap to
-            // more lines, so the dashed box must expand (minHeight) rather than
-            // let the text bleed past its border. `justify-center` keeps short
-            // (Korean) content vertically centered in the base height.
+            // #94/#95 — grow to wrapped text instead of clipping. 상자는 감긴
+            // 글자만큼 자란다(minHeight).
+            //
+            // ⚠️ 2026-08-04 정정 — 예전 주석은 이 성장을 「영어처럼 긴 문장일
+            // 때를 위한 것」이라고 적었지만 **한글 기본 화면에서 이미
+            // 발동한다**: LEFT 질문(「비슷하거나 대체할 수 있는 것은?」)이
+            // 1512×900 에서 두 줄로 감겨 64 → 82px 이 된다(영어는 98px).
+            // 그때 `top` 고정이면 상자는 아래로만 자라고, 점선이 닿는 자리
+            // (CY)가 상자 중심에서 ko 9px · en 8px 빗나갔다 — 좌우 대칭이 이
+            // 그림의 뜻 전부인데 도해가 자기 문법을 어긴 것이다.
+            // 그래서 좌·우는 자란 만큼을 위아래로 나눠 갖는다(위 `top`).
             minHeight: layout.socket.h,
             ...stageStyle,
             border: view.recommended

--- a/tests/e2e/studio-compass-symmetry.spec.ts
+++ b/tests/e2e/studio-compass-symmetry.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * 나침 무대의 **좌우 대칭** — 점선이 닿는 자리와 상자의 중심이 같은가.
+ *
+ * ## 무엇을 지키나
+ *
+ * 공방은 관계 종류를 고정 방위에 놓는다(UP=is_a · DOWN=contains ·
+ * RIGHT=depends · LEFT=relates). 「나침」이라는 그림의 뜻 전부가 그 방위의
+ * 대칭에 있다. 좌·우 팔은 점선이 상자의 **세로 한가운데**로 들어오도록
+ * 그려지므로(`StudioCompass` `layoutLane` 의 `struts`/`anchor`), 상자의 중심이
+ * 그 자리에서 벗어나면 도해가 자기 문법을 어긴다.
+ *
+ * ## 왜 기계가 재야 하나
+ *
+ * 2026-08-04 실측: LEFT 질문(「비슷하거나 대체할 수 있는 것은?」)이 **한글
+ * 기본 화면(1512×900)에서 이미 두 줄로 감겨** 상자가 64 → 82px 로 자랐다.
+ * 상자는 `top` 고정 + `minHeight` 라 **아래로만** 자랐고, 그래서 점선이 닿는
+ * 자리가 상자 중심에서 **9px**(영어는 8px) 빗나갔다. 코드에는 아무 값도 안
+ * 남는 결함이다 — 두 값 다 정당한 램프 안이고 lint 가 볼 것이 없다. 재야만
+ * 보인다.
+ *
+ * 그 자리의 주석은 이 성장을 「영어처럼 긴 문장일 때를 위한 의도」로 적어
+ * 뒀는데, 한글 기본 화면에서 이미 발동하므로 그 전제가 틀렸다.
+ *
+ * ## 기준선을 무엇으로 잡나
+ *
+ * 중심 카드다. 카드는 언제나 무대의 세로 한가운데(CY)에 앉고(`cardTop =
+ * CY - cardH / 2`), 좌·우 팔의 점선도 그 CY 로 들어온다. 그래서 「카드 중심 =
+ * 좌우 소켓 중심」한 줄이 방위·모드·로케일과 무관한 계약이 된다.
+ */
+
+/** 1024 폭에서 무대는 0.797 로 축소된다 — 부분 픽셀 반올림만 허용한다. */
+const CENTERLINE_TOLERANCE_PX = 0.75;
+
+type SocketBox = {
+  bearing: string;
+  centerY: number;
+  height: number;
+  width: number;
+};
+
+async function measureStage(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const card = document.querySelector('[data-testid="studio-center-card"]');
+    if (!card) return null;
+    const cardRect = card.getBoundingClientRect();
+    const sockets = [...document.querySelectorAll('[data-testid^="studio-socket-"]')].map(
+      (el) => {
+        const rect = el.getBoundingClientRect();
+        return {
+          bearing: (el.getAttribute("data-testid") ?? "").replace("studio-socket-", ""),
+          centerY: rect.y + rect.height / 2,
+          height: rect.height,
+          width: rect.width,
+        };
+      },
+    );
+    return { cardCenterY: cardRect.y + cardRect.height / 2, sockets };
+  });
+}
+
+for (const locale of ["ko", "en"] as const) {
+  for (const width of [1512, 1280] as const) {
+    test(`나침 무대 좌우 소켓의 중심선이 카드 중심과 같다 (${locale} · ${width}px)`, async ({
+      page,
+    }) => {
+      await seedFirstRunSeen(page);
+      await page.setViewportSize({ width, height: 900 });
+      // create 모드는 네 방위가 전부 빈 소켓이라 좌·우가 한 화면에 같이 선다.
+      await page.goto(`/${locale}/ontology/studio/?guides=off&mode=create`, {
+        waitUntil: "networkidle",
+      });
+
+      const stage = page.getByTestId("studio-compass-stage");
+      await expect(stage).toBeVisible({ timeout: 20_000 });
+      await expect(page.getByTestId("studio-socket-left")).toBeVisible();
+      await expect(page.getByTestId("studio-socket-right")).toBeVisible();
+
+      const measured = await measureStage(page);
+      expect(measured, "중심 카드가 없으면 이 게이트는 아무것도 안 잰다").not.toBeNull();
+
+      const sockets = measured!.sockets as SocketBox[];
+      const horizontal = sockets.filter((s) => s.bearing === "left" || s.bearing === "right");
+      expect(
+        horizontal.map((s) => s.bearing).sort(),
+        "좌·우 소켓이 둘 다 있어야 대칭을 잴 수 있다",
+        // 검사가 빈 집합 위에서 조용히 통과하는 것을 막는다.
+      ).toEqual(["left", "right"]);
+
+      for (const socket of horizontal) {
+        expect(
+          Math.abs(socket.centerY - measured!.cardCenterY),
+          `${socket.bearing} 소켓의 중심선이 카드 중심에서 벗어났다 — 점선이 상자 한가운데로 안 들어온다 (h=${socket.height})`,
+        ).toBeLessThanOrEqual(CENTERLINE_TOLERANCE_PX);
+      }
+
+      const left = horizontal.find((s) => s.bearing === "left")!;
+      const right = horizontal.find((s) => s.bearing === "right")!;
+      expect(
+        Math.abs(left.centerY - right.centerY),
+        "좌우 팔의 중심선이 서로 다르다 — 나침의 대칭이 깨졌다",
+      ).toBeLessThanOrEqual(CENTERLINE_TOLERANCE_PX);
+      expect(left.width, "좌우 팔의 폭은 같다").toBe(right.width);
+
+      // 이 스펙이 재는 결함은 「자란 상자」에서만 나타난다. 아무것도 안 자라는
+      // 화면만 재고 있으면 검사기가 헛도는 것이므로 그때 알아야 한다. 기준선은
+      // 같은 렌더 안에서 절대 안 감기는 DOWN 소켓이다(숫자를 박지 않는다).
+      const down = sockets.find((s) => s.bearing === "down");
+      expect(down, "DOWN 소켓이 없으면 기준 높이를 못 잡는다").toBeTruthy();
+      if (locale === "en") {
+        expect(
+          Math.max(left.height, right.height),
+          "영어에서 좌·우 소켓이 하나도 안 감겼다 — 문안이나 폭이 바뀌었으니 이 게이트의 전제를 다시 확인해라",
+        ).toBeGreaterThan(down!.height);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

공방(`/ontology/studio`) 나침 무대의 **좌·우 팔 중심선이 9px 어긋나 있었다.**

좌·우 빈 소켓은 점선 연결선이 상자의 **세로 한가운데**(무대 중앙 CY)로
들어오게 그려지는데(`layoutLane` 의 `struts`/`anchor`), 상자는 `top` 고정 +
`minHeight` 라 감긴 글자만큼 **아래로만** 자랐다. 그래서 선이 닿는 자리가
상자 중심에서 벗어났다. 「나침」이라는 그림의 뜻 전부가 네 방위의 대칭에
있으므로, 그 대칭이 깨지면 도해가 자기 문법을 어긴다.

**자란 만큼을 위아래로 나눠 갖게 해 중심선을 고정했다.** 폭·문안·토큰은
그대로고 새 값은 0개다.

### 네 방위 전수 실측 (1512×900 · ko · `?mode=create`)

| 방위 | before y / h / **중심선** | after y / h / **중심선** |
|---|---|---|
| UP | 216 / 82 / **257** | 216 / 82 / **257** (불변) |
| RIGHT | 430 / 64 / **462** | 430 / 64 / **462** (불변) |
| LEFT | 430 / 82 / **471** | **421** / 82 / **462** |
| DOWN | 626 / 64 / **658** | 626 / 64 / **658** (불변) |

좌우 중심선 차 **9 → 0px**. 움직인 상자는 LEFT 하나뿐이다.

### 두 폭 · 두 로케일

| | before L/R 중심선 차 | after |
|---|---:|---:|
| ko 1512 | 9px | **0** |
| ko 1280 | 9px | **0** |
| ko 1024 (무대 0.797 축소) | 7.17px | **0** |
| en 1512 | 8px | **0** |
| en 1280 | 8px | **0** |
| en 1024 | 6.37px | **0** |

### 왜 이 갈래인가

세 갈래를 실측하고 하나만 골랐다.

- **채택 — 중심 고정.** 결함의 *종류*를 없앤다. 어떤 로케일이든 몇 줄로 감기든
  중심선이 안 움직인다.
- **기각 — 폭 늘려 1줄로.** 영어(`What is similar to or can replace this?`)는
  좌우 여백(gutter 276px) 안에서 1줄이 원리적으로 불가능하다. 실측: en LEFT 는
  204px 폭에서 **3줄(98px)**, RIGHT 는 2줄(82px). 한글만 오늘 고치고 영어는
  그대로 깨진다.
- **기각 — 문안 단축.** 같은 이유로 한 로케일만 고치고, 다음 번역이 다시 깨뜨린다.

### `transform` 이 아니라 `translate` 인 이유

`.studio-stage-in` 이 `transform: translateY(6px→0)` 을 `both` 로 재생한다.
같은 속성에 인라인으로 적으면 애니메이션이 덮어써서 중심 고정이 사라진다.
`translate` 는 별도 속성이라 겹쳐 쓸 수 있다.

### 주석 정정

그 자리의 `#94/#95` 주석이 이 성장을 「영어처럼 긴 문장일 때를 위한 의도」로
적어 뒀는데, **한글 기본 화면(1512×900)에서 이미 발동**하므로 전제가 오늘
틀렸다. 실측값과 함께 정정했다.

## Test plan

- **새 게이트** `tests/e2e/studio-compass-symmetry.spec.ts` — ko/en × 1512/1280
  4건. 기준선은 **중심 카드**다(카드는 언제나 무대 중앙이고 점선도 거기로
  들어오므로 모드·로케일과 무관하다). 빈 집합 위에서 조용히 통과하지 않도록
  좌·우 소켓이 둘 다 있는지, 영어에서 실제로 감기는지(DOWN 소켓 높이 기준)를
  함께 단언한다.
- **프로브** — 고침을 되돌리고 다시 빌드하니 4건 전부 빨강(`Received: 9` /
  `Received: 8`). 검사가 헛돌지 않는다.
- `studio-navigation` · `studio-fill-arrival` — 통과 (계약은 치수를 잡지 않는다.
  전자는 save/exit 버튼 높이, 후자는 소켓 클릭 → 도착 애니메이션)
- `a11y-ratchet` · `contrast-ratchet` · `a11y-open-surfaces` ·
  `dense-row-target-size` · `touch-target-contract` — 13건 통과
- `pnpm test:contracts` — 112 파일 / 1344건 통과 (컨트롤 채택 래칫 · 하드컷
  래칫 포함)
- `pnpm exec tsc --noEmit` · `pnpm exec eslint <changed>` — 0
- `pnpm decisions:check` — no council trigger (규격 파일 무변경)
- 검증은 전부 **정적 export**(`PLAYWRIGHT_STATIC=1`, 전용 포트)에서 돌렸다.

## Design Guardian verdict

- **PO problem**: 나침 무대에서 좌우 팔이 어긋나 보여, 방위가 뜻을 나르는
  도해의 문법이 스스로 깨진다.
- **Attention**: winner=중심 카드 + 네 소켓의 방위 / demote=없음(장식 무변경).
- **Typed fact**: 소켓 = 아직 안 채워진 relation(UP=is_a · DOWN=contains ·
  RIGHT=depends · LEFT=relates). 중심선은 그 relation 이 붙는 자리다.
- **Tokens**: 재사용 0 · **신규 0** · 갭 없음 (기하 앵커만 바뀜).
- **Motion**: 무변경. `.studio-stage-in`(`--motion-base`)이 그대로 재생되도록
  `transform` 대신 `translate` 를 썼다. reduced-motion=전역 규칙 그대로.
- **Evidence**: 정적 export 실측 6종(ko/en × 1512/1280/1024) + before/after
  크롭. installed app=**waived** — 공유 번들의 레이아웃 변경이고 글자
  렌더링·스크롤·창 테두리를 안 건드린다(`surfaces.md` 검증 표).
- **Surface stack**: transient=0 · blocking=none.
- **Verdict**: **Build and verify**

## 남은 관찰 (이 PR 범위 밖 — 세어서 보고만)

1. **좌우 상자 높이는 여전히 다르다** — ko 82 vs 64(18px), en 98 vs 82(16px).
   중심선은 맞았지만 「치수 규칙성」(`design.md`)이 말하는 *반복 묶음의 높이
   고정*은 아직 아니다. 좌·우 base 높이를 UP 과 같은 82 로 올릴지는 규격
   변경이라 **「체계」 소집 대상**이다.
2. **UP 은 바깥 모서리가 고정점인데 `top` 으로 앉는다** — 오늘은 base 82 가
   두 줄을 다 담아 어느 로케일에서도 안 자라므로(실측 ko/en 82) 잠복이다.
   UP 문안이 세 줄이 되는 날 점선이 상자 안에서 끝난다.
3. **`pnpm dev` 가 현재 500 이다** — `app/globals.css` 생성 단계에서
   `.text-\[var\(…\)\]` 규칙이 만들어져 Turbopack CSS 파서가 거절한다.
   출처는 오늘 머지된 `.claude/rules/design.md`(#931)의 산문 안 `text-[var(…)]`
   리터럴 — Tailwind 소스 스캐너가 그 파일을 읽는다. **프로덕션 빌드는
   정상**이라 CI 는 초록이고, 깨지는 것은 로컬 dev 뿐이다.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275
