### PR TITLE
fix: 스튜디오 피커의 묶음이 하나뿐이면 접힌 층을 건너뛴다

### DIFF
--- a/src/views/ontology-studio/ui/StudioCompass.test.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.test.tsx
@@ -743,6 +743,42 @@ describe("StudioCompass — 발견 표면 (browse + 추천)", () => {
     expect(screen.queryByTestId("studio-browse-node-capability:billing")).not.toBeInTheDocument();
   });
 
+  it("묶음이 하나뿐이면 접힌 층을 건너뛰고 후보를 바로 펼친다 — 뒤로 갈 곳도 없다", () => {
+    const SOLE: PickerDiscovery = {
+      suggestions: [],
+      domains: [{ domainId: null, key: "__no_domain__", title: null, count: 1 }],
+      nodesByDomain: {
+        __no_domain__: [REFUND],
+      },
+    };
+    const bearings: CompassBearingView[] = [
+      bearing("isA", "up"),
+      bearing("dependsOn", "right"),
+      bearing("contains", "down"),
+      bearing("relates", "left"),
+    ];
+    render(
+      <StudioCompass
+        mode="enhance"
+        labels={labels}
+        kindLabelFor={(k) => k}
+        focal={{ kindLabel: "capability", domainLabel: null, name: "MCP Server", definition: "" }}
+        bearings={bearings}
+        filledBearings={0}
+        writable
+        candidatesFor={() => [CANDIDATE]}
+        discoveryFor={() => SOLE}
+        onFill={vi.fn()}
+        onSave={vi.fn()}
+        onExit={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("studio-socket-right"));
+    expect(screen.getByTestId("studio-browse-node-capability:refund")).toBeInTheDocument();
+    expect(screen.queryByTestId("studio-browse-domain-__no_domain__")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("studio-browse-back")).not.toBeInTheDocument();
+  });
+
   it("picking from a suggestion stages the fill (reuses onFill)", () => {
     const onFill = renderDiscovery();
     fireEvent.click(screen.getByTestId("studio-socket-right"));

--- a/src/views/ontology-studio/ui/StudioPicker.tsx
+++ b/src/views/ontology-studio/ui/StudioPicker.tsx
@@ -139,6 +139,12 @@ export function InlinePicker({
   );
   // Which domain the 둘러보기 drill-down is inside (null = top-level domain list).
   const [browseKey, setBrowseKey] = useState<string | null>(null);
+  // 묶음이 하나뿐이면 접힌 층을 건너뛴다 — 후보 1개가 「도메인 없음 (1)」 뒤에
+  // 숨어 한 번 더 눌러야 보였다(2026-08-13 flow 실측, 2노드 볼트). 자동 진입일
+  // 때는 되돌아갈 목록도 없으므로 뒤로 줄도 그리지 않는다.
+  const soleDomainKey =
+    discovery && discovery.domains.length === 1 ? discovery.domains[0].key : null;
+  const effectiveBrowseKey = browseKey ?? soleDomainKey;
   const reasonLabel = (reason: PickerSuggestionReason): string =>
     reason === "sameDomain"
       ? labels.reasonSameDomain
@@ -247,7 +253,7 @@ export function InlinePicker({
               {/* 둘러보기 — domain drill-down (default = domain list). */}
               <div data-testid="studio-picker-browse">
                 <PickerSectionHeading label={labels.browseHeading} />
-                {browseKey === null ? (
+                {effectiveBrowseKey === null ? (
                   discovery.domains.map((d) => (
                     <button
                       key={d.key}
@@ -271,6 +277,7 @@ export function InlinePicker({
                   ))
                 ) : (
                   <>
+                    {soleDomainKey === null ? (
                     <button
                       type="button"
                       data-testid="studio-browse-back"
@@ -284,7 +291,8 @@ export function InlinePicker({
                     >
                       {labels.browseBack}
                     </button>
-                    {(discovery.nodesByDomain[browseKey] ?? []).map((c) => (
+                    ) : null}
+                    {(discovery.nodesByDomain[effectiveBrowseKey] ?? []).map((c) => (
                       <button
                         key={c.id}
                         type="button"


### PR DESCRIPTION
## Summary
- 스튜디오 쓰기 flow 실측(볼트 열기→소켓→피커→저장, 2노드 볼트): 둘러보기의 유일한 후보가 **「도메인 없음 (1)」 접힌 묶음** 뒤에 숨어 한 번 더 눌러야 보였다. 묶음이 하나뿐일 때 드릴다운은 이득 없는 마찰.
- 묶음이 1개면 자동 진입해 후보를 바로 펼친다. 자동 진입 시 「← 도메인」 뒤로 줄도 없음(갈 목록이 없다). 묶음 2개 이상은 종전 드릴다운 그대로.
- 걷기의 나머지는 건강: 선택→채움→확인하고 저장→토스트→Git 레일 배지까지 한 호흡으로 이어짐(스크린샷).

## Test plan
- TDD: 「묶음 하나면 바로 펼친다·뒤로 없음」 빨강 확인 후 구현 → StudioCompass 71 pass · studio 전체 275 pass.
- 실측(dev :3423): 같은 볼트에서 후보 직접 노출 → 클릭 → 저장 → 「1가지를 기록했어요」.
- e2e `studio-stage-motion`+`navigation` 9 pass · `pnpm test:contracts` 1639 · tsc·lint 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD