### PR TITLE
fix: 작업중 패널이 존재하지 않는 클래스로 「배어 든다」고 말하고 있었다

### DIFF
--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -1359,6 +1359,31 @@ describe("StudioCompass — 작업중 목록 (drafts)", () => {
     expect(screen.getByTestId("studio-drafts-panel")).toBeInTheDocument();
   });
 
+  /**
+   * **작업중 패널도 나머지 셋과 같은 문법을 쓴다** (2026-08-12).
+   *
+   * 그 전에는 `studio-fade-in` 이 붙어 있었는데 **저장소 어디에도 정의가 없는
+   * 클래스**였다(실행 중인 앱에서 확인: 그 이름을 담은 CSS 규칙 0개). 이름이
+   * 「배어 들어온다」고 말하는데 실제로는 등장도 퇴장도 없었다.
+   *
+   * 존재하지 않는 클래스는 **코드에 아무 값도 남기지 않아서** 값을 보는 lint 도
+   * 타입 검사도 전체 테스트도 전부 통과시킨다 — 이 저장소가 `text-large` ·
+   * `text-callout` 으로 두 번 값을 치른 그 실패다. 그래서 이름을 여기서 잠근다.
+   */
+  it("작업중 패널이 앵커된 표면 문법으로 들어오고 나간다", () => {
+    renderDrafts();
+    fireEvent.click(screen.getByTestId("studio-drafts-open"));
+
+    const panel = screen.getByTestId("studio-drafts-panel");
+    expect(panel.className).toContain("studio-anchored-in");
+    expect(panel.className).not.toContain("studio-fade-in");
+    // 원점은 트리거가 있는 오른쪽 위 — 없으면 상자 가운데에서 자란다.
+    expect(panel.getAttribute("style")).toContain("--studio-anchor-origin");
+
+    fireEvent.click(screen.getByTestId("studio-drafts-open"));
+    expectAnchoredClosing("studio-drafts-panel");
+  });
+
   it("지금 무대인 노드는 '이어서 하기' 대신 '지금 무대' 로 표시한다", () => {
     renderDrafts();
     fireEvent.click(screen.getByTestId("studio-drafts-open"));
@@ -1377,7 +1402,7 @@ describe("StudioCompass — 작업중 목록 (drafts)", () => {
     fireEvent.click(screen.getByTestId("studio-draft-resume-capability:cli"));
 
     expect(onOpenDraft).toHaveBeenCalledWith("capability:cli");
-    expect(screen.queryByTestId("studio-drafts-panel")).not.toBeInTheDocument();
+    expectAnchoredClosing("studio-drafts-panel");
   });
 
   it("'버리기' 는 그 노드의 초안만 버린다 (명시적 폐기 경로)", () => {

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -800,6 +800,8 @@ export function StudioCompass(props: StudioCompassProps) {
     openEdit ? `${openEdit.relation}|${openEdit.neighbor.id}` : null,
   );
   const editPresence = usePanelPresence(Boolean(openEdit));
+  /** 작업중 패널도 같은 문법 — 붙들 값은 없다(목록은 `drafts` prop 에서 온다). */
+  const draftsPresence = usePanelPresence(draftsOpen);
 
   // #62 — 무대 위 임시 표면은 서로 배타적이다. 예전엔 '+90 더 보기' 접힘
   // 목록이 열린 채 소켓 피커가 그 위에 그대로 쌓여, 아래 목록이 반쯤 가린
@@ -1547,13 +1549,38 @@ export function StudioCompass(props: StudioCompassProps) {
           우측에서 밀려나오는 비-모달 패널. 저장 전 변경이 노드별 초안으로 남는다는
           약속(#60)을 눈에 보이게 만드는 곳 — "어디에 남았지?" 를 묻지 않게 한다.
           비-모달이므로 무대를 가리지 않고, Esc 로 닫힌다. */}
-      {draftsOpen ? (
+      {draftsPresence.mounted ? (
         <div
           data-testid="studio-drafts-panel"
           role="dialog"
           aria-label={labels.draftsTitle}
-          className="studio-fade-in absolute right-3 top-[52px] z-[11] flex w-[288px] flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]"
-          style={{ boxShadow: "var(--shadow-elevation-2)", maxHeight: "min(420px, calc(100% - 96px))" }}
+          inert={draftsPresence.exiting || undefined}
+          data-exiting={draftsPresence.exiting ? "true" : undefined}
+          /*
+           * ⚠️ **여기 붙어 있던 `studio-fade-in` 은 존재하지 않는 클래스였다**
+           * (2026-08-12, 실행 중인 앱에서 확인: `.studio-fade-in` 을 담은 CSS 규칙
+           * **0개**). 이름은 「배어 들어온다」고 말하는데 정의가 저장소 어디에도
+           * 없었으니, 이 패널은 **등장도 퇴장도 없이 툭 나타나고 툭 사라졌다.**
+           *
+           * 이 저장소가 이미 두 번 값을 치른 실패다 — 존재하지 않는 클래스는
+           * 코드에 아무 값도 남기지 않아서, 값을 보는 lint 도 타입 검사도 전체
+           * 테스트도 전부 통과시킨다(`text-large` · `text-callout` 전례).
+           *
+           * 이 패널도 트리거(우측 상단 「작업중」 칩) 바로 아래에 붙는 앵커된
+           * 표면이라, 나머지 셋과 같은 문법을 쓴다. 원점은 오른쪽 위 — 그 칩이
+           * 있는 자리다.
+           */
+          className={cn(
+            "absolute right-3 top-[52px] z-[11] flex w-[288px] flex-col rounded-panel border border-[color:var(--color-border-strong)] bg-[color:var(--color-elevated)]",
+            draftsPresence.exiting ? "studio-anchored-out pointer-events-none" : "studio-anchored-in",
+          )}
+          style={
+            {
+              boxShadow: "var(--shadow-elevation-2)",
+              maxHeight: "min(420px, calc(100% - 96px))",
+              "--studio-anchor-origin": "100% 0",
+            } as React.CSSProperties
+          }
         >
           <div className="flex items-start gap-2 px-3.5 pt-3">
             <div className="min-w-0 flex-1">

--- a/tests/e2e/studio-stage-motion.spec.ts
+++ b/tests/e2e/studio-stage-motion.spec.ts
@@ -176,6 +176,13 @@ const ANCHORED = [
   { id: "studio-picker", label: "소켓 피커" },
   { id: "studio-lane-list", label: "접힘 목록" },
   { id: "studio-edit-card", label: "관계 편집 카드" },
+  /*
+   * 작업중 패널은 **초안이 하나라도 있을 때만** 트리거가 뜨고, 초안은 현재 그래프에
+   * 있는 노드로만 열린다 — 얇은 볼트에서는 열 수 없어 아래 표가 「건너뜀」으로
+   * 남긴다(조용히 통과하지 않는다). 배선은 단위 시험이 잠근다:
+   * 「작업중 패널이 앵커된 표면 문법으로 들어오고 나간다」.
+   */
+  { id: "studio-drafts-panel", label: "작업중 패널", openWith: "studio-drafts-open" },
 ] as const;
 
 test("공방 · 앵커된 임시 표면 셋이 같은 문법으로 나간다", async ({ page }) => {
@@ -241,6 +248,10 @@ test("공방 · 앵커된 임시 표면 셋이 같은 문법으로 나간다", a
       "studio-edit-card": async () => {
         const edit = page.locator('[data-testid^="studio-edit-"]').first();
         if (await edit.count()) await edit.click();
+      },
+      "studio-drafts-panel": async () => {
+        const chip = page.getByTestId("studio-drafts-open");
+        if (await chip.count()) await chip.click();
       },
     };
     // 접힘 목록은 방위마다 testid 가 다르다 — 접두사로 잡는다.


### PR DESCRIPTION
## Summary

무대의 마지막 두 표면을 재려다 **미리보기는 이미 정확**하다는 것을 확인했다(`panelCrossfadeIn` 0.00→1.00, 닫으면 `overlayFadeOut` 1.00→0.00 — 공용 `Surface` 부품이 처리한다).

작업중 패널에는 `studio-fade-in` 이 붙어 있었는데, **실행 중인 앱에서 확인하니 그 이름을 담은 CSS 규칙이 0개**였다. 저장소 어디에도 정의가 없는 클래스다.

이름은 「배어 들어온다」고 말하는데 실제로는 등장도 퇴장도 없었다. 이 저장소가 **이미 두 번 값을 치른 실패**다 — 존재하지 않는 클래스는 코드에 아무 값도 남기지 않아서 값을 보는 lint 도 타입 검사도 전체 테스트도 전부 통과시킨다(`text-large` · `text-callout` 전례).

이 패널도 트리거(우측 상단 「작업중」 칩) 바로 아래에 붙는 앵커된 표면이라 나머지 셋과 같은 문법을 쓴다. 원점은 오른쪽 위 — 그 칩이 있는 자리다.

## Test plan

**배선은 단위 시험이 잠근다** — 열면 `studio-anchored-in` 을 갖고 원점이 실려 있는가, 닫으면 나가는 표시가 붙고 조작을 받지 않는가.

**프로브**: 죽은 클래스를 되돌리니 이름을 대며 빨개진다 —
`expected 'absolute right-3 top-[52px] …' to contain 'studio-anchored-in'`.

**e2e 게이트 표**에도 한 줄 넣었다. 초안이 있어야 트리거가 뜨므로 얇은 볼트에서는 「건너뜀」으로 남는다 — **조용히 통과하지 않는다**:

```
[anchored] 소켓 피커: 등장 65프레임 0.00→1.00 · 퇴장 17프레임 1.00→0.00
[anchored] 접힘 목록: 등장 63프레임 0.00→1.00 · 퇴장 16프레임 1.00→0.00
[anchored] 관계 편집 카드: 등장 63프레임 0.00→1.00 · 퇴장 16프레임 1.00→0.00
[anchored] 작업중 패널: 이 볼트에서 열 수 없어 건너뜀
```

| 검사 | 결과 |
|---|---|
| `eslint` | 0 error / 0 warning |
| `tsc --noEmit` | 통과 |
| `vitest` 조립대 전체 | 21 파일 / 263 passed |
| `test:contracts` | 137 파일 / 1598 passed |
| `playwright studio-stage-motion` | 4 passed |

## 만들지 않기로 한 것 (근거와 수치)

「DOM 에 있는 클래스는 CSS 규칙을 가져야 한다」를 게이트로 만들려다 **기각**했다. 8개 라우트 3,081개 요소에서 **467종**이 걸렸고 거의 전부 **내 셀렉터 추출이 틀린 것**이었다 — Tailwind 변형 클래스의 셀렉터는 이스케이프돼 있어 정규식이 중간에 잘린다. 제대로 하려면 CSS 셀렉터 파서가 필요하고, 지금 모양으로 켜면 강제가 아니라 소음이다. 소스 쪽으로도 두 번 좁혀 봤지만 679종 → 61종에서 여전히 대부분이 `className` 이 아니라 testid 였다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD