### PR TITLE
fix: 릴리스 게이트를 막고 있던 high 취약점을 닫는다 — nanoid 3.3.16 → 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
   "pnpm": {
     "overrides": {
       "brace-expansion@<1.1.16": "1.1.16",
+      "nanoid@<3.3.17": "3.3.18",
       "@hono/node-server@<2.0.5": "2.0.11",
       "postcss@<8.5.10": "8.5.22",
       "sharp@<0.35.0": "0.35.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion@<1.1.16: 1.1.16
+  nanoid@<3.3.17: 3.3.18
   '@hono/node-server@<2.0.5': 2.0.11
   postcss@<8.5.10: 8.5.22
   sharp@<0.35.0: 0.35.3
@@ -3445,8 +3446,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7550,7 +7551,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -7778,7 +7779,7 @@ snapshots:
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

`pnpm audit --prod --audit-level=high` 는 **macOS 릴리스와 Windows 베타 검증
둘 다**가 돌리는 스텝이고, 그 스텝이 실패하고 있었다.

```
high  nanoid: custom generators can loop indefinitely when size is zero
Paths .>next>postcss>nanoid        (vulnerable <3.3.17, 설치된 것 3.3.16)
```

#988 의 「Verify unsigned Windows x64 beta」 실패가 Windows 빌드 문제처럼 보였는데
실은 이것이었다 — 로그 583줄이 전부 초록이고 마지막에 audit 표만 있었다.

이미 있는 `pnpm.overrides` 관례(`brace-expansion@<…` · `postcss@<…` 등)를 그대로
따라 한 줄 더했다. 새 dependency 를 들이는 것이 아니라 전이 의존성의 패치
버전을 올리는 것이다.

`--prod` 기준 high 는 이 한 건뿐이었다 — brace-expansion · js-yaml · undici 는
dev 전용이라 게이트 범위 밖이다.

## 남기는 것

postcss 8.5.22 의 **moderate** 1건. `--audit-level=high` 가 보지 않으므로 게이트를
막지 않고, CSS 파이프라인 버전을 올리는 일이라 릴리스를 여는 이 PR 에 섞지 않는다.

## Test plan

| 검사 | 전 | 후 |
|---|---|---|
| `pnpm audit --prod --audit-level=high` (게이트가 돌리는 그 명령) | **high 1건** | **0건** (moderate 1, exit 0) |
| `pnpm build` (nanoid 는 빌드 시점 의존성이다) | — | 통과 |
| `pnpm desktop:check` | — | 통과 |
| `pnpm test:mcp:package` | — | 통과 |
| `pnpm test:dogfood:script-refs` | — | 통과 |
| `pnpm package:check` | — | 통과 |

`pnpm checks:changed -- package.json pnpm-lock.yaml` 가 권한 것을 전부 돌렸고,
nanoid 가 빌드 파이프라인에 들어 있으므로 `pnpm build` 를 더했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)