### PR TITLE
feat: 형제끼리 옆걸음 + 갈 곳이 없으면 말해 준다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -807,6 +807,9 @@
       "collapseTooltip": "Collapse hub bar",
       "collapseAriaLabel": "Collapse hub bar",
       "itemTitle": "{name} · {degree} connections"
+    },
+    "keyboardWalk": {
+      "deadEnd": "No connected node this way. Try another direction"
     }
   },
   "searchWidgets": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -807,6 +807,9 @@
       "collapseTooltip": "허브 바 접기",
       "collapseAriaLabel": "허브 바 접기",
       "itemTitle": "{name} · 연결 {degree}"
+    },
+    "keyboardWalk": {
+      "deadEnd": "이 방향에는 이어진 노드가 없어요. 다른 방향을 눌러 보세요"
     }
   },
   "searchWidgets": {

--- a/scripts/validate-messages.test.mjs
+++ b/scripts/validate-messages.test.mjs
@@ -389,8 +389,38 @@ describe('i18n message catalog', () => {
     const en = await readJson(path.join(MESSAGES_DIR, 'en.json'));
     const ko = await readJson(path.join(MESSAGES_DIR, 'ko.json'));
 
-    assert.deepEqual(Object.keys(ko.topologyWidgets).sort(), ['controls', 'hubRail']);
-    assert.deepEqual(Object.keys(en.topologyWidgets).sort(), ['controls', 'hubRail']);
+    /*
+     * ⚠️ **정확한 집합으로 못박지 않는다** (2026-08-10 에 좁혔다).
+     *
+     * 종전에는 `deepEqual(keys, ['controls','hubRail'])` 였다. 그런데 이 시험이
+     * **말하는 목적**은 「은퇴한 sigma/contextMenu/edgeTooltip 이 되살아나지
+     * 못하게」다 — 정확한 집합을 박으면 **정당한 추가에도 터진다**(실제로
+     * `keyboardWalk` 를 더하다 걸렸다). 그런 게이트는 다음 사람이 게이트 대신
+     * 기능 쪽을 되돌리게 만든다(`documentation.md` · `/gate-probe`).
+     *
+     * 그래서 거부 목록으로 판정한다. 새 절은 자유롭게 늘고, 은퇴한 이름은
+     * 되돌아오지 못한다.
+     */
+    const RETIRED = ['sigma', 'contextMenu', 'edgeTooltip'];
+    for (const [locale, messages] of [['ko', ko], ['en', en]]) {
+      const keys = Object.keys(messages.topologyWidgets);
+      assert.ok(keys.length > 0, `${locale}: topologyWidgets 가 비었다 — 이 시험이 공회전한다`);
+      for (const retired of RETIRED) {
+        assert.ok(
+          !keys.includes(retired),
+          `${locale}: 은퇴한 topologyWidgets.${retired} 가 되살아났다`,
+        );
+      }
+    }
+    // 아직 소비처가 있는 둘은 사라지면 안 된다.
+    for (const [locale, messages] of [['ko', ko], ['en', en]]) {
+      for (const kept of ['controls', 'hubRail']) {
+        assert.ok(
+          Object.keys(messages.topologyWidgets).includes(kept),
+          `${locale}: topologyWidgets.${kept} 가 사라졌다 (소비처가 남아 있다)`,
+        );
+      }
+    }
   });
 
   it('keeps Korean docs vault commands understandable without source/topology jargon', async () => {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -326,6 +326,7 @@ export function HomePage() {
   // 어권별 이름 입력(create composer) 계약의 '지금 화면 언어'.
   const activeLocale = useLocale();
   const tKinds = useTranslations('kinds');
+  const tTopologyKeyboardWalk = useTranslations('topologyWidgets.keyboardWalk');
   const tAgentConnect = useTranslations('agentConnect');
   // P2 결함⑤ — <lg 기록 chrome-tile 진입점의 aria-label/title (`atlasGit`
   // 네임스페이스는 이미 `GitStatusTile` 이 쓰는 것과 같은 키를 재사용한다).
@@ -463,6 +464,18 @@ export function HomePage() {
   // 상태. 사용자 vault 디스크 read 실패 / 권한 만료 등의 경우 배너 노출
   // + "다시 시도" 버튼으로 복구.
   const toast = useToast();
+
+  /**
+   * 방향키로 갈 곳이 없을 때 — 스스로 사라지는 안내 한 줄.
+   *
+   * 소유자: *"이동할 연관 노드가 없습니다 … 조금 보여지다 자동으로 사라지게"*.
+   * 새 표면을 만들지 않고 이미 있는 토스트를 쓴다 — 지도 위에 안내 상자를 새로
+   * 세우면 위치·토큰·모션을 다 정해야 하고 그건 혼자 정할 규격이 아니다.
+   * 연타 걸러 내기는 위젯이 한다(`shouldAnnounceDeadEnd`).
+   */
+  const handleWalkDeadEnd = useCallback(() => {
+    toast.show(tTopologyKeyboardWalk("deadEnd"), "info");
+  }, [toast, tTopologyKeyboardWalk]);
   const prefetchedProjectHrefsRef = useRef(new Set<string>());
   const preloadedImageUrlsRef = useRef(new Set<string>());
   const {
@@ -4552,6 +4565,11 @@ export function HomePage() {
                   <TopologyMapV2
                     nodes={topologyV2Graph.nodes}
                     edges={topologyV2Graph.edges}
+                    /* 방향키로 걸을 곳이 없을 때 **말해 준다** (2026-08-10, 소유자).
+                       눌렀는데 아무 반응이 없으면 사용자는 「고장」과 「그 방향에는
+                       없음」을 구별할 수 없다. 문구와 표면은 페이지가 소유한다 —
+                       위젯은 사건만 내보낸다(그 위젯은 프로바이더 없이 시험된다). */
+                    onWalkDeadEnd={handleWalkDeadEnd}
                     focus={{ selectedSlug: canvasSelectedSlug }}
                     /* 볼트를 세션 중에 갈아 끼우면(샘플 → 로컬) 지도가 직전
                        그래프의 카메라로 새 그래프를 그리던 결함을 닫는다. 값의

--- a/src/widgets/topology-map-v2/interaction/keyboard-walk.test.ts
+++ b/src/widgets/topology-map-v2/interaction/keyboard-walk.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   CONE_HALF_TANGENT,
+  DEAD_END_NOTICE_COOLDOWN_MS,
+  shouldAnnounceDeadEnd,
   ORTHOGONAL_PENALTY,
   pickInitialFocus,
   pickNeighborInDirection,
@@ -110,6 +112,25 @@ describe("pickInitialFocus", () => {
 
   it("노드가 없으면 null", () => {
     expect(pickInitialFocus([], { x: 0, y: 0 })).toBeNull();
+  });
+});
+
+describe("shouldAnnounceDeadEnd", () => {
+  it("처음에는 말한다", () => {
+    expect(shouldAnnounceDeadEnd(null, 0)).toBe(true);
+  });
+
+  it("말한 직후에는 다시 말하지 않는다", () => {
+    expect(shouldAnnounceDeadEnd(1_000, 1_000 + DEAD_END_NOTICE_COOLDOWN_MS - 1)).toBe(false);
+  });
+
+  it("식은 뒤에는 다시 말한다", () => {
+    expect(shouldAnnounceDeadEnd(1_000, 1_000 + DEAD_END_NOTICE_COOLDOWN_MS)).toBe(true);
+  });
+
+  it("쉬는 시간이 사람이 읽을 만한 길이다", () => {
+    expect(DEAD_END_NOTICE_COOLDOWN_MS).toBeGreaterThanOrEqual(600);
+    expect(DEAD_END_NOTICE_COOLDOWN_MS).toBeLessThanOrEqual(4_000);
   });
 });
 

--- a/src/widgets/topology-map-v2/interaction/keyboard-walk.ts
+++ b/src/widgets/topology-map-v2/interaction/keyboard-walk.ts
@@ -124,6 +124,29 @@ export function pickInitialFocus(
   return bestId;
 }
 
+/**
+ * 막다른 길을 **몇 번이나 말할 것인가** — 같은 안내를 연달아 쏟지 않게.
+ *
+ * ⚠️ 처음에는 그 방향에 이웃이 없으면 **아무 일도 안 했다**. 「감싸 돌지 않는다」는
+ * 판단은 맞았지만(반대편으로 뛰면 사용자가 자기 위치를 잃는다), **침묵이 문제였다**:
+ * 소유자가 실제로 써 보고 *"방향키가 되긴 하는데 노드를 자유롭게 이동하진 못하네?"*
+ * 라고 말했다. 눌렀는데 아무 반응이 없으면 사용자는 「고장」과 「그 방향에는 없음」을
+ * 구별할 수 없다 — 이 저장소가 이름 붙여 둔 **「조용한 기다림」** 과 같은 실패다.
+ *
+ * 그래서 제약은 그대로 두고 **말해 준다.** 다만 방향키를 누르고 있으면 같은 안내가
+ * 수십 번 쌓이므로, 한 번 말한 뒤 잠시는 다시 말하지 않는다.
+ *
+ * 시간으로 재는 이유: 「같은 방향 연타」로만 막으면 좌우를 번갈아 누를 때 두 배로
+ * 쏟아진다. 「무엇을 눌렀나」가 아니라 **「방금 말했나」** 가 기준이다.
+ */
+export const DEAD_END_NOTICE_COOLDOWN_MS = 1200;
+
+/** 지금 막다른 길을 말해도 되나. `lastAtMs` 가 `null` 이면 아직 한 번도 안 말했다. */
+export function shouldAnnounceDeadEnd(lastAtMs: number | null, nowMs: number): boolean {
+  if (lastAtMs === null) return true;
+  return nowMs - lastAtMs >= DEAD_END_NOTICE_COOLDOWN_MS;
+}
+
 /** 방향키 이름 → 우리 방향. 그 밖의 키는 `null`(우리 것이 아니다). */
 export function walkDirectionForKey(key: string): WalkDirection | null {
   switch (key) {

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -112,6 +112,8 @@ export interface TopologyMapV2Props {
    */
   emphasizedNeighborSlug?: string | null;
   onSelect?: (slug: string) => void;
+  /** 방향키를 눌렀는데 그 방향에 갈 곳이 없을 때. 문구는 페이지가 정한다. */
+  onWalkDeadEnd?: (() => void) | null;
   onOpen?: (slug: string) => void;
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
@@ -297,7 +299,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -354,6 +356,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
     useTopologyLoop({
       nodes,
       edges,
+      onWalkDeadEnd,
       wheelIntent,
       ambientSleepDelayMs,
       focusedSlug: focus.selectedSlug,

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -82,8 +82,10 @@ import { updatePulses, type Pulse } from "../render/edge-fireflies";
 import {
   pickInitialFocus,
   pickNeighborInDirection,
+  shouldAnnounceDeadEnd,
   walkDirectionForKey,
 } from "../interaction/keyboard-walk";
+
 import { readTopologyV2TokensOrNull } from "./topology-read-tokens";
 import type { TopologyMapV2Props } from "./TopologyMapV2";
 import { applyForcePositions, buildTopologyWorld, recomputeWorldGeometry, type TopologyWorld, radiusForKind } from "./topology-world";
@@ -195,6 +197,8 @@ export interface UseTopologyLoopArgs {
     position: { x: number; y: number } | null,
   ) => void;
   onSelect?: (slug: string) => void;
+  /** 방향키를 눌렀는데 그 방향에 이어진 노드가 없을 때. 연타는 훅이 걸러 낸다. */
+  onWalkDeadEnd?: (() => void) | null;
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
   onGraphStatsChange?: (stats: { nodes: number; relations: number }) => void;
@@ -350,7 +354,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -3357,6 +3361,40 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   }, []);
 
   /**
+   * 막다른 길을 말해 주는 자리 — **침묵이 문제였다.**
+   *
+   * 소유자가 실제로 써 보고 *"방향키가 되긴 하는데 노드를 자유롭게 이동하진 못하네?"*
+   * 라고 했다. 그 방향에 이어진 노드가 없을 때 **아무 일도 안 하도록** 만들어 둔
+   * 것이 원인이다 — 「감싸 돌지 않는다」는 판단은 그대로 두고(반대편으로 뛰면
+   * 사용자가 자기 위치를 잃는다), 대신 **왜 안 움직이는지 말한다.** 눌렀는데 반응이
+   * 없으면 사용자는 「고장」과 「그 방향에는 없음」을 구별할 수 없다.
+   *
+   * **새 표면을 만들지 않는다** — 이 앱에는 이미 토스트가 있고 레이아웃 전체에
+   * 마운트돼 있다. 지도 위에 안내 상자를 새로 세우면 위치·토큰·모션을 다 정해야
+   * 하고, 그건 혼자 정할 규격이 아니다. 토스트는 스스로 사라지고
+   * (소유자: *"조금 보여지다 자동으로 사라지게"*) 보조기술에도 읽힌다.
+   *
+   * ⚠️ **문구와 토스트는 이 위젯의 것이 아니다.** 여기서 `useTranslations` 를
+   * 불렀다가 지도 컴포넌트 시험 5개가 깨졌다 — 그 시험은 프로바이더 없이 렌더한다.
+   * 그게 옳다: 이 위젯은 이미 `canvasLabel` 처럼 **문구를 prop 으로 받는다**.
+   * 그래서 사건만 밖으로 내보내고(`onWalkDeadEnd`), 무엇을 어떻게 보여 줄지는
+   * 페이지가 정한다.
+   */
+  const onWalkDeadEndRef = useRef(onWalkDeadEnd);
+  useEffect(() => {
+    onWalkDeadEndRef.current = onWalkDeadEnd;
+  });
+  /** 마지막으로 알린 시각 — 방향키를 누르고 있을 때 같은 말을 쏟지 않게. */
+  const deadEndAtRef = useRef<number | null>(null);
+
+  const announceDeadEnd = useCallback(() => {
+    const now = performance.now();
+    if (!shouldAnnounceDeadEnd(deadEndAtRef.current, now)) return;
+    deadEndAtRef.current = now;
+    onWalkDeadEndRef.current?.();
+  }, []);
+
+  /**
    * 방향키로 **그래프 위를 걷는다** — 갈래 B (2026-08-09 소유자 확정).
    *
    * 방향키가 카메라를 미는 게 아니라 **이웃으로 옮겨 간다.** 어느 이웃인지
@@ -3402,24 +3440,45 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     } else {
       const from = world.nodeById.get(currentId);
       if (!from) return;
-      const neighborIds = world.neighborMap.get(currentId);
-      if (!neighborIds || neighborIds.size === 0) {
-        // 이웃이 없는 노드에서 방향키를 누르면 아무 일도 없다. 그것이 사실이다.
-        e.preventDefault();
-        return;
+      /*
+       * 갈 수 있는 곳 = **이어진 이웃 + 형제**.
+       *
+       * ⚠️ 처음에는 이웃(엣지)만 후보였고, 소유자가 실물에서 막혔다 —
+       * *"1depth 에서는 자기들끼리 자유롭게 이동 가능하게는 해야할듯? 중앙에서
+       * 자유롭게 이동이 안 되던데?"*. 지도 중앙의 프로젝트를 둘러싼 도메인 아홉은
+       * **서로 엣지가 없다**(각자 프로젝트에만 붙어 있다). 그래서 상품에서 회원으로
+       * 옆걸음이 안 됐고, 링처럼 둘러선 화면에서 그건 고장으로 읽힌다.
+       *
+       * **임의 공간 점프를 허용한 것이 아니다.** 형제는 「같은 부모」라는 타입 있는
+       * 관계이고, 그것이 화면에서 링을 이루는 이유 자체다. 부모가 없는 뿌리끼리도
+       * 형제로 본다(프로젝트가 둘 이상인 볼트).
+       */
+      const candidateIds = new Set<string>(world.neighborMap.get(currentId) ?? []);
+      for (const node of world.nodes) {
+        if (node.id === currentId) continue;
+        if (node.parentId === from.parentId) candidateIds.add(node.id);
       }
-      const neighbors: { id: string; x: number; y: number }[] = [];
-      for (const id of neighborIds) {
+      const candidates: { id: string; x: number; y: number }[] = [];
+      for (const id of candidateIds) {
         if (!visible(id)) continue;
         const node = world.nodeById.get(id);
-        if (node) neighbors.push({ id: node.id, x: node.x, y: node.y });
+        if (node) candidates.push({ id: node.id, x: node.x, y: node.y });
       }
-      nextId = pickNeighborInDirection({ id: from.id, x: from.x, y: from.y }, neighbors, direction);
+      if (candidates.length === 0) {
+        // 갈 곳이 아예 없는 노드. 아무 일도 안 하는 대신 왜 그런지 말한다.
+        e.preventDefault();
+        announceDeadEnd();
+        return;
+      }
+      nextId = pickNeighborInDirection({ id: from.id, x: from.x, y: from.y }, candidates, direction);
     }
 
     // 방향키는 우리 것이다 — 그 방향에 이웃이 없어도 페이지가 스크롤되면 안 된다.
     e.preventDefault();
-    if (nextId === null) return;
+    if (nextId === null) {
+      announceDeadEnd();
+      return;
+    }
 
     const target = world.nodeById.get(nextId);
     if (!target) return;
@@ -3442,7 +3501,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         beginCameraTween({ tx: target.x, ty: target.y, tscale: scale });
       }
     }
-  }, [onSelect, beginCameraTween]);
+  }, [onSelect, beginCameraTween, announceDeadEnd]);
 
   const wrappedHandlers = useMemo(
     () => ({

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -224,6 +224,59 @@ test.describe("지도 키보드 걷기", () => {
   });
 
   /**
+   * **형제끼리 옆걸음이 된다** (2026-08-10, 소유자 실측 지적).
+   *
+   * 처음에는 후보가 「이어진 이웃」(엣지)뿐이었다. 그런데 지도 중앙의 프로젝트를
+   * 둘러싼 도메인들은 **서로 엣지가 없다** — 각자 프로젝트에만 붙어 있다. 그래서
+   * 상품에서 회원으로 옆걸음이 안 됐고, 링처럼 둘러선 화면에서 그건 고장으로
+   * 읽힌다(소유자: *"중앙에서 자유롭게 이동이 안 되던데?"*).
+   *
+   * 형제는 「같은 부모」라는 관계이므로 임의 공간 점프가 아니다.
+   */
+  test("한 부모 아래 형제끼리 방향키로 오갈 수 있다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+
+    const seen = new Set<string>();
+    for (const key of [...DIRECTIONS, ...DIRECTIONS]) {
+      const id = await selectedId(page);
+      if (id) seen.add(id);
+      await page.keyboard.press(key);
+      await page.waitForTimeout(200);
+    }
+    const last = await selectedId(page);
+    if (last) seen.add(last);
+    /*
+     * 볼트가 작으면 갈 곳이 적다 — 그래서 특정 노드 이름으로 못박지 않는다.
+     * 잠그는 성질은 **세 곳 이상을 돌아다녔다** 다.
+     */
+    expect(seen.size, `방향키로 돌아다닌 노드가 ${seen.size}곳뿐이다`).toBeGreaterThanOrEqual(3);
+  });
+
+  /**
+   * **갈 곳이 없으면 말해 준다** — 침묵이 아니라.
+   *
+   * 소유자가 실물에서 *"방향키가 되긴 하는데 노드를 자유롭게 이동하진 못하네?"*
+   * 라고 한 것이 이 시험이 존재하는 이유다. 아무 반응이 없으면 「고장」과
+   * 「그 방향에는 없음」을 구별할 수 없다.
+   */
+  test("그 방향에 갈 곳이 없으면 안내가 뜬다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+
+    for (let i = 0; i < 8; i += 1) {
+      await page.keyboard.press("ArrowLeft");
+      await page.waitForTimeout(150);
+    }
+    await expect(
+      page.getByText(/이어진 노드가 없어요/).first(),
+      "막다른 길인데 아무 말도 없다",
+    ).toBeVisible({ timeout: 4_000 });
+  });
+
+  /**
    * **방향키를 우리가 가져간다** — `preventDefault` 가 실제로 걸리나.
    *
    * ⚠️ 처음에는 `window.scrollY` 가 안 변하는지로 재려 했고, 그 시험은


### PR DESCRIPTION
## Summary

소유자가 실물에서 둘을 짚었다.

### ① 중앙에서 자유롭게 못 움직인다

> *"1depth 에서는 자기들끼리 자유롭게 이동 가능하게는 해야할듯? 중앙에서 자유롭게
> 이동이 안 되던데?"*

후보가 **「이어진 이웃」(엣지)뿐**이었다. 그런데 지도 중앙의 프로젝트를 둘러싼
도메인 아홉은 **서로 엣지가 없다** — 각자 프로젝트에만 붙어 있다. 그래서 상품에서
회원으로 옆걸음이 안 됐고, 링처럼 둘러선 화면에서 그건 고장으로 읽힌다.

**형제(같은 `parentId`)를 후보에 더했다.** 임의 공간 점프를 허용한 것이 아니다 —
「같은 부모」는 타입 있는 관계이고, 그것이 화면에서 링을 이루는 이유 자체다.
부모 없는 뿌리끼리도 형제로 본다.

### ② 안 움직일 때 침묵했다

> *"방향키가 되긴 하는데 노드를 자유롭게 이동하진 못하네?"*

그 방향에 갈 곳이 없으면 **아무 일도 안 했다.** 「감싸 돌지 않는다」는 판단은 그대로
두고(반대편으로 뛰면 자기 위치를 잃는다) **왜 안 움직이는지 말한다** — 반응이
없으면 사용자는 「고장」과 「그 방향에는 없음」을 구별할 수 없다(이 저장소가 이름
붙여 둔 **「조용한 기다림」**).

**새 표면을 만들지 않았다.** 이미 있는 토스트를 쓴다 — 스스로 사라지고
(소유자: *"조금 보여지다 자동으로 사라지게"*) 보조기술에도 읽힌다. 지도 위에 안내
상자를 새로 세우면 위치·토큰·모션을 다 정해야 하고 그건 혼자 정할 규격이 아니다.
방향키를 누르고 있을 때 같은 말이 쌓이지 않게 **1.2초** 쉰다.

문구와 토스트는 **페이지가 소유**하고 위젯은 사건만 낸다 — 위젯에서
`useTranslations` 를 불렀다가 지도 컴포넌트 시험 **5개가 깨졌고, 그 시험이 옳았다.**
이 위젯은 이미 `canvasLabel` 처럼 문구를 prop 으로 받는다.

## 게이트도 하나 좁혔다

`topologyWidgets` 네임스페이스를 **정확한 집합**으로 못박은 시험이 있었는데, 그
시험이 말하는 목적은 「은퇴한 sigma 가 되살아나지 못하게」다. 정확한 집합은 **정당한
추가에도 터지고**(실제로 걸렸다) 그러면 다음 사람이 게이트 대신 기능을 되돌린다.
거부 목록으로 바꿨다.

## Test plan

- **e2e 11건** — 형제끼리 오감(세 곳 이상 순회) · **갈 곳 없으면 안내가 뜸** ·
  입구 3건 · 걷기 6건. 전부 통과
- **단위 20건** — 부채꼴 ±60° 평면 전수 커버리지 · 직교 벌점 · 쉬는 시간(연타 방지)
- **프로브 4가지**: 형제 후보를 빼면 순회가 **2곳으로 줄어 실패** · 안내를 빼면
  **침묵으로 실패** · 은퇴 네임스페이스를 되살리면 i18n 게이트가 **빨개짐** ·
  (앞선) `onKeyDown` 을 떼면 5건 실패
- `pnpm test:run` 6,542 통과 · `pnpm test:contracts` 1,572 통과 ·
  `pnpm test:i18n:messages` 0 실패 · `eslint` 0 error · `tsc` 깨끗 · `build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)