### PR TITLE
fix: 공방 진행 힌트가 숫자를 되풀이했다 — 「4방향 중 1 채움 · 하나 채웠어요」

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -224,7 +224,7 @@
       "half": "· halfway there",
       "almost": "· almost done",
       "done": "· all filled",
-      "first": "· one filled in"
+      "first": "· started"
     },
     "domainMembership": "Already in ‘{domain}’",
     "framePrompt": "Complete what {name} is by linking it to nearby nodes",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -224,7 +224,7 @@
       "half": "· 반쯤 왔어요",
       "almost": "· 거의 다 됐어요",
       "done": "· 다 채웠어요",
-      "first": "· 하나 채웠어요"
+      "first": "· 시작했어요"
     },
     "domainMembership": "이미 ‘{domain}’ 소속이에요",
     "framePrompt": "‘{name}’의 의미를 주변 노드와 이어 완성해요",

--- a/tests/contract/studio-progress-hint.contract.test.ts
+++ b/tests/contract/studio-progress-hint.contract.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../../messages/en.json';
+import ko from '../../messages/ko.json';
+
+/**
+ * **진행 힌트는 숫자가 이미 말한 것을 되풀이하지 않는다.**
+ *
+ * 공방 무대의 좌상단은 두 조각으로 한 줄을 만든다 —
+ * `flowCount`(「4방향 중 1 채움」)과 `flowHint`(단계별 한마디). 힌트의 존재
+ * 이유는 숫자가 **말하지 않는 것**을 말하는 것이다: 어디쯤 왔는지에 대한 판단
+ * (「반쯤 왔어요」 · 「거의 다 됐어요」)이나 다음 행동(「여기서 시작해요」).
+ *
+ * ## 무엇이 났나 (2026-08-08 실측)
+ *
+ * 다섯 단계 중 `first` 하나가 **숫자를 그대로 되풀이**했다:
+ *
+ * ```
+ * 4방향 중 1 채움 · 하나 채웠어요          (ko)
+ * 1 of 4 directions filled · one filled in  (en)
+ * ```
+ *
+ * 한 줄에서 같은 사실을 두 번 말한 것이다. 나머지 넷은 각자 새로운 것을
+ * 말하므로 자리를 얻는다 — 문제는 «힌트가 있다» 가 아니라 «이 단계의 힌트가
+ * 숫자의 사본» 이었다는 것이다. 같은 무대의 하단 바에도 같은 숫자가
+ * (`bottomProgress`) 또 있어서, 그 화면에서 같은 사실이 세 가지 표현으로
+ * 나왔다.
+ *
+ * ## 이 게이트가 잠그는 성질
+ *
+ * *어느 단계의 힌트도 셈을 다시 말하지 않는다.* 문장은 자유롭게 바꿔도 되고
+ * 번역해도 된다 — 막는 것은 **숫자·수량어**가 힌트로 새어 드는 것뿐이다.
+ * (`documentation.md`: 사람이 쓴 문장 하나를 못박지 않는다.)
+ *
+ * ⚠️ 「다 채웠어요 / all filled」는 예외로 둔다. 그것은 셈이 아니라 **완료
+ * 상태**이고, 완료를 알리는 말에서 「다/all」을 뺄 수는 없다.
+ */
+
+type FlowNamespace = {
+  flowCount: string;
+  flowHint: Record<string, string>;
+};
+
+/** `flowHint` 를 가진 네임스페이스를 이름으로 찾지 않고 **구조로** 찾는다. */
+function findFlowNamespace(node: unknown): FlowNamespace | null {
+  if (!node || typeof node !== 'object') return null;
+  const record = node as Record<string, unknown>;
+  if (
+    typeof record.flowCount === 'string' &&
+    record.flowHint &&
+    typeof record.flowHint === 'object'
+  ) {
+    return record as FlowNamespace;
+  }
+  for (const value of Object.values(record)) {
+    const hit = findFlowNamespace(value);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * 셈을 나르는 말 — 숫자, 한글 수량어, 영어 수량어.
+ *
+ * ⚠️ 영어 수량어에는 **단어 경계가 반드시 필요하다**. 처음엔 `one` 을 그냥
+ * 넣었다가 정상 문구 「· almost d**one**」이 걸렸다 — 잘못 잰 숫자는 멀쩡한
+ * 것을 결함이라 부른다. 한글은 조사가 붙어 경계를 쓸 수 없으므로, 대신 다른
+ * 낱말에 흔히 박히는 「개」 같은 조각은 목록에서 빼고 셈에만 쓰이는 말
+ * (채움 · 방향 · 하나 · 둘 · 셋 · 넷)만 본다.
+ */
+const COUNT_WORDS =
+  /[0-9]|하나|둘|셋|넷|방향|채움|\b(?:one|two|three|four)\b|filled in/i;
+
+/** 완료 상태는 셈이 아니다 — 이 단계만 면제한다. */
+const COMPLETION_TIER = 'done';
+
+describe('공방 진행 힌트는 셈을 되풀이하지 않는다', () => {
+  for (const [locale, messages] of [
+    ['ko', ko],
+    ['en', en],
+  ] as const) {
+    const ns = findFlowNamespace(messages);
+
+    it(`${locale} — flowCount 와 flowHint 를 실제로 찾았다 (없으면 이 시험이 공회전한다)`, () => {
+      expect(ns, `${locale}: flowCount + flowHint 네임스페이스를 못 찾았다 — 게이트가 낡았다`).not.toBeNull();
+      expect(Object.keys(ns?.flowHint ?? {}).length, '검사할 단계가 0개다').toBeGreaterThan(3);
+    });
+
+    it(`${locale} — 어느 단계도 셈을 다시 말하지 않는다`, () => {
+      if (!ns) return;
+      const offenders = Object.entries(ns.flowHint)
+        .filter(([tier]) => tier !== COMPLETION_TIER)
+        .filter(([, text]) => COUNT_WORDS.test(text))
+        .map(([tier, text]) => `${tier}: "${text}"`);
+      expect(
+        offenders,
+        `이 단계의 힌트가 「${ns.flowCount}」 이 이미 말한 셈을 되풀이한다 — ` +
+          '힌트는 숫자가 말하지 않는 것(어디쯤 왔나 · 다음에 무엇을)만 말해야 한다.',
+      ).toEqual([]);
+    });
+
+    /**
+     * 계기가 살아 있는지 — 셈을 넣은 값은 정말 잡히고, 정상 문구는 통과하는가.
+     * 이 프로브가 없으면 위 초록이 「깨끗해서」인지 「정규식이 아무것도 안 봐서」
+     * 인지 갈리지 않는다.
+     */
+    it(`${locale} — 계기가 살아 있다`, () => {
+      expect(COUNT_WORDS.test('· 하나 채웠어요')).toBe(true);
+      expect(COUNT_WORDS.test('· one filled in')).toBe(true);
+      expect(COUNT_WORDS.test('· 반쯤 왔어요')).toBe(false);
+      expect(COUNT_WORDS.test('· halfway there')).toBe(false);
+      expect(COUNT_WORDS.test('· 시작했어요')).toBe(false);
+      expect(COUNT_WORDS.test('· started')).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

*"또 이런 부분들 없는지 하나하나 다 보면서"* — 소유자 지시로 전 화면을 훑었다.
계기 셋을 만들어 실제로 재고 나온 것 하나를 고친다.

공방 무대 좌상단이 **한 줄에서 같은 사실을 두 번** 말했다:

```
4방향 중 1 채움 · 하나 채웠어요            (ko)
1 of 4 directions filled · one filled in   (en)
```

`flowHint` 는 다섯 단계인데 **넷은 숫자가 말하지 않는 것**을 말한다 —
「여기서 시작해요」(다음 행동) · 「반쯤 왔어요」 · 「거의 다 됐어요」(위치 판단) ·
「다 채웠어요」(완료). `first` 하나만 셈의 사본이었다. 같은 무대 하단 바에도 같은
숫자(`bottomProgress` 「4개 중 1개 채웠어요 · 3군데 남음」)가 있어서 그 화면에서
같은 사실이 **세 가지 표현**으로 나왔다.

## 고친 것

그 한 단계만: 「· 하나 채웠어요」 → **「· 시작했어요」** (en: `· started`).

0에서 1로 넘어간 것은 셈이 아니라 **문턱을 넘은 사건**이고 그건 숫자가 말하지
않는다. 사다리의 나머지와 같은 종류(위치 판단)가 된다.

## 게이트

**어느 단계의 힌트도 셈을 다시 말하지 않는다.** 문장은 자유롭게 바꾸고 번역해도
되고, 막는 것은 숫자·수량어가 힌트로 새어 드는 것뿐이다 —
`documentation.md` 의 「사람이 쓴 문장을 못박지 않는다」를 지킨다. 네임스페이스는
이름이 아니라 **구조로** 찾으므로 카탈로그가 재편돼도 따라간다.

⚠️ **오탐을 한 번 밟았고 그 사연을 주석에 남겼다**: 영어 수량어 `one` 을 경계
없이 넣으니 정상 문구 「· almost d**one**」이 걸렸다. 단어 경계를 넣어 고쳤다 —
잘못 잰 숫자는 멀쩡한 것을 결함이라 부른다.

## 같이 훑었지만 **고치지 않은** 것 (재 보고 기각)

| 후보 | 실측 | 판정 |
|---|---|---|
| `/projects` 카드가 `/ontology/?node=` 리다이렉트를 거친다 | 클릭 후 프레임 209장 중 **빈 프레임 0**, ~100ms 에 `/topology` 도착 | 화면에 안 보이는 홉 — 고칠 것 아님 |
| 같은 카드 4장의 높이가 56·57px | 첫 행만 `border-top: 0`, **내용 높이는 전부 동일** | 구분선이지 편차 아님 |
| 공방 소켓 3개가 82·64·83px | 코드가 그 숫자를 이미 적어 둔 기록된 결정(잘림 대신 성장) + 대칭 **편차 0px**(중앙 788/443 ↔ UP·DOWN cx 788, LEFT cy 443) | 의도된 설계 |
| 공방 소켓 색이 셋(인디고·앰버·회색) | `recommended`/`expected`/그 외 — **타입 있는 사실**에 묶여 있다 | 헌장대로 |

## 훑은 범위와 숫자

| 화면 | 로딩 깜빡임 | 말줄임 없는 잘림 | 반복 산문 | 치수 편차 |
|---|---|---|---|---|
| `/topology` | 노드 8회 클릭 · **0** | — | — | — |
| `/ontology/insights` | 탭 10회 전환 · **0** | — | 반복 0 (문자열 5) | — |
| `/projects` | (링크 이동) | — | 반복 0 (문자열 25) | 21항목 · 실제 0 (구분선 오탐 1) |
| `/docs` | #999 로 8/8 → **0** | 160 검사 · **0** (의도된 줄임 136) | #1000·#1001 로 0 | 139항목 · 실제 0 |
| `/ontology/studio` | — | 36 검사 · **0** | — | 9항목 · 실제 0 |
| `/git` | **미측정** — 웹에서는 강등 카드다(git 은 앱 전용) | | | |

계기마다 **몇 개를 실제로 검사했는지** 함께 셌다 — 검사 수가 0이면 그 0은
「깨끗하다」가 아니라 「아무것도 안 봤다」다.

## Test plan

| 검사 | 결과 |
|---|---|
| `pnpm exec vitest run tests/contract/studio-progress-hint.contract.test.ts` | 6 통과 (신규) |
| `pnpm test:contracts` | 131 파일 · **1546** 통과 |
| `pnpm test:i18n:messages` | 16 통과 |
| `pnpm test:desktop:check` (문구를 읽는 게이트) | 통과 |
| `pnpm exec tsc --noEmit` | 통과 |

**게이트 프로브**: ko 값을 「· 하나 채웠어요」로 그 줄만 되돌리니 **빨개졌고**,
복구 후 6/6 초록. 공회전 차단으로 ① 네임스페이스를 실제로 찾았는지 ② 단계가
3개 초과인지 ③ 셈이 든 값은 잡히고 정상 문구는 통과하는지를 함께 단언한다.

`pnpm checks:changed -- <바꾼 경로 전부>` 가 권한 것을 전부 돌렸다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)