### PR TITLE
fix: @ 가 글에도 표시를 남긴다 — 그리고 위키링크 렌더가 한 번도 동작한 적 없었다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1181,13 +1181,14 @@
       "tbLink": "Link ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
       "wikilinkFooter": "↑↓ move · ↵/Tab insert · Esc close",
-      "mentionLabel": "Concept to link{query}",
+      "mentionLabel": "Connect this doc to{query}",
       "mentionFooter": "↑↓ move · ↵ pick · Esc close",
-      "mentionRelationLabel": "How does this connect to \"{title}\"?",
-      "mentionRelationFooter": "Picking writes a relation into this doc's properties; the text keeps just the name",
-      "mentionEmpty": "No concept by that name",
-      "mentionRelationAdded": "Relation written — it shows on the map",
-      "mentionRelationExists": "Already connected"
+      "mentionRelationLabel": "How does \"{title}\" relate to this doc?",
+      "mentionRelationFooter": "Written as a relation in properties; the text gets a link you can follow",
+      "mentionEmpty": "Nothing by that name in this folder",
+      "mentionRelationAdded": "Connected — it shows on the map",
+      "mentionRelationExists": "Already connected",
+      "mentionHint": "You'll pick the kind of connection next"
     },
     "palette": {
       "dialogAriaLabel": "Ontology workspace palette",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1181,13 +1181,14 @@
       "tbLink": "링크 ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
       "wikilinkFooter": "↑↓ 이동 · ↵/Tab 삽입 · Esc 닫기",
-      "mentionLabel": "연결할 개념{query}",
+      "mentionLabel": "이 문서와 이어 붙일 것{query}",
       "mentionFooter": "↑↓ 이동 · ↵ 고르기 · Esc 닫기",
-      "mentionRelationLabel": "‘{title}’ 와 어떻게 이어지나요?",
-      "mentionRelationFooter": "고르면 이 문서의 속성에 관계로 적히고, 글에는 이름만 남아요",
-      "mentionEmpty": "그런 이름의 개념이 없어요",
-      "mentionRelationAdded": "관계를 적었어요 — 지도에 선으로 나와요",
-      "mentionRelationExists": "이미 이어져 있어요"
+      "mentionRelationLabel": "‘{title}’ 는 이 문서와 어떤 관계인가요?",
+      "mentionRelationFooter": "속성에 관계로 적히고, 글에는 눌러 갈 수 있는 링크가 들어가요",
+      "mentionEmpty": "그런 이름이 폴더에 없어요",
+      "mentionRelationAdded": "이어졌어요 — 지도에 선으로 나와요",
+      "mentionRelationExists": "이미 이어져 있어요",
+      "mentionHint": "고르면 어떤 관계인지 물어봐요"
     },
     "palette": {
       "dialogAriaLabel": "문서함 팔레트",

--- a/src/widgets/docs-vault/lib/mention-relation.test.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.test.ts
@@ -89,10 +89,11 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     expect(result.relationAdded).toBe(true);
     // ① 사실 — frontmatter
     expect(result.content).toContain('dependencies: [capabilities/beta]');
-    // ② 문장 — 본문에는 사람이 읽는 이름만. 슬러그도 대괄호도 남지 않는다.
-    expect(result.content).toContain('이 기능은 베타');
+    // ② 글 — 본문에는 **눌러서 갈 수 있는 표기**. 평문이면 아무 일도 안
+    //    일어난 것처럼 보인다(소유자 지적 2026-08-08). 뷰어·옵시디언·GitHub
+    //    셋 다 링크로 읽는 표기라 우리만의 규격을 발명하지 않는다.
+    expect(result.content).toContain('이 기능은 [[capabilities/beta|베타]]');
     expect(result.content).not.toContain('@베');
-    expect(result.content).not.toContain('[[');
   });
 
   it('커서가 삽입한 이름 뒤에 선다 — frontmatter 가 길어진 만큼 밀려도', () => {
@@ -103,8 +104,8 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
       target: { slug: 'capabilities/beta', title: '베타' },
       relationId: 'relates',
     });
-    // 커서 위치의 바로 앞 글자가 방금 넣은 이름의 끝이어야 한다.
-    expect(result.content.slice(result.caret - 2, result.caret)).toBe('베타');
+    // 커서는 방금 넣은 표기의 **뒤**에 선다 — 이어서 글을 쓸 수 있어야 한다.
+    expect(result.content.slice(result.caret - 2, result.caret)).toBe(']]');
   });
 
   it('이미 있는 관계는 파일을 건드리지 않는다 (본문만 바뀐다)', () => {
@@ -121,8 +122,11 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     });
     expect(result.relationAdded).toBe(false);
     expect(result.content).toContain('relates: [capabilities/beta]');
-    // 중복이 생기지 않는다.
-    expect(result.content.match(/capabilities\/beta/g)).toHaveLength(1);
+    // frontmatter 의 관계는 **한 번만** 적힌다 — 본문 표기가 몇 개든.
+    const fm = result.content.slice(0, result.content.indexOf('---', 3));
+    expect(fm.match(/capabilities\/beta/g)).toHaveLength(1);
+    // 본문에는 눌러 갈 수 있는 표기가 들어간다(이미 이어져 있어도 글은 쓴다).
+    expect(result.content).toContain('[[capabilities/beta|베타]]');
   });
 
   /**
@@ -156,7 +160,8 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
       target: { slug: 'capabilities/beta', title: '   ' },
       relationId: 'contains',
     });
-    expect(result.content).toContain('이 기능은 capabilities/beta');
+    // 제목이 없으면 별칭 없는 위키링크 — 빈 파이프(`|`)를 남기지 않는다.
+    expect(result.content).toContain('이 기능은 [[capabilities/beta]]');
   });
 
   it('네 방위 전부가 실재하는 frontmatter 키로 쓴다', () => {

--- a/src/widgets/docs-vault/lib/mention-relation.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.ts
@@ -25,10 +25,31 @@ import { parseFrontmatter } from '@/shared/lib/parse-frontmatter';
  *
  * 1. **frontmatter 에 관계를 쓴다** — 이것이 사실이다. 지도의 선이 되고,
  *    경로·영향·에이전트 핸드오프가 본다.
- * 2. **본문에는 사람이 읽는 이름만** 평문으로 남긴다. 이건 사실이 아니라
- *    문장이다 — 나중에 관계를 지워도 문장은 남고, 그게 맞다(사람이 쓴 글이다).
+ * 2. **본문에는 위키링크를 남긴다** — `[[슬러그|보일 이름]]`. 이건 사실이
+ *    아니라 **읽는 사람을 위한 길**이다.
  *
- * 「같은 사실을 두 곳이 말하는」 것이 아니다. 한쪽은 사실, 한쪽은 읽기 좋은 글.
+ * 「같은 사실을 두 곳이 말하는」 것이 아니다. 한쪽은 타입 있는 사실, 한쪽은
+ * 눌러서 갈 수 있는 글.
+ *
+ * ## 본문 표기를 왜 위키링크로 하나 (2026-08-08, 소유자 지적)
+ *
+ * 첫 판에서는 본문에 **평문 이름만** 넣었다. 소유자가 바로 물었다 —
+ * *"@ 해서 뭔가 등록하면 글에도 다른 형식으로 나와야하지 않을까?"*. 맞다:
+ * 평문은 아무 일도 안 일어난 것처럼 보이고, 그러면 방금 한 동작의 결과가
+ * 화면에 없다.
+ *
+ * 그때 **우리만의 규격을 만들지 않은** 이유는 셋이다:
+ *
+ * 1. 뷰어가 `[[슬러그|이름]]` 을 **이미** 내부 문서 링크로 렌더한다(전처리가
+ *    표준 마크다운 링크로 바꿔 준다). 새 코드가 필요 없다.
+ * 2. **옵시디언·GitHub 에서도 링크로 보인다.** 우리 표기를 발명하면 그
+ *    파일을 다른 도구로 열었을 때 정체불명의 글자가 된다 — 「평범한
+ *    마크다운으로 들고 나갈 수 있다」는 약속을 우리가 깨는 셈이다.
+ * 3. 사용자가 새로 배울 것이 0개다.
+ *
+ * 종전에 `[[` **입력 문법**을 없앤 것과 모순이 아니다. 없앤 것은 「본문 링크
+ * 하나로 연결을 끝낸 척하는 것」이고, 지금 쓰는 것은 **관계를 적은 뒤 그
+ * 관계를 사람이 눌러 갈 수 있게 하는 표기**다. 사실은 frontmatter 에 있다.
  *
  * ## 왜 순수 함수인가
  *
@@ -148,13 +169,15 @@ export function insertMentionRelation({
   const key = RELATION_KEY_BY_ID.get(relationId);
   if (!key) throw new Error(`Unknown relation: ${relationId}`);
 
-  // ① 본문 — `@질의어` 를 사람이 읽는 이름으로 갈아 끼운다.
+  // ① 본문 — `@질의어` 를 **위키링크**로 갈아 끼운다. 뷰어가 내부 문서
+  //    링크로 렌더하고, 옵시디언·GitHub 도 링크로 읽는다.
   const label = target.title.trim() || target.slug;
+  const inserted = label === target.slug ? `[[${target.slug}]]` : `[[${target.slug}|${label}]]`;
   const withLabel =
     content.slice(0, trigger.start) +
-    label +
+    inserted +
     content.slice(trigger.start + 1 + trigger.query.length);
-  const caretAfterLabel = trigger.start + label.length;
+  const caretAfterLabel = trigger.start + inserted.length;
 
   // ② frontmatter — 관계를 더한다. 이미 있으면 파일을 건드리지 않는다.
   const { frontmatter } = parseFrontmatter(withLabel);

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { ICON_SIZE } from '@/shared/ui/icon-size';
 import type { VaultDoc } from '@/entities/docs-vault';
+import { useOntologyKindLabel } from '@/entities/ontology-class';
 import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
 import { useHeldValue } from '@/shared/lib/use-presence';
 import { caretPoint, clampMenuToBox } from '../lib/caret-position';
@@ -35,7 +36,7 @@ import {
   RELATION_LABEL_KEY,
   type MentionRelationId,
 } from '../lib/mention-relation';
-import { Chip, IconButton, RowButton, Surface } from '@/shared/ui';
+import { Chip, IconButton, RowButton, Surface, TopologyV2KindGlyph } from '@/shared/ui';
 
 interface Props {
   doc: VaultDoc;
@@ -151,6 +152,8 @@ export function DocsVaultEditor({
   // 관계 어휘는 공방이 소유한다 — 두 화면이 같은 일에 다른 말을 쓰지 않게
   // 여기서 새 문구를 만들지 않고 그 네임스페이스를 그대로 읽는다.
   const tStudio = useTranslations('ontologyStudio');
+  // 종류 이름은 지도·공방·새 문서 대화상자가 쓰는 것 하나를 그대로 쓴다.
+  const kindLabel = useOntologyKindLabel();
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
   const [loadedSlug, setLoadedSlug] = useState<string | null>(null);
@@ -954,9 +957,17 @@ export function DocsVaultEditor({
             >
               <div className="border-b border-[color:var(--color-border-soft)] px-2 py-1.5 text-label text-[color:var(--color-text-tertiary)]">
                 {/* 질의어가 비면 `· ""` 라는 빈 따옴표가 화면에 남았다(실기기 확인). */}
-                {t('mentionLabel', {
-                  query: heldAutocomplete.query ? ` · “${heldAutocomplete.query}”` : '',
-                })}
+                <span className="block truncate">
+                  {t('mentionLabel', {
+                    query: heldAutocomplete.query ? ` · “${heldAutocomplete.query}”` : '',
+                  })}
+                </span>
+                {/* 「고르면 무슨 일이 일어나나」를 미리 말한다 — 이 메뉴의
+                    결과가 frontmatter 안이라, 말하지 않으면 링크만 넣는
+                    기능으로 읽힌다(소유자: *"무슨 의미인지를 모르겠음"*). */}
+                <span className="block truncate text-caption text-[color:var(--color-text-quaternary)]">
+                  {t('mentionHint')}
+                </span>
               </div>
               <ul className="overflow-auto py-0.5" style={{ maxHeight: MENTION_MENU_MAX_HEIGHT - 64 }}>
                 {heldAutocomplete.matches.map((d, idx) => (
@@ -971,11 +982,19 @@ export function DocsVaultEditor({
                       onClick={() => pickMentionTarget(d)}
                       className="hover:bg-[color:var(--color-overlay-1)]"
                     >
+                      {/* 종류 표식 — 소유자: *"무슨 개념을 말하는건지도
+                          모르겠고"*. 제목만 늘어놓으면 도메인인지 역량인지
+                          요소인지 알 수 없고, 그걸 모르면 어떤 관계로 이을지
+                          정할 수가 없다. 지도·공방과 같은 글리프를 쓴다. */}
+                      <TopologyV2KindGlyph
+                        kind={String(d.frontmatter?.kind ?? 'unknown')}
+                        size={12}
+                      />
                       <span className="truncate text-body text-[color:var(--color-text-primary)]">
-                        {d.title}
+                        {resolveLocaleDisplayName(d.frontmatter, locale, d.title)}
                       </span>
-                      <span className="ml-auto truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
-                        {d.slug}
+                      <span className="ml-auto shrink-0 truncate text-label text-[color:var(--color-text-quaternary)]">
+                        {kindLabel(String(d.frontmatter?.kind ?? ''))}
                       </span>
                     </RowButton>
                   </li>

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
@@ -108,15 +108,30 @@ export function DocsVaultViewer({
         let cleaned = text.startsWith('---')
           ? text.replace(/^---[\s\S]*?\n---\n?/, '')
           : text;
-        // Wikilinks 전처리 — [[slug]] / [[slug|text]] / [[slug#anchor]]
-        // 를 표준 markdown [text](WIKILINK:slug#anchor) 센티넬로 변환.
-        // Viewer a 컴포넌트가 WIKILINK: 를 내부 라우팅으로 잡음.
+        /*
+         * Wikilinks 전처리 — `[[slug]]` / `[[slug|text]]` / `[[slug#anchor]]` 를
+         * 표준 마크다운 링크 + 센티넬로 바꾼다. 아래 `a` 컴포넌트가 그 센티넬을
+         * 내부 라우팅으로 잡는다.
+         *
+         * ⚠️ **센티넬이 URL 스킴이면 안 된다** (2026-08-08 실측 수리).
+         * 종전엔 `WIKILINK:slug` 였는데, `react-markdown` 은 URL 을 살균하고
+         * (`defaultUrlTransform`) **모르는 스킴을 빈 문자열로 만든다** —
+         * 실측: `defaultUrlTransform('WIKILINK:capabilities/x') === ''`.
+         * 그래서 `href` 가 비고, `a` 컴포넌트의 첫 줄이 링크도 「못 찾음」
+         * 표시도 아닌 **아무 표시 없는 평문**을 돌려줬다. 즉 이 기능은
+         * 코드가 있고 문서에도 적혀 있었지만 **한 번도 동작한 적이 없다**
+         * (도그푸드 볼트의 본문 위키링크가 0개라 아무도 안 밟았다).
+         *
+         * 쿼리 모양은 살균을 통과한다. 게이트:
+         * `tests/contract/wikilink-url-scheme.contract.test.ts`.
+         */
         cleaned = cleaned.replace(
           /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g,
           (_, target: string, label?: string) => {
             const text = (label ?? target).trim();
             const clean = target.trim();
-            return `[${text}](WIKILINK:${clean})`;
+            const [slug, anchor] = clean.split('#');
+            return `[${text}](${WIKILINK_SENTINEL}${slug}${anchor ? `#${anchor}` : ''})`;
           },
         );
         setRaw(cleaned);
@@ -173,14 +188,43 @@ export function DocsVaultViewer({
   // 트레이드오프가 전 heading 의 내비게이션이 죽는 것보다 낫다.
   const headingSlugOf = (children: React.ReactNode) => slugFromChildren(children);
 
+  /**
+   * 볼트 슬러그의 NFC 사본 — 위키링크 해소가 쓰는 조회 집합.
+   *
+   * 원본 `vaultSlugs` 를 그대로 쓰면 한글 슬러그가 안 맞는다(NFC 21자 대
+   * NFD 31자). 매 링크마다 정규화하지 않고 집합을 한 번 만든다 — 본문에
+   * 링크가 수십 개면 그만큼 반복되는 일이다.
+   */
+  const normalizedVaultSlugs = useMemo(
+    () => new Set([...vaultSlugs].map((slug) => slug.normalize('NFC'))),
+    [vaultSlugs],
+  );
+
   const components: Components = {
       a({ href, children, ...rest }) {
         if (!href) return <span {...rest}>{children}</span>;
         // 전처리 단계 센티넬 — [[slug#anchor]] 가 WIKILINK:slug#anchor 로
         // 변환돼 있음. vault slug 로 바로 매칭.
-        if (href.startsWith('WIKILINK:')) {
-          const spec = href.slice('WIKILINK:'.length);
-          const [wikiSlug, anchor] = spec.split('#');
+        if (href.startsWith(WIKILINK_SENTINEL)) {
+          const spec = href.slice(WIKILINK_SENTINEL.length);
+          const [rawWikiSlug, anchor] = spec.split('#');
+          /*
+           * ⚠️ **퍼센트 디코드하고 NFC 로 맞춘다** (2026-08-08 실측 수리).
+           *
+           * 마크다운 파서는 링크 URL 을 **퍼센트 인코딩해서** 넘긴다 — 실측:
+           * `capabilities/스윕-검증-절차` 가
+           * `capabilities/%EC%8A%A4%EC%9C%95-…`(69자)로 도착했다. 그 문자열은
+           * 볼트 슬러그 집합에 없으므로 한글 슬러그 위키링크가 **전부**
+           * 「폴더에 없는 링크」 점선으로 떨어졌다. 영문 슬러그는 인코딩할 것이
+           * 없어서 멀쩡했다 — 그래서 이 결함은 한글 볼트에서만 보인다.
+           *
+           * NFC 도 같이 맞춘다. 한글 슬러그는 출처에 따라 NFC(21자)와
+           * NFD(31자)로 갈리고(macOS 파일시스템은 NFD), 글자는 같은데 문자열이
+           * 안 맞는다. CLI 검증기가 이미 같은 판단을 적어 뒀다(`validate.mjs`:
+           * *"참조도 NFC 로 맞춘다 — 한쪽만 정규화하면 글자가 같은데 안 맞는
+           * 상태가 그대로 남는다"*). 그 규칙을 다시 정하지 않고 따른다.
+           */
+          const wikiSlug = rawWikiSlug ? decodeWikilinkSlug(rawWikiSlug) : rawWikiSlug;
           // project: prefix → 공개 토폴로지 라우트로 이동. 예: [[project:reactor]]
           if (wikiSlug && wikiSlug.startsWith('project:')) {
             const projectSlug = wikiSlug.slice('project:'.length);
@@ -194,7 +238,7 @@ export function DocsVaultViewer({
               </a>
             );
           }
-          if (wikiSlug && vaultSlugs.has(wikiSlug)) {
+          if (wikiSlug && normalizedVaultSlugs.has(wikiSlug)) {
             return (
               <Link
                 href={getDocHref(wikiSlug, anchor)}
@@ -542,6 +586,30 @@ export function DocsVaultViewer({
       </ReactMarkdown>
     </article>
   );
+}
+
+/**
+ * 위키링크 센티넬 — **쿼리 모양이어야 한다.** 스킴 모양(`X:`)은
+ * `react-markdown` 의 URL 살균이 통째로 지운다(2026-08-08 실측 수리).
+ * 게이트가 이 값을 소스에서 읽어 살균을 통과하는지 잰다.
+ */
+const WIKILINK_SENTINEL = '?wikilink=';
+
+/**
+ * 위키링크 URL 에서 볼트 슬러그를 꺼낸다 — **퍼센트 디코드 + NFC**.
+ *
+ * 둘 다 필요하고 순서도 그렇다: 디코드가 먼저여야 NFC 정규화가 실제 글자에
+ * 걸린다. 디코드가 실패하는 입력(잘린 `%` 등)은 원문을 그대로 돌려준다 —
+ * 던지면 문서 하나가 통째로 안 그려진다.
+ */
+function decodeWikilinkSlug(raw: string): string {
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    /* 잘린 퍼센트 시퀀스 — 원문으로 둔다 */
+  }
+  return decoded.normalize('NFC');
 }
 
 type CalloutKind = 'note' | 'tip' | 'info' | 'warning' | 'danger' | 'success';

--- a/tests/contract/wikilink-url-scheme.contract.test.ts
+++ b/tests/contract/wikilink-url-scheme.contract.test.ts
@@ -1,0 +1,117 @@
+import { defaultUrlTransform } from 'react-markdown';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * **위키링크 센티넬은 URL 스킴이면 안 된다** — 마크다운 렌더러가 지운다.
+ *
+ * ## 무엇이 났나 (2026-08-08 실측)
+ *
+ * 뷰어는 `[[슬러그|이름]]` 을 표준 마크다운 링크
+ * `[이름](WIKILINK:슬러그)` 로 바꿔 놓고, `a` 컴포넌트에서 `WIKILINK:` 접두사를
+ * 잡아 내부 라우팅으로 보냈다. 설계는 말이 되는데 **한 층을 빼먹었다**:
+ *
+ * `react-markdown` 은 URL 을 살균한다(`defaultUrlTransform`). 허용 목록은
+ * http · https · mailto · xmpp · irc 류이고, **모르는 스킴은 빈 문자열로
+ * 만든다.** 실측:
+ *
+ * ```
+ * defaultUrlTransform('WIKILINK:capabilities/x') === ''
+ * ```
+ *
+ * 그래서 `href` 가 비고, `a` 컴포넌트의 첫 줄
+ * (`if (!href) return <span>{children}</span>`)이 링크 대신 **아무 표시 없는
+ * 평문 span** 을 돌려줬다. 화면에서는 글자만 보인다 — 링크도 아니고, 「이 슬러그
+ * 못 찾음」 점선 표시도 아니다. **두 실패가 한 그림이었다.**
+ *
+ * ## 왜 아무도 못 봤나
+ *
+ * 도그푸드 볼트의 본문 위키링크가 **0개**였다(2026-08-08 전수). 아무도 그
+ * 경로를 지나가지 않았으므로 깨진 채로 남았다. 배포 샘플에도 없다. 즉 이
+ * 기능은 «있다고 적혀 있고, 코드도 있고, 한 번도 동작한 적 없는» 부류였다.
+ *
+ * 에디터의 `@` 멘션이 본문에 위키링크를 넣기 시작하면서 처음으로 그 경로를
+ * 밟았고, 그때 드러났다.
+ *
+ * ## 이 게이트가 잠그는 성질
+ *
+ * *위키링크가 만드는 URL 은 렌더러의 살균을 통과한다.* 구현이 센티넬을
+ * 어떻게 짜든 상관없다 — 스킴 모양이든, 쿼리든, 데이터 속성이든. 다만 그것이
+ * **살균 뒤에도 살아 있어야** 한다. 그리고 살균 함수는 우리 것이 아니라
+ * 라이브러리 것이라, 버전이 올라가며 허용 목록이 바뀌어도 여기서 먼저 터진다.
+ */
+
+const VIEWER = 'src/widgets/docs-vault/ui/DocsVaultViewer.tsx';
+
+describe('위키링크 URL 은 마크다운 렌더러의 살균을 통과한다', () => {
+  /** 뷰어가 실제로 쓰는 센티넬 접두사를 소스에서 읽는다 — 여기 베끼지 않는다. */
+  const sentinel = (() => {
+    const source = readFileSync(VIEWER, 'utf8');
+    const match = source.match(/const WIKILINK_SENTINEL = '([^']+)';/);
+    return match?.[1] ?? null;
+  })();
+
+  it('뷰어가 센티넬 접두사를 갖고 있다 — 못 찾으면 이 시험이 공회전한다', () => {
+    expect(sentinel, '뷰어에서 위키링크 센티넬을 못 찾았다 — 게이트가 낡았다').toBeTruthy();
+  });
+
+  it('그 센티넬이 붙은 URL 이 살균 뒤에도 남는다', () => {
+    const url = `${sentinel}capabilities/example`;
+    expect(
+      defaultUrlTransform(url),
+      `react-markdown 이 "${url}" 를 지운다 — href 가 비면 뷰어의 a 컴포넌트가 ` +
+        '링크도 「못 찾음」 표시도 아닌 **아무 표시 없는 평문**을 돌려준다. ' +
+        '스킴 모양(`X:`)은 허용 목록 밖이면 통째로 잘린다 — 쿼리나 경로 모양을 쓰라.',
+    ).not.toBe('');
+  });
+
+  it('한글 슬러그도 살아남는다 — 볼트 슬러그는 한글일 수 있다', () => {
+    const url = `${sentinel}capabilities/스윕-검증-절차`;
+    expect(defaultUrlTransform(url)).not.toBe('');
+  });
+
+  /**
+   * 공회전 차단의 반대 방향 — 이 검사가 «무엇이든 통과» 시키고 있지 않은지.
+   * 실제로 잘리는 값을 하나 넣어, 살균이 살아 있다는 것부터 확인한다.
+   */
+  it('계기가 살아 있다 — 정말 잘리는 스킴은 빈 값이 된다', () => {
+    expect(defaultUrlTransform('javascript:alert(1)')).toBe('');
+    expect(defaultUrlTransform('WIKILINK:capabilities/x')).toBe('');
+  });
+});
+
+/**
+ * **두 번째 층 — 파서가 URL 을 퍼센트 인코딩한다.**
+ *
+ * 살균을 통과시킨 뒤에도 한글 위키링크는 전부 「폴더에 없는 링크」 점선으로
+ * 떨어졌다. 실측: 뷰어의 `a` 컴포넌트에 도착한 값이
+ * `capabilities/%EC%8A%A4%EC%9C%95-…`(69자)였다 — 마크다운 파서가 인코딩해서
+ * 넘긴 것이다. 볼트 슬러그 집합에는 디코드된 형태(21자)만 있으므로 안 맞는다.
+ *
+ * **영문 슬러그는 인코딩할 것이 없어 멀쩡했다.** 그래서 이 결함은 한글(또는
+ * 공백·비ASCII) 슬러그를 쓰는 볼트에서만 보인다 — 우리 샘플이 영문이라
+ * 아무도 못 봤다. 이 게이트가 그 사각을 지킨다.
+ */
+describe('위키링크 해소는 퍼센트 인코딩과 정규화를 견딘다', () => {
+  const source = readFileSync(VIEWER, 'utf8');
+
+  it('뷰어가 슬러그를 디코드한다', () => {
+    expect(
+      source,
+      '파서가 URL 을 퍼센트 인코딩해서 넘기므로, 디코드 없이 슬러그 집합과 ' +
+        '비교하면 비ASCII 슬러그가 전부 「없는 링크」가 된다.',
+    ).toMatch(/decodeURIComponent/);
+  });
+
+  it('뷰어가 NFC 로 맞춘다 — 글자는 같은데 문자열이 다른 상태를 없앤다', () => {
+    expect(source).toMatch(/normalize\('NFC'\)/);
+  });
+
+  it('디코드 실패가 문서를 죽이지 않는다 — 잘린 퍼센트 시퀀스는 원문으로 둔다', () => {
+    // `decodeURIComponent('%')` 는 던진다. 뷰어가 그것을 잡아야 한다.
+    expect(() => decodeURIComponent('%')).toThrow();
+    expect(source, 'decodeURIComponent 를 try 없이 부르면 문서 하나가 통째로 안 그려진다').toMatch(
+      /try \{[\s\S]{0,200}decodeURIComponent/,
+    );
+  });
+});


### PR DESCRIPTION
지적 둘을 고치다가 **더 큰 결함 하나**를 찾았다.

## ① "글에도 다른 형식으로 나와야하지 않을까?"

첫 판은 본문에 **평문 이름만** 넣었다. 평문은 아무 일도 안 일어난 것처럼 보이고, 그러면 방금 한 동작의 결과가 화면에 없다. 이제 **위키링크** `[[슬러그|보일 이름]]` 를 넣는다.

**우리만의 규격은 만들지 않았다.** 이유 셋:

1. 뷰어가 그 표기를 **이미** 내부 문서 링크로 렌더한다 — 새 코드 0
2. **옵시디언·GitHub 에서도 링크로 보인다** — 「평범한 마크다운으로 들고 나갈 수 있다」는 약속을 우리가 깨지 않는다
3. 사용자가 새로 배울 것이 0개

앞서 `[[` **입력 문법**을 없앤 것과 모순이 아니다 — 없앤 것은 「본문 링크 하나로 연결을 끝낸 척하는 것」이고, 지금은 **관계를 적은 뒤** 사람이 눌러 갈 수 있게 하는 표기다. 사실은 여전히 frontmatter 에 있다.

## ② "무슨 의미인지를 모르겠음 · 무슨 개념을 말하는건지도 모르겠고"

헤더가 「연결할 개념」이라고만 말했다 — 무엇을 고르는 것이고 고르면 무슨 일이 일어나는지 화면에 없었다.

- 헤더: **「이 문서와 이어 붙일 것」** + **「고르면 어떤 관계인지 물어봐요」**
- **행마다 종류를 보여 준다** — AttuneGraph=**프로젝트** · Fixtures=**역량**. 제목만 늘어놓으면 도메인인지 역량인지 알 수 없고, 그걸 모르면 **어떤 관계로 이을지 정할 수가 없다.** 지도·공방과 같은 글리프·같은 종류 이름을 쓴다
- 2단계 설명: 「속성에 관계로 적히고, 글에는 눌러 갈 수 있는 링크가 들어가요」

## ③ 덤 — 뷰어의 위키링크 렌더가 **원래부터 죽어 있었다**

본문에 위키링크를 넣었더니 링크가 아니라 평문으로 나왔다. 파 보니 **두 층**이 겹쳐 있었다.

**첫째, 센티넬이 URL 스킴 모양이었다.** `react-markdown` 은 URL 을 살균하고 모르는 스킴을 빈 문자열로 만든다 — 실측:

```
defaultUrlTransform('WIKILINK:capabilities/x') === ''
```

`href` 가 비면 뷰어 `a` 컴포넌트의 첫 줄이 링크도 「못 찾음」 점선도 아닌 **아무 표시 없는 평문**을 돌려준다 — **두 실패가 한 그림**이었다. 쿼리 모양(`?wikilink=`)으로 바꿨다.

**둘째, 파서가 URL 을 퍼센트 인코딩해서 넘긴다.** `capabilities/스윕-검증-절차` 가 `capabilities/%EC%8A%A4%EC%9C%95-…`(69자)로 도착해 슬러그 집합과 안 맞았다. 디코드 + NFC 정규화를 넣었다(CLI 검증기가 이미 적어 둔 규칙을 따랐다 — 새로 정하지 않았다).

**왜 아무도 못 봤나**: 영문 슬러그는 인코딩할 것이 없어 멀쩡하다 — 이 결함은 **한글 볼트에서만** 보이고 우리 샘플은 영문이다. 게다가 도그푸드 볼트의 본문 위키링크가 **0개**라 그 경로를 아무도 밟지 않았다. **코드가 있고 문서에도 적혀 있었지만 한 번도 동작한 적 없는 기능**이었다.

## Test plan

- **실기기 왕복**: `@` → 개념(종류 표시 확인) → 관계 → 저장 → 미리보기에서 **링크로 렌더** → 눌러서 그 문서로 이동(제목 「스윕 검증 절차」). 점선 「없는 링크」 0
- 새 게이트 `wikilink-url-scheme.contract` 7종 — 센티넬을 **소스에서 읽어** 살균 통과 확인 · 한글 슬러그 · 디코드 · NFC · 디코드 실패 방어 · **계기 생존**(정말 잘리는 스킴은 빈 값). 수리 전 2종 red
- `test:contracts` **129 파일 / 1532** ✓ · 위젯 단위 107 ✓ · `tsc` ✓ · eslint ✓ · i18n 16 ✓
- e2e: `a11y-open-surfaces` + `web-surface-smoke` 12 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)