### PR TITLE
fix: 새 프로젝트 폼의 개발자 용어를 사용자 말로 — slug·CSV·GFM 누출 정리

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2686,16 +2686,16 @@
         "extrasCaption": "Body text, tags, connected projects, dates: all fine to add after creating."
       },
       "fields": {
-        "slug": "slug",
+        "slug": "Document address",
         "name": "Name",
         "nameEn": "English name (optional)",
         "category": "Category",
         "status": "Status",
         "description": "Short description",
         "detail": "Detail (markdown, optional)",
-        "tagsCsv": "Tags (CSV)",
-        "stackCsv": "Stack (CSV)",
-        "linksText": "Links (one label|url per line)",
+        "tagsCsv": "Tags (comma-separated)",
+        "stackCsv": "Stack (comma-separated)",
+        "linksText": "Links (one per line, name|url)",
         "dependencies": "Dependencies",
         "startedAt": "Start date",
         "launchedAt": "Launch date",
@@ -2704,7 +2704,7 @@
         "progress": "Progress %",
         "slugHint": "Used in URLs. Letters (any script, including non-Latin), digits, and hyphens only, no spaces. Cannot change after creation.",
         "slugGenerate": "Generate from name",
-        "slugDuplicate": "Slug already exists.",
+        "slugDuplicate": "That address already exists.",
         "duplicateNotice": "Starting from a copy of the existing project.",
         "categoryMissingWarning": "Current category reference is broken. Pick another category to recover.",
         "statusMissingWarning": "Current status reference is broken. Pick another status to recover.",
@@ -2823,7 +2823,7 @@
     "markdown": {
       "tabWrite": "Write",
       "tabPreview": "Preview",
-      "footer": "Markdown · GFM",
+      "footer": "Markdown supported",
       "previewEmpty": "Nothing to preview"
     },
     "quickEdit": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2686,16 +2686,16 @@
         "extrasCaption": "소개 본문, 태그, 연결 프로젝트, 일정: 만든 뒤에 채워도 됩니다."
       },
       "fields": {
-        "slug": "slug",
+        "slug": "문서 주소",
         "name": "이름",
         "nameEn": "영문 이름 (선택)",
         "category": "카테고리",
         "status": "상태",
         "description": "짧은 설명",
         "detail": "상세 (마크다운, 선택)",
-        "tagsCsv": "태그 (CSV)",
-        "stackCsv": "스택 (CSV)",
-        "linksText": "링크 (줄별 label|url)",
+        "tagsCsv": "태그 (쉼표로 구분)",
+        "stackCsv": "스택 (쉼표로 구분)",
+        "linksText": "링크 (한 줄에 하나, 이름|주소)",
         "dependencies": "의존 프로젝트",
         "startedAt": "시작일",
         "launchedAt": "출시일",
@@ -2704,7 +2704,7 @@
         "progress": "진행도 %",
         "slugHint": "URL에 쓰임. 문자(한글 등 유니코드 포함)·숫자·하이픈만, 공백 없이. 생성 후엔 변경 불가.",
         "slugGenerate": "이름에서 생성",
-        "slugDuplicate": "이미 존재하는 slug입니다.",
+        "slugDuplicate": "이미 있는 주소예요.",
         "duplicateNotice": "기존 프로젝트 내용을 복제해서 시작합니다.",
         "categoryMissingWarning": "현재 카테고리 참조가 깨졌습니다. 다른 카테고리를 선택해 복구하세요.",
         "statusMissingWarning": "현재 상태 참조가 깨졌습니다. 다른 상태를 선택해 복구하세요.",
@@ -2821,9 +2821,9 @@
       "hubBadge": "HUB"
     },
     "markdown": {
-      "tabWrite": "Write",
-      "tabPreview": "Preview",
-      "footer": "Markdown · GFM",
+      "tabWrite": "쓰기",
+      "tabPreview": "미리보기",
+      "footer": "마크다운 지원",
       "previewEmpty": "미리볼 내용 없음"
     },
     "quickEdit": {


### PR DESCRIPTION
## Summary
- flow 걷기(dev :3423, /ko/project/new): 접힌 상태는 「문서 주소」인데 「직접 정하기」로 펼치면 라벨이 **「slug」** — 한 항목이 이름 둘. 「더 채우기」에는 **태그 (CSV) · 스택 (CSV) · 링크 (줄별 label|url)**, 마크다운 에디터 탭은 **Write / Preview / Markdown · GFM** — 한국어 화면에 개발자 용어가 그대로.
- ko: 문서 주소 · 쉼표로 구분 · 한 줄에 하나, 이름|주소 · 쓰기/미리보기 · 마크다운 지원. slug 중복 오류도 「이미 있는 주소예요.」
- en: slug→Document address(접힌 라벨과 동일), CSV→comma-separated, footer→Markdown supported.
- 같은 걷기에서 잰 건강한 것들: 폴더 없을 때 주 버튼 비활성 55% 흐림+not-allowed(계기로 교차 확인 — 눈으로는 활성처럼 보였음), 저장 안 됨 칩, 카드 미리보기 실시간 갱신.

## Test plan
- `pnpm test:i18n:messages` 16 pass · `pnpm test:run src/features/project-edit` 47 pass(라벨 테스트는 카탈로그 값을 키로 재사용) · `pnpm test:desktop:check` 279 pass
- 라이브 실측: 펼친 폼 전체 텍스트에 SLUG/CSV/GFM/label|url/Write/Preview 0건, 문서 주소·쉼표로 구분·쓰기·미리보기 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD