### PR TITLE
fix: 분석 화면의 끊긴 높이 사슬을 잇는다 — 「빈 밴드 금지」가 처음으로 작동한다

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -888,7 +888,14 @@ export function OntologyInsightsPage() {
   return (
     <div className="flex min-h-full w-full">
       {/* 레일은 perf/persistent-shell 이후 layout(AppShell) 상주. */}
-      <div className="min-w-0 flex-1">
+      {/*
+        * **높이 사슬** (2026-08-12 실측). 이 아래 `main` 까지 세로 flex 가 이어져야
+        * 탭패널의 `flex-1` 이 실제로 남은 높이를 받는다. 끊겨 있던 동안: 「구성」
+        * 카드들의 `flex-1`("빈 밴드 금지" 설계)이 한 번도 늘어난 적 없고, 「경계」
+        * 빈 상태 아래로 614px 이 죽은 공백이었다(1512×900 실측). `min-h-full` 사슬
+        * 이라 내용이 길면 그대로 자라 스크롤은 그대로다.
+        */}
+      <div className="flex min-w-0 flex-1 flex-col">
         {/*
          * ⚠️ **실시간 표시를 뺐다** (2026-08-03, 소유자 지적 — 프로젝트 목록과
          * 같은 이유). 「실시간 · 변경 N」은 **지도의 물건**이다: 무엇이 바뀌었는지
@@ -908,7 +915,7 @@ export function OntologyInsightsPage() {
       tabIndex={-1}
           data-insights-surface="maintenance-board"
           data-insights-question-model="one-tab-one-question"
-          className={`${PAGE_FRAME} pb-8 max-lg:pb-[calc(var(--topology-mobile-bottom-tab-reserve)+24px)]`}
+          className={`${PAGE_FRAME} flex min-h-0 flex-1 flex-col pb-8 max-lg:pb-[calc(var(--topology-mobile-bottom-tab-reserve)+24px)]`}
         >
         <MountedGlobalSearch open={searchPaletteOpen} onOpenChange={setSearchPaletteOpen} />
 

--- a/src/views/ontology-insights/ui/tabs/DomainCouplingCard.tsx
+++ b/src/views/ontology-insights/ui/tabs/DomainCouplingCard.tsx
@@ -8,6 +8,7 @@ import type {
   DomainCouplingPairRow,
 } from "../../lib/domain-coupling-rows";
 import { InsightsSectionTitle } from "../parts/InsightsSectionTitle";
+import { PAGE_COLUMN_STAGE } from "@/shared/ui/page-frame";
 import { controlClass } from '@/shared/ui/control-class';
 
 export interface DomainCouplingCardLabels {
@@ -101,10 +102,18 @@ export function DomainCouplingCard({
 
   if (isColdStart) {
     return (
+      /*
+       * **빈 상태는 무대다** (2026-08-12 실측). 높이 사슬을 잇기 전 이 카드는
+       * 폭 1368 × 높이 118 로 위에 붙어 있었고 아래로 614px 이 죽은 공백이었다 —
+       * 스킬 빈 화면과 같은 병(잉크 3개가 벽까지 퍼진 띠 + 아래 구멍). 같은
+       * 처방을 쓴다: 칸은 무대 폭(`PAGE_COLUMN_STAGE`, 조립대 입구·스킬 빈
+       * 상태와 같은 640)으로 모으고, 남은 높이는 이 래퍼가 소유해 가운데 세운다.
+       */
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
       <section
         aria-label={labels.title}
         data-testid="domain-coupling-empty"
-        className="rounded-panel border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] p-[var(--card-pad)] text-center"
+        className={`${PAGE_COLUMN_STAGE} rounded-panel border border-dashed border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] p-[var(--card-pad)] text-center`}
       >
         <p className="text-body-lg font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">{labels.emptyTitle}</p>
         <p className="mt-1.5 text-body text-[color:var(--color-text-tertiary)]">{labels.emptyDescription}</p>
@@ -116,6 +125,7 @@ export function DomainCouplingCard({
           {labels.emptyAction}
         </Link>
       </section>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary

경계 탭의 빈 상태가 폭 1368 × 높이 118 띠로 위에 붙어 있었고 **아래로 614px 이 죽은 공백**이었다(1512×900 실측). 파 보니 개별 화면의 문제가 아니었다:

- 탭패널과 그 래퍼에는 `flex-1` 이 **이미** 붙어 있다
- 그런데 `main` 과 그 부모에서 세로 flex 가 끊겨 **높이가 아예 내려오지 않았다**
- 「구성」 카드들의 `flex-1` 주석(*"카드는 flex:1 로 세로를 채운다 — 빈 밴드 금지"*)이 **한 번도 작동한 적 없는** 설계였다

### 고침

**① 높이 사슬을 `min-h-full` 로 잇는다.** 내용이 뷰포트보다 길면 그대로 자라 셸 슬롯이 스크롤한다 — 내장 견본(125 노드)으로 실측: 구성 탭 슬롯 스크롤 1027/900, 바닥의 AI 스트립까지 정상 도달.

**② 다섯 탭 전부에서 AI 핸드오프 스트립이 같은 자리(y=834)에 고정**된다 — 종전엔 탭마다 내용 길이를 따라 떠돌았다(구성 y≈600 · 경계 y≈310 …).

**③ 경계 빈 상태에 무대 문법** — 칸은 `PAGE_COLUMN_STAGE`(조립대 입구 · 스킬 빈 상태와 같은 640), 남은 높이는 래퍼가 소유해 가운데 세운다.

| | 종전 | 고친 뒤 |
|---|---|---|
| 경계 빈 카드 | 1368×118, 위에 붙음, 아래 614px 공백 | 640 칸, 화면 가운데 |
| AI 스트립 | 탭마다 다른 y | 다섯 탭 모두 y=834 |
| 구성 카드 `flex-1` | 늘어난 적 없음 | 남은 높이를 채움 |

## Test plan

| 검사 | 결과 |
|---|---|
| `vitest` 분석 전체 (DomainCouplingCard 포함) | 26 파일 / 194 passed |
| `eslint` | 0 error (경고 1은 기존 것 — 래칫 7 passed, 증가 0) |
| `tsc --noEmit` | 통과 |
| `test:contracts` | 137 파일 / 1598 passed |
| `playwright scroll-end-gap` (17 라우트 × 3폭 — 탭바 예약 검증) | 3 passed |
| 큰 볼트 넘침 실측 | 슬롯 스크롤 1027/900 · 스트립 도달 확인 · 잉크 클리핑 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD