### PR TITLE
fix: 편집기의 신원 가드 경고가 사용자 언어로 말한다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1161,6 +1161,8 @@
       "closeTooltip": "Close (Esc)",
       "saveFailed": "Save failed",
       "saveConflict": "This file changed on disk before the save completed. Your edits are kept. Copy them, refresh, then apply them to the latest file.",
+      "saveIdentityUid": "A document's uid is its permanent identity, so it can't be removed or changed. Restore the uid line and the save will go through.",
+      "saveIdentityHistory": "merged_uids is merge-owned history and can't be edited here. Restore that line and the save will go through.",
       "discardConfirm": "Discard unsaved changes and close the editor?",
       "linkText": "Link text",
       "placeholder": "Text",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1161,6 +1161,8 @@
       "closeTooltip": "닫기 (Esc)",
       "saveFailed": "저장 실패",
       "saveConflict": "디스크에서 먼저 변경되어 저장하지 못했습니다. 편집 내용은 유지됩니다. 내용을 복사한 뒤 새로고침해 최신 파일에 다시 반영하세요.",
+      "saveIdentityUid": "문서의 uid 는 이 노드의 영구 신원이라 지우거나 바꿀 수 없어요. uid 줄을 원래대로 되돌리면 저장됩니다.",
+      "saveIdentityHistory": "merged_uids 는 합치기 기록이라 여기서 고칠 수 없어요. 그 줄을 원래대로 되돌리면 저장됩니다.",
       "discardConfirm": "저장하지 않은 변경 사항을 버리고 편집을 닫을까요?",
       "linkText": "링크 텍스트",
       "placeholder": "텍스트",

--- a/src/features/docs-vault-local/model/use-local-vault.ts
+++ b/src/features/docs-vault-local/model/use-local-vault.ts
@@ -147,13 +147,23 @@ function assertNodeIdentityContent(
   }
 }
 
+/**
+ * 신원 가드 오류 — `name` 으로 갈래를 싣는다. 에디터가 이 이름을 보고
+ * 사용자 언어 문장으로 바꾼다(`VaultConflictError` 와 같은 문법). 영어
+ * 원문은 남긴다: 콘솔·로그·미지원 표면의 폴백이다.
+ */
+function identityError(name: 'VaultIdentityUidError' | 'VaultIdentityHistoryError', message: string): Error {
+  return Object.assign(new Error(message), { name });
+}
+
 function assertIdentityPatch(
   raw: string,
   updates: Record<string, FrontmatterUpdateValue>,
 ): void {
   const previous = parseFrontmatter(raw).frontmatter;
   if ('merged_uids' in updates) {
-    throw new Error(
+    throw identityError(
+      'VaultIdentityHistoryError',
       '`merged_uids:` is merge-owned identity history and cannot be edited by a generic browser patch.',
     );
   }
@@ -162,10 +172,10 @@ function assertIdentityPatch(
   const previousUid = previous.uid;
   const hasPreviousUid = previousUid !== undefined && previousUid !== null && previousUid !== '';
   if (hasPreviousUid && nextUid !== previousUid) {
-    throw new Error('`uid:` is immutable. Rename or reclassify the node without changing its UID.');
+    throw identityError('VaultIdentityUidError', '`uid:` is immutable. Rename or reclassify the node without changing its UID.');
   }
   if (typeof nextUid !== 'string' || !NODE_UID_RE.test(nextUid)) {
-    throw new Error('`uid:` must be a lowercase UUIDv4.');
+    throw identityError('VaultIdentityUidError', '`uid:` must be a lowercase UUIDv4.');
   }
 }
 
@@ -179,10 +189,11 @@ function assertIdentityTransition(previousRaw: string, nextRaw: string): void {
     previousUid !== '' &&
     next.uid !== previousUid
   ) {
-    throw new Error('`uid:` is immutable. Rename or reclassify the node without changing its UID.');
+    throw identityError('VaultIdentityUidError', '`uid:` is immutable. Rename or reclassify the node without changing its UID.');
   }
   if (JSON.stringify(next.merged_uids) !== JSON.stringify(previous.merged_uids)) {
-    throw new Error(
+    throw identityError(
+      'VaultIdentityHistoryError',
       '`merged_uids:` is merge-owned identity history and cannot be edited by a generic browser save.',
     );
   }

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx
@@ -282,6 +282,29 @@ describe('DocsVaultEditor', () => {
     expect(screen.queryByDisplayValue('DISK VERSION')).not.toBeInTheDocument();
   });
 
+  // 신원 가드(uid 지움·바꿈, merged_uids 편집)에 막힌 저장도 충돌과 같은
+  // 문법으로 번역된다 — 종전에는 영어 개발자 문장이 KO 화면에 그대로 떴다.
+  it('surfaces a localized message when the save is rejected by the uid identity guard', async () => {
+    const guard = Object.assign(
+      new Error('`uid:` is immutable. Rename or reclassify the node without changing its UID.'),
+      { name: 'VaultIdentityUidError' },
+    );
+    const onSave = vi.fn().mockRejectedValue(guard);
+    render(
+      <DocsVaultEditor vaultScope={VAULT_SCOPE} doc={doc} getDocContent={async () => 'initial'} onSave={onSave} onClose={vi.fn()} />,
+    );
+    const editor = await screen.findByDisplayValue('initial');
+    fireEvent.change(editor, { target: { value: 'uid deleted' } });
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(
+      screen.getByText(
+        '문서의 uid 는 이 노드의 영구 신원이라 지우거나 바꿀 수 없어요. uid 줄을 원래대로 되돌리면 저장됩니다.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/is immutable/)).not.toBeInTheDocument();
+  });
+
   it('asks before closing with unsaved changes', async () => {
     const onClose = vi.fn();
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -434,13 +434,17 @@ export function DocsVaultEditor({
       // setSavedContent, so dirty stays true and the #5(a) poll guard keeps the
       // unsaved edits safe. Surface a localized, reassuring message for the
       // conflict case (the raw message is technical English).
-      const conflict = err instanceof Error && err.name === 'VaultConflictError';
+      const name = err instanceof Error ? err.name : '';
       setError(
-        conflict
+        name === 'VaultConflictError'
           ? t('saveConflict')
-          : err instanceof Error
-            ? err.message
-            : t('saveFailed'),
+          : name === 'VaultIdentityUidError'
+            ? t('saveIdentityUid')
+            : name === 'VaultIdentityHistoryError'
+              ? t('saveIdentityHistory')
+              : err instanceof Error
+                ? err.message
+                : t('saveFailed'),
       );
     } finally {
       setSaving(false);


### PR DESCRIPTION
## Summary
- 문서함 쓰기 flow 실측(볼트 열기→문서 편집→저장, 지난 회차의 장치 오염 수리 후 재걷기): uid 를 지운 저장을 가드가 옳게 막지만 **경고가 KO 화면에 영어 개발자 문장**으로 떴다("\`uid:\` is immutable. Rename or reclassify the node…").
- `VaultConflictError` 의 기존 문법(err.name 매칭→번역)을 신원 가드로 확장: 다섯 throw 자리에 이름 둘(`VaultIdentityUidError` · `VaultIdentityHistoryError`)을 싣고, 에디터 배너가 사용자 문장으로 번역(「원래대로 되돌리면 저장됩니다」 — 다음 행동까지). 이름 없는 오류는 종전대로 원문 폴백.

## Test plan
- TDD: 가드 거절 시 번역 문장·영어 원문 부재 단언 빨강 확인 후 구현 → editor 14 + docs-vault-local 254 pass.
- `pnpm test:i18n:messages` 16 · `pnpm test:contracts` 1639 · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD