### PR TITLE
fix: main 에서는 전체 Playwright 가 한 번도 돈 적이 없었다 — 「변경 없음」과 「비교 불가」를 가른다

### DIFF
--- a/scripts/classify-change.mjs
+++ b/scripts/classify-change.mjs
@@ -70,6 +70,46 @@ export function classify(files) {
   };
 }
 
+/**
+ * **「변경 없음」과 「비교할 것이 없음」은 다르다** (2026-08-08 실측).
+ *
+ * 이 파일 아래쪽 주석은 의도를 정확히 적어 뒀다 — *"No comparable base
+ * (shallow checkout, fresh clone, **push to main**) means we cannot tell what
+ * changed — run everything. **Failing open would silently disable CI**, which
+ * is the one outcome worse than a slow pipeline."*
+ *
+ * 그런데 코드는 그 반대를 했다. `resolveBase` 는 `merge-base HEAD origin/main`
+ * 을 돌려주고, **main 으로 푸시하면 HEAD 가 곧 origin/main** 이라 그 merge-base
+ * 는 HEAD 자신이다. `HEAD...HEAD` 의 diff 는 비고, 빈 목록이
+ * `{runtime:false, browser:false}` 로 떨어져 **전부 생략**됐다.
+ *
+ * 결과: 전체 Playwright 가 **main 에서 한 번도 돈 적이 없다.** 확인한 main 런
+ * 넷이 모두 `[classify] runtime=false browser=false — no files changed` 였고,
+ * 잡은 47초에 초록으로 끝났다(체크아웃하고 정리만 했다). 그 초록이 실제
+ * 파손을 태우고 갔다 — #987 이 문서함 헤더 컨트롤을 옮기며 e2e 스펙 둘을
+ * 깼는데, PR 에서는 빨갰지만 main 에서는 생략돼 초록이었다.
+ *
+ * **생략과 통과는 화면에서 똑같이 생긴다.** 그래서 여기서 갈라 준다: base 가
+ * HEAD 자신이면 그것은 「아무것도 안 바뀌었다」가 아니라 「무엇이 바뀌었는지
+ * 알 수 없다」이고, 답은 전부 돌리는 것이다.
+ */
+export function decide({ base, head, files }) {
+  if (!base) {
+    return { runtime: true, browser: true, reason: "no comparable base ref — running everything" };
+  }
+  if (head && base === head) {
+    return {
+      runtime: true,
+      browser: true,
+      reason: "base resolves to HEAD itself (push to the default branch) — running everything",
+    };
+  }
+  if (files.length === 0) {
+    return { runtime: false, browser: false, reason: "no files changed" };
+  }
+  return classify(files);
+}
+
 function git(args) {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
 }
@@ -101,14 +141,17 @@ function emit({ runtime, browser, reason }) {
 if (process.argv[1] && process.argv[1].endsWith("classify-change.mjs")) {
   const baseArg = process.argv.find((a) => a.startsWith("--base="))?.slice("--base=".length);
   const base = resolveBase(baseArg?.trim());
+  const head = (() => {
+    try {
+      return git(["rev-parse", "HEAD"]);
+    } catch {
+      return null;
+    }
+  })();
 
-  // No comparable base (shallow checkout, fresh clone, push to main) means we
-  // cannot tell what changed — run everything. Failing open would silently
-  // disable CI, which is the one outcome worse than a slow pipeline.
-  if (!base) {
-    emit({ runtime: true, browser: true, reason: "no comparable base ref — running everything" });
-  }
-
-  const files = git(["diff", "--name-only", `${base}...HEAD`]).split("\n").filter(Boolean);
-  emit(files.length === 0 ? { runtime: false, browser: false, reason: "no files changed" } : classify(files));
+  // 판정은 `decide` 가 한다 — 순수 함수라 git fixture 없이 시험된다. 무엇을
+  // 「비교할 수 없음」으로 볼지가 이 게이트의 급소이고, 그 판정이 여기 인라인으로
+  // 있던 동안 main 에서 전체 Playwright 가 통째로 생략됐다(`decide` 주석).
+  const files = base ? git(["diff", "--name-only", `${base}...HEAD`]).split("\n").filter(Boolean) : [];
+  emit(decide({ base, head, files }));
 }

--- a/scripts/classify-change.test.mjs
+++ b/scripts/classify-change.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { classify } from "./classify-change.mjs";
+import { classify, decide } from "./classify-change.mjs";
 
 test("runs everything when shipped code changes", () => {
   assert.deepEqual(
@@ -48,11 +48,66 @@ test("a real runtime change still wins even when bundled with prose", () => {
   );
 });
 
-test("fails open — an empty or unknown diff never silently disables CI", () => {
+/*
+ * ⚠️ 이 시험의 예전 이름은 「fails open — an empty or unknown diff never
+ * silently disables CI」였는데, 단언은 **정확히 그 반대**를 못박고 있었다:
+ * 빈 diff → 전부 생략. 이름이 주장하는 성질을 단언이 부정한 것이다.
+ *
+ * `classify` 는 경로를 맞춰 보는 층이라 빈 목록에 대해 «맞는 것 없음» 을
+ * 돌려주는 것이 맞다. 「비교할 수 없으면 전부 돌린다」는 판정은 `decide` 의
+ * 몫이고, 그 판정이 없던 동안 main 에서 전체 Playwright 가 통째로 생략됐다.
+ * 그래서 이름을 사실대로 바꾸고, 성질은 아래 `decide` 시험이 지킨다.
+ */
+test("classify — 경로가 하나도 안 맞으면 빠른 게이트만 (판정층이 아니다)", () => {
   assert.deepEqual({ runtime: false, browser: false }, pick(classify([])));
   // Anything unrecognised outside the runtime list is prose-shaped by
   // definition; the fast gates still run and catch governance drift.
   assert.deepEqual({ runtime: false, browser: false }, pick(classify(["README.md"])));
+});
+
+/*
+ * **여기가 그 사고를 막는 자리다.**
+ *
+ * 실측(2026-08-08): main 런 넷이 전부 `no files changed` 로 전체 Playwright 를
+ * 생략했고 47초에 초록으로 끝났다. `merge-base HEAD origin/main` 이 main 푸시
+ * 에서는 HEAD 자신이라 `HEAD...HEAD` diff 가 비었기 때문이다. 그 초록이 실제
+ * 파손(#987 이 깬 e2e 스펙 둘)을 태우고 갔다.
+ */
+test("decide — base 가 HEAD 자신이면 전부 돌린다 (main 푸시)", () => {
+  const sha = "b85e4eaa9c0ffee0000000000000000000000000";
+  assert.deepEqual(
+    { runtime: true, browser: true },
+    pick(decide({ base: sha, head: sha, files: [] })),
+  );
+});
+
+test("decide — 비교할 base 가 없으면 전부 돌린다", () => {
+  assert.deepEqual(
+    { runtime: true, browser: true },
+    pick(decide({ base: null, head: "abc", files: [] })),
+  );
+});
+
+/*
+ * 공회전 차단 — 위 둘이 「전부 돌린다」를 말할 때, `decide` 가 **무엇이든**
+ * 전부 돌리는 상태가 아닌지 확인한다. base 가 HEAD 와 다르고 걸릴 경로가
+ * 없으면 여전히 빠른 게이트만이어야 한다. 이 단언이 없으면 위의 두 초록은
+ * 「고쳤다」가 아니라 「전부 켜 놓고 잊었다」와 구별되지 않는다.
+ */
+test("decide — 계기가 살아 있다: 진짜 산문 변경은 여전히 빠른 게이트만", () => {
+  assert.deepEqual(
+    { runtime: false, browser: false },
+    pick(decide({ base: "aaa", head: "bbb", files: ["README.md"] })),
+  );
+  assert.deepEqual(
+    { runtime: false, browser: false },
+    pick(decide({ base: "aaa", head: "bbb", files: [] })),
+  );
+  // 그리고 브라우저 경로는 base 가 달라도 제대로 잡힌다.
+  assert.deepEqual(
+    { runtime: true, browser: true },
+    pick(decide({ base: "aaa", head: "bbb", files: ["src/app/providers.tsx"] })),
+  );
 });
 
 function pick({ runtime, browser }) {

--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -277,6 +277,18 @@ const RULES = [
     ],
   },
   {
+    /*
+     * **CI 가 무엇을 돌릴지 정하는 스크립트인데 추천 매핑이 없었다** (2026-08-08).
+     * `pnpm checks:changed -- scripts/classify-change.mjs` 가 «no focused
+     * mapping» 을 돌려줬다 — 이 저장소에서 결과가 가장 큰 스크립트가 정작
+     * 자기 시험을 가리키는 줄을 못 갖고 있었다. 실제로 이 파일의 판정 결함
+     * 하나가 main 에서 전체 Playwright 를 통째로 생략시켰다.
+     */
+    command: 'pnpm exec node --test scripts/classify-change.test.mjs',
+    reason: 'the CI change classifier decides what CI runs at all',
+    matches: [/^scripts\/classify-change\.(?:mjs|test\.mjs)$/],
+  },
+  {
     command: 'pnpm exec vitest run src/shared/lib/cn.test.ts tests/contract/vault-schema.contract.test.ts',
     reason: 'Vitest config, setup, or test discovery changed',
     matches: [/^vitest\.config\.ts$/, /^vitest\.setup\.ts$/],


### PR DESCRIPTION
## Summary

**main 의 초록은 증거가 아니었다.** `scripts/classify-change.mjs` 가 main 푸시
에서 전체 Playwright 와 전체 단위 스위트를 **매번 생략**하고 있었다.

이 파일의 주석은 의도를 정확히 적어 뒀다:

> No comparable base (shallow checkout, fresh clone, **push to main**) means we
> cannot tell what changed — run everything. **Failing open would silently
> disable CI**, which is the one outcome worse than a slow pipeline.

코드는 그 반대를 했다. `resolveBase` 는 `merge-base HEAD origin/main` 을
돌려주는데, **main 으로 푸시하면 HEAD 가 곧 origin/main** 이라 그 merge-base 는
HEAD 자신이다. `HEAD...HEAD` 의 diff 는 비고, 빈 목록이 그대로
`{runtime:false, browser:false}` 로 떨어져 전부 생략됐다.

### 실측

확인한 main 런 넷이 전부 같은 줄을 남겼다:

```
[classify] runtime=false browser=false — no files changed
```

그 잡은 **47초**에 초록으로 끝났다 — 체크아웃하고 정리만 했다. **생략과 통과는
`gh pr checks` 에서 똑같이 `pass` 로 보인다.**

그 초록이 실제 파손을 태우고 갔다: #987 이 문서함 헤더 컨트롤을 볼트 칩 메뉴로
옮기며 e2e 스펙 둘을 깼는데, PR 에서는 `Playwright (chromium 1/3, 2/3)` 가
빨갰지만 main 에서는 생략돼 초록이었다. 그 사이 7개 PR(#987 · #988 · #990~#994)
이 같은 두 샤드를 빨간 채로 머지됐다.

## 무엇을 고쳤나

- 판정을 순수 함수 `decide({base, head, files})` 로 뺐다 — git fixture 없이
  시험된다. **base 가 HEAD 자신이면 「아무것도 안 바뀌었다」가 아니라 「무엇이
  바뀌었는지 알 수 없다」**이고, 답은 전부 돌리는 것이다.
- 기존 시험 하나는 이름이 「fails open — an empty or unknown diff never silently
  disables CI」인데 **단언은 정확히 그 반대**(빈 diff → 전부 생략)를 못박고
  있었다. `classify` 는 경로 맞추기 층이라 그 단언 자체는 맞다 — **이름이
  거짓이었다.** 이름을 사실대로 바꾸고, 그 성질은 새 `decide` 시험이 지킨다.
- 추천 도구가 이 스크립트를 몰랐다 — `pnpm checks:changed --
  scripts/classify-change.mjs` 가 «no focused mapping» 을 돌려줬다. CI 가 무엇을
  돌릴지 정하는 스크립트가 자기 시험을 가리키는 줄을 못 갖고 있었다.

## 대가

main 푸시마다 전체 스위트가 돈다. 그게 이 파일이 스스로 정해 둔 교환이다 —
*"A missed test is a bug that ships; a redundant test is four minutes."*
PR 쪽 절감은 그대로다(경로 기반 판정에 변화 없음).

## Test plan

| 검사 | 결과 |
|---|---|
| `pnpm exec node --test scripts/classify-change.test.mjs` | 9 통과 (신규 4) |
| `pnpm exec node --test scripts/lib/focused-check-suggestions.test.mjs` | 62 통과 |
| `pnpm test:checks:changed` | 통과 |
| 실제 스크립트 재현 실행 | `runtime=true browser=true — base resolves to HEAD itself (push to the default branch)` |

**게이트 프로브** (`/gate-probe` — 통과는 증거가 아니다):

- **지키는 property**: main 으로 푸시할 때 전체 e2e·단위 스위트가 생략되지 않는다.
- **되돌리기**: `if (head && base === head)` 를 `if (false && …)` 로 그 줄만
  되돌렸다 → `decide — base 가 HEAD 자신이면 전부 돌린다 (main 푸시)` 가
  **빨개졌다**. 복구 후 9/9 초록.
- **공회전 차단**: 「계기가 살아 있다」 시험이 base≠head 인 산문 변경은 여전히
  빠른 게이트만 받는지 단언한다 — 없으면 「고쳤다」와 「전부 켜 놓고 잊었다」가
  구별되지 않는다.
- **물려 있는 곳**: `.github/workflows/e2e.yml` · `checks.yml` 이 이 스크립트를
  부르고, `checks:changed` 가 이제 그 시험을 추천한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)