### PR TITLE
fix: 샘플 안내를 문서 헤더 줄로 들인다 — 세로 53px 을 0으로, 지운 말은 없다

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -2287,7 +2287,7 @@ function DocsVaultContent() {
                   레이블이었다. title 을 1행 주 레이블로 올리고, 파일 경로는
                   2행 caption(secondary)으로 낮춘다 — 트리(`DocsVaultTree`)의
                   `title ?? name` 우선순위와 같은 계약을 여기도 일관 적용. */}
-              <div className="flex flex-none items-center gap-3 border-b border-[color:var(--color-border-soft)] px-4 py-2">
+              <div className="flex flex-none flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-[color:var(--color-border-soft)] px-4 py-2">
                 <div className="flex min-w-0 flex-1 flex-col">
                   <span className="truncate text-body font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
                     {selectedDocDisplayTitle}
@@ -2297,6 +2297,17 @@ function DocsVaultContent() {
                     {splitVaultSlugPath(selectedDoc.slug).name}.md
                   </span>
                 </div>
+                {/* #4 샘플 안내 — 읽기 전용인 이유 + 켜는 법. 종전엔 제목 위의
+                    자기 띠(53px)였다. 말하는 사실이 **볼트** 의 것이라 문서마다
+                    반복될 이유가 없고, 샘플 볼트에서는 이 줄의 오른쪽이 비어
+                    있으므로 세로 픽셀 0으로 같은 말을 한다 (po-pass.md §1-3 의
+                    판단은 그대로 — 지우지 않고 자리만 옮겼다). */}
+                {!editing && !isLocalSourceLoaded ? (
+                  <SampleNotice
+                    canOpenLocalVault={!localSourceDisabled}
+                    onOpenFolder={() => handleSourceChange('local')}
+                  />
+                ) : null}
                 {canEditCurrent ? (
                   <div
                     role="tablist"
@@ -2342,16 +2353,6 @@ function DocsVaultContent() {
                   </span>
                 ) : null}
               </div>
-
-              {/* #4 샘플 안내 — 읽기 전용인 이유 + 켜는 법을 평문으로. 기존
-                  우상단 점 칩(위)은 상태 인디케이터로 유지하고, 이 스트립이
-                  설명 + 액션을 맡는다 (po-pass.md §1-3). */}
-              {!editing && !isLocalSourceLoaded ? (
-                <SampleNotice
-                  canOpenLocalVault={!localSourceDisabled}
-                  onOpenFolder={() => handleSourceChange('local')}
-                />
-              ) : null}
 
               <div className="flex min-h-0 flex-1">
                 {/* relative 래퍼 — #1 목차 레일(빈 띠 절대 위치)과 #2 맨

--- a/src/views/docs-vault/ui/parts/SampleNotice.tsx
+++ b/src/views/docs-vault/ui/parts/SampleNotice.tsx
@@ -28,10 +28,38 @@ export function SampleNotice({ canOpenLocalVault, onOpenFolder }: SampleNoticePr
   return (
     <div
       data-testid="docs-vault-sample-notice"
-      className="flex flex-none flex-wrap items-center gap-3 border-b border-l-2 border-b-[color:var(--color-divider)] border-l-[color:var(--color-indigo-brand)] bg-[color:var(--color-elevated)] px-6 py-2.5 md:px-10"
+      /*
+       * **이 안내는 볼트의 사실이지 문서의 사실이 아니다** (2026-08-08).
+       *
+       * 종전엔 자기 띠(전체 폭 · 위아래 여백 · 왼쪽 인디고 레일)로 문서 제목
+       * **위에** 앉아 있었다. 실측: 53px 을 먹고, 배포 샘플 볼트의 **112개 문서
+       * 전부**에서 같은 문장을 반복하며 본문을 아래로 밀었다.
+       *
+       * 그런데 이 문장이 말하는 것(「이 볼트는 읽기 전용이다」)은 문서를 바꿔도
+       * 안 바뀐다. 그래서 문서 헤더 줄로 들어간다 — 샘플 볼트에서는 그 줄의
+       * 오른쪽이 **완전히 비어 있다**(편집 탭과 동기 표시가 둘 다 로컬 볼트
+       * 전용이다. 코드와 실측 모두 확인). 세로 픽셀 0으로 같은 말을 한다.
+       *
+       * **지우지 않는 이유**: 샘플 문서에는 편집 컨트롤이 아예 없어서
+       * (실측 0개) 「왜 편집이 안 되나」를 붙일 다른 자리가 없다. 이 줄이 그
+       * 이유와 「내 폴더 열기」를 나르는 유일한 자리다 — 그것이 이 부품을 만든
+       * 원래 판단(po-pass §1-3)이고 여전히 유효하다. 값만 낮춘다.
+       *
+       * 브레이크포인트를 새로 만들지 않는다: 헤더 줄이 `flex-wrap` 이라
+       * 넓으면 한 줄에 들어가고 좁으면 자기 줄로 떨어진다 — 유지할 모양은
+       * 하나이고, 좁은 폭에서도 종전보다 나빠지지 않는다.
+       */
+      className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5"
     >
-      <p className="min-w-0 flex-1 text-body leading-body text-[color:var(--color-text-secondary)]">
-        <span className="font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
+      <p className="min-w-0 flex-1 text-body leading-body text-[color:var(--color-text-tertiary)]">
+        {/*
+         * 문서 헤더 줄로 들어오면서 **주목 승자가 둘이 됐다** — 「읽기 전용
+         * 샘플이에요」가 문서 제목과 같은 굵기·같은 밝기라 한 줄에서 경쟁했다.
+         * 읽는 화면의 주인공은 문서 제목이므로 이 안내를 한 단 낮춘다:
+         * 잉크는 secondary(제목은 primary), 설명은 tertiary. 굵기는 남겨서
+         * 「상태 라벨」로는 계속 읽힌다 — 낮춘 것은 밝기이고 지운 말은 없다.
+         */}
+        <span className="font-[var(--font-weight-emphasis)] text-[color:var(--color-text-secondary)]">
           {t("sampleNotice.title")}
         </span>{" "}
         — {t("sampleNotice.body")}


### PR DESCRIPTION
## Summary

#1000 에서 「결정이 필요하다」고 남겨 뒀던 마지막 띠. 소유자가 *"니가 체크해봐"* 로
맡겼으므로 조사해서 처리했다.

「읽기 전용 샘플이에요 — 이 문서는 Atlas 자체 예시라 편집이 잠겨 있어요.」 +
「내 폴더 열기」가 문서 제목 위에 **자기 띠(53px)** 로 앉아 있었고, 배포 샘플 볼트의
**112개 문서 전부**에서 같은 문장을 반복했다.

## 지우지 않은 이유 (먼저 확인한 것)

- **샘플 문서에는 편집 컨트롤이 아예 없다** — 브라우저에서 세니 **0개**. 그러니
  「왜 편집이 안 되나」를 붙일 다른 자리가 없다.
- 이 부품을 만든 판단이 컴포넌트 주석에 기록돼 있다 — *"우상단 작은 칩만으로는
  '왜/어떻게' 가 전달되지 않는다는 관찰(po-pass §1-3)을 해소한다"*. **여전히
  유효하므로 인용하고 지키되, 값만 낮춘다.**
- 단위 시험 셋도 «왜»와 «어떻게»만 단언하고 위치는 안 본다 — 그 성질은 그대로 산다.

## 대신 한 것 — 세로 픽셀 0으로 같은 말을 한다

이 문장이 말하는 것(「이 **볼트**는 읽기 전용」)은 문서를 바꿔도 안 바뀐다. 그래서
문서 헤더 줄로 들어간다. 샘플 볼트에서는 **그 줄의 오른쪽이 완전히 비어 있다** —
편집 탭과 동기 표시가 둘 다 로컬 볼트 전용이다(코드와 실측 모두 확인).

**헤더 줄 높이는 51px 그대로다.**

브레이크포인트를 새로 만들지 않았다 — 헤더 줄이 `flex-wrap` 이라 넓으면 한 줄,
좁으면 자기 줄로 떨어진다. **유지할 모양은 하나**이고 좁은 폭에서도 나빠지지 않는다.

| 폭 | 전 | 후 |
|---|---|---|
| 1512 | 헤더 51 + 띠 53 = **104** | 헤더 **51** (한 줄) |
| 768 | 104 | **51** (한 줄) |
| 500 | 104+ | **97** (자기 줄로 떨어짐) |

## 옮기면서 만든 위계 충돌도 같이 고쳤다

합치고 나니 「읽기 전용 샘플이에요」가 문서 제목과 **같은 굵기·같은 밝기**라 한 줄에서
둘이 경쟁했다. 읽는 화면의 주인공은 문서 제목이므로 안내의 잉크를 한 단 낮췄다.

| | 대비 | AA(4.5) |
|---|---|---|
| 문서 제목 「배송」 | **18.73** | 통과 |
| 안내 라벨 | 13.64 | 통과 |
| 안내 본문 | 6.13 | 통과 |

위계가 **단조롭게** 내려가고 셋 다 통과다. 낮춘 것은 밝기이고 **지운 말은 없다**.

## 누적 (이 문서함 라운드 전체)

| | 처음 | #1000 뒤 | 지금 |
|---|---:|---:|---:|
| 문서 제목 위 크롬 | 377px (44%) | 300px (35%) | **247px (29%)** |
| 제목 위의 띠 | 5겹 | 5겹 | **4겹** |

남은 넷은 전부 **앱 크롬이거나 문서마다 달라지는 사실**이다 — 탭 줄 · 문서 이름/경로
(+이 안내) · 속성 · 사실 줄. 문서마다 반복되는 설명은 0개다.

## Test plan

| 검사 | 결과 |
|---|---|
| 브라우저 실측 (1512 · 768 · 500) | 헤더 51px 유지 · 겹침 **0** · CTA 누를 수 있음 · 가로 스크롤 없음 |
| 대비 (WCAG 1.4.3) | 18.73 / 13.64 / 6.13 — 미달 0 |
| `pnpm exec vitest run …SampleNotice.test.tsx` | 3 통과 (왜/어떻게 · 폴더 열기 · 웹 강등) |
| `pnpm test:contracts` | 130 파일 · 1540 통과 |
| Playwright `docs-deeplink` · `document-scroll-lock` · `vault-truth-telling` | 17 통과 |
| `pnpm desktop:check` | 통과 |
| `pnpm exec tsc --noEmit` · `eslint` | 통과 (새 error 0) |
| `pnpm build` | 통과 |

`pnpm checks:changed -- <바꾼 경로 전부>` 가 권한 것을 전부 돌렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)