### PR TITLE
fix: 부모가 이미 있는 노드에 「부모가 없다」고 경고하지 않는다 — 갓 만든 볼트가 자기 검사를 통과한다

### DIFF
--- a/cli/src/commands/validate.mjs
+++ b/cli/src/commands/validate.mjs
@@ -4,7 +4,7 @@ import { relative } from 'node:path';
 import { walkMd } from '../lib/walk-vault.mjs';
 import { parseFrontmatter } from '../lib/parse-frontmatter.mjs';
 import { resolveVaultRoot } from '../lib/resolve-vault.mjs';
-import { validateVaultDocument } from '../lib/validate.mjs';
+import { validateVaultDocument, suppressParentedExpectedFieldIssues } from '../lib/validate.mjs';
 import {
   formatUnknownFlagError,
   parseCsvListFlag,
@@ -178,6 +178,24 @@ export function runValidate(args) {
     entries.push({ file, slug, frontmatter });
     const report = validateVaultDocument(raw);
     reportByFile.set(file, report);
+  }
+
+  /*
+   * 부모가 이미 있는 노드에 「부모가 없다」고 말하지 않는다 (2026-08-11) — MCP 쪽
+   * `validate_vault` 와 같은 좁히기다. 파일 하나만 보는 검사로는 알 수 없다.
+   */
+  const issuesBySlugForParents = new Map();
+  const fileBySlug = new Map();
+  for (const { file, slug } of entries) {
+    const report = reportByFile.get(file);
+    if (!report) continue;
+    issuesBySlugForParents.set(slug, report.issues);
+    fileBySlug.set(slug, file);
+  }
+  suppressParentedExpectedFieldIssues(issuesBySlugForParents, entries);
+  for (const [slug, issues] of issuesBySlugForParents) {
+    const report = reportByFile.get(fileBySlug.get(slug));
+    if (report) report.issues = issues;
   }
 
   for (const { file, issue } of findDuplicateSlugIssues(entries)) {

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -418,6 +418,55 @@ await test('init --quick-start — scaffolds, bootstraps from the repo, and ends
   }
 });
 
+/**
+ * **갓 만든 볼트는 자기 검사를 통과해야 한다** (2026-08-11, 북극성 여정 실측).
+ *
+ * 이 결함은 코드를 읽어서가 아니라 **여정을 걸어서** 나왔다. `init --quick-start` 로
+ * 만든 볼트에서 가이드가 시키는 다음 명령들을 그대로 돌렸더니 여덟 중 셋이 종료코드
+ * 1이었다 — `health` · `mcp-verify` · `agent-brief`. 걸린 것은 경고 하나
+ * (`missing-expected-field: domain`)뿐이었고, 그 문구가 *"트리에서 부모를 찾을 수
+ * 있습니다"* 인데 프로젝트 노드는 **이미 그 역량들을 `contains:` 로 담고 있었다.**
+ *
+ * 사람에게는 *"내가 뭘 잘못했나"* 이고 **에이전트에게는 연결 실패 신호**다 — 이 제품
+ * 사용자의 절반이 에이전트인데, 설정 직후 `mcp-verify` 가 1을 내면 「안 붙었다」로
+ * 읽힌다. 실제로는 서버도 도구 35개도 정상이었다.
+ *
+ * 그래서 이 시험은 **첫 명령이 만든 상태가 다음 명령에서 실패로 보고되지 않는다**를
+ * 잠근다. 도메인이 없는 것 자체는 그대로다(README 제목이 없는 저장소에서 경계를
+ * 지어내지 않는다) — 바뀐 것은 **부모가 있는데 없다고 말하던 것**이다.
+ */
+await test('init --quick-start — 갓 만든 볼트가 자기 검사를 통과한다 (health · validate)', async () => {
+  const repo = makeQuickStartRepoFixture();
+  try {
+    const init = await run(['init', 'ontology', '--quick-start'], { cwd: repo });
+    assert.equal(init.code, 0, `stdout: ${init.stdout}\nstderr: ${init.stderr}`);
+
+    /*
+     * ⚠️ **종료코드로 잠그면 안 된다** — `validate` 는 경고에 0을 낸다. 첫 판이 그래서
+     * 좁히기를 떼어도 초록이었다(통과가 증거가 아니다). 잠글 것은 **경고 0**이다.
+     */
+    const validate = await run(['validate', 'ontology'], { cwd: repo });
+    const validateOut = stripAnsi(validate.stdout) + stripAnsi(validate.stderr);
+    assert.equal(validate.code, 0, `validate 가 실패했다:\n${validateOut}`);
+    assert.doesNotMatch(
+      validateOut,
+      /missing-expected-field/,
+      `갓 만든 볼트가 자기 검사에서 경고를 받았다 — 첫 명령이 만든 상태가 다음 명령에서 실패로 보고된다:\n${validateOut}`,
+    );
+    assert.match(validateOut, /issue 0/, `경고 0이어야 한다:\n${validateOut}`);
+
+    const health = await run(['health', 'ontology'], { cwd: repo });
+    assert.equal(
+      health.code,
+      0,
+      `갓 만든 볼트가 health 에서 needs_attention 이 됐다:\n${stripAnsi(health.stdout)}`,
+    );
+    assert.match(stripAnsi(health.stdout), /vault health healthy/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 await test('init --quick-start — suggests absorbing an existing AGENTS.md without auto-absorbing it', async () => {
   const repo = makeQuickStartRepoFixture();
   try {

--- a/cli/src/lib/validate.mjs
+++ b/cli/src/lib/validate.mjs
@@ -159,3 +159,52 @@ function pushNonCanonicalGraphArrayIssues(frontmatter, issues) {
     }
   }
 }
+
+/**
+ * **포함이 세워 준 부모** — 다른 노드가 이 슬러그를 담고 있으면 트리에서 부모가 있다.
+ *
+ * 2026-08-11: 북극성 여정을 걸어 보다 나왔다. `init --quick-start` 가 만든 볼트가
+ * 자기 검사기를 통과하지 못했는데, 경고는 하나(`missing-expected-field: domain`)였고
+ * 그 하나가 `health` · `mcp-verify` · `agent-brief` 셋을 빨갛게 만들었다. 그런데 그
+ * 경고의 문구가 *"트리에서 부모를 찾을 수 있습니다"* 이고, 정작 그 볼트의 프로젝트
+ * 노드는 이미 `contains:` 로 그 역량들을 담고 있었다 — **부모가 있는데 없다고 말한
+ * 것이다.** 검사기가 파일 하나만 보기 때문이고, 그래서 볼트 단위에서 좁힌다.
+ */
+export function parentedSlugs(docs) {
+  const parented = new Set();
+  for (const doc of docs ?? []) {
+    const frontmatter = doc?.frontmatter;
+    if (!frontmatter || typeof frontmatter !== 'object') continue;
+    for (const key of CONTAINMENT_KEYS) {
+      const value = frontmatter[key];
+      if (!Array.isArray(value)) continue;
+      for (const ref of value) {
+        if (typeof ref === 'string' && ref.trim()) parented.add(ref.trim());
+      }
+    }
+  }
+  return parented;
+}
+
+/** 포함이 부모를 세워 주는 키들 — 프로젝트/도메인이 아래를 담는 방향만 본다. */
+const CONTAINMENT_KEYS = ['contains', 'capabilities', 'elements', 'domains'];
+
+/**
+ * 부모가 이미 있는 노드에서 **`domain:` 누락 경고만** 지운다.
+ *
+ * ⚠️ 없애는 것이 아니라 **좁히는 것**이다 — 아무도 안 담은 노드에는 그대로 남고,
+ * 그때는 진짜로 부모가 없다. 다른 코드의 경고와 `domain` 이 아닌 기대 필드는
+ * 건드리지 않는다(포함이 세워 주는 것은 부모뿐이다).
+ */
+export function suppressParentedExpectedFieldIssues(issuesBySlug, docs) {
+  const parented = parentedSlugs(docs);
+  if (parented.size === 0) return issuesBySlug;
+  for (const [slug, issues] of issuesBySlug) {
+    if (!parented.has(slug) || !Array.isArray(issues)) continue;
+    const kept = issues.filter(
+      (issue) => !(issue?.code === 'missing-expected-field' && /^`domain:`/.test(issue?.message ?? '')),
+    );
+    if (kept.length !== issues.length) issuesBySlug.set(slug, kept);
+  }
+  return issuesBySlug;
+}

--- a/mcp/src/containment-parent.test.mjs
+++ b/mcp/src/containment-parent.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parentedSlugs, suppressParentedExpectedFieldIssues } from './validate.mjs';
+
+/**
+ * **부모가 이미 있는 노드에 「부모가 없다」고 경고하지 않는다** (2026-08-11).
+ *
+ * ## 어디서 나왔나 — 북극성 여정을 실제로 걸어서
+ *
+ * `init --quick-start` 로 갓 만든 볼트가 **자기 검사기를 통과하지 못했다.** 경고는
+ * 하나뿐인데(`missing-expected-field: domain`) 그 하나가 셋을 빨갛게 만들었다:
+ * `health` exit 1 · `mcp-verify` exit 1(`vaultWarnings present`) · `agent-brief`
+ * exit 1(`needs_shape 45/100`). 사람에게는 *"내가 뭘 잘못했나"* 이고, **에이전트에게는
+ * 연결 실패 신호**다 — 실제로는 서버도 도구 35개도 정상이었다.
+ *
+ * 원인은 검사기가 **파일 하나만 보기 때문**이다. 그 경고의 문구 자체가
+ * *"트리에서 부모를 찾을 수 있습니다"* 인데, 그 볼트의 프로젝트 노드는 이미
+ * `contains: [capabilities/catalog, capabilities/checkout]` 로 그 둘을 담고 있었다.
+ * **부모가 이미 있는데 부모가 없다고 말한 것이다.**
+ *
+ * ## 왜 도메인을 지어내지 않았나
+ *
+ * 분석기는 도메인을 **README 제목에서만** 얻는다. 제목이 없는 저장소에서 도메인을
+ * 만들어 붙이는 것은 이 제품이 스스로 금한 일이다 — 분석기 자신의 문구가
+ * *"source folder is implementation evidence, not proof of a shared capability
+ * meaning"* 이고 *"README heading is a concept clue, not proof of a shared business
+ * boundary"* 다. 없는 경계를 지어내는 대신, **이미 있는 부모를 인정한다.**
+ *
+ * 이 저장소의 계약과도 같은 방향이다: *"Project containment is implicit"* —
+ * `projectIds` 는 포함을 따라 BFS 로 유도된다.
+ *
+ * ⚠️ **경고를 없애는 것이 아니라 좁히는 것이다.** 아무도 안 담은 역량에는 그대로
+ * 남는다 — 그때는 진짜로 부모가 없다.
+ */
+
+const doc = (slug, frontmatter) => ({ slug, frontmatter });
+
+test('containment parent · 프로젝트가 담은 역량은 부모가 있다', () => {
+  const docs = [
+    doc('shop', { kind: 'project', contains: ['capabilities/checkout', 'capabilities/catalog'] }),
+    doc('capabilities/checkout', { kind: 'capability' }),
+    doc('capabilities/catalog', { kind: 'capability' }),
+  ];
+  const parented = parentedSlugs(docs);
+  assert.equal(parented.has('capabilities/checkout'), true);
+  assert.equal(parented.has('capabilities/catalog'), true);
+  assert.equal(parented.has('shop'), false, '아무도 프로젝트를 담지 않는다');
+});
+
+test('containment parent · 도메인의 capabilities 목록도 부모다', () => {
+  const docs = [
+    doc('domains/auth', { kind: 'domain', capabilities: ['capabilities/login'] }),
+    doc('capabilities/login', { kind: 'capability' }),
+  ];
+  assert.equal(parentedSlugs(docs).has('capabilities/login'), true);
+});
+
+test('containment parent · 아무도 안 담으면 부모가 없다', () => {
+  const docs = [
+    doc('shop', { kind: 'project', contains: [] }),
+    doc('capabilities/orphan', { kind: 'capability' }),
+  ];
+  assert.equal(parentedSlugs(docs).has('capabilities/orphan'), false);
+});
+
+test('suppress · 부모가 있으면 domain 누락 경고를 지운다', () => {
+  const docs = [
+    doc('shop', { kind: 'project', contains: ['capabilities/checkout'] }),
+    doc('capabilities/checkout', { kind: 'capability' }),
+  ];
+  const issuesBySlug = new Map([
+    [
+      'capabilities/checkout',
+      [{ code: 'missing-expected-field', severity: 'warning', message: '`domain:` 가 비어있습니다: …' }],
+    ],
+  ]);
+  suppressParentedExpectedFieldIssues(issuesBySlug, docs);
+  assert.deepEqual(issuesBySlug.get('capabilities/checkout'), []);
+});
+
+test('suppress · 부모가 없으면 그대로 남는다 — 그때는 진짜 결함이다', () => {
+  const docs = [doc('capabilities/orphan', { kind: 'capability' })];
+  const issuesBySlug = new Map([
+    [
+      'capabilities/orphan',
+      [{ code: 'missing-expected-field', severity: 'warning', message: '`domain:` 가 비어있습니다: …' }],
+    ],
+  ]);
+  suppressParentedExpectedFieldIssues(issuesBySlug, docs);
+  assert.equal(issuesBySlug.get('capabilities/orphan').length, 1);
+});
+
+test('suppress · 다른 코드의 경고는 건드리지 않는다', () => {
+  const docs = [doc('shop', { kind: 'project', contains: ['capabilities/checkout'] }), doc('capabilities/checkout', { kind: 'capability' })];
+  const issuesBySlug = new Map([
+    [
+      'capabilities/checkout',
+      [
+        { code: 'missing-expected-field', severity: 'warning', message: '`domain:` 가 비어있습니다: …' },
+        { code: 'dangling-graph-reference', severity: 'warning', message: '없는 노드를 가리킵니다' },
+      ],
+    ],
+  ]);
+  suppressParentedExpectedFieldIssues(issuesBySlug, docs);
+  assert.deepEqual(
+    issuesBySlug.get('capabilities/checkout').map((i) => i.code),
+    ['dangling-graph-reference'],
+  );
+});
+
+test('suppress · domain 이 아닌 expected 필드 경고는 포함으로 지워지지 않는다', () => {
+  // 포함이 세워 주는 것은 **부모**뿐이다. 다른 기대 필드는 그 논리가 닿지 않는다.
+  const docs = [doc('shop', { kind: 'project', contains: ['capabilities/checkout'] }), doc('capabilities/checkout', { kind: 'capability' })];
+  const issuesBySlug = new Map([
+    [
+      'capabilities/checkout',
+      [{ code: 'missing-expected-field', severity: 'warning', message: '`path:` 가 비어있습니다: …' }],
+    ],
+  ]);
+  suppressParentedExpectedFieldIssues(issuesBySlug, docs);
+  assert.equal(issuesBySlug.get('capabilities/checkout').length, 1);
+});

--- a/mcp/src/index.js
+++ b/mcp/src/index.js
@@ -178,6 +178,7 @@ import {
   VAULT_ISSUE_CODE_VALUES,
   isValidVaultTitle,
   validateVaultDocument,
+  suppressParentedExpectedFieldIssues,
 } from './validate.mjs';
 import {
   buildFrontmatter,
@@ -5704,15 +5705,23 @@ function listConcepts({ kind, domain, since, summary, limit = 100 }) {
   // 가시화. AI agent 가 vault 상태를 한 번에 인지 가능 (UI banner #14 의 짝).
   let errorCount = 0;
   let warningCount = 0;
+  /*
+   * ⚠️ **집계 전에 좁힌다** (2026-08-11). 이 숫자가 `list_concepts.vaultWarnings` 이고,
+   * `mcp-verify` 는 그 값이 0이 아니면 실패한다. 갓 만든 볼트가 정확히 그것 때문에
+   * 「연결 실패」로 보고됐다 — 걸린 경고는 「부모가 없다」였는데 프로젝트가 이미 그
+   * 노드를 담고 있었다. 세기 전에 슬러그별로 모아야 포함을 볼 수 있다.
+   */
+  const issuesBySlugForCount = new Map();
   for (const doc of docs) {
     if (!doc.raw) continue;
     const report = validateVaultDocument(doc.raw);
-    for (const issue of report.issues) {
-      if (issue.severity === 'error') errorCount += 1;
-      else warningCount += 1;
-    }
+    if (report.issues.length > 0) issuesBySlugForCount.set(doc.slug, [...report.issues]);
   }
-  for (const issues of groupDanglingIssuesBySlug(docs).values()) {
+  for (const [slug, issues] of groupDanglingIssuesBySlug(docs)) {
+    issuesBySlugForCount.set(slug, [...(issuesBySlugForCount.get(slug) ?? []), ...issues]);
+  }
+  suppressParentedExpectedFieldIssues(issuesBySlugForCount, docs);
+  for (const issues of issuesBySlugForCount.values()) {
     for (const issue of issues) {
       if (issue.severity === 'error') errorCount += 1;
       else warningCount += 1;
@@ -7927,6 +7936,11 @@ function validateVaultTool({ repoRoot } = {}) {
     issues.push(...danglingIssues);
     docIssues.set(slug, issues);
   }
+  /*
+   * 부모가 이미 있는 노드에 「부모가 없다」고 말하지 않는다 (2026-08-11).
+   * 파일 하나만 보는 검사로는 알 수 없고, 여기는 볼트 전체를 갖고 있다.
+   */
+  suppressParentedExpectedFieldIssues(docIssues, docs);
   const problems = [];
   let errorFiles = 0;
   let warningFiles = 0;

--- a/mcp/src/validate.mjs
+++ b/mcp/src/validate.mjs
@@ -208,3 +208,52 @@ function pushNonCanonicalGraphArrayIssues(frontmatter, issues) {
     }
   }
 }
+
+/**
+ * **포함이 세워 준 부모** — 다른 노드가 이 슬러그를 담고 있으면 트리에서 부모가 있다.
+ *
+ * 2026-08-11: 북극성 여정을 걸어 보다 나왔다. `init --quick-start` 가 만든 볼트가
+ * 자기 검사기를 통과하지 못했는데, 경고는 하나(`missing-expected-field: domain`)였고
+ * 그 하나가 `health` · `mcp-verify` · `agent-brief` 셋을 빨갛게 만들었다. 그런데 그
+ * 경고의 문구가 *"트리에서 부모를 찾을 수 있습니다"* 이고, 정작 그 볼트의 프로젝트
+ * 노드는 이미 `contains:` 로 그 역량들을 담고 있었다 — **부모가 있는데 없다고 말한
+ * 것이다.** 검사기가 파일 하나만 보기 때문이고, 그래서 볼트 단위에서 좁힌다.
+ */
+export function parentedSlugs(docs) {
+  const parented = new Set();
+  for (const doc of docs ?? []) {
+    const frontmatter = doc?.frontmatter;
+    if (!frontmatter || typeof frontmatter !== 'object') continue;
+    for (const key of CONTAINMENT_KEYS) {
+      const value = frontmatter[key];
+      if (!Array.isArray(value)) continue;
+      for (const ref of value) {
+        if (typeof ref === 'string' && ref.trim()) parented.add(ref.trim());
+      }
+    }
+  }
+  return parented;
+}
+
+/** 포함이 부모를 세워 주는 키들 — 프로젝트/도메인이 아래를 담는 방향만 본다. */
+const CONTAINMENT_KEYS = ['contains', 'capabilities', 'elements', 'domains'];
+
+/**
+ * 부모가 이미 있는 노드에서 **`domain:` 누락 경고만** 지운다.
+ *
+ * ⚠️ 없애는 것이 아니라 **좁히는 것**이다 — 아무도 안 담은 노드에는 그대로 남고,
+ * 그때는 진짜로 부모가 없다. 다른 코드의 경고와 `domain` 이 아닌 기대 필드는
+ * 건드리지 않는다(포함이 세워 주는 것은 부모뿐이다).
+ */
+export function suppressParentedExpectedFieldIssues(issuesBySlug, docs) {
+  const parented = parentedSlugs(docs);
+  if (parented.size === 0) return issuesBySlug;
+  for (const [slug, issues] of issuesBySlug) {
+    if (!parented.has(slug) || !Array.isArray(issues)) continue;
+    const kept = issues.filter(
+      (issue) => !(issue?.code === 'missing-expected-field' && /^`domain:`/.test(issue?.message ?? '')),
+    );
+    if (kept.length !== issues.length) issuesBySlug.set(slug, kept);
+  }
+  return issuesBySlug;
+}


### PR DESCRIPTION
## Summary

**북극성 여정(링크 → 설치 → 에이전트가 내 노드를 인용)을 실제로 걸어서** 나온 결함이다.

`init --quick-start` 로 볼트를 만들고 가이드가 시키는 다음 명령들을 **적힌 그대로** 돌렸더니 여덟 중 셋이 종료코드 1이었다:

| 명령 | 결과 |
|---|---|
| `health` | exit 1 · `needs_attention` (나머지 검사 6개는 전부 통과) |
| `mcp-verify` | exit 1 · `✗ list_concepts vaultWarnings present` |
| `agent-brief` | exit 1 · `needs_shape 45/100` |

걸린 것은 경고 **하나** — `missing-expected-field: domain`. 그런데 그 문구가 「트리에서 부모를 찾을 수 있습니다」이고, 정작 그 볼트의 프로젝트 노드는 이미 `contains: [capabilities/checkout, capabilities/catalog]` 로 담고 있었다. **부모가 있는데 없다고 말한 것이다** — 검사기가 파일 하나만 보기 때문이다.

사람에게는 「내가 뭘 잘못했나」이고 **에이전트에게는 연결 실패 신호**다. 이 제품 사용자의 절반이 에이전트인데, 설정 직후 `mcp-verify` 가 1을 내면 「안 붙었다」로 읽힌다 — 실제로는 정상이었다(서버 부팅 **122ms** · 도구 35개 · 노드 인용까지 **0.15초**).

## 왜 도메인을 지어내지 않았나

분석기는 도메인을 **README 제목에서만** 얻는다. 제목 없는 저장소에서 경계를 만들어 붙이는 것은 이 제품이 스스로 금한 일이다 — 분석기 자신의 문구가 *"source folder is implementation evidence, not proof of a shared capability meaning"* · *"README heading is a concept clue, not proof of a shared business boundary"*. 없는 경계를 지어내는 대신 **이미 있는 부모를 인정한다.** 저장소 계약과도 같은 방향이다: *"Project containment is implicit"*.

## 무엇이 바뀌나

볼트 **전체**를 보는 세 자리에서 `domain:` 누락 경고를 좁힌다 — 다른 노드가 그 슬러그를 담고 있으면 부모가 있다(`validate_vault` · `list_concepts` 경고 집계 · CLI `validate`).

**없애는 게 아니라 좁히는 것이다**: 아무도 안 담은 노드에는 그대로 남는다(그때는 진짜로 부모가 없다). 파일 단위 함수는 손대지 않아 3-way 파서 계약도 그대로다.

결과: `validate` · `health` · `mcp-verify` 가 **exit 0**. `agent-brief` 는 여전히 1이지만 이유가 바뀌었다 — `healthy` 인데 볼트가 얇다(3노드 · 70/100, 이전 45/100). 그건 다른 축이고 맞는 신호다.

## 프로브에서 내 시험이 먼저 틀렸다

여정 시험을 처음 `validate` **종료코드**로 잠갔는데 `validate` 는 경고에 exit 0 을 낸다 — 그래서 좁히기를 떼어도 초록이었다. **통과가 증거가 아니었다.** 잠글 것은 「경고 0」이라 출력 내용으로 바꿨고, 그 뒤 양쪽 프로브가 전부 빨개졌다:

- CLI 좁히기 제거 → 「갓 만든 볼트가 자기 검사에서 경고를 받았다」 빨강
- MCP 좁히기 제거 → `mcp-verify` 가 `✗ vaultWarnings present` 로 빨강
- 되돌리면 둘 다 초록

## Test plan

- 새 단위 7건(`mcp/src/containment-parent.test.mjs`): 포함이 부모를 세운다 · 도메인의 `capabilities:` 도 부모다 · 아무도 안 담으면 남는다 · 다른 코드의 경고는 안 건드린다 · `domain` 이 아닌 기대 필드는 안 지운다
- 새 여정 시험 1건(CLI 통합): `init --quick-start` → `validate` 경고 0 + `health healthy`
- `pnpm test:contracts` 137 파일 · 1,597건 · `pnpm test:mcp:unit` **601 pass / 0 fail**
- `node --test cli/src/integration.test.mjs` 285 pass (남은 3건은 이 기계의 `mcp-verify` 3초 타임아웃 — 실측 4.1초)
- `pnpm docs:surface:check` · `pnpm dogfood:status`(전부 0) · `pnpm integration:mcp:vault-read` · `tsc` · eslint 통과
- 도그푸드 볼트(71파일)는 이 변경 전후 모두 issue 0 — 가려진 것이 없다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD