### PR TITLE
fix: 웹 연결 시트의 1단 제목이 없는 버튼을 약속하지 않는다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2968,6 +2968,7 @@
     "otherToolsCodexNote": "config file or CLI command",
     "otherToolsClaudeDesktopNote": "Register manually in Settings → Developer (dedicated extension later)",
     "step1Title": "Press a connect button",
+    "step1TitleManual": "Create the connect config",
     "step1Desc": "Press the button for your tool and it's ready to read and write this folder with you.",
     "step2Title": "Restart the agent",
     "step2Desc": "Quit and reopen Claude Code, Codex, Cursor, or Antigravity to apply the connection.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2968,6 +2968,7 @@
     "otherToolsCodexNote": "설정 파일 또는 CLI 명령",
     "otherToolsClaudeDesktopNote": "설정 → Developer 에서 수동 등록 (전용 확장은 후속)",
     "step1Title": "연결 버튼 누르기",
+    "step1TitleManual": "연결 설정 만들기",
     "step1Desc": "쓰는 도구의 버튼을 누르면 이 폴더를 함께 읽고 쓸 준비가 돼요.",
     "step2Title": "에이전트 다시 시작",
     "step2Desc": "Claude Code·Codex·Cursor·Antigravity 를 껐다 켜면 연결이 반영돼요.",

--- a/src/widgets/agent-connect/ui/AgentConnectSheet.test.tsx
+++ b/src/widgets/agent-connect/ui/AgentConnectSheet.test.tsx
@@ -132,6 +132,10 @@ describe("AgentConnectSheet focus contract", () => {
 
     const card = screen.getByTestId("agent-server-unavailable");
     expect(card).toHaveTextContent("cannot save the config file for you");
+    // 1단 제목도 거짓말하지 않는다 — 이 화면에 연결 버튼은 없으므로
+    // 「버튼 누르기」가 아니라 이 화면이 실제로 해 주는 일을 말한다.
+    expect(screen.getByText("Create the connect config")).toBeInTheDocument();
+    expect(screen.queryByText("Press a connect button")).not.toBeInTheDocument();
     expect(card).not.toHaveTextContent("cannot connect an agent");
     // 대신 그 자리에서 끝나는 길이 살아 있다 — 이유만 말하는 카드는 막다른 길이다.
     expect(screen.getByTestId("web-manual-connect")).toBeInTheDocument();

--- a/src/widgets/agent-connect/ui/AgentConnectSheet.tsx
+++ b/src/widgets/agent-connect/ui/AgentConnectSheet.tsx
@@ -264,7 +264,9 @@ export function AgentConnectSheet({
               {/* ① 연결 버튼 누르기 — 클라이언트별 원클릭 */}
               <StepRow
                 n={1}
-                title={t("step1Title")}
+                // 웹(수동 경로)에는 눌러 줄 연결 버튼이 없다 — 제목이 없는
+                // 버튼을 약속하면 그 자체가 거짓 캡션이다(2026-08-13 flow 실측).
+                title={serverAvailability.launch ? t("step1Title") : t("step1TitleManual")}
                 desc={
                   serverAvailability.launch
                     ? scope === "global"


### PR DESCRIPTION
## Summary
- 에이전트 연결 flow 실측(웹 수동 경로): 1단 제목 「연결 버튼 누르기」 아래에 「…이 화면이 못 해요」 강등 카드 — 제목이 존재하지 않는 버튼을 약속하는 거짓 캡션이었다(웹 모드는 2·3단도 접혀 1단 제목만 남는다).
- `serverAvailability.launch` 로 제목을 갈래: 앱은 종전 「연결 버튼 누르기」, 웹은 **「연결 설정 만들기 / Create the connect config」** — 이 화면이 실제로 해 주는 일.

## Test plan
- TDD: noServer 케이스에 제목 단언 추가, 빨강 확인 후 구현 → agent-connect 9 pass.
- 실측(dev :3423): 볼트 열고 시트 진입 → 「연결 설정 만들기」 렌더 · 「연결 버튼 누르기」 0건.
- `pnpm test:i18n:messages` 16 · `test:desktop:check` 276 · `pnpm test:contracts` 1639 · tsc 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD