### PR TITLE
fix: 이름 변경 성공에 「못 찾았어요」 경고가 붙던 것 — 주소가 새 이름을 따라간다

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -894,9 +894,14 @@ function DocsVaultContent() {
       await localVault.renameDoc(selectedSlug, nextSlug, {
         rewriteBacklinks: true,
       });
-      // selection + recent/pinned 마이그레이트
+      // selection + 주소 + 활성 기억 + recent/pinned 마이그레이트.
+      // 주소를 안 옮기면 매니페스트 갱신 순간 「URL 이 요청한 문서가 없다」
+      // 판정이 옛 주소를 잡아 거짓 경고가 뜬다(2026-08-13 걷기 실측). 새
+      // 이름은 매니페스트에 나타날 때까지 「아직 모름」으로 지연 판정한다.
       const prev = selectedSlug;
+      pendingRenameRef.current = { from: prev, to: nextSlug };
       setSelectedSlug(nextSlug);
+      replaceUrlState({ slug: nextSlug });
       setRecentSlugs((list) => {
         const mapped = list.map((s) => (s === prev ? nextSlug : s));
         // 갱신 함수 안 직접 쓰기 금지 — 위 삭제 경로와 같은 이유(2026-08-13).
@@ -931,7 +936,7 @@ function DocsVaultContent() {
         t('dialog.renameFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, setPinnedSlugs, setRecentSlugs, t]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, replaceUrlState, setPinnedSlugs, setRecentSlugs, t]);
 
   // P5c — "새 문서" 는 kind 선택이 먼저 온다(도메인/역량/요소/문서). generic
   // `title:` 템플릿을 없애 "이 vault 의 문서는 노드다" 를 생성 순간에 강제
@@ -1189,8 +1194,28 @@ function DocsVaultContent() {
    * 다시 뜨지 않는다. 사용자가 문서를 직접 고르면 닫힌다.
    */
   const [missingQuerySlug, setMissingQuerySlug] = useState<string | null>(null);
+  /**
+   * **앱이 방금 이름을 바꾼 문서는 「없음」이 아니다** (2026-08-13 걷기 실측).
+   *
+   * 이름 변경 뒤 두 주소가 판정에 걸릴 수 있다: ① 옛 주소 — 트리 클릭은
+   * 라우터 내비라 `useSearchParams` 가 옛 `?slug=` 를 물고 있고,
+   * `replaceUrlState` 의 `history.replaceState` 는 그 훅에 보이지 않는다.
+   * 매니페스트가 갱신되어 옛 이름이 사라지는 순간 「요청한 문서가 없다」가
+   * 걸려 **방금 성공한 이름 변경에 실패 경고가 붙었다**(0.5초 만에
+   * 「못 찾았어요」). ② 새 주소 — 매니페스트는 다음 폴링까지 옛 판이라 그
+   * 공백에서 새 이름도 「없다」로 보인다. 둘 다 밖에서 온 요청이 아니라 앱
+   * 자신의 행위이므로 판정 대상이 아니다. 사용자가 다른 문서로 가면(질의가
+   * 두 주소 밖으로 바뀌면) 가드를 걷는다.
+   */
+  const pendingRenameRef = useRef<{ from: string; to: string } | null>(null);
   useEffect(() => {
     if (!normalizedQuerySlug || docsBySlug.size === 0) return;
+    const rename = pendingRenameRef.current;
+    if (rename && normalizedQuerySlug !== rename.from && normalizedQuerySlug !== rename.to) {
+      pendingRenameRef.current = null;
+    } else if (rename) {
+      return;
+    }
     if (docsBySlug.has(normalizedQuerySlug)) {
       // 문서가 나타났으면 잡아 둔 판정을 걷는다 — 부팅 중 샘플 창에서 내렸던
       // 「없다」가 로컬 볼트 도착으로 거짓이 된 경우다(2026-08-08).

--- a/tests/e2e/docs-rename-address.spec.ts
+++ b/tests/e2e/docs-rename-address.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+import { stubDirectoryPicker } from "./vault-picker-stub";
+
+/**
+ * **이름 변경 뒤 주소가 새 이름을 따라간다** (2026-08-13 걷기에서 발견).
+ *
+ * 이름 변경 핸들러가 선택(`setSelectedSlug`)만 옮기고 주소(`?slug=`)와 활성
+ * 기억은 옛 주소에 남겼다. 볼트 매니페스트가 갱신되어 옛 주소가 사라지는
+ * 순간, 「URL 이 요청한 문서가 없다」 판정이 걸려 **방금 자기가 바꾼 이름을
+ * 못 찾았다는 경고**가 떴다 — 이름 변경은 성공했는데 화면은 실패를 알렸다.
+ *
+ * 두 가지를 잰다: ① 이름 변경 뒤 「못 찾았어요」 배너가 (매니페스트 갱신
+ * 공백을 포함해) 끝까지 안 뜬다 ② 주소창의 `?slug=` 가 새 이름을 가리킨다 —
+ * 그 주소를 복사해 공유하면 받는 사람도 같은 문서로 와야 한다.
+ */
+const VAULT = {
+  "README.md": "# 걷기 볼트\n",
+  "domains/order.md":
+    "---\nkind: domain\nslug: domains/order\ntitle: 주문\nuid: 11111111-1111-4111-8111-111111111111\n---\n\n주문 도메인.\n",
+  "capabilities/cart.md":
+    "---\nkind: capability\nslug: capabilities/cart\ntitle: 장바구니\nuid: 22222222-2222-4222-8222-222222222222\nrelations:\n  - type: belongs_to\n    to: domains/order\n---\n\n장바구니 역량.\n",
+};
+
+test("이름 변경 뒤 — 경고가 안 뜨고 주소가 새 이름을 가리킨다", async ({ page }) => {
+  test.setTimeout(150_000);
+  page.on("dialog", (d) => void d.accept("capabilities/cart-renamed"));
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await stubDirectoryPicker(page, VAULT);
+  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2000);
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await page.getByTestId("first-run-starter-open").click();
+  await page.waitForTimeout(500);
+  const pick = page.getByTestId("vault-guide-pick-existing");
+  if (await pick.isVisible().catch(() => false)) await pick.click();
+  await page.waitForTimeout(2500);
+
+  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2500);
+  await page.getByText("capabilities", { exact: true }).first().click();
+  await page.waitForTimeout(500);
+  await page.getByText("장바구니", { exact: true }).first().click();
+  await page.waitForTimeout(1200);
+
+  // 팔레트 → 이름 변경 명령 (prompt 는 위 dialog 핸들러가 새 주소로 답한다)
+  await page.keyboard.press("Meta+k");
+  await page.waitForTimeout(600);
+  await page.keyboard.type("이름 변경");
+  await page.waitForTimeout(600);
+  await page.keyboard.press("Enter");
+
+  // 매니페스트 갱신 공백(웹 폴링 1.5s/5s)을 넘겨 가며 배너가 한 번도 안
+  // 뜨는지 본다 — 공백 중 한 프레임만 떠도 거짓 경고다.
+  const banner = page.getByText(/못 찾았어요/);
+  for (let i = 0; i < 12; i += 1) {
+    await page.waitForTimeout(500);
+    expect(await banner.count(), `이름 변경 ${(i + 1) * 0.5}s 후 거짓 「못 찾았어요」 경고`).toBe(0);
+  }
+
+  // 주소가 새 이름을 가리킨다 — 문서도 여전히 열려 있다.
+  expect(page.url()).toContain("slug=capabilities%2Fcart-renamed");
+  await expect(page.getByText("장바구니").first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- 문서함 쓰기 flow 걷기(OPFS 스텁, 실제 편집→저장→이름 변경): 이름 변경은 성공하는데 0.5초 뒤 **「capabilities/cart 문서를 못 찾았어요. 대신 다른 문서를 열었습니다」** 경고가 떴다 — 앱이 방금 자기가 은퇴시킨 주소를 찾다 실패했다고 사용자에게 알림.
- 원인: 핸들러가 `setSelectedSlug` 만 하고 `replaceUrlState({slug})` 를 안 함 + 트리 클릭이 라우터 내비라 `useSearchParams` 가 옛 주소 유지 + 매니페스트 폴링 공백. 「URL 요청 문서 없음」 래치가 옛 주소를 잡았다.
- 수리: 주소를 새 이름으로 이관 + 앱 자신이 방금 바꾼 두 주소(옛/새)는 판정 제외(질의가 그 밖으로 바뀌면 가드 해제). 진짜 깨진 외부 딥링크 판정은 그대로.

## Test plan
- 신규 영구 게이트 `tests/e2e/docs-rename-address.spec.ts` — 수리 전 **빨강**(0.5s 거짓 경고) 확인 → 수리 후 초록(6초 폴링 창 내 경고 0 + `?slug=` 새 이름)
- 문서함 e2e 3종(deeplink·scroll-lock·truth-telling) 17 passed · `pnpm test:contracts` 1643 · tsc/eslint 통과
- 저장 여정도 같은 걷기에서 확인: 수정→저장 필요→⌘S→동기화됨, 콘솔 오류 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD