### PR TITLE
fix: main 을 빨갛게 두던 기존 실패 2건 — 도구 수 드리프트와 배럴 통째 모킹

### DIFF
--- a/cli/templates/vault/README.md
+++ b/cli/templates/vault/README.md
@@ -118,15 +118,16 @@ For an agent opened at your codebase root instead of this vault folder, replace
 
 ## What an AI agent can do for you
 
-Once you register the `ontology-atlas-mcp` server, the agent gets 33
+Once you register the `ontology-atlas-mcp` server, the agent gets 35
 tools to read/write this vault:
 
 - **read 19**: connection_info / git_status / git_history / list_concepts / get_concept / get_concepts / find_evidence /
   find_backlinks / find_neighbors / find_path / list_kinds / find_orphans /
   query_concepts / compile_ontology / query_ontology / validate_vault /
   analyze_repo_structure / infer_imports / index_project
-- **write 14**: absorb_document / add_concept / add_concepts / add_relation / add_relations /
+- **write 16**: absorb_document / add_concept / add_concepts / add_relation / add_relations /
   remove_relation / replace_relation / patch_concept / reclassify_concept /
-  delete_concept / rename_concept / merge_concepts / git_snapshot / finalize_project_meaning
+  delete_concept / rename_concept / merge_concepts / git_snapshot / finalize_project_meaning /
+  connect_project_source / disconnect_project_source
 
 Details: https://github.com/wlsdks/ontology-atlas/tree/main/mcp

--- a/src/features/docs-vault-local/lib/ontology-starter.ts
+++ b/src/features/docs-vault-local/lib/ontology-starter.ts
@@ -147,16 +147,17 @@ For an agent opened at your codebase root instead of this vault folder, replace
 
 ## What an AI agent can do for you
 
-Once you register the \`ontology-atlas-mcp\` server, the agent gets 33
+Once you register the \`ontology-atlas-mcp\` server, the agent gets 35
 tools to read/write this vault:
 
 - **read 19**: connection_info / git_status / git_history / list_concepts / get_concept / get_concepts / find_evidence /
   find_backlinks / find_neighbors / find_path / list_kinds / find_orphans /
   query_concepts / compile_ontology / query_ontology / validate_vault /
   analyze_repo_structure / infer_imports / index_project
-- **write 14**: absorb_document / add_concept / add_concepts / add_relation / add_relations /
+- **write 16**: absorb_document / add_concept / add_concepts / add_relation / add_relations /
   remove_relation / replace_relation / patch_concept / reclassify_concept /
-  delete_concept / rename_concept / merge_concepts / git_snapshot / finalize_project_meaning
+  delete_concept / rename_concept / merge_concepts / git_snapshot / finalize_project_meaning /
+  connect_project_source / disconnect_project_source
 
 Details: https://github.com/wlsdks/ontology-atlas/tree/main/mcp
 `;

--- a/src/views/project-editor/ui/ProjectEditorPage.loading.test.tsx
+++ b/src/views/project-editor/ui/ProjectEditorPage.loading.test.tsx
@@ -62,7 +62,20 @@ vi.mock("@/shared/lib/use-document-title", () => ({
   useDocumentTitle: vi.fn(),
 }));
 
-vi.mock("@/shared/ui", () => ({
+/*
+ * **부분 모킹이다 — 배럴을 통째로 갈아치우지 않는다.**
+ *
+ * 여기서 스텁이 필요한 것은 `useToast` 하나뿐이다(프로바이더 없이 렌더하므로).
+ * 그런데 종전엔 배럴 전체를 `{ useToast }` 로 대체해서, 컴포넌트가 같은
+ * 배럴에서 **다른 것을 하나라도 더 쓰기 시작하는 순간** 테스트가 깨졌다 —
+ * 실제로 `controlClass` 가 추가되면서 *"No controlClass export is defined on
+ * the @/shared/ui mock"* 으로 죽었고, 그 상태로 `main` 에 남아 있었다.
+ *
+ * `controlClass` 는 프로바이더가 필요 없는 순수 함수라 애초에 모킹할 이유가
+ * 없다. 원본을 펼친 뒤 필요한 것만 덮으면 이 부류의 실패가 재발하지 않는다.
+ */
+vi.mock("@/shared/ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/ui")>()),
   useToast: () => ({ show: vi.fn() }),
 }));
 


### PR DESCRIPTION
## Summary

`main` 에서 `pnpm test:run` 이 계속 2건 실패하고 있었다. 이 세션의 변경과 무관한 **기존 결함**이고, **런타임 파일을 건드리는 다음 PR 부터 CI 를 빨갛게 만든다.**

> ⚠️ #942 · #943 의 `Unit · Contract` 가 초록이었던 것은 고쳐져서가 아니다 — CI 가 **"Contract tests only (no runtime change)"** 스텝으로 갈아타 전체 유닛을 안 돌렸다. 초록이 증거가 아니었다.

## ① starter README 의 도구 수가 진실원 뒤에 처졌다

| | 값 |
|---|---|
| 진실원 `mcp/package.json` | **35** tools (19 read + **16** write) |
| starter README | 33 tools / read 19 / **write 14** |

빠진 둘은 `connect_project_source` · `disconnect_project_source` — #936~938 이 더했는데 목록에 안 들어갔다. **사용자가 볼트를 만들면 첫 화면에서 받는 문서**라 틀린 개수가 그대로 나간다.

**테스트는 이미 옳게 짜여 있었다.** 개수를 손으로 적지 않고 `mcp/package.json` description 에서 뽑아 대조한다(`documentation.md` 의 「기댓값을 코드에서 뽑아 대조」 갈래). 게이트가 드리프트를 정확히 잡고 있었고 **아무도 안 고쳤을 뿐**이다.

사본이 둘이라 CLI 템플릿(`cli/templates/vault/README.md`)도 같이 고쳤다 — 그리고 **둘이 바이트 동일해야 한다는 계약이 그 두 번째 사본을 잡아냈다**(앱 starter 만 고쳤을 때 빨개짐).

## ② `@/shared/ui` 배럴을 통째로 갈아치운 모킹

```ts
vi.mock("@/shared/ui", () => ({ useToast: () => ({ show: vi.fn() }) }));
```

스텁이 필요한 것은 프로바이더 없이 렌더하느라 막아야 하는 `useToast` **하나뿐**인데 배럴 전체를 대체해서, 컴포넌트가 같은 배럴에서 **무엇이든 하나 더 쓰기 시작하면 깨진다.** 실제로 `controlClass` 가 추가되면서 죽었다.

`importOriginal` 로 **부분 모킹**한다. `controlClass` 는 프로바이더가 필요 없는 순수 함수라 애초에 모킹할 이유가 없었고, 이렇게 두면 이 부류의 실패가 재발하지 않는다.

## Test plan

- `pnpm test:run` ✅ **630 파일 · 6212 통과 · 실패 0** — 이 저장소에서 처음으로 완전히 초록
- `pnpm test:contracts` ✅ 1364 · `pnpm exec tsc --noEmit` ✅ · `pnpm exec eslint <changed>` ✅ 0
- `pnpm docs:links` ✅ 387 · `pnpm dogfood:status` ✅ 0/0/0/0 · `pnpm package:check` ✅ (CLI 템플릿을 건드려서 함께 돌림)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HssZ1CKzcyJZCFhjmnDWmX