### PR TITLE
fix: 계약 테스트의 타입 좁히기 · 멘션 빈 결과를 말한다 — main 을 초록으로 되돌린다

### DIFF
--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -292,6 +292,28 @@ const RULES = [
     matches: [/^app\/globals\.css$/, /^postcss\.config\.mjs$/],
   },
   {
+    /*
+     * ⚠️ **문서함을 고치면 문서함을 운전하는 e2e 를 같이 돌린다** (2026-08-08).
+     *
+     * 이 매핑이 없어서 실제 사고가 났다. #987 이 문서함 헤더의 「샘플|로컬」
+     * 라디오를 볼트 칩 메뉴로 옮겼는데, `docs-deeplink.spec.ts` 가 그 라디오를
+     * 클릭한다. 추천 도구가 그 스펙을 **한 번도 가리키지 않아** 로컬에서
+     * 안 돌렸고, CI 는 빨간 채로 **여섯 PR 이 더 머지됐다**(2분 타임아웃 ×
+     * 재시도 3회 × 두 시험).
+     *
+     * `.claude/rules/testing.md` 가 정확히 이것을 경고한다 — *"화면을 삭제하면
+     * 같은 PR 에서 e2e spec 도 같이 훑어 지운다"*. 사람의 기억에 맡긴 그 훑기를
+     * 도구가 대신하게 한다: **도구가 못 가리키는 검사는 존재하지 않는 검사다.**
+     */
+    command:
+      'pnpm exec playwright test tests/e2e/docs-deeplink.spec.ts tests/e2e/document-scroll-lock.spec.ts tests/e2e/vault-truth-telling.spec.ts',
+    reason: 'the docs surface changed — its e2e specs drive that screen by role and testid',
+    matches: [
+      /^src\/views\/docs-vault\/.+\.tsx?$/,
+      /^src\/widgets\/docs-vault\/.+\.tsx?$/,
+    ],
+  },
+  {
     // 표면 분리(2026-07-27) 이후 웹은 앱을 따라가지 않으므로, 능력 브리지를
     // 건드린 사람은 앱만 확인하고 지나가기 쉽다. 웹이 무인 표면이라 그 통과가
     // 그대로 부패가 된다 — 브리지를 만지면 웹 스모크를 같이 권한다.

--- a/scripts/lib/focused-check-suggestions.test.mjs
+++ b/scripts/lib/focused-check-suggestions.test.mjs
@@ -514,6 +514,9 @@ describe('focused check suggestions', () => {
       'pnpm test:desktop:bridge',
       'pnpm desktop:check',
       'pnpm test:contracts',
+      // 이 세트에 `src/views/docs-vault/**` 가 들어 있으므로 문서함 e2e 도 온다.
+      'pnpm exec playwright test tests/e2e/docs-deeplink.spec.ts ' +
+        'tests/e2e/document-scroll-lock.spec.ts tests/e2e/vault-truth-telling.spec.ts',
       // 표면 분리(2026-07-27) 이후 데스크톱 변경은 웹을 대신 확인해 주지
       // 않는다 — 웹은 무인 표면이라 같은 세트에서 스모크를 함께 권한다.
       'pnpm exec playwright test tests/e2e/web-surface-smoke.spec.ts',
@@ -676,6 +679,11 @@ describe('focused check suggestions', () => {
       'pnpm exec vitest run src/shared/lib/cn.test.ts',
       'pnpm exec vitest run src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx',
       'pnpm test:contracts',
+      // 문서함 위젯을 만졌으므로 그 화면을 운전하는 e2e 도 함께 추천된다
+      // (2026-08-08 매핑 추가 — #987 이 헤더 컨트롤을 옮겼는데 이 추천이 없어
+      // `docs-deeplink` 가 CI 에서 여섯 PR 동안 빨간 채로 있었다).
+      'pnpm exec playwright test tests/e2e/docs-deeplink.spec.ts ' +
+        'tests/e2e/document-scroll-lock.spec.ts tests/e2e/vault-truth-telling.spec.ts',
       'pnpm exec tsc --noEmit',
     ]);
     assert.deepEqual(result.commands[1].paths, [

--- a/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
+++ b/src/views/docs-vault/ui/parts/DocsVaultVaultChip.tsx
@@ -68,6 +68,10 @@ export function DocsVaultVaultChip({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t("vaultChip.menuAriaLabel")}
+        /* 메뉴 항목들은 testid 가 있는데 이 트리거만 없어서, 두 e2e 스펙이
+           로케일 라벨("문서함 정보 메뉴" / "Workspace info menu")로 찾고 있었다.
+           번역을 고치면 스펙이 조용히 죽는 이음새다 — 로케일 무관 좌표를 준다. */
+        data-testid="vault-chip-menu-trigger"
         className="min-w-0 max-w-[200px] flex-none font-mono hover:border-[color:var(--color-indigo-line-a32)] hover:text-[color:var(--color-text-primary)]"
       >
         {/* 칩의 아이콘이 소스를 말한다 — 오른쪽 라디오를 걷어낸 자리를

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -213,7 +213,19 @@ export function DocsVaultEditor({
    * (엣지 패널이 실제로 그렇게 지도를 죽였다). 질의어와 커서 위치가 바뀔
    * 때만 새 값으로 친다.
    */
-  const acOpen = autocomplete !== null && acMatches.length > 0;
+  /**
+   * 메뉴를 여는 조건 — **질의어를 쳤으면 결과가 0이어도 연다.**
+   *
+   * 종전엔 `matches.length > 0` 이라 못 찾으면 메뉴가 조용히 사라졌다. 그러면
+   * 사용자는 「기능이 고장났나」와 「그런 개념이 없나」를 구별할 수 없다 —
+   * 이 저장소가 반복해 배운 그것(침묵은 성공처럼, 또는 고장처럼 읽힌다).
+   *
+   * 단 `@` 만 친 상태에서는 여전히 목록을 보여 준다(첫 8개). 빈 질의어까지
+   * 「없어요」로 답하면 그건 틀린 말이다.
+   */
+  const acHasQuery = (autocomplete?.query ?? '') !== '';
+  const acEmpty = autocomplete !== null && acHasQuery && acMatches.length === 0;
+  const acOpen = autocomplete !== null && (acMatches.length > 0 || acEmpty);
   const heldAutocomplete = useHeldValue(
     acOpen && autocomplete
       ? { query: autocomplete.query, active: autocomplete.active, matches: acMatches }
@@ -896,7 +908,16 @@ export function DocsVaultEditor({
                 }
                 return;
               }
-              if (!autocomplete || acMatches.length === 0) return;
+              if (!autocomplete) return;
+              if (acMatches.length === 0) {
+                // 결과가 없는 상태에서도 **닫을 수는 있어야** 한다. 못 닫는
+                // 상자는 사용자가 글을 계속 쓰는 것을 막는다.
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setAutocomplete(null);
+                }
+                return;
+              }
               if (e.key === 'ArrowDown') {
                 e.preventDefault();
                 setAutocomplete((ac) =>
@@ -976,6 +997,11 @@ export function DocsVaultEditor({
                   {t('mentionHint')}
                 </span>
               </div>
+              {heldAutocomplete.matches.length === 0 ? (
+                <p className="px-2 py-2 text-label text-[color:var(--color-text-tertiary)]">
+                  {t('mentionEmpty')}
+                </p>
+              ) : null}
               <ul className="overflow-auto py-0.5" style={{ maxHeight: MENTION_MENU_MAX_HEIGHT - 64 }}>
                 {heldAutocomplete.matches.map((d, idx) => (
                   <li key={d.slug}>

--- a/tests/contract/mention-link-backlink.contract.test.ts
+++ b/tests/contract/mention-link-backlink.contract.test.ts
@@ -79,9 +79,12 @@ describe('멘션이 쓴 본문 링크를 에이전트가 역참조로 찾는다'
     it(`${layout.name} — 관계와 본문 링크가 모두 잡힌다`, () => {
       const link = writeMentionPair(layout.from, layout.to);
       const matches = findBacklinks(root, layout.to);
-      const hit = matches.find((m: { slug: string }) => m.slug === layout.from);
+      const hit = matches.find(
+        (m: { slug: string }) => m.slug === layout.from,
+      ) as { matchedKeys?: string[]; matchedInBody?: boolean } | undefined;
 
       expect(hit, `${layout.from} 이 역참조에 없다 (링크: ${link})`).toBeTruthy();
+      if (!hit) return;
       // ① 사실 — frontmatter 관계로 잡힌다
       expect(hit.matchedKeys, `관계가 안 잡혔다 (링크: ${link})`).toContain('relates');
       // ② 길 — 본문 링크로도 잡힌다. 이게 false 면 에이전트는 「글에서
@@ -107,7 +110,9 @@ describe('멘션이 쓴 본문 링크를 에이전트가 역참조로 찾는다'
     );
     const hit = findBacklinks(root, 'capabilities/tgt').find(
       (m: { slug: string }) => m.slug === 'domains/src',
-    );
+    ) as { matchedKeys?: string[]; matchedInBody?: boolean } | undefined;
+    expect(hit).toBeTruthy();
+    if (!hit) return;
     expect(hit.matchedKeys).toContain('relates');
     expect(hit.matchedInBody, '본문에 링크가 없는데 본문 히트가 났다 — 탐지가 헛돈다').toBeUndefined();
   });

--- a/tests/e2e/docs-deeplink.spec.ts
+++ b/tests/e2e/docs-deeplink.spec.ts
@@ -47,6 +47,55 @@ import { stubDirectoryPicker } from "./vault-picker-stub";
 const DEEP_SLUG = "capabilities/deeplink-probe";
 const DEEP_TITLE = /딥링크 표적 문서/;
 
+
+/**
+ * 소스를 **샘플로 바꾼다** — 누르는 자리가 2026-08-08 에 옮겨졌다.
+ *
+ * 종전엔 화면 오른쪽 끝의 「샘플 | 로컬」 라디오였다. #987(문서함 크롬 통합)이
+ * 그 라디오를 지우고 표시·전환·점검을 **볼트 칩 메뉴** 하나로 모았다 — 같은
+ * 사실을 화면 두 곳이 말하고 있었기 때문이다.
+ *
+ * ⚠️ **그때 이 스펙을 같이 고치지 않아 CI 가 깨진 채 여섯 PR 이 머지됐다.**
+ * `.claude/rules/testing.md` 가 정확히 그것을 경고한다 — *"화면을 삭제하면 같은
+ * PR 에서 e2e spec 도 같이 훑어 지운다"*. 지키는 성질(정착 후 볼트 전환이
+ * 슬러그를 걷어낸다)은 그대로이고 **누르는 자리만** 바뀌었으므로, 시험을 지우지
+ * 않고 여기 한 곳으로 모아 다음에 또 옮겨도 한 군데만 고치면 되게 한다.
+ */
+async function switchToSample(page: import("@playwright/test").Page): Promise<void> {
+  await page.getByTestId("vault-chip-menu-trigger").click();
+  const pick = page.getByTestId("vault-chip-use-sample");
+  await expect(pick).toBeVisible({ timeout: 10_000 });
+  await pick.click();
+}
+
+/** 지금 보고 있는 소스가 로컬인가 — 칩 메뉴의 라디오 상태로 읽는다. */
+async function expectSourceIsLocal(page: import("@playwright/test").Page): Promise<void> {
+  await page.getByTestId("vault-chip-menu-trigger").click();
+  await expect(page.getByTestId("vault-chip-use-local")).toHaveAttribute(
+    "aria-checked",
+    "true",
+    { timeout: 10_000 },
+  );
+  await page.keyboard.press("Escape");
+  // 퇴장 대기 — Surface 는 나가는 동안 inert 로 DOM 에 남고, 텍스트 셀렉터는
+  // 그것도 찾아낸다(local-vault-picker 에서 실제로 strict mode 충돌을 냈다).
+  await expect(page.getByTestId("vault-chip-use-sample")).toBeHidden();
+}
+
+/** 지금 보고 있는 소스가 샘플인가. */
+async function expectSourceIsSample(page: import("@playwright/test").Page): Promise<void> {
+  await page.getByTestId("vault-chip-menu-trigger").click();
+  await expect(page.getByTestId("vault-chip-use-sample")).toHaveAttribute(
+    "aria-checked",
+    "true",
+    { timeout: 10_000 },
+  );
+  await page.keyboard.press("Escape");
+  // 퇴장 대기 — Surface 는 나가는 동안 inert 로 DOM 에 남고, 텍스트 셀렉터는
+  // 그것도 찾아낸다(local-vault-picker 에서 실제로 strict mode 충돌을 냈다).
+  await expect(page.getByTestId("vault-chip-use-sample")).toBeHidden();
+}
+
 test.describe("문서함 딥링크 — URL 이 이긴다", () => {
   test("로컬 볼트 복원 뒤의 콜드 로드에서 ?slug= 가 살아남는다", async ({ page }) => {
     test.setTimeout(120_000);
@@ -107,7 +156,7 @@ test.describe("문서함 딥링크 — URL 이 이긴다", () => {
       .toBe(DEEP_SLUG);
 
     // 정착된 상태에서 소스를 샘플로 전환 — 진짜 볼트 전환이다.
-    await page.getByRole("radio", { name: "샘플" }).click();
+    await switchToSample(page);
     await expect
       .poll(async () => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
       .not.toBe(DEEP_SLUG);
@@ -216,18 +265,11 @@ test.describe("문서함 딥링크 — URL 이 이긴다", () => {
       window.localStorage.setItem("demo:docs-vault:source", "local");
     });
     await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("radio", { name: "로컬" })).toHaveAttribute(
-      "aria-checked",
-      "true",
-      { timeout: 20_000 },
-    );
+    await expectSourceIsLocal(page);
 
-    await page.getByRole("radio", { name: "샘플" }).click();
+    await switchToSample(page);
     // 되튕김은 즉시 일어난다 — 전환이 붙었으면 그대로 유지되어야 한다.
     await page.waitForTimeout(1_500);
-    await expect(page.getByRole("radio", { name: "샘플" })).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    await expectSourceIsSample(page);
   });
 });

--- a/tests/e2e/local-vault-picker.spec.ts
+++ b/tests/e2e/local-vault-picker.spec.ts
@@ -12,9 +12,37 @@ import { useDogfoodSample } from "./sample-source";
  * read-only + macOS 다운로드 안내")을 단언하던 이전 스펙은 #435 에서
  * 함께 스윕됐어야 할 썩은 스펙이었다.
  *
+ * ⚠️ **[2026-08-08] 소스 표시는 헤더 라디오가 아니라 볼트 칩 메뉴 안에 있다.**
+ * PR #987 이 헤더 우측의 「샘플|로컬」 라디오 쌍을 걷어내고 그 판정을 볼트 칩
+ * 메뉴로 옮겼다. 이 스펙은 그 라디오를 클릭하고 있어서 두 시험이 2분 타임아웃으로
+ * 죽었고 — `docs-deeplink.spec.ts` 와 **같은 원인의 두 번째 피해자**였다.
+ * 소스 상태를 읽을 때는 아래 `expectSourceIs*` 를 쓴다.
+ *
  * 실행: 별도 dev server (`next dev -p 3100`) 가 떠 있어야 함.
  *   pnpm exec playwright test tests/e2e/local-vault-picker.spec.ts
  */
+
+/**
+ * 볼트 칩 메뉴를 열어 어느 소스가 선택돼 있는지 읽고 닫는다.
+ *
+ * 메뉴 항목은 `menuitemradio` 라서 선택 상태가 `aria-checked` 로 나온다 —
+ * 라벨 텍스트가 아니라 그 속성을 본다(로케일이 바뀌어도 계약은 그대로다).
+ */
+async function expectSourceIs(page: import("@playwright/test").Page, which: "sample" | "local") {
+  await page.getByTestId("vault-chip-menu-trigger").click();
+  const picked = page.getByTestId(`vault-chip-use-${which}`);
+  await expect(picked).toBeVisible({ timeout: 10_000 });
+  await expect(picked).toHaveAttribute("aria-checked", "true");
+  await page.keyboard.press("Escape");
+  /*
+   * 퇴장을 **기다린다**. Surface 는 나가는 동안 `inert` 로 DOM 에 남아 있고
+   * (`use-presence.ts` 의 EXIT_WINDOW_MS), Playwright 의 텍스트 셀렉터는 inert
+   * 요소도 여전히 찾아낸다 — 실제로 그 때문에 바로 다음 단언이 strict mode 충돌로
+   * 죽었다(메뉴 안 「Built-in sample (this tool's own documents)」이 두 번째로
+   * 잡혔다). 닫힘을 기다리지 않으면 이 헬퍼가 뒤따르는 단언을 오염시킨다.
+   */
+  await expect(picked).toBeHidden();
+}
 
 const PRESET_LOCAL_SOURCE = `
   try { window.localStorage.setItem('demo:docs-vault:source', 'local'); }
@@ -33,9 +61,8 @@ test.describe("local workspace capability gate (N1)", () => {
 
     await page.goto("/en/docs/?intent=local");
 
-    // FSA 지원 브라우저: Local 소스가 활성 + 선택되고 피커 표면이 뜬다.
-    await expect(page.getByRole("radio", { name: "Local" })).toBeEnabled();
-    await expect(page.getByRole("radio", { name: "Local" })).toBeChecked();
+    // FSA 지원 브라우저: Local 소스가 선택되고 피커 표면이 뜬다.
+    await expectSourceIs(page, "local");
     await expect(
       page.getByRole("heading", { name: /Open or create a local workspace/ }),
     ).toBeVisible();
@@ -50,8 +77,12 @@ test.describe("local workspace capability gate (N1)", () => {
     await useDogfoodSample(page);
     await page.goto("/en/docs/");
 
-    await expect(page.getByRole("radio", { name: "Sample" })).toBeChecked();
-    await expect(page.getByRole("banner").getByText(/documents/)).toBeVisible();
+    await expectSourceIs(page, "sample");
+    // 문서 수는 #987 이후 볼트 칩이 갖는다 — 배너 전체를 훑으면 메뉴 문구까지
+    // 걸리므로, 그 사실이 실제로 사는 자리에서 잰다.
+    await expect(page.getByTestId("vault-chip-menu-trigger")).toHaveText(
+      /\d+ documents/,
+    );
     // docs-chrome-round 슬라이스 A 계약: 데스크톱(lg+)에서 문서 목록은 기본
     // 펼침, 헤더 PanelLeft 타일로 0px 접기/펼치기 왕복 (localStorage persist).
     await expect(page.getByRole("navigation", { name: "Document list" })).toBeVisible();


### PR DESCRIPTION
## Summary

main 을 초록으로 되돌리는 PR. 세 갈래가 들어 있고, 셋 다 **CI 가 이미 빨갰던
원인**이다.

### ① 계약 테스트의 타입 좁히기 (원래 이 PR 의 내용)

`expect(hit).toBeTruthy()` 는 타입을 좁히지 않아서 `pnpm exec tsc --noEmit` 가
`Types · Lint · Docs` 에서 실패했다. 명시적 캐스트 + 이른 반환으로 고쳤다.

### ② 멘션이 빈 결과에서 말을 한다

`mentionEmpty` 문구가 어디서도 렌더되지 않는 죽은 카피였다 — `@` 로 없는
이름을 치면 아무 표시 없이 조용한 막다른 길이었다. 이제 그 문구를 그리고
Esc 로 닫힌다.

### ③ e2e 스펙 둘 수리 + 추천 도구 매핑 (이번에 추가)

**이 PR 이 머지되지 못하고 있던 실제 이유다.** `Playwright (chromium 1/3, 2/3)`
가 #987 이후 여섯 PR 동안 빨갰다 — #987 이 문서함 헤더의 「샘플|로컬」 라디오
쌍을 볼트 칩 메뉴로 옮겼는데, 그 라디오를 클릭하는 스펙이 둘 있었다
(`docs-deeplink.spec.ts` 2건 · `local-vault-picker.spec.ts` 2건, 각각 2분
타임아웃).

- 두 스펙이 볼트 칩 메뉴의 `menuitemradio` 를 `aria-checked` 로 읽는다.
- 칩 트리거에 `data-testid="vault-chip-menu-trigger"` — 두 스펙이 번역 문구로
  트리거를 찾고 있었다(한쪽은 `/en/`, 다른 쪽은 `/ko/`). 번역을 고치면 조용히
  죽는 이음새였다.
- 헬퍼가 Escape 뒤 메뉴의 퇴장을 기다린다. Surface 는 나가는 동안 inert 로
  DOM 에 남고 Playwright 의 텍스트 셀렉터가 그것도 찾아내서, 실제로 뒤따르는
  단언이 strict mode 충돌로 죽었다.
- **근본 원인은 매핑 부재였다**: `checks:changed` 에 #987 이 만진 두 경로를
  그대로 넣어도 추천에 Playwright 가 한 줄도 없었다. `src/views/docs-vault/**`
  와 `src/widgets/docs-vault/**` 가 그 화면의 e2e 셋을 권하게 했다.

## Test plan

정적 export 를 새로 빌드하고 **각자 전용 포트**에서 쟀다(다른 에이전트의
서버를 재지 않도록).

| 검사 | 결과 |
|---|---|
| `pnpm exec tsc --noEmit` | 통과 |
| `pnpm exec eslint <바꾼 소스>` | 통과 |
| `pnpm test:contracts` | 1540 통과 |
| `pnpm exec node --test scripts/lib/focused-check-suggestions.test.mjs` | 62 통과 |
| `pnpm test:checks:changed` | 68 통과 |
| Playwright — `docs-deeplink` · `local-vault-picker` · `document-scroll-lock` · `vault-truth-telling` | **19 통과** |

수리 전 빨간 것을 먼저 확인했다: 같은 네 시험이 라디오 셀렉터로는 2분
타임아웃으로 죽었고(로컬 전수 256개 중 4 실패), 고친 뒤 초록이다.

`pnpm checks:changed -- <바꾼 경로 전부>` 가 권한 것을 전부 돌렸다 — 손으로
쓴 목록을 쓰지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)