### PR TITLE
fix: 새 노드 카드의 정의 안내문이 반 줄 잘리지 않는다 (236→256)

### DIFF
--- a/src/views/ontology-studio/ui/StudioCompass.tsx
+++ b/src/views/ontology-studio/ui/StudioCompass.tsx
@@ -61,7 +61,12 @@ const STAGE_LANE_DELAY_MS = 40;
 
 // ── Board geometry (fixed coordinate system, centered in the stage) ──────────
 
-const CARD_CREATE_H = 236;
+/*
+ * 도메인 셀렉트가 함께 그려질 때 정의 입력칸이 44px 로 줄어 안내문 둘째 줄
+ * (18px)이 잘렸다(2026-08-13 실측: clientH 42 vs scrollH 60). 두 줄을 항상
+ * 보장하도록 +20. 경고 배너 카드(320)와의 순서는 유지된다.
+ */
+const CARD_CREATE_H = 256;
 /** Create-mode card grows when the near-dup / slug-collision banner is shown so
  * the warning always lives INSIDE the dashed border (never bleeds past it). */
 const CARD_CREATE_H_WARN = 320;


### PR DESCRIPTION
## Summary
- 새 노드 만들기 flow 실측(도메인 있는 볼트): 도메인 셀렉트가 함께 그려지면 정의 입력칸이 44px 로 줄어 **안내문 둘째 줄이 카드 바닥에 반쯤 잘림**(clientH 42 vs scrollH 60). 도메인 없는 볼트에서는 안 잘려 기존 어떤 검사도 못 본 조합 의존 결함.
- `CARD_CREATE_H` 236→**256**(+20, 두 줄 보장). 근거 주석 동봉. 경고 배너 변형(320)과의 순서 유지.

## Test plan
- 실측(dev :3423): 수리 전 42/60(1줄 잘림) → 수리 후 **62/62 잘림 0**, 아래 소켓과 카드 여유 65px(겹침 없음), 스크린샷.
- `pnpm test:run src/views/ontology-studio` 275 pass · e2e `studio-compass-symmetry`+`stage-motion` 8 pass(기하 대칭 게이트 포함) · `pnpm test:contracts` 1641 pass · tsc 깨끗.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD