### PR TITLE
style: CLI·MCP 가 찍는 글에서 작대기를 걷는다 — 형식으로 쓰이는 것만 남긴다

### DIFF
--- a/cli/src/commands/absorb.mjs
+++ b/cli/src/commands/absorb.mjs
@@ -89,7 +89,7 @@ export function runAbsorb(args) {
     if (existsSync(backupPath)) {
       process.stderr.write(
         `${COLORS.red}error${COLORS.reset}  backup already exists, refusing to overwrite: ` +
-          `${relative(process.cwd(), backupPath)} — remove or rename it first\n`,
+          `${relative(process.cwd(), backupPath)}: remove or rename it first\n`,
       );
       exitCode = 1;
       continue;
@@ -131,7 +131,7 @@ export function runAbsorb(args) {
       `${totals.injectionSuspect} injection-suspect · ${totals.unclassified} unclassified\n`,
   );
   if (!opts.write && totals.files > 0) {
-    process.stdout.write(`${COLORS.dim}(dry-run — pass --write to actually land the plan)${COLORS.reset}\n`);
+    process.stdout.write(`${COLORS.dim}(dry-run: pass --write to actually land the plan)${COLORS.reset}\n`);
   }
 
   return exitCode;
@@ -152,7 +152,7 @@ function formatSectionLine(section) {
     const patterns = section.injection.matches.map((m) => m.pattern).join(', ');
     return (
       `${COLORS.red}⚠ injection-suspect${COLORS.reset}  ${section.heading} ` +
-      `${COLORS.dim}— matched: ${patterns} (excluded from absorption)${COLORS.reset}`
+      `${COLORS.dim}· matched: ${patterns} (excluded from absorption)${COLORS.reset}`
     );
   }
   if (section.action === 'absorb') {
@@ -167,7 +167,7 @@ function formatSectionLine(section) {
       `${COLORS.dim}→ candidate ${section.kind} · ${section.targetSlug} (not written)${COLORS.reset}`
     );
   }
-  return `${COLORS.dim}skip     ${section.heading} — ${section.reason}${COLORS.reset}`;
+  return `${COLORS.dim}skip     ${section.heading} · ${section.reason}${COLORS.reset}`;
 }
 
 function parseArgs(args) {
@@ -205,10 +205,10 @@ function printUsage(stream = process.stderr) {
       `  ontology-atlas absorb <file...> [--vault path] [--write]\n` +
       `\n` +
       `  CLAUDE.md/AGENTS.md 스타일 markdown 을 typed vault 노드로 변환. 기본값은\n` +
-      `  dry-run — 전환 계획만 출력하고 디스크는 건드리지 않는다. --write 를 주면\n` +
+      `  dry-run: 전환 계획만 출력하고 디스크는 건드리지 않는다. --write 를 주면\n` +
       `  정책/규칙 섹션은 document 노드로 실제 작성되고, 원본은 흡수 요약 + 미흡수\n` +
       `  섹션 원문을 보존한 slim pointer 로 재작성된다 (원본은 .pre-absorb.bak 로 백업).\n` +
-      `  아키텍처/컴포넌트 섹션은 후보 제안만 — 절대 자동 작성하지 않는다.\n` +
+      `  아키텍처/컴포넌트 섹션은 후보 제안만: 절대 자동 작성하지 않는다.\n` +
       `  인젝션 의심 섹션 (Tier 1) 은 흡수에서 제외되고 원문 그대로 pointer 에 남는다.\n` +
       `\n${COLORS.bold}options:${COLORS.reset}\n` +
       `  --vault path    target vault (default: cwd)\n` +

--- a/cli/src/commands/add.mjs
+++ b/cli/src/commands/add.mjs
@@ -83,7 +83,7 @@ export async function runAdd(args) {
     const missing = missingExpectedFields(kind, fm);
     for (const key of missing) {
       process.stderr.write(
-        `${COLORS.yellow}warn${COLORS.reset}  expected field "${key}" missing for kind "${kind}" — add it later with --domain or by editing the file.\n`,
+        `${COLORS.yellow}warn${COLORS.reset}  expected field "${key}" missing for kind "${kind}": add it later with --domain or by editing the file.\n`,
       );
     }
     // [폐기 2026-08-01] 구 R15 「element slug 두 패턴(flat / path-style)」
@@ -211,7 +211,7 @@ function printAddUsage(stream = process.stderr) {
       `  ontology-atlas add <kind> <slug> --title="..." [--domain X] [--path repo/path] [--body "..."] [--vault path] [--raw-slug] [--created-by human|agent:<name>]\n` +
       `\n${COLORS.bold}kind:${COLORS.reset} ${VAULT_KINDS.join(' / ')}\n` +
       `\n${COLORS.bold}slug layout:${COLORS.reset} kind→folder prefix is default (capability foo → capabilities/foo). Use --raw-slug to opt out.\n` +
-      `${COLORS.bold}slug shape:${COLORS.reset} flat under the kind folder — a slug names a role, never a file path (put the path in path:).\n` +
+      `${COLORS.bold}slug shape:${COLORS.reset} flat under the kind folder: a slug names a role, never a file path (put the path in path:).\n` +
       `${COLORS.bold}implementation path:${COLORS.reset} capability/element may carry one repo-relative canonical entrypoint via --path.\n` +
       `${COLORS.bold}created_by:${COLORS.reset} defaults to agent:<heartbeat|unknown> (same stamp as MCP add_concept). A person adding by hand passes --created-by human.\n` +
       `\nExample:\n` +

--- a/cli/src/commands/agent-activity.mjs
+++ b/cli/src/commands/agent-activity.mjs
@@ -632,7 +632,7 @@ async function showActivityLog({ vaultRoot, json, limit }) {
     return 0;
   }
   if (entries.length === 0) {
-    process.stdout.write(`${COLORS.dim}활동 로그가 비어 있어요 — 에이전트가 vault 에 쓰면 여기 기록됩니다.${COLORS.reset}\n`);
+    process.stdout.write(`${COLORS.dim}활동 로그가 비어 있어요: 에이전트가 vault 에 쓰면 여기 기록됩니다.${COLORS.reset}\n`);
     return 0;
   }
   for (const entry of entries) {
@@ -640,6 +640,6 @@ async function showActivityLog({ vaultRoot, json, limit }) {
     const why = entry.why ? `\n      ${COLORS.dim}why: ${entry.why}${COLORS.reset}` : '';
     process.stdout.write(`${COLORS.dim}${entry.at}${COLORS.reset}  ${entry.summary}${COLORS.dim}${agent}${COLORS.reset}${why}\n`);
   }
-  process.stdout.write(`${COLORS.dim}— ${entries.length}건 (최신순 아래) · 승인은 git diff 로${COLORS.reset}\n`);
+  process.stdout.write(`${COLORS.dim}· ${entries.length}건 (최신순 아래) · 승인은 git diff 로${COLORS.reset}\n`);
   return 0;
 }

--- a/cli/src/commands/agent-brief.mjs
+++ b/cli/src/commands/agent-brief.mjs
@@ -607,7 +607,7 @@ function render(result) {
   const rc = READINESS_COLORS[readiness.status] ?? COLORS.dim;
   process.stdout.write(
     `${COLORS.bold}agent brief${COLORS.reset} ${sc}${status}${COLORS.reset}` +
-      ` ${COLORS.dim}— readiness ${rc}${readiness.status}${COLORS.reset}` +
+      ` ${COLORS.dim}· readiness ${rc}${readiness.status}${COLORS.reset}` +
       ` ${COLORS.dim}${readiness.score}/100 · ${graph.nodes ?? 0} 노드 · ${graph.edges ?? 0} 관계` +
       ` · ${readiness.healthChecks} health checks${COLORS.reset}\n\n`,
   );
@@ -654,7 +654,7 @@ function render(result) {
     for (let i = 0; i < Math.min(entrypoints.length, 5); i += 1) {
       const node = entrypoints[i];
       const kc = KIND_COLORS[node.kind] || COLORS.dim;
-      const titleText = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+      const titleText = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
       process.stdout.write(
         `  ${String(i + 1).padStart(2)} ${kc}${node.slug.padEnd(48)}${COLORS.reset}` +
           `${titleText} ${COLORS.dim}deg ${node.degree}${COLORS.reset}\n`,
@@ -944,14 +944,14 @@ function printUsage(stream = process.stderr) {
       `${COLORS.bold}Exit code${COLORS.reset} (readiness signal, not success/failure):\n` +
       `  0 = ready and healthy. 1 = the command ran and printed valid data, but graph\n` +
       `  readiness is "needs_attention"/"needs_shape", a health check failed, or a\n` +
-      `  fail-severity nextAction is present — this is advisory graph state, NOT a\n` +
+      `  fail-severity nextAction is present: this is advisory graph state, NOT a\n` +
       `  command failure. 2 = the MCP call itself failed (parse/connection error).\n` +
       `  Naive \`agent-brief && next-step\` scripting misreads exit 1 as failure the\n` +
-      `  first time a vault has any warning — pass --exit-zero to always exit 0 and\n` +
+      `  first time a vault has any warning: pass --exit-zero to always exit 0 and\n` +
       `  read readiness/status from the JSON output instead (parse/MCP-call errors\n` +
-      `  still exit 1/2 even with --exit-zero — only the readiness-driven part is silenced).\n` +
+      `  still exit 1/2 even with --exit-zero: only the readiness-driven part is silenced).\n` +
       `  --verify-fallbacks --exit-zero still exits 1 when a generated fallback command\n` +
-      `  itself fails to run — that is a real failure, not a readiness signal.\n\n` +
+      `  itself fails to run: that is a real failure, not a readiness signal.\n\n` +
       `Tuning flags forward to query_ontology agent_brief for focused diagnostics.\n`,
   );
 }

--- a/cli/src/commands/agent-files.mjs
+++ b/cli/src/commands/agent-files.mjs
@@ -29,7 +29,7 @@ const ROOT_FILE_CANDIDATES = Object.freeze([
   '.github/copilot-instructions.md',
 ]);
 
-/** Directories walked recursively — the only dot-dirs this command touches. */
+/** Directories walked recursively: the only dot-dirs this command touches. */
 const SCAN_DIRS = Object.freeze([
   '.claude/rules',
   '.claude/skills',
@@ -90,7 +90,7 @@ function buildAgentFilesReport(parsed) {
   };
 }
 
-/** Scan only the known agent-file patterns — never the whole disk (local-first). */
+/** Scan only the known agent-file patterns: never the whole disk (local-first). */
 function scanAgentFiles(root) {
   const entries = [];
   for (const candidate of ROOT_FILE_CANDIDATES) {
@@ -174,11 +174,11 @@ const CODEX_HEADROOM_WARN_RATIO = 0.1;
 function renderCodexHeadroom(check) {
   if (!check || check.agentsMdBytes === null || check.status === 'not-applicable') return;
   const headroom = check.capBytes - check.agentsMdBytes;
-  if (headroom <= 0) return; // 이미 drift 로 보고된다 — 두 번 말하지 않는다
+  if (headroom <= 0) return; // 이미 drift 로 보고된다: 두 번 말하지 않는다
   if (headroom > check.capBytes * CODEX_HEADROOM_WARN_RATIO) return;
   process.stdout.write(
     `${COLORS.yellow}near cap${COLORS.reset} ${COLORS.dim}AGENTS.md ${check.agentsMdBytes} / ${check.capBytes} bytes` +
-      ` — ${headroom} bytes of headroom before Codex silently truncates${COLORS.reset}\n`,
+      ` · ${headroom} bytes of headroom before Codex silently truncates${COLORS.reset}\n`,
   );
 }
 
@@ -188,7 +188,7 @@ function render(result) {
   const color = summary.driftCount === 0 ? COLORS.green : COLORS.yellow;
   process.stdout.write(
     `${color}${COLORS.bold}${status}${COLORS.reset} ${COLORS.dim}agent files${COLORS.reset}` +
-      ` — ${summary.files} file(s) · ${summary.driftCount} drift finding(s)\n`,
+      ` · ${summary.files} file(s) · ${summary.driftCount} drift finding(s)\n`,
   );
   process.stdout.write(`${COLORS.dim}root${COLORS.reset} ${result.root}\n`);
   renderCodexHeadroom(result.checks?.codexSizeCap);
@@ -249,7 +249,7 @@ function render(result) {
       );
     }
     process.stdout.write(
-      `\n${COLORS.dim}Read-only detection — fix files by hand (or with your agent); this command never rewrites them.${COLORS.reset}\n`,
+      `\n${COLORS.dim}Read-only detection: fix files by hand (or with your agent); this command never rewrites them.${COLORS.reset}\n`,
     );
   }
 }

--- a/cli/src/commands/agent-setup.mjs
+++ b/cli/src/commands/agent-setup.mjs
@@ -174,7 +174,7 @@ function installPreCommitHook(codebaseRoot) {
         ? 'created pre-commit hook running `ontology-atlas preflight --staged`'
         : action === 'appended'
           ? 'appended the preflight block to your existing pre-commit hook (existing hook body preserved)'
-          : 'pre-commit hook already runs ontology-atlas preflight — left untouched',
+          : 'pre-commit hook already runs ontology-atlas preflight: left untouched',
   };
 }
 
@@ -402,7 +402,7 @@ function render(result) {
   const color = status === 'ready' ? COLORS.green : COLORS.yellow;
   process.stdout.write(
     `${color}${COLORS.bold}${status}${COLORS.reset} ${COLORS.dim}agent setup${COLORS.reset}` +
-      ` — ${summary.ready}/${summary.total} ready` +
+      ` · ${summary.ready}/${summary.total} ready` +
       ` · ${summary.missing} missing · ${summary.review} review` +
       (result.sideEffect ? ` · ${summary.written} written · ${summary.examples} example(s)` : '') +
       `\n`,
@@ -429,18 +429,18 @@ function render(result) {
   process.stdout.write(`  ${COLORS.cyan}${result.commands.setupGate}${COLORS.reset}\n`);
   process.stdout.write(`  ${COLORS.dim}Global Codex fallback: ${result.commands.codexGlobal}${COLORS.reset}\n`);
   process.stdout.write(`  ${COLORS.dim}Other MCP client (opencode, custom harness, ...): register ${result.commands.genericClient}${COLORS.reset}\n`);
-  process.stdout.write(`  ${COLORS.dim}Feature guide: ${result.docs.workflowGuide} — ${result.docs.workflowGuideDescription}${COLORS.reset}\n`);
+  process.stdout.write(`  ${COLORS.dim}Feature guide: ${result.docs.workflowGuide} · ${result.docs.workflowGuideDescription}${COLORS.reset}\n`);
   process.stdout.write(`\n${COLORS.bold}Read-first graph runbook:${COLORS.reset}\n`);
   for (const command of result.commands.graphRunbook) {
     process.stdout.write(`  ${COLORS.cyan}${command}${COLORS.reset}\n`);
   }
   process.stdout.write(`\n${COLORS.bold}Mode guide:${COLORS.reset}\n`);
   for (const mode of result.docs.modeComparison) {
-    process.stdout.write(`  ${COLORS.cyan}${mode.label}${COLORS.reset} — ${mode.gives}\n`);
+    process.stdout.write(`  ${COLORS.cyan}${mode.label}${COLORS.reset} · ${mode.gives}\n`);
   }
   process.stdout.write(`\n${COLORS.bold}First-contact proof contract:${COLORS.reset}\n`);
   for (const proof of result.docs.firstContactProofContract) {
-    process.stdout.write(`  ${COLORS.cyan}${proof.label}${COLORS.reset} — ${proof.proves}\n`);
+    process.stdout.write(`  ${COLORS.cyan}${proof.label}${COLORS.reset} · ${proof.proves}\n`);
   }
   process.stdout.write(`\n${COLORS.bold}After code changes:${COLORS.reset}\n`);
   for (const rule of result.docs.postChangeSync) {
@@ -586,7 +586,7 @@ function printUsage(stream = process.stderr) {
       `  \`ontology-atlas preflight --staged\` before every commit. If a pre-commit\n` +
       `  hook already exists, the block is appended (your existing hook body is\n` +
       `  preserved); if our block is already present, nothing changes. The hook\n` +
-      `  is purely informational and never fails the commit — \`git commit\n` +
+      `  is purely informational and never fails the commit: \`git commit\n` +
       `  --no-verify\` still skips it like any other hook.\n`,
   );
 }

--- a/cli/src/commands/all-paths.mjs
+++ b/cli/src/commands/all-paths.mjs
@@ -112,7 +112,7 @@ function printHuman(result) {
     : '';
   process.stdout.write(
     `${COLORS.bold}${result.from}${COLORS.reset} ${COLORS.dim}⇄${COLORS.reset} ${COLORS.bold}${result.to}${COLORS.reset}` +
-      ` ${COLORS.dim}— all_paths maxHops=${result.maxHops} limit=${result.limit} searchBudget=${result.searchBudget}${typeLabel}${COLORS.reset}\n`,
+      ` ${COLORS.dim}· all_paths maxHops=${result.maxHops} limit=${result.limit} searchBudget=${result.searchBudget}${typeLabel}${COLORS.reset}\n`,
   );
   process.stdout.write(
     `  ${COLORS.bold}evidence${COLORS.reset} ${evidenceColor}${result.evidence.status}${COLORS.reset}` +
@@ -156,7 +156,7 @@ function formatHop(node) {
   if (!node?.title || node.title === node.slug) {
     return `${COLORS.cyan}${node.slug}${COLORS.reset}`;
   }
-  return `${COLORS.cyan}${node.slug}${COLORS.reset} ${COLORS.dim}— ${node.title}${COLORS.reset}`;
+  return `${COLORS.cyan}${node.slug}${COLORS.reset} ${COLORS.dim}· ${node.title}${COLORS.reset}`;
 }
 
 function parseArgs(args) {

--- a/cli/src/commands/analyze.mjs
+++ b/cli/src/commands/analyze.mjs
@@ -93,7 +93,7 @@ export async function runAnalyze(args) {
 
   if (proj) {
     process.stdout.write(
-      `  ${KIND_COLOR.project}project${COLORS.reset}     ${proj.slug} ${COLORS.dim}— ${proj.title}${COLORS.reset}\n\n`,
+      `  ${KIND_COLOR.project}project${COLORS.reset}     ${proj.slug} ${COLORS.dim}· ${proj.title}${COLORS.reset}\n\n`,
     );
   }
 
@@ -124,7 +124,7 @@ export async function runAnalyze(args) {
   }
 
   process.stdout.write(
-    `${COLORS.dim}side effect 0 — vault 변경 안 함. 후보가 맞으면${COLORS.reset} ` +
+    `${COLORS.dim}side effect 0: vault 변경 안 함. 후보가 맞으면${COLORS.reset} ` +
       `${COLORS.bold}ontology-atlas add${COLORS.reset} ` +
       `${COLORS.dim}또는 AI agent 의 add_concept 로 명시 작성.${COLORS.reset}\n`,
   );
@@ -285,14 +285,14 @@ async function runApply(vaultRoot, result, json) {
   conceptRows.forEach((row, index) => {
     if (row.ok === false) {
       process.stdout.write(
-        `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index)} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index)} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
       );
     }
   });
   relationRows.forEach((row, index) => {
     if (row.ok === false) {
       process.stdout.write(
-        `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index)} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index)} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
       );
     }
   });
@@ -350,9 +350,9 @@ function printUsage(stream = process.stderr) {
       `${COLORS.bold}What it does:${COLORS.reset}\n` +
       `  Walk a code repository (default: cwd), detect package.json / README\n` +
       `  H2 sections / src/ folders, propose ontology node candidates.\n` +
-      `  Default: ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함, 후보만 출력.\n` +
+      `  Default: ${COLORS.bold}side effect 0${COLORS.reset}: vault 변경 안 함, 후보만 출력.\n` +
       `  ${COLORS.bold}--apply${COLORS.reset}: 후보를 vault 에 batch land (add_concepts + add_relations).\n` +
-      `  partial result — 이미 존재하는 노드는 skip, 새 노드만 land.\n` +
+      `  partial result: 이미 존재하는 노드는 skip, 새 노드만 land.\n` +
       `  ${COLORS.bold}--max-depth N${COLORS.reset}: default 2, range 0-${MAX_DEPTH_CAP}.\n\n` +
       `${COLORS.bold}Examples:${COLORS.reset}\n` +
       `  ontology-atlas analyze                 # preview only (no writes)\n` +

--- a/cli/src/commands/backlinks.mjs
+++ b/cli/src/commands/backlinks.mjs
@@ -48,11 +48,11 @@ export async function runBacklinks(args) {
   }
 
   process.stdout.write(
-    `${COLORS.bold}${slug}${COLORS.reset} ${COLORS.dim}— ${matches.length} backlink(s)${COLORS.reset}\n\n`,
+    `${COLORS.bold}${slug}${COLORS.reset} ${COLORS.dim}· ${matches.length} backlink(s)${COLORS.reset}\n\n`,
   );
   for (const bl of matches) {
     const keys = Array.isArray(bl.matchedKeys) ? bl.matchedKeys.join(', ') : '';
-    const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}— ${bl.title}${COLORS.reset}` : '';
+    const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}· ${bl.title}${COLORS.reset}` : '';
     process.stdout.write(
       `  ${COLORS.cyan}${bl.kind ?? '?'}${COLORS.reset}  ` +
         `${bl.slug}${titleText}` +

--- a/cli/src/commands/blast-radius.mjs
+++ b/cli/src/commands/blast-radius.mjs
@@ -101,7 +101,7 @@ function render(result, requestedSlug) {
   const risk = result?.risk ?? 'unknown';
   const rc = RISK_COLORS[risk] || COLORS.dim;
   process.stdout.write(
-    `${COLORS.bold}${requestedSlug}${COLORS.reset} ${COLORS.dim}— blast radius${COLORS.reset}` +
+    `${COLORS.bold}${requestedSlug}${COLORS.reset} ${COLORS.dim}· blast radius${COLORS.reset}` +
       ` ${COLORS.dim}(depth ${result?.depth ?? 2}, ${result?.direction ?? 'incoming'})${COLORS.reset}\n` +
       `  risk ${rc}${risk}${COLORS.reset}` +
       ` · ${sum.affectedNodes ?? 0} 노드 · ${sum.affectedEdges ?? 0} 관계` +
@@ -139,7 +139,7 @@ function render(result, requestedSlug) {
       const kind = r.node?.kind ?? '?';
       const kc = KIND_COLORS[kind] || COLORS.dim;
       const dist = `${COLORS.dim}d${r.distance}${COLORS.reset}`;
-      const titleText = r.node?.title && r.node.title !== r.slug ? ` ${COLORS.dim}— ${r.node.title}${COLORS.reset}` : '';
+      const titleText = r.node?.title && r.node.title !== r.slug ? ` ${COLORS.dim}· ${r.node.title}${COLORS.reset}` : '';
       process.stdout.write(`  ${dist} ${kc}${r.slug}${COLORS.reset}${titleText}\n`);
     }
     printNextImpact(rows, requestedSlug, result?.depth ?? 2);
@@ -152,7 +152,7 @@ function printNextImpact(rows, requestedSlug, depth) {
   const planDepth = Math.max(0, Math.min(DEPTH_CAP, Number.isInteger(depth) ? depth : 2));
   process.stdout.write(
     `\n${COLORS.bold}next impact${COLORS.reset} ${COLORS.cyan}${focus.slug}${COLORS.reset}` +
-      ` ${COLORS.dim}— impact rows are candidates, not proof; inspect backlinks and node detail before refactor decisions${COLORS.reset}\n` +
+      ` ${COLORS.dim}· impact rows are candidates, not proof; inspect backlinks and node detail before refactor decisions${COLORS.reset}\n` +
       `  ontology-atlas node ${focus.slug} [vault] --limit 20\n` +
       `  ontology-atlas backlinks ${requestedSlug} [vault]\n` +
       `  ontology-atlas reachability ${requestedSlug} [vault] --plan --depth ${planDepth} --direction both --limit 20\n`,

--- a/cli/src/commands/bootstrap.mjs
+++ b/cli/src/commands/bootstrap.mjs
@@ -232,11 +232,11 @@ export async function runBootstrap(args) {
     const onlyReadme = domainSplit.corroborated.length === 0;
     process.stdout.write(
       `                ${COLORS.yellow}README 제목 ${heldReadmeDomains.length}개는 심지 않고 검토 후보로 남김${COLORS.reset}` +
-        `${COLORS.dim} — 문서 절이지 도메인이 아닐 수 있어요. 그대로 심으려면 --apply-readme-domains${COLORS.reset}\n`,
+        `${COLORS.dim} · 문서 절이지 도메인이 아닐 수 있어요. 그대로 심으려면 --apply-readme-domains${COLORS.reset}\n`,
     );
     if (onlyReadme) {
       process.stdout.write(
-        `                ${COLORS.dim}코드에서 구조를 못 찾았어요(하위 폴더 없는 src 등) — 도메인 확정은 에이전트/공방에서 하는 편이 맞아요.${COLORS.reset}\n`,
+        `                ${COLORS.dim}코드에서 구조를 못 찾았어요(하위 폴더 없는 src 등): 도메인 확정은 에이전트/공방에서 하는 편이 맞아요.${COLORS.reset}\n`,
       );
     }
     for (const d of heldReadmeDomains.slice(0, 12)) {
@@ -260,7 +260,7 @@ export async function runBootstrap(args) {
     process.stdout.write(
       `  ${COLORS.bold}2) imports${COLORS.reset}    ` +
         `${COLORS.yellow}${importReviewCandidates.length}${COLORS.reset} review candidates · ` +
-        `${COLORS.dim}0 automatic semantic writes — rationale review required${COLORS.reset}` +
+        `${COLORS.dim}0 automatic semantic writes: rationale review required${COLORS.reset}` +
         (thr
           ? ` ${COLORS.dim}(--threshold ${thr.threshold} filtered ${thr.filteredOut})${COLORS.reset}`
           : '') +
@@ -275,7 +275,7 @@ export async function runBootstrap(args) {
     if (row.ok === false) {
       if (errCount < 12) {
         process.stdout.write(
-          `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index, 'concept')} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+          `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index, 'concept')} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
         );
       }
       errCount += 1;
@@ -285,7 +285,7 @@ export async function runBootstrap(args) {
     if (row.ok === false) {
       if (errCount < 12) {
         process.stdout.write(
-          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'suggested')} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'suggested')} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
         );
       }
       errCount += 1;
@@ -295,7 +295,7 @@ export async function runBootstrap(args) {
     if (row.ok === false) {
       if (errCount < 12) {
         process.stdout.write(
-          `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index, 'import endpoint')} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+          `  ${COLORS.red}✗${COLORS.reset} ${formatConceptBatchFailureLabel(row, index, 'import endpoint')} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
         );
       }
       errCount += 1;
@@ -305,7 +305,7 @@ export async function runBootstrap(args) {
     if (row.ok === false) {
       if (errCount < 12) {
         process.stdout.write(
-          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'import containment')} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'import containment')} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
         );
       }
       errCount += 1;
@@ -315,7 +315,7 @@ export async function runBootstrap(args) {
     if (row.ok === false) {
       if (errCount < 12) {
         process.stdout.write(
-          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'import')} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+          `  ${COLORS.red}✗${COLORS.reset} ${formatRelationBatchFailureLabel(row, index, 'import')} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
         );
       }
       errCount += 1;

--- a/cli/src/commands/compile.mjs
+++ b/cli/src/commands/compile.mjs
@@ -259,7 +259,7 @@ function renderArtifact(artifact) {
   }
   if (actions > 0) {
     process.stdout.write(
-      `\n${COLORS.yellow}reorder available${COLORS.reset} — run with ${COLORS.bold}--fix${COLORS.reset} to canonicalize relation arrays.\n`,
+      `\n${COLORS.yellow}reorder available${COLORS.reset}: run with ${COLORS.bold}--fix${COLORS.reset} to canonicalize relation arrays.\n`,
     );
   }
 }

--- a/cli/src/commands/components.mjs
+++ b/cli/src/commands/components.mjs
@@ -75,7 +75,7 @@ function assertComponentsShape(result) {
 function render(result) {
   process.stdout.write(
     `${COLORS.bold}graph components${COLORS.reset}` +
-      ` ${COLORS.dim}— ${result.totalComponents} islands · largest ${result.largestSize}` +
+      ` ${COLORS.dim}· ${result.totalComponents} islands · largest ${result.largestSize}` +
       ` · singletons ${result.singletonCount}${result.limited ? ' · limited' : ''}${COLORS.reset}\n\n`,
   );
   for (const component of result.components) {
@@ -90,7 +90,7 @@ function render(result) {
         '\n',
     );
     for (const node of Array.isArray(component.nodes) ? component.nodes : []) {
-      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
       process.stdout.write(`  ${COLORS.cyan}${node.slug}${COLORS.reset}${title} ${COLORS.dim}${node.kind}${COLORS.reset}\n`);
     }
     process.stdout.write('\n');

--- a/cli/src/commands/connect-source.mjs
+++ b/cli/src/commands/connect-source.mjs
@@ -139,7 +139,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n`
     + `  ontology-atlas connect-source <projectSlug> [vault] [--root path] [--confirm] [--repair] [--json]\n\n`
-    + `${COLORS.bold}Default${COLORS.reset} dry-run — proposes a folder and reports how many declared\n`
+    + `${COLORS.bold}Default${COLORS.reset} dry-run: proposes a folder and reports how many declared\n`
     + `        \`path:\` claims actually exist inside it. Nothing is written.\n`
     + `${COLORS.bold}--root${COLORS.reset}    bind this folder instead of the inferred one (also replaces an existing binding)\n`
     + `${COLORS.bold}--confirm${COLORS.reset} write the binding + receipt to .ontology-atlas/project-sources.json (gitignored)\n`

--- a/cli/src/commands/cycles.mjs
+++ b/cli/src/commands/cycles.mjs
@@ -48,7 +48,7 @@ export async function runCycles(args) {
   const cycles = Array.isArray(result?.cycles) ? result.cycles : [];
   const total = result?.totalCycles ?? cycles.length;
   if (total === 0) {
-    process.stdout.write(`${COLORS.green}cycles 0 — dependency graph clean ✓${COLORS.reset}\n`);
+    process.stdout.write(`${COLORS.green}cycles 0: dependency graph clean ✓${COLORS.reset}\n`);
     return 0;
   }
   process.stdout.write(
@@ -80,7 +80,7 @@ function printNextCycle(cycle, maxDepth) {
   process.stdout.write(
     `${COLORS.bold}next cycle${COLORS.reset} ${COLORS.cyan}${from}${COLORS.reset}` +
       ` ${COLORS.dim}→${COLORS.reset} ${COLORS.cyan}${to}${COLORS.reset}` +
-      ` ${COLORS.dim}— cycle rows are failures, but fix the edge only after inspecting path evidence and maintenance guidance${COLORS.reset}\n` +
+      ` ${COLORS.dim}· cycle rows are failures, but fix the edge only after inspecting path evidence and maintenance guidance${COLORS.reset}\n` +
       `  ontology-atlas path ${from} ${to} [vault] --max-hops ${boundedMaxHops}\n` +
       `  ontology-atlas match-edges [vault] --from ${from} --to ${to} --types depends_on --limit 10\n` +
       `  ontology-atlas maintenance [vault] --phases repair --severities fail --kinds break_dependency_cycle --limit 3\n`,
@@ -88,7 +88,7 @@ function printNextCycle(cycle, maxDepth) {
 }
 
 function formatCycleNode(slug, summary) {
-  const title = summary?.title && summary.title !== slug ? ` ${COLORS.dim}— ${summary.title}${COLORS.reset}` : '';
+  const title = summary?.title && summary.title !== slug ? ` ${COLORS.dim}· ${summary.title}${COLORS.reset}` : '';
   return `${COLORS.yellow}${slug}${COLORS.reset}${title}`;
 }
 

--- a/cli/src/commands/delete.mjs
+++ b/cli/src/commands/delete.mjs
@@ -47,10 +47,10 @@ export async function runDelete(args) {
     process.stdout.write(
       `${COLORS.yellow}dry-run${COLORS.reset}  ` +
         `delete ${COLORS.bold}${slug}${COLORS.reset} ` +
-        `${COLORS.dim}(${backlinks.length} backlink(s)${backlinks.length > 0 ? ' — would block without --force' : ''})${COLORS.reset}\n`,
+        `${COLORS.dim}(${backlinks.length} backlink(s)${backlinks.length > 0 ? ': would block without --force' : ''})${COLORS.reset}\n`,
     );
     for (const bl of backlinks) {
-      const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}— ${bl.title}${COLORS.reset}` : '';
+      const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}· ${bl.title}${COLORS.reset}` : '';
       process.stdout.write(
         `  ${COLORS.cyan}${bl.slug}${COLORS.reset}${titleText}` +
           (Array.isArray(bl.matchedKeys)
@@ -94,7 +94,7 @@ export async function runDelete(args) {
   );
   process.stdout.write(formatCapturedSummary(result?.captured, 'deleted node', COLORS));
   for (const bl of backlinksAtDelete) {
-    const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}— ${bl.title}${COLORS.reset}` : '';
+    const titleText = bl.title && bl.title !== bl.slug ? ` ${COLORS.dim}· ${bl.title}${COLORS.reset}` : '';
     process.stdout.write(
       `  ${COLORS.cyan}${bl.slug}${COLORS.reset}${titleText}` +
         (Array.isArray(bl.matchedKeys)
@@ -138,7 +138,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
       `  ontology-atlas delete <slug> [vault] [--confirm] [--force] [--json]\n\n` +
-      `${COLORS.bold}Default${COLORS.reset} dry-run — preview backlinks.\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run: preview backlinks.\n` +
       `${COLORS.bold}--confirm${COLORS.reset}  apply (refuses if backlinks exist)\n` +
       `${COLORS.bold}--force${COLORS.reset}    delete even with backlinks (use carefully)\n\n` +
       `${COLORS.bold}Example:${COLORS.reset}\n` +

--- a/cli/src/commands/disconnect-source.mjs
+++ b/cli/src/commands/disconnect-source.mjs
@@ -44,7 +44,7 @@ export async function runDisconnectSource(args) {
   const bindings = Array.isArray(result.bindings) ? result.bindings : [];
   if (bindings.length === 0) {
     process.stdout.write(
-      `${COLORS.dim}nothing to disconnect — ${result.projectSlug} has no source binding.${COLORS.reset}\n`,
+      `${COLORS.dim}nothing to disconnect: ${result.projectSlug} has no source binding.${COLORS.reset}\n`,
     );
     return 0;
   }
@@ -96,7 +96,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n`
     + `  ontology-atlas disconnect-source <projectSlug> [vault] [--confirm] [--json]\n\n`
-    + `${COLORS.bold}Default${COLORS.reset} dry-run — lists the binding that would be removed.\n`
+    + `${COLORS.bold}Default${COLORS.reset} dry-run: lists the binding that would be removed.\n`
     + `${COLORS.bold}--confirm${COLORS.reset} remove it. Other projects' bindings are untouched.\n\n`
     + `${COLORS.bold}Example:${COLORS.reset}\n`
     + `  ontology-atlas disconnect-source my-product docs/ontology\n`

--- a/cli/src/commands/domain-matrix.mjs
+++ b/cli/src/commands/domain-matrix.mjs
@@ -79,7 +79,7 @@ function render(result) {
     process.stdout.write(`${COLORS.dim}DOMAINS${COLORS.reset}\n`);
     for (const domain of result.domains) {
       const title = domain.node.title && domain.node.title !== domain.slug
-        ? ` ${COLORS.dim}— ${domain.node.title}${COLORS.reset}`
+        ? ` ${COLORS.dim}· ${domain.node.title}${COLORS.reset}`
         : '';
       process.stdout.write(
         `  ${COLORS.blue}${domain.slug}${COLORS.reset}${title}` +
@@ -122,7 +122,7 @@ function render(result) {
     process.stdout.write(
       `\n${COLORS.dim}next${COLORS.reset} coupling ${COLORS.bold}${focus.from}${COLORS.reset}` +
         ` ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${focus.to}${COLORS.reset}` +
-        `${COLORS.dim} — matrix rows are hotspots, not proof; inspect matching edges before boundary decisions${COLORS.reset}\n`,
+        `${COLORS.dim} · matrix rows are hotspots, not proof; inspect matching edges before boundary decisions${COLORS.reset}\n`,
     );
     process.stdout.write(
       `  ${COLORS.cyan}ontology-atlas match-edges [vault] --from ${example.from} --to ${example.to} --types ${relationLabel} --limit 20${COLORS.reset}\n`,

--- a/cli/src/commands/explain.mjs
+++ b/cli/src/commands/explain.mjs
@@ -137,7 +137,7 @@ function renderNextRelation(result, query) {
   process.stdout.write(
     `\n${COLORS.bold}next relation${COLORS.reset} ${COLORS.cyan}${query.from}${COLORS.reset}` +
       ` ${COLORS.dim}→${COLORS.reset} ${COLORS.cyan}${query.to}${COLORS.reset}` +
-      ` ${COLORS.dim}— explanation is evidence, not write approval; run path and preflight before changing graph${COLORS.reset}\n` +
+      ` ${COLORS.dim}· explanation is evidence, not write approval; run path and preflight before changing graph${COLORS.reset}\n` +
       `  ontology-atlas path ${query.from} ${query.to} [vault] --max-hops ${maxHops}\n` +
       `  ontology-atlas match-edges [vault] --from ${query.from} --to ${query.to} --types ${typeList} --limit 10\n` +
       `  ontology-atlas relation-check ${query.from} ${query.to} ${relationType} [vault]\n`,
@@ -154,7 +154,7 @@ function formatEdgeList(edges) {
 
 function formatNode(node) {
   if (!node?.title || node.title === node.slug) return `${COLORS.cyan}${node?.slug ?? '(unknown)'}${COLORS.reset}`;
-  return `${COLORS.cyan}${node.slug}${COLORS.reset} ${COLORS.dim}— ${node.title}${COLORS.reset}`;
+  return `${COLORS.cyan}${node.slug}${COLORS.reset} ${COLORS.dim}· ${node.title}${COLORS.reset}`;
 }
 
 function formatVerdict(verdict) {

--- a/cli/src/commands/export.mjs
+++ b/cli/src/commands/export.mjs
@@ -133,8 +133,8 @@ function printUsage(stream = process.stderr) {
       `  ontology-atlas export [vault] [--format jsonld|graphml|json]\n\n` +
       `Export the compiled ontology to a portable interchange format.\n\n` +
       `Options:\n` +
-      `  --format jsonld   RDF 1.1 JSON-LD — rdflib / Protégé / triplestores (default)\n` +
-      `  --format graphml  XML graph — Gephi / Cytoscape / NetworkX\n` +
+      `  --format jsonld   RDF 1.1 JSON-LD: rdflib / Protégé / triplestores (default)\n` +
+      `  --format graphml  XML graph: Gephi / Cytoscape / NetworkX\n` +
       `  --format json     raw deterministic compile artifact (nodes/edges/graphHash)\n` +
       `  --vault path      vault root (default: cwd or OATLAS_VAULT)\n\n` +
       `The payload is written to stdout (pipe-safe); status goes to stderr.\n` +

--- a/cli/src/commands/facets.mjs
+++ b/cli/src/commands/facets.mjs
@@ -75,7 +75,7 @@ function render(result) {
   const graph = result.graph;
   process.stdout.write(
     `${COLORS.bold}graph facets${COLORS.reset}` +
-      ` ${COLORS.dim}— ${graph.nodes} nodes · ${graph.edges} edges` +
+      ` ${COLORS.dim}· ${graph.nodes} nodes · ${graph.edges} edges` +
       ` · resolved ${graph.resolvedEdges} · external ${graph.externalEdges}` +
       `${graph.unresolvedEdges ? ` · unresolved ${graph.unresolvedEdges}` : ''}${COLORS.reset}\n\n`,
   );
@@ -90,7 +90,7 @@ function render(result) {
   if (topNodes.length > 0) {
     process.stdout.write(`${COLORS.dim}top degree${COLORS.reset}\n`);
     for (const node of topNodes) {
-      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
       process.stdout.write(
         `  ${COLORS.cyan}${node.slug}${COLORS.reset}${title}` +
           ` ${COLORS.dim}${node.kind} · degree ${node.degree ?? ((node.inDegree ?? 0) + (node.outDegree ?? 0))}${COLORS.reset}\n`,

--- a/cli/src/commands/find.mjs
+++ b/cli/src/commands/find.mjs
@@ -100,7 +100,7 @@ export function runFind(args) {
   }
 
   console.log(
-    `${COLORS.bold}"${query}"${COLORS.reset} ${COLORS.dim}— ${matches.length} 매칭${kindFilter ? ` (kind=${kindFilter})` : ''}${COLORS.reset}\n`,
+    `${COLORS.bold}"${query}"${COLORS.reset} ${COLORS.dim}· ${matches.length} 매칭${kindFilter ? ` (kind=${kindFilter})` : ''}${COLORS.reset}\n`,
   );
   for (const m of matches) {
     const color = KIND_COLORS[m.kind] || '';

--- a/cli/src/commands/growth.mjs
+++ b/cli/src/commands/growth.mjs
@@ -64,7 +64,7 @@ function renderGrowth(result) {
   const summary = result.summary;
   process.stdout.write(
     `${COLORS.bold}growth plan${COLORS.reset}` +
-      ` ${COLORS.dim}— ${summary.totalActions} actions${COLORS.reset}\n`,
+      ` ${COLORS.dim}· ${summary.totalActions} actions${COLORS.reset}\n`,
   );
   process.stdout.write(
     `${COLORS.dim}summary:${COLORS.reset} ` +
@@ -96,7 +96,7 @@ function renderGrowth(result) {
     const rows = group?.[rowsKey] ?? [];
     const total = key === 'relationRecommendations' ? group.totalRecommendations : group.total;
     if (!total) continue;
-    process.stdout.write(`${COLORS.bold}${label}${COLORS.reset} ${COLORS.dim}— ${rows.length}/${total}${group.limited ? ' limited' : ''}${COLORS.reset}\n`);
+    process.stdout.write(`${COLORS.bold}${label}${COLORS.reset} ${COLORS.dim}· ${rows.length}/${total}${group.limited ? ' limited' : ''}${COLORS.reset}\n`);
     for (const row of rows) renderGrowthRow(row);
     process.stdout.write('\n');
   }
@@ -133,7 +133,7 @@ function printNextGrowth(result) {
   process.stdout.write(
     `${COLORS.bold}next growth${COLORS.reset} ${COLORS.cyan}${args.from}${COLORS.reset}` +
       ` ${COLORS.dim}→${COLORS.reset} ${COLORS.cyan}${args.to}${COLORS.reset}` +
-      ` ${COLORS.dim}— growth rows are proposals, not writes; preflight the relation before changing the vault${COLORS.reset}\n` +
+      ` ${COLORS.dim}· growth rows are proposals, not writes; preflight the relation before changing the vault${COLORS.reset}\n` +
       `  ontology-atlas relation-check ${args.from} ${args.to} ${args.type} [vault]\n` +
       `  ontology-atlas path ${args.from} ${args.to} [vault] --max-hops 5\n`,
   );

--- a/cli/src/commands/health.mjs
+++ b/cli/src/commands/health.mjs
@@ -54,7 +54,7 @@ export async function runHealth(args) {
   const sum = result?.summary ?? {};
   process.stdout.write(
     `${COLORS.bold}vault health${COLORS.reset} ${sc}${status}${COLORS.reset}` +
-      ` ${COLORS.dim}— ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계${COLORS.reset}\n\n`,
+      ` ${COLORS.dim}· ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계${COLORS.reset}\n\n`,
   );
   const checks = Array.isArray(result?.checks) ? result.checks : [];
   for (const c of checks) {
@@ -68,12 +68,12 @@ export async function runHealth(args) {
   }
   // dependency cycle / 분리된 그래프(islands) 강조 — 각 실패 검사에 드릴다운 명령 안내.
   if (sum.dependencyCycles) {
-    process.stdout.write(`\n${COLORS.red}cycles ${sum.dependencyCycles}${COLORS.reset} — \`cycles\` 명령으로 자세히\n`);
+    process.stdout.write(`\n${COLORS.red}cycles ${sum.dependencyCycles}${COLORS.reset}: \`cycles\` 명령으로 자세히\n`);
   }
   // actionableComponents > 1 = 의미있는 노드가 분리된 섬으로 나뉨(연결 안 됨).
   // vault-readme 등 ignored 는 제외한 수라 1 초과면 실제 단절. `components` 로 목록.
   if (sum.actionableComponents > 1) {
-    process.stdout.write(`${COLORS.yellow}components ${sum.actionableComponents}${COLORS.reset} — 그래프가 분리됨, \`components\` 명령으로 자세히\n`);
+    process.stdout.write(`${COLORS.yellow}components ${sum.actionableComponents}${COLORS.reset}: 그래프가 분리됨, \`components\` 명령으로 자세히\n`);
   }
   return healthResultExitCode(result);
 }

--- a/cli/src/commands/hubs.mjs
+++ b/cli/src/commands/hubs.mjs
@@ -106,7 +106,7 @@ function render(result) {
       const score =
         typeof h[scoreKey] === 'number' ? h[scoreKey].toFixed(scoreKey === 'pageRank' ? 4 : 0) : '-';
       const deg = `${COLORS.dim}${scoreKey} ${score}${COLORS.reset} ${COLORS.dim}(deg ${h.degree})${COLORS.reset}`;
-      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}— ${h.title}${COLORS.reset}` : '';
+      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}· ${h.title}${COLORS.reset}` : '';
       process.stdout.write(`  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${slug}${COLORS.reset}${titleText} ${deg}\n`);
     }
     process.stdout.write('\n');
@@ -119,7 +119,7 @@ function render(result) {
   if (focus?.slug) {
     process.stdout.write(
       `${COLORS.dim}next${COLORS.reset} hub ${COLORS.bold}${focus.slug}${COLORS.reset}` +
-        `${COLORS.dim} — ranking rows are hotspots, not proof; inspect the node and impact before onboarding/refactor decisions${COLORS.reset}\n`,
+        `${COLORS.dim} · ranking rows are hotspots, not proof; inspect the node and impact before onboarding/refactor decisions${COLORS.reset}\n`,
     );
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas node ${focus.slug} [vault] --limit 20${COLORS.reset}\n`);
     process.stdout.write(

--- a/cli/src/commands/import.mjs
+++ b/cli/src/commands/import.mjs
@@ -94,20 +94,20 @@ export async function runImport(args) {
       case 'kindless':
         summary.kindless += 1;
         process.stderr.write(
-          `${COLORS.yellow}skip${COLORS.reset}  ${relative(process.cwd(), src)} — no kind in frontmatter and no --kind fallback\n`,
+          `${COLORS.yellow}skip${COLORS.reset}  ${relative(process.cwd(), src)}: no kind in frontmatter and no --kind fallback\n`,
         );
         break;
       case 'conflict':
         summary.conflicts += 1;
         process.stderr.write(
-          `${COLORS.yellow}skip${COLORS.reset}  ${relative(process.cwd(), src)} — slug already exists in vault: ${result.slug} (use --rename to write under a fresh slug)\n`,
+          `${COLORS.yellow}skip${COLORS.reset}  ${relative(process.cwd(), src)}: slug already exists in vault: ${result.slug} (use --rename to write under a fresh slug)\n`,
         );
         break;
       case 'error':
         summary.skipped += 1;
         firstError = firstError ?? result.error;
         process.stderr.write(
-          `${COLORS.red}error${COLORS.reset}  ${relative(process.cwd(), src)} — ${result.error}\n`,
+          `${COLORS.red}error${COLORS.reset}  ${relative(process.cwd(), src)} · ${result.error}\n`,
         );
         break;
     }

--- a/cli/src/commands/index.mjs
+++ b/cli/src/commands/index.mjs
@@ -345,7 +345,7 @@ function printPlan(payload) {
       `            report business/product domain + capability first; use code rows as implementation evidence\n\n` +
       evidenceBlock +
       reviewBlock +
-      `${COLORS.dim}side effect 0 — --apply can land analyzer concepts/containment. Import evidence always remains rationale-review-required.${COLORS.reset}\n`,
+      `${COLORS.dim}side effect 0: --apply can land analyzer concepts/containment. Import evidence always remains rationale-review-required.${COLORS.reset}\n`,
   );
 }
 

--- a/cli/src/commands/infer-imports.mjs
+++ b/cli/src/commands/infer-imports.mjs
@@ -83,7 +83,7 @@ export async function runInferImports(args) {
 
   process.stdout.write(
     `${COLORS.bold}infer-imports${COLORS.reset} ${COLORS.dim}${target}${COLORS.reset} ` +
-      `${COLORS.dim}— ${result.filesScanned} files / ${fileEdges} edges / ${ext} external / ${unres} unresolved${COLORS.reset}\n\n`,
+      `${COLORS.dim}· ${result.filesScanned} files / ${fileEdges} edges / ${ext} external / ${unres} unresolved${COLORS.reset}\n\n`,
   );
 
   if (edgeKindSummary) {
@@ -100,7 +100,7 @@ export async function runInferImports(args) {
 
   if (modEdges.length > 0) {
     process.stdout.write(
-      `  ${COLORS.bold}module edges${COLORS.reset} ${COLORS.dim}(${modEdges.length}) — rationale review required${COLORS.reset}\n`,
+      `  ${COLORS.bold}module edges${COLORS.reset} ${COLORS.dim}(${modEdges.length}): rationale review required${COLORS.reset}\n`,
     );
     for (const m of modEdges.slice(0, 16)) {
       const kindSummary = formatKindCounts(m.kindCounts);
@@ -123,7 +123,7 @@ export async function runInferImports(args) {
   }
 
   process.stdout.write(
-    `${COLORS.dim}side effect 0 — vault 변경 안 함. import는 코드 근거일 뿐 의미 관계를 자동 승인하지 않습니다. ` +
+    `${COLORS.dim}side effect 0: vault 변경 안 함. import는 코드 근거일 뿐 의미 관계를 자동 승인하지 않습니다. ` +
       `양쪽 개념과 근거를 검토하고 이유를 설명한 뒤 사용자 승인을 받아 한 건씩 기록하세요.${COLORS.reset}\n`,
   );
   return 0;
@@ -205,8 +205,8 @@ function printUsage(stream = process.stderr) {
       `  resolve relative imports, tsconfig paths, and fallback @/* aliases,\n` +
       `  classify external (npm) separately and unresolved aliases explicitly,\n` +
       `  collapse to module edges (capability A → B with import count).\n\n` +
-      `  Default: ${COLORS.bold}side effect 0${COLORS.reset} — vault 변경 안 함, moduleEdges 만 출력.\n` +
-      `  ${COLORS.bold}--apply${COLORS.reset}: disabled — import evidence cannot self-approve a semantic relation.\n` +
+      `  Default: ${COLORS.bold}side effect 0${COLORS.reset}: vault 변경 안 함, moduleEdges 만 출력.\n` +
+      `  ${COLORS.bold}--apply${COLORS.reset}: disabled: import evidence cannot self-approve a semantic relation.\n` +
       `  ${COLORS.bold}--threshold N${COLORS.reset}: count < N 인 약한 module edge 를 필터.\n` +
       `  큰 codebase 의 accidental cross-feature import 가 ontology 에\n` +
       `  들어가는 걸 차단. preview / --apply / --json 모두 적용.\n` +

--- a/cli/src/commands/list.mjs
+++ b/cli/src/commands/list.mjs
@@ -72,13 +72,13 @@ export function runList(args) {
 
   if (nodes.length === 0) {
     console.log(
-      `${COLORS.dim}[ontology-atlas] ${vaultPath} 에서 ontology 노드 0 — vault 가 비었거나 frontmatter \`kind:\` 가 없는 듯.${COLORS.reset}`,
+      `${COLORS.dim}[ontology-atlas] ${vaultPath} 에서 ontology 노드 0: vault 가 비었거나 frontmatter \`kind:\` 가 없는 듯.${COLORS.reset}`,
     );
     return 0;
   }
 
   console.log(
-    `${COLORS.bold}${vaultPath}${COLORS.reset} ${COLORS.dim}— ${nodes.length} ontology 노드${kindFilter ? ` (kind=${kindFilter})` : ''}${COLORS.reset}\n`,
+    `${COLORS.bold}${vaultPath}${COLORS.reset} ${COLORS.dim}· ${nodes.length} ontology 노드${kindFilter ? ` (kind=${kindFilter})` : ''}${COLORS.reset}\n`,
   );
   for (const n of nodes) {
     const color = KIND_COLORS[n.kind] || '';

--- a/cli/src/commands/maintenance.mjs
+++ b/cli/src/commands/maintenance.mjs
@@ -74,7 +74,7 @@ function renderMaintenance(result) {
 
   process.stdout.write(
     `${COLORS.bold}maintenance plan${COLORS.reset}` +
-      ` ${COLORS.dim}— ${summary.remainingActions ?? 0} remaining / ${summary.filteredActions ?? 0} filtered / ${summary.totalActions ?? 0} total${COLORS.reset}\n`,
+      ` ${COLORS.dim}· ${summary.remainingActions ?? 0} remaining / ${summary.filteredActions ?? 0} filtered / ${summary.totalActions ?? 0} total${COLORS.reset}\n`,
   );
   process.stdout.write(
     `${COLORS.dim}cursor:${COLORS.reset} found=${String(cursor.found)}` +
@@ -146,7 +146,7 @@ function printNextMaintenance(result) {
   const cursor = result.cursor ?? {};
   process.stdout.write(
     `${COLORS.bold}next maintenance${COLORS.reset} ${COLORS.cyan}${pointer.id}${COLORS.reset}` +
-      ` ${COLORS.dim}— queue rows are work items, not proof; narrow the queue before acting${COLORS.reset}\n` +
+      ` ${COLORS.dim}· queue rows are work items, not proof; narrow the queue before acting${COLORS.reset}\n` +
       `  ontology-atlas maintenance [vault] --phases ${pointer.phase} --severities ${pointer.severity} --kinds ${pointer.kind} --limit 5\n`,
   );
   if (cursor.nextAfterActionId) {

--- a/cli/src/commands/match-edges.mjs
+++ b/cli/src/commands/match-edges.mjs
@@ -120,8 +120,8 @@ function render(result) {
     const toKind = edge.toKind || '?';
     const fromColor = KIND_COLORS[fromKind] || COLORS.dim;
     const toColor = KIND_COLORS[toKind] || COLORS.dim;
-    const fromTitle = edge.fromNode?.title ? ` ${COLORS.dim}— ${edge.fromNode.title}${COLORS.reset}` : '';
-    const toTitle = edge.toNode?.title ? ` ${COLORS.dim}— ${edge.toNode.title}${COLORS.reset}` : '';
+    const fromTitle = edge.fromNode?.title ? ` ${COLORS.dim}· ${edge.fromNode.title}${COLORS.reset}` : '';
+    const toTitle = edge.toNode?.title ? ` ${COLORS.dim}· ${edge.toNode.title}${COLORS.reset}` : '';
     const relationLabel = edge.relationType || edge.via;
     process.stdout.write(
       `  ${COLORS.bold}${rank}${COLORS.reset} ${fromColor}${edge.from}${COLORS.reset}` +
@@ -136,7 +136,7 @@ function render(result) {
       `\n${COLORS.dim}next${COLORS.reset} edge ${COLORS.bold}${followUp.focusEdge.from}${COLORS.reset}` +
         ` ${COLORS.yellow}--${relationLabel}-->${COLORS.reset} ` +
         `${COLORS.bold}${followUp.focusEdge.to}${COLORS.reset}` +
-        `${COLORS.dim} — scan rows are candidates, not proof; explain/preflight before write/refactor decisions${COLORS.reset}\n`,
+        `${COLORS.dim} · scan rows are candidates, not proof; explain/preflight before write/refactor decisions${COLORS.reset}\n`,
     );
     for (const command of followUp.cliFallbackCommands.slice(0, 3)) {
       process.stdout.write(`  ${COLORS.cyan}${command}${COLORS.reset}\n`);

--- a/cli/src/commands/match-nodes.mjs
+++ b/cli/src/commands/match-nodes.mjs
@@ -120,7 +120,7 @@ function render(result) {
     const node = nodes[index];
     const kc = KIND_COLORS[node.kind] || COLORS.dim;
     const rank = String(index + 1).padStart(2);
-    const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+    const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
     const degree = `deg ${node.degree} in ${node.inDegree ?? 0} out ${node.outDegree ?? 0}`;
     process.stdout.write(
       `  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${(node.kind || '?').padEnd(12)}${COLORS.reset} ` +
@@ -131,7 +131,7 @@ function render(result) {
   if (followUp?.focusSlug && Array.isArray(followUp.cliFallbackCommands) && followUp.cliFallbackCommands.length > 0) {
     process.stdout.write(
       `\n${COLORS.dim}next${COLORS.reset} focus ${COLORS.bold}${followUp.focusSlug}${COLORS.reset}` +
-        `${COLORS.dim} — scan rows are candidates, not proof; cite follow-up detail before onboarding/refactor decisions${COLORS.reset}\n`,
+        `${COLORS.dim} · scan rows are candidates, not proof; cite follow-up detail before onboarding/refactor decisions${COLORS.reset}\n`,
     );
     for (const command of followUp.cliFallbackCommands.slice(0, 4)) {
       process.stdout.write(`  ${COLORS.cyan}${command}${COLORS.reset}\n`);

--- a/cli/src/commands/merge.mjs
+++ b/cli/src/commands/merge.mjs
@@ -103,7 +103,7 @@ function graphUpdates(result) {
 
 function graphUpdateTitle(update) {
   return update?.title && update.title !== update.slug
-    ? ` ${COLORS.dim}— ${update.title}${COLORS.reset}`
+    ? ` ${COLORS.dim}· ${update.title}${COLORS.reset}`
     : '';
 }
 
@@ -152,7 +152,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
       `  ontology-atlas merge <fromSlug> <intoSlug> [vault] [--confirm] [--json]\n\n` +
-      `${COLORS.bold}Default${COLORS.reset} dry-run — preview the redirects.\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run: preview the redirects.\n` +
       `${COLORS.bold}--confirm${COLORS.reset}  apply: redirect every backlink, delete fromSlug.md.\n\n` +
       `${COLORS.bold}Example:${COLORS.reset}\n` +
       `  ontology-atlas merge capabilities/dup capabilities/canonical\n` +

--- a/cli/src/commands/moment.mjs
+++ b/cli/src/commands/moment.mjs
@@ -52,7 +52,7 @@ function render(summary) {
 
   if (!summary.hasBaseline) {
     process.stdout.write(
-      `${COLORS.yellow}no init/absorb baseline yet${COLORS.reset} — run ` +
+      `${COLORS.yellow}no init/absorb baseline yet${COLORS.reset}: run ` +
         `${COLORS.cyan}${cliInvocation()} init --quick-start${COLORS.reset} or ` +
         `${COLORS.cyan}${cliInvocation()} absorb <file> --write${COLORS.reset} first.\n`,
     );
@@ -68,7 +68,7 @@ function render(summary) {
 
   if (!summary.moment) {
     process.stdout.write(
-      `\n${COLORS.yellow}moment not reached yet${COLORS.reset} — run ` +
+      `\n${COLORS.yellow}moment not reached yet${COLORS.reset}: run ` +
         `${COLORS.cyan}${cliInvocation()} agent-brief${COLORS.reset} once your agent answers citing a vault\n` +
         `node, or ${COLORS.cyan}${cliInvocation()} moment --mark${COLORS.reset} by hand if your agent calls the\n` +
         `MCP tools directly (agent_brief/get_concept are read-only and are not auto-stamped).\n`,
@@ -85,7 +85,7 @@ function render(summary) {
         : `${COLORS.dim}target unknown (no baseline)${COLORS.reset}`;
   process.stdout.write(
     `\n${COLORS.green}moment reached${COLORS.reset}        ${summary.moment.at} via ${summary.moment.source}\n` +
-      `elapsed               ${elapsedLabel} — ${withinLabel}\n`,
+      `elapsed               ${elapsedLabel} · ${withinLabel}\n`,
   );
 }
 
@@ -122,10 +122,10 @@ function printUsage(stream = process.stderr) {
       `  Prints the Slice 0 magic-moment north star (PRODUCT-PLAN-2026-07.md §4/§9):\n` +
       `  the elapsed time from ${COLORS.bold}init${COLORS.reset}/${COLORS.bold}absorb --write${COLORS.reset} to the first ` +
       `${COLORS.bold}agent-brief${COLORS.reset} run afterward,\n` +
-      `  target ≤5 minutes. All data lives in ${COLORS.dim}.ontology-atlas/telemetry.local.json${COLORS.reset} — local\n` +
+      `  target ≤5 minutes. All data lives in ${COLORS.dim}.ontology-atlas/telemetry.local.json${COLORS.reset}: local\n` +
       `  only, never transmitted.\n\n` +
       `${COLORS.bold}options:${COLORS.reset}\n` +
-      `  --mark   manually stamp the moment now — fallback for agents that call the\n` +
+      `  --mark   manually stamp the moment now: fallback for agents that call the\n` +
       `           MCP tools (agent_brief/get_concept) directly instead of this CLI;\n` +
       `           those two are read-only and are not auto-stamped\n` +
       `  --json   machine-readable momentSummary output\n` +

--- a/cli/src/commands/node-profile.mjs
+++ b/cli/src/commands/node-profile.mjs
@@ -113,7 +113,7 @@ function render(result, filters = {}) {
   if (incoming?.total > 0) {
     process.stdout.write(
       `\n${COLORS.dim}INCOMING${COLORS.reset} ${COLORS.bold}${incoming.total}${COLORS.reset}` +
-        ` ${COLORS.dim}— 어디가 이 노드를 reference 하나${COLORS.reset}\n`,
+        ` ${COLORS.dim}· 어디가 이 노드를 reference 하나${COLORS.reset}\n`,
     );
     renderEdgesByRelation(incoming.edges, 'from');
     renderLimitedHint(incoming, 'incoming');
@@ -124,7 +124,7 @@ function render(result, filters = {}) {
   if (outgoing?.total > 0) {
     process.stdout.write(
       `\n${COLORS.dim}OUTGOING${COLORS.reset} ${COLORS.bold}${outgoing.total}${COLORS.reset}` +
-        ` ${COLORS.dim}— 이 노드가 무엇을 reference 하나${COLORS.reset}\n`,
+        ` ${COLORS.dim}· 이 노드가 무엇을 reference 하나${COLORS.reset}\n`,
     );
     renderEdgesByRelation(outgoing.edges, 'to');
     renderLimitedHint(outgoing, 'outgoing');
@@ -134,7 +134,7 @@ function render(result, filters = {}) {
     if (hasActiveEdgeFilter(filters)) {
       process.stdout.write(`\n${COLORS.dim}no matching edges for current filters${COLORS.reset}\n`);
     } else {
-      process.stdout.write(`\n${COLORS.dim}isolated — 어떤 노드와도 연결 안 됨${COLORS.reset}\n`);
+      process.stdout.write(`\n${COLORS.dim}isolated: 어떤 노드와도 연결 안 됨${COLORS.reset}\n`);
     }
   }
 }
@@ -171,7 +171,7 @@ function renderEdgesByRelation(edges, peerField) {
       const other = e[peerField];
       const otherKind = e.otherKind || (e.external ? 'external' : '?');
       const kc = KIND_COLORS[otherKind] || COLORS.dim;
-      const title = e.otherNode?.title ? ` ${COLORS.dim}— ${e.otherNode.title}${COLORS.reset}` : '';
+      const title = e.otherNode?.title ? ` ${COLORS.dim}· ${e.otherNode.title}${COLORS.reset}` : '';
       const externalMark = e.external ? ` ${COLORS.dim}[external]${COLORS.reset}` : '';
       process.stdout.write(`    ${kc}${other}${COLORS.reset}${title}${externalMark}\n`);
     }
@@ -252,7 +252,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
       `  ontology-atlas node <slug> [vault] [--limit N] [--types A,B] [--no-external] [--no-unresolved] [--json]\n\n` +
-      `한 노드의 전체 deep dive — header · 도메인 · lineage · incoming/outgoing edges (relation 별 그룹).\n` +
+      `한 노드의 전체 deep dive: header · 도메인 · lineage · incoming/outgoing edges (relation 별 그룹).\n` +
       `--limit N 은 incoming/outgoing edge, lineage, containment rows 를 1..500 범위로 조절합니다.\n` +
       `--types A,B 는 관계 타입을 먼저 필터링합니다. 예: --types dependencies,relates\n` +
       `--no-external / --no-unresolved 는 외부 파일 ref 또는 미해결 ref 를 edge 목록에서 숨깁니다.\n`,

--- a/cli/src/commands/orphans.mjs
+++ b/cli/src/commands/orphans.mjs
@@ -57,7 +57,7 @@ export async function runOrphans(args) {
     const kindFilter = kind ? ` (kind=${kind})` : '';
     process.stdout.write(
       `${COLORS.green}[ontology-atlas] ${COLORS.reset}` +
-        `${COLORS.dim}orphan 0${kindFilter} — vault clean ✓${COLORS.reset}\n`,
+        `${COLORS.dim}orphan 0${kindFilter}: vault clean ✓${COLORS.reset}\n`,
     );
     return 0;
   }
@@ -65,7 +65,7 @@ export async function runOrphans(args) {
   const kindFilter = kind ? ` (kind=${kind})` : '';
   process.stdout.write(
     `${COLORS.bold}${result?.total ?? orphans.length} orphan(s)${COLORS.reset}` +
-      `${COLORS.dim}${kindFilter} — 어디서도 frontmatter 로 reference 받지 않은 노드${COLORS.reset}\n\n`,
+      `${COLORS.dim}${kindFilter}: 어디서도 frontmatter 로 reference 받지 않은 노드${COLORS.reset}\n\n`,
   );
   for (const o of orphans) {
     const color = KIND_COLORS[o.kind] || '';

--- a/cli/src/commands/overview.mjs
+++ b/cli/src/commands/overview.mjs
@@ -67,7 +67,7 @@ function renderOverview(result, hubsLimit) {
   const referencedOnly = graph.referencedOnly ?? 0;
   process.stdout.write(
     `${COLORS.bold}vault overview${COLORS.reset}` +
-      ` ${COLORS.dim}— ${nodes} 노드 · ${edges} 관계 (resolved ${resolved} · external ${external}${unresolved ? ` · unresolved ${unresolved}` : ''})${COLORS.reset}\n`,
+      ` ${COLORS.dim}· ${nodes} 노드 · ${edges} 관계 (resolved ${resolved} · external ${external}${unresolved ? ` · unresolved ${unresolved}` : ''})${COLORS.reset}\n`,
   );
   // 화면(지도·인사이트)은 문서 없이 이름만 적힌 개념까지 세므로 총계가 더
   // 크다. 그 차이를 여기서 밝히지 않으면 두 입구가 같은 볼트에 다른 수를
@@ -83,7 +83,7 @@ function renderOverview(result, hubsLimit) {
   // 2로 센다. 지도·인사이트는 같은 사실을 서로 다른 관계 하나로 접어 센다.
   if (edges > 0) {
     process.stdout.write(
-      `${COLORS.dim}  관계 ${edges} 는 적힌 참조 기준 — 양쪽 문서가 같은 관계를 적으면 2로 셉니다 (지도는 접어서 1)${COLORS.reset}\n`,
+      `${COLORS.dim}  관계 ${edges} 는 적힌 참조 기준: 양쪽 문서가 같은 관계를 적으면 2로 셉니다 (지도는 접어서 1)${COLORS.reset}\n`,
     );
   }
   process.stdout.write('\n');
@@ -139,7 +139,7 @@ function renderOverview(result, hubsLimit) {
       const slug = h.slug.padEnd(50);
       const deg = `${COLORS.dim}deg ${h.degree}${COLORS.reset}` +
         ` ${COLORS.dim}(in ${h.inDegree} · out ${h.outDegree})${COLORS.reset}`;
-      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}— ${h.title}${COLORS.reset}` : '';
+      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}· ${h.title}${COLORS.reset}` : '';
       process.stdout.write(`  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${slug}${COLORS.reset}${titleText} ${deg}\n`);
     }
   }

--- a/cli/src/commands/path.mjs
+++ b/cli/src/commands/path.mjs
@@ -75,14 +75,14 @@ export async function runPath(args) {
   // Trivial path (from === to).
   if (hopCount === 0) {
     process.stdout.write(
-      `${formatHop(hops[0], nodesBySlug)} ${COLORS.dim}(same slug — 0 hops)${COLORS.reset}\n`,
+      `${formatHop(hops[0], nodesBySlug)} ${COLORS.dim}(same slug: 0 hops)${COLORS.reset}\n`,
     );
     return 0;
   }
 
   process.stdout.write(
     `${COLORS.bold}${from}${COLORS.reset} ${COLORS.dim}→${COLORS.reset} ${COLORS.bold}${to}${COLORS.reset}` +
-      ` ${COLORS.dim}— ${hopCount} hop${hopCount === 1 ? '' : 's'}${COLORS.reset}\n\n`,
+      ` ${COLORS.dim}· ${hopCount} hop${hopCount === 1 ? '' : 's'}${COLORS.reset}\n\n`,
   );
 
   // Render: hop i  --(via)-->  hop i+1
@@ -102,7 +102,7 @@ function formatHop(slug, nodesBySlug) {
   if (!node?.title || node.title === slug) {
     return `${COLORS.cyan}${slug}${COLORS.reset}`;
   }
-  return `${COLORS.cyan}${slug}${COLORS.reset} ${COLORS.dim}— ${node.title}${COLORS.reset}`;
+  return `${COLORS.cyan}${slug}${COLORS.reset} ${COLORS.dim}· ${node.title}${COLORS.reset}`;
 }
 
 function parseArgs(args) {

--- a/cli/src/commands/pattern-walk.mjs
+++ b/cli/src/commands/pattern-walk.mjs
@@ -74,7 +74,7 @@ function render(result) {
       const node = row.node ?? row;
       const slug = row.slug ?? node.slug;
       const color = KIND_COLORS[node.kind] || COLORS.cyan;
-      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+      const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
       process.stdout.write(`  ${color}${slug}${COLORS.reset}${title}\n`);
     }
     if (layer.limited) {
@@ -97,7 +97,7 @@ function render(result) {
     const end = focus.end ?? focus.path[focus.path.length - 1];
     process.stdout.write(
       `\n${COLORS.dim}next${COLORS.reset} containment ${COLORS.bold}${end}${COLORS.reset}` +
-        `${COLORS.dim} — pattern rows are traversal evidence; inspect the endpoint before writing${COLORS.reset}\n`,
+        `${COLORS.dim} · pattern rows are traversal evidence; inspect the endpoint before writing${COLORS.reset}\n`,
     );
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas node ${end} [vault] --limit 20${COLORS.reset}\n`);
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas path ${result.start} ${end} [vault] --max-hops ${result.pattern.length + 1}${COLORS.reset}\n`);

--- a/cli/src/commands/preflight.mjs
+++ b/cli/src/commands/preflight.mjs
@@ -169,7 +169,7 @@ function render(rows, { vaultRoot, stagedFiles, truncated, depth, decisionWarnin
       `  ${stagedFiles.length} staged file(s) touch ${COLORS.bold}${rows.length}${COLORS.reset} vault node(s)` +
       ` ${COLORS.dim}(depth ${depth})${COLORS.reset}` +
       (decisionWarnings > 0
-        ? ` — ${COLORS.yellow}⚠ ${decisionWarnings} node(s) reach a kind:decision node${COLORS.reset}`
+        ? ` · ${COLORS.yellow}⚠ ${decisionWarnings} node(s) reach a kind:decision node${COLORS.reset}`
         : '') +
       '\n\n',
   );
@@ -180,7 +180,7 @@ function render(rows, { vaultRoot, stagedFiles, truncated, depth, decisionWarnin
     const slugCol = row.slug.padEnd(42);
     if (row.error) {
       process.stdout.write(
-        `  ${kindCol} ${slugCol} ${COLORS.red}blast-radius error${COLORS.reset} ${COLORS.dim}— ${row.error}${COLORS.reset}\n`,
+        `  ${kindCol} ${slugCol} ${COLORS.red}blast-radius error${COLORS.reset} ${COLORS.dim}· ${row.error}${COLORS.reset}\n`,
       );
       continue;
     }
@@ -235,7 +235,7 @@ function printUsage(stream = process.stderr) {
       `  \`path:\`/\`elements:\` frontmatter, then runs blast-radius (query_ontology)\n` +
       `  on each matched node so you see what this commit reaches before it lands.\n` +
       `  A ${COLORS.yellow}⚠${COLORS.reset} marks nodes whose blast radius includes a kind:decision node.\n\n` +
-      `  Purely informational — never blocks the commit. Silent exit 0 when there is\n` +
+      `  Purely informational: never blocks the commit. Silent exit 0 when there is\n` +
       `  no vault, no staged files, or no matching node (no disable-fatigue noise).\n` +
       `  ${COLORS.bold}--staged${COLORS.reset} is the only supported mode today (explicit form for hook scripts).\n` +
       `  ${COLORS.bold}--depth N${COLORS.reset} default ${DEFAULT_DEPTH}, range 0-${DEPTH_CAP} (forwarded to blast-radius).\n\n` +

--- a/cli/src/commands/project-map.mjs
+++ b/cli/src/commands/project-map.mjs
@@ -63,7 +63,7 @@ function render(result) {
     process.stdout.write(`${COLORS.dim}domains${COLORS.reset}\n`);
     for (const row of result.domains) {
       const title = row.node?.title && row.node.title !== row.slug
-        ? ` ${COLORS.dim}— ${row.node.title}${COLORS.reset}`
+        ? ` ${COLORS.dim}· ${row.node.title}${COLORS.reset}`
         : '';
       const rowSummary = row.summary ?? {};
       process.stdout.write(
@@ -99,7 +99,7 @@ function render(result) {
   if (focus) {
     process.stdout.write(
       `\n${COLORS.dim}next${COLORS.reset} domain ${COLORS.bold}${focus.slug}${COLORS.reset}` +
-        `${COLORS.dim} — map rows are placement evidence; inspect the domain and containment path before moving nodes${COLORS.reset}\n`,
+        `${COLORS.dim} · map rows are placement evidence; inspect the domain and containment path before moving nodes${COLORS.reset}\n`,
     );
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas node ${focus.slug} [vault] --limit 20${COLORS.reset}\n`);
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas pattern-walk ${result.project} [vault] --pattern domains,capabilities --limit 20${COLORS.reset}\n`);

--- a/cli/src/commands/query.mjs
+++ b/cli/src/commands/query.mjs
@@ -54,7 +54,7 @@ export async function runQuery(args) {
   const limited = result?.limited === true;
   process.stdout.write(
     `${COLORS.dim}filter:${COLORS.reset} ${COLORS.bold}${filter}${COLORS.reset} ` +
-      `${COLORS.dim}— showing ${matches.length}/${total} match(es)${limited ? ' (limited)' : ''}${COLORS.reset}\n`,
+      `${COLORS.dim}· showing ${matches.length}/${total} match(es)${limited ? ' (limited)' : ''}${COLORS.reset}\n`,
   );
   if (result?.parsedAs && result.parsedAs !== filter) {
     process.stdout.write(`${COLORS.dim}parsed:${COLORS.reset} ${result.parsedAs}\n`);
@@ -65,7 +65,7 @@ export async function runQuery(args) {
     const kc = KIND_COLORS[m.kind] || COLORS.dim;
     process.stdout.write(
       `  ${kc}${(m.kind || '?').padEnd(12)}${COLORS.reset} ${m.slug}` +
-        (m.title ? ` ${COLORS.dim}— ${m.title}${COLORS.reset}` : '') +
+        (m.title ? ` ${COLORS.dim}· ${m.title}${COLORS.reset}` : '') +
         `\n`,
     );
   }

--- a/cli/src/commands/reachability.mjs
+++ b/cli/src/commands/reachability.mjs
@@ -122,7 +122,7 @@ export async function runReachability(args) {
 function render(result, filters = {}) {
   const summary = result.summary ?? {};
   process.stdout.write(
-    `${COLORS.bold}${result.start}${COLORS.reset} ${COLORS.dim}— reachability${COLORS.reset}` +
+    `${COLORS.bold}${result.start}${COLORS.reset} ${COLORS.dim}· reachability${COLORS.reset}` +
       ` ${COLORS.dim}(depth ${result.depth}, ${result.direction})${COLORS.reset}\n` +
       `  ${summary.reachableNodes ?? 0} reachable node(s)` +
       ` · ${summary.traversedEdges ?? 0} traversed edge(s)` +
@@ -144,7 +144,7 @@ function render(result, filters = {}) {
       process.stdout.write(`  ${COLORS.bold}d${layer.distance}${COLORS.reset} ${COLORS.dim}(${layer.total})${COLORS.reset}\n`);
       for (const node of layer.nodes) {
         const kc = KIND_COLORS[node.kind] || COLORS.dim;
-        const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+        const title = node.title && node.title !== node.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
         process.stdout.write(`    ${kc}${node.slug}${COLORS.reset}${title}\n`);
       }
     }
@@ -172,7 +172,7 @@ function render(result, filters = {}) {
       : '';
     process.stdout.write(
       `\n${COLORS.dim}next${COLORS.reset} reachable ${COLORS.bold}${focusTarget}${COLORS.reset}` +
-        `${COLORS.dim} — traversal rows are candidates, not proof; inspect the node and bounded paths before writing${COLORS.reset}\n`,
+        `${COLORS.dim} · traversal rows are candidates, not proof; inspect the node and bounded paths before writing${COLORS.reset}\n`,
     );
     process.stdout.write(`  ${COLORS.cyan}ontology-atlas node ${focusTarget} [vault] --limit 20${COLORS.reset}\n`);
     process.stdout.write(

--- a/cli/src/commands/relate.mjs
+++ b/cli/src/commands/relate.mjs
@@ -76,7 +76,7 @@ export async function runRelate(args) {
     if (json) {
       process.stdout.write(JSON.stringify({ ...check, written: false, dryRun, alreadyExists: true, filePath: null }, null, 2) + '\n');
     } else {
-      process.stdout.write(`\n${COLORS.green}ok${COLORS.reset}    already exists — nothing to write\n`);
+      process.stdout.write(`\n${COLORS.green}ok${COLORS.reset}    already exists: nothing to write\n`);
     }
     return 0;
   }

--- a/cli/src/commands/rename.mjs
+++ b/cli/src/commands/rename.mjs
@@ -104,7 +104,7 @@ function graphUpdates(result) {
 
 function graphUpdateTitle(update) {
   return update?.title && update.title !== update.slug
-    ? ` ${COLORS.dim}— ${update.title}${COLORS.reset}`
+    ? ` ${COLORS.dim}· ${update.title}${COLORS.reset}`
     : '';
 }
 
@@ -155,7 +155,7 @@ function printUsage(stream = process.stderr) {
   stream.write(
     `\n${COLORS.bold}Usage:${COLORS.reset}\n` +
       `  ontology-atlas rename <oldSlug> <newSlug> [vault] [--confirm] [--overwrite] [--json]\n\n` +
-      `${COLORS.bold}Default${COLORS.reset} dry-run only — preview the changes.\n` +
+      `${COLORS.bold}Default${COLORS.reset} dry-run only: preview the changes.\n` +
       `${COLORS.bold}--confirm${COLORS.reset}  apply: move .md, update slug:, rewrite every backlink.\n\n` +
       `${COLORS.bold}--overwrite${COLORS.reset} allow replacing an existing target slug.\n\n` +
       `${COLORS.bold}Example:${COLORS.reset}\n` +

--- a/cli/src/commands/schema.mjs
+++ b/cli/src/commands/schema.mjs
@@ -85,7 +85,7 @@ function assertSchemaShape(result) {
 function render(result) {
   process.stdout.write(
     `${COLORS.bold}relation schema${COLORS.reset}` +
-      ` ${COLORS.dim}— ${result.totalPatterns} patterns${result.limited ? ' · limited' : ''}${COLORS.reset}\n\n`,
+      ` ${COLORS.dim}· ${result.totalPatterns} patterns${result.limited ? ' · limited' : ''}${COLORS.reset}\n\n`,
   );
   for (const pattern of result.patterns) {
     process.stdout.write(

--- a/cli/src/commands/similar.mjs
+++ b/cli/src/commands/similar.mjs
@@ -61,10 +61,10 @@ function render(result, query) {
   const total = result?.totalMatches ?? matches.length;
   process.stdout.write(
     `${COLORS.bold}similar to:${COLORS.reset} ${COLORS.bold}${query}${COLORS.reset}` +
-      ` ${COLORS.dim}— ${total} match${total === 1 ? '' : 'es'}${result?.limited ? ' (limited)' : ''}${COLORS.reset}\n\n`,
+      ` ${COLORS.dim}· ${total} match${total === 1 ? '' : 'es'}${result?.limited ? ' (limited)' : ''}${COLORS.reset}\n\n`,
   );
   if (matches.length === 0) {
-    process.stdout.write(`${COLORS.green}no similar node — safe to create new${COLORS.reset}\n`);
+    process.stdout.write(`${COLORS.green}no similar node: safe to create new${COLORS.reset}\n`);
     return;
   }
   for (let i = 0; i < matches.length; i += 1) {
@@ -74,7 +74,7 @@ function render(result, query) {
     const score = (m.score ?? 0).toFixed(3);
     const scoreColor = m.score >= 0.5 ? COLORS.red : m.score >= 0.25 ? COLORS.yellow : COLORS.dim;
     const rank = String(i + 1).padStart(2);
-    const title = n.title ? ` ${COLORS.dim}— ${n.title}${COLORS.reset}` : '';
+    const title = n.title ? ` ${COLORS.dim}· ${n.title}${COLORS.reset}` : '';
     process.stdout.write(
       `  ${COLORS.bold}${rank}${COLORS.reset} ${scoreColor}${score}${COLORS.reset}` +
         ` ${kc}${(n.kind || '?').padEnd(11)}${COLORS.reset} ${kc}${n.slug || '?'}${COLORS.reset}${title}\n`,
@@ -98,11 +98,11 @@ function render(result, query) {
   const top = matches[0];
   if (top && top.score >= 0.5) {
     process.stdout.write(
-      `\n${COLORS.red}⚠${COLORS.reset} ${COLORS.dim}top score ≥ 0.5 — \`patch_concept\` 가 \`add_concept\` 보다 안전${COLORS.reset}\n`,
+      `\n${COLORS.red}⚠${COLORS.reset} ${COLORS.dim}top score ≥ 0.5: \`patch_concept\` 가 \`add_concept\` 보다 안전${COLORS.reset}\n`,
     );
   } else if (top && top.score >= 0.25) {
     process.stdout.write(
-      `\n${COLORS.yellow}~${COLORS.reset} ${COLORS.dim}top score 0.25-0.5 — 새 노드 + \`relates\` edge 가 보통 더 깨끗${COLORS.reset}\n`,
+      `\n${COLORS.yellow}~${COLORS.reset} ${COLORS.dim}top score 0.25-0.5: 새 노드 + \`relates\` edge 가 보통 더 깨끗${COLORS.reset}\n`,
     );
   }
 }
@@ -172,8 +172,8 @@ function printUsage(stream = process.stderr) {
       `  ontology-atlas similar "auth flow" --kind capability\n` +
       `  ontology-atlas similar --slug capabilities/auth-login\n\n` +
       `${COLORS.bold}Score 가이드:${COLORS.reset}\n` +
-      `  ≥ 0.5  — 같은 노드 가능성 높음 → \`patch_concept\` 권장\n` +
-      `  0.25-0.5 — 인접 개념 → 새 노드 + \`relates\` edge 깨끗\n` +
-      `  < 0.25 — 무관 → 새 노드 안전\n`,
+      `  ≥ 0.5 : 같은 노드 가능성 높음 → \`patch_concept\` 권장\n` +
+      `  0.25-0.5: 인접 개념 → 새 노드 + \`relates\` edge 깨끗\n` +
+      `  < 0.25: 무관 → 새 노드 안전\n`,
   );
 }

--- a/cli/src/commands/snapshot.mjs
+++ b/cli/src/commands/snapshot.mjs
@@ -141,7 +141,7 @@ export async function runSnapshot(args) {
       push = {
         pushed: false,
         reason: 'no-upstream',
-        message: 'push 실패 — 이 브랜치에 upstream 이 없어요. 커밋은 로컬에 기록됨.',
+        message: 'push 실패: 이 브랜치에 upstream 이 없어요. 커밋은 로컬에 기록됨.',
         guidance: `git push -u origin ${branch}`,
       };
       exitCode = 1;
@@ -201,7 +201,7 @@ function emitNotAGitRepo(json, vaultRoot) {
   }
   process.stderr.write(
     `${COLORS.red}error${COLORS.reset}  ${vaultRoot} is not inside a git repository.\n` +
-      `${COLORS.dim}  snapshot never runs 'git init' for you — run it yourself if you want version history here:${COLORS.reset}\n` +
+      `${COLORS.dim}  snapshot never runs 'git init' for you: run it yourself if you want version history here:${COLORS.reset}\n` +
       `  ${COLORS.cyan}git init${COLORS.reset}\n`,
   );
   return 1;
@@ -328,7 +328,7 @@ function emitDiff({ json, vaultRoot, repoRoot, pathspec }) {
   if (diffText.trim()) {
     process.stdout.write(`\n${diffText.replace(/\n$/, '')}\n`);
   } else {
-    process.stdout.write(`\n${COLORS.dim}추적 파일의 텍스트 diff 없음 (신규 파일만) — 위 목록 참고${COLORS.reset}\n`);
+    process.stdout.write(`\n${COLORS.dim}추적 파일의 텍스트 diff 없음 (신규 파일만): 위 목록 참고${COLORS.reset}\n`);
   }
   return 0;
 }
@@ -350,7 +350,7 @@ function runPull({ json, vaultRoot, repoRoot }) {
       return 1;
     }
     process.stderr.write(
-      `${COLORS.red}error${COLORS.reset}  이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요.\n` +
+      `${COLORS.red}error${COLORS.reset}  이 브랜치에 연결된 원격이 없어요: 먼저 upstream 을 설정하세요.\n` +
         `  ${COLORS.cyan}git push -u origin ${branch}${COLORS.reset}\n`,
     );
     return 1;
@@ -432,7 +432,7 @@ function render({ json, dryRun, vaultRoot, repoRoot, subject, autoSummary, messa
   }
 
   if (dryRun) {
-    process.stdout.write(`\n${COLORS.dim}no commit made — rerun without --dry-run to commit${COLORS.reset}\n`);
+    process.stdout.write(`\n${COLORS.dim}no commit made: rerun without --dry-run to commit${COLORS.reset}\n`);
     return;
   }
 
@@ -513,7 +513,7 @@ function printUsage(stream = process.stderr) {
       `  and up to 3 representative slugs, e.g.:\n` +
       `    ontology snapshot: +2 concepts, ~3 updated (capabilities/foo, elements/bar, +1)\n\n` +
       `  Exits 0 with no output change when there is nothing to snapshot. Never runs\n` +
-      `  'git init' for you — if the vault is outside a git repo it exits 1 with that\n` +
+      `  'git init' for you: if the vault is outside a git repo it exits 1 with that\n` +
       `  suggestion. Files already staged outside the vault are left untouched (git's\n` +
       `  pathspec-scoped partial commit never touches them). A rejected commit (hook /\n` +
       `  gpg / merge in progress) or a rejected push (remote ahead) prints a one-line\n` +
@@ -521,7 +521,7 @@ function printUsage(stream = process.stderr) {
       `${COLORS.bold}Flags:${COLORS.reset}\n` +
       `  ${COLORS.bold}--dry-run${COLORS.reset}   preview the summary + file list, no commit\n` +
       `  ${COLORS.bold}--push${COLORS.reset}      after committing, push to the current branch's existing\n` +
-      `              upstream. Never configures one — no upstream prints setup guidance\n` +
+      `              upstream. Never configures one: no upstream prints setup guidance\n` +
       `              and exits 1 (the commit itself still lands). Prints the remote URL\n` +
       `              on success (trust charter: transport is opt-in and explicit).\n` +
       `  ${COLORS.bold}--message "..."${COLORS.reset} use this as the commit subject instead of the auto\n` +

--- a/cli/src/commands/topological-order.mjs
+++ b/cli/src/commands/topological-order.mjs
@@ -76,12 +76,12 @@ function render(result) {
   const status = result.acyclic ? `${COLORS.green}acyclic${COLORS.reset}` : `${COLORS.red}blocked${COLORS.reset}`;
   process.stdout.write(
     `${COLORS.bold}topological order${COLORS.reset} ${status}` +
-      ` ${COLORS.dim}— ${result.orderedCount}/${result.totalNodes} ordered` +
+      ` ${COLORS.dim}· ${result.orderedCount}/${result.totalNodes} ordered` +
       ` · ${result.selectedEdges} selected edges${result.limited ? ' · limited' : ''}${COLORS.reset}\n\n`,
   );
   for (const row of result.order) {
     const node = row.node || {};
-    const title = node.title && node.title !== row.slug ? ` ${COLORS.dim}— ${node.title}${COLORS.reset}` : '';
+    const title = node.title && node.title !== row.slug ? ` ${COLORS.dim}· ${node.title}${COLORS.reset}` : '';
     process.stdout.write(
       `  ${String(row.rank).padStart(2)} ${COLORS.cyan}${row.slug}${COLORS.reset}${title}` +
         ` ${COLORS.dim}${node.kind || ''}${COLORS.reset}\n`,

--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -26,22 +26,22 @@ export const KNOWN_CODES = [
   {
     code: 'unclosed-frontmatter',
     severity: 'error',
-    description: '`---` 가 닫히지 않음 — 파일 머리에 frontmatter 가 끝나지 않았습니다.',
+    description: '`---` 가 닫히지 않음: 파일 머리에 frontmatter 가 끝나지 않았습니다.',
   },
   {
     code: 'parse-zero-keys',
     severity: 'warning',
-    description: 'frontmatter 가 0 keys 로 파싱됨 — YAML syntax 깨짐 가능.',
+    description: 'frontmatter 가 0 keys 로 파싱됨: YAML syntax 깨짐 가능.',
   },
   {
     code: 'missing-kind',
     severity: 'warning',
-    description: '`kind:` 키 자체가 없음 — 그래프에서 빠짐.',
+    description: '`kind:` 키 자체가 없음: 그래프에서 빠짐.',
   },
   {
     code: 'empty-kind',
     severity: 'error',
-    description: '`kind:` 값이 비어있음 — 그래프에서 빠지고 invalid.',
+    description: '`kind:` 값이 비어있음: 그래프에서 빠지고 invalid.',
   },
   {
     code: 'unknown-kind',
@@ -88,7 +88,7 @@ export const KNOWN_CODES = [
     code: 'duplicate-slug',
     severity: 'error',
     scope: 'vault',
-    description: '두 문서가 같은 canonical slug 를 주장 — 관계가 어느 쪽인지 정할 수 없음.',
+    description: '두 문서가 같은 canonical slug 를 주장: 관계가 어느 쪽인지 정할 수 없음.',
   },
   {
     code: 'duplicate-uid',
@@ -277,10 +277,10 @@ export function runValidate(args) {
   // 가 열어 보지도 못한 파일까지 보증하는 문장이 된다.
   if (unreadable.length > 0) {
     console.log(
-      `\n${COLORS.yellow}[validate] 읽지 못한 파일 ${unreadable.length}건 — 아래는 검사 범위 밖입니다.${COLORS.reset}`,
+      `\n${COLORS.yellow}[validate] 읽지 못한 파일 ${unreadable.length}건: 아래는 검사 범위 밖입니다.${COLORS.reset}`,
     );
     for (const { file, message } of unreadable) {
-      console.log(`  ${COLORS.yellow}?${COLORS.reset} ${relative(vaultPath, file).replace(/\\/g, '/')} — ${message}`);
+      console.log(`  ${COLORS.yellow}?${COLORS.reset} ${relative(vaultPath, file).replace(/\\/g, '/')} · ${message}`);
     }
   }
 
@@ -293,10 +293,10 @@ export function runValidate(args) {
     // "needs_attention" 이라고 답했고 어느 쪽이 맞는지 알 방법이 없었다.
     // 검사 범위를 문장이 말하면 두 답은 모순이 아니라 서로 다른 두 검사가 된다.
     console.log(
-      `${COLORS.green}[validate] ${files.length - unreadable.length} 파일 스캔 — frontmatter · 그래프 참조 issue 0 ✓${COLORS.reset}`,
+      `${COLORS.green}[validate] ${files.length - unreadable.length} 파일 스캔: frontmatter · 그래프 참조 issue 0 ✓${COLORS.reset}`,
     );
     console.log(
-      `${COLORS.dim}          코드 경로 대조(elements:/path: 가 실재하는 파일인가)는 이 검사에 없다 — \`ontology-atlas health\` 가 본다.${COLORS.reset}`,
+      `${COLORS.dim}          코드 경로 대조(elements:/path: 가 실재하는 파일인가)는 이 검사에 없다: \`ontology-atlas health\` 가 본다.${COLORS.reset}`,
     );
     return unreadable.length > 0 ? 1 : 0;
   }
@@ -326,7 +326,7 @@ export function runValidate(args) {
       const head = g.files.slice(0, 3).join(', ');
       const tail = g.files.length > 3 ? ` (+${g.files.length - 3} more)` : '';
       console.log(
-        `  ${color}${tag}${COLORS.reset} ${g.code} — ${g.count} occurrence${g.count === 1 ? '' : 's'}` +
+        `  ${color}${tag}${COLORS.reset} ${g.code} · ${g.count} occurrence${g.count === 1 ? '' : 's'}` +
           `\n     ${COLORS.dim}${head}${tail}${COLORS.reset}`,
       );
     }
@@ -399,7 +399,7 @@ function printUsage(stream = process.stderr) {
       `  ontology-atlas validate [vault] [--json] [--strict]\n` +
       `  ontology-atlas validate [vault] [--fail-on code,...]\n` +
       `  ontology-atlas validate --list-codes [--json]\n\n` +
-      `Validate ontology vault frontmatter integrity — frontmatter shape and graph\n` +
+      `Validate ontology vault frontmatter integrity: frontmatter shape and graph\n` +
       `references only. It does NOT check whether elements:/path: point at files that\n` +
       `exist; \`ontology-atlas health\` runs that source-path check.\n`,
   );
@@ -519,7 +519,7 @@ function findDuplicateSlugIssues(entries) {
           severity: 'error',
           message:
             `\`slug: ${declared}\` 를 다른 문서도 주장합니다 (${rest.join(', ')}). ` +
-            `같은 이름을 가리키는 관계가 어느 쪽을 뜻하는지 정할 수 없습니다 — ` +
+            `같은 이름을 가리키는 관계가 어느 쪽을 뜻하는지 정할 수 없습니다: ` +
             `한쪽의 slug 를 바꾸거나 rename_concept 으로 합치세요.`,
         },
       });
@@ -628,7 +628,7 @@ function findDanglingGraphReferenceIssues(entries) {
           severity: 'warning',
           message: isNonNodeDoc
             ? `\`${key}:\` graph reference "${ref}" 는 vault 에 파일로 있지만 **node 가 아닙니다** ` +
-              '(`kind:` 없음 — 메모·회의록은 그래프 밖입니다). 노드로 올리려면 `kind:` 를 주고, ' +
+              '(`kind:` 없음: 메모·회의록은 그래프 밖입니다). 노드로 올리려면 `kind:` 를 주고, ' +
               '아니면 이 관계를 지우세요.'
             : `\`${key}:\` graph reference "${ref}" 가 vault 의 어떤 node 로도 resolve 되지 않습니다.`,
         },

--- a/cli/src/commands/workspace-brief.mjs
+++ b/cli/src/commands/workspace-brief.mjs
@@ -57,7 +57,7 @@ function render(result) {
   const sc = diagnosisStatusColor(status, COLORS);
   process.stdout.write(
     `${COLORS.bold}workspace brief${COLORS.reset} ${sc}${status}${COLORS.reset}` +
-      ` ${COLORS.dim}— ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계` +
+      ` ${COLORS.dim}· ${sum.nodes ?? 0} 노드 · ${sum.edges ?? 0} 관계` +
       ` · ${sum.projects ?? 0} 프로젝트 · ${sum.domains ?? 0} 도메인${COLORS.reset}\n\n`,
   );
 
@@ -69,7 +69,7 @@ function render(result) {
       const h = hotspots[i];
       const kc = KIND_COLORS[h.kind] || COLORS.dim;
       const rank = String(i + 1).padStart(2);
-      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}— ${h.title}${COLORS.reset}` : '';
+      const titleText = h.title && h.title !== h.slug ? ` ${COLORS.dim}· ${h.title}${COLORS.reset}` : '';
       process.stdout.write(
         `  ${COLORS.bold}${rank}${COLORS.reset} ${kc}${h.slug.padEnd(50)}${COLORS.reset}` +
           `${titleText} ${COLORS.dim}deg ${h.degree}${COLORS.reset}\n`,

--- a/cli/src/index.mjs
+++ b/cli/src/index.mjs
@@ -73,7 +73,7 @@ const SUBCOMMAND = ARGS[0];
 function printHelp(stream = stdout) {
   stream.write(`${COLORS.bold}ontology-atlas${COLORS.reset} ${COLORS.dim}v${PKG.version}${COLORS.reset}
 
-AI-native codebase ontology workbench — ${CLI_COMMAND_COUNT} commands + MCP setup.
+AI-native codebase ontology workbench: ${CLI_COMMAND_COUNT} commands + MCP setup.
 
 ${COLORS.dim}Run it from an ontology-atlas source checkout: ${COLORS.reset}${COLORS.bold}node cli/src/index.mjs <command>${COLORS.reset}
 ${COLORS.dim}(The rows below shorten that to \`ontology-atlas <command>\`. There is no npm package —${COLORS.reset}
@@ -109,29 +109,29 @@ ${COLORS.bold}Usage:${COLORS.reset}
        --raw-slug --rename --dry-run          ${COLORS.dim}no folder prefix · slug rename · plan-only${COLORS.reset}
   ontology-atlas absorb <file...>             ${COLORS.green}Absorb CLAUDE.md/AGENTS.md into typed vault nodes${COLORS.reset} (Slice 0)
        --vault path --write                   ${COLORS.dim}default dry-run plan · --write lands + rewrites source as slim pointer${COLORS.reset}
-  ontology-atlas moment [vault]                ${COLORS.green}Slice 0 magic-moment readout${COLORS.reset} — init/absorb → first agent-brief elapsed
+  ontology-atlas moment [vault]                ${COLORS.green}Slice 0 magic-moment readout${COLORS.reset}: init/absorb → first agent-brief elapsed
        --mark --json                           ${COLORS.dim}manual stamp fallback · machine output${COLORS.reset}
 
-${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17 — autonomous ingest base)${COLORS.reset}
-  ontology-atlas index [rootPath]             ${COLORS.green}project ontology index${COLORS.reset} — analyze + imports + validate plan
+${COLORS.bold}Bootstrap${COLORS.reset} ${COLORS.dim}(R16/R17: autonomous ingest base)${COLORS.reset}
+  ontology-atlas index [rootPath]             ${COLORS.green}project ontology index${COLORS.reset}: analyze + imports + validate plan
        --apply --threshold N --json           ${COLORS.dim}analyzer land · import review filter · machine output${COLORS.reset}
-  ontology-atlas bootstrap [rootPath]         ${COLORS.green}1줄 full bootstrap${COLORS.reset} — analyzer write + import review
+  ontology-atlas bootstrap [rootPath]         ${COLORS.green}1줄 full bootstrap${COLORS.reset}: analyzer write + import review
        --threshold N --skip-imports --json    ${COLORS.dim}review filter · imports skip · machine output${COLORS.reset}
   ontology-atlas analyze [rootPath]           Walk a repo, propose ontology node candidates (side effect 0)
        --apply --max-depth N --json           ${COLORS.dim}or land via batch · folder walk depth · machine output${COLORS.reset}
   ontology-atlas infer-imports [rootPath] TS/JS/Python import graph → depends_on edge candidates (side effect 0)
        --apply --threshold N --max-files N    ${COLORS.dim}apply disabled · review filter · default 5000 max${COLORS.reset}
-  ontology-atlas preflight [vault]            ${COLORS.green}Commit preflight${COLORS.reset} — staged files → vault nodes → blast-radius summary
+  ontology-atlas preflight [vault]            ${COLORS.green}Commit preflight${COLORS.reset}: staged files → vault nodes → blast-radius summary
        --staged --depth N --json              ${COLORS.dim}non-blocking, silent when nothing matches${COLORS.reset}
-  ontology-atlas snapshot [vault]             ${COLORS.green}Snapshot the vault${COLORS.reset} — vault-scoped git commit with a semantic summary
+  ontology-atlas snapshot [vault]             ${COLORS.green}Snapshot the vault${COLORS.reset}: vault-scoped git commit with a semantic summary
        --dry-run --push --message "..." --json ${COLORS.dim}local commit by default · --push sends to your existing upstream${COLORS.reset}
        --history [N] --diff --pull             ${COLORS.dim}vault commit log · uncommitted preview · graceful pull (opt-in)${COLORS.reset}
-  ontology-atlas connect-source <project>     ${COLORS.green}Connect the code${COLORS.reset} — bind a project node to the folder it describes
+  ontology-atlas connect-source <project>     ${COLORS.green}Connect the code${COLORS.reset}: bind a project node to the folder it describes
        --root path --confirm --repair --json  ${COLORS.dim}dry-run by default · folder inferred from the vault's git repo${COLORS.reset}
   ontology-atlas disconnect-source <project>  Undo that binding (dry-run by default)
        --confirm --json                       ${COLORS.dim}removes only this project's binding · no markdown changes${COLORS.reset}
 
-${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps the MCP server, same authority as an AI agent)${COLORS.reset}
+${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15: wraps the MCP server, same authority as an AI agent)${COLORS.reset}
   ${COLORS.dim}Set OATLAS_CLI_MCP_TIMEOUT_MS=N when a large / slow vault needs a longer one-shot MCP call window.${COLORS.reset}
   ontology-atlas backlinks <slug>             Every node referencing the slug (--json)
   ontology-atlas orphans [vault]              Isolated nodes (어떤 다른 노드도 reference 안 함)
@@ -147,7 +147,7 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
   ontology-atlas relation-check <from> <to> <type>
                                              ${COLORS.dim}schema-aware add_relation preflight${COLORS.reset}
   ontology-atlas relate <from> <to> <type>
-                                             ${COLORS.green}Write a relation${COLORS.reset} — same preflight as relation-check, then lands it
+                                             ${COLORS.green}Write a relation${COLORS.reset}: same preflight as relation-check, then lands it
        --dry-run --json                     ${COLORS.dim}preview only · machine output${COLORS.reset}
   ontology-atlas query "<filter>"             Typed filter DSL (kind=X AND has(elements))
        --limit N --json                       ${COLORS.dim}default limit 100${COLORS.reset}
@@ -155,9 +155,9 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --kind K --min-degree N --plan --json  ${COLORS.dim}filter-preserving query_plan support${COLORS.reset}
   ontology-atlas match-edges [vault]          Graph DB-style edge scan with type/kind/external filters
        --type T --from-kind K --plan --json   ${COLORS.dim}edge pattern rows + totalMatches${COLORS.reset}
-  ontology-atlas domain-matrix [vault]        Domain coupling matrix — cross-domain edges + examples
+  ontology-atlas domain-matrix [vault]        Domain coupling matrix: cross-domain edges + examples
        --project SLUG --limit N --json         ${COLORS.dim}scope to one project containment tree${COLORS.reset}
-  ontology-atlas facets [vault]              Graph dashboard facets — buckets + top nodes/patterns
+  ontology-atlas facets [vault]              Graph dashboard facets: buckets + top nodes/patterns
        --limit N --json
   ontology-atlas schema [vault]               Relation schema patterns for traversal/write preflight
        --limit N --json
@@ -167,11 +167,11 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --limit N --item-limit N --json
   ontology-atlas compile [vault]             Deterministic graph compile + optional reorder
        --summary --fix --json                 ${COLORS.dim}hash/counts · canonicalize relation arrays${COLORS.reset}
-  ontology-atlas export [vault]              ${COLORS.green}Interop export${COLORS.reset} — compile → standard exchange format (stdout)
+  ontology-atlas export [vault]              ${COLORS.green}Interop export${COLORS.reset}: compile → standard exchange format (stdout)
        --format jsonld|graphml|json           ${COLORS.dim}RDF JSON-LD · Gephi GraphML · raw artifact${COLORS.reset}
   ontology-atlas overview [vault]             Vault first-contact dashboard (counts + 분포 + 허브)
        --limit N --json                       ${COLORS.dim}허브 N 개 (default 10) · machine output${COLORS.reset}
-  ontology-atlas hubs [vault]                 Centrality 4 rankings — PageRank / Bridges / Authorities / Hubs
+  ontology-atlas hubs [vault]                 Centrality 4 rankings: PageRank / Bridges / Authorities / Hubs
        --limit N --json                       ${COLORS.dim}각 랭킹 N rows (default 10)${COLORS.reset}
   ontology-atlas blast-radius <slug>          선언된 의존 영향 + 근거 자격 (구조 제외)
        --depth N --direction incoming|outgoing|both --json
@@ -183,7 +183,7 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --limit N --types A,B --include-isolated --json
   ontology-atlas health [vault]               Graph 무결성 dashboard (6 checks, 코드 경로 대조 포함)
        --json --component-types A,B          ${COLORS.dim}focused diagnosis tuning 지원${COLORS.reset}
-  ontology-atlas agent-brief [vault]          Claude Code/Codex handoff — readiness + first MCP calls
+  ontology-atlas agent-brief [vault]          Claude Code/Codex handoff: readiness + first MCP calls
        --prompt --graph-db-pack --verify-fallbacks
                                               ${COLORS.dim}pasteable handoff · shell Graph DB pack · fallback self-check${COLORS.reset}
   ontology-atlas workspace-brief [vault]      Status + hotspots + project_scope 포함 노드 + next actions 한 화면
@@ -192,14 +192,14 @@ ${COLORS.bold}Graph-level commands${COLORS.reset} ${COLORS.dim}(R15 — wraps th
        --limit N --json                       ${COLORS.dim}relations · external refs · dangling refs · ignored refs${COLORS.reset}
   ontology-atlas maintenance [vault]          Ordered graph cleanup/repair work queue
        --limit N --after-action-id ID --json  ${COLORS.dim}cursor page · filterable maintenance_plan${COLORS.reset}
-  ontology-atlas node <slug> [vault]          한 노드 deep dive — header · lineage · incoming/outgoing edges
+  ontology-atlas node <slug> [vault]          한 노드 deep dive: header · lineage · incoming/outgoing edges
        --limit N --types A,B --no-external --no-unresolved --json
                                              ${COLORS.dim}hotspot edge group + relation/ref filter${COLORS.reset}
   ontology-atlas similar "<title>" [vault] vault 에서 비슷한 노드 찾기 (duplicate 회피, /ontology-extract 짝)
        --slug X --kind K --limit N --json    ${COLORS.dim}slug 기반 / kind 필터 / 결과 N / machine${COLORS.reset}
-  ontology-atlas rename <old> <new>           Atomic rename — moves .md, redirects every backlink
+  ontology-atlas rename <old> <new>           Atomic rename: moves .md, redirects every backlink
        --confirm --overwrite                  ${COLORS.dim}default dry-run; --overwrite replaces existing target${COLORS.reset}
-  ontology-atlas merge <from> <into>          Atomic merge — redirect backlinks then delete fromSlug
+  ontology-atlas merge <from> <into>          Atomic merge: redirect backlinks then delete fromSlug
        --confirm                              ${COLORS.dim}default dry-run; --confirm to apply${COLORS.reset}
   ontology-atlas delete <slug>                Permanent delete (refuses if backlinks remain)
        --confirm --force                      ${COLORS.dim}--confirm to apply; --force to ignore backlinks${COLORS.reset}
@@ -385,7 +385,7 @@ async function runInit(targetArg, opts = {}) {
   }
   const locale = typeof opts.locale === 'string' ? opts.locale.toLowerCase() : 'en';
   if (!Object.hasOwn(TEMPLATE_ROOTS, locale)) {
-    fail(`unknown --locale "${locale}" — supported: ${Object.keys(TEMPLATE_ROOTS).join(', ')}`);
+    fail(`unknown --locale "${locale}": supported: ${Object.keys(TEMPLATE_ROOTS).join(', ')}`);
     return 2;
   }
   const templateRoot = resolveTemplateRoot(locale);
@@ -399,7 +399,7 @@ async function runInit(targetArg, opts = {}) {
   const { created, skipped } = copyTree(templateRoot, target);
 
   if (created === 0) {
-    warn(`no new files written — target already has matching files`);
+    warn(`no new files written: target already has matching files`);
   }
   if (skipped > 0) {
     warn(`${skipped} existing file(s) preserved (not overwritten)`);
@@ -434,7 +434,7 @@ async function runInit(targetArg, opts = {}) {
       ok(`  ${label}/.mcp.json (OATLAS_VAULT=${omotVault})`);
     } else {
       warn(
-        `  ${label}/.mcp.json already exists — preserved (manual merge if needed)`,
+        `  ${label}/.mcp.json already exists: preserved (manual merge if needed)`,
       );
       if (!existsSync(mcpExample)) {
         writeFileSync(mcpExample, mcpJsonText);
@@ -470,7 +470,7 @@ async function runInit(targetArg, opts = {}) {
       ok(`  ${label}/.codex/config.toml (OATLAS_VAULT=${omotVault})`);
     } else {
       warn(
-        `  ${label}/.codex/config.toml already exists — preserved (manual merge if needed)`,
+        `  ${label}/.codex/config.toml already exists: preserved (manual merge if needed)`,
       );
     }
   }
@@ -532,7 +532,7 @@ async function runInit(targetArg, opts = {}) {
   }
 
   stdout.write(`
-${COLORS.green}${COLORS.bold}done${COLORS.reset} — vault scaffolded.
+${COLORS.green}${COLORS.bold}done${COLORS.reset}: vault scaffolded.
 
 ${COLORS.bold}Next steps:${COLORS.reset}
 
@@ -542,7 +542,7 @@ ${COLORS.bold}Next steps:${COLORS.reset}
        ${COLORS.cyan}${CLI} validate${COLORS.reset}                    ${COLORS.dim}# frontmatter integrity${COLORS.reset}
        ${COLORS.cyan}${CLI} mcp-verify${COLORS.reset}                  ${COLORS.dim}# server + ${MCP_TOOL_COUNT}-tool MCP + graph smoke${COLORS.reset}
 
-  ${COLORS.dim}2.${COLORS.reset} ${COLORS.bold}Bootstrap from your codebase${COLORS.reset} (recommended — agent-less, 1 line):
+  ${COLORS.dim}2.${COLORS.reset} ${COLORS.bold}Bootstrap from your codebase${COLORS.reset} (recommended: agent-less, 1 line):
        ${COLORS.cyan}${analyzeCommand}${COLORS.reset}     ${COLORS.dim}# preview candidates only${COLORS.reset}
        ${COLORS.cyan}${bootstrapCommand}${COLORS.reset}   ${COLORS.dim}# apply nodes + edges${COLORS.reset}
        ${COLORS.dim}analyze can apply reviewed concepts + containment; infer-imports stays read-only${COLORS.reset}
@@ -553,7 +553,7 @@ ${COLORS.bold}Next steps:${COLORS.reset}
        ${COLORS.cyan}${CLI} add capability auth/token-issue --title="Token issue" --domain=auth${COLORS.reset}
        ${COLORS.cyan}${CLI} find token${COLORS.reset}                  ${COLORS.dim}# verify it shows up${COLORS.reset}
 
-  ${COLORS.dim}4.${COLORS.reset} ${COLORS.bold}Edit project.md${COLORS.reset} — set your project's real name + description.
+  ${COLORS.dim}4.${COLORS.reset} ${COLORS.bold}Edit project.md${COLORS.reset}: set your project's real name + description.
        Then add domains / capabilities / elements as you discover them.
 
   ${COLORS.dim}5.${COLORS.reset} ${COLORS.bold}Open this folder in an AI agent${COLORS.reset}:
@@ -588,15 +588,15 @@ ${COLORS.dim}AI agents and humans now share the same vault. Have fun.${COLORS.re
 // exists (approval-tier principle: never auto-absorbed, human opt-in only)
 // + a compact next-steps block (3 lines max).
 async function runQuickStart({ target, cwdVaultArg }) {
-  stdout.write(`\n${COLORS.bold}quick start${COLORS.reset} — bootstrapping from your repo...\n`);
+  stdout.write(`\n${COLORS.bold}quick start${COLORS.reset}: bootstrapping from your repo...\n`);
   const bootstrapCode = await runBootstrap(['.', '--vault', cwdVaultArg]);
 
   const repoRoot = cwd();
   const foundGuides = ['AGENTS.md', 'CLAUDE.md'].filter((name) => existsSync(join(repoRoot, name)));
   if (foundGuides.length > 0) {
     stdout.write(
-      `\n${COLORS.yellow}note${COLORS.reset}  found ${foundGuides.join(', ')} — consider absorbing ` +
-        `${foundGuides.length > 1 ? 'them' : 'it'} into the vault (never automatic — your call):\n`,
+      `\n${COLORS.yellow}note${COLORS.reset}  found ${foundGuides.join(', ')}: consider absorbing ` +
+        `${foundGuides.length > 1 ? 'them' : 'it'} into the vault (never automatic: your call):\n`,
     );
     for (const guide of foundGuides) {
       // 붙여넣어 실행하라고 청록색으로 찍는 줄 — `cliInvocation()` 을 통과해야
@@ -609,12 +609,12 @@ async function runQuickStart({ target, cwdVaultArg }) {
       stdout.write(`       ${COLORS.cyan}${absorbCommand}${COLORS.reset}\n`);
     }
     stdout.write(
-      `       ${COLORS.dim}dry-run by default — review the plan, then land it yourself by adding --write${COLORS.reset}\n`,
+      `       ${COLORS.dim}dry-run by default: review the plan, then land it yourself by adding --write${COLORS.reset}\n`,
     );
   }
 
   stdout.write(`
-${COLORS.green}${COLORS.bold}quick start done${COLORS.reset} — vault scaffolded + bootstrapped from your repo.
+${COLORS.green}${COLORS.bold}quick start done${COLORS.reset}: vault scaffolded + bootstrapped from your repo.
 
 ${COLORS.bold}Next:${COLORS.reset}
   ${COLORS.dim}1.${COLORS.reset} Open the vault        ${COLORS.cyan}cd ${target} && ${CLI} list${COLORS.reset}

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -372,13 +372,13 @@ await test('init --locale=ko — Korean starter bodies, identical graph, English
     for (const dir of ['vault-ko', 'vault-en']) {
       const v = await run(['validate', dir], { cwd: repo });
       assert.equal(v.code, 0, `${dir} validate failed: ${v.stdout}${v.stderr}`);
-      assert.match(stripAnsi(v.stdout), /5 파일 스캔 — frontmatter · 그래프 참조 issue 0/);
+      assert.match(stripAnsi(v.stdout), /5 파일 스캔: frontmatter · 그래프 참조 issue 0/);
     }
 
     // 모르는 로케일은 조용히 영어로 떨어지지 않고 명확히 실패한다.
     const bad = await run(['init', 'vault-fr', '--locale=fr'], { cwd: repo });
     assert.equal(bad.code, 2);
-    assert.match(stripAnsi(bad.stderr), /unknown --locale "fr" — supported: en, ko/);
+    assert.match(stripAnsi(bad.stderr), /unknown --locale "fr": supported: en, ko/);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
@@ -577,13 +577,13 @@ await test('agent-setup — terminal output points humans to the workflow guide'
     assert.match(clean, /Repair missing configs only if needed: ontology-atlas agent-setup .*ontology.* --root .* --write/);
     assert.match(clean, /Restart Claude Code, Cursor, or Codex from .* after repair/);
     assert.match(clean, /Mode guide:/);
-    assert.match(clean, /MCP-connected — direct read\/write tools/);
+    assert.match(clean, /MCP-connected · direct read\/write tools/);
     assert.match(clean, /graph DB differences/);
     assert.match(clean, /First-contact proof contract:/);
-    assert.match(clean, /Config state — agent-setup --json reports root-specific/);
-    assert.match(clean, /MCP verify — mcp-verify can boot the local MCP server/);
-    assert.match(clean, /JSON setup gate — agent-brief --verify-fallbacks --json returns ok\/performanceOk/);
-    assert.match(clean, /Graph briefs — workspace-brief and agent-brief --graph-db-pack/);
+    assert.match(clean, /Config state · agent-setup --json reports root-specific/);
+    assert.match(clean, /MCP verify · mcp-verify can boot the local MCP server/);
+    assert.match(clean, /JSON setup gate · agent-brief --verify-fallbacks --json returns ok\/performanceOk/);
+    assert.match(clean, /Graph briefs · workspace-brief and agent-brief --graph-db-pack/);
     assert.match(clean, /After code changes:/);
     assert.match(clean, /sync docs\/ontology before finishing/);
   } finally {
@@ -1118,7 +1118,7 @@ await test('mcp-verify — runs MCP package verify against a resolved vault', as
     assert.match(clean, new RegExp(escapeRegExp(expectedToolsListAnnotationSummary())));
     assert.match(clean, /get_concepts/);
     assert.match(clean, /2 ok rows, 1 partial row/);
-    assert.match(clean, /query_concepts limited — 1 query result \/ 4 total query results \(limited true\)/);
+    assert.match(clean, /query_concepts limited: 1 query result \/ 4 total query results \(limited true\)/);
     assert.match(clean, /analyze_repo_structure/);
     assert.match(clean, /infer_imports/);
     assert.match(clean, /find_orphans/);
@@ -1130,20 +1130,20 @@ await test('mcp-verify — runs MCP package verify against a resolved vault', as
     assert.match(clean, /relation_recommendations:warn/);
     assert.match(clean, /health/);
     assert.match(clean, /compile_ontology/);
-    assert.match(clean, /compile_ontology page — 1\/5 nodes, 1\/\d+ edges/);
-    assert.match(clean, /compile_ontology indexes — out \d+, in \d+, edgeById \d+, aliases \d+, edges \d+\/\d+\/\d+/);
+    assert.match(clean, /compile_ontology page: 1\/5 nodes, 1\/\d+ edges/);
+    assert.match(clean, /compile_ontology indexes: out \d+, in \d+, edgeById \d+, aliases \d+, edges \d+\/\d+\/\d+/);
     assert.match(clean, /overview/);
     assert.match(clean, /overview query_plan/);
     assert.match(clean, /project_map query_plan/);
-    assert.match(clean, /maintenance cursor — missing afterActionId reported/);
+    assert.match(clean, /maintenance cursor: missing afterActionId reported/);
     assert.match(clean, /phase none; severity none; kind none; executable none; review none/);
-    assert.match(clean, /maintenance cursor — ready page stable/);
-    assert.match(clean, /neighbors — elements\/example-element/);
-    assert.match(clean, /path — elements\/example-element → project \(1 hop, 1 edge\)/);
+    assert.match(clean, /maintenance cursor: ready page stable/);
+    assert.match(clean, /neighbors: elements\/example-element/);
+    assert.match(clean, /path: elements\/example-element → project \(1 hop, 1 edge\)/);
     assert.match(clean, /project_scope/);
-    assert.match(clean, /destructive dry-runs — rename_concept · merge_concepts · delete_concept previewReady\/canConfirm contract without write-maintenance/);
-    assert.match(clean, /all_paths — elements\/example-element → project/);
-    assert.match(clean, /structuredContent — direct 16\/16, write 5\/5 \(batch row-isolation 2\/2, batch no-write metadata 2\/2, destructive dry-run 3\/3\), maintenance 3\/3, graph 13\/13/);
+    assert.match(clean, /destructive dry-runs: rename_concept · merge_concepts · delete_concept previewReady\/canConfirm contract without write-maintenance/);
+    assert.match(clean, /all_paths: elements\/example-element → project/);
+    assert.match(clean, /structuredContent: direct 16\/16, write 5\/5 \(batch row-isolation 2\/2, batch no-write metadata 2\/2, destructive dry-run 3\/3\), maintenance 3\/3, graph 13\/13/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1199,13 +1199,13 @@ await test('mcp-verify — verifies maintenance cursor resume when actions exist
     const r = await run(['mcp-verify', root, '--timeout-ms', '3000']);
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /maintenance cursor — ready page stable \(2 remaining actions/);
+    assert.match(clean, /maintenance cursor: ready page stable \(2 remaining actions/);
     assert.match(clean, /kind add_missing_relation:1,capability_without_evidence:1/);
-    assert.match(clean, /maintenance cursor — resume afterActionId advanced \(maint_[a-f0-9]{8}; 1 remaining action/);
-    assert.match(clean, /query_concepts limited — 1 query result \/ 2 total query results \(limited true\)/);
-    assert.match(clean, /destructive dry-runs — rename_concept · merge_concepts · delete_concept previewReady\/canConfirm contract without write-maintenance/);
-    assert.match(clean, /all_paths — core → project/);
-    assert.match(clean, /structuredContent — direct 16\/16, write 5\/5 \(batch row-isolation 2\/2, batch no-write metadata 2\/2, destructive dry-run 3\/3\), maintenance 3\/3, graph 13\/13/);
+    assert.match(clean, /maintenance cursor: resume afterActionId advanced \(maint_[a-f0-9]{8}; 1 remaining action/);
+    assert.match(clean, /query_concepts limited: 1 query result \/ 2 total query results \(limited true\)/);
+    assert.match(clean, /destructive dry-runs: rename_concept · merge_concepts · delete_concept previewReady\/canConfirm contract without write-maintenance/);
+    assert.match(clean, /all_paths: core → project/);
+    assert.match(clean, /structuredContent: direct 16\/16, write 5\/5 \(batch row-isolation 2\/2, batch no-write metadata 2\/2, destructive dry-run 3\/3\), maintenance 3\/3, graph 13\/13/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1231,11 +1231,11 @@ await test('mcp-verify — allows valid vaults without a project node', async ()
     const r = await run(['mcp-verify', root, '--timeout-ms', '3000']);
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /maintenance cursor — missing afterActionId reported/);
-    assert.match(clean, /maintenance cursor — ready page stable/);
-    assert.match(clean, /neighbors — domains\/core/);
-    assert.match(clean, /path — domains\/core → domains\/core \(0 hops, 0 edges\)/);
-    assert.match(clean, /project_scope — skipped \(no project node in vault\)/);
+    assert.match(clean, /maintenance cursor: missing afterActionId reported/);
+    assert.match(clean, /maintenance cursor: ready page stable/);
+    assert.match(clean, /neighbors: domains\/core/);
+    assert.match(clean, /path: domains\/core → domains\/core \(0 hops, 0 edges\)/);
+    assert.match(clean, /project_scope: skipped \(no project node in vault\)/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -2186,7 +2186,7 @@ await test('validate — 2+ 같은 code → "grouped by code" 요약 섹션 (R+)
     assert.match(clean, /cap2\.md/);
     // grouped section 등장
     assert.match(clean, /grouped by code/);
-    assert.match(clean, /missing-expected-field — 3 occurrences/);
+    assert.match(clean, /missing-expected-field · 3 occurrences/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3301,8 +3301,8 @@ await test('backlinks — capabilities/foo 의 backlinks (bar relates + auth cap
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /backlink/);
-    assert.match(clean, /capabilities\/bar\s+— Bar/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /capabilities\/bar\s+· Bar/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -3357,8 +3357,8 @@ await test('path — capabilities/bar → capabilities/foo (1 hop, via relates)'
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /1 hop/);
-    assert.match(clean, /capabilities\/bar — Bar/);
-    assert.match(clean, /capabilities\/foo — Foo/);
+    assert.match(clean, /capabilities\/bar · Bar/);
+    assert.match(clean, /capabilities\/foo · Foo/);
     // bar.relates 가 foo 를 가리키므로 via=relates 로 노출
     assert.match(clean, /relates/);
   } finally {
@@ -3400,7 +3400,7 @@ await test('path — same slug → 0 hops trivial', async () => {
     const r = await run(['path', 'capabilities/foo', 'capabilities/foo', root]);
     assert.equal(r.code, 0);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /capabilities\/foo — Foo/);
+    assert.match(clean, /capabilities\/foo · Foo/);
     assert.match(clean, /same slug|0 hops/);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -3469,14 +3469,14 @@ await test('explain — renders direct edges, shortest path, and common neighbor
     ]);
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /explain_relation capabilities\/bar — Bar → capabilities\/foo — Foo/);
+    assert.match(clean, /explain_relation capabilities\/bar · Bar → capabilities\/foo · Foo/);
     assert.match(clean, /verdict direct/);
     assert.match(clean, /domains domains\/auth → domains\/auth · same=true/);
     assert.match(clean, /DIRECT EDGES 1\/1/);
     assert.match(clean, /capabilities\/bar --relates--> capabilities\/foo/);
     assert.match(clean, /SHORTEST PATH 1 hop/);
     assert.match(clean, /COMMON NEIGHBORS 1\/1/);
-    assert.match(clean, /domains\/auth — Auth/);
+    assert.match(clean, /domains\/auth · Auth/);
     assert.match(clean, /next relation capabilities\/bar → capabilities\/foo/);
     assert.match(clean, /explanation is evidence, not write approval; run path and preflight before changing graph/);
     assert.match(clean, /ontology-atlas path capabilities\/bar capabilities\/foo \[vault\] --max-hops 5/);
@@ -3662,8 +3662,8 @@ await test('all-paths — bounded alternatives with completeness evidence', asyn
     assert.match(clean, /evidence complete/);
     assert.match(clean, /pathsComplete=true/);
     assert.match(clean, /totalPathsExact=true/);
-    assert.match(clean, /capabilities\/bar — Bar/);
-    assert.match(clean, /capabilities\/foo — Foo/);
+    assert.match(clean, /capabilities\/bar · Bar/);
+    assert.match(clean, /capabilities\/foo · Foo/);
     assert.match(clean, /via relates/);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -4744,8 +4744,8 @@ await test('match-nodes — graph DB-style node rows with degree filters', async
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /match_nodes 2\/2 node\(s\)/);
     assert.match(clean, /filters .*kind=capability.*minInDegree=1.*sort=inDegree/);
-    assert.match(clean, /capabilities\/foo\s+— Foo.*deg 4 in 2 out 2/);
-    assert.match(clean, /capabilities\/bar\s+— Bar.*deg 3 in 1 out 2/);
+    assert.match(clean, /capabilities\/foo\s+· Foo.*deg 4 in 2 out 2/);
+    assert.match(clean, /capabilities\/bar\s+· Bar.*deg 3 in 1 out 2/);
     assert.match(clean, /next focus capabilities\/foo/);
     assert.match(clean, /scan rows are candidates, not proof; cite follow-up detail before onboarding\/refactor decisions/);
     assert.match(clean, /ontology-atlas node capabilities\/foo \[vault\] --limit 12/);
@@ -4903,8 +4903,8 @@ await test('domain-matrix — renders cross-domain coupling rows with examples',
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /domain_matrix 2 domain\(s\).*1 cross-domain edge\(s\)/);
     assert.match(clean, /project project/);
-    assert.match(clean, /domains\/auth\s+— Auth.*out 1/);
-    assert.match(clean, /domains\/billing\s+— Billing.*in 1/);
+    assert.match(clean, /domains\/auth\s+· Auth.*out 1/);
+    assert.match(clean, /domains\/billing\s+· Billing.*in 1/);
     assert.match(clean, /domains\/auth → domains\/billing 1 depends_on:1/);
     assert.match(clean, /capabilities\/login --depends_on--> capabilities\/invoice/);
     assert.match(clean, /next coupling domains\/auth → domains\/billing/);
@@ -5017,9 +5017,9 @@ await test('pattern-walk — prints explicit containment traversal evidence', as
     assert.match(clean, /pattern_walk project outgoing domains -> capabilities/);
     assert.match(clean, /2 step\(s\)/);
     assert.match(clean, /step 1 domains/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
     assert.match(clean, /step 2 capabilities/);
-    assert.match(clean, /capabilities\/login\s+— Login/);
+    assert.match(clean, /capabilities\/login\s+· Login/);
     assert.match(clean, /next containment capabilities\/login/);
     assert.match(clean, /ontology-atlas node capabilities\/login \[vault\] --limit 20/);
 
@@ -5075,7 +5075,7 @@ await test('project-map — prints domain placement and containment follow-up', 
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /project_map project/);
     assert.match(clean, /1 domain\(s\)/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
     assert.match(clean, /capability capabilities\/login/);
     assert.match(clean, /element\s+elements\/login-api/);
     assert.match(clean, /next domain domains\/auth/);
@@ -5106,13 +5106,13 @@ await test('reachability — transitive reachable nodes are grouped by layer', a
     ]);
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /capabilities\/bar — reachability/);
+    assert.match(clean, /capabilities\/bar · reachability/);
     assert.match(clean, /2 reachable node\(s\)/);
     assert.match(clean, /by relation/);
     assert.match(clean, /relates\s+1/);
     assert.match(clean, /domain\s+1/);
-    assert.match(clean, /d1[\s\S]*capabilities\/foo\s+— Foo/);
-    assert.match(clean, /d1[\s\S]*domains\/auth\s+— Auth/);
+    assert.match(clean, /d1[\s\S]*capabilities\/foo\s+· Foo/);
+    assert.match(clean, /d1[\s\S]*domains\/auth\s+· Auth/);
     assert.match(clean, /shortest paths/);
     assert.match(clean, /next reachable capabilities\/foo/);
     assert.match(clean, /traversal rows are candidates, not proof; inspect the node and bounded paths before writing/);
@@ -5166,7 +5166,7 @@ await test('overview — graph fixture 의 counts + 허브 정확', async () => 
     assert.match(clean, /domain\s+1/);
     // 허브 — degree 가 가장 큰 domains/auth 가 top
     assert.match(clean, /domains\/auth/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -5273,7 +5273,7 @@ await test('blast-radius — affected node rows include node titles for scanabil
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /affected nodes/);
-    assert.match(clean, /capabilities\/bar\s+— Bar/);
+    assert.match(clean, /capabilities\/bar\s+· Bar/);
     assert.match(clean, /next impact capabilities\/bar/);
     assert.match(clean, /impact rows are candidates, not proof; inspect backlinks and node detail before refactor decisions/);
     assert.match(clean, /ontology-atlas node capabilities\/bar \[vault\] --limit 20/);
@@ -5320,8 +5320,8 @@ await test('hubs — human rankings include node titles for scanability', async 
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /PageRank/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
-    assert.match(clean, /capabilities\/foo\s+— Foo/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
+    assert.match(clean, /capabilities\/foo\s+· Foo/);
     assert.match(clean, /next hub domains\/auth/);
     assert.match(clean, /ranking rows are hotspots, not proof; inspect the node and impact before onboarding\/refactor decisions/);
     assert.match(clean, /ontology-atlas node domains\/auth \[vault\] --limit 20/);
@@ -5357,7 +5357,7 @@ await test('components — scans connected islands without health JSON indirecti
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /graph components/);
     assert.match(clean, /component 1/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
 
     const json = await run(['components', root, '--json', '--limit=1', '--node-limit=2']);
     assert.equal(json.code, 0, `stdout: ${json.stdout}\nstderr: ${json.stderr}`);
@@ -5463,7 +5463,7 @@ await test('workspace-brief — prints health check coverage', async () => {
     assert.equal(r.code, 0, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(r.stdout, /\x1b\[32mhealthy\x1b\[0m/);
-    assert.match(clean, /capabilities\/foo\s+— Foo/);
+    assert.match(clean, /capabilities\/foo\s+· Foo/);
     assert.match(clean, /HEALTH CHECKS/);
     assert.match(clean, /compile_issues:pass:0/);
     assert.match(clean, /components:pass:1/);
@@ -5611,7 +5611,7 @@ await test('agent-brief — prints agent handoff entrypoints and playbooks', asy
     assert.match(clean, /MCP-connected\s+direct read\/write tools/);
     assert.match(clean, /Setup gate\s+config repair commands, JSON readiness/);
     assert.match(clean, /ENTRYPOINTS/);
-    assert.match(clean, /capabilities\/foo\s+— Foo|domains\/auth\s+— Auth/);
+    assert.match(clean, /capabilities\/foo\s+· Foo|domains\/auth\s+· Auth/);
     assert.match(clean, /FIRST MCP CALLS/);
     assert.match(clean, /query_ontology\(\{"operation":"workspace_brief"/);
     assert.match(clean, /CLI FALLBACKS/);
@@ -6496,8 +6496,8 @@ await test('cycles — human output includes node titles', async () => {
     const r = await run(['cycles', root]);
     assert.equal(r.code, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /capabilities\/a\s+— A/);
-    assert.match(clean, /capabilities\/b\s+— B/);
+    assert.match(clean, /capabilities\/a\s+· A/);
+    assert.match(clean, /capabilities\/b\s+· B/);
     assert.match(clean, /next cycle capabilities\/a → capabilities\/b/);
     assert.match(clean, /cycle rows are failures, but fix the edge only after inspecting path evidence and maintenance guidance/);
     assert.match(clean, /ontology-atlas path capabilities\/a capabilities\/b \[vault\] --max-hops 8/);
@@ -6651,7 +6651,7 @@ await test('node --no-external/--no-unresolved — noisy refs can be hidden from
     const clean = stripAnsi(noMatches.stdout);
     assert.match(clean, /filters types=elements .* external=false/);
     assert.match(clean, /no matching edges for current filters/);
-    assert.doesNotMatch(clean, /isolated — 어떤 노드와도 연결 안 됨/);
+    assert.doesNotMatch(clean, /isolated: 어떤 노드와도 연결 안 됨/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -6774,7 +6774,7 @@ await test('rename — dry-run preview, no disk change', async () => {
     assert.match(clean, /dry-run/);
     assert.match(clean, /capabilities\/foo-renamed/);
     assert.match(clean, /[1-9]\d* file\(s\) would change/);
-    assert.match(clean, /capabilities\/bar\s+— Bar/);
+    assert.match(clean, /capabilities\/bar\s+· Bar/);
     assert.match(clean, /relates changed/);
     // foo.md 그대로 존재 (dry-run)
     assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), true);
@@ -6800,7 +6800,7 @@ await test('rename --confirm — 파일 이동 + backlink redirect', async () =>
     assert.equal(r.code, 0, `stderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /[1-9]\d* file\(s\) updated/);
-    assert.match(clean, /capabilities\/bar\s+— Bar/);
+    assert.match(clean, /capabilities\/bar\s+· Bar/);
     assert.match(clean, /relates changed/);
     assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), false);
     assert.equal(
@@ -6859,8 +6859,8 @@ await test('delete — backlinks 있으면 dry-run 에서 경고', async () => {
     const clean = stripAnsi(r.stdout);
     assert.match(clean, /dry-run/);
     assert.match(clean, /backlink/);
-    assert.match(clean, /capabilities\/bar\s+— Bar/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /capabilities\/bar\s+· Bar/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
     assert.match(clean, /--force/);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -6902,8 +6902,8 @@ await test('delete --confirm --force — 적용 출력에 dangling backlink 를 
     assert.match(clean, /deleted node\s+Foo/);
     assert.match(clean, /# Foo/);
     assert.match(clean, /2 dangling backlink\(s\) left/);
-    assert.match(clean, /capabilities\/bar\s+— Bar\s+\(relates\)/);
-    assert.match(clean, /domains\/auth\s+— Auth\s+\(capabilities\)/);
+    assert.match(clean, /capabilities\/bar\s+· Bar\s+\(relates\)/);
+    assert.match(clean, /domains\/auth\s+· Auth\s+\(capabilities\)/);
     assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), false);
     assert.match(readFileSync(join(root, 'capabilities/bar.md'), 'utf-8'), /capabilities\/foo/);
   } finally {
@@ -6952,7 +6952,7 @@ await test('merge — dry-run preview', async () => {
     assert.match(clean, /capabilities\/foo/);
     assert.match(clean, /capabilities\/bar/);
     assert.match(clean, /[1-9]\d* file\(s\) would change/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
     assert.match(clean, /capabilities changed/);
     // foo.md 그대로 존재 (dry-run)
     assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), true);
@@ -6977,7 +6977,7 @@ await test('merge --confirm — 적용 출력에 변경 파일과 key 를 보여
     assert.match(clean, /capabilities\/foo\.md deleted/);
     assert.match(clean, /deleted source\s+Foo/);
     assert.match(clean, /# Foo/);
-    assert.match(clean, /domains\/auth\s+— Auth/);
+    assert.match(clean, /domains\/auth\s+· Auth/);
     assert.match(clean, /capabilities changed/);
     assert.equal(existsSyncTest(join(root, 'capabilities/foo.md')), false);
     const authText = readFileSync(join(root, 'domains/auth.md'), 'utf-8');
@@ -7462,8 +7462,8 @@ await test('analyze --apply — labels row-level failures without slug or relati
     });
     assert.equal(r.code, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /✗ concepts\[0\] — concepts\[0\] missing slug/);
-    assert.match(clean, /✗ relations\[0\] — relations\[0\] missing source/);
+    assert.match(clean, /✗ concepts\[0\] · concepts\[0\] missing slug/);
+    assert.match(clean, /✗ relations\[0\] · relations\[0\] missing source/);
     assert.doesNotMatch(clean, /undefined/);
   } finally {
     rmSync(vault, { recursive: true, force: true });
@@ -8485,7 +8485,7 @@ await test('bootstrap --skip-imports — sole README domain yields a verifier-cl
       stripAnsi(verify.stdout),
       new RegExp(`tools\\/list ${EXPECTED_TOOL_COUNT}\\/${EXPECTED_TOOL_COUNT}`),
     );
-    assert.match(stripAnsi(verify.stdout), /All passed —/);
+    assert.match(stripAnsi(verify.stdout), /All passed:/);
   } finally {
     rmSync(vault, { recursive: true, force: true });
     rmSync(repo, { recursive: true, force: true });
@@ -8698,7 +8698,7 @@ await test('bootstrap --skip-imports — labels row-level failures without slug 
       "    return;",
       "  }",
       "  if (msg.params?.name === 'analyze_repo_structure') {",
-      "    const payload = { rootPath: '/repo', framework: 'generic', project: { slug: 'demo', title: 'Demo' }, domains: [{ slug: 'domains/core', title: 'Core', evidence: { source: 'src/core' } /* 2026-08-08: README 출처면 보류 규칙에 걸려 이 시험의 본래 목적(행 드리프트 라벨)이 아예 안 돈다 — 확증된 출처로 */ }], capabilities: [], elements: [], suggestedRelations: [{ from: 'demo', to: 'domains/core', type: 'contains' }], skipped: [] };",
+      "    const payload = { rootPath: '/repo', framework: 'generic', project: { slug: 'demo', title: 'Demo' }, domains: [{ slug: 'domains/core', title: 'Core', evidence: { source: 'src/core' } /* 2026-08-08: README 출처면 보류 규칙에 걸려 이 시험의 본래 목적(행 드리프트 라벨)이 아예 안 돈다: 확증된 출처로 */ }], capabilities: [], elements: [], suggestedRelations: [{ from: 'demo', to: 'domains/core', type: 'contains' }], skipped: [] };",
       "    console.log(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { content: [{ text: JSON.stringify(payload) }], structuredContent: payload } }));",
       "    return;",
       "  }",
@@ -8721,8 +8721,8 @@ await test('bootstrap --skip-imports — labels row-level failures without slug 
     });
     assert.equal(r.code, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`);
     const clean = stripAnsi(r.stdout);
-    assert.match(clean, /✗ concept concepts\[0\] — concepts\[0\] missing slug/);
-    assert.match(clean, /✗ suggested relations\[0\] — relations\[0\] missing source/);
+    assert.match(clean, /✗ concept concepts\[0\] · concepts\[0\] missing slug/);
+    assert.match(clean, /✗ suggested relations\[0\] · relations\[0\] missing source/);
     assert.doesNotMatch(clean, /undefined/);
   } finally {
     rmSync(vault, { recursive: true, force: true });
@@ -8787,7 +8787,7 @@ await test('bootstrap — fails closed when add_relations response rows drift', 
       "    return;",
       "  }",
       "  if (msg.params?.name === 'analyze_repo_structure') {",
-      "    const payload = { rootPath: '/repo', framework: 'generic', project: { slug: 'demo', title: 'Demo' }, domains: [{ slug: 'domains/core', title: 'Core', evidence: { source: 'src/core' } /* 2026-08-08: README 출처면 보류 규칙이 관계까지 걸러 이 시험이 안 돈다 — 확증된 출처로 */ }], capabilities: [], elements: [], suggestedRelations: [{ from: 'demo', to: 'domains/core', type: 'contains' }], skipped: [] };",
+      "    const payload = { rootPath: '/repo', framework: 'generic', project: { slug: 'demo', title: 'Demo' }, domains: [{ slug: 'domains/core', title: 'Core', evidence: { source: 'src/core' } /* 2026-08-08: README 출처면 보류 규칙이 관계까지 걸러 이 시험이 안 돈다: 확증된 출처로 */ }], capabilities: [], elements: [], suggestedRelations: [{ from: 'demo', to: 'domains/core', type: 'contains' }], skipped: [] };",
       "    console.log(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { content: [{ text: JSON.stringify(payload) }], structuredContent: payload } }));",
       "    return;",
       "  }",

--- a/cli/src/lib/absorb.mjs
+++ b/cli/src/lib/absorb.mjs
@@ -348,7 +348,7 @@ export function buildSlimPointer(plan) {
   lines.push('');
   lines.push('> **Absorbed into the ontology-atlas vault.** The sections below were');
   lines.push('> converted into typed vault nodes. Edit the vault, not this file, for');
-  lines.push('> the sections that moved — this file is now a slim pointer.');
+  lines.push('> the sections that moved: this file is now a slim pointer.');
   lines.push('');
   if (plan.intro) {
     lines.push(plan.intro);
@@ -365,7 +365,7 @@ export function buildSlimPointer(plan) {
   }
 
   if (suggested.length > 0) {
-    lines.push('## Suggested (not written — review before adding)');
+    lines.push('## Suggested (not written: review before adding)');
     lines.push('');
     for (const s of suggested) {
       lines.push(`- **${s.heading}** → candidate \`${s.targetKind}\` \`${s.targetSlug}\``);
@@ -378,7 +378,7 @@ export function buildSlimPointer(plan) {
     lines.push('');
     for (const s of injectionSuspects) {
       const patterns = s.injection.matches.map((m) => m.pattern).join(', ');
-      lines.push(`- **${s.heading}** — matched: ${patterns}`);
+      lines.push(`- **${s.heading}**: matched: ${patterns}`);
     }
     lines.push('');
   }

--- a/cli/src/lib/activity-log.mjs
+++ b/cli/src/lib/activity-log.mjs
@@ -76,6 +76,6 @@ export async function recordCliWrite(vaultRoot, { tool, target, summary, why = n
       }),
     );
   } catch {
-    /* 감사 로그는 부수 — 쓰기 결과 / exit code 를 절대 해치지 않는다. */
+    /* 감사 로그는 부수: 쓰기 결과 / exit code 를 절대 해치지 않는다. */
   }
 }

--- a/cli/src/lib/agent-files.mjs
+++ b/cli/src/lib/agent-files.mjs
@@ -114,7 +114,7 @@ function normalizePath(path) {
   for (const part of path.split('/')) {
     if (part === '' || part === '.') continue;
     if (part === '..') {
-      if (parts.length === 0) return null; // escapes the root — never resolvable
+      if (parts.length === 0) return null; // escapes the root: never resolvable
       parts.pop();
       continue;
     }
@@ -163,7 +163,7 @@ function checkClaudeAgentsBridge(recordByPath, existingPathSet, drift) {
       check: 'claude-agents-bridge',
       code: 'missing-agents-import',
       path: 'CLAUDE.md',
-      message: 'CLAUDE.md does not import @AGENTS.md — Claude Code and AGENTS.md readers see different instructions',
+      message: 'CLAUDE.md does not import @AGENTS.md: Claude Code and AGENTS.md readers see different instructions',
       detail: { ref: 'AGENTS.md' },
     });
     claude.drift.push('missing-agents-import');
@@ -388,7 +388,7 @@ function checkCodexSizeCap(recordByPath, drift) {
       check: 'codex-size-cap',
       code: 'agents-md-over-codex-cap',
       path: 'AGENTS.md',
-      message: `AGENTS.md is ${bytes} bytes — over the Codex project_doc_max_bytes default of ${CODEX_PROJECT_DOC_CAP_BYTES}`,
+      message: `AGENTS.md is ${bytes} bytes: over the Codex project_doc_max_bytes default of ${CODEX_PROJECT_DOC_CAP_BYTES}`,
       detail: { bytes, capBytes: CODEX_PROJECT_DOC_CAP_BYTES },
     });
     agents.drift.push('agents-md-over-codex-cap');

--- a/cli/src/lib/git-snapshot.mjs
+++ b/cli/src/lib/git-snapshot.mjs
@@ -38,7 +38,7 @@ export function findGitRepoRoot(vaultRoot, { run = defaultRun } = {}) {
   }
 }
 
-/** repoRoot 기준 vault 의 pathspec — vault 가 repo root 자체면 '.'. */
+/** repoRoot 기준 vault 의 pathspec: vault 가 repo root 자체면 '.'. */
 export function vaultPathspec(repoRoot, vaultRoot) {
   const rel = relative(repoRoot, vaultRoot).replace(/\\/g, '/');
   return rel === '' ? '.' : rel;
@@ -61,7 +61,7 @@ export function getPorcelainStatus({ repoRoot, pathspec, run = defaultRun }) {
   return parsePorcelain(out);
 }
 
-/** pathspec 없는 전체 repo `git status --porcelain` — staged-outside-vault 가드용. */
+/** pathspec 없는 전체 repo `git status --porcelain` · staged-outside-vault 가드용. */
 export function getFullPorcelainStatus({ repoRoot, run = defaultRun }) {
   let out;
   try {
@@ -156,7 +156,7 @@ export function formatSnapshotSummary(changes) {
   return `${headline}${slugText}`;
 }
 
-/** vault pathspec 밖에서 이미 staged 된 경로 목록 — 보호 경고용. */
+/** vault pathspec 밖에서 이미 staged 된 경로 목록: 보호 경고용. */
 export function findStagedOutsideVault(fullStatusRows, pathspec) {
   return fullStatusRows
     .filter((row) => {
@@ -172,7 +172,7 @@ function isUnderPathspec(path, pathspec) {
   return path === pathspec || path.startsWith(`${pathspec}/`);
 }
 
-/** vault 범위의 untracked 파일만 골라 add — vault 밖 파일은 절대 건드리지 않는다. */
+/** vault 범위의 untracked 파일만 골라 add: vault 밖 파일은 절대 건드리지 않는다. */
 export function addPaths({ repoRoot, paths, run = defaultRun }) {
   if (!paths || paths.length === 0) return;
   run(['add', '--', ...paths], repoRoot);
@@ -194,7 +194,7 @@ export function getCurrentBranch({ repoRoot, run = defaultRun }) {
   return run(['rev-parse', '--abbrev-ref', 'HEAD'], repoRoot).trim();
 }
 
-/** 현재 브랜치의 upstream ref (예: `origin/main`) — 없으면 null. */
+/** 현재 브랜치의 upstream ref (예: `origin/main`): 없으면 null. */
 export function getUpstreamRef({ repoRoot, run = defaultRun }) {
   try {
     const out = run(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], repoRoot);
@@ -205,7 +205,7 @@ export function getUpstreamRef({ repoRoot, run = defaultRun }) {
   }
 }
 
-/** upstream 이 이미 설정된 브랜치로만 push — 자동 `-u` 설정 금지 (신뢰 헌장). */
+/** upstream 이 이미 설정된 브랜치로만 push: 자동 `-u` 설정 금지 (신뢰 헌장). */
 export function pushCurrentBranch({ repoRoot, run = defaultRun }) {
   run(['push'], repoRoot);
 }
@@ -252,7 +252,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   ) {
     return {
       reason: 'push-non-fast-forward',
-      message: '원격이 앞섰어요 — `git pull` 후 다시 스냅샷하세요.',
+      message: '원격이 앞섰어요: `git pull` 후 다시 스냅샷하세요.',
       note: '커밋은 이미 로컬에 기록됨',
       guidance: 'git pull',
     };
@@ -266,7 +266,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   ) {
     return {
       reason: 'gpg-sign-failed',
-      message: '커밋 서명(gpg)에 실패했어요 — 서명 키를 확인하세요.',
+      message: '커밋 서명(gpg)에 실패했어요: 서명 키를 확인하세요.',
       note: firstLine,
       guidance: 'git config commit.gpgsign false   # 서명을 끄고 다시 스냅샷',
     };
@@ -280,7 +280,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   ) {
     return {
       reason: 'merge-in-progress',
-      message: '머지/리베이스가 진행 중이라 vault 범위만 커밋할 수 없어요 — 진행 중인 작업을 먼저 마치거나 중단하세요.',
+      message: '머지/리베이스가 진행 중이라 vault 범위만 커밋할 수 없어요: 진행 중인 작업을 먼저 마치거나 중단하세요.',
       note: null,
       guidance: 'git status   # 진행 중 상태 확인',
     };
@@ -290,7 +290,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   if (text.includes('conflict') || text.includes('automatic merge failed')) {
     return {
       reason: 'pull-conflict',
-      message: 'pull 중 충돌이 났어요 — 충돌 파일을 해결한 뒤 커밋하세요.',
+      message: 'pull 중 충돌이 났어요: 충돌 파일을 해결한 뒤 커밋하세요.',
       note: null,
       guidance: 'git status   # 충돌 파일 확인',
     };
@@ -300,7 +300,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   if (text.includes('would be overwritten') || text.includes('overwritten by merge')) {
     return {
       reason: 'local-changes',
-      message: '커밋 안 된 로컬 변경이 있어 막혔어요 — 먼저 snapshot 으로 커밋하거나 stash 하세요.',
+      message: '커밋 안 된 로컬 변경이 있어 막혔어요: 먼저 snapshot 으로 커밋하거나 stash 하세요.',
       note: null,
       guidance: 'ontology-atlas snapshot   # 로컬 변경을 먼저 커밋',
     };
@@ -314,7 +314,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   ) {
     return {
       reason: 'no-upstream',
-      message: '이 브랜치에 연결된 원격이 없어요 — 먼저 upstream 을 설정하세요.',
+      message: '이 브랜치에 연결된 원격이 없어요: 먼저 upstream 을 설정하세요.',
       note: null,
       guidance: 'git push -u origin <branch>',
     };
@@ -324,7 +324,7 @@ export function classifyGitError(err, { operation = 'git' } = {}) {
   if (text.includes('pre-commit') || text.includes('commit-msg') || text.includes('hook')) {
     return {
       reason: 'pre-commit-hook',
-      message: '커밋 훅이 스냅샷을 거부했어요 — 훅이 보고한 문제를 고친 뒤 다시 스냅샷하세요.',
+      message: '커밋 훅이 스냅샷을 거부했어요: 훅이 보고한 문제를 고친 뒤 다시 스냅샷하세요.',
       note: firstLine,
       guidance: null,
     };

--- a/cli/src/lib/mcp-call.mjs
+++ b/cli/src/lib/mcp-call.mjs
@@ -341,7 +341,7 @@ export function parseMcpToolResponse(toolResp, { toolName } = {}) {
       throw new Error(`mcp tool structuredContent text is not JSON${toolLabel}: ${previewValue(text)}`);
     }
     if (!isDeepStrictEqual(textPayload, result.structuredContent)) {
-      throw new Error(`mcp tool structuredContent mismatch${toolLabel} — ${structuredContentMismatchSummary(textPayload, result.structuredContent)}`);
+      throw new Error(`mcp tool structuredContent mismatch${toolLabel} · ${structuredContentMismatchSummary(textPayload, result.structuredContent)}`);
     }
     return result.structuredContent;
   }

--- a/cli/src/lib/pre-commit-hook.mjs
+++ b/cli/src/lib/pre-commit-hook.mjs
@@ -15,13 +15,13 @@
 //     hook 이 아무 것도 강제하지 않는 것으로 충분하다.
 
 export const PRE_COMMIT_MARKER_START =
-  '# >>> ontology-atlas preflight (managed block — safe to remove) >>>';
+  '# >>> ontology-atlas preflight (managed block: safe to remove) >>>';
 export const PRE_COMMIT_MARKER_END =
-  '# <<< ontology-atlas preflight (managed block — safe to remove) <<<';
+  '# <<< ontology-atlas preflight (managed block: safe to remove) <<<';
 
 const HOOK_BLOCK = [
   PRE_COMMIT_MARKER_START,
-  '# Shows which vault nodes this commit touches — informational only, never',
+  '# Shows which vault nodes this commit touches: informational only, never',
   '# blocks the commit. `git commit --no-verify` skips this like any other hook.',
   'if command -v ontology-atlas >/dev/null 2>&1; then',
   '  ontology-atlas preflight --staged',

--- a/cli/src/lib/schema.mjs
+++ b/cli/src/lib/schema.mjs
@@ -263,7 +263,7 @@ export const VAULT_KIND_SCHEMA = {
     ],
     bodyTemplate: (title) =>
       `# ${title}\n\n` +
-      `One- or two-line summary of this project — *what / for whom / why*.\n\n` +
+      `One- or two-line summary of this project: *what / for whom / why*.\n\n` +
       `## How it grows\n\n` +
       `- Fill \`domains: [...]\` in the frontmatter and the domain nodes hang\n` +
       `  off the project tree automatically.\n` +
@@ -473,7 +473,7 @@ export function flatSlugIssue(kind, slug) {
   if (!rest.includes('/') && !rest.includes('\\')) return null;
   const tail = rest.split(/[\\/]/).filter(Boolean).pop() ?? rest;
   return (
-    `slug "${slug}" nests a path under ${folder} — a slug is the node's NAME, not a location. ` +
+    `slug "${slug}" nests a path under ${folder}: a slug is the node's NAME, not a location. ` +
     `Node identity is resolved by the slug tail on three surfaces (web derivation, unique-tail lookup, deep links), ` +
     `so path-style slugs silently merge distinct nodes the moment two files share a basename. ` +
     `Use a flat slug under the kind folder (e.g. "${folder}${tail}") and record the file location in path: instead.`

--- a/cli/src/lib/self-invocation.mjs
+++ b/cli/src/lib/self-invocation.mjs
@@ -42,7 +42,7 @@ export function cliInvocation(io = {}) {
   return `node ${shellQuoteIfNeeded(path.resolve(entry))}`;
 }
 
-/** 공백·따옴표가 든 경로만 감싼다 — 멀쩡한 경로에 따옴표를 붙이면 읽기 나쁘다. */
+/** 공백·따옴표가 든 경로만 감싼다: 멀쩡한 경로에 따옴표를 붙이면 읽기 나쁘다. */
 export function shellQuoteIfNeeded(value) {
   return /[\s"'$`\\]/.test(value) ? `'${value.replace(/'/g, `'\\''`)}'` : value;
 }

--- a/cli/src/lib/telemetry.mjs
+++ b/cli/src/lib/telemetry.mjs
@@ -33,7 +33,7 @@ function telemetryPath(vaultRoot) {
 
 function defaultTelemetry() {
   return {
-    '//': 'local only, never transmitted — see AGENTS.md trust charter (PRODUCT-PLAN-2026-07.md §7)',
+    '//': 'local only, never transmitted: see AGENTS.md trust charter (PRODUCT-PLAN-2026-07.md §7)',
     initCompletedAt: null,
     absorbWriteCompletedAt: null,
     moment: null,

--- a/cli/src/lib/validate.mjs
+++ b/cli/src/lib/validate.mjs
@@ -41,7 +41,7 @@ export function validateVaultDocument(raw) {
       code: 'unclosed-frontmatter',
       severity: 'error',
       message:
-        'frontmatter 시작 `---` 만 있고 끝 `---` 가 없습니다 — 노드로 인식되지 않습니다.',
+        'frontmatter 시작 `---` 만 있고 끝 `---` 가 없습니다: 노드로 인식되지 않습니다.',
     });
     return { ok: false, issues };
   }
@@ -58,7 +58,7 @@ export function validateVaultDocument(raw) {
       code: 'parse-zero-keys',
       severity: 'warning',
       message:
-        'frontmatter 블록은 있지만 key 가 하나도 추출되지 않았습니다 — 들여쓰기 또는 콜론 누락 의심.',
+        'frontmatter 블록은 있지만 key 가 하나도 추출되지 않았습니다: 들여쓰기 또는 콜론 누락 의심.',
     });
     return { ok: true, issues };
   }
@@ -71,13 +71,13 @@ export function validateVaultDocument(raw) {
       code: 'missing-kind',
       severity: 'warning',
       message:
-        'frontmatter 에 `kind:` 가 없습니다 — graph 노드가 되려면 kind 가 필요합니다.',
+        'frontmatter 에 `kind:` 가 없습니다: graph 노드가 되려면 kind 가 필요합니다.',
     });
   } else if (typeof rawKind !== 'string' || rawKind.trim() === '') {
     issues.push({
       code: 'empty-kind',
       severity: 'error',
-      message: '`kind:` 값이 비어있습니다 — graph 노드로 인식되지 않습니다.',
+      message: '`kind:` 값이 비어있습니다: graph 노드로 인식되지 않습니다.',
     });
   } else if (!KNOWN_VAULT_KINDS.includes(rawKind.trim())) {
     issues.push({
@@ -93,7 +93,7 @@ export function validateVaultDocument(raw) {
       issues.push({
         code: 'missing-expected-field',
         severity: 'warning',
-        message: `\`${key}:\` 가 비어있습니다 — kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
+        message: `\`${key}:\` 가 비어있습니다: kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
       });
     }
   }
@@ -116,7 +116,7 @@ function pushUidIssues(frontmatter, issues) {
     issues.push({
       code: 'missing-uid',
       severity: 'error',
-      message: '`uid:`가 없습니다 — 모든 ontology 노드는 생성 후 바뀌지 않는 lowercase UUIDv4 영구 식별자를 가져야 합니다.',
+      message: '`uid:`가 없습니다: 모든 ontology 노드는 생성 후 바뀌지 않는 lowercase UUIDv4 영구 식별자를 가져야 합니다.',
     });
     return;
   }
@@ -154,7 +154,7 @@ function pushNonCanonicalGraphArrayIssues(frontmatter, issues) {
       issues.push({
         code: 'non-canonical-graph-array',
         severity: 'warning',
-        message: `\`${key}:\` graph 배열이 정렬/중복제거된 canonical set 이 아닙니다 — add_relation 또는 patch_concept 로 다시 저장하면 정리됩니다.`,
+        message: `\`${key}:\` graph 배열이 정렬/중복제거된 canonical set 이 아닙니다: add_relation 또는 patch_concept 로 다시 저장하면 정리됩니다.`,
       });
     }
   }

--- a/cli/src/lib/write-vault.mjs
+++ b/cli/src/lib/write-vault.mjs
@@ -139,7 +139,7 @@ export function writeFrontmatterKey(rootPath, slug, key, value) {
   return writeFrontmatterKeys(rootPath, slug, { [key]: value });
 }
 
-/** 복수 키를 한 번의 파일 쓰기로 — 관계+relation_notes 원자성 (P6 게이트 ③ CLI 측). */
+/** 복수 키를 한 번의 파일 쓰기로: 관계+relation_notes 원자성 (P6 게이트 ③ CLI 측). */
 export function writeFrontmatterKeys(rootPath, slug, patch) {
   const { filePath, frontmatter, body } = readDocFrontmatter(rootPath, slug);
   if ('uid' in patch && patch.uid !== frontmatter.uid) {

--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -266,7 +266,7 @@ export function toolsListInventoryFailure(tools) {
     typeof name === 'string' && names.indexOf(name) !== index
   )))];
   if (missing.length === 0 && extra.length === 0 && duplicates.length === 0 && invalidNameCount === 0) return null;
-  return `tools mismatch — missing: ${missing.join(',') || '(none)'}, extra: ${extra.join(',') || '(none)'}, duplicates: ${duplicates.join(',') || '(none)'}, invalidNames: ${invalidNameCount}`;
+  return `tools mismatch: missing: ${missing.join(',') || '(none)'}, extra: ${extra.join(',') || '(none)'}, duplicates: ${duplicates.join(',') || '(none)'}, invalidNames: ${invalidNameCount}`;
 }
 
 export function expectedToolTitle(name) {
@@ -3058,7 +3058,7 @@ export function structuredErrorFailure(response, label, { errorCode } = {}) {
     return `${label} structured error code missing`;
   }
   if (errorCode && structured.errorCode !== errorCode) {
-    return `${label} structured error code mismatch — expected ${errorCode}, got ${structured.errorCode}`;
+    return `${label} structured error code mismatch: expected ${errorCode}, got ${structured.errorCode}`;
   }
   return null;
 }
@@ -3736,7 +3736,7 @@ export function structuredContentFailure(response, parsed, label) {
     return `${label} structuredContent missing`;
   }
   if (status === 'mismatch') {
-    return `${label} structuredContent mismatch — ${structuredContentMismatchSummary(parsed, structured)}`;
+    return `${label} structuredContent mismatch: ${structuredContentMismatchSummary(parsed, structured)}`;
   }
   return null;
 }
@@ -3891,24 +3891,24 @@ export const FIRST_CONTACT_RESPONSE_LABELS = new Map([
 ]);
 
 export const OPTIONAL_FIRST_CONTACT_RESPONSE_IDS = [
-  30, // maintenance_resume_cursor — sent only when maintenance has an action to resume after.
-  31, // get_concept — sent only when list_concepts returns a real node.
-  33, // find_backlinks — sent only when list_concepts returns a real node.
-  35, // find_neighbors — sent only when a direct graph-read target exists.
-  36, // find_path — sent only when a direct graph-read target exists.
-  37, // query_concepts_limited — sent only when the vault has a non-trivial excluded slug.
-  43, // rename_concept_dry_run — sent only when a real writable node exists.
-  44, // merge_concepts_dry_run — sent only when two real writable nodes exist.
-  45, // delete_concept_dry_run — sent only when a real writable node exists.
-  61, // patch_concept_conflict_guard — sent only when a real writable node exists.
+  30, // maintenance_resume_cursor: sent only when maintenance has an action to resume after.
+  31, // get_concept: sent only when list_concepts returns a real node.
+  33, // find_backlinks: sent only when list_concepts returns a real node.
+  35, // find_neighbors: sent only when a direct graph-read target exists.
+  36, // find_path: sent only when a direct graph-read target exists.
+  37, // query_concepts_limited: sent only when the vault has a non-trivial excluded slug.
+  43, // rename_concept_dry_run: sent only when a real writable node exists.
+  44, // merge_concepts_dry_run: sent only when two real writable nodes exist.
+  45, // delete_concept_dry_run: sent only when a real writable node exists.
+  61, // patch_concept_conflict_guard: sent only when a real writable node exists.
 ];
 
 export const DYNAMIC_FIRST_CONTACT_RESPONSE_IDS = [
-  11, // get_concepts — sent after list_concepts returns the current sample slugs.
-  13, // neighbors — sent after graph smoke target selection.
-  14, // path — sent after graph smoke target selection.
-  15, // project_scope — sent after project probe/listing discovers a project node.
-  67, // all_paths — sent after graph smoke target selection.
+  11, // get_concepts: sent after list_concepts returns the current sample slugs.
+  13, // neighbors: sent after graph smoke target selection.
+  14, // path: sent after graph smoke target selection.
+  15, // project_scope: sent after project probe/listing discovers a project node.
+  67, // all_paths: sent after graph smoke target selection.
   ...OPTIONAL_FIRST_CONTACT_RESPONSE_IDS,
 ];
 
@@ -4176,7 +4176,7 @@ export function verifyTimeoutValueErrorMessage(value, env = process.env) {
 }
 
 export function verifySuccessMessage(toolCount = EXPECTED_TOOLS.length) {
-  return `All passed — register .mcp.json with your MCP client and restart to use the ${toolCount} tools.`;
+  return `All passed: register .mcp.json with your MCP client and restart to use the ${toolCount} tools.`;
 }
 
 export function verifyUsage() {
@@ -4200,7 +4200,7 @@ export function verifyUsage() {
     'tools/list inventory names, initialize-instruction tool inventory, schema strictness, and annotation coverage (title/read/write/destructive/idempotent/local-only),\n' +
     'batch reader/writer row isolation for non-object rows and unknown row fields with concepts[n]/relations[n] error labels, invalid add_relations type closest-value hints, and 50-row batch cap rejection,\n' +
     'destructive writer dry-runs for rename_concept/merge_concepts/delete_concept with every planned response present and no changed/postWriteMaintenance,\n' +
-    'an absorb_document dry-run against a temp fixture file (Slice 0 — never the vault under test) covering both the policy-absorb and architecture-suggest classification branches,\n' +
+    'an absorb_document dry-run against a temp fixture file (Slice 0: never the vault under test) covering both the policy-absorb and architecture-suggest classification branches,\n' +
     'structuredContent coverage summary splits direct reads, batch row-isolation writes with no write metadata, destructive dry-runs, maintenance cursor checks, and graph queries,\n' +
     'and maintenance_plan cursor handling: ready page (cursor.found=true, cursor.reason=null)\n' +
     'plus missing afterActionId (cursor.found=false, reason, empty page, nextAfterActionId=null, hasMore=false).\n' +
@@ -5284,7 +5284,7 @@ export function vaultWarningsFailure(parsed) {
   const errorCount = warnings.errorCount;
   const warningCount = warnings.warningCount;
   if (errorCount === 0 && warningCount === 0) return null;
-  return `list_concepts vaultWarnings present — errors ${errorCount}, warnings ${warningCount}. Run validate_vault for file-level diagnostics before writing.`;
+  return `list_concepts vaultWarnings present: errors ${errorCount}, warnings ${warningCount}. Run validate_vault for file-level diagnostics before writing.`;
 }
 
 export function listKindsFailure(parsed) {
@@ -5305,7 +5305,7 @@ export function listKindsFailure(parsed) {
     sum += count;
   }
   if (sum !== parsed.total) {
-    return `list_kinds response total mismatch — total ${parsed.total}, byKind ${sum}`;
+    return `list_kinds response total mismatch: total ${parsed.total}, byKind ${sum}`;
   }
   return null;
 }
@@ -5321,7 +5321,7 @@ export function listConceptsFailure(parsed) {
     return 'list_concepts response missing nodes array';
   }
   if (parsed.nodes.length > parsed.total) {
-    return `list_concepts response node count exceeds total — nodes ${parsed.nodes.length}, total ${parsed.total}`;
+    return `list_concepts response node count exceeds total: nodes ${parsed.nodes.length}, total ${parsed.total}`;
   }
   for (const [index, node] of parsed.nodes.entries()) {
     if (!node || typeof node !== 'object' || Array.isArray(node)) {
@@ -5361,7 +5361,7 @@ export function projectProbeFailure(parsed, kinds) {
     return `project probe returned non-project node: ${nonProject.slug || '(unknown)'}`;
   }
   if (Number.isInteger(kindProjectCount) && parsed.total >= 1 && parsed.total !== kindProjectCount) {
-    return `project probe count mismatch — list_kinds project ${kindProjectCount}, probe ${parsed.total}`;
+    return `project probe count mismatch: list_kinds project ${kindProjectCount}, probe ${parsed.total}`;
   }
   return null;
 }
@@ -5408,7 +5408,7 @@ export function getConceptsFailure(parsed) {
     return 'get_concepts response expected partial row to be ok:false';
   }
   if (missing.slug !== 'missing-verify-slug') {
-    return `get_concepts response partial row slug mismatch — ${missing.slug}`;
+    return `get_concepts response partial row slug mismatch: ${missing.slug}`;
   }
   if (typeof missing.error !== 'string' || !/not found/i.test(missing.error)) {
     return 'get_concepts response missing partial row error';
@@ -5421,7 +5421,7 @@ export function getConceptFailure(parsed, expectedSlug) {
     return 'get_concept response malformed';
   }
   if (parsed.slug !== expectedSlug) {
-    return `get_concept response slug mismatch — expected ${expectedSlug}, got ${parsed.slug}`;
+    return `get_concept response slug mismatch: expected ${expectedSlug}, got ${parsed.slug}`;
   }
   if (!hasNonEmptyString(parsed.uid) || !NODE_UID_RE.test(parsed.uid)) {
     return `get_concept response missing uid: ${expectedSlug}`;
@@ -5520,7 +5520,7 @@ export function findEvidenceFailure(parsed) {
 
 export function findBacklinksFailure(parsed, expectedTarget) {
   if (parsed?.target !== expectedTarget) {
-    return `find_backlinks response target mismatch — expected ${expectedTarget}, got ${parsed?.target}`;
+    return `find_backlinks response target mismatch: expected ${expectedTarget}, got ${parsed?.target}`;
   }
   if (!Number.isInteger(parsed.total) || parsed.total < 0) {
     return 'find_backlinks response missing total count';
@@ -5529,7 +5529,7 @@ export function findBacklinksFailure(parsed, expectedTarget) {
     return 'find_backlinks response missing matches array';
   }
   if (parsed.matches.length > parsed.total) {
-    return `find_backlinks response match count exceeds total — matches ${parsed.matches.length}, total ${parsed.total}`;
+    return `find_backlinks response match count exceeds total: matches ${parsed.matches.length}, total ${parsed.total}`;
   }
   for (const [index, row] of parsed.matches.entries()) {
     const failure = readMatchRowFailure('find_backlinks', row, index, { backlinks: true });
@@ -5555,10 +5555,10 @@ export function queryConceptsFailure(parsed) {
     return 'query_concepts response missing matches array';
   }
   if (parsed.matches.length > parsed.total) {
-    return `query_concepts response match count exceeds total — matches ${parsed.matches.length}, total ${parsed.total}`;
+    return `query_concepts response match count exceeds total: matches ${parsed.matches.length}, total ${parsed.total}`;
   }
   if (!parsed.limited && parsed.matches.length !== parsed.total) {
-    return `query_concepts response match count mismatch — matches ${parsed.matches.length}, total ${parsed.total}`;
+    return `query_concepts response match count mismatch: matches ${parsed.matches.length}, total ${parsed.total}`;
   }
   for (const [index, row] of parsed.matches.entries()) {
     const failure = readMatchRowFailure('query_concepts', row, index);
@@ -5571,13 +5571,13 @@ export function limitedQueryConceptsFailure(parsed, excludedSlug, expectedTotal)
   const baseFailure = queryConceptsFailure(parsed);
   if (baseFailure) return baseFailure;
   if (parsed.filter !== `slug!=${excludedSlug}`) {
-    return `query_concepts limited filter mismatch — expected slug!=${excludedSlug}, got ${parsed.filter}`;
+    return `query_concepts limited filter mismatch: expected slug!=${excludedSlug}, got ${parsed.filter}`;
   }
   if (parsed.total !== expectedTotal) {
-    return `query_concepts limited total mismatch — expected ${expectedTotal}, got ${parsed.total}`;
+    return `query_concepts limited total mismatch: expected ${expectedTotal}, got ${parsed.total}`;
   }
   if (parsed.matches.length !== 1) {
-    return `query_concepts limited match count mismatch — expected 1, got ${parsed.matches.length}`;
+    return `query_concepts limited match count mismatch: expected 1, got ${parsed.matches.length}`;
   }
   if (parsed.limited !== true) {
     return 'query_concepts limited response did not set limited=true';
@@ -5940,7 +5940,7 @@ export function indexProjectFailure(parsed) {
 
 export function findNeighborsFailure(parsed, expectedSlug) {
   if (parsed?.center !== expectedSlug) {
-    return `find_neighbors center mismatch — expected ${expectedSlug}, got ${parsed?.center}`;
+    return `find_neighbors center mismatch: expected ${expectedSlug}, got ${parsed?.center}`;
   }
   if (typeof parsed.requested !== 'string' || parsed.requested.length === 0) {
     return 'find_neighbors response missing requested slug';
@@ -5961,10 +5961,10 @@ export function findNeighborsFailure(parsed, expectedSlug) {
     return 'find_neighbors response missing edges array';
   }
   if (parsed.edges.length > parsed.totalEdges) {
-    return `find_neighbors response edge count exceeds total — edges ${parsed.edges.length}, total ${parsed.totalEdges}`;
+    return `find_neighbors response edge count exceeds total: edges ${parsed.edges.length}, total ${parsed.totalEdges}`;
   }
   if (!parsed.limited && parsed.edges.length !== parsed.totalEdges) {
-    return `find_neighbors response edge count mismatch — edges ${parsed.edges.length}, total ${parsed.totalEdges}`;
+    return `find_neighbors response edge count mismatch: edges ${parsed.edges.length}, total ${parsed.totalEdges}`;
   }
   if (!Array.isArray(parsed.nodes)) {
     return 'find_neighbors response missing nodes array';
@@ -5985,7 +5985,7 @@ export function findNeighborsFailure(parsed, expectedSlug) {
 
 export function findPathFailure(parsed, expectedFrom, expectedTo) {
   if (parsed?.from !== expectedFrom || parsed?.to !== expectedTo) {
-    return `find_path endpoint mismatch — expected ${expectedFrom}->${expectedTo}, got ${parsed?.from}->${parsed?.to}`;
+    return `find_path endpoint mismatch: expected ${expectedFrom}->${expectedTo}, got ${parsed?.from}->${parsed?.to}`;
   }
   if (typeof parsed.found !== 'boolean') {
     return 'find_path response missing found flag';
@@ -6300,7 +6300,7 @@ export function findOrphansFailure(parsed) {
     return 'find_orphans response missing orphans array';
   }
   if (parsed.orphans.length > parsed.total) {
-    return `find_orphans response orphan count exceeds total — orphans ${parsed.orphans.length}, total ${parsed.total}`;
+    return `find_orphans response orphan count exceeds total: orphans ${parsed.orphans.length}, total ${parsed.total}`;
   }
   for (const [index, node] of parsed.orphans.entries()) {
     if (!node || typeof node !== 'object' || Array.isArray(node)) {
@@ -6371,8 +6371,8 @@ export function validateVaultFailure(parsed) {
     return 'validate_vault response missing byCode entries for problem files';
   }
   const codeSummary = validationCodeSummary(summary.byCode);
-  const suffix = codeSummary ? ` — codes ${codeSummary}` : '';
-  return `validate_vault found ${formatCount(problemFiles, 'problem file')} — errors ${summary.errorFiles}, warnings ${summary.warningFiles}${suffix}`;
+  const suffix = codeSummary ? ` · codes ${codeSummary}` : '';
+  return `validate_vault found ${formatCount(problemFiles, 'problem file')}: errors ${summary.errorFiles}, warnings ${summary.warningFiles}${suffix}`;
 }
 
 export function compileSummaryFailure(parsed) {
@@ -6403,12 +6403,12 @@ export function compileSummaryFailure(parsed) {
   if (byDomainFailure) return byDomainFailure;
   const byKindTotal = Object.values(parsed.byKind).reduce((sum, count) => sum + count, 0);
   if (byKindTotal !== parsed.nodeCount) {
-    return `compile_ontology response byKind mismatch — nodeCount ${parsed.nodeCount}, byKind ${byKindTotal}`;
+    return `compile_ontology response byKind mismatch: nodeCount ${parsed.nodeCount}, byKind ${byKindTotal}`;
   }
   const edgeTotal =
     parsed.resolvedEdgeCount + parsed.externalEdgeCount + parsed.unresolvedEdgeCount;
   if (edgeTotal !== parsed.edgeCount) {
-    return `compile_ontology response edge count mismatch — edgeCount ${parsed.edgeCount}, resolved+external+unresolved ${edgeTotal}`;
+    return `compile_ontology response edge count mismatch: edgeCount ${parsed.edgeCount}, resolved+external+unresolved ${edgeTotal}`;
   }
   return null;
 }
@@ -6488,14 +6488,14 @@ export function compileFullArtifactFailure(parsed) {
   ]);
   if (fullSummaryFailure) return fullSummaryFailure;
   if (parsed.summary.nodes !== parsed.nodeCount || parsed.summary.edges !== parsed.edgeCount) {
-    return `compile_ontology full response summary mismatch — summary ${parsed.summary.nodes}/${parsed.summary.edges}, counts ${parsed.nodeCount}/${parsed.edgeCount}`;
+    return `compile_ontology full response summary mismatch: summary ${parsed.summary.nodes}/${parsed.summary.edges}, counts ${parsed.nodeCount}/${parsed.edgeCount}`;
   }
   if (
     parsed.summary.aliases !== parsed.aliasCount ||
     parsed.summary.ambiguousAliases !== parsed.ambiguousAliasCount ||
     parsed.summary.issues !== parsed.issueCount
   ) {
-    return `compile_ontology full response summary count mismatch — summary aliases/ambiguous/issues ${parsed.summary.aliases}/${parsed.summary.ambiguousAliases}/${parsed.summary.issues}, counts ${parsed.aliasCount}/${parsed.ambiguousAliasCount}/${parsed.issueCount}`;
+    return `compile_ontology full response summary count mismatch: summary aliases/ambiguous/issues ${parsed.summary.aliases}/${parsed.summary.ambiguousAliases}/${parsed.summary.issues}, counts ${parsed.aliasCount}/${parsed.ambiguousAliasCount}/${parsed.issueCount}`;
   }
   if (parsed.summary.graphHash !== parsed.graphHash) {
     return 'compile_ontology full response summary graphHash mismatch';
@@ -6556,7 +6556,7 @@ function fullArtifactArrayCountFailure(parsed) {
   ];
   for (const [arrayName, countName] of checks) {
     if (parsed[arrayName].length !== parsed[countName]) {
-      return `compile_ontology full response ${arrayName} count mismatch — ${arrayName} ${parsed[arrayName].length}, ${countName} ${parsed[countName]}`;
+      return `compile_ontology full response ${arrayName} count mismatch: ${arrayName} ${parsed[arrayName].length}, ${countName} ${parsed[countName]}`;
     }
   }
   return null;
@@ -6572,10 +6572,10 @@ function paginationMetaFailure(label, meta, total, returned) {
     }
   }
   if (meta.total !== total) {
-    return `${label} total mismatch — meta ${meta.total}, count ${total}`;
+    return `${label} total mismatch: meta ${meta.total}, count ${total}`;
   }
   if (meta.returned !== returned) {
-    return `${label} returned mismatch — meta ${meta.returned}, array ${returned}`;
+    return `${label} returned mismatch: meta ${meta.returned}, array ${returned}`;
   }
   if (typeof meta.hasMore !== 'boolean') {
     return `${label} missing hasMore`;
@@ -6627,7 +6627,7 @@ function groupedIndexCountFailure(label, value, counts) {
 function indexedEdgeMembershipCountFailure(label, value, expected, expectedLabel) {
   const actual = Object.values(value).reduce((sum, row) => sum + row.length, 0);
   if (actual !== expected) {
-    return `${label} count mismatch — index ${actual}, ${expectedLabel} ${expected}`;
+    return `${label} count mismatch: index ${actual}, ${expectedLabel} ${expected}`;
   }
   return null;
 }
@@ -6648,7 +6648,7 @@ export function compileIndexesFailure(parsed) {
   }
   const edgeIds = Object.keys(indexes.edgeById);
   if (edgeIds.length !== parsed.edgeCount) {
-    return `compile_ontology.indexes.edgeById count mismatch — index ${edgeIds.length}, edgeCount ${parsed.edgeCount}`;
+    return `compile_ontology.indexes.edgeById count mismatch: index ${edgeIds.length}, edgeCount ${parsed.edgeCount}`;
   }
   for (const [id, edge] of Object.entries(indexes.edgeById)) {
     if (
@@ -6680,7 +6680,7 @@ export function compileIndexesFailure(parsed) {
     indexedExternal !== parsed.externalEdgeCount ||
     indexedUnresolved !== parsed.unresolvedEdgeCount
   ) {
-    return `compile_ontology.indexes.edgeById edge breakdown mismatch — index ${indexedResolved}/${indexedExternal}/${indexedUnresolved}, counts ${parsed.resolvedEdgeCount}/${parsed.externalEdgeCount}/${parsed.unresolvedEdgeCount}`;
+    return `compile_ontology.indexes.edgeById edge breakdown mismatch: index ${indexedResolved}/${indexedExternal}/${indexedUnresolved}, counts ${parsed.resolvedEdgeCount}/${parsed.externalEdgeCount}/${parsed.unresolvedEdgeCount}`;
   }
   for (const [id, edge] of Object.entries(indexes.edgeById)) {
     if (!indexes.out[edge.from]?.includes(id)) {
@@ -6695,7 +6695,7 @@ export function compileIndexesFailure(parsed) {
   }
   const aliasKeys = Object.keys(indexes.aliasToSlug);
   if (aliasKeys.length !== parsed.aliasCount) {
-    return `compile_ontology.indexes.aliasToSlug count mismatch — index ${aliasKeys.length}, aliasCount ${parsed.aliasCount}`;
+    return `compile_ontology.indexes.aliasToSlug count mismatch: index ${aliasKeys.length}, aliasCount ${parsed.aliasCount}`;
   }
   for (const [alias, slug] of Object.entries(indexes.aliasToSlug)) {
     if (!alias || typeof slug !== 'string' || !slug) {
@@ -6709,10 +6709,10 @@ export function compileIndexesFailure(parsed) {
   }
   const primaryUidRows = parsed.nodes.map((node) => [node.uid, node.slug]);
   if (Object.keys(indexes.uidToSlug).length !== parsed.nodeCount) {
-    return `compile_ontology.indexes.uidToSlug count mismatch — index ${Object.keys(indexes.uidToSlug).length}, nodeCount ${parsed.nodeCount}`;
+    return `compile_ontology.indexes.uidToSlug count mismatch: index ${Object.keys(indexes.uidToSlug).length}, nodeCount ${parsed.nodeCount}`;
   }
   if (Object.keys(indexes.slugToUid).length !== parsed.nodeCount) {
-    return `compile_ontology.indexes.slugToUid count mismatch — index ${Object.keys(indexes.slugToUid).length}, nodeCount ${parsed.nodeCount}`;
+    return `compile_ontology.indexes.slugToUid count mismatch: index ${Object.keys(indexes.slugToUid).length}, nodeCount ${parsed.nodeCount}`;
   }
   for (const [uid, slug] of Object.entries(indexes.uidToSlug)) {
     if (!NODE_UID_RE.test(uid) || typeof slug !== 'string' || !slug) {
@@ -6733,7 +6733,7 @@ export function compileIndexesFailure(parsed) {
     (node.merged_uids || []).map((uid) => [uid, node.slug]),
   );
   if (parsed.nodes.length === parsed.nodeCount && Object.keys(indexes.mergedUidToSlug).length !== historicalUidRows.length) {
-    return `compile_ontology.indexes.mergedUidToSlug count mismatch — index ${Object.keys(indexes.mergedUidToSlug).length}, merged_uids ${historicalUidRows.length}`;
+    return `compile_ontology.indexes.mergedUidToSlug count mismatch: index ${Object.keys(indexes.mergedUidToSlug).length}, merged_uids ${historicalUidRows.length}`;
   }
   for (const [uid, slug] of Object.entries(indexes.mergedUidToSlug)) {
     if (!NODE_UID_RE.test(uid) || typeof slug !== 'string' || !slug) {
@@ -6817,13 +6817,13 @@ export function overviewFailure(parsed) {
   }
   const edgeTotal = graph.resolvedEdges + graph.externalEdges + graph.unresolvedEdges;
   if (edgeTotal !== graph.edges) {
-    return `overview response edge count mismatch — edges ${graph.edges}, resolved+external+unresolved ${edgeTotal}`;
+    return `overview response edge count mismatch: edges ${graph.edges}, resolved+external+unresolved ${edgeTotal}`;
   }
   const byKindFailure = countMapFailure('overview', 'byKind', parsed.byKind);
   if (byKindFailure) return byKindFailure;
   const byKindTotal = Object.values(parsed.byKind).reduce((sum, count) => sum + count, 0);
   if (byKindTotal !== graph.nodes) {
-    return `overview response byKind mismatch — nodes ${graph.nodes}, byKind ${byKindTotal}`;
+    return `overview response byKind mismatch: nodes ${graph.nodes}, byKind ${byKindTotal}`;
   }
   if (!Array.isArray(parsed.hubs)) {
     return 'overview response missing hubs array';
@@ -6902,7 +6902,7 @@ export function neighborsFailure(parsed, expectedSlug) {
     return `neighbors returned unexpected operation: ${parsed?.operation}`;
   }
   if (parsed.center !== expectedSlug) {
-    return `neighbors center mismatch — expected ${expectedSlug}, got ${parsed.center}`;
+    return `neighbors center mismatch: expected ${expectedSlug}, got ${parsed.center}`;
   }
   if (!parsed.node || parsed.node.slug !== parsed.center) {
     return 'neighbors response missing center node';
@@ -6917,10 +6917,10 @@ export function neighborsFailure(parsed, expectedSlug) {
     return 'neighbors response missing edges array';
   }
   if (parsed.edges.length > parsed.total) {
-    return `neighbors response edge count exceeds total — edges ${parsed.edges.length}, total ${parsed.total}`;
+    return `neighbors response edge count exceeds total: edges ${parsed.edges.length}, total ${parsed.total}`;
   }
   if (!parsed.limited && parsed.edges.length !== parsed.total) {
-    return `neighbors response edge count mismatch — edges ${parsed.edges.length}, total ${parsed.total}`;
+    return `neighbors response edge count mismatch: edges ${parsed.edges.length}, total ${parsed.total}`;
   }
   if (!Array.isArray(parsed.nodes)) {
     return 'neighbors response missing nodes array';
@@ -6940,7 +6940,7 @@ export function pathQueryFailure(parsed, expectedFrom, expectedTo = expectedFrom
     return `path returned unexpected operation: ${parsed?.operation}`;
   }
   if (parsed.from !== expectedFrom || parsed.to !== expectedTo) {
-    return `path endpoint mismatch — expected ${expectedFrom}->${expectedTo}, got ${parsed.from}->${parsed.to}`;
+    return `path endpoint mismatch: expected ${expectedFrom}->${expectedTo}, got ${parsed.from}->${parsed.to}`;
   }
   if (parsed.found !== true) {
     return 'path response expected found:true';
@@ -6988,7 +6988,7 @@ export function allPathsQueryFailure(parsed, expectedFrom, expectedTo = expected
     return `all_paths returned unexpected operation: ${parsed?.operation}`;
   }
   if (parsed.from !== expectedFrom || parsed.to !== expectedTo) {
-    return `all_paths endpoint mismatch — expected ${expectedFrom}->${expectedTo}, got ${parsed.from}->${parsed.to}`;
+    return `all_paths endpoint mismatch: expected ${expectedFrom}->${expectedTo}, got ${parsed.from}->${parsed.to}`;
   }
   if (typeof parsed.found !== 'boolean') {
     return 'all_paths response missing found flag';
@@ -7003,7 +7003,7 @@ export function allPathsQueryFailure(parsed, expectedFrom, expectedTo = expected
     return 'all_paths response missing expandedStates';
   }
   if (parsed.expandedStates > parsed.searchBudget) {
-    return `all_paths response exceeded searchBudget — expanded ${parsed.expandedStates}, budget ${parsed.searchBudget}`;
+    return `all_paths response exceeded searchBudget: expanded ${parsed.expandedStates}, budget ${parsed.searchBudget}`;
   }
   if (typeof parsed.exhaustive !== 'boolean') {
     return 'all_paths response missing exhaustive flag';
@@ -7027,13 +7027,13 @@ export function allPathsQueryFailure(parsed, expectedFrom, expectedTo = expected
     return 'all_paths response missing paths array';
   }
   if (parsed.paths.length > parsed.limit) {
-    return `all_paths response path count exceeds limit — paths ${parsed.paths.length}, limit ${parsed.limit}`;
+    return `all_paths response path count exceeds limit: paths ${parsed.paths.length}, limit ${parsed.limit}`;
   }
   if (parsed.paths.length > parsed.totalPaths) {
-    return `all_paths response path count exceeds total — paths ${parsed.paths.length}, total ${parsed.totalPaths}`;
+    return `all_paths response path count exceeds total: paths ${parsed.paths.length}, total ${parsed.totalPaths}`;
   }
   if (!parsed.limited && parsed.paths.length !== parsed.totalPaths) {
-    return `all_paths response total mismatch — paths ${parsed.paths.length}, total ${parsed.totalPaths}`;
+    return `all_paths response total mismatch: paths ${parsed.paths.length}, total ${parsed.totalPaths}`;
   }
   const evidenceFailure = allPathsEvidenceFailure(parsed.evidence, parsed);
   if (evidenceFailure) return evidenceFailure;
@@ -7108,7 +7108,7 @@ export function projectScopeFailure(parsed, expectedProject) {
     return `project_scope returned unexpected operation: ${parsed?.operation}`;
   }
   if (parsed.project !== expectedProject) {
-    return `project_scope project mismatch — expected ${expectedProject}, got ${parsed.project}`;
+    return `project_scope project mismatch: expected ${expectedProject}, got ${parsed.project}`;
   }
   if (!parsed.node || parsed.node.slug !== parsed.project) {
     return 'project_scope response missing project node';
@@ -7130,7 +7130,7 @@ export function projectScopeFailure(parsed, expectedProject) {
     return 'project_scope nodes missing total';
   }
   if (parsed.nodes.total !== parsed.summary.nodes) {
-    return `project_scope node total mismatch — summary ${parsed.summary.nodes}, bucket ${parsed.nodes.total}`;
+    return `project_scope node total mismatch: summary ${parsed.summary.nodes}, bucket ${parsed.nodes.total}`;
   }
   if (typeof parsed.nodes.limited !== 'boolean') {
     return 'project_scope nodes missing limited flag';
@@ -7139,14 +7139,14 @@ export function projectScopeFailure(parsed, expectedProject) {
     return 'project_scope nodes missing rows';
   }
   if (parsed.nodes.rows.length > parsed.nodes.total) {
-    return `project_scope nodes exceed total — rows ${parsed.nodes.rows.length}, total ${parsed.nodes.total}`;
+    return `project_scope nodes exceed total: rows ${parsed.nodes.rows.length}, total ${parsed.nodes.total}`;
   }
   if (!parsed.nodes.limited && parsed.nodes.rows.length !== parsed.nodes.total) {
-    return `project_scope node count mismatch — rows ${parsed.nodes.rows.length}, total ${parsed.nodes.total}`;
+    return `project_scope node count mismatch: rows ${parsed.nodes.rows.length}, total ${parsed.nodes.total}`;
   }
   const byKindTotal = Object.values(parsed.byKind).reduce((sum, count) => sum + count, 0);
   if (byKindTotal !== parsed.summary.nodes) {
-    return `project_scope byKind mismatch — nodes ${parsed.summary.nodes}, byKind ${byKindTotal}`;
+    return `project_scope byKind mismatch: nodes ${parsed.summary.nodes}, byKind ${byKindTotal}`;
   }
   if (!parsed.edges || typeof parsed.edges !== 'object' || Array.isArray(parsed.edges)) {
     return 'project_scope response missing edges';
@@ -7162,7 +7162,7 @@ export function projectScopeFailure(parsed, expectedProject) {
     const bucketFailure = scopeEdgeBucketFailure(`project_scope ${key}`, bucket);
     if (bucketFailure) return bucketFailure;
     if (bucket.total !== expectedTotal) {
-      return `project_scope ${key} edge total mismatch — summary ${expectedTotal}, bucket ${bucket.total}`;
+      return `project_scope ${key} edge total mismatch: summary ${expectedTotal}, bucket ${bucket.total}`;
     }
   }
   return null;
@@ -7194,10 +7194,10 @@ function scopeEdgeBucketFailure(label, bucket) {
     return `${label} missing edges array`;
   }
   if (bucket.edges.length > bucket.total) {
-    return `${label} edges exceed total — edges ${bucket.edges.length}, total ${bucket.total}`;
+    return `${label} edges exceed total: edges ${bucket.edges.length}, total ${bucket.total}`;
   }
   if (!bucket.limited && bucket.edges.length !== bucket.total) {
-    return `${label} edge count mismatch — edges ${bucket.edges.length}, total ${bucket.total}`;
+    return `${label} edge count mismatch: edges ${bucket.edges.length}, total ${bucket.total}`;
   }
   for (const [index, edge] of bucket.edges.entries()) {
     const edgeFailure = graphEdgeFailure(label, edge, index);
@@ -7229,7 +7229,7 @@ export function verifyCountConsistencyFailure({ kinds, list, validation, compile
   const [baseLabel, baseValue] = counts[0];
   for (const [label, value] of counts.slice(1)) {
     if (value !== baseValue) {
-      return `verify count mismatch — ${baseLabel} ${baseValue}, ${label} ${value}`;
+      return `verify count mismatch: ${baseLabel} ${baseValue}, ${label} ${value}`;
     }
   }
   if (kinds?.byKind && compiled?.byKind) {
@@ -7238,7 +7238,7 @@ export function verifyCountConsistencyFailure({ kinds, list, validation, compile
       const kindsCount = kinds.byKind[kind] ?? 0;
       const compiledCount = compiled.byKind[kind] ?? 0;
       if (kindsCount !== compiledCount) {
-        return `verify byKind mismatch — ${kind}: list_kinds ${kindsCount}, compile_ontology ${compiledCount}`;
+        return `verify byKind mismatch: ${kind}: list_kinds ${kindsCount}, compile_ontology ${compiledCount}`;
       }
     }
   }
@@ -7248,7 +7248,7 @@ export function verifyCountConsistencyFailure({ kinds, list, validation, compile
       const kindsCount = kinds.byKind[kind] ?? 0;
       const overviewCount = overview.byKind[kind] ?? 0;
       if (kindsCount !== overviewCount) {
-        return `verify byKind mismatch — ${kind}: list_kinds ${kindsCount}, overview ${overviewCount}`;
+        return `verify byKind mismatch: ${kind}: list_kinds ${kindsCount}, overview ${overviewCount}`;
       }
     }
   }
@@ -8523,7 +8523,7 @@ function agentGuardrailCallsFailure(label, calls) {
 }
 
 async function step1ParserSmoke() {
-  log('info', 'step 1 — parser smoke test');
+  log('info', 'step 1: parser smoke test');
   return new Promise((res) => {
     const proc = spawn(process.execPath, [PARSER_TEST], { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
@@ -8559,7 +8559,7 @@ async function step2BootAndCall() {
     log('fail', verifyKillGraceValueErrorMessage());
     return false;
   }
-  log('info', `step 2 — server boot + tools/list + list_concepts/project probe/get_concept/get_concepts/find_evidence/find_backlinks/query_concepts/limited query_concepts/analyze_repo_structure/infer_imports/index_project/find_neighbors/find_path/find_orphans/list_kinds/destructive dry-runs (vault=${VAULT}, timeout=${timeoutMs}ms)`);
+  log('info', `step 2: server boot + tools/list + list_concepts/project probe/get_concept/get_concepts/find_evidence/find_backlinks/query_concepts/limited query_concepts/analyze_repo_structure/infer_imports/index_project/find_neighbors/find_path/find_orphans/list_kinds/destructive dry-runs (vault=${VAULT}, timeout=${timeoutMs}ms)`);
 
   // Slice 0 — the absorb_document dry-run request (id 69, part of the
   // initial batch above) targets this temp fixture. Must exist before the
@@ -8865,7 +8865,7 @@ async function step2BootAndCall() {
           log('fail', serverStartupFailure(stderr, verifyRetryEnvForVault(VAULT)));
           return res(false);
         }
-        log('ok', `initialize OK — server ${initRes.result.serverInfo?.name}@${initRes.result.serverInfo?.version}`);
+        log('ok', `initialize OK: server ${initRes.result.serverInfo?.name}@${initRes.result.serverInfo?.version}`);
         if (!callRes || !callRes.result) {
           log('fail', 'no list_concepts response');
           return res(false);
@@ -8880,7 +8880,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `list_concepts — vault total ${earlyEmptyVaultPayload.total} nodes (vaultRoot ${earlyEmptyVaultPayload.vaultRoot})`);
+        log('ok', `list_concepts: vault total ${earlyEmptyVaultPayload.total} nodes (vaultRoot ${earlyEmptyVaultPayload.vaultRoot})`);
         log('fail', emptyVerifyVaultFailure(earlyEmptyVaultPayload));
         return res(false);
       }
@@ -8889,14 +8889,14 @@ async function step2BootAndCall() {
         log('fail', serverStartupFailure(stderr, verifyRetryEnvForVault(VAULT)));
         return res(false);
       }
-      log('ok', `initialize OK — server ${initRes.result.serverInfo?.name}@${initRes.result.serverInfo?.version}`);
+      log('ok', `initialize OK: server ${initRes.result.serverInfo?.name}@${initRes.result.serverInfo?.version}`);
 
       const instructionFailure = initializeInstructionsFailure(initRes);
       if (instructionFailure) {
         log('fail', instructionFailure);
         return res(false);
       }
-      log('ok', 'initialize instructions — tool inventory plus first-contact safety and recovery guidance present');
+      log('ok', 'initialize instructions: tool inventory plus first-contact safety and recovery guidance present');
 
       if (!listRes || !listRes.result?.tools) {
         log('fail', 'no tools/list response');
@@ -8908,44 +8908,44 @@ async function step2BootAndCall() {
         return res(false);
       }
       const toolNames = listRes.result.tools.map((t) => t.name).sort();
-      log('ok', `tools/list ${toolNames.length}/${EXPECTED_TOOLS.length} (${toolsListAnnotationSummary(listRes.result.tools)}) — ${toolNames.join(' · ')}`);
-      log('ok', 'tools/list inventory names — missing/extra/duplicate/invalid checks passed');
+      log('ok', `tools/list ${toolNames.length}/${EXPECTED_TOOLS.length} (${toolsListAnnotationSummary(listRes.result.tools)}): ${toolNames.join(' · ')}`);
+      log('ok', 'tools/list inventory names: missing/extra/duplicate/invalid checks passed');
       const schemaFailure = toolsListSchemaFailure(listRes.result.tools);
       if (schemaFailure) {
         log('fail', schemaFailure);
         return res(false);
       }
-      log('ok', `tools/list schema contract — ${TOOLS_LIST_SCHEMA_CONTRACT_SUMMARY}`);
+      log('ok', `tools/list schema contract: ${TOOLS_LIST_SCHEMA_CONTRACT_SUMMARY}`);
       const strictFailure = strictArgsFailure(strictArgsRes);
       if (strictFailure) {
         log('fail', strictFailure);
         return res(false);
       }
-      log('ok', 'strict arguments — unknown tool argument rejected at runtime');
+      log('ok', 'strict arguments: unknown tool argument rejected at runtime');
       const strictMultiFailure = strictMultiArgsFailure(strictMultiArgsRes);
       if (strictMultiFailure) {
         log('fail', strictMultiFailure);
         return res(false);
       }
-      log('ok', 'strict arguments — multiple unknown tool arguments reported together');
+      log('ok', 'strict arguments: multiple unknown tool arguments reported together');
       const strictUnknownToolFailureMessage = strictUnknownToolFailure(strictUnknownToolRes);
       if (strictUnknownToolFailureMessage) {
         log('fail', strictUnknownToolFailureMessage);
         return res(false);
       }
-      log('ok', 'strict tool names — unknown tool rejected with closest-name hint');
+      log('ok', 'strict tool names: unknown tool rejected with closest-name hint');
       const addConceptsRowIsolationFailure = batchRowIsolationFailure(addConceptsRowIsolationRes, 'concepts', 'add_concepts');
       if (addConceptsRowIsolationFailure) {
         log('fail', addConceptsRowIsolationFailure);
         return res(false);
       }
-      log('ok', 'add_concepts — non-object, single/multi unknown-field repair, Received fields, duplicate-slug rows isolated with input indexes, and invalid-only batches return no write metadata');
+      log('ok', 'add_concepts: non-object, single/multi unknown-field repair, Received fields, duplicate-slug rows isolated with input indexes, and invalid-only batches return no write metadata');
       const addRelationsRowIsolationFailure = batchRowIsolationFailure(addRelationsRowIsolationRes, 'relations', 'add_relations');
       if (addRelationsRowIsolationFailure) {
         log('fail', addRelationsRowIsolationFailure);
         return res(false);
       }
-      log('ok', 'add_relations — non-object, single/multi unknown-field repair, Received fields, invalid-type rows isolated with input indexes and closest-value hints, and invalid-only batches return no write metadata');
+      log('ok', 'add_relations: non-object, single/multi unknown-field repair, Received fields, invalid-type rows isolated with input indexes and closest-value hints, and invalid-only batches return no write metadata');
       const getConceptsBatchCapFailure = batchCapFailure(responses.find((r) => r.id === 64), 'get_concepts', 'slugs');
       if (getConceptsBatchCapFailure) {
         log('fail', getConceptsBatchCapFailure);
@@ -8961,7 +8961,7 @@ async function step2BootAndCall() {
         log('fail', addRelationsBatchCapFailure);
         return res(false);
       }
-      log('ok', 'batch caps — get_concepts/add_concepts/add_relations reject 51 rows with invalid_arguments');
+      log('ok', 'batch caps: get_concepts/add_concepts/add_relations reject 51 rows with invalid_arguments');
       const destructiveDryRunResponses = destructiveDryRunExpectedResponses.map(([toolName, id]) => [
         toolName,
         responses.find((response) => response.id === id),
@@ -8973,28 +8973,28 @@ async function step2BootAndCall() {
           return res(false);
         }
         destructiveDryRunCount = destructiveDryRunResponses.length;
-        log('ok', `destructive dry-runs — ${destructiveDryRunResponses.map(([toolName]) => toolName).join(' · ')} previewReady/canConfirm contract without write-maintenance`);
+        log('ok', `destructive dry-runs: ${destructiveDryRunResponses.map(([toolName]) => toolName).join(' · ')} previewReady/canConfirm contract without write-maintenance`);
       }
       const absorbDocumentDryRunFailureMessage = absorbDocumentDryRunFailure(absorbDocumentDryRunRes);
       if (absorbDocumentDryRunFailureMessage) {
         log('fail', absorbDocumentDryRunFailureMessage);
         return res(false);
       }
-      log('ok', 'absorb_document dry-run — outside-repo temp fixture explicitly opted in, classified (policy + architecture sections), and not written');
+      log('ok', 'absorb_document dry-run: outside-repo temp fixture explicitly opted in, classified (policy + architecture sections), and not written');
       if (patchConflictGuardRes) {
         const patchConflictFailure = patchConflictGuardFailure(patchConflictGuardRes);
         if (patchConflictFailure) {
           log('fail', patchConflictFailure);
           return res(false);
         }
-        log('ok', 'patch_concept conflict guard — stale expected_mtime rejected with vault_conflict');
+        log('ok', 'patch_concept conflict guard: stale expected_mtime rejected with vault_conflict');
       }
       const strictEnum = strictEnumFailure(strictEnumRes);
       if (strictEnum) {
         log('fail', strictEnum);
         return res(false);
       }
-      log('ok', 'strict enums — invalid query operation rejected with closest-value hint');
+      log('ok', 'strict enums: invalid query operation rejected with closest-value hint');
       const strictMaintenancePhaseFilter = strictMaintenanceFilterFailure(strictMaintenancePhaseFilterRes, 'phases');
       if (strictMaintenancePhaseFilter) {
         log('fail', strictMaintenancePhaseFilter);
@@ -9010,19 +9010,19 @@ async function step2BootAndCall() {
         log('fail', strictMaintenanceKindFilter);
         return res(false);
       }
-      log('ok', `strict maintenance filters — invalid phase/severity/kind rejected at runtime (${maintenanceFilterEnumSummary()})`);
+      log('ok', `strict maintenance filters: invalid phase/severity/kind rejected at runtime (${maintenanceFilterEnumSummary()})`);
       const strictRelationFilter = strictRelationFilterFailure(strictRelationFilterRes);
       if (strictRelationFilter) {
         log('fail', strictRelationFilter);
         return res(false);
       }
-      log('ok', 'strict relation filters — invalid dependencyTypes rejected with closest-value hint');
+      log('ok', 'strict relation filters: invalid dependencyTypes rejected with closest-value hint');
       const strictFindNeighborsTypeFilter = strictFindNeighborsTypeFailure(strictFindNeighborsTypeFilterRes);
       if (strictFindNeighborsTypeFilter) {
         log('fail', strictFindNeighborsTypeFilter);
         return res(false);
       }
-      log('ok', 'strict find_neighbors filters — invalid relation types rejected before slug resolution with closest-value hint');
+      log('ok', 'strict find_neighbors filters: invalid relation types rejected before slug resolution with closest-value hint');
       const strictFindOrphansKindFilter = strictFindOrphansKindFailure(strictFindOrphansKindFilterRes);
       if (strictFindOrphansKindFilter) {
         log('fail', strictFindOrphansKindFilter);
@@ -9033,13 +9033,13 @@ async function step2BootAndCall() {
         log('fail', strictFindOrphansExcludeKindFilter);
         return res(false);
       }
-      log('ok', 'strict find_orphans filters — invalid kind/excludeKinds rejected with closest-value hints');
+      log('ok', 'strict find_orphans filters: invalid kind/excludeKinds rejected with closest-value hints');
       const strictListConceptsKindFilter = strictListConceptsKindFailure(strictListConceptsKindFilterRes);
       if (strictListConceptsKindFilter) {
         log('fail', strictListConceptsKindFilter);
         return res(false);
       }
-      log('ok', 'strict list_concepts filters — invalid kind rejected with closest-value hint');
+      log('ok', 'strict list_concepts filters: invalid kind rejected with closest-value hint');
       const strictQueryConceptsKindFilter = strictQueryConceptsFilterFailure(strictQueryConceptsKindFilterRes);
       if (strictQueryConceptsKindFilter) {
         log('fail', strictQueryConceptsKindFilter);
@@ -9053,19 +9053,19 @@ async function step2BootAndCall() {
         log('fail', strictQueryConceptsHasKeyFilter);
         return res(false);
       }
-      log('ok', 'strict query_concepts filters — invalid kind/has-key rejected with closest-value hints');
+      log('ok', 'strict query_concepts filters: invalid kind/has-key rejected with closest-value hints');
       const strictRelationCheck = strictRelationCheckFailure(strictRelationCheckRes);
       if (strictRelationCheck) {
         log('fail', strictRelationCheck);
         return res(false);
       }
-      log('ok', 'strict relation_check — invalid type rejected before endpoint resolution with closest-value hint and structured repair');
+      log('ok', 'strict relation_check: invalid type rejected before endpoint resolution with closest-value hint and structured repair');
       const strictAddRelation = strictAddRelationFailure(strictAddRelationRes);
       if (strictAddRelation) {
         log('fail', strictAddRelation);
         return res(false);
       }
-      log('ok', 'strict add_relation — invalid type rejected before endpoint resolution with structured repair and no write metadata');
+      log('ok', 'strict add_relation: invalid type rejected before endpoint resolution with structured repair and no write metadata');
       const strictGraphKindFilter = strictGraphKindFilterFailure(strictGraphKindFilterRes);
       if (strictGraphKindFilter) {
         log('fail', strictGraphKindFilter);
@@ -9094,7 +9094,7 @@ async function step2BootAndCall() {
         log('fail', strictMatchEdgesTypeFilter);
         return res(false);
       }
-      log('ok', 'strict graph filters — invalid match_nodes.kind/sort, match_edges.type, and recommend_relations.kind rejected with narrowed diagnostics');
+      log('ok', 'strict graph filters: invalid match_nodes.kind/sort, match_edges.type, and recommend_relations.kind rejected with narrowed diagnostics');
       const strictGraphFromKindFilter = strictGraphKindFilterFailure(strictGraphFromKindFilterRes, { field: 'fromKind' });
       if (strictGraphFromKindFilter) {
         log('fail', strictGraphFromKindFilter);
@@ -9109,7 +9109,7 @@ async function step2BootAndCall() {
         log('fail', strictGraphToKindFilter);
         return res(false);
       }
-      log('ok', 'strict graph edge kind filters — invalid match_edges.fromKind/toKind rejected with closest-value hints');
+      log('ok', 'strict graph edge kind filters: invalid match_edges.fromKind/toKind rejected with closest-value hints');
 
       if (!maintenanceMissingCursorRes || !maintenanceMissingCursorRes.result) {
         log('fail', 'no query_ontology maintenance missing-cursor response');
@@ -9128,7 +9128,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `maintenance cursor — missing afterActionId reported (${parsed.cursor.reason}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
+        log('ok', `maintenance cursor: missing afterActionId reported (${parsed.cursor.reason}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
       } catch (err) {
         log('fail', `failed to parse maintenance missing-cursor response: ${err.message}`);
         return res(false);
@@ -9153,7 +9153,7 @@ async function step2BootAndCall() {
           return res(false);
         }
         maintenanceReadyCursorPayload = parsed;
-        log('ok', `maintenance cursor — ready page stable (${formatCount(parsed.summary.remainingActions, 'remaining action')}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
+        log('ok', `maintenance cursor: ready page stable (${formatCount(parsed.summary.remainingActions, 'remaining action')}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
       } catch (err) {
         log('fail', `failed to parse maintenance ready-cursor response: ${err.message}`);
         return res(false);
@@ -9180,14 +9180,14 @@ async function step2BootAndCall() {
             return res(false);
           }
           maintenanceResumeVerified = true;
-          log('ok', `maintenance cursor — resume afterActionId advanced (${resumeAfterActionId}; ${formatCount(parsed.summary.remainingActions, 'remaining action')}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
+          log('ok', `maintenance cursor: resume afterActionId advanced (${resumeAfterActionId}; ${formatCount(parsed.summary.remainingActions, 'remaining action')}; ${maintenanceBucketOutputSummary(parsed)}; ${maintenanceNextActionOutputSummary(parsed)})`);
         } catch (err) {
           log('fail', `failed to parse maintenance resume-cursor response: ${err.message}`);
           return res(false);
         }
       } else {
         maintenanceResumeSkipped = true;
-        log('info', 'maintenance cursor — resume skipped (ready page has no actions)');
+        log('info', 'maintenance cursor: resume skipped (ready page has no actions)');
       }
 
       if (!callRes || !callRes.result) {
@@ -9218,7 +9218,7 @@ async function step2BootAndCall() {
           }
         }
         graphSmokeArgs = buildGraphQuerySmokeArgs(parsed, projectProbePayloadForSmoke);
-        log('ok', `list_concepts — vault total ${parsed.total} nodes (vaultRoot ${parsed.vaultRoot})`);
+        log('ok', `list_concepts: vault total ${parsed.total} nodes (vaultRoot ${parsed.vaultRoot})`);
         const emptyVaultFailure = emptyVerifyVaultFailure(parsed);
         if (emptyVaultFailure) {
           log('fail', emptyVaultFailure);
@@ -9253,7 +9253,7 @@ async function step2BootAndCall() {
             return res(false);
           }
           getConceptVerified = true;
-          log('ok', `get_concept — ${parsed.slug} (${parsed.outgoingEdges.length} outgoing edges)`);
+          log('ok', `get_concept: ${parsed.slug} (${parsed.outgoingEdges.length} outgoing edges)`);
         } catch (err) {
           log('fail', `failed to parse get_concept response: ${err.message}`);
           return res(false);
@@ -9274,7 +9274,7 @@ async function step2BootAndCall() {
         }
         const okRows = parsed.concepts.filter((row) => row?.ok === true).length;
         const partialRows = parsed.concepts.filter((row) => row?.ok === false).length;
-        log('ok', `get_concepts — ${formatCount(okRows, 'ok row')}, ${formatCount(partialRows, 'partial row')}`);
+        log('ok', `get_concepts: ${formatCount(okRows, 'ok row')}, ${formatCount(partialRows, 'partial row')}`);
       } catch (err) {
         log('fail', `failed to parse get_concepts response: ${err.message}`);
         return res(false);
@@ -9297,7 +9297,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `find_evidence — ${formatCount(parsed.matches.length, 'evidence result')} for "${parsed.query}"`);
+        log('ok', `find_evidence: ${formatCount(parsed.matches.length, 'evidence result')} for "${parsed.query}"`);
       } catch (err) {
         log('fail', `failed to parse find_evidence response: ${err.message}`);
         return res(false);
@@ -9323,7 +9323,7 @@ async function step2BootAndCall() {
             return res(false);
           }
           findBacklinksVerified = true;
-          log('ok', `find_backlinks — ${parsed.target} (${formatCount(parsed.total, 'backlink')})`);
+          log('ok', `find_backlinks: ${parsed.target} (${formatCount(parsed.total, 'backlink')})`);
         } catch (err) {
           log('fail', `failed to parse find_backlinks response: ${err.message}`);
           return res(false);
@@ -9347,7 +9347,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `query_concepts — ${formatCount(parsed.matches.length, 'query result')} / ${formatCount(parsed.total, 'total query result')}`);
+        log('ok', `query_concepts: ${formatCount(parsed.matches.length, 'query result')} / ${formatCount(parsed.total, 'total query result')}`);
       } catch (err) {
         log('fail', `failed to parse query_concepts response: ${err.message}`);
         return res(false);
@@ -9377,7 +9377,7 @@ async function step2BootAndCall() {
             return res(false);
           }
           limitedQueryConceptsVerified = true;
-          log('ok', `query_concepts limited — ${formatCount(parsed.matches.length, 'query result')} / ${formatCount(parsed.total, 'total query result')} (limited ${parsed.limited})`);
+          log('ok', `query_concepts limited: ${formatCount(parsed.matches.length, 'query result')} / ${formatCount(parsed.total, 'total query result')} (limited ${parsed.limited})`);
         } catch (err) {
           log('fail', `failed to parse query_concepts_limited response: ${err.message}`);
           return res(false);
@@ -9401,7 +9401,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `analyze_repo_structure — ${parsed.framework} (${formatCount(parsed.domains.length, 'domain candidate')}, ${formatCount(parsed.capabilities.length, 'capability candidate')}, ${formatCount(parsed.elements.length, 'element candidate')})`);
+        log('ok', `analyze_repo_structure: ${parsed.framework} (${formatCount(parsed.domains.length, 'domain candidate')}, ${formatCount(parsed.capabilities.length, 'capability candidate')}, ${formatCount(parsed.elements.length, 'element candidate')})`);
       } catch (err) {
         log('fail', `failed to parse analyze_repo_structure response: ${err.message}`);
         return res(false);
@@ -9424,7 +9424,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `infer_imports — ${formatCount(parsed.filesScanned, 'file')} scanned, ${formatCount(parsed.moduleEdges.length, 'module edge')} (${importModuleEdgeKindOutputSummary(parsed.moduleEdges)})`);
+        log('ok', `infer_imports: ${formatCount(parsed.filesScanned, 'file')} scanned, ${formatCount(parsed.moduleEdges.length, 'module edge')} (${importModuleEdgeKindOutputSummary(parsed.moduleEdges)})`);
       } catch (err) {
         log('fail', `failed to parse infer_imports response: ${err.message}`);
         return res(false);
@@ -9447,7 +9447,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `index_project — ${formatCount(parsed.plan.concepts, 'concept candidate')}, ${formatCount(parsed.plan.importRelations, 'import relation')}, validation ${formatCount(parsed.validation.problemFiles, 'problem file')}`);
+        log('ok', `index_project: ${formatCount(parsed.plan.concepts, 'concept candidate')}, ${formatCount(parsed.plan.importRelations, 'import relation')}, validation ${formatCount(parsed.validation.problemFiles, 'problem file')}`);
       } catch (err) {
         log('fail', `failed to parse index_project response: ${err.message}`);
         return res(false);
@@ -9471,7 +9471,7 @@ async function step2BootAndCall() {
             log('fail', structuredFailure);
             return res(false);
           }
-          log('ok', `find_neighbors — ${parsed.center} (${parsed.edges.length}/${parsed.totalEdges} edges, limited ${parsed.limited})`);
+          log('ok', `find_neighbors: ${parsed.center} (${parsed.edges.length}/${parsed.totalEdges} edges, limited ${parsed.limited})`);
         } catch (err) {
           log('fail', `failed to parse find_neighbors response: ${err.message}`);
           return res(false);
@@ -9495,7 +9495,7 @@ async function step2BootAndCall() {
             return res(false);
           }
           directGraphReadsVerified = true;
-          log('ok', `find_path — ${parsed.from} → ${parsed.to} (${formatHopCount(parsed.hopCount)}, ${formatCount(parsed.edges.length, 'edge')})`);
+          log('ok', `find_path: ${parsed.from} → ${parsed.to} (${formatHopCount(parsed.hopCount)}, ${formatCount(parsed.edges.length, 'edge')})`);
         } catch (err) {
           log('fail', `failed to parse find_path response: ${err.message}`);
           return res(false);
@@ -9519,7 +9519,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `find_orphans — ${formatCount(parsed.total, 'orphan')} (root/sentinel defaults excluded)`);
+        log('ok', `find_orphans: ${formatCount(parsed.total, 'orphan')} (root/sentinel defaults excluded)`);
       } catch (err) {
         log('fail', `failed to parse find_orphans response: ${err.message}`);
         return res(false);
@@ -9547,7 +9547,7 @@ async function step2BootAndCall() {
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([kind, count]) => `${kind}:${count}`)
           .join(', ');
-        log('ok', `list_kinds — ${parsed.total} nodes (${kindSummary})`);
+        log('ok', `list_kinds: ${parsed.total} nodes (${kindSummary})`);
       } catch (err) {
         log('fail', `failed to parse list_kinds response: ${err.message}`);
         return res(false);
@@ -9573,7 +9573,7 @@ async function step2BootAndCall() {
         validationPayload = parsed;
         log(
           'ok',
-          `validate_vault — ${formatCount(parsed.scanned ?? 0, 'file')}, ${formatCount(
+          `validate_vault: ${formatCount(parsed.scanned ?? 0, 'file')}, ${formatCount(
             parsed.summary?.problemFiles ?? 0,
             'problem file',
           )}`,
@@ -9600,7 +9600,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `project probe — ${formatCount(parsed.total, 'project node')}`);
+        log('ok', `project probe: ${formatCount(parsed.total, 'project node')}`);
       } catch (err) {
         log('fail', `failed to parse project probe response: ${err.message}`);
         return res(false);
@@ -9625,10 +9625,10 @@ async function step2BootAndCall() {
         }
         log(
           'ok',
-          `workspace_brief — ${parsed.status} (${workspaceBriefSummary(parsed)})`,
+          `workspace_brief: ${parsed.status} (${workspaceBriefSummary(parsed)})`,
         );
         const advisory = advisoryNextActionsSummary(parsed.nextActions);
-        if (advisory) log('info', `workspace_brief non-blocking advisory nextActions — ${advisory}`);
+        if (advisory) log('info', `workspace_brief non-blocking advisory nextActions: ${advisory}`);
       } catch (err) {
         log('fail', `failed to parse workspace_brief response: ${err.message}`);
         return res(false);
@@ -9651,7 +9651,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `agent_brief — ${parsed.status} (${agentBriefSummary(parsed)})`);
+        log('ok', `agent_brief: ${parsed.status} (${agentBriefSummary(parsed)})`);
       } catch (err) {
         log('fail', `failed to parse agent_brief response: ${err.message}`);
         return res(false);
@@ -9676,10 +9676,10 @@ async function step2BootAndCall() {
         }
         log(
           'ok',
-          `workspace_brief_tuned — ${parsed.status} (${workspaceBriefSummary(parsed)}; ${tunedWorkspaceBriefScopeOutputSummary()})`,
+          `workspace_brief_tuned: ${parsed.status} (${workspaceBriefSummary(parsed)}; ${tunedWorkspaceBriefScopeOutputSummary()})`,
         );
         const advisory = advisoryNextActionsSummary(parsed.nextActions);
-        if (advisory) log('info', `workspace_brief_tuned non-blocking advisory nextActions — ${advisory}`);
+        if (advisory) log('info', `workspace_brief_tuned non-blocking advisory nextActions: ${advisory}`);
       } catch (err) {
         log('fail', `failed to parse tuned workspace_brief response: ${err.message}`);
         return res(false);
@@ -9705,12 +9705,12 @@ async function step2BootAndCall() {
         const checksSummary = healthChecksSummary(parsed.checks);
         log(
           'ok',
-          `health — ${parsed.status} (${healthSummary(parsed)}${
+          `health: ${parsed.status} (${healthSummary(parsed)}${
             checksSummary ? `: ${checksSummary}` : ''
           })`,
         );
         const advisory = advisoryHealthChecksSummary(parsed.checks);
-        if (advisory) log('info', `health non-blocking advisory checks — ${advisory}`);
+        if (advisory) log('info', `health non-blocking advisory checks: ${advisory}`);
       } catch (err) {
         log('fail', `failed to parse health response: ${err.message}`);
         return res(false);
@@ -9736,12 +9736,12 @@ async function step2BootAndCall() {
         const checksSummary = healthChecksSummary(parsed.checks);
         log(
           'ok',
-          `health_tuned — ${parsed.status} (${healthSummary(parsed)}${
+          `health_tuned: ${parsed.status} (${healthSummary(parsed)}${
             checksSummary ? `: ${checksSummary}` : ''
           }; ${tunedHealthScopeOutputSummary()})`,
         );
         const advisory = advisoryHealthChecksSummary(parsed.checks);
-        if (advisory) log('info', `health_tuned non-blocking advisory checks — ${advisory}`);
+        if (advisory) log('info', `health_tuned non-blocking advisory checks: ${advisory}`);
       } catch (err) {
         log('fail', `failed to parse tuned health response: ${err.message}`);
         return res(false);
@@ -9765,7 +9765,7 @@ async function step2BootAndCall() {
           return res(false);
         }
         compilePayload = parsed;
-        log('ok', `compile_ontology — graph ${parsed.graphHash.slice(0, 12)} (${parsed.nodeCount} nodes, ${parsed.edgeCount} edges, issues ${parsed.issueCount})`);
+        log('ok', `compile_ontology: graph ${parsed.graphHash.slice(0, 12)} (${parsed.nodeCount} nodes, ${parsed.edgeCount} edges, issues ${parsed.issueCount})`);
       } catch (err) {
         log('fail', `failed to parse compile_ontology response: ${err.message}`);
         return res(false);
@@ -9788,7 +9788,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `compile_ontology page — ${parsed.nodes.length}/${parsed.nodeCount} nodes, ${parsed.edges.length}/${parsed.edgeCount} edges`);
+        log('ok', `compile_ontology page: ${parsed.nodes.length}/${parsed.nodeCount} nodes, ${parsed.edges.length}/${parsed.edgeCount} edges`);
       } catch (err) {
         log('fail', `failed to parse compile_ontology paginated response: ${err.message}`);
         return res(false);
@@ -9813,7 +9813,7 @@ async function step2BootAndCall() {
         }
         log(
           'ok',
-          `compile_ontology indexes — ${compileIndexesSummary(parsed)}`,
+          `compile_ontology indexes: ${compileIndexesSummary(parsed)}`,
         );
       } catch (err) {
         log('fail', `failed to parse compile_ontology indexes response: ${err.message}`);
@@ -9838,7 +9838,7 @@ async function step2BootAndCall() {
           return res(false);
         }
         overviewPayload = parsed;
-        log('ok', `overview — graph ${parsed.graph.graphHash.slice(0, 12)} (${parsed.graph.nodes} nodes, ${parsed.graph.edges} edges, hubs ${(parsed.hubs || []).length})`);
+        log('ok', `overview: graph ${parsed.graph.graphHash.slice(0, 12)} (${parsed.graph.nodes} nodes, ${parsed.graph.edges} edges, hubs ${(parsed.hubs || []).length})`);
       } catch (err) {
         log('fail', `failed to parse overview response: ${err.message}`);
         return res(false);
@@ -9861,7 +9861,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `overview query_plan — ${parsed.estimate.strategy} (${parsed.estimate.costClass}, nodes ${parsed.estimate.nodeScans}, edges ${parsed.estimate.edgeScans})`);
+        log('ok', `overview query_plan: ${parsed.estimate.strategy} (${parsed.estimate.costClass}, nodes ${parsed.estimate.nodeScans}, edges ${parsed.estimate.edgeScans})`);
       } catch (err) {
         log('fail', `failed to parse overview query_plan response: ${err.message}`);
         return res(false);
@@ -9884,7 +9884,7 @@ async function step2BootAndCall() {
           log('fail', structuredFailure);
           return res(false);
         }
-        log('ok', `project_map query_plan — ${parsed.estimate.strategy} (${parsed.estimate.costClass}, nodes ${parsed.estimate.nodeScans}, edges ${parsed.estimate.edgeScans})`);
+        log('ok', `project_map query_plan: ${parsed.estimate.strategy} (${parsed.estimate.costClass}, nodes ${parsed.estimate.nodeScans}, edges ${parsed.estimate.edgeScans})`);
       } catch (err) {
         log('fail', `failed to parse project_map query_plan response: ${err.message}`);
         return res(false);
@@ -9909,7 +9909,7 @@ async function step2BootAndCall() {
             log('fail', structuredFailure);
             return res(false);
           }
-          log('ok', `neighbors — ${parsed.center} (${parsed.edges.length}/${parsed.total} edges, limited ${parsed.limited})`);
+          log('ok', `neighbors: ${parsed.center} (${parsed.edges.length}/${parsed.total} edges, limited ${parsed.limited})`);
         } catch (err) {
           log('fail', `failed to parse neighbors response: ${err.message}`);
           return res(false);
@@ -9933,7 +9933,7 @@ async function step2BootAndCall() {
             log('fail', structuredFailure);
             return res(false);
           }
-          log('ok', `path — ${parsed.from} → ${parsed.to} (${formatHopCount(parsed.hopCount)}, ${formatCount(parsed.edges.length, 'edge')})`);
+          log('ok', `path: ${parsed.from} → ${parsed.to} (${formatHopCount(parsed.hopCount)}, ${formatCount(parsed.edges.length, 'edge')})`);
         } catch (err) {
           log('fail', `failed to parse path response: ${err.message}`);
           return res(false);
@@ -9961,14 +9961,14 @@ async function step2BootAndCall() {
           allPathsVerified = true;
           log(
             'ok',
-            `all_paths — ${parsed.from} → ${parsed.to} (${parsed.paths.length}/${parsed.totalPaths} paths, budget ${parsed.searchBudget}, expanded ${parsed.expandedStates}, exhaustive ${parsed.exhaustive}, evidence ${parsed.evidence.status})`,
+            `all_paths: ${parsed.from} → ${parsed.to} (${parsed.paths.length}/${parsed.totalPaths} paths, budget ${parsed.searchBudget}, expanded ${parsed.expandedStates}, exhaustive ${parsed.exhaustive}, evidence ${parsed.evidence.status})`,
           );
         } catch (err) {
           log('fail', `failed to parse all_paths response: ${err.message}`);
           return res(false);
         }
       } else {
-        log('info', 'neighbors/path/all_paths — skipped (vault has no nodes)');
+        log('info', 'neighbors/path/all_paths: skipped (vault has no nodes)');
       }
 
       if (graphSmokeArgs?.hasProject) {
@@ -9990,13 +9990,13 @@ async function step2BootAndCall() {
             log('fail', structuredFailure);
             return res(false);
           }
-          log('ok', `project_scope — ${parsed.project} (${parsed.summary.nodes} nodes, internalEdges ${parsed.summary.internalEdges})`);
+          log('ok', `project_scope: ${parsed.project} (${parsed.summary.nodes} nodes, internalEdges ${parsed.summary.internalEdges})`);
         } catch (err) {
           log('fail', `failed to parse project_scope response: ${err.message}`);
           return res(false);
         }
       } else {
-        log('info', 'project_scope — skipped (no project node in vault)');
+        log('info', 'project_scope: skipped (no project node in vault)');
       }
 
       const countFailure = verifyCountConsistencyFailure({
@@ -10017,11 +10017,11 @@ async function step2BootAndCall() {
         overview: overviewPayload,
       });
       if (countSummary) {
-        log('ok', `read census consistency — ${countSummary}`);
+        log('ok', `read census consistency: ${countSummary}`);
       }
       log(
         'ok',
-        `structuredContent — ${structuredContentVerifySummary({
+        `structuredContent: ${structuredContentVerifySummary({
           hasNode: Boolean(graphSmokeArgs?.hasNode),
           hasProject: Boolean(graphSmokeArgs?.hasProject),
           hasGetConcept: getConceptVerified,

--- a/mcp/src/absorb.mjs
+++ b/mcp/src/absorb.mjs
@@ -348,7 +348,7 @@ export function buildSlimPointer(plan) {
   lines.push('');
   lines.push('> **Absorbed into the ontology-atlas vault.** The sections below were');
   lines.push('> converted into typed vault nodes. Edit the vault, not this file, for');
-  lines.push('> the sections that moved — this file is now a slim pointer.');
+  lines.push('> the sections that moved: this file is now a slim pointer.');
   lines.push('');
   if (plan.intro) {
     lines.push(plan.intro);
@@ -365,7 +365,7 @@ export function buildSlimPointer(plan) {
   }
 
   if (suggested.length > 0) {
-    lines.push('## Suggested (not written — review before adding)');
+    lines.push('## Suggested (not written: review before adding)');
     lines.push('');
     for (const s of suggested) {
       lines.push(`- **${s.heading}** → candidate \`${s.targetKind}\` \`${s.targetSlug}\``);
@@ -378,7 +378,7 @@ export function buildSlimPointer(plan) {
     lines.push('');
     for (const s of injectionSuspects) {
       const patterns = s.injection.matches.map((m) => m.pattern).join(', ');
-      lines.push(`- **${s.heading}** — matched: ${patterns}`);
+      lines.push(`- **${s.heading}**: matched: ${patterns}`);
     }
     lines.push('');
   }

--- a/mcp/src/activity-log.mjs
+++ b/mcp/src/activity-log.mjs
@@ -13,7 +13,7 @@ import { dirname, join } from 'node:path';
 
 export const ACTIVITY_LOG_RELATIVE_PATH = '.ontology-atlas/activity.jsonl';
 
-/** 로테이션 상한 — 초과 시 앞 절반 절삭 (단순·결정론). */
+/** 로테이션 상한: 초과 시 앞 절반 절삭 (단순·결정론). */
 export const ACTIVITY_LOG_MAX_LINES = 4000;
 
 /**
@@ -33,7 +33,7 @@ export function buildActivityEntry({ tool, target, summary, agent = null, why = 
   };
 }
 
-/** heartbeat 파일에서 agent 이름을 읽는다 — 없거나 깨졌으면 null (조작 금지). */
+/** heartbeat 파일에서 agent 이름을 읽는다: 없거나 깨졌으면 null (조작 금지). */
 export function readHeartbeatAgent(rootPath) {
   try {
     const raw = readFileSync(join(rootPath, '.ontology-atlas/agent-activity.json'), 'utf-8');

--- a/mcp/src/growth-hint.mjs
+++ b/mcp/src/growth-hint.mjs
@@ -105,7 +105,7 @@ export function buildSlugNotFoundGrowthHint({ slug, candidateSlugs = [], referen
     return {
       reason: `"${slug}" has no document of its own, but ${referencedBy.length} vault doc(s) reference it: ${cited}${more}.`,
       suggestion:
-        'This is a referenced-only concept — the map counts it, the compiled graph does not, because nothing defines it yet. Create its document at exactly this slug so the existing references resolve to it.',
+        'This is a referenced-only concept: the map counts it, the compiled graph does not, because nothing defines it yet. Create its document at exactly this slug so the existing references resolve to it.',
       exampleCall: {
         tool: 'add_concept',
         args: { slug, kind: 'element', title: titleCaseFromSlug(slug) },
@@ -115,7 +115,7 @@ export function buildSlugNotFoundGrowthHint({ slug, candidateSlugs = [], referen
   if (candidateSlugs.length > 0) {
     return {
       reason: `"${slug}" does not resolve to a vault node.`,
-      suggestion: `Closest existing slug(s): ${candidateSlugs.join(', ')} — likely a typo or a missing folder segment rather than a missing node.`,
+      suggestion: `Closest existing slug(s): ${candidateSlugs.join(', ')}: likely a typo or a missing folder segment rather than a missing node.`,
       exampleCall: {
         tool: 'get_concept',
         args: { slug: candidateSlugs[0] },
@@ -125,7 +125,7 @@ export function buildSlugNotFoundGrowthHint({ slug, candidateSlugs = [], referen
   return {
     reason: `"${slug}" does not resolve to a vault node, and no similarly-named node exists.`,
     suggestion:
-      'This may be a real gap in the vault — add it if it describes an actual capability/element/domain.',
+      'This may be a real gap in the vault: add it if it describes an actual capability/element/domain.',
     exampleCall: {
       tool: 'add_concept',
       args: { slug, kind: 'element', title: titleCaseFromSlug(slug) },
@@ -157,7 +157,7 @@ export function buildQueryConceptsZeroRowsGrowthHint({ filter, byKind = {}, byDo
       ...missingDomains.map((domain) => `domain="${domain}" has 0 nodes in this vault`),
     ];
     return {
-      reason: `query_concepts matched 0 rows — ${facts.join('; ')}.`,
+      reason: `query_concepts matched 0 rows: ${facts.join('; ')}.`,
       suggestion:
         'Check list_kinds / list_concepts for the real kind/domain census before retrying, or add the missing nodes.',
       exampleCall: { tool: 'list_kinds', args: {} },
@@ -166,7 +166,7 @@ export function buildQueryConceptsZeroRowsGrowthHint({ filter, byKind = {}, byDo
 
   return {
     reason: `query_concepts matched 0 rows for filter: ${filterText}`,
-    suggestion: 'Loosen the filter — drop an AND clause or widen an equality — and retry.',
+    suggestion: 'Loosen the filter: drop an AND clause or widen an equality: and retry.',
     exampleCall: { tool: 'list_kinds', args: {} },
   };
 }
@@ -180,13 +180,13 @@ export function buildFindEvidenceZeroHitsGrowthHint({ title, nearMatches = [] })
     const names = nearMatches.map((match) => `${match.title} (${match.slug})`);
     return {
       reason: `No vault doc mentions "${title}".`,
-      suggestion: `Closest existing node(s) by title: ${names.join(', ')} — confirm this isn't the same concept under a different name before adding a new one.`,
+      suggestion: `Closest existing node(s) by title: ${names.join(', ')}: confirm this isn't the same concept under a different name before adding a new one.`,
       exampleCall: { tool: 'get_concept', args: { slug: nearMatches[0].slug } },
     };
   }
   return {
     reason: `No vault doc mentions "${title}", and no similarly-titled node exists.`,
-    suggestion: 'This concept may not be captured in the vault yet — add it if it describes a real capability/element/domain.',
+    suggestion: 'This concept may not be captured in the vault yet: add it if it describes a real capability/element/domain.',
     exampleCall: {
       tool: 'add_concept',
       args: { slug: slugify(title), kind: 'element', title: String(title ?? '') },

--- a/mcp/src/ontology-compiler.mjs
+++ b/mcp/src/ontology-compiler.mjs
@@ -519,7 +519,7 @@ function validateGraphIdentity(graphDocs) {
 const IDENTITY_REPAIR_HINT = Object.freeze({
   'missing-uid':
     'Hand-written nodes have no `uid:` yet. Any write repairs it: patch_concept(slug, {...}) mints one, ' +
-    'or add the line yourself — `uid:` must be a lowercase UUIDv4.',
+    'or add the line yourself: `uid:` must be a lowercase UUIDv4.',
   'invalid-uid': '`uid:` must be a lowercase UUIDv4. Fix the value in the file, or let patch_concept rewrite it.',
 });
 

--- a/mcp/src/ontology-engine.mjs
+++ b/mcp/src/ontology-engine.mjs
@@ -2680,7 +2680,7 @@ export function createOntologyEngine(artifact, options = {}) {
           suggestedSlug: kind ? suggestedSlugForReference(edge.ref, kind) : null,
           didYouMean: didYouMean || null,
           reason: didYouMean
-            ? `Graph reference "${edge.ref}" from "${edge.from}" via "${edge.via}" does not resolve, but "${didYouMean}" is an existing node with a matching name — likely a missing folder prefix or typo. Fix the "${edge.via}" reference on "${edge.from}" (e.g. \`ontology-atlas relate ${edge.from} ${didYouMean} ${RELATION_TYPE_FOR_KEY[edge.via] || edge.via}\`, or edit the "domain:" field directly for a scalar reference) instead of creating a duplicate node.`
+            ? `Graph reference "${edge.ref}" from "${edge.from}" via "${edge.via}" does not resolve, but "${didYouMean}" is an existing node with a matching name: likely a missing folder prefix or typo. Fix the "${edge.via}" reference on "${edge.from}" (e.g. \`ontology-atlas relate ${edge.from} ${didYouMean} ${RELATION_TYPE_FOR_KEY[edge.via] || edge.via}\`, or edit the "domain:" field directly for a scalar reference) instead of creating a duplicate node.`
             : `Graph reference "${edge.ref}" from "${edge.from}" via "${edge.via}" does not resolve to a vault node.`,
           proposedAction: didYouMean
             ? null
@@ -2836,7 +2836,7 @@ export function createOntologyEngine(artifact, options = {}) {
         score: 0.55,
         slug: node.slug,
         reason: sameKindParent
-          ? `${node.slug} sits under "${sameKindParent.slug}", a node of its own kind, but groups nothing — it has no children that resolve to real nodes. A bridge node earns its place by holding the children it was created for. Either patch_concept the children that share its behavior to point at it, or delete_concept it; an empty layer adds a hop to every path through it and answers no question.`
+          ? `${node.slug} sits under "${sameKindParent.slug}", a node of its own kind, but groups nothing: it has no children that resolve to real nodes. A bridge node earns its place by holding the children it was created for. Either patch_concept the children that share its behavior to point at it, or delete_concept it; an empty layer adds a hop to every path through it and answers no question.`
           : `${node.slug} still carries the starter body it was created with and groups nothing. It was created and never given meaning. Either write what it covers and reparent the children that belong to it, or delete_concept it.`,
         node: summarizeNode(node),
       }));
@@ -2951,7 +2951,7 @@ export function createOntologyEngine(artifact, options = {}) {
         reason: truncatedByBudget ? 'search_budget' : rows.length > limit ? 'limit' : 'complete',
         nextStep: complete ? 'use' : 'narrow',
         recommendation: complete
-          ? 'Safe to treat totalCycles as complete for the requested bounds — zero means acyclic within maxDepth.'
+          ? 'Safe to treat totalCycles as complete for the requested bounds: zero means acyclic within maxDepth.'
           : truncatedByBudget
             ? 'Search budget hit before the graph was exhausted; zero cycles here does NOT mean acyclic. Reduce maxHops, narrow types, or raise searchBudget.'
             : 'totalCycles is exact, but the list is truncated by limit; raise limit to see the rest.',
@@ -5273,7 +5273,7 @@ function findNearMatchSlug(ref, nodes) {
   const prefixTail = [];
   for (const node of nodes) {
     const slug = node.slug;
-    if (slug === raw) continue; // already resolves — wouldn't be dangling
+    if (slug === raw) continue; // already resolves: wouldn't be dangling
     const tail = (slug.split('/').pop() || slug).toLowerCase();
     if (tail === lowerRaw) {
       exactTail.push(slug);

--- a/mcp/src/project-source-receipt.mjs
+++ b/mcp/src/project-source-receipt.mjs
@@ -9,7 +9,7 @@ import {
 export { PROJECT_SOURCE_RECEIPT_VERSION, buildProjectSourceReceipt };
 export const PROJECT_SOURCE_STATE_RELATIVE_PATH = '.ontology-atlas/project-sources.json';
 /** Keeps the private absolute root out of git. Mirrors the app's sidecar guard. */
-const SIDECAR_IGNORE_CONTENT = '# Ontology Atlas local runtime state — not for commit.\n*\n';
+const SIDECAR_IGNORE_CONTENT = '# Ontology Atlas local runtime state: not for commit.\n*\n';
 
 const RECEIPT_STATUSES = new Set(['needs_evidence', 'review_required', 'verified_current']);
 const GAP_IDS = new Set([

--- a/mcp/src/project-source-witnesses.mjs
+++ b/mcp/src/project-source-witnesses.mjs
@@ -38,7 +38,7 @@ function roleForKind(kind) {
   return kind === 'capability' || kind === 'project' ? 'entrypoint' : 'implementation';
 }
 
-/** The app's graph node id for a vault doc — `${kind}:${last slug segment}`. */
+/** The app's graph node id for a vault doc: `${kind}:${last slug segment}`. */
 function graphNodeId(doc) {
   const kind = typeof doc.frontmatter?.kind === 'string' ? doc.frontmatter.kind.trim() : '';
   const fmSlug = typeof doc.frontmatter?.slug === 'string' ? doc.frontmatter.slug.trim() : '';

--- a/mcp/src/schema.mjs
+++ b/mcp/src/schema.mjs
@@ -263,7 +263,7 @@ export const VAULT_KIND_SCHEMA = {
     ],
     bodyTemplate: (title) =>
       `# ${title}\n\n` +
-      `One- or two-line summary of this project — *what / for whom / why*.\n\n` +
+      `One- or two-line summary of this project: *what / for whom / why*.\n\n` +
       `## How it grows\n\n` +
       `- Fill \`domains: [...]\` in the frontmatter and the domain nodes hang\n` +
       `  off the project tree automatically.\n` +
@@ -473,7 +473,7 @@ export function flatSlugIssue(kind, slug) {
   if (!rest.includes('/') && !rest.includes('\\')) return null;
   const tail = rest.split(/[\\/]/).filter(Boolean).pop() ?? rest;
   return (
-    `slug "${slug}" nests a path under ${folder} — a slug is the node's NAME, not a location. ` +
+    `slug "${slug}" nests a path under ${folder}: a slug is the node's NAME, not a location. ` +
     `Node identity is resolved by the slug tail on three surfaces (web derivation, unique-tail lookup, deep links), ` +
     `so path-style slugs silently merge distinct nodes the moment two files share a basename. ` +
     `Use a flat slug under the kind folder (e.g. "${folder}${tail}") and record the file location in path: instead.`

--- a/mcp/src/validate.mjs
+++ b/mcp/src/validate.mjs
@@ -90,7 +90,7 @@ export function validateVaultDocument(raw) {
       code: 'unclosed-frontmatter',
       severity: 'error',
       message:
-        'frontmatter 시작 `---` 만 있고 끝 `---` 가 없습니다 — 노드로 인식되지 않습니다.',
+        'frontmatter 시작 `---` 만 있고 끝 `---` 가 없습니다: 노드로 인식되지 않습니다.',
     });
     return { ok: false, issues };
   }
@@ -107,7 +107,7 @@ export function validateVaultDocument(raw) {
       code: 'parse-zero-keys',
       severity: 'warning',
       message:
-        'frontmatter 블록은 있지만 key 가 하나도 추출되지 않았습니다 — 들여쓰기 또는 콜론 누락 의심.',
+        'frontmatter 블록은 있지만 key 가 하나도 추출되지 않았습니다: 들여쓰기 또는 콜론 누락 의심.',
     });
     return { ok: true, issues };
   }
@@ -120,13 +120,13 @@ export function validateVaultDocument(raw) {
       code: 'missing-kind',
       severity: 'warning',
       message:
-        'frontmatter 에 `kind:` 가 없습니다 — graph 노드가 되려면 kind 가 필요합니다.',
+        'frontmatter 에 `kind:` 가 없습니다: graph 노드가 되려면 kind 가 필요합니다.',
     });
   } else if (typeof rawKind !== 'string' || rawKind.trim() === '') {
     issues.push({
       code: 'empty-kind',
       severity: 'error',
-      message: '`kind:` 값이 비어있습니다 — graph 노드로 인식되지 않습니다.',
+      message: '`kind:` 값이 비어있습니다: graph 노드로 인식되지 않습니다.',
     });
   } else if (!KNOWN_VAULT_KINDS.includes(rawKind.trim())) {
     issues.push({
@@ -142,7 +142,7 @@ export function validateVaultDocument(raw) {
       issues.push({
         code: 'missing-expected-field',
         severity: 'warning',
-        message: `\`${key}:\` 가 비어있습니다 — kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
+        message: `\`${key}:\` 가 비어있습니다: kind=${trimmedKind} 노드는 ${key} 가 있어야 트리에서 부모를 찾을 수 있습니다.`,
       });
     }
   }
@@ -165,7 +165,7 @@ function pushUidIssues(frontmatter, issues) {
     issues.push({
       code: 'missing-uid',
       severity: 'error',
-      message: '`uid:`가 없습니다 — 모든 ontology 노드는 생성 후 바뀌지 않는 lowercase UUIDv4 영구 식별자를 가져야 합니다.',
+      message: '`uid:`가 없습니다: 모든 ontology 노드는 생성 후 바뀌지 않는 lowercase UUIDv4 영구 식별자를 가져야 합니다.',
     });
     return;
   }
@@ -203,7 +203,7 @@ function pushNonCanonicalGraphArrayIssues(frontmatter, issues) {
       issues.push({
         code: 'non-canonical-graph-array',
         severity: 'warning',
-        message: `\`${key}:\` graph 배열이 정렬/중복제거된 canonical set 이 아닙니다 — add_relation 또는 patch_concept 로 다시 저장하면 정리됩니다.`,
+        message: `\`${key}:\` graph 배열이 정렬/중복제거된 canonical set 이 아닙니다: add_relation 또는 patch_concept 로 다시 저장하면 정리됩니다.`,
       });
     }
   }

--- a/mcp/src/vault.mjs
+++ b/mcp/src/vault.mjs
@@ -49,7 +49,7 @@ import { hasCapabilityImplementationEvidence } from './capability-evidence.mjs';
 export class VaultConflictError extends Error {
   constructor(slug, expectedMtime, currentMtime) {
     super(
-      `Vault conflict — "${slug}" was modified externally between read and write. ` +
+      `Vault conflict: "${slug}" was modified externally between read and write. ` +
         `expectedMtime=${expectedMtime} currentMtime=${currentMtime}. ` +
         // **없는 복구법을 알려주지 않는다** (2026-07-29 실측).
         //
@@ -674,7 +674,7 @@ const GATE = {
    * came from (`patch_concept` on `elements:`, never a child announcing itself).
    */
   parentGrewBy: new Map(),
-  /** Lazy slug index — { rootPath, names: Set<string> }. */
+  /** Lazy slug index: { rootPath, names: Set<string> }. */
   index: null,
 };
 
@@ -794,7 +794,7 @@ const DENSE_PARENT_RELATIONS = Object.freeze({
   capability: Object.freeze({ key: 'elements', childKind: 'element', bootstrap: 'capability_to_element' }),
 });
 
-/** Nearest-rank p90 — no interpolation, so the answer is always an observed count. */
+/** Nearest-rank p90: no interpolation, so the answer is always an observed count. */
 function percentile90(values) {
   const sorted = [...values].sort((a, b) => a - b);
   return sorted[Math.max(0, Math.ceil(0.9 * sorted.length) - 1)];
@@ -1160,7 +1160,7 @@ export function writeDoc(rootPath, slug, { frontmatter, body = '' }) {
   const filePath = slugToPath(rootPath, slug);
   if (existsSync(filePath)) {
     throw new Error(
-      `Doc already exists at "${slug}". To update fields, use patch_concept(slug, frontmatter, body, expected_mtime). To rename, use rename_concept(oldSlug, newSlug). Never delete-then-add — that loses backlinks.`,
+      `Doc already exists at "${slug}". To update fields, use patch_concept(slug, frontmatter, body, expected_mtime). To rename, use rename_concept(oldSlug, newSlug). Never delete-then-add: that loses backlinks.`,
     );
   }
   assertPlainObject(frontmatter, 'frontmatter');
@@ -1648,7 +1648,7 @@ export function applyAllOrNothing(plan) {
   }
   if (blocked.length > 0) {
     throw new Error(
-      `Refused before writing anything — ${blocked.length} file(s) are not writable, `
+      `Refused before writing anything: ${blocked.length} file(s) are not writable, `
         + `so this operation could not finish as one unit:\n  ${blocked.join('\n  ')}\n`
         + 'The vault is unchanged. Fix permissions (or close the editor/sync client '
         + 'holding them) and re-run with confirm: true.',
@@ -1684,14 +1684,14 @@ export function applyAllOrNothing(plan) {
     if (unrecovered.length > 0) {
       throw new Error(
         `Write failed (${reason}) and the rollback could not finish. `
-          + `The vault is INCONSISTENT — these files still hold rewritten content:\n  `
+          + `The vault is INCONSISTENT: these files still hold rewritten content:\n  `
           + `${unrecovered.join('\n  ')}\n`
           + 'If the vault is a git repository, `git diff` shows exactly what changed '
           + 'and `git checkout -- <path>` restores it.',
       );
     }
     throw new Error(
-      `Write failed (${reason}). Every change was rolled back — the vault is unchanged.`,
+      `Write failed (${reason}). Every change was rolled back: the vault is unchanged.`,
     );
   }
 }
@@ -1759,7 +1759,7 @@ export function redirectBacklinks(rootPath, targetSlug, nextSlug, options = {}) 
   }
 
   const updates = [];
-  /** 디스크에 낼 쓰기 계획 — 루프가 끝난 뒤 한 번에 적용한다. */
+  /** 디스크에 낼 쓰기 계획: 루프가 끝난 뒤 한 번에 적용한다. */
   const plan = [];
   for (const doc of docs) {
     if (doc.slug === targetSlug || excluded.has(doc.slug)) continue;
@@ -1913,7 +1913,7 @@ export function detectDuplicateTitle(title, slug, docs) {
     if (normalizeForDuplicateTitle(docTitle(doc)) === norm) {
       const kind = doc.frontmatter?.kind ?? 'unknown';
       return (
-        `a node titled "${title}" already exists at "${doc.slug}" (kind: ${kind}) — ` +
+        `a node titled "${title}" already exists at "${doc.slug}" (kind: ${kind}): ` +
         `if this is the same concept, patch_concept on "${doc.slug}" instead of adding a duplicate.`
       );
     }

--- a/mcp/src/verify-script.test.mjs
+++ b/mcp/src/verify-script.test.mjs
@@ -375,18 +375,18 @@ describe('verify.mjs first-contact gates', () => {
         ...tools,
         { name: 'list_concepts' },
       ]),
-      'tools mismatch — missing: (none), extra: (none), duplicates: list_concepts, invalidNames: 0',
+      'tools mismatch: missing: (none), extra: (none), duplicates: list_concepts, invalidNames: 0',
     );
     assert.equal(
       toolsListInventoryFailure(tools.filter((tool) => tool.name !== 'get_concept')),
-      'tools mismatch — missing: get_concept, extra: (none), duplicates: (none), invalidNames: 0',
+      'tools mismatch: missing: get_concept, extra: (none), duplicates: (none), invalidNames: 0',
     );
     assert.equal(
       toolsListInventoryFailure([
         ...tools,
         { name: 'unknown_tool' },
       ]),
-      'tools mismatch — missing: (none), extra: unknown_tool, duplicates: (none), invalidNames: 0',
+      'tools mismatch: missing: (none), extra: unknown_tool, duplicates: (none), invalidNames: 0',
     );
     assert.equal(
       toolsListInventoryFailure([
@@ -394,7 +394,7 @@ describe('verify.mjs first-contact gates', () => {
         { name: '' },
         {},
       ]),
-      'tools mismatch — missing: (none), extra: (none), duplicates: (none), invalidNames: 2',
+      'tools mismatch: missing: (none), extra: (none), duplicates: (none), invalidNames: 2',
     );
   });
 
@@ -849,12 +849,12 @@ describe('verify.mjs first-contact gates', () => {
               type: 'number',
               minimum: 0,
               description:
-                'Non-negative mtime threshold. Filter to nodes with `mtime > since` (ms). Pair with the `mtime` returned in earlier `list_concepts` / `get_concept` responses for incremental sync — "what changed since I last looked". Strict greater-than (mtime === since 는 제외) so re-passing the max from a previous response does not double-fetch.',
+                'Non-negative mtime threshold. Filter to nodes with `mtime > since` (ms). Pair with the `mtime` returned in earlier `list_concepts` / `get_concept` responses for incremental sync: "what changed since I last looked". Strict greater-than (mtime === since 는 제외) so re-passing the max from a previous response does not double-fetch.',
             },
             summary: {
               type: 'boolean',
               description:
-                'When true, each node row includes a `summary` (max 200 chars, prose-only — heading / 표 / 코드블록 / 리스트 / 인용 skip 후 첫 단락만, same `extractSummaryExcerpt` helper as `get_concept` / `find_evidence`). Useful for "scan + overview" without N follow-up `get_concept` calls. Default false to keep payload small.',
+                'When true, each node row includes a `summary` (max 200 chars, prose-only: heading / 표 / 코드블록 / 리스트 / 인용 skip 후 첫 단락만, same `extractSummaryExcerpt` helper as `get_concept` / `find_evidence`). Useful for "scan + overview" without N follow-up `get_concept` calls. Default false to keep payload small.',
             },
             limit: {
               type: 'integer',
@@ -951,7 +951,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'find_orphans',
         description:
-          'List orphan nodes — docs that no other node references via any frontmatter array key. Useful as a cleanup starting point or to answer "which nodes are unused?". Same matching policy as find_backlinks (full slug or final segment). Root/sentinel kinds like project and vault-readme are excluded by default.',
+          'List orphan nodes: docs that no other node references via any frontmatter array key. Useful as a cleanup starting point or to answer "which nodes are unused?". Same matching policy as find_backlinks (full slug or final segment). Root/sentinel kinds like project and vault-readme are excluded by default.',
         inputSchema: {
           additionalProperties: false,
           properties: {
@@ -1410,7 +1410,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'list_kinds',
         description:
-          'Vault kind distribution — { total, byKind: { capability: N, ... } }. A quick census so AI agents can size up the vault without paging through list_concepts.',
+          'Vault kind distribution: { total, byKind: { capability: N, ... } }. A quick census so AI agents can size up the vault without paging through list_concepts.',
         inputSchema: { additionalProperties: false, properties: {} },
         outputSchema: {
           type: 'object',
@@ -1428,7 +1428,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'query_concepts',
         description:
-          'Typed filter DSL — search vault nodes by predicate.\n\n' +
+          'Typed filter DSL: search vault nodes by predicate.\n\n' +
           'Grammar (case-insensitive keywords, whitespace-tolerant):\n' +
           '  filter    := atom (AND|OR atom)*\n' +
           '  atom      := NOT? predicate\n' +
@@ -1481,7 +1481,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'compile_ontology',
         description:
-          'Compile the whole markdown vault into a deterministic graph artifact. Includes a stable semantic graphHash and maxMtime for cache invalidation. side effect 0. Large vaults (100+ nodes) can exceed the MCP token cap with the default full payload — use `summary: true` for cheap polling, or `nodesLimit/nodesOffset` / `edgesLimit/edgesOffset` to slice arrays.',
+          'Compile the whole markdown vault into a deterministic graph artifact. Includes a stable semantic graphHash and maxMtime for cache invalidation. side effect 0. Large vaults (100+ nodes) can exceed the MCP token cap with the default full payload: use `summary: true` for cheap polling, or `nodesLimit/nodesOffset` / `edgesLimit/edgesOffset` to slice arrays.',
         inputSchema: {
           additionalProperties: false,
           properties: {
@@ -1740,7 +1740,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'analyze_repo_structure',
         description:
-          'R16 (autonomous ingest base) — analyze a code repository and propose ontology node candidates. side effect 0 (vault frontmatter NOT modified). Returns deterministic candidates the agent should review and selectively pass to add_concept. Use this once when a user asks "bootstrap the ontology". Single source of truth preserved — only the user writes to the vault.',
+          'R16 (autonomous ingest base): analyze a code repository and propose ontology node candidates. side effect 0 (vault frontmatter NOT modified). Returns deterministic candidates the agent should review and selectively pass to add_concept. Use this once when a user asks "bootstrap the ontology". Single source of truth preserved: only the user writes to the vault.',
         inputSchema: {
           additionalProperties: false,
           properties: {
@@ -1869,7 +1869,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'infer_imports',
         description:
-          'R17 (autonomous ingest deeper) — walk TS/JS files in a code repo and infer file-level + module-level import edges. side effect 0 (vault frontmatter NOT modified). moduleEdges are source-backed review candidates with kindCounts and a bounded exact file-edge `evidence` receipt. For approval start with reviewMode:"next": exactly one compact, non-writing `nextRelationReview:v1` packet. Missing edges are rationale_review_required. Ask the user before add_relation and include `why`. Use after analyze_repo_structure to pull real dependency edges from the code, not just suggestedRelations heuristics. Single source of truth preserved — only the user writes to the vault.',
+          'R17 (autonomous ingest deeper): walk TS/JS files in a code repo and infer file-level + module-level import edges. side effect 0 (vault frontmatter NOT modified). moduleEdges are source-backed review candidates with kindCounts and a bounded exact file-edge `evidence` receipt. For approval start with reviewMode:"next": exactly one compact, non-writing `nextRelationReview:v1` packet. Missing edges are rationale_review_required. Ask the user before add_relation and include `why`. Use after analyze_repo_structure to pull real dependency edges from the code, not just suggestedRelations heuristics. Single source of truth preserved: only the user writes to the vault.',
         inputSchema: {
           additionalProperties: false,
           properties: {
@@ -2110,7 +2110,7 @@ describe('verify.mjs first-contact gates', () => {
       {
         name: 'validate_vault',
         description:
-          'R+ (cycle 46) — validate every doc in the vault, return per-doc + per-code aggregate. side effect 0. Use when an agent needs the whole-vault health view: first-contact before writes, before / after a batch write, or surfacing issues to the user.',
+          'R+ (cycle 46): validate every doc in the vault, return per-doc + per-code aggregate. side effect 0. Use when an agent needs the whole-vault health view: first-contact before writes, before / after a batch write, or surfacing issues to the user.',
         inputSchema: { additionalProperties: false, properties: {} },
         outputSchema: {
           type: 'object',
@@ -5364,7 +5364,7 @@ describe('verify.mjs first-contact gates', () => {
         `unexpected verify stderr:\n${result.stderr}`,
       );
       assert.doesNotMatch(result.stderr, /MaxListenersExceededWarning/);
-      assert.match(result.stdout, /list_concepts — vault total 0 nodes/);
+      assert.match(result.stdout, /list_concepts: vault total 0 nodes/);
       assert.match(result.stdout, /verify vault has 0 ontology nodes/);
       assert.match(result.stdout, /Point verify at a populated ontology vault/);
       assert.doesNotMatch(result.stdout, /verify timed out/);
@@ -5635,7 +5635,7 @@ describe('verify.mjs first-contact gates', () => {
   it('keeps the verify success message MCP-client neutral', () => {
     assert.equal(
       verifySuccessMessage(24),
-      'All passed — register .mcp.json with your MCP client and restart to use the 24 tools.',
+      'All passed: register .mcp.json with your MCP client and restart to use the 24 tools.',
     );
     assert.doesNotMatch(verifySuccessMessage(24), /Claude Code/);
   });
@@ -5680,7 +5680,7 @@ describe('verify.mjs first-contact gates', () => {
     );
     assert.equal(
       strictArgsFailure({ result: { isError: true, content: [{ text: `Error: ${error}` }], structuredContent: { ok: false, errorCode: 'invalid_arguments', error } } }),
-      'strict arguments structured error code mismatch — expected unknown_argument, got invalid_arguments',
+      'strict arguments structured error code mismatch: expected unknown_argument, got invalid_arguments',
     );
     assert.equal(
       strictArgsFailure({ result: { isError: true, content: [{ text: 'different error' }], structuredContent: { ok: false, errorCode: 'unknown_argument', error: 'different error' } } }),
@@ -5828,7 +5828,7 @@ describe('verify.mjs first-contact gates', () => {
           structuredContent: { ok: false, errorCode: 'unknown_argument', error },
         },
       }),
-      'strict unknown-tool structured error code mismatch — expected unknown_tool, got unknown_argument',
+      'strict unknown-tool structured error code mismatch: expected unknown_tool, got unknown_argument',
     );
     assert.equal(
       strictUnknownToolFailure({
@@ -6250,18 +6250,18 @@ describe('verify.mjs first-contact gates', () => {
           },
         },
       }, 'concepts', 'add_concepts'),
-      'add_concepts row isolation structuredContent mismatch — $.concepts[3].error: parsed "concepts[3] duplicate slug in input batch; first seen at concepts[2]", structuredContent "concepts[3] duplicate slug in input batch; first seen at concepts[1]"',
+      'add_concepts row isolation structuredContent mismatch: $.concepts[3].error: parsed "concepts[3] duplicate slug in input batch; first seen at concepts[2]", structuredContent "concepts[3] duplicate slug in input batch; first seen at concepts[1]"',
     );
   });
 
   it('fails malformed batch cap smoke responses', () => {
     assert.equal(
       batchCapFailure(
-        strictErrorResponse('Too many concepts: 51. Max 50 per call — split into multiple add_concepts batches.', {
+        strictErrorResponse('Too many concepts: 51. Max 50 per call: split into multiple add_concepts batches.', {
           structuredContent: {
             ok: false,
             errorCode: 'invalid_arguments',
-            error: 'Too many concepts: 51. Max 50 per call — split into multiple add_concepts batches.',
+            error: 'Too many concepts: 51. Max 50 per call: split into multiple add_concepts batches.',
           },
         }),
         'add_concepts',
@@ -6289,17 +6289,17 @@ describe('verify.mjs first-contact gates', () => {
     );
     assert.equal(
       batchCapFailure(
-        strictErrorResponse('Too many relations: 51. Max 50 per call — split into multiple add_relations batches.', {
+        strictErrorResponse('Too many relations: 51. Max 50 per call: split into multiple add_relations batches.', {
           structuredContent: {
             ok: false,
             errorCode: 'tool_error',
-            error: 'Too many relations: 51. Max 50 per call — split into multiple add_relations batches.',
+            error: 'Too many relations: 51. Max 50 per call: split into multiple add_relations batches.',
           },
         }),
         'add_relations',
         'relations',
       ),
-      'add_relations batch cap structured error code mismatch — expected invalid_arguments, got tool_error',
+      'add_relations batch cap structured error code mismatch: expected invalid_arguments, got tool_error',
     );
   });
 
@@ -6315,7 +6315,7 @@ describe('verify.mjs first-contact gates', () => {
       newSlug: 'new',
       moved: false,
       backlinkUpdates: { totalUpdated: 0, updates: [] },
-      message: 'dry-run — confirm:true to apply',
+      message: 'dry-run: confirm:true to apply',
     };
     assert.equal(
       destructiveDryRunFailure({
@@ -6589,7 +6589,7 @@ describe('verify.mjs first-contact gates', () => {
             blockedReasons: [],
             slug: 'gone',
             backlinks: [],
-            message: 'dry-run — force:true to apply',
+            message: 'dry-run: force:true to apply',
           }) }],
           structuredContent: {
             ok: false,
@@ -6600,7 +6600,7 @@ describe('verify.mjs first-contact gates', () => {
             blockedReasons: [],
             slug: 'gone',
             backlinks: [],
-            message: 'dry-run — force:true to apply',
+            message: 'dry-run: force:true to apply',
           },
         },
       }, 'delete_concept'),
@@ -6620,7 +6620,7 @@ describe('verify.mjs first-contact gates', () => {
                 blockedReasons: ['1 backlink requires force:true'],
                 slug: 'gone',
                 backlinks: [{ slug: ' ref', kind: 'capability', title: 'Ref', mtime: 1 }],
-                message: 'dry-run — force:true to apply',
+                message: 'dry-run: force:true to apply',
               }),
             },
           ],
@@ -6633,7 +6633,7 @@ describe('verify.mjs first-contact gates', () => {
             blockedReasons: ['1 backlink requires force:true'],
             slug: 'gone',
             backlinks: [{ slug: ' ref', kind: 'capability', title: 'Ref', mtime: 1 }],
-            message: 'dry-run — force:true to apply',
+            message: 'dry-run: force:true to apply',
           },
         },
       }, 'delete_concept'),
@@ -6653,7 +6653,7 @@ describe('verify.mjs first-contact gates', () => {
                 blockedReasons: ['1 backlink requires force:true'],
                 slug: 'gone',
                 backlinks: [{ slug: 'ref', kind: 'capability', title: 'Ref', mtime: 1, matchedKeys: [' relates'] }],
-                message: 'dry-run — force:true to apply',
+                message: 'dry-run: force:true to apply',
               }),
             },
           ],
@@ -6666,7 +6666,7 @@ describe('verify.mjs first-contact gates', () => {
             blockedReasons: ['1 backlink requires force:true'],
             slug: 'gone',
             backlinks: [{ slug: 'ref', kind: 'capability', title: 'Ref', mtime: 1, matchedKeys: [' relates'] }],
-            message: 'dry-run — force:true to apply',
+            message: 'dry-run: force:true to apply',
           },
         },
       }, 'delete_concept'),
@@ -6684,7 +6684,7 @@ describe('verify.mjs first-contact gates', () => {
       blockedReasons: [],
       slug: 'gone',
       backlinks: [],
-      message: 'dry-run — force:true to apply',
+      message: 'dry-run: force:true to apply',
     };
     assert.equal(
       destructiveDryRunSmokeFailure([
@@ -6718,7 +6718,7 @@ describe('verify.mjs first-contact gates', () => {
   });
 
   it('fails malformed patch_concept conflict guard smoke responses', () => {
-    const error = 'VaultConflictError: expected_mtime conflict — file was modified externally';
+    const error = 'VaultConflictError: expected_mtime conflict: file was modified externally';
     assert.equal(
       patchConflictGuardFailure({
         result: {
@@ -6746,7 +6746,7 @@ describe('verify.mjs first-contact gates', () => {
           structuredContent: { ok: false, errorCode: 'conflict', error },
         },
       }),
-      'patch_concept conflict guard structured error code mismatch — expected vault_conflict, got conflict',
+      'patch_concept conflict guard structured error code mismatch: expected vault_conflict, got conflict',
     );
     assert.equal(
       patchConflictGuardFailure({
@@ -8028,7 +8028,7 @@ describe('verify.mjs first-contact gates', () => {
     );
   });
 
-  it('sends an absorb_document dry-run request against the temp fixture at boot (unconditional — no vault dependency)', () => {
+  it('sends an absorb_document dry-run request against the temp fixture at boot (unconditional: no vault dependency)', () => {
     const requests = buildFirstContactRequests();
     const request = requests.find((r) => r.id === 69);
     assert.ok(request, 'expected an id:69 absorb_document request in the first-contact batch');
@@ -8102,7 +8102,7 @@ describe('verify.mjs first-contact gates', () => {
               injectionMatches: [],
             },
           ],
-          message: 'dry-run — 1 section(s) would be absorbed as document/policy nodes, 1 suggested (not written), 0 injection-suspect (excluded from absorption). Pass confirm:true to write.',
+          message: 'dry-run: 1 section(s) would be absorbed as document/policy nodes, 1 suggested (not written), 0 injection-suspect (excluded from absorption). Pass confirm:true to write.',
         }),
       ),
       null,
@@ -8129,7 +8129,7 @@ describe('verify.mjs first-contact gates', () => {
         injectionSuspect: false,
         injectionMatches: [],
       }],
-      message: 'dry-run — pass confirm:true to write.',
+      message: 'dry-run: pass confirm:true to write.',
     };
     const wrap = wrapAbsorbResponse;
 
@@ -8453,7 +8453,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(findOrphansFailure({ total: 0 }), 'find_orphans response missing orphans array');
     assert.equal(
       findOrphansFailure({ total: 0, orphans: [{ slug: 'capabilities/orphan' }] }),
-      'find_orphans response orphan count exceeds total — orphans 1, total 0',
+      'find_orphans response orphan count exceeds total: orphans 1, total 0',
     );
     assert.equal(
       findOrphansFailure({
@@ -8671,7 +8671,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(getConceptFailure(null, 'capabilities/mcp-server'), 'get_concept response malformed');
     assert.equal(
       getConceptFailure({ ...okConcept, slug: 'capabilities/other' }, 'capabilities/mcp-server'),
-      'get_concept response slug mismatch — expected capabilities/mcp-server, got capabilities/other',
+      'get_concept response slug mismatch: expected capabilities/mcp-server, got capabilities/other',
     );
     assert.equal(
       getConceptFailure({ ...okConcept, excerpt: null }, 'capabilities/mcp-server'),
@@ -8705,7 +8705,7 @@ describe('verify.mjs first-contact gates', () => {
     );
     assert.equal(
       findBacklinksFailure({ target: 'other', total: 0, matches: [] }, 'project'),
-      'find_backlinks response target mismatch — expected project, got other',
+      'find_backlinks response target mismatch: expected project, got other',
     );
     assert.equal(
       findBacklinksFailure({ target: 'project', total: 1, matches: [match] }, 'project'),
@@ -8714,7 +8714,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(queryConceptsFailure({ matches: [] }), 'query_concepts response missing filter');
     assert.equal(
       queryConceptsFailure({ filter: 'kind=project', parsedAs: 'kind = project', total: 0, matches: [match], limited: false }),
-      'query_concepts response match count exceeds total — matches 1, total 0',
+      'query_concepts response match count exceeds total: matches 1, total 0',
     );
     assert.equal(
       limitedQueryConceptsFailure({ filter: 'slug!=project', parsedAs: 'slug != project', total: 2, matches: [match], limited: true }, 'project', 2),
@@ -8738,7 +8738,7 @@ describe('verify.mjs first-contact gates', () => {
         edges: [],
         nodes: [],
       }, 'project'),
-      'find_neighbors center mismatch — expected project, got other',
+      'find_neighbors center mismatch: expected project, got other',
     );
     assert.equal(
       findNeighborsFailure({
@@ -8886,7 +8886,7 @@ describe('verify.mjs first-contact gates', () => {
         nodes: [],
         vaultWarnings: { errorCount: 1, warningCount: 2 },
       }),
-      'list_concepts vaultWarnings present — errors 1, warnings 2. Run validate_vault for file-level diagnostics before writing.',
+      'list_concepts vaultWarnings present: errors 1, warnings 2. Run validate_vault for file-level diagnostics before writing.',
     );
   });
 
@@ -8894,7 +8894,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(listKindsFailure({ byKind: {} }), 'list_kinds response missing total count');
     assert.equal(listKindsFailure({ total: 0 }), 'list_kinds response missing byKind aggregate');
     assert.equal(listKindsFailure({ total: 1, byKind: { project: -1 } }), 'list_kinds response missing count for kind: project');
-    assert.equal(listKindsFailure({ total: 2, byKind: { project: 1 } }), 'list_kinds response total mismatch — total 2, byKind 1');
+    assert.equal(listKindsFailure({ total: 2, byKind: { project: 1 } }), 'list_kinds response total mismatch: total 2, byKind 1');
     assert.equal(listKindsFailure({ total: 1, byKind: { project: 1 } }), null);
   });
 
@@ -8904,7 +8904,7 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(listConceptsFailure({ total: 0, vaultRoot: '/tmp/vault' }), 'list_concepts response missing nodes array');
     assert.equal(
       listConceptsFailure({ total: 0, vaultRoot: '/tmp/vault', nodes: [{ uid: TEST_UID, slug: 'project', kind: 'project', title: 'Project', mtime: 1 }] }),
-      'list_concepts response node count exceeds total — nodes 1, total 0',
+      'list_concepts response node count exceeds total: nodes 1, total 0',
     );
     assert.equal(listConceptsFailure({ total: 1, vaultRoot: '/tmp/vault', nodes: [null] }), 'list_concepts response malformed node at index 0');
     assert.equal(listConceptsFailure({ total: 1, vaultRoot: '/tmp/vault', nodes: [{}] }), 'list_concepts response missing node slug at index 0');
@@ -8938,7 +8938,7 @@ describe('verify.mjs first-contact gates', () => {
         vaultRoot: '/tmp/vault',
         nodes: [{ uid: TEST_UID, slug: 'project', kind: 'project', title: 'Project', mtime: 1 }],
       }, { byKind: { project: 1 } }),
-      'project probe count mismatch — list_kinds project 1, probe 2',
+      'project probe count mismatch: list_kinds project 1, probe 2',
     );
     assert.equal(
       projectProbeFailure({
@@ -8980,7 +8980,7 @@ describe('verify.mjs first-contact gates', () => {
           },
         },
       }),
-      'validate_vault found 2 problem files — errors 1, warnings 1 — codes dangling-graph-reference:warning:2, missing-kind:error:1',
+      'validate_vault found 2 problem files: errors 1, warnings 1 · codes dangling-graph-reference:warning:2, missing-kind:error:1',
     );
   });
 
@@ -9091,18 +9091,18 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(compileSummaryFailure({ ...clean, nodeCount: undefined }), 'compile_ontology response missing nodeCount');
     assert.equal(compileSummaryFailure({ ...clean, byKind: null }), 'compile_ontology response missing byKind aggregate');
     assert.equal(compileSummaryFailure({ ...clean, byDomain: { '': 1 } }), 'compile_ontology response has empty byDomain key');
-    assert.equal(compileSummaryFailure({ ...clean, byKind: { project: 2 } }), 'compile_ontology response byKind mismatch — nodeCount 1, byKind 2');
+    assert.equal(compileSummaryFailure({ ...clean, byKind: { project: 2 } }), 'compile_ontology response byKind mismatch: nodeCount 1, byKind 2');
     assert.equal(
       compileSummaryFailure({ ...clean, edgeCount: 2, resolvedEdgeCount: 1, externalEdgeCount: 0, unresolvedEdgeCount: 1 }),
       null,
     );
     assert.equal(
       compileSummaryFailure({ ...clean, edgeCount: 3, resolvedEdgeCount: 1, externalEdgeCount: 1 }),
-      'compile_ontology response edge count mismatch — edgeCount 3, resolved+external+unresolved 2',
+      'compile_ontology response edge count mismatch: edgeCount 3, resolved+external+unresolved 2',
     );
     assert.equal(
       compileSummaryFailure({ ...clean, edgeCount: 1, resolvedEdgeCount: 1, externalEdgeCount: 1 }),
-      'compile_ontology response edge count mismatch — edgeCount 1, resolved+external+unresolved 2',
+      'compile_ontology response edge count mismatch: edgeCount 1, resolved+external+unresolved 2',
     );
   });
 
@@ -9198,13 +9198,13 @@ describe('verify.mjs first-contact gates', () => {
     };
 
     assert.equal(compileFullArtifactFailure({ ...clean, nodes: undefined }), 'compile_ontology full response missing nodes array');
-    assert.equal(compileFullArtifactFailure({ ...clean, nodesPagination: { ...clean.nodesPagination, returned: 2 } }), 'compile_ontology.nodesPagination returned mismatch — meta 2, array 1');
+    assert.equal(compileFullArtifactFailure({ ...clean, nodesPagination: { ...clean.nodesPagination, returned: 2 } }), 'compile_ontology.nodesPagination returned mismatch: meta 2, array 1');
     assert.equal(compileFullArtifactFailure({ ...clean, nodes: [{ ...clean.nodes[0], outDegree: -1 }] }), 'compile_ontology full response malformed node row');
     assert.equal(compileFullArtifactFailure({ ...clean, edges: [{ ...clean.edges[0], resolved: 'true' }] }), 'compile_ontology full response malformed edge row');
     assert.equal(compileFullArtifactFailure({ ...clean, canonicalizationActions: null }), 'compile_ontology full response missing canonicalizationActions array');
-    assert.equal(compileFullArtifactFailure({ ...clean, aliases: [] }), 'compile_ontology full response aliases count mismatch — aliases 0, aliasCount 1');
-    assert.equal(compileFullArtifactFailure({ ...clean, summary: { ...clean.summary, aliases: 0 } }), 'compile_ontology full response summary count mismatch — summary aliases/ambiguous/issues 0/1/1, counts 1/1/1');
-    assert.equal(compileFullArtifactFailure({ ...clean, summary: { ...clean.summary, nodes: 2 } }), 'compile_ontology full response summary mismatch — summary 2/1, counts 1/1');
+    assert.equal(compileFullArtifactFailure({ ...clean, aliases: [] }), 'compile_ontology full response aliases count mismatch: aliases 0, aliasCount 1');
+    assert.equal(compileFullArtifactFailure({ ...clean, summary: { ...clean.summary, aliases: 0 } }), 'compile_ontology full response summary count mismatch: summary aliases/ambiguous/issues 0/1/1, counts 1/1/1');
+    assert.equal(compileFullArtifactFailure({ ...clean, summary: { ...clean.summary, nodes: 2 } }), 'compile_ontology full response summary mismatch: summary 2/1, counts 1/1');
   });
 
   it('accepts clean compile_ontology includeIndexes payloads', () => {
@@ -9296,12 +9296,12 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(compileIndexesSummary(clean), 'out 1, in 1, edgeById 1, aliases 1, edges 1/0/0');
     assert.equal(compileIndexesFailure({ ...clean, indexes: undefined }), 'compile_ontology indexes response missing indexes');
     assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, out: { project: edgeId } } }), 'compile_ontology.indexes.out malformed row');
-    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, edgeById: {} } }), 'compile_ontology.indexes.edgeById count mismatch — index 0, edgeCount 1');
-    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, aliasToSlug: {} } }), 'compile_ontology.indexes.aliasToSlug count mismatch — index 0, aliasCount 1');
+    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, edgeById: {} } }), 'compile_ontology.indexes.edgeById count mismatch: index 0, edgeCount 1');
+    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, aliasToSlug: {} } }), 'compile_ontology.indexes.aliasToSlug count mismatch: index 0, aliasCount 1');
     assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, out: { project: ['missing-edge'] } } }), 'compile_ontology.indexes.out references unknown edge id');
-    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, out: { project: [edgeId, edgeId] } } }), 'compile_ontology.indexes.out count mismatch — index 2, edgeCount 1');
-    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, in: { 'domains/core': [edgeId, edgeId] } } }), 'compile_ontology.indexes.in count mismatch — index 2, resolvedEdgeCount 1');
-    assert.equal(compileIndexesFailure({ ...clean, resolvedEdgeCount: 0, unresolvedEdgeCount: 1, indexes: { ...clean.indexes, in: {} } }), 'compile_ontology.indexes.edgeById edge breakdown mismatch — index 1/0/0, counts 0/0/1');
+    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, out: { project: [edgeId, edgeId] } } }), 'compile_ontology.indexes.out count mismatch: index 2, edgeCount 1');
+    assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, in: { 'domains/core': [edgeId, edgeId] } } }), 'compile_ontology.indexes.in count mismatch: index 2, resolvedEdgeCount 1');
+    assert.equal(compileIndexesFailure({ ...clean, resolvedEdgeCount: 0, unresolvedEdgeCount: 1, indexes: { ...clean.indexes, in: {} } }), 'compile_ontology.indexes.edgeById edge breakdown mismatch: index 1/0/0, counts 0/0/1');
     assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, out: { other: [edgeId] } } }), 'compile_ontology.indexes.out missing edgeById edge');
     assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, in: { other: [edgeId] } } }), 'compile_ontology.indexes.in missing resolved edge');
     assert.equal(compileIndexesFailure({ ...clean, indexes: { ...clean.indexes, byKind: { project: ['missing-node'] } } }), 'compile_ontology.indexes.byKind references unknown node slug');
@@ -9531,11 +9531,11 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(overviewFailure({ ...cleanOverview, graph: { ...cleanOverview.graph, graphHash: '' } }), 'overview response missing graphHash');
     assert.equal(
       overviewFailure({ ...cleanOverview, graph: { ...cleanOverview.graph, edges: 3 } }),
-      'overview response edge count mismatch — edges 3, resolved+external+unresolved 2',
+      'overview response edge count mismatch: edges 3, resolved+external+unresolved 2',
     );
     assert.equal(
       overviewFailure({ ...cleanOverview, byKind: { project: 2 } }),
-      'overview response byKind mismatch — nodes 1, byKind 2',
+      'overview response byKind mismatch: nodes 1, byKind 2',
     );
     assert.equal(overviewFailure({ ...cleanOverview, hubs: null }), 'overview response missing hubs array');
 
@@ -9587,7 +9587,7 @@ describe('verify.mjs first-contact gates', () => {
         edges: [],
         nodes: [],
       }, 'project'),
-      'neighbors center mismatch — expected project, got other',
+      'neighbors center mismatch: expected project, got other',
     );
     assert.equal(
       neighborsFailure({
@@ -9599,7 +9599,7 @@ describe('verify.mjs first-contact gates', () => {
         edges: [{ from: 'project', to: 'domains/auth', via: 'domains', direction: 'outgoing' }],
         nodes: [],
       }, 'project'),
-      'neighbors response edge count mismatch — edges 1, total 2',
+      'neighbors response edge count mismatch: edges 1, total 2',
     );
     assert.equal(pathQueryFailure({ operation: 'neighbors' }, 'project'), 'path returned unexpected operation: neighbors');
     assert.equal(
@@ -9699,7 +9699,7 @@ describe('verify.mjs first-contact gates', () => {
         limited: true,
         paths: [],
       }, 'capabilities/login', 'project'),
-      'all_paths response exceeded searchBudget — expanded 3, budget 2',
+      'all_paths response exceeded searchBudget: expanded 3, budget 2',
     );
     assert.equal(
       allPathsQueryFailure({
@@ -9744,7 +9744,7 @@ describe('verify.mjs first-contact gates', () => {
         },
         paths: [],
       }, 'capabilities/login', 'project'),
-      'all_paths response total mismatch — paths 0, total 2',
+      'all_paths response total mismatch: paths 0, total 2',
     );
     assert.equal(projectScopeFailure({ operation: 'project_map' }, 'project'), 'project_scope returned unexpected operation: project_map');
     assert.equal(
@@ -9769,7 +9769,7 @@ describe('verify.mjs first-contact gates', () => {
           unresolved: { total: 0, limited: false, edges: [] },
         },
       }, 'project'),
-      'project_scope node count mismatch — rows 0, total 2',
+      'project_scope node count mismatch: rows 0, total 2',
     );
   });
 
@@ -9822,12 +9822,12 @@ describe('verify.mjs first-contact gates', () => {
     assert.equal(verifyCountConsistencyFailure({ kinds, list, validation, compiled, overview }), null);
     assert.equal(
       verifyCountConsistencyFailure({ kinds: { total: 2, byKind: { project: 2 } }, list, validation, compiled }),
-      'verify count mismatch — list_kinds.total 2, list_concepts.total 1',
+      'verify count mismatch: list_kinds.total 2, list_concepts.total 1',
     );
     assert.equal(verifyCountConsistencyFailure({ kinds, list, validation: { ...validation, scanned: 2 }, compiled }), null);
     assert.equal(
       verifyCountConsistencyFailure({ kinds, list, validation, compiled: { ...compiled, nodeCount: 2, byKind: { project: 2 } } }),
-      'verify count mismatch — list_kinds.total 1, compile_ontology.nodeCount 2',
+      'verify count mismatch: list_kinds.total 1, compile_ontology.nodeCount 2',
     );
     assert.equal(
       verifyCountConsistencyFailure({
@@ -9837,7 +9837,7 @@ describe('verify.mjs first-contact gates', () => {
         compiled,
         overview: { ...overview, graph: { ...overview.graph, nodes: 2 }, byKind: { project: 2 } },
       }),
-      'verify count mismatch — list_kinds.total 1, overview.graph.nodes 2',
+      'verify count mismatch: list_kinds.total 1, overview.graph.nodes 2',
     );
     assert.equal(
       verifyCountConsistencyFailure({
@@ -9846,7 +9846,7 @@ describe('verify.mjs first-contact gates', () => {
         validation,
         compiled,
       }),
-      'verify byKind mismatch — capability: list_kinds 1, compile_ontology 0',
+      'verify byKind mismatch: capability: list_kinds 1, compile_ontology 0',
     );
     assert.equal(
       verifyCountConsistencyFailure({
@@ -9856,7 +9856,7 @@ describe('verify.mjs first-contact gates', () => {
         compiled: { ...compiled, byKind: { capability: 1 } },
         overview,
       }),
-      'verify byKind mismatch — capability: list_kinds 1, overview 0',
+      'verify byKind mismatch: capability: list_kinds 1, overview 0',
     );
   });
 
@@ -10049,7 +10049,7 @@ describe('verify.mjs first-contact gates', () => {
     );
     assert.equal(
       structuredContentFailure({ result: { structuredContent: { operation: 'overview', graph: { nodes: 2 } } } }, parsed, 'overview'),
-      'overview structuredContent mismatch — $.graph.nodes: parsed 1, structuredContent 2',
+      'overview structuredContent mismatch: $.graph.nodes: parsed 1, structuredContent 2',
     );
     assert.equal(
       structuredContentFailure({ result: { structuredContent: { graph: { nodes: 1 }, operation: 'overview' } } }, parsed, 'overview'),

--- a/src/views/docs-vault/lib/agent-files.ts
+++ b/src/views/docs-vault/lib/agent-files.ts
@@ -32,7 +32,7 @@ export type AgentTool = 'claude-code' | 'codex' | 'cursor' | 'gemini-cli' | 'cop
 
 export type AgentDriftCheckStatus = 'ok' | 'drift' | 'not-applicable';
 
-/** Tool ids → human labels (proper nouns — not translated). */
+/** Tool ids → human labels (proper nouns: not translated). */
 export const AGENT_TOOL_LABELS: Readonly<Record<AgentTool, string>> = Object.freeze({
   'claude-code': 'Claude Code',
   codex: 'Codex',
@@ -270,7 +270,7 @@ export function analyzeAgentFiles({
         code: 'missing-agents-import',
         path: 'CLAUDE.md',
         message:
-          'CLAUDE.md does not import @AGENTS.md — Claude Code and AGENTS.md readers see different instructions',
+          'CLAUDE.md does not import @AGENTS.md: Claude Code and AGENTS.md readers see different instructions',
         detail: { ref: 'AGENTS.md' },
       });
       claude.drift.push('missing-agents-import');
@@ -493,7 +493,7 @@ export function analyzeAgentFiles({
         check: 'codex-size-cap',
         code: 'agents-md-over-codex-cap',
         path: 'AGENTS.md',
-        message: `AGENTS.md is ${bytes} bytes — over the Codex project_doc_max_bytes default of ${CODEX_PROJECT_DOC_CAP_BYTES}`,
+        message: `AGENTS.md is ${bytes} bytes: over the Codex project_doc_max_bytes default of ${CODEX_PROJECT_DOC_CAP_BYTES}`,
         detail: { bytes, capBytes: CODEX_PROJECT_DOC_CAP_BYTES },
       });
       agents.drift.push('agents-md-over-codex-cap');


### PR DESCRIPTION
## Summary

UI 문구 494개는 2026-08-09 에 이미 치웠는데(래칫 0), **터미널로 찍는 글은 그대로 남아 있었다.** 소유자 판정은 표면을 가리지 않는다: *"이거는 ai 패턴이거든? 이런거 있으면 다 변경해줘 작대기 안쓰도록"*.

자리마다 답이 달라서 모양별로 처리했다:

| 모양 | 처방 | 예 |
|---|---|---|
| 라벨 ↔ 수·세부 구분자 | **가운뎃점** (이 저장소가 이미 쓰는 구분자) | `slug · 2 backlink(s)` |
| 줄 머리 각주 대시 | 가운뎃점 | `· growth rows are proposals, not writes` |
| 문장 안 | 콜론 | `nothing to disconnect: X has no source binding` |

## 건드리지 않은 것 셋 — 이게 이 작업의 핵심이다

1. **관계 글리프**(`from —type→ to` · `—imports→`)는 글이 아니라 **데이터**다. 디자인 규칙이 「뜻이 있는 화살표」를 예외로 두는 것과 같은 이유다.
2. **`project-meaning-receipt.mjs` 는 통째로 되돌렸다** — 거기 작대기는 문구가 아니라 **직렬화 형식**이었다(`### ${id} — ${status}` 를 파서가 `${id} — ` 로 되읽는다). 바꿨더니 라운드트립 시험 12개가 터졌고, **그대로 나갔으면 이미 디스크에 쓰인 영수증이 안 읽혔을 것이다.**
3. **에이전트 시스템 프롬프트**(`construction-rules.mjs`)도 되돌렸다 — 화면에 찍는 글이 아니라 모델에 보내는 지시문이고, 웹 사본과 **바이트가 같아야 한다**(계약 테스트가 잡았다).

`agent-files` 진단 문구는 CLI 와 화면이 **같은 문자열을 공유**하므로 웹 사본도 같이 바꿨다(바이트 동일 계약).

## Test plan

- `pnpm test:contracts` 137 파일 · **1,597건** — 바이트 동일 계약 둘이 위 ②③을 잡아냈고, 되돌린 뒤 초록
- `pnpm test:mcp:unit` **594 pass / 0 fail** (되돌리기 전 12 fail — 그 12건이 형식 토큰이라는 증거다)
- `node --test cli/src/integration.test.mjs` **284 pass / 3 fail**
- `pnpm exec tsc --noEmit` 통과 · lint 경고 래칫 유지(57)

⚠️ **남은 3건은 `mcp-verify` 타임아웃이고 이 기계 탓이다.** 시험에 3,000ms 가 박혀 있는데 지금 이 기계에서 실제 verify 가 **4.1초** 걸린다(세션 내내 Tauri 빌드로 프로세스 136개). 문자열만 바꾼 변경이 서버 부팅을 느리게 만들 수는 없고, CI 의 MCP 잡은 이번 세션 내내 초록이었다 — **CI 판정을 그대로 따르겠다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD