### PR TITLE
feat: 화면 안내 자동 표시 기본값을 끔으로 — 필요한 사람만 켠다

### DIFF
--- a/src/features/first-run-starter/model/vault-guide-auto-open.test.ts
+++ b/src/features/first-run-starter/model/vault-guide-auto-open.test.ts
@@ -13,12 +13,17 @@ describe('전역 「자동 표시」 스위치의 사정거리', () => {
   });
 
   it('스위치가 켜져 있고 아직 안 봤으면 자동으로 뜬다 — 탐지기가 놀지 않는다', () => {
+    window.localStorage.setItem('ontology-atlas:guide-auto-start:v1', '1');
     expect(readVaultGuideAutoOpened()).toBe(false);
   });
 
   it('스위치를 끄면 폴더-우선 시트도 자동으로 뜨지 않는다', () => {
     window.localStorage.setItem('ontology-atlas:guide-auto-start:v1', '0');
     // 「이미 열었음」으로 취급 = 자동 표시 안 함.
+    expect(readVaultGuideAutoOpened()).toBe(true);
+  });
+
+  it('기본(저장값 없음)도 자동으로 뜨지 않는다 — 2026-08-13 소유자 확정', () => {
     expect(readVaultGuideAutoOpened()).toBe(true);
   });
 });

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.test.tsx
@@ -276,8 +276,10 @@ describe('FirstRunStarterModule', () => {
 
   // 폴더-우선 첫 방문 (소유자 지시 2026-07-24) — 첫 화면을 열자마자 폴더
   // 지정 유도 시트가 1회 자동으로 열리고, 플래그가 있으면 다시 안 뜬다.
+  // 2026-08-13 부터 자동 표시는 전역 기본 끔(opt-in)이라 켠 상태를 전제한다.
   it('auto-opens the folder guide sheet once on the very first visit', () => {
     vi.useFakeTimers();
+    window.localStorage.setItem('ontology-atlas:guide-auto-start:v1', '1');
     window.localStorage.removeItem('vault-open-guide:auto:v1');
     render(<FirstRunStarterModule concepts={1} relations={1} domains={1} />);
     expect(screen.queryByTestId('vault-guide-sheet')).not.toBeInTheDocument();

--- a/src/features/guided-tour/ui/DestinationGuide.test.tsx
+++ b/src/features/guided-tour/ui/DestinationGuide.test.tsx
@@ -37,7 +37,10 @@ beforeEach(() => {
   // jsdom 기본값은 포커스 없음이라 명시적으로 세운다.
   vi.spyOn(document, "hasFocus").mockReturnValue(true);
   window.localStorage.removeItem(DOCS_KEY);
-  window.localStorage.removeItem(AUTO_START_KEY);
+  // 자동 표시는 2026-08-13 부터 기본 끔(opt-in) — 자동 발화 행동을 검사하는
+  // 아래 테스트들은 스위치를 켠 상태를 전제로 한다. 기본값 자체의 검사는
+  // 「기본(저장값 없음)이면」 테스트가 따로 한다.
+  window.localStorage.setItem(AUTO_START_KEY, "1");
   vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
@@ -193,11 +196,21 @@ describe("화면 안내 자동 표시 스위치", () => {
   });
 
   it("켜져 있으면 저절로 뜬다 — 스위치가 실제로 그 발화를 막고 있다는 증거", async () => {
+    window.localStorage.setItem(AUTO_START_KEY, "1");
     renderGuide();
     await act(async () => {
       vi.advanceTimersByTime(6000);
     });
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+  });
+
+  it("기본(저장값 없음)이면 저절로 뜨지 않는다 — 2026-08-13 소유자 확정", async () => {
+    window.localStorage.removeItem(AUTO_START_KEY);
+    renderGuide();
+    await act(async () => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
   });
 
   it("꺼져 있어도 「다시 보기」로는 열린다 — 스위치는 삭제가 아니다", async () => {

--- a/src/shared/lib/guide-auto-start.test.ts
+++ b/src/shared/lib/guide-auto-start.test.ts
@@ -20,27 +20,27 @@ describe("guide auto-start switch", () => {
     window.localStorage.clear();
   });
 
-  it("기본값은 켬 — 처음 오는 사람에게 안내는 유일한 설명이다", () => {
-    expect(DEFAULT_GUIDE_AUTO_START).toBe(true);
-    expect(readGuideAutoStart()).toBe(true);
+  it("기본값은 끔 — 필요한 사람만 켠다 (2026-08-13 소유자 확정)", () => {
+    expect(DEFAULT_GUIDE_AUTO_START).toBe(false);
+    expect(readGuideAutoStart()).toBe(false);
   });
 
-  it("끄면 저장되고, 켜면 되돌아온다", () => {
-    writeGuideAutoStart(false);
-    expect(readGuideAutoStart()).toBe(false);
+  it("켜면 저장되고, 끄면 되돌아온다", () => {
     writeGuideAutoStart(true);
     expect(readGuideAutoStart()).toBe(true);
+    writeGuideAutoStart(false);
+    expect(readGuideAutoStart()).toBe(false);
   });
 
   /**
-   * `"0"` 만 끔이다. 저장값이 깨졌거나 옛 형식이면 **켬으로 살아난다** —
-   * 반대로 두면 값 하나가 망가진 사용자에게서 설명이 통째로 사라지고, 그건
-   * 조용한 실패다.
+   * 명시적 선택만 존중한다 — 기본을 끔으로 뒤집기 전에 직접 켜 둔 사람의
+   * "1" 이 살아남아야 하고, 모르는 값·빈 값·깨진 값은 기본값(끔)이다.
    */
-  it("모르는 값·빈 값은 켬으로 산다", () => {
-    for (const raw of [null, "", "yes", "true", "1", "nope"]) {
-      expect(resolveGuideAutoStart(raw)).toBe(true);
-    }
+  it("켜 둔 저장값(\"1\")은 살아남고, 모르는 값은 끔이다", () => {
+    expect(resolveGuideAutoStart("1")).toBe(true);
     expect(resolveGuideAutoStart("0")).toBe(false);
+    for (const raw of [null, "", "yes", "true", "nope"]) {
+      expect(resolveGuideAutoStart(raw)).toBe(false);
+    }
   });
 });

--- a/src/shared/lib/guide-auto-start.ts
+++ b/src/shared/lib/guide-auto-start.ts
@@ -18,8 +18,13 @@ import { useCallback, useSyncExternalStore } from "react";
  * "아니면 클릭했을때나" 가 이 상태다. 안내를 지우는 게 아니라 **부를 때만
  * 오게** 하는 것이다.
  *
- * 기본값은 켬 — 처음 오는 사람에게 안내는 유일한 설명이라, 끄는 쪽을 기본으로
- * 두면 그 사람은 아무 안내도 못 받는다.
+ * ## 기본값은 끔 (2026-08-13 소유자 확정 — 2026-07-29 의 「기본 켬」을 뒤집음)
+ *
+ * *"이런거 이제 안나오게 안되나? 맨날 나와서 불편한데.. 가이드는 기본적으로
+ * 설정에서 off해놓는건 어떤지? 필요한 사람만 키도록.."* — 전역 스위치를 만든
+ * 뒤에도 「매번 나온다」는 실보고가 다시 왔다. 처음 오는 사람의 설명 경로는
+ * 나침반 타일과 설정 › 다시 보기가 맡는다. 명시적으로 켠 저장값("1")은
+ * 그대로 존중된다.
  */
 
 const GUIDE_AUTO_START_KEY = "ontology-atlas:guide-auto-start:v1";
@@ -27,11 +32,17 @@ const GUIDE_AUTO_START_KEY = "ontology-atlas:guide-auto-start:v1";
 /** 같은 탭 구독자에게 알리는 커스텀 이벤트(cross-tab 은 `storage`). */
 const GUIDE_AUTO_START_EVENT = "ontology-atlas:guide-auto-start-change";
 
-export const DEFAULT_GUIDE_AUTO_START = true;
+export const DEFAULT_GUIDE_AUTO_START = false;
 
-/** 저장값 → 불리언. 순수 함수 — `"0"` 만 끔이고 나머지는 전부 켬(기본값 보존). */
+/**
+ * 저장값 → 불리언. 순수 함수 — 명시적 선택("1" 켬 · "0" 끔)만 존중하고
+ * 모르는 값·빈 값은 기본값(끔)이다. 기본을 끔으로 뒤집을 때 켜 둔 사람의
+ * "1" 은 그대로 살아남는다.
+ */
 export function resolveGuideAutoStart(saved: string | null): boolean {
-  return saved === "0" ? false : DEFAULT_GUIDE_AUTO_START;
+  if (saved === "1") return true;
+  if (saved === "0") return false;
+  return DEFAULT_GUIDE_AUTO_START;
 }
 
 export function readGuideAutoStart(): boolean {

--- a/tests/e2e/dialog-focus-ring.spec.ts
+++ b/tests/e2e/dialog-focus-ring.spec.ts
@@ -40,6 +40,11 @@ import { expect, test, type Page } from "@playwright/test";
  * **아무것도 클릭하지 않는다**(위 경고 참고).
  */
 async function openGuideSheetOnFirstRun(page: Page) {
+  // 자동 표시는 2026-08-13 부터 기본 끔(opt-in) — 이 스펙이 재는 것은 시트의
+  // 포커스 링이지 자동 표시 여부가 아니므로, 켠 상태를 심고 연다.
+  await page.addInitScript(() => {
+    window.localStorage.setItem("ontology-atlas:guide-auto-start:v1", "1");
+  });
   await page.goto("/ko/topology/");
   await expect(page.getByTestId("vault-guide-sheet")).toBeVisible({ timeout: 20_000 });
 }


### PR DESCRIPTION
## Summary
- 소유자 확정(2026-08-13, 스크린샷 제보): 목적지 안내 카드가 «맨날 나와서 불편» → **기본 끔, opt-in**. 2026-07-29 의 「기본 켬」 결정을 소유자 지시로 뒤집는다.
- `DEFAULT_GUIDE_AUTO_START` true→false. 저장값 해석은 명시적 선택만 존중: "1" 켬 · "0" 끔 · 그 외/없음 = 끔 — **기본 뒤집기 전에 직접 켜 둔 사람의 "1" 은 살아남는다.**
- 안내가 사라지는 게 아니다: 지도의 나침반 타일과 설정 › 화면 안내 「다시 보기」로는 그대로 열린다(기존 계약 유지).

## Test plan
- 단위: 기본값·저장 왕복·해석 표 갱신 + DestinationGuide 에 「기본(저장값 없음)이면 저절로 안 뜬다」 신규 케이스, 자동 발화 행동 테스트는 스위치 켠 전제로 이관 — 94 passed
- `pnpm test:desktop:check` 279 pass
- 라이브 실측(dev :3423, localStorage 순정): /ko/docs · /ko/ontology/insights · /ko/projects 첫 방문 6초 대기 — 안내 카드 0, 화면 즉시 사용 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD