### PR TITLE
fix: 판의 출구 두 개를 들어가는 폭에서만 나란히 세운다 — 눌린 여백 15px

### DIFF
--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -717,7 +717,21 @@ function PlateExitRow({ published }: { published: boolean }) {
   return (
     <div
       data-testid="download-exit-row"
-      className="mt-5 grid min-w-0 grid-cols-1 gap-2.5 border-t border-[color:var(--color-divider)] pt-3.5 sm:grid-cols-[1.08fr_0.92fr] [@media(min-width:64rem)_and_(max-height:56.25rem)]:mt-3 [@media(min-width:64rem)_and_(max-height:56.25rem)]:pt-2.5"
+      /*
+       * ⚠️ **2열은 두 버튼이 설계 여백으로 들어갈 때만 선다** (2026-08-08 실측).
+       *
+       * 종전엔 `sm:`(640px)부터 두 칸을 `1.08fr 0.92fr` 로 갈랐는데, 640~830
+       * 구간에서는 그 칸이 내용보다 좁다. 실측(768·ko): 행 폭 310px 인데 두
+       * 버튼이 설계 여백(px-6=24)을 지키려면 325px 이 필요하다. 부족분 15px 은
+       * **여백에서 조용히 깎였다** — GitHub 버튼의 실효 좌우 여백이 24 → 15.5 로
+       * 눌리고, 그 옆 형제는 22 라서 나란히 선 두 출구의 여백이 서로 달라졌다.
+       * 글자가 잘리거나 삐져나오지는 않아서 넘침 계측에는 안 잡히는 종류다.
+       *
+       * 그래서 문턱을 «칸이 있다» 가 아니라 «내용이 들어간다» 로 옮긴다.
+       * 52rem(832px)은 실측 임계(≈825px)에 여유를 둔 값이고, 그 아래에서는
+       * `<sm` 과 같은 한 줄 쌓기가 된다 — 눌러 담기보다 낫다.
+       */
+      className="mt-5 grid min-w-0 grid-cols-1 gap-2.5 border-t border-[color:var(--color-divider)] pt-3.5 [@media(min-width:52rem)]:grid-cols-[1.08fr_0.92fr] [@media(min-width:64rem)_and_(max-height:56.25rem)]:mt-3 [@media(min-width:64rem)_and_(max-height:56.25rem)]:pt-2.5"
     >
       <a
         href={GITHUB_REPOSITORY_URL}

--- a/tests/e2e/download-gateway-grid.spec.ts
+++ b/tests/e2e/download-gateway-grid.spec.ts
@@ -449,3 +449,98 @@ test.describe("관문 다운로드의 그리드", () => {
     });
   }
 });
+
+/**
+ * **설계 여백은 눌러 담기의 완충재가 아니다** (2026-08-08 실측).
+ *
+ * 판의 출구 두 개(GitHub · 웹버전)를 640px 부터 두 칸으로 갈랐는데,
+ * 640~830 구간에서는 그 칸이 내용보다 좁다. 실측(768 · ko): 행 폭 310px 인데
+ * 두 버튼이 설계 여백(`px-6` = 24)을 지키려면 325px 이 필요했고, **부족분
+ * 15px 이 여백에서 조용히 깎였다** — GitHub 버튼의 실효 좌우 여백 15.5,
+ * 그 옆 형제 22. 나란히 선 두 출구의 여백이 서로 달라진 것이다.
+ *
+ * ## 왜 기존 게이트가 못 봤나 — 셋 다 각자 이유가 있다
+ *
+ * | 게이트 | 왜 침묵했나 |
+ * |---|---|
+ * | 이 파일의 x·넘침 시험 | 폭 목록이 **1440 이상**뿐이었다. 768 은 한 번도 측정된 적이 없다 |
+ * | 글자 넘침 계측 | 글자가 **버튼 테두리 안에** 있다 — 잘리지도 삐져나오지도 않는다 |
+ * | 단위 시험 | 담김·순서·문구만 본다. 렌더된 px 은 jsdom 에 없다 |
+ *
+ * 셋 다 자기 일은 했다. 아무도 «여백이 설계값대로인가» 를 묻지 않았을 뿐이다.
+ *
+ * ## 이 시험이 지키는 property
+ *
+ * *판 안의 컨트롤은 자기 내용을 담을 만큼 넓다* — 선언한 좌우 여백이 실제로
+ * 그만큼 남는다. 이 성질이 깨지는 방식은 잘림이 아니라 **압축**이라, 재는
+ * 방법도 rect 비교가 아니라 «content box 대 잉크 폭» 이다.
+ */
+test.describe("판의 컨트롤은 선언한 여백을 지킨다", () => {
+  /** 좁은 쪽 임계 주변 — 여기가 한 번도 측정된 적 없는 구간이다. */
+  const NARROW_WIDTHS = [
+    { width: 640, height: 900 },
+    { width: 768, height: 1024 },
+    { width: 820, height: 1180 },
+    { width: 1024, height: 768 },
+  ];
+
+  for (const locale of ["ko", "en"] as const) {
+    for (const { width, height } of NARROW_WIDTHS) {
+      test(`${locale} @ ${width}×${height} — 눌린 여백 0`, async ({ page }) => {
+        await page.setViewportSize({ width, height });
+        await seedFirstRunSeen(page);
+        await page.goto(`/${locale}/download/`, { waitUntil: "networkidle" });
+        await expect(page.getByTestId("download-plate")).toBeVisible({ timeout: 15_000 });
+
+        const squeezed = await page.evaluate(() => {
+          const plate = document.querySelector('[data-testid="download-plate"]')!;
+          const rows: { id: string; declared: number; effective: number }[] = [];
+          for (const el of plate.querySelectorAll("a, button")) {
+            const box = el.getBoundingClientRect();
+            if (box.width < 40 || box.height < 20) continue;
+            const cs = getComputedStyle(el);
+            const declared = parseFloat(cs.paddingLeft);
+            if (declared < 1) continue; // 여백을 선언하지 않은 텍스트 링크는 대상 밖
+            // 실제 잉크 폭 — 자식 rect 의 합집합(텍스트 노드 포함)
+            const marks: DOMRect[] = [];
+            for (const node of el.childNodes) {
+              if (node.nodeType === Node.TEXT_NODE) {
+                if (!node.textContent?.trim()) continue;
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                marks.push(range.getBoundingClientRect());
+              } else if (node instanceof Element) {
+                marks.push(node.getBoundingClientRect());
+              }
+            }
+            const painted = marks.filter((m) => m.width > 0);
+            if (!painted.length) continue;
+            const inkLeft = Math.min(...painted.map((m) => m.left));
+            const inkRight = Math.max(...painted.map((m) => m.right));
+            const effective = Math.min(inkLeft - box.left, box.right - inkRight);
+            rows.push({
+              id: el.getAttribute("data-testid") ?? el.textContent?.trim().slice(0, 24) ?? "?",
+              declared: Math.round(declared),
+              effective: Math.round(effective),
+            });
+          }
+          return rows;
+        });
+
+        // 공회전 차단 — 여백을 선언한 컨트롤을 하나도 못 찾으면 아래 0 은 무의미하다.
+        expect(
+          squeezed.length,
+          "판에서 여백을 선언한 컨트롤을 못 찾았다 — 계기가 헛돈다",
+        ).toBeGreaterThanOrEqual(2);
+
+        // 1px 은 서브픽셀 반올림 몫이다. 그보다 크게 깎였으면 압축이다.
+        const offenders = squeezed.filter((r) => r.effective < r.declared - 1);
+        expect(
+          offenders,
+          "선언한 여백보다 좁게 렌더된 컨트롤 — 칸이 내용보다 좁아 여백에서 깎인다. " +
+            "칸을 넓히거나, 그 폭에서는 한 줄로 쌓아라.",
+        ).toEqual([]);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

3차 전수조사의 글자 넘침 계측이 "768에서 여백이 0에 수렴한다"를 **소견**으로 남겼고, 직접 재 보니 소견이 아니라 결함이었다.

관문/다운로드 판의 출구 둘(GitHub · 웹버전)을 `sm`(640px)부터 두 칸으로 갈랐는데, **640~830 구간에서는 그 칸이 내용보다 좁다**. 실측(768 · ko):

| | 값 |
|---|---|
| 행 폭 | 310px |
| 두 버튼이 설계 여백(`px-6`=24)을 지키려면 | **325px** |
| 부족분 | 15px — **여백에서 조용히 깎였다** |
| GitHub 버튼 실효 좌우 여백 | 24 → **15.5** |
| 형제(웹버전) 실효 여백 | 22 |

나란히 선 두 출구의 여백이 서로 달라졌다. 글자는 버튼 테두리 **안에** 있어 잘리지도 삐져나오지도 않으므로, 넘침 계측에는 원리적으로 안 잡히는 종류다.

**수리는 문턱을 옮긴 것뿐이다** — 「칸이 있다」(640) → 「내용이 들어간다」(52rem = 832px, 실측 임계 ≈825 에 여유). 그 아래는 `<sm` 과 같은 한 줄 쌓기가 된다. 눌러 담기보다 낫다.

### 기존 게이트 셋이 왜 전부 침묵했나

| 게이트 | 이유 |
|---|---|
| 이 스펙의 x·넘침 시험 | 폭 목록이 **1440 이상**뿐 — 768 은 한 번도 측정된 적이 없다 |
| 글자 넘침 전수 계측 | 글자가 버튼 테두리 안에 있다 (잘림 0 · 이탈 0) |
| `DownloadPage.test.tsx` | 담김·순서·문구만 본다. 렌더된 px 은 jsdom 에 없다 |

셋 다 자기 일은 했다. 아무도 **「여백이 설계값대로인가」**를 묻지 않았을 뿐이다. 그 질문을 게이트로 만들었다 — 640·768·820·1024 × ko/en, «content box 대 잉크 폭» 으로 재고, 여백 선언 컨트롤을 못 찾으면 실패하는 공회전 차단 포함.

## Test plan

- **프로브(진짜 빨강 확인)**: 수리를 stash 하고 게이트만 돌리니 **768 ko·en 2건 red**, 나머지 6건 green → 수리 복원 후 **27/27 green**
- `DownloadPage.test.tsx` 27 ✓ · `gateway-reading-reach` + `scroll-end-gap` 7 ✓ (전 라우트 예약고 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)