### PR TITLE
fix: 카메라 목표를 정하는 식을 하나로 모은다 — 초점 다이브엔 그 식이 아예 없었다

### DIFF
--- a/src/widgets/topology-map-v2/interaction/free-area.test.ts
+++ b/src/widgets/topology-map-v2/interaction/free-area.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-  cameraCenteringNode,
+  measureCanvasInsets,
   computeFreeArea,
-  freeAreaOffset,
   SIDE_PANEL_HEIGHT_RATIO,
   type Rect,
 } from "./free-area";
@@ -86,55 +85,49 @@ describe("computeFreeArea", () => {
   });
 });
 
-describe("freeAreaOffset", () => {
-  it("덮는 것이 없으면 0이다 — 지금 동작을 바꾸지 않는다", () => {
-    expect(freeAreaOffset(CANVAS, [])).toEqual({ dx: 0, dy: 0 });
-  });
-
-  it("오른쪽 팝오버가 있으면 왼쪽으로 밀린다 (실측 −192)", () => {
-    const { dx, dy } = freeAreaOffset(CANVAS, [RIGHT_POPOVER]);
-    expect(Math.round(dx)).toBe(-192);
-    expect(dy).toBe(0);
-  });
-});
-
-describe("cameraCenteringNode", () => {
-  it("오프셋이 0이면 노드를 그대로 가운데 둔다", () => {
-    expect(cameraCenteringNode({ x: 500, y: 300 }, { dx: 0, dy: 0 }, 1)).toEqual({ tx: 500, ty: 300 });
-  });
-
+describe("measureCanvasInsets", () => {
   /**
-   * **배율로 나눈다** — 같은 화면 오프셋이 배율이 클수록 더 짧은 월드 거리다.
-   * 이걸 빼먹으면 확대했을 때 노드가 패널 쪽으로 다시 밀려 들어간다.
+   * DOM 을 흉내 내는 최소 대역 — `collectCanvasObstacles` 가 쓰는 것만 갖춘다.
+   * jsdom 에는 레이아웃이 없어 `getBoundingClientRect` 가 전부 0이므로, 그것을
+   * 심어 주지 않으면 이 시험이 **환경을 재게 된다**(이 파일이 이미 한 번 밟은 함정).
    */
-  it("같은 화면 오프셋이 배율에 따라 다른 월드 거리다", () => {
-    const at1 = cameraCenteringNode({ x: 0, y: 0 }, { dx: -192, dy: 0 }, 1);
-    const at2 = cameraCenteringNode({ x: 0, y: 0 }, { dx: -192, dy: 0 }, 2);
-    expect(at1.tx).toBe(192);
-    expect(at2.tx).toBe(96);
+  const fakeCanvas = (panels: (Rect & { hidden?: boolean })[]) => {
+    const make = (r: Rect, hidden?: boolean) => {
+      const el = document.createElement("div");
+      el.getBoundingClientRect = (() => ({
+        x: r.x, y: r.y, width: r.width, height: r.height,
+        left: r.x, top: r.y, right: r.x + r.width, bottom: r.y + r.height,
+        toJSON: () => ({}),
+      })) as typeof el.getBoundingClientRect;
+      if (hidden) el.style.display = "none";
+      return el;
+    };
+    document.body.innerHTML = "";
+    const canvas = make({ x: 64, y: 0, width: 1448, height: 982 });
+    document.body.append(canvas);
+    for (const p of panels) document.body.append(make(p, p.hidden));
+    return canvas;
+  };
+
+  it("오른쪽 팝오버를 오른쪽 인셋으로 잰다 — 실측 기하", () => {
+    const canvas = fakeCanvas([RIGHT_POPOVER]);
+    const insets = measureCanvasInsets(canvas, CANVAS);
+    // 캔버스 오른쪽 끝(1512) − 팝오버 왼쪽(1128) = 384 (실측값과 같다)
+    expect(insets).toEqual({ left: 0, right: 384 });
   });
 
-  it("배율이 0에 가까워도 터지지 않는다", () => {
-    const out = cameraCenteringNode({ x: 10, y: 10 }, { dx: -100, dy: 0 }, 0);
-    expect(Number.isFinite(out.tx)).toBe(true);
-    expect(Number.isFinite(out.ty)).toBe(true);
+  it("왼쪽 패널을 왼쪽 인셋으로 잰다", () => {
+    const canvas = fakeCanvas([{ x: 64, y: 0, width: 324, height: 900 }]);
+    expect(measureCanvasInsets(canvas, CANVAS)).toEqual({ left: 324, right: 0 });
   });
 
-  /**
-   * 왕복 검사 — 이 카메라를 쓰면 노드가 정말 자유 영역 가운데에 오나.
-   * 화면 좌표 식은 그리는 쪽과 `nodes()` 창구가 함께 쓰는 그것이다.
-   */
-  it("이 카메라로 그리면 노드가 자유 영역 가운데에 온다", () => {
-    const node = { x: 4321, y: -876 };
-    const scale = 1.37;
-    const offset = freeAreaOffset(CANVAS, [RIGHT_POPOVER]);
-    const cam = cameraCenteringNode(node, offset, scale);
-    // 캔버스 지역 좌표: (world - cam) * scale + size/2
-    const screenX = (node.x - cam.tx) * scale + CANVAS.width / 2;
-    const screenY = (node.y - cam.ty) * scale + CANVAS.height / 2;
-    const free = computeFreeArea(CANVAS, [RIGHT_POPOVER]);
-    // `free` 는 문서 좌표, `screenX` 는 캔버스 지역 좌표 — 캔버스 원점을 뺀다.
-    expect(screenX + CANVAS.x).toBeCloseTo(free.x + free.width / 2, 6);
-    expect(screenY + CANVAS.y).toBeCloseTo(free.y + free.height / 2, 6);
+  it("숨은 패널은 세지 않는다", () => {
+    const canvas = fakeCanvas([{ ...RIGHT_POPOVER, hidden: true }]);
+    expect(measureCanvasInsets(canvas, CANVAS)).toEqual({ left: 0, right: 0 });
+  });
+
+  it("위·아래 바는 좌·우 인셋에 섞이지 않는다", () => {
+    const canvas = fakeCanvas([{ x: 64, y: 0, width: 1448, height: 96 }]);
+    expect(measureCanvasInsets(canvas, CANVAS)).toEqual({ left: 0, right: 0 });
   });
 });

--- a/src/widgets/topology-map-v2/interaction/free-area.ts
+++ b/src/widgets/topology-map-v2/interaction/free-area.ts
@@ -1,6 +1,18 @@
 /**
- * 자유 영역 — **패널에 가리지 않는 자리로 데려간다** (2026-08-10 소유자 확정:
+ * 자유 영역 — **패널에 가리지 않는 자리를 잰다** (2026-08-10 소유자 확정:
  * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*).
+ *
+ * ## 이 모듈이 하는 일과 하지 않는 일
+ *
+ * **잰다**: 캔버스에서 그것을 덮는 패널을 뺀 사각형(`computeFreeArea`)과, 그 패널이
+ * 좌·우에서 먹는 폭(`measureCanvasInsets`).
+ *
+ * **계산하지 않는다**: 「그래서 카메라를 어디로 둘까」. 그 식은
+ * `ui/topology-camera-math.ts` 의 `centerForInsets` 한 곳에만 있다. 처음에는 이
+ * 모듈이 그 식(`freeAreaOffset` + `cameraCenteringNode`)을 자기도 갖고 있었는데,
+ * 그러면 카메라 목표를 정하는 식이 **두 벌**이 된다 — 그리고 실제로 한쪽(초점
+ * 다이브)에는 그 식이 아예 없어서 고른 노드가 패널 뒤로 들어갔다. 재는 것과
+ * 정하는 것을 갈라 둔 이유가 이것이다.
  *
  * ## 왜 필요한가 — 실측
  *
@@ -92,37 +104,6 @@ export function computeFreeArea(canvas: Rect, obstacles: readonly Rect[]): Rect 
 }
 
 /**
- * 자유 영역의 가운데가 캔버스 가운데에서 얼마나 밀렸나 — **화면 픽셀**.
- *
- * 카메라는 「뷰포트 가운데에 무엇을 둘까」로 표현되므로, 목표를 이 값만큼 되밀면
- * 노드가 자유 영역 가운데에 온다.
- */
-export function freeAreaOffset(canvas: Rect, obstacles: readonly Rect[]): { dx: number; dy: number } {
-  const free = computeFreeArea(canvas, obstacles);
-  return {
-    dx: free.x + free.width / 2 - (canvas.x + canvas.width / 2),
-    dy: free.y + free.height / 2 - (canvas.y + canvas.height / 2),
-  };
-}
-
-/**
- * 노드를 자유 영역 가운데에 두는 카메라 좌표.
- *
- * 화면 좌표는 `(world - camera) * scale + size/2` 로 나오므로(그 식은
- * `use-topology-loop` 의 `nodes()` 창구와 그리는 쪽이 함께 쓴다), 원하는 화면 위치를
- * 그 식에 넣고 카메라를 풀면 이 형태가 된다. **배율로 나누는 것**이 요점이다 —
- * 같은 화면 오프셋이 배율이 클수록 더 작은 월드 거리에 해당한다.
- */
-export function cameraCenteringNode(
-  node: { readonly x: number; readonly y: number },
-  offset: { readonly dx: number; readonly dy: number },
-  scale: number,
-): { tx: number; ty: number } {
-  const safeScale = Math.abs(scale) < 1e-6 ? 1 : scale;
-  return { tx: node.x - offset.dx / safeScale, ty: node.y - offset.dy / safeScale };
-}
-
-/**
  * 캔버스를 덮고 있는 것들을 **DOM 에서 잰다.**
  *
  * 「보인다」 판정은 이 저장소가 이미 정리해 둔 규율을 따른다(`/design-audit`
@@ -155,4 +136,56 @@ export function collectCanvasObstacles(canvas: Element, canvasRect: Rect): Rect[
     out.push({ x: box.x, y: box.y, width: box.width, height: box.height });
   }
   return out;
+}
+
+/**
+ * 캔버스의 **좌·우 인셋을 잰다** — 카메라 수학이 이미 쓰는 그 인셋에 먹일 값.
+ *
+ * ## 왜 재나 — 토큰은 정적인데 패널 상태는 바뀐다
+ *
+ * `topology-camera-math.ts` 는 **이미** 안전 인셋을 쓴다(`safeInsetLeft/Right/...`,
+ * *"the left ReaderLens panel, right popover rail"*). 그런데 그 값이 CSS 토큰이라
+ * 고정이고, 실제 기하는 상태에 따라 달라진다. 실측(1512×982):
+ *
+ * | | 왼쪽 | 오른쪽 |
+ * |---|---|---|
+ * | 토큰이 예약한 값 | 78 | 120 |
+ * | 실제 (선택 전, INDEX 열림) | **324** | 0 |
+ * | 실제 (선택 후, 팝오버 열림) | 0 | **384** |
+ *
+ * 즉 어느 상태에서도 맞지 않는다. 그래서 **어제 나는 두 번째 보정을 만들었다** —
+ * 선택 경로에만 자유 영역 시프트를 얹었고, 그건 같은 관심사에 대한 둘째 체계였다
+ * (이 저장소가 「따로 노는 두 번째 시스템」이라고 부르는 것). 옳은 처방은 시프트를
+ * 하나 더 만드는 게 아니라 **이미 있는 인셋에 참값을 먹이는 것**이다.
+ *
+ * ## 위·아래는 재지 않는다 — 그건 패널이 아니다
+ *
+ * `safeInsetTop`(148)은 상단 도구 레인 + 도킹 칩이고 `safeInsetBottom`(96)은
+ * **라벨 자리 예약**이다(`LABEL_OFFSET` 에서 파생 — 그 예약이 없어서 최하단 노드
+ * 라벨이 조용히 사라진 사고가 있었다). 둘은 「덮는 패널」이 아니라 레이아웃 약속이라
+ * 측정으로 대체하면 그 사고가 돌아온다. 그래서 **좌·우만** 잰다.
+ *
+ * 그리고 토큰값과 **큰 쪽을 쓴다** — 토큰이 패널 말고 다른 이유로 예약한 폭이 있으면
+ * 그것을 잃지 않는다.
+ */
+export interface CanvasInsets {
+  left: number;
+  right: number;
+}
+
+export function measureCanvasInsets(canvas: Element, canvasRect: Rect): CanvasInsets {
+  let left = 0;
+  let right = 0;
+  for (const panel of collectCanvasObstacles(canvas, canvasRect)) {
+    const tall = panel.height >= canvasRect.height * SIDE_PANEL_HEIGHT_RATIO;
+    const wide = panel.width >= canvasRect.width * TOP_BAR_WIDTH_RATIO;
+    if (!tall || wide) continue;
+    const panelCenter = panel.x + panel.width / 2;
+    if (panelCenter >= canvasRect.x + canvasRect.width / 2) {
+      right = Math.max(right, canvasRect.x + canvasRect.width - panel.x);
+    } else {
+      left = Math.max(left, panel.x + panel.width - canvasRect.x);
+    }
+  }
+  return { left: Math.round(left), right: Math.round(right) };
 }

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.test.ts
@@ -412,3 +412,94 @@ describe("computeUnfocusedPanBounds — 팬 목줄", () => {
     );
   });
 });
+
+describe("computeFocusCameraTarget — 안전 인셋", () => {
+  /**
+   * ⚠️ 종전에 이 함수는 인셋을 **전혀** 쓰지 않았다(2026-08-10 에 고쳤다). 그래서
+   * 노드를 고르면 그것이 **그것을 설명하는 패널 뒤로** 들어갈 수 있었다. 개요 경로는
+   * 이미 같은 문제를 인셋으로 풀고 있었으므로, 처방은 새 보정 체계가 아니라 이 함수를
+   * 그 기구에 맞추는 것이었다 — 하루 전에는 호출부에 둘째 시프트를 얹었고 그것이
+   * 188px 어긋남과 64px 과보정을 만들었다.
+   */
+  const base = {
+    cameraScaleMax: 2.6,
+    cameraMaxZoomRatio: 3.2,
+    cameraScaleMin: 0.24,
+    overviewEntryRatio: 0.95,
+    focusFitMaxScale: 1.9,
+    focusBboxMargin: 1.15,
+    radiusProject: 25,
+    radiusDomain: 17,
+    radiusCapability: 11,
+    radiusElement: 7,
+  } as unknown as TopologyV2Tokens;
+
+  /** 초점 노드 f 와 이웃 둘 — bbox 가운데가 원점이 아니게 일부러 밀어 둔다. */
+  const XY: Record<string, { x: number; y: number; kind: "domain" | "capability" }> = {
+    f: { x: 400, y: 200, kind: "domain" },
+    n1: { x: 550, y: 200, kind: "capability" },
+    n2: { x: 250, y: 200, kind: "capability" },
+  };
+  const CENTER = { x: 400, y: 200 };
+
+  function world(): TopologyWorld {
+    const nodeById = new Map(
+      Object.entries(XY).map(([id, v]) => [
+        id,
+        { id, kind: v.kind, label: id, x: v.x, y: v.y, homeX: v.x, homeY: v.y, parentId: null, isHub: false, fresh: false, stale: false, count: 0, magnitudeScale: 1 },
+      ]),
+    );
+    return {
+      nodes: [...nodeById.values()],
+      nodeById,
+      edges: [],
+      edgeIndexByNode: new Map(),
+      neighborMap: new Map([["f", new Set(["n1", "n2"])]]),
+      childrenByParent: new Map(),
+      clusterMetaByParent: new Map(),
+      brightStarIds: new Set(),
+      bounds: { minX: 0, minY: 0, maxX: 800, maxY: 400 },
+      spineBounds: { minX: 0, minY: 0, maxX: 800, maxY: 400 },
+    } as TopologyWorld;
+  }
+
+  const focus = (tokens: TopologyV2Tokens) => computeFocusCameraTarget(world(), tokens, 1448, 982, "f", 1);
+
+  it("인셋이 없으면 ego bbox 가운데 그대로 — 종전 동작 불변", () => {
+    const t = focus(base);
+    expect(t).not.toBeNull();
+    expect(t!.tx).toBeCloseTo(CENTER.x, 6);
+    expect(t!.ty).toBeCloseTo(CENTER.y, 6);
+  });
+
+  /**
+   * 오른쪽이 가려지면 자유 영역 가운데는 화면 가운데보다 **왼쪽**이다. 화면 식
+   * `(world − tx) × scale + W/2` 에 그 자리를 넣고 풀면 **tx 는 커진다** — 카메라를
+   * 오른쪽으로 옮기면 내용이 왼쪽으로 간다. 부호를 뒤집으면 노드가 패널 **속으로**
+   * 더 들어가므로, 이 방향 단언이 이 시험의 핵심이다.
+   */
+  it("오른쪽 팝오버가 열리면 노드가 그 왼쪽 자유 영역 가운데로 온다", () => {
+    const t = focus({ ...base, safeInsetRight: 384 } as TopologyV2Tokens)!;
+    expect(t.tx).toBeCloseTo(CENTER.x + 384 / (2 * t.tscale), 6);
+    const screenX = (CENTER.x - t.tx) * t.tscale + 1448 / 2;
+    expect(screenX).toBeCloseTo((1448 - 384) / 2, 6); // 자유 영역 가운데
+    expect(screenX).toBeLessThan(1448 - 384); // 팝오버 왼쪽 경계보다 왼쪽
+  });
+
+  it("왼쪽 패널이 열리면 반대로 밀린다", () => {
+    const t = focus({ ...base, safeInsetLeft: 324 } as TopologyV2Tokens)!;
+    const screenX = (CENTER.x - t.tx) * t.tscale + 1448 / 2;
+    expect(screenX).toBeCloseTo((324 + 1448) / 2, 6);
+  });
+
+  it("좌우가 같으면 상쇄된다 — 보정이 공짜로 생기지 않는다", () => {
+    const t = focus({ ...base, safeInsetLeft: 200, safeInsetRight: 200 } as TopologyV2Tokens)!;
+    expect(t.tx).toBeCloseTo(CENTER.x, 6);
+  });
+
+  it("인셋이 크면 배율이 줄어든다 — 보이는 영역에 맞춘다", () => {
+    const plain = focus(base)!;
+    const tight = focus({ ...base, safeInsetRight: 900 } as TopologyV2Tokens)!;
+    expect(tight.tscale).toBeLessThan(plain.tscale);
+  });
+});

--- a/src/widgets/topology-map-v2/ui/topology-camera-math.ts
+++ b/src/widgets/topology-map-v2/ui/topology-camera-math.ts
@@ -137,6 +137,31 @@ interface SafeInsets {
 }
 
 /**
+ * **패널을 뺀 자리 가운데에 무엇을 둘 카메라인가** — 이 식이 사는 단 하나의 곳.
+ *
+ * `worldToScreen` 은 화면의 **날 가운데**를 기준으로 그리므로, 보이는 영역의
+ * 가운데에 두려면 카메라를 좌우 인셋 차의 절반만큼 되민다. **배율로 나누는 것**이
+ * 요점이다 — 같은 화면 오프셋이 배율이 클수록 더 짧은 월드 거리다.
+ *
+ * ⚠️ 이 식은 한때 **네 곳**에 각각 적혀 있었다(개요 · 팬 목줄 · 그리고 하루 동안은
+ * 호출부의 「자유 영역」 시프트까지). 그중 초점 다이브만 이 식을 **아예 안 갖고
+ * 있어서**, 노드를 고르면 그것을 설명하는 패널 뒤로 들어갈 수 있었다. 사본이
+ * 여럿이면 빠진 사본이 생기는 쪽이 기본값이다 — 그래서 한 곳으로 모았다.
+ */
+export function centerForInsets(
+  cx: number,
+  cy: number,
+  insets: SafeInsets,
+  scale: number,
+): { tx: number; ty: number } {
+  const safeScale = Math.abs(scale) < 1e-6 ? 1 : scale;
+  return {
+    tx: cx - (insets.left - insets.right) / (2 * safeScale),
+    ty: cy - (insets.top - insets.bottom) / (2 * safeScale),
+  };
+}
+
+/**
  * 검수 Pass B 결함 1 (2026-07-23) — 오버뷰 핏은 노드 지오메트리 bounds 만
  * safe 영역에 맞춰, 최하단 스파인 노드의 라벨 anchor(= 노드 아래
  * `radius + LABEL_OFFSET`, frame-draw:794 — 컬은 폰트 높이가 아니라 anchor
@@ -225,11 +250,7 @@ export function computeOverviewCameraTarget(
   const centerY = (bounds.minY + bounds.maxY) / 2;
   // worldToScreen centers on the raw screen midpoint; offset the camera so the
   // graph center renders at the visible-area midpoint instead.
-  return {
-    tx: centerX - (insets.left - insets.right) / (2 * tscale),
-    ty: centerY - (insets.top - insets.bottom) / (2 * tscale),
-    tscale,
-  };
+  return { ...centerForInsets(centerX, centerY, insets, tscale), tscale };
 }
 
 /**
@@ -262,8 +283,12 @@ export function computeUnfocusedPanBounds(
   const leash = tokens.cameraPanLeash ?? 0;
   if (!(leash > 0) || !(cameraScale > 0)) return computePanBounds(bounds);
   const insets = readSafeInsets(tokens);
-  const anchorX = (bounds.minX + bounds.maxX) / 2 - (insets.left - insets.right) / (2 * cameraScale);
-  const anchorY = (bounds.minY + bounds.maxY) / 2 - (insets.top - insets.bottom) / (2 * cameraScale);
+  const { tx: anchorX, ty: anchorY } = centerForInsets(
+    (bounds.minX + bounds.maxX) / 2,
+    (bounds.minY + bounds.maxY) / 2,
+    insets,
+    cameraScale,
+  );
   return computePanBounds(
     { minX: anchorX, minY: anchorY, maxX: anchorX, maxY: anchorY },
     leash,
@@ -375,7 +400,24 @@ export function computeFocusCameraTarget(
   const centerY = (egoBounds.minY + egoBounds.maxY) / 2;
   const w = Math.max(1, (egoBounds.maxX - egoBounds.minX) * marginRatio);
   const h = Math.max(1, (egoBounds.maxY - egoBounds.minY) * marginRatio);
-  const fitScale = Math.min(viewportWidth / w, viewportHeight / h);
+  /*
+   * **안전 인셋을 개요 경로와 같은 방식으로 쓴다** (2026-08-10 소유자 확정:
+   * *"가려선 안되지 패널 뺀 공간 가운데로 맞춰줘"*).
+   *
+   * ⚠️ 종전에 이 함수는 인셋을 **전혀** 쓰지 않았다 — `tx: centerX` 를 그대로 돌려주고
+   * 배율도 전체 뷰포트로 맞췄다. 그래서 노드를 고르면 그 노드가 **그것을 설명하는
+   * 패널 뒤로** 들어갈 수 있었다. 실측(1512×982): 팝오버가 열리면 오른쪽 384px 이
+   * 가려지는데 목표는 여전히 화면 가운데였다.
+   *
+   * 개요 경로(`computeOverviewCameraTarget`)는 **이미** 같은 문제를 인셋으로 풀고
+   * 있었다. 그래서 처방은 새 보정 체계를 만드는 것이 아니라 이 함수를 그 기구에
+   * 맞추는 것이다 — 하루 전 나는 반대로 했고(호출부에 둘째 시프트를 얹었다) 그것이
+   * 188px 어긋남과 64px 과보정을 만들었다.
+   */
+  const insets = readSafeInsets(tokens);
+  const effW = Math.max(1, viewportWidth - insets.left - insets.right);
+  const effH = Math.max(1, viewportHeight - insets.top - insets.bottom);
+  const fitScale = Math.min(effW / w, effH / h);
   const effectiveMax = computeEffectiveCameraScaleMax(overviewEntryScale, tokens.cameraMaxZoomRatio, tokens.cameraScaleMax);
   // 소유자 실보고 (2026-07-24) — 이웃이 숨은 상태(스포트라이트 등)에선 ego
   // bbox 가 작아 fit 이 현미경 줌으로 치솟는다. 선택 프레이밍의 줌인은
@@ -384,11 +426,11 @@ export function computeFocusCameraTarget(
   const focusZoomInCeiling = overviewEntryScale * (tokens.focusMaxZoomRatio ?? Number.POSITIVE_INFINITY);
   const scale = Math.min(effectiveMax, focusZoomInCeiling, Math.max(overviewEntryScale, fitScale));
 
-  return {
-    tx: centerX,
-    ty: centerY,
-    tscale: scale,
-  };
+  /*
+   * 인셋만큼 목표를 되민다 — 개요 경로와 **같은 식**이다(`(left - right) / (2 × scale)`).
+   * 배율로 나누는 이유: 같은 화면 오프셋이 배율이 클수록 더 짧은 월드 거리다.
+   */
+  return { ...centerForInsets(centerX, centerY, insets, scale), tscale: scale };
 }
 
 /**

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -37,7 +37,7 @@ import { createAnimatedBackground, type AnimatedBackground } from "../render/ani
 import { buildDustPoints, buildRealmCosmosPoints, computeStarDustCount, type DustPoint } from "../render/starfield";
 import { DEFAULT_EXPAND } from "@/shared/lib/appearance-preferences";
 import type { CanvasBackground, ExpandPreference, FootprintPreference, GlyphSet } from "@/shared/lib/appearance-preferences";
-import { computeClusterFitTarget, computeFocusCameraTarget, computeOverviewCameraTarget, computeOverviewFitScale, fitWorldTarget, hasAnyNodeOnScreen, worldToScreen } from "./topology-camera-math";
+import { centerForInsets, computeClusterFitTarget, computeFocusCameraTarget, computeOverviewCameraTarget, computeOverviewFitScale, fitWorldTarget, hasAnyNodeOnScreen, worldToScreen } from "./topology-camera-math";
 import { drawTopologyFrame } from "./topology-frame-draw";
 import { relaxNewlyVisible } from "../model/layout";
 import { computeTopologyClusterState } from "./topology-cluster-state";
@@ -86,10 +86,9 @@ import {
   walkDirectionForKey,
 } from "../interaction/keyboard-walk";
 import {
-  cameraCenteringNode,
   collectCanvasObstacles,
   computeFreeArea,
-  freeAreaOffset,
+  measureCanvasInsets,
   type Rect,
 } from "../interaction/free-area";
 
@@ -823,6 +822,50 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
    * Stable identity (refs only) so listing it in the programmatic-move effects'
    * deps never re-fires them.
    */
+  /**
+   * 카메라 목표 계산에 쓸 토큰 — **좌·우 안전 인셋만 실측값으로 바꾼다.**
+   *
+   * ## 왜 (2026-08-10, 프로브가 드러낸 것)
+   *
+   * `topology-camera-math` 는 **이미** 안전 인셋으로 패널을 피한다. 그런데 그 값이
+   * CSS 토큰이라 정적이고, 실제 기하는 상태에 따라 바뀐다. 실측(1512×982):
+   * 토큰은 좌 78 · 우 120 인데, 실제는 **선택 전 좌 324 · 우 0**, **선택 후 좌 0 ·
+   * 우 384** 였다(선택하면 INDEX 가 접히고 팝오버가 열린다).
+   *
+   * 어제 나는 이 사실을 모르고 **선택 경로에만 두 번째 보정**(자유 영역 시프트)을
+   * 얹었다. 그건 같은 관심사의 둘째 체계이고, 그래서 한 번은 188px 어긋나고 한 번은
+   * 64px 과보정됐다. 옳은 처방은 시프트를 더 만드는 게 아니라 **이미 있는 인셋에
+   * 참값을 먹이는 것**이다.
+   *
+   * ## 왜 좌·우만, 왜 카메라 목표에만
+   *
+   * `safeInsetTop`(148)은 상단 도구 레인과 도킹 칩, `safeInsetBottom`(96)은 **라벨
+   * 자리 예약**이다(그 예약이 없어 최하단 라벨이 조용히 사라진 사고가 있었다) —
+   * 「덮는 패널」이 아니라 레이아웃 약속이라 측정으로 대체하면 그 사고가 돌아온다.
+   *
+   * 그리고 `safeInset*` 는 **라벨 컬링**(`topology-frame-draw`)도 읽는다. 전역으로
+   * 덮으면 카메라와 무관한 관심사를 건드리므로, 목표를 계산하는 자리에서만 갈아 끼운다.
+   *
+   * 토큰값과 **큰 쪽**을 쓴다 — 토큰이 패널 말고 다른 이유로 예약한 폭을 잃지 않는다.
+   */
+  const cameraTokens = useCallback(<T extends { safeInsetLeft: number; safeInsetRight: number }>(tokens: T): T => {
+    const canvasEl = canvasRef.current;
+    if (!canvasEl) return tokens;
+    const box = canvasEl.getBoundingClientRect();
+    if (box.width <= 0 || box.height <= 0) return tokens;
+    const measured = measureCanvasInsets(canvasEl, {
+      x: box.x,
+      y: box.y,
+      width: box.width,
+      height: box.height,
+    });
+    return {
+      ...tokens,
+      safeInsetLeft: Math.max(tokens.safeInsetLeft, measured.left),
+      safeInsetRight: Math.max(tokens.safeInsetRight, measured.right),
+    };
+  }, []);
+
   const beginCameraTween = useCallback((target: CameraTarget, durationOverrideMs?: number) => {
     if (reducedMotionRef.current) {
       cameraTweenRef.current = null;
@@ -1595,6 +1638,18 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     // 재배치 좌표계(원점 0,0)와 어긋나 화면 밖으로 날아갔다. 영역 active 중
     // deselect 복귀 목표는 영역 콘텐츠 bbox(가시 멤버 기준) — entryCamera(영역
     // '해제' 전용)가 아니라 현재 영역 fit 이다.
+    /*
+     * ⚠️ **목표 계산 자체를 한 프레임 미룬다.**
+     *
+     * 피해야 할 팝오버는 **바로 이 선택 때문에** 열리므로, 이 effect 가 도는 시점에는
+     * DOM 에 없다. 그때 인셋을 재면 오른쪽이 0으로 나오고 보정이 사라진다 —
+     * 게이트가 정확히 그것을 잡았다(「자유 127px · 화면 64px」). 그래서 **재는 것과
+     * 계산하는 것을 같은 프레임**에 둔다.
+     *
+     * 200~420ms 이동 앞의 한 프레임(≈16ms)은 보이지 않고, 「한 사건」 게이트가 그
+     * 시차를 프레임 수로 지킨다.
+     */
+    const raf = requestAnimationFrame(() => {
     let target: CameraTarget | null;
     if (focusedSlug === null && realmActive && realmData) {
       const bounds = realmVisibleBounds(
@@ -1606,7 +1661,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       target = realmCameraTarget(bounds, tokens, width, height);
     } else {
       const realmMembers = realmActive ? realmData?.memberIds ?? null : null;
-      target = computeFocusCameraTarget(world, tokens, width, height, focusedSlug, overviewEntryScale, realmMembers);
+      target = computeFocusCameraTarget(world, cameraTokens(tokens), width, height, focusedSlug, overviewEntryScale, realmMembers);
     }
     if (!target) return;
     /*
@@ -1624,32 +1679,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
      * 패널 폭을 상수로 박지 않고 DOM 에서 잰다: 값을 박으면 패널이 바뀌는 날 조용히
      * 어긋난다. 선택이 바뀔 때만 도는 계산이라 프레임 예산과 무관하다.
      */
-    /*
-     * ⚠️ **한 프레임 뒤에 잰다.** 피해야 할 팝오버는 **바로 이 선택 때문에** 열리므로,
-     * 이 effect 가 도는 시점에는 아직 DOM 에 없다. 그때 재면 장애물이 0개라 보정이
-     * 0이 되고, 실측에서 정확히 그 일이 났다(노드가 자유 영역 가운데에서 188px
-     * 벗어나 화면 가운데에 앉았다 — 게이트가 잡았다).
-     *
-     * 200~420ms 이동 앞의 한 프레임(≈16ms)은 보이지 않는다. 대안(패널 폭을 상수로
-     * 박기)은 패널이 바뀌는 날 조용히 어긋난다.
-     */
-    const aimed = target;
-    const raf = requestAnimationFrame(() => {
-      let finalTarget = aimed;
-      const canvasEl = canvasRef.current;
-      if (canvasEl) {
-        const box = canvasEl.getBoundingClientRect();
-        const canvasRect: Rect = { x: box.x, y: box.y, width: box.width, height: box.height };
-        const offset = freeAreaOffset(canvasRect, collectCanvasObstacles(canvasEl, canvasRect));
-        if (offset.dx !== 0 || offset.dy !== 0) {
-          const shifted = cameraCenteringNode(
-            { x: aimed.tx, y: aimed.ty },
-            offset,
-            aimed.tscale,
-          );
-          finalTarget = { tx: shifted.tx, ty: shifted.ty, tscale: aimed.tscale };
-        }
-      }
+      const finalTarget = target;
       dampingRef.current = tokens.cameraDampingDefault;
       cameraTargetRef.current = finalTarget;
       userDrivenCameraRef.current = false;
@@ -1662,7 +1692,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       beginCameraTween(finalTarget);
     });
     return () => cancelAnimationFrame(raf);
-  }, [focusedSlug, beginCameraTween]);
+  }, [focusedSlug, beginCameraTween, cameraTokens]);
 
   // --- S4 "영역 전개" — realmRootId 변경 시 서브트리 재배치 + 전환 안무 시작.
   // 진입: 서브트리를 그 노드 임시 루트로 재배치, 안 노드는 FLIP·밖 노드는 중력
@@ -3562,7 +3592,6 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       };
       const obstacles = collectCanvasObstacles(canvasEl, canvasRect);
       const free = computeFreeArea(canvasRect, obstacles);
-      const offset = freeAreaOffset(canvasRect, obstacles);
 
       // 초점이 지금 자유 영역 안에 넉넉히 들어와 있나 (문서 좌표로 비교).
       const sx = canvasBox.x + (target.x - camera.x.value) * scale + width / 2;
@@ -3574,7 +3603,16 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         sy < free.y + margin ||
         sy > free.y + free.height - margin;
       if (outside) {
-        const centered = cameraCenteringNode(target, offset, scale);
+        /*
+         * 목표는 **카메라 수학의 그 식**으로 낸다(`centerForInsets`) — 여기 따로
+         * 적으면 그 식의 사본이 둘이 되고, 사본이 여럿이면 빠진 사본이 생기는 쪽이
+         * 기본값이다(초점 다이브가 실제로 그 빠진 사본이었다).
+         *
+         * 자유 영역은 목표가 아니라 **「밖으로 나갔나」 판정**에만 남는다 — 인셋은
+         * 밀 거리를 주지만 담고 있는 사각형을 주지 않으므로, 그 판정은 인셋으로
+         * 표현할 수 없는 다른 질문이다.
+         */
+        const centered = centerForInsets(target.x, target.y, { ...measureCanvasInsets(canvasEl, canvasRect), top: 0, bottom: 0 }, scale);
         const cameraTarget = { tx: centered.tx, ty: centered.ty, tscale: scale };
         /*
          * ⚠️ **트윈만 세우면 안 된다** (게이트가 잡았다). 트윈이 끝나면 스프링이


### PR DESCRIPTION
## Summary

어제 넣은 「패널 뺀 자리 가운데」 보정은 호출부에 얹은 **둘째 체계**였다. 원인을 다시 재 보니 첫 체계가 잘못된 게 아니라, **초점 다이브에는 그 체계가 아예 없었다**:

- `computeOverviewCameraTarget`, `computeUnfocusedPanBounds` — 안전 인셋을 읽어 목표를 되민다
- `computeFocusCameraTarget` — `tx: centerX` 를 그대로 돌려주고, 배율도 **전체** 뷰포트로 맞춘다 (인셋 참조 0건)

그래서 노드를 고르면 그것이 자기를 설명하는 팝오버 뒤로 들어갈 수 있었다. 실측(1512×982): 오른쪽 384px 이 가려지는데 목표는 여전히 화면 가운데.

식이 네 곳에 흩어져 있으면 **빠진 사본이 생기는 쪽이 기본값**이다. 그래서:

- `centerForInsets(cx, cy, insets, scale)` — 이 식이 사는 단 하나의 곳. 개요 · 팬 목줄 · 초점 다이브 · 걷기 추종이 전부 이것을 부른다
- 초점 다이브는 배율도 **인셋을 뺀 실제 보이는 영역**에 맞춘다 (`effW`/`effH`)
- `free-area` 는 **재기만** 한다 — 자유 사각형(「밖으로 나갔나」 판정: 인셋은 밀 거리를 주지만 담는 사각형을 주지 않으므로 표현 불가능한 다른 질문)과 좌·우 인셋 실측. 목표를 계산하던 `freeAreaOffset`·`cameraCenteringNode` 는 지웠다

## Test plan

- **프로브** (`/gate-probe`): 인셋 항을 빼니 단위 2건 + e2e 「자유 영역 가운데」가 빨개졌다 — `노드가 자유 영역 가운데(561)보다 화면 가운데(752)에 가깝다 (자유 127px · 화면 64px)`. 되돌리면 초록
- 새 단위 5건 (`topology-camera-math.test.ts`): 인셋 0 → 종전 동작 불변 · 오른쪽 팝오버 → 자유 영역 가운데 도착 + 팝오버 경계보다 왼쪽 · 왼쪽 패널 → 반대 방향 · 좌우 동일 → 상쇄(보정이 공짜로 안 생긴다) · 큰 인셋 → 배율 감소
- `pnpm exec vitest run tests/contract` — 136 파일 · 1,574건 통과
- `pnpm exec vitest run src/widgets/topology-map-v2` — 60 파일 · 894건 통과
- `pnpm exec playwright test map-keyboard-walk camera-transition` — 19건 통과
- `pnpm exec tsc --noEmit` 통과 · `pnpm exec eslint <바뀐 5파일>` 0 error (내가 넣은 경고 1건도 의존성 추가로 제거; `cameraTokens` 는 `useCallback(…, [])` 이라 다이브를 다시 트리거하지 않는다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD