### PR TITLE
fix: 화면에 실제로 보이는 램프 부채부터 39건 치우고 예외 5줄 회수

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -464,14 +464,9 @@ export const rampCoveredGlobs = ['src/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'];
 export const rampDebtExemptions = [
   'src/entities/project/ui/ProjectCard.tsx', // 16
   'src/entities/project/ui/ProjectMetaGrid.tsx', // 2
-  'src/features/project-edit/ui/DependencyPicker.tsx', // 6
-  'src/features/project-edit/ui/MarkdownField.tsx', // 3
-  'src/features/project-edit/ui/ProjectForm.tsx', // 15
   'src/features/vault-ontology/ui/LiveActivityIndicator.tsx', // 23
   'src/views/first-run/ui/FirstRunPage.tsx', // 14
   'src/views/ontology-studio/ui/StudioCompass.tsx', // 24
-  'src/views/project-detail/ui/DomainCompositionGrid.tsx', // 4
-  'src/views/project-detail/ui/ProjectDetailPage.tsx', // 11
   'src/views/project-editor/ui/ProjectEditorPage.tsx', // 2
   'src/views/root-entry/ui/RootEntryPage.tsx', // 5
 ];

--- a/src/features/project-edit/ui/DependencyPicker.tsx
+++ b/src/features/project-edit/ui/DependencyPicker.tsx
@@ -157,7 +157,7 @@ export function DependencyPicker({
               className="text-[color:var(--color-indigo-accent)]"
               aria-hidden="true"
             />
-            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
+            <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-indigo-accent)]">
               {t('suggestionsHeading')}
             </p>
           </div>
@@ -172,7 +172,7 @@ export function DependencyPicker({
                   <span className="truncate text-body text-[color:var(--color-text-primary)]">
                     {suggestion.name}
                   </span>
-                  <span className="truncate text-[10px] text-[color:var(--color-text-tertiary)]">
+                  <span className="truncate text-caption text-[color:var(--color-text-tertiary)]">
                     {suggestion.excerpt}
                   </span>
                 </div>
@@ -230,7 +230,7 @@ export function DependencyPicker({
           data-testid="dependency-missing-group"
           className="flex flex-col gap-2 rounded-card border border-[color:var(--color-amber-source-a25)] bg-[color:var(--color-amber-source-a08)] p-3"
         >
-          <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-status-warning)]">
+          <p className="font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-status-warning)]">
             {t('missingHeading')}
           </p>
           <div className="flex flex-wrap gap-1.5">
@@ -300,16 +300,16 @@ export function DependencyPicker({
             >
               <span>{p.name}</span>
               {invalidSlugSet.has(p.slug) && (
-                <span className="rounded-micro border border-[color:var(--color-divider)] px-1 font-mono text-[8px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+                <span className="rounded-micro border border-[color:var(--color-divider)] px-1 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                   cycle
                 </span>
               )}
               {p.isHub && (
-                <span className="rounded-micro bg-[color:var(--color-indigo-brand)] px-1 font-mono text-[8px] uppercase tracking-[0.08em] text-[color:var(--color-text-primary)]">
+                <span className="rounded-micro bg-[color:var(--color-indigo-brand)] px-1 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-primary)]">
                   HUB
                 </span>
               )}
-              <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+              <span className="font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                 {categoryLabel(p.category)}
               </span>
             </button>

--- a/src/features/project-edit/ui/MarkdownField.tsx
+++ b/src/features/project-edit/ui/MarkdownField.tsx
@@ -33,7 +33,7 @@ export function MarkdownField({ id, value, onChange, placeholder, rows = 8 }: Pr
         <TabButton active={mode === 'preview'} onClick={() => setMode('preview')}>
           {t('tabPreview')}
         </TabButton>
-        <span className="ml-auto font-mono text-[9px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+        <span className="ml-auto font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
           {t('footer')}
         </span>
       </div>
@@ -62,8 +62,8 @@ export function MarkdownField({ id, value, onChange, placeholder, rows = 8 }: Pr
             '[&>p]:my-1.5',
             '[&>ul]:my-1.5 [&>ul]:list-disc [&>ul]:pl-5',
             '[&>ol]:my-1.5 [&>ol]:list-decimal [&>ol]:pl-5',
-            '[&_code]:rounded-micro [&_code]:bg-[color:var(--color-elevated)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[13px]',
-            '[&>pre]:rounded-chip [&>pre]:bg-[color:var(--color-elevated)] [&>pre]:p-3 [&>pre]:my-2 [&>pre]:font-mono [&>pre]:text-[12px] [&>pre>code]:bg-transparent [&>pre>code]:px-0',
+            '[&_code]:rounded-micro [&_code]:bg-[color:var(--color-elevated)] [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-body',
+            '[&>pre]:rounded-chip [&>pre]:bg-[color:var(--color-elevated)] [&>pre]:p-3 [&>pre]:my-2 [&>pre]:font-mono [&>pre]:text-body [&>pre>code]:bg-transparent [&>pre>code]:px-0',
             '[&_a]:text-[color:var(--color-indigo-accent)] [&_a]:underline',
             '[&>blockquote]:border-l-2 [&>blockquote]:border-[color:var(--color-border-strong)] [&>blockquote]:pl-3 [&>blockquote]:text-[color:var(--color-text-tertiary)]',
           )}

--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1269,7 +1269,7 @@ export function ProjectForm({
         <div className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {editorModeLabel}
               </p>
               <p className="mt-2 hidden text-body-lg text-[color:var(--color-text-secondary)] md:block">
@@ -1277,7 +1277,7 @@ export function ProjectForm({
               </p>
               <span
                 className={cn(
-                  "mt-2 inline-flex rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.08em] md:hidden",
+                  "mt-2 inline-flex rounded-full border px-3 py-1 font-mono text-caption uppercase tracking-[0.08em] md:hidden",
                   isDirty
                     ? "border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a12)] text-[color:var(--color-text-primary)]"
                     : "border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]",
@@ -1288,7 +1288,7 @@ export function ProjectForm({
             </div>
             <span
               className={cn(
-                "hidden rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.08em] md:inline-flex",
+                "hidden rounded-full border px-3 py-1 font-mono text-caption uppercase tracking-[0.08em] md:inline-flex",
                 isDirty
                   ? "border-[color:var(--color-indigo-a30)] bg-[color:var(--color-indigo-a12)] text-[color:var(--color-text-primary)]"
                   : "border-[color:var(--color-divider)] text-[color:var(--color-text-tertiary)]",
@@ -1343,7 +1343,7 @@ export function ProjectForm({
 
       <div className="rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-panel)] px-4 py-4">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+          <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
             {t("sections.navLabel")}
           </p>
           <nav className="flex flex-wrap gap-2">
@@ -1497,7 +1497,7 @@ export function ProjectForm({
             className="mb-4 flex w-full items-center justify-between rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-panel)] px-4 py-4 text-left lg:hidden"
           >
             <div>
-              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+              <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                 {t("preview.toggleEyebrow")}
               </p>
               <p className="mt-2 text-body-lg text-[color:var(--color-text-secondary)]">
@@ -1519,7 +1519,7 @@ export function ProjectForm({
                 화면 밖에 있을 때 쓰던 변명이었다. 지금은 마주 보므로 뺀다. */}
             {(mode === "edit" || saveNotice) && (
               <div className="mb-4 rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-panel)] p-4">
-                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                   {t("preview.previewEyebrow")}
                 </p>
                 {saveNotice ? (
@@ -1544,7 +1544,7 @@ export function ProjectForm({
                 ) : null}
               </div>
             )}
-            <p className="mb-3 font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+            <p className="mb-3 font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
               {t("preview.cardEyebrow")}
             </p>
             <div className="flex items-start justify-center rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-canvas)] p-6">
@@ -1581,15 +1581,15 @@ export function ProjectForm({
             <div className="mt-4 rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-panel)] p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                     {t("preview.completenessLabel")}
                   </p>
-                  <p className="mt-2 text-[28px] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
+                  <p className="mt-2 text-hero font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                     {completenessInsight.score}%
                   </p>
                 </div>
                 <div className="text-right">
-                  <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
+                  <p className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
                     {t("preview.publicStatusLabel")}
                   </p>
                   <p className="mt-2 text-body-lg text-[color:var(--color-text-secondary)]">
@@ -1681,7 +1681,7 @@ function ExtrasGroup({
   return (
     <div className="flex flex-col gap-5">
       <div className="flex items-center gap-2.5">
-        <p className="shrink-0 font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
+        <p className="shrink-0 font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]">
           {label}
         </p>
         <span aria-hidden className="h-px flex-1 bg-[color:var(--color-divider)]" />
@@ -1708,7 +1708,7 @@ function FieldRow({
     <div className="flex flex-col gap-1.5">
       <label
         htmlFor={fieldId}
-        className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]"
+        className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]"
       >
         {label}
       </label>
@@ -1762,7 +1762,7 @@ function FormSection({
         <div className="mb-3 flex items-center gap-2.5">
           <p
             id={headingId}
-            className="shrink-0 font-mono text-[10px] uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]"
+            className="shrink-0 font-mono text-caption uppercase tracking-[0.16em] text-[color:var(--color-text-tertiary)]"
           >
             {label}
           </p>
@@ -1776,7 +1776,7 @@ function FormSection({
           </div>
           <div className="flex items-center gap-2">
             {helperBadge ? (
-              <span className="rounded-full border border-[color:var(--color-divider)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
+              <span className="rounded-full border border-[color:var(--color-divider)] px-2.5 py-1 font-mono text-caption uppercase tracking-[0.08em] text-[color:var(--color-text-quaternary)]">
                 {helperBadge}
               </span>
             ) : null}
@@ -1821,7 +1821,7 @@ function FormSection({
 
 function Hint({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-[11px] text-[color:var(--color-text-quaternary)]">
+    <p className="text-label text-[color:var(--color-text-quaternary)]">
       {children}
     </p>
   );

--- a/src/views/project-detail/ui/DomainCompositionGrid.tsx
+++ b/src/views/project-detail/ui/DomainCompositionGrid.tsx
@@ -73,12 +73,12 @@ export function DomainCompositionGrid({
           >
             <div className="flex items-center gap-2">
               <TopologyV2KindGlyph kind="domain" size={16} />
-              <span className="min-w-0 flex-1 truncate text-[13.5px] font-[560] tracking-[-0.01em] text-[color:var(--color-text-primary)]">
+              <span className="min-w-0 flex-1 truncate text-body-lg font-[560] tracking-[-0.01em] text-[color:var(--color-text-primary)]">
                 {domain.title}
               </span>
               <span
                 data-token="engraved-numeral"
-                className="shrink-0 font-mono text-[13px] text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
+                className="shrink-0 font-mono text-body-lg text-[color:var(--engraved-numeral-face)] [text-shadow:var(--engraved-numeral-text-shadow)]"
               >
                 {domain.total}
               </span>
@@ -95,7 +95,7 @@ export function DomainCompositionGrid({
                   }}
                 />
               </span>
-              <span className="shrink-0 font-mono text-[10.5px] whitespace-nowrap text-[color:var(--color-text-quaternary)]">
+              <span className="shrink-0 font-mono text-label whitespace-nowrap text-[color:var(--color-text-quaternary)]">
                 {capabilityLabel}{" "}
                 <b
                   data-token="engraved-numeral"
@@ -132,7 +132,7 @@ export function DomainCompositionGrid({
               ))}
               {/* 발줄은 비어도 자리를 지킨다 — 사라지면 카드 높이가 흔들린다. */}
               <span
-                className="mt-auto pt-1 text-[11px] text-[color:var(--color-text-quaternary)]"
+                className="mt-auto pt-1 text-label text-[color:var(--color-text-quaternary)]"
                 aria-hidden={domain.moreCapabilityCount === 0}
               >
                 {domain.moreCapabilityCount > 0 ? moreLine(domain.moreCapabilityCount) : " "}

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -496,7 +496,7 @@ export function ProjectDetailPage({
 
       {/* zone 1 — hero band: 글리프+타이틀+설명 + 음각 메트릭 스트립 + 정직한
           미니 도메인 지도(실카운트 비례) + topology/편집 액션. */}
-      <header className="mt-6 flex flex-col gap-6 rounded-[11px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[18px_20px] shadow-[inset_0_1px_0_var(--color-overlay-1)] lg:flex-row lg:items-stretch lg:gap-[30px] lg:p-[18px_26px]">
+      <header className="mt-6 flex flex-col gap-6 rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[18px_20px] shadow-[inset_0_1px_0_var(--color-overlay-1)] lg:flex-row lg:items-stretch lg:gap-[30px] lg:p-[18px_26px]">
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex flex-wrap items-start gap-3.5 sm:flex-nowrap">
             <TopologyV2KindGlyph kind="project" size={30} className="mt-1 shrink-0" />
@@ -507,7 +507,7 @@ export function ProjectDetailPage({
                 editable={canManageProject}
                 onSave={(next) => saveProjectField("name", next)}
                 ariaLabel={t("inlineNameAria")}
-                className="text-[27px] leading-display-tight font-[650] tracking-[-0.015em] text-pretty text-[color:var(--color-text-primary)]"
+                className="text-display leading-display-tight font-[650] tracking-[-0.015em] text-pretty text-[color:var(--color-text-primary)]"
               />
               {/*
                 메타 행은 여기서 끝난다. 예전엔 설명이 이 점-행 **안으로**
@@ -515,7 +515,7 @@ export function ProjectDetailPage({
                 "답답하다" 는 인상의 절반이 그것이었다. 정의는 메타보다 중요하니
                 한 단계 위 톤(secondary)으로 독립 블록에 둔다.
               */}
-              <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-[color:var(--color-text-tertiary)]">
+              <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-body text-[color:var(--color-text-tertiary)]">
                 <span>{heroMeta}</span>
                 <span aria-hidden className="text-[color:var(--color-text-quaternary)]">
                   ·
@@ -552,7 +552,7 @@ export function ProjectDetailPage({
                   data-testid="project-detail-readonly-badge"
                   // flex-none 은 390px 에서 페이지 가로 overflow 를 만들었다
                   // (overflow-sweep 회귀) — 좁으면 배지 텍스트가 줄바꿈된다.
-                  className="inline-flex min-w-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-[11px] leading-snug text-[color:var(--color-text-tertiary)]"
+                  className="inline-flex min-w-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-1.5 font-mono text-label text-[color:var(--color-text-tertiary)]"
                 >
                   {t("readOnlyBadge")}
                 </span>
@@ -725,7 +725,7 @@ export function ProjectDetailPage({
           className="rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]"
         >
           <div className="mb-2.5 flex items-baseline gap-2">
-            <span className="text-[13px] font-[560] text-[color:var(--color-text-primary)]">
+            <span className="text-body-lg font-[560] text-[color:var(--color-text-primary)]">
               {t("bodyCardTitle")}
             </span>
             <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
@@ -759,7 +759,7 @@ export function ProjectDetailPage({
           <section className="rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[inset_0_1px_0_var(--color-overlay-1)] md:p-[16px_18px]">
             <div className="mb-2.5 flex items-baseline gap-2">
               <TopologyV2TraceMark containment={false} />
-              <span className="text-[13px] font-[560] text-[color:var(--color-text-primary)]">
+              <span className="text-body-lg font-[560] text-[color:var(--color-text-primary)]">
                 {t("connectedTitle")}
               </span>
               <span className="font-mono text-caption uppercase tracking-[0.12em] text-[color:var(--color-text-quaternary)]">
@@ -820,21 +820,21 @@ export function ProjectDetailPage({
               말하고, 코드는 보고 싶은 사람만 편다.
             */}
             <div className="mb-2">
-              <span className="text-[13px] font-[560] text-[color:var(--color-text-primary)]">
+              <span className="text-body-lg font-[560] text-[color:var(--color-text-primary)]">
                 {t("handoffTitle")}
               </span>
             </div>
-            <p className="mb-3 text-[12px] leading-body text-[color:var(--color-text-tertiary)]">
+            <p className="mb-3 text-body leading-body text-[color:var(--color-text-tertiary)]">
               {t("handoffDesc")}
             </p>
             <Button type="button" variant="outline" size="sm" onClick={handleCopyHandoff}>
               {handoffCopyLabel}
             </Button>
             <details className="mt-3">
-              <summary className="cursor-pointer select-none text-[12px] leading-body text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-secondary)]">
+              <summary className="cursor-pointer select-none text-body leading-body text-[color:var(--color-text-tertiary)] transition-colors hover:text-[color:var(--color-text-secondary)]">
                 {t("handoffHumanCaption")}
               </summary>
-              <pre className="mt-2 overflow-x-auto font-mono text-[11.5px] leading-prose whitespace-pre-wrap text-[color:var(--color-text-quaternary)]">
+              <pre className="mt-2 overflow-x-auto font-mono text-body leading-prose whitespace-pre-wrap text-[color:var(--color-text-quaternary)]">
                 {handoffSnippet}
               </pre>
             </details>
@@ -843,7 +843,7 @@ export function ProjectDetailPage({
       </section>
 
       <footer className="mt-[var(--section-gap)] border-t border-[color:var(--color-overlay-2)] pt-6 pb-[var(--page-bottom-breath)]">
-        <p className="font-mono text-[10px] uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
+        <p className="font-mono text-caption uppercase tracking-[0.1em] text-[color:var(--color-text-quaternary)]">
           {t("footerSummary", { slug: project.slug, date: formatDate(project.updatedAt) })}
         </p>
       </footer>

--- a/tests/contract/named-offramp-utility-ratchet.contract.test.ts
+++ b/tests/contract/named-offramp-utility-ratchet.contract.test.ts
@@ -104,7 +104,7 @@ const FAMILIES: ReadonlyArray<readonly [name: string, re: RegExp, budget: number
    */
   ['leading-none', /(?<![-\w])leading-none(?![-\w])/g, 9],
   ['leading-tight', /(?<![-\w])leading-tight(?![-\w])/g, 8],
-  ['leading-snug', /(?<![-\w])leading-snug(?![-\w])/g, 17],
+  ['leading-snug', /(?<![-\w])leading-snug(?![-\w])/g, 16],
   ['leading-normal', /(?<![-\w])leading-normal(?![-\w])/g, 0],
   ['leading-relaxed', /(?<![-\w])leading-relaxed(?![-\w])/g, 71],
   ['leading-loose', /(?<![-\w])leading-loose(?![-\w])/g, 0],

--- a/tests/contract/type-ramp-coverage.contract.test.ts
+++ b/tests/contract/type-ramp-coverage.contract.test.ts
@@ -58,14 +58,9 @@ import {
 const EXEMPT_DEBT: ReadonlyArray<readonly [string, number]> = [
   ["src/entities/project/ui/ProjectCard.tsx", 16],
   ["src/entities/project/ui/ProjectMetaGrid.tsx", 2],
-  ["src/features/project-edit/ui/DependencyPicker.tsx", 6],
-  ["src/features/project-edit/ui/MarkdownField.tsx", 3],
-  ["src/features/project-edit/ui/ProjectForm.tsx", 15],
   ["src/features/vault-ontology/ui/LiveActivityIndicator.tsx", 23],
   ["src/views/first-run/ui/FirstRunPage.tsx", 14],
   ["src/views/ontology-studio/ui/StudioCompass.tsx", 24],
-  ["src/views/project-detail/ui/DomainCompositionGrid.tsx", 4],
-  ["src/views/project-detail/ui/ProjectDetailPage.tsx", 11],
   ["src/views/project-editor/ui/ProjectEditorPage.tsx", 2],
   ["src/views/root-entry/ui/RootEntryPage.tsx", 5],
 ];


### PR DESCRIPTION
## Summary

소유자 지적 — *"디자인 시스템이 제대로 적용 안된 것들이 있네? 하나하나 캡쳐하면서 살펴봐줘야할듯?"*

부채 125건을 파일 12개로 세어 둔 장부(`rampDebtExemptions`)는 있었지만, **어느 것이 화면에 보이는지는 아무도 안 쟀다.** 감사가 라우트 단위로 집계해 왔기 때문이다. 이번엔 라우트 16개를 열어 **보이는 텍스트 원소마다 computed font-size 를 램프와 대조**했다(`elementFromPoint` 로 가시성 확인).

### 실측 — 부채는 두 화면에 몰려 있다

| 화면 | 보이는 텍스트 | 램프 밖 | 크기 종류 |
|---|---|---|---|
| `/ko/project/storefront/edit/` | 40 | **18 (45%)** | 8종 |
| `/ko/project/storefront/` | 63 | **27 (43%)** | **11종** |
| `/ko/project/new/` | 25 | 9 (36%) | 7종 |
| `/ko/projects/` | 60 | 0 | 6종 |
| `/ko/ontology/studio/` | 29 | 0 | 4종 |

그 안에 **위계가 뒤집힌 자리**가 있었다 — 카드 제목 「본문」·「연결된 프로젝트」·「AI에게 이어서 맡기기」가 13px 인데 그 카드가 담은 본문은 14px 이라, **제목이 자기가 이끄는 글보다 작았다.** 헤드라인도 이 화면만 27px 이고 나머지 페이지 헤드라인 6곳(`/projects`·`/docs`·`/git`·인사이트·fallback·404)은 전부 23px 이었다.

### 무엇을 고쳤나 (5파일 · 39건)

치환은 램프의 **가장 가까운 칸**으로 하되, 헤드라인만 값이 아니라 **형제 화면**을 기준으로 맞췄다.

| 파일 | 건수 | 주요 치환 |
|---|---|---|
| `ProjectDetailPage.tsx` | 11 | 헤드라인 `27px → text-display(23)` · 카드 제목 3곳 `13px → text-body-lg(14)` · `rounded-[11px] → rounded-panel` |
| `ProjectForm.tsx` | 15 | 마이크로 라벨 13곳 `10px → text-caption(9.5)` · 완성도 수치 `28px → text-hero(30)` |
| `DependencyPicker.tsx` | 6 | `8/9/10px → text-caption` |
| `DomainCompositionGrid.tsx` | 4 | `13.5/13px → text-body-lg` · `10.5/11px → text-label` |
| `MarkdownField.tsx` | 3 | code/pre `12·13px → text-body` |

**다섯 파일 모두 0이 되었으므로 예외 목록에서 뺐다** — 부채가 장부에서만 줄고 화면에서 안 줄면 그건 회계다. `rampDebtExemptions` 12 → 7줄, 총 부채 **125 → 86**.

### 고친 뒤 다시 쟀다

| 화면 | before | after |
|---|---|---|
| `/project/storefront/` | 27/63 (43%) · 크기 11종 · 행간 13종 | **16/63 (25%) · 크기 8종 · 행간 11종** |
| `/project/storefront/edit/` | 18/40 (45%) | **4/38 (11%)** |
| `/project/new/` | 9/25 (36%) | **1/25 (4%)** |

### 이 라운드가 찾은 게이트 구멍 2건 (후속)

1. **`LiveActivityIndicator.tsx`(부채 23건 = 18%)는 어디에도 렌더되지 않는다.** barrel 에서 export 만 되고 JSX 사용처가 0이다. 라우트 16개 어디에서도 `[data-testid=live-activity-badge]` 가 잡히지 않았다 — 장부의 두 번째로 큰 항목이 **화면 영향 0** 이다.
2. **`MiniDomainMap.tsx` 의 SVG `fontSize={10|9}`** 는 클래스가 아니라 JSX 숫자 prop 이라 램프 셀렉터가 **원리적으로** 못 본다. `/project/storefront/` 에 남은 램프 밖 16건이 전부 이것이다(저장소 전체 3곳).

## Test plan

- `pnpm exec tsc --noEmit` — 통과
- `pnpm lint` — **0 errors · 91 warnings** (main 93 에서 감소, 새 소음 0)
- `pnpm test:contracts` — 113 files · 1347 tests 통과
- `pnpm exec vitest run src/views/project-detail/ui/ProjectDetailPage.test.tsx` — 19 통과
- `named-offramp-utility-ratchet` — `leading-snug` 기준선 17 → **16** 으로 하향(래칫이 감소를 요구했다)
- `pnpm build` 후 자체 포트(3148) 정적 export 로 e2e:
  - `a11y-ratchet` · `contrast-ratchet` · `a11y-open-surfaces` · `dense-row-target-size` · `touch-target-contract` — 13 통과
  - `a11y-vault-backed` · `vault-truth-telling` — 6 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnAfeNr4HCCoeqfq316275