### PR TITLE
fix: 검색에서 이름 정확 일치를 접두 일치 위로 올린다

### DIFF
--- a/src/shared/lib/node-name-match.ts
+++ b/src/shared/lib/node-name-match.ts
@@ -56,6 +56,11 @@ export function nodeNameCandidates(node: NodeNameSource): string[] {
   return out;
 }
 
+/** 이름 중 하나라도 질의와 정확히 같은가 (정규화된 질의를 받는다). */
+export function nameEquals(node: NodeNameSource, normalizedQuery: string): boolean {
+  return nodeNameCandidates(node).some((name) => normalizeForMatch(name) === normalizedQuery);
+}
+
 /** 이름 중 하나라도 질의로 시작하는가 (정규화된 질의를 받는다). */
 export function nameStartsWith(node: NodeNameSource, normalizedQuery: string): boolean {
   return nodeNameCandidates(node).some((name) => normalizeForMatch(name).startsWith(normalizedQuery));

--- a/src/widgets/global-search/lib/match.test.ts
+++ b/src/widgets/global-search/lib/match.test.ts
@@ -30,11 +30,28 @@ describe("matchOntologyNodes", () => {
     expect(r.every((m) => m.score === 0)).toBe(true);
   });
 
-  it("title prefix > substring > summary > id 순 점수", () => {
+  it("title exact > prefix > substring > summary > id 순 점수", () => {
     const r = matchOntologyNodes("세션", corpus);
-    // "세션" 은 title prefix
+    // "세션" 은 title 과 글자까지 같다 — 정확 일치.
     expect(r[0]?.node.id).toBe("session");
-    expect(r[0]?.score).toBe(4);
+    expect(r[0]?.score).toBe(5);
+  });
+
+  it("정확 일치는 더 최근에 승인된 prefix 매치보다 위다 (2026-08-13 실측 회귀)", () => {
+    // 실측: 「주문」을 치면 도메인 「주문」(정확 일치)이 「주문서 작성」 등
+    // 나중에 승인된 접두 일치 5개 아래 6위였다 — 동점(4) 후 최신순이 정확
+    // 일치를 가라앉혔다. 이름을 끝까지 친 사용자가 찾는 것은 그 이름의 노드다.
+    const earlier = new Date("2026-04-01T00:00:00Z");
+    const later = new Date("2026-04-27T00:00:00Z");
+    const vault = [
+      node({ id: "cap-checkout", title: "주문서 작성", lastApprovedAt: later }),
+      node({ id: "cap-cancel", title: "주문 취소", lastApprovedAt: later }),
+      node({ id: "domain-order", title: "주문", kind: "domain", lastApprovedAt: earlier }),
+    ];
+    const r = matchOntologyNodes("주문", vault);
+    expect(r[0]?.node.id).toBe("domain-order");
+    expect(r[0]?.score).toBe(5);
+    expect(r[1]?.score).toBe(4);
   });
 
   it("summary 매치 (title 에 없음) — score 2", () => {
@@ -87,8 +104,8 @@ describe("matchOntologyNodes", () => {
       const r = matchOntologyNodes("온톨로지 코어", [localized]);
       expect(r).toHaveLength(1);
       expect(r[0]?.node.id).toBe("ontology-core");
-      // 화면에 보이는 이름은 title 과 동급 — prefix 매치는 4.
-      expect(r[0]?.score).toBe(4);
+      // 화면에 보이는 이름은 title 과 동급 — 표시 이름 정확 일치도 5.
+      expect(r[0]?.score).toBe(5);
     });
 
     it("표시 이름 부분 일치는 substring 점수", () => {
@@ -99,7 +116,7 @@ describe("matchOntologyNodes", () => {
     it("원문 title 로도 그대로 찾힌다 (범위는 넓히기만 한다)", () => {
       const r = matchOntologyNodes("Ontology Core", [localized]);
       expect(r).toHaveLength(1);
-      expect(r[0]?.score).toBe(4);
+      expect(r[0]?.score).toBe(5);
     });
 
     it("한국어 화면에서도 다른 어권 이름으로 찾힌다", () => {
@@ -112,7 +129,7 @@ describe("matchOntologyNodes", () => {
       });
       const r = matchOntologyNodes("payments", [koScreen]);
       expect(r).toHaveLength(1);
-      expect(r[0]?.score).toBe(4);
+      expect(r[0]?.score).toBe(5);
     });
 
     it("자소 분리(NFD) 입력도 같은 결과", () => {
@@ -252,6 +269,12 @@ describe("matchProjects", () => {
     const r = matchProjects("ia", corpus);
     expect(r[0]?.project.slug).toBe("demo-iam"); // "IAM" prefix 매치
     expect(r[0]?.score).toBe(4);
+  });
+
+  it("name 정확 일치는 5 — 노드 매처와 같은 사다리", () => {
+    const r = matchProjects("iam", corpus);
+    expect(r[0]?.project.slug).toBe("demo-iam");
+    expect(r[0]?.score).toBe(5);
   });
 
   it("description / tags / category 도 매치", () => {

--- a/src/widgets/global-search/lib/match.ts
+++ b/src/widgets/global-search/lib/match.ts
@@ -1,6 +1,6 @@
 import type { KnowledgeGraphNode } from "@/entities/knowledge-graph";
 import type { Project } from "@/entities/project";
-import { nameIncludes, nameStartsWith, normalizeForMatch } from "@/shared/lib/node-name-match";
+import { nameEquals, nameIncludes, nameStartsWith, normalizeForMatch } from "@/shared/lib/node-name-match";
 
 /**
  * N12 (persona-ux-2026-07 report) — element nodes are often titled after the
@@ -51,6 +51,9 @@ export interface MatchOntologyOptions {
  * ontology 노드 검색.
  *
  * 점수 (낮을수록 약한 매치):
+ *   5 — 이름 정확 일치 — 이름을 끝까지 친 사용자가 찾는 것은 그 이름의
+ *       노드다. prefix 와 동점이면 최신순 동점 처리가 정확 일치를 가라앉힌다
+ *       (2026-08-13 실측: 「주문」이 「주문서 작성」 등 5개 아래 6위)
  *   4 — 이름 prefix 매치
  *   3 — 이름 substring 매치
  *   2 — summary substring 매치
@@ -114,7 +117,8 @@ export function matchOntologyNodes(
     const id = normalizeForMatch(node.id);
 
     let score = 0;
-    if (nameStartsWith(node, trimmed)) score = 4;
+    if (nameEquals(node, trimmed)) score = 5;
+    else if (nameStartsWith(node, trimmed)) score = 4;
     else if (nameIncludes(node, trimmed)) score = 3;
     else if (summary.includes(trimmed)) score = 2;
     else if (id.includes(trimmed)) score = 1;
@@ -144,6 +148,8 @@ export interface ProjectSearchResult {
  * project 검색.
  *
  * 점수:
+ *   5 — name / nameEn 정확 일치 (노드 매처와 같은 이유 — 동점 최신순이
+ *       정확 일치를 가라앉히지 못하게)
  *   4 — name / nameEn prefix 매치
  *   3 — name / nameEn substring 매치
  *   2 — description / tags / category substring 매치
@@ -179,7 +185,8 @@ export function matchProjects(
     const slug = project.slug.toLowerCase();
 
     let score = 0;
-    if (name.startsWith(trimmed) || nameEn.startsWith(trimmed)) score = 4;
+    if (name === trimmed || nameEn === trimmed) score = 5;
+    else if (name.startsWith(trimmed) || nameEn.startsWith(trimmed)) score = 4;
     else if (name.includes(trimmed) || nameEn.includes(trimmed)) score = 3;
     else if (
       description.includes(trimmed)


### PR DESCRIPTION
## Summary
- 실측(dev :3423, 예시 볼트): 검색 팔레트에 「주문」을 치면 제목이 글자까지 같은 도메인 「주문」이 **6위** — 위 5개는 「주문서 작성」 등 나중에 승인된 접두 일치였다.
- 원인: 점수 사다리 최고가 4(접두)라 정확 일치와 접두 일치가 동점이고, 동점은 최신 승인순이라 정확 일치가 가라앉는다.
- 수정: `nameEquals`(단일 출처 `node-name-match`)로 정확 일치 단계 5를 사다리 맨 위에 추가. `matchProjects` 도 같은 사다리.

## Test plan
- `pnpm test:run src/widgets/global-search/lib/match.test.ts src/widgets/global-search/ui/GlobalSearch.test.tsx` — 41 passed (회귀 테스트 「정확 일치는 더 최근에 승인된 prefix 매치보다 위다」 포함, 수정 전 5건 빨강 확인)
- `pnpm exec eslint` 대상 3파일 · `pnpm exec tsc --noEmit` 통과
- 라이브 실측: 수정 후 「주문」 1위 = 도메인 「주문」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD