### PR TITLE
fix: 승격 후보의 「여러 곳에서 참조」를 실제 참조 수로 말한다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1470,7 +1470,7 @@
         "touchUpFlowHint": "Inspect on map → open source → edit in workshop → verify with agent",
         "touchUpWhyNeglectedHub": "{degree} places use it, but it hasn't changed in {days} days",
         "touchUpWhyCycle": "{length} concepts point at each other, so there is no starting point",
-        "touchUpWhyPromotion": "Referenced from many places: worth promoting to a parent concept",
+        "touchUpWhyPromotion": "Referenced from {count} places: worth promoting to a parent concept",
         "rowMenuTrigger": "More actions",
         "askAgent": "Ask the agent about this",
         "reviewFallback": "Selected item",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1470,7 +1470,7 @@
         "touchUpFlowHint": "지도에서 확인 → 원문 확인 → 스튜디오에서 수정 → 에이전트로 검증",
         "touchUpWhyNeglectedHub": "{degree}군데에서 쓰는데 {days}일째 손대지 않았어요",
         "touchUpWhyCycle": "개념 {length}개가 서로를 가리켜 시작점이 없어요",
-        "touchUpWhyPromotion": "여러 곳에서 참조돼요. 상위 개념으로 올릴 만해요",
+        "touchUpWhyPromotion": "{count}곳에서 참조돼요. 상위 개념으로 올릴 만해요",
         "rowMenuTrigger": "더보기",
         "askAgent": "에이전트에게 말로 시키기",
         "reviewFallback": "선택한 항목",

--- a/src/views/ontology-insights/lib/todays-touch-ups.test.ts
+++ b/src/views/ontology-insights/lib/todays-touch-ups.test.ts
@@ -29,8 +29,8 @@ function orphan(nodeId: string): DoNextQueue["rows"][number] {
   return { id: `orphan:${nodeId}`, rowKind: "orphan", nodeId, title: nodeId, nodeKind: "element", evidenceOnly: false, handoffPayload: `o ${nodeId}` };
 }
 
-function promotion(nodeId: string): DoNextQueue["rows"][number] {
-  return { id: `promotion:${nodeId}`, rowKind: "promotion", nodeId, title: nodeId, nodeKind: "element", evidenceOnly: false, handoffPayload: `p ${nodeId}` };
+function promotion(nodeId: string, fanIn = 5): DoNextQueue["rows"][number] {
+  return { id: `promotion:${nodeId}`, rowKind: "promotion", nodeId, title: nodeId, nodeKind: "element", degree: fanIn, evidenceOnly: false, handoffPayload: `p ${nodeId}` };
 }
 
 function queueOf(rows: DoNextQueue["rows"]): DoNextQueue {
@@ -75,6 +75,13 @@ describe("pickTodaysTouchUps (③ 오늘의 손질 절단)", () => {
     expect(picked.map((p) => p.source)).toEqual(["neglected-hub", "promotion", "promotion"]);
     const hub = picked[0];
     expect(hub.reason).toEqual({ kind: "neglected-hub", degree: 12, agoDays: 40 });
+  });
+
+  it("승격 후보의 이유는 참조 수를 나른다 — 「여러 곳」이 아니라 몇 곳인지", () => {
+    const queue = queueOf([neglected("n1", 12, 40), promotion("p1", 7), promotion("p2", 4)]);
+    const picked = pickTodaysTouchUps(queue, noCycles, resolvers);
+    expect(picked[1].reason).toEqual({ kind: "promotion", fanIn: 7 });
+    expect(picked[2].reason).toEqual({ kind: "promotion", fanIn: 4 });
   });
 
   it("콜드스타트 가드 — 소형 vault 는 3건이 있어도 빈 배열", () => {

--- a/src/views/ontology-insights/lib/todays-touch-ups.ts
+++ b/src/views/ontology-insights/lib/todays-touch-ups.ts
@@ -21,7 +21,9 @@ import type { DependencyCycle, DependencyCyclesResult } from "./dependency-cycle
 export type TouchUpReason =
   | { kind: "cycle"; length: number }
   | { kind: "neglected-hub"; degree: number; agoDays: number }
-  | { kind: "promotion" };
+  /** fanIn = 들어오는 참조 수 — 큐 행이 이미 나르는 근거(「여러 곳」이라
+   *  뭉뚱그리면 세 행이 같은 문구를 반복한다, 2026-08-13 실측). */
+  | { kind: "promotion"; fanIn: number };
 
 export interface TouchUpItem {
   /** 밴드 행 고유 id — 세션 완료 표기의 키로도 쓴다. */
@@ -102,7 +104,7 @@ export function pickTodaysTouchUps(
       nodeId: row.nodeId,
       title: row.title,
       nodeKind: row.nodeKind,
-      reason: { kind: "promotion" as const },
+      reason: { kind: "promotion" as const, fanIn: row.degree ?? 0 },
       handoffPayload: row.handoffPayload,
     }));
 

--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -591,7 +591,9 @@ export function OntologyInsightsPage() {
       case "cycle":
         return t("doNext.touchUpWhyCycle", { length: item.reason.length });
       case "promotion":
-        return t("doNext.touchUpWhyPromotion");
+        // 참조 수를 그대로 말한다 — 「여러 곳」은 세 행이 같은 문구를 반복하게
+        // 만들었고, 수는 큐 행이 이미 나르고 있었다.
+        return t("doNext.touchUpWhyPromotion", { count: item.reason.fanIn });
     }
   };
   // #63 — 이 화면의 단일 판정. 탭 배지 · 빈 상태 문구 · 건강 주장이 모두


### PR DESCRIPTION
## Summary
- flow 실측(분석 「할 일」 탭): 「오늘 먼저 볼 일」 세 행이 전부 동일 문구 「이유 · 여러 곳에서 참조돼요. 상위 개념으로 올릴 만해요」를 반복 — 근거(들어오는 참조 수 fanIn)는 큐 행(`DoNextRow.degree`)이 이미 나르는데 손질 밴드의 이유 타입(`{kind:"promotion"}`)이 떨어뜨리고 있었다.
- `TouchUpReason` promotion 갈래에 `fanIn` 을 싣고 문구를 「{count}곳에서 참조돼요」로. 방치 허브(연결 N·N일째)·사이클(길이 N)은 이미 수치를 말하고 있었다 — 승격만 뭉뚱그려져 있던 것.

## Test plan
- TDD: 「이유는 참조 수를 나른다」 빨강 확인 후 구현 → `todays-touch-ups` 7 pass · insights 199 pass.
- 실측(dev :3423): 세 행이 「5곳 · 6곳 · 5곳에서 참조돼요」로 갈라짐(스크린샷·텍스트 덤프).
- `pnpm exec tsc --noEmit` · `pnpm test:contracts` 1639 · `test:desktop:check` 276 · `test:i18n:messages` 16. lint 신규 0(기존 경고 1건은 변경 밖 줄).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD