### PR TITLE
fix: 스킬 화면의 글자 단을 형제 화면 수준으로 올린다

### DIFF
--- a/src/views/agent-skills/ui/AgentSkillsPage.tsx
+++ b/src/views/agent-skills/ui/AgentSkillsPage.tsx
@@ -161,7 +161,7 @@ export function AgentSkillsPage() {
             {folderName || scan?.skippedNotInstalled || scan?.truncated ? (
               <p
                 data-testid="skills-scan-note"
-                className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-label leading-prose text-[color:var(--color-text-tertiary)]"
+                className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-body leading-body text-[color:var(--color-text-tertiary)]"
               >
                 <span>
                   {sample ? t("sampleNotice") : t("stat.folder", { folder: folderName ?? "" })}

--- a/src/views/agent-skills/ui/FindingsPanel.tsx
+++ b/src/views/agent-skills/ui/FindingsPanel.tsx
@@ -127,10 +127,12 @@ function Block({
   return (
     <section className="rounded-[var(--radius-card)] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-2 py-2.5">
       <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5 px-1">
-        <h3 className="text-label font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
+        {/* 분석 화면의 같은 카드(제목 + 우측 mono 수치)가 14/11 인데 여기만
+            11/9.5 였다(2026-08-12 실측·처방). 같은 역할 = 같은 단. */}
+        <h3 className="text-body-lg font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
           {title}
         </h3>
-        <p className="text-caption text-[color:var(--color-text-tertiary)]">{note}</p>
+        <p className="font-mono text-label text-[color:var(--color-text-tertiary)]">{note}</p>
       </div>
       <div className="mt-1.5">{children}</div>
     </section>
@@ -146,7 +148,7 @@ function Row({ onClick, children }: { onClick: () => void; children: React.React
       className={controlClass({
         shape: "row",
         size: "sm",
-        className: "justify-between gap-2 text-label",
+        className: "justify-between gap-2 text-body",
       })}
     >
       {children}

--- a/src/views/agent-skills/ui/SkillDetail.tsx
+++ b/src/views/agent-skills/ui/SkillDetail.tsx
@@ -46,7 +46,7 @@ export function SkillDetail({
   return (
     <article className="flex flex-col gap-3" data-testid="skill-detail">
       <header className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
-        <h2 className="text-title text-[color:var(--color-text-primary)]">{skill.name}</h2>
+        <h2 className="text-title font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">{skill.name}</h2>
         <p className="text-label text-[color:var(--color-text-tertiary)]">
           {skill.origin.personal ? t("group.mine") : skill.origin.source}
         </p>
@@ -57,7 +57,7 @@ export function SkillDetail({
           data-testid="skill-detail-rivals"
           className="rounded-[var(--radius-card)] border border-[color:var(--color-amber-source-a25)] bg-[color:var(--color-amber-source-a06)] px-3 py-2.5"
         >
-          <p className="text-label font-[var(--font-weight-emphasis)] text-[color:var(--color-amber-source-text-a80)]">
+          <p className="text-body-lg font-[var(--font-weight-emphasis)] text-[color:var(--color-amber-source-text-a80)]">
             {t("detail.competing")}
           </p>
           <ul className="mt-1.5 flex flex-col gap-1">
@@ -83,10 +83,10 @@ export function SkillDetail({
       ) : null}
 
       <SkillInvocationChain skill={skill} />
-
-      <p className="text-caption leading-prose text-[color:var(--color-text-quaternary)]">
-        {skill.origin.relativePath}
-      </p>
+      {/* 하단에 경로 한 줄이 더 있었는데 지웠다(2026-08-12 실측) — 2단 「뜨면
+          실려요」의 경로와 **바이트 동일**한 문자열이 라벨 없이 136px 아래에 한 번
+          더, 그보다 작은 9.5px 로 떠 있었다. 같은 사실을 라벨 없이 두 번 말하는
+          것은 정보가 아니다. */}
     </article>
   );
 }
@@ -100,7 +100,7 @@ function Jump({ onClick, children }: { onClick: () => void; children: React.Reac
       className={controlClass({
         shape: "link",
         size: "sm",
-        className: "text-left text-label text-[color:var(--color-amber-source-text-a80)]",
+        className: "text-left text-body text-[color:var(--color-amber-source-text-a80)]",
       })}
     >
       {children}

--- a/src/views/agent-skills/ui/SkillInvocationChain.tsx
+++ b/src/views/agent-skills/ui/SkillInvocationChain.tsx
@@ -48,7 +48,7 @@ export function SkillInvocationChain({ skill }: { skill: AgentSkill }) {
         title={t("chain.onTrigger")}
         note={t("chain.chars", { count: onTrigger.chars })}
       >
-        <p className="text-label leading-prose text-[color:var(--color-text-tertiary)]">
+        <p className="text-body leading-body text-[color:var(--color-text-tertiary)]">
           {onTrigger.files[0]}
         </p>
       </Rung>
@@ -59,7 +59,7 @@ export function SkillInvocationChain({ skill }: { skill: AgentSkill }) {
         note={t("chain.fileCount", { count: onDemand.files.length })}
       >
         {onDemand.files.length === 0 ? (
-          <p className="text-label leading-prose text-[color:var(--color-text-tertiary)]">
+          <p className="text-body leading-body text-[color:var(--color-text-tertiary)]">
             {t("chain.noFiles")}
           </p>
         ) : (
@@ -72,8 +72,8 @@ export function SkillInvocationChain({ skill }: { skill: AgentSkill }) {
                   <span
                     className={
                       missing
-                        ? "text-label leading-prose text-[color:var(--color-danger-text)] line-through"
-                        : "text-label leading-prose text-[color:var(--color-text-secondary)]"
+                        ? "text-body leading-body text-[color:var(--color-danger-text)] line-through"
+                        : "text-body leading-body text-[color:var(--color-text-secondary)]"
                     }
                   >
                     {shorten(file)}
@@ -117,11 +117,18 @@ function Rung({
   return (
     <li className="rounded-[var(--radius-card)] border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-3 py-2.5">
       <div className="flex items-baseline justify-between gap-3">
-        <p className="text-label font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
+        {/*
+          * **폴더를 열면 화면이 스스로 2단 작아졌다** (2026-08-12 실측·처방).
+          * 같은 뷰의 빈 화면은 이 3단 약속을 `text-body-lg`(14)로 그리는데, 실제
+          * 사실이 도착하는 이 자리는 `text-label`(11)이었다. 우측 수치도 분석
+          * 화면의 같은 자리(카드 머리 우측 mono 수치)가 11인데 여기만 9.5였다.
+          * 소유자: *"스킬쪽 뭔가 내부 너무작지않음?"* — 램프 단만 올린다, 신설 0.
+          */}
+        <p className="text-body-lg font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
           <span className="mr-1.5 text-[color:var(--color-text-tertiary)]">{index}</span>
           {title}
         </p>
-        <p className="shrink-0 text-caption text-[color:var(--color-text-tertiary)]">{note}</p>
+        <p className="shrink-0 font-mono text-label text-[color:var(--color-text-tertiary)]">{note}</p>
       </div>
       <div className="mt-1.5">{children}</div>
     </li>

--- a/src/views/agent-skills/ui/SkillList.tsx
+++ b/src/views/agent-skills/ui/SkillList.tsx
@@ -68,7 +68,12 @@ export function SkillList({
     <div className="flex flex-col gap-3" data-testid="skills-list">
       {groups.map((group) => (
         <section key={group.source}>
-          <h3 className="px-1 pb-1 text-caption text-[color:var(--color-text-tertiary)]">
+          {/* 소유자: *"스킬쪽 뭔가 내부 너무작지않음?"* (2026-08-12). 실측:
+              뭉치 머리·행 메타·경고 배지가 **전부 9.5px** 라 세 역할이 크기로
+              구분되지 않았다. 머리와 메타는 label(11)로 — 문서함 트리 카운트와
+              같은 단이다. 배지(「이름겹침」)만 caption 에 남는다(규격이 배지에
+              caption 을 허용한 자리). */}
+          <h3 className="px-1 pb-1 text-label text-[color:var(--color-text-tertiary)]">
             {group.personal ? t("group.mine") : group.source}
             <span className="ml-1.5">({group.skills.length})</span>
           </h3>
@@ -107,7 +112,7 @@ export function SkillList({
                     </span>
                     {/* 숫자 셋은 오른쪽 끝에 붙여 **세로로 줄이 맞게** 둔다 —
                         행마다 들쭉날쭉하면 훑을 때 눈이 그 줄을 못 잡는다. */}
-                    <span className="shrink-0 tabular-nums text-caption text-[color:var(--color-text-tertiary)]">
+                    <span className="shrink-0 tabular-nums text-label text-[color:var(--color-text-tertiary)]">
                       {t("row.metrics", {
                         chars: skill.invocation.steps[0].chars,
                         files: skill.invocation.steps[2].files.length,


### PR DESCRIPTION
## Summary

소유자: *"스킬쪽 뭔가 내부 너무작지않음? 우리 디자인 시스템중에 조금 크기 큰걸로 해야할듯"*.

렌더된 화면을 전수 실측하니 지적 그대로였다 — **본문 영역 글자 55개 중 12.5px 를 넘는 것이 2개뿐**(분석 5 · 프로젝트 23), 그중 하나는 내용이 아니라 「다른 폴더 열기」 버튼. 9.5px 하나가 뭉치 머리 · 행 메타 · 경고 배지 · 단계 수치 **네 역할**을 동시에 해 크기로 아무것도 구분되지 않았다.

### 전부 기존 램프 단으로만 (신설 0)

| 요소 | 전 | 후 | 근거 |
|---|---|---|---|
| 호출 사슬 3단 제목 | 11 | **14** | **같은 뷰의 빈 화면이 같은 3단 약속을 이미 14로 그린다** — 폴더를 열면 화면이 스스로 2단 작아지고 있었다 |
| 경쟁 경고 제목 · 개요 카드 제목 | 11 | **14** | 규격 표 「카드 = title + body」 · 분석 화면의 같은 카드가 14 |
| 경쟁 본문 · 개요 행 · 2/3단 페이로드 · 상태 줄 | 11 | **12.5** | 같은 스킬 이름이 좌측 목록(12.5)과 우측(11)에 동시에 다른 크기로 · 페이로드/상태 줄은 `leading-prose`(사용자 글용) 오짝도 `leading-body` 로 |
| 행 메타 · 단계 수치 · 뭉치 머리 | 9.5 | **11** | 분석의 같은 자리(카드 머리 우측 mono 수치)가 11 |
| 상세 h2 | 16/400 | 16/**510** | 크기가 아니라 무게 결함 — 앱에서 무게 400인 16px 제목은 여기뿐 |
| 「실행됨」 칩 · 1단 본문 | 유지 | 유지 | 칩은 규격이 배지에 caption 을 허용한 자리 · 본문까지 올리면 14가 넷 몰려 위계가 도로 납작해진다 |
| 하단 경로 한 줄 | — | **삭제** | 2단 경로와 **바이트 동일**한 문자열이 라벨 없이 136px 아래 9.5px 로 한 번 더 |

측정·처방은 design-guardian(서브에이전트 — 소유자 허가)이 형제 화면 3곳 실측 + 1차 자료 2건 대조로 냈다.

## Test plan

**적용 후 재측정** (렌더된 computed style): 3단 제목 `14px/560` · 행 메타 `11px` · h2 `16px/510` · 2단 페이로드 `12.5px` · 상태 줄 `12.5px` · 하단 중복 경로 **0개** · 12.5px 초과 census 2 → **5**.

| 검사 | 결과 |
|---|---|
| `eslint` (변경 5파일) | 0 error / 0 warning |
| `tsc --noEmit` | 통과 |
| `test:contracts` | 137 파일 / 1598 passed |
| `playwright skills-inventory + screen-hierarchy` | 10 passed (위계 게이트 — h1 초과 없음 확인) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD