### PR TITLE
fix: 문서를 바꿀 때 회색 줄 3개가 한 프레임 깜빡였다 — 0ms 짜리 일에 로딩 표시를 안 그린다

### DIFF
--- a/src/shared/lib/use-delayed-visible.test.tsx
+++ b/src/shared/lib/use-delayed-visible.test.tsx
@@ -1,0 +1,94 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SKELETON_DELAY_MS, useDelayedVisible } from './use-presence';
+
+/**
+ * **0ms 짜리 일에 로딩 표시를 그리지 않는다** — 이 시험이 지키는 성질.
+ *
+ * 소유자 제보(2026-08-08): *"문서 선택해서 이동할때 우측 문서화면에 좀 이상하게
+ * 회색선이 3개 생겼다가 사라지거든? 거의 1초도 안걸려서 깜빡이다 사라져서"*.
+ *
+ * 브라우저 실측으로 원인을 확정했다: 문서 8회 전환 전부에서 뷰어의 3줄 스켈레톤이
+ * **8.2~15.9ms**(중앙값 9.7ms) 동안 그려졌다 — 60Hz 한 프레임(16.7ms) 안쪽이다.
+ * 느린 로딩이 아니라, 부모의 `key={doc.slug}` 리마운트 때문에 본문 상태가 매번
+ * null 로 시작하고 프로미스가 다음 틱에 풀리면서 **최소 한 프레임은 스켈레톤이
+ * 이기는** 구조였다.
+ *
+ * 그래서 잠그는 성질은 「빠르면 아예 안 나타난다」와 「느리면 여전히 나타난다」
+ * **둘 다**다. 앞만 잠그면 다음 사람이 스켈레톤을 통째로 지워도 초록이고, 뒤만
+ * 잠그면 원래 결함이 그대로 통과한다.
+ */
+
+function Probe({ active }: { active: boolean }) {
+  const visible = useDelayedVisible(active);
+  return <span data-testid="state">{visible ? 'visible' : 'hidden'}</span>;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDelayedVisible — 기다릴 것이 있을 때만 보인다', () => {
+  it('창보다 먼저 끝나면 한 번도 나타나지 않는다', () => {
+    const { getByTestId, rerender } = render(<Probe active />);
+    expect(getByTestId('state').textContent).toBe('hidden');
+
+    // 실측된 실제 소요(≈10ms)만큼 흐른 뒤 로딩이 끝난다.
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+    rerender(<Probe active={false} />);
+
+    // 남은 창이 다 지나도 끝까지 안 나타나야 한다 — 타이머가 살아 있으면
+    // 여기서 'visible' 이 되고, 그게 소유자가 본 그 깜빡임이다.
+    act(() => {
+      vi.advanceTimersByTime(SKELETON_DELAY_MS * 2);
+    });
+    expect(getByTestId('state').textContent).toBe('hidden');
+  });
+
+  it('창을 넘겨 오래 걸리면 나타난다 — 진짜 기다림은 여전히 알린다', () => {
+    const { getByTestId } = render(<Probe active />);
+
+    act(() => {
+      vi.advanceTimersByTime(SKELETON_DELAY_MS - 1);
+    });
+    expect(getByTestId('state').textContent).toBe('hidden');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(getByTestId('state').textContent).toBe('visible');
+  });
+
+  it('다시 기다리게 되면 창도 다시 시작한다 — 이전 표시가 남아 있지 않다', () => {
+    const { getByTestId, rerender } = render(<Probe active />);
+    act(() => {
+      vi.advanceTimersByTime(SKELETON_DELAY_MS);
+    });
+    expect(getByTestId('state').textContent).toBe('visible');
+
+    rerender(<Probe active={false} />);
+    expect(getByTestId('state').textContent).toBe('hidden');
+
+    rerender(<Probe active />);
+    act(() => {
+      vi.advanceTimersByTime(SKELETON_DELAY_MS - 1);
+    });
+    expect(getByTestId('state').textContent).toBe('hidden');
+  });
+
+  /**
+   * 값이 감각 문턱 아래로 내려가면 이 게이트는 아무것도 안 지킨다 — 한 프레임
+   * (16.7ms)보다 큰지, 그리고 「생각의 흐름이 끊긴다」는 1초보다 훨씬 작은지.
+   */
+  it('창 값이 의미 있는 범위에 있다', () => {
+    expect(SKELETON_DELAY_MS).toBeGreaterThan(17);
+    expect(SKELETON_DELAY_MS).toBeLessThan(400);
+  });
+});

--- a/src/shared/lib/use-presence.ts
+++ b/src/shared/lib/use-presence.ts
@@ -18,6 +18,56 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 export const EXIT_WINDOW_MS = 140;
 
 /**
+ * **0ms 짜리 일에 로딩 표시를 그리지 않는다.**
+ *
+ * 실측(2026-08-08, 소유자 제보 — *"회색선이 3개 생겼다가 사라지거든? 거의
+ * 1초도 안걸려서 깜빡이다 사라져서"*): 문서함에서 문서를 바꿀 때 뷰어의 3줄
+ * 스켈레톤이 **8.2~15.9ms**(중앙값 9.7ms) 동안 그려졌다 — 60Hz 한 프레임
+ * (16.7ms) 안쪽이다. 8회 전환 전부에서 났다.
+ *
+ * 원인은 느린 로딩이 아니다. 부모가 `key={doc.slug}` 로 뷰어를 **리마운트**
+ * 하므로 본문 상태가 매번 `null` 로 시작하고, 본문이 이미 메모리에 있어도
+ * 프로미스는 다음 틱에 풀리므로 **최소 한 프레임은 스켈레톤이 이긴다.**
+ * 즉 기다릴 것이 없는데 기다리라고 말하는 표시였다.
+ *
+ * 그래서 이 창이 지나기 전에 끝나는 일은 **아무것도 그리지 않는다.**
+ *
+ * 값의 근거: Nielsen(1993)의 0.1초 — 그 안에 끝나면 사람은 지연을 아예
+ * 느끼지 않으므로 알릴 것이 없다. 여유 50ms 는 느린 프레임 두어 장에
+ * 스켈레톤이 걸려 도로 깜빡이지 않게 하는 몫이고, 진짜 느린 읽기는 여전히
+ * 「생각의 흐름이 끊긴다」는 1초 경계보다 훨씬 앞서 표시를 받는다.
+ *
+ * `EXIT_WINDOW_MS` 와 같은 부류다 — **모션 값이 아니라 마운트 타이머**라서
+ * `--motion-*` 램프를 읽지 않는다.
+ */
+export const SKELETON_DELAY_MS = 150;
+
+/**
+ * `active` 가 이 창보다 오래 유지될 때만 `true` 가 된다. 먼저 끝나면 한 번도
+ * `true` 가 되지 않으므로 화면에 아무것도 안 나타난다.
+ */
+export function useDelayedVisible(
+  active: boolean,
+  delayMs: number = SKELETON_DELAY_MS,
+): boolean {
+  const [elapsed, setElapsed] = useState(false);
+  useEffect(() => {
+    if (!active) return;
+    const timer = setTimeout(() => setElapsed(true), delayMs);
+    /*
+     * 정리 단계에서 되돌린다 — effect 본문에서 동기로 state 를 바꾸면 렌더가
+     * 연쇄된다(lint 가 경고한다). 그리고 `active` 를 곱해서 돌려주므로,
+     * 되돌리기가 한 틱 늦어도 그 사이에 표시가 새지 않는다.
+     */
+    return () => {
+      clearTimeout(timer);
+      setElapsed(false);
+    };
+  }, [active, delayMs]);
+  return active && elapsed;
+}
+
+/**
  * 하나의 표면이 열리고 닫히는 경우. `open` 이 꺼져도 퇴장 애니가 끝날 때까지
  * `mounted` 를 유지하고, 그 동안 `exiting` 으로 퇴장 클래스를 입힌다.
  */

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx
@@ -323,9 +323,18 @@ describe('DocsVaultEditor', () => {
     ).toBeInTheDocument();
   });
 
-  it('로딩 스켈레톤이 role=status 로 announce 된다 (a11y)', async () => {
-    // content 가 resolve 되기 전 초기 로딩 상태 — 스켈레톤이 스크린리더에
-    // "불러오는 중" 으로 announce 돼야 한다.
+  /*
+   * **오래 걸리는 로딩은 여전히 알린다.**
+   *
+   * 2026-08-08 에 스켈레톤을 `SKELETON_DELAY_MS`(150ms) 뒤로 미뤘다 — 문서를
+   * 바꿀 때 3줄 바가 한 프레임만 깜빡이던 결함 때문이다(실측 8.2~15.9ms).
+   * 그래서 이 시험도 **창을 넘긴 뒤** 재야 한다.
+   *
+   * ⚠️ 이 시험을 지우지 않는 이유: 지연은 「빠르면 안 보인다」를 위한 것이고,
+   * 「느리면 알린다」는 성질은 그대로 살아 있어야 한다. 지우면 다음 사람이
+   * 스켈레톤을 통째로 없애도 아무것도 안 터진다.
+   */
+  it('오래 걸리는 로딩은 role=status 로 announce 된다 (a11y)', async () => {
     let resolve!: (v: string) => void;
     render(
       <DocsVaultEditor vaultScope={VAULT_SCOPE}
@@ -335,7 +344,9 @@ describe('DocsVaultEditor', () => {
         onClose={vi.fn()}
       />,
     );
-    const status = screen.getByRole('status');
+    // 창이 지나기 전에는 아무것도 알리지 않는다 — 기다릴 것이 없을 수 있다.
+    expect(screen.queryByRole('status')).toBeNull();
+    const status = await screen.findByRole('status', {}, { timeout: 2_000 });
     expect(status).toHaveAttribute('aria-label', '파일 불러오는 중…');
     // 마무리: resolve 해서 dangling promise 정리.
     resolve('done');

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -27,7 +27,7 @@ import { ICON_SIZE } from '@/shared/ui/icon-size';
 import type { VaultDoc } from '@/entities/docs-vault';
 import { useOntologyKindLabel } from '@/entities/ontology-class';
 import { resolveLocaleDisplayName } from '@/shared/lib/locale-display-name';
-import { useHeldValue } from '@/shared/lib/use-presence';
+import { useDelayedVisible, useHeldValue } from '@/shared/lib/use-presence';
 import { caretPoint, clampMenuToBox } from '../lib/caret-position';
 import {
   detectMentionTrigger,
@@ -589,6 +589,12 @@ export function DocsVaultEditor({
   }, [doSave, insertLink, requestClose, wrapSelection]);
 
   const loading = loadedSlug !== doc.slug;
+  /*
+   * 뷰어와 같은 이유로 지연시킨다 — 문서를 바꿀 때 이 3줄 바가 한 프레임만
+   * 깜빡였다(`SKELETON_DELAY_MS` 주석의 실측). 같은 화면에서 두 표면이 같은
+   * 규율을 따라야 편집/읽기를 왕복할 때 한쪽만 깜빡이지 않는다.
+   */
+  const showSkeleton = useDelayedVisible(loading || content === null);
   const saveState = saving
     ? { label: t('saving'), body: t('savingDetail'), tone: 'saving' }
     : dirty
@@ -620,6 +626,7 @@ export function DocsVaultEditor({
     );
   }
   if (loading || content === null) {
+    if (!showSkeleton) return <div className="p-8" aria-hidden />;
     return (
       <div className="flex flex-col gap-3 p-8" role="status" aria-label={t('loadingLabel')}>
         <div className="h-3 w-2/3 animate-pulse rounded-micro bg-[color:var(--color-border-soft)]" aria-hidden />

--- a/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultViewer.tsx
@@ -16,6 +16,7 @@ import { useStaticVaultSource } from '@/features/vault-sample-source';
 import { IconButton } from '@/shared/ui';
 import { splitHighlightSegments } from '@/shared/lib/highlight-match';
 import { useCopyFeedback } from '@/shared/lib/use-copy-feedback';
+import { useDelayedVisible } from '@/shared/lib/use-presence';
 import { fetchServerDocContent } from '../lib/server-doc-content';
 import { resolveDocLink } from '../lib/resolve-doc-link';
 
@@ -71,6 +72,13 @@ export function DocsVaultViewer({
   const t = useTranslations('vaultWidgets.viewer');
   const [raw, setRaw] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /*
+   * 스켈레톤은 **기다릴 것이 있을 때만** 나온다. 이 컴포넌트는 문서를 바꿀
+   * 때마다 리마운트되므로 `raw` 가 매번 null 로 시작하는데, 본문이 이미
+   * 손에 있는 경우가 대부분이라 종전에는 3줄 바가 한 프레임만 깜빡였다
+   * (실측 8.2~15.9ms · `SKELETON_DELAY_MS` 주석).
+   */
+  const showSkeleton = useDelayedVisible(raw === null && error === null);
   // static 볼트의 번들 본문 — 매니페스트를 고른 것과 **같은 볼트**에서 와야
   // 한다. 예전 결함이 정확히 이 어긋남이었다(매니페스트는 예시 쇼핑몰,
   // 본문은 도그푸드라 제목과 내용이 다른 문서를 가리켰다).
@@ -568,6 +576,12 @@ export function DocsVaultViewer({
     );
   }
   if (raw === null) {
+    /*
+     * 창이 지나기 전에 본문이 오면 아무것도 그리지 않는다 — 빈 자리가
+     * 한 프레임 깜빡이는 로딩 바보다 조용하다. 읽어 줄 것도 없으므로
+     * `role="status"` 도 그때는 만들지 않는다.
+     */
+    if (!showSkeleton) return <div className="p-8" aria-hidden />;
     return (
       <div className="flex flex-col gap-3 p-8" role="status" aria-label={t('loadingLabel')}>
         <div className="h-3 w-2/3 animate-pulse rounded-micro bg-[color:var(--color-border-soft)]" aria-hidden />


### PR DESCRIPTION
## Summary

소유자 제보: *"문서 선택해서 이동할때 우측 문서화면에 좀 이상하게 회색선이 3개
생겼다가 사라지거든? 거의 1초도 안걸려서 깜빡이다 사라져서"*.

브라우저에서 `MutationObserver` 로 그 요소의 수명을 재서 원인을 확정했다.

| | 전 | 후 |
|---|---|---|
| 문서 전환 8회 중 스켈레톤이 나타난 횟수 | **8회** | **0회** |
| 그때 화면에 머문 시간 | **8.2 · 13.2 · 15.9 · 8.2 · 9.6 · 9.8 · 9.7 · 9.5 ms** | — |

중앙값 9.7ms — **60Hz 한 프레임(16.7ms) 안쪽**이다. 즉 느린 로딩이 아니었다.

## 왜 그랬나

부모가 `key={doc.slug}` 로 뷰어를 **리마운트**하므로 본문 상태가 매번 `null` 로
시작한다. 본문이 이미 메모리에 있어도 프로미스는 다음 틱에 풀리므로 **최소 한
프레임은 스켈레톤이 이긴다.** 기다릴 것이 없는데 기다리라고 말하는 표시였다.

## 무엇을 고쳤나

창(`SKELETON_DELAY_MS` = 150ms)이 지나기 전에 끝나는 일은 **아무것도 그리지
않는다**. 값의 근거는 Nielsen(1993)의 0.1초 — 그 안에 끝나면 사람은 지연을 아예
느끼지 않으므로 알릴 것이 없다. 여유 50ms 는 느린 프레임 두어 장에 걸려 도로
깜빡이지 않게 하는 몫이고, 진짜 느린 읽기는 「생각의 흐름이 끊긴다」는 1초
경계보다 훨씬 앞서 표시를 받는다.

**편집기도 같은 스켈레톤을 같은 경로에서 그린다** — 한쪽만 고치면 읽기/편집을
왕복할 때 한쪽만 깜빡인다. 둘 다 같은 훅을 쓴다.

값의 자리: `EXIT_WINDOW_MS` 와 같은 부류라 같은 파일에 뒀다 — **모션 값이 아니라
마운트 타이머**라서 `--motion-*` 램프를 읽지 않는다(그 파일이 이미 그 구분을
문서화해 두고 있다). 램프 스텝을 새로 만들지 않았으므로 새 토큰 0개.

## 지운 것이 아니라 옮긴 것

기존 a11y 시험 「로딩 스켈레톤이 role=status 로 announce 된다」는 **지우지 않고**
창을 넘긴 뒤 재도록 고쳤다. 지연은 「빠르면 안 보인다」를 위한 것이고, 「느리면
알린다」는 성질은 그대로 살아 있어야 한다 — 지우면 다음 사람이 스켈레톤을 통째로
없애도 아무것도 안 터진다.

## Test plan

| 검사 | 결과 |
|---|---|
| `pnpm exec vitest run src/shared/lib/use-delayed-visible.test.tsx` | 4 통과 (신규) |
| `pnpm exec vitest run …DocsVaultViewer.test.tsx …DocsVaultEditor.test.tsx` | 21 통과 |
| `pnpm test:contracts` | 130 파일 · 1540 통과 |
| Playwright `docs-deeplink` · `document-scroll-lock` · `vault-truth-telling` | 17 통과 |
| `pnpm exec tsc --noEmit` · `pnpm exec eslint <바꾼 파일>` | 통과 (새 경고 0) |
| `pnpm build` | 통과 |
| 브라우저 실측 (1512×900, 정적 export) | 전환 8회 · 스켈레톤 등장 **0회** · 본문 정상 렌더 |

**게이트 프로브** (`/gate-probe`):

- **지키는 property**: 문서를 바꿀 때, 감각 문턱 아래에서 끝나는 로딩은 화면에
  아무것도 그리지 않는다 — 그러나 진짜 느린 로딩은 여전히 알린다.
- **되돌리기**: `return active && elapsed` → `return active` 로 그 줄만 되돌렸다
  → 4개 중 **3개가 빨개졌다**. 복구 후 4/4 초록.
- **공회전 차단**: 「창을 넘겨 오래 걸리면 나타난다」와 창 값이 한 프레임보다
  크고 1초보다 작은지 재는 단언이 함께 있다 — 앞만 잠그면 스켈레톤을 통째로
  지워도 초록이 된다.
- **물려 있는 곳**: `checks:changed` 가 세 단위 시험 + 문서함 e2e 셋을 권한다.

`pnpm checks:changed -- <바꾼 경로 전부>` 가 권한 것을 전부 돌렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)