### PR TITLE
fix: 간격 셋을 사다리에 착지시킨다 — 30px 형제·29px 탭·2px 차 리듬

### DIFF
--- a/src/shared/ui/tab-bar.tsx
+++ b/src/shared/ui/tab-bar.tsx
@@ -129,8 +129,22 @@ export function TabBar({
             title={item.count !== undefined ? item.countTitle : undefined}
             onClick={() => activateTab(item.key)}
             onKeyDown={(event) => handleKeyDown(event, index)}
+            /*
+             * ⚠️ **아래 여백은 사다리에 착지한다** (2026-08-08 실측).
+             *
+             * 종전엔 `pb-[11px]` 이었다 — 4px 배수도 2px 반스텝도 아닌, 그
+             * 자리에서 손으로 고른 값. 그래서 탭 높이가 **29px**(행간 16 +
+             * 아래 여백 11 + 밑줄 2)로, 컨트롤 사다리 어디에도 없는 값이었다.
+             * `min-h-*` 이 없어 높이가 전적으로 패딩 산술로 정해지는데,
+             * 그건 `DESIGN-SYSTEM.md` 가 *"패딩+행간+보더의 합을 램프라고
+             * 부르지 마라"* 고 적어 둔 바로 그 모양이다.
+             *
+             * `pb-2.5`(10) 로 1px 만 줄이면 16 + 10 + 2 = **28** —
+             * `--control-h-sm` 에 정확히 선다. 밑줄이 글자에 1px 가까워지는
+             * 것이 이 변경의 시각적 전부다.
+             */
             className={
-              "-mb-px inline-flex items-baseline gap-2 border-b-[length:var(--tabbar-underline)] px-0.5 pb-[11px] font-mono text-label font-[var(--font-weight-emphasis)] uppercase tracking-[var(--tracking-caps-14)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--color-indigo-ring-a46)] " +
+              "-mb-px inline-flex items-baseline gap-2 border-b-[length:var(--tabbar-underline)] px-0.5 pb-2.5 font-mono text-label font-[var(--font-weight-emphasis)] uppercase tracking-[var(--tracking-caps-14)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--color-indigo-ring-a46)] " +
               (active
                 ? "border-[color:var(--color-indigo-accent)] text-[color:var(--color-text-primary)]"
                 : "border-transparent text-[color:var(--color-text-quaternary)] hover:text-[color:var(--color-text-secondary)]")

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -834,7 +834,7 @@ function PendingActions() {
           동시에 그려지지 않으므로 중복 매치는 없다. */}
       <p
         data-testid="download-platform-macos"
-        className="mt-2.5 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-label leading-label text-[color:var(--color-text-quaternary)]"
+        className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-label leading-label text-[color:var(--color-text-quaternary)]"
       >
         <span>
           {RELEASE_MIN_MACOS}
@@ -852,6 +852,21 @@ function PendingActions() {
  * Tailscale 은 최소 OS 를 버튼에 붙인다). 날짜가 버전과 짝인 이유: `v1.0.0`
  * 만으로는 이게 지난주 빌드인지 재작년 빌드인지 알 수 없다.
  */
+/*
+ * ⚠️ **이 블록의 세로 리듬은 세 값이다** (2026-08-08 실측).
+ *
+ * 히어로 액션 블록의 형제 간 간격을 재 보니 **네 종류**였다 —
+ * 0 · 10 · 8 · 12(1440) / 0 · 10 · 8 · 20(768). 0 과 큰 값은 뜻이 분명하다:
+ * 앞은 「제목과 버튼은 한 덩어리」, 뒤는 「구분선을 낀 다른 절」. 문제는
+ * 가운데 둘이다 — **8 과 10 은 2px 차이라 위계 신호가 되지 못하고**, 자리마다
+ * 골랐다는 인상만 남긴다.
+ *
+ * 그래서 캡션 두 줄(출시 사실 · 신뢰 칩)을 같은 8 로 묶었다. 남는 값은
+ * 0(한 덩어리) · 8(보통 쌓임) · 12~20(절 전환) 셋이고, 셋은 서로 충분히 멀어
+ * 실제로 읽힌다. 8 인 것은 4px 배수이기 때문이다 — 10 은 반스텝이다.
+ * 게시/미게시 두 분기가 같은 값을 쓴다(동시에 그려지지 않지만, 릴리스 당일에
+ * 리듬이 바뀌면 그건 디자인이 아니라 사고다).
+ */
 function ReleaseFactLine() {
   const t = useTranslations('download');
   const format = useFormatter();
@@ -863,7 +878,7 @@ function ReleaseFactLine() {
   return (
     <p
       data-testid="download-platform-macos"
-      className="mt-2.5 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-label leading-label text-[color:var(--color-text-quaternary)]"
+      className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-label leading-label text-[color:var(--color-text-quaternary)]"
     >
       <span>
         {RELEASE_MIN_MACOS}

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -708,7 +708,26 @@ function DuplicateRow({
       <span className="flex w-full items-center justify-end gap-1.5 sm:w-auto sm:shrink-0">
         <Link
           href={mapHref(pair.keepId)}
-          className={controlClass({ shape: "chip", tone: "muted", className: "min-h-7 border-[color:var(--color-border-soft)] px-2 text-label hover:text-[color:var(--color-text-primary)]" })}
+          /*
+           * ⚠️ **같은 행의 같은 무게 액션은 같은 높이다** (2026-08-08 실측).
+           *
+           * 여기만 `min-h-7 px-2 text-label` 을 손으로 덧대고 있어서 **30px**
+           * 로 렌더됐다 — 바로 옆 `HandoffCopyButton`(32)과 2px 어긋난다.
+           * 30 은 칩 사다리(24/32/32)에 없는 값이고, `min-h-7`(28)은 자연
+           * 높이가 이미 30이라 한 번도 적용된 적이 없다.
+           *
+           * 사연은 형제 쪽 주석이 이미 적어 뒀다: 2026-08-03 에 칩 램프가
+           * 32 로 수렴하며 30/32 를 고르던 `compact` 프롭을 지웠는데, **이
+           * 링크만 그 수렴을 안 따라왔다.** 손으로 덧댄 값은 램프가 움직일 때
+           * 같이 안 움직인다 — 그래서 값 층의 단을 쓴다.
+           */
+          className={controlClass({
+            shape: "chip",
+            size: "md",
+            tone: "muted",
+            className:
+              "border-[color:var(--color-border-soft)] hover:text-[color:var(--color-text-primary)]",
+          })}
         >
           {labels.openMap}
         </Link>


### PR DESCRIPTION
3차 전수조사의 간격 계측이 5건을 올렸다. **셋은 진짜였고 둘은 재 보니 결함이 아니었다.** 기각한 둘의 근거도 같이 남긴다 — 그냥 고쳤으면 멀쩡한 위계를 뭉갤 뻔했다.

## 고친 셋

### ① 같은 행의 같은 무게 액션이 30 vs 32 (인사이트 중복 행)

「지도에서 확인」만 `min-h-7 px-2 text-label` 을 **손으로 덧대** 30px 로 렌더됐다. 바로 옆 「넘길 명령 복사」는 32. 30 은 칩 사다리(24/32/32)에 **없는 값**이고, `min-h-7`(28)은 자연 높이가 이미 30이라 **한 번도 적용된 적이 없다.**

사연은 형제 쪽 주석이 이미 적어 뒀다 — 2026-08-03 에 칩 램프가 32 로 수렴하며 30/32 를 고르던 `compact` 프롭을 지웠는데 **이 링크만 그 수렴을 안 따라왔다.** 손으로 덧댄 값은 램프가 움직일 때 같이 안 움직인다. → `size: "md"`

### ② 밑줄 탭이 29px — 사다리 어디에도 없다

`pb-[11px]` 이라 높이가 전적으로 패딩 산술(16+11+2)로 정해졌고 `min-h` 도 없다. `DESIGN-SYSTEM.md` 가 *"패딩+행간+보더의 합을 램프라고 부르지 마라"* 고 적어 둔 그 모양이다. `pb-2.5`(10)로 **1px** 줄이면 16+10+2 = **28 = `--control-h-sm`** 에 정확히 선다.

### ③ 관문 히어로 블록의 세로 간격 4종

0 · 10 · 8 · 12(1440) / 0 · 10 · 8 · 20(768). 0 과 큰 값은 뜻이 분명한데 **가운데 둘이 2px 차이**라 위계 신호가 못 되고 자리마다 골랐다는 인상만 남긴다. 캡션 두 줄을 같은 8 로 묶었다 → **0(한 덩어리) · 8(보통 쌓임) · 12~20(절 전환)**, 셋은 서로 충분히 멀어 실제로 읽힌다.

## 기각한 둘 (재서 확인)

**④ 페이지 섹션 스택** (인사이트 4종·프로젝트 3종) — 재 보니 **각 값이 다른 관계를 말한다**: 8 이하는 한 묶음 안(제목↔설명), 16~20 은 그룹 사이, 28 은 절 사이. `design.md` 의 「치수 규칙성」은 *"눈이 훑고 지나가는 반복 묶음"* 에 걸리고 한 번만 나오는 페이지 구조는 **명시적으로 사정거리 밖**이다. 28로 흡수하면 제목과 그 설명이 28 떨어진다 — 개선이 아니라 파괴다.

**⑤ 언어 토글의 1px 안쪽 여백** — 세그먼트 트랙 관용구다(`p-px` + `gap-px` 로 1px 헤어라인 트랙). **설정 시트가 같은 패턴을 똑같이 쓴다** — 두 곳이 같은 모양이면 드리프트가 아니라 패턴이다. 여백을 램프로 강제하지 않는다는 결론도 2026-07-26 원장에 실측(하드코딩 27건 중 대부분이 광학 보정)과 함께 서 있다.

## 남긴 관측 — 「체계」 자리로

①의 뿌리는 **값 층을 쓰면서 높이를 손으로 덧대는 패턴**이고, 전수로 세니 **11곳**이다(`min-h-7`·`h-7`·`h-8`·`min-h-8` 등). 지금 하드 룰을 켜면 `design.md` 가 경고하는 «소음이 신호를 덮는» 규모라 **켜지 않았다** — 이 PR 은 인사이트 안의 1건(그 화면에서 유일했다)만 고친다. 사다리 축을 건드리는 결정은 `control-class.ts` 소유자(「체계」)의 몫이다.

## Test plan

- **실측 전후**: 중복 행 두 컨트롤 30/32 → **32/32** · 탭 29 → **28** · 히어로 간격 고유값 **4종 → 3종**{0,8,12}
- `test:contracts` 128 파일 / 1525 ✓ · 짝 단위 시험 66 ✓ · `tsc` ✓ · eslint ✓
- e2e: `download-gateway-grid` + `touch-target-contract` **36/36** ✓ (판의 정렬·여백 계약과 WCAG 2.5.8 타깃이 이 변경에 안 깨졌다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)