### PR TITLE
fix: 지도를 키보드로 잡을 길이 없었다 (Tab 30번)

### DIFF
--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, type ReactNode } from "react";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import { useDestinationShortcuts } from "@/shared/lib/use-destination-shortcuts";
+import { focusMapCanvasWhenReady } from "@/shared/lib/focus-map-canvas";
 import {
   AppNavRail,
   NavRailShellProvider,
@@ -248,7 +249,16 @@ function AppNavRailSlot() {
    * 입구가 없는데 키보드에만 있으면, 그건 발견할 수 없는 기능이다.
    */
   useDestinationShortcuts({
-    navigate: (href) => router.push(href),
+    navigate: (href, id) => {
+      router.push(href);
+      /*
+       * 지도는 **데려가는 것으로 끝나지 않는다** — 캔버스에 초점을 줘야 방향키로
+       * 걸을 수 있다. 실측: 키보드로 그 캔버스에 닿으려면 Tab **30번**이었다
+       * (`shared/lib/focus-map-canvas.ts` 에 이유를 적어 뒀다). 새 단축키를
+       * 만들지 않고 이미 있는 `G M` 에 이 일을 준다.
+       */
+      if (id === "map") focusMapCanvasWhenReady();
+    },
     disabled: gateway,
     hrefOverrides: contextHrefs?.docs ? { docs: contextHrefs.docs } : undefined,
   });

--- a/src/shared/lib/focus-map-canvas.ts
+++ b/src/shared/lib/focus-map-canvas.ts
@@ -1,0 +1,85 @@
+/**
+ * 지도 캔버스에 초점을 준다 — **`G M` 이 「지도로 가기」가 아니라 「지도를 잡기」가
+ * 되도록.**
+ *
+ * ## 왜 이 파일이 필요한가 — 실측이 구멍을 냈다
+ *
+ * 방향키로 그래프를 걷는 기능(2026-08-09)을 붙인 뒤 브라우저에서 재 보니,
+ * **키보드로 그 캔버스에 닿으려면 Tab 을 30번 눌러야 했다**(1440×900, 지도 화면
+ * 실측). 좌측 레일 · 상단 도구 · INDEX 패널의 컨트롤이 전부 그 앞에 있다.
+ * 걷는 기능이 아무리 잘 돌아도, 그 앞에 30번이 있으면 **그것을 쓸 사람이 도달할
+ * 수 없다** — 기능을 만든 대상이 정확히 키보드 사용자다.
+ *
+ * 그래서 이미 있는 키에 일을 하나 더 준다: `G M` 은 지도로 데려가는 키였고, 지도에
+ * **이미 있을 때는 아무 일도 안 하던** 키였다. 이제 그 키가 캔버스를 잡는다.
+ * 새 단축키를 만들지 않았으므로 외울 것이 늘지 않고, 단축키 시트가 이미 그 키를
+ * 안내하므로 발견 경로도 그대로다.
+ *
+ * ## 왜 즉시 한 번이 아니라 몇 프레임을 기다리나
+ *
+ * 다른 화면에서 `G M` 을 누르면 라우터가 지도를 **그리기 전에** 이 함수가 불린다.
+ * 그 순간 캔버스는 DOM 에 없다. 한 번만 찾고 포기하면 「같은 화면에서는 되는데
+ * 다른 화면에서 오면 안 되는」 상태가 되고, 그건 사용자가 원인을 짐작할 수 없는
+ * 종류의 결함이다.
+ *
+ * 기다리는 단위가 시간(ms)이 아니라 **프레임**인 이유: 그려지는 시점은 기계 속도에
+ * 딸려 있어서 밀리초로 정하면 느린 기계에서만 실패한다(`architecture.md` 의
+ * 「게이트는 밀리초가 아니라 횟수로 잠근다」와 같은 이유).
+ */
+
+/** 캔버스를 찾는 표식. `data-testid` 를 런타임 선택자로 쓰지 않는다 — 그건 시험의 것이다. */
+export const MAP_CANVAS_SURFACE_ROLE = 'map-canvas';
+
+/**
+ * 몇 프레임까지 기다리나. 라우트 전환 + 첫 그림이 이 안에 들어야 한다.
+ *
+ * ⚠️ **처음에 30으로 뒀고 그게 부족했다** — 다른 화면에서 `G M` 을 눌렀을 때만
+ * 실패했다(같은 화면에서는 캔버스가 이미 있어 첫 프레임에 끝난다). 실측:
+ * 프로젝트 목록에서 `G M` 을 누르면 캔버스가 **395ms** 뒤에 생긴다. 30프레임은
+ * 이상적으로 500ms 지만 라우트 전환 중에는 프레임이 고르지 않아 그 안에 못 든다.
+ *
+ * 그리고 이 값이 넉넉해도 초점 싸움이 나지 않는다: `RouteFocusManager` 는
+ * **이미 `#main` 안에 초점이 있으면 건드리지 않는다**(그 파일의 규칙). 캔버스는
+ * `#main` 안이라(실측 확인) 우리가 먼저 잡으면 그쪽이 물러난다 — 우리가 늦으면
+ * 그쪽이 읽기 시작점을 잡고, 그건 정상적인 접근성 동작이다.
+ */
+export const FOCUS_MAP_CANVAS_MAX_FRAMES = 120;
+
+function findMapCanvas(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    `[data-surface-role="${MAP_CANVAS_SURFACE_ROLE}"]`,
+  );
+}
+
+/**
+ * 캔버스가 나타나면 초점을 준다. 이미 있으면 그 프레임에 끝난다.
+ *
+ * 되돌리는 함수를 준다 — 사용자가 그 사이 다른 곳을 눌렀으면 호출자가 취소할 수
+ * 있어야 한다(초점을 뺏는 것은 사용자를 놀라게 하는 일이다).
+ */
+export function focusMapCanvasWhenReady(
+  maxFrames: number = FOCUS_MAP_CANVAS_MAX_FRAMES,
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const immediate = findMapCanvas();
+  if (immediate) {
+    immediate.focus();
+    return () => {};
+  }
+
+  let frame = 0;
+  let raf = 0;
+  const tick = () => {
+    const canvas = findMapCanvas();
+    if (canvas) {
+      canvas.focus();
+      return;
+    }
+    frame += 1;
+    if (frame >= maxFrames) return;
+    raf = window.requestAnimationFrame(tick);
+  };
+  raf = window.requestAnimationFrame(tick);
+  return () => window.cancelAnimationFrame(raf);
+}

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, type RefObject } from "react";
 import { Orbit } from "lucide-react";
+import { MAP_CANVAS_SURFACE_ROLE } from "@/shared/lib/focus-map-canvas";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
 import { useTopologyLoop } from "./use-topology-loop";
 import type { TierRevealConfig } from "../model/tier-visibility";
@@ -409,6 +410,10 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       <canvas
         ref={canvasRef}
         data-testid="topology-map-v2-canvas"
+        /* `G M` 이 이 캔버스를 찾아 초점을 주는 표식 — 자세한 이유는
+           `shared/lib/focus-map-canvas.ts`. `data-testid` 는 시험의 것이라
+           런타임 선택자로 쓰지 않는다. */
+        data-surface-role={MAP_CANVAS_SURFACE_ROLE}
         /**
          * **끌 수 있는 것은 그림이 아니다** (2026-07-28 모션석 P3).
          *

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -40,6 +40,80 @@ async function focusCanvas(page: import("@playwright/test").Page) {
 const selectedId = (page: import("@playwright/test").Page) =>
   page.evaluate(() => window.__atlasMap?.selection().nodeId ?? null);
 
+test.describe("지도에 초점을 주는 길", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await seedFirstRunSeen(page);
+  });
+
+  /**
+   * **`G M` 이 지도를 잡는다** — 걷는 기능의 입구다.
+   *
+   * ⚠️ 이 시험이 없던 동안 실측한 값: 키보드로 이 캔버스에 닿으려면 **Tab 30번**
+   * (1440×900). 걷는 기능이 아무리 잘 돌아도 그 앞에 30번이 있으면, 그것을 쓸
+   * 사람이 도달할 수 없다 — 기능을 만든 대상이 정확히 키보드 사용자다.
+   *
+   * `Tab` 횟수를 상한으로 잠그지 않는 이유: 레일에 목적지가 하나 늘면 그 수가
+   * 늘어나는 게 정상이고, 그때마다 이 시험이 터지면 다음 사람은 시험을 고친다.
+   * 잠글 성질은 **「한 번의 키로 닿는 길이 있다」** 다.
+   */
+  test("다른 화면에서 G M 을 누르면 지도 캔버스가 초점을 받는다", async ({ page }) => {
+    await page.goto("/ko/projects/?guides=off&e2e=1");
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("g");
+    await page.keyboard.press("m");
+    await expect(page).toHaveURL(/\/ko\/topology\/?($|\?)/, { timeout: 10_000 });
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-surface-role") ?? "",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe("map-canvas");
+  });
+
+  test("지도에 이미 있을 때 G M 을 누르면 캔버스를 잡는다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off&e2e=1");
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("g");
+    await page.keyboard.press("m");
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-surface-role") ?? "",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe("map-canvas");
+  });
+
+  /** 잡은 다음 바로 걸을 수 있나 — 입구와 기능이 실제로 이어졌는지. */
+  test("G M 으로 잡은 다음 방향키로 걸을 수 있다", async ({ page }) => {
+    await page.goto("/ko/topology/?guides=off&e2e=1");
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("g");
+    await page.keyboard.press("m");
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.activeElement?.getAttribute("data-surface-role") ?? "",
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe("map-canvas");
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(() => page.evaluate(() => window.__atlasMap?.selection().nodeId ?? null), {
+        timeout: 5_000,
+      })
+      .not.toBeNull();
+  });
+});
+
 test.describe("지도 키보드 걷기", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });


### PR DESCRIPTION
## Summary

방향키로 걷는 기능(#1019)을 **설치 앱에서 눌러 봤는데 아무 일도 안 났다.** 재 보니
원인은 걷기가 아니라 **입구**다: 키보드로 그 캔버스에 닿으려면 **Tab 을 30번**
눌러야 한다(1440×900 실측). 좌측 레일 · 상단 도구 · INDEX 의 컨트롤이 전부 앞에 있다.

기능이 아무리 잘 돌아도 그 앞에 30번이 있으면 **그것을 쓸 사람이 도달할 수 없다** —
대상이 정확히 키보드 사용자다.

### 내 e2e 가 그 구멍을 못 봤다

`canvas.focus()` 를 직접 불러서 **「사람이 초점을 줄 수 있나」를 건너뛰었다.**
통과했지만 증명한 것은 「초점이 있으면 걷는다」까지였다. 입구 시험 셋을 새로 넣었다.

### 새 단축키를 만들지 않았다

`G M` 은 지도로 데려가는 키였고, **지도에 이미 있으면 아무 일도 안 하던** 키다.
이제 그 키가 캔버스를 잡는다. 외울 것이 늘지 않고 단축키 시트가 이미 안내한다.

### 초점 싸움을 하지 않는다

`RouteFocusManager` 는 라우트 전환 뒤 읽기 시작점(`h1`)을 잡는다. 그런데 그 파일의
규칙이 **「이미 `#main` 안에 초점이 있으면 건드리지 않는다」** 이고, 캔버스는 `#main`
안이다(실측 확인). 우리가 먼저 잡으면 그쪽이 물러나고, 늦으면 그쪽이 읽기 시작점을
잡는다 — 그건 정상적인 접근성 동작이라 덮지 않는다.

### 프레임 예산 30 → 120

30프레임은 **다른 화면에서 왔을 때만** 부족했다(같은 화면은 캔버스가 이미 있어 첫
프레임에 끝난다). 실측: 프로젝트 목록에서 `G M` 을 누르면 캔버스가 **395ms** 뒤에
생기고, 라우트 전환 중 프레임이 고르지 않아 30프레임 안에 못 든다. 밀리초가 아니라
**프레임**으로 세는 이유는 기계 속도에 딸리지 않게 하려는 것이다.

## Test plan

- **e2e 9건** (기존 6 + 입구 3) — 다른 화면에서 `G M` → 캔버스가 초점 받음 ·
  지도에서 `G M` → 캔버스 잡음 · **잡은 다음 방향키로 걸림** · 그리고 기존 걷기 6건.
  **2회 연속 9/9**
- `Tab` 횟수를 상한으로 잠그지 않았다 — 레일에 목적지가 늘면 그 수가 늘어나는 게
  정상이고, 그때마다 터지면 다음 사람이 시험을 고친다. 잠글 성질은
  **「한 번의 키로 닿는 길이 있다」**
- `pnpm test:run` 6,533 통과 · `eslint` 0 error · `tsc --noEmit` 깨끗 · `pnpm build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)