### PR TITLE
feat: 활동 칩이 누가 작업 중인지 이름으로 말한다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3416,8 +3416,10 @@
   },
   "agentActivity": {
     "writing": "Working",
+    "writingAgent": "{agent} working",
     "quietUnknown": "Quiet",
     "lastWorkedAt": "Last worked {age}",
+    "lastWorkedAtAgent": "{agent} · last worked {age}",
     "openOnMap": "Open {name} on the map",
     "bellAria": "Open notifications",
     "bellUnreadAria": "Open notifications: {count} new",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3416,8 +3416,10 @@
   },
   "agentActivity": {
     "writing": "작업 중",
+    "writingAgent": "{agent} 작업 중",
     "quietUnknown": "조용함",
     "lastWorkedAt": "마지막 작업 {age}",
+    "lastWorkedAtAgent": "{agent} · 마지막 작업 {age}",
     "openOnMap": "지도에서 {name} 열기",
     "bellAria": "알림함 열기",
     "bellUnreadAria": "알림함 열기: 새 알림 {count}개",

--- a/src/features/agent-activity/model/use-agent-activity-feed.ts
+++ b/src/features/agent-activity/model/use-agent-activity-feed.ts
@@ -96,6 +96,12 @@ export interface AgentActivityFeed {
   /** 마지막 쓰기가 「쓰는 중」 창(2분) 안인가. */
   writing: boolean;
   lastAt: number | null;
+  /**
+   * 마지막 작업에서 이름을 밝힌 에이전트 (하트비트 > MCP 연결 인사 이름 순 —
+   * 로그가 이미 그 우선순위로 기록한다). 모르면 null 이고, 화면은 이름 없이
+   * 상태만 말한다 — 지어내지 않는다.
+   */
+  agentName: string | null;
   /** 마지막 대상 — **매니페스트에 실재하는 슬러그일 때만** 채워진다. */
   lastNode: VaultShapeNode | null;
   /** 대상이 배치·문서 흡수라 이름이 없거나, 볼트에서 사라졌다. */
@@ -266,6 +272,7 @@ export function useAgentActivityFeed(): AgentActivityFeed {
     nowMs,
     writing: busy,
     lastAt,
+    agentName: last?.agent ?? null,
     lastNode,
     lastTargetUnnamed: lastAt !== null && lastNode === null,
     notifications: notificationsEnabled ? notifications : [],

--- a/src/features/agent-activity/ui/AgentActivityChip.test.tsx
+++ b/src/features/agent-activity/ui/AgentActivityChip.test.tsx
@@ -19,6 +19,7 @@ function feed(overrides: Partial<AgentActivityFeed> = {}): AgentActivityFeed {
     nowMs: NOW,
     writing: false,
     lastAt: NOW - 5 * 60_000,
+    agentName: null,
     lastNode: { slug: "capabilities/checkout", name: "주문서 작성", kind: "capability" },
     lastTargetUnnamed: false,
     notifications: [],
@@ -45,6 +46,22 @@ describe("AgentActivityChip", () => {
     renderChip({ writing: true });
     expect(screen.getByTestId("agent-activity-status")).toHaveTextContent("작업 중");
     expect(screen.getByTestId("agent-activity-target")).toHaveTextContent("주문서 작성");
+  });
+
+  it("이름을 아는 에이전트는 이름으로 말한다 — 「claude-code 작업 중」", () => {
+    renderChip({ writing: true, agentName: "claude-code" });
+    expect(screen.getByTestId("agent-activity-status")).toHaveTextContent("claude-code 작업 중");
+  });
+
+  it("조용해진 뒤에도 이름은 남는다 — 「codex · 마지막 작업 N분 전」", () => {
+    renderChip({ writing: false, agentName: "codex" });
+    const status = screen.getByTestId("agent-activity-status");
+    expect(status.textContent).toMatch(/^codex · 마지막 작업/);
+  });
+
+  it("이름을 모르면 이름 없이 상태만 — 지어내지 않는다", () => {
+    renderChip({ writing: true, agentName: null });
+    expect(screen.getByTestId("agent-activity-status")).toHaveTextContent(/^작업 중$/);
   });
 
   it("조용하면 마지막 작업 시각을 말한다 — 「연결됨」이라고 쓰지 않는다", () => {

--- a/src/features/agent-activity/ui/AgentActivityChip.tsx
+++ b/src/features/agent-activity/ui/AgentActivityChip.tsx
@@ -111,11 +111,17 @@ export function AgentActivityChip({ suppressed = false }: { suppressed?: boolean
               data-testid="agent-activity-status"
               className="min-w-0 truncate text-[color:var(--color-text-primary)]"
             >
+              {/* 이름은 로그가 아는 만큼만 — claude-code/codex 처럼 스스로
+                  밝힌 그대로 쓰고, 모르면 이름 없이 상태만 말한다. */}
               {feed.writing
-                ? t('writing')
+                ? feed.agentName
+                  ? t('writingAgent', { agent: feed.agentName })
+                  : t('writing')
                 : feed.lastAt === null
                   ? t('quietUnknown')
-                  : t('lastWorkedAt', { age: relative(feed.lastAt) })}
+                  : feed.agentName
+                    ? t('lastWorkedAtAgent', { agent: feed.agentName, age: relative(feed.lastAt) })
+                    : t('lastWorkedAt', { age: relative(feed.lastAt) })}
             </span>
             {/* 대상이 없으면(배치 쓰기·문서 흡수, 또는 볼트에서 사라진 슬러그)
                 **대상 없이 상태만** 말한다. 죽은 링크를 만들지 않는다. */}

--- a/src/shared/lib/agent-notifications.test.ts
+++ b/src/shared/lib/agent-notifications.test.ts
@@ -19,6 +19,7 @@ function session(overrides: Partial<AgentWorkSession> = {}): AgentWorkSession {
     counts: { added: 3, edited: 0, removed: 1 },
     lastTarget: "capabilities/checkout",
     lastTool: "add_relation",
+    agent: null,
     done: true,
     ...overrides,
   };

--- a/src/shared/lib/agent-work-session.test.ts
+++ b/src/shared/lib/agent-work-session.test.ts
@@ -121,6 +121,34 @@ describe("deriveAgentWorkSessions", () => {
     expect(session.lastTool).toBe("add_relations");
   });
 
+  it("작업은 마지막으로 이름을 밝힌 에이전트를 기억한다 (null 이 이름을 지우지 않는다)", () => {
+    const [session] = deriveAgentWorkSessions(
+      [
+        entry({ at: at(3_000), agent: "codex" }),
+        // 하트비트도 연결 인사도 없던 줄 — 이름 없음이 직전 이름을 지우면 안 된다.
+        entry({ at: at(2_000), agent: null }),
+      ],
+      NOW,
+    );
+    expect(session.agent).toBe("codex");
+  });
+
+  it("이름을 한 번도 못 들은 작업의 agent 는 null 이다 (공백은 이름이 아니다)", () => {
+    const [session] = deriveAgentWorkSessions(
+      [entry({ at: at(2_000), agent: null }), entry({ at: at(1_000), agent: "  " })],
+      NOW,
+    );
+    expect(session.agent).toBeNull();
+  });
+
+  it("나중 줄의 새 이름이 이긴다 — 한 폴더를 두 에이전트가 이어 쓰면 마지막 쪽", () => {
+    const [session] = deriveAgentWorkSessions(
+      [entry({ at: at(3_000), agent: "claude-code" }), entry({ at: at(1_000), agent: "codex" })],
+      NOW,
+    );
+    expect(session.agent).toBe("codex");
+  });
+
   it("조용해진 지 임계값이 지나야 끝난 작업이다", () => {
     const running = deriveAgentWorkSessions([entry({ at: at(1_000) })], NOW);
     const finished = deriveAgentWorkSessions([entry({ at: at(AGENT_TASK_IDLE_MS + 1) })], NOW);

--- a/src/shared/lib/agent-work-session.ts
+++ b/src/shared/lib/agent-work-session.ts
@@ -115,6 +115,13 @@ export interface AgentWorkSession {
   /** 마지막으로 손댄 대상 슬러그 후보. 배치·문서 흡수면 null. */
   lastTarget: string | null;
   lastTool: string | null;
+  /**
+   * 이 작업에서 마지막으로 이름을 밝힌 에이전트 (하트비트 또는 MCP 연결 인사의
+   * clientInfo.name, `mcp/src/activity-log.mjs` `resolveAgentName`). 이름 없는
+   * 줄이 직전 이름을 지우지 않는 것은 `lastTarget` 과 같은 이유다 — 배치 한
+   * 줄 때문에 화면이 말할 수 있던 것을 잃지 않는다. 한 번도 못 들었으면 null.
+   */
+  agent: string | null;
   /** 조용해진 지 `idleMs` 가 지났나 — 끝난 작업만 true. */
   done: boolean;
 }
@@ -158,6 +165,7 @@ export function deriveAgentWorkSessions(
         counts: emptyCounts(),
         lastTarget: null,
         lastTool: null,
+        agent: null,
         done: false,
       };
       sessions.push(current);
@@ -170,6 +178,7 @@ export function deriveAgentWorkSessions(
     // 마지막 대상은 **슬러그일 때만** 갱신한다. 배치가 마지막 줄이라고 해서
     // 직전에 알아낸 대상을 지우면, 화면이 말할 수 있던 것을 잃는다.
     current.lastTarget = toSlugTarget(entry.target) ?? current.lastTarget;
+    current.agent = entry.agent?.trim() || current.agent;
   }
 
   for (const session of sessions) {

--- a/tests/e2e/agent-activity-chip.spec.ts
+++ b/tests/e2e/agent-activity-chip.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+import { stubDirectoryPicker } from "./vault-picker-stub";
+
+/**
+ * **「누가 작업 중인지」 칩이 실제 로그에서 이름을 읽는가** (2026-08-13).
+ *
+ * ## 왜 이 spec 이 생겼나
+ *
+ * 활동 칩(`AgentActivityChip`)에는 e2e 가 하나도 없었다 — 단위 테스트는 피드를
+ * 통째로 목으로 갈아 끼우므로, 「볼트의 `activity.jsonl` 한 줄 → 파서 → 세션
+ * 묶음 → 피드 → 화면 문구」 사슬 전체를 본 게이트가 없었다. 그 사슬에 방금
+ * `agent` 이름 칸이 하나 늘었다(MCP 연결 인사의 clientInfo.name, PR #1066) —
+ * 늘어난 칸이 화면까지 실제로 흐르는지는 이 층만 잴 수 있다.
+ *
+ * 픽커만 스텁하고 그 뒤는 전부 실제 코드다(`vault-picker-stub` 머리말).
+ *
+ * ## 시각은 스펙 실행 시점에 만든다
+ *
+ * 「작업 중」 창은 마지막 쓰기 후 2분(`AGENT_WRITING_WINDOW_MS`)이라 고정
+ * 타임스탬프는 하루만 지나도 창 밖이다. 씨앗의 `at` 은 실행 순간 기준 30초
+ * 전으로 계산한다 — 페이지 로드가 2분을 넘기면 이 spec 은 시간 초과로 죽지
+ * 문구가 조용히 틀리지는 않는다(그때는 「마지막 작업」 문구가 되므로 단언이
+ * 명시적으로 실패한다).
+ */
+test("활동 칩은 로그의 에이전트 이름으로 「작업 중」을 말한다", async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 1512, height: 900 });
+
+  const recentAt = new Date(Date.now() - 30_000).toISOString();
+  const activityLine = JSON.stringify({
+    v: 1,
+    at: recentAt,
+    tool: "add_concept",
+    target: "capabilities/pay",
+    summary: "add_concept capability:capabilities/pay",
+    agent: "claude-code",
+    why: null,
+  });
+
+  await seedFirstRunSeen(page);
+  await stubDirectoryPicker(page, {
+    "shop.md": `---\nuid: 11111111-1111-4111-8111-111111111111\nslug: shop\nkind: project\ntitle: Chip Shop\ncontains:\n  - capabilities/pay\n---\n\n# Chip Shop\n`,
+    "capabilities/pay.md": `---\nuid: 22222222-2222-4222-8222-222222222222\nslug: capabilities/pay\nkind: capability\ntitle: Pay\n---\n\n# Pay\n`,
+    ".ontology-atlas/activity.jsonl": `${activityLine}\n`,
+  });
+
+  await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("first-run-starter-open").click();
+  await page.getByTestId("vault-guide-pick-existing").click();
+
+  const status = page.getByTestId("agent-activity-status");
+  await expect(status, "활동 칩이 안 떴다 — 30초 전 쓰기는 24시간 창 안이다").toBeVisible({
+    timeout: 30_000,
+  });
+  // 이름이 로그에 있으면 화면도 이름으로 말한다. 「작업 중」만 남고 이름이
+  // 빠지면 파서→세션→피드 어딘가에서 agent 칸이 떨어진 것이다.
+  await expect(status).toHaveText(/claude-code 작업 중/);
+  // 대상 링크도 같은 줄에서 산다 — 매니페스트에 실재하는 슬러그라 링크여야 한다.
+  await expect(page.getByTestId("agent-activity-target")).toHaveText("Pay");
+});


### PR DESCRIPTION
## Summary
- 실시간 에이전트 표시 2번 조각(1번 조각 #1066 의 데이터를 화면에 올리는 첫 소비처): 지도 우하단 활동 칩이 「작업 중」 대신 **「claude-code 작업 중」**, 조용해진 뒤에는 **「codex · 마지막 작업 N분 전」**으로 말한다.
- `AgentWorkSession.agent` 신설 — 작업 묶음이 마지막으로 이름을 밝힌 줄의 이름을 기억한다(이름 없는 줄이 직전 이름을 지우지 않음, `lastTarget` 과 같은 규칙). 이름을 모르면 기존 문구 그대로 — 지어내지 않는다.
- 칩에 e2e 가 0개였다: 단위 테스트가 피드를 목으로 갈아 끼워 `activity.jsonl → 파서 → 세션 → 피드 → 문구` 사슬을 아무도 안 봤다. OPFS 픽커 스텁으로 실제 사슬을 재는 `tests/e2e/agent-activity-chip.spec.ts` 신설.

## Test plan
- TDD: 세션 3케이스 red→green(`agent-work-session.test.ts` 15 pass) · 칩 3케이스(`AgentActivityChip.test.tsx`, 28 pass 합산).
- **프로브**: 피드의 `agentName` 을 null 로 떨어뜨리면 새 e2e 빨강 확인 후 복구(1 failed → 1 passed).
- 배치 실측(dev :3423, 1024/1512): 칩 폭 225px · 뷰포트 넘침 0 · 문구 잘림 0 · 컨테이너 외 겹침 0.
- `pnpm exec tsc --noEmit` · eslint(변경 5파일) · `pnpm test:contracts` 1639 pass · `test:desktop:check` 276 pass · `test:i18n:messages` 16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD