### PR TITLE
fix: 알림의 「브릿지 끼어듦」을 「중간 개념 끼어듦」으로

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3447,7 +3447,7 @@
       "taskEndAgent": "{agent} finished a task",
       "domainAdded": "Domain added",
       "domainRemoved": "Domain removed",
-      "bridgeInserted": "Bridge inserted",
+      "bridgeInserted": "Middle concept inserted",
       "vaultProblem": "Folder problem"
     }
   },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3447,7 +3447,7 @@
       "taskEndAgent": "{agent} 작업 끝",
       "domainAdded": "도메인 생김",
       "domainRemoved": "도메인 사라짐",
-      "bridgeInserted": "브릿지 끼어듦",
+      "bridgeInserted": "중간 개념 끼어듦",
       "vaultProblem": "폴더 문제"
     }
   },


### PR DESCRIPTION
## Summary
- 설정 시트(알림 절) flow 실측: 받을 알림 칩 + 알림함 이벤트 줄의 「브릿지 끼어듦」이 **사용자 화면에서 브릿지라는 내부 용어를 쓰는 유일한 2곳**(같은 값 `agentActivity.event.bridgeInserted` 를 두 표면이 공유). 브릿지는 아직 정식 도입 중인 내부 개념 이름이다(`design.md` 노드 규격 절).
- 같은 알림의 상세줄이 이미 「자식 {count}개를 데려감」이라 쉬운 말이므로, 제목을 그 짝인 **「중간 개념 끼어듦」/Middle concept inserted** 로 수렴.

## Test plan
- 실측(dev :3423): 설정→알림 절에서 새 문구 렌더 · 「브릿지」 0건.
- 소비처 단위(agent-activity·AgentActivitySettings) 19 pass · `test:i18n:messages` 16 · `test:desktop:check` 276 · `pnpm test:contracts` 1639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD