### PR TITLE
perf: 증분 재빌드가 mtime 을 알아내려고 파일을 열지 않는다 — getFile 71회 → 1회

### DIFF
--- a/src/entities/docs-vault/index.ts
+++ b/src/entities/docs-vault/index.ts
@@ -29,6 +29,7 @@ export {
   buildLocalManifestWithEntries,
   rebuildLocalManifestIncremental,
   computeLocalVaultFingerprint,
+  computeLocalVaultFingerprintWithStamps,
 } from './lib/build-local-manifest';
 export type {
   LocalVaultBuild,

--- a/src/entities/docs-vault/lib/build-local-manifest.native-mtime.test.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.native-mtime.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { VaultManifest } from '../model/types';
+
+/**
+ * **증분 재빌드가 mtime 을 알아내려고 파일을 열지 않는다.**
+ *
+ * ## 무엇이 났나 (2026-08-09, 설치된 앱 실측)
+ *
+ * `rebuildLocalManifestIncremental` 의 존재 이유는 「바뀐 파일만 다시 읽는다」인데,
+ * 정작 *무엇이 바뀌었는지* 알아내려고 **파일마다 `getFile()`** 을 불렀다. Tauri
+ * 에서 그건 `read_vault_text_file` IPC 왕복이고 그 명령은 **본문 전체를 함께**
+ * 돌려준다. 그래서 본문 재파싱은 아꼈지만 전송과 왕복은 하나도 못 아꼈다.
+ *
+ * 실측 — 파일 하나를 고쳤을 때 앱의 지도가 따라오기까지:
+ *
+ * | 볼트 | 반영까지 |
+ * |---|---|
+ * | 71파일 | 2.0초 (1.6초엔 아직) |
+ * | 5파일 | 0.7초 |
+ *
+ * 파일 수에 비례했고 건당 ≈20ms 로 IPC 왕복과 맞았다. 정작 같은 71파일을
+ * 디스크에서 읽는 비용은 **1.8ms** 다 — 시간은 일이 아니라 다리에서 갔다.
+ *
+ * 고친 방법은 새 네이티브 명령이 아니다: 경로와 mtime 만 한 번에 주는
+ * `vault_fingerprint` 가 **이미 있고 같은 파일에서 쓰고 있었다.**
+ *
+ * ## 이 게이트가 잠그는 성질
+ *
+ * *네이티브 스탬프를 쓸 수 있으면, 바뀌지 않은 파일은 열지 않는다.*
+ *
+ * ⚠️ **밀리초로 재지 않는다** — 기계마다 달라 들쭉날쭉 실패한다(`architecture.md`
+ * 가 이미 정해 둔 규율: 「몇 ms」가 아니라 「몇 번」으로 잠근다). 그래서 여기서
+ * 세는 것은 `getFile()` **호출 횟수**이고, 그건 어느 기계에서나 같다.
+ */
+
+const nativeVaultFingerprint = vi.fn();
+vi.mock('@/shared/lib/tauri-vault-fs', () => ({
+  nativeVaultFingerprint: (rootPath: string) => nativeVaultFingerprint(rootPath),
+}));
+
+const { buildLocalManifest, buildLocalManifestWithEntries, rebuildLocalManifestIncremental } =
+  await import('./build-local-manifest');
+
+interface FakeFile {
+  text: string;
+  lastModified: number;
+}
+
+/** `getFile()` 호출을 경로별로 세는 mock root. */
+function makeRoot(
+  files: Record<string, FakeFile>,
+  opens: Map<string, number>,
+  rootPath?: string,
+): FileSystemDirectoryHandle {
+  const groups: Record<string, Record<string, FakeFile>> = {};
+  for (const [p, file] of Object.entries(files)) {
+    const parts = p.split('/');
+    const dir = parts.slice(0, -1).join('/');
+    const name = parts[parts.length - 1];
+    if (!groups[dir]) groups[dir] = {};
+    groups[dir][name] = file;
+  }
+
+  const fileHandle = (name: string, file: FakeFile, fullPath: string) =>
+    ({
+      kind: 'file',
+      name,
+      getFile: async () => {
+        opens.set(fullPath, (opens.get(fullPath) ?? 0) + 1);
+        return {
+          text: async () => file.text,
+          lastModified: file.lastModified,
+        } as unknown as File;
+      },
+    }) as unknown as FileSystemFileHandle;
+
+  const buildHandle = (dirKey: string): FileSystemDirectoryHandle => {
+    const myFiles = groups[dirKey] ?? {};
+    const subDirs = new Set<string>();
+    for (const k of Object.keys(groups)) {
+      if (k === dirKey) continue;
+      if (dirKey === '' && !k.includes('/')) subDirs.add(k);
+      else if (dirKey !== '' && k.startsWith(`${dirKey}/`)) {
+        const tail = k.slice(dirKey.length + 1);
+        if (!tail.includes('/')) subDirs.add(k);
+      }
+    }
+    const handle = {
+      kind: 'directory',
+      name: dirKey || 'root',
+      entries: async function* () {
+        for (const [name, file] of Object.entries(myFiles)) {
+          yield [name, fileHandle(name, file, dirKey ? `${dirKey}/${name}` : name)] as const;
+        }
+        for (const sub of subDirs) {
+          const subName = sub.includes('/') ? sub.slice(sub.lastIndexOf('/') + 1) : sub;
+          yield [subName, buildHandle(sub)] as const;
+        }
+      },
+    } as Record<string, unknown>;
+    if (dirKey === '' && rootPath) handle.rootPath = rootPath;
+    return handle as unknown as FileSystemDirectoryHandle;
+  };
+
+  return buildHandle('');
+}
+
+function node(slug: string, title: string, body = 'x') {
+  return `---\nkind: capability\nslug: ${slug}\ntitle: ${title}\n---\n\n${body}\n`;
+}
+
+function stripGenerated(manifest: VaultManifest) {
+  const { generatedAt: _ignored, ...rest } = manifest;
+  void _ignored;
+  return rest;
+}
+
+const FILES: Record<string, FakeFile> = {
+  'README.md': { text: node('README', 'Readme'), lastModified: 100 },
+  'capabilities/a.md': { text: node('capabilities/a', 'A'), lastModified: 200 },
+  'capabilities/b.md': { text: node('capabilities/b', 'B'), lastModified: 300 },
+  'capabilities/c.md': { text: node('capabilities/c', 'C'), lastModified: 400 },
+  'capabilities/d.md': { text: node('capabilities/d', 'D'), lastModified: 500 },
+};
+
+const stampsFor = (files: Record<string, FakeFile>) => ({
+  entries: Object.entries(files).map(([relativePath, f]) => ({
+    relativePath,
+    lastModified: f.lastModified,
+  })),
+  truncated: false,
+  prunedDirs: [],
+});
+
+beforeEach(() => {
+  nativeVaultFingerprint.mockReset();
+});
+
+describe('증분 재빌드 — 네이티브 스탬프가 있으면 안 바뀐 파일을 열지 않는다', () => {
+  it('한 파일만 바뀌면 그 파일만 연다', async () => {
+    // 1차: 전체 빌드로 직전 entries 를 만든다(여기서는 전부 열어야 정상).
+    const seedOpens = new Map<string, number>();
+    const seed = await buildLocalManifestWithEntries(makeRoot(FILES, seedOpens, '/vault'));
+    expect(seedOpens.size, '1차 빌드가 파일을 하나도 안 열었다 — 이 시험이 헛돈다').toBe(5);
+
+    // 2차: b.md 만 mtime 이 바뀐다.
+    const changed: Record<string, FakeFile> = {
+      ...FILES,
+      'capabilities/b.md': { text: node('capabilities/b', 'B2'), lastModified: 999 },
+    };
+    nativeVaultFingerprint.mockResolvedValue(stampsFor(changed));
+
+    const opens = new Map<string, number>();
+    const result = await rebuildLocalManifestIncremental(
+      makeRoot(changed, opens, '/vault'),
+      seed.entries,
+    );
+
+    expect(nativeVaultFingerprint, '네이티브 스탬프를 한 번만 물어야 한다').toHaveBeenCalledTimes(1);
+    expect(
+      [...opens.keys()],
+      '바뀐 파일 하나만 열려야 한다 — 나머지는 mtime 만 보고 재사용',
+    ).toEqual(['capabilities/b.md']);
+
+    // 그리고 결과는 전체 빌드와 같아야 한다(증분의 안전 계약).
+    const fullOpens = new Map<string, number>();
+    const full = await buildLocalManifest(makeRoot(changed, fullOpens, '/vault'));
+    expect(stripGenerated(result.build.manifest)).toEqual(stripGenerated(full.manifest));
+  });
+
+  it('아무것도 안 바뀌면 파일을 하나도 열지 않는다', async () => {
+    const seedOpens = new Map<string, number>();
+    const seed = await buildLocalManifestWithEntries(makeRoot(FILES, seedOpens, '/vault'));
+    nativeVaultFingerprint.mockResolvedValue(stampsFor(FILES));
+
+    const opens = new Map<string, number>();
+    await rebuildLocalManifestIncremental(makeRoot(FILES, opens, '/vault'), seed.entries);
+    expect([...opens.keys()], '변경이 없는데 파일을 열었다').toEqual([]);
+  });
+
+  it('새로 생긴 파일은 스탬프가 알려 줘도 읽어야 한다 — 직전 결과가 없으니까', async () => {
+    const seedOpens = new Map<string, number>();
+    const seed = await buildLocalManifestWithEntries(makeRoot(FILES, seedOpens, '/vault'));
+    const added: Record<string, FakeFile> = {
+      ...FILES,
+      'capabilities/e.md': { text: node('capabilities/e', 'E'), lastModified: 600 },
+    };
+    nativeVaultFingerprint.mockResolvedValue(stampsFor(added));
+
+    const opens = new Map<string, number>();
+    await rebuildLocalManifestIncremental(makeRoot(added, opens, '/vault'), seed.entries);
+    expect([...opens.keys()]).toEqual(['capabilities/e.md']);
+  });
+
+  /**
+   * 폴백 — 웹에는 이 일괄 API 가 없다(`null`). 그러면 종전 경로로 떨어져
+   * **파일마다 열어** mtime 을 본다. 동작이 달라지지 않는 것이 계약이다.
+   */
+  it('네이티브가 없으면(웹) 종전대로 파일별로 확인한다', async () => {
+    const seedOpens = new Map<string, number>();
+    const seed = await buildLocalManifestWithEntries(makeRoot(FILES, seedOpens));
+    nativeVaultFingerprint.mockResolvedValue(null);
+
+    const opens = new Map<string, number>();
+    await rebuildLocalManifestIncremental(makeRoot(FILES, opens), seed.entries);
+    expect(
+      opens.size,
+      '웹 경로에서는 파일마다 열어 mtime 을 봐야 한다(그것이 종전 동작)',
+    ).toBe(5);
+  });
+
+  it('네이티브가 던져도 폴백한다 — 조용히 멈추지 않는다', async () => {
+    const seedOpens = new Map<string, number>();
+    const seed = await buildLocalManifestWithEntries(makeRoot(FILES, seedOpens, '/vault'));
+    nativeVaultFingerprint.mockRejectedValue(new Error('bridge down'));
+
+    const opens = new Map<string, number>();
+    const result = await rebuildLocalManifestIncremental(
+      makeRoot(FILES, opens, '/vault'),
+      seed.entries,
+    );
+    expect(opens.size, '네이티브 실패 시 파일별 경로로 떨어져야 한다').toBe(5);
+    expect(result.build.manifest.docs.length).toBe(5);
+  });
+});

--- a/src/entities/docs-vault/lib/build-local-manifest.ts
+++ b/src/entities/docs-vault/lib/build-local-manifest.ts
@@ -255,6 +255,31 @@ function fingerprintFromEntries(
  * 만든다. 같은 fingerprint = 마지막 빌드 후 .md / 이미지 변경 없음. 호출자
  * (예: focus auto-refresh) 가 이를 비교해 불필요한 전체 재빌드를 회피.
  */
+/**
+ * 지문과 **그 지문을 만든 스탬프**를 함께 준다.
+ *
+ * `computeLocalVaultFingerprint` 만 있던 동안, 호출자는 「바뀌었나」를 알고
+ * 나면 그 근거를 버렸다. 그래서 증분 재빌드가 같은 볼트를 **한 번 더** 걸었다.
+ * 여기서 둘을 같이 돌려주면 걷기는 변경당 한 번이면 된다.
+ */
+export async function computeLocalVaultFingerprintWithStamps(
+  root: FileSystemDirectoryHandle,
+): Promise<{ fingerprint: string; nativeStamps: Map<string, number> | null }> {
+  const nativeRoot = (root as { rootPath?: unknown }).rootPath;
+  if (typeof nativeRoot === 'string' && nativeRoot) {
+    const native = await nativeVaultFingerprint(nativeRoot);
+    if (native) {
+      return {
+        fingerprint: fingerprintFromEntries(native.entries),
+        nativeStamps: new Map(
+          native.entries.map((e) => [e.relativePath, e.lastModified] as const),
+        ),
+      };
+    }
+  }
+  return { fingerprint: await computeLocalVaultFingerprint(root), nativeStamps: null };
+}
+
 export async function computeLocalVaultFingerprint(
   root: FileSystemDirectoryHandle,
 ): Promise<string> {
@@ -546,11 +571,69 @@ export async function buildLocalManifest(
 export async function rebuildLocalManifestIncremental(
   root: FileSystemDirectoryHandle,
   previous: BuiltVaultEntry[],
+  /**
+   * 이미 받아 둔 네이티브 스탬프(경로→mtime). `refresh()` 는 「바뀌었나」를
+   * 판정하려고 방금 같은 걸 걷었으므로, 그걸 넘겨받아 **두 번 걷지 않는다.**
+   * 안 넘기면 여기서 직접 한 번 받는다.
+   */
+  providedStamps?: Map<string, number> | null,
 ): Promise<{ build: LocalVaultBuild; entries: BuiltVaultEntry[] }> {
   const files = await walk(root);
   const prevByPath = new Map(previous.map((e) => [e.relativePath, e] as const));
+  /*
+   * **mtime 을 알아내려고 본문을 다리 너머로 끌어오지 않는다** (2026-08-09 실측).
+   *
+   * 이 함수는 「바뀐 파일만 다시 읽는다」가 존재 이유인데, 정작 *무엇이
+   * 바뀌었는지* 알아내려고 **파일마다 `getFile()`** 을 불렀다. Tauri 에서 그건
+   * `read_vault_text_file` IPC 왕복이고 그 명령은 본문 전체를 함께 돌려준다 —
+   * 위 `computeLocalVaultFingerprint` 주석이 이미 같은 낭비를 지적하며
+   * *"쓰이는 것은 숫자 하나인데 볼트 전체가 다리를 건넜다"* 고 적어 둔 그것이다.
+   * 그래서 본문 재파싱은 아꼈지만 **전송과 왕복은 하나도 아끼지 못했다.**
+   *
+   * 설치된 앱 실측: 파일을 하나 고쳤을 때 지도가 따라오기까지
+   * **71파일 볼트 2.0초 / 5파일 볼트 0.7초** — 파일 수에 비례했다(건당 ≈20ms,
+   * IPC 왕복과 일치). 정작 같은 71파일을 디스크에서 읽는 비용은 **1.8ms** 다.
+   *
+   * 고치는 방법은 새 네이티브 명령이 아니다 — 경로와 mtime 만 한 번에 주는
+   * `vault_fingerprint` 가 **이미 있고 300줄 위에서 쓰고 있다.** 그것으로 먼저
+   * 판정하고, mtime 이 다른 파일에만 `getFile()` 을 부른다.
+   *
+   * 웹에는 그 일괄 API 가 없어 `null` 이 오고 지금까지의 경로로 떨어진다 —
+   * `surfaces.md` 의 브리지 관례(없으면 `null`, 조용히 강등) 그대로다.
+   */
+  let nativeStamps: Map<string, number> | null = providedStamps ?? null;
+  if (!nativeStamps) {
+    const nativeRoot = (root as { rootPath?: unknown }).rootPath;
+    if (typeof nativeRoot === 'string' && nativeRoot) {
+      try {
+        const native = await nativeVaultFingerprint(nativeRoot);
+        if (native) {
+          nativeStamps = new Map(
+            native.entries.map((e) => [e.relativePath, e.lastModified] as const),
+          );
+        }
+      } catch {
+        /* 네이티브 실패 → 아래 파일별 경로로 폴백(동작은 종전과 동일) */
+      }
+    }
+  }
   const entries: BuiltVaultEntry[] = [];
   for (const entry of files) {
+    // 네이티브가 이 경로의 mtime 을 알고 그것이 직전과 같으면 **파일을 아예
+    // 열지 않는다.** 모르는 경로(방금 생겼거나 목록이 어긋남)는 아래로 흘려
+    // 보내 종전과 같이 처리한다 — 「모르면 읽는다」가 안전한 쪽이다.
+    const nativeMtime = nativeStamps?.get(entry.relativePath);
+    if (nativeMtime !== undefined) {
+      const prevNative = prevByPath.get(entry.relativePath);
+      if (
+        prevNative &&
+        prevNative.kind === entry.kind &&
+        prevNative.lastModified === nativeMtime
+      ) {
+        entries.push({ ...prevNative, handle: entry.handle });
+        continue;
+      }
+    }
     const file = await entry.handle.getFile();
     const prev = prevByPath.get(entry.relativePath);
     if (

--- a/src/features/docs-vault-local/model/use-local-vault.test.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.test.ts
@@ -29,6 +29,18 @@ vi.mock('@/entities/docs-vault', () => ({
   buildLocalManifestWithEntries: entitiesMocks.buildLocalManifestWithEntries,
   rebuildLocalManifestIncremental: entitiesMocks.rebuildLocalManifestIncremental,
   computeLocalVaultFingerprint: entitiesMocks.computeLocalVaultFingerprint,
+  /*
+   * `refresh()` 는 지문과 **스탬프**를 함께 받는 쪽을 부른다(변경당 네이티브
+   * 순회를 한 번으로 줄이기 위해, 2026-08-09). 아래 시험들은 전부
+   * `computeLocalVaultFingerprint` 의 반환값으로 시나리오를 구동하므로,
+   * 새 함수는 **그것에 위임**한다 — 그러면 기존 시나리오 넷(같음 · 바뀜 ·
+   * 실패 · 폴링)이 한 곳에서 그대로 조종된다. 여기서 값을 따로 두면 두 목킹이
+   * 어긋나 「시험은 통과하는데 훅은 다른 값을 본다」가 된다.
+   */
+  computeLocalVaultFingerprintWithStamps: async (root: unknown) => ({
+    fingerprint: await entitiesMocks.computeLocalVaultFingerprint(root),
+    nativeStamps: null,
+  }),
 }));
 
 const fsHandleMocks = vi.hoisted(() => ({

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -6,6 +6,7 @@ import { parseAgentActivityLog, type AgentActivityEntry } from '@/shared/lib/age
 import {
   buildLocalManifestWithEntries,
   rebuildLocalManifestIncremental,
+  computeLocalVaultFingerprintWithStamps,
   computeLocalVaultFingerprint,
   type BuiltVaultEntry,
   type LocalVaultBuild,
@@ -560,6 +561,8 @@ export function useLocalVaultInternal() {
 
   /** 마지막 성공 빌드의 fingerprint — auto-refresh 시 변경 없으면 skip 의 비교 기준. */
   const lastFingerprintRef = useRef<string | null>(null);
+  /** `refresh()` 가 방금 얻은 네이티브 스탬프를 `load()` 로 넘기는 한 칸. */
+  const pendingStampsRef = useRef<Map<string, number> | null>(null);
 
   /**
    * 마지막 성공 빌드의 재사용 가능한 entries + 그 때의 handle. 같은 vault 의
@@ -609,7 +612,9 @@ export function useLocalVaultInternal() {
       let result: { build: LocalVaultBuild; entries: BuiltVaultEntry[] };
       if (reuse) {
         try {
-          result = await rebuildLocalManifestIncremental(handle, reuse);
+          // `refresh()` 가 방금 걸어서 얻은 스탬프가 있으면 그것을 쓴다 —
+          // 없으면 증분 쪽이 스스로 한 번 받는다(첫 로드·다른 경로).
+          result = await rebuildLocalManifestIncremental(handle, reuse, pendingStampsRef.current);
         } catch {
           result = await buildLocalManifestWithEntries(handle);
         }
@@ -794,16 +799,29 @@ export function useLocalVaultInternal() {
     if (!state.handle) return;
     const handle = state.handle;
     try {
-      const fp = await computeLocalVaultFingerprint(handle);
+      /*
+       * 지문과 **그 근거인 스탬프**를 함께 받는다. 종전엔 지문만 받고 버려서,
+       * 곧바로 이어지는 증분 재빌드가 같은 볼트를 한 번 더 걸었다 — 변경
+       * 하나에 네이티브 순회가 둘이었다. 이제 하나다.
+       */
+      const { fingerprint: fp, nativeStamps } =
+        await computeLocalVaultFingerprintWithStamps(handle);
       if (fp === lastFingerprintRef.current) {
         const sidecars = await readVaultSidecarStatuses(handle);
         setState((s) => ({ ...s, ...sidecars, lastLoadedAt: Date.now() }));
         return;
       }
+      pendingStampsRef.current = nativeStamps;
     } catch {
       /* fingerprint 실패 → 안전하게 전체 재빌드로 폴백 */
+      pendingStampsRef.current = null;
     }
-    await load(handle);
+    try {
+      await load(handle);
+    } finally {
+      // 다음 호출이 남은 스탬프를 재사용하면 낡은 mtime 으로 판정한다.
+      pendingStampsRef.current = null;
+    }
   }, [state.handle, load]);
 
   // 탭 포커스 복귀 시 자동 refresh — IDE 에서 편집 후 브라우저로 돌아오면


### PR DESCRIPTION
## Summary

「폴더 감시가 볼트 전체를 다시 읽는다」던 구멍을 파 보니 원인이 달랐다.

증분 재빌드(`rebuildLocalManifestIncremental`)는 **이미 있었고 연결도 돼 있었다.**
「바뀐 파일만 다시 읽는다」가 존재 이유인데, 정작 *무엇이 바뀌었는지* 알아내려고
**파일마다 `getFile()`** 을 불렀다. Tauri 에서 그건 `read_vault_text_file` IPC
왕복이고, 그 명령은 **본문 전체를 함께** 돌려준다. 그래서 본문 재파싱은 아꼈지만
**전송과 왕복은 하나도 아끼지 못했다.**

같은 파일 300줄 위 주석이 이미 그 낭비를 지적해 뒀다:

> 쓰이는 것은 숫자 하나인데 볼트 전체가 다리를 건넜다.

지문 함수는 그것을 `vault_fingerprint`(경로+mtime 한 번에)로 해결했는데,
**증분 경로만 그 교훈을 못 받았다.**

## 고친 것 — 새 Rust 코드 0줄

1. 이미 있는 `vault_fingerprint` 로 mtime 을 받아 판정하고 **다른 것만** 파일을 연다.
2. `refresh()` 가 「바뀌었나」를 판정하려고 방금 걸은 결과를 **버리지 않고 넘긴다** —
   네이티브 순회가 변경당 **둘 → 하나**.

웹에는 그 일괄 API 가 없어 `null` 이 오고 종전 경로로 떨어진다 — 브리지 관례
(없으면 `null`, 조용히 강등) 그대로다.

## 근거 (기계와 무관한 것만)

| | 전 | 후 |
|---|---|---|
| 파일 하나 변경 시 `getFile()` | **71회** | **1회** |
| 변경 없을 때 | 71회 | **0회** |
| 네이티브 순회 (변경당) | 2회 | **1회** |
| 웹(FSA) | 71회 | 71회 (변화 없음) |

- 결과 매니페스트는 전체 빌드와 **등가** — 기존 등가성 시험 7건이 그대로 통과한다.
- 바닥값 실측: 같은 71파일을 디스크에서 읽는 비용은 **1.8ms**(순회 1.5ms). 즉 앱이
  2초를 쓰던 것은 일이 아니라 **다리**였다.

## ⚠️ 벽시계 숫자는 이 PR 의 근거로 쓰지 않는다

앱에서 반영 시간을 반복 측정했지만 **환경이 오염됐다** — 러스트 빌드와 앱 반복
실행으로 부하가 4.5~6.9였고, 전/후 표본이 서로 다른 부하에서 나왔다. 실제로 같은
빌드가 같은 조건에서 다른 결과를 냈다. 그래서 "2.0초 → 0.7초" 같은 비교는 **쓰지
않는다.** 조용한 기계에서 다시 재는 것은 별도 과제다.

밀리초로 게이트를 걸지도 않았다 — 기계마다 들쭉날쭉 실패한다는 것이 이 저장소가
이미 정해 둔 규율이다(`architecture.md`: 「몇 ms」가 아니라 「몇 번」으로 잠근다).

`surfaces.md` 의 「반영까지 1.6~2.0초」는 **고치기 전** 값이고 그 문서 정정의
근거이므로 그대로 둔다.

## Test plan

| 검사 | 결과 |
|---|---|
| `…build-local-manifest.native-mtime.test.ts` | **5 통과** (신규) |
| `…build-local-manifest.incremental.test.ts` (등가성) | 7 통과 |
| `…use-local-vault.test.ts` | 21 통과 |
| `pnpm exec tsc --noEmit` · `eslint` | 통과 (새 error 0) |
| `pnpm build` | 통과 |
| Playwright `web-surface-smoke` (브리지를 만졌으므로) | 10 통과 |

**게이트 프로브**: 네이티브 스탬프를 안 쓰게 그 한 줄만 되돌리니 **3건 빨개짐**,
복구 후 12/12 초록.

**공회전 차단**: ① 1차 빌드가 파일 5개를 실제로 열었는지 먼저 단언(안 열었으면
시험이 헛돈다) ② 변경 없으면 0회 ③ 새로 생긴 파일은 스탬프가 있어도 읽는지
④ 웹 폴백은 종전대로 5회 ⑤ 네이티브가 던져도 폴백.

**기존 시험이 잡아 준 것**: 「변경 없으면 전체 재빌드를 skip 한다」가 빨개졌다 —
`refresh()` 가 새 함수를 부르는데 그 시험의 목킹엔 없어서 지문이 `undefined` 가
됐고, 그러면 **매번 재빌드**가 된다. 시험을 무력화하지 않고, 새 목킹이 기존
목킹에 **위임**하게 해서 시나리오 넷이 한 곳에서 조종되도록 고쳤다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)