### PR TITLE
test: 훑기를 목적지 전부로 넓히고, 못 재는 종류를 이유와 함께 못박는다

### DIFF
--- a/tests/contract/transient-surface-declaration.contract.test.ts
+++ b/tests/contract/transient-surface-declaration.contract.test.ts
@@ -51,6 +51,20 @@ const declaredKinds = declaringFiles.flatMap((file) =>
   [...readCode(join(REPO_ROOT, file)).matchAll(/transientSurface\("([^"]+)"\)/g)].map(([, kind]) => kind),
 );
 
+/**
+ * **오늘 이 하네스로는 못 재는 종류** — 이유를 여기 적는다 (2026-08-11).
+ *
+ * ⚠️ 이 칸이 비어 있는 것이 이상적이지만, **비어 있는 척하는 것이 더 나쁘다.** 선언만
+ * 해 두고 아무도 재지 않으면 그 선언은 장식이고, 그건 이 변경의 결정 기록에 내가 직접
+ * 적어 둔 반대 의견이다. 그래서 못 재는 것은 「없는 것」이 아니라 **여기 적힌 것**이 된다.
+ *
+ * 줄이는 것은 되고 늘리는 것은 안 된다(아래 래칫).
+ */
+const UNMEASURED_KINDS: Readonly<Record<string, string>> = {
+  menu: "캔버스 오른쪽 클릭으로만 열린다. 볼트를 안 고른 브라우저에서는 지도 위 패널이 캔버스를 덮어 클릭이 120초 타임아웃이 나고, 합성 PointerEvent 는 캔버스의 포인터 파이프라인에 닿지 않는다(2026-08-11 실측 3회). 볼트를 실제로 붙이는 하네스가 생기면 이 줄을 지운다.",
+  hint: "마우스를 올려서만 열린다. 위와 같은 이유로 포인터를 못 보낸다. 그리고 어느 좌표에 대상이 있는지는 그래프가 정하므로, 억지로 열려고 좌표를 훑으면 「없는 것」을 결함으로 신고하게 된다.",
+};
+
 describe("잠깐 뜨는 표면 선언 계약", () => {
   /**
    * 2026-08-11 최초 등재 7곳 — 지도 안내 · 노드 상세 팝오버 · 컨텍스트 메뉴 ·
@@ -96,6 +110,48 @@ describe("잠깐 뜨는 표면 선언 계약", () => {
    * 찾으면(예: 「가장 큰 요소」) 이 선언은 아무 일도 하지 않는 장식이 된다 — 그 방식이
    * 실제로 위반 6건을 헛보고했고, 그래서 이 표시가 생겼다.
    */
+  /**
+   * **선언한 종류마다 그것을 실제로 여는 시험이 있나** — 없으면 이유가 적혀 있어야 한다.
+   * 이 시험이 이 파일의 값어치다: 표시를 붙이는 것만으로는 아무것도 지켜지지 않는다.
+   */
+  it("모든 종류가 재지거나, 못 재는 이유가 적혀 있다", () => {
+    const specs = readdirSync(join(REPO_ROOT, "tests/e2e"))
+      .filter((f) => f.endsWith(".spec.ts"))
+      .map((f) => readCode(join(REPO_ROOT, "tests/e2e", f)))
+      .join("\n");
+    /*
+     * 스윕은 화면에서 종류를 읽으므로 코드에 종류 문자열이 없다. 그래서 스윕이 「반드시
+     * 연다」고 선언한 목록(`SWEEP_MUST_OPEN`)도 함께 읽는다 — 그 목록은 스윕 안에서
+     * 런타임으로 단언되므로 빈말이 될 수 없다.
+     */
+    const sweepDeclared =
+      readCode(join(REPO_ROOT, "tests/e2e/transient-surface-contract.spec.ts")).match(
+        /const SWEEP_MUST_OPEN = \[([^\]]*)\]/,
+      )?.[1] ?? "";
+    const unexercised = KINDS.filter(
+      (kind) =>
+        !specs.includes(`data-transient-surface="${kind}"`) &&
+        !sweepDeclared.includes(`"${kind}"`) &&
+        !(kind in UNMEASURED_KINDS),
+    );
+    expect(
+      unexercised,
+      `선언만 되고 아무 시험도 열지 않는 종류: ${unexercised.join(", ")} — 여는 시험을 쓰거나 UNMEASURED_KINDS 에 이유를 적어라.`,
+    ).toEqual([]);
+  });
+
+  it("못 재는 종류가 늘지 않는다", () => {
+    // 2026-08-11 실측 2종(menu · hint). 늘리려면 그 종류를 재는 방법이 없다는 근거가 필요하다.
+    expect(
+      Object.keys(UNMEASURED_KINDS).length,
+      `못 재는 종류가 ${Object.keys(UNMEASURED_KINDS).length}개로 늘었다 — 재는 하네스를 만드는 쪽이 답이다.`,
+    ).toBeLessThanOrEqual(2);
+    for (const [kind, reason] of Object.entries(UNMEASURED_KINDS)) {
+      expect(KINDS, `.${kind} 는 종류 목록에 없다 — 죽은 면제다`).toContain(kind as TransientSurfaceKind);
+      expect(reason.length, `${kind} 의 이유가 너무 짧다 — 「왜 못 재는가」가 답이어야 한다`).toBeGreaterThan(40);
+    }
+  });
+
   it("스윕이 이 표시로 표면을 찾는다", () => {
     const spec = readCode(join(REPO_ROOT, "tests/e2e/transient-surface-contract.spec.ts"));
     expect(spec, "스윕이 선언 표시를 셀렉터로 쓰지 않는다").toContain(`[${TRANSIENT_SURFACE_ATTR}]`);

--- a/tests/e2e/transient-surface-contract.spec.ts
+++ b/tests/e2e/transient-surface-contract.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { FIRST_RUN_STARTER_DISMISSED_KEY } from "../../src/features/first-run-starter/model/first-run-starter-dismiss";
 
 /**
  * **잠깐 뜨는 표면의 3계약을 전 라우트에서 훑는다** (2026-08-11).
@@ -31,7 +32,30 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * 2026-08 에 릴리스 하나를 잃은 방식이다.
  */
 
-const ROUTES = ["/ko/topology/", "/ko/docs/", "/ko/ontology/insights/"] as const;
+/**
+ * 훑는 라우트 — **목적지 전부**(2026-08-11 확장). 관문 읽을거리(`/guide`·`/changelog`)는
+ * 여닫는 트리거가 0개라 넣어도 아무것도 안 잰다(실측).
+ */
+const ROUTES = [
+  "/ko/",
+  "/ko/topology/",
+  "/ko/docs/",
+  "/ko/ontology/studio/",
+  "/ko/ontology/insights/",
+  "/ko/projects/",
+  "/ko/project/new/",
+  "/ko/skills/",
+  "/ko/git/",
+] as const;
+
+/**
+ * **이 스윕이 반드시 열어야 하는 종류** — 런타임에 단언하고, 선언 계약이 이 줄을 읽는다
+ * (`transient-surface-declaration.contract.test.ts`).
+ *
+ * 스윕은 화면에서 종류를 읽어 오므로 코드에 종류 문자열이 남지 않는다. 그래서 「어느
+ * 종류가 실제로 재지고 있나」를 정적으로 알 방법이 없었다 — 이 줄이 그 구멍을 메운다.
+ */
+const SWEEP_MUST_OPEN = ["sheet"] as const;
 
 const FOCUSLESS = new Set(["notice", "hint"]);
 const NEEDS_ESCAPE = new Set(["anchored", "menu", "sheet"]);
@@ -220,6 +244,18 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
       }
     }
 
+    console.log(
+      `[transient-sweep] 라우트 ${ROUTES.length} · 열어 본 표면 ${opened.length}개 · ` +
+        `종류 ${[...new Set(opened.map((o) => o.kind))].join(",")}`,
+    );
+
+    for (const kind of SWEEP_MUST_OPEN) {
+      expect(
+        opened.map((o) => o.kind),
+        `스윕이 ${kind} 를 한 번도 열지 못했다 — 사정거리가 줄었다`,
+      ).toContain(kind);
+    }
+
     expect(
       opened.length,
       `선언한 표면을 ${opened.length}개만 열었다 — 이 스윕이 공회전한다(표시가 빠졌거나 트리거를 못 눌렀다)`,
@@ -234,6 +270,22 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
   test("키보드로만 나타나는 안내도 초점을 받지 않는다", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await seedFirstRunSeen(page);
+    /*
+     * ⚠️ **「시작하기」 카드를 접어 둔다.** 볼트를 안 고른 브라우저에서는 그 카드가
+     * 캔버스를 덮어 **마우스로 여는 표면에 닿을 수 없다**(실측: `.map-overlay-in` 이
+     * 오른쪽 클릭을 삼키고, 그 클릭이 팝오버까지 닫았다). 키보드는 통과하므로 위의
+     * 걷기 시험들은 영향을 받지 않았고, 그래서 이 구멍이 여태 안 보였다.
+     *
+     * 접는 방법은 제품이 이미 가진 것을 쓴다 — 「그냥 둘러볼게요」가 쓰는 그 키다.
+     * 시험용 우회로를 새로 만들지 않는다.
+     */
+    await page.addInitScript((key: string) => {
+      try {
+        window.sessionStorage.setItem(key, "1");
+      } catch {
+        /* private mode */
+      }
+    }, FIRST_RUN_STARTER_DISMISSED_KEY);
     await page.goto("/ko/topology/?e2e=1&guides=off");
     const canvas = page.getByTestId("topology-map-v2-canvas");
     await canvas.waitFor({ state: "visible", timeout: 20_000 });
@@ -261,5 +313,74 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
     expect(state.tookFocus, "안내가 초점을 가져갔다").toBe(false);
     expect(state.canFocus, "안내 안에 초점을 받을 수 있는 것이 있다 — 그것이 키를 가로챈다").toBe(0);
     expect(state.animated, "안내가 하드컷으로 나타났다").toBe(true);
+  });
+
+  /**
+   * **노드 팝오버(`anchored`)를 실제로 열어 잰다** (2026-08-11).
+   *
+   * ⚠️ 라우트 훑기는 `[aria-expanded]`·`[aria-haspopup]` 트리거로 여는 것만 본다.
+   * 실측: 9라우트에서 열린 표면 8개가 **전부 `sheet`** 였다. 그래서 캔버스 위에서만
+   * 열리는 종류는 여기서 따로 연다 — **선언만 해 두고 아무도 재지 않으면 그 선언은
+   * 장식이다**(이 변경의 결정 기록에 적어 둔 반대 의견이 그것이었다).
+   *
+   * ⚠️ **노드를 마우스로 누르지 않는다.** 볼트를 안 고른 브라우저에서는 지도 위 패널이
+   * 캔버스를 덮어 클릭이 그 패널에 먹힌다(실측: 오른쪽 클릭이 120초 타임아웃, 그리고
+   * 그 클릭이 팝오버까지 닫았다). 방향키로 고르면 같은 팝오버가 열린다 — 사용자 흐름
+   * 으로도 그게 맞고, 이 시험이 재려는 것은 「무엇으로 열었나」가 아니라 「열린 것이
+   * 계약을 지키나」다.
+   */
+  test("노드 팝오버가 부른 것 옆에 서고 Escape 로 닫힌다", async ({ page }) => {
+    test.setTimeout(180_000);
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await seedFirstRunSeen(page);
+    await page.goto("/ko/topology/?e2e=1&guides=off");
+    const canvas = page.getByTestId("topology-map-v2-canvas");
+    await canvas.waitFor({ state: "visible", timeout: 20_000 });
+    await expect
+      .poll(() => page.evaluate(() => window.__atlasMap?.nodes().length ?? 0), { timeout: 20_000 })
+      .toBeGreaterThan(3);
+    await canvas.focus();
+
+    await page.keyboard.press("ArrowRight");
+    const anchored = page.locator('[data-transient-surface="anchored"]').first();
+    await expect(anchored, "노드를 골랐는데 팝오버가 종류를 선언하지 않는다").toBeVisible({ timeout: 8_000 });
+
+    const geom = await page.evaluate(() => {
+      const probe = window.__atlasMap;
+      const id = probe?.selection().nodeId;
+      const node = probe?.nodes().find((n) => n.id === id);
+      const box = document.querySelector('[data-surface-role="map-canvas"]')!.getBoundingClientRect();
+      const el = document.querySelector('[data-transient-surface="anchored"]')!;
+      const surface = el.getBoundingClientRect();
+      if (!node) return null;
+      return {
+        dx: Math.abs(surface.x + surface.width / 2 - (box.x + node.x)),
+        canvasWidth: box.width,
+        animated: (el.getAnimations?.({ subtree: true }) ?? []).length > 0,
+        tookFocus: el.contains(document.activeElement),
+      };
+    });
+    expect(geom, "고른 노드를 못 찾았다 — 이 시험이 공회전한다").not.toBeNull();
+    // 「부른 것 옆」 — 한 화면 반보다 멀면 원인과 이어지지 않는다.
+    expect(geom!.dx, "팝오버가 고른 노드에서 너무 멀다").toBeLessThan(geom!.canvasWidth / 2);
+    /*
+     * `anchored` 는 초점을 받아도 되지만, **방향키로 고른 경우에는 받아선 안 된다** —
+     * 받으면 다음 방향키가 지도에 도착하지 않고, 그게 2026-08-10 결함의 정확한 모양이다.
+     */
+    expect(geom!.tookFocus, "방향키로 열린 팝오버가 초점을 가져갔다 — 다음 걸음이 막힌다").toBe(false);
+
+    /*
+     * ⚠️ **카메라 전환이 끝난 뒤에 닫는다.** 전환 중에 Escape 를 누른 판은 팝오버가
+     * 그대로 남았다(실측). 사람은 지도가 움직이는 동안 닫지 않고, 이 시험이 재려는 것은
+     * 「닫히나」이지 「전환 중에도 닫히나」가 아니다.
+     */
+    await page.waitForTimeout(600);
+    await page.keyboard.press("Escape");
+    await expect(anchored, "Escape 로 팝오버가 닫히지 않는다").toBeHidden({ timeout: 4_000 });
+    // 초점은 캔버스에 남아야 한다 — 여기서는 캔버스가 「부른 것」이다.
+    expect(
+      await page.evaluate(() => document.activeElement?.getAttribute("data-surface-role") === "map-canvas"),
+      "팝오버를 닫고 나서 초점이 지도를 떠났다",
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

훑기가 3라우트였다. **9라우트로 넓히니 열린 표면 8개가 전부 `sheet`** 였다 — 나머지 네 종류(`anchored`·`menu`·`hint`·`notice`)는 선언만 돼 있고 아무도 재지 않았다. #1031 의 결정 기록에 내가 직접 적어 둔 반대 의견(*"표시가 장식이 될 수 있다"*)이 그대로 실현된 상태였다.

| 종류 | 이제 무엇이 재나 |
|---|---|
| `sheet` | 9라우트 훑기 (8개 열림) |
| `notice` | 키보드 걷기 시험 (#1031) |
| **`anchored`** | **신설** — 방향키로 노드 선택 → 팝오버 |
| `menu` · `hint` | **「못 잰다」를 이유와 함께 코드에 박음** |

### 새 시험 — `anchored`

방향키로 노드를 고르면 팝오버가 열린다. 재는 것 셋: 자리(노드에서 한 화면 반 안) · **초점을 안 가져감**(가져가면 다음 걸음이 막힌다 = 2026-08-10 결함의 모양) · Escape 로 닫히고 초점이 지도에 남음.

**마우스로 누르지 않는다**: 볼트를 안 고른 브라우저에서는 지도 위 패널이 캔버스를 덮어 오른쪽 클릭이 **120초 타임아웃**이었고, 그 클릭이 팝오버까지 닫았다. 방향키는 통과하므로 이 구멍이 여태 안 보였다.

### 못 재는 둘을 숨기지 않는다

`menu`(오른쪽 클릭) · `hint`(마우스 올리기)는 합성 `PointerEvent` 가 캔버스의 포인터 파이프라인에 닿지 않아 **오늘 이 하네스로는 열 수 없다**(실측 3회: 실제 클릭 타임아웃 · DOM dispatch 무반응 · 시작하기 카드를 접어도 다른 패널이 덮음). 비어 있는 척하는 것보다 **이유를 적어 두는 것**이 낫고, 그 목록은 게이트가 **늘지 못하게** 막는다(≤2, 이유는 40자 이상, 죽은 면제 금지).

### 스윕이 무엇을 여는지 선언한다

스윕은 화면에서 종류를 읽으므로 코드에 종류 문자열이 남지 않는다 — 정적으로는 「무엇이 재지는지」 알 방법이 없었다. `SWEEP_MUST_OPEN` 을 선언하게 하고(런타임 단언이 붙어 빈말이 될 수 없다), 선언 계약이 그 줄을 읽어 다섯 종류의 사정거리를 판정한다.

## Test plan

- **프로브**: `UNMEASURED_KINDS` 에서 `hint` 를 빼면 「선언만 되고 아무 시험도 열지 않는 종류: hint」 빨강 · 되돌리면 초록
- `pnpm test:contracts` 137 파일 · **1,592건** · `transient-surface-contract.spec.ts` 3건 통과
- 스윕 실측 로그: `라우트 9 · 열어 본 표면 8개 · 종류 sheet` (다음 사람이 사정거리를 눈으로 확인할 수 있게 남겼다)
- `pnpm exec tsc --noEmit` · eslint 0 error

**되짚어 둘 것**: 프로브를 되돌릴 때 `git checkout -- <file>` 을 써서 같은 파일의 새 시험 둘을 날렸다(다시 썼다). 이 저장소의 프로브 절차가 *"되돌릴 때는 그 줄만 고친다"* 라고 경고하는 바로 그 사고다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD