### PR TITLE
fix: 막다른 길 안내를 노드 옆으로 — 토스트는 초점을 가져가 이동 자체를 막았다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -809,7 +809,7 @@
       "itemTitle": "{name} · {degree} connections"
     },
     "keyboardWalk": {
-      "deadEnd": "No connected node this way. Try another direction"
+      "deadEnd": "No connected node this way"
     }
   },
   "searchWidgets": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -809,7 +809,7 @@
       "itemTitle": "{name} · 연결 {degree}"
     },
     "keyboardWalk": {
-      "deadEnd": "이 방향에는 이어진 노드가 없어요. 다른 방향을 눌러 보세요"
+      "deadEnd": "이 방향엔 이어진 노드가 없어요"
     }
   },
   "searchWidgets": {

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -473,9 +473,7 @@ export function HomePage() {
    * 세우면 위치·토큰·모션을 다 정해야 하고 그건 혼자 정할 규격이 아니다.
    * 연타 걸러 내기는 위젯이 한다(`shouldAnnounceDeadEnd`).
    */
-  const handleWalkDeadEnd = useCallback(() => {
-    toast.show(tTopologyKeyboardWalk("deadEnd"), "info");
-  }, [toast, tTopologyKeyboardWalk]);
+
   const prefetchedProjectHrefsRef = useRef(new Set<string>());
   const preloadedImageUrlsRef = useRef(new Set<string>());
   const {
@@ -4569,7 +4567,7 @@ export function HomePage() {
                        눌렀는데 아무 반응이 없으면 사용자는 「고장」과 「그 방향에는
                        없음」을 구별할 수 없다. 문구와 표면은 페이지가 소유한다 —
                        위젯은 사건만 내보낸다(그 위젯은 프로바이더 없이 시험된다). */
-                    onWalkDeadEnd={handleWalkDeadEnd}
+                    walkNoticeLabel={tTopologyKeyboardWalk("deadEnd")}
                     focus={{ selectedSlug: canvasSelectedSlug }}
                     /* 볼트를 세션 중에 갈아 끼우면(샘플 → 로컬) 지도가 직전
                        그래프의 카메라로 새 그래프를 그리던 결함을 닫는다. 값의

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type RefObject } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { Orbit } from "lucide-react";
 import { MAP_CANVAS_SURFACE_ROLE } from "@/shared/lib/focus-map-canvas";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
@@ -10,6 +10,23 @@ import type { ClusterBarLabels } from "../render/cluster-chips";
 import { DEFAULT_EXPAND } from "@/shared/lib/appearance-preferences";
 import type { CanvasBackground, ExpandPreference, FootprintPreference, GlyphSet } from "@/shared/lib/appearance-preferences";
 import { controlClass } from '@/shared/ui/control-class';
+import { usePanelPresence } from "@/shared/lib/use-presence";
+
+/**
+ * 안내가 화면에 머무는 시간.
+ *
+ * ⚠️ 처음 1100ms 로 뒀다가 **시험이 먼저 잡았다** — 여덟 번 누르는 동안 이미
+ * 사라져서 안내를 한 번도 못 봤다. 사람도 같은 처지다: 한 줄을 읽는 데 그보다
+ * 오래 걸린다. 1900ms 는 읽고 다음 방향을 누를 만큼이고, 여전히 스스로 사라진다.
+ *
+ * 쿨다운(`DEAD_END_NOTICE_COOLDOWN_MS` 1200ms)보다 길어도 된다 — 다시 막히면
+ * 타이머가 새로 서고 안내가 **새 노드 옆으로** 옮겨 간다.
+ */
+const WALK_NOTICE_HOLD_MS = 1900;
+
+/** 노드 중심에서 안내 아래변까지 — 노드 반지름 최대(30) + 숨 8. */
+const WALK_NOTICE_NODE_GAP = 38;
+import { useReducedMotion } from "framer-motion";
 
 /**
  * `TopologyMapV2` — the product's single current canvas-2D topology renderer.
@@ -113,7 +130,7 @@ export interface TopologyMapV2Props {
   emphasizedNeighborSlug?: string | null;
   onSelect?: (slug: string) => void;
   /** 방향키를 눌렀는데 그 방향에 갈 곳이 없을 때. 문구는 페이지가 정한다. */
-  onWalkDeadEnd?: (() => void) | null;
+  onWalkDeadEnd?: ((point: { x: number; y: number } | null) => void) | null;
   onOpen?: (slug: string) => void;
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
@@ -204,6 +221,12 @@ export interface TopologyMapV2Props {
    * 단다(회귀 0).
    */
   canvasLabel?: string;
+  /**
+   * 막다른 길 안내 문구 — **문구는 페이지의 것이다**(`canvasLabel` 과 같은 이유:
+   * 이 위젯은 프로바이더 없이 렌더되는 시험을 가진다). 자리와 사라지는 시점은
+   * 위젯이 정한다 — 그 둘은 캔버스 좌표를 아는 쪽만 알 수 있다.
+   */
+  walkNoticeLabel?: string;
   /**
    * 발자국 트레일 (fable 설계) — 세션 동안 방문(ego 포커스)한 노드 id 목록
    * (오래된 → 최근). 각 방문 노드에 최근성 감쇠 pale 인디고 헤어라인 링을
@@ -299,7 +322,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, walkNoticeLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -352,11 +375,58 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
 
   // `handleWheel` is wired natively (non-passive) inside `useTopologyLoop` —
   // see its own FIX comment — not bound here as a JSX prop.
+  /**
+   * 막다른 길 안내 — **노드 옆에, 스스로 사라지고, 초점을 빼앗지 않는다**
+   * (2026-08-10 소유자 실사용 지적 3건).
+   *
+   * ## 왜 앱 공용 토스트를 버렸나
+   *
+   * 처음에는 토스트로 띄웠다. 「새 표면을 만들지 않는다」는 판단은 그때도 옳았지만,
+   * 실물에서 세 가지가 한꺼번에 틀렸다 — 셋 다 **한 원인**에서 나왔다:
+   *
+   * | 소유자가 본 것 | 원인 |
+   * |---|---|
+   * | *"이렇게 나오면 모르겠는데?"* | 토스트 자리는 화면 우하단이다. 막힌 노드는 화면 가운데 어딘가에 있고, 500px 떨어진 곳의 문장은 「지금 누른 것」과 이어지지 않는다 |
+   * | *"사라지지도 않고 계속떠있고"* | 닫기 버튼이 초점을 받으면 sonner 는 스스로 사라지는 시계를 멈춘다 |
+   * | *"x버튼 안누르면 아예 이동도 안됨"* | 초점이 토스트로 넘어가면 방향키가 캔버스에 도착하지 않는다 |
+   *
+   * 그래서 이 안내는 **초점을 받을 수 없는 것**이어야 한다 — 버튼이 없고
+   * `pointer-events: none` 이다. 놓쳐도 잃는 것이 없으므로(그 방향에 노드가 없다는
+   * 사실은 다시 눌러 보면 또 알 수 있다) 토스트의 규율(*"놓치면 곤란한 일은 상주
+   * 표면이 맡는다"*)과도 맞다. 보조기술에는 `aria-live` 로 읽힌다.
+   *
+   * 모션은 **이미 있는 기구**를 쓴다 — `usePanelPresence` + `overlay-spring-surface`
+   * (감속 사용자는 `overlay-fade-only`). 새 키프레임 0 · 새 토큰 0.
+   */
+  const [notice, setNotice] = useState<{ x: number; y: number; key: number } | null>(null);
+  const noticeTimerRef = useRef<number | null>(null);
+  const reducedMotion = useReducedMotion();
+  const noticePresence = usePanelPresence(notice !== null);
+  const handleWalkDeadEnd = useCallback(
+    (point: { x: number; y: number } | null) => {
+      onWalkDeadEnd?.(point);
+      if (!walkNoticeLabel || !point) return;
+      if (noticeTimerRef.current !== null) window.clearTimeout(noticeTimerRef.current);
+      setNotice({ x: point.x, y: point.y, key: performance.now() });
+      noticeTimerRef.current = window.setTimeout(() => {
+        noticeTimerRef.current = null;
+        setNotice(null);
+      }, WALK_NOTICE_HOLD_MS);
+    },
+    [onWalkDeadEnd, walkNoticeLabel],
+  );
+  useEffect(
+    () => () => {
+      if (noticeTimerRef.current !== null) window.clearTimeout(noticeTimerRef.current);
+    },
+    [],
+  );
+
   const { canvasRef, containerRef, handlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, handleContextMenu, handleKeyDown } =
     useTopologyLoop({
       nodes,
       edges,
-      onWalkDeadEnd,
+      onWalkDeadEnd: handleWalkDeadEnd,
       wheelIntent,
       ambientSleepDelayMs,
       focusedSlug: focus.selectedSlug,
@@ -535,6 +605,28 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
             visibility: tourAnchorNodeId ? "visible" : "hidden",
           }}
         />
+      ) : null}
+      {noticePresence.mounted && notice ? (
+        <div
+          key={notice.key}
+          data-walk-notice=""
+          /* 보조기술에는 읽히고, 포인터·초점에는 존재하지 않는다. */
+          role="status"
+          aria-live="polite"
+          data-state={noticePresence.exiting ? "closed" : "open"}
+          className={[
+            reducedMotion ? "overlay-fade-only" : "overlay-spring-surface",
+            "pointer-events-none absolute z-40 max-w-[240px] -translate-x-1/2 -translate-y-full rounded-[var(--topology-v2-panel-radius)] border border-[color:var(--topology-v2-panel-border)] bg-[color:var(--topology-v2-panel-surface)] px-2.5 py-1.5 text-label text-[color:var(--topology-v2-panel-text-primary)] shadow-[var(--topology-v2-panel-shadow)]",
+          ].join(" ")}
+          style={{
+            left: notice.x,
+            // 노드 **위쪽**에 띄운다 — 아래는 라벨 자리다(`LABEL_OFFSET`).
+            top: notice.y - WALK_NOTICE_NODE_GAP,
+            ["--overlay-spring-origin" as string]: "center bottom",
+          }}
+        >
+          {walkNoticeLabel}
+        </div>
       ) : null}
       {clusterHint ? (
         <span

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -204,7 +204,11 @@ export interface UseTopologyLoopArgs {
   ) => void;
   onSelect?: (slug: string) => void;
   /** 방향키를 눌렀는데 그 방향에 이어진 노드가 없을 때. 연타는 훅이 걸러 낸다. */
-  onWalkDeadEnd?: (() => void) | null;
+  /**
+   * 막다른 길 — **어디서** 막혔는지까지 실어 보낸다(캔버스 지역 좌표).
+   * 자리를 아는 곳은 여기뿐이고, 안내를 노드 옆에 띄우려면 그 자리가 필요하다.
+   */
+  onWalkDeadEnd?: ((point: { x: number; y: number } | null) => void) | null;
   onPaneClick?: () => void;
   onVisibleCountChange?: (visible: number) => void;
   onGraphStatsChange?: (stats: { nodes: number; relations: number }) => void;
@@ -3472,7 +3476,27 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
     const now = performance.now();
     if (!shouldAnnounceDeadEnd(deadEndAtRef.current, now)) return;
     deadEndAtRef.current = now;
-    onWalkDeadEndRef.current?.();
+    /*
+     * **막힌 그 노드의 화면 자리**를 함께 보낸다 (2026-08-10 소유자 실사용 지적:
+     * *"그냥 이동하던 노드 바로 옆에 좀 잘보이게 나타났다가 사라지는게 좋을듯"*).
+     *
+     * 화면 좌표 식은 `nodes()` 창구와 그리는 쪽이 함께 쓰는 그것이다 — 여기서 따로
+     * 만들면 세 번째 사본이 된다. 좌표를 못 내면 `null` 을 보내고, 받는 쪽이
+     * 「자리를 모르니 안 띄운다」를 스스로 정한다.
+     */
+    const world = worldRef.current;
+    const camera = cameraRef.current;
+    const id = focusedSlugRef.current;
+    const node = world && id ? world.nodeById.get(id) : null;
+    const { width, height } = viewportRef.current;
+    const point =
+      node && camera && width > 0 && height > 0
+        ? {
+            x: (node.x - camera.x.value) * camera.scale.value + width / 2,
+            y: (node.y - camera.y.value) * camera.scale.value + height / 2,
+          }
+        : null;
+    onWalkDeadEndRef.current?.(point);
   }, []);
 
   /**

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -30,6 +30,22 @@ async function focusCanvas(page: import("@playwright/test").Page) {
 const selectedId = (page: import("@playwright/test").Page) =>
   page.evaluate(() => window.__atlasMap?.selection().nodeId ?? null);
 
+/**
+ * **막다른 길이 나올 때까지 한 방향으로 걷는다.**
+ *
+ * ⚠️ 예전에는 「여덟 번 누르고 나서 확인」이었다. 안내가 스스로 사라지게 되자 그
+ * 방식이 **먼저 깨졌다** — 누르는 동안 안내가 떴다 사라져서 한 번도 못 봤다.
+ * 안내가 뜨는 순간 멈추는 것이 옳다: 사람도 막힌 직후에 그것을 본다.
+ */
+async function walkUntilDeadEnd(page: import("@playwright/test").Page, direction = "ArrowLeft") {
+  for (let i = 0; i < 12; i += 1) {
+    await page.keyboard.press(direction);
+    await page.waitForTimeout(140);
+    if ((await page.locator("[data-walk-notice]").count()) > 0) return true;
+  }
+  return false;
+}
+
 test.describe("지도에 초점을 주는 길", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
@@ -256,14 +272,82 @@ test.describe("지도 키보드 걷기", () => {
     await page.keyboard.press("ArrowRight");
     await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
 
-    for (let i = 0; i < 8; i += 1) {
-      await page.keyboard.press("ArrowLeft");
-      await page.waitForTimeout(150);
-    }
+    expect(await walkUntilDeadEnd(page), "막다른 길에 닿지 못했다 — 이 시험이 아무것도 안 재고 있다").toBe(true);
     await expect(
       page.getByText(/이어진 노드가 없어요/).first(),
       "막다른 길인데 아무 말도 없다",
     ).toBeVisible({ timeout: 4_000 });
+  });
+
+  /**
+   * **안내는 걸으려던 노드 옆에 뜨고, 스스로 사라지고, 걸음을 막지 않는다**
+   * (2026-08-10 소유자 실사용 지적 3건).
+   *
+   * 소유자가 실물에서 본 것: *"이렇게 나오면 모르겠는데? 그냥 이동하던 노드 바로
+   * 옆에 좀 잘보이게 나타났다가 사라지는게 좋을듯? 심지어 지금은 사라지지도 않고
+   * 계속떠있고.. 이거 떠있는동안 x버튼 안누르면 아예 이동도 안됨."*
+   *
+   * 셋을 한 자리에서 재는 이유: **셋 다 「어디에 무엇으로 띄웠나」 하나에서 나온
+   * 결과**다. 앱 공용 토스트로 띄우면 자리는 화면 구석이고, 닫기 버튼이 초점을
+   * 받으므로 방향키가 캔버스에 도착하지 않고, 초점이 들어온 토스트는 스스로 사라지는
+   * 시계를 멈춘다. 하나만 고치면 나머지 둘이 남는다.
+   */
+  test("막다른 길 안내가 노드 옆에 뜬다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    expect(await walkUntilDeadEnd(page), "막다른 길에 닿지 못했다 — 이 시험이 아무것도 안 재고 있다").toBe(true);
+
+    const geom = await page.evaluate(() => {
+      const probe = window.__atlasMap;
+      const id = probe?.selection().nodeId;
+      const canvas = document.querySelector('[data-surface-role="map-canvas"]');
+      const notice = document.querySelector("[data-walk-notice]");
+      if (!probe || !id || !canvas || !notice) return null;
+      const node = probe.nodes().find((n) => n.id === id);
+      if (!node) return null;
+      const cbox = canvas.getBoundingClientRect();
+      const nbox = notice.getBoundingClientRect();
+      return {
+        dx: Math.abs(nbox.x + nbox.width / 2 - (cbox.x + node.x)),
+        dy: Math.abs(nbox.y + nbox.height / 2 - (cbox.y + node.y)),
+      };
+    });
+    expect(geom, "안내가 DOM 에 없다 — `data-walk-notice` 로 찾을 수 없다").not.toBeNull();
+    // 노드 옆이라는 것은 **거리로만 잴 수 있다.** 실측 토스트는 화면 우하단이라
+    // 1440×900 에서 500px 이상 떨어져 있었다.
+    expect(geom!.dx, "안내가 노드에서 가로로 너무 멀다").toBeLessThan(280);
+    expect(geom!.dy, "안내가 노드에서 세로로 너무 멀다").toBeLessThan(200);
+  });
+
+  test("막다른 길 안내는 스스로 사라진다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    expect(await walkUntilDeadEnd(page), "막다른 길에 닿지 못했다 — 이 시험이 아무것도 안 재고 있다").toBe(true);
+    await expect(page.locator("[data-walk-notice]").first()).toBeVisible({ timeout: 4_000 });
+    // 누르지 않아도 사라진다 — 소유자: *"조금 보여지다 자동으로 사라지게"*.
+    await expect(page.locator("[data-walk-notice]")).toHaveCount(0, { timeout: 6_000 });
+  });
+
+  test("안내가 떠 있어도 계속 걸을 수 있다 — 초점을 빼앗지 않는다", async ({ page }) => {
+    await focusCanvas(page);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
+    expect(await walkUntilDeadEnd(page), "막다른 길에 닿지 못했다 — 이 시험이 아무것도 안 재고 있다").toBe(true);
+    await expect(page.locator("[data-walk-notice]").first()).toBeVisible({ timeout: 4_000 });
+
+    const stillOnCanvas = await page.evaluate(
+      () => document.activeElement?.getAttribute("data-surface-role") === "map-canvas",
+    );
+    expect(stillOnCanvas, "안내가 초점을 가져갔다 — 그러면 방향키가 지도에 도착하지 않는다").toBe(true);
+
+    // 그리고 실제로 걸을 수 있어야 한다. 왔던 방향으로 되돌아가면 이웃이 있다.
+    const before = await selectedId(page);
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(() => selectedId(page), { timeout: 4_000 })
+      .not.toBe(before);
   });
 
   /**


### PR DESCRIPTION
## Summary

소유자 실사용 지적 셋이 **한 원인**이었다 — 앱 공용 토스트로 띄운 것.

| 소유자가 본 것 | 원인 |
|---|---|
| *"이렇게 나오면 모르겠는데?"* | 토스트 자리는 화면 우하단. 막힌 노드에서 500px 떨어진 문장은 방금 누른 것과 이어지지 않는다 |
| *"사라지지도 않고 계속떠있고"* | 닫기 버튼이 초점을 받으면 sonner 가 자동 소멸 시계를 멈춘다 |
| *"x버튼 안누르면 아예 이동도 안됨"* | 초점이 토스트로 넘어가면 방향키가 캔버스에 도착하지 않는다 |

**처방**: 이 안내는 초점을 받을 수 없는 것이어야 한다.

- 위젯이 막힌 노드의 화면 좌표를 사건에 실어 보낸다 (`onWalkDeadEnd(point)`) — 자리를 아는 곳은 거기뿐이다. 좌표 식은 `nodes()` 창구가 쓰는 그것이고 세 번째 사본을 만들지 않았다
- 노드 **바로 위**에 한 줄로, 1.9초 뒤 스스로 사라진다. 버튼 없음 · `pointer-events: none` · `role="status" aria-live="polite"`
- 모션은 이미 있는 기구 — `usePanelPresence` + `overlay-spring-surface`(감속 사용자 `overlay-fade-only`). **새 키프레임 0 · 새 토큰 0**
- 문구 한 줄로 축약 — 노드 옆 작은 안내라 두 문장이 세 줄로 접혔다

실측(1512×982): 노드 (487, 484) · 안내 중심 (519, 423) → 가로 32px · 세로 61px.

## Test plan

- **게이트 셋을 먼저 빨갛게** 만들고 고쳤다(TDD): 자리(노드에서 가로 <280 · 세로 <200) · 자동 소멸(6초 안에 count 0) · 초점 유지(`activeElement` 가 캔버스이고 그 상태에서 실제로 걸을 수 있다). 고치기 전 3/3 빨강 → 후 4/4 초록
- **지속 1100ms 를 시험이 먼저 잡았다** — 여덟 번 누르는 동안 이미 사라져 한 번도 못 봤다. 사람도 같은 처지라 1900ms. 시험은 「뜨는 순간을 기다린다」로 바꿨고, 헬퍼에 「막다른 길에 닿지 못했다」 공회전 차단 단언을 넣었다
- `pnpm test:contracts` 136 파일 · 1,574건 · `pnpm exec vitest run src/widgets/topology-map-v2 src/views/home` 108 파일 · 1,321건
- `pnpm exec playwright test map-keyboard-walk camera-transition` 22건 · `pnpm test:i18n:messages` · `pnpm test:desktop:check` 통과
- `pnpm exec tsc --noEmit` 통과 · eslint 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD