### PR TITLE
feat: 에디터의 @ 는 링크가 아니라 관계를 적는다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1180,7 +1180,14 @@
       "tbQuote": "Quote",
       "tbLink": "Link ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
-      "wikilinkFooter": "↑↓ move · ↵/Tab insert · Esc close"
+      "wikilinkFooter": "↑↓ move · ↵/Tab insert · Esc close",
+      "mentionLabel": "Concept to link{query}",
+      "mentionFooter": "↑↓ move · ↵ pick · Esc close",
+      "mentionRelationLabel": "How does this connect to \"{title}\"?",
+      "mentionRelationFooter": "Picking writes a relation into this doc's properties; the text keeps just the name",
+      "mentionEmpty": "No concept by that name",
+      "mentionRelationAdded": "Relation written — it shows on the map",
+      "mentionRelationExists": "Already connected"
     },
     "palette": {
       "dialogAriaLabel": "Ontology workspace palette",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1180,7 +1180,14 @@
       "tbQuote": "인용",
       "tbLink": "링크 ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
-      "wikilinkFooter": "↑↓ 이동 · ↵/Tab 삽입 · Esc 닫기"
+      "wikilinkFooter": "↑↓ 이동 · ↵/Tab 삽입 · Esc 닫기",
+      "mentionLabel": "연결할 개념{query}",
+      "mentionFooter": "↑↓ 이동 · ↵ 고르기 · Esc 닫기",
+      "mentionRelationLabel": "‘{title}’ 와 어떻게 이어지나요?",
+      "mentionRelationFooter": "고르면 이 문서의 속성에 관계로 적히고, 글에는 이름만 남아요",
+      "mentionEmpty": "그런 이름의 개념이 없어요",
+      "mentionRelationAdded": "관계를 적었어요 — 지도에 선으로 나와요",
+      "mentionRelationExists": "이미 이어져 있어요"
     },
     "palette": {
       "dialogAriaLabel": "문서함 팔레트",

--- a/src/widgets/docs-vault/lib/caret-position.test.ts
+++ b/src/widgets/docs-vault/lib/caret-position.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampMenuToBox } from './caret-position';
+
+/**
+ * `caretPoint` 자체는 브라우저의 줄바꿈 계산에 기대므로 jsdom 에서 잴 수 없다
+ * (jsdom 은 레이아웃을 하지 않아 `offsetTop` 이 항상 0 이다). 그래서 여기서는
+ * **자리 잡기 규칙**만 잰다 — 그 규칙이 순수 산술이고, 실제로 사고가 나는
+ * 지점이기도 하다: 메뉴가 편집기 밖으로 나가면 잘리거나 스크롤을 만들어
+ * 편집 중인 글이 흔들린다.
+ *
+ * 캐럿 좌표 자체는 실기기에서 확인한다(브라우저 없이 증명할 수 없는 층).
+ */
+describe('clampMenuToBox — 메뉴는 편집기 밖으로 나가지 않는다', () => {
+  const box = { width: 800, height: 600 };
+  const menu = { width: 320, height: 240 };
+
+  it('자리가 있으면 캐럿 줄 바로 아래에 붙는다', () => {
+    const at = clampMenuToBox({
+      caret: { top: 100, left: 200, lineHeight: 20 },
+      box,
+      menu,
+    });
+    expect(at).toEqual({ top: 126, left: 200 });
+  });
+
+  it('아래로 못 펴면 캐럿 위로 뒤집는다 — 잘린 메뉴는 없는 것과 같다', () => {
+    const at = clampMenuToBox({
+      caret: { top: 520, left: 100, lineHeight: 20 },
+      box,
+      menu,
+    });
+    // 520 + 20 + 6 + 240 = 786 > 600 → 위로
+    expect(at.top).toBe(520 - 240 - 6);
+  });
+
+  it('오른쪽 끝에서는 왼쪽으로 당겨 붙인다', () => {
+    const at = clampMenuToBox({
+      caret: { top: 100, left: 760, lineHeight: 20 },
+      box,
+      menu,
+    });
+    expect(at.left).toBe(800 - 320 - 6);
+  });
+
+  it('좁은 편집기에서도 음수로 나가지 않는다', () => {
+    const at = clampMenuToBox({
+      caret: { top: 10, left: 5, lineHeight: 20 },
+      box: { width: 200, height: 120 },
+      menu,
+    });
+    expect(at.left).toBeGreaterThanOrEqual(0);
+    expect(at.top).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/widgets/docs-vault/lib/caret-position.ts
+++ b/src/widgets/docs-vault/lib/caret-position.ts
@@ -1,0 +1,123 @@
+/**
+ * textarea 안 **캐럿의 화면 좌표** — 멘션 메뉴가 「적던 자리」에 뜨게 하는 값.
+ *
+ * ## 왜 필요한가 (2026-08-08, 소유자 지적)
+ *
+ * `@` 멘션 메뉴가 편집기 **왼쪽 아래 구석**에 떴다. 종전 위키링크 팝오버가
+ * 거기 고정돼 있었고 그 자리를 그대로 물려받았기 때문이다. 소유자가 바로
+ * 잡았다 — *"적던 위치에 바로 나와야"*. 맞는 지적이고, 이유가 있다: 멘션
+ * 메뉴는 **지금 치고 있는 글자의 연장**이라, 눈이 있는 곳에서 멀어지면
+ * 「내가 방금 한 행동의 결과」로 안 읽힌다.
+ *
+ * ## 어떻게 재나 — 미러 방식
+ *
+ * `textarea` 는 캐럿 좌표를 알려 주는 API 가 없다. 그래서 **같은 글꼴·같은
+ * 폭·같은 여백**을 가진 보이지 않는 `div` 를 만들어 캐럿 앞까지의 글자를 넣고,
+ * 그 끝에 표식 `span` 을 두어 그 위치를 읽는다. 브라우저가 줄바꿈을 우리 대신
+ * 계산해 주므로 우리가 줄바꿈 규칙을 흉내 낼 필요가 없다 — 흉내 내면 한글
+ * 줄바꿈·탭·긴 단어에서 반드시 어긋난다.
+ *
+ * 복사해야 하는 속성이 많은 이유도 그것이다. 하나라도 빠지면 미러의 줄바꿈이
+ * 원본과 달라지고, 그러면 좌표가 **조금 틀린 게 아니라 다른 줄**을 가리킨다.
+ */
+
+/** 미러가 원본과 같은 모양을 갖기 위해 반드시 복사해야 하는 속성. */
+const MIRRORED_PROPERTIES = [
+  'boxSizing',
+  'width',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'fontStyle',
+  'letterSpacing',
+  'lineHeight',
+  'textTransform',
+  'textIndent',
+  'whiteSpace',
+  'wordBreak',
+  'overflowWrap',
+  'tabSize',
+] as const;
+
+export interface CaretPoint {
+  /** textarea 의 패딩 박스 기준 — 스크롤을 이미 뺀 값. */
+  top: number;
+  left: number;
+  /** 캐럿이 선 줄의 높이. 메뉴를 그 줄 **아래**에 놓을 때 쓴다. */
+  lineHeight: number;
+}
+
+export function caretPoint(textarea: HTMLTextAreaElement, index: number): CaretPoint {
+  const doc = textarea.ownerDocument;
+  const style = doc.defaultView?.getComputedStyle(textarea);
+  const lineHeight = style ? parseFloat(style.lineHeight) || parseFloat(style.fontSize) * 1.5 : 20;
+  if (!style) return { top: 0, left: 0, lineHeight };
+
+  const mirror = doc.createElement('div');
+  for (const property of MIRRORED_PROPERTIES) {
+    mirror.style[property] = style[property];
+  }
+  // 화면에 나오지 않게 두되 **레이아웃은 실제로 계산되게** 둔다.
+  // `display:none` 이면 폭이 0 이라 줄바꿈이 전혀 달라진다.
+  mirror.style.position = 'absolute';
+  mirror.style.visibility = 'hidden';
+  mirror.style.top = '0';
+  mirror.style.left = '0';
+  mirror.style.height = 'auto';
+  mirror.style.overflow = 'hidden';
+  // textarea 는 항상 줄바꿈을 유지한다 — computed 값이 `pre-wrap` 이 아니어도.
+  mirror.style.whiteSpace = 'pre-wrap';
+
+  mirror.textContent = textarea.value.slice(0, index);
+  const marker = doc.createElement('span');
+  // 빈 span 은 높이가 0 이라 위치를 못 읽는다 — 폭 0 문자를 하나 둔다.
+  marker.textContent = '​';
+  mirror.appendChild(marker);
+
+  // 원본 바로 옆에 붙여 폰트 상속·확대 배율까지 같은 조건으로 만든다.
+  const host = textarea.parentElement ?? doc.body;
+  host.appendChild(mirror);
+  const markerTop = marker.offsetTop;
+  const markerLeft = marker.offsetLeft;
+  host.removeChild(mirror);
+
+  return {
+    top: markerTop - textarea.scrollTop,
+    left: markerLeft - textarea.scrollLeft,
+    lineHeight,
+  };
+}
+
+/**
+ * 메뉴가 **편집기 밖으로 나가지 않게** 캐럿 좌표를 자리로 옮긴다.
+ *
+ * 캐럿이 오른쪽 끝이나 아래쪽 끝에 있으면 메뉴가 그대로는 잘린다. 그때는
+ * 붙이는 방향을 뒤집는다 — 잘린 메뉴는 없는 것과 같고, 화면 밖으로 밀린 채
+ * 스크롤을 만들면 편집 중인 글이 흔들린다.
+ */
+export function clampMenuToBox({
+  caret,
+  box,
+  menu,
+  gap = 6,
+}: {
+  caret: CaretPoint;
+  box: { width: number; height: number };
+  menu: { width: number; height: number };
+  gap?: number;
+}): { top: number; left: number } {
+  const belowTop = caret.top + caret.lineHeight + gap;
+  // 아래로 못 펴면 캐럿 위로 뒤집는다.
+  const top =
+    belowTop + menu.height <= box.height ? belowTop : Math.max(gap, caret.top - menu.height - gap);
+  const left = Math.max(gap, Math.min(caret.left, box.width - menu.width - gap));
+  return { top, left };
+}

--- a/src/widgets/docs-vault/lib/mention-relation.test.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectMentionTrigger,
+  insertMentionRelation,
+  MENTION_RELATIONS,
+} from './mention-relation';
+
+/**
+ * `@` 멘션이 지키는 성질은 하나다: **고르면 그래프가 바뀐다.**
+ *
+ * 종전 `[[` 위키링크는 그러지 않았다 — 같은 볼트에서 위키링크를 넣었다 뺐을 때
+ * 컴파일 엣지 수도 그래프 해시도 동일했다(9 · `c07785b6`, 2026-08-08 실측).
+ * 그래서 이 시험들은 「메뉴가 뜨나」가 아니라 **「frontmatter 가 바뀌나」**를
+ * 잰다. 뜨기만 하고 안 바뀌면 이름만 바꾼 같은 결함이다.
+ */
+
+const DOC = [
+  '---',
+  'uid: 11111111-2222-4333-8444-555555555555',
+  'slug: capabilities/alpha',
+  'kind: capability',
+  'title: 알파',
+  'domain: domains/orders',
+  '---',
+  '',
+  '# 알파',
+  '',
+  '이 기능은 ',
+].join('\n');
+
+describe('detectMentionTrigger — 매칭이 없으면 평범한 글자로 남는다', () => {
+  it('공백 뒤의 @ 를 잡고 질의어를 돌려준다', () => {
+    const src = '이 기능은 @결제';
+    const hit = detectMentionTrigger(src, src.length);
+    expect(hit).toEqual({ query: '결제', start: src.indexOf('@') });
+  });
+
+  it('줄머리의 @ 도 잡는다', () => {
+    const src = '@결제';
+    expect(detectMentionTrigger(src, src.length)?.query).toBe('결제');
+  });
+
+  /**
+   * 문서함은 로컬 볼트를 열면 `CLAUDE.md`·`AGENTS.md` 도 편집할 수 있고,
+   * 그 파일에서 `@AGENTS.md` 는 **진짜 import 문법**이다. 메뉴가 거기 끼어들면
+   * 남의 문법을 가로채는 것이다.
+   */
+  it('경로 표기(@AGENTS.md · @docs/…)는 가로채지 않는다', () => {
+    for (const src of ['@AGENTS.md', '읽어라 @docs/FOUNDATIONS.md', '@.claude/rules']) {
+      const hit = detectMentionTrigger(src, src.length);
+      // `.` 또는 `/` 로 시작하는 질의어는 트리거가 아니다.
+      expect(hit === null || !/^[/.]/.test(hit.query)).toBe(true);
+    }
+    // 「경로가 되는 순간」이 아니라 **경로 글자가 들어오는 순간** 물러난다 —
+    // 타이핑 도중 메뉴가 떴다 사라지면 그 깜빡임 사이의 Enter 가 남의 문법을
+    // 노드 이름으로 바꿔 버린다.
+    expect(detectMentionTrigger('@AGENTS', 7)).not.toBeNull(); // 아직 평범한 질의어
+    expect(detectMentionTrigger('@AGENTS.md', 10)).toBeNull(); // 점이 들어오면 끝
+    expect(detectMentionTrigger('@docs/x', 7)).toBeNull();
+  });
+
+  it('이메일·핸들 중간의 @ 는 안 잡는다', () => {
+    expect(detectMentionTrigger('me@example', 10)).toBeNull();
+  });
+
+  it('줄바꿈을 건너 잡지 않는다', () => {
+    expect(detectMentionTrigger('@결제\n다음 줄', '@결제\n다음 줄'.length)).toBeNull();
+  });
+});
+
+describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', () => {
+  const trigger = (content: string) => {
+    const caret = content.length;
+    const hit = detectMentionTrigger(content, caret);
+    if (!hit) throw new Error('트리거를 못 잡았다 — 시험 전제가 깨졌다');
+    return hit;
+  };
+
+  it('관계가 frontmatter 에 canonical 로 들어가고 본문에는 이름만 남는다', () => {
+    const content = `${DOC}@베`;
+    const result = insertMentionRelation({
+      content,
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '베타' },
+      relationId: 'dependencies',
+    });
+
+    expect(result.relationAdded).toBe(true);
+    // ① 사실 — frontmatter
+    expect(result.content).toContain('dependencies: [capabilities/beta]');
+    // ② 문장 — 본문에는 사람이 읽는 이름만. 슬러그도 대괄호도 남지 않는다.
+    expect(result.content).toContain('이 기능은 베타');
+    expect(result.content).not.toContain('@베');
+    expect(result.content).not.toContain('[[');
+  });
+
+  it('커서가 삽입한 이름 뒤에 선다 — frontmatter 가 길어진 만큼 밀려도', () => {
+    const content = `${DOC}@베`;
+    const result = insertMentionRelation({
+      content,
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '베타' },
+      relationId: 'relates',
+    });
+    // 커서 위치의 바로 앞 글자가 방금 넣은 이름의 끝이어야 한다.
+    expect(result.content.slice(result.caret - 2, result.caret)).toBe('베타');
+  });
+
+  it('이미 있는 관계는 파일을 건드리지 않는다 (본문만 바뀐다)', () => {
+    const withRelation = DOC.replace(
+      'domain: domains/orders',
+      'domain: domains/orders\nrelates: [capabilities/beta]',
+    );
+    const content = `${withRelation}@베`;
+    const result = insertMentionRelation({
+      content,
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '베타' },
+      relationId: 'relates',
+    });
+    expect(result.relationAdded).toBe(false);
+    expect(result.content).toContain('relates: [capabilities/beta]');
+    // 중복이 생기지 않는다.
+    expect(result.content.match(/capabilities\/beta/g)).toHaveLength(1);
+  });
+
+  /**
+   * 정렬 규칙을 여기서 새로 정하지 않는다 — `validate-vault-document.ts` 의
+   * `non-canonical-graph-array` 가 이미 «중복 제거 + localeCompare 정렬» 을
+   * 요구한다. 그것과 다르게 쓰면 우리가 방금 쓴 파일이 우리 검사에서 경고를
+   * 받는다.
+   */
+  it('기존 항목이 있으면 정렬된 집합으로 합친다', () => {
+    const withRelation = DOC.replace(
+      'domain: domains/orders',
+      'domain: domains/orders\nrelates: [capabilities/zeta, capabilities/alpha2]',
+    );
+    const content = `${withRelation}@베`;
+    const result = insertMentionRelation({
+      content,
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '베타' },
+      relationId: 'relates',
+    });
+    expect(result.content).toContain(
+      'relates: [capabilities/alpha2, capabilities/beta, capabilities/zeta]',
+    );
+  });
+
+  it('제목이 비면 슬러그를 본문에 쓴다 — 빈 글자를 남기지 않는다', () => {
+    const content = `${DOC}@x`;
+    const result = insertMentionRelation({
+      content,
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '   ' },
+      relationId: 'contains',
+    });
+    expect(result.content).toContain('이 기능은 capabilities/beta');
+  });
+
+  it('네 방위 전부가 실재하는 frontmatter 키로 쓴다', () => {
+    for (const relation of MENTION_RELATIONS) {
+      const content = `${DOC}@베`;
+      const result = insertMentionRelation({
+        content,
+        trigger: trigger(content),
+        target: { slug: 'capabilities/beta', title: '베타' },
+        relationId: relation.id,
+      });
+      expect(result.content).toContain(`${relation.frontmatterKey}: [capabilities/beta]`);
+    }
+  });
+});

--- a/src/widgets/docs-vault/lib/mention-relation.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.ts
@@ -1,0 +1,184 @@
+import { applyFrontmatterUpdates } from '@/entities/docs-vault/lib/frontmatter-updates';
+import { parseFrontmatter } from '@/shared/lib/parse-frontmatter';
+
+/**
+ * 에디터의 `@` 멘션 — **고르면 관계가 된다.**
+ *
+ * ## 왜 이것이 필요했나 (2026-08-08 실측)
+ *
+ * 종전 에디터의 유일한 보조 기능은 `[[` 위키링크 자동완성이었다. 그런데 본문
+ * 위키링크는 **컴파일된 그래프를 1비트도 바꾸지 않는다** — 같은 볼트에서
+ * 위키링크를 넣었다 뺐을 때 엣지 수도 그래프 해시도 동일했다(9 · `c07785b6`).
+ * 그래프는 frontmatter 키만 읽기 때문이다.
+ *
+ * 그래서 사람은 「이었다」고 믿는데 지도에는 선이 없고, 경로 찾기·영향 분석에도
+ * 안 잡힌다. 도그푸드 볼트가 그 결말을 보여 준다 — **본문 위키링크 0개**,
+ * frontmatter 관계 154개. 우리 자신도 안 쓴다.
+ *
+ * (정확히는 `find_backlinks` 하나가 본문도 훑어 `matchedInBody` 로 **구별해서**
+ * 알려 준다. 데이터 모델은 이미 「두 종류의 연결」을 알고 있었고, 에디터만
+ * 그 사실을 안 말하고 있었다.)
+ *
+ * ## 무엇을 하나
+ *
+ * `@` 로 노드를 고르고 관계를 고르면:
+ *
+ * 1. **frontmatter 에 관계를 쓴다** — 이것이 사실이다. 지도의 선이 되고,
+ *    경로·영향·에이전트 핸드오프가 본다.
+ * 2. **본문에는 사람이 읽는 이름만** 평문으로 남긴다. 이건 사실이 아니라
+ *    문장이다 — 나중에 관계를 지워도 문장은 남고, 그게 맞다(사람이 쓴 글이다).
+ *
+ * 「같은 사실을 두 곳이 말하는」 것이 아니다. 한쪽은 사실, 한쪽은 읽기 좋은 글.
+ *
+ * ## 왜 순수 함수인가
+ *
+ * 에디터는 **frontmatter 를 포함한 원문 전체**를 textarea 로 편집한다. 그러니
+ * 이 기능은 저장 경로를 새로 만들 필요가 없다 — 버퍼 문자열 변환 하나다.
+ * 부수효과가 없으니 관계 배열의 canonical 규칙(중복 제거 + 정렬)을 브라우저
+ * 없이 시험할 수 있다.
+ */
+
+/** `@` 트리거가 잡은 것 — 커서 앞의 질의어와 그 시작 위치. */
+export interface MentionTrigger {
+  query: string;
+  start: number;
+}
+
+/**
+ * 커서 바로 앞의 `@질의어` 를 찾는다.
+ *
+ * 열려 있는 조건이 좁다 — **매칭이 없으면 조용히 평범한 글자로 남아야** 하기
+ * 때문이다. 문서함은 로컬 볼트를 열면 `CLAUDE.md`·`AGENTS.md` 도 편집할 수
+ * 있는데, 그 파일들에서 `@AGENTS.md` 는 **진짜 import 문법**이다. 거기서 메뉴가
+ * 끼어들면 남의 문법을 가로채는 것이 된다.
+ *
+ * 그래서 셋을 요구한다: ① `@` 앞이 줄머리이거나 공백일 것(이메일·핸들
+ * 중간의 `@` 를 안 잡는다) ② 질의어에 줄바꿈이 없을 것 ③ 질의어가 `/` 나
+ * `.` 로 시작하지 않을 것(`@docs/…`·`@AGENTS.md` 같은 경로 표기를 비켜간다).
+ */
+export function detectMentionTrigger(source: string, caret: number): MentionTrigger | null {
+  if (caret < 1 || caret > source.length) return null;
+  const back = source.slice(Math.max(0, caret - 120), caret);
+  const at = back.lastIndexOf('@');
+  if (at === -1) return null;
+  const before = at === 0 ? (caret - back.length === 0 ? '' : source[caret - back.length - 1]) : back[at - 1];
+  if (before && !/\s/.test(before)) return null;
+  const query = back.slice(at + 1);
+  if (/[\n\r]/.test(query)) return null;
+  /*
+   * 질의어에 `/` 나 `.` 가 **들어가는 순간** 물러난다 — 시작 글자만 보면
+   * `@docs/…` 를 타이핑하는 중에 `@docs` 까지는 메뉴가 떠 있다가 슬래시에서
+   * 사라진다. 그 깜빡임이 「가로채려다 만 것」으로 보이고, 무엇보다 그 사이
+   * Enter 를 누르면 남의 문법이 노드 이름으로 바뀐다.
+   */
+  if (/[/.]/.test(query)) return null;
+  return { query, start: caret - (back.length - at) };
+}
+
+/**
+ * 관계 방위 — 공방의 나침반과 **같은 어휘**를 쓴다.
+ *
+ * 두 화면이 같은 일(관계 맺기)을 하는데 다른 말을 쓰면 사용자는 둘을 다른
+ * 기능으로 배운다. 여기서 쓰는 frontmatter 키도 공방이 쓰는 것 그대로다 —
+ * 새 키를 만들지 않는다(스키마는 `mcp/src/schema.mjs` 하나가 소유한다).
+ */
+export const MENTION_RELATIONS = [
+  { id: 'broader', frontmatterKey: 'broader' },
+  { id: 'contains', frontmatterKey: 'contains' },
+  { id: 'dependencies', frontmatterKey: 'dependencies' },
+  { id: 'relates', frontmatterKey: 'relates' },
+] as const;
+
+export type MentionRelationId = (typeof MENTION_RELATIONS)[number]['id'];
+
+/**
+ * 관계 id → **공방의 라벨 키.** 문구를 여기서 새로 만들지 않는다 — 공방이
+ * 이미 「상위 개념 · 필요한 항목 · 하위 항목 · 관련 항목」을 갖고 있고,
+ * 두 화면이 같은 일에 다른 말을 쓰면 사용자가 두 기능으로 배운다.
+ */
+export const RELATION_LABEL_KEY: Record<MentionRelationId, string> = {
+  broader: 'isA',
+  contains: 'contains',
+  dependencies: 'dependsOn',
+  relates: 'relates',
+};
+
+const RELATION_KEY_BY_ID = new Map<string, string>(
+  MENTION_RELATIONS.map((relation) => [relation.id, relation.frontmatterKey]),
+);
+
+/**
+ * 관계 배열의 정본 모양 — **중복 제거 + `localeCompare` 정렬.**
+ *
+ * 이 규칙을 여기서 새로 정하지 않는다. `validate-vault-document.ts` 의
+ * `non-canonical-graph-array` 가 이미 그 모양을 요구하고 있고, 그것과 다르게
+ * 쓰면 우리가 방금 쓴 파일이 우리 검사에서 경고를 받는다.
+ */
+function canonicalRefs(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+export interface MentionInsertResult {
+  /** 갱신된 원문 전체(frontmatter 포함). */
+  content: string;
+  /** 삽입 뒤 커서가 있어야 할 위치. */
+  caret: number;
+  /** 이번 삽입이 실제로 관계를 **새로** 추가했나(이미 있었으면 false). */
+  relationAdded: boolean;
+}
+
+/**
+ * `@` 로 고른 노드를 **관계로 적고, 본문에는 이름을 남긴다.**
+ *
+ * `content` 는 frontmatter 를 포함한 원문 전체다. `caret` 은 그 안의 절대 위치.
+ */
+export function insertMentionRelation({
+  content,
+  trigger,
+  target,
+  relationId,
+}: {
+  content: string;
+  trigger: MentionTrigger;
+  target: { slug: string; title: string };
+  relationId: MentionRelationId;
+}): MentionInsertResult {
+  const key = RELATION_KEY_BY_ID.get(relationId);
+  if (!key) throw new Error(`Unknown relation: ${relationId}`);
+
+  // ① 본문 — `@질의어` 를 사람이 읽는 이름으로 갈아 끼운다.
+  const label = target.title.trim() || target.slug;
+  const withLabel =
+    content.slice(0, trigger.start) +
+    label +
+    content.slice(trigger.start + 1 + trigger.query.length);
+  const caretAfterLabel = trigger.start + label.length;
+
+  // ② frontmatter — 관계를 더한다. 이미 있으면 파일을 건드리지 않는다.
+  const { frontmatter } = parseFrontmatter(withLabel);
+  const existingRaw = frontmatter[key];
+  const existing = Array.isArray(existingRaw)
+    ? existingRaw.filter((item): item is string => typeof item === 'string')
+    : [];
+  if (existing.some((ref) => ref.trim() === target.slug)) {
+    return { content: withLabel, caret: caretAfterLabel, relationAdded: false };
+  }
+  const next = canonicalRefs([...existing, target.slug]);
+
+  /*
+   * ⚠️ **본문을 먼저 바꾸고 frontmatter 를 나중에 쓴다.** 순서가 반대면
+   * `applyFrontmatterUpdates` 가 돌려준 문자열에서 frontmatter 길이가 달라져
+   * 본문 오프셋(`trigger.start`)이 어긋난다. 커서가 엉뚱한 데로 가는 정도가
+   * 아니라 **글자를 다른 자리에서 잘라낸다.**
+   */
+  const withRelation = applyFrontmatterUpdates(withLabel, { [key]: next });
+  const grew = withRelation.length - withLabel.length;
+  return {
+    content: withRelation,
+    // frontmatter 가 길어진 만큼 본문의 커서도 뒤로 밀린다.
+    caret: caretAfterLabel + grew,
+    relationAdded: true,
+  };
+}

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -25,7 +25,16 @@ import {
 } from 'lucide-react';
 import { ICON_SIZE } from '@/shared/ui/icon-size';
 import type { VaultDoc } from '@/entities/docs-vault';
+import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
 import { useHeldValue } from '@/shared/lib/use-presence';
+import { caretPoint, clampMenuToBox } from '../lib/caret-position';
+import {
+  detectMentionTrigger,
+  insertMentionRelation,
+  MENTION_RELATIONS,
+  RELATION_LABEL_KEY,
+  type MentionRelationId,
+} from '../lib/mention-relation';
 import { Chip, IconButton, RowButton, Surface } from '@/shared/ui';
 
 interface Props {
@@ -56,6 +65,10 @@ interface EditorDraft {
   diskMtime?: number;
   updatedAt: number;
 }
+
+/** 멘션 메뉴의 폭과 최대 높이 — 자리 계산과 실제 그리기가 같은 값을 쓴다. */
+const MENTION_MENU_WIDTH = 320;
+const MENTION_MENU_MAX_HEIGHT = 280;
 
 const DRAFT_STORAGE_PREFIX = 'ontology-atlas:docs-vault-editor-draft:';
 
@@ -134,6 +147,10 @@ export function DocsVaultEditor({
   vaultScope,
 }: Props) {
   const t = useTranslations('vaultWidgets.editor');
+  const locale = useLocale();
+  // 관계 어휘는 공방이 소유한다 — 두 화면이 같은 일에 다른 말을 쓰지 않게
+  // 여기서 새 문구를 만들지 않고 그 네임스페이스를 그대로 읽는다.
+  const tStudio = useTranslations('ontologyStudio');
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
   const [loadedSlug, setLoadedSlug] = useState<string | null>(null);
@@ -158,22 +175,18 @@ export function DocsVaultEditor({
     active: number;
   } | null>(null);
 
-  // 현재 캐럿 기준으로 `[[ ` 트리거 검사. 매치되면 query, start index 반환.
-  const detectWikilinkTrigger = (
-    src: string,
-    caret: number,
-  ): { query: string; start: number } | null => {
-    // 직전 200자 내에서 `[[` 찾기 + 그 사이에 `]]` 이 없어야 함.
-    const back = src.slice(Math.max(0, caret - 200), caret);
-    const idx = back.lastIndexOf('[[');
-    if (idx === -1) return null;
-    const between = back.slice(idx);
-    if (between.includes(']]')) return null;
-    // query 에 줄바꿈 있으면 off
-    if (/\n/.test(between.slice(2))) return null;
-    const start = caret - (back.length - idx);
-    return { query: between.slice(2), start };
-  };
+  /*
+   * 트리거는 `@` 다 — 종전 `[[` 를 2026-08-08 에 갈아치웠다.
+   *
+   * 두 가지가 바뀌었다. 표기(`[[` → `@`)는 겉이고, **고른 뒤에 무엇이 쓰이나**가
+   * 속이다. 종전엔 본문에 `[[slug]]` 를 넣었는데 **그건 그래프를 1비트도 바꾸지
+   * 않았다**(같은 볼트에서 넣었다 뺀 컴파일 결과가 엣지 9 · 해시 동일). 지금은
+   * 관계 종류를 묻고 **frontmatter 에 적는다** — 판정 로직은 `lib/mention-relation`
+   * 의 순수 함수가 갖고, 여기는 화면만 맡는다.
+   *
+   * `[[` 를 남겨 두지 않는다. 두 문법이 공존하면 사용자는 「어느 쪽이 진짜
+   * 연결인가」를 매번 판단해야 하고, 그 판단은 화면에 단서가 없다.
+   */
 
   const acMatches = useMemo<VaultDoc[]>(() => {
     if (!autocomplete || !allDocs) return [];
@@ -267,24 +280,92 @@ export function DocsVaultEditor({
   // Wikilink autocomplete 선택 — content 의 [[<query> 부분을 [[slug]] 로
   // 치환. caret 대신 autocomplete.start + 2 + query.length 를 명시적으로
   // 써서 사용자가 화살표로 caret 을 옮겼어도 트리거 범위를 정확히 덮는다.
-  const applyWikilink = useCallback((slug: string) => {
+  /**
+   * 고른 개념 — 아직 **관계를 안 정했다.** 이 단계가 존재하는 것이 이 기능의
+   * 전부다: 이름만 넣고 끝내면 종전 위키링크와 같아지고, 그건 그래프에 안 잡힌다.
+   */
+  const [pendingMention, setPendingMention] = useState<{
+    doc: VaultDoc;
+    trigger: { query: string; start: number };
+  } | null>(null);
+  /** 2단계에서 지금 고른 방위 — 키보드 이동의 커서. */
+  const [pendingRelation, setPendingRelation] = useState<MentionRelationId>(
+    MENTION_RELATIONS[0].id,
+  );
+
+  /**
+   * 관계가 적혔다는 것을 **말한다.** 이 동작의 결과는 frontmatter 안이라
+   * 아무 말도 안 하면 본문에 이름만 들어간 것처럼 보인다 — 그러면 사용자는
+   * 종전 위키링크와 같은 일이 일어났다고 읽는다.
+   */
+  const [mentionNotice, setMentionNotice] = useState<'added' | 'exists' | null>(null);
+  useEffect(() => {
+    if (!mentionNotice) return;
+    const timer = setTimeout(() => setMentionNotice(null), 2600);
+    return () => clearTimeout(timer);
+  }, [mentionNotice]);
+
+  /**
+   * 메뉴가 설 자리 — **적던 그 자리**. 종전엔 편집기 왼쪽 아래 구석에
+   * 고정이었다(위키링크 팝오버에서 물려받은 자리). 멘션 메뉴는 지금 치고
+   * 있는 글자의 연장이라, 눈에서 멀면 「방금 내가 한 행동의 결과」로 안
+   * 읽힌다 — 소유자 지적 2026-08-08.
+   */
+  const [menuAt, setMenuAt] = useState<{ top: number; left: number } | null>(null);
+  const placeMenuAtCaret = useCallback((caretIndex: number) => {
     const ta = taRef.current;
-    if (!ta || content === null || !autocomplete) return;
-    const replacement = `[[${slug}]]`;
-    const triggerEnd =
-      autocomplete.start + 2 + autocomplete.query.length;
-    const next =
-      content.slice(0, autocomplete.start) +
-      replacement +
-      content.slice(triggerEnd);
-    setContent(next);
-    setAutocomplete(null);
-    requestAnimationFrame(() => {
-      ta.focus();
-      const p = autocomplete.start + replacement.length;
-      ta.setSelectionRange(p, p);
-    });
-  }, [autocomplete, content]);
+    const host = ta?.parentElement;
+    if (!ta || !host) return;
+    const caret = caretPoint(ta, caretIndex);
+    setMenuAt(
+      clampMenuToBox({
+        caret,
+        box: { width: ta.clientWidth, height: ta.clientHeight },
+        // 메뉴 실제 크기는 그린 뒤에야 알지만, 자리를 정하는 데는 상한이면
+        // 충분하다 — 실제가 더 작으면 여유가 남을 뿐 잘리지 않는다.
+        menu: { width: MENTION_MENU_WIDTH, height: MENTION_MENU_MAX_HEIGHT },
+      }),
+    );
+  }, []);
+
+  const pickMentionTarget = useCallback(
+    (doc: VaultDoc) => {
+      if (!autocomplete) return;
+      setPendingMention({
+        doc,
+        trigger: { query: autocomplete.query, start: autocomplete.start },
+      });
+      setPendingRelation(MENTION_RELATIONS[0].id);
+      setAutocomplete(null);
+    },
+    [autocomplete],
+  );
+
+  const applyMentionRelation = useCallback(
+    (relationId: MentionRelationId) => {
+      const ta = taRef.current;
+      if (!ta || content === null || !pendingMention) return;
+      const { doc, trigger } = pendingMention;
+      const result = insertMentionRelation({
+        content,
+        trigger,
+        target: {
+          slug: doc.slug,
+          title: resolveLocaleDisplayName(doc.frontmatter, locale, doc.title),
+        },
+        relationId,
+      });
+      setContent(result.content);
+      setMentionNotice(result.relationAdded ? 'added' : 'exists');
+      setPendingMention(null);
+      requestAnimationFrame(() => {
+        ta.focus();
+        ta.setSelectionRange(result.caret, result.caret);
+      });
+    },
+    [content, locale, pendingMention],
+  );
+
 
   // 링크 형식 [text](url) 삽입. 선택이 있으면 그걸 text 로.
   const insertLink = useCallback(() => {
@@ -769,13 +850,42 @@ export function DocsVaultEditor({
               setContent(next);
               if (allDocs && taRef.current) {
                 const caret = taRef.current.selectionStart;
-                const match = detectWikilinkTrigger(next, caret);
+                const match = detectMentionTrigger(next, caret);
+                if (match) placeMenuAtCaret(caret);
                 setAutocomplete(
                   match ? { ...match, active: 0 } : null,
                 );
               }
             }}
             onKeyDown={(e) => {
+              /*
+               * 2단계(관계 고르기)도 **키보드로 끝까지 간다.** 1단계를 Enter 로
+               * 고른 사람은 손이 이미 키보드에 있는데, 거기서 마우스를 요구하면
+               * 그 흐름이 끊긴다 — 그리고 키보드만 쓰는 사람에게는 아예 막힌
+               * 문이 된다. 포커스는 textarea 에 남아 있으므로 여기서 받는다.
+               */
+              if (pendingMention) {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setPendingMention(null);
+                  return;
+                }
+                const index = MENTION_RELATIONS.findIndex((r) => r.id === pendingRelation);
+                if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  const step = e.key === 'ArrowDown' ? 1 : -1;
+                  const next =
+                    (index + step + MENTION_RELATIONS.length) % MENTION_RELATIONS.length;
+                  setPendingRelation(MENTION_RELATIONS[next].id);
+                  return;
+                }
+                if (e.key === 'Enter' || e.key === 'Tab') {
+                  e.preventDefault();
+                  applyMentionRelation(pendingRelation);
+                  return;
+                }
+                return;
+              }
               if (!autocomplete || acMatches.length === 0) return;
               if (e.key === 'ArrowDown') {
                 e.preventDefault();
@@ -800,7 +910,7 @@ export function DocsVaultEditor({
                 e.preventDefault();
                 const pick = acMatches[autocomplete.active];
                 if (!pick) return;
-                applyWikilink(pick.slug);
+                pickMentionTarget(pick);
               } else if (e.key === 'Escape') {
                 e.preventDefault();
                 setAutocomplete(null);
@@ -811,7 +921,8 @@ export function DocsVaultEditor({
               if (!allDocs || !taRef.current) return;
               const caret = taRef.current.selectionStart;
               const src = (e.target as HTMLTextAreaElement).value;
-              const match = detectWikilinkTrigger(src, caret);
+              const match = detectMentionTrigger(src, caret);
+              if (match) placeMenuAtCaret(caret);
               setAutocomplete((cur) => {
                 if (!match) return null;
                 if (cur && cur.start === match.start && cur.query === match.query)
@@ -827,12 +938,27 @@ export function DocsVaultEditor({
               open={acOpen}
               // 편집기 왼쪽 아래에 매달려 위로 자란다 — 등장 원점도 그 모서리.
               origin="bottom left"
-              className="pointer-events-auto absolute bottom-3 left-3 z-10 w-[320px] overflow-hidden rounded-chip border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-surface-deep-a98)] shadow-[var(--shadow-elevation-2)]"
+              /*
+                이 저장소의 메뉴 방언을 쓴다 — 볼트 칩·정렬 메뉴와 같은
+                `--chrome-radius-inner` · `border-soft` · `elevated` ·
+                `--chrome-shadow`. 종전엔 인디고 테두리 + `surface-deep` +
+                `elevation-2` 라 이 화면에서 **이 메뉴만 다른 물건**처럼
+                보였다(소유자 지적 2026-08-08).
+              */
+              className="pointer-events-auto absolute z-10 overflow-hidden rounded-[var(--chrome-radius-inner)] border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] shadow-[var(--chrome-shadow)]"
+              style={{
+                width: MENTION_MENU_WIDTH,
+                top: menuAt?.top ?? 0,
+                left: menuAt?.left ?? 0,
+              }}
             >
-              <div className="border-b border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-caption uppercase tracking-[var(--tracking-caps-14)] text-[color:var(--color-text-quaternary)]">
-                {t('wikilinkLabel', { query: heldAutocomplete.query })}
+              <div className="border-b border-[color:var(--color-border-soft)] px-2 py-1.5 text-label text-[color:var(--color-text-tertiary)]">
+                {/* 질의어가 비면 `· ""` 라는 빈 따옴표가 화면에 남았다(실기기 확인). */}
+                {t('mentionLabel', {
+                  query: heldAutocomplete.query ? ` · “${heldAutocomplete.query}”` : '',
+                })}
               </div>
-              <ul className="max-h-[220px] overflow-auto py-0.5">
+              <ul className="overflow-auto py-0.5" style={{ maxHeight: MENTION_MENU_MAX_HEIGHT - 64 }}>
                 {heldAutocomplete.matches.map((d, idx) => (
                   <li key={d.slug}>
                     <RowButton
@@ -842,7 +968,7 @@ export function DocsVaultEditor({
                           ac ? { ...ac, active: idx } : ac,
                         )
                       }
-                      onClick={() => applyWikilink(d.slug)}
+                      onClick={() => pickMentionTarget(d)}
                       className="hover:bg-[color:var(--color-overlay-1)]"
                     >
                       <span className="truncate text-body text-[color:var(--color-text-primary)]">
@@ -855,8 +981,90 @@ export function DocsVaultEditor({
                   </li>
                 ))}
               </ul>
-              <div className="border-t border-[color:var(--color-overlay-2)] px-2 py-1 font-mono text-caption uppercase tracking-[var(--tracking-caps-12)] text-[color:var(--color-text-quaternary)]">
-                {t('wikilinkFooter')}
+              <div className="border-t border-[color:var(--color-border-soft)] px-2 py-1.5 text-label text-[color:var(--color-text-quaternary)]">
+                {t('mentionFooter')}
+              </div>
+            </Surface>
+          ) : null}
+          {/*
+            2단계 — **관계를 고르는 자리.** 이 단계가 이 기능의 전부다.
+            여기서 이름만 넣고 끝내면 종전 위키링크와 같아지고, 그건 지도에도
+            경로 찾기에도 안 잡힌다(실측: 넣었다 뺀 컴파일 결과가 동일).
+            어휘는 공방의 나침반과 같은 것을 쓴다 — 같은 일에 다른 말을 쓰면
+            사용자가 두 기능으로 배운다.
+          */}
+          {/*
+            관계는 frontmatter 안에 적히므로 **말하지 않으면 안 보인다.**
+            침묵하면 사용자는 본문에 이름만 들어간 것으로 읽고, 그건 정확히
+            우리가 없앤 종전 위키링크의 인상이다. 보조기술에도 같이 간다.
+          */}
+          {mentionNotice ? (
+            <p
+              role="status"
+              aria-live="polite"
+              data-testid="editor-mention-notice"
+              className="pointer-events-none absolute bottom-3 left-3 z-10 rounded-chip border border-[color:var(--color-indigo-line-a32)] bg-[color:var(--color-surface-deep-a98)] px-2 py-1 text-label text-[color:var(--color-text-secondary)]"
+            >
+              {mentionNotice === 'added'
+                ? t('mentionRelationAdded')
+                : t('mentionRelationExists')}
+            </p>
+          ) : null}
+          {pendingMention ? (
+            <Surface
+              open
+              origin="bottom left"
+              role="menu"
+              aria-label={t('mentionRelationLabel', {
+                title: resolveLocaleDisplayName(
+                  pendingMention.doc.frontmatter,
+                  locale,
+                  pendingMention.doc.title,
+                ),
+              })}
+              /*
+                이 저장소의 메뉴 방언을 쓴다 — 볼트 칩·정렬 메뉴와 같은
+                `--chrome-radius-inner` · `border-soft` · `elevated` ·
+                `--chrome-shadow`. 종전엔 인디고 테두리 + `surface-deep` +
+                `elevation-2` 라 이 화면에서 **이 메뉴만 다른 물건**처럼
+                보였다(소유자 지적 2026-08-08).
+              */
+              className="pointer-events-auto absolute z-10 overflow-hidden rounded-[var(--chrome-radius-inner)] border border-[color:var(--color-border-soft)] bg-[color:var(--color-elevated)] shadow-[var(--chrome-shadow)]"
+              style={{
+                width: MENTION_MENU_WIDTH,
+                top: menuAt?.top ?? 0,
+                left: menuAt?.left ?? 0,
+              }}
+            >
+              <div className="border-b border-[color:var(--color-border-soft)] px-2 py-1.5 text-label text-[color:var(--color-text-tertiary)]">
+                {t('mentionRelationLabel', {
+                  title: resolveLocaleDisplayName(
+                    pendingMention.doc.frontmatter,
+                    locale,
+                    pendingMention.doc.title,
+                  ),
+                })}
+              </div>
+              <ul className="py-0.5">
+                {MENTION_RELATIONS.map((relation) => (
+                  <li key={relation.id}>
+                    <RowButton
+                      role="menuitem"
+                      active={relation.id === pendingRelation}
+                      onMouseEnter={() => setPendingRelation(relation.id)}
+                      data-testid={`editor-mention-relation-${relation.id}`}
+                      onClick={() => applyMentionRelation(relation.id)}
+                      className="hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]"
+                    >
+                      <span className="truncate text-body">
+                        {tStudio(`relationShort.${RELATION_LABEL_KEY[relation.id]}`)}
+                      </span>
+                    </RowButton>
+                  </li>
+                ))}
+              </ul>
+              <div className="border-t border-[color:var(--color-border-soft)] px-2 py-1.5 text-label leading-label text-[color:var(--color-text-quaternary)]">
+                {t('mentionRelationFooter')}
               </div>
             </Surface>
           ) : null}

--- a/tests/contract/surface-motion-ratchet.contract.test.ts
+++ b/tests/contract/surface-motion-ratchet.contract.test.ts
@@ -137,7 +137,12 @@ const BASELINE_HARD_CUTS = 0;
  * `AgentSetupStep.test.tsx` 가 고정한다(프로브: 문법을 벗기면 ①·②, 떠 있는
  * 문법을 되입히면 ③ 이 빨개진다).
  */
-const BASELINE_APPEARING_SURFACES = 20;
+/*
+ * 20 → 21 (2026-08-08): 에디터 `@` 멘션의 **관계 고르기 2단계**. 이 수는
+ * `a11y-open-surfaces.spec.ts` 의 분모와 짝이므로 둘을 같이 올린다 — 한쪽만
+ * 올리면 그 파일의 자기 대조가 먼저 터진다(그게 이 짝의 존재 이유다).
+ */
+const BASELINE_APPEARING_SURFACES = 21;
 
 const SELF = 'tests/contract/surface-motion-ratchet.contract.test.ts';
 const FIXTURES = 'tests/fixtures/surface-motion';

--- a/tests/e2e/a11y-open-surfaces.spec.ts
+++ b/tests/e2e/a11y-open-surfaces.spec.ts
@@ -92,8 +92,15 @@ const MIN_RULES_PASSED = 15;
  * 상자 상시 렌더 + 내용만 접힘)으로 옮겨 가면서 조건부 «등장 표면» 이 아니게
  * 됐다 — 접힌 내용의 접근성(탭 순서·AT 노출 없음)은 상자의 `inert` 가 지고,
  * 그 계약은 `AgentSetupStep.test.tsx` 가 잰다.
+ *
+ * 20 → 21 (2026-08-08): 에디터의 `@` 멘션이 **관계 고르기 2단계**를 얻었다.
+ * 1단계(개념 고르기)는 종전 위키링크 팝오버 자리를 물려받은 것이라 수가 그대로였고,
+ * 새로 는 것은 그 2단계 하나다. 이 표면은 **로컬 볼트 + 문서 열기 + 편집 진입 +
+ * `@` 입력 + 개념 고르기**를 지나야 나오므로 아래 한 번 클릭짜리 `OPENERS` 문법에
+ * 안 들어간다 — 그 사실을 분모가 말한다. 대신 키보드 계약(↑↓·Enter·Esc)은
+ * 이 파일이 아니라 위젯 단위 시험이 진다.
  */
-const APPEARING_SURFACES_IN_SOURCE = 20;
+const APPEARING_SURFACES_IN_SOURCE = 21;
 
 interface Opener {
   readonly name: string;


### PR DESCRIPTION
## 왜

종전 에디터의 유일한 보조 기능은 `[[` 위키링크 자동완성이었다. 그런데 **본문 위키링크는 컴파일된 그래프를 1비트도 바꾸지 않는다** — 같은 볼트에서 넣었다 뺐을 때 엣지 수도 그래프 해시도 동일했다(9 · `c07785b6`, 실측). 그래프는 frontmatter 키만 읽기 때문이다.

| | 본문 `[[위키링크]]` | frontmatter 관계 |
|---|---|---|
| 눌러서 이동 | ✓ | ✓ |
| **지도에 선으로** | ✗ | ✓ |
| **경로 찾기·영향 분석** | ✗ | ✓ |
| **에이전트가 관계로 읽음** | ✗ | ✓ |

도그푸드 볼트가 결말을 보여 준다 — **본문 위키링크 0개**, frontmatter 관계 154개. 우리 자신도 안 쓴다. 즉 그 기능은 **옵시디언의 일(무타입 링크)을 우리가 조금 못하게 흉내 낸 자리**였다.

(정확히는 `find_backlinks` 하나가 본문도 훑어 `matchedInBody` 로 **구별해서** 알려 준다. 데이터 모델은 이미 「두 종류의 연결」을 알고 있었고 에디터만 그 사실을 안 말하고 있었다.)

## 무엇을

`@` 로 개념을 고르면 **관계 종류를 묻고 frontmatter 에 적는다.** 본문에는 사람이 읽는 이름만 남는다 — 한쪽은 사실, 한쪽은 읽기 좋은 문장이다(관계를 지워도 문장은 남고, 그게 맞다).

- 관계 어휘는 **공방의 나침반 것을 그대로** 읽는다 — 새 문구 0. 같은 일에 다른 말을 쓰면 사용자가 두 기능으로 배운다
- **새 frontmatter 키 0** — 스키마는 `mcp/src/schema.mjs` 하나가 소유한다. 배열은 검증기가 요구하는 canonical 모양(중복 제거 + 정렬)으로 쓴다
- `[[` 는 **남기지 않았다.** 두 문법이 공존하면 「어느 쪽이 진짜 연결인가」를 매번 판단해야 하는데 화면에 단서가 없다
- `@` 는 매칭이 없으면 조용히 평범한 글자로 남는다 — 문서함은 `CLAUDE.md`·`AGENTS.md` 도 편집할 수 있고 거기서 `@AGENTS.md` 는 **진짜 import 문법**이다

## 소유자 지적 두 건 (같은 PR)

> *"적던 위치에 바로 나와야하고 우리 디자인 시스템 기반으로 개발된거 맞음? 모양이 좀 이상한데"*

둘 다 맞았고, 원인은 **위키링크 팝오버의 자리와 방언을 그대로 물려받은 것**이다.

- **위치**: 편집기 왼쪽 아래 구석 고정 → **캐럿 옆**. 미러 방식으로 좌표를 재고 편집기 밖으로 나가면 방향을 뒤집는다. 실측 추적: 맨앞 74 · 중간 223 · 끝 372
- **방언**: 인디고 테두리 + `surface-deep` + `elevation-2` → 볼트 칩·정렬 메뉴와 같은 `--chrome-radius-inner` · `border-soft` · `elevated` · `--chrome-shadow`. 헤더/푸터 9.5px → 11px. 질의어가 비면 화면에 남던 빈 따옴표(`· ""`)도 제거

**키보드로 끝까지 간다** (↑↓ · Enter · Esc). 1단계를 Enter 로 고른 사람에게 마우스를 요구하면 흐름이 끊기고, 키보드만 쓰는 사람에겐 막힌 문이 된다.

## 계약이 제 일을 했다

열 수 있는 표면이 **20 → 21** 로 늘자 `surface-motion-ratchet` 이 먼저 빨개졌다. 접근성 측정 분모 둘을 **이유와 함께** 올렸다(이 표면은 볼트+편집 진입+입력을 지나야 나와서 한 번 클릭짜리 `OPENERS` 문법에 안 들어간다 — 그 사실을 분모가 말한다).

## Test plan

- **순수 함수 TDD** 15종: 트리거 판정(경로 표기·이메일·줄바꿈 비켜가기) · frontmatter canonical 병합 · 중복 시 무변경 · 커서 보정 · 4방위 전부
- **실기기 왕복**: `@` → 후보 → 관계 → `broader: [capabilities/fixtures]` 가 frontmatter 에, 본문엔 「이 도메인은 Fixtures」, `@` 잔재 0, 기존 관계 보존, 저장 후 「동기화됨」
- `test:contracts` 128 파일 / **1525** ✓ · 위젯 단위 **107** ✓ · `tsc` ✓ · eslint ✓ · `test:i18n:messages` 16 ✓
- e2e: `a11y-open-surfaces` + `web-surface-smoke` **12** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)