### PR TITLE
fix: 지도 팝오버의 「+N」이 죽은 수에서 그 자리에서 펼치는 문이 된다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2114,6 +2114,8 @@
       "statsEvidenceDocs": "Source docs",
       "metricHelp": "Every count here is a direct connection to this node: not a multi-hop total.",
       "containsShowAll": "view all",
+      "groupShowMore": "more",
+      "groupShowFewer": "fewer",
       "containsShowSummary": "summary",
       "containsOtherGroup": "other",
       "noConnections": "no relations recorded yet · relations are declared in frontmatter",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2114,6 +2114,8 @@
       "statsEvidenceDocs": "근거 문서",
       "metricHelp": "모두 이 노드와 직접 연결된 것만 셉니다. 여러 단계 건너뛴 합계가 아니에요.",
       "containsShowAll": "전체 보기",
+      "groupShowMore": "더 보기",
+      "groupShowFewer": "접기",
       "containsShowSummary": "요약 보기",
       "containsOtherGroup": "기타",
       "noConnections": "아직 기록된 관계 없음 · 관계는 문서 상단 속성으로 기록돼요",

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -5039,6 +5039,8 @@ export function HomePage() {
                   // typed groups read in one consistent word family.
                   metricContains: relationVocabulary("contains", "plain"),
                   containsShowAll: t("nodeDatasheet.containsShowAll"),
+                  groupShowMore: t("nodeDatasheet.groupShowMore"),
+                  groupShowFewer: t("nodeDatasheet.groupShowFewer"),
                   containsShowSummary: t("nodeDatasheet.containsShowSummary"),
                   containsOtherGroup: t("nodeDatasheet.containsOtherGroup"),
                   metricUsedBy: t("nodeDatasheet.metricUsedBy"),

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -40,6 +40,8 @@ const labels = {
   containsShowAll: "view all",
   containsShowSummary: "summary",
   containsOtherGroup: "other",
+  groupShowMore: "more",
+  groupShowFewer: "fewer",
   metricUsedBy: "used by",
   metricDependsOn: "leans on",
   metricBelongsTo: "belongs to",
@@ -724,6 +726,34 @@ describe("TopologyV2DetailPanel — full-detail A1 opt-in link", () => {
 // 실제 레이아웃을 하지 않으므로 clamp 계약(토큰 기반 max-height + 내부
 // overflow)이 className 에 실제로 걸려 있는지로 회귀를 잡는다.
 describe("TopologyV2DetailPanel — viewport clamp (P3-③)", () => {
+  it("+N 은 죽은 수가 아니다 — 누르면 그 자리에서 전부 펼쳐지고, 다시 누르면 접힌다", () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({
+      id: `capability:c${i}`,
+      title: `Cap ${i}`,
+      kind: "capability",
+      relationType: "contains",
+      direction: "outgoing" as const,
+    }));
+    const groups: TopologyV2DetailPanelProps["groups"] = {
+      contains: { rows: many.slice(0, 6), allRows: many, total: 9 },
+      usedBy: { rows: [], total: 0 },
+      dependsOn: { rows: [], total: 0 },
+      belongsTo: { rows: [], total: 0 },
+    };
+    renderPanel(undefined, undefined, { groups });
+
+    expect(screen.getByText("Cap 0")).toBeInTheDocument();
+    expect(screen.queryByText("Cap 8")).not.toBeInTheDocument();
+
+    const more = screen.getByTestId("topology-v2-group-more-contains");
+    expect(more).toHaveTextContent("+3");
+    fireEvent.click(more);
+    expect(screen.getByText("Cap 8")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("topology-v2-group-more-contains"));
+    expect(screen.queryByText("Cap 8")).not.toBeInTheDocument();
+  });
+
   it("always carries a viewport-bounded max-height and internal scroll so the footer link stays reachable", () => {
     renderPanel(vi.fn());
     const panel = screen.getByTestId("topology-v2-detail-panel");

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -131,6 +131,10 @@ export interface TopologyV2DetailPanelLabels {
   containsShowSummary: string;
   /** S2 파트 3 — 경로 프리픽스 요약의 나머지 버킷 라벨("기타"). */
   containsOtherGroup: string;
+  /** 그룹 「+N」 뒤에 붙는 펼침 라벨("더 보기") — +N 이 죽은 수가 아니게 한다. */
+  groupShowMore: string;
+  /** 펼친 그룹을 캡 상태로 되돌리는 라벨("접기"). */
+  groupShowFewer: string;
   metricUsedBy: string;
   metricDependsOn: string;
   /**
@@ -919,6 +923,10 @@ export function TopologyV2DetailPanel({
   // 토글로 기존 리스트를 편다(세션 임시 상태). 노드가 바뀌면 기본(요약)으로 리셋
   // 되도록 slug 를 key 로 쓴다(호출부 HomePage 가 key 를 주므로 재마운트).
   const [showAllContains, setShowAllContains] = useState(false);
+  // 「+N」 펼침 — 그룹별로 독립(하위 항목을 펼쳤다고 기대는 곳까지 길어지면
+  // 패널이 한 번에 다 자란다). 노드가 바뀌면 부모가 패널을 새로 세우므로
+  // 여기 상태는 그 노드의 것만 산다.
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
   const [showProjectRelations, setShowProjectRelations] = useState(false);
 
   const handleKeyDown = useCallback(
@@ -944,6 +952,8 @@ export function TopologyV2DetailPanel({
     view: V2ConnectionGroupView,
   ) => {
     if (view.total === 0) return null;
+    const expanded = expandedGroups.has(group);
+    const shownRows = expanded ? (view.allRows ?? view.rows) : view.rows;
     const overflow = view.total - view.rows.length;
     // S2 파트 3 — 긴 "담는 것"은 경로 프리픽스 요약을 기본으로, "전체 보기"로 리스트.
     // B4 (H1) — 요약이 "기타" 한 덩어리로 무너지면(`usable=false`) 요약을 건너뛰고
@@ -1010,7 +1020,7 @@ export function TopologyV2DetailPanel({
           </ul>
         ) : (
           <ul className="flex flex-col">
-            {view.rows.map((row: V2DatasheetConnection) => (
+            {shownRows.map((row: V2DatasheetConnection) => (
               // Neighbor `id` is unique within a direction group post-dedup
               // (`groupV2ConnectionsByDirection`) — the same neighbor can still
               // appear once per group (mutual dependency, item 5 — no
@@ -1034,12 +1044,31 @@ export function TopologyV2DetailPanel({
           </ul>
         )}
         {overflow > 0 && !useSummary ? (
-          <span
+          // 죽은 수였던 「+N」이 문이 된다 — 프로젝트 상세의 「역량 N개 더」
+          // 반려(2026-08-12 B안 근거)와 같은 계보: 수를 보여 놓고 그 수로
+          // 가는 길이 없으면 사용자는 지도를 떠나 다시 찾아야 한다.
+          <button
+            type="button"
+            aria-expanded={expanded}
             data-datasheet-group-overflow={group}
-            className="pl-[34px] pt-0.5 font-mono text-label text-[color:var(--topology-v2-panel-text-quaternary)]"
+            data-testid={`topology-v2-group-more-${group}`}
+            onClick={() =>
+              setExpandedGroups((current) => {
+                const next = new Set(current);
+                if (next.has(group)) next.delete(group);
+                else next.add(group);
+                return next;
+              })
+            }
+            className={controlClass({
+              shape: "link",
+              size: "sm",
+              className:
+                "ml-[34px] mt-0.5 font-mono text-label text-[color:var(--topology-v2-panel-text-tertiary)] hover:text-[color:var(--topology-v2-panel-text-secondary)]",
+            })}
           >
-            +{overflow}
-          </span>
+            {expanded ? labels.groupShowFewer : `+${overflow} ${labels.groupShowMore}`}
+          </button>
         ) : null}
       </RelationGroupShell>
     );

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.test.ts
@@ -177,10 +177,10 @@ describe("buildV2ConnectionGroups — M-2 ROLE axis, single source for metric + 
     const groups = buildV2ConnectionGroups([]);
     expect(groups).toEqual({
       // S2 파트 3 — contains 는 경로 프리픽스 요약을 함께 싣는다(빈 입력이면 빈 요약).
-      contains: { rows: [], total: 0, summary: { groups: [], otherCount: 0, total: 0, usable: false } },
-      usedBy: { rows: [], total: 0 },
-      dependsOn: { rows: [], total: 0 },
-      belongsTo: { rows: [], total: 0 },
+      contains: { rows: [], allRows: [], total: 0, summary: { groups: [], otherCount: 0, total: 0, usable: false } },
+      usedBy: { rows: [], allRows: [], total: 0 },
+      dependsOn: { rows: [], allRows: [], total: 0 },
+      belongsTo: { rows: [], allRows: [], total: 0 },
     });
   });
 

--- a/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
+++ b/src/widgets/topology-map-v2/ui/topology-v2-datasheet.ts
@@ -151,6 +151,12 @@ export interface V2ConnectionGroupView {
   rows: V2DatasheetConnection[];
   total: number;
   /**
+   * 캡 없는 전체 행 — 「+N」이 죽은 수가 아니라 그 자리에서 펼치는 문이 되기
+   * 위한 재료(2026-08-13, 프로젝트 상세의 「역량 N개 더」 반려와 같은 계보).
+   * 캡 이전 배열을 그대로 참조하므로 추가 비용은 참조 하나다.
+   */
+  allRows?: V2DatasheetConnection[];
+  /**
    * S2 파트 3 — "담는 것" 그룹에만 채워지는 경로 프리픽스 집계(총 행이 임계를
    * 넘을 때 개별 리스트 대신 표시). 전체 행 기준으로 계산(캡 이전).
    */
@@ -198,6 +204,7 @@ export function buildV2ConnectionGroups(
   const toView = (rows: readonly V2DatasheetConnection[]): V2ConnectionGroupView => ({
     rows: rows.slice(0, cap),
     total: rows.length,
+    allRows: rows.slice(),
   });
   return {
     // S2 파트 3 — contains 는 전체 행 기준 경로 프리픽스 요약을 함께 싣는다


### PR DESCRIPTION
## Summary
- 지도 flow 실측(도메인 클릭 → 팝오버): 하위 항목 14개 중 6개 표시 후 **「+ 8」이 눌리지 않는 span** — 프로젝트 상세에서 반려된 「갈 곳 없는 수」(2026-08-12 B안 근거) 패턴의 지도판.
- `V2ConnectionGroupView.allRows`(캡 이전 전체, 참조 하나 비용)를 싣고, 패널의 「+N」을 **그 자리 펼침 버튼**으로: `+8 더 보기` ↔ `접기`, 그룹별 독립 상태. 15개 초과 contains 의 경로 요약 모드(전체 보기 토글)는 종전 그대로.
- i18n `nodeDatasheet.groupShowMore/groupShowFewer`(ko 더 보기/접기 · en more/fewer).

## Test plan
- TDD: 「+N 은 죽은 수가 아니다」 빨강 확인 후 구현 → topology-map-v2 위젯 895 pass.
- 실측(dev :3423): 「주문」 팝오버 행 12 → **20**(하위 6→14) → 접기 복귀. 스크린샷.
- `pnpm test:contracts` 1639 · `test:desktop:check` 276 · `test:i18n:messages` 16 · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD