### PR TITLE
fix: 스튜디오의 9.5px 읽는 글을 한 단 올린다 (글자 키우기 4탄)

### DIFF
--- a/src/shared/ui/entry-choice-card.tsx
+++ b/src/shared/ui/entry-choice-card.tsx
@@ -59,7 +59,7 @@ export const EntryChoiceCard = ({
       <span className="text-body-lg font-[var(--font-weight-signature)] text-[color:var(--color-text-primary)] [word-break:keep-all]">
         {title}
       </span>
-      <span className="text-caption leading-caption text-[color:var(--color-text-tertiary)] [word-break:keep-all]">
+      <span className="text-label leading-label text-[color:var(--color-text-tertiary)] [word-break:keep-all]">
         {desc}
       </span>
     </span>

--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -1477,7 +1477,7 @@ export function StudioCompass(props: StudioCompassProps) {
               borderRight: "1.6px solid var(--color-indigo-brand)",
             }}
           />
-          <span className="text-caption text-[color:var(--color-text-secondary)]" data-testid="studio-bottom-progress">
+          <span className="text-label text-[color:var(--color-text-secondary)]" data-testid="studio-bottom-progress">
             {labels.bottomProgress(filledBearings, 4)}
           </span>
         </div>
@@ -1852,7 +1852,7 @@ function CenterCard(
         />
       ) : definition ? (
         <div className="relative mt-3">
-          <div className="max-w-[322px] text-caption leading-caption text-[color:var(--color-text-tertiary)] line-clamp-3 [word-break:keep-all]">
+          <div className="max-w-[322px] text-label leading-label text-[color:var(--color-text-tertiary)] line-clamp-3 [word-break:keep-all]">
             {definition}
           </div>
           {definitionLong ? (


### PR DESCRIPTION
## Summary
- 글자 census 후속 4탄(#1077 스킬 → #1078 분석 → #1079 프로젝트): 스튜디오 flow 를 걸어 9.5px 읽는 글 셋을 특정 — ① 입구 카드 설명(공용 `EntryChoiceCard` desc, 스킬 빈 화면도 공유) ② 무대 가운데 카드의 본문 발췌(line-clamp-3) ③ 하단 진행 상태줄. 셋 다 **11px(label)** 로.
- 무대는 픽셀 고정 기하(가운데 카드 172px)라 실측으로 확인: 발췌 3줄 바닥 428 vs 카드 바닥 481(여유 53px) · 입구 카드 scrollHeight 넘침 0.

## Test plan
- `pnpm test:run`(studio·agent-skills·shared/ui) 494 pass · `pnpm test:contracts` 1639 pass · e2e `studio-stage-motion` 4 pass · tsc 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD