### PR TITLE
fix: 조립대 피커에 나가는 길을 놓는다 — 누른 그것만 0프레임이었다

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1334,6 +1334,37 @@
     transform-origin: var(--studio-picker-origin, center);
   }
 
+  /* 피커가 **나가는 길** (2026-08-12 실측). 그 전까지는 나가는 길이 없었다:
+     Escape 는 `+2ms`(한 프레임), 행을 고르면 `+39ms` 에 **opacity 1.00 그대로**
+     소멸했다. 그동안 결과 쪽(소켓이 채워지는 색 전이 130ms · 도착 표시 240ms)은
+     제대로 움직였으니, **사용자가 누른 그것만 0프레임을 받은** 것이다 —
+     헌장이 「주인공이 하드컷인데 배경만 움직이면 결함」이라고 적어 둔 그 모양.
+
+     되감기(`reverse`)를 쓰지 않는다: 같은 원소에서 클래스만 바뀌는 자리에서는
+     이름이 그대로면 재생이 다시 시작되지 않아 **아예 안 보인다**(이 저장소의
+     `exit-motion-restart` 계약). 그래서 자기 이름으로 정방향 재생한다.
+
+     원점은 등장과 **같은 소켓**이다(`--studio-picker-origin`). 열릴 때 그 소켓에서
+     자랐으니 닫힐 때도 그 소켓으로 되접혀야 「이건 그 방위의 일이었다」가 읽힌다.
+     시간도 등장과 같은 `--motion-fast` — 닫는 것이 여는 것보다 느리면 걸리적거린다.
+     새 duration/이징 값 0. */
+  @keyframes studioPickerDismiss {
+    from {
+      opacity: 1;
+      transform: scale(1);
+    }
+
+    to {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+  }
+
+  .studio-picker-dismiss {
+    animation: studioPickerDismiss var(--motion-fast) var(--motion-ease) both;
+    transform-origin: var(--studio-picker-origin, center);
+  }
+
   /* 라우트 로딩 자막 — 대부분의 진입은 400ms 안에 끝나므로 그 전에는 침묵한다.
      즉시 그리면 정상 진입마다 자막이 번쩍이고, 그건 고치려던 빈 화면보다 나쁘다.
      지연은 duration 이 아니라 delay 라서 prefers-reduced-motion 전역 규칙
@@ -3839,7 +3870,8 @@
      * ③ 요약이 모이며 **사라지는** 것 — 이건 퇴장이라 이름을 등장 크로스페이드로
      * 바꾸면 반대로 나타나 버린다. 그래서 이동만 지우고 방향은 지킨다.
      */
-    .studio-summary-converge {
+    .studio-summary-converge,
+    .studio-picker-dismiss {
       animation-name: overlayFadeOut !important;
       animation-duration: var(--motion-fast) !important;
     }

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -156,6 +156,26 @@ function renderEnhance(
   return onFill;
 }
 
+/**
+ * **「닫혔다」의 뜻이 바뀌었다** (2026-08-12) — 피커는 이제 나가는 길을 갖는다.
+ *
+ * 그 전까지 피커는 `openRelation` 이 `null` 이 되는 순간 언마운트였고, 프레임으로
+ * 재니 Escape 는 +2ms(한 프레임) · 행 선택은 +39ms 에 **opacity 1.00 그대로**
+ * 사라졌다. 결과 쪽(소켓 색 전이 · 도착 표시)은 제대로 움직이는데 **누른 그것만
+ * 0프레임**을 받은 것이다. 이제 퇴장 창(140ms) 동안 남아 되접히며 나간다.
+ *
+ * 그래서 이 시험들이 잠글 성질도 바뀐다: 「DOM 에서 없어졌나」가 아니라
+ * **「닫히는 중인가」** — 나가는 표시가 붙었고, 그 사이 조작을 받지 않는가.
+ * 없어졌는지까지 보려면 타이머를 돌려야 하고, 그건 이 시험들이 묻는 것이 아니다
+ * (밀리초를 못박지 않는다 — 기계마다 다르다).
+ */
+function expectPickerClosing() {
+  const picker = screen.getByTestId("studio-picker");
+  expect(picker).toHaveAttribute("data-exiting", "true");
+  expect(picker.className).toContain("studio-picker-dismiss");
+  expect(picker, "나가는 동안 조작을 받으면 착지하는 소켓을 가로막는다").toHaveAttribute("inert");
+}
+
 describe("StudioCompass — enhance", () => {
   it("owns a main landmark and focal-node page heading for route arrival", () => {
     renderEnhance();
@@ -187,7 +207,7 @@ describe("StudioCompass — enhance", () => {
 
   it("opens the inline picker on the recommended socket and fills it in place", () => {
     const onFill = renderEnhance();
-    // picker is closed at rest.
+    // picker is closed at rest — 아직 한 번도 열리지 않았으므로 DOM 에 없다.
     expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("studio-socket-up"));
@@ -198,7 +218,7 @@ describe("StudioCompass — enhance", () => {
     fireEvent.click(screen.getByTestId("studio-picker-row-capability:server-interface"));
     expect(onFill).toHaveBeenCalledWith("isA", CANDIDATE);
     // picker closes after a fill.
-    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+    expectPickerClosing();
   });
 
   it("C4 — a FILLED lane exposes a '＋ 더 잇기' add chip that opens the same picker", () => {
@@ -628,7 +648,7 @@ describe("StudioCompass — 발견 표면 (browse + 추천)", () => {
     fireEvent.click(screen.getByTestId("studio-suggest-row-capability:refund"));
     expect(onFill).toHaveBeenCalledWith("isA", REFUND);
     // picker closes after a pick.
-    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+    expectPickerClosing();
   });
 
   it("typing switches to search results, clearing returns to discovery", () => {
@@ -1443,7 +1463,7 @@ describe("StudioCompass — 임시 표면 상호 배타 (#62)", () => {
 
     fireEvent.click(screen.getByTestId("studio-lane-more-down"));
     expect(screen.getByTestId("studio-lane-list-down")).toBeInTheDocument();
-    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+    expectPickerClosing();
   });
 
   it("작업중 패널을 열면 피커·접힘 목록이 함께 닫힌다", () => {
@@ -1454,7 +1474,7 @@ describe("StudioCompass — 임시 표면 상호 배타 (#62)", () => {
 
     fireEvent.click(screen.getByTestId("studio-drafts-open"));
     expect(screen.getByTestId("studio-drafts-panel")).toBeInTheDocument();
-    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+    expectPickerClosing();
   });
 });
 
@@ -1568,7 +1588,7 @@ describe("StudioCompass — 소켓 피커 Esc 계약", () => {
     expect(screen.getByTestId("studio-picker")).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(screen.queryByTestId("studio-picker")).not.toBeInTheDocument();
+    expectPickerClosing();
   });
 
   it("Esc 로 닫아도 채우기는 일어나지 않는다 — 취소는 취소다", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -31,6 +31,7 @@ import type { CreateCandidate, CreateNodeKind } from "../lib/build-create-node";
 import type { PickerDiscovery, PickerSuggestionReason } from "../lib/build-picker-discovery";
 import type { DeltaPreviewLayout, DeltaSatellite, DeltaSatelliteState } from "../lib/build-delta-preview";
 import { fieldClass } from '@/shared/ui/control-class';
+import { useHeldValue, usePanelPresence } from "@/shared/lib/use-presence";
 
 /** 무대 등장의 두 번째 박자 — 잎(레인)이 카드보다 반 박자 늦게 정착한다. */
 const STAGE_LANE_DELAY_MS = 40;
@@ -750,6 +751,41 @@ export function StudioCompass(props: StudioCompassProps) {
   const similarHit =
     openRelation && similarFor ? similarFor(openRelation, query) : null;
 
+  /**
+   * **피커가 나가는 길** (2026-08-12 실측으로 생겼다).
+   *
+   * 그 전까지 피커는 나가는 길이 없었다 — `openRelation` 이 `null` 이 되는 순간
+   * 언마운트다. 프레임으로 재니 Escape 는 **+2ms**(한 프레임), 행을 고르면
+   * **+39ms 에 `opacity: 1.00` 그대로** 사라졌다. 그동안 결과 쪽은 제대로
+   * 움직인다(소켓 색 전이 130ms · 도착 표시 240ms). 즉 **누른 그것만 0프레임**을
+   * 받았고, 이 저장소가 이름 붙여 둔 그 결함이다.
+   *
+   * 창을 열어 두는 것만으로는 부족하다 — 내용은 부모가 주므로 `openRelation` 이
+   * 사라지면 **예쁘게 사라지는 빈 상자**가 된다(`useHeldValue` 머리말의 그 함정).
+   * 그래서 피커가 필요한 것을 한 덩어리로 묶어 붙든다.
+   *
+   * 키를 `관계|검색어` 로 잡는 이유: 붙드는 값이 객체라 정체성으로 비교하면 무한
+   * 재렌더가 나고(그 훅이 실측으로 배운 것), 관계만으로 잡으면 **검색어가 바뀔 때
+   * 붙든 값이 갱신되지 않아** 닫는 순간 목록이 처음 상태로 되돌아가 보인다.
+   * 피커의 내용은 이 둘로 완전히 결정된다(`pickerRows`·`similarHit` 둘 다 그 함수).
+   */
+  const pickerAnchor = openLayout
+    ? (openLayout.layout.socket ?? openLayout.layout.addChip ?? null)
+    : null;
+  const pickerBundle =
+    openRelation && pickerAnchor && openLayout
+      ? {
+          relation: openRelation,
+          socket: pickerAnchor,
+          bearing: openLayout.view.bearing,
+          rows: pickerRows,
+          similarHit,
+          query,
+        }
+      : null;
+  const heldPicker = useHeldValue(pickerBundle, pickerBundle ? `${openRelation}|${query}` : null);
+  const pickerPresence = usePanelPresence(Boolean(pickerBundle));
+
   // #62 — 무대 위 임시 표면은 서로 배타적이다. 예전엔 '+90 더 보기' 접힘
   // 목록이 열린 채 소켓 피커가 그 위에 그대로 쌓여, 아래 목록이 반쯤 가린
   // 상태로 둘 다 살아 있었다(opus5 검수 스크린샷). 피커를 열 때 접힘 목록·
@@ -1293,21 +1329,22 @@ export function StudioCompass(props: StudioCompassProps) {
 
           {/* inline anchored picker — anchors to the empty socket OR (C4) to the
               filled lane's "＋ 더 잇기" add chip (same {x,y,w,h} shape). */}
-          {openRelation && openLayout && (openLayout.layout.socket ?? openLayout.layout.addChip) ? (
+          {pickerPresence.mounted && heldPicker ? (
             <InlinePicker
-              key={openRelation}
-              socket={(openLayout.layout.socket ?? openLayout.layout.addChip)!}
-              bearing={openLayout.view.bearing}
+              key={heldPicker.relation}
+              exiting={pickerPresence.exiting}
+              socket={heldPicker.socket}
+              bearing={heldPicker.bearing}
               cardLeft={cardLeft}
               cardRight={cardRight}
-              relation={openRelation}
-              question={bearings.find((b) => b.relation === openRelation)?.question ?? ""}
+              relation={heldPicker.relation}
+              question={bearings.find((b) => b.relation === heldPicker.relation)?.question ?? ""}
               labels={labels}
-              rows={pickerRows}
-              similarHit={similarHit}
+              rows={heldPicker.rows}
+              similarHit={heldPicker.similarHit}
               discoveryFor={props.discoveryFor}
               kindLabelFor={kindLabelFor}
-              query={query}
+              query={heldPicker.query}
               onQuery={setQuery}
               onPick={pick}
               onClose={closePicker}
@@ -2510,6 +2547,7 @@ function PickerSectionHeading({ label }: { label: string }) {
 }
 
 function InlinePicker({
+  exiting,
   socket,
   bearing,
   cardLeft,
@@ -2527,6 +2565,8 @@ function InlinePicker({
   onClose,
   onCreateNew,
 }: {
+  /** 퇴장 창(140ms) 동안 `true` — 되접히며 나가고, 그 사이 조작을 받지 않는다. */
+  exiting: boolean;
   socket: { x: number; y: number; w: number; h: number };
   bearing: StudioBearing;
   cardLeft: number;
@@ -2580,7 +2620,17 @@ function InlinePicker({
     <div
       data-testid="studio-picker"
       data-relation={relation}
-      className="studio-picker-pop absolute z-[8] flex flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]"
+      /*
+       * 나가는 동안은 **조작을 받지 않는다.** 클릭이 통과하지 않으면 뒤에서
+       * 착지하는 소켓을 140ms 동안 가로막고, 초점이 남아 있으면 화면에서 사라진
+       * 상자 안으로 Tab 이 들어간다.
+       */
+      inert={exiting || undefined}
+      data-exiting={exiting ? "true" : undefined}
+      className={cn(
+        "absolute z-[8] flex flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]",
+        exiting ? "studio-picker-dismiss pointer-events-none" : "studio-picker-pop",
+      )}
       style={
         {
           left,

--- a/tests/e2e/studio-stage-motion.spec.ts
+++ b/tests/e2e/studio-stage-motion.spec.ts
@@ -25,7 +25,7 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * ## 잠그는 성질
  *
  * ① 채울 때 **입장이 다시 재생되지 않는다** ② 그러면서 **도착은 움직인다**
- * ③ 그리고 **무대가 처음 열릴 때는 입장이 재생된다**.
+ * ③ 무대가 처음 열릴 때는 입장이 재생된다 ④ 그리고 **피커는 나가는 길을 갖는다**.
  *
  * ## ⚠️ ③ 이 없어서 이 게이트가 자기가 지킨다던 것을 놓쳤다 (2026-08-12)
  *
@@ -159,4 +159,85 @@ test("공방 · 무대가 처음 열릴 때는 입장이 재생된다", async ({
     samples[0].opacity,
     `입장이 첫 프레임에 이미 끝나 있다(opacity ${samples[0].opacity}) — 이름만 있고 움직임이 없다`,
   ).toBeLessThan(0.5);
+});
+
+test("공방 · 피커는 나가는 길을 갖는다", async ({ page }) => {
+  test.setTimeout(240_000);
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await page.goto("/ko/ontology/studio/?guides=off", { waitUntil: "domcontentloaded" });
+
+  const entry = page.getByTestId("studio-entry-create");
+  await expect(entry).toBeVisible({ timeout: 30_000 });
+  await page.waitForTimeout(1_500);
+  await entry.click();
+  await expect(page.getByTestId("studio-create-name")).toBeVisible({ timeout: 30_000 });
+  await page.getByTestId("studio-socket-down").click();
+  await expect(page.getByTestId("studio-picker")).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(700);
+
+  /*
+   * **닫는 순간부터 프레임을 잡는다.** 그 전까지 피커는 나가는 길이 없었다 —
+   * Escape 는 +2ms(한 프레임), 행 선택은 +39ms 에 `opacity: 1.00` 그대로
+   * 소멸했다. 그동안 결과 쪽(소켓 색 전이 130ms · 도착 표시 240ms)은 제대로
+   * 움직였으니 **사용자가 누른 그것만 0프레임**을 받은 것이다.
+   */
+  const frames = await page.evaluate(async () => {
+    const out: { name: string; opacity: number; inert: boolean }[] = [];
+    let stop = false;
+    const tick = () => {
+      if (stop) return;
+      const el = document.querySelector('[data-testid="studio-picker"]') as HTMLElement | null;
+      if (el) {
+        const style = getComputedStyle(el);
+        out.push({
+          name: style.animationName,
+          opacity: Number(style.opacity),
+          inert: el.hasAttribute("inert"),
+        });
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    stop = true;
+    return out;
+  });
+
+  const dismissing = frames.filter((f) => f.name === "studioPickerDismiss");
+  console.log(
+    `[studio-dismiss] 살아 있던 프레임 ${frames.length} · 퇴장 프레임 ${dismissing.length} · ` +
+      `불투명도 ${dismissing.map((f) => f.opacity.toFixed(2)).join("→") || "(없음)"}`,
+  );
+
+  // 공회전 차단: 피커를 한 프레임도 못 봤으면 이 시험은 아무것도 안 쟀다.
+  expect(frames.length, "닫기 직후 피커를 한 프레임도 못 봤다").toBeGreaterThan(0);
+
+  /*
+   * ④-a **자기 이름으로 정방향 재생된다.** 되감기(`reverse`)는 같은 원소에서
+   * 클래스만 바뀌는 자리에서 아예 재생되지 않는다(`exit-motion-restart` 계약).
+   */
+  expect(
+    dismissing.length,
+    `피커가 퇴장 애니메이션 없이 사라졌다 — 하드컷이다: ${frames.map((f) => f.name).join(", ") || "(프레임 0)"}`,
+  ).toBeGreaterThan(1);
+
+  /*
+   * ④-b **실제로 배어 나간다.** 이름만 보면 「0.01ms 짜리 퇴장」도 통과한다.
+   * 프레임 수·밀리초는 못박지 않는다(기계마다 다르다) — 잠글 성질은 처음이
+   * 불투명하고 끝이 투명한가다.
+   */
+  expect(dismissing[0].opacity, "퇴장 첫 프레임이 이미 투명하다").toBeGreaterThan(0.5);
+  expect(
+    dismissing[dismissing.length - 1].opacity,
+    "퇴장이 끝났는데 아직 불투명하다 — 배어 나가지 않고 잘렸다",
+  ).toBeLessThan(0.5);
+
+  // ④-c 나가는 동안 조작을 받지 않는다 — 착지하는 소켓을 가로막지 않게.
+  expect(
+    dismissing.every((f) => f.inert),
+    "나가는 피커가 여전히 조작을 받는다",
+  ).toBe(true);
 });


### PR DESCRIPTION
## Summary

지난 회차 대기 항목(「채운 뒤 재배치가 0.46초 늦게 시작」)부터 재 봤는데 **결함이 아니었다** — 두 채움 모두 전부 같은 프레임(+16ms / +18ms)에 시작하고 중간에 아무것도 안 움직이는 구간이 없다. 지난번 「0.46초」는 제 계측이 **전환(transition)을 `?` 로 뭉갠** 결과였다(`getAnimations()` 는 전환도 돌려주는데 그것들은 `animationName` 이 없다). 진행 표시 점들의 시차 113ms 도 규격(120ms) 안이다.

대신 **피커가 나가는 길이 없는 것**을 찾았다:

| 닫는 방법 | 사라진 시점 | 마지막 프레임 |
|---|---|---|
| Escape | **+2ms** (한 프레임) | — |
| 행 선택 | **+39ms** | **opacity 1.00** 그대로 |

그동안 결과 쪽은 제대로 움직인다 — 소켓이 채워지는 색 전이 130ms, 도착 표시 240ms. 즉 **사용자가 누른 그것만 0프레임**을 받았고, 헌장이 「주인공이 하드컷인데 배경만 움직이면 결함」이라고 적어 둔 그 모양이다.

### 고친 방법

`studioPickerDismiss` 를 만들었다.

- **되감기(`reverse`)를 쓰지 않는다** — 같은 원소에서 클래스만 바뀌는 자리에서는 이름이 그대로면 재생이 다시 시작되지 않아 **아예 안 보인다**(이 저장소의 `exit-motion-restart` 계약). 자기 이름으로 정방향 재생한다.
- **원점은 등장과 같은 소켓**(`--studio-picker-origin`). 그 소켓에서 자랐으니 그 소켓으로 되접혀야 「이건 그 방위의 일이었다」가 읽힌다.
- **시간도 등장과 같은 `--motion-fast`** — 닫는 것이 여는 것보다 느리면 걸리적거린다. 새 duration/이징 값 0.

창을 여는 것만으로는 부족하다. 내용은 부모가 주므로 `openRelation` 이 사라지면 **예쁘게 사라지는 빈 상자**가 된다(`useHeldValue` 머리말의 그 함정). 그래서 피커가 필요한 것을 한 덩어리로 붙들고, 키를 `관계|검색어` 로 잡는다 — 관계만으로 잡으면 검색어가 바뀔 때 붙든 값이 갱신되지 않아 **닫는 순간 목록이 처음 상태로 되돌아가 보인다**.

나가는 동안 `inert` + `pointer-events-none` — 안 그러면 140ms 동안 착지하는 소켓을 가로막고, 화면에서 사라진 상자 안으로 Tab 이 들어간다.

## Test plan

**실측(복구 후)** — 15~18프레임에 걸쳐 배어 나간다:

```
[studio-dismiss] 살아 있던 프레임 19 · 퇴장 프레임 18 ·
불투명도 1.00→1.00→0.94→0.83→0.67→0.52→0.39→0.29→0.22→0.14→0.10→0.06→0.03→0.02→0.01→0.00
```

**감속 모드** — 이름이 `overlayFadeOut` 으로 바뀌고 확대 축이 사라진다(`transform: none`), 불투명도만 남는다. ⚠️ 첫 계측은 감속이 **안 켜진 채**였다(`matchMedia(...).matches === false`) — `test.use` 가 안 먹었고, `page.emulateMedia` 로 바꿔서 다시 쟀다. 확인 없이 보고했으면 멀쩡한 예외를 결함으로 신고했을 것이다.

**프로브** (`/gate-probe`) — 게이트에 ④「피커는 나가는 길을 갖는다」를 더하고 두 갈래로 되돌려 봤다:

| 되돌린 것 | 결과 |
|---|---|
| 퇴장 창을 없앰(즉시 언마운트) | `살아 있던 프레임 0` → **공회전 단언**이 잡는다 |
| 창은 있는데 퇴장 표시를 안 입힘 | `피커가 퇴장 애니메이션 없이 사라졌다 — 하드컷이다: studioPickerPop ×18` |

밀리초·프레임 수는 못박지 않았다. 잠근 성질은 ① 자기 이름으로 재생되나 ② 첫 프레임이 불투명하고 끝이 투명한가 ③ 나가는 동안 조작을 받지 않나.

**단위 시험 6건이 「닫으면 즉시 사라진다」를 단언**하고 있었다 — 그게 고친 결함이다. 성질로 바꿨다: DOM 에서 없어졌나가 아니라 **닫히는 중인가**(나가는 표시 + 조작 차단). 열기 전 상태를 보는 한 건은 원문 그대로 뒀다(제 자동 변환이 그것까지 바꿔서 되돌렸다).

**`pnpm checks:changed` 가 권한 것 전부**:

| 검사 | 결과 |
|---|---|
| `eslint` (변경 소스 2) | 0 error / 0 warning |
| `tsc --noEmit` | 통과 |
| `vitest` 조립대 전체 | 21 파일 / 262 passed |
| `test:contracts` | 137 파일 / 1598 passed |
| `playwright studio-stage-motion` | 3 passed |
| `playwright overflow-sweep` | 10 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD