### PR TITLE
fix: 분석 화면의 읽는 글도 한 단 올린다 (11px 가 화면 글자의 대부분이었다)

### DIFF
--- a/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
+++ b/src/views/ontology-insights/ui/OntologyInsightsPage.tsx
@@ -945,7 +945,7 @@ export function OntologyInsightsPage() {
             정비 보드다. 카피 전면 개편 대신 청중을 정직하게 선언해 기대치를
             맞춘다 — 일반 방문자가 여기서 "내 프로젝트" 같은 걸 찾다가 헤매지
             않도록. */}
-        <p className="mt-1 max-w-2xl text-label text-[color:var(--color-text-quaternary)]">
+        <p className="mt-1 max-w-2xl text-body text-[color:var(--color-text-quaternary)]">
           {t("audienceBanner")}
         </p>
 

--- a/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
+++ b/src/views/ontology-insights/ui/tabs/DoNextTab.tsx
@@ -335,7 +335,7 @@ function WorkGroupHeading({
         </span>
         {action ? <span className="ms-auto self-center">{action}</span> : null}
       </div>
-      <p className="text-label leading-label text-[color:var(--color-text-quaternary)]">{hint}</p>
+      <p className="text-body leading-body text-[color:var(--color-text-quaternary)]">{hint}</p>
     </div>
   );
 }
@@ -386,7 +386,7 @@ function TouchUpBand({
       </div>
       <p
         data-testid="do-next-touchups-flow"
-        className="text-label leading-label text-[color:var(--color-text-quaternary)]"
+        className="text-body leading-body text-[color:var(--color-text-quaternary)]"
       >
         {labels.touchUpFlowHint}
       </p>
@@ -417,7 +417,7 @@ function TouchUpBand({
                 <span className="truncate text-body text-[color:var(--color-text-secondary)]">
                   {item.title}
                 </span>
-                <span className="truncate text-label text-[color:var(--color-text-quaternary)]">
+                <span className="truncate text-body text-[color:var(--color-text-quaternary)]">
                   {labels.digestWhyPrefix}
                   {item.why}
                 </span>
@@ -495,7 +495,7 @@ function QueueSection({
           </span>
         </div>
         {hint ? (
-          <p className="text-label leading-label text-[color:var(--color-text-quaternary)]">{hint}</p>
+          <p className="text-body leading-body text-[color:var(--color-text-quaternary)]">{hint}</p>
         ) : null}
       </div>
       {rows.map((row) => {
@@ -564,7 +564,7 @@ function QueueSection({
         );
       })}
       {hiddenCount > 0 ? (
-        <p className="pt-2 text-label text-[color:var(--color-text-quaternary)]">{labels.moreCount(hiddenCount)}</p>
+        <p className="pt-2 text-body text-[color:var(--color-text-quaternary)]">{labels.moreCount(hiddenCount)}</p>
       ) : null}
     </section>
   );
@@ -628,7 +628,7 @@ function DuplicateSection({
             {totalCount}
           </span>
         </div>
-        <p className="text-label leading-label text-[color:var(--color-text-quaternary)]">
+        <p className="text-body leading-body text-[color:var(--color-text-quaternary)]">
           {labels.hintDuplicate}
         </p>
       </div>
@@ -664,7 +664,7 @@ function DuplicateSection({
         </div>
       ) : null}
       {totalCount > shownCount ? (
-        <p className="pt-2 text-label text-[color:var(--color-text-quaternary)]">
+        <p className="pt-2 text-body text-[color:var(--color-text-quaternary)]">
           {labels.duplicateTruncated(shownCount, totalCount)}
         </p>
       ) : null}
@@ -838,7 +838,7 @@ function CycleSection({
         );
       })}
       {cycles.hiddenCycles > 0 ? (
-        <p className="pt-2 text-label text-[color:var(--color-text-quaternary)]">
+        <p className="pt-2 text-body text-[color:var(--color-text-quaternary)]">
           {labels.moreCount(cycles.hiddenCycles)}
         </p>
       ) : null}
@@ -1225,7 +1225,7 @@ export function DoNextTab({
                 data-testid="insights-agent-readiness-breakdown"
                 // `leading-*` 을 안 쓴다 — `text-label` 이 자기 행간을 싣는다
                 // (램프 companion 결합). 옆 줄을 복사하면 off-ramp 래칫이 오른다.
-                className="mt-1 text-label text-[color:var(--color-text-tertiary)]"
+                className="mt-1 text-body text-[color:var(--color-text-tertiary)]"
               >
                 {labels.agentReadinessBlockedBreakdown(
                   agentReadiness.blockedDocuments,
@@ -1241,7 +1241,7 @@ export function DoNextTab({
                * 없으면 단어 중간이다). 원인은 `word-break: normal` 이고, 이 저장소는 이미
                * 다른 자리에서 `break-keep` 을 쓰고 있었다.
                */
-              <p className="mt-1 break-keep text-label leading-label text-[color:var(--color-text-quaternary)]">
+              <p className="mt-1 break-keep text-body leading-body text-[color:var(--color-text-quaternary)]">
                 {labels.agentReadinessHint}
               </p>
             ) : null}
@@ -1433,7 +1433,7 @@ export function DoNextTab({
                 </div>
               ))}
             </div>
-            <p className="mt-2 text-label text-[color:var(--color-text-quaternary)]">{labels.digestApproveHint}</p>
+            <p className="mt-2 text-body text-[color:var(--color-text-quaternary)]">{labels.digestApproveHint}</p>
           </div>
         ) : null}
       </section>

--- a/tests/e2e/a11y-open-surfaces.spec.ts
+++ b/tests/e2e/a11y-open-surfaces.spec.ts
@@ -22,7 +22,7 @@ import { expect, test, type Page } from "@playwright/test";
  * |---|---|---:|---|
  * | 설정 시트 | `color-contrast` | 2 | `#7170ff`(표식 인디고)가 `#1f2230` 위 **4.1:1** · `#232634` 위 **3.9:1** |
  * | 글로벌 검색 | `color-contrast` | 3 | `#82828a`(`--color-text-quaternary`)가 오버레이 위 **4.38 · 4.14 · 4.38** |
- * | 다음 할 일 행 메뉴 | `target-size` | 2 | 메뉴가 행 액션을 **가려서** 남는 자리가 81.8×17 · 32×17 (요구 24×24) |
+ * | 다음 할 일 행 메뉴 | `target-size` | 2→0 | 메뉴가 행 액션을 가려 남는 자리가 81.8×17 · 32×17 이었는데, 2026-08-13 분석 산문 한 단 올림(11→12.5px)이 행 높이를 키워 24×24 를 되찾았다 |
  * | 단축키 시트 · 문서 정렬 메뉴 | — | 0 | |
  *
  * **셋 다 그 라운드가 고치지 않았다 — 규격의 일이기 때문이다.** 그리고 규격
@@ -30,8 +30,8 @@ import { expect, test, type Page } from "@playwright/test";
  * accent×틴트 23곳 전수 이관(`accent-ink-contrast` 기준선 23 → 0)에 포함됐고,
  * `#82828a` 3건은 「올라선 바탕 위의 글자는 tertiary 부터」 라이선스로 치환됐다
  * (`tests/contract/quaternary-ink-surface.contract.test.ts`). 그래서 아래
- * `color-contrast` 기준선이 5 → 0 이다. `target-size` 2건은 잉크가 아니라
- * 겹침 레이아웃이라 그대로 남아 있다.
+ * `color-contrast` 기준선이 5 → 0 이다. `target-size` 2건도 2026-08-13
+ * 글자 한 단 올림이 행을 키우면서 0 이 됐다.
  *
  * - 인디고 5건은 **잉크 램프 판정**이다. `--color-indigo-accent` 는 「맨 어두운
  *   바탕만」이 라이선스인데(`accent-ink-contrast.contract.test.ts`) 여기서는 틴트
@@ -226,7 +226,7 @@ const OPENERS: readonly Opener[] = [
  */
 const BASELINE: Readonly<Record<string, number>> = {
   "color-contrast": 0,
-  "target-size": 2,
+  "target-size": 0,
 };
 
 async function openAndAudit(page: Page, o: Opener) {


### PR DESCRIPTION
## Summary
- #1077(스킬 글자 키움)의 후속: 같은 계측을 5개 목적지에 돌린 잉크 가중 census 에서 **분석 화면이 최악** — 첫 화면 가시 글자 중 11px 가 **487자**(12.5px 78 · 14px 38). 부제, 「오늘 먼저 볼 일」 이유 줄, 준비도/중복 패널 설명이 전부 11px.
- 산문 12곳을 12.5px(body)로. 눌리는 칩(「지도에서 확인」)·모노 수치·uppercase 아이브로우는 그대로 — 본문보다 조용해야 하는 층. 새 토큰 0.
- 참고 census: /projects 는 9.5px 256자로 다음 후보(별도 회차).

## Test plan
- 실측(dev :3423, 1512): 11px 487→95자 · 12.5px 470자 · 전후 스크린샷, 레이아웃 겹침/잘림 0.
- `pnpm test:run src/views/ontology-insights` 199 pass · `pnpm test:contracts` 1639 pass · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD