### PR TITLE
fix: 조립대 입장을 되살린다 — 억제 창을 페이지 시간이 아니라 무대에 건다

### DIFF
--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -1516,12 +1516,48 @@ export function OntologyStudioPage() {
    * 시간을 쓰는 이유: 입장 자체는 살려야 하므로 첫 프레임에 끄면 안 된다. 값은 입장
    * 길이(`--motion-base` 180ms)에 스태거 여유를 더한 것이고, 늦게 켜져도 잃는 것이
    * 없다(그동안 재마운트가 없으면 아무 일도 일어나지 않는다).
+   *
+   * ## ⚠️ 이 창을 **페이지 시간**에 걸었던 것이 입장을 통째로 없앴다 (2026-08-12 정정)
+   *
+   * 첫 구현은 타이머를 `[]` 로 걸었다 — 즉 **페이지가 뜬 시점**부터 520ms 였다.
+   * 그런데 공방은 카드 화면(또는 빈 볼트 화면)을 먼저 보여 주고, 사람이 「새로
+   * 만들기」를 누르는 것은 그 뒤다. 그 사이에 520ms 는 이미 지나가 있다.
+   *
+   * 그래서 무대는 **억제된 채로 마운트됐다.** 실측(클릭 직후 5프레임):
+   *
+   * ```
+   * FRAME {"f":0,"card":true,"suppressor":"true","animName":"none","opacity":"1"}
+   * ```
+   *
+   * 첫 프레임에 이미 `opacity: 1` 이고 애니메이션이 `none` — **하드컷**이다. 고치려던
+   * 것(모든 것이 같이 움직여서 아무것도 도착하지 않는 것)의 반대쪽 끝으로 넘어간
+   * 것이고, 이 저장소가 「주인공이 하드컷인데 배경만 움직이면 결함」이라고 적어 둔
+   * 그 자리에서 **주인공이 아예 안 움직이게** 됐다.
+   *
+   * 축이 틀렸다. 잠글 것은 「페이지가 뜬 뒤 얼마나 지났나」가 아니라 **「이 무대가
+   * 이미 한 번 들어왔나」** 다. 그래서 창을 무대의 정체성(`mode` + `node`)에 건다:
+   *
+   * - 카드 화면에서 「새로 만들기」 → 주소가 `?mode=create` 로 바뀐다 → 새 정체성
+   *   → 입장이 재생된다.
+   * - 다른 노드로 옮긴다 → `node` 가 바뀐다 → 새 무대이므로 입장이 재생된다.
+   * - **방위를 채운다 → 주소는 그대로다** → 정체성이 같으므로 억제가 유지된다.
+   *   여기가 원래 고치려던 그 지점이고, 그대로 지켜진다.
+   *
+   * 주소를 읽는 훅을 쓰는 이유: 공방 안의 이동은 라우터가 아니라 `history.pushState`
+   * 로 일어나서(`use-studio-search-params.ts`) `useSearchParams` 만으로는 주소가
+   * 바뀐 것을 모른다.
    */
-  const [stageEntered, setStageEntered] = useState(false);
+  const stageParams = useStudioSearchParams();
+  const stageIdentity = `${stageParams.get("mode") ?? "enhance"}:${stageParams.get("node") ?? ""}`;
+  const [enteredIdentity, setEnteredIdentity] = useState<string | null>(null);
   useEffect(() => {
-    const timer = window.setTimeout(() => setStageEntered(true), STAGE_ENTRANCE_WINDOW_MS);
+    const timer = window.setTimeout(
+      () => setEnteredIdentity(stageIdentity),
+      STAGE_ENTRANCE_WINDOW_MS,
+    );
     return () => window.clearTimeout(timer);
-  }, []);
+  }, [stageIdentity]);
+  const stageEntered = enteredIdentity === stageIdentity;
 
   const t = useTranslations("ontologyStudio");
   const toast = useToast();

--- a/tests/e2e/studio-stage-motion.spec.ts
+++ b/tests/e2e/studio-stage-motion.spec.ts
@@ -24,9 +24,20 @@ import { seedFirstRunSeen } from "./first-run-seed";
  *
  * ## 잠그는 성질
  *
- * ① 채울 때 **입장이 다시 재생되지 않는다** ② 그러면서 **도착은 움직인다**.
- * 둘을 같이 잠근다 — ①만 잠그면 「전부 끄기」로도 통과하고, 그건 이 화면을 정적으로
- * 만드는 것이다.
+ * ① 채울 때 **입장이 다시 재생되지 않는다** ② 그러면서 **도착은 움직인다**
+ * ③ 그리고 **무대가 처음 열릴 때는 입장이 재생된다**.
+ *
+ * ## ⚠️ ③ 이 없어서 이 게이트가 자기가 지킨다던 것을 놓쳤다 (2026-08-12)
+ *
+ * 처음에는 ①②만 잠갔다. ①만으로는 「전부 끄기」가 통과한다는 것을 알고 ②를 넣었는데,
+ * ②가 보는 것은 **채우는 순간의 도착 애니메이션**이라 입장과는 다른 애니메이션이다.
+ * 그래서 **입장을 통째로 죽여도 이 게이트는 초록이었다** — 실제로 그렇게 됐다:
+ * 억제 창을 페이지 시간에 걸어 놨더니 사람이 카드를 누르기 전에 창이 지나가 버려서,
+ * 무대가 `animation-name: none` · 첫 프레임 `opacity: 1` 로 마운트됐다(하드컷).
+ *
+ * 「억제가 제때 켜지는가」와 「억제가 항상 켜져 있는가」는 화면에서 서로 다른데
+ * ①②만 보는 게이트에서는 **똑같이 초록**이다. 그래서 ③ 을 같이 잠근다 —
+ * 억제를 잠그는 게이트는 그 반대편도 같이 잠가야 한다.
  */
 
 test("공방 · 방위를 채우면 도착한 것만 움직인다", async ({ page }) => {
@@ -94,4 +105,58 @@ test("공방 · 방위를 채우면 도착한 것만 움직인다", async ({ pag
     names.some((entry) => entry.startsWith("studioFillArrive@") || entry.startsWith("studioStrutFlow@")),
     `채웠는데 아무것도 도착하지 않았다: ${names.join(", ") || "(애니메이션 0)"}`,
   ).toBe(true);
+});
+
+test("공방 · 무대가 처음 열릴 때는 입장이 재생된다", async ({ page }) => {
+  test.setTimeout(240_000);
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await page.goto("/ko/ontology/studio/?guides=off", { waitUntil: "domcontentloaded" });
+
+  const entry = page.getByTestId("studio-entry-create");
+  await expect(entry).toBeVisible({ timeout: 30_000 });
+  /*
+   * 하이드레이션 + **입장 창이 지나가기를 기다린다.** 이 기다림이 이 시험의 요점이다 —
+   * 사람은 카드를 보고 읽은 뒤에 누르므로 창은 이미 지나가 있다. 창을 페이지 시간에
+   * 걸면 여기서 죽는다.
+   */
+  await page.waitForTimeout(2_500);
+
+  const frames = await page.evaluate(async () => {
+    const button = document.querySelector('[data-testid="studio-entry-create"]') as HTMLElement | null;
+    if (!button) return null;
+    button.click();
+    const out: { name: string; opacity: number }[] = [];
+    for (let i = 0; i < 6; i += 1) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      const card = document.querySelector('[data-testid="studio-center-card"]') as HTMLElement | null;
+      if (!card) continue;
+      const style = getComputedStyle(card);
+      out.push({ name: style.animationName, opacity: Number(style.opacity) });
+    }
+    return out;
+  });
+
+  expect(frames, "생성 카드를 못 찾았다 — 이 시험이 공회전한다").not.toBeNull();
+  const samples = frames!;
+  expect(samples.length, "무대가 열리지 않았다 — 중앙 카드가 없다").toBeGreaterThan(2);
+  console.log(
+    `[studio-entrance] ${samples.map((s) => `${s.name}/${s.opacity.toFixed(2)}`).join(" · ")}`,
+  );
+
+  // ③ 입장이 실제로 재생된다.
+  expect(
+    samples.every((s) => s.name === "studioStageIn"),
+    `무대가 열리는데 입장 애니메이션이 없다 — 하드컷이다: ${samples.map((s) => s.name).join(", ")}`,
+  ).toBe(true);
+
+  /*
+   * 그리고 **첫 프레임에 끝나 있지 않다.** 이름만 보면 「0.01ms 짜리 입장」도 통과한다.
+   * 잠글 성질은 기계와 무관한 쪽이다 — 첫 프레임이 아직 투명한가.
+   * (밀리초나 프레임 수를 못박지 않는다: 기계마다 다르다.)
+   */
+  expect(
+    samples[0].opacity,
+    `입장이 첫 프레임에 이미 끝나 있다(opacity ${samples[0].opacity}) — 이름만 있고 움직임이 없다`,
+  ).toBeLessThan(0.5);
 });


### PR DESCRIPTION
## Summary

지난 회차(#1043)에 「방위를 채우면 화면 전체가 다시 입장한다」를 고치면서 억제 창을 `[]` 로 걸었다 — 즉 **페이지가 뜬 시점**부터 520ms. 그런데 조립대는 카드 화면을 먼저 보여 주고, 사람이 「새로 만들기」를 누르는 것은 그 뒤다. **그 사이에 창은 이미 지나가 있다.**

그래서 무대가 억제된 채로 마운트됐다. 클릭 직후 5프레임 실측:

```
FRAME {"f":0,"card":true,"suppressor":"true","animName":"none","opacity":"1"}
FRAME {"f":1,"card":true,"suppressor":"true","animName":"none","opacity":"1"}
...
```

첫 프레임에 이미 `opacity: 1`, 애니메이션은 `none` — **하드컷**이다. 고치려던 것(모든 것이 같이 움직여 아무것도 도착하지 않는 것)의 **반대쪽 끝**으로 넘어간 것이고, 이 저장소가 「주인공이 하드컷이면 결함」이라고 적어 둔 그 자리에서 주인공이 아예 안 움직이게 됐다.

### 축이 틀렸다

잠글 것은 「페이지가 뜬 뒤 얼마나 지났나」가 아니라 **「이 무대가 이미 한 번 들어왔나」**다. 창을 무대의 정체성(`mode` + `node`)에 건다:

| 동작 | 정체성 | 입장 |
|---|---|---|
| 카드 → 「새로 만들기」 | `enhance:` → `create:` | **재생** (opacity 0 → 0.03 → 0.08 → 0.16 → 0.26, 첫 프레임 지분 0%) |
| 다른 노드로 이동 | `node` 변경 | **재생** — 새 무대다 |
| 방위를 채움 | 주소 그대로 | **억제 유지** — 원래 고치려던 그 지점 |

주소를 읽는 훅을 쓰는 이유: 조립대 안의 이동은 라우터가 아니라 `history.pushState` 로 일어나서(`use-studio-search-params.ts`) `useSearchParams` 만으로는 주소가 바뀐 것을 모른다.

### 게이트에 구멍이 있었다

`studio-stage-motion.spec.ts` 는 ①「채울 때 다시 입장하지 않는다」와 ②「도착은 움직인다」를 잠갔다. ①만으로는 「전부 끄기」가 통과한다는 걸 알고 ②를 넣었는데, **②가 보는 것은 채우는 순간의 도착 애니메이션**이라 입장과 다른 것이다. 그래서 **입장을 통째로 죽여도 이 게이트는 초록이었다.**

「억제가 제때 켜지는가」와 「억제가 항상 켜져 있는가」는 화면에서 다른데 ①②만 보면 똑같이 초록이다. ③「무대가 처음 열릴 때는 입장이 재생된다」를 같이 잠근다 — **억제를 잠그는 게이트는 그 반대편도 같이 잠가야 한다.**

## Test plan

**프로브** (`/gate-probe`) — 창을 다시 페이지 시간에 걸어 결함을 되돌렸다:

```
[studio-entrance] none/1.00 · none/1.00 · none/1.00 · none/1.00 · none/1.00 · none/1.00
    Error: 무대가 열리는데 입장 애니메이션이 없다 — 하드컷이다: none, none, none, ...
  1 failed / 1 passed
```

①②는 그대로 초록이었다 — **이게 구멍의 증거다.** 복구 후:

```
[studio-motion] 채울 때 도는 애니메이션: studioStrutFlow@path · studioFillArrive@studio-fill-arrival
[studio-entrance] studioStageIn/0.00 · studioStageIn/0.00 · studioStageIn/0.03 · studioStageIn/0.08 · studioStageIn/0.16 · studioStageIn/0.26
  2 passed
```

밀리초·프레임 수는 못박지 않는다(기계마다 다르다). 잠근 성질은 ③ 이름이 `studioStageIn` 인가 + 첫 프레임이 아직 투명한가.

**실사용** — 무대를 열고 두 방위(위=회원 탈퇴, 아래=배송지 정보)를 채웠다. 지지대 파선 흐름·도착 표시·진행 문구(「4방향 중 2 채움」) 모두 정상. 스크린샷에서 저장 버튼이 잘려 보였는데 재 보니 결함이 아니었다 — 폭 102px·오른쪽 여백 20px·`scrollWidth` 초과 0이고, 겹친 검은 원은 **Next 개발 모드 표시기**로 제품에는 없다.

**`pnpm checks:changed` 가 권한 것 전부**:

| 검사 | 결과 |
|---|---|
| `eslint` (변경 소스) | 0 error (기존 경고 1건은 609줄 · 이번 변경은 1550줄) |
| `tsc --noEmit` | 통과 |
| `vitest` 조립대 전체 | 21 파일 / 262 passed |
| `test:contracts` | 137 파일 / 1597 passed |
| `playwright studio-stage-motion` | 2 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD