### PR TITLE
fix: 문서함 부팅의 랜딩 소스 판정을 상태로 종결한다 — 딥링크 걷힘·샘플 전환 되튕김

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -328,6 +328,9 @@ function DocsVaultContent() {
   }, []);
   const localVault = useLocalVault();
   const localVaultStatus = localVault.status;
+  // IDB 핸들 복원 **시도가 종결됐는가** — status 와 달리 「아직 모른다」와
+  // 「없는 게 확정이다」를 가른다. 랜딩 소스 판정(C5)의 유일한 출발 신호.
+  const localVaultRestoreAttempted = localVault.restoreAttempted;
   const openLocalVault = localVault.open;
   const openRecentLocalVault = localVault.openRecent;
   const localVaultRootPath = localVault.handle
@@ -456,19 +459,52 @@ function DocsVaultContent() {
   // the Sample (`server`) source just because that was the last stored
   // preference. Users read that flip as "내 데이터가 사라졌다". The local vault
   // restores asynchronously from IndexedDB, so we watch for it and, ONCE per
-  // mount (before any manual source switch), prefer `local`. The one-shot ref
-  // means a later deliberate switch to Sample is respected — we only guard the
-  // initial landing, never the user's own choice. Not persisted, so we don't
-  // overwrite an intentional stored preference on disk.
-  const autoLocalOnLandingRef = useRef(false);
+  // mount (before any manual source switch), prefer `local`. Not persisted, so
+  // we don't overwrite an intentional stored preference on disk.
+  //
+  // ⚠️ **랜딩 판정은 복원 시도가 끝나는 순간 단 한 번으로 종결된다** (2026-08-08).
+  // 종전엔 「한 번 쏘면 소진」인 원샷 ref 였는데, 그 설계에는 두 구멍이 있었다:
+  //
+  // ① 저장 취향이 로컬인 부팅에서는 쏠 일이 없어 ref 가 장전된 채 남았고, 그
+  //    장전된 한 발이 **사용자의 첫 「샘플」 전환을 그 자리에서 로컬로
+  //    되튕겼다**(실기기: 클릭 후 300ms·1800ms 모두 로컬 — 첫 전환이 조용히
+  //    무시됨). 랜딩 가드가 사용자의 선택을 잡아먹은 것이다.
+  // ② 판정 시점이 열려 있어서, 아래 스코프 정리·「없는 문서」 판정·기본 선택이
+  //    「랜딩 전환이 아직 올 수 있는가」를 알 방법이 없었다 — 그래서 부팅의
+  //    샘플 창이 「정착」으로 관측됐다(그 결과는 스코프 정리 effect 주석 참조).
+  //
+  // `restoreAttempted` 는 IDB 복원 시도가 **종결된 뒤에만** 참이 되므로
+  // (use-local-vault: load 완료 후 set), 이 시점의 status 는 최종값이고 판정은
+  // 한 번으로 충분하다. ref 가 아니라 **상태**인 이유: ref 는 판정이 「전환
+  // 없음」으로 끝났을 때 재렌더를 만들지 않아, 이 값에 기대는 아래 소비자들이
+  // 영영 깨어나지 못한다.
+  const [landingSourceResolved, setLandingSourceResolved] = useState(false);
   useEffect(() => {
-    if (autoLocalOnLandingRef.current) return;
-    if (!sourcePreferenceHydrated) return;
+    if (landingSourceResolved) return;
+    if (!sourcePreferenceHydrated || !localVaultRestoreAttempted) return;
+    setLandingSourceResolved(true);
     if (shouldPreferLocalOnLanding(localVaultStatus, source, querySource)) {
-      autoLocalOnLandingRef.current = true;
       setSource('local');
     }
-  }, [sourcePreferenceHydrated, localVaultStatus, querySource, source]);
+  }, [
+    landingSourceResolved,
+    sourcePreferenceHydrated,
+    localVaultRestoreAttempted,
+    localVaultStatus,
+    querySource,
+    source,
+  ]);
+  /**
+   * **볼트 스코프가 정착했는가** — 부팅이 끝나 「지금 보이는 볼트」가 사용자의
+   * 의도와 일치한다고 말할 수 있는 최초 시점 이후인가. 세 소비자가 같은 술어를
+   * 쓴다: 스코프 전환 정리 · 「없는 문서」 배너 · 기본 문서 선택. 셋 중 하나라도
+   * 이보다 이른 시점에 판정하면 부팅의 샘플 창을 실재로 오인한다(2026-08-08 —
+   * 세 소비자가 각자 다른 술어를 쓰다 딥링크가 걷혔다).
+   */
+  const vaultScopeSettled =
+    sourcePreferenceHydrated &&
+    landingSourceResolved &&
+    (source === 'server' || localVaultStatus === 'loaded');
 
   // 문서함 점검 중앙 모달 — design-prescription.md ③-5: 로드마다 모달이 뜨면
   // modality 위반이므로 open 상태는 persist 하지 않고 항상 닫힌 채 시작한다.
@@ -1149,11 +1185,20 @@ function DocsVaultContent() {
   const [missingQuerySlug, setMissingQuerySlug] = useState<string | null>(null);
   useEffect(() => {
     if (!normalizedQuerySlug || docsBySlug.size === 0) return;
-    // 볼트가 아직 안 실린 동안(`docsBySlug` 가 빈 동안)은 "없다" 가 아니라
-    // "아직 모른다" 다 — 그 구간에서 말하면 깜빡임이 된다.
-    if (docsBySlug.has(normalizedQuerySlug)) return;
+    if (docsBySlug.has(normalizedQuerySlug)) {
+      // 문서가 나타났으면 잡아 둔 판정을 걷는다 — 부팅 중 샘플 창에서 내렸던
+      // 「없다」가 로컬 볼트 도착으로 거짓이 된 경우다(2026-08-08).
+      setMissingQuerySlug((prev) => (prev === normalizedQuerySlug ? null : prev));
+      return;
+    }
+    // 볼트가 아직 안 실린 동안(`docsBySlug` 가 빈 동안)과 부팅이 아직 어느
+    // 볼트를 보여줄지 못 정한 동안(`vaultScopeSettled` 전)은 "없다" 가 아니라
+    // "아직 모른다" 다 — 그 구간에서 말하면 깜빡임이거나, 더 나쁘게는 로컬
+    // 볼트에 실재하는 문서를 샘플 매니페스트 기준으로 "없다" 고 선고하는
+    // 오판이 된다(2026-08-08 실기기 — 그 선고가 딥링크를 걷어냈다).
+    if (!vaultScopeSettled) return;
     setMissingQuerySlug((prev) => prev ?? normalizedQuerySlug);
-  }, [normalizedQuerySlug, docsBySlug]);
+  }, [normalizedQuerySlug, docsBySlug, vaultScopeSettled]);
 
   /**
    * **볼트가 바뀌면 볼트 전용 주소 상태를 걷어낸다** — 이게 근본 수리다.
@@ -1199,13 +1244,20 @@ function DocsVaultContent() {
    * 바로 위 주석이 스스로 *"첫 마운트의 `?slug=` 는 잔재가 아니라 누군가 준
    * 것"* 이라 적어 뒀는데, 그 보호가 첫 실행(run)에만 걸리고 **부팅 중
    * hydration 전환**에는 안 닿았던 것이다. 그래서 기준선을 「첫 실행」이 아니라
-   * **「정착된 첫 스코프」**로 옮긴다 — 술어는 기본 선택 effect 가 이미 쓰는
-   * `selectionReady` 그대로다(취향 hydration 완료 + 로컬이면 로드 완료).
-   * 정착 후의 스코프 변화만이 진짜 볼트 전환이다.
+   * **「정착된 첫 스코프」**로 옮긴다 — 정착 후의 스코프 변화만이 진짜 볼트
+   * 전환이다.
+   *
+   * **2026-08-08 2차 검수 — 그 「정착」의 정의가 틀려서 같은 사고가 남아
+   * 있었다.** 첫 수리의 술어는 `source === 'server'` 를 즉시 정착으로 쳤는데,
+   * 저장 취향이 샘플인 부팅에서는 로컬 볼트 복원이 끝나는 순간 랜딩 자동
+   * 전환(C5)이 소스를 뒤집는다 — 즉 그 「서버 정착」은 몇백 ms 짜리 가짜였고,
+   * 뒤집히는 순간이 다시 「볼트 전환」으로 읽혀 딥링크가 걷혔다. 지금의
+   * `vaultScopeSettled`(위에서 정의)는 **랜딩 판정 종결**(`landingSourceResolved`)
+   * 을 포함하므로 그 창이 정착으로 관측되지 않는다. e2e:
+   * `docs-deeplink.spec.ts` 「샘플을 먼저 쓰던 프로필…」이 replaceState 전수
+   * 기록으로 「딥링크를 잃은 호출 0건」까지 잰다.
    */
   const vaultScopeRef = useRef<string | null>(null);
-  const vaultScopeSettled =
-    sourcePreferenceHydrated && (source === 'server' || localVaultStatus === 'loaded');
   useEffect(() => {
     if (!vaultScopeSettled) return;
     const previous = vaultScopeRef.current;
@@ -1408,9 +1460,10 @@ function DocsVaultContent() {
       shouldDeferDocsVaultDefaultSelection({
         normalizedQuerySlug,
         selectedSlug,
-        selectionReady:
-          sourcePreferenceHydrated &&
-          (source === 'server' || localVaultStatus === 'loaded'),
+        // 부팅이 어느 볼트를 보여줄지 정하기 전(랜딩 판정 미종결)에는 기본
+        // 선택도 미룬다 — 샘플 창에서 고른 기본값이 곧 도착할 로컬 볼트의
+        // 딥링크를 덮는다(2026-08-08). 세 소비자가 같은 술어를 쓴다.
+        selectionReady: vaultScopeSettled,
       })
     ) {
       return;
@@ -1447,7 +1500,7 @@ function DocsVaultContent() {
        */
       replaceUrlState({ slug: nextSlug });
     });
-  }, [collectionDocSlugs, collectionDocs, collectionPinnedSlugs, collectionRecentSlugs, docsBySlug, localVaultStatus, normalizedQuerySlug, openDocTabsHydrated, pendingRestoredActiveSlug, replaceUrlState, selectedSlug, source, sourcePreferenceHydrated]);
+  }, [collectionDocSlugs, collectionDocs, collectionPinnedSlugs, collectionRecentSlugs, docsBySlug, normalizedQuerySlug, openDocTabsHydrated, pendingRestoredActiveSlug, replaceUrlState, selectedSlug, vaultScopeSettled]);
 
   const handleSelect = useCallback(
     (slug: string, query?: string) => {

--- a/tests/e2e/docs-deeplink.spec.ts
+++ b/tests/e2e/docs-deeplink.spec.ts
@@ -35,8 +35,17 @@ import { stubDirectoryPicker } from "./vault-picker-stub";
  * 낡은 슬러그 소음이 되돌아온다.
  */
 
-/** 픽스처에 실재하는 중첩 슬러그 — 폴더 접두사가 있어야 결함이 재현된다. */
-const DEEP_SLUG = "capabilities/checkout";
+/**
+ * 픽스처에 실재하는 중첩 슬러그 — 폴더 접두사가 있어야 결함이 재현된다.
+ *
+ * ⚠️ **픽스처에만 있는 슬러그여야 한다** (2026-08-08). 처음엔
+ * `capabilities/checkout` 이었는데, 그 이름은 **배포 샘플 볼트에도 있다** —
+ * 그래서 부팅이 샘플 창을 지나는 동안 딥링크가 걷히고 샘플의 같은 문서가
+ * 열려도 시험이 초록이었다. 표적이 두 볼트에 다 있으면 「어느 볼트가
+ * 열었나」를 재지 못한다.
+ */
+const DEEP_SLUG = "capabilities/deeplink-probe";
+const DEEP_TITLE = /딥링크 표적 문서/;
 
 test.describe("문서함 딥링크 — URL 이 이긴다", () => {
   test("로컬 볼트 복원 뒤의 콜드 로드에서 ?slug= 가 살아남는다", async ({ page }) => {
@@ -73,7 +82,7 @@ test.describe("문서함 딥링크 — URL 이 이긴다", () => {
       .toBe(DEEP_SLUG);
     await expect(
       page.getByTestId("gateway-doc-title").or(page.locator("main")).first(),
-    ).toContainText(/결제|checkout/i, { timeout: 20_000 });
+    ).toContainText(DEEP_TITLE, { timeout: 20_000 });
   });
 
   test("정착 뒤 샘플로 바꾸면 볼트 전용 슬러그를 걷어낸다 — 2026-08-01 보장 유지", async ({
@@ -102,5 +111,123 @@ test.describe("문서함 딥링크 — URL 이 이긴다", () => {
     await expect
       .poll(async () => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
       .not.toBe(DEEP_SLUG);
+  });
+
+  /**
+   * 2026-08-08 2차 실사용 검수가 잡은 사각. 위 첫 시험은 통과하는데 실기기가
+   * 실패했다 — 차이는 **프로필이 샘플 스코프를 먼저 썼는가**였다. 저장된 소스
+   * 취향이 `server` 인 부팅은 「서버는 즉시 정착」 술어에 걸려 샘플 창이
+   * 정착으로 관측되고, 로컬 볼트 복원이 끝나 랜딩 자동 전환(C5)이 뒤집는 순간
+   * 그 전환이 「사용자 볼트 전환」으로 오인되어 딥링크가 걷혔다.
+   */
+  test("샘플을 먼저 쓰던 프로필의 콜드 로드에서도 로컬 전용 딥링크가 살아남는다", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await stubDirectoryPicker(page, FIXTURE_VAULT);
+    await seedFirstRunSeen(page);
+
+    // ① 샘플 스코프의 흔적을 만든다 — 실기기 사고 프로필 그대로:
+    //    문서함을 샘플로 먼저 쓰고(취향 저장 + 샘플 탭·최근), 그 뒤 볼트를 연다.
+    await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+    await expect
+      .poll(async () => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
+      .not.toBeNull();
+    await page.evaluate(() => {
+      window.localStorage.setItem("demo:docs-vault:source", "server");
+    });
+
+    // ② 지도에서 볼트를 열고, 문서함을 로컬로 한 번 써서 **로컬 스코프의
+    //    「마지막 문서」**를 만든다 — 걷힌 딥링크의 빈자리를 차지할 후보다.
+    //    (실기기 사고에서 최종 URL 을 쓴 것이 바로 이 탭 복원이었다.)
+    await page.goto("/ko/topology/?guides=off");
+    await page.waitForLoadState("networkidle");
+    await page.getByTestId("first-run-starter-open").click();
+    await expect(page.getByTestId("vault-guide-sheet")).toBeVisible();
+    await page.getByTestId("vault-guide-pick-existing").click();
+    await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 30_000 });
+    await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+    await expect
+      .poll(async () => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
+      .not.toBeNull();
+    const localRestedSlug = new URL(page.url()).searchParams.get("slug");
+    expect(localRestedSlug).not.toBe(DEEP_SLUG);
+
+    // ③ 저장 취향은 여전히 샘플인 채로 콜드 로드 딥링크 — 부팅이
+    //    「샘플 정착 → 랜딩 자동 전환」을 지나는 동안 딥링크가 살아남아야 한다.
+    // 주소가 딥링크를 **한 순간이라도** 부정하면 결함이다 — 걷힌 찰나를 어느
+    //    경주가 굳히는지는 기기마다 다르고(실기기에서는 탭 복원이 굳혀 README 로
+    //    남았다), 최종값 폴링만 재면 자가 치유된 쪽만 초록이 된다. 그래서
+    //    replaceState 전수를 기록해 「슬러그를 잃은 호출 0건」을 단언한다.
+    await page.addInitScript(() => {
+      const w = window as unknown as { __urlTrace?: string[] };
+      w.__urlTrace = [];
+      const orig = history.replaceState.bind(history);
+      history.replaceState = (s, ti, url) => {
+        w.__urlTrace?.push(String(url));
+        return orig(s, ti, url);
+      };
+    });
+    await page.evaluate(() => {
+      window.localStorage.setItem("demo:docs-vault:source", "server");
+    });
+    await page.goto(`/ko/docs/?guides=off&slug=${encodeURIComponent(DEEP_SLUG)}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect
+      .poll(async () => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
+      .toBe(DEEP_SLUG);
+    await expect(
+      page.getByTestId("gateway-doc-title").or(page.locator("main")).first(),
+    ).toContainText(DEEP_TITLE, { timeout: 20_000 });
+    // 부팅이 끝난 지금까지의 전체 기록에서 슬러그를 떨군 호출을 찾는다.
+    const trace = await page.evaluate(
+      () => (window as unknown as { __urlTrace?: string[] }).__urlTrace ?? [],
+    );
+    expect(trace.length, "replaceState 가 한 번도 안 불렸다 — 계측이 헛돈다").toBeGreaterThan(0);
+    const dropped = trace.filter(
+      (url) => !url.includes(`slug=${encodeURIComponent(DEEP_SLUG)}`),
+    );
+    expect(
+      dropped,
+      "부팅 중 주소가 딥링크를 잃었다 — 이 찰나를 탭 복원이 굳히면 실기기 사고가 된다",
+    ).toEqual([]);
+  });
+
+  /**
+   * 같은 뿌리의 둘째 결함 — 저장 취향이 `local` 인 부팅에서는 랜딩 자동 전환이
+   * 쏘일 일이 없어 원샷 ref 가 소진되지 않았고, 그 장전된 한 발이 **사용자의
+   * 첫 「샘플」 전환을 그 자리에서 로컬로 되튕겼다**(2026-08-08 실기기:
+   * 클릭 후 300ms·1800ms 모두 로컬). 랜딩 판정은 복원 시도가 끝나는 순간
+   * 단 한 번으로 종결되어야 하고, 그 뒤의 수동 전환에 관여하면 안 된다.
+   */
+  test("저장 취향이 로컬인 부팅에서 첫 샘플 전환이 즉시 먹는다", async ({ page }) => {
+    test.setTimeout(120_000);
+    await stubDirectoryPicker(page, FIXTURE_VAULT);
+    await seedFirstRunSeen(page);
+    await page.goto("/ko/topology/?guides=off");
+    await page.waitForLoadState("networkidle");
+    await page.getByTestId("first-run-starter-open").click();
+    await expect(page.getByTestId("vault-guide-sheet")).toBeVisible();
+    await page.getByTestId("vault-guide-pick-existing").click();
+    await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 30_000 });
+
+    await page.evaluate(() => {
+      window.localStorage.setItem("demo:docs-vault:source", "local");
+    });
+    await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("radio", { name: "로컬" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+      { timeout: 20_000 },
+    );
+
+    await page.getByRole("radio", { name: "샘플" }).click();
+    // 되튕김은 즉시 일어난다 — 전환이 붙었으면 그대로 유지되어야 한다.
+    await page.waitForTimeout(1_500);
+    await expect(page.getByRole("radio", { name: "샘플" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
   });
 });

--- a/tests/e2e/fixture-vault.ts
+++ b/tests/e2e/fixture-vault.ts
@@ -182,6 +182,14 @@ export const FIXTURE_VAULT: Readonly<Record<string, string>> = {
     dependencies: ["invoice"],
   }),
   "capabilities/tax-report.md": capability("tax-report", "세금 신고 자료", "settlement"),
+  // ⚠️ **배포 샘플 볼트에 절대 없는 슬러그** — 딥링크 시험의 표적. `checkout`
+  // 같은 쇼핑몰 어휘는 배포 샘플(sample-storefront, 112 노드)에도 있어서,
+  // 「어느 볼트가 이 문서를 열었나」를 시험이 가를 수 없었다(2026-08-08 —
+  // 부팅 경주 결함이 샘플 겹침 뒤에 숨어 초록이었다). 이 이름이 샘플에
+  // 생기면 그 시험들이 다시 눈이 먼다 — 샘플에 넣지 말 것.
+  "capabilities/deeplink-probe.md": capability("deeplink-probe", "딥링크 표적 문서", "settlement", {
+    desc: "픽스처 볼트에만 존재해, 열린 문서가 어느 볼트에서 왔는지를 시험이 가른다.",
+  }),
   "capabilities/product-detail.md": capability("product-detail", "상품 상세", "catalog", {
     relates: ["invoice"],
     elements: ["product-page"],


### PR DESCRIPTION
## Summary

2차 전체검수(실기기 Chrome, 실사용)가 어제 딥링크 수리(#982)의 사각 둘을 잡았다. 한 뿌리에서 나온 결함 둘:

**① 샘플을 먼저 쓰던 프로필의 콜드 로드에서 로컬 전용 딥링크가 README 로 덮인다.**
저장 소스 취향이 `server` 인 부팅은 「서버는 즉시 정착」 술어에 걸려 **샘플 창이 정착으로 관측**되고, 로컬 볼트 복원이 끝나는 순간 랜딩 자동 전환(C5)이 소스를 뒤집으면 그 전환이 「사용자 볼트 전환」으로 오인되어 `?slug=` 가 걷혔다. 걷힌 자리를 탭 복원이 굳혀, 에이전트가 남긴 핸드오프 링크가 받는 사람의 마지막 화면에 진다.

**② 저장 취향이 로컬인 부팅에서 첫 「샘플」 전환이 조용히 무시된다.**
랜딩 원샷 ref 가 장전된 채 남아, 사용자의 첫 수동 전환을 그 자리에서 로컬로 되튕겼다(실측: 클릭 후 300ms·1800ms 모두 로컬).

**수리**: 랜딩 판정을 복원 시도 종결(`restoreAttempted`) 시점에 **단 한 번 판정하고 상태(`landingSourceResolved`)로 종결**한다. 스코프 전환 정리 · 「없는 문서」 배너 · 기본 문서 선택 셋이 같은 정착 술어를 쓴다 — 셋이 각자 다른 술어를 쓰던 것이 사각의 구조였다.

**시험의 사각도 함께 막았다**: 어제 스펙의 딥슬러그(`capabilities/checkout`)는 **배포 샘플 볼트에도 있어서**, 걷힌 딥링크를 샘플의 동명 문서가 가려 시험이 초록이었다. 픽스처 전용 슬러그(`capabilities/deeplink-probe`)로 바꾸자 수리 전 코드에서 4개 중 3개가 빨개졌다(가짜 초록의 증명). replaceState 전수 기록으로 「부팅 중 딥링크를 잃은 호출 0건」까지 잰다.

## Test plan

- `tests/e2e/docs-deeplink.spec.ts` 4종 — 수리 전 3 red → 수리 후 4 green (정적 export, 자기 포트)
- 실기기 검증: 사고를 낸 바로 그 프로필(sweep2)에서 `capabilities/temporal-graph` 딥링크 생존 + 첫 샘플 전환 즉시 반영 확인
- `pnpm exec tsc --noEmit` ✓ · eslint(변경 파일) ✓ · `pnpm test:contracts` 1521 ✓ · `pnpm desktop:check` ✓ · `a11y-vault-backed.spec.ts` ✓ (픽스처 노드 수 파생 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)