### PR TITLE
feat: 구성 탭 도메인 행이 지도로 가는 문이 된다 (#969)

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -1073,6 +1073,20 @@ export function OntologyInsightsPage() {
                 domainRows={domainRows}
                 edgeTypeSummary={edgeTypeSummary}
                 kindLabel={kindLabel}
+                domainLink={{
+                  href: mapNodeHref,
+                  // 막대는 aria-hidden 이라 행의 세 수를 링크 이름에 실어
+                  // 보낸다 — 화면에 있는 사실이 스크린리더에서 사라지면 안 된다
+                  // (「연결」 탭 impactRowAriaLabel 과 같은 규율). 목적지 문구는
+                  // 허브·신선도 행이 이미 쓰는 한 벌(`… : 지도에서 보기`)을
+                  // 그대로 쓴다 — 이 행이 더할 것은 수치뿐이라 새 문구 키를
+                  // 만들지 않는다. 순서는 화면에 보이는 순서 그대로(이름 →
+                  // 합계 → 역량·요소).
+                  ariaLabel: (row) =>
+                    t("hubRowAriaLabel", {
+                      title: `${row.title} ${row.total} · ${kindLabel("capability")} ${row.capabilityCount} · ${kindLabel("element")} ${row.elementCount}`,
+                    }),
+                }}
                 labels={overviewLabels}
               />
             ) : null}

--- a/src/views/ontology-insights/ui/tabs/OverviewTab.test.tsx
+++ b/src/views/ontology-insights/ui/tabs/OverviewTab.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { buildOntologyNodeHref } from "@/entities/knowledge-graph";
 import { OverviewTab, type OverviewTabLabels } from "./OverviewTab";
 
 vi.mock("@/i18n/navigation", () => ({
@@ -31,6 +32,13 @@ const LABELS = {
   elementUnit: "요소",
 } as unknown as OverviewTabLabels;
 
+/** 페이지가 내리는 것과 같은 계약 — 주소는 실제 빌더, 이름은 행의 수치를 싣는다. */
+const DOMAIN_LINK = {
+  href: (nodeId: string) => buildOntologyNodeHref(nodeId, { via: "insights:composition" }),
+  ariaLabel: (row: { title: string; total: number; capabilityCount: number; elementCount: number }) =>
+    `${row.title} ${row.total} · 역량 ${row.capabilityCount} · 요소 ${row.elementCount}: 지도에서 보기`,
+};
+
 const BASE = {
   totalNodes: 5,
   totalEdges: 4,
@@ -49,7 +57,16 @@ const BASE = {
   ],
   edgeTypeSummary: [],
   kindLabel: (kind: string) => kind,
+  domainLink: DOMAIN_LINK,
   labels: LABELS,
+};
+
+const AUTH_ROW = {
+  id: "domain:auth",
+  title: "Auth",
+  capabilityCount: 2,
+  elementCount: 1,
+  total: 3,
 };
 
 /**
@@ -71,21 +88,75 @@ describe("OverviewTab — 도메인 용량", () => {
   });
 
   it("행이 있으면 캡션이 돌아오고 빈 상태 행동은 사라진다", () => {
+    render(<OverviewTab {...BASE} domainRows={[AUTH_ROW]} />);
+    expect(screen.getByText(/왼쪽이 역량/)).toBeInTheDocument();
+    expect(screen.queryByTestId("domain-capacity-empty-action")).not.toBeInTheDocument();
+  });
+
+  /**
+   * 행이 지도로 가는 문인가 — 이 카드가 여섯 행을 그려 놓고 **아무것도 누를 수
+   * 없던** 것이 2026-08-12 census 의 지적이다. 「연결」 탭 허브 행과 같은 문법.
+   */
+  it("도메인 행이 그 도메인의 지도 주소로 간다", () => {
     render(
       <OverviewTab
         {...BASE}
-        domainRows={[
-          {
-            id: "domains/auth",
-            title: "Auth",
-            capabilityCount: 2,
-            elementCount: 1,
-            total: 3,
-          },
-        ]}
+        domainRows={[AUTH_ROW, { id: "domain:billing", title: "Billing", capabilityCount: 1, elementCount: 4, total: 5 }]}
       />,
     );
-    expect(screen.getByText(/왼쪽이 역량/)).toBeInTheDocument();
-    expect(screen.queryByTestId("domain-capacity-empty-action")).not.toBeInTheDocument();
+    const rows = screen.getAllByTestId("insights-domain-row-link");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAttribute(
+      "href",
+      buildOntologyNodeHref("domain:auth", { via: "insights:composition" }),
+    );
+    expect(rows[1]).toHaveAttribute(
+      "href",
+      buildOntologyNodeHref("domain:billing", { via: "insights:composition" }),
+    );
+  });
+
+  /**
+   * 막대·열쇠가 `aria-hidden` 이라, 화면에 보이는 세 수(합계 · 역량 · 요소)가
+   * 링크 이름에 실려야 한다 — 실리지 않으면 스크린리더에서는 이름만 남는다.
+   */
+  it("링크 이름이 그 행의 수치를 싣는다", () => {
+    render(<OverviewTab {...BASE} domainRows={[AUTH_ROW]} />);
+    expect(screen.getByTestId("insights-domain-row-link")).toHaveAttribute(
+      "aria-label",
+      "Auth 3 · 역량 2 · 요소 1: 지도에서 보기",
+    );
+  });
+
+  /**
+   * **감싼 링크는 행의 치수를 바꾸지 않는다.** 이 카드의 여섯 행은 높이가
+   * 같아야 경계 자리를 나란히 비교할 수 있다(치수 규칙성). 값 층의 `row` 는
+   * 세로 인셋(`py-1.5`)과 flex 배치(`flex w-full`)를 싣는데, 안쪽 막대가 자기
+   * 배치를 이미 갖고 있으므로 둘 다 비워야 한다 — 이 단언이 그 세 값이 병합
+   * 결과에 되살아나는 것을 막는다. jsdom 은 레이아웃을 계산하지 않으니 재는
+   * 것은 클래스이고, 그것이 이 층에서 결정론적으로 잴 수 있는 전부다.
+   */
+  it("링크가 행 높이를 늘리지 않는다 — 세로 인셋 0 · 배치는 막대의 것", () => {
+    render(<OverviewTab {...BASE} domainRows={[AUTH_ROW]} />);
+    const classes = screen.getByTestId("insights-domain-row-link").className.split(/\s+/);
+    expect(classes).toContain("py-0");
+    expect(classes).toContain("block");
+    expect(classes).toContain("w-auto");
+    expect(classes).not.toContain("py-1.5");
+    expect(classes).not.toContain("flex");
+    expect(classes).not.toContain("w-full");
+    // 좌우는 허브 행과 같은 상쇄쌍 — 인셋만 밖으로 나가고 축은 그대로다.
+    expect(classes).toContain("-mx-1.5");
+    expect(classes).toContain("px-1.5");
+    expect(classes).not.toContain("px-2");
+    // 배치를 비워도 값 층이 주는 나머지는 남아야 한다 — 초점 링(OS 하늘색이
+    // 아니라 인디고)과 손가락 바닥. 이 둘이 없으면 손으로 쓴 링크와 같다.
+    expect(classes).toContain("focus-visible:ring-2");
+    expect(classes).toContain("atlas-touch-floor");
+  });
+
+  it("빈 상태에는 링크가 없다 — 갈 곳 없는 행을 지어내지 않는다", () => {
+    render(<OverviewTab {...BASE} domainRows={[]} />);
+    expect(screen.queryByTestId("insights-domain-row-link")).not.toBeInTheDocument();
   });
 });

--- a/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/OverviewTab.tsx
@@ -23,6 +23,22 @@ export interface OverviewTabLabels extends InsightsHeroCensusLabels {
   elementUnit: string;
 }
 
+/**
+ * 도메인 행 → 지도 딥링크. 「연결」 탭의 `ConnectionsTabHubLink` 와 **같은
+ * 모양**이다 — 두 탭의 행이 같은 일(그 개념을 지도에서 연다)을 하므로 계약도
+ * 하나여야 한다.
+ */
+export interface OverviewTabDomainLink {
+  /** `buildOntologyNodeHref` — 출처 마커(`via=insights:composition`)까지 실린다. */
+  href: (nodeId: string) => string;
+  /**
+   * 막대는 `aria-hidden` 이므로 **행의 수치가 링크 이름에 실려야 한다**
+   * (「연결」 탭 `impactRowAriaLabel` 과 같은 규율). 그래서 title 만이 아니라
+   * 행 전체를 넘긴다.
+   */
+  ariaLabel: (row: DomainCapacityRow) => string;
+}
+
 export interface OverviewTabProps {
   totalNodes: number;
   totalEdges: number;
@@ -33,6 +49,8 @@ export interface OverviewTabProps {
   domainRows: DomainCapacityRow[];
   edgeTypeSummary: Array<{ key: string; label: string; count: number }>;
   kindLabel: (kind: string) => string;
+  /** 필수다 — 링크 없는 행이 조용히 돌아오는 길을 남기지 않는다. */
+  domainLink: OverviewTabDomainLink;
   labels: OverviewTabLabels;
 }
 
@@ -59,6 +77,7 @@ export function OverviewTab({
   domainRows,
   edgeTypeSummary,
   kindLabel,
+  domainLink,
   labels,
 }: OverviewTabProps) {
   const kindMax = kindRows[0]?.count ?? 0;
@@ -153,12 +172,41 @@ export function OverviewTab({
                 labels={{ capabilityUnit: labels.capabilityUnit, elementUnit: labels.elementUnit }}
               />
               <div className="mt-2.5 flex flex-1 flex-col justify-evenly gap-1">
+                {/*
+                 * **행이 지도로 가는 문이다** (2026-08-12 census: 이 탭에 누를 수
+                 * 있는 것이 0개였다). 링크는 **소비처가 두른다** — 막대 부품은
+                 * `/projects` 카드와 공유되고 그 카드는 이미 전체가 눌리는
+                 * 표면이라, 부품 안에 링크를 넣으면 그쪽이 중첩 인터랙티브가
+                 * 된다(2026-08-09 원장 「두 화면이 같이 바뀐다」). 그래서 부품은
+                 * 표현 전용으로 남는다.
+                 *
+                 * 감싼 링크가 더하는 것은 **히트 영역 · 호버 · 초점 링 · 손가락
+                 * 바닥**뿐이고, 행의 배치는 한 픽셀도 건드리지 않는다:
+                 * `block`/`w-auto` 로 값 층의 flex 행 배치를 비우고(안쪽 막대가
+                 * 자기 배치를 이미 갖는다), `py-0` 로 세로 인셋을 0 으로 되돌려
+                 * **행 높이를 그대로 둔다**(치수 규칙성 — 여섯 행이 같은 높이여야
+                 * 경계 자리를 나란히 비교할 수 있다). 좌우는 허브 행과 같은
+                 * `-mx-1.5 px-1.5` — 호버 면만 카드 인셋 밖으로 6px 나가고
+                 * 글자·막대의 축은 캡션·열쇠와 계속 한 줄에 선다.
+                 */}
                 {domainRows.map((row) => (
-                  <DomainCapacityBar
+                  <Link
                     key={row.id}
-                    row={row}
-                    labels={{ capabilityUnit: labels.capabilityUnit, elementUnit: labels.elementUnit }}
-                  />
+                    href={domainLink.href(row.id)}
+                    aria-label={domainLink.ariaLabel(row)}
+                    data-testid="insights-domain-row-link"
+                    className={controlClass({
+                      shape: "row",
+                      size: "sm",
+                      className:
+                        "-mx-1.5 block w-auto px-1.5 py-0 hover:bg-[color:var(--color-overlay-1)]",
+                    })}
+                  >
+                    <DomainCapacityBar
+                      row={row}
+                      labels={{ capabilityUnit: labels.capabilityUnit, elementUnit: labels.elementUnit }}
+                    />
+                  </Link>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
census 에서 구성 탭은 도메인 행을 그려 놓고 누를 것이 0개였다 — 「어느
영역이 말만 있나」를 본 사람이 그 영역을 지도에서 열 길이 없었다. 연결
탭 허브 행이 이미 하는 그 일(그 개념을 지도에서 연다)이라 계약도 같은
모양으로 맞췄다(href + ariaLabel, via=insights:composition 복귀 마커).

링크는 소비처가 두른다 — 막대 부품은 /projects 카드와 공유되고 그 카드는
전체가 이미 눌리는 표면이라, 부품 안에 링크를 넣으면 그쪽이 중첩
인터랙티브가 된다(2026-08-09 원장 「두 화면이 같이 바뀐다」). 부품은 표현
전용으로 남고 /projects 픽셀 변화 0.

막대는 aria-hidden 이므로 행의 세 수(합계·역량·요소)를 링크 이름에 실어
보낸다. 새 문구 키는 만들지 않았다 — 허브·신선도 행이 쓰는 「…: 지도에서
보기」 한 벌에 수치를 실었다(messages 는 이 회차 소유 밖).

구현: design-guardian(서브에이전트, 소유자 허가). 통합자 재검증:
vitest 27파일 211 통과 · tsc 클린 · 실측(내장 견본, 도메인 9행) 높이
전부 42(치수 규칙성) · 겹침 0 · x 정렬 한 값 · href/aria 정확.
프로브: href 상수화 + aria 제거 → 시험 2건 빨강 → 복구 초록.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD
