### PR TITLE
fix: 분석 화면 대형 숫자가 내 폴더 대신 내장 견본을 세고 있었다

### DIFF
--- a/src/shared/lib/use-count-up.test.ts
+++ b/src/shared/lib/use-count-up.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useCountUp } from "./use-count-up";
 
 function mockReducedMotion(matches: boolean) {
@@ -29,5 +29,55 @@ describe("useCountUp — insights count-up (#3)", () => {
     const { result } = renderHook(() => useCountUp(42));
     // First committed value is the animation floor; it climbs to target via rAF.
     expect(result.current).toBe(0);
+  });
+
+  /**
+   * **인트로 도중 target 이 바뀌면 새 target 에서 끝난다** (2026-08-12 실측 회귀).
+   *
+   * 분석 화면의 첫 렌더는 내장 견본(125 노드)으로 그려지고, 인트로가 0→125 로
+   * 세기 시작한다. 그 400ms 안에 사용자 볼트(5 노드)가 도착한다 — 동기화
+   * 이펙트가 5 로 스냅하지만, **인트로 rAF 루프는 마운트 때 클로저에 잡은 125 를
+   * 향해 계속 달려** 그 5 를 덮어쓰고 125 에 정착했다. 그 뒤 target 은 다시 안
+   * 바뀌므로 화면은 영원히 125 였다.
+   *
+   * 실측(구성 탭, 사용자 볼트 5 노드): +400ms 「개념 116」 → +900ms 「개념 125」
+   * 정착 · 같은 화면의 종류 분포와 상단 칩은 5 — **한 화면에서 숫자가 모순**됐고,
+   * 그 화면의 부제가 "모든 숫자는 문서에서 자동으로 계산돼요" 다.
+   */
+  it("인트로 도중 target 이 바뀌면 새 target 에서 끝난다 — 견본이 사용자 폴더를 덮으면 안 된다", () => {
+    mockReducedMotion(false);
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+
+    try {
+      const { result, rerender } = renderHook(({ target }) => useCountUp(target), {
+        initialProps: { target: 125 },
+      });
+
+      // 인트로가 절반쯤 달린 시점 —
+      clock = 200;
+      act(() => frames.shift()!(clock));
+      expect(result.current).toBeGreaterThan(0);
+
+      // — 사용자 볼트가 도착한다.
+      rerender({ target: 5 });
+
+      // 남은 인트로를 끝까지 돌린다.
+      clock = 1_000;
+      while (frames.length > 0) {
+        act(() => frames.shift()!(clock));
+      }
+
+      expect(result.current, "인트로가 옛 target 으로 착지해 사용자 값을 덮었다").toBe(5);
+    } finally {
+      nowSpy.mockRestore();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/shared/lib/use-count-up.ts
+++ b/src/shared/lib/use-count-up.ts
@@ -18,6 +18,21 @@ export function useCountUp(target: number, durationMs = 400): number {
   const [value, setValue] = useState(canAnimate ? 0 : target);
   const introDone = useRef(false);
   const synced = useRef(false);
+  /**
+   * ★ 인트로 루프는 **이 ref 를 통해** target 을 읽는다 (2026-08-12 실측 회귀).
+   *
+   * 종전에는 마운트 클로저에 잡힌 target 을 향해 달렸다. 분석 화면의 첫 렌더는
+   * 내장 견본(125 노드)이고 사용자 볼트(5 노드)는 그 인트로 400ms **안에**
+   * 도착한다 — 아래 동기화 이펙트가 5 로 스냅해도 다음 프레임이 125 를 향한
+   * 값으로 되덮었고, 125 에 정착한 뒤에는 target 이 다시 안 바뀌므로 화면이
+   * 영원히 125 였다. 같은 화면의 종류 분포·상단 칩은 5 를 말하고 있었다.
+   */
+  const targetRef = useRef(target);
+  // 렌더 중 ref 쓰기는 lint 가 막는다 — 이펙트로 갱신해도 늦지 않다: 이펙트는
+  // 커밋 직후, 다음 rAF 프레임보다 먼저 돌므로 인트로 루프가 항상 최신 값을 본다.
+  useEffect(() => {
+    targetRef.current = target;
+  }, [target]);
 
   useEffect(() => {
     if (introDone.current) return;
@@ -25,17 +40,17 @@ export function useCountUp(target: number, durationMs = 400): number {
     if (!canAnimate) return; // already at target
     let raf = 0;
     const start = performance.now();
-    const from = 0;
     const tick = (now: number) => {
       const t = Math.min(1, (now - start) / durationMs);
       const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic — quick then settle
-      setValue(Math.round(from + (target - from) * eased));
+      setValue(Math.round(targetRef.current * eased));
       if (t < 1) raf = requestAnimationFrame(tick);
-      else setValue(target);
+      else setValue(targetRef.current);
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-    // Intro runs exactly once (guarded by introDone); target/duration read at mount.
+    // Intro runs exactly once (guarded by introDone); duration read at mount and
+    // the live target arrives through targetRef.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/tests/e2e/insights-badge-agreement.spec.ts
+++ b/tests/e2e/insights-badge-agreement.spec.ts
@@ -79,3 +79,86 @@ test.describe("인사이트 할 일 — 탭 배지와 묶음 배지가 같은 �
     ).toBe(groupSum + blocking);
   });
 });
+
+/**
+ * **큰 숫자도 같은 폴더를 센다** (2026-08-12 실측 회귀).
+ *
+ * 구성 탭의 대형 숫자(개념·관계)가 상단 칩과 **다른 수**를 말했다 — 칩은 사용자
+ * 볼트(5 개념 · 4 관계), 큰 숫자는 내장 견본(125 · 258). 원인은 카운트업 인트로:
+ * 첫 렌더가 견본으로 그려지며 0→125 로 세기 시작하고, 사용자 볼트가 그 400ms
+ * **안에** 도착하면 동기화 스냅을 다음 프레임이 되덮은 뒤 125 에 영구 정착했다.
+ * 그 화면의 부제가 "모든 숫자는 문서에서 자동으로 계산돼요" 인데, 숫자가 견본을
+ * 세고 있었다.
+ *
+ * 기전은 `use-count-up.test.ts` 가 잠근다. 이 시험이 맡는 것은 그 위 —
+ * **화면에 실제로 같은 수가 찍히는가.** 볼트를 물리고(스텁 피커) 인트로가 끝난
+ * 뒤 큰 숫자와 상단 칩을 함께 읽는다. 시간이 아니라 값의 일치를 단언하므로
+ * 기계 속도와 무관하다.
+ */
+test.describe("인사이트 구성 — 큰 숫자와 상단 칩이 같은 폴더를 센다", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("개념·관계 대형 숫자 = 상단 칩", async ({ page }) => {
+    const { seedFirstRunSeen } = await import("./first-run-seed");
+    const { stubDirectoryPicker } = await import("./vault-picker-stub");
+    await seedFirstRunSeen(page);
+    await stubDirectoryPicker(page, {
+      "shop.md": [
+        "---",
+        "uid: 11111111-1111-4111-8111-111111111111",
+        "slug: shop",
+        "kind: project",
+        "title: Census Shop",
+        "contains:",
+        "  - capabilities/pay",
+        "---",
+        "",
+        "# Census Shop",
+        "",
+      ].join("\n"),
+      "capabilities/pay.md": [
+        "---",
+        "uid: 22222222-2222-4222-8222-222222222222",
+        "slug: capabilities/pay",
+        "kind: capability",
+        "title: Pay",
+        "---",
+        "",
+        "# Pay",
+        "",
+      ].join("\n"),
+    });
+
+    await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+    await page.getByTestId("first-run-starter-open").click();
+    await page.getByTestId("vault-guide-pick-existing").click();
+    await expect(page.getByTestId("topology-index-panel")).toContainText("Census Shop", {
+      timeout: 30_000,
+    });
+
+    await page.goto("/ko/ontology/insights/?guides=off&tab=composition", {
+      waitUntil: "domcontentloaded",
+    });
+    // 인트로(400ms)가 끝나고도 남을 만큼 — 그리고 견본→볼트 교체가 이 안에 있다.
+    await page.waitForTimeout(2_000);
+
+    const seen = await page.evaluate(() => {
+      const chip = [...document.querySelectorAll("header span")].map((el) => (el.textContent ?? "").trim())
+        .find((text) => /개념/.test(text) && /관계/.test(text));
+      const bignums = [...document.querySelectorAll('[data-testid="insights-bignum"]')].map((el) =>
+        Number(/(\d[\d,]*)/.exec(el.textContent ?? "")?.[1]?.replace(/,/g, "") ?? NaN),
+      );
+      return { chip: chip ?? null, bignums };
+    });
+
+    expect(seen.chip, "상단 칩을 못 찾았다 — 이 시험이 공회전한다").not.toBeNull();
+    const chipConcepts = Number(/(\d+)\s*개념/.exec(seen.chip!)?.[1]);
+    const chipRelations = Number(/(\d+)\s*관계/.exec(seen.chip!)?.[1]);
+    console.log(`[census-agreement] 칩 ${seen.chip} · 대형 숫자 ${seen.bignums.join(", ")}`);
+
+    // 공회전 차단: 대형 숫자가 하나도 없으면 아무것도 안 잰 것이다.
+    expect(seen.bignums.length, "대형 숫자를 하나도 못 찾았다").toBeGreaterThanOrEqual(2);
+    expect(seen.bignums[0], `개념 대형 숫자가 칩(${chipConcepts})과 다른 폴더를 센다`).toBe(chipConcepts);
+    expect(seen.bignums[1], `관계 대형 숫자가 칩(${chipRelations})과 다른 폴더를 센다`).toBe(chipRelations);
+  });
+});


### PR DESCRIPTION
## Summary

분석 화면 강화 회차의 첫 실측에서 나온 **정합 결함**이다. 사용자 볼트(5 개념 · 4 관계)를 물리고 구성 탭을 열면:

| 자리 | 말하는 수 |
|---|---|
| 상단 칩 | 5 개념 · 4 관계 · 0 도메인 ✓ |
| 종류 분포 카드 | 5 (역량 3 · 요소 1 · 프로젝트 1) ✓ |
| **대형 숫자** | **개념 125 · 관계 258 · 건강 100%** ← 내장 견본의 수 |

그 화면의 부제가 *"모든 숫자는 문서에서 자동으로 계산돼요"* 인데, 숫자가 견본을 세고 있었다. `forbidden.md` 가 금하는 그 모양이다 — 같은 개념의 값이 두 곳에서 서로 다른 정답 행세를 한다.

### 원인 — 카운트업 인트로의 경합

시간축 실측(+400ms 「개념 116」 → +900ms 「개념 125」 정착 → 이후 불변):

1. 첫 렌더는 **내장 견본**(125)으로 그려지고 인트로가 0→125 로 세기 시작(400ms)
2. 사용자 볼트(5)가 그 400ms **안에** 도착 → 동기화 이펙트가 5 로 스냅
3. **인트로 rAF 루프는 마운트 클로저에 잡힌 125 를 향해 계속 달려** 그 5 를 되덮음
4. 125 정착 후엔 target 이 다시 안 바뀌므로 **영원히 125**

### 고침

인트로 루프가 target 을 클로저가 아니라 **ref** 로 읽는다. 갱신은 이펙트로 — 렌더 중 ref 쓰기는 lint 가 막고(실제로 걸렸고 경고 래칫이 막았다), 이펙트는 다음 rAF 프레임보다 먼저 돌므로 루프가 항상 최신 값을 본다. 도중에 target 이 바뀌면 인트로가 새 값으로 착지한다.

고친 뒤 +400ms 부터 개념 5 · 관계 4 로 전 화면이 한목소리이고, **건강도 견본의 100% 가 아니라 진짜 값**(이 볼트는 도메인이 없어 0%)을 말한다.

## Test plan

**TDD** — 실패하는 단위 시험 먼저: 가짜 rAF 로 인트로 중간에 target 을 125→5 로 바꾸고 끝까지 돌리면 5 에서 끝나는가. 빨강 확인(`expected 125 to be 5`) 후 고쳐서 초록.

**e2e 는 기전이 아니라 화면을 잠근다** — 스텁 피커로 볼트를 물리고 「대형 숫자 = 상단 칩」을 단언한다(`insights-badge-agreement.spec.ts` 에 동거 — 같은 부류: 한 화면이 같은 것을 두 수로 세지 않는다). 시간이 아니라 값의 일치라 기계 속도와 무관하다.

**프로브** (`/gate-probe`) — 수정을 되돌리니 둘 다 그 자리를 지목하며 빨개진다:

```
단위: AssertionError: 인트로가 옛 target 으로 착지해 사용자 값을 덮었다: expected 125 to be 5
e2e:  [census-agreement] 칩 2 개념·1 관계·0 도메인 · 대형 숫자 125, 258, 100
      Error: 개념 대형 숫자가 칩(2)과 다른 폴더를 센다
```

| 검사 | 결과 |
|---|---|
| `eslint` (변경 2파일) | 0 error / 0 warning |
| `tsc --noEmit` | 통과 |
| `vitest use-count-up` | 3 passed |
| **전체 unit** (shared 훅 변경이므로) | 662 파일 / 6589 passed |
| `playwright insights-badge-agreement` | 2 passed |
| lint 경고 래칫 | 7 passed (경고 증가 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD