### PR TITLE
feat: 알림함의 작업 알림이 누가 했는지 이름으로 말한다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3436,7 +3436,9 @@
     "bridgeChildren": "took {count} children",
     "event": {
       "taskStart": "Task started",
+      "taskStartAgent": "{agent} started a task",
       "taskEnd": "Task finished",
+      "taskEndAgent": "{agent} finished a task",
       "domainAdded": "Domain added",
       "domainRemoved": "Domain removed",
       "bridgeInserted": "Bridge inserted",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3436,7 +3436,9 @@
     "bridgeChildren": "자식 {count}개를 데려감",
     "event": {
       "taskStart": "작업 시작",
+      "taskStartAgent": "{agent} 작업 시작",
       "taskEnd": "작업 끝",
+      "taskEndAgent": "{agent} 작업 끝",
       "domainAdded": "도메인 생김",
       "domainRemoved": "도메인 사라짐",
       "bridgeInserted": "브릿지 끼어듦",

--- a/src/features/agent-activity/ui/AgentActivityChip.test.tsx
+++ b/src/features/agent-activity/ui/AgentActivityChip.test.tsx
@@ -113,6 +113,21 @@ describe("AgentActivityChip", () => {
     expect(markAllRead).toHaveBeenCalledOnce();
   });
 
+  it("이름을 아는 작업 알림은 이름으로 말한다 — 「claude-code 작업 끝」", () => {
+    renderChip({
+      notifications: [
+        { id: "a", kind: "task-end", at: NOW - 1000, node: null, agent: "claude-code", counts: { added: 2, edited: 0, removed: 0 } },
+        { id: "b", kind: "task-start", at: NOW - 2000, node: null },
+      ],
+    });
+    fireEvent.click(screen.getByTestId("agent-activity-bell"));
+    const rows = screen.getAllByTestId("agent-activity-inbox-row");
+    expect(rows[0].textContent).toContain("claude-code 작업 끝");
+    // 이름 모르는 줄은 예전 문구 그대로 — 지어내지 않는다.
+    expect(rows[1].textContent).toContain("작업 시작");
+    expect(rows[1].textContent).not.toContain("claude-code");
+  });
+
   it("설정에서 알림을 끄면 벨 자체가 없다", () => {
     renderChip({ notificationsEnabled: false });
     expect(screen.queryByTestId("agent-activity-bell")).toBeNull();

--- a/src/features/agent-activity/ui/AgentActivityChip.tsx
+++ b/src/features/agent-activity/ui/AgentActivityChip.tsx
@@ -249,6 +249,12 @@ const EVENT_LABEL_KEY: Readonly<Record<AgentNotificationKind, string>> = {
   'vault-problem': 'event.vaultProblem',
 };
 
+/** 이름을 아는 작업 알림의 문구 — 상태 칩과 같은 문법(「claude-code 작업 끝」). */
+const EVENT_LABEL_KEY_WITH_AGENT: Readonly<Partial<Record<AgentNotificationKind, string>>> = {
+  'task-start': 'event.taskStartAgent',
+  'task-end': 'event.taskEndAgent',
+};
+
 /**
  * 한 줄은 **2행 고정**이다 — 제목이 길든 짧든, 세부가 있든 없든 같은 리듬으로
  * 읽힌다(치수 규칙성: 반복 세트에서 높이가 글자 수로 정해지면 격자가 무너진다).
@@ -295,7 +301,9 @@ function NotificationRow({ item, age }: { item: AgentNotification; age: string }
               : 'text-[color:var(--color-text-primary)]',
           )}
         >
-          {t(EVENT_LABEL_KEY[item.kind])}
+          {item.agent && EVENT_LABEL_KEY_WITH_AGENT[item.kind]
+            ? t(EVENT_LABEL_KEY_WITH_AGENT[item.kind] as string, { agent: item.agent })
+            : t(EVENT_LABEL_KEY[item.kind])}
         </span>
         {item.node ? (
           <Link

--- a/src/shared/lib/agent-notifications.test.ts
+++ b/src/shared/lib/agent-notifications.test.ts
@@ -33,6 +33,18 @@ describe("deriveTaskNotifications", () => {
     expect(out[1].node?.slug).toBe("capabilities/checkout");
   });
 
+  it("작업이 이름을 알면 시작·끝 알림 둘 다 그 이름을 나른다", () => {
+    const out = deriveTaskNotifications([session({ agent: "claude-code" })]);
+    expect(out[0].agent).toBe("claude-code");
+    expect(out[1].agent).toBe("claude-code");
+  });
+
+  it("이름 모르는 작업의 알림에는 agent 칸이 없다 — 지어내지 않는다", () => {
+    const out = deriveTaskNotifications([session({ agent: null })]);
+    expect(out[0].agent).toBeUndefined();
+    expect(out[1].agent).toBeUndefined();
+  });
+
   it("아직 안 끝난 작업엔 끝 알림이 없다", () => {
     const out = deriveTaskNotifications([session({ done: false })]);
     expect(out.map((n) => n.kind)).toEqual(["task-start"]);

--- a/src/shared/lib/agent-notifications.ts
+++ b/src/shared/lib/agent-notifications.ts
@@ -56,6 +56,11 @@ export interface AgentNotification {
    * 링크를 만들지 않으면서도 「무엇이」를 잃지 않기 위한 자리.
    */
   label?: string;
+  /**
+   * `task-start`/`task-end` — 이 작업에서 이름을 밝힌 에이전트(하트비트 또는
+   * MCP 연결 인사, 세션이 이미 나른다). 모르면 칸 자체가 없다 — 지어내지 않는다.
+   */
+  agent?: string;
   /** `task-end` 전용 요약. */
   counts?: AgentWriteCounts;
   /** `bridge-inserted` 전용 — 데려간 자식 수. */
@@ -78,6 +83,7 @@ export function deriveTaskNotifications(
       kind: "task-start",
       at: session.startAt,
       node: null,
+      ...(session.agent ? { agent: session.agent } : {}),
     });
     // 끝나지 않은 작업엔 끝 알림이 없다. 0건 요약도 내보내지 않는다 —
     // 「추가 0 · 편집 0 · 삭제 0」은 정보가 아니라 소음이다.
@@ -88,6 +94,7 @@ export function deriveTaskNotifications(
         at: session.endAt,
         node: session.lastTarget ? { slug: session.lastTarget, name: session.lastTarget } : null,
         counts: session.counts,
+        ...(session.agent ? { agent: session.agent } : {}),
       });
     }
   }

--- a/tests/e2e/agent-activity-chip.spec.ts
+++ b/tests/e2e/agent-activity-chip.spec.ts
@@ -81,3 +81,50 @@ test("활동 칩은 로그의 에이전트 이름으로 「작업 중」을 말�
     )
     .toEqual(["capability:pay"]);
 });
+
+/**
+ * 알림함도 같은 이름을 말한다 — 끝난 작업(마지막 쓰기 후 5분 초과)의 「작업 끝」
+ * 줄이 「claude-code 작업 끝」이 된다. 씨앗은 20분 전 쓰기 두 줄: 한 작업으로
+ * 묶이고, 이미 조용해졌으므로 끝 알림이 있다.
+ */
+test("알림함의 작업 알림이 에이전트 이름으로 말한다", async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width: 1512, height: 900 });
+
+  const at = (minAgo: number) => new Date(Date.now() - minAgo * 60_000).toISOString();
+  const line = (iso: string) =>
+    JSON.stringify({
+      v: 1,
+      at: iso,
+      tool: "add_concept",
+      target: "capabilities/pay",
+      summary: "add_concept capability:capabilities/pay",
+      agent: "claude-code",
+      why: null,
+    });
+
+  await seedFirstRunSeen(page);
+  await stubDirectoryPicker(page, {
+    "shop.md": `---\nuid: 11111111-1111-4111-8111-111111111111\nslug: shop\nkind: project\ntitle: Chip Shop\ncontains:\n  - capabilities/pay\n---\n\n# Chip Shop\n`,
+    "capabilities/pay.md": `---\nuid: 22222222-2222-4222-8222-222222222222\nslug: capabilities/pay\nkind: capability\ntitle: Pay\n---\n\n# Pay\n`,
+    ".ontology-atlas/activity.jsonl": `${line(at(21))}\n${line(at(20))}\n`,
+  });
+
+  await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("first-run-starter-open").click();
+  await page.getByTestId("vault-guide-pick-existing").click();
+
+  const bell = page.getByTestId("agent-activity-bell");
+  await expect(bell, "알림 벨이 안 떴다").toBeVisible({ timeout: 30_000 });
+  // dev 서버 전용: Next 개발 배지(<nextjs-portal>, 우하단)가 벨과 같은 구석에
+  // 떠서 클릭을 가로챈다(실측 — 콘솔 에러 0, 순수 배지). 제품에는 없는
+  // 요소라 치우는 것이 화면을 왜곡하지 않는다. 정적 빌드에서는 no-op.
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await bell.click();
+
+  const endRow = page
+    .getByTestId("agent-activity-inbox-row")
+    .and(page.locator('[data-kind="task-end"]'));
+  await expect(endRow).toHaveCount(1);
+  await expect(endRow, "끝난 작업 줄이 이름을 잃었다").toContainText("claude-code 작업 끝");
+});


### PR DESCRIPTION
## Summary
- 실시간 에이전트 표시 후속: 상태 칩(#1067)·지도 링(#1068)에 이어 **알림함**도 이름을 말한다 — 「작업 끝」→「claude-code 작업 끝」. 세션이 이미 나르는 `agent` 를 task-start/task-end 알림 파생(`deriveTaskNotifications`)이 싣지 않던 것을 이었다.
- 이름 모르는 작업은 예전 문구 그대로(칸 자체가 없음) — 지어내지 않는다.

## Test plan
- TDD: 파생 2케이스(이름 나름/모르면 없음) 빨강 확인 후 구현 → 관련 단위 31 pass.
- **프로브**: 줄 문구 분기를 옛 모습으로 되돌리면 단위 1 failed 확인 후 복구.
- e2e 확장: 20분 전 쓰기 2줄 씨딩 → 벨 열기 → task-end 줄에 「claude-code 작업 끝」(2 pass). dev 전용 `<nextjs-portal>` 배지가 벨과 같은 우하단에서 클릭을 가로채는 것은 스펙에서 제거(제품에 없는 요소, 콘솔 에러 0 실측).
- `pnpm exec tsc --noEmit` · eslint 0 문제 · `pnpm test:contracts` 1639 · `test:desktop:check` 276 · `test:i18n:messages` 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD