### PR TITLE
fix: 공방은 키보드 함정이었다 (막힐 때도 말해 준다)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -912,6 +912,7 @@
         "docsActions": "Ontology workspace · document actions"
       },
       "rows": {
+        "navBlockedByOverlay": "Close the open panel first. Press Esc to close it",
         "goTo_map": "Go to map",
         "goTo_docs": "Go to docs",
         "goTo_studio": "Go to studio",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -912,6 +912,7 @@
         "docsActions": "문서함 · 문서 액션"
       },
       "rows": {
+        "navBlockedByOverlay": "열려 있는 창을 먼저 닫아 주세요. Esc 를 누르면 닫혀요",
         "goTo_map": "지도로",
         "goTo_docs": "문서함으로",
         "goTo_studio": "공방으로",

--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -4,6 +4,8 @@ import { useCallback, useState, type ReactNode } from "react";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import { useDestinationShortcuts } from "@/shared/lib/use-destination-shortcuts";
 import { focusMapCanvasWhenReady } from "@/shared/lib/focus-map-canvas";
+import { useToast } from "@/shared/ui";
+import { useTranslations } from "next-intl";
 import {
   AppNavRail,
   NavRailShellProvider,
@@ -240,6 +242,9 @@ function AppNavRailSlot() {
   const { changeset: gitChangeset } = useAtlasGitContext();
   const gitDirtyCount = gitChangeset.touchedNodeIds.size;
 
+  const toast = useToast();
+  const tShortcutRows = useTranslations("searchWidgets.shortcuts.rows");
+
   /**
    * 목적지 이동 단축키(`G` 다음 한 글자) — **레일과 같은 자리**에서 배선한다.
    *
@@ -258,6 +263,14 @@ function AppNavRailSlot() {
        * 만들지 않고 이미 있는 `G M` 에 이 일을 준다.
        */
       if (id === "map") focusMapCanvasWhenReady();
+    },
+    /*
+     * 막는 창 때문에 못 갈 때 **말해 준다.** 이것이 없던 동안 공방은 키보드
+     * 함정이었다 — 도착하면 「무엇을 할까요?」 선택 창이 뜨고, 그 뒤로는 어떤
+     * 이동 단축키도 조용히 먹지 않았다(2026-08-10 전체 검수에서 잡혔다).
+     */
+    onBlockedByOverlay: () => {
+      toast.show(tShortcutRows("navBlockedByOverlay"), "info");
     },
     disabled: gateway,
     hrefOverrides: contextHrefs?.docs ? { docs: contextHrefs.docs } : undefined,

--- a/src/shared/lib/use-destination-shortcuts.test.ts
+++ b/src/shared/lib/use-destination-shortcuts.test.ts
@@ -156,6 +156,37 @@ describe("useDestinationShortcuts", () => {
    * 남아 이동 단축키 전체를 영구히 죽이는 상태를 아무도 못 잡는다(실제로 그
    * 결함을 냈다 — 훅 주석 참고).
    */
+  /**
+   * **막힐 때 말해 준다** — 침묵이 아니라.
+   *
+   * 이것이 없던 동안 공방은 키보드 함정이었다: 도착하면 선택 창이 뜨고, 그 뒤로는
+   * 어떤 이동 단축키도 **조용히** 먹지 않았다(2026-08-10 전체 검수에서 잡혔다).
+   */
+  it("막는 표면이 있으면 이동하지 않고 알린다", () => {
+    const onBlockedByOverlay = vi.fn();
+    renderHook(() => useDestinationShortcuts({ navigate, onBlockedByOverlay }));
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    modal.getClientRects = (() => [{}] as unknown as DOMRectList) as typeof modal.getClientRects;
+    document.body.append(modal);
+    press("g");
+    press("p");
+    expect(navigate, "모달이 떠 있는데 이동했다").not.toHaveBeenCalled();
+    expect(onBlockedByOverlay, "막혔는데 아무 말도 안 했다").toHaveBeenCalledTimes(1);
+  });
+
+  it("갈 곳을 지목하지 않은 키에는 아무 말도 하지 않는다", () => {
+    const onBlockedByOverlay = vi.fn();
+    renderHook(() => useDestinationShortcuts({ navigate, onBlockedByOverlay }));
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    modal.getClientRects = (() => [{}] as unknown as DOMRectList) as typeof modal.getClientRects;
+    document.body.append(modal);
+    // 모달 안에서 그냥 타이핑하는 상황 — 안내가 쏟아지면 그게 소음이다.
+    for (const key of ["a", "b", "c", "z"]) press(key);
+    expect(onBlockedByOverlay, "지목도 안 했는데 말했다").not.toHaveBeenCalled();
+  });
+
   it("숨은 막는 표면은 이동을 막지 않는다", () => {
     renderHook(() => useDestinationShortcuts({ navigate }));
     const hidden = document.createElement("div");

--- a/src/shared/lib/use-destination-shortcuts.ts
+++ b/src/shared/lib/use-destination-shortcuts.ts
@@ -109,12 +109,26 @@ export interface DestinationShortcutOptions {
   disabled?: boolean;
   /** 문맥에 따라 기본 주소를 덮어쓸 때. 없으면 `DESTINATION_HREF`. */
   hrefOverrides?: Partial<Record<DestinationId, string>>;
+  /**
+   * 막는 표면 때문에 이동을 거절했을 때 — **사용자가 실제로 갈 곳을 지목했을 때만** 불린다.
+   *
+   * ⚠️ 이것이 없던 동안 공방은 **키보드 함정**이었다(2026-08-10 전체 검수에서 잡혔다).
+   * 공방에 도착하면 「무엇을 할까요?」 선택 창이 뜨고 그것이 `aria-modal` 이라, 이동
+   * 단축키가 규칙대로 거절된다 — 그런데 **아무 말도 안 했다.** 검수에서 `G S` 이후
+   * `G I`·`G P`·`G K`·`G G` 가 전부 먹지 않는 것으로 나타났고, 화면에는 단서가 없었다.
+   *
+   * 모달을 통과시키는 쪽으로 고치지 않는다: 모달이 안 막으면 모달이 아니고, 안에
+   * 저장 안 한 입력이 있을 수 있다. 대신 **왜 안 가는지 말한다** — 막다른 길 안내와
+   * 같은 처방이다.
+   */
+  onBlockedByOverlay?: (() => void) | null;
 }
 
 export function useDestinationShortcuts({
   navigate,
   disabled = false,
   hrefOverrides,
+  onBlockedByOverlay = null,
 }: DestinationShortcutOptions) {
   /**
    * 리더를 누른 시각. `null` 이면 안 누른 것.
@@ -130,6 +144,10 @@ export function useDestinationShortcuts({
    * 런타임이 0 을 주는 순간 기능이 통째로 사라지고 화면에는 아무 단서도 없다.
    */
   const leaderAt = useRef<number | null>(null);
+  const onBlockedByOverlayRef = useRef(onBlockedByOverlay);
+  useEffect(() => {
+    onBlockedByOverlayRef.current = onBlockedByOverlay;
+  });
 
   useEffect(() => {
     if (disabled) {
@@ -143,12 +161,6 @@ export function useDestinationShortcuts({
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
 
-      // 막는 표면이 떠 있으면 이동하지 않는다 (위 3번).
-      if (blockingSurfaceOpen()) {
-        leaderAt.current = null;
-        return;
-      }
-
       const now = performance.now();
 
       if (leaderAt.current !== null && now - leaderAt.current <= NAV_LEADER_WINDOW_MS) {
@@ -156,10 +168,25 @@ export function useDestinationShortcuts({
         leaderAt.current = null;
         if (!id) return;
         event.preventDefault();
+        /*
+         * 막는 표면이 떠 있으면 **가지 않고 말한다** (위 3번 · `onBlockedByOverlay`).
+         * 판정을 이 자리까지 미룬 이유: 사용자가 **실제로 갈 곳을 지목했을 때만**
+         * 말해야 한다. 모든 키에서 판정하면 모달 안에서 타이핑할 때마다 안내가 쏟아진다.
+         */
+        if (blockingSurfaceOpen()) {
+          onBlockedByOverlayRef.current?.();
+          return;
+        }
         navigate(hrefOverrides?.[id] ?? DESTINATION_HREF[id], id);
         return;
       }
 
+      /*
+       * 막는 표면이 떠 있어도 **리더는 그대로 기억한다.** 여기서 끊으면
+       * `G` 다음 `P` 가 「지목」으로 성립하지 않아 위 분기가 아예 안 돌고, 결국
+       * 다시 침묵으로 돌아간다(시험이 그것을 잡았다). 이동을 막는 판정은 위
+       * 분기 하나에만 있고, 그래서 「막혔다」와 「말해 준다」가 같은 자리에 있다.
+       */
       // 리더를 새로 누른다. `G G`(git)가 성립하려면 리더 자신도 두 번째 글자가
       // 될 수 있어야 하는데, 그 판정은 위 블록이 먼저 하므로 순서가 중요하다.
       leaderAt.current = matchesLetter(event, NAV_LEADER_KEY) ? now : null;


### PR DESCRIPTION
## Summary

**전체 검수에서 잡혔다.** 설치 앱에서 한글 입력기를 켠 채 일곱 목적지를 차례로
눌러 보니 `G M` · `G D` 는 되는데 **`G S`(공방) 이후 `G I` · `G P` · `G K` · `G G` 가
전부 먹지 않았다.**

원인: 공방에 도착하면 **「무엇을 할까요?」 선택 창**이 뜨고 그것이 `aria-modal` 이라
이동 단축키가 규칙대로 거절된다. 그런데 **아무 말도 안 했다** — 화면에 단서가 0개라
사용자는 고장으로 읽는다.

**모달을 통과시키는 쪽으로 고치지 않았다.** 모달이 안 막으면 모달이 아니고, 안에
저장 안 한 입력이 있을 수 있다. 대신 **왜 안 가는지 말한다** — 어제 넣은 막다른 길
안내와 같은 처방이고 **새 표면 0개**다.

### 「지목했을 때만」 말한다

판정을 **목적지가 확정되는 자리**까지 미뤘다. 모든 키에서 판정하면 모달 안에서
타이핑할 때마다 안내가 쏟아진다. 시험 둘로 못박았다: 지목하면 말하고, 아무 글자나
누르면 조용하다.

### 시험이 내 첫 구현을 잡았다

처음에는 모달이 열려 있으면 **리더 자체를 등록하지 않았다.** 그러면 `G` 다음 `P` 가
「지목」으로 성립하지 않아 안내 분기가 아예 안 돌고, **결국 다시 침묵으로 돌아간다.**
이동을 막는 판정을 한 자리에만 두어 「막혔다」와 「말해 준다」가 같은 곳에 있게 했다.

## Test plan

- **단위 20건** — 막히면 이동 안 하고 알림 · 지목 안 한 키에는 침묵 · 한글 입력기 ·
  배열 · `timeStamp` 0 · 시간 제한 안/밖 · 숨은 모달은 안 막음 · 입력 중 무시
- **프로브 3가지**: 안내를 떼면 **침묵으로 실패** · 막힘 판정을 떼면 **모달 뒤로 이동해
  실패** · 리더 등록을 끊으면 **안내가 안 나와 실패**
- **e2e 16건**(이동 5 + 지도 11) 통과
- 전체 검수: `tsc` 깨끗 · `lint` 0 error · `test:contracts` 1,572 · `test:run` 6,544 ·
  `build` OK · `docs:links` 402파일 0 · `vault:validate` 0 · `agents:check` ok ·
  `decisions:check` ok · `i18n` 0 · `desktop:check` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)