### PR TITLE
fix: 삭제 성공에도 「못 찾았어요」 경고가 붙던 것 — 이름 변경과 같은 병

### DIFF
--- a/src/views/docs-vault/ui/DocsVaultPage.tsx
+++ b/src/views/docs-vault/ui/DocsVaultPage.tsx
@@ -735,8 +735,12 @@ function DocsVaultContent() {
     if (!ok) return;
     try {
       await localVault.deleteDoc(slug);
-      // 삭제 성공 — selection/pinned/recent 정리
+      // 삭제 성공 — selection/주소/pinned/recent 정리. 주소를 안 걷어내면
+      // 매니페스트 갱신 순간 「요청한 문서가 없다」 판정이 방금 지운 주소를
+      // 잡아 거짓 경고가 뜬다(2026-08-13 걷기 실측 — 이름 변경과 같은 병).
+      appTouchedSlugsRef.current = new Set([slug]);
       setSelectedSlug(null);
+      replaceUrlState({ slug: null });
       setEditing(false);
       setRecentSlugs((list) => list.filter((s) => s !== slug));
       setPinnedSlugs((list) => {
@@ -763,7 +767,7 @@ function DocsVaultContent() {
         t('dialog.deleteFailed', { message: err instanceof Error ? err.message : String(err) }),
       );
     }
-  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, setPinnedSlugs, setRecentSlugs, t]);
+  }, [canEditCurrent, selectedSlug, manifest, localVault, recentKey, replaceUrlState, setPinnedSlugs, setRecentSlugs, t]);
 
   const handleScaffoldOntologyStarter = useCallback(async () => {
     // #73 — 화면 언어로 만든 볼트는 그 언어로 읽히게 한다.
@@ -899,7 +903,7 @@ function DocsVaultContent() {
       // 판정이 옛 주소를 잡아 거짓 경고가 뜬다(2026-08-13 걷기 실측). 새
       // 이름은 매니페스트에 나타날 때까지 「아직 모름」으로 지연 판정한다.
       const prev = selectedSlug;
-      pendingRenameRef.current = { from: prev, to: nextSlug };
+      appTouchedSlugsRef.current = new Set([prev, nextSlug]);
       setSelectedSlug(nextSlug);
       replaceUrlState({ slug: nextSlug });
       setRecentSlugs((list) => {
@@ -1195,25 +1199,26 @@ function DocsVaultContent() {
    */
   const [missingQuerySlug, setMissingQuerySlug] = useState<string | null>(null);
   /**
-   * **앱이 방금 이름을 바꾼 문서는 「없음」이 아니다** (2026-08-13 걷기 실측).
+   * **앱이 방금 손댄 주소는 「없음」이 아니다** (2026-08-13 걷기 실측 2건).
    *
-   * 이름 변경 뒤 두 주소가 판정에 걸릴 수 있다: ① 옛 주소 — 트리 클릭은
+   * 이름 변경·삭제 뒤 판정에 걸리는 주소들: ① 은퇴한 옛 주소 — 트리 클릭은
    * 라우터 내비라 `useSearchParams` 가 옛 `?slug=` 를 물고 있고,
    * `replaceUrlState` 의 `history.replaceState` 는 그 훅에 보이지 않는다.
-   * 매니페스트가 갱신되어 옛 이름이 사라지는 순간 「요청한 문서가 없다」가
-   * 걸려 **방금 성공한 이름 변경에 실패 경고가 붙었다**(0.5초 만에
-   * 「못 찾았어요」). ② 새 주소 — 매니페스트는 다음 폴링까지 옛 판이라 그
-   * 공백에서 새 이름도 「없다」로 보인다. 둘 다 밖에서 온 요청이 아니라 앱
-   * 자신의 행위이므로 판정 대상이 아니다. 사용자가 다른 문서로 가면(질의가
-   * 두 주소 밖으로 바뀌면) 가드를 걷는다.
+   * 매니페스트가 갱신되어 그 이름이 사라지는 순간 「요청한 문서가 없다」가
+   * 걸려 **방금 성공한 이름 변경/삭제에 실패 경고가 붙었다**(둘 다 0.5초
+   * 만에 「못 찾았어요」 — 삭제는 확인 대화상자까지 거친 행위다). ② 이름
+   * 변경의 새 주소 — 매니페스트는 다음 폴링까지 옛 판이라 그 공백에서 새
+   * 이름도 「없다」로 보인다. 전부 밖에서 온 요청이 아니라 앱 자신의
+   * 행위이므로 판정 대상이 아니다. 사용자가 다른 문서로 가면(질의가 그
+   * 집합 밖으로 바뀌면) 가드를 걷는다.
    */
-  const pendingRenameRef = useRef<{ from: string; to: string } | null>(null);
+  const appTouchedSlugsRef = useRef<ReadonlySet<string>>(new Set());
   useEffect(() => {
     if (!normalizedQuerySlug || docsBySlug.size === 0) return;
-    const rename = pendingRenameRef.current;
-    if (rename && normalizedQuerySlug !== rename.from && normalizedQuerySlug !== rename.to) {
-      pendingRenameRef.current = null;
-    } else if (rename) {
+    const touched = appTouchedSlugsRef.current;
+    if (touched.size > 0 && !touched.has(normalizedQuerySlug)) {
+      appTouchedSlugsRef.current = new Set();
+    } else if (touched.has(normalizedQuerySlug)) {
       return;
     }
     if (docsBySlug.has(normalizedQuerySlug)) {

--- a/tests/e2e/docs-rename-address.spec.ts
+++ b/tests/e2e/docs-rename-address.spec.ts
@@ -63,3 +63,44 @@ test("이름 변경 뒤 — 경고가 안 뜨고 주소가 새 이름을 가리�
   expect(page.url()).toContain("slug=capabilities%2Fcart-renamed");
   await expect(page.getByText("장바구니").first()).toBeVisible();
 });
+
+/**
+ * 삭제도 같은 병이었다 (2026-08-13 걷기 실측): 사용자가 확인 대화상자까지
+ * 거쳐 지운 문서를, 앱이 「못 찾았어요 — 문서함을 바꿔 보라」고 알렸다.
+ * 자기가 방금 지운 주소는 밖에서 온 깨진 링크가 아니다.
+ */
+test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키지 않는다", async ({ page }) => {
+  test.setTimeout(150_000);
+  page.on("dialog", (d) => void d.accept());
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await stubDirectoryPicker(page, VAULT);
+  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2000);
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await page.getByTestId("first-run-starter-open").click();
+  await page.waitForTimeout(500);
+  const pick = page.getByTestId("vault-guide-pick-existing");
+  if (await pick.isVisible().catch(() => false)) await pick.click();
+  await page.waitForTimeout(2500);
+
+  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2500);
+  await page.getByText("capabilities", { exact: true }).first().click();
+  await page.waitForTimeout(500);
+  await page.getByText("장바구니", { exact: true }).first().click();
+  await page.waitForTimeout(1200);
+
+  await page.keyboard.press("Meta+k");
+  await page.waitForTimeout(600);
+  await page.keyboard.type("삭제");
+  await page.waitForTimeout(600);
+  await page.keyboard.press("Enter");
+
+  const banner = page.getByText(/못 찾았어요/);
+  for (let i = 0; i < 12; i += 1) {
+    await page.waitForTimeout(500);
+    expect(await banner.count(), `삭제 ${(i + 1) * 0.5}s 후 거짓 「못 찾았어요」 경고`).toBe(0);
+  }
+  expect(page.url()).not.toContain("slug=capabilities%2Fcart");
+});


### PR DESCRIPTION
## Summary
- #1105(이름 변경 거짓 경고)의 형제 경로 걷기: **삭제**도 같은 병 재현 — 확인 대화상자까지 거쳐 지운 문서를 0.5초 뒤 「capabilities/cart 문서를 못 찾았어요. **다른 폴더의 문서라면 문서함을 바꿔 주세요**」라고 알림.
- 수리: 이름 변경용 가드를 「앱이 방금 손댄 주소 집합」(`appTouchedSlugsRef`) 일반형으로 확장 — 이름 변경은 {옛,새}, 삭제는 {지운 주소}. 질의가 집합 밖으로 바뀌면 가드 해제(외부 깨진 딥링크 판정은 그대로). 삭제 시 `?slug=` 파라미터 제거.

## Test plan
- 게이트 `docs-rename-address.spec.ts` 에 삭제 케이스 추가 — 수리 전 **빨강**(0.5s 거짓 경고) → 수리 후 2/2 초록(6초 폴링 창 내 경고 0 + 주소가 지운 문서를 가리키지 않음)
- 이웃 스펙 `docs-deeplink` + `vault-truth-telling` 9 passed(외부 깨진 링크 배너 정상 동작 유지) · tsc/eslint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD