### PR TITLE
fix: 방향키 걷기를 아무데도 안내하지 않았다 (사용성 검수)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -912,6 +912,7 @@
         "docsActions": "Ontology workspace · document actions"
       },
       "rows": {
+        "walkNeighbors": "Move to a connected concept",
         "navBlockedByOverlay": "Close the open panel first. Press Esc to close it",
         "goTo_map": "Go to map",
         "goTo_docs": "Go to docs",
@@ -2476,7 +2477,7 @@
       "clickHint": "Click for details · source doc"
     },
     "canvas": {
-      "ariaLabel": "Product map: the INDEX panel lets you explore the same information by keyboard"
+      "ariaLabel": "Product map: walk connected concepts with the arrow keys. The INDEX panel shows the same information"
     },
     "cluster": {
       "hint": "Dense groups are folded into +N chips: click a chip to expand that group, click again to collapse.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -912,6 +912,7 @@
         "docsActions": "문서함 · 문서 액션"
       },
       "rows": {
+        "walkNeighbors": "이어진 개념으로 이동",
         "navBlockedByOverlay": "열려 있는 창을 먼저 닫아 주세요. Esc 를 누르면 닫혀요",
         "goTo_map": "지도로",
         "goTo_docs": "문서함으로",
@@ -2476,7 +2477,7 @@
       "clickHint": "클릭하면 상세 · 출처 문서"
     },
     "canvas": {
-      "ariaLabel": "제품 지도: INDEX 패널에서 같은 정보를 키보드로 탐색할 수 있어요"
+      "ariaLabel": "제품 지도: 방향키로 이어진 개념을 옮겨 다닐 수 있어요. INDEX 패널에서도 같은 정보를 볼 수 있어요"
     },
     "cluster": {
       "hint": "자식이 많은 그룹은 +N 칩으로 접혀 있습니다. 칩을 클릭하면 그 그룹이 펼쳐지고, 다시 클릭하면 접힙니다.",

--- a/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
+++ b/src/widgets/shortcut-sheet/ui/ShortcutSheet.tsx
@@ -108,6 +108,14 @@ const SECTIONS: ShortcutSection[] = [
     titleKey: "topology",
     surface: "topology",
     rows: [
+      /*
+       * 방향키 걷기 — **이 줄이 없어서 사용성 검수에 걸렸다** (2026-08-10).
+       * 2026-08-09~10 에 방향키로 이웃을 걷는 기능을 넣었는데, 키보드를 가르치는
+       * 유일한 자리인 이 시트는 그것을 모른 채 클릭·드래그·스크롤만 안내했다.
+       * 「발견할 수 없는 기능은 기능이 아니다」 — 게이트:
+       * `tests/e2e/map-keyboard-walk.spec.ts` 의 「시트가 방향키 걷기를 안내한다」.
+       */
+      { keys: ["↑", "↓", "←", "→"], labelKey: "walkNeighbors" },
       { keys: [k("click")], labelKey: "clickSelect" },
       { keys: [k("drag")], labelKey: "dragPan" },
       { keys: [k("scroll")], labelKey: "wheelZoom" },

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -409,6 +409,53 @@ test.describe("지도 키보드 걷기", () => {
   });
 
   /**
+   * **발견할 수 없는 기능은 기능이 아니다** (2026-08-10 사용성 검수에서 잡혔다).
+   *
+   * 방향키 걷기를 넣고도, 키보드를 가르치는 **유일한 자리**인 단축키 시트의 지형도
+   * 절은 그것을 몰랐다 — 실측으로 그 절에 있던 것은 `클릭 · 드래그 · 스크롤` 셋뿐이다.
+   * 그 시트는 예전에 **없는 기능을 안내**해 문제가 됐던 자리이기도 하다(그 파일 주석).
+   * 이번은 그 반대 방향의 같은 실패다.
+   */
+  test("단축키 시트가 방향키 걷기를 안내한다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.locator("main").first().click({ position: { x: 5, y: 5 } });
+    await page.keyboard.press("?");
+    const sheet = page.getByTestId("shortcut-sheet-scroll");
+    await expect(sheet).toBeVisible({ timeout: 5_000 });
+    const all = page.getByTestId("shortcut-sheet-scope-all");
+    if (await all.isVisible().catch(() => false)) await all.click();
+
+    const section = await sheet.evaluate((el) => {
+      const lines = (el as HTMLElement).innerText.split("\n").map((s) => s.trim()).filter(Boolean);
+      const start = lines.findIndex((l, i) => l === "지형도" && i > 3);
+      if (start < 0) return null;
+      const rest = lines.slice(start);
+      const next = rest.findIndex((l, i) => i > 0 && /^(검색 팔레트|허브|문서함)/.test(l));
+      return rest.slice(0, next > 0 ? next : 24);
+    });
+    expect(section, "시트에서 「지형도」 절을 못 찾았다 — 이 시험이 공회전한다").not.toBeNull();
+    expect(
+      section!.some((line) => /↑|↓|←|→|방향키/.test(line)),
+      `지형도 절이 방향키를 안내하지 않는다: ${section!.join(" · ")}`,
+    ).toBe(true);
+  });
+
+  /**
+   * **캔버스 라벨이 다른 곳으로 보내지 않는다** (2026-08-10 사용성 검수).
+   *
+   * 라벨이 *"INDEX 패널에서 같은 정보를 키보드로 탐색할 수 있어요"* 였다 — 어제는
+   * 사실이었지만 지금은 **이 캔버스가 직접 그 일을 한다.** 초점을 받은 사람에게
+   * 「여기서는 안 되니 저기로 가라」고 말하는 라벨은 낡은 정보다.
+   */
+  test("캔버스 라벨이 여기서 되는 일을 먼저 말한다", async ({ page }) => {
+    const canvas = page.getByTestId("topology-map-v2-canvas");
+    await canvas.waitFor({ state: "visible", timeout: 20_000 });
+    const label = await canvas.getAttribute("aria-label");
+    expect(label, "캔버스에 접근 이름이 없다").toBeTruthy();
+    expect(label!, `라벨이 방향키를 말하지 않는다: ${label}`).toMatch(/방향키/);
+  });
+
+  /**
    * **방향키를 우리가 가져간다** — `preventDefault` 가 실제로 걸리나.
    *
    * ⚠️ 처음에는 `window.scrollY` 가 안 변하는지로 재려 했고, 그 시험은


### PR DESCRIPTION
## Summary

사용성 검수를 `/user-walkthrough` 규율로 돌렸다 — **패턴을 이름으로 부르고**, 사람
머릿속에 있는 것(원할까)은 주장하지 않는다. 첫 방문부터 걸었더니 둘이 나왔고, **둘 다
「발견할 수 없는 기능은 기능이 아니다」**의 사례다.

### ① 단축키 시트가 방향키 걷기를 모른다

키보드를 가르치는 **유일한 자리**인데, 지형도 절에 있던 것은 실측으로
`클릭 · 드래그 · 스크롤` **셋뿐**이었다. 어제·오늘 방향키 걷기를 넣으면서 그 줄을 안 넣었다.

그 시트는 **예전에 「없는 기능을 안내」해 문제가 됐던 자리**이기도 하다(그 파일 주석:
*"the previous rows described interactions the v2 canvas never implemented"*).
이번은 같은 실패의 **반대 방향**이다.

### ② 캔버스 라벨이 다른 곳으로 보낸다

라벨이 *"제품 지도: INDEX 패널에서 같은 정보를 키보드로 탐색할 수 있어요"* 였다.
어제는 사실이었지만 **지금은 이 캔버스가 직접 그 일을 한다.** 초점을 받은 사람에게
「여기서는 안 되니 저기로 가라」고 말하는 것은 낡은 정보다. 여기서 되는 일을 먼저
말하고 INDEX 는 대안으로 남긴다.

## 검수에서 확인한 것 (결함 아님)

- 관문 첫 화면: 볼 수 있는 행동 11개, 막다른 CTA 0개
- 지도 첫 실행: 「내 폴더 열기 ⌘O」 · 「2분 구경하기」 · 「새 폴더」 — 다음 단계가 있다
- `?` 는 **눌 수 있는 버튼**으로도 있다(「키보드 단축키 보기」) — 키를 모르는 사람도 닿는다
- 목적지 이동 `G` + 글자 일곱 줄은 시트에 **표에서 파생돼** 실려 있다

## Test plan

- e2e **15건** 통과 — 새 2건(시트가 방향키를 안내하는가 · 캔버스 라벨이 방향키를
  말하는가) 포함
- **프로브**: 시트 줄을 지우면 「클릭·드래그·스크롤만 남았다」로 **실패** · 라벨을 옛
  문장으로 되돌리면 **실패**
- 앞 시험은 **공회전 차단**도 단언한다 — 절 제목이 바뀌어 절을 못 찾으면 0건을 통과로
  세지 않는다
- `pnpm test:run` 6,562 · `tsc` 깨끗 · `eslint` 0 error · `i18n` 0 · `desktop:check` 0 ·
  `build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)