### PR TITLE
fix: 한글 입력기가 켜져 있으면 단축키가 하나도 안 먹었다 (물리 키로 판정)

### DIFF
--- a/src/shared/lib/use-destination-shortcuts.test.ts
+++ b/src/shared/lib/use-destination-shortcuts.test.ts
@@ -144,16 +144,53 @@ describe("useDestinationShortcuts", () => {
     expect(navigate).toHaveBeenCalledTimes(1);
   });
 
-  it("리더를 누른 지 오래되면 글자만으로는 이동하지 않는다", () => {
+  /**
+   * ⚠️ **이 시험이 설치 앱의 결함을 잡는 자리다** (2026-08-10).
+   *
+   * 처음 구현은 시각을 **`event.timeStamp`** 로 읽고 «0 이면 리더를 안 누른 것»
+   * 으로 판정했다. 브라우저에서는 잘 돌았고 e2e 도 통과했는데, **설치 앱
+   * (WKWebView)에서는 리더 조합이 하나도 안 먹었다** — `G P` 도 `G M` 도. 같은
+   * 화면에서 `?` 는 정상이었으니 키가 WebView 에 닿기는 했다.
+   *
+   * 0 을 «안 누름» 의 뜻으로 겸용한 것이 원인이고, 어떤 런타임이 0 을 주면 기능이
+   * 통째로 사라지면서 **화면에는 아무 단서도 없다.** 그래서 두 사건의 `timeStamp`
+   * 를 **둘 다 0** 으로 두고도 이동해야 한다고 못박는다.
+   */
+  it("event.timeStamp 가 0 이어도 이동한다 — 시계를 사건에서 읽지 않는다", () => {
     renderHook(() => useDestinationShortcuts({ navigate }));
-    // `timeStamp` 로 재므로 시계를 건드리지 않고 사건 자신의 시각을 벌린다.
-    const leader = new KeyboardEvent("keydown", { key: "g", bubbles: true, cancelable: true });
-    Object.defineProperty(leader, "timeStamp", { value: 0 });
-    window.dispatchEvent(leader);
-    const late = new KeyboardEvent("keydown", { key: "p", bubbles: true, cancelable: true });
-    Object.defineProperty(late, "timeStamp", { value: NAV_LEADER_WINDOW_MS + 1 });
-    window.dispatchEvent(late);
-    expect(navigate, "시간 제한이 안 걸렸다").not.toHaveBeenCalled();
+    for (const key of ["g", "p"]) {
+      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      Object.defineProperty(event, "timeStamp", { value: 0 });
+      window.dispatchEvent(event);
+    }
+    expect(navigate, "사건의 timeStamp 에 기대고 있다").toHaveBeenCalledWith("/projects/", "projects");
+  });
+
+  it("리더를 누른 지 오래되면 글자만으로는 이동하지 않는다", () => {
+    // 시계는 `performance.now()` 다 — 그것만 가짜로 만든다.
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useDestinationShortcuts({ navigate }));
+      press("g");
+      vi.advanceTimersByTime(NAV_LEADER_WINDOW_MS + 50);
+      press("p");
+      expect(navigate, "시간 제한이 안 걸렸다").not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("시간 제한 안이면 이동한다 — 위 시험이 늘 통과하는 게 아니라는 증거", () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useDestinationShortcuts({ navigate }));
+      press("g");
+      vi.advanceTimersByTime(Math.floor(NAV_LEADER_WINDOW_MS / 2));
+      press("p");
+      expect(navigate).toHaveBeenCalledWith("/projects/", "projects");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("disabled 면 아무것도 하지 않는다", () => {

--- a/src/shared/lib/use-destination-shortcuts.test.ts
+++ b/src/shared/lib/use-destination-shortcuts.test.ts
@@ -19,6 +19,21 @@ import { NAV_LEADER_WINDOW_MS } from "@/shared/config/destinations";
  * `tests/e2e/destination-shortcuts.spec.ts`.
  */
 
+/**
+ * 한글 입력기가 켜진 상태의 키 사건 — `key` 는 자모, `code` 는 물리 위치.
+ *
+ * ⚠️ **이 함수가 있는 이유가 실제 결함이다** (2026-08-10, 설치 앱 실측).
+ * 한글 입력 상태에서 물리 `G` 는 `key="ㅎ"`, `P` 는 `key="ㅔ"` 로 온다. 조합키도
+ * 없고 초점도 body 였고 막는 표면도 없었는데, **단지 글자가 달라 하나도 안 먹었다.**
+ * 이 제품의 주 언어가 한국어이므로 그건 드문 환경이 아니라 **평소 상태**였고,
+ * 브라우저 e2e 는 Latin 을 타이핑하므로 원리적으로 못 잡는다.
+ */
+function pressHangul(jamo: string, code: string) {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", { key: jamo, code, bubbles: true, cancelable: true }),
+  );
+}
+
 function press(key: string, target?: Element, extra: Partial<KeyboardEventInit> = {}) {
   const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...extra });
   (target ?? window).dispatchEvent(event);
@@ -44,6 +59,28 @@ describe("useDestinationShortcuts", () => {
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(navigate.mock.calls[0]?.[0]).toBe("/projects/");
     expect(navigate.mock.calls[0]?.[1]).toBe("projects");
+  });
+
+  it("한글 입력기가 켜져 있어도 이동한다 — 물리 키로 판정한다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    pressHangul("ㅎ", "KeyG"); // 리더
+    pressHangul("ㅔ", "KeyP"); // 프로젝트
+    expect(navigate, "한글 입력 상태에서 안 먹는다").toHaveBeenCalledWith("/projects/", "projects");
+  });
+
+  it("한글 입력기에서 G G(git)도 성립한다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    pressHangul("ㅎ", "KeyG");
+    pressHangul("ㅎ", "KeyG");
+    expect(navigate).toHaveBeenCalledWith("/git/", "git");
+  });
+
+  it("자판이 QWERTY 가 아니어도 찍힌 글자로 맞는다", () => {
+    renderHook(() => useDestinationShortcuts({ navigate }));
+    // AZERTY 에서 사용자가 `G` 라고 찍힌 키를 누르면 `code` 는 다를 수 있다.
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "g", code: "KeyZ", bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "p", code: "KeyX", bubbles: true }));
+    expect(navigate).toHaveBeenCalledWith("/projects/", "projects");
   });
 
   it("리더 없이 글자만 누르면 아무 일도 없다", () => {

--- a/src/shared/lib/use-destination-shortcuts.ts
+++ b/src/shared/lib/use-destination-shortcuts.ts
@@ -66,6 +66,42 @@ function blockingSurfaceOpen(): boolean {
   return false;
 }
 
+/**
+ * 이 키가 그 글자인가 — **입력기(IME)와 자판 배열에 안 넘어가게.**
+ *
+ * ⚠️ **`event.key` 만 보면 한글 입력 상태에서 통째로 안 먹는다** (2026-08-10,
+ * 설치 앱 실측). 한글 입력기가 켜져 있으면 물리 `G` 키의 `event.key` 는 `ㅎ`,
+ * `P` 는 `ㅔ` 다. 조합키도 안 눌렸고 초점도 body 였고 막는 표면도 없었는데, 단지
+ * 글자가 달라서 `DESTINATION_BY_KEY` 에 걸리지 않았다.
+ *
+ * **이 제품의 주 언어가 한국어다.** 즉 이 버그는 «드문 환경» 이 아니라 소유자와
+ * 대상 사용자의 **평소 상태**였고, 브라우저 e2e 는 Latin 을 타이핑하므로 원리적으로
+ * 못 잡는다.
+ *
+ * 그래서 둘 중 하나라도 맞으면 통과시킨다:
+ *
+ * - `event.code === 'KeyG'` — **물리 위치**. 입력기와 무관하다(한글·일본어·중국어).
+ * - `event.key === 'g'` — **찍힌 글자**. QWERTY 가 아닌 Latin 배열(AZERTY·Dvorak)
+ *   에서 사용자가 실제로 누르는 키다.
+ *
+ * 하나만 쓰면 각각 반대쪽을 잃는다: `code` 만 보면 AZERTY 에서 `A` 를 눌러야
+ * `KeyQ` 가 되고, `key` 만 보면 한글에서 아무것도 안 된다.
+ */
+export function matchesLetter(event: Pick<KeyboardEvent, 'key' | 'code'>, letter: string): boolean {
+  if (event.key.toLowerCase() === letter) return true;
+  return event.code === `Key${letter.toUpperCase()}`;
+}
+
+/** 이 사건이 어느 목적지의 글자인가. 없으면 `null`. */
+function destinationForEvent(
+  event: Pick<KeyboardEvent, 'key' | 'code'>,
+): DestinationId | null {
+  for (const [letter, id] of Object.entries(DESTINATION_BY_KEY)) {
+    if (matchesLetter(event, letter)) return id;
+  }
+  return null;
+}
+
 export interface DestinationShortcutOptions {
   /** 목적지로 데려간다. 라우터는 호출자가 쥔다 — `shared` 가 라우터를 모르게. */
   navigate: (href: string, id: DestinationId) => void;
@@ -113,11 +149,10 @@ export function useDestinationShortcuts({
         return;
       }
 
-      const key = event.key.toLowerCase();
       const now = performance.now();
 
       if (leaderAt.current !== null && now - leaderAt.current <= NAV_LEADER_WINDOW_MS) {
-        const id = DESTINATION_BY_KEY[key];
+        const id = destinationForEvent(event);
         leaderAt.current = null;
         if (!id) return;
         event.preventDefault();
@@ -127,7 +162,7 @@ export function useDestinationShortcuts({
 
       // 리더를 새로 누른다. `G G`(git)가 성립하려면 리더 자신도 두 번째 글자가
       // 될 수 있어야 하는데, 그 판정은 위 블록이 먼저 하므로 순서가 중요하다.
-      leaderAt.current = key === NAV_LEADER_KEY ? now : null;
+      leaderAt.current = matchesLetter(event, NAV_LEADER_KEY) ? now : null;
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);

--- a/src/shared/lib/use-destination-shortcuts.ts
+++ b/src/shared/lib/use-destination-shortcuts.ts
@@ -80,12 +80,24 @@ export function useDestinationShortcuts({
   disabled = false,
   hrefOverrides,
 }: DestinationShortcutOptions) {
-  /** 리더를 누른 시각. 0 이면 안 누른 것. */
-  const leaderAt = useRef(0);
+  /**
+   * 리더를 누른 시각. `null` 이면 안 누른 것.
+   *
+   * ⚠️ **`event.timeStamp` 를 쓰면 안 된다** (2026-08-10, 설치 앱 실측). 처음에는
+   * 시각을 `event.timeStamp` 로 읽고 «0 이면 안 누른 것» 으로 판정했다. 브라우저
+   * (Chromium)에서는 잘 돌았고 e2e 도 통과했는데, **설치 앱(WKWebView)에서는
+   * 리더 조합이 하나도 안 먹었다** — `G P` 도 `G M` 도. 같은 화면에서 `?` 는
+   * 정상이었으니 키가 WebView 에 닿기는 했다.
+   *
+   * 그래서 시계를 사건에서 떼어 낸다: 시각은 `performance.now()` 로, 「눌렀나」는
+   * **`null` 이 아닌가**로 판정한다. 0 을 «안 누름» 의 뜻으로 겸용하면, 어떤
+   * 런타임이 0 을 주는 순간 기능이 통째로 사라지고 화면에는 아무 단서도 없다.
+   */
+  const leaderAt = useRef<number | null>(null);
 
   useEffect(() => {
     if (disabled) {
-      leaderAt.current = 0;
+      leaderAt.current = null;
       return;
     }
     const handler = (event: KeyboardEvent) => {
@@ -97,16 +109,16 @@ export function useDestinationShortcuts({
 
       // 막는 표면이 떠 있으면 이동하지 않는다 (위 3번).
       if (blockingSurfaceOpen()) {
-        leaderAt.current = 0;
+        leaderAt.current = null;
         return;
       }
 
       const key = event.key.toLowerCase();
-      const now = event.timeStamp;
+      const now = performance.now();
 
-      if (leaderAt.current > 0 && now - leaderAt.current <= NAV_LEADER_WINDOW_MS) {
+      if (leaderAt.current !== null && now - leaderAt.current <= NAV_LEADER_WINDOW_MS) {
         const id = DESTINATION_BY_KEY[key];
-        leaderAt.current = 0;
+        leaderAt.current = null;
         if (!id) return;
         event.preventDefault();
         navigate(hrefOverrides?.[id] ?? DESTINATION_HREF[id], id);
@@ -115,7 +127,7 @@ export function useDestinationShortcuts({
 
       // 리더를 새로 누른다. `G G`(git)가 성립하려면 리더 자신도 두 번째 글자가
       // 될 수 있어야 하는데, 그 판정은 위 블록이 먼저 하므로 순서가 중요하다.
-      leaderAt.current = key === NAV_LEADER_KEY ? now : 0;
+      leaderAt.current = key === NAV_LEADER_KEY ? now : null;
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);


### PR DESCRIPTION
## Summary

설치 앱에서 `G P` · `G M` 이 **안 먹었다.** 원인을 **네 번 잘못 짚은 뒤**(낡은 빌드 ·
막는 모달 · 입력칸 초점 · `event.timeStamp`) 임시 진단 배지를 화면에 띄워 앱 안을
직접 읽었다:

```
mount=1 gw=false keys=2 last=p|m0c0a1 modals=0/0 tag=BODY
```

훅은 붙었고(`mount=1`) 관문도 아니고 키도 둘 다 도착했고 모달도 없고 초점도 body 였다.
물리 키코드로 다시 눌러 보니 **`last=ㅔ`** — **한글 입력기가 켜져 있으면 `event.key`
가 자모다**(G→`ㅎ`, P→`ㅔ`). 조합키도 없었다. 단지 글자가 달라
`DESTINATION_BY_KEY` 에 걸리지 않았다.

**이 제품의 주 언어가 한국어다.** 이 결함은 「드문 환경」이 아니라 소유자와 대상
사용자의 **평소 상태**였고, 브라우저 e2e 는 Latin 을 타이핑하므로 **원리적으로 못
잡는다.**

### `event.key` 와 `event.code` 를 둘 다 본다

- `event.code === 'KeyG'` — **물리 위치**. 입력기와 무관(한글·일본어·중국어)
- `event.key === 'g'` — **찍힌 글자**. QWERTY 가 아닌 Latin 배열(AZERTY·Dvorak)

하나만 쓰면 각각 반대쪽을 잃는다: `code` 만 보면 AZERTY 에서 `A` 를 눌러야 `KeyQ` 가
되고, `key` 만 보면 한글에서 아무것도 안 된다.

### 그리고 `event.timeStamp` 의존도 걷어냈다 (같은 브랜치의 앞 커밋)

리더를 누른 시각을 `event.timeStamp` 로 읽고 «0 이면 안 누름» 으로 겸용했다. 0 을
센티넬로 겸용하면 어떤 런타임이 0 을 주는 순간 기능이 통째로 사라지고 **화면에는
아무 단서도 없다.** `performance.now()` + `null` 센티넬로 바꿨다.

## Test plan

- **단위 18건** — 한글 입력기(`ㅎ`+`KeyG` → `ㅔ`+`KeyP`) · 한글에서 `G G`(git) ·
  QWERTY 아닌 배열(찍힌 글자로) · `timeStamp` 0 이어도 이동 · 시간 제한 안/밖 ·
  입력 중 무시 · 조합키 무시 · 보이는/숨은 모달 · disabled · 문맥 주소
- **프로브**: `code` 판정을 지우면 **한글 시험이 빨개짐** · `key` 판정을 지우면
  **배열 시험이 빨개짐** · `timeStamp` 로 되돌리면 그 회귀 시험이 빨개짐
- **설치 앱 실측**: 한글 입력기를 켠 채 물리 `G`·`P` → 프로젝트 화면으로 이동 확인 ·
  `G M` → 지도 복귀 확인
- `pnpm test:run` 6,538 통과 · `tsc --noEmit` 깨끗

## 아직 확인 못 한 것

**지도의 방향키 걷기를 설치 앱에서 확인하지 못했다.** 브라우저 e2e 9건은 통과하고
`G M` 으로 지도 복귀도 되는데, 앱에서 `G M` 뒤 방향키를 눌렀을 때 노드가 잡히는
것을 아직 화면으로 확인하지 못했다. 다음 차례에 그것부터 본다 —
「브라우저 통과는 앱의 증거가 아니다」가 이번에 두 번 확인됐다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)