### PR TITLE
fix: 새 문서 대화상자의 개발자 문장을 사용자 말로 — kind·vault·frontmatter 정리

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2062,7 +2062,7 @@
     },
     "newDocDialog": {
       "title": "New document",
-      "subtitle": "Pick what kind of node this document is: the folder and starter frontmatter follow the kind.",
+      "subtitle": "Pick what kind of node this document is first: its folder and starter content follow that choice.",
       "cancel": "Cancel"
     },
     "dialog": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2062,7 +2062,7 @@
     },
     "newDocDialog": {
       "title": "새 문서",
-      "subtitle": "이 문서가 어떤 kind 의 노드인지 먼저 고르세요. vault 폴더와 시작 frontmatter 가 kind 를 따라갑니다.",
+      "subtitle": "이 문서가 어떤 종류의 노드인지 먼저 고르세요. 저장될 폴더와 시작 내용이 그 종류를 따라가요.",
       "cancel": "취소"
     },
     "dialog": {


### PR DESCRIPTION
## Summary
- 새 문서 만들기 flow 걷기(OPFS 스텁, 실제 생성까지): 종류 선택지는 한국어(도메인·역량·요소·문서)인데 안내문 한 문장에 **kind·vault·frontmatter** 셋이 그대로 — 「이 문서가 어떤 kind 의 노드인지 먼저 고르세요. vault 폴더와 시작 frontmatter 가 kind 를 따라갑니다.」
- ko: 「이 문서가 어떤 종류의 노드인지 먼저 고르세요. 저장될 폴더와 시작 내용이 그 종류를 따라가요.」 · en 도 frontmatter→starter content.
- 같은 걷기에서 잰 건강한 것: 생성 직후 거짓 「못 찾았어요」 경고 0(#1105/#1107 계열 무병), 주소가 새 문서를 가리킴, 필수 필드 빈 것 안내 정상, 콘솔 오류 0.

## Test plan
- `pnpm test:i18n:messages` 16 · `pnpm test:desktop:check` 279 · `pnpm test:run src/views/docs-vault` 227 pass
- 라이브 실측: 대화상자 텍스트에 kind/vault/frontmatter 0건, 「종류」 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD