### PR TITLE
fix: 스튜디오 검색·피커에 순위를 놓는다 — 정확 일치가 컷에 잘리지 않게

### DIFF
--- a/src/views/ontology-studio/lib/match-candidate.test.ts
+++ b/src/views/ontology-studio/lib/match-candidate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CreateCandidate } from "./build-create-node";
-import { candidateMatches, normalizeForMatch } from "./match-candidate";
+import { candidateMatches, normalizeForMatch, rankCandidates } from "./match-candidate";
 
 const LOCALIZED: CreateCandidate = {
   id: "element:example-element",
@@ -66,5 +66,59 @@ describe("candidateMatches", () => {
       displayLocales: { ko: "예시 구성요소", en: "Sample piece" },
     };
     expect(candidateMatches(bilingual, "sample piece")).toBe(true);
+  });
+});
+
+describe("rankCandidates", () => {
+  const cand = (id: string, title: string, ref = id): CreateCandidate => ({
+    id,
+    title,
+    canonicalTitle: title,
+    kind: "capability",
+    ref,
+  });
+
+  it("정확 일치는 접두 일치들보다 위다 — 풀 순서가 늦어도 (2026-08-13 실측 회귀)", () => {
+    // 실측: 스튜디오 검색에 「주문」을 치면 도메인 「주문」이 접두 역량 5개 아래
+    // 6위였다 — 필터 → 앞 8개 자르기뿐이라 순위가 아예 없어서, 풀 순서상 늦은
+    // 정확 일치는 컷에 잘려 안 보일 수도 있다.
+    const pool = [
+      cand("cap-checkout", "주문서 작성"),
+      cand("cap-cancel", "주문 취소"),
+      cand("domain-order", "주문"),
+      cand("elem-draft", "주문서 초안"),
+    ];
+    const r = rankCandidates(pool, "주문", 8).map((c) => c.id);
+    expect(r[0]).toBe("domain-order");
+  });
+
+  it("접두 일치는 부분 일치보다, 이름 일치는 ref 일치보다 위다", () => {
+    const pool = [
+      cand("ref-only", "결제 수단", "capabilities/주문-결제"),
+      cand("substr", "재주문"),
+      cand("prefix", "주문 확정"),
+    ];
+    const r = rankCandidates(pool, "주문", 8).map((c) => c.id);
+    expect(r).toEqual(["prefix", "substr", "ref-only"]);
+  });
+
+  it("같은 층 안에서는 풀 순서를 지킨다 (안정 정렬)", () => {
+    const pool = [cand("a", "주문 취소"), cand("b", "주문 조회"), cand("c", "주문 확정")];
+    expect(rankCandidates(pool, "주문", 8).map((c) => c.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("빈 검색어는 풀 순서 그대로 limit 까지", () => {
+    const pool = [cand("a", "하나"), cand("b", "둘"), cand("c", "셋")];
+    expect(rankCandidates(pool, "", 2).map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("limit 은 순위를 매긴 뒤에 자른다 — 정확 일치가 컷에 잘리지 않는다", () => {
+    const pool = [
+      ...Array.from({ length: 8 }, (_, i) => cand(`p${i}`, `주문 파생 ${i}`)),
+      cand("exact", "주문"),
+    ];
+    const r = rankCandidates(pool, "주문", 8).map((c) => c.id);
+    expect(r[0]).toBe("exact");
+    expect(r).toHaveLength(8);
   });
 });

--- a/src/views/ontology-studio/lib/match-candidate.ts
+++ b/src/views/ontology-studio/lib/match-candidate.ts
@@ -1,4 +1,4 @@
-import { nameIncludes, normalizeForMatch } from "@/shared/lib/node-name-match";
+import { nameEquals, nameIncludes, nameStartsWith, normalizeForMatch } from "@/shared/lib/node-name-match";
 import type { CreateCandidate } from "./build-create-node";
 
 /**
@@ -22,18 +22,51 @@ import type { CreateCandidate } from "./build-create-node";
 
 export { normalizeForMatch };
 
+function nameSource(candidate: CreateCandidate) {
+  return {
+    // 후보의 `title` 은 현재 로케일의 표시 이름, `canonicalTitle` 이 원문.
+    title: candidate.canonicalTitle ?? candidate.title,
+    display: candidate.title,
+    displayLocales: candidate.displayLocales,
+  };
+}
+
 /** 이 후보가 검색어와 일치하는가. 빈 검색어는 모두 통과. */
 export function candidateMatches(candidate: CreateCandidate, query: string): boolean {
   const q = normalizeForMatch(query);
   if (q === "") return true;
-  const nameMatch = nameIncludes(
-    {
-      // 후보의 `title` 은 현재 로케일의 표시 이름, `canonicalTitle` 이 원문.
-      title: candidate.canonicalTitle ?? candidate.title,
-      display: candidate.title,
-      displayLocales: candidate.displayLocales,
-    },
-    q,
-  );
-  return nameMatch || normalizeForMatch(candidate.ref).includes(q);
+  return nameIncludes(nameSource(candidate), q) || normalizeForMatch(candidate.ref).includes(q);
+}
+
+/**
+ * 필터 + 순위 + 컷을 한 번에 (2026-08-13).
+ *
+ * 결함: 두 소비처(상단 NodeSearch · 관계 피커)가 `candidateMatches` 로 거른 뒤
+ * **풀 순서 그대로 앞 8개를 잘랐다** — 순위가 없어서 「주문」을 치면 정확 일치
+ * 도메인 「주문」이 접두 역량 5개 아래 6위였고, 풀 순서상 더 늦었다면 컷에
+ * 잘려 아예 안 보였을 것이다.
+ *
+ * 사다리는 전역 검색(`widgets/global-search/lib/match.ts`)과 같은 모양이다:
+ * 이름 정확 일치 > 이름 접두 > 이름 부분 > ref 부분. 같은 층 안에서는 풀
+ * 순서를 지킨다(발견-우선 목록의 기존 순서 존중 — `Array.sort` 는 안정 정렬).
+ */
+export function rankCandidates(
+  candidates: readonly CreateCandidate[],
+  query: string,
+  limit: number,
+): CreateCandidate[] {
+  const q = normalizeForMatch(query);
+  if (q === "") return candidates.slice(0, limit);
+  const scored: Array<{ candidate: CreateCandidate; score: number }> = [];
+  for (const candidate of candidates) {
+    const source = nameSource(candidate);
+    let score = 0;
+    if (nameEquals(source, q)) score = 4;
+    else if (nameStartsWith(source, q)) score = 3;
+    else if (nameIncludes(source, q)) score = 2;
+    else if (normalizeForMatch(candidate.ref).includes(q)) score = 1;
+    if (score > 0) scored.push({ candidate, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map((s) => s.candidate);
 }

--- a/src/views/ontology-studio/ui/OntologyStudioPage.tsx
+++ b/src/views/ontology-studio/ui/OntologyStudioPage.tsx
@@ -79,7 +79,7 @@ import {
   type PracticeArtifact,
 } from "../lib/studio-practice-guide";
 import { allowedKindsFor } from "../lib/allowed-kinds";
-import { candidateMatches } from "../lib/match-candidate";
+import { rankCandidates } from "../lib/match-candidate";
 import { clearCreateDraft, readCreateDraft, saveCreateDraft } from "../lib/create-draft-store";
 import {
   clearStudioDraft,
@@ -400,14 +400,14 @@ function StudioStage({
       exclude: ReadonlySet<string>,
     ): CreateCandidate[] => {
       const allow = allowedKindsFor(relation, focalKind);
-      return candidates
-        .filter((c) => allow.has(c.kind))
-        .filter((c) => !exclude.has(c.id))
-        // #66 — 표시 이름뿐 아니라 canonical title 과 ref 까지 정규화해 본다.
-        // 예전엔 `c.title`(= display) 만 봐서 `display_ko` 가 달린 노드를 원문
-        // 이름으로 검색할 수 없었다.
-        .filter((c) => candidateMatches(c, query))
-        .slice(0, 8);
+      // #66 — 표시 이름뿐 아니라 canonical title 과 ref 까지 정규화해 보고,
+      // 정확 일치 > 접두 > 부분 > ref 순으로 올린다(2026-08-13 — 순위 없는
+      // 앞 8개 컷은 정확 일치를 자를 수 있다).
+      return rankCandidates(
+        candidates.filter((c) => allow.has(c.kind)).filter((c) => !exclude.has(c.id)),
+        query,
+        8,
+      );
     },
     [candidates],
   );

--- a/src/views/ontology-studio/ui/StudioPicker.tsx
+++ b/src/views/ontology-studio/ui/StudioPicker.tsx
@@ -14,7 +14,7 @@ import { ChevronDown, Plus, Search, X } from "lucide-react";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
 import { IconButton, controlClass } from "@/shared/ui";
 import { fieldClass } from "@/shared/ui/control-class";
-import { candidateMatches } from "../lib/match-candidate";
+import { rankCandidates } from "../lib/match-candidate";
 import { cn } from "@/shared/lib/cn";
 import type { StudioBearing, StudioRelation } from "../lib/build-studio-item";
 import type { CreateCandidate } from "../lib/build-create-node";
@@ -405,11 +405,14 @@ export function NodeSearch({
   }
 
 
-  const rows = nodes
-    // #66 — 표시 이름 · canonical title · ref 를 함께 본다(정규화 포함).
-    .filter((n) => candidateMatches(n, query))
-    .filter((n) => n.title !== currentName)
-    .slice(0, 8);
+  // #66 — 표시 이름 · canonical title · ref 를 함께 보고(정규화 포함),
+  // 정확 일치 > 접두 > 부분 > ref 순으로 올린다 — 순위 없이 앞 8개만 자르면
+  // 정확 일치가 컷에 잘릴 수 있다(2026-08-13 실측: 「주문」이 6위).
+  const rows = rankCandidates(
+    nodes.filter((n) => n.title !== currentName),
+    query,
+    8,
+  );
 
   const pick = (id: string) => {
     onOpenNode(id);


### PR DESCRIPTION
## Summary
- 실측(dev :3423, 예시 볼트): 스튜디오 상단 검색에 「주문」을 치면 정확 일치 도메인 「주문」이 접두 역량 5개 아래 **6위** — 전역 검색에서 #1099 로 고친 것과 같은 병이 스튜디오에 남아 있었다.
- 원인이 더 나쁘다: 두 소비처(상단 NodeSearch · 관계 피커)가 `candidateMatches` 필터 후 **풀 순서 그대로 앞 8개를 잘랐다** — 순위가 아예 없어서, 정확 일치가 풀 순서상 늦으면 컷에 잘려 안 보일 수도 있는 구조.
- `rankCandidates`(정확>접두>부분>ref, 같은 층은 풀 순서 유지 — 안정 정렬)를 `match-candidate` 단일 출처에 만들어 두 소비처가 같이 쓴다. 이름 규칙은 기존처럼 `shared/lib/node-name-match` 공유.
- 참고: 문서함 검색도 같은 질의로 걸어 봤고 거기는 정확 일치가 이미 1위(건강).

## Test plan
- TDD: `rankCandidates` 테스트 5건(실측 회귀 · 층 순서 · 안정 정렬 · 빈 질의 · **컷보다 순위가 먼저**)을 먼저 넣어 빨강 확인 → 구현 → 15/15 초록
- `pnpm test:contracts` 1643 pass · `pnpm test:run src/views/ontology-studio` 280 pass · `pnpm exec tsc --noEmit` · eslint(신규 경고 0 — 기존 1건은 #1090 이전부터)
- 라이브 실측: 수정 후 「주문」 1위 = 도메인 「주문」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD