### PR TITLE
fix: 스튜디오 임시저장이 렌더 중 남의 setState 를 깨우지 않는다

### DIFF
--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -1264,7 +1264,15 @@ function StudioStage({
   const stage = (action: Parameters<typeof reduceStudioChanges>[1]) =>
     setChanges((prev) => {
       const next = reduceStudioChanges(prev, action);
-      saveStudioDraft(focalItem.node.id, focalItem.node.label, next);
+      /*
+       * ⚠️ 갱신 함수 안에서 곧장 저장하면 안 된다 — 이 함수는 React 가 **렌더
+       * 중에** 실행할 수 있고, `saveStudioDraft` 는 `DRAFT_EVENT` 를 동기로
+       * dispatch 해 「작업중」 목록 구독자(useSyncExternalStore)의 setState 를
+       * 렌더 한가운데서 깨운다 — "Cannot update a component while rendering"
+       * (2026-08-13 소켓 채움 flow 실측). 마이크로태스크로 렌더 밖에 내보낸다.
+       * dev 이중 호출로 두 번 예약돼도 같은 값이라 무해하다(멱등 쓰기).
+       */
+      queueMicrotask(() => saveStudioDraft(focalItem.node.id, focalItem.node.label, next));
       return next;
     });
 


### PR DESCRIPTION
## Summary
- 저장 미리보기 flow 실측(모달 자체는 건강 — 미니 그래프·같은 문장 목록·닫기/저장) 중 dev 오버레이가 세는 React 오류 1건을 추적: 소켓 채움 순간 `Cannot update a component (StudioStage) while rendering a different component (StudioStage)`.
- 원인: `stage()` 의 **상태 갱신 함수 안** `saveStudioDraft` — 갱신 함수는 렌더 중 실행될 수 있고, 저장이 `DRAFT_EVENT` 를 동기 dispatch 해 「작업중」 목록 구독자(`useSyncExternalStore`)의 setState 를 렌더 중에 깨움. `queueMicrotask` 로 저장을 렌더 밖으로 이연(멱등 쓰기라 dev 이중 호출 무해). 단계별 오류 계측으로 「pick」 단계 특정 → 자리 확정.

## Test plan
- **프로브**: 수리 전 같은 flow 오류 1건(단계 계측: load 0 → picker 0 → pick 1) → 수리 후 **0건**. 새로고침 후 초안 복원(「저장 대기」 칩)으로 미룬 저장 도착 확인.
- `pnpm test:run src/views/ontology-studio` 275 pass · e2e studio 2스펙 9 pass · `pnpm test:contracts` 1639 pass · tsc 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD