### PR TITLE
fix: 변경 내역이 기여자용 영어 머리말로 열리지 않는다

### DIFF
--- a/src/views/gateway-doc/ui/GatewayDocPage.tsx
+++ b/src/views/gateway-doc/ui/GatewayDocPage.tsx
@@ -106,10 +106,19 @@ export function GatewayDocPage({
      * 번역된 제목과 원문 제목이 나란히 서면 같은 것이 두 번 나온다.
      */
     const withoutH1 = raw.replace(/^#\s+.*(\r?\n)+/, '');
+    /*
+     * 변경 내역(entryNav)의 머리 인용구도 지운다 — 저장소 기여자에게 이 파일을
+     * 어떻게 쓰라고 말하는 메타라서, 화면 lead 가 같은 말을 사용자 언어로 이미
+     * 한다(2026-08-13 실측: KO 페이지의 첫 문단이 영어 관리 문서였다). 뒤따르는
+     * `---` 구분선까지 한 덩어리다. 인용구가 없으면 아무것도 안 지운다.
+     */
+    const withoutPreamble = entryNav
+      ? withoutH1.replace(/^(?:>.*(?:\r?\n)+)+(?:---(?:\r?\n)+)?/, '')
+      : withoutH1;
     return recentSectionLimit
-      ? trimToRecentSections(withoutH1, recentSectionLimit)
-      : { body: withoutH1, omittedSections: 0 };
-  }, [slug, recentSectionLimit]);
+      ? trimToRecentSections(withoutPreamble, recentSectionLimit)
+      : { body: withoutPreamble, omittedSections: 0 };
+  }, [slug, recentSectionLimit, entryNav]);
 
   /**
    * 항목 목록과 본문 제목의 id 는 **같은 함수**가 낸다 — 두 곳이 각자 만들면

--- a/tests/e2e/changelog-preamble.spec.ts
+++ b/tests/e2e/changelog-preamble.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+
+/**
+ * **변경 내역이 관리자용 영어 머리말로 열리지 않는다** (2026-08-13 실측).
+ *
+ * `docs/CHANGELOG.md` 의 머리 인용구("Major change history … not PR-level
+ * granularity")는 저장소 기여자에게 이 파일을 어떻게 쓰라고 말하는 메타다.
+ * 화면의 lead(「무엇이 언제 바뀌었는지. 최신이 위입니다.」)가 같은 말을
+ * 사용자 언어로 이미 하므로, KO 방문자의 첫 문단이 영어 관리 문서가 되는
+ * 것은 중복이자 용어 누출이었다. 본문은 첫 날짜 항목부터 시작해야 한다.
+ */
+test("변경 내역 본문은 기여자용 머리말 없이 첫 항목부터 시작한다", async ({ page }) => {
+  await seedFirstRunSeen(page);
+  await page.goto("/ko/changelog/?guides=off", { waitUntil: "domcontentloaded" });
+  const body = page.getByTestId("gateway-doc-body");
+  await expect(body).toBeVisible();
+  await expect(body).not.toContainText("PR-level granularity");
+  // 첫 자식이 인용구가 아니라 날짜 항목(h2)이다 — 머리말이 사라진 자리에
+  // 다른 무언가가 슬며시 서지 않는지까지 잰다.
+  const firstTag = await body.evaluate((el) => el.firstElementChild?.tagName ?? null);
+  expect(firstTag).toBe("H2");
+});


### PR DESCRIPTION
## Summary
- 변경 내역 flow 실측: `/ko/changelog` 첫 문단이 `docs/CHANGELOG.md` 머리 인용구 — 기여자에게 파일 사용법을 말하는 **영어 메타**("… not PR-level granularity")였다. 화면 lead 가 같은 말을 이미 사용자 언어로 한다(중복+용어 누출).
- 이 뷰의 기존 선례(첫 `# H1` 제거 — 화면 제목과 중복)와 같은 논리로, **변경 내역 모드(entryNav)에서만** 머리 인용구+`---` 를 지운다. 인용구가 없으면 no-op. 가이드 장은 건드리지 않는다. 문서 원본은 그대로 — GitHub 독자(기여자)에게는 필요한 문단.
- 이번 walk 에서 오탐 하나 정정: 알림 갈래 칩의 켬/끔은 `role="switch"`+`aria-checked` 로 완전히 건강했다(첫 계기가 엉뚱한 속성을 읽었다).

## Test plan
- 새 e2e `changelog-preamble.spec.ts`(구현 전 빨강 확인): 본문에 영어 머리말 0건 + 첫 자식이 날짜 항목(H2).
- 관문 e2e(pager·inbody·preamble) 5 pass · `pnpm test:contracts` 1639 pass · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD