### PR TITLE
fix: 무대의 앵커된 임시 표면 셋을 한 문법으로 모은다 — 둘이 하드컷이었다

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1275,7 +1275,7 @@
   }
 
   /* 2) 피커 열림 원점 스케일 — 소켓(앵커)에서 자라난다. transform-origin 은
-     소비처가 --studio-picker-origin 으로 소켓의 로컬 좌표를 주입. */
+     소비처가 --studio-anchor-origin 으로 소켓의 로컬 좌표를 주입. */
   /* ── 채움 확정의 안무 (2026-07-28, 소유자 "세팅할때마다 뭔가 움직이면서") ──
      실측: 채움의 절정(제안 선택 → 위성 등장)에서 **아무것도 이동하지
      않았다**. 피커·소켓이 0프레임에 사라지고 완성된 위성이 0프레임에
@@ -1317,7 +1317,19 @@
     }
   }
 
-  @keyframes studioPickerPop {
+  /* ── 무대의 **앵커된 임시 표면** 문법 (2026-08-12) ─────────────────────────
+     소켓 피커 · 접힘 목록 · 관계 편집 카드 — 셋 다 «누른 것 옆에 붙어 열리고
+     그 자리로 되접히는» 같은 종류다. 그래서 값도 한 벌이다.
+
+     ⚠️ **이름이 한때 `studioPickerPop` 이었다.** 피커에만 있던 시절의 이름인데,
+     같은 문법을 접힘 목록·편집 카드에 붙이면서 「피커」라는 이름이 거짓이 됐다 —
+     다음 사람이 편집 카드에 `studio-picker-pop` 을 붙이게 된다. 그래서 문법의
+     이름으로 바꿨다(값·시간·이징 전부 그대로, 렌더 결과 변화 0).
+
+     원점은 **누른 그것**이다(`--studio-anchor-origin`). 소비처가 자기 트리거의
+     로컬 좌표를 주입한다 — 원점이 없으면 상자 가운데에서 자라서, 어디서 왔는지가
+     화면에서 사라진다. */
+  @keyframes studioAnchoredIn {
     from {
       opacity: 0;
       transform: scale(0.96);
@@ -1329,9 +1341,9 @@
     }
   }
 
-  .studio-picker-pop {
-    animation: studioPickerPop var(--motion-fast) var(--motion-ease) both;
-    transform-origin: var(--studio-picker-origin, center);
+  .studio-anchored-in {
+    animation: studioAnchoredIn var(--motion-fast) var(--motion-ease) both;
+    transform-origin: var(--studio-anchor-origin, center);
   }
 
   /* 피커가 **나가는 길** (2026-08-12 실측). 그 전까지는 나가는 길이 없었다:
@@ -1344,11 +1356,11 @@
      이름이 그대로면 재생이 다시 시작되지 않아 **아예 안 보인다**(이 저장소의
      `exit-motion-restart` 계약). 그래서 자기 이름으로 정방향 재생한다.
 
-     원점은 등장과 **같은 소켓**이다(`--studio-picker-origin`). 열릴 때 그 소켓에서
+     원점은 등장과 **같은 소켓**이다(`--studio-anchor-origin`). 열릴 때 그 소켓에서
      자랐으니 닫힐 때도 그 소켓으로 되접혀야 「이건 그 방위의 일이었다」가 읽힌다.
      시간도 등장과 같은 `--motion-fast` — 닫는 것이 여는 것보다 느리면 걸리적거린다.
      새 duration/이징 값 0. */
-  @keyframes studioPickerDismiss {
+  @keyframes studioAnchoredOut {
     from {
       opacity: 1;
       transform: scale(1);
@@ -1360,9 +1372,9 @@
     }
   }
 
-  .studio-picker-dismiss {
-    animation: studioPickerDismiss var(--motion-fast) var(--motion-ease) both;
-    transform-origin: var(--studio-picker-origin, center);
+  .studio-anchored-out {
+    animation: studioAnchoredOut var(--motion-fast) var(--motion-ease) both;
+    transform-origin: var(--studio-anchor-origin, center);
   }
 
   /* 라우트 로딩 자막 — 대부분의 진입은 400ms 안에 끝나므로 그 전에는 침묵한다.
@@ -3861,7 +3873,7 @@
 
     /* ② 이동·확대가 실린 등장 — 이름만 불투명도 전용으로 바꿔 자기 시간을 그대로 탄다. */
     .studio-stage-in,
-    .studio-picker-pop {
+    .studio-anchored-in {
       animation-name: panelCrossfadeIn !important;
       animation-duration: var(--motion-fast) !important;
     }
@@ -3871,7 +3883,7 @@
      * 바꾸면 반대로 나타나 버린다. 그래서 이동만 지우고 방향은 지킨다.
      */
     .studio-summary-converge,
-    .studio-picker-dismiss {
+    .studio-anchored-out {
       animation-name: overlayFadeOut !important;
       animation-duration: var(--motion-fast) !important;
     }

--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -169,11 +169,15 @@ function renderEnhance(
  * 없어졌는지까지 보려면 타이머를 돌려야 하고, 그건 이 시험들이 묻는 것이 아니다
  * (밀리초를 못박지 않는다 — 기계마다 다르다).
  */
+function expectAnchoredClosing(testId: string) {
+  const surface = screen.getByTestId(testId);
+  expect(surface).toHaveAttribute("data-exiting", "true");
+  expect(surface.className).toContain("studio-anchored-out");
+  expect(surface, "나가는 동안 조작을 받으면 그 아래 것을 가로막는다").toHaveAttribute("inert");
+}
+
 function expectPickerClosing() {
-  const picker = screen.getByTestId("studio-picker");
-  expect(picker).toHaveAttribute("data-exiting", "true");
-  expect(picker.className).toContain("studio-picker-dismiss");
-  expect(picker, "나가는 동안 조작을 받으면 착지하는 소켓을 가로막는다").toHaveAttribute("inert");
+  expectAnchoredClosing("studio-picker");
 }
 
 describe("StudioCompass — enhance", () => {
@@ -452,7 +456,7 @@ describe("StudioCompass — 지지대 편집 (edit existing relations)", () => {
     expect(screen.getByRole("button", { name: "close" })).toBeInTheDocument();
     fireEvent.keyDown(window, { key: "Escape" });
 
-    expect(screen.queryByTestId("studio-edit-card")).not.toBeInTheDocument();
+    expectAnchoredClosing("studio-edit-card");
     expect(trigger).toHaveFocus();
   });
 
@@ -1253,8 +1257,8 @@ describe("StudioCompass — motion catalog (#2)", () => {
     renderMotion();
     fireEvent.click(screen.getByTestId("studio-socket-up"));
     const picker = screen.getByTestId("studio-picker");
-    expect(picker.className).toContain("studio-picker-pop");
-    expect(picker.style.getPropertyValue("--studio-picker-origin")).not.toBe("");
+    expect(picker.className).toContain("studio-anchored-in");
+    expect(picker.style.getPropertyValue("--studio-anchor-origin")).not.toBe("");
   });
 
   it("satellite FLIP — filled-lane satellites register a FLIP node for lane moves", () => {
@@ -1452,7 +1456,7 @@ describe("StudioCompass — 임시 표면 상호 배타 (#62)", () => {
     // 그 상태에서 빈 소켓의 피커를 연다.
     fireEvent.click(screen.getByTestId("studio-socket-up"));
     expect(screen.getByTestId("studio-picker")).toBeInTheDocument();
-    expect(screen.queryByTestId("studio-lane-list-down")).not.toBeInTheDocument();
+    expectAnchoredClosing("studio-lane-list-down");
   });
 
   it("접힘 목록을 열면 피커가 닫힌다 (반대 방향도 대칭)", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -786,6 +786,21 @@ export function StudioCompass(props: StudioCompassProps) {
   const heldPicker = useHeldValue(pickerBundle, pickerBundle ? `${openRelation}|${query}` : null);
   const pickerPresence = usePanelPresence(Boolean(pickerBundle));
 
+  /**
+   * 관계 편집 카드도 같은 문법 — 그 위성에서 자라고 그 위성으로 되접힌다
+   * (2026-08-12 실측: 등장 `+33ms 있음/none/1.00`, Esc 뒤 `+544ms 없음` — 둘 다
+   * 하드컷이었다).
+   *
+   * 여기는 **값을 붙들어야 한다.** 카드가 그리는 것(관계·이웃)이 `openEdit` 에서
+   * 오므로, 그 값이 `null` 이 되는 순간 예쁘게 사라지는 빈 상자가 된다.
+   * 키는 원시값이어야 한다(객체 정체성으로 비교하면 무한 재렌더).
+   */
+  const heldEdit = useHeldValue(
+    openEdit,
+    openEdit ? `${openEdit.relation}|${openEdit.neighbor.id}` : null,
+  );
+  const editPresence = usePanelPresence(Boolean(openEdit));
+
   // #62 — 무대 위 임시 표면은 서로 배타적이다. 예전엔 '+90 더 보기' 접힘
   // 목록이 열린 채 소켓 피커가 그 위에 그대로 쌓여, 아래 목록이 반쯤 가린
   // 상태로 둘 다 살아 있었다(opus5 검수 스크린샷). 피커를 열 때 접힘 목록·
@@ -901,6 +916,28 @@ export function StudioCompass(props: StudioCompassProps) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [openEdit]);
+
+  /*
+   * 접힘 목록도 같은 계약 — Esc 로 닫힌다 (2026-08-12).
+   *
+   * 바로 위 주석이 「관계 편집 카드 · 미리보기 · 작업중 패널엔 Esc 가 있다」고
+   * 적어 뒀는데 **접힘 목록만 빠져 있었다.** 실측(연속 기록): 열고 Esc 를 눌러도
+   * `+1072ms` 까지 그대로 떠 있었고, 그때 사라진 것은 Esc 가 아니라 「더 보기」
+   * 칩을 다시 누른 것 때문이었다. 즉 이 표면은 **키보드로 빠져나올 길이 없었다.**
+   *
+   * 무대 위 임시 표면은 서로 배타적이라 한 번에 하나만 열려 있고, 그래서 전역
+   * Esc 하나가 열린 그것만 닫는다 — 위 셋과 같은 문법이다.
+   */
+  useEffect(() => {
+    if (!openFold) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      event.preventDefault();
+      setOpenFold(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [openFold]);
 
   // 소켓 피커도 같은 계약 — Esc 로 닫힌다. 최종 검수에서 이것만 빠져 있었다:
   // 관계 편집 카드 · 미리보기 · 작업중 패널엔 Esc 가 있는데 피커는 없어서, 검색
@@ -1353,27 +1390,28 @@ export function StudioCompass(props: StudioCompassProps) {
           ) : null}
 
           {/* inline anchored edit card (Slice 1 — 지지대 편집) */}
-          {openEdit ? (
+          {editPresence.mounted && heldEdit ? (
             <InlineEditCard
-              relation={openEdit.relation}
-              neighbor={openEdit.neighbor}
-              bearing={layouts.find((l) => l.view.relation === openEdit.relation)?.view.bearing ?? "right"}
-              layout={layouts.find((l) => l.view.relation === openEdit.relation)?.layout ?? null}
+              exiting={editPresence.exiting}
+              relation={heldEdit.relation}
+              neighbor={heldEdit.neighbor}
+              bearing={layouts.find((l) => l.view.relation === heldEdit.relation)?.view.bearing ?? "right"}
+              layout={layouts.find((l) => l.view.relation === heldEdit.relation)?.layout ?? null}
               cardLeft={cardLeft}
               cardRight={cardRight}
               labels={labels}
-              editable={props.editabilityOf?.(openEdit.relation, openEdit.neighbor) ?? false}
+              editable={props.editabilityOf?.(heldEdit.relation, heldEdit.neighbor) ?? false}
               bearingLabelFor={props.bearingLabelFor ?? ((r) => r)}
               onRetype={(to) => {
-                props.onRetype?.(openEdit.relation, to, openEdit.neighbor);
+                props.onRetype?.(heldEdit.relation, to, heldEdit.neighbor);
                 setOpenEdit(null);
               }}
               onRemove={() => {
-                props.onRemove?.(openEdit.relation, openEdit.neighbor);
+                props.onRemove?.(heldEdit.relation, heldEdit.neighbor);
                 setOpenEdit(null);
               }}
               onOpenOther={() => {
-                const target = openEdit.neighbor.id;
+                const target = heldEdit.neighbor.id;
                 setOpenEdit(null);
                 guardedOpen(target);
               }}
@@ -1919,6 +1957,19 @@ function LaneRender({
   onEditNeighbor?: (neighbor: StudioSatellite) => void;
   pendingNeighborIds?: ReadonlySet<string>;
 }) {
+  /**
+   * 접힘 목록도 **나가는 길**을 갖는다 (2026-08-12 실측).
+   *
+   * 그 전까지는 열 때도 닫을 때도 애니메이션이 없었다 — 연속 기록:
+   * `+35ms 있음/none/1.00` … `+1072ms 없음`. 즉 등장·퇴장 둘 다 하드컷이고,
+   * 같은 무대의 소켓 피커는 되접히며 나가므로 **같은 자리 같은 종류의 표면 둘이
+   * 서로 다른 문법**을 쓰고 있었다.
+   *
+   * 붙들 값은 없다 — 목록의 내용은 `view.neighbors` 에서 오고 그건 닫아도
+   * 사라지지 않는다(피커는 `openRelation` 이 사라지면 내용도 사라져서 붙들어야
+   * 했다). 그래서 창만 열면 된다.
+   */
+  const foldPresence = usePanelPresence(foldOpen);
   const satNav = (id: string) => {
     if (onOpenNode) return () => onOpenNode(id);
     return undefined;
@@ -2082,8 +2133,9 @@ function LaneRender({
       ) : null}
 
       {/* fold overflow list */}
-      {layout.fold && foldOpen ? (
+      {layout.fold && foldPresence.mounted ? (
         <LaneOverflowList
+          exiting={foldPresence.exiting}
           view={view}
           layout={layout}
           labels={labels}
@@ -2202,6 +2254,7 @@ function LaneRender({
 
 // ── Lane overflow list — all of one lane's neighbors, scrollable, navigable ────
 function LaneOverflowList({
+  exiting,
   view,
   layout,
   labels,
@@ -2211,6 +2264,8 @@ function LaneOverflowList({
   pendingNeighborIds,
   onClose,
 }: {
+  /** 퇴장 창 동안 `true` — 「더 보기」 칩으로 되접히며 나가고, 그 사이 조작을 받지 않는다. */
+  exiting: boolean;
   view: CompassBearingView;
   layout: LaneLayout;
   labels: StudioCompassLabels;
@@ -2237,11 +2292,31 @@ function LaneOverflowList({
     view.bearing === "up" || view.bearing === "down"
       ? clampY(CY - estH / 2, estH)
       : clampY(foldY + 30 - estH / 2, estH);
+  /*
+   * 자라고 되접히는 **원점은 「더 보기」 칩**이다 — 목록은 그 칩 옆 여백에 붙으므로
+   * 원점이 없으면 상자 가운데에서 커져, 어느 방위의 목록인지가 화면에서 사라진다.
+   * 상자 밖으로 나간 값은 클램프한다(원점이 상자 밖이면 방향이 뒤집혀 보인다).
+   */
+  const originX = Math.max(0, Math.min(W, foldX + SAT.w / 2 - left));
+  const originY = Math.max(0, Math.min(estH, foldY + 15 - top));
   return (
     <div
       data-testid={`studio-lane-list-${view.bearing}`}
-      className="absolute z-[8] rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]"
-      style={{ left, top, width: W, boxShadow: "var(--shadow-elevation-2)" }}
+      inert={exiting || undefined}
+      data-exiting={exiting ? "true" : undefined}
+      className={cn(
+        "absolute z-[8] rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]",
+        exiting ? "studio-anchored-out pointer-events-none" : "studio-anchored-in",
+      )}
+      style={
+        {
+          left,
+          top,
+          width: W,
+          boxShadow: "var(--shadow-elevation-2)",
+          "--studio-anchor-origin": `${originX}px ${originY}px`,
+        } as React.CSSProperties
+      }
     >
       <div className="flex items-center gap-2 border-b border-[color:var(--color-divider)] px-3.5 py-2.5">
         <span className="min-w-0 truncate text-caption font-[var(--font-weight-emphasis)] text-[color:var(--color-text-secondary)] [word-break:keep-all]">
@@ -2304,6 +2379,7 @@ function LaneOverflowList({
  * card shows an honest note + a re-center button instead of a broken write.
  */
 function InlineEditCard({
+  exiting,
   relation,
   neighbor,
   bearing,
@@ -2330,6 +2406,8 @@ function InlineEditCard({
   onRetype: (to: StudioRelation) => void;
   onRemove: () => void;
   onOpenOther: () => void;
+  /** 퇴장 창 동안 `true` — 그 위성으로 되접히며 나가고, 그 사이 조작을 받지 않는다. */
+  exiting: boolean;
   onClose: () => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -2347,12 +2425,31 @@ function InlineEditCard({
   const otherRelations = (["isA", "dependsOn", "contains", "relates"] as StudioRelation[]).filter(
     (r) => r !== relation,
   );
+  /*
+   * 원점은 **그 위성**이다(`anchor`) — 카드는 위성 옆 여백에 붙으므로, 원점이
+   * 없으면 상자 가운데에서 커져 「어느 관계의 카드인지」가 화면에서 사라진다.
+   */
+  const originX = Math.max(0, Math.min(W, anchor.x - left));
+  const originY = Math.max(0, Math.min(estH, anchor.y - top));
   return (
     <div
       data-testid="studio-edit-card"
       data-relation={relation}
-      className="absolute z-[9] flex flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]"
-      style={{ left, top, width: W, boxShadow: "var(--shadow-elevation-2)" }}
+      inert={exiting || undefined}
+      data-exiting={exiting ? "true" : undefined}
+      className={cn(
+        "absolute z-[9] flex flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]",
+        exiting ? "studio-anchored-out pointer-events-none" : "studio-anchored-in",
+      )}
+      style={
+        {
+          left,
+          top,
+          width: W,
+          boxShadow: "var(--shadow-elevation-2)",
+          "--studio-anchor-origin": `${originX}px ${originY}px`,
+        } as React.CSSProperties
+      }
     >
       <div className="flex items-center gap-2 border-b border-[color:var(--color-divider)] px-3.5 py-2.5">
         <span className="min-w-0 flex-1 truncate text-caption font-[var(--font-weight-emphasis)] text-[color:var(--color-text-secondary)] [word-break:keep-all]">
@@ -2629,7 +2726,7 @@ function InlinePicker({
       data-exiting={exiting ? "true" : undefined}
       className={cn(
         "absolute z-[8] flex flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]",
-        exiting ? "studio-picker-dismiss pointer-events-none" : "studio-picker-pop",
+        exiting ? "studio-anchored-out pointer-events-none" : "studio-anchored-in",
       )}
       style={
         {
@@ -2638,7 +2735,7 @@ function InlinePicker({
           width: W,
           maxHeight,
           boxShadow: "var(--shadow-elevation-2)",
-          "--studio-picker-origin": `${originX}px ${originY}px`,
+          "--studio-anchor-origin": `${originX}px ${originY}px`,
         } as React.CSSProperties
       }
     >

--- a/tests/e2e/studio-stage-motion.spec.ts
+++ b/tests/e2e/studio-stage-motion.spec.ts
@@ -161,6 +161,135 @@ test("공방 · 무대가 처음 열릴 때는 입장이 재생된다", async ({
   ).toBeLessThan(0.5);
 });
 
+/**
+ * ⑤ **앵커된 임시 표면 셋이 한 문법을 쓴다** (2026-08-12).
+ *
+ * 피커에 나가는 길을 놓은 다음 나머지 둘을 재 보니 둘 다 하드컷이었다 —
+ * 접힘 목록은 `+35ms 있음/none/1.00`(등장·퇴장 둘 다) 게다가 **Esc 로도 안 닫혔고**,
+ * 관계 편집 카드는 `+33ms` 등장 · Esc 뒤 한 프레임에 소멸. 같은 무대 같은 자리의
+ * 같은 종류 표면 셋이 **서로 다른 문법**을 쓰고 있었던 것이다.
+ *
+ * 그래서 이 시험은 표면마다 따로 쓰지 않고 **표를 돌린다** — 넷째 표면이 생기면
+ * 여기 한 줄을 더하는 것이 그 표면에 문법을 붙이는 것과 같은 일이 된다.
+ */
+const ANCHORED = [
+  { id: "studio-picker", label: "소켓 피커" },
+  { id: "studio-lane-list", label: "접힘 목록" },
+  { id: "studio-edit-card", label: "관계 편집 카드" },
+] as const;
+
+test("공방 · 앵커된 임시 표면 셋이 같은 문법으로 나간다", async ({ page }) => {
+  test.setTimeout(300_000);
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await page.goto("/ko/ontology/studio/?guides=off", { waitUntil: "domcontentloaded" });
+
+  // 강화 모드 — 이미 채워진 방위가 있어야 접힘 목록·편집 카드가 존재한다.
+  const enhance = page.getByTestId("studio-entry-enhance");
+  await expect(page.getByTestId("studio-entry-create")).toBeVisible({ timeout: 30_000 });
+  await page.waitForTimeout(1_500);
+  if (await enhance.count()) await enhance.click();
+  else await page.getByTestId("studio-entry-create").click();
+  await page.waitForTimeout(2_000);
+
+  /** 열었다 Esc 로 닫으며 그 표면의 프레임을 잡는다. */
+  const trace = async (selector: string, open: () => Promise<void>) => {
+    await page.evaluate(([sel]: [string]) => {
+      const w = window as unknown as { __rec?: unknown[]; __stop?: () => void };
+      w.__rec = [];
+      let stop = false;
+      const tick = () => {
+        if (stop) return;
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (el) {
+          const cs = getComputedStyle(el);
+          (w.__rec as unknown[]).push({
+            a: cs.animationName,
+            o: Number(cs.opacity),
+            inert: el.hasAttribute("inert"),
+          });
+        }
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+      w.__stop = () => {
+        stop = true;
+      };
+    }, [selector] as [string]);
+    await open();
+    await page.waitForTimeout(500);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+    return (await page.evaluate(() => {
+      const w = window as unknown as { __rec: { a: string; o: number; inert: boolean }[]; __stop: () => void };
+      w.__stop();
+      return w.__rec;
+    })) as { a: string; o: number; inert: boolean }[];
+  };
+
+  let measured = 0;
+  for (const surface of ANCHORED) {
+    const openers: Record<string, () => Promise<void>> = {
+      "studio-picker": async () => {
+        const socket = page.locator('[data-testid^="studio-socket-"]').first();
+        if (await socket.count()) await socket.click();
+      },
+      "studio-lane-list": async () => {
+        const more = page.locator('[data-testid^="studio-lane-more-"]').first();
+        if (await more.count()) await more.click();
+      },
+      "studio-edit-card": async () => {
+        const edit = page.locator('[data-testid^="studio-edit-"]').first();
+        if (await edit.count()) await edit.click();
+      },
+    };
+    // 접힘 목록은 방위마다 testid 가 다르다 — 접두사로 잡는다.
+    const selector =
+      surface.id === "studio-lane-list"
+        ? '[data-testid^="studio-lane-list-"]'
+        : `[data-testid="${surface.id}"]`;
+
+    const rows = await trace(selector, openers[surface.id]);
+    if (rows.length === 0) {
+      console.log(`[anchored] ${surface.label}: 이 볼트에서 열 수 없어 건너뜀`);
+      continue;
+    }
+    measured += 1;
+    const entering = rows.filter((r) => r.a === "studioAnchoredIn");
+    const leaving = rows.filter((r) => r.a === "studioAnchoredOut");
+    console.log(
+      `[anchored] ${surface.label}: 등장 ${entering.length}프레임 ` +
+        `${entering.length ? `${entering[0].o.toFixed(2)}→${entering[entering.length - 1].o.toFixed(2)}` : ""} · ` +
+        `퇴장 ${leaving.length}프레임 ` +
+        `${leaving.length ? `${leaving[0].o.toFixed(2)}→${leaving[leaving.length - 1].o.toFixed(2)}` : ""}`,
+    );
+
+    expect(
+      entering.length,
+      `${surface.label}가 등장 애니메이션 없이 나타났다 — 하드컷이다: ${[...new Set(rows.map((r) => r.a))].join(", ")}`,
+    ).toBeGreaterThan(1);
+    expect(entering[0].o, `${surface.label} 등장 첫 프레임이 이미 불투명하다`).toBeLessThan(0.5);
+
+    /*
+     * 퇴장은 **Esc 로** 재는 것이 요점이다. 접힘 목록은 Esc 핸들러가 아예 없어서
+     * 「닫히지 않는다」와 「하드컷으로 닫힌다」가 여기서 같은 실패로 잡힌다.
+     */
+    expect(
+      leaving.length,
+      `${surface.label}가 Esc 로 부드럽게 나가지 않았다 — 핸들러가 없거나 하드컷이다: ${[...new Set(rows.map((r) => r.a))].join(", ")}`,
+    ).toBeGreaterThan(1);
+    expect(leaving[0].o, `${surface.label} 퇴장 첫 프레임이 이미 투명하다`).toBeGreaterThan(0.5);
+    expect(
+      leaving[leaving.length - 1].o,
+      `${surface.label} 퇴장이 배어 나가지 않고 잘렸다`,
+    ).toBeLessThan(0.5);
+    expect(leaving.every((r) => r.inert), `나가는 ${surface.label}가 여전히 조작을 받는다`).toBe(true);
+  }
+
+  // 공회전 차단: 하나도 못 열었으면 이 시험은 아무것도 재지 않았다.
+  expect(measured, "앵커된 표면을 하나도 열지 못했다").toBeGreaterThan(2);
+});
+
 test("공방 · 피커는 나가는 길을 갖는다", async ({ page }) => {
   test.setTimeout(240_000);
   await page.setViewportSize({ width: 1512, height: 900 });
@@ -206,7 +335,7 @@ test("공방 · 피커는 나가는 길을 갖는다", async ({ page }) => {
     return out;
   });
 
-  const dismissing = frames.filter((f) => f.name === "studioPickerDismiss");
+  const dismissing = frames.filter((f) => f.name === "studioAnchoredOut");
   console.log(
     `[studio-dismiss] 살아 있던 프레임 ${frames.length} · 퇴장 프레임 ${dismissing.length} · ` +
       `불투명도 ${dismissing.map((f) => f.opacity.toFixed(2)).join("→") || "(없음)"}`,


### PR DESCRIPTION
## Summary

지난 회차(#1046)에 소켓 피커에 나가는 길을 놓았다. 이번에 **같은 무대의 나머지 임시 표면 둘**을 재 봤더니 둘 다 하드컷이었다. 연속 기록:

| 표면 | 등장 | 퇴장 |
|---|---|---|
| 접힘 목록 | `+35ms 있음/none/1.00` | 하드컷 — **그리고 Esc 로 아예 안 닫힘** |
| 관계 편집 카드 | `+33ms 있음/none/1.00` | Esc 뒤 `+544ms` 한 프레임에 소멸 |

접힘 목록이 사라진 시점(`+1072ms`)은 Esc 때문이 아니라 **「더 보기」 칩을 다시 누른 것** 때문이었다. 바로 그 자리의 주석이 「관계 편집 카드 · 미리보기 · 작업중 패널엔 Esc 가 있다」고 적어 뒀는데 **접힘 목록만 빠져 있었다** — 키보드로 빠져나올 길이 없는 표면이었다.

즉 **같은 무대 같은 자리의 같은 종류 표면 셋이 서로 다른 문법**을 쓰고 있었다.

### 값을 한 벌로 모은다

셋 다 「누른 것 옆에 붙어 열리고 그 자리로 되접히는」 같은 종류다. 그래서 값도 하나다 — 각자 자기 트리거의 로컬 좌표를 원점으로 주입한다(피커=소켓, 접힘 목록=「더 보기」 칩, 편집 카드=그 위성).

**이름도 일반화했다.** `studioPickerPop` 은 피커에만 있던 시절의 이름이고, 같은 문법을 나머지에 붙이면 거짓이 된다 — 다음 사람이 편집 카드에 `studio-picker-pop` 을 붙이게 된다. `studioAnchoredIn`/`Out` · `--studio-anchor-origin` 으로 바꿨다. **값·시간·이징 전부 그대로**라 렌더 결과 변화 0.

편집 카드는 **값도 붙들어야** 했다 — 그리는 것이 `openEdit` 에서 오므로 그 값이 `null` 이 되는 순간 예쁘게 사라지는 빈 상자가 된다. 접힘 목록은 내용이 `view.neighbors` 에서 와서 붙들 것이 없다(닫아도 안 사라진다).

## Test plan

**실측(복구 후)** — 셋이 같은 값을 탄다:

```
[anchored] 소켓 피커:      등장 64프레임 0.00→1.00 · 퇴장 17프레임 1.00→0.00
[anchored] 접힘 목록:      등장 64프레임 0.00→1.00 · 퇴장 16프레임 1.00→0.00
[anchored] 관계 편집 카드: 등장 63프레임 0.00→1.00 · 퇴장 16프레임 1.00→0.00
```

**감속 모드** — 셋 다 이름이 `panelCrossfadeIn`/`overlayFadeOut` 으로 바뀌고 확대 축이 사라진다(`transform: none`), 불투명도만 남는다.

**게이트는 표를 돈다.** 표면마다 시험을 따로 쓰지 않았다 — 넷째 표면이 생기면 표에 한 줄 더하는 것이 그 표면에 문법을 붙이는 것과 같은 일이 된다. 퇴장은 **Esc 로** 재는 것이 요점이다: 「닫히지 않는다」와 「하드컷으로 닫힌다」가 같은 실패로 잡힌다.

**프로브** (`/gate-probe`) — 둘 다 그 표면을 **이름으로 지목**해 빨개진다:

| 되돌린 것 | 결과 |
|---|---|
| 접힘 목록의 Esc 핸들러 제거 | `접힘 목록: 등장 122프레임 · 퇴장 0프레임` → `접힘 목록가 Esc 로 부드럽게 나가지 않았다 — 핸들러가 없거나 하드컷이다` |
| 편집 카드의 등장 문법 벗김 | `관계 편집 카드: 등장 0프레임` → `관계 편집 카드가 등장 애니메이션 없이 나타났다 — 하드컷이다: none` |

공회전 차단: 앵커된 표면을 셋 다 못 열면 실패한다(볼트가 얇으면 열 수 없는 것이 있으므로 건너뛴 것은 로그에 남는다).

**단위 시험 2건**이 「닫으면 즉시 사라진다」를 단언하고 있었다 — 지난 회차에 피커에 만든 판정 헬퍼를 **세 표면 공용**으로 일반화해서 「닫히는 중인가」로 바꿨다.

**`pnpm checks:changed` 가 권한 것 전부**:

| 검사 | 결과 |
|---|---|
| `eslint` (변경 소스 2) | 0 error / 0 warning |
| `tsc --noEmit` | 통과 |
| `vitest` 조립대 전체 | 21 파일 / 262 passed |
| `test:contracts` | 137 파일 / 1598 passed |
| `playwright studio-stage-motion` | 4 passed |
| `playwright overflow-sweep` | 10 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD