### PR TITLE
feat: 프로젝트 구성 탭의 역량 이름이 지도 딥링크가 된다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1586,6 +1586,7 @@
       "domainRowsLegendCaption": "The number on the right is how many concepts live in that domain. The bar shows how they split between capabilities and elements, and clicking a row unfolds every capability inside it.",
       "domainRowToggleAria": "{title}: {total} concepts, {capabilities} capabilities, {elements} elements. Unfold the capabilities inside",
       "domainRowMapLink": "Open this domain in the map",
+      "domainCapabilityLinkAria": "Open {name} on the map",
       "domainRowCapabilitiesEmpty": "No capability inside yet. Elements only.",
       "domainOverlapNote": "Concepts in several domains are counted once per domain, so these rows can sum higher than the counts above.",
       "bodyCardTitle": "Overview",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1586,6 +1586,7 @@
       "domainRowsLegendCaption": "오른쪽 숫자는 그 도메인에 담긴 개념 수예요. 막대는 그중 역량과 요소의 비율이고, 행을 누르면 담긴 역량이 전부 펼쳐져요.",
       "domainRowToggleAria": "{title}: 담긴 개념 {total}개, 역량 {capabilities}개, 요소 {elements}개. 담긴 역량 펼치기",
       "domainRowMapLink": "지도에서 이 도메인 열기",
+      "domainCapabilityLinkAria": "지도에서 {name} 열기",
       "domainRowCapabilitiesEmpty": "담긴 역량이 아직 없어요. 요소만 있어요.",
       "domainOverlapNote": "여러 도메인에 속한 개념은 도메인마다 한 번씩 세어져요. 행의 합이 위 역량·요소 수보다 클 수 있어요.",
       "bodyCardTitle": "본문",

--- a/src/views/project-detail/model/domain-composition.test.ts
+++ b/src/views/project-detail/model/domain-composition.test.ts
@@ -82,7 +82,8 @@ describe("buildProjectDomainComposition", () => {
     const [views] = result.domains;
     // 「상위 2 + N개 더」가 아니라 전부다 — 행을 펼치면 목록이 다 보이므로
     // 갈 곳 없는 수(「역량 1개 더」)를 만들 이유가 없다.
-    expect(views.capabilities).toEqual(["Bravo", "Alpha", "Charlie"]);
+    expect(views.capabilities.map((cap) => cap.title)).toEqual(["Bravo", "Alpha", "Charlie"]);
+    expect(views.capabilities[0]).toEqual({ id: "capability:b", title: "Bravo" });
     expect(views.capabilityCount).toBe(3);
   });
 

--- a/src/views/project-detail/model/domain-composition.ts
+++ b/src/views/project-detail/model/domain-composition.ts
@@ -23,8 +23,13 @@ export interface DomainCompositionRow {
   capabilityCount: number;
   elementCount: number;
   total: number;
-  /** degree 내림차순 · 동률은 제목 오름차순. 표시용 짧은 제목(`display`) 우선. */
-  capabilities: string[];
+  /**
+   * degree 내림차순 · 동률은 제목 오름차순. 표시용 짧은 제목(`display`) 우선.
+   * `id` 는 그래프 노드 id (예: `capability:pay`) — 이름이 지도 딥링크가 되는 데
+   * 쓴다(2026-08-13: 제목만 나르던 시절 펼친 목록이 막다른 텍스트였다 — B안이
+   * 지운 「갈 곳 없는 수」와 같은 결함이 이름에 남아 있었다).
+   */
+  capabilities: { id: string; title: string }[];
 }
 
 export interface ProjectDomainComposition {
@@ -72,7 +77,7 @@ export function buildProjectDomainComposition(
         elementCount: row.elementCount,
         total: row.total,
         // 과제 ⑩ — 역량 이름도 표시용 짧은 제목.
-        capabilities: capabilities.map((cap) => cap.display ?? cap.title),
+        capabilities: capabilities.map((cap) => ({ id: cap.id, title: cap.display ?? cap.title })),
       };
     });
 

--- a/src/views/project-detail/ui/DomainCompositionRows.test.tsx
+++ b/src/views/project-detail/ui/DomainCompositionRows.test.tsx
@@ -20,7 +20,11 @@ const DOMAINS: DomainCompositionRow[] = [
     capabilityCount: 3,
     elementCount: 11,
     total: 14,
-    capabilities: ["주문 생성", "주문 취소", "주문 조회"],
+    capabilities: [
+      { id: "capability:order-create", title: "주문 생성" },
+      { id: "capability:order-cancel", title: "주문 취소" },
+      { id: "capability:order-view", title: "주문 조회" },
+    ],
   },
   {
     id: "domain:inventory",
@@ -40,6 +44,7 @@ const LABELS = {
   rowToggleAria: (row: DomainCompositionRow) =>
     `${row.title}: 전체 ${row.total} · 역량 ${row.capabilityCount} · 요소 ${row.elementCount} — 담긴 역량 보기`,
   mapLinkLabel: "지도에서 이 도메인 열기",
+  capabilityLinkAria: (title: string) => `지도에서 ${title} 열기`,
   capabilitiesEmpty: "담긴 역량이 아직 없어요.",
 };
 
@@ -91,7 +96,7 @@ describe("DomainCompositionRows", () => {
     ).toBeInTheDocument();
   });
 
-  it("지도로 가는 길은 펼친 안에 하나뿐 — 접힌 상태에는 없다", () => {
+  it("도메인 단위 지도 문은 펼친 안에 하나뿐 — 접힌 상태에는 없다", () => {
     renderRows();
     expect(screen.queryByTestId("project-detail-domain-map-link")).not.toBeInTheDocument();
 
@@ -100,6 +105,20 @@ describe("DomainCompositionRows", () => {
     const links = screen.getAllByTestId("project-detail-domain-map-link");
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute("href", "/topology/?mode=focus&p=domain%3Aorders");
+  });
+
+  it("펼친 역량 이름은 그 노드의 지도 딥링크다 — 막다른 텍스트가 아니다", () => {
+    renderRows();
+    fireEvent.click(screen.getAllByTestId("project-detail-domain-row-toggle")[0]);
+
+    const capabilityLinks = screen.getAllByTestId("project-detail-capability-link");
+    expect(capabilityLinks).toHaveLength(3);
+    expect(capabilityLinks[0]).toHaveAttribute(
+      "href",
+      "/topology/?mode=focus&p=capability%3Aorder-create",
+    );
+    expect(capabilityLinks[0]).toHaveAccessibleName("지도에서 주문 생성 열기");
+    expect(capabilityLinks[0]).toHaveTextContent("주문 생성");
   });
 
   it("역량이 0인 도메인은 빈 목록 대신 그 사실을 말한다", () => {

--- a/src/views/project-detail/ui/DomainCompositionRows.tsx
+++ b/src/views/project-detail/ui/DomainCompositionRows.tsx
@@ -21,6 +21,8 @@ export interface DomainCompositionRowsLabels {
   /** 막대가 `aria-hidden` 이므로 수치는 여기 실린다. */
   rowToggleAria: (row: DomainCompositionRow) => string;
   mapLinkLabel: string;
+  /** 역량 링크의 접근 이름 — 눈에는 제목만 보이므로 목적지를 여기서 말한다. */
+  capabilityLinkAria: (title: string) => string;
   capabilitiesEmpty: string;
 }
 
@@ -51,12 +53,16 @@ interface Props {
  * 인터랙티브가 된다. 그래서 감싸는 쪽이 히트 영역·호버·초점 링·손가락 바닥을
  * 더하고, 행의 배치는 한 픽셀도 건드리지 않는다(`block`/`w-auto`/`py-0`).
  *
- * ## 지도로 가는 문은 펼친 안에 하나
+ * ## 지도로 가는 문 — 접힌 행에는 0, 펼친 안에는 이름이 곧 문이다
  *
  * 행마다 지도 칩을 달면 아홉 개짜리 잉크 열이 하나 더 생기고, 접힌 행이 두
  * 개의 목적지를 갖는다(무엇이 주인공인지 사라진다). 접힌 행의 일은 하나 —
- * 「무엇이 들어 있나」를 펼치는 것 — 이고, 펼친 뒤에 그 목록과 함께 지도 문이
- * 나온다. 프로젝트 전체를 지도에서 여는 길은 히어로의 주 버튼이 이미 갖고 있다.
+ * 「무엇이 들어 있나」를 펼치는 것 — 이다. 펼친 안에서는 **역량 이름 자체가 그
+ * 노드의 지도 딥링크**이고(2026-08-13 — 이름 7개가 막다른 텍스트였던 실측이
+ * 근거다: B안이 지운 「갈 곳 없는 수」와 같은 결함이 이름에 남아 있었다), 도메인
+ * 단위 문은 목록 끝의 칩 하나다. 새 잉크 열은 없다 — 링크는 이미 있던 제목
+ * 글자이고, 눌린다는 사실은 호버 면과 커서가 말한다. 프로젝트 전체를 지도에서
+ * 여는 길은 히어로의 주 버튼이 이미 갖고 있다.
  */
 export function DomainCompositionRows({ domains, labels }: Props) {
   return (
@@ -163,17 +169,25 @@ function DomainRow({
                 단에 서서 「도메인이 여덟 개 더 생긴 것」처럼 읽힌다. */}
             {domain.capabilities.length > 0 ? (
               <ul className="flex flex-col pl-[23px]">
-                {domain.capabilities.map((title, index) => (
-                  <li
-                    // 같은 표시 제목이 둘 있을 수 있다(다른 슬러그, 같은 이름).
-                    key={`${title}-${index}`}
-                    // 높이를 내용에 맡기지 않는다 — 목록 안에서도 리듬이 같아야
-                    // 「몇 개인가」가 길이로 읽힌다(치수 규칙성).
-                    style={{ height: "var(--card-row-h)" }}
-                    className="flex items-center gap-1.5 text-body text-[color:var(--color-text-secondary)]"
-                  >
-                    <TopologyV2KindGlyph kind="capability" size={13} />
-                    <span className="min-w-0 flex-1 truncate">{title}</span>
+                {domain.capabilities.map((capability) => (
+                  <li key={capability.id} style={{ height: "var(--card-row-h)" }}>
+                    <Link
+                      href={getTopologyFocusHref(capability.id)}
+                      aria-label={labels.capabilityLinkAria(capability.title)}
+                      data-testid="project-detail-capability-link"
+                      className={controlClass({
+                        shape: "row",
+                        size: "sm",
+                        // 높이를 내용에 맡기지 않는다 — 목록 안에서도 리듬이 같아야
+                        // 「몇 개인가」가 길이로 읽힌다(치수 규칙성). 행 높이는
+                        // li 가 갖고, 링크가 그 안을 가득 채워 히트 면이 된다.
+                        className:
+                          "-mx-1.5 h-full w-[calc(100%+0.75rem)] gap-1.5 px-1.5 py-0 text-body text-[color:var(--color-text-secondary)] hover:bg-[color:var(--color-overlay-1)] hover:text-[color:var(--color-text-primary)]",
+                      })}
+                    >
+                      <TopologyV2KindGlyph kind="capability" size={13} />
+                      <span className="min-w-0 flex-1 truncate">{capability.title}</span>
+                    </Link>
                   </li>
                 ))}
               </ul>

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -754,6 +754,7 @@ export function ProjectDetailPage({
                       elements: row.elementCount,
                     }),
                   mapLinkLabel: t("domainRowMapLink"),
+                  capabilityLinkAria: (title) => t("domainCapabilityLinkAria", { name: title }),
                   capabilitiesEmpty: t("domainRowCapabilitiesEmpty"),
                 }}
               />


### PR DESCRIPTION
## Summary
- flow 실측(storefront, 1512): 구성 탭에서 도메인 행을 펼치면 역량 이름 7개가 전부 **막다른 텍스트**(링크 0개)였다. 다음 행동이 도메인 단위 「지도에서 열기」 하나뿐이라 특정 역량은 지도에서 다시 찾아야 했다 — B안이 지운 「갈 곳 없는 수」와 같은 결함이 이름에 남아 있었다.
- 모델 `DomainCompositionRow.capabilities` 를 `string[]` → `{id, title}[]` 로, 펼친 목록의 역량 이름을 그 노드의 지도 focus 딥링크로(`getTopologyFocusHref`, 칩·알림함과 같은 URL 계약). 접근 이름은 「지도에서 {name} 열기」.
- 새 잉크 열 없음 — 링크는 이미 있던 제목 글자이고, 도메인 단위 문(칩 1개)은 그대로. 컴포넌트 머리말의 「문은 하나」 결정을 실측 근거와 함께 갱신.

## Test plan
- TDD: 새 단언(역량 링크 3개·href·접근 이름) 빨강 확인 후 구현 → `project-detail` 87 pass.
- 실측(dev :3423): 링크 7개 높이 28px 균일·좌 129 정렬·폭 921 히트 면. 클릭 → `?mode=focus&p=capability:customer-messaging` 착지, 팝오버(다음 행동 5개) 열림 스크린샷 확인.
- `pnpm exec tsc --noEmit` · eslint(변경 5파일 0 문제) · `pnpm test:contracts` 1639 pass · `test:desktop:check` 276 · `test:i18n:messages` 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD