### PR TITLE
fix: 문서 위에 상주하던 「가르치는 줄」 둘을 걷어낸다 — 제목 위 크롬 377 → 300px

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1238,8 +1238,6 @@
         "recordProofAria": "Map evidence",
         "recordProofLabel": "Map evidence",
         "pathLabel": "Path",
-        "recordProofBody": "Local markdown evidence agents can cite before updating the map.",
-        "recordProofOntologyBody": "This document's fields connect it to a {kind} concept. Agents can query, cite, and update this evidence.",
         "wordsUnit": "{count} words",
         "readingMinutes": "≈ {minutes} min read",
         "ontologyKindTitle": "Open {kind} node in the map",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1238,8 +1238,6 @@
         "recordProofAria": "지도 근거",
         "recordProofLabel": "지도 근거",
         "pathLabel": "경로",
-        "recordProofBody": "그래프를 뒷받침하는 로컬 마크다운 근거로, 에이전트가 지도 갱신 전 인용할 수 있습니다.",
-        "recordProofOntologyBody": "이 문서 속성이 {kind} 개념으로 연결됩니다. 에이전트는 이 근거를 쿼리, 인용, 갱신할 수 있습니다.",
         "wordsUnit": "{count} 단어",
         "readingMinutes": "≈ {minutes}분 읽기",
         "ontologyKindTitle": "{kind} 노드를 지도에서 보기",

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.test.tsx
@@ -53,6 +53,34 @@ describe("DocFrontmatterBlock", () => {
     expect(summary.getByText("속성 6개")).toBeInTheDocument();
   });
 
+  /**
+   * **문서마다 반복되는 「가르치는 줄」은 상주하지 않는다** (2026-08-08, 소유자
+   * 지적 — *"문서 볼 때 상단이 조금 이상한데.. 보기좋게 구성할순없나?"*).
+   *
+   * 「규격 예시 보기」는 문서마다 달라지지 않는 설명이다. 그런데 접힌 상태에서도
+   * 자기 줄을 갖고 있어서, 읽으러 온 사람의 화면에서 본문을 25px 씩 아래로
+   * 밀었다 — 배포 샘플 볼트의 **112개 문서 전부**에서.
+   *
+   * 필요한 순간은 「이 속성이 무엇을 받나」를 알고 싶을 때이고, 그건 이 속성
+   * 블록을 여는 순간이다. 그래서 그 안으로 옮겼다.
+   *
+   * ⚠️ 이 시험이 없으면 되돌아간다 — 앞선 단위 시험들은 `getByTestId` 로 DOM
+   * 존재만 보므로 토글이 details **밖**에 있어도 전부 초록이었다(실측).
+   */
+  it("규격 예시 토글은 접힌 속성 블록 안에 있다 — 읽는 화면에 상주하지 않는다", () => {
+    renderBlock();
+    const details = screen.getByTestId("doc-frontmatter-block").querySelector("details");
+    expect(details).not.toHaveAttribute("open");
+
+    const toggle = screen.queryByTestId("doc-frontmatter-example-toggle");
+    // 예시가 없는 kind 면 이 시험은 공회전한다 — 그 경우를 먼저 배제한다.
+    expect(toggle, "이 fixture 에 규격 예시가 없다 — 시험이 헛돈다").not.toBeNull();
+    expect(
+      toggle?.closest("details:not([open])"),
+      "「규격 예시 보기」가 접힌 속성 블록 밖에 있다 — 읽으러 온 사람의 본문을 밀어낸다",
+    ).toBe(details);
+  });
+
   it("reveals the full mono frontmatter block when expanded", () => {
     renderBlock();
     const summary = screen.getByTestId("doc-frontmatter-summary");

--- a/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
+++ b/src/views/docs-vault/ui/parts/DocFrontmatterBlock.tsx
@@ -703,6 +703,54 @@ export function DocFrontmatterBlock({
           </svg>
           {t("note")}
         </p>
+        {/* 규격 예시는 **속성을 열었을 때** 자리를 얻는다 (2026-08-08).
+            문서마다 달라지지 않는 가르치는 줄이 112개 문서 위에 상주하고
+            있었다 — 읽으러 온 사람에게는 한 줄을 먹는 노이즈이고, 정작
+            필요한 순간(속성이 뭘 받는지 알고 싶을 때)은 이 속성 블록을
+            여는 순간이다. 그 순간으로 옮긴다. */}
+        {exampleDoc ? (
+          <div className="mt-2 font-sans">
+            <button
+              type="button"
+              onClick={() => setExampleOpen((v) => !v)}
+              aria-expanded={exampleOpen}
+              aria-controls="doc-frontmatter-example"
+              data-testid="doc-frontmatter-example-toggle"
+              className={controlClass({
+                shape: "link",
+                tone: "muted",
+                className: "touch-hit-expand hover:text-[color:var(--color-text-secondary)]",
+              })}
+            >
+              <ChevronRight
+                size={ICON_SIZE.sm}
+                aria-hidden
+                className={`transition-transform motion-reduce:transition-none ${
+                  exampleOpen ? "rotate-90" : ""
+                }`}
+              />
+              {t("exampleToggle")}
+            </button>
+            {exampleOpen ? (
+              <div
+                id="doc-frontmatter-example"
+                data-testid="doc-frontmatter-example"
+                className="mt-2 flex items-start gap-2 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2"
+              >
+                <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-label leading-label text-[color:var(--color-text-secondary)]">
+                  {exampleDoc}
+                </pre>
+                <CompactCopyButton
+                  copied={exampleCopyState === "copied"}
+                  label={exampleCopyState === "copied" ? t("exampleCopied") : t("exampleCopy")}
+                  ariaLabel={t("exampleCopyAriaLabel")}
+                  onClick={() => void copyExample(exampleDoc)}
+                  data-testid="doc-frontmatter-example-copy"
+                />
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </details>
       {lastEditSubjectRow ? (
         <div className="mt-2 font-sans">
@@ -720,49 +768,6 @@ export function DocFrontmatterBlock({
         </div>
       ) : null}
       {issueRows}
-      {exampleDoc ? (
-        <div className="mt-2 font-sans">
-          <button
-            type="button"
-            onClick={() => setExampleOpen((v) => !v)}
-            aria-expanded={exampleOpen}
-            aria-controls="doc-frontmatter-example"
-            data-testid="doc-frontmatter-example-toggle"
-            className={controlClass({
-              shape: "link",
-              tone: "muted",
-              className: "touch-hit-expand hover:text-[color:var(--color-text-secondary)]",
-            })}
-          >
-            <ChevronRight
-              size={ICON_SIZE.sm}
-              aria-hidden
-              className={`transition-transform motion-reduce:transition-none ${
-                exampleOpen ? "rotate-90" : ""
-              }`}
-            />
-            {t("exampleToggle")}
-          </button>
-          {exampleOpen ? (
-            <div
-              id="doc-frontmatter-example"
-              data-testid="doc-frontmatter-example"
-              className="mt-2 flex items-start gap-2 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2.5 py-2"
-            >
-              <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-label leading-label text-[color:var(--color-text-secondary)]">
-                {exampleDoc}
-              </pre>
-              <CompactCopyButton
-                copied={exampleCopyState === "copied"}
-                label={exampleCopyState === "copied" ? t("exampleCopied") : t("exampleCopy")}
-                ariaLabel={t("exampleCopyAriaLabel")}
-                onClick={() => void copyExample(exampleDoc)}
-                data-testid="doc-frontmatter-example-copy"
-              />
-            </div>
-          ) : null}
-        </div>
-      ) : null}
     </section>
   );
 }

--- a/src/views/docs-vault/ui/parts/DocMetaBar.render.test.tsx
+++ b/src/views/docs-vault/ui/parts/DocMetaBar.render.test.tsx
@@ -49,7 +49,18 @@ function renderMetaBar(targetDoc: VaultDoc = doc) {
 }
 
 describe("DocMetaBar", () => {
-  it("frames ontology records as readable evidence instead of frontmatter jargon", () => {
+  /*
+   * **이름이 바뀐 이유 (2026-08-08)**: 종전 이 시험은 지도에 **있는** 문서에서도
+   * 설명 문장이 렌더되는 것을 계약으로 못박고 있었다. 그건 계약이 아니라 낭비였다 —
+   * 그 문장은 바로 왼쪽 칩(「지도 근거」)과 오른쪽 링크(「지형도」)가 이미 말한 것을
+   * 다시 말하면서 본문 위에 한 줄을 통째로 먹는다. 실측: 배포 샘플 볼트는 112개
+   * 문서 **전부가 노드**라 같은 문장이 112번 반복됐다.
+   *
+   * 지키는 성질은 그대로다 — 「지도에 있다」가 **사람이 읽는 말**로 나오고,
+   * frontmatter 전문용어가 화면에 안 나온다. 설명이 필요한 경우(지도에 없는 문서)는
+   * 아래 시험이 따로 지킨다.
+   */
+  it("in-graph 문서는 칩으로만 말한다 — 같은 말을 문장으로 되풀이하지 않는다", () => {
     renderMetaBar();
 
     expect(
@@ -61,12 +72,13 @@ describe("DocMetaBar", () => {
     expect(
       screen.queryByText("docs/ontology/capabilities/agent-graph-readiness.md"),
     ).not.toBeInTheDocument();
+    // 칩이 말한 것을 문장으로 한 번 더 말하지 않는다.
     expect(
-      screen.getByText(
-        "이 문서 속성이 capability 개념으로 연결됩니다. 에이전트는 이 근거를 쿼리, 인용, 갱신할 수 있습니다.",
-      ),
-    ).toBeInTheDocument();
+      screen.queryByText(/개념으로 연결됩니다/),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/frontmatter/)).not.toBeInTheDocument();
+    // 그러나 지도로 가는 길은 그대로 있다 — 줄인 것은 설명이고 사실이 아니다.
+    expect(screen.getByTestId("doc-map-open")).toBeInTheDocument();
   });
 
   // 이름이 바뀐 이유 (2026-08-04): 종전 이 테스트는 그래프에 **없는** 문서가

--- a/src/views/docs-vault/ui/parts/DocMetaBar.tsx
+++ b/src/views/docs-vault/ui/parts/DocMetaBar.tsx
@@ -1,7 +1,6 @@
 import { useLocale, useTranslations } from "next-intl";
 import { FileText, Network } from "lucide-react";
 import {
-  buildOntologyDeeplinkForDoc,
   buildTopologyDeeplinkForDoc,
   type VaultDoc,
 } from "@/entities/docs-vault";
@@ -33,10 +32,6 @@ export function DocMetaBar({ doc }: { doc: VaultDoc }) {
   const numberLocale = locale === "ko" ? "ko-KR" : "en-US";
   const readingMinutes = estimateReadingMinutes(doc.wordCount);
   const updated = new Date(doc.updatedAt);
-  const ontologyHref = buildOntologyDeeplinkForDoc(doc);
-  const kindValue = ontologyHref
-    ? String(doc.frontmatter?.kind ?? "").trim()
-    : "";
   // 토폴로지가 전체 ontology 그래프를 렌더하므로 project·domain·capability·element
   // 모두 1:1 노드를 가져 토폴로지로 점프 가능 (buildTopologyDeeplinkForDoc 이 kind 별 처리).
   const topologyHref = buildTopologyDeeplinkForDoc(doc);
@@ -51,37 +46,69 @@ export function DocMetaBar({ doc }: { doc: VaultDoc }) {
    * 말하는데 CTA 가 못 가는 상태가 구조적으로 불가능해진다.
    */
   const inGraph = topologyHref != null;
-  const proofBody = !inGraph
-    ? t("notOnMapBody")
-    : ontologyHref && kindValue
-      ? t("recordProofOntologyBody", { kind: kindValue })
-      : t("recordProofBody");
+  /*
+   * **설명은 그것이 무언가를 바꿀 때만 자리를 얻는다** (2026-08-08, 소유자 지적
+   * — *"문서 볼 때 상단이 조금 이상한데.. 보기좋게 구성할순없나?"*).
+   *
+   * 종전엔 어느 문서에서나 이 줄이 나왔다. 그런데 지도에 **있는** 문서에서
+   * 그 문장은 아무것도 새로 말하지 않는다 — 바로 왼쪽 칩이 「지도 근거」라고
+   * 적혀 있고 오른쪽에 「지형도」로 가는 링크가 있다. 그러면서 본문 위에 한 줄을
+   * 통째로 먹는다. 실측: 배포 샘플 볼트는 **112개 문서 전부가 노드**라, 같은
+   * 문장이 112번 반복되며 매번 본문을 아래로 밀었다.
+   *
+   * 지도에 **없는** 문서에서는 반대다 — 왜 없는지와 무엇을 할지가 그 문장에만
+   * 있다(도그푸드 볼트의 82개가 그 경우다). 그래서 그때만 남긴다. 이 저장소의
+   * 강등 카드 규율과 같은 모양이다: 못 하는 경우에 이유와 갈 곳을 말한다.
+   *
+   * 툴팁으로 옮기지 않은 이유: 손가락으로 만지는 기기에서 호버가 없어 사실상
+   * 사라지고, 그러면 「타입 있는 사실을 숨긴다」가 된다.
+   */
+  const proofBody = inGraph ? null : t("notOnMapBody");
 
   return (
     <section
       aria-label={inGraph ? t("recordProofAria") : t("notOnMapAria")}
-      className="mx-auto flex max-w-[760px] flex-col gap-2 border-b border-[color:var(--color-overlay-2)] px-6 py-3 text-label text-[color:var(--color-text-quaternary)] md:px-10"
+      className="mx-auto flex max-w-[760px] flex-col gap-2 border-b border-[color:var(--color-overlay-2)] px-6 py-2 text-label text-[color:var(--color-text-quaternary)] md:px-10"
     >
-      <div className="flex min-w-0 flex-wrap items-start gap-x-2 gap-y-1.5">
+      {/* 지도에 없는 문서만 자기 줄을 갖는다 — 그때는 왜 없는지가 사실이다. */}
+      {proofBody ? (
+        <div className="flex min-w-0 flex-wrap items-start gap-x-2 gap-y-1.5">
         <span
-          data-testid="doc-map-evidence"
-          data-in-graph={inGraph ? "true" : "false"}
-          className={
-            inGraph
-              ? "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-label text-[color:var(--color-text-secondary)]"
-              : // 지도에 없다는 말은 경보가 아니라 사실이다 — 무채색으로 낮춘다.
-                "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-recessed-a12)] px-2.5 font-mono text-label text-[color:var(--color-text-quaternary)]"
-          }
-        >
-          <FileText className="h-3.5 w-3.5" aria-hidden="true" />
-          {inGraph ? t("recordProofLabel") : t("notOnMapLabel")}
-        </span>
-        <span className="min-h-7 min-w-0 flex-1 py-1 text-[color:var(--color-text-tertiary)]">
-          {proofBody}
-        </span>
-      </div>
+            data-testid="doc-map-evidence"
+            data-in-graph={inGraph ? "true" : "false"}
+            className={
+              inGraph
+                ? "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-label text-[color:var(--color-text-secondary)]"
+                : // 지도에 없다는 말은 경보가 아니라 사실이다 — 무채색으로 낮춘다.
+                  "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-recessed-a12)] px-2.5 font-mono text-label text-[color:var(--color-text-quaternary)]"
+            }
+          >
+            <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+            {inGraph ? t("recordProofLabel") : t("notOnMapLabel")}
+          </span>
+          <span className="min-h-7 min-w-0 flex-1 py-1 text-[color:var(--color-text-tertiary)]">
+            {proofBody}
+          </span>
+        </div>
+      ) : null}
 
       <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2">
+        {/* 지도에 있으면 칩이 이 줄에 합류한다 — 두 줄이 한 줄이 된다. */}
+        {proofBody ? null : (
+        <span
+            data-testid="doc-map-evidence"
+            data-in-graph={inGraph ? "true" : "false"}
+            className={
+              inGraph
+                ? "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-overlay-2)] bg-[color:var(--color-overlay-1)] px-2.5 font-mono text-label text-[color:var(--color-text-secondary)]"
+                : // 지도에 없다는 말은 경보가 아니라 사실이다 — 무채색으로 낮춘다.
+                  "inline-flex min-h-7 shrink-0 items-center gap-1.5 rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-recessed-a12)] px-2.5 font-mono text-label text-[color:var(--color-text-quaternary)]"
+            }
+          >
+            <FileText className="h-3.5 w-3.5" aria-hidden="true" />
+            {inGraph ? t("recordProofLabel") : t("notOnMapLabel")}
+          </span>
+        )}
         <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
           <span className="font-mono tabular-nums">
             {t("wordsUnit", { count: doc.wordCount.toLocaleString(numberLocale) })}


### PR DESCRIPTION
## Summary

소유자 지적: *"이렇게 문서 볼 때 상단이 조금 이상한데.. 보기좋게 구성할순없나?
항상 기본적으로 저렇게 상단에 떠서 그런가?"*

브라우저에서 재 보니 문서 제목 위에 띠가 **다섯 겹 · 377px**, 화면(862px)의
**44%** 였고 문서 이름이 본문 전에 **세 번** 나왔다(헤더 · 속성 줄 · 본문 제목).

그중 **문서마다 달라지지 않는 것** 둘이 각자 줄을 먹고 있었다. 그 둘만 옮겼다 —
새 표면 0개, 숨긴 사실 0개.

### ① 지도 근거 설명 문장 (93 → 49px)

> 이 문서 속성이 domain 개념으로 연결됩니다. 에이전트는 이 근거를 쿼리, 인용,
> 갱신할 수 있습니다.

지도에 **있는** 문서에서 이 문장은 아무것도 새로 말하지 않는다 — 바로 왼쪽 칩이
「지도 근거」라고 적혀 있고 오른쪽에 「지형도」로 가는 링크가 있다. 실측: **배포
샘플 볼트는 112개 문서 전부가 노드**라 같은 문장이 112번 반복되며 매번 본문을
아래로 밀었다.

지도에 **없는** 문서에서는 반대다 — 왜 없는지와 무엇을 할지가 그 문장에만 있다
(도그푸드 볼트의 82개가 그 경우). 그래서 **그때만** 남긴다. 이 저장소의 강등 카드
규율(못 하는 경우에 이유와 갈 곳을 말한다)과 같은 모양이다.

칩이 아래 줄에 합류해서 두 줄이 한 줄이 됐다:
`지도 근거 · 43 단어 · ≈1분 읽기 · 지형도 · 2026.08.02.`

### ② 「규격 예시 보기」 (80 → 47px)

접힌 상태에서도 자기 줄을 갖고 있었다. 필요한 순간은 「이 속성이 무엇을 받나」를
알고 싶을 때이고, 그건 속성 블록을 **여는** 순간이다. 그 안으로 옮겼다.

### 툴팁으로 옮기지 않은 이유

손가락으로 만지는 기기에는 호버가 없어 사실상 사라지고, 그러면 「타입 있는 사실을
숨긴다」가 된다. 칩과 지도 링크는 접힌 상태에서도 그대로 보인다.

### 죽은 문구 정리

`recordProofBody` · `recordProofOntologyBody` 두 키를 지웠다 — 아무도 안 쓰는
문구는 규격이 아니라 틀린 정보다. 문구 파일은 두 줄씩만 줄었다(재정렬 없음).

## 남긴 것 (일부러)

- **헤더의 「배송 / domains/fulfillment.md」** — 스크롤했을 때 «지금 어느 문서인가»를
  말하는 자리라 남긴다.
- **「읽기 전용 샘플이에요 … 내 폴더 열기」** — 112개 문서에 똑같이 나오지만, 이건
  설명이 아니라 **제약 안내 + 주 전환 CTA** 다. 없애는 것은 정리가 아니라 제품
  판단이므로 이 PR 에 섞지 않았다.

## Test plan

| 검사 | 결과 |
|---|---|
| 브라우저 실측 (1512×900, 정적 export) | 제목 y **377 → 300** (44% → 35%) · 메타바 93 → 49 · 속성 블록 80 → 47 |
| 칩·링크가 살아 있나 | `doc-map-evidence` · `doc-map-open` 둘 다 여전히 렌더 |
| `pnpm exec vitest run` (속성 블록 · 메타바 3종) | 34 통과 |
| `pnpm test:contracts` | 130 파일 · 1540 통과 |
| Playwright `docs-deeplink` · `document-scroll-lock` · `vault-truth-telling` | 17 통과 |
| `pnpm test:desktop:check` (문구를 읽는 게이트) | 통과 |
| `pnpm test:i18n:messages` | 16 통과 |
| `pnpm exec tsc --noEmit` · `eslint` | 통과 (새 error 0) |

**게이트 프로브** (`/gate-probe`):

- **지키는 property**: 문서마다 달라지지 않는 설명은 읽는 화면에 상주하지 않는다 —
  그러나 지도에 없는 문서의 이유와 지도로 가는 길은 그대로 보인다.
- **되돌리기**: 속성 블록을 기본 펼침(`useState(false)` → `true`)으로 한 줄 되돌리니
  새 시험을 포함해 **4개가 빨개졌다**. 복구 후 28/28 초록.
- **공회전 차단**: 새 시험이 먼저 «이 fixture 에 규격 예시가 있는가» 를 단언한다 —
  예시 없는 kind 였다면 그 시험은 아무것도 안 보고 초록이 된다. 그리고 **기존
  단위 시험들은 `getByTestId` 로 DOM 존재만 봐서 토글이 접힌 블록 밖에 있어도 전부
  초록이었다**(실측) — 그래서 위치를 직접 재는 단언을 새로 넣었다.
- **물려 있는 곳**: `checks:changed` 가 두 단위 시험 + 문서함 e2e 셋 + 문구 게이트를
  권한다.

`pnpm checks:changed -- <바꾼 경로 전부>` 가 권한 것을 전부 돌렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)