### PR TITLE
fix: 웹이 depends_on 관계를 잃어버리고 있었다 — 정본 키를 드디어 읽는다 (#971)

### DIFF
--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.test.ts
@@ -262,6 +262,48 @@ describe('deriveOntologyFromVault', () => {
     expect(depEdges.find((e) => e.to === 'project:user-store')).toBeDefined();
   });
 
+  it('depends_on (스키마 정본 키) → dependencies 와 같은 자리에서 depends_on edge', () => {
+    // mcp/src/schema.mjs 는 capability/element 의 캐논 키를 `depends_on` 으로
+    // 두고, MCP vault.mjs 는 alias 로 둘 다 읽는다. 웹 derive 가 `dependencies`
+    // 만 읽으면 에이전트가 정본 키로 쓴 의존 관계가 지도에서 통째로 소실된다.
+    const result = deriveOntologyFromVault(
+      makeManifest([
+        makeDoc({
+          slug: 'capabilities/token-issue',
+          frontmatter: {
+            kind: 'capability',
+            depends_on: ['jwt-signer', 'key-store'],
+          },
+        }),
+      ]),
+    );
+    const depEdges = result.edges.filter((e) => e.type === 'depends_on');
+    expect(depEdges).toHaveLength(2);
+    expect(depEdges.find((e) => e.to === 'capability:jwt-signer')).toBeDefined();
+    expect(depEdges.find((e) => e.to === 'capability:key-store')).toBeDefined();
+  });
+
+  it('dependencies + depends_on 합집합 — 같은 대상은 한 번만', () => {
+    const result = deriveOntologyFromVault(
+      makeManifest([
+        makeDoc({
+          slug: 'capabilities/session',
+          frontmatter: {
+            kind: 'capability',
+            dependencies: ['shared-target', 'only-dep'],
+            depends_on: ['shared-target', 'only-alias'],
+          },
+        }),
+      ]),
+    );
+    const depEdges = result.edges.filter((e) => e.type === 'depends_on');
+    expect(depEdges.map((e) => e.to).sort()).toEqual([
+      'capability:only-alias',
+      'capability:only-dep',
+      'capability:shared-target',
+    ]);
+  });
+
   it('kind 없는 doc 은 무시', () => {
     const result = deriveOntologyFromVault(
       makeManifest([

--- a/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
+++ b/src/entities/docs-vault/lib/derive-ontology-from-vault.ts
@@ -549,8 +549,16 @@ function deriveOntologyFromVaultUncached(
       });
     }
 
-    // dependencies[] — depends_on edge
-    for (const dep of asStringArray(fm.dependencies)) {
+    // dependencies[] + depends_on[] — depends_on edge. 스키마 정본
+    // (mcp/src/schema.mjs)은 capability/element 의 캐논 키가 `depends_on`,
+    // project 가 `dependencies` 이고, MCP 는 alias 로 둘 다 읽는다
+    // (vault.mjs NEIGHBOR_KEY_ALIASES). 웹 derive 만 `dependencies` 하나를
+    // 읽어서 에이전트가 정본 키로 쓴 의존 관계가 지도·캡션에서 통째로
+    // 소실됐다(2026-08-12) — describes(2026-07-27)와 같은 부류의 구멍.
+    // 같은 대상이 두 키에 있으면 resolve 된 depId 기준으로 한 번만.
+    // 게이트: tests/contract/derive-relation-keys.contract.test.ts.
+    const seenDepIds = new Set<string>();
+    for (const dep of [...asStringArray(fm.dependencies), ...asStringArray(fm.depends_on)]) {
       const folderRef = resolveFolderPrefixedRef(dep);
       const depSlug = folderRef
         ? folderRef.id.split(':').at(-1)
@@ -558,6 +566,8 @@ function deriveOntologyFromVaultUncached(
       if (!depSlug) continue;
       // dependencies 는 같은 종 (project) 사이를 가리키는 게 일반적이라 추측.
       const depId = existingNodeIdFor(dep) ?? folderRef?.id ?? `${docNode.kind}:${depSlug}`;
+      if (seenDepIds.has(depId)) continue;
+      seenDepIds.add(depId);
       if (!nodes.has(depId)) {
         nodes.set(depId, {
           id: depId,

--- a/tests/contract/derive-relation-keys.contract.test.ts
+++ b/tests/contract/derive-relation-keys.contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { DEPENDS_UNION_CASE, RELATION_KEY_CASES } from "../fixtures/relation-keys-cases.mjs";
+import { deriveOntologyFromVault } from "@/entities/docs-vault/lib/derive-ontology-from-vault";
+import type { VaultDoc, VaultManifest } from "@/entities/docs-vault/model/types";
+// MCP 는 정본 (읽기 전용) — 웹이 이쪽을 따라간다.
+import { GRAPH_ARRAY_KEYS, collectNeighborRefs } from "../../mcp/src/vault.mjs";
+
+/**
+ * 2-way 계약 — 관계 키를 읽는 곳이 두 패키지에 산다:
+ *   - mcp/src/vault.mjs (AI agent surface — 정본, GRAPH_ARRAY_KEYS)
+ *   - src/entities/docs-vault/lib/derive-ontology-from-vault.ts (웹 지도·공방·인사이트)
+ *
+ * 웹 derive 가 MCP 의 관계 키 하나를 안 읽으면, 에이전트가 정본 키로 쓴
+ * 관계가 사람 화면에서 소실된다 — describes(2026-07-27) 와 depends_on
+ * (2026-08-12) 이 정확히 그렇게 새어 나갔다. 같은 fixture 표
+ * (`tests/fixtures/relation-keys-cases.mjs`) 를 양쪽에 넣어 대조한다.
+ */
+
+function makeDoc(slug: string, frontmatter: Record<string, unknown>): VaultDoc {
+  return {
+    slug,
+    path: `${slug}.md`,
+    title: slug,
+    description: undefined,
+    tags: [],
+    frontmatter,
+    headings: [],
+    excerpt: "",
+    wordCount: 0,
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    linksOut: [],
+  };
+}
+
+function makeManifest(docs: VaultDoc[]): VaultManifest {
+  return {
+    version: "2026-04-23",
+    generatedAt: new Date().toISOString(),
+    docs,
+    backlinksDetail: {},
+    tags: {},
+    tree: { name: "root", path: "", type: "dir" },
+  };
+}
+
+describe("relation-keys contract — 웹 derive 가 MCP 관계 키를 전부 읽는다", () => {
+  it("fixture 표가 MCP GRAPH_ARRAY_KEYS 전집합을 덮는다 (새 키 → 즉시 fail)", () => {
+    const fixtureKeys = RELATION_KEY_CASES.map((c) => c.key).sort();
+    const mcpKeys = [...GRAPH_ARRAY_KEYS].sort();
+    expect(fixtureKeys).toEqual(mcpKeys);
+  });
+
+  // 공회전 방지 — 표가 비어 있으면 아래 루프는 아무것도 증명하지 않는다.
+  it("fixture 표는 공집합이 아니다", () => {
+    expect(RELATION_KEY_CASES.length).toBeGreaterThanOrEqual(9);
+  });
+
+  for (const c of RELATION_KEY_CASES) {
+    describe(`key: ${c.key}`, () => {
+      it("MCP collectNeighborRefs 가 이 키를 읽는다", () => {
+        const refs = collectNeighborRefs({ frontmatter: c.frontmatter }) as {
+          key: string;
+          ref: string;
+        }[];
+        expect(refs.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it("웹 derive 가 같은 키에서 엣지를 만든다", () => {
+        const result = deriveOntologyFromVault(
+          makeManifest([makeDoc(`fixtures/${c.key}-case`, c.frontmatter)]),
+        );
+        const matched = result.edges.filter((e) => e.type === c.expectedEdgeType);
+        expect(matched.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  }
+
+  describe("dependencies + depends_on 합집합 — 같은 대상은 한 번만", () => {
+    it("MCP: canonical dependencies ref 3개", () => {
+      const refs = collectNeighborRefs({ frontmatter: DEPENDS_UNION_CASE.frontmatter }) as {
+        key: string;
+        ref: string;
+      }[];
+      const depRefs = refs.filter((r) => r.key === "dependencies").map((r) => r.ref);
+      expect(depRefs.sort()).toEqual(DEPENDS_UNION_CASE.expectedRefs);
+    });
+
+    it("웹 derive: depends_on 엣지 3개", () => {
+      const result = deriveOntologyFromVault(
+        makeManifest([makeDoc("capabilities/union-case", DEPENDS_UNION_CASE.frontmatter)]),
+      );
+      const targets = result.edges
+        .filter((e) => e.type === "depends_on")
+        .map((e) => e.to.split(":").at(-1))
+        .sort();
+      expect(targets).toEqual(DEPENDS_UNION_CASE.expectedRefs);
+    });
+  });
+});

--- a/tests/fixtures/relation-keys-cases.mjs
+++ b/tests/fixtures/relation-keys-cases.mjs
@@ -1,0 +1,78 @@
+/**
+ * 관계 키 매트릭스 — MCP 가 그래프 엣지로 읽는 frontmatter 키 전집합
+ * (`mcp/src/vault.mjs` GRAPH_ARRAY_KEYS = NEIGHBOR_KEYS + alias `depends_on`)
+ * 과, 각 키가 웹 derive (`derive-ontology-from-vault`) 에서 만들어야 하는
+ * 엣지 타입의 표. 이 표 하나만 진실원이다.
+ *
+ * 계약 (`tests/contract/derive-relation-keys.contract.test.ts`):
+ *   1. MCP 가 키를 새로 들이면 이 표가 그 키를 모를 것이므로 즉시 fail —
+ *      웹 derive 가 조용히 그 키를 흘리는 회귀(describes 2026-07-27,
+ *      depends_on 2026-08-12)를 구조적으로 차단한다.
+ *   2. 표의 각 행을 MCP `collectNeighborRefs` 와 웹 derive 양쪽에 넣어
+ *      둘 다 그 키를 실제로 읽는지 대조한다.
+ */
+export const RELATION_KEY_CASES = [
+  {
+    key: 'domains',
+    frontmatter: { kind: 'project', domains: ['billing'] },
+    /** 웹 derive 가 이 키에서 만들어야 하는 OntologyStubEdge.type */
+    expectedEdgeType: 'contains',
+  },
+  {
+    key: 'capabilities',
+    frontmatter: { kind: 'project', capabilities: ['checkout'] },
+    expectedEdgeType: 'contains',
+  },
+  {
+    key: 'elements',
+    frontmatter: { kind: 'capability', elements: ['jwt-signer'] },
+    expectedEdgeType: 'contains',
+  },
+  {
+    key: 'contains',
+    frontmatter: { kind: 'domain', contains: ['sub-area'] },
+    expectedEdgeType: 'contains',
+  },
+  {
+    key: 'dependencies',
+    frontmatter: { kind: 'project', dependencies: ['user-store'] },
+    expectedEdgeType: 'depends_on',
+  },
+  {
+    // 스키마 정본 키 (capability/element 캐논, mcp/src/schema.mjs) —
+    // MCP 는 alias 로 dependencies 에 접는다. 웹 derive 도 같은 자리에서
+    // 읽어야 한다 (2026-08-12: 이 키만 웹에서 소실되던 구멍).
+    key: 'depends_on',
+    frontmatter: { kind: 'capability', depends_on: ['key-store'] },
+    expectedEdgeType: 'depends_on',
+  },
+  {
+    key: 'relates',
+    frontmatter: { kind: 'capability', relates: ['sibling-cap'] },
+    expectedEdgeType: 'related_to',
+  },
+  {
+    key: 'describes',
+    frontmatter: { kind: 'document', describes: ['capabilities/checkout'] },
+    expectedEdgeType: 'describes',
+  },
+  {
+    key: 'broader',
+    frontmatter: { kind: 'capability', broader: ['parent-concept'] },
+    expectedEdgeType: 'is_a',
+  },
+];
+
+/**
+ * 합집합 계약 — 같은 대상이 `dependencies` 와 `depends_on` 두 키에 다 있으면
+ * 한 번만 센다. MCP `collectNeighborRefs` 는 canonical-key+ref 로 dedupe 해
+ * 3개의 ref 를, 웹 derive 는 3개의 depends_on 엣지를 내야 한다.
+ */
+export const DEPENDS_UNION_CASE = {
+  frontmatter: {
+    kind: 'capability',
+    dependencies: ['shared-target', 'only-dep'],
+    depends_on: ['shared-target', 'only-alias'],
+  },
+  expectedRefs: ['only-alias', 'only-dep', 'shared-target'],
+};


### PR DESCRIPTION
에이전트가 MCP 스키마 정본 키(depends_on)로 쓴 관계가 사람 화면에서
소실되고 있었다. 실측: 시드 관계 4(contains 3 + depends_on 1) → 지도
실엣지 3(전부 contains), 캡션 「4 개념 · 3 관계」. 지도 범례는 「의존」
채널을 광고하면서 그 채널로 올 것을 반쪽만 읽고 있었다 — 웹 derive 가
fm.dependencies 만 읽고 정본 별칭을 안 읽었다. 공방 쓰기 병합·건강 지표·
검증기는 이미 둘 다 읽는데 그래프원만 빠져 있었다.

두 키를 합집합으로 읽는다(같은 대상이 두 키에 있으면 한 번). 계약으로
잠근다: MCP GRAPH_ARRAY_KEYS 9키 전집합 커버리지 단언 + 키별 MCP·웹
2-way 대조 fixture 표(tests/fixtures/relation-keys-cases.mjs) — 한쪽이
키를 더하거나 빼면 표가 먼저 막는다.

TDD: 수리 전 4건 빨강(전부 웹 derive 쪽, MCP 쪽 단언은 통과) → 수리 후
전부 초록.

남긴 구멍 하나(반쪽 수리 금지): 문서함 백링크(build-local-manifest.ts)도
depends_on·broader 를 누락하는데, 짝인 scripts/build-docs-vault.mjs 와
같은 커밋으로 고쳐야 해서 다음 회차로 — 백로그에 기록.

구현: 서브에이전트(소유자 허가). 통합자 재검증: vitest 22파일 186 통과 ·
계약 138파일 1621 통과 · tsc 클린 · 웹 스모크 10 통과.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD
