### PR TITLE
feat: 목적지를 키보드로 간다 (G 다음 한 글자, 표가 정본)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -909,6 +909,13 @@
         "docsActions": "Ontology workspace · document actions"
       },
       "rows": {
+        "goTo_map": "Go to map",
+        "goTo_docs": "Go to docs",
+        "goTo_studio": "Go to studio",
+        "goTo_insights": "Go to insights",
+        "goTo_projects": "Go to projects",
+        "goTo_skills": "Go to skills",
+        "goTo_git": "Go to git history",
         "openProjectPalette": "Open the search palette",
         "openGlobalPalette": "Search concepts, docs, and projects together",
         "toggleDocsDrawer": "Toggle the ontology workspace preview drawer (with edit access)",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -909,6 +909,13 @@
         "docsActions": "문서함 · 문서 액션"
       },
       "rows": {
+        "goTo_map": "지도로",
+        "goTo_docs": "문서함으로",
+        "goTo_studio": "공방으로",
+        "goTo_insights": "인사이트로",
+        "goTo_projects": "프로젝트로",
+        "goTo_skills": "스킬로",
+        "goTo_git": "Git 기록으로",
         "openProjectPalette": "검색 팔레트 열기",
         "openGlobalPalette": "개념 · 문서 · 프로젝트 통합 검색",
         "toggleDocsDrawer": "문서함 빠른 보기 드로어 토글 (편집 권한 시)",

--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type ReactNode } from "react";
 import { useRouter, usePathname } from "@/i18n/navigation";
+import { useDestinationShortcuts } from "@/shared/lib/use-destination-shortcuts";
 import {
   AppNavRail,
   NavRailShellProvider,
@@ -237,6 +238,20 @@ function AppNavRailSlot() {
   // 동작한다 — 데스크톱 정밀 카운트(`git_status.changedCount`)는 후속.
   const { changeset: gitChangeset } = useAtlasGitContext();
   const gitDirtyCount = gitChangeset.touchedNodeIds.size;
+
+  /**
+   * 목적지 이동 단축키(`G` 다음 한 글자) — **레일과 같은 자리**에서 배선한다.
+   *
+   * 레일이 그리는 목적지와 키보드가 데려가는 목적지가 어긋나면 안 되고, 그
+   * 어긋남을 막는 가장 싼 방법은 둘이 같은 `contextHrefs` 와 같은 `gateway`
+   * 판정을 보는 것이다. 관문 화면에서는 레일이 없으므로 키도 없다 — 화면에
+   * 입구가 없는데 키보드에만 있으면, 그건 발견할 수 없는 기능이다.
+   */
+  useDestinationShortcuts({
+    navigate: (href) => router.push(href),
+    disabled: gateway,
+    hrefOverrides: contextHrefs?.docs ? { docs: contextHrefs.docs } : undefined,
+  });
 
   // 2026-07-25 — 기록은 **목적지로 승격**됐고 이 유틸 타일은 흡수됐다. 입구가
   // 둘이면(타일 + 목적지) #65 와 같은 계열의 혼란이 재발한다. 미커밋 변경 수는

--- a/src/shared/config/destinations.ts
+++ b/src/shared/config/destinations.ts
@@ -1,0 +1,80 @@
+/**
+ * 목적지 정본 — id · 기본 주소 · 키보드 단축키 한 곳.
+ *
+ * ## 왜 이 파일이 생겼나
+ *
+ * 목적지 일곱의 주소가 `AppNavRail` **컴포넌트 안에** 인라인으로 있었다. 화면을
+ * 그리는 데는 충분했지만, 그 목록을 **데이터로 읽어야 하는 두 번째 소비처**
+ * (키보드 이동 · 단축키 시트)가 생기면서 문제가 됐다 — 컴포넌트 안의 배열은
+ * `t()` 와 아이콘이 섞여 있어 import 할 수 없고, 사본을 만들면 그 순간부터
+ * 라우트가 어긋나기 시작한다(Carbon).
+ *
+ * 그래서 **id 와 주소만** 여기로 내린다. 라벨과 아이콘은 화면의 것이므로 레일에
+ * 남는다 — 이 파일은 "무엇이 있고 어디로 가나"만 답한다.
+ *
+ * ## 이동 단축키는 왜 리더 키(`G` 다음 한 글자)인가
+ *
+ * ⌘1~⌘9 는 **브라우저의 탭 전환**이다. 웹에서 그것을 가로채면 앱이 사용자의
+ * 브라우저를 망가뜨리는 셈이고, 이 제품은 웹이 관문이라 그 대가를 낼 수 없다.
+ * 한 글자 단독(`M` · `D` …)도 못 쓴다 — `D`(문서 서랍) · `F`(발표) · `?`(단축키
+ * 시트) · `/`(팔레트)가 이미 단독 글자를 쓰고 있어 부딪힌다.
+ *
+ * 리더 키는 그 둘을 다 피하고, **공개된 선례가 있다** — GitHub(`g c` · `g i`)와
+ * Linear 가 같은 문법을 쓴다. 순서열이라 기존 단독 글자와도 충돌하지 않는다:
+ * `G` 를 누른 다음 `D` 를 누르는 것과 `D` 만 누르는 것은 다른 입력이다.
+ *
+ * 시간 제한을 두는 이유는 **`G` 를 눌렀다가 마음이 바뀌는 경우**다. 제한이 없으면
+ * 한참 뒤에 누른 글자가 이동으로 해석된다.
+ */
+
+export const DESTINATION_IDS = [
+  'map',
+  'docs',
+  'studio',
+  'insights',
+  'projects',
+  'skills',
+  'git',
+] as const;
+
+export type DestinationId = (typeof DESTINATION_IDS)[number];
+
+/**
+ * 기본 주소. 레일이 문맥에 따라 다른 주소를 줄 수 있는 자리가 하나 있고
+ * (`docs` 는 프로젝트 문맥에서 그 프로젝트의 문서함으로 간다), 그때는 레일의
+ * 값이 이긴다 — 여기 있는 것은 문맥이 없을 때의 기본이다.
+ */
+export const DESTINATION_HREF: Record<DestinationId, string> = {
+  map: '/topology/',
+  docs: '/docs/',
+  studio: '/ontology/studio/',
+  insights: '/ontology/insights/',
+  projects: '/projects/',
+  skills: '/skills/',
+  git: '/git/',
+};
+
+/** 리더 키 — 이것을 누른 다음 아래 글자를 누르면 이동한다. */
+export const NAV_LEADER_KEY = 'g';
+
+/**
+ * 리더 다음에 오는 글자. 첫 글자를 쓰되 겹치면 뜻이 남는 다른 글자로 간다 —
+ * `studio` 가 `s` 를 가져가므로 `skills` 는 s**k**ills 의 `k`.
+ */
+export const DESTINATION_KEY: Record<DestinationId, string> = {
+  map: 'm',
+  docs: 'd',
+  studio: 's',
+  insights: 'i',
+  projects: 'p',
+  skills: 'k',
+  git: 'g',
+};
+
+/** 리더를 누른 뒤 다음 글자를 기다리는 시간(ms). */
+export const NAV_LEADER_WINDOW_MS = 1500;
+
+/** 글자 → 목적지. 핸들러가 쓰는 방향의 표. */
+export const DESTINATION_BY_KEY: Record<string, DestinationId> = Object.fromEntries(
+  DESTINATION_IDS.map((id) => [DESTINATION_KEY[id], id]),
+) as Record<string, DestinationId>;

--- a/src/shared/lib/use-destination-shortcuts.test.ts
+++ b/src/shared/lib/use-destination-shortcuts.test.ts
@@ -1,0 +1,174 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDestinationShortcuts } from "./use-destination-shortcuts";
+import { NAV_LEADER_WINDOW_MS } from "@/shared/config/destinations";
+
+/**
+ * 이동 단축키의 **거절 조건**은 여기서 잰다 — e2e 가 아니라.
+ *
+ * ⚠️ **e2e 로 재려다 실패했다** (2026-08-09). 「입력 중에는 이동하지 않는다」를
+ * 브라우저에서 재려면 입력칸에 초점을 줘야 하는데, 볼트를 안 고른 상태의 이 앱에는
+ * **화면에 입력칸이 없다**(실측: `/topology` · `/projects` · `/docs` · `/git` 네
+ * 라우트 전부 `input:visible` 0개). 그래서 ⌘K 팔레트를 열어 그 입력칸을 썼는데,
+ * 팔레트가 **자기도 `aria-modal`** 이라 모달 판정이 먼저 걸렸다 — 입력 판정을
+ * 통째로 지워도 그 시험은 초록이었다. **원리적으로 실패할 수 없는 시험**이었고,
+ * 그건 게이트가 아니다(`/gate-probe`).
+ *
+ * 여기서는 키보드 사건을 직접 만들어 보내므로 조건이 서로 가려지지 않는다.
+ * 「정말 이동하나」는 여전히 e2e 의 몫이다 —
+ * `tests/e2e/destination-shortcuts.spec.ts`.
+ */
+
+function press(key: string, target?: Element, extra: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...extra });
+  (target ?? window).dispatchEvent(event);
+  return event;
+}
+
+describe("useDestinationShortcuts", () => {
+  let navigate: ReturnType<typeof vi.fn<(href: string, id: string) => void>>;
+
+  beforeEach(() => {
+    navigate = vi.fn();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("리더 다음 글자를 누르면 그 목적지로 데려간다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    press("g");
+    press("p");
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate.mock.calls[0]?.[0]).toBe("/projects/");
+    expect(navigate.mock.calls[0]?.[1]).toBe("projects");
+  });
+
+  it("리더 없이 글자만 누르면 아무 일도 없다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    press("p");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("리더를 두 번 누르면 git 으로 간다 — 리더 자신도 둘째 글자가 될 수 있다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    press("g");
+    press("g");
+    expect(navigate).toHaveBeenCalledWith("/git/", "git");
+  });
+
+  it("입력칸에 초점이 있으면 이동하지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const input = document.createElement("input");
+    document.body.append(input);
+    press("g", input);
+    press("p", input);
+    expect(navigate, "입력 중에 화면을 바꿨다").not.toHaveBeenCalled();
+  });
+
+  it("textarea 도 같다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const area = document.createElement("textarea");
+    document.body.append(area);
+    press("g", area);
+    press("p", area);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * ⚠️ `isContentEditable` 을 **흉내 내야 한다** — jsdom 은 그것을 구현하지 않아
+   * `contentEditable = "true"` 를 줘도 늘 `false` 다(실측으로 확인했다). 흉내를
+   * 안 내면 이 시험은 훅이 아니라 jsdom 을 재는 셈이 된다.
+   */
+  it("contentEditable 도 같다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const editable = document.createElement("div");
+    editable.contentEditable = "true";
+    Object.defineProperty(editable, "isContentEditable", { value: true });
+    document.body.append(editable);
+    press("g", editable);
+    press("p", editable);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("조합키가 눌린 입력은 우리 것이 아니다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    press("g", undefined, { metaKey: true });
+    press("p");
+    expect(navigate, "⌘G 를 리더로 먹었다").not.toHaveBeenCalled();
+  });
+
+  it("보이는 막는 표면이 있으면 이동하지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    // jsdom 은 레이아웃이 없어 `getClientRects()` 가 늘 비었다 — 그려진 것으로
+    // 보이게 흉내 낸다. 이 흉내가 필요하다는 사실 자체가, 화면 기준 판정을
+    // 브라우저에서 한 번 더 재야 하는 이유다(e2e 가 그 몫을 맡는다).
+    modal.getClientRects = (() => [{}] as unknown as DOMRectList) as typeof modal.getClientRects;
+    document.body.append(modal);
+    press("g");
+    press("p");
+    expect(navigate, "모달이 떠 있는데 뒤 화면을 바꿨다").not.toHaveBeenCalled();
+  });
+
+  /**
+   * **숨은 모달은 막지 않는다.** 이 단언이 없으면, 퇴장 중인 표면 하나가 DOM 에
+   * 남아 이동 단축키 전체를 영구히 죽이는 상태를 아무도 못 잡는다(실제로 그
+   * 결함을 냈다 — 훅 주석 참고).
+   */
+  it("숨은 막는 표면은 이동을 막지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const hidden = document.createElement("div");
+    hidden.setAttribute("aria-modal", "true");
+    // 그려지지 않은 상태 = `getClientRects()` 가 비어 있다(jsdom 기본값).
+    document.body.append(hidden);
+    press("g");
+    press("p");
+    expect(navigate, "숨은 모달이 이동을 막았다").toHaveBeenCalledTimes(1);
+  });
+
+  it("aria-hidden 조상 안의 모달도 세지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("aria-hidden", "true");
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    modal.getClientRects = (() => [{}] as unknown as DOMRectList) as typeof modal.getClientRects;
+    wrapper.append(modal);
+    document.body.append(wrapper);
+    press("g");
+    press("p");
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("리더를 누른 지 오래되면 글자만으로는 이동하지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    // `timeStamp` 로 재므로 시계를 건드리지 않고 사건 자신의 시각을 벌린다.
+    const leader = new KeyboardEvent("keydown", { key: "g", bubbles: true, cancelable: true });
+    Object.defineProperty(leader, "timeStamp", { value: 0 });
+    window.dispatchEvent(leader);
+    const late = new KeyboardEvent("keydown", { key: "p", bubbles: true, cancelable: true });
+    Object.defineProperty(late, "timeStamp", { value: NAV_LEADER_WINDOW_MS + 1 });
+    window.dispatchEvent(late);
+    expect(navigate, "시간 제한이 안 걸렸다").not.toHaveBeenCalled();
+  });
+
+  it("disabled 면 아무것도 하지 않는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate, disabled: true }));
+    press("g");
+    press("p");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("문맥 주소가 있으면 그것으로 간다", () => {
+    renderHook(() =>
+      useDestinationShortcuts({ navigate, hrefOverrides: { docs: "/project/atlas/docs/" } }),
+    );
+    press("g");
+    press("d");
+    expect(navigate).toHaveBeenCalledWith("/project/atlas/docs/", "docs");
+  });
+});

--- a/src/shared/lib/use-destination-shortcuts.ts
+++ b/src/shared/lib/use-destination-shortcuts.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  DESTINATION_BY_KEY,
+  DESTINATION_HREF,
+  NAV_LEADER_KEY,
+  NAV_LEADER_WINDOW_MS,
+  type DestinationId,
+} from '@/shared/config/destinations';
+
+/**
+ * 목적지 이동 단축키 — `G` 를 누른 다음 목적지의 글자를 누른다.
+ *
+ * 문법과 왜 리더 키인지는 `shared/config/destinations.ts` 에 있다. 이 파일은
+ * **그 문법을 키보드 사건으로 옮기는 것**만 한다.
+ *
+ * ## 안 먹어야 하는 자리 셋
+ *
+ * 1. **입력 중** — `input` · `textarea` · `contentEditable`. 「go」를 타이핑하다가
+ *    화면이 바뀌면 그건 단축키가 아니라 결함이다.
+ * 2. **조합키가 눌린 채** — `⌘G`(찾기 다음) · `⌃G` 는 브라우저와 OS 의 것이다.
+ *    리더는 **아무 조합키 없이** 눌린 `G` 만이다.
+ * 3. **막는 표면이 열려 있을 때** — 모달·시트는 뒤를 막기로 되어 있고
+ *    (`design.md` 「뒤를 막지 않는 모달」 금지), 그 약속이 키보드에서도 지켜져야
+ *    한다. 설정 시트를 열어 둔 채 `G D` 를 누르면 시트는 그대로인데 뒤 화면만
+ *    바뀐다 — 막는다고 한 표면이 안 막은 것이다.
+ *
+ *    **판정을 호출자에게 맡기지 않고 DOM 에서 읽는다.** `disabled` prop 으로
+ *    두면 새 모달을 만드는 사람이 그 배선을 빠뜨리고, 그건 이 저장소가 이미
+ *    낸 값이다(레일 유틸 슬롯을 페이지마다 손으로 등록하다 공방이 빠뜨린 #65).
+ *    `aria-modal="true"` 는 그 표면들이 **이미** 달고 있는 것이라, 접근성 속성이
+ *    곧 배선이 된다 — 새 모달은 그 속성을 달아야 정상이므로 공짜로 지켜진다.
+ *    `disabled` 는 그래도 남긴다: 모달이 아니면서 키를 독점하는 상태
+ *    (관문 화면처럼)를 호출자가 알릴 길이 필요하다.
+ *
+ * ## 순서열을 `useRef` 로 두는 이유
+ *
+ * 리더를 눌렀다는 사실은 **화면에 아무것도 바꾸지 않는다**. `useState` 로 두면
+ * 리더를 누를 때마다 앱 전체가 다시 그려지고, 그 비용을 가장 잦은 입력이 낸다
+ * (`architecture.md` 「아직 화면에 안 그려진 것의 데이터는 미리 만들지 않는다」와
+ * 같은 결의 이야기다).
+ */
+/**
+ * 지금 **화면에 실제로 떠 있는** 막는 표면이 있나.
+ *
+ * ⚠️ **`querySelector('[aria-modal="true"]')` 하나로는 틀린다** (2026-08-09,
+ * e2e 가 잡았다). 그것은 문서의 **첫** 일치를 돌려주는데, 그게 화면에 없는 것일
+ * 수 있다 — 이 앱의 표면들은 퇴장 애니메이션 동안 DOM 에 남아 있고
+ * (`use-presence.ts` 의 `EXIT_WINDOW_MS`), 그 사이 `aria-hidden` 이 붙는다.
+ * 숨은 하나가 먼저 걸리면 **이동 단축키가 영구히 죽는다** — 화면에는 아무 단서도
+ * 없이. 실측에서 설정 시트를 열었을 때 정확히 그 상태가 됐다.
+ *
+ * 그래서 **모두 훑고, 그려진 것이 하나라도 있으면** 막는다. 판정은 화면 기준이다
+ * (`design-audit` 의 「사각형이 나온다고 보이는 것은 아니다」와 같은 규율).
+ */
+function blockingSurfaceOpen(): boolean {
+  for (const el of document.querySelectorAll('[aria-modal="true"]')) {
+    if (el.closest('[aria-hidden="true"]')) continue;
+    if (el.getClientRects().length === 0) continue;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') continue;
+    if (Number(style.opacity) < 0.05) continue;
+    return true;
+  }
+  return false;
+}
+
+export interface DestinationShortcutOptions {
+  /** 목적지로 데려간다. 라우터는 호출자가 쥔다 — `shared` 가 라우터를 모르게. */
+  navigate: (href: string, id: DestinationId) => void;
+  /** 막는 표면이 열려 있으면 true. */
+  disabled?: boolean;
+  /** 문맥에 따라 기본 주소를 덮어쓸 때. 없으면 `DESTINATION_HREF`. */
+  hrefOverrides?: Partial<Record<DestinationId, string>>;
+}
+
+export function useDestinationShortcuts({
+  navigate,
+  disabled = false,
+  hrefOverrides,
+}: DestinationShortcutOptions) {
+  /** 리더를 누른 시각. 0 이면 안 누른 것. */
+  const leaderAt = useRef(0);
+
+  useEffect(() => {
+    if (disabled) {
+      leaderAt.current = 0;
+      return;
+    }
+    const handler = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+
+      // 막는 표면이 떠 있으면 이동하지 않는다 (위 3번).
+      if (blockingSurfaceOpen()) {
+        leaderAt.current = 0;
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      const now = event.timeStamp;
+
+      if (leaderAt.current > 0 && now - leaderAt.current <= NAV_LEADER_WINDOW_MS) {
+        const id = DESTINATION_BY_KEY[key];
+        leaderAt.current = 0;
+        if (!id) return;
+        event.preventDefault();
+        navigate(hrefOverrides?.[id] ?? DESTINATION_HREF[id], id);
+        return;
+      }
+
+      // 리더를 새로 누른다. `G G`(git)가 성립하려면 리더 자신도 두 번째 글자가
+      // 될 수 있어야 하는데, 그 판정은 위 블록이 먼저 하므로 순서가 중요하다.
+      leaderAt.current = key === NAV_LEADER_KEY ? now : 0;
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [navigate, disabled, hrefOverrides]);
+}

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -29,6 +29,7 @@ import {
   Map as MapIcon,
   Wand2,
 } from "lucide-react";
+import { DESTINATION_HREF } from "@/shared/config/destinations";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
 import { useLocalVault } from "@/features/docs-vault-local";
 import { formatActivityAge } from "@/features/vault-ontology";
@@ -251,12 +252,15 @@ export function AppNavRail({
       : null;
   const agentTitle = [baseAgentTitle, lastActivitySuffix].filter(Boolean).join(" · ");
 
+  // 주소는 `shared/config/destinations` 가 정본이다 — 키보드 이동과 단축키 시트가
+  // 같은 표를 읽어야 해서 컴포넌트 밖으로 내렸다(사본이 둘이면 라우트가 어긋난다).
+  // 라벨과 아이콘은 화면의 것이라 여기 남는다.
   const destinations: RailDestination[] = [
-    { id: "map", href: "/topology/", label: t("map"), Icon: MapIcon },
-    { id: "docs", href: contextHrefs?.docs ?? "/docs/", label: t("docs"), Icon: BookOpen },
-    { id: "studio", href: "/ontology/studio/", label: t("studio"), Icon: Gem },
-    { id: "insights", href: "/ontology/insights/", label: t("insights"), Icon: BarChart3 },
-    { id: "projects", href: "/projects/", label: t("projects"), Icon: FolderKanban },
+    { id: "map", href: DESTINATION_HREF.map, label: t("map"), Icon: MapIcon },
+    { id: "docs", href: contextHrefs?.docs ?? DESTINATION_HREF.docs, label: t("docs"), Icon: BookOpen },
+    { id: "studio", href: DESTINATION_HREF.studio, label: t("studio"), Icon: Gem },
+    { id: "insights", href: DESTINATION_HREF.insights, label: t("insights"), Icon: BarChart3 },
+    { id: "projects", href: DESTINATION_HREF.projects, label: t("projects"), Icon: FolderKanban },
     // 발자취 — 2026-07-25 목적지 승격. 구 "레일 하단 유틸 타일 + 560px 모달"
     // 은 흡수됐다(입구가 둘이면 #65 계열 결함 재발). 아이콘은 History 유지 —
     // git 3-노드 그래프 글리프는 이 레일에서 "온톨로지 그래프" 로 읽혀 지도
@@ -264,8 +268,8 @@ export function AppNavRail({
     // 스킬 — 2026-08-09 소유자 확정으로 목적지 신설. 문서함과 나란히 두지 않고
     // 따로 세운 이유는 답하는 질문이 다르기 때문이다: 문서함은 「이 문서가 지도
     // 어디에 붙나」, 여기는 「이게 언제 뜨고 뜨면 뭐가 열리나」.
-    { id: "skills", href: "/skills/", label: t("skills"), Icon: Wand2 },
-    { id: "git", href: "/git/", label: t("git"), Icon: HistoryIcon, badgeCount: gitDirtyCount },
+    { id: "skills", href: DESTINATION_HREF.skills, label: t("skills"), Icon: Wand2 },
+    { id: "git", href: DESTINATION_HREF.git, label: t("git"), Icon: HistoryIcon, badgeCount: gitDirtyCount },
   ];
 
   return (

--- a/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
+++ b/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
@@ -4,6 +4,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
+import {
+  DESTINATION_IDS,
+  DESTINATION_KEY,
+  NAV_LEADER_KEY,
+} from "@/shared/config/destinations";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
 import { MOTION, OVERLAY_SPRING_REDUCED } from "@/shared/motion";
 import { useBodyScrollLock } from "@/shared/lib/use-body-scroll-lock";
@@ -63,11 +68,28 @@ const GLOSSARY_TERMS = [
   "nodeNumber",
 ] as const;
 
+/**
+ * 목적지 이동 줄 — **표에서 만든다**(손으로 적지 않는다).
+ *
+ * 이 시트의 나머지 줄은 손으로 적힌 목록이고, 그것을 실제 핸들러와 맞춰 주는
+ * 검사가 없다. 그 방식이 이미 낸 값이 이 파일 아래 주석에 남아 있다 —
+ * *"the previous rows described interactions the v2 canvas never implemented"*.
+ * 즉 시트가 **없는 기능을 안내하고 있었다.**
+ *
+ * 이동 단축키는 같은 실수를 하지 않게 `DESTINATION_KEY` 에서 파생시킨다. 키를
+ * 하나 더하면 시트에 저절로 나타나고, 지우면 저절로 사라진다.
+ */
+const DESTINATION_ROWS: ShortcutRow[] = DESTINATION_IDS.map((id) => ({
+  keys: [NAV_LEADER_KEY.toUpperCase(), DESTINATION_KEY[id].toUpperCase()],
+  labelKey: `goTo_${id}`,
+}));
+
 const SECTIONS: ShortcutSection[] = [
   {
     titleKey: "navigation",
     surface: "global",
     rows: [
+      ...DESTINATION_ROWS,
       { keys: ["⌘", "K"], labelKey: "openProjectPalette" },
       { keys: ["⇧", "⌘", "K"], labelKey: "openGlobalPalette" },
       { keys: ["D"], labelKey: "toggleDocsDrawer" },

--- a/tests/contract/destination-shortcuts.contract.test.ts
+++ b/tests/contract/destination-shortcuts.contract.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  DESTINATION_BY_KEY,
+  DESTINATION_HREF,
+  DESTINATION_IDS,
+  DESTINATION_KEY,
+  NAV_LEADER_KEY,
+  NAV_LEADER_WINDOW_MS,
+} from "@/shared/config/destinations";
+
+/**
+ * 목적지 이동 단축키 — **목록 · 화면 · 안내가 한 표에서 나온다.**
+ *
+ * ## 이 게이트가 막으려는 것
+ *
+ * 이 저장소에서 단축키 안내는 이미 한 번 거짓말을 했다. `ShortcutSheet` 의 지도
+ * 절에 남아 있는 주석이 그 기록이다 — *"the previous rows described interactions
+ * the v2 canvas never implemented — stale carryover from an earlier design that
+ * never shipped"*. 즉 시트가 **없는 기능**(Tab 이웃 이동 · Shift+클릭 경로 …)을
+ * 안내하고 있었고, 아무 검사도 그것을 잡지 못했다.
+ *
+ * 원인은 시트가 **손으로 적은 목록**이라는 것이다. 그래서 이동 단축키는 표
+ * (`shared/config/destinations.ts`)를 정본으로 두고, 시트가 그 표에서 줄을
+ * 만든다. 이 파일은 그 배선이 살아 있는지 잰다.
+ *
+ * ## 왜 「누를 수 있나」는 여기서 못 재나
+ *
+ * 실제로 키를 눌러 화면이 바뀌는지는 브라우저가 있어야 한다 —
+ * `tests/e2e/destination-shortcuts.spec.ee.ts` 가 그 몫이다. 이 계약은 **표와
+ * 배선**을 본다. 둘을 갈라 두는 이유는 e2e 가 느려서 표 실수를 잡는 데 쓰기엔
+ * 비싸고, 계약만으로는 「정말 이동하나」를 증명할 수 없어서다.
+ */
+
+const REPO = process.cwd();
+const read = (path: string) => readFileSync(`${REPO}/${path}`, "utf8");
+
+/**
+ * 주석을 뺀 소스. **주석을 안 빼면 규격을 설명하는 문장 자체가 위반으로 잡힌다** —
+ * 이 파일에서 실제로 밟았다: 훅의 주석이 *"`querySelector(...)` 하나로는 틀린다"*
+ * 라고 적어 두었더니 「그 코드가 남았다」로 판정됐다. 그러면 규격을 적을수록
+ * 게이트가 빨개지는 뒤집힌 유인이 생긴다(설정 방언 게이트가 남긴 교훈과 같다).
+ */
+const readCode = (path: string) =>
+  read(path)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+describe("목적지 이동 단축키 — 표가 정본이다", () => {
+  it("목적지마다 글자가 하나씩 있고 서로 겹치지 않는다", () => {
+    const keys = DESTINATION_IDS.map((id) => DESTINATION_KEY[id]);
+    expect(keys.length, "목적지가 비었다 — 표가 사라졌으면 이 시험 전체가 공회전한다").toBeGreaterThan(
+      3,
+    );
+    expect(new Set(keys).size, `글자가 겹친다: ${keys.join(" ")}`).toBe(keys.length);
+    for (const key of keys) {
+      expect(key, `${key} 는 한 글자여야 한다`).toMatch(/^[a-z]$/);
+    }
+    // 역방향 표가 정방향과 같은 것을 말하는가.
+    expect(Object.keys(DESTINATION_BY_KEY).length).toBe(keys.length);
+    for (const id of DESTINATION_IDS) {
+      expect(DESTINATION_BY_KEY[DESTINATION_KEY[id]]).toBe(id);
+    }
+  });
+
+  it("목적지마다 주소가 있고 라우트 모양이다", () => {
+    for (const id of DESTINATION_IDS) {
+      const href = DESTINATION_HREF[id];
+      expect(href, `${id} 의 주소가 없다`).toBeTruthy();
+      // 로케일 접두사는 `@/i18n/navigation` 이 붙인다 — 표에 박으면 두 번 붙는다.
+      expect(href, `${id}: 로케일을 표에 박지 않는다`).not.toMatch(/^\/(en|ko)\//);
+      expect(href, `${id}: 슬래시로 시작하고 끝나야 한다(정적 export 규약)`).toMatch(/^\/.*\/$/);
+    }
+  });
+
+  /**
+   * ⌘1~⌘9 를 쓰지 않는다는 결정이 코드에 남아 있는가. 리더는 조합키 없이 눌린
+   * 글자이고, 훅이 조합키가 눌린 경우를 **먼저** 걸러야 한다.
+   */
+  it("조합키가 눌린 입력은 우리 것이 아니다", () => {
+    const hook = read("src/shared/lib/use-destination-shortcuts.ts");
+    expect(hook, "메타/컨트롤/알트가 눌린 사건을 안 걸러낸다").toMatch(
+      /if\s*\(event\.metaKey\s*\|\|\s*event\.ctrlKey\s*\|\|\s*event\.altKey\)\s*return/,
+    );
+  });
+
+  it("입력 중에는 이동하지 않는다", () => {
+    const hook = read("src/shared/lib/use-destination-shortcuts.ts");
+    expect(hook).toContain("INPUT");
+    expect(hook).toContain("TEXTAREA");
+    expect(hook).toContain("isContentEditable");
+  });
+
+  /**
+   * 막는 표면이 떠 있으면 이동하지 않는다. **`aria-modal` 로 판정**하는 것이
+   * 계약이다 — 호출자마다 `disabled` 를 기억하게 하면 새 모달이 그것을 빠뜨린다
+   * (레일 유틸 슬롯을 페이지마다 등록하다 공방이 빠뜨린 #65 와 같은 계열).
+   */
+  it("막는 표면이 열려 있으면 이동하지 않는다", () => {
+    const hook = read("src/shared/lib/use-destination-shortcuts.ts");
+    expect(hook, "aria-modal 로 막는 표면을 판정하지 않는다").toContain('[aria-modal="true"]');
+  });
+
+  /**
+   * **숨은 모달을 세면 이동이 영구히 죽는다** (2026-08-09, e2e 가 잡았다).
+   * 처음 구현은 `querySelector` 한 번이었고, 그것은 문서의 첫 일치를 돌려준다 —
+   * 퇴장 애니메이션 동안 DOM 에 남은 표면이 먼저 걸리면 화면에는 아무 단서 없이
+   * 단축키 전체가 먹지 않는다. 그래서 **모두 훑고 그려진 것만** 센다.
+   */
+  it("숨은 모달을 막는 표면으로 세지 않는다", () => {
+    const hook = read("src/shared/lib/use-destination-shortcuts.ts");
+    expect(hook, "첫 일치만 보면 숨은 모달에 걸린다").toContain("querySelectorAll");
+    expect(hook, "화면에 그려졌는지 재지 않는다").toContain("getClientRects");
+    expect(hook, "aria-hidden 조상을 건너뛰지 않는다").toContain('aria-hidden="true"');
+    expect(readCode("src/shared/lib/use-destination-shortcuts.ts"), "querySelector 한 번으로 판정하는 코드가 남았다").not.toMatch(
+      /querySelector\(\s*'\[aria-modal/,
+    );
+  });
+
+  it("리더를 누른 뒤 기다리는 시간이 있다", () => {
+    expect(NAV_LEADER_WINDOW_MS).toBeGreaterThan(300);
+    expect(NAV_LEADER_WINDOW_MS).toBeLessThanOrEqual(3000);
+    expect(read("src/shared/lib/use-destination-shortcuts.ts")).toContain("NAV_LEADER_WINDOW_MS");
+  });
+});
+
+describe("레일 · 시트 · 셸이 같은 표를 본다", () => {
+  it("레일이 주소를 손으로 다시 적지 않는다", () => {
+    const rail = read("src/widgets/app-nav-rail/ui/AppNavRail.tsx");
+    expect(rail, "레일이 표를 import 하지 않는다").toContain("DESTINATION_HREF");
+    /*
+     * 레일의 목적지 배열 안에 리터럴 주소가 남아 있으면 사본이 둘이다. 배열
+     * 블록만 잘라 본다 — 파일 다른 곳의 주소(관문 링크 등)까지 금지하면 엉뚱하게
+     * 걸린다.
+     */
+    const block = rail.slice(
+      rail.indexOf("const destinations"),
+      rail.indexOf("];", rail.indexOf("const destinations")),
+    );
+    expect(block.length, "목적지 배열을 못 찾았다 — 이 단언이 공회전한다").toBeGreaterThan(120);
+    const literals = block.match(/href:\s*["'][^"']+["']/g) ?? [];
+    expect(literals, `레일에 리터럴 주소가 남았다: ${literals.join(", ")}`).toEqual([]);
+  });
+
+  it("셸이 훅을 배선한다", () => {
+    const shell = read("src/app/providers/AppShell.tsx");
+    expect(shell, "셸이 이동 단축키를 마운트하지 않는다").toContain("useDestinationShortcuts");
+  });
+
+  it("시트가 표에서 줄을 만든다 — 손으로 적지 않는다", () => {
+    const sheet = read("src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx");
+    expect(sheet, "시트가 표를 import 하지 않는다").toContain("DESTINATION_IDS");
+    expect(sheet, "시트가 표에서 줄을 파생시키지 않는다").toMatch(
+      /DESTINATION_IDS\.map\(/,
+    );
+    // 파생 줄이 이동 절에 실제로 꽂혔는가.
+    expect(sheet).toMatch(/rows:\s*\[\s*\.\.\.DESTINATION_ROWS/);
+  });
+
+  it("두 로케일 모두 목적지마다 문구가 있다", () => {
+    for (const locale of ["ko", "en"] as const) {
+      const messages = JSON.parse(read(`messages/${locale}.json`));
+      const rows = messages.searchWidgets?.shortcuts?.rows ?? {};
+      for (const id of DESTINATION_IDS) {
+        const key = `goTo_${id}`;
+        expect(rows[key], `${locale}: ${key} 문구가 없다`).toBeTruthy();
+      }
+    }
+  });
+
+  /**
+   * 이미 쓰이는 단독 글자와 부딪히지 않는가. 리더 문법이라 원리적으로는 충돌이
+   * 없지만(`G` 다음 `D` ≠ `D`), **리더 자신**이 단독 글자로 쓰이고 있으면
+   * 그 기능이 못 발동한다.
+   */
+  it("리더 글자가 다른 단독 단축키와 겹치지 않는다", () => {
+    const SINGLE_KEY_SHORTCUTS = ["d", "f", "?", "/"];
+    expect(
+      SINGLE_KEY_SHORTCUTS,
+      `리더(${NAV_LEADER_KEY})가 이미 단독으로 쓰이는 글자다`,
+    ).not.toContain(NAV_LEADER_KEY);
+  });
+});

--- a/tests/e2e/destination-shortcuts.spec.ts
+++ b/tests/e2e/destination-shortcuts.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * 목적지 이동 단축키 — **키보드만으로 일곱 목적지를 다 간다.**
+ *
+ * 이 spec 이 곧 그 기능의 값어치다. 소유자가 요구한 것이 *"단축키만으로도 다
+ * 이동하면서 테스트 가능"* 이었고, 그 문장을 증명하는 자리가 여기다. 통과하면
+ * 사람도 에이전트도 좌표를 찍지 않고 이 앱을 돌아다닐 수 있다는 뜻이다.
+ *
+ * ⚠️ **좌표로 클릭해 확인하지 않는다.** 그렇게 하면 이 spec 이 증명하려는 것과
+ * 반대되는 방식으로 자기를 증명하는 셈이다.
+ */
+
+/** 표와 같은 순서 — 표가 바뀌면 여기도 바뀌어야 하고, 계약 시험이 그것을 잡는다. */
+const DESTINATIONS = [
+  { key: "m", path: "/topology" },
+  { key: "d", path: "/docs" },
+  { key: "s", path: "/ontology/studio" },
+  { key: "i", path: "/ontology/insights" },
+  { key: "p", path: "/projects" },
+  { key: "k", path: "/skills" },
+  { key: "g", path: "/git" },
+] as const;
+
+async function go(page: import("@playwright/test").Page, key: string) {
+  await page.keyboard.press("g");
+  await page.keyboard.press(key);
+}
+
+/**
+ * ⚠️ **공방은 도착하면 막는 선택 창을 띄운다** (2026-08-09, 이 spec 이 찾아냈다).
+ *
+ * `aria-label="공방을 어떻게 시작할지 고르기"` 가 `aria-modal="true"` 로 떠서,
+ * 이동 단축키가 **규칙대로** 거부된다(막는 표면이 있으면 뒤 화면을 바꾸지 않는다).
+ * 즉 키보드만 쓰는 사람은 공방에 도착한 순간 **다른 곳으로 못 나간다** — 먼저
+ * Esc 를 눌러야 한다.
+ *
+ * 훅을 고쳐서 우회하지 않는다. 모달이 안 막으면 그건 모달이 아니고, 그 금지는
+ * 헌장에 있다. **이건 공방 첫 화면의 설계 질문**이라 소유자 몫으로 넘긴다 —
+ * 여기서는 사실을 그대로 적고, 순회가 실제 사람이 하는 것과 같은 순서를 밟게 한다.
+ */
+async function dismissBlockingSurface(page: import("@playwright/test").Page) {
+  const visibleModal = page.locator('[aria-modal="true"]:visible').first();
+  if (await visibleModal.isVisible().catch(() => false)) {
+    await page.keyboard.press("Escape");
+    await expect(visibleModal).toBeHidden({ timeout: 3_000 });
+  }
+}
+
+test.describe("목적지 이동 단축키", () => {
+  // 폭을 고정한다. 기본 폭(1280×720)에서는 레일과 하단 탭바가 **둘 다** 설정
+  // 트리거를 갖고 있고, 지도 INDEX 의 검색칸은 아예 그려지지 않는다(실측:
+  // `input` 0개). 폭이 흔들리면 이 spec 이 기능이 아니라 폭을 재게 된다.
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await seedFirstRunSeen(page);
+  });
+
+  test("G + 글자로 일곱 목적지를 전부 간다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off");
+    await page.waitForLoadState("domcontentloaded");
+
+    for (const { key, path } of DESTINATIONS) {
+      const expected = new RegExp(`/ko${path.replace(/\//g, "\\/")}/?($|\\?)`);
+      /*
+       * **한 번 더 시도한다.** 막는 표면은 도착 직후 마운트되면서 뜨는 것이 있어
+       * (공방의 시작 선택), 닫기를 «누르기 전에» 확인해도 그 사이에 뜰 수 있다.
+       * 그러면 첫 시도가 규칙대로 거절되고 순회가 간헐적으로 깨진다 — 실제로 그
+       * 흔들림을 봤다. 재시도는 결함을 감추는 것이 아니라 **경합을 없애는 것**이고,
+       * 두 번째 시도도 안 가면 그때는 진짜로 실패한다.
+       */
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await dismissBlockingSurface(page);
+        await go(page, key);
+        try {
+          await expect(page).toHaveURL(expected, { timeout: 3_000 });
+          break;
+        } catch (error) {
+          if (attempt === 1) throw error;
+        }
+      }
+      await expect(page, `G ${key.toUpperCase()} 가 ${path} 로 가지 않았다`).toHaveURL(expected);
+    }
+  });
+
+  /**
+   * 공회전 차단 — 위 시험이 «어차피 그 주소에 있어서» 통과할 수 있다. 한 목적지에서
+   * **다른** 목적지로 실제로 옮겨 갔는지 한 번 못박는다.
+   */
+  test("이동 전후의 주소가 실제로 다르다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off");
+    const before = page.url();
+    await go(page, "p");
+    await expect(page).toHaveURL(/\/ko\/projects\/?($|\?)/);
+    expect(page.url(), "주소가 안 바뀌었다").not.toBe(before);
+  });
+
+  /*
+   * 「입력 중에는 이동하지 않는다」는 **여기서 재지 않는다** — 볼트를 안 고른 이
+   * 앱에는 화면에 입력칸이 없고(네 라우트 실측 0개), ⌘K 팔레트로 얻은 입력칸은
+   * 그 팔레트가 `aria-modal` 이라 모달 판정이 먼저 걸려 **입력 판정을 지워도
+   * 초록이었다**. 조건이 서로를 가리면 게이트가 아니다.
+   * 그 조건은 `src/shared/lib/use-destination-shortcuts.test.ts` 가 잰다.
+   */
+
+  /**
+   * 잠그는 성질은 **「모달이 떠 있는 동안 뒤 화면이 안 바뀐다」** 하나다.
+   * 「모달이 계속 떠 있나」는 그 표면 자신의 키 동작이라 여기서 재지 않는다 —
+   * 남의 성질을 끼워 넣으면 그쪽이 바뀔 때 이 spec 이 엉뚱하게 터진다.
+   *
+   * 모달은 **키보드로 여는 것**을 고른다(단축키 시트). 설정 시트를 클릭으로 열면
+   * 트리거가 폭에 따라 둘이라 간헐 실패했다 — 그리고 이 spec 의 취지가 「키보드만
+   * 으로 된다」이므로 마우스로 상태를 만드는 것 자체가 어울리지 않는다.
+   */
+  test("막는 표면이 열려 있으면 이동하지 않는다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off");
+    await dismissBlockingSurface(page);
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("?");
+    const modal = page.locator('[aria-modal="true"]:visible').first();
+    await expect(modal, "단축키 시트가 안 열렸다").toBeVisible({ timeout: 5_000 });
+
+    const before = page.url();
+    await go(page, "p");
+    await page.waitForTimeout(600);
+    expect(page.url(), "모달이 떠 있는데 뒤 화면이 바뀌었다").toBe(before);
+  });
+
+  test("리더를 누른 지 오래되면 글자만으로는 이동하지 않는다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off");
+    const before = page.url();
+    await page.keyboard.press("g");
+    await page.waitForTimeout(2_000); // NAV_LEADER_WINDOW_MS 보다 길게
+    await page.keyboard.press("p");
+    await page.waitForTimeout(600);
+    expect(page.url(), "시간 제한이 안 걸렸다").toBe(before);
+  });
+
+  test("단축키 시트가 일곱 목적지를 전부 안내한다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off");
+    await dismissBlockingSurface(page);
+    // `?` 는 지도(HomePage)가 `useTypingShortcuts` 로 잇는다. 입력칸에 초점이
+    // 있으면 안 먹으므로 본문을 한 번 눌러 초점을 옮긴다.
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("?");
+    const sheet = page.getByTestId("shortcut-sheet-scroll");
+    await expect(sheet).toBeVisible({ timeout: 5_000 });
+    const text = await sheet.innerText();
+    for (const { key } of DESTINATIONS) {
+      expect(
+        text.toUpperCase(),
+        `시트에 G ${key.toUpperCase()} 안내가 없다 — 발견할 수 없는 단축키는 기능이 아니다`,
+      ).toContain(key.toUpperCase());
+    }
+  });
+});


### PR DESCRIPTION
## Summary

소유자 요청 *"키보드 만으로도 다 제어 가능하게 하자"* 의 **1·2번**이다 —
① 목록의 정본 하나 ② 화면 간 이동. 3번(노드 선택·펼침)은 캔버스에 초점 개념을
새로 넣는 일이라 갈래를 그려 소유자가 고른 뒤에 짓는다.

**먼저 전수로 셌다**: 키 핸들러가 있는 파일 59개 · 전역 리스너 23곳 · 그런데
**화면 간 이동 단축키는 0개**. 단축키 시트는 있는데 손으로 적은 목록이고, 그
방식이 이미 낸 값이 그 파일 주석에 남아 있다 — *"the previous rows described
interactions the v2 canvas never implemented"*. **시트가 없는 기능을 안내했고
아무 검사도 못 잡았다.**

### 왜 리더 키(`G` 다음 한 글자)인가

⌘1~⌘9 는 **브라우저의 탭 전환**이다. 웹이 이 제품의 관문이라 가로챌 수 없다.
한 글자 단독도 못 쓴다 — `D`(문서 서랍) · `F`(발표) · `?`(시트) · `/`(팔레트)가
이미 쓴다. 리더는 둘 다 피하고 **공개 선례가 있다**(GitHub `g c` · Linear).

`G M`(지도) `G D`(문서함) `G S`(공방) `G I`(인사이트) `G P`(프로젝트)
`G K`(스킬) `G G`(Git). 새 토큰 0개.

### 정본을 하나로

목적지 일곱의 주소가 레일 컴포넌트 안에 인라인으로 있었다.
`shared/config/destinations.ts` 로 내리고 **레일 · 키보드 · 시트가 같은 표**를
본다. 시트의 이동 줄은 그 표에서 만든다 — 키를 더하면 저절로 나타난다.

## 게이트가 내 결함 셋을 잡았다

1. **`querySelector('[aria-modal]')` 하나로는 틀린다** — 문서의 첫 일치를
   돌려주므로 퇴장 애니메이션 중인 표면이 먼저 걸리면 **이동 단축키가 화면에
   아무 단서 없이 영구히 죽는다.** 실측에서 실제로 그 상태가 됐다. 전부 훑고
   그려진 것만 세도록 고쳤다.
2. **「입력 중에는 이동하지 않는다」e2e 가 원리적으로 실패할 수 없었다** — 이 앱은
   볼트 없이는 화면에 `input` 이 **0개**다(`/topology` `/projects` `/docs` `/git`
   실측). ⌘K 팔레트를 썼는데 그 팔레트가 자기도 `aria-modal` 이라 모달 판정이
   먼저 걸렸고, **입력 판정을 통째로 지워도 초록**이었다. 단위 시험으로 옮겼다.
3. **계약 단언이 훅의 주석을 코드로 셌다** — *"querySelector 로 판정하면 안 된다"*
   고 적은 문장이 위반으로 잡혔다. 주석을 빼고 본다.

## 게이트가 제품 결함도 하나 찾았다 (소유자 판단 필요)

**공방에 도착하면 막는 선택 창이 뜬다.** 그래서 키보드만 쓰는 사람은 공방에서
다른 곳으로 **못 나간다** — 먼저 Esc 를 눌러야 한다. 훅을 고쳐 우회하지 않았다:
모달이 안 막으면 모달이 아니고 그 금지는 헌장에 있다. 공방 첫 화면의 설계
질문이라 소유자 몫으로 남기고 e2e 주석에 사실로 적었다.

## Test plan

- **e2e 5건** — 키보드만으로 일곱 목적지 순회 · 주소가 실제로 바뀜 · 모달 중 이동
  거절 · 리더 시간 제한 · 시트가 일곱을 다 안내. **3회 연속 5/5**(간헐 제거 확인)
- **단위 13건** — 거절 조건 전부(입력·textarea·contentEditable·조합키·보이는 모달·
  **숨은 모달은 막지 않음**·aria-hidden 조상·시간 제한·disabled·문맥 주소)
- **계약 12건** — 글자 유일성 · 주소 모양 · 레일에 리터럴 주소 0 · 셸 배선 ·
  시트가 표에서 파생 · 두 로케일 문구 · 리더 충돌 없음 · 공회전 차단
- **프로브**: 세 판정(입력·시간 제한·모달)을 하나씩 지워 **전부 빨개지는 것 확인**
- `pnpm test:contracts` 1,572 · `pnpm test:run` 6,517 · `pnpm build` OK ·
  `eslint` 0 error · `tsc --noEmit` 깨끗

🤖 Generated with [Claude Code](https://claude.com/claude-code)