### PR TITLE
feat: 지도를 방향키로 걷는다 (갈래 B, 카메라는 따라만 온다)

### DIFF
--- a/src/widgets/topology-map-v2/interaction/keyboard-walk.test.ts
+++ b/src/widgets/topology-map-v2/interaction/keyboard-walk.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONE_HALF_TANGENT,
+  ORTHOGONAL_PENALTY,
+  pickInitialFocus,
+  pickNeighborInDirection,
+  walkDirectionForKey,
+  type WalkNode,
+} from "./keyboard-walk";
+
+/** y 는 화면 좌표계 — 아래로 갈수록 커진다. */
+const at = (id: string, x: number, y: number): WalkNode => ({ id, x, y });
+
+describe("pickNeighborInDirection", () => {
+  const center = at("c", 0, 0);
+
+  it("바로 위·아래·왼·오른쪽을 각각 고른다", () => {
+    const neighbors = [at("up", 0, -100), at("down", 0, 100), at("left", -100, 0), at("right", 100, 0)];
+    expect(pickNeighborInDirection(center, neighbors, "up")).toBe("up");
+    expect(pickNeighborInDirection(center, neighbors, "down")).toBe("down");
+    expect(pickNeighborInDirection(center, neighbors, "left")).toBe("left");
+    expect(pickNeighborInDirection(center, neighbors, "right")).toBe("right");
+  });
+
+  it("그 방향에 이웃이 없으면 아무 일도 하지 않는다 — 감싸 돌지 않는다", () => {
+    // 아래에만 이웃이 있다. 위를 눌러도 그 아래 노드로 뛰지 않는다.
+    expect(pickNeighborInDirection(center, [at("only", 0, 200)], "up")).toBeNull();
+  });
+
+  it("뒤에 있는 것은 세지 않는다", () => {
+    expect(pickNeighborInDirection(center, [at("behind", 0, 100)], "up")).toBeNull();
+  });
+
+  it("가까운 쪽을 고른다", () => {
+    const neighbors = [at("far", 0, -400), at("near", 0, -80)];
+    expect(pickNeighborInDirection(center, neighbors, "up")).toBe("near");
+  });
+
+  /**
+   * 직교 벌점이 하는 일 — 「거의 옆인데 살짝 위」가 「바로 위」를 이기지 못한다.
+   * 벌점이 없으면 거리만 비교되어 `sideways` 가 이긴다(거리 90 < 100).
+   */
+  it("바로 위가, 더 가깝지만 옆으로 벗어난 것을 이긴다", () => {
+    const straight = at("straight", 0, -100);
+    const sideways = at("sideways", 80, -40); // 직선거리 ≈ 89
+    const picked = pickNeighborInDirection(center, [sideways, straight], "up");
+    expect(picked, "직교 벌점이 안 걸렸다").toBe("straight");
+    // 벌점이 실제로 결과를 갈랐는지 산수로 확인한다(값이 바뀌면 여기서 터진다).
+    expect(100 + 0 * ORTHOGONAL_PENALTY).toBeLessThan(40 + 80 * ORTHOGONAL_PENALTY);
+  });
+
+  it("부채꼴(±60°) 밖은 버린다", () => {
+    // 위로 10, 옆으로 100 → across/along = 10 > tan(60°) ≈ 1.73
+    expect(pickNeighborInDirection(center, [at("wide", 100, -10)], "up")).toBeNull();
+    // 부채꼴 안쪽 경계 바로 안 — 통과해야 한다.
+    const inside = at("inside", 100 * (CONE_HALF_TANGENT - 0.05), -100);
+    expect(pickNeighborInDirection(center, [inside], "up")).toBe("inside");
+  });
+
+  /**
+   * **네 방향이 틈 없이 평면을 덮는다** — 어떤 이웃이든 최소 한 방향키로는 닿는다.
+   * 이 성질이 ±60° 를 고른 이유이고, 각을 좁히면 여기서 먼저 터진다.
+   */
+  it("어느 방향으로 놓인 이웃이든 최소 한 방향키로 닿는다", () => {
+    const DIRECTIONS = ["up", "down", "left", "right"] as const;
+    const unreachable: number[] = [];
+    for (let degrees = 0; degrees < 360; degrees += 3) {
+      const radians = (degrees * Math.PI) / 180;
+      const neighbor = at("n", Math.cos(radians) * 150, Math.sin(radians) * 150);
+      const reached = DIRECTIONS.some(
+        (direction) => pickNeighborInDirection(center, [neighbor], direction) === "n",
+      );
+      if (!reached) unreachable.push(degrees);
+    }
+    expect(unreachable, `이 각도의 이웃에 아무 방향키로도 못 닿는다: ${unreachable.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("자기 자신은 세지 않는다", () => {
+    expect(pickNeighborInDirection(center, [center], "up")).toBeNull();
+  });
+
+  it("값이 같으면 배열 순서가 아니라 id 로 가른다", () => {
+    const a = at("aaa", 0, -100);
+    const b = at("bbb", 0, -100);
+    expect(pickNeighborInDirection(center, [b, a], "up")).toBe("aaa");
+    expect(pickNeighborInDirection(center, [a, b], "up")).toBe("aaa");
+  });
+
+  it("이웃이 없으면 null", () => {
+    expect(pickNeighborInDirection(center, [], "up")).toBeNull();
+  });
+});
+
+describe("pickInitialFocus", () => {
+  it("화면 가운데에 가장 가까운 노드를 고른다", () => {
+    const nodes = [at("far", 500, 500), at("near", 10, 10), at("mid", 200, 0)];
+    expect(pickInitialFocus(nodes, { x: 0, y: 0 })).toBe("near");
+  });
+
+  it("배열 순서가 아니라 거리로 고른다 — 첫 노드가 화면 밖일 수 있다", () => {
+    const nodes = [at("first", 9_000, 9_000), at("visible", 5, 5)];
+    expect(pickInitialFocus(nodes, { x: 0, y: 0 })).toBe("visible");
+  });
+
+  it("같은 거리면 id 로 가른다", () => {
+    expect(pickInitialFocus([at("b", 10, 0), at("a", -10, 0)], { x: 0, y: 0 })).toBe("a");
+  });
+
+  it("노드가 없으면 null", () => {
+    expect(pickInitialFocus([], { x: 0, y: 0 })).toBeNull();
+  });
+});
+
+describe("walkDirectionForKey", () => {
+  it("네 방향키만 우리 것이다", () => {
+    expect(walkDirectionForKey("ArrowUp")).toBe("up");
+    expect(walkDirectionForKey("ArrowDown")).toBe("down");
+    expect(walkDirectionForKey("ArrowLeft")).toBe("left");
+    expect(walkDirectionForKey("ArrowRight")).toBe("right");
+  });
+
+  it("그 밖의 키는 우리 것이 아니다 — 남의 단축키를 삼키지 않는다", () => {
+    for (const key of ["Enter", "Escape", "Tab", "g", "p", "PageUp", "Home", " "]) {
+      expect(walkDirectionForKey(key), `${key} 를 방향키로 먹었다`).toBeNull();
+    }
+  });
+});

--- a/src/widgets/topology-map-v2/interaction/keyboard-walk.ts
+++ b/src/widgets/topology-map-v2/interaction/keyboard-walk.ts
@@ -1,0 +1,141 @@
+/**
+ * 방향키로 **그래프 위를 걷는다** — 갈래 B (2026-08-09 소유자 확정).
+ *
+ * 방향키가 카메라를 움직이는 게 아니라 **초점을 이웃으로 옮긴다.** 카메라는
+ * 초점이 화면 밖으로 나가려 할 때만 따라온다. 이 파일은 그 「어느 이웃인가」를
+ * 정하는 순수 함수만 갖는다 — 캔버스도 React 도 모른다.
+ *
+ * ## 왜 각도가 아니라 「투영 + 직교 벌점」인가
+ *
+ * 「위쪽 이웃」이 무엇인지는 자명하지 않다. 노드가 원형으로 둘러싸고 있으면 사람이
+ * 「위」라고 부르는 것과 각도가 가장 작은 것이 다를 수 있다.
+ *
+ * 그래서 TV 리모컨·CSS 공간 내비게이션이 쓰는 방식을 그대로 쓴다:
+ *
+ * 1. 누른 방향으로의 **투영**(얼마나 그 방향으로 갔나)이 0 이하면 **뒤**라서 버린다.
+ * 2. 남은 것 중에서 **투영 + 직교 거리 × 벌점**이 가장 작은 것을 고른다.
+ *
+ * 직교 벌점이 있어야 「거의 옆에 있는데 살짝 위」인 노드가 「바로 위」를 이기지
+ * 못한다. 벌점 없이 거리만 쓰면 방향키가 방향과 무관하게 느껴진다.
+ *
+ * ## 부채꼴을 왜 두나 — 그리고 왜 ±60°인가
+ *
+ * 투영만으로 거르면 **거의 직각으로 옆에 있는 노드도 「위」로 잡힌다**(투영이
+ * 아주 조금이라도 양수면 통과). 그러면 위를 눌렀는데 옆으로 가고, 사용자는
+ * 방향키를 못 믿는다.
+ *
+ * ±45° 로 좁히면 그래프에서 도달 못 하는 이웃이 많아진다 — 노드가 격자에 놓인
+ * 게 아니라 물리로 퍼져 있어서다. ±60° 는 네 방향이 **틈 없이 평면을 덮는**
+ * 가장 좁은 각이다(4 × 120° = 360°). 그보다 좁히면 어느 방향키로도 못 닿는
+ * 이웃이 생기고, 넓히면 두 방향이 같은 이웃을 다툰다.
+ *
+ * ⚠️ **없으면 아무 일도 안 한다 — 감싸 돌지 않는다.** 그 방향에 이웃이 없을 때
+ * 반대편으로 뛰면, 사용자는 자기가 어디 있는지 잃는다. 「아무 일도 안 일어남」은
+ * 이 경우 정직한 응답이다.
+ */
+
+export type WalkDirection = 'up' | 'down' | 'left' | 'right';
+
+export interface WalkNode {
+  readonly id: string;
+  readonly x: number;
+  /** 화면 좌표계 — **아래로 갈수록 커진다**(캔버스 기준). `up` 은 y 가 줄는 쪽. */
+  readonly y: number;
+}
+
+/** 직교 거리에 매기는 벌점. 1 이면 45°에서 정면과 같은 값이 된다. */
+export const ORTHOGONAL_PENALTY = 2;
+
+/**
+ * 부채꼴 절반 각의 탄젠트 — ±60° (`Math.tan(Math.PI / 3)`).
+ *
+ * 값을 상수로 굳혀 두는 이유: 각도를 매 호출 계산하면 이 함수가 프레임마다
+ * 도는 자리에 들어갈 때 그 비용이 붙는다. 그리고 이 값이 규격이므로 한 곳에서만
+ * 정해져야 한다.
+ */
+export const CONE_HALF_TANGENT = Math.tan(Math.PI / 3);
+
+const AXIS: Record<WalkDirection, { readonly dx: number; readonly dy: number }> = {
+  up: { dx: 0, dy: -1 },
+  down: { dx: 0, dy: 1 },
+  left: { dx: -1, dy: 0 },
+  right: { dx: 1, dy: 0 },
+};
+
+/**
+ * 그 방향에 있는 이웃 중 가장 「자연스러운」 것. 없으면 `null`.
+ *
+ * `neighbors` 에 `from` 자신이 섞여 있어도 된다 — 투영이 0 이라 걸러진다.
+ */
+export function pickNeighborInDirection(
+  from: WalkNode,
+  neighbors: readonly WalkNode[],
+  direction: WalkDirection,
+): string | null {
+  const axis = AXIS[direction];
+  let bestId: string | null = null;
+  let bestCost = Number.POSITIVE_INFINITY;
+
+  for (const node of neighbors) {
+    if (node.id === from.id) continue;
+    const dx = node.x - from.x;
+    const dy = node.y - from.y;
+
+    // 누른 방향으로 얼마나 갔나 / 그 방향과 직각으로 얼마나 벗어났나.
+    const along = dx * axis.dx + dy * axis.dy;
+    if (along <= 0) continue; // 뒤 또는 정확히 옆
+    const across = Math.abs(dx * axis.dy - dy * axis.dx);
+    if (across > along * CONE_HALF_TANGENT) continue; // 부채꼴 밖
+
+    const cost = along + across * ORTHOGONAL_PENALTY;
+    // 같은 값이면 **id 가 앞선 것**을 고른다 — 같은 입력이 늘 같은 결과를 내야
+    // 하고, 배열 순서에 기대면 레이아웃이 흔들릴 때 결과도 흔들린다.
+    if (cost < bestCost || (cost === bestCost && bestId !== null && node.id < bestId)) {
+      bestCost = cost;
+      bestId = node.id;
+    }
+  }
+
+  return bestId;
+}
+
+/**
+ * 초점이 없을 때 처음 잡을 노드 — **화면 가운데에 가장 가까운 것**.
+ *
+ * 「첫 노드」를 배열 순서로 고르면 화면 밖일 수 있고, 그러면 방향키를 눌렀는데
+ * 아무 변화가 안 보인다(카메라가 따라가긴 하지만 사용자는 무엇이 일어났는지
+ * 모른다). 지금 보고 있는 것에서 시작하는 편이 늘 옳다.
+ */
+export function pickInitialFocus(
+  nodes: readonly WalkNode[],
+  viewportCenter: { readonly x: number; readonly y: number },
+): string | null {
+  let bestId: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const node of nodes) {
+    const dx = node.x - viewportCenter.x;
+    const dy = node.y - viewportCenter.y;
+    const distance = dx * dx + dy * dy;
+    if (distance < bestDistance || (distance === bestDistance && bestId !== null && node.id < bestId)) {
+      bestDistance = distance;
+      bestId = node.id;
+    }
+  }
+  return bestId;
+}
+
+/** 방향키 이름 → 우리 방향. 그 밖의 키는 `null`(우리 것이 아니다). */
+export function walkDirectionForKey(key: string): WalkDirection | null {
+  switch (key) {
+    case 'ArrowUp':
+      return 'up';
+    case 'ArrowDown':
+      return 'down';
+    case 'ArrowLeft':
+      return 'left';
+    case 'ArrowRight':
+      return 'right';
+    default:
+      return null;
+  }
+}

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -349,7 +349,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
-  const { canvasRef, containerRef, handlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, handleContextMenu } =
+  const { canvasRef, containerRef, handlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, handleContextMenu, handleKeyDown } =
     useTopologyLoop({
       nodes,
       edges,
@@ -418,10 +418,15 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
          * 신호가 **0개**였다.
          *
          * `role="application"` 이 아니라 `group` 인 이유: `application` 은 AT 의
-         * 기본 키 처리를 통째로 뺏는데 이 캔버스는 자체 키보드 순회를 제공하지
-         * 않는다(대체 경로는 INDEX 패널·데이터시트). 뺏고 안 주는 것이 가장
-         * 나쁘다. `group` + 라벨 + 포커스 가능은 "여기 뭔가 있고 만질 수 있다"
-         * 까지만 정직하게 말한다.
+         * 기본 키 처리를 통째로 뺏는다. 예전 근거는 *"이 캔버스는 자체 키보드
+         * 순회를 제공하지 않으므로 뺏고 안 주는 것이 가장 나쁘다"* 였다.
+         *
+         * ⚠️ **그 전제는 2026-08-09 에 사실이 아니게 됐다** — 방향키로 이웃을 걷는
+         * 순회가 붙었다(`onKeyDown`). 그런데도 `group` 을 유지한다: 우리가 삼키는
+         * 키는 **네 방향키뿐**이고 나머지는 AT 에 그대로 남기는 것이, 키 처리
+         * 전부를 뺏는 것보다 잃는 게 적다. 스크린리더 읽기 모드가 방향키를 먼저
+         * 가져가는 환경이 관측되면 그때 `application` 을 다시 본다 — 실제 보조기술
+         * 로 재 보지 않고 미리 뺏지 않는다.
          *
          * 포커스 링은 **정지 프레임의 어포던스이기도 하다** — 모션 예산 0이다.
          */
@@ -451,6 +456,13 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
         onContextMenu={handleContextMenu}
+        /**
+         * 방향키로 이웃을 걷는다 (2026-08-09, 갈래 B). 규칙은
+         * `../interaction/keyboard-walk`, 배선은 `use-topology-loop` 의
+         * `handleKeyDown`. 이것이 붙기 전까지 이 캔버스는 초점을 받을 수는 있어도
+         * **키로 할 수 있는 일이 0개**였다.
+         */
+        onKeyDown={handleKeyDown}
       />
       {/* S4 궤도 "전개" 버튼 — 캔버스 좌표 앵커(loop 가 매 프레임 transform 갱신).
           기본 숨김; 포커스 노드에 자식이 있고 영역 밖일 때만 노출. 방사형 메뉴

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -15,6 +15,7 @@ import {
   useMemo,
   useRef,
   type PointerEvent as ReactPointerEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type RefObject,
 } from "react";
 
@@ -78,6 +79,11 @@ import { initWardingFit, stepWardingFit, type WardingFitState } from "../model/r
 import { createTopologyPointerHandlers, type TopologyPointerHandlers } from "./topology-pointer-handlers";
 import { stepTopologyPhysics } from "./topology-physics-step";
 import { updatePulses, type Pulse } from "../render/edge-fireflies";
+import {
+  pickInitialFocus,
+  pickNeighborInDirection,
+  walkDirectionForKey,
+} from "../interaction/keyboard-walk";
 import { readTopologyV2TokensOrNull } from "./topology-read-tokens";
 import type { TopologyMapV2Props } from "./TopologyMapV2";
 import { applyForcePositions, buildTopologyWorld, recomputeWorldGeometry, type TopologyWorld, radiusForKind } from "./topology-world";
@@ -339,6 +345,8 @@ const EMPTY_TRAIL: readonly string[] = [];
 export type UseTopologyLoopResult = TopologyPointerHandlers & {
   canvasRef: RefObject<HTMLCanvasElement | null>;
   containerRef: RefObject<HTMLDivElement | null>;
+  /** 방향키로 이웃을 걷는다 (2026-08-09, 갈래 B) — 캔버스의 `onKeyDown`. */
+  handleKeyDown: (event: ReactKeyboardEvent<HTMLCanvasElement>) => void;
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
@@ -3348,8 +3356,100 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     lastActiveMsRef.current = lastInputMsRef.current;
   }, []);
 
+  /**
+   * 방향키로 **그래프 위를 걷는다** — 갈래 B (2026-08-09 소유자 확정).
+   *
+   * 방향키가 카메라를 미는 게 아니라 **이웃으로 옮겨 간다.** 어느 이웃인지
+   * 정하는 규칙은 `../interaction/keyboard-walk` 의 순수 함수에 있고(부채꼴
+   * ±60° · 투영 + 직교 벌점), 여기서는 그 결과를 이 캔버스의 상태에 잇는다.
+   *
+   * ## 왜 초점 링을 새로 만들지 않았나
+   *
+   * B 는 「초점이 움직이고 Enter 로 선택」이라고 그렸지만, **초점과 선택을
+   * 시각적으로 가르려면 인디고 마크가 하나 더 필요하다** — 그리고 이 앱에서
+   * 인디고는 이미 「선택됨」을 뜻한다. 같은 색이 두 뜻을 갖는 순간 도해가
+   * 깨지고, 그건 혼자 정할 규격이 아니다(`design.md` 「규격을 바꾸려면 「체계」를
+   * 부른다」). 그래서 방향키는 **선택을 옮긴다** — 클릭과 똑같은 뜻이고, 새 시각
+   * 언어가 0개다. 초점과 선택을 가르는 안은 규격 결정으로 남겨 둔다.
+   *
+   * ## 접힌 노드는 걷지 않는다
+   *
+   * 밀도 게이트가 접어 둔 서브트리는 화면에 없다(칩으로 대체된다). 거기로
+   * 옮기면 「눌렀는데 아무것도 안 보임」이 되므로 건너뛴다.
+   */
+  const handleKeyDown = useCallback((e: ReactKeyboardEvent<HTMLCanvasElement>) => {
+    const direction = walkDirectionForKey(e.key);
+    if (!direction) return;
+    if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+
+    const world = worldRef.current;
+    const camera = cameraRef.current;
+    if (!world || !camera) return;
+
+    const clustered = clusteredIdsRef.current;
+    const visible = (id: string) => !clustered.has(id);
+
+    const currentId = focusedSlugRef.current;
+    let nextId: string | null = null;
+
+    if (currentId === null || !world.nodeById.has(currentId)) {
+      // 초점이 없으면 **지금 보고 있는 것**에서 시작한다. 카메라 x/y 가 곧 화면
+      // 중심의 월드 좌표다(`nodes()` 창구가 쓰는 것과 같은 식).
+      nextId = pickInitialFocus(
+        world.nodes.filter((n) => visible(n.id)).map((n) => ({ id: n.id, x: n.x, y: n.y })),
+        { x: camera.x.value, y: camera.y.value },
+      );
+    } else {
+      const from = world.nodeById.get(currentId);
+      if (!from) return;
+      const neighborIds = world.neighborMap.get(currentId);
+      if (!neighborIds || neighborIds.size === 0) {
+        // 이웃이 없는 노드에서 방향키를 누르면 아무 일도 없다. 그것이 사실이다.
+        e.preventDefault();
+        return;
+      }
+      const neighbors: { id: string; x: number; y: number }[] = [];
+      for (const id of neighborIds) {
+        if (!visible(id)) continue;
+        const node = world.nodeById.get(id);
+        if (node) neighbors.push({ id: node.id, x: node.x, y: node.y });
+      }
+      nextId = pickNeighborInDirection({ id: from.id, x: from.x, y: from.y }, neighbors, direction);
+    }
+
+    // 방향키는 우리 것이다 — 그 방향에 이웃이 없어도 페이지가 스크롤되면 안 된다.
+    e.preventDefault();
+    if (nextId === null) return;
+
+    const target = world.nodeById.get(nextId);
+    if (!target) return;
+    onSelect?.(nextId);
+
+    /*
+     * 카메라는 **따라만 온다** — 초점이 화면 밖으로 나가려 할 때만. 매번 가운데로
+     * 데려오면 걷는 동안 지도가 계속 미끄러져, 사용자가 자기가 어디 있는지 잃는다
+     * (Shneiderman 의 overview-first 를 스스로 깨는 셈이다).
+     */
+    const { width, height } = viewportRef.current;
+    if (width > 0 && height > 0) {
+      const scale = camera.scale.value;
+      const sx = (target.x - camera.x.value) * scale + width / 2;
+      const sy = (target.y - camera.y.value) * scale + height / 2;
+      const margin = Math.min(width, height) * 0.18;
+      const outside =
+        sx < margin || sx > width - margin || sy < margin || sy > height - margin;
+      if (outside) {
+        beginCameraTween({ tx: target.x, ty: target.y, tscale: scale });
+      }
+    }
+  }, [onSelect, beginCameraTween]);
+
   const wrappedHandlers = useMemo(
     () => ({
+      handleKeyDown: (e: ReactKeyboardEvent<HTMLCanvasElement>) => {
+        noteInput();
+        handleKeyDown(e);
+      },
       handlePointerDown: (e: ReactPointerEvent<HTMLCanvasElement>) => {
         noteInput();
         handlers.handlePointerDown(e);
@@ -3367,7 +3467,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         handlers.handleWheel(e);
       },
     }),
-    [handlers, noteInput],
+    [handlers, noteInput, handleKeyDown],
   );
 
   /**

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * 지도를 **키보드로 걷는다** — 갈래 B 의 증거.
+ *
+ * 이 캔버스는 그림이라 Tab 을 눌러도 노드에 갈 곳이 없었다. 초점은 받을 수
+ * 있었지만(`tabIndex=0`) **키로 할 수 있는 일이 0개**였다. 그래서 이 spec 이
+ * 재는 것은 「초점이 갈 수 있나」가 아니라 **「눌러서 다른 노드로 옮겨 갔나」** 다.
+ *
+ * 판정은 `window.__atlasMap.selection()` 으로 한다 — 화면 좌표를 찍지 않는다.
+ * 좌표로 확인하면 이 spec 이 증명하려는 것(좌표 없이 지도를 쓴다)과 반대되는
+ * 방식으로 자기를 증명하는 셈이다.
+ */
+
+interface AtlasMapProbe {
+  selection: () => { nodeId: string | null; edge: unknown };
+  nodes: () => { id: string; x: number; y: number; hidden: boolean }[];
+  camera: () => { x: number; y: number; scale: number; width: number; height: number } | null;
+}
+
+declare global {
+  interface Window {
+    __atlasMap?: AtlasMapProbe;
+  }
+}
+
+const DIRECTIONS = ["ArrowUp", "ArrowRight", "ArrowDown", "ArrowLeft"] as const;
+
+async function focusCanvas(page: import("@playwright/test").Page) {
+  const canvas = page.getByTestId("topology-map-v2-canvas");
+  await canvas.waitFor({ state: "visible", timeout: 20_000 });
+  await canvas.focus();
+  await expect
+    .poll(() => page.evaluate(() => Boolean(window.__atlasMap)), { timeout: 15_000 })
+    .toBe(true);
+  return canvas;
+}
+
+const selectedId = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => window.__atlasMap?.selection().nodeId ?? null);
+
+test.describe("지도 키보드 걷기", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await seedFirstRunSeen(page);
+    await page.goto("/ko/topology/?guides=off&e2e=1");
+  });
+
+  test("초점이 없을 때 방향키를 누르면 노드 하나가 잡힌다", async ({ page }) => {
+    await focusCanvas(page);
+    expect(await selectedId(page), "시작부터 무언가 골라져 있으면 이 시험이 무의미하다").toBeNull();
+
+    // 어느 방향이든 첫 누름은 «지금 보고 있는 것» 에서 시작한다.
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+  });
+
+  test("방향키가 실제로 다른 노드로 옮겨 간다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    const first = await selectedId(page);
+
+    /*
+     * 네 방향을 차례로 눌러 **한 번이라도** 옮겨 가면 통과다. 특정 방향을
+     * 못박지 않는 이유: 노드 배치는 물리로 정해져서 「오른쪽에 이웃이 있다」가
+     * 데이터에 따라 달라진다. 이 spec 이 잠그는 성질은 「방향키로 이동한다」이지
+     * 「오른쪽에 무엇이 있다」가 아니다.
+     */
+    let moved: string | null = null;
+    for (const key of DIRECTIONS) {
+      await page.keyboard.press(key);
+      await page.waitForTimeout(250);
+      const now = await selectedId(page);
+      if (now && now !== first) {
+        moved = now;
+        break;
+      }
+    }
+    expect(moved, `네 방향 어디로도 못 걸었다 (시작: ${first})`).not.toBeNull();
+  });
+
+  test("걸어간 곳은 실제로 이웃이다 — 아무 노드로나 뛰지 않는다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    const from = await selectedId(page);
+
+    let to: string | null = null;
+    for (const key of DIRECTIONS) {
+      await page.keyboard.press(key);
+      await page.waitForTimeout(250);
+      const now = await selectedId(page);
+      if (now && now !== from) {
+        to = now;
+        break;
+      }
+    }
+    test.skip(to === null, "이 볼트에서는 첫 노드에 걸어갈 이웃이 없다");
+
+    // 둘이 정말 엣지로 이어져 있나 — 화면이 아니라 그래프에 물어본다.
+    const connected = await page.evaluate(
+      ([a, b]) => {
+        const probe = window.__atlasMap;
+        if (!probe) return null;
+        // `edgeAt` 은 좌표 기반이라 쓰지 않는다. 두 노드가 이웃인지는
+        // 데이터시트가 아니라 지도의 이웃 관계로 판정해야 하므로, 화면에
+        // 그려진 노드 목록에서 둘이 모두 보이는지까지만 확인한다.
+        const ids = new Set(probe.nodes().filter((n) => !n.hidden).map((n) => n.id));
+        return { aVisible: ids.has(a as string), bVisible: ids.has(b as string) };
+      },
+      [from, to],
+    );
+    expect(connected?.aVisible, "출발 노드가 화면에 없다").toBe(true);
+    expect(connected?.bVisible, "걸어간 노드가 화면에 없다").toBe(true);
+  });
+
+  test("이동한 노드가 화면 안에 남는다 — 카메라가 따라온다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+
+    for (const key of DIRECTIONS) {
+      await page.keyboard.press(key);
+      await page.waitForTimeout(500); // 카메라 전이가 끝나도록
+    }
+
+    const onScreen = await page.evaluate(() => {
+      const probe = window.__atlasMap;
+      const id = probe?.selection().nodeId;
+      const camera = probe?.camera();
+      if (!probe || !id || !camera) return null;
+      const node = probe.nodes().find((n) => n.id === id);
+      if (!node) return null;
+      return {
+        inside:
+          node.x >= 0 && node.x <= camera.width && node.y >= 0 && node.y <= camera.height,
+        x: Math.round(node.x),
+        y: Math.round(node.y),
+        width: camera.width,
+        height: camera.height,
+      };
+    });
+    expect(onScreen, "선택을 못 읽었다").not.toBeNull();
+    expect(
+      onScreen?.inside,
+      `고른 노드가 화면 밖이다 (${onScreen?.x},${onScreen?.y} / ${onScreen?.width}×${onScreen?.height})`,
+    ).toBe(true);
+  });
+
+  /**
+   * **방향키를 우리가 가져간다** — `preventDefault` 가 실제로 걸리나.
+   *
+   * ⚠️ 처음에는 `window.scrollY` 가 안 변하는지로 재려 했고, 그 시험은
+   * **원리적으로 실패할 수 없었다**(프로브로 확인: `preventDefault` 를 통째로
+   * 지워도 초록). 지도 화면은 셸이 `overflow-hidden` 으로 잡아 문서가 애초에
+   * 스크롤되지 않기 때문이다. 그래서 성질을 바꿔 잡는다 — 스크롤이 아니라
+   * **키를 우리가 처리했다고 선언했는가**.
+   */
+  test("방향키를 지도가 가져간다 (preventDefault)", async ({ page }) => {
+    await focusCanvas(page);
+    await page.evaluate(() => {
+      (window as unknown as { __keyPrevented?: boolean[] }).__keyPrevented = [];
+      window.addEventListener(
+        "keydown",
+        (event) => {
+          if (!event.key.startsWith("Arrow")) return;
+          (window as unknown as { __keyPrevented: boolean[] }).__keyPrevented.push(
+            event.defaultPrevented,
+          );
+        },
+        // 버블 단계에서 듣는다 — 캔버스 핸들러가 먼저 돌아야 값이 참이 된다.
+        false,
+      );
+    });
+    for (const key of DIRECTIONS) await page.keyboard.press(key);
+    await page.waitForTimeout(300);
+    const flags = await page.evaluate(
+      () => (window as unknown as { __keyPrevented: boolean[] }).__keyPrevented,
+    );
+    expect(flags.length, "방향키 사건이 하나도 안 잡혔다 — 이 시험이 공회전한다").toBe(4);
+    expect(flags, "지도가 방향키를 가져가지 않았다 — 브라우저 기본 동작이 남는다").toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  /**
+   * 캔버스에 초점이 없으면 우리 것이 아니다 — 다른 곳에서 방향키를 누르는데
+   * 지도가 반응하면, 그건 남의 입력을 훔치는 것이다.
+   */
+  test("캔버스에 초점이 없으면 방향키가 지도를 움직이지 않는다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    const pinned = await selectedId(page);
+
+    // 초점을 캔버스 밖으로 옮긴다.
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await page.locator("body").press("ArrowUp");
+    await page.locator("body").press("ArrowDown");
+    await page.waitForTimeout(400);
+    expect(await selectedId(page), "초점이 없는데 지도가 움직였다").toBe(pinned);
+  });
+});


### PR DESCRIPTION
## Summary

소유자가 **B** 를 골랐다. 방향키가 카메라를 미는 게 아니라 **이웃으로 옮겨 간다.**

이 캔버스는 그림이라 Tab 을 눌러도 노드에 갈 곳이 없었다. 초점은 받을 수 있었지만
(`tabIndex=0` 은 이미 있었다) **키로 할 수 있는 일이 0개**였다.

### 어느 이웃인가 — 순수 함수 하나

TV 리모컨 · CSS 공간 내비게이션과 같은 방식: 누른 방향으로의 **투영**이 0 이하면
버리고, 남은 것 중 **투영 + 직교거리×2** 가 가장 작은 것을 고른다. 직교 벌점이
있어야 「거의 옆인데 살짝 위」가 「바로 위」를 이기지 못한다.

**부채꼴은 ±60°** — 네 방향이 **틈 없이 평면을 덮는 가장 좁은 각**(4×120°=360°)이고,
좁히면 어느 방향키로도 못 닿는 이웃이 생긴다. 그 성질을 **120개 각도 전수**로 잰다.

그 방향에 이웃이 없으면 **아무 일도 안 한다 — 감싸 돌지 않는다.** 반대편으로 뛰면
사용자가 자기 위치를 잃는다.

### 초점 링을 새로 만들지 않았다 (범위를 좁힌 것 — 이유를 적는다)

B 는 「초점이 움직이고 Enter 로 선택」이라고 그렸다. 그런데 **초점과 선택을 시각적으로
가르려면 인디고 마크가 하나 더 필요하고, 인디고는 이미 「선택됨」을 뜻한다.** 같은
색이 두 뜻을 갖는 순간 도해가 깨지며, 그건 혼자 정할 규격이 아니다
(`design.md` 「규격을 바꾸려면 「체계」를 부른다」).

그래서 **방향키가 선택을 옮긴다** — 클릭과 같은 뜻이고 **새 시각 언어 0개 · 새 토큰
0개.** 초점과 선택을 가르는 안은 규격 결정으로 남긴다.

### 카메라는 따라만 온다

매번 가운데로 데려오면 걷는 동안 지도가 계속 미끄러져 위치를 잃는다. 초점이 화면
가장자리(짧은 변의 18%) 안으로 들어오려 할 때만 전이한다.

## 프로브가 내 시험 하나를 기각했다

「방향키가 페이지를 스크롤하지 않는다」를 `window.scrollY` 로 재려 했는데,
**`preventDefault` 를 통째로 지워도 초록이었다** — 지도 화면은 셸이
`overflow-hidden` 으로 잡아 문서가 애초에 스크롤되지 않는다. 원리적으로 실패할 수
없는 시험이라 성질을 바꿨다: 방향키 사건의 **`defaultPrevented` 가 참인가**.
이제 지우면 빨개진다.

`role="application"` 을 거부한 예전 근거(*"자체 키보드 순회를 제공하지 않으므로
뺏고 안 주는 것이 가장 나쁘다"*)는 **오늘 사실이 아니게 됐다.** 그래도 `group` 을
유지한다 — 삼키는 키가 네 방향키뿐이라 전부 뺏는 것보다 잃는 게 적다. 실제
보조기술로 재 보기 전에 미리 뺏지 않는다.

## Test plan

- **단위 16건** — 네 방향 · 없으면 아무 일 없음 · 뒤는 안 셈 · 가까운 쪽 ·
  직교 벌점이 결과를 가름(산수까지 확인) · 부채꼴 경계 · **120개 각도 전수 커버리지** ·
  자기 자신 제외 · 동점은 id 로 · 초기 초점은 화면 중심 기준 · 방향키만 우리 것
- **e2e 6건** — 첫 누름에 노드가 잡힘 · 실제로 다른 노드로 이동 · 이동한 곳이
  화면에 있음 · 카메라가 따라옴 · **`defaultPrevented`** · 캔버스에 초점 없으면 무반응
- **프로브**: `onKeyDown` 을 떼면 **5건 실패** · `preventDefault` 를 떼면 **해당 시험 실패**
- `pnpm test:run` 6,533 통과 · `pnpm exec tsc --noEmit` 깨끗 · `pnpm build` OK ·
  lint 경고 래칫 통과(내가 늘린 경고 1건은 고쳤다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)