### PR TITLE
fix: 프로젝트 목록의 9.5px 읽는 글을 한 단 올린다

### DIFF
--- a/src/views/project-selector/ui/ProjectSelectorPage.tsx
+++ b/src/views/project-selector/ui/ProjectSelectorPage.tsx
@@ -353,7 +353,7 @@ function ProjectFullCard({ project, facts, domainRows, description, docPath, kin
           생겼다(램프는 0.02 · 0.06 · 0.10). 대체값으로 이미 `overlay-1` 이 적혀
           있었으니 원래 목적지를 알고 있었던 셈이다. 실제 차이는 알파 0.01. */}
       <div className="mt-4 rounded-chip border border-[color:var(--color-border-soft)] bg-[color:var(--color-overlay-1)] px-4 py-2.5">
-        <p className="mb-1.5 text-caption text-[color:var(--color-text-quaternary)]">
+        <p className="mb-1.5 text-label text-[color:var(--color-text-quaternary)]">
           {t("factStripGloss")}
         </p>
         <div className="flex flex-wrap items-baseline gap-x-5 gap-y-1.5 text-body">
@@ -394,7 +394,7 @@ function ProjectFullCard({ project, facts, domainRows, description, docPath, kin
               여기서는 어긋난 수로만 보였다. 막대의 각주이므로 막대 아래에 둔다. */}
           <p
             data-testid="project-selector-domain-overlap-note"
-            className="mt-1.5 text-caption text-[color:var(--color-text-quaternary)]"
+            className="mt-1.5 text-label text-[color:var(--color-text-quaternary)]"
           >
             {t("domainOverlapNote")}
           </p>

--- a/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.tsx
+++ b/src/widgets/domain-capacity-bar/ui/DomainCapacityBar.tsx
@@ -136,7 +136,7 @@ export function DomainCapacityBar({
         <span className="block font-mono text-title tabular-nums text-[color:var(--topology-v2-numeral-face)]">
           {row.total}
         </span>
-        <span className="block truncate font-mono text-caption tabular-nums text-[color:var(--color-text-quaternary)]">
+        <span className="block truncate font-mono text-label tabular-nums text-[color:var(--color-text-quaternary)]">
           {labels.capabilityUnit} {row.capabilityCount} · {labels.elementUnit} {row.elementCount}
         </span>
       </span>


### PR DESCRIPTION
## Summary
- 글자 크기 census 후속(#1077 스킬 → #1078 분석 → 이번 /projects): 9.5px 가 **256자**로 최다. 주인 셋 — 카드 설명문(`factStripGloss`) · 막대 각주(`domainOverlapNote`) · 공용 막대 부품 `DomainCapacityBar` 의 「역량 N · 요소 M」 수치줄(9행). 셋 다 **11px(label)** 로 한 단 위로.
- 막대 부품은 프로젝트 상세 구성 탭·분석 구성 탭도 소비 — 세 화면이 같이 오른다. 프로젝트 상세의 같은 각주가 이미 label(11)이라 **각주 단이 두 화면에서 처음으로 같아졌다**.
- 남은 9.5px(61자)는 레일 라벨(스케일 고정 계약 층)과 uppercase 아이브로우(설정 사전이 허용한 유일 자리) — 별도 규격이라 범위 밖.

## Test plan
- 실측(dev :3423, 1512): 9.5px 256→61자 · 11px 212자 · `w-[156px]` 수치 열 잘림 **0** · 스크린샷.
- `pnpm test:run`(selector·bar·detail) 136 pass · `pnpm test:contracts` 1639 pass · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD