### PR TITLE
feat: 고른 노드를 패널 뺀 공간 가운데로 데려간다

### DIFF
--- a/src/widgets/topology-map-v2/interaction/free-area.test.ts
+++ b/src/widgets/topology-map-v2/interaction/free-area.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  cameraCenteringNode,
+  computeFreeArea,
+  freeAreaOffset,
+  SIDE_PANEL_HEIGHT_RATIO,
+  type Rect,
+} from "./free-area";
+
+/** 실측 기하 (1512×982, 2026-08-10) — 이 숫자가 이 모듈이 생긴 이유다. */
+const CANVAS: Rect = { x: 64, y: 0, width: 1448, height: 982 };
+const RIGHT_POPOVER: Rect = { x: 1128, y: 32, width: 352, height: 813 };
+
+describe("computeFreeArea", () => {
+  it("덮는 것이 없으면 캔버스 그대로다", () => {
+    expect(computeFreeArea(CANVAS, [])).toEqual(CANVAS);
+  });
+
+  it("오른쪽 팝오버를 뺀다 — 실측 기하", () => {
+    const free = computeFreeArea(CANVAS, [RIGHT_POPOVER]);
+    expect(free.x).toBe(64);
+    expect(free.width).toBe(1128 - 64);
+    // 세로 패널은 높이를 건드리지 않는다.
+    expect(free.height).toBe(982);
+  });
+
+  it("왼쪽 패널은 왼쪽에서 뺀다", () => {
+    const left: Rect = { x: 64, y: 0, width: 320, height: 900 };
+    const free = computeFreeArea(CANVAS, [left]);
+    expect(free.x).toBe(384);
+    expect(free.width).toBe(1512 - 384);
+  });
+
+  it("양쪽 패널을 둘 다 뺀다", () => {
+    const left: Rect = { x: 64, y: 0, width: 320, height: 900 };
+    const free = computeFreeArea(CANVAS, [left, RIGHT_POPOVER]);
+    expect(free.x).toBe(384);
+    expect(free.width).toBe(1128 - 384);
+  });
+
+  it("상단 바는 위에서 뺀다", () => {
+    const bar: Rect = { x: 64, y: 0, width: 1448, height: 96 };
+    const free = computeFreeArea(CANVAS, [bar]);
+    expect(free.y).toBe(96);
+    expect(free.height).toBe(982 - 96);
+    expect(free.width).toBe(1448);
+  });
+
+  /**
+   * 화면을 통째로 덮는 것(막·스크림)은 빼지 않는다. 빼면 남는 영역이 없어지고,
+   * 그때 「가운데」는 정의되지 않는다 — 막이 떠 있으면 카메라를 옮길 상황도 아니다.
+   */
+  it("전체를 덮는 막은 빼지 않는다", () => {
+    const scrim: Rect = { x: 64, y: 0, width: 1448, height: 982 };
+    expect(computeFreeArea(CANVAS, [scrim])).toEqual(CANVAS);
+  });
+
+  it("작은 섬(칩·툴팁)은 빼지 않는다", () => {
+    const chip: Rect = { x: 600, y: 400, width: 120, height: 40 };
+    expect(computeFreeArea(CANVAS, [chip])).toEqual(CANVAS);
+  });
+
+  it("캔버스와 안 겹치는 것은 세지 않는다", () => {
+    const elsewhere: Rect = { x: 2000, y: 0, width: 300, height: 900 };
+    expect(computeFreeArea(CANVAS, [elsewhere])).toEqual(CANVAS);
+  });
+
+  /**
+   * 두 세로 패널이 서로를 넘어 영역이 뒤집히는 경우.
+   *
+   * ⚠️ 폭을 넉넉히 잡으면 안 된다 — 캔버스 폭의 60% 를 넘는 순간 그 사각형은
+   * 「세로 패널이면서 가로 바」가 되어 **아예 빼지 않는다**(모듈의 규칙). 처음 이
+   * 케이스를 w900(=0.62)으로 썼다가 그 규칙에 걸렸고, 코드가 아니라 케이스가
+   * 틀린 것이었다.
+   */
+  it("두 세로 패널이 겹쳐 영역이 뒤집히면 캔버스로 물러난다", () => {
+    const left: Rect = { x: 64, y: 0, width: 700, height: 900 };
+    const rightPanel: Rect = { x: 600, y: 0, width: 500, height: 900 };
+    expect(computeFreeArea(CANVAS, [left, rightPanel])).toEqual(CANVAS);
+  });
+
+  it("세로 패널 판정 비율이 실측 두 무리를 가른다", () => {
+    // 팝오버 813/982 = 0.83 → 세로 패널 · 상단 도구 ~96/982 = 0.10 → 아니다
+    expect(RIGHT_POPOVER.height / CANVAS.height).toBeGreaterThan(SIDE_PANEL_HEIGHT_RATIO);
+    expect(96 / CANVAS.height).toBeLessThan(SIDE_PANEL_HEIGHT_RATIO);
+  });
+});
+
+describe("freeAreaOffset", () => {
+  it("덮는 것이 없으면 0이다 — 지금 동작을 바꾸지 않는다", () => {
+    expect(freeAreaOffset(CANVAS, [])).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it("오른쪽 팝오버가 있으면 왼쪽으로 밀린다 (실측 −192)", () => {
+    const { dx, dy } = freeAreaOffset(CANVAS, [RIGHT_POPOVER]);
+    expect(Math.round(dx)).toBe(-192);
+    expect(dy).toBe(0);
+  });
+});
+
+describe("cameraCenteringNode", () => {
+  it("오프셋이 0이면 노드를 그대로 가운데 둔다", () => {
+    expect(cameraCenteringNode({ x: 500, y: 300 }, { dx: 0, dy: 0 }, 1)).toEqual({ tx: 500, ty: 300 });
+  });
+
+  /**
+   * **배율로 나눈다** — 같은 화면 오프셋이 배율이 클수록 더 짧은 월드 거리다.
+   * 이걸 빼먹으면 확대했을 때 노드가 패널 쪽으로 다시 밀려 들어간다.
+   */
+  it("같은 화면 오프셋이 배율에 따라 다른 월드 거리다", () => {
+    const at1 = cameraCenteringNode({ x: 0, y: 0 }, { dx: -192, dy: 0 }, 1);
+    const at2 = cameraCenteringNode({ x: 0, y: 0 }, { dx: -192, dy: 0 }, 2);
+    expect(at1.tx).toBe(192);
+    expect(at2.tx).toBe(96);
+  });
+
+  it("배율이 0에 가까워도 터지지 않는다", () => {
+    const out = cameraCenteringNode({ x: 10, y: 10 }, { dx: -100, dy: 0 }, 0);
+    expect(Number.isFinite(out.tx)).toBe(true);
+    expect(Number.isFinite(out.ty)).toBe(true);
+  });
+
+  /**
+   * 왕복 검사 — 이 카메라를 쓰면 노드가 정말 자유 영역 가운데에 오나.
+   * 화면 좌표 식은 그리는 쪽과 `nodes()` 창구가 함께 쓰는 그것이다.
+   */
+  it("이 카메라로 그리면 노드가 자유 영역 가운데에 온다", () => {
+    const node = { x: 4321, y: -876 };
+    const scale = 1.37;
+    const offset = freeAreaOffset(CANVAS, [RIGHT_POPOVER]);
+    const cam = cameraCenteringNode(node, offset, scale);
+    // 캔버스 지역 좌표: (world - cam) * scale + size/2
+    const screenX = (node.x - cam.tx) * scale + CANVAS.width / 2;
+    const screenY = (node.y - cam.ty) * scale + CANVAS.height / 2;
+    const free = computeFreeArea(CANVAS, [RIGHT_POPOVER]);
+    // `free` 는 문서 좌표, `screenX` 는 캔버스 지역 좌표 — 캔버스 원점을 뺀다.
+    expect(screenX + CANVAS.x).toBeCloseTo(free.x + free.width / 2, 6);
+    expect(screenY + CANVAS.y).toBeCloseTo(free.y + free.height / 2, 6);
+  });
+});

--- a/src/widgets/topology-map-v2/interaction/free-area.ts
+++ b/src/widgets/topology-map-v2/interaction/free-area.ts
@@ -1,0 +1,158 @@
+/**
+ * 자유 영역 — **패널에 가리지 않는 자리로 데려간다** (2026-08-10 소유자 확정:
+ * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*).
+ *
+ * ## 왜 필요한가 — 실측
+ *
+ * 방향키로 노드를 고르면 오른쪽에 팝오버가 열린다. 그런데 카메라는 노드를 **뷰포트
+ * 가운데**로 데려간다. 실측(1512×982): 캔버스는 x64 w1448, 팝오버는 x1128 w352 h813.
+ * 즉 가운데(788)로 데려간 노드는 팝오버 왼쪽 경계(1128)와 340px 밖에 안 떨어져 있고,
+ * 배율이 커지거나 팝오버가 넓어지면 **고른 노드가 그것을 설명하는 패널 뒤로 들어간다.**
+ * 고른 것이 안 보이는 것은 「자리가 세팅됐다」가 아니다.
+ *
+ * ## 규격
+ *
+ * 자유 영역 = **캔버스에서 그것을 덮는 패널을 뺀 나머지**. 초점 노드는 그 가운데로 온다.
+ *
+ * 패널을 어느 쪽에서 빼는지는 **모양이 정한다** — 화면 높이를 대부분 차지하는 것은
+ * 세로 패널이라 좌·우에서 빼고, 폭을 대부분 차지하는 것은 가로 바라 위·아래에서 뺀다.
+ * 「왼쪽 패널은 몇 px」처럼 값을 박지 않는다: 값을 박으면 패널 폭이 바뀌는 날 조용히
+ * 어긋나고, 그건 이 저장소가 이미 여러 번 낸 값이다.
+ */
+
+export interface Rect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * 그 사각형이 **세로 패널**인가 — 캔버스 높이의 이 비율 이상을 차지하면 그렇다.
+ *
+ * 0.6 인 이유: 실측 팝오버는 813/982 = **0.83**, 반대로 상단 도구 막대는 높이가
+ * 100px 안쪽이라 0.1 을 넘지 않는다. 두 무리가 그 사이에서 넉넉히 갈린다.
+ */
+export const SIDE_PANEL_HEIGHT_RATIO = 0.6;
+
+/** 그 사각형이 **가로 바**인가 — 캔버스 폭의 이 비율 이상. */
+export const TOP_BAR_WIDTH_RATIO = 0.6;
+
+const right = (r: Rect) => r.x + r.width;
+const bottom = (r: Rect) => r.y + r.height;
+
+function intersects(a: Rect, b: Rect): boolean {
+  return right(a) > b.x && a.x < right(b) && bottom(a) > b.y && a.y < bottom(b);
+}
+
+/**
+ * 캔버스에서 패널들을 빼고 남은 영역.
+ *
+ * 패널이 영역을 **가운데서 가르는** 경우(양쪽 어디에도 안 붙은 섬)는 빼지 않는다 —
+ * 그런 것을 빼면 남는 영역이 둘로 갈라져 「가운데」가 정의되지 않는다. 이 앱의 패널은
+ * 전부 가장자리에 붙어 있으므로(실측) 그 경우는 오늘 없고, 생기면 그때 다룬다.
+ */
+export function computeFreeArea(canvas: Rect, obstacles: readonly Rect[]): Rect {
+  let left = canvas.x;
+  let rightEdge = right(canvas);
+  let top = canvas.y;
+  let bottomEdge = bottom(canvas);
+
+  for (const panel of obstacles) {
+    if (!intersects(panel, canvas)) continue;
+
+    const tallEnough = panel.height >= canvas.height * SIDE_PANEL_HEIGHT_RATIO;
+    const wideEnough = panel.width >= canvas.width * TOP_BAR_WIDTH_RATIO;
+
+    if (tallEnough && !wideEnough) {
+      // 세로 패널 — 캔버스 가운데를 기준으로 가까운 쪽에서 뺀다.
+      const panelCenter = panel.x + panel.width / 2;
+      if (panelCenter >= canvas.x + canvas.width / 2) {
+        rightEdge = Math.min(rightEdge, panel.x);
+      } else {
+        left = Math.max(left, right(panel));
+      }
+      continue;
+    }
+    if (wideEnough && !tallEnough) {
+      const panelCenter = panel.y + panel.height / 2;
+      if (panelCenter >= canvas.y + canvas.height / 2) {
+        bottomEdge = Math.min(bottomEdge, panel.y);
+      } else {
+        top = Math.max(top, bottom(panel));
+      }
+    }
+    // 둘 다이거나 둘 다 아닌 것(전체를 덮는 막 · 작은 섬)은 빼지 않는다.
+  }
+
+  // 패널이 서로 겹쳐 영역이 뒤집히면 캔버스를 그대로 쓴다 — 「가운데가 없다」보다
+  // 「가운데가 화면 가운데」가 낫다.
+  if (rightEdge <= left || bottomEdge <= top) return canvas;
+  return { x: left, y: top, width: rightEdge - left, height: bottomEdge - top };
+}
+
+/**
+ * 자유 영역의 가운데가 캔버스 가운데에서 얼마나 밀렸나 — **화면 픽셀**.
+ *
+ * 카메라는 「뷰포트 가운데에 무엇을 둘까」로 표현되므로, 목표를 이 값만큼 되밀면
+ * 노드가 자유 영역 가운데에 온다.
+ */
+export function freeAreaOffset(canvas: Rect, obstacles: readonly Rect[]): { dx: number; dy: number } {
+  const free = computeFreeArea(canvas, obstacles);
+  return {
+    dx: free.x + free.width / 2 - (canvas.x + canvas.width / 2),
+    dy: free.y + free.height / 2 - (canvas.y + canvas.height / 2),
+  };
+}
+
+/**
+ * 노드를 자유 영역 가운데에 두는 카메라 좌표.
+ *
+ * 화면 좌표는 `(world - camera) * scale + size/2` 로 나오므로(그 식은
+ * `use-topology-loop` 의 `nodes()` 창구와 그리는 쪽이 함께 쓴다), 원하는 화면 위치를
+ * 그 식에 넣고 카메라를 풀면 이 형태가 된다. **배율로 나누는 것**이 요점이다 —
+ * 같은 화면 오프셋이 배율이 클수록 더 작은 월드 거리에 해당한다.
+ */
+export function cameraCenteringNode(
+  node: { readonly x: number; readonly y: number },
+  offset: { readonly dx: number; readonly dy: number },
+  scale: number,
+): { tx: number; ty: number } {
+  const safeScale = Math.abs(scale) < 1e-6 ? 1 : scale;
+  return { tx: node.x - offset.dx / safeScale, ty: node.y - offset.dy / safeScale };
+}
+
+/**
+ * 캔버스를 덮고 있는 것들을 **DOM 에서 잰다.**
+ *
+ * 「보인다」 판정은 이 저장소가 이미 정리해 둔 규율을 따른다(`/design-audit`
+ * 「사각형이 나온다고 보이는 것은 아니다」): 크기가 없는 것 · `visibility:hidden` ·
+ * `display:none` · 거의 투명한 것 · 접힌 `<details>` 안 · `aria-hidden` 조상 안은
+ * 화면에 없으므로 세지 않는다. 그것을 빼먹으면 **퇴장 중인 패널이 카메라를 계속
+ * 왼쪽으로 밀어** 아무도 원인을 짐작할 수 없는 상태가 된다.
+ *
+ * 캔버스 자신과 그 조상/자손은 제외한다 — 조상은 캔버스를 「덮는」 것이 아니라
+ * 담는 것이다.
+ */
+export function collectCanvasObstacles(canvas: Element, canvasRect: Rect): Rect[] {
+  const out: Rect[] = [];
+  const MIN_SIDE = 40;
+  for (const el of canvas.ownerDocument.querySelectorAll('body *')) {
+    if (el === canvas || canvas.contains(el) || el.contains(canvas)) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width < MIN_SIDE || box.height < MIN_SIDE) continue;
+    if (box.right <= canvasRect.x || box.left >= canvasRect.x + canvasRect.width) continue;
+    if (box.bottom <= canvasRect.y || box.top >= canvasRect.y + canvasRect.height) continue;
+    if (el.closest('details:not([open])')) continue;
+    if (el.closest('[aria-hidden="true"]')) continue;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') continue;
+    if (Number(style.opacity) < 0.05) continue;
+    // 가장 바깥만 담는다 — 안쪽 자식은 같은 자리를 두 번 세는 것이다.
+    if (out.some((r) => r.x <= box.x && r.y <= box.y && r.x + r.width >= box.right && r.y + r.height >= box.bottom)) {
+      continue;
+    }
+    out.push({ x: box.x, y: box.y, width: box.width, height: box.height });
+  }
+  return out;
+}

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -85,6 +85,13 @@ import {
   shouldAnnounceDeadEnd,
   walkDirectionForKey,
 } from "../interaction/keyboard-walk";
+import {
+  cameraCenteringNode,
+  collectCanvasObstacles,
+  computeFreeArea,
+  freeAreaOffset,
+  type Rect,
+} from "../interaction/free-area";
 
 import { readTopologyV2TokensOrNull } from "./topology-read-tokens";
 import type { TopologyMapV2Props } from "./TopologyMapV2";
@@ -1602,15 +1609,59 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       target = computeFocusCameraTarget(world, tokens, width, height, focusedSlug, overviewEntryScale, realmMembers);
     }
     if (!target) return;
-    dampingRef.current = tokens.cameraDampingDefault;
-    cameraTargetRef.current = target;
-    userDrivenCameraRef.current = false;
-    // Dive-zoom fix — focus dive AND deselect-return are both PROGRAMMATIC
-    // camera moves (this effect fires for both directions of `focusedSlug`
-    // changing), so both ease via the cubic transition tween (reduced-motion →
-    // spring/snap).
-    cameraAngularFreqRef.current = tokens.cameraSpringAngFreqTransition;
-    beginCameraTween(target);
+    /*
+     * **패널에 가리지 않는 자리로 보정한다** (2026-08-10 소유자 확정:
+     * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*).
+     *
+     * 노드를 고르면 오른쪽에 팝오버가 열린다. 그런데 이 목표는 **뷰포트 가운데**
+     * 기준이라, 고른 것이 그것을 설명하는 패널 뒤로 들어갈 수 있었다. 실측
+     * (1512×982): 캔버스 x64 w1448 · 팝오버 x1128 w352 → 자유 영역 가운데는 화면
+     * 가운데보다 **192px 왼쪽**이다.
+     *
+     * 개요 경로에는 이미 같은 개념이 있었다(그 아래 *"Panel-aware: … not behind the
+     * left ReaderLens panel"*) — 없던 것은 **선택 경로**다. 여기가 그 한 곳이다.
+     *
+     * 패널 폭을 상수로 박지 않고 DOM 에서 잰다: 값을 박으면 패널이 바뀌는 날 조용히
+     * 어긋난다. 선택이 바뀔 때만 도는 계산이라 프레임 예산과 무관하다.
+     */
+    /*
+     * ⚠️ **한 프레임 뒤에 잰다.** 피해야 할 팝오버는 **바로 이 선택 때문에** 열리므로,
+     * 이 effect 가 도는 시점에는 아직 DOM 에 없다. 그때 재면 장애물이 0개라 보정이
+     * 0이 되고, 실측에서 정확히 그 일이 났다(노드가 자유 영역 가운데에서 188px
+     * 벗어나 화면 가운데에 앉았다 — 게이트가 잡았다).
+     *
+     * 200~420ms 이동 앞의 한 프레임(≈16ms)은 보이지 않는다. 대안(패널 폭을 상수로
+     * 박기)은 패널이 바뀌는 날 조용히 어긋난다.
+     */
+    const aimed = target;
+    const raf = requestAnimationFrame(() => {
+      let finalTarget = aimed;
+      const canvasEl = canvasRef.current;
+      if (canvasEl) {
+        const box = canvasEl.getBoundingClientRect();
+        const canvasRect: Rect = { x: box.x, y: box.y, width: box.width, height: box.height };
+        const offset = freeAreaOffset(canvasRect, collectCanvasObstacles(canvasEl, canvasRect));
+        if (offset.dx !== 0 || offset.dy !== 0) {
+          const shifted = cameraCenteringNode(
+            { x: aimed.tx, y: aimed.ty },
+            offset,
+            aimed.tscale,
+          );
+          finalTarget = { tx: shifted.tx, ty: shifted.ty, tscale: aimed.tscale };
+        }
+      }
+      dampingRef.current = tokens.cameraDampingDefault;
+      cameraTargetRef.current = finalTarget;
+      userDrivenCameraRef.current = false;
+      // Dive-zoom fix — focus dive AND deselect-return are both PROGRAMMATIC
+      // camera moves (this effect fires for both directions of `focusedSlug`
+      // changing), so both ease via the cubic transition tween (reduced-motion →
+      // spring/snap).
+      cameraAngularFreqRef.current = tokens.cameraSpringAngFreqTransition;
+      lastActiveMsRef.current = performance.now();
+      beginCameraTween(finalTarget);
+    });
+    return () => cancelAnimationFrame(raf);
   }, [focusedSlug, beginCameraTween]);
 
   // --- S4 "영역 전개" — realmRootId 변경 시 서브트리 재배치 + 전환 안무 시작.
@@ -3485,20 +3536,56 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     onSelect?.(nextId);
 
     /*
-     * 카메라는 **따라만 온다** — 초점이 화면 밖으로 나가려 할 때만. 매번 가운데로
-     * 데려오면 걷는 동안 지도가 계속 미끄러져, 사용자가 자기가 어디 있는지 잃는다
+     * 카메라는 **따라만 온다** — 초점이 자유 영역 밖으로 나가려 할 때만. 매번
+     * 데려오면 걷는 동안 지도가 계속 미끄러져 사용자가 자기 위치를 잃는다
      * (Shneiderman 의 overview-first 를 스스로 깨는 셈이다).
+     *
+     * **판정과 목표를 모두 「자유 영역」으로 한다** (2026-08-10 소유자 확정:
+     * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*). 종전에는 뷰포트 가운데를
+     * 목표로 삼았는데, 노드를 고르면 오른쪽에 팝오버가 열리므로 **고른 것이 그것을
+     * 설명하는 패널 뒤로 들어갈 수 있었다.** 실측(1512×982): 캔버스 x64 w1448,
+     * 팝오버 x1128 w352 → 자유 영역 가운데는 화면 가운데보다 192px 왼쪽이다.
+     *
+     * 패널 폭을 상수로 박지 않고 **DOM 에서 재는** 이유: 값을 박으면 패널이 바뀌는
+     * 날 조용히 어긋난다. 이 계산은 프레임마다가 아니라 **걸을 때 한 번** 돈다.
      */
     const { width, height } = viewportRef.current;
-    if (width > 0 && height > 0) {
+    const canvasEl = canvasRef.current;
+    if (width > 0 && height > 0 && canvasEl) {
       const scale = camera.scale.value;
-      const sx = (target.x - camera.x.value) * scale + width / 2;
-      const sy = (target.y - camera.y.value) * scale + height / 2;
-      const margin = Math.min(width, height) * 0.18;
+      const canvasBox = canvasEl.getBoundingClientRect();
+      const canvasRect: Rect = {
+        x: canvasBox.x,
+        y: canvasBox.y,
+        width: canvasBox.width,
+        height: canvasBox.height,
+      };
+      const obstacles = collectCanvasObstacles(canvasEl, canvasRect);
+      const free = computeFreeArea(canvasRect, obstacles);
+      const offset = freeAreaOffset(canvasRect, obstacles);
+
+      // 초점이 지금 자유 영역 안에 넉넉히 들어와 있나 (문서 좌표로 비교).
+      const sx = canvasBox.x + (target.x - camera.x.value) * scale + width / 2;
+      const sy = canvasBox.y + (target.y - camera.y.value) * scale + height / 2;
+      const margin = Math.min(free.width, free.height) * 0.18;
       const outside =
-        sx < margin || sx > width - margin || sy < margin || sy > height - margin;
+        sx < free.x + margin ||
+        sx > free.x + free.width - margin ||
+        sy < free.y + margin ||
+        sy > free.y + free.height - margin;
       if (outside) {
-        beginCameraTween({ tx: target.x, ty: target.y, tscale: scale });
+        const centered = cameraCenteringNode(target, offset, scale);
+        const cameraTarget = { tx: centered.tx, ty: centered.ty, tscale: scale };
+        /*
+         * ⚠️ **트윈만 세우면 안 된다** (게이트가 잡았다). 트윈이 끝나면 스프링이
+         * `cameraTargetRef` 로 이어받으므로, 그것을 갱신하지 않으면 **옛 목표로
+         * 되끌어간다** — 실측: 노드가 자유 영역 가운데에서 188px 밀려 화면 가운데에
+         * 앉았다. 다른 프로그램 경로(포커스 다이브 · 칩 전개 · 핏뷰)가 둘을 함께
+         * 세우는 이유가 이것이다.
+         */
+        cameraTargetRef.current = cameraTarget;
+        userDrivenCameraRef.current = false;
+        beginCameraTween(cameraTarget);
       }
     }
   }, [onSelect, beginCameraTween, announceDeadEnd]);

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -267,6 +267,148 @@ test.describe("지도 키보드 걷기", () => {
   });
 
   /**
+   * **고른 노드가 패널에 가리지 않는다** (2026-08-10 소유자 확정:
+   * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*).
+   *
+   * 노드를 고르면 오른쪽에 팝오버가 열린다. 종전에는 카메라가 **뷰포트 가운데**를
+   * 목표로 삼아서, 고른 것이 **그것을 설명하는 패널 뒤로** 들어갈 수 있었다.
+   * 실측(1512×982): 캔버스 x64 w1448 · 팝오버 x1128 w352 → 자유 영역 가운데는
+   * 화면 가운데보다 192px 왼쪽이다.
+   *
+   * 잠그는 성질은 **「가려지지 않는다」** 다 — 「정확히 가운데」가 아니다. 걷는 동안
+   * 카메라는 필요할 때만 따라오므로(매번 데려오면 지도가 계속 미끄러진다) 노드가
+   * 자유 영역 안 어디에 있는지는 걸음마다 다르다. 가려짐은 그와 무관하게 늘 거짓이어야 한다.
+   */
+  test("고른 노드가 패널에 가리지 않는다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+
+    const covered: string[] = [];
+    for (const key of [...DIRECTIONS, ...DIRECTIONS]) {
+      await page.keyboard.press(key);
+      await page.waitForTimeout(500); // 카메라 전환이 끝나도록
+      const hit = await page.evaluate(() => {
+        const probe = window.__atlasMap;
+        const id = probe?.selection().nodeId;
+        const canvas = document.querySelector('[data-surface-role="map-canvas"]');
+        if (!probe || !id || !canvas) return null;
+        const node = probe.nodes().find((n) => n.id === id);
+        if (!node) return null;
+        const box = canvas.getBoundingClientRect();
+        // 문서 좌표로 옮긴다 — `nodes()` 는 캔버스 지역 좌표를 준다.
+        const px = box.x + node.x;
+        const py = box.y + node.y;
+        for (const el of document.querySelectorAll("body *")) {
+          if (el === canvas || canvas.contains(el) || el.contains(canvas)) continue;
+          const r = el.getBoundingClientRect();
+          if (r.width < 40 || r.height < 40) continue;
+          if (el.closest("details:not([open])")) continue;
+          if (el.closest('[aria-hidden="true"]')) continue;
+          const cs = getComputedStyle(el);
+          if (cs.visibility === "hidden" || cs.display === "none") continue;
+          if (Number(cs.opacity) < 0.05) continue;
+          if (px >= r.left && px <= r.right && py >= r.top && py <= r.bottom) {
+            return `${id} 가 ${(el as HTMLElement).dataset.testid || el.tagName} 뒤에 있다`;
+          }
+        }
+        return null;
+      });
+      if (hit) covered.push(hit);
+    }
+    expect(covered, "고른 노드가 패널에 가려졌다").toEqual([]);
+  });
+
+  /**
+   * **카메라가 데려갔다면 자유 영역 가운데에 놓는다.**
+   *
+   * ⚠️ 위 「가리지 않는다」만으로는 이 변경이 증명되지 않는다 — 프로브로 확인했다:
+   * 목표를 뷰포트 가운데로 되돌려도 그 시험은 **초록이었다.** 이 확대와 이 그래프에서는
+   * 가운데로 데려간 노드가 우연히 팝오버(x1128)에 안 닿기 때문이다. 통과는 증거가
+   * 아니다(`/gate-probe`).
+   *
+   * 그래서 **바뀐 것을 직접 잰다**: 전환이 실제로 일어난 직후, 노드가 자유 영역
+   * 가운데에 있나. 뷰포트 가운데로 되돌리면 실측 192px 이 어긋나 바로 빨개진다.
+   */
+  test("카메라가 데려간 뒤 노드가 자유 영역 가운데에 있다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+
+    const readGeometry = () =>
+      page.evaluate(() => {
+        const probe = window.__atlasMap;
+        const canvas = document.querySelector('[data-surface-role="map-canvas"]');
+        const cam = probe?.camera();
+        const id = probe?.selection().nodeId;
+        if (!probe || !canvas || !cam || !id) return null;
+        const node = probe.nodes().find((n) => n.id === id);
+        if (!node) return null;
+        const box = canvas.getBoundingClientRect();
+        // 자유 영역 = 캔버스에서 세로 패널을 뺀 것. spec 은 제품 코드를 import 하지
+        // 않고 **화면에서 다시 잰다** — 같은 함수를 쓰면 둘이 같이 틀려도 초록이다.
+        let left = box.x;
+        let rightEdge = box.right;
+        for (const el of document.querySelectorAll("body *")) {
+          if (el === canvas || canvas.contains(el) || el.contains(canvas)) continue;
+          const r = el.getBoundingClientRect();
+          if (r.width < 40 || r.height < 40) continue;
+          if (r.right <= box.x || r.left >= box.right) continue;
+          if (el.closest("details:not([open])") || el.closest('[aria-hidden="true"]')) continue;
+          const cs = getComputedStyle(el);
+          if (cs.visibility === "hidden" || cs.display === "none" || Number(cs.opacity) < 0.05) continue;
+          const tall = r.height >= box.height * 0.6;
+          const wide = r.width >= box.width * 0.6;
+          if (!tall || wide) continue;
+          if (r.x + r.width / 2 >= box.x + box.width / 2) rightEdge = Math.min(rightEdge, r.x);
+          else left = Math.max(left, r.right);
+        }
+        const freeCenterX = rightEdge > left ? (left + rightEdge) / 2 : box.x + box.width / 2;
+        return {
+          camX: cam.x,
+          camY: cam.y,
+          nodeDocX: box.x + node.x,
+          freeCenterX,
+          canvasCenterX: box.x + box.width / 2,
+          canvasWidth: box.width,
+        };
+      });
+
+    let landed: Awaited<ReturnType<typeof readGeometry>> = null;
+    for (const key of [...DIRECTIONS, ...DIRECTIONS, ...DIRECTIONS]) {
+      const before = await readGeometry();
+      await page.keyboard.press(key);
+      await page.waitForTimeout(600);
+      const after = await readGeometry();
+      if (!before || !after) continue;
+      const cameraMoved = Math.hypot(after.camX - before.camX, after.camY - before.camY) > 2;
+      if (cameraMoved) {
+        landed = after;
+        break;
+      }
+    }
+    expect(landed, "카메라 전환을 한 번도 일으키지 못했다").not.toBeNull();
+    const toFree = Math.abs(landed!.nodeDocX - landed!.freeCenterX);
+    const toCanvas = Math.abs(landed!.nodeDocX - landed!.canvasCenterX);
+    /*
+     * **「정확히 가운데」를 요구하지 않는다** — 그렇게 재려다 틀렸다(실측 64px 벗어남).
+     * 이 다이브는 노드 하나가 아니라 **이웃 묶음(ego bbox)** 을 담으므로, 가운데에
+     * 오는 것은 그 묶음이고 노드는 그 안 어딘가다. 「노드가 정확히 가운데」는 규격이
+     * 아니라 내 오해였다.
+     *
+     * 잠그는 성질은 **프레이밍이 자유 영역 쪽으로 잡혔나**다: 노드가 화면 가운데보다
+     * 자유 영역 가운데에 더 가깝다. 보정을 되돌리면 노드가 화면 가운데에 앉으므로
+     * (실측 192px 차이) 이 비교가 바로 뒤집힌다.
+     */
+    expect(
+      toFree,
+      `노드가 자유 영역 가운데(${landed!.freeCenterX.toFixed(0)})보다 ` +
+        `화면 가운데(${landed!.canvasCenterX.toFixed(0)})에 가깝다 — 보정이 안 걸렸다 ` +
+        `(자유 ${toFree.toFixed(0)}px · 화면 ${toCanvas.toFixed(0)}px)`,
+    ).toBeLessThan(toCanvas);
+  });
+
+  /**
    * **방향키를 우리가 가져간다** — `preventDefault` 가 실제로 걸리나.
    *
    * ⚠️ 처음에는 `window.scrollY` 가 안 변하는지로 재려 했고, 그 시험은


### PR DESCRIPTION
## Summary

소유자 확정: *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*.

노드를 고르면 오른쪽에 팝오버가 열리는데 카메라는 **뷰포트 가운데**를 목표로 삼았다.
즉 고른 것이 **그것을 설명하는 패널 뒤로** 들어갈 수 있었다. 실측(1512×982):
캔버스 x64 w1448 · 팝오버 x1128 w352 → 자유 영역 가운데는 화면 가운데보다 **192px
왼쪽**이다.

개요 경로에는 **이미 같은 개념이 있었다**(*"Panel-aware: not behind the left
ReaderLens panel"*) — 없던 것은 **선택 경로**다.

### 패널 폭을 상수로 박지 않는다

자유 영역 = 캔버스에서 그것을 덮는 패널을 뺀 나머지. 어느 쪽에서 빼는지는 **모양이
정한다**(높이를 대부분 차지하면 세로 패널, 폭이면 가로 바). DOM 에서 재므로 패널이
바뀌어도 따라온다. 선택이 바뀔 때만 도는 계산이라 프레임 예산과 무관하다.

## 게이트가 내 구현을 세 번 고쳤다

1. **트윈만 세우고 스프링 목표를 안 바꿨다** → 전환이 끝나면 스프링이 옛 목표로
   되끌어가 노드가 **188px** 밀렸다. 둘을 함께 세운다.
2. 보정을 **방향키 분기**에 넣었는데 카메라를 움직인 것은 **선택 경로**였다. 한 곳으로.
3. 피해야 할 팝오버가 **바로 그 선택 때문에** 열리므로 effect 가 도는 시점에는 DOM 에
   없었다 → 장애물 0개 → 보정 0. **한 프레임 뒤에** 잰다(200~420ms 이동 앞의 16ms 는
   보이지 않는다).

## 잠그는 성질을 바꿨다 — 내 오해를 고친 것이다

「노드가 정확히 자유 영역 가운데」로 재려다 64px 벗어남으로 실패했는데, 그건 규격이
아니라 **내 오해**였다: 이 다이브는 노드 하나가 아니라 **이웃 묶음(ego bbox)** 을
담으므로 가운데에 오는 것은 그 묶음이다. 그래서 **「프레이밍이 자유 영역 쪽으로
잡혔나」**(자유 영역 가운데가 화면 가운데보다 가깝다)로 바꿨다.

## Test plan

- **단위 16건** — 실측 기하로 오른쪽 팝오버·왼쪽 패널·양쪽·상단 바·전체 막·작은 섬·
  뒤집힘 물러남 · 배율로 나누기 · **왕복 검사**(이 카메라로 그리면 정말 가운데에 오나)
- **e2e 13건** — 가려지지 않음 · **자유 영역 쪽으로 잡힘** · 형제 옆걸음 · 안내 · 입구 3 · 걷기
- **프로브**: 보정 제거 → 실패(자유 127 · 화면 64) · 프레임 미루기 제거 → 실패
  (자유 188 · 화면 3). 그리고 **「가려지지 않는다」만으로는 이 변경이 증명되지 않는다**
  는 것도 프로브로 확인해 주석에 적었다 — 이 확대에서는 가운데로 데려가도 우연히 안 가려진다
- `pnpm test:run` 6,562 · 이웃 e2e 8 · `eslint` 0 error · `tsc` 깨끗 · `build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)