### PR TITLE
fix: accent×틴트 짝 규칙이 삼항식을 못 보던 구멍을 막고, 그 구멍으로 산 위반 2곳을 고친다 (#978)

### DIFF
--- a/.claude/rules/design-gates.md
+++ b/.claude/rules/design-gates.md
@@ -168,6 +168,26 @@ paths:
   조용히 건너뛰었다. **자기검증 프로브가 그 구멍에서 실패해 잡아냈다** — 심어 둔
   미달을 못 잡으면 이 게이트의 0건은 증거가 아니다.
 
+### 직계 결합자(`>`)는 삼항식을 못 본다 (2026-08-13)
+
+accent×틴트 짝 규칙이 `[name.name="tone"] > Literal[value="accent"]` 로 **직계
+리터럴만** 봤다. `tone={cond ? "accent" : …}` 는 리터럴이
+JSXExpressionContainer→ConditionalExpression 아래라 그냥 통과했고, 실사용 2곳이
+그 모양으로 살아 있었다 — 하나는 조건이 className 삼항과 **상관**이라 accent
+가지와 인디고 틴트 가지가 정확히 같이 켜졌다(VaultStartChecklist), 다른 하나는
+두 가지 모두 틴트 면이었다(DependencyPicker).
+
+확장 형태: 각 짝을 「직계 리터럴 ∪ `ConditionalExpression > Literal`」 로.
+가지 위치(consequent/alternate)만 잡히므로 `x === "accent"` 같은 **비교
+리터럴은 오탐하지 않는다**(BinaryExpression 아래라 `>` 에 안 걸림) — 프로브
+5종(직계 위반·JSX 삼항 위반·객체 삼항 위반·비교 리터럴 정상·틴트 없는 삼항
+정상)으로 확인했다.
+
+**켜기 전 census 의 함정**: 첫 전수는 `tone={` 만 grep 해서 JSX 삼항 1곳만
+찾았다 — 객체 표기(`tone: cond ? …`)를 안 봤고, 룰을 넓히자마자 두 번째
+현장이 걸렸다. 같은 규격에 표기가 둘이면 census 도 두 벌이어야 한다(위
+「클래스가 아니라 문법으로」와 같은 계열).
+
 ### 클래스가 아니라 문법으로 빠져나간 경우 (2026-08-04)
 
 위의 기하 허용목록은 `shadow-[…]` 라는 **클래스 문자열**을 본다. 그림자를 JSX

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -384,7 +384,7 @@ particle·rarity(gold)·shimmer 를 `--studio-*` 토큰과 `.studio-stage` 안�
 | **중복 커서** | `<button>`·`<summary>` 의 className 에 `cursor-pointer` 를 다시 적는 것 금지 — 정책은 `globals.css` base 한 곳 (2026-08-05) | 동일 (켤 때 위반 0 — 13곳 선정리) |
 | **비활성 흐림** | `disabled:opacity-*` 는 55 외 값 금지 — 정본은 값 층 `CONTROL_DISABLED_CLASS`(한 세트: 흐림·커서·그림자·호버 무력화), 손 컨트롤은 상수 조합 (2026-08-06) | 동일 (켤 때 위반 0 — 9곳 선치환) |
 | 금지 그라디언트 | `scaleGradientSelectors` | 동일 |
-| **accent×틴트 페어링** | `accentTintPairingSelectors` — `tone accent` 와 인디고/앰버 틴트 `bg-` 가 같은 호출/원소에 공존 금지 (상수 우회는 `accent-ink-contrast` 계약이 맡는다) | 전역 error (켤 때 위반 0 — 26곳 선치환) |
+| **accent×틴트 페어링** | `accentTintPairingSelectors` — `tone accent` 와 인디고/앰버 틴트 `bg-` 가 같은 호출/원소에 공존 금지. **삼항식 가지(`tone={cond ? "accent" : …}`)도 잡는다**(2026-08-13 확장 — 직계만 보던 시절 실사용 2곳이 빠져나가 있었다). 상수 우회는 `accent-ink-contrast` 계약이 맡는다 | 전역 error |
 
 > **표에 나온 말 넷** — 「램프(ramp)」는 쓸 수 있는 값을 미리 정해 둔 사다리이고,
 > 그 밖의 값은 lint 가 막는다. 「셀렉터」는 ESLint 가 코드에서 무엇을 찾아낼지

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -354,18 +354,27 @@ const layerSelectors = [
   },
 ];
 
+/*
+ * ⚠️ **직계(`>`)만 보면 삼항식이 빠져나간다** (2026-08-13 실측 — design-gates.md
+ * 「정적 셀렉터는 리터럴만 본다」 계열). `tone={cond ? "accent" : …}` 는 Literal
+ * 이 JSXExpressionContainer→ConditionalExpression 아래라 종전 셀렉터에 안 걸렸고,
+ * 실제로 VaultStartChecklist 가 그 모양으로 accent+인디고 틴트를 한 원소에 얹은
+ * 채 살아 있었다. 그래서 각 짝을 「직계 리터럴 ∪ 삼항 가지의 리터럴」로 넓힌다 —
+ * `ConditionalExpression > Literal` 은 가지(consequent/alternate) 위치만 잡으므로
+ * `x === "accent"` 같은 비교 리터럴(BinaryExpression 아래)은 오탐하지 않는다.
+ */
 const accentTintPairingSelectors = [
   {
     selector:
-      'CallExpression[callee.name="controlClass"] ObjectExpression:has(Property[key.name="tone"] > Literal[value="accent"]):has(Property[key.name="className"] :matches(Literal[value=/bg-\\[color:var\\(--color-(indigo|amber)/], TemplateElement[value.raw=/bg-\\[color:var\\(--color-(indigo|amber)/]))',
+      'CallExpression[callee.name="controlClass"] ObjectExpression:has(:matches(Property[key.name="tone"] > Literal[value="accent"], Property[key.name="tone"] ConditionalExpression > Literal[value="accent"])):has(Property[key.name="className"] :matches(Literal[value=/bg-\\[color:var\\(--color-(indigo|amber)/], TemplateElement[value.raw=/bg-\\[color:var\\(--color-(indigo|amber)/]))',
     message:
-      '인디고/앰버 틴트 채움 위 잉크는 tone accent(#7170ff, 합성 대비 3.5~4.4:1 — AA 미달)가 아니라 accentOnTint 다. 근거: tests/contract/accent-ink-contrast.contract.test.ts',
+      '인디고/앰버 틴트 채움 위 잉크는 tone accent(#7170ff, 합성 대비 3.5~4.4:1 — AA 미달)가 아니라 accentOnTint 다. 삼항식 가지도 같다. 근거: tests/contract/accent-ink-contrast.contract.test.ts',
   },
   {
     selector:
-      'JSXOpeningElement:has(JSXAttribute[name.name="tone"] > Literal[value="accent"]):has(JSXAttribute[name.name="className"] :matches(Literal[value=/bg-\\[color:var\\(--color-(indigo|amber)/], TemplateElement[value.raw=/bg-\\[color:var\\(--color-(indigo|amber)/]))',
+      'JSXOpeningElement:has(:matches(JSXAttribute[name.name="tone"] > Literal[value="accent"], JSXAttribute[name.name="tone"] JSXExpressionContainer ConditionalExpression > Literal[value="accent"])):has(JSXAttribute[name.name="className"] :matches(Literal[value=/bg-\\[color:var\\(--color-(indigo|amber)/], TemplateElement[value.raw=/bg-\\[color:var\\(--color-(indigo|amber)/]))',
     message:
-      '인디고/앰버 틴트 채움 위 잉크는 tone="accent"(#7170ff, AA 미달)가 아니라 tone="accentOnTint" 다. 근거: tests/contract/accent-ink-contrast.contract.test.ts',
+      '인디고/앰버 틴트 채움 위 잉크는 tone="accent"(#7170ff, AA 미달)가 아니라 tone="accentOnTint" 다. 삼항식 가지(tone={cond ? "accent" : …})도 같다. 근거: tests/contract/accent-ink-contrast.contract.test.ts',
   },
 ];
 

--- a/src/features/project-edit/ui/DependencyPicker.tsx
+++ b/src/features/project-edit/ui/DependencyPicker.tsx
@@ -124,7 +124,13 @@ export function DependencyPicker({
               className={controlClass({
                 shape: 'pill',
                 size: 'lg',
-                tone: p.isHub ? 'accent' : 'strong',
+                /*
+                 * 두 가지 다 인디고 틴트 면(아래 a20/a12) 위라 accent 잉크는 AA
+                 * 미달이다(합성 3.5~4.4:1 — accent-ink-contrast 계약). 허브 강조는
+                 * accentOnTint 가 같은 인디고 계열로 진다. 이 줄은 객체 삼항이라
+                 * 종전 짝 규칙을 빠져나가 있었다(2026-08-13 게이트 구멍 수리).
+                 */
+                tone: p.isHub ? 'accentOnTint' : 'strong',
                 className: cn(
                   'group gap-1.5 border-[color:var(--color-indigo-brand)]',
                   p.isHub

--- a/src/widgets/topology-controls/ui/VaultStartChecklist.tsx
+++ b/src/widgets/topology-controls/ui/VaultStartChecklist.tsx
@@ -117,7 +117,13 @@ export function VaultStartChecklist({
       cta: onOpenAgentConnect ? (
         <Chip
           size="md"
-          tone={hasDocs ? "secondary" : "accent"}
+          /*
+           * 인디고 틴트 면(아래 className 의 indigo-a16) 위 잉크는 accent 가
+           * 아니라 accentOnTint 다 — accent(#7170ff)는 틴트 위 합성 대비
+           * 3.5~4.4:1 로 AA 미달(accent-ink-contrast 계약). 이 줄은 삼항식이라
+           * 짝 규칙 lint 를 빠져나가 있었다(2026-08-13 게이트 구멍 수리에서 적발).
+           */
+          tone={hasDocs ? "secondary" : "accentOnTint"}
           onClick={onOpenAgentConnect}
           data-testid="checklist-cta-agent"
           /*


### PR DESCRIPTION
위생 소탕이 지목한 게이트 구멍: 규칙이 직계 리터럴(> Literal)만 봐서
tone={cond ? "accent" : …} 가 빠져나갔다. 넓혀 보니 실사용 위반이 정말
둘 있었다 —

- VaultStartChecklist: hasDocs=false 갈래에서 accent 잉크 + 인디고 a16
  틴트가 같은 원소에(조건이 className 삼항과 상관이라 두 가지가 정확히
  같이 켜짐). 첫 실행 지도에서 사람이 실제로 보는 화면이다.
- DependencyPicker: 객체 삼항(tone: p.isHub ? 'accent' : 'strong')인데
  두 가지 모두 인디고 틴트 면 위였다.

둘 다 accentOnTint 로 — accent(#7170ff)는 틴트 위 합성 대비 3.5~4.4:1 로
AA 미달(accent-ink-contrast 계약이 문서화한 값), accentOnTint 가 같은
인디고 계열로 8.9:1 대를 진다.

셀렉터는 「직계 리터럴 ∪ ConditionalExpression > Literal」 — 가지 위치만
잡히므로 x === "accent" 같은 비교 리터럴은 오탐하지 않는다. 프로브 5종:
직계 위반·JSX 삼항 위반·객체 삼항 위반 = 빨강 셋, 비교 리터럴·틴트 없는
삼항 = 초록 둘.

켜기 전 census 의 함정도 기록했다(design-gates.md): 첫 전수가 tone={ 만
grep 해 객체 표기를 놓쳤고, 룰을 넓히자마자 둘째 현장이 걸렸다 — 표기가
둘이면 census 도 두 벌.

검증: 전체 lint 0 error/경고 57 유지 · 계약 140파일 · 관련 vitest
(topology-controls 35 · project-edit 47) · tsc 클린.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD
