### PR TITLE
fix: 절 이름만 9.5px 로 남아 있었다 (내가 만든 면제가 근거 없었다)

### DIFF
--- a/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
+++ b/src/widgets/app-settings-menu/ui/VaultAgentSetupPanel.tsx
@@ -25,6 +25,7 @@ import {
   ONTOLOGY_STARTER_JSON_GATE_COMMAND,
   ONTOLOGY_POST_CHANGE_SYNC_LINES,
 } from '@/features/docs-vault-local';
+import { SETTINGS_SECTION_LABEL } from './settings-primitives';
 import { formatAgentPostChangeSyncPacket } from '@/shared/lib/ontology-tree';
 import type { VaultManifest } from '@/entities/docs-vault';
 import type { AgentClientId } from '@/features/docs-vault-local';
@@ -1462,16 +1463,15 @@ export function VaultAgentSetupPanel({
 }
 
 /**
- * 접기 안의 묶음 제목 — **아이브로우 한 단**.
+ * 접기 안의 묶음 제목 — 루트 시트의 그룹 헤더와 **같은 규격**을 가리킨다.
  *
- * 이 자리의 `text-caption`(9.5px)은 설정 루트 시트에서 금지된 그 쓰임이 아니다.
- * 램프 정의가 말하는 「마이크로 라벨」이고, 누르는 글자도 설명도 아니다
- * (`settings-sheet-type-dialect` 계약이 이 파일을 사정거리 밖에 두는 이유와 같다).
+ * ⚠️ 여기 있던 주석은 *"이 자리의 `text-caption`(9.5px)은 금지된 그 쓰임이 아니다 —
+ * 램프 정의가 말하는 「마이크로 라벨」이다"* 라고 적혀 있었고, **그게 틀렸다**
+ * (2026-08-09, 소유자 지적 2차). 한글에는 `uppercase` 가 아무 일도 하지 않아서
+ * 「대문자 마이크로 라벨」이라는 타이포 장치가 성립하지 않고, 남는 건 그냥 9.5px
+ * 흐린 글자다. 게다가 루트 시트가 같은 역할에 이미 11px 을 쓰고 있었다.
+ * 값은 `SETTINGS_SECTION_LABEL` 한 곳에 있다.
  */
 function SectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <h4 className="text-caption font-[var(--font-weight-signature)] uppercase tracking-[var(--tracking-caps-12)] text-[color:var(--color-text-quaternary)]">
-      {children}
-    </h4>
-  );
+  return <h4 className={SETTINGS_SECTION_LABEL}>{children}</h4>;
 }

--- a/src/widgets/app-settings-menu/ui/settings-primitives.tsx
+++ b/src/widgets/app-settings-menu/ui/settings-primitives.tsx
@@ -66,6 +66,28 @@ export const DETAIL_TOGGLE_CHIP =
  */
 export const RESET_LINK_INK = 'justify-self-start hover:text-[color:var(--color-text-primary)]';
 
+/**
+ * 설정 시트의 **절 이름** 한 벌 — 루트 시트의 그룹 헤더와 드릴인의 절 헤더가 같은 것.
+ *
+ * ⚠️ **셋이 따로 자랐고, 그중 하나만 한 단 작았다** (2026-08-09, 소유자 지적 2차).
+ * 루트 시트의 `SettingsGroup` 은 `text-label`(11), `AiConnectionPanel` 의
+ * `SupportingSection` 도 `text-label`, 그런데 `VaultAgentSetupPanel` 의
+ * `SectionLabel` 만 **`text-caption`(9.5)** 이었다. 네 자리(연결 파일 상태 ·
+ * 에이전트가 이 폴더를 쓰는 방식 · 확인 · 연결)가 전부 그것이라, 그 절들만
+ * 이름이 내용보다 작았다.
+ *
+ * **「아이브로우는 9.5px 이어도 된다」는 내 면제가 틀렸다.** 근거로 든 것은 램프의
+ * 정의("마이크로 라벨")와 `uppercase` 였는데, **한글에는 `uppercase` 가 아무 일도
+ * 하지 않는다** — 대문자 마이크로 라벨이라는 타이포 장치 자체가 성립하지 않고
+ * 남는 건 그냥 9.5px 흐린 글자다. 게다가 루트 시트가 같은 역할에 이미 11px 을
+ * 쓰고 있었으니, 면제는 **아무도 쓰지 않는 규격**이었다.
+ *
+ * 그래서 값을 여기 한 곳에 두고 소비처가 가리킨다 — 사본이 셋이면 어긋나는 쪽이
+ * 기본값이다(Carbon).
+ */
+export const SETTINGS_SECTION_LABEL =
+  'font-mono text-label uppercase tracking-[var(--tracking-caps-14)] text-[color:var(--color-text-quaternary)]';
+
 /** 그룹 헤더 + 행 컨테이너 — Toss 식 "그룹 헤더 + 즉시 조작 행" 문법의 뼈대. */
 /**
  * 한 무리의 설정 행. `label` 은 **선택**이다 — LNB 가 이미 그 칸의 이름을 말하는
@@ -76,9 +98,7 @@ export function SettingsGroup({ label, children }: { label?: string; children: R
   return (
     <section aria-label={label}>
       {label ? (
-        <h3 className="px-1 font-mono text-label uppercase tracking-[var(--tracking-caps-14)] text-[color:var(--color-text-quaternary)]">
-          {label}
-        </h3>
+        <h3 className={`px-1 ${SETTINGS_SECTION_LABEL}`}>{label}</h3>
       ) : null}
       <div className={`${label ? 'mt-1.5 ' : ''}divide-y divide-[color:var(--color-divider)] overflow-hidden rounded-card border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)]`}>
         {children}

--- a/tests/contract/settings-sheet-type-dialect.contract.test.ts
+++ b/tests/contract/settings-sheet-type-dialect.contract.test.ts
@@ -113,16 +113,23 @@ function sourceAtPath(path: string): string {
 }
 
 /**
- * 9.5px 을 쓴 줄 중 **아이브로우가 아닌 것**. 아이브로우는 `uppercase` 가 같은
- * className 에 붙은 것이고, 그것만 램프 정의("마이크로 라벨")에 맞는 쓰임이다.
+ * 9.5px 을 쓴 줄. **면제는 없다.**
  *
- * 판정이 한 줄 안에서 끝나야 한다 — 요소의 역할(`dt` 인가 설명인가)로 가르려면
- * JSX 를 파싱해야 하고, 그러면 게이트가 자기가 못 보는 층을 갖게 된다.
+ * ⚠️ 처음에는 «`uppercase` 가 붙은 아이브로우» 를 면제했고, 그것이 소유자 지적
+ * 2차를 불렀다(2026-08-09). 근거로 든 것이 램프 정의("마이크로 라벨")와
+ * `uppercase` 였는데 **한글에는 `uppercase` 가 아무 일도 하지 않는다** — 대문자
+ * 마이크로 라벨이라는 타이포 장치가 성립하지 않고, 남는 것은 그냥 9.5px 흐린
+ * 글자다. 실제로 그 면제를 타고 절 이름 네 자리(연결 파일 상태 · 에이전트가 이
+ * 폴더를 쓰는 방식 · 확인 · 연결)가 9.5px 로 남았다.
+ *
+ * 결정적인 것은 **루트 시트가 같은 역할에 이미 11px 을 쓰고 있었다**는 사실이다
+ * (`SETTINGS_SECTION_LABEL`). 아무도 쓰지 않는 규격을 위해 열어 둔 면제였으니,
+ * 면제를 지우는 것이 규칙을 더 단순하게 만든다.
  */
-function nonEyebrowCaptionLines(source: string): string[] {
+function captionLines(source: string): string[] {
   return source
     .split("\n")
-    .filter((line) => line.includes("text-caption") && !line.includes("uppercase"))
+    .filter((line) => line.includes("text-caption"))
     .map((line) => line.trim().slice(0, 100));
 }
 
@@ -144,21 +151,39 @@ describe("설정 루트 시트 — 타입 방언은 하나다", () => {
    * 공회전 차단 — 파일 목록이 오타/이동으로 비면 위 시험은 «위반 0» 을 영원히
    * 보고한다. 실제로 무엇인가를 읽었고, 그것이 타입 램프를 쓰는 파일인지 본다.
    */
-  /**
-   * 드릴인 목적지 — 루트와 같은 방언이다. 여기서만 **아이브로우**(`uppercase`)가
-   * 9.5px 을 쓸 수 있다: 루트 시트는 그 자리를 `SettingsGroup` 이 소유하지만
-   * 드릴인은 자기 안에서 절을 나눠야 해서 자기 아이브로우를 갖는다.
-   */
-  it("드릴인 목적지에도 아이브로우 밖의 9.5px 이 없다", () => {
-    const offenders = DRILL_IN_FILES.flatMap((path) => {
-      const lines = nonEyebrowCaptionLines(sourceAtPath(path));
-      return lines.map((line) => `${path.split("/").pop()}: ${line}`);
-    });
+  /** 드릴인 목적지 — 루트와 **똑같은** 방언이다. 9.5px 면제는 없다(위 주석). */
+  it("드릴인 목적지에도 9.5px 이 없다", () => {
+    const offenders = DRILL_IN_FILES.flatMap((path) =>
+      captionLines(sourceAtPath(path)).map((line) => `${path.split("/").pop()}: ${line}`),
+    );
     expect(
       offenders,
       "드릴인 칸이 루트 시트보다 한 단 작아졌다. 이름은 text-body(12.5), " +
-        "설명·값·경로는 text-label(11), 9.5px 은 uppercase 아이브로우만.",
+        "설명·값·경로는 text-label(11). 절 이름은 SETTINGS_SECTION_LABEL 을 쓴다.",
     ).toEqual([]);
+  });
+
+  /**
+   * 절 이름은 **한 벌**이다 — 루트 시트의 그룹 헤더와 드릴인의 절 헤더가 같은 것.
+   * 사본이 생기면 그중 하나가 다시 한 단 작아진다(그게 이번에 일어난 일이다).
+   */
+  it("절 이름 규격이 한 곳에 있고 소비처가 그것을 가리킨다", () => {
+    const primitives = sourceWithoutComments("settings-primitives.tsx");
+    expect(primitives, "SETTINGS_SECTION_LABEL 이 없다").toContain("SETTINGS_SECTION_LABEL");
+    expect(primitives, "절 이름은 text-label(11) 이다").toMatch(
+      /SETTINGS_SECTION_LABEL\s*=\s*\n?\s*'[^']*\btext-label\b/,
+    );
+    /*
+     * 소비처가 값을 다시 적지 않고 가리키는가.
+     *
+     * ⚠️ **`toContain(이름)` 으로는 이것을 못 본다** — import 줄에 이름이 남아 있으면
+     * 본문에서 손으로 값을 적어도 통과한다(프로브에서 실제로 통과했다). 그래서
+     * **`className` 자리에서** 쓰이는지를 본다.
+     */
+    const setup = sourceWithoutComments("VaultAgentSetupPanel.tsx");
+    expect(setup, "드릴인 절 이름이 규격을 className 으로 쓰지 않는다").toMatch(
+      /className=\{[^}]*SETTINGS_SECTION_LABEL/,
+    );
   });
 
   it("게이트가 빈 집합 위에서 돌지 않는다", () => {


### PR DESCRIPTION
## Summary

소유자: *"위에는 해결된듯한데.. 「잘 안 되나요?」 여기는 누르니까 왜 똑같이 작고 이상하지?"*

범인은 절 이름 네 자리(연결 파일 상태 · 에이전트가 이 폴더를 쓰는 방식 · 확인 ·
연결)이고, **전부 직전 PR(#1016)에서 내가 일부러 면제한 자리**다.

면제 근거로 램프 정의("마이크로 라벨")와 `uppercase` 를 댔는데 둘 다 틀렸다:

- **한글에는 `uppercase` 가 아무 일도 하지 않는다.** 대문자 마이크로 라벨이라는
  타이포 장치가 성립하지 않고 남는 것은 그냥 9.5px 흐린 글자다
- **루트 시트가 같은 역할에 이미 11px 을 쓰고 있었다**(`SettingsGroup`).
  `AiConnectionPanel` 의 `SupportingSection` 도 11px. **셋 중 하나만 작았던 것**이고,
  면제는 아무도 쓰지 않는 규격을 위해 열어 둔 구멍이었다

**면제를 지운다** — 설정 시트 트리에 9.5px 은 없다. 규칙이 더 단순해졌다. 그리고
절 이름 값을 `SETTINGS_SECTION_LABEL` 한 곳으로 모았다(사본이 셋이면 어긋나는
쪽이 기본값이다 — 이번이 그 예다).

## 직전 PR 의 측정에 있던 구멍

#1016 은 「여덟 칸 전부 9.5px 0」이라고 보고했는데, **그때 「잘 안 되나요?」는 접혀
있었다.** 그 절은 `publicPackagesReady` 가 참일 때만 그려져서 브라우저 빌드에
아예 없다 — 데스크톱 전용이다. 브라우저로는 원리적으로 못 재는 자리였고, 그걸
「0」에 포함해 말한 것이 과장이었다. 이 자리는 설치 앱에서만 잰다.

## Test plan

- 게이트 프로브 3가지 — ① 아이브로우로 위장한 9.5px ② 규격 자체를 9.5px 로
  되돌리기 ③ 소비처가 값을 손으로 다시 적기 → **셋 다 빨개진다** ✅
  ③ 은 처음에 안 걸렸다(`toContain` 이 import 줄만으로 통과) → `className` 자리에서
  쓰이는지로 바꿨다. **프로브가 게이트의 구멍을 잡은 것**
- `pnpm exec eslint` 0 · `pnpm exec tsc --noEmit` 깨끗
- 설정 위젯 테스트 132 통과 · `pnpm test:contracts` 1,560 통과
- 머지 후 설치 앱에서 그 절을 다시 열어 확인한다

🤖 Generated with [Claude Code](https://claude.com/claude-code)