### PR TITLE
fix: 본문 표기를 마크다운 표준 링크로 · 문구를 다시 쓴다 · 섀도잉 버그 하나

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1181,14 +1181,14 @@
       "tbLink": "Link ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
       "wikilinkFooter": "↑↓ move · ↵/Tab insert · Esc close",
-      "mentionLabel": "Connect this doc to{query}",
+      "mentionLabel": "Pick a document{query}",
       "mentionFooter": "↑↓ move · ↵ pick · Esc close",
-      "mentionRelationLabel": "How does \"{title}\" relate to this doc?",
-      "mentionRelationFooter": "Written as a relation in properties; the text gets a link you can follow",
+      "mentionRelationLabel": "Pick how this relates to \"{title}\"",
+      "mentionRelationFooter": "Saved as a relation in this doc's properties; the text gets a link",
       "mentionEmpty": "Nothing by that name in this folder",
       "mentionRelationAdded": "Connected — it shows on the map",
       "mentionRelationExists": "Already connected",
-      "mentionHint": "You'll pick the kind of connection next"
+      "mentionHint": "You choose the relation next"
     },
     "palette": {
       "dialogAriaLabel": "Ontology workspace palette",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1181,14 +1181,14 @@
       "tbLink": "링크 ⌘K",
       "wikilinkLabel": "wikilink · \"{query}\"",
       "wikilinkFooter": "↑↓ 이동 · ↵/Tab 삽입 · Esc 닫기",
-      "mentionLabel": "이 문서와 이어 붙일 것{query}",
+      "mentionLabel": "문서 고르기{query}",
       "mentionFooter": "↑↓ 이동 · ↵ 고르기 · Esc 닫기",
-      "mentionRelationLabel": "‘{title}’ 는 이 문서와 어떤 관계인가요?",
-      "mentionRelationFooter": "속성에 관계로 적히고, 글에는 눌러 갈 수 있는 링크가 들어가요",
+      "mentionRelationLabel": "‘{title}’ 와의 관계를 고르세요",
+      "mentionRelationFooter": "이 문서 속성에 관계로 저장되고, 글에는 링크가 들어갑니다",
       "mentionEmpty": "그런 이름이 폴더에 없어요",
       "mentionRelationAdded": "이어졌어요 — 지도에 선으로 나와요",
       "mentionRelationExists": "이미 이어져 있어요",
-      "mentionHint": "고르면 어떤 관계인지 물어봐요"
+      "mentionHint": "고른 뒤에 관계를 지정합니다"
     },
     "palette": {
       "dialogAriaLabel": "문서함 팔레트",

--- a/src/widgets/docs-vault/lib/mention-relation.test.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.test.ts
@@ -81,6 +81,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const content = `${DOC}@베`;
     const result = insertMentionRelation({
       content,
+      editingSlug: 'capabilities/alpha',
       trigger: trigger(content),
       target: { slug: 'capabilities/beta', title: '베타' },
       relationId: 'dependencies',
@@ -92,7 +93,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     // ② 글 — 본문에는 **눌러서 갈 수 있는 표기**. 평문이면 아무 일도 안
     //    일어난 것처럼 보인다(소유자 지적 2026-08-08). 뷰어·옵시디언·GitHub
     //    셋 다 링크로 읽는 표기라 우리만의 규격을 발명하지 않는다.
-    expect(result.content).toContain('이 기능은 [[capabilities/beta|베타]]');
+    expect(result.content).toContain('이 기능은 [베타](./beta.md)');
     expect(result.content).not.toContain('@베');
   });
 
@@ -100,12 +101,13 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const content = `${DOC}@베`;
     const result = insertMentionRelation({
       content,
+      editingSlug: 'capabilities/alpha',
       trigger: trigger(content),
       target: { slug: 'capabilities/beta', title: '베타' },
       relationId: 'relates',
     });
     // 커서는 방금 넣은 표기의 **뒤**에 선다 — 이어서 글을 쓸 수 있어야 한다.
-    expect(result.content.slice(result.caret - 2, result.caret)).toBe(']]');
+    expect(result.content.slice(result.caret - 1, result.caret)).toBe(')');
   });
 
   it('이미 있는 관계는 파일을 건드리지 않는다 (본문만 바뀐다)', () => {
@@ -116,6 +118,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const content = `${withRelation}@베`;
     const result = insertMentionRelation({
       content,
+      editingSlug: 'capabilities/alpha',
       trigger: trigger(content),
       target: { slug: 'capabilities/beta', title: '베타' },
       relationId: 'relates',
@@ -126,7 +129,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const fm = result.content.slice(0, result.content.indexOf('---', 3));
     expect(fm.match(/capabilities\/beta/g)).toHaveLength(1);
     // 본문에는 눌러 갈 수 있는 표기가 들어간다(이미 이어져 있어도 글은 쓴다).
-    expect(result.content).toContain('[[capabilities/beta|베타]]');
+    expect(result.content).toContain('[베타](./beta.md)');
   });
 
   /**
@@ -143,6 +146,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const content = `${withRelation}@베`;
     const result = insertMentionRelation({
       content,
+      editingSlug: 'capabilities/alpha',
       trigger: trigger(content),
       target: { slug: 'capabilities/beta', title: '베타' },
       relationId: 'relates',
@@ -156,12 +160,49 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
     const content = `${DOC}@x`;
     const result = insertMentionRelation({
       content,
+      editingSlug: 'capabilities/alpha',
       trigger: trigger(content),
       target: { slug: 'capabilities/beta', title: '   ' },
       relationId: 'contains',
     });
-    // 제목이 없으면 별칭 없는 위키링크 — 빈 파이프(`|`)를 남기지 않는다.
-    expect(result.content).toContain('이 기능은 [[capabilities/beta]]');
+    // 제목이 없으면 슬러그를 라벨로 — 빈 대괄호를 남기지 않는다.
+    expect(result.content).toContain('이 기능은 [capabilities/beta](./beta.md)');
+  });
+
+  /**
+   * **자기 자신과는 이을 수 없다** — 그리고 이 단언이 실제 버그를 잡았다.
+   *
+   * 2026-08-08: 호출부에서 `const { doc, trigger } = pendingMention` 이
+   * 컴포넌트 prop `doc`(편집 중 문서)를 가려, 기준점으로 **고른 대상**이
+   * 넘어갔다. 그러면 기준점과 목적지가 같아져 링크가 `./같은폴더.md` 로 나온다.
+   * 화면에서 실측으로 잡았지만, 이 단언이 있었으면 **호출하는 순간** 터졌다.
+   * 잘못 쓰기 어려운 API 가 주석보다 강하다.
+   */
+  it('편집 중 문서와 고른 문서가 같으면 거절한다', () => {
+    const content = `${DOC}@알`;
+    expect(() =>
+      insertMentionRelation({
+        content,
+        editingSlug: 'capabilities/alpha',
+        trigger: trigger(content),
+        target: { slug: 'capabilities/alpha', title: '알파' },
+        relationId: 'relates',
+      }),
+    ).toThrow(/itself|same document/i);
+  });
+
+  it('링크의 기준점은 **편집 중 문서**다 — 고른 문서가 아니다', () => {
+    const content = `${DOC}@베`;
+    const result = insertMentionRelation({
+      content,
+      // 편집 중 문서는 domains/ 아래, 고른 것은 capabilities/ 아래.
+      editingSlug: 'domains/orders',
+      trigger: trigger(content),
+      target: { slug: 'capabilities/beta', title: '베타' },
+      relationId: 'relates',
+    });
+    // 기준점을 잘못 넘기면 `./beta.md`(같은 폴더)가 되어 해소되지 않는다.
+    expect(result.content).toContain('[베타](../capabilities/beta.md)');
   });
 
   it('네 방위 전부가 실재하는 frontmatter 키로 쓴다', () => {
@@ -169,6 +210,7 @@ describe('insertMentionRelation — 본문은 문장, frontmatter 는 사실', (
       const content = `${DOC}@베`;
       const result = insertMentionRelation({
         content,
+        editingSlug: 'capabilities/alpha',
         trigger: trigger(content),
         target: { slug: 'capabilities/beta', title: '베타' },
         relationId: relation.id,

--- a/src/widgets/docs-vault/lib/mention-relation.ts
+++ b/src/widgets/docs-vault/lib/mention-relation.ts
@@ -1,5 +1,6 @@
 import { applyFrontmatterUpdates } from '@/entities/docs-vault/lib/frontmatter-updates';
 import { parseFrontmatter } from '@/shared/lib/parse-frontmatter';
+import { buildDocLinkMarkdown } from './relative-doc-path';
 
 /**
  * 에디터의 `@` 멘션 — **고르면 관계가 된다.**
@@ -25,27 +26,32 @@ import { parseFrontmatter } from '@/shared/lib/parse-frontmatter';
  *
  * 1. **frontmatter 에 관계를 쓴다** — 이것이 사실이다. 지도의 선이 되고,
  *    경로·영향·에이전트 핸드오프가 본다.
- * 2. **본문에는 위키링크를 남긴다** — `[[슬러그|보일 이름]]`. 이건 사실이
- *    아니라 **읽는 사람을 위한 길**이다.
+ * 2. **본문에는 표준 마크다운 링크를 남긴다** — `[이름](../경로.md)`. 이건
+ *    사실이 아니라 **읽는 사람을 위한 길**이다.
  *
  * 「같은 사실을 두 곳이 말하는」 것이 아니다. 한쪽은 타입 있는 사실, 한쪽은
  * 눌러서 갈 수 있는 글.
  *
- * ## 본문 표기를 왜 위키링크로 하나 (2026-08-08, 소유자 지적)
+ * ## 본문 표기를 왜 표준 링크로 하나 (2026-08-08, 소유자 지적 두 번)
  *
- * 첫 판에서는 본문에 **평문 이름만** 넣었다. 소유자가 바로 물었다 —
- * *"@ 해서 뭔가 등록하면 글에도 다른 형식으로 나와야하지 않을까?"*. 맞다:
- * 평문은 아무 일도 안 일어난 것처럼 보이고, 그러면 방금 한 동작의 결과가
- * 화면에 없다.
+ * **첫 판**: 평문 이름만 넣었다. 소유자 — *"@ 해서 뭔가 등록하면 글에도 다른
+ * 형식으로 나와야하지 않을까?"*. 맞다. 평문은 아무 일도 안 일어난 것처럼
+ * 보이고, 그러면 방금 한 동작의 결과가 화면에 없다.
  *
- * 그때 **우리만의 규격을 만들지 않은** 이유는 셋이다:
+ * **둘째 판**: 위키링크(`[[슬러그|이름]]`)로 바꿨다. 소유자 — *"`[[` 이거는
+ * 옵시디언 특유라서 우리가 쓰면 안되는거 아닌가?"*. 이것도 짚은 것이 맞다.
+ * 위키링크는 MediaWiki(2001)에서 온 PKM 공통 관습이지 옵시디언 발명은 아니지만,
+ * **인상은 옵시디언**이다.
  *
- * 1. 뷰어가 `[[슬러그|이름]]` 을 **이미** 내부 문서 링크로 렌더한다(전처리가
- *    표준 마크다운 링크로 바꿔 준다). 새 코드가 필요 없다.
- * 2. **옵시디언·GitHub 에서도 링크로 보인다.** 우리 표기를 발명하면 그
- *    파일을 다른 도구로 열었을 때 정체불명의 글자가 된다 — 「평범한
- *    마크다운으로 들고 나갈 수 있다」는 약속을 우리가 깨는 셈이다.
- * 3. 사용자가 새로 배울 것이 0개다.
+ * **그럼 우리만의 문법?** 아니다 — 그건 더 나쁘다. 우리 표기는 옵시디언·
+ * GitHub·VS Code·모든 마크다운 뷰어에서 **정체불명의 글자**가 되고, 그건
+ * 「평범한 마크다운으로 들고 나갈 수 있다」는 이 제품의 약속을 우리가 깨는
+ * 것이다. 남의 문법도 우리 문법도 아닌 **마크다운 표준**을 쓴다.
+ *
+ * 재 보니 표준 링크가 모든 축에서 낫다 — 특히 **GitHub 에서 읽힌다**(위키링크는
+ * 깨진 글자다). 「위키링크는 슬러그라서 파일 이동에 견딘다」는 것도 틀렸다:
+ * `redirectBacklinks` 는 frontmatter 만 고치고 본문은 손대지 않아서(실측)
+ * 두 표기가 그 축에서 같다. 비교표: `lib/relative-doc-path.ts`.
  *
  * 종전에 `[[` **입력 문법**을 없앤 것과 모순이 아니다. 없앤 것은 「본문 링크
  * 하나로 연결을 끝낸 척하는 것」이고, 지금 쓰는 것은 **관계를 적은 뒤 그
@@ -157,22 +163,50 @@ export interface MentionInsertResult {
  */
 export function insertMentionRelation({
   content,
+  editingSlug,
   trigger,
   target,
   relationId,
 }: {
   content: string;
+  /**
+   * **지금 편집 중인 문서**의 슬러그 — 상대 경로의 기준점.
+   *
+   * 이름이 `currentSlug` 였을 때 호출부에서 실제로 틀렸다(2026-08-08):
+   * `const { doc, trigger } = pendingMention` 이 컴포넌트의 `doc`(편집 중
+   * 문서)를 가렸고, `currentSlug: doc.slug` 가 **고른 대상**을 넘겼다. 그러면
+   * 기준점과 목적지가 같아져 링크가 `./같은폴더.md` 로 나온다 — 실측으로
+   * 잡았다. 이름을 `editingSlug` 로 바꾼 것은 그 자리에서 «편집 중인 것» 과
+   * «고른 것» 이 눈으로 갈리게 하려는 것이다.
+   */
+  editingSlug: string;
   trigger: MentionTrigger;
   target: { slug: string; title: string };
   relationId: MentionRelationId;
 }): MentionInsertResult {
   const key = RELATION_KEY_BY_ID.get(relationId);
   if (!key) throw new Error(`Unknown relation: ${relationId}`);
+  /*
+   * **자기 자신과는 이을 수 없다.** `broader: [자기]` 는 뜻이 없는 관계이고,
+   * 컴파일러에게는 자기 참조 엣지다. 화면에서도 목록에서 현재 문서를 빼지만
+   * (그게 진짜 수리다) 여기서도 막는다 — 기준점과 목적지가 같아지는 위 버그가
+   * **이 단언에 먼저 걸렸을 것**이기 때문이다. 잘못 쓰기 어려운 API 가
+   * 주석보다 강하다.
+   */
+  if (editingSlug === target.slug) {
+    throw new Error(
+      'insertMentionRelation: editingSlug and target.slug are the same document — ' +
+        'a node cannot relate to itself. Exclude the editing doc from the candidate list.',
+    );
+  }
 
-  // ① 본문 — `@질의어` 를 **위키링크**로 갈아 끼운다. 뷰어가 내부 문서
-  //    링크로 렌더하고, 옵시디언·GitHub 도 링크로 읽는다.
-  const label = target.title.trim() || target.slug;
-  const inserted = label === target.slug ? `[[${target.slug}]]` : `[[${target.slug}|${label}]]`;
+  // ① 본문 — `@질의어` 를 **표준 마크다운 링크**로 갈아 끼운다. 우리 뷰어·
+  //    옵시디언·GitHub·VS Code 가 전부 링크로 읽는다(위 「왜 표준 링크인가」).
+  const inserted = buildDocLinkMarkdown({
+    fromSlug: editingSlug,
+    toSlug: target.slug,
+    label: target.title,
+  });
   const withLabel =
     content.slice(0, trigger.start) +
     inserted +

--- a/src/widgets/docs-vault/lib/relative-doc-path.test.ts
+++ b/src/widgets/docs-vault/lib/relative-doc-path.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDocLink } from './resolve-doc-link';
+import { buildDocLinkMarkdown, relativeDocPath } from './relative-doc-path';
+
+/**
+ * 이 시험의 핵심은 «경로 문자열이 예쁜가» 가 아니다 — **뷰어가 그 링크를 다시
+ * 그 문서로 풀어내는가** 다. 그래서 만드는 쪽(`relativeDocPath`)과 푸는 쪽
+ * (`resolveDocLink`)을 **왕복**으로 잰다. 한쪽만 재면 둘이 어긋난 채로 초록이
+ * 될 수 있고, 실제로 그게 이 기능에서 났던 사고다(파서가 URL 을 인코딩해
+ * 넘기는 것을 푸는 쪽이 몰랐다).
+ */
+
+const VAULT = new Set([
+  'domains/typed-api',
+  'domains/orders',
+  'capabilities/fixtures',
+  'capabilities/스윕-검증-절차',
+  'README',
+  'guides/deep/nested-note',
+]);
+
+/** 왕복 — 만든 링크를 뷰어의 해소기에 넣어 원래 슬러그가 나오는지 본다. */
+function roundTrip(fromSlug: string, toSlug: string) {
+  const href = relativeDocPath(fromSlug, toSlug);
+  return resolveDocLink({ href, fromSlug, vaultSlugs: VAULT });
+}
+
+describe('relativeDocPath — 만든 링크를 뷰어가 다시 푼다', () => {
+  it('다른 폴더로 — 올라갔다 내려간다', () => {
+    expect(relativeDocPath('domains/typed-api', 'capabilities/fixtures')).toBe(
+      '../capabilities/fixtures.md',
+    );
+    expect(roundTrip('domains/typed-api', 'capabilities/fixtures')).toEqual({
+      kind: 'internal',
+      slug: 'capabilities/fixtures',
+      anchor: undefined,
+    });
+  });
+
+  it('같은 폴더로 — `./` 를 붙여 링크임을 눈으로도 알 수 있게', () => {
+    expect(relativeDocPath('domains/typed-api', 'domains/orders')).toBe('./orders.md');
+    expect(roundTrip('domains/typed-api', 'domains/orders')).toMatchObject({
+      kind: 'internal',
+      slug: 'domains/orders',
+    });
+  });
+
+  it('볼트 루트 문서에서 폴더 안으로', () => {
+    expect(relativeDocPath('README', 'capabilities/fixtures')).toBe('capabilities/fixtures.md');
+    expect(roundTrip('README', 'capabilities/fixtures')).toMatchObject({
+      kind: 'internal',
+      slug: 'capabilities/fixtures',
+    });
+  });
+
+  it('깊은 폴더에서 루트 문서로', () => {
+    expect(relativeDocPath('guides/deep/nested-note', 'README')).toBe('../../README.md');
+    expect(roundTrip('guides/deep/nested-note', 'README')).toMatchObject({
+      kind: 'internal',
+      slug: 'README',
+    });
+  });
+
+  /**
+   * 한글 슬러그가 이 기능의 급소다. 위키링크 쪽에서 같은 결함이 났다 — 마크다운
+   * 파서가 URL 을 퍼센트 인코딩해서 넘기는데 푸는 쪽이 디코드를 안 했다.
+   * **영문 슬러그는 인코딩할 것이 없어 멀쩡하므로 한글 볼트에서만 보인다.**
+   */
+  it('한글 슬러그도 왕복한다 — 인코딩되어 도착해도', () => {
+    const href = relativeDocPath('domains/typed-api', 'capabilities/스윕-검증-절차');
+    expect(href).toBe('../capabilities/스윕-검증-절차.md');
+    // 그대로 넣었을 때
+    expect(roundTrip('domains/typed-api', 'capabilities/스윕-검증-절차')).toMatchObject({
+      kind: 'internal',
+      slug: 'capabilities/스윕-검증-절차',
+    });
+    // **파서가 인코딩해 넘긴 형태**로 넣었을 때 — 실제로 이렇게 도착한다.
+    expect(
+      resolveDocLink({
+        href: encodeURI(href),
+        fromSlug: 'domains/typed-api',
+        vaultSlugs: VAULT,
+      }),
+      '퍼센트 인코딩된 링크를 못 풀면 한글 볼트의 모든 링크가 죽는다',
+    ).toMatchObject({ kind: 'internal', slug: 'capabilities/스윕-검증-절차' });
+  });
+
+  it('앵커를 붙여도 슬러그를 찾는다', () => {
+    const href = `${relativeDocPath('domains/typed-api', 'capabilities/fixtures')}#정의`;
+    expect(
+      resolveDocLink({ href, fromSlug: 'domains/typed-api', vaultSlugs: VAULT }),
+    ).toMatchObject({ kind: 'internal', slug: 'capabilities/fixtures', anchor: '정의' });
+  });
+});
+
+describe('buildDocLinkMarkdown — 링크 문법이 라벨에 깨지지 않는다', () => {
+  it('제목을 라벨로 쓴다', () => {
+    expect(
+      buildDocLinkMarkdown({
+        fromSlug: 'domains/typed-api',
+        toSlug: 'capabilities/fixtures',
+        label: 'Fixtures',
+      }),
+    ).toBe('[Fixtures](../capabilities/fixtures.md)');
+  });
+
+  it('제목이 비면 슬러그를 쓴다 — 빈 라벨을 남기지 않는다', () => {
+    expect(
+      buildDocLinkMarkdown({
+        fromSlug: 'README',
+        toSlug: 'capabilities/fixtures',
+        label: '   ',
+      }),
+    ).toBe('[capabilities/fixtures](capabilities/fixtures.md)');
+  });
+
+  /** 제목은 사람이 쓴 값이다 — 대괄호가 들어오면 링크가 그 자리에서 끊긴다. */
+  it('라벨의 대괄호를 이스케이프한다', () => {
+    const md = buildDocLinkMarkdown({
+      fromSlug: 'README',
+      toSlug: 'capabilities/fixtures',
+      label: '[초안] 결제',
+    });
+    expect(md).toBe('[\\[초안\\] 결제](capabilities/fixtures.md)');
+  });
+});

--- a/src/widgets/docs-vault/lib/relative-doc-path.ts
+++ b/src/widgets/docs-vault/lib/relative-doc-path.ts
@@ -1,0 +1,78 @@
+/**
+ * 두 볼트 슬러그 사이의 **상대 마크다운 경로** — `@` 멘션이 본문에 넣는 링크.
+ *
+ * ## 왜 표준 링크인가 (2026-08-08, 소유자 지적)
+ *
+ * 첫 판은 본문에 `[[슬러그|이름]]` 위키링크를 넣었다. 소유자가 물었다 —
+ * *"`[[` 이거는 옵시디언 특유라서 우리가 쓰면 안되는거 아닌가?"*
+ *
+ * 짚은 것이 맞다. 위키링크는 MediaWiki(2001)에서 왔고 Roam·Logseq·Obsidian·
+ * Foam·Dendron 이 다 쓰는 **PKM 공통 관습**이지 옵시디언 발명은 아니다. 그러나
+ * 인상은 옵시디언이고, 무엇보다 **재 보니 표준 링크가 모든 축에서 낫다**:
+ *
+ * | | `[[슬러그\|이름]]` | `[이름](../경로.md)` |
+ * |---|---|---|
+ * | 우리 뷰어 | 링크 | 링크 (`resolveDocLink`) |
+ * | 옵시디언 | 링크 | 링크 |
+ * | **GitHub · VS Code · 일반 마크다운 뷰어** | **깨진 글자** | **링크** |
+ * | 노드 이름을 바꾸면 | 낡는다 | 낡는다 |
+ *
+ * 마지막 줄이 결정적이었다. 위키링크가 «슬러그라서 파일 이동에 견딘다» 고
+ * 생각했는데, `redirectBacklinks` 는 **frontmatter 만** 고치고 본문은 손대지
+ * 않는다(실측). 즉 두 표기가 그 축에서 같고, 남는 차이는 **GitHub 에서
+ * 읽히는가** 하나다.
+ *
+ * 그래서 답은 「우리만의 문법을 만든다」가 아니다 — 우리 문법은 **모든 다른
+ * 도구에서 깨진 글자**가 되고, 그건 「평범한 마크다운으로 들고 나갈 수 있다」는
+ * 이 제품의 약속을 우리가 깨는 것이다. 남의 문법도 아니고 우리 문법도 아닌
+ * **마크다운 표준**을 쓴다.
+ */
+
+/**
+ * `fromSlug` 문서에서 `toSlug` 문서로 가는 상대 경로(`.md` 포함).
+ *
+ * 뷰어의 `resolveDocLink` 가 링크를 **그 문서의 폴더 기준**으로 푼다. 그래서
+ * 볼트 루트 기준 경로를 그대로 쓰면 안 된다 — `domains/typed-api` 에서
+ * `capabilities/fixtures.md` 라고 쓰면 `domains/capabilities/fixtures` 를
+ * 찾으러 간다(실측으로 확인한 해소 규칙).
+ */
+export function relativeDocPath(fromSlug: string, toSlug: string): string {
+  const fromParts = fromSlug.split('/');
+  const toParts = toSlug.split('/');
+  // 마지막 조각은 파일 이름이므로 디렉터리 비교에서 뺀다.
+  fromParts.pop();
+  const fileName = `${toParts.pop()}.md`;
+
+  let shared = 0;
+  while (shared < fromParts.length && shared < toParts.length && fromParts[shared] === toParts[shared]) {
+    shared += 1;
+  }
+  const up = fromParts.length - shared;
+  const segments = [...Array.from({ length: up }, () => '..'), ...toParts.slice(shared), fileName];
+  const path = segments.join('/');
+  /*
+   * 같은 폴더면 `./` 를 붙인다. 없으면 `fixtures.md` 가 되는데, 그건 링크로도
+   * 읽히지만 **글 속에서 파일 이름처럼 보인다** — 링크임을 눈으로 알 수 있게
+   * 한다. 해소 쪽은 `./` 를 이미 벗겨 낸다.
+   */
+  return up === 0 && toParts.length === shared ? `./${path}` : path;
+}
+
+/**
+ * 본문에 넣을 마크다운 링크 한 줄.
+ *
+ * 라벨에 `]` 가 있으면 링크 문법이 그 자리에서 끊긴다 — 이스케이프한다.
+ * 제목은 사람이 쓴 값이라 무엇이든 들어올 수 있다.
+ */
+export function buildDocLinkMarkdown({
+  fromSlug,
+  toSlug,
+  label,
+}: {
+  fromSlug: string;
+  toSlug: string;
+  label: string;
+}): string {
+  const text = (label.trim() || toSlug).replace(/([[\]])/g, '\\$1');
+  return `[${text}](${relativeDocPath(fromSlug, toSlug)})`;
+}

--- a/src/widgets/docs-vault/lib/resolve-doc-link.ts
+++ b/src/widgets/docs-vault/lib/resolve-doc-link.ts
@@ -58,6 +58,23 @@ function collapsePath(pathStr: string): string {
   return out.join('/');
 }
 
+/**
+ * 볼트 경로 조각을 비교 가능한 형태로 — **퍼센트 디코드 + NFC**.
+ *
+ * 디코드가 먼저여야 정규화가 실제 글자에 걸린다. 잘린 퍼센트 시퀀스(`%`)는
+ * `decodeURIComponent` 가 던지므로 원문을 그대로 돌려준다 — 던지면 그 문서가
+ * 통째로 안 그려진다.
+ */
+function decodeVaultPath(value: string): string {
+  let decoded = value;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    /* 잘린 퍼센트 시퀀스 — 원문으로 둔다 */
+  }
+  return decoded.normalize('NFC');
+}
+
 export function resolveDocLink({
   href,
   fromSlug,
@@ -69,8 +86,26 @@ export function resolveDocLink({
   if (!href || href.startsWith('#') || /^[a-z][a-z0-9+.-]*:/i.test(href)) {
     return { kind: 'passthrough' };
   }
-  const [target, anchorRaw] = href.split('#');
-  const anchor = anchorRaw || undefined;
+  const [rawTarget, rawAnchor] = href.split('#');
+  /*
+   * ⚠️ **퍼센트 디코드하고 NFC 로 맞춘다** (2026-08-08 실측 수리).
+   *
+   * 마크다운 파서는 링크 URL 을 퍼센트 인코딩해서 넘긴다 —
+   * `../capabilities/스윕-검증-절차.md` 가 `%EC%8A%A4%EC%9C%95…` 로 도착한다.
+   * 그 문자열은 볼트 슬러그 집합에 없으므로 **한글 슬러그로 가는 링크가 전부
+   * 「알 수 없는 문서」로 떨어졌다.** 영문 슬러그는 인코딩할 것이 없어 멀쩡해서
+   * 이 결함은 한글(또는 공백·비ASCII) 슬러그 볼트에서만 보인다 — 우리 샘플이
+   * 영문이라 아무도 못 봤다.
+   *
+   * 위키링크 쪽에서 같은 결함을 먼저 잡았고(`DocsVaultViewer`), 여기는 **손으로
+   * 쓴 표준 링크**도 같이 살린다.
+   *
+   * NFC 도 맞춘다: 한글은 출처에 따라 NFC/NFD 로 갈리고(macOS 파일시스템은
+   * NFD) 글자는 같은데 문자열이 안 맞는다. 한쪽만 정규화하면 그 상태가 그대로
+   * 남는다(`cli/src/commands/validate.mjs` 가 같은 판단을 적어 뒀다).
+   */
+  const target = decodeVaultPath(rawTarget);
+  const anchor = rawAnchor ? decodeVaultPath(rawAnchor) : undefined;
   if (!target || !target.endsWith('.md')) {
     return { kind: 'passthrough' };
   }

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -194,15 +194,16 @@ export function DocsVaultEditor({
   const acMatches = useMemo<VaultDoc[]>(() => {
     if (!autocomplete || !allDocs) return [];
     const q = autocomplete.query.toLowerCase();
-    if (!q) return allDocs.slice(0, 8);
+    // 현재 문서는 후보가 아니다 — 자기 자신과 이을 수는 없다.
+    if (!q) return allDocs.filter((d) => d.slug !== doc.slug).slice(0, 8);
     return allDocs
       .filter(
         (d) =>
-          d.title.toLowerCase().includes(q) ||
-          d.slug.toLowerCase().includes(q),
+          d.slug !== doc.slug &&
+          (d.title.toLowerCase().includes(q) || d.slug.toLowerCase().includes(q)),
       )
       .slice(0, 8);
-  }, [autocomplete, allDocs]);
+  }, [autocomplete, allDocs, doc.slug]);
 
   /**
    * 자동완성의 **열림**과 **내용**을 가른다 — 그래야 퇴장이 성립한다.
@@ -348,13 +349,19 @@ export function DocsVaultEditor({
     (relationId: MentionRelationId) => {
       const ta = taRef.current;
       if (!ta || content === null || !pendingMention) return;
-      const { doc, trigger } = pendingMention;
+      /*
+       * ⚠️ `doc` 으로 받지 않는다 — 이 컴포넌트의 prop 이름이 이미 `doc`
+       * (편집 중 문서)이라 섀도잉된다. 실제로 그 실수를 했고, 링크의 기준점이
+       * 목적지와 같아져 `./같은폴더.md` 가 나왔다(2026-08-08 실측).
+       */
+      const { doc: targetDoc, trigger } = pendingMention;
       const result = insertMentionRelation({
         content,
+        editingSlug: doc.slug,
         trigger,
         target: {
-          slug: doc.slug,
-          title: resolveLocaleDisplayName(doc.frontmatter, locale, doc.title),
+          slug: targetDoc.slug,
+          title: resolveLocaleDisplayName(targetDoc.frontmatter, locale, targetDoc.title),
         },
         relationId,
       });
@@ -366,7 +373,7 @@ export function DocsVaultEditor({
         ta.setSelectionRange(result.caret, result.caret);
       });
     },
-    [content, locale, pendingMention],
+    [content, doc.slug, locale, pendingMention],
   );
 
 


### PR DESCRIPTION
지적 셋을 고쳤고, 그 과정에서 **내 버그 하나와 원래 있던 결함 하나**를 더 찾았다.

## ① "`[[` 이거는 옵시디언 특유라서 우리가 쓰면 안되는거 아닌가?"

짚은 것이 맞다. 위키링크는 MediaWiki(2001)에서 온 **PKM 공통 관습**이지 옵시디언 발명은 아니지만, **인상은 옵시디언**이다.

그런데 답은 **「우리만의 문법」이 아니다** — 우리 표기는 옵시디언·GitHub·VS Code·모든 마크다운 뷰어에서 **정체불명의 글자**가 되고, 그건 「평범한 마크다운으로 들고 나갈 수 있다」는 약속을 우리가 깨는 것이다. 남의 문법도 우리 문법도 아닌 **마크다운 표준**을 쓴다.

| | `[[슬러그\|이름]]` | **`[이름](../경로.md)`** |
|---|---|---|
| 우리 뷰어 | 링크 | 링크 |
| 옵시디언 | 링크 | 링크 |
| **GitHub · VS Code · 일반 마크다운** | **깨진 글자** | **링크** |
| 이름을 바꾸면 | 낡는다 | 낡는다 |

마지막 줄이 결정적이었다. 「위키링크는 슬러그라서 파일 이동에 견딘다」고 생각했는데 **`redirectBacklinks` 는 frontmatter 만 고치고 본문은 손대지 않는다**(실측) — 두 표기가 그 축에서 같고, 남는 차이는 **GitHub 에서 읽히는가** 하나다.

## ② "이 문서와 이어 붙일 것 → 뭔말이지" · "고르면 어떤 관계인지 물어봐요 → 이것도"

대안까지 주셨다(*선택한 뒤 관계를 지정*). 그 어투로 다시 썼다:

| | 전 | 후 |
|---|---|---|
| 1단계 머리 | 이 문서와 이어 붙일 것 | **문서 고르기** |
| 1단계 힌트 | 고르면 어떤 관계인지 물어봐요 | **고른 뒤에 관계를 지정합니다** |
| 2단계 | ‘X’ 는 이 문서와 어떤 관계인가요? | **‘X’ 와의 관계를 고르세요** |

추상 명사(「이어 붙일 것」)를 **목록의 실체**(「문서」)로 바꾼 것이 핵심이다.

## ③ 내 섀도잉 버그 — 링크 경로가 틀렸다

`const { doc, trigger } = pendingMention` 이 컴포넌트 prop `doc`(편집 중 문서)를 **가려서**, 상대 경로의 기준점으로 **고른 대상**이 넘어갔다. 그러면 기준점과 목적지가 같아져 `./같은폴더.md` 가 나온다 — `domains/` 문서에서 `capabilities/` 문서를 걸었더니 `./fixtures.md` 였다(실측).

수리 셋: 이름을 `editingSlug` 로(그 자리에서 눈으로 갈리게) · **후보 목록에서 현재 문서 제외**(자기 자신과 이을 수는 없다) · **순수 함수가 자기 참조를 거절**. 마지막 것이 있었으면 **호출하는 순간** 터졌다 — 잘못 쓰기 어려운 API 가 주석보다 강하다.

## ④ 원래 있던 결함 — 표준 링크도 한글에서 죽어 있었다

`resolveDocLink` 가 퍼센트 디코드를 안 해서, **손으로 쓴 `[이름](../한글.md)` 링크가 전부 「알 수 없는 문서」**로 떨어졌다. 위키링크 쪽에서 먼저 잡은 것과 같은 가족이고, 영문 슬러그는 멀쩡해서 **한글 볼트에서만** 보인다. 디코드 + NFC 를 넣었다 — 이 수리는 `@` 와 무관하게 손으로 쓴 링크도 살린다.

## Test plan

- **왕복 시험**: 만드는 쪽(`relativeDocPath`)과 푸는 쪽(`resolveDocLink`)을 **한 시험에서** 잰다 — 한쪽만 재면 둘이 어긋난 채 초록이 될 수 있고 실제로 그게 이 기능에서 난 사고다. 다른 폴더·같은 폴더·루트↔깊은 폴더·**한글(인코딩된 형태 포함)**·앵커
- **회귀 시험 2종**: 자기 참조 거절 · 「기준점은 편집 중 문서다」(③이 재발하면 red)
- **실기기**: `domains/public-interfaces` 에서 `@fix` → 관계 → 본문 `[Fixtures](../capabilities/fixtures.md)` · frontmatter `broader: [capabilities/fixtures]` → 저장 → 미리보기에서 **링크로 렌더** → **눌러서 그 문서로 이동**
- `vitest src/widgets/docs-vault/ tests/contract/` **143 파일 / 1651** ✓ · `tsc` ✓ · eslint **0** ✓ · i18n 16 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)