### PR TITLE
fix: 프로젝트 상세·404 의 단어 끊김 5건과 「지도에서 보기」 중복을 정리한다 (#972)

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -66,7 +66,11 @@ export default function LocaleNotFound() {
         <h1 className="mt-4 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {t("title")}
         </h1>
-        <p className="mt-3 text-body leading-body text-[color:var(--color-text-secondary)]">
+        {/*
+         * `break-keep` — 루트 not-found 와 같은 문단 · 같은 처방 (2026-08-12 실측
+         * 「바뀌었|을」, 실폭 382px). 두 404 는 쌍둥이라 한쪽만 고치면 어긋난다.
+         */}
+        <p className="mt-3 break-keep text-body leading-body text-[color:var(--color-text-secondary)]">
           {t("body")}
         </p>
         <div className="mt-5 flex flex-col gap-2">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -87,7 +87,15 @@ export default function NotFound() {
         <h1 className="mt-4 text-display tracking-[var(--tracking-section)] font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)]">
           {t.title}
         </h1>
-        <p className="mt-3 text-body leading-body text-[color:var(--color-text-secondary)]">
+        {/*
+         * `break-keep` — **한국어는 단어 중간에서 끊기면 읽다가 걸린다** (2026-08-12 실측).
+         *
+         * 이 문단이 440px 카드(실폭 382px)에서 「바뀌었|을」로 끊겼다 (계기: 글자마다
+         * Range 를 재서 줄이 바뀐 자리의 앞뒤 글자를 본다 — 둘 다 한글이고 공백이
+         * 없으면 단어 중간이다). 원인은 `word-break: normal` 이고, 이 저장소는 이미
+         * 다른 자리에서 `break-keep` 을 쓰고 있었다.
+         */}
+        <p className="mt-3 break-keep text-body leading-body text-[color:var(--color-text-secondary)]">
           {t.body}
         </p>
         <div className="mt-5 flex flex-col gap-2">

--- a/messages/en.json
+++ b/messages/en.json
@@ -1651,7 +1651,6 @@
       "metricRelations": "Relations",
       "minimapLabel": "Domain map",
       "minimapSublabel": "more inside draws bigger",
-      "minimapOpenInTopology": "Open in topology",
       "minimapAria": "Mini domain map: {domains} domains, {relations} relations",
       "domainSectionTitle": "Domain composition",
       "domainSectionRelation": "Contains",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1651,7 +1651,6 @@
       "metricRelations": "관계",
       "minimapLabel": "도메인 지도",
       "minimapSublabel": "많이 담긴 도메인이 더 크게",
-      "minimapOpenInTopology": "지도에서 보기",
       "minimapAria": "도메인 구성 미니 지도: 도메인 {domains}개, 관계 {relations}개",
       "domainSectionTitle": "도메인 구성",
       "domainSectionRelation": "포함",

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -614,15 +614,16 @@ export function ProjectDetailPage({
 
         {domainComposition.domains.length > 0 ? (
           <div className="flex flex-none flex-col border-t border-[color:var(--color-divider)] pt-4 lg:w-[380px] lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
+            {/*
+              여기 있던 「지도에서 보기」 링크를 지웠다 (2026-08-12 실측). 같은
+              히어로 밴드의 주 액션 버튼(project-detail-topology-link)과 라벨도
+              목적지(getTopologyProjectHref)도 완전히 같아, 한 화면 같은 행에
+              같은 라벨이 두 번 있었다 — 같은 라벨 반복 금지(design.md, 「개념
+              정보」 3회 전례). 진짜 같은 일이므로 분화가 아니라 하나만 남긴다.
+            */}
             <div className="flex items-baseline gap-2 font-mono text-caption uppercase tracking-[var(--tracking-caps-14)] text-[color:var(--color-text-quaternary)]">
               <span>{t("minimapLabel")}</span>
               <span className="normal-case tracking-[var(--tracking-caption)]">{t("minimapSublabel")}</span>
-              <Link
-                href={getTopologyProjectHref(project.slug)}
-                className={controlClass({ shape: "link", tone: "muted", className: "ml-auto shrink-0 normal-case tracking-[var(--tracking-caption)] hover:text-[color:var(--color-text-secondary)]" })}
-              >
-                {t("minimapOpenInTopology")}
-              </Link>
             </div>
             <MiniDomainMap
               projectTitle={project.name}
@@ -745,8 +746,11 @@ export function ProjectDetailPage({
           </div>
           {bodyContent ? (
             // #10 — 본문은 읽기 좋은 가로폭(measure)으로 제한한다.
+            // `break-keep` — 한국어 본문이 584px 에서 「장바|구니」처럼 단어
+            // 중간에 끊겼다 (2026-08-12 실측). word-break 는 상속되므로 이
+            // 래퍼 한 곳이 마크다운 문단 전부를 덮는다.
             <div
-              className={`${storyMarkdownClassName} max-w-[var(--measure-prose)]`}
+              className={`${storyMarkdownClassName} max-w-[var(--measure-prose)] break-keep`}
               data-testid="project-detail-body-content"
             >
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{dedupedBodyContent}</ReactMarkdown>
@@ -812,7 +816,12 @@ export function ProjectDetailPage({
                   size="compact"
                   icon={<Waypoints size={ICON_SIZE.lg} aria-hidden />}
                   title={t("connectedEmpty")}
-                  description={t("connectedEmptyHint")}
+                  /*
+                   * `break-keep` — 이 설명이 280px 에서 「여기 나타|납니다」로 단어
+                   * 중간에 끊겼다 (2026-08-12 실측, 같은 계기). EmptyState 의 설명
+                   * `<p>` 는 공용이라 여기서 감싼 span 으로만 좁게 건다.
+                   */
+                  description={<span className="break-keep">{t("connectedEmptyHint")}</span>}
                 />
               </div>
             )}
@@ -835,7 +844,15 @@ export function ProjectDetailPage({
                 {t("handoffTitle")}
               </span>
             </div>
-            <p className="mb-3 text-body leading-body text-[color:var(--color-text-tertiary)]">
+            {/*
+             * `break-keep` — **한국어는 단어 중간에서 끊기면 읽다가 걸린다** (2026-08-12 실측).
+             *
+             * 이 문단이 400px 레일(실폭 362px)에서 「이 프로젝|트의 지도를」로 끊겼다
+             * (계기: 글자마다 Range 를 재서 줄이 바뀐 자리의 앞뒤 글자를 본다 — 둘 다
+             * 한글이고 공백이 없으면 단어 중간이다). 원인은 `word-break: normal` 이고,
+             * 이 저장소는 이미 다른 자리에서 `break-keep` 을 쓰고 있었다.
+             */}
+            <p className="mb-3 break-keep text-body leading-body text-[color:var(--color-text-tertiary)]">
               {t("handoffDesc")}
             </p>
             <Button type="button" variant="outline" size="sm" onClick={handleCopyHandoff}>

--- a/tests/e2e/korean-word-break.spec.ts
+++ b/tests/e2e/korean-word-break.spec.ts
@@ -38,6 +38,25 @@ const ROUTES = [
   "/ko/projects/",
   "/ko/docs/",
   "/ko/",
+  /*
+   * 프로젝트 상세 (2026-08-12 census S급). **slug 쿼리가 꼭 있어야 한다** — 맨
+   * `/ko/project/fallback/` 은 `resolveProjectFallbackRoute` 가 null 을 돌려줘
+   * `/projects` 로 리다이렉트되므로, 그대로 넣으면 이 라우트는 위 `/ko/projects/`
+   * 를 두 번 재는 공회전이 된다. `storefront` 는 볼트 없이도 항상 있는 빌드타임
+   * dogfood 데모 프로젝트다. 여기서 실측 4건: 본문 마크다운 「장바|구니」 ·
+   * 연결-빈 상태 「여기 나타|납니다」(280px) · 핸드오프 「이 프로젝|트의
+   * 지도를」(362px) 외 1.
+   */
+  "/ko/project/fallback/?slug=storefront",
+  /*
+   * 404 (census 「바뀌었|을」 382px). 실제로 404 를 그리는 주소여야 한다 —
+   * dev 는 미해결 경로에 루트 `app/not-found.tsx` 를 그리고, 정적 export 는
+   * `scripts/serve-static-export.mjs` 가 같은 컴포넌트로 빌드된 `/404.html` 을
+   * 내려 준다(locale 은 URL 첫 세그먼트로 클라이언트 감지 → ko 문구).
+   * ⚠️ `/ko/project/<없는-slug>/` 는 못 쓴다 — dev 에서 동적 [slug] 라우트가
+   * 404 대신 500 을 낸다(output:'export' + 미생성 param, 2026-08-12 실측).
+   */
+  "/ko/이런-주소는-없다/",
 ] as const;
 
 interface BreakScan {
@@ -100,7 +119,10 @@ test("한국어 문장이 단어 중간에서 끊기지 않는다", async ({ pag
   let wrappedTotal = 0;
 
   for (const route of ROUTES) {
-    await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
+    // 쿼리를 이미 가진 라우트(`?slug=`)에 `?guides=off` 를 그대로 붙이면
+    // `?…?…` 로 slug 가 깨진다 — 구분자를 라우트 모양에 따라 고른다.
+    const separator = route.includes("?") ? "&" : "?";
+    await page.goto(`${route}${separator}guides=off`, { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(1_800);
     const result = await scan(page);
     wrappedTotal += result.wrappedTexts;


### PR DESCRIPTION
census 실측 후속. 프로젝트 상세(fallback)와 404 화면에서 한국어가 단어
중간에서 끊기고 있었다 — 「바뀌었|을」(382px) · 「이 프로젝|트의
지도를」(362px) · 「여기 나타|납니다」(280px), 그리고 조사 중 2건 더
(본문 마크다운 「장바|구니」 포함). 전부 break-keep 으로, 렌더 확인까지
(computed keep-all). 404 는 쌍둥이 둘(app/not-found + [locale]/not-found)
다 고쳤다.

korean-word-break 게이트의 사정거리를 넓혔다: /ko/project/fallback/
?slug=storefront (맨 fallback 은 /projects 리다이렉트라 공회전 — slug
필수, 주석 명기)와 404 실주소. 쿼리 가진 라우트의 ?guides=off 구분자
분기도 함께. 프로브: break-keep 하나를 되돌리니 정확히 그 라우트·그
문장으로 빨강 → 복구 초록 (접힌 문장 8개 관측 — 공회전 아님).

「지도에서 보기」는 census 의 3회가 아니라 실측 2회였고, 같은 행(y=131)
에서 같은 라벨·같은 목적지였다 — 분화가 아니라 중복이라 미니맵 헤더
링크를 지우고 주 액션 버튼만 남겼다. 죽은 키는 두 로케일에서 삭제.

구현: 서브에이전트(소유자 허가). 통합자 재검증: vitest 12파일 83 통과 ·
i18n 16 통과 · word-break 게이트 초록(접힘 8 · 끊김 0) · tsc 클린.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD
