### PR TITLE
feat: 가이드 장 끝에 이전/다음 장 내비를 단다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3414,6 +3414,9 @@
       "cli": "CLI",
       "trust": "On trust"
     },
+    "guidePrev": "Previous chapter",
+    "guideNext": "Next chapter",
+    "guidePagerLabel": "Guide chapter navigation",
     "guideNavLabel": "Guide contents",
     "onThisGuide": "Guide",
     "entryNavLabel": "Entries"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3414,6 +3414,9 @@
       "cli": "CLI",
       "trust": "신뢰에 관하여"
     },
+    "guidePrev": "이전 장",
+    "guideNext": "다음 장",
+    "guidePagerLabel": "가이드 장 이동",
     "guideNavLabel": "가이드 차례",
     "onThisGuide": "가이드",
     "entryNavLabel": "변경 항목"

--- a/src/views/gateway-doc/ui/GatewayDocPage.tsx
+++ b/src/views/gateway-doc/ui/GatewayDocPage.tsx
@@ -18,7 +18,7 @@ import {
   trimToRecentSections,
   type DocEntry,
 } from '../lib/vault-doc';
-import { GUIDE_PAGES } from '../model/guide-pages';
+import { GUIDE_ENTRY_PAGE, GUIDE_PAGES, type GuidePage } from '../model/guide-pages';
 import { Link } from '@/i18n/navigation';
 import { controlClass } from '@/shared/ui/control-class';
 
@@ -231,6 +231,14 @@ export function GatewayDocPage({
            * 라우트에는 푸터가 없어서, 종전에는 가이드 안에서 변경 내역으로
            * (그 반대로도) 갈 길이 390 에서 0개였다.
            */}
+          {/*
+           * 장 끝의 이전/다음 — 순서 있는 13장인데 본문이 끝나는 자리에 다음
+           * 장으로 가는 길이 0개였다(2026-08-13 실측: 다 읽은 사람이 왼쪽
+           * 차례로 되돌아가 방금 읽은 장을 스스로 찾아야 했다). 순서의 정본은
+           * `GUIDE_PAGES` 하나다. 변경 내역(sidebar 없음)은 장이 아니라서 없다.
+           */}
+          {sidebar ? <GuidePager activeSegment={activeSegment} /> : null}
+
           <GatewayReadingLinks className="mt-12 w-full max-w-[var(--measure-prose)]" />
 
           {/*
@@ -535,6 +543,71 @@ function GuideChapterList({ activeSegment }: { activeSegment?: string }) {
         );
       })}
     </ul>
+  );
+}
+
+/**
+ * 장 끝 이전/다음. 화살표 글자는 쓰지 않는다 — 방향은 「이전 장/다음 장」
+ * 아이브로우와 정렬(왼쪽/오른쪽)이 이미 말하고, 라벨 끝 화살표는 헌장이
+ * 장식으로 판정한다(`label-decoration` 게이트).
+ */
+function GuidePager({ activeSegment }: { activeSegment?: string }) {
+  const t = useTranslations('gatewayNav');
+  const segment = activeSegment ?? GUIDE_ENTRY_PAGE.segment;
+  const index = GUIDE_PAGES.findIndex((page) => page.segment === segment);
+  if (index === -1) return null;
+  const prev = GUIDE_PAGES[index - 1] ?? null;
+  const next = GUIDE_PAGES[index + 1] ?? null;
+  if (!prev && !next) return null;
+  return (
+    <nav
+      aria-label={t('guidePagerLabel')}
+      data-testid="guide-pager"
+      className="mt-12 flex w-full max-w-[var(--measure-prose)] items-stretch gap-3 border-t border-[color:var(--color-divider)] pt-4"
+    >
+      {prev ? (
+        <GuidePagerLink page={prev} eyebrow={t('guidePrev')} edge="start" testId="guide-pager-prev" />
+      ) : (
+        <span aria-hidden className="flex-1" />
+      )}
+      {next ? (
+        <GuidePagerLink page={next} eyebrow={t('guideNext')} edge="end" testId="guide-pager-next" />
+      ) : (
+        <span aria-hidden className="flex-1" />
+      )}
+    </nav>
+  );
+}
+
+function GuidePagerLink({
+  page,
+  eyebrow,
+  edge,
+  testId,
+}: {
+  page: GuidePage;
+  eyebrow: string;
+  edge: 'start' | 'end';
+  testId: string;
+}) {
+  const t = useTranslations('gatewayNav');
+  return (
+    <Link
+      href={`/guide/${page.segment}`}
+      data-testid={testId}
+      className={controlClass({
+        shape: 'card',
+        className: cn(
+          'flex-1 flex-col gap-1 rounded-card border-[color:var(--color-border-soft)] px-4 py-3 hover:border-[color:var(--color-indigo-a46)] hover:bg-[color:var(--color-indigo-a06)]',
+          edge === 'end' ? 'items-end text-right' : 'items-start text-left',
+        ),
+      })}
+    >
+      <span className="text-label text-[color:var(--color-text-quaternary)]">{eyebrow}</span>
+      <span className="text-body-lg text-[color:var(--color-text-primary)] [word-break:keep-all]">
+        {t(`guidePages.${page.titleKey}`)}
+      </span>
+    </Link>
   );
 }
 

--- a/tests/e2e/guide-pager.spec.ts
+++ b/tests/e2e/guide-pager.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * **가이드 장 끝이 막다른 길이 아니다** (2026-08-13 실측에서 생긴 게이트).
+ *
+ * 가이드는 순서가 있는 13장인데, 본문이 끝나는 자리에 다음 장으로 가는 길이
+ * 0개였다 — 다 읽은 사람이 왼쪽 차례로 되돌아가 방금 읽은 장이 몇 번째인지
+ * 스스로 찾아야 했다. 순서의 정본(`guide-pages.ts`)이 이미 있으므로 장 끝
+ * 이전/다음 내비가 그 순서를 그대로 쓴다.
+ *
+ * 첫 장은 다음만, 마지막 장(trust)은 이전만 갖는 것까지 잰다 — 없는 장으로
+ * 가는 문을 그리면 그게 새 막다른 길이다.
+ */
+test.describe("가이드 장 끝 이전/다음", () => {
+  test("첫 장은 다음만 갖고, 누르면 실제로 다음 장에 착지한다", async ({ page }) => {
+    await seedFirstRunSeen(page);
+    await page.goto("/ko/guide/?guides=off", { waitUntil: "domcontentloaded" });
+    const pager = page.getByTestId("guide-pager");
+    await expect(pager).toBeVisible();
+    await expect(page.getByTestId("guide-pager-prev")).toHaveCount(0);
+    const next = page.getByTestId("guide-pager-next");
+    await expect(next).toBeVisible();
+    await next.click();
+    await page.waitForURL(/\/guide\/first-five-minutes/, { timeout: 15_000 });
+    // 가운데 장은 양쪽 다 갖는다.
+    await expect(page.getByTestId("guide-pager-prev")).toBeVisible();
+    await expect(page.getByTestId("guide-pager-next")).toBeVisible();
+  });
+
+  test("마지막 장은 이전만 갖는다", async ({ page }) => {
+    await seedFirstRunSeen(page);
+    await page.goto("/ko/guide/trust/?guides=off", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("guide-pager")).toBeVisible();
+    await expect(page.getByTestId("guide-pager-next")).toHaveCount(0);
+    await expect(page.getByTestId("guide-pager-prev")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- 가이드 flow 실측: 13장짜리 순서 있는 가이드의 장 끝이 막다른 길(다음 장으로 가는 길 0개) — 「다음 단계가 없음」 패턴. 장 끝에 이전/다음 카드 내비(`GuidePager`)를 단다.
- 순서 정본 `GUIDE_PAGES` 재사용 · 첫 장 다음만/마지막 장 이전만 · 화살표 글자 0(장식 화살표 게이트와 충돌 없이 아이브로우+정렬이 방향을 말함) · 변경 내역(장 아님)에는 없음.
- 앵커는 `controlClass({shape:"card"})` 값 층 경유 — 처음 raw `<Link>` 로 썼다가 **채택 래칫이 빨강으로 잡아 줘** 값 층으로 옮겼다(게이트가 일했다).

## Test plan
- 새 e2e `guide-pager.spec.ts`(구현 전 빨강 확인): 첫 장 다음만→클릭→`first-five-minutes` 착지·가운데 장 양쪽·마지막 장(trust) 이전만 — 2 pass.
- `pnpm test:contracts` 1639 pass(채택 래칫 포함) · `test:i18n:messages` 16 · 관문 e2e 3스펙 8 pass · tsc·lint 깨끗. 스크린샷: 이전/다음 카드 렌더.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD