### PR TITLE
fix: 관문 설치 3단의 「AI 어시스턴트」를 「AI 에이전트」로

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -732,7 +732,7 @@
     "installTitle": "What using it looks like",
     "step1Title": "Drag it to Applications",
     "step2Title": "Pick a markdown folder",
-    "step3Title": "Connect your AI assistant",
+    "step3Title": "Connect your AI agent",
     "macosPlatformTitle": "macOS",
     "macosTrustBadge": "Signed and notarized",
     "macosPendingBadge": "Release candidate",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -732,7 +732,7 @@
     "installTitle": "설치하면 이렇게 씁니다",
     "step1Title": "응용 프로그램으로 옮기기",
     "step2Title": "마크다운 폴더 고르기",
-    "step3Title": "AI 어시스턴트 연결하기",
+    "step3Title": "AI 에이전트 연결하기",
     "macosPlatformTitle": "macOS",
     "macosTrustBadge": "서명·공증 완료",
     "macosPendingBadge": "릴리스 후보",

--- a/src/views/download/ui/DownloadPage.test.tsx
+++ b/src/views/download/ui/DownloadPage.test.tsx
@@ -410,7 +410,7 @@ describe('DownloadPage', () => {
       'href',
       'https://github.com/wlsdks/ontology-atlas',
     );
-    expect(screen.getByText(/Connect your AI assistant/i)).toBeInTheDocument();
+    expect(screen.getByText(/Connect your AI agent/i)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Open my markdown folder/i })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- 관문(`/download`) flow 실측: 설치 3단 중 「03 AI 어시스턴트 연결하기」만 어시스턴트 — 앱 전체 97곳이 「에이전트」다. ko/en(`assistant` 1곳) 둘 다 「에이전트/agent」로 수렴, 테스트 핀 1곳 갱신.
- 같은 걸음에서 본 관찰 하나(수리 안 함): 히어로 캡션의 `docs/ontology` 폴더명은 처음 온 사람에게 불투명하지만, 「우리 저장소를 우리가 그린다」는 신뢰 주장과 캡션=그래프 단일 훅 계약이 걸려 있어 단독 판단으로 바꾸지 않았다.

## Test plan
- e2e 스팟체크(dev :3423): 「AI 에이전트 연결하기」 렌더 · 「어시스턴트」 0건.
- `pnpm test:run src/views/download` 58 pass · `pnpm test:i18n:messages` 16 · `pnpm test:desktop:check` 276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD