### PR TITLE
fix: 셸이 뷰포트 소유권의 나머지 절반을 갖는다 — 관문 펼침 뒤 빈 화면 소멸

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -101,7 +101,13 @@ export default function RootLayout({
       lang="en"
       className={`${pretendard.variable} ${jetbrainsMono.variable} h-full overflow-x-hidden`}
     >
-      <body className="flex min-h-full flex-col overflow-x-hidden pb-[calc(56px+env(safe-area-inset-bottom))] md:pb-0">
+      {/* 탭바 예약 패딩(pb-56px)을 지웠다 (2026-08-08) — 셸이 `h-dvh` 로
+          뷰포트를 소유하기 전(2026-04-30 최초 임포트) 문서 스크롤 시대의
+          유산이다. 지금 그 패딩은 아무것도 보호하지 않으면서 `<md` 전 페이지에
+          56px 의 죽은 문서 스크롤을 만들었다. 탭바 예약은 각 페이지의 스크롤
+          표면이 소유한다(.claude/rules/design.md) — body 가 아니다.
+          게이트: document-scroll-lock.spec.ts + scroll-end-gap.spec.ts. */}
+      <body className="flex min-h-full flex-col overflow-x-hidden">
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -120,7 +120,14 @@ function ShellColumn({ children }: { children: ReactNode }) {
     // 구조" 라 #65(레일 유틸 티어가 화면마다 1/2/3 개였던 결함)와 같은 drift 를
     // 부른다. 셸이 `h-dvh` 를 잡고 본문을 스크롤 영역으로 가두면 어떤 페이지도
     // 아무것도 몰라도 된다.
-    <div className="flex h-dvh w-full flex-col overflow-hidden">
+    //
+    // `relative` 는 그 소유권의 나머지 절반이다 (2026-08-08): 셸이 `static` 이면
+    // positioned 조상이 없는 `absolute` 원소(대표적으로 `sr-only`)의 위치 기준이
+    // **뷰포트**가 되고, `overflow-hidden` 은 자기 containing block 이 아닌
+    // 원소를 자르지 못하므로 그 원소가 **문서 스크롤 범위를 늘린다** — 관문에서
+    // 펼침 콘텐츠 속 sr-only 둘이 문서를 1108px 늘려, 끝까지 스크롤하면 빈
+    // 화면이 나왔다(600×900 실측). 게이트: document-scroll-lock.spec.ts.
+    <div className="relative flex h-dvh w-full flex-col overflow-hidden">
       <div className="flex min-h-0 flex-1">
         <AppNavRailSlot />
         {/* 본문 슬롯은 **스크롤 컨테이너**다 — 그러니 자기 자식을 압축하면 안 된다.

--- a/tests/e2e/document-scroll-lock.spec.ts
+++ b/tests/e2e/document-scroll-lock.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * **문서(html)는 스크롤하지 않는다 — 뷰포트는 셸이 소유한다.**
+ *
+ * ## 무엇이 났나 (2026-08-08 반응형 전수 실측)
+ *
+ * 관문(`/`)에서 「받아도 되는 이유」를 펼치고 휠로 끝까지 내리면 **화면 전체가
+ * 빈 검정**이 됐다 (600×900 실측: 푸터가 뷰포트 위로 −270px, 문서 scrollHeight
+ * 862→1970). 본문은 셸의 내부 스크롤 슬롯이 갖고 있는데 문서 자체도 스크롤
+ * 범위를 얻어 **이중 스크롤**이 됐고, 휠 체이닝이 내부를 다 쓰고 나면 문서를
+ * 콘텐츠 전체 너머로 밀었다.
+ *
+ * ## 원인 둘 — 이 스펙이 재는 성질의 반례들
+ *
+ * 1. **positioned 조상이 없는 `absolute` 원소는 문서를 늘린다.** 펼친 내용 속
+ *    `sr-only`(= `position:absolute`) 스팬의 위치 기준이 — 셸 루트가 `static`
+ *    이라 — **뷰포트**가 됐고, 정적 `overflow-hidden` 은 자기 containing block
+ *    이 아닌 원소를 자르지 못하므로 문서 스크롤 범위가 그 스팬까지 늘었다.
+ *    수리: 셸 루트에 `relative` — 이후 어떤 absolute 원소도 문서를 못 늘린다.
+ * 2. **body 의 탭바 예약 패딩(56px)은 셸 이전 시대의 유산이다** (2026-04-30
+ *    최초 임포트부터). 셸이 `h-dvh` 로 뷰포트를 소유한 지금, 그 패딩은 아무
+ *    것도 보호하지 않으면서 `<md` 전 페이지에 56px 의 죽은 문서 스크롤을 만든다.
+ *
+ * ## 왜 이 모양의 게이트인가
+ *
+ * `scroll-end-gap.spec.ts` 는 **닫힌 기본 상태**의 스크롤 끝 여백을 잰다 —
+ * 접힘 표면을 펼친 상태는 재지 않았고, 그래서 이 결함군은 그 게이트를 영원히
+ * 통과했다. 여기서는 상태를 바꿔 가며(펼침 포함) **문서 스크롤 범위가 0** 인지
+ * 하나만 잰다. 성질이 하나면 반례도 명확하다: 문서가 1px 이라도 스크롤되면
+ * 어떤 원소가 뷰포트 밖으로 샌 것이다.
+ */
+
+const WIDTHS = [
+  { w: 600, h: 900 },
+  { w: 1440, h: 900 },
+] as const;
+
+const ROUTES = ["/ko/?guides=off", "/ko/topology/?guides=off", "/ko/docs/?guides=off"] as const;
+
+async function documentScrollSlack(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.scrollingElement ?? document.documentElement;
+    return el.scrollHeight - el.clientHeight;
+  });
+}
+
+test.describe("문서 스크롤 잠금 — 셸이 뷰포트를 소유한다", () => {
+  for (const { w, h } of WIDTHS) {
+    for (const route of ROUTES) {
+      test(`${route} @ ${w}×${h} — 문서 스크롤 범위 0`, async ({ page }) => {
+        await seedFirstRunSeen(page);
+        await page.setViewportSize({ width: w, height: h });
+        await page.goto(route, { waitUntil: "domcontentloaded" });
+        // 관문은 Suspense 교체 창에 <main> 이 잠깐 2개다 — first() 로 준비만 확인.
+        await expect(page.locator("main").first()).toBeVisible({ timeout: 20_000 });
+        // hydration 이 레이아웃을 흔들 수 있다 — 정착값을 폴링한다.
+        await expect
+          .poll(() => documentScrollSlack(page), { timeout: 10_000 })
+          .toBeLessThanOrEqual(0);
+      });
+    }
+
+    test(`관문 「받아도 되는 이유」 펼침 @ ${w}×${h} — 펼쳐도 문서는 안 자란다`, async ({
+      page,
+    }) => {
+      await seedFirstRunSeen(page);
+      await page.setViewportSize({ width: w, height: h });
+      await page.goto("/ko/?guides=off", { waitUntil: "domcontentloaded" });
+      const trust = page.getByTestId("download-trust");
+      await expect(trust, "관문 신뢰 디스클로저가 사라졌다 — 이 시험이 헛돈다").toBeVisible({
+        timeout: 20_000,
+      });
+      await trust.locator("summary").click();
+      // 펼침 콘텐츠가 실제로 나타났는지 — 안 나타나면 아래 0 이 공회전이다.
+      await expect(trust).toHaveAttribute("open", "");
+      await expect
+        .poll(() => documentScrollSlack(page), { timeout: 10_000 })
+        .toBeLessThanOrEqual(0);
+      // 펼친 내용의 끝(체크섬 영역)이 **내부 슬롯 스크롤로** 닿는지 — 문서를
+      // 잠갔더니 내용에 못 닿는 반대 방향 회귀를 막는다.
+      const copy = trust.locator("button", { hasText: /복사/ }).first();
+      await copy.scrollIntoViewIfNeeded();
+      await expect(copy).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

3차 전수조사(반응형 실측 에이전트)가 잡은 결함: **관문(`/`)에서 「받아도 되는 이유」를 펼치고 휠로 끝까지 내리면 화면 전체가 빈 검정**이 된다(600×900 실측: 푸터가 뷰포트 위로 −270px, 문서 scrollHeight 862→1970, 전 폭에서 재현). 첫 방문자가 「이 앱을 믿어도 되나」를 읽으려는 바로 그 경로다.

원인 둘, 수리 둘:

1. **셸 루트가 `static` 이었다.** positioned 조상이 없는 `absolute` 원소(펼침 내용 속 `sr-only` 스팬 둘)의 위치 기준이 뷰포트가 되고, 정적 `overflow-hidden` 은 자기 containing block 이 아닌 원소를 자르지 못하므로 그 스팬들이 **문서 스크롤 범위를 1108px 늘렸다**. 셸 루트에 `relative` 한 단어 — 이후 어떤 absolute 원소도 문서를 못 늘린다(결함 개별 수리가 아니라 결함 부류의 봉인).
2. **body 의 탭바 예약 패딩 56px 는 유산이다** (2026-04-30 최초 임포트부터 — 셸이 `h-dvh` 로 뷰포트를 소유하기 전 시대). 아무것도 보호하지 않으면서 `<md` 전 페이지에 56px 의 죽은 문서 스크롤을 만들었다. 제거 — 예약은 각 페이지의 스크롤 표면이 소유한다는 기존 규칙 그대로.

**게이트**: `document-scroll-lock.spec.ts` — 「문서(html)는 스크롤하지 않는다」 성질 하나를 3개 라우트 × 2폭 + **펼침 상태**에서 잰다. 기존 `scroll-end-gap` 은 닫힌 기본 상태만 재서 이 결함군을 영원히 통과시켰다(공회전 방지 단언 포함: 펼침이 실제로 열렸는지, 펼친 내용 끝에 내부 스크롤로 닿는지까지).

## Test plan

- 새 게이트: 수리 전 **6/8 빨강**(결함 실증) → 수리 후 **8/8 초록**
- 파급 게이트: `scroll-end-gap.spec.ts` 3/3 (17 라우트 × 3폭 예약 유지) · `web-surface-smoke` + `touch-target` 19/19 · `AppShell.test.tsx` 5/5 · eslint · tsc ✓
- 실기기 재검증: 600×900 펼침 + 끝까지 스크롤 → 문서 슬랙 0 · 푸터 화면 안(710px) · 중앙에 실제 콘텐츠

🤖 Generated with [Claude Code](https://claude.com/claude-code)