### PR TITLE
fix: 스킬 상세에서 전체 진단으로 돌아가는 문을 놓는다 — 유일한 복귀가 새로고침이었다

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3519,6 +3519,7 @@
     },
     "detail": {
       "back": "Skill list",
+      "backOverview": "All findings",
       "showLoadChain": "Show the three-stage load chain",
       "hideLoadChain": "Hide the three-stage load chain",
       "competing": "Competes with this skill",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3519,6 +3519,7 @@
     },
     "detail": {
       "back": "스킬 목록",
+      "backOverview": "전체 진단으로",
       "showLoadChain": "3단 로드 체인 보기",
       "hideLoadChain": "3단 로드 체인 닫기",
       "competing": "이 스킬과 경쟁하는 것",

--- a/src/views/agent-skills/ui/AgentSkillsPage.test.tsx
+++ b/src/views/agent-skills/ui/AgentSkillsPage.test.tsx
@@ -87,4 +87,23 @@ describe("AgentSkillsPage responsive workbench", () => {
     expect(screen.getByTestId("skill-row-toggle")).toHaveAttribute("data-active", "true");
     expect(screen.getByTestId("skill-row-toggle")).toHaveFocus();
   });
+
+  /**
+   * 넓은 화면의 되돌아갈 문 (2026-08-13 걷기 실측). 진단 개요(FindingsPanel)는
+   * 아무것도 안 골랐을 때만 우측에 뜨는데, 스킬을 하나라도 고르면 같은 행
+   * 재클릭도 Escape 도 무효라 **유일한 복귀가 새로고침**이었다.
+   */
+  it("split view: detail offers a door back to the findings overview", () => {
+    viewport(false);
+    renderPage();
+    // 개요가 먼저 보인다
+    expect(screen.getByTestId("skills-findings")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("skill-row-toggle"));
+    expect(screen.queryByTestId("skills-findings")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("skills-detail-overview"));
+    expect(screen.getByTestId("skills-findings")).toBeInTheDocument();
+    // 목록의 활성 표시도 걷힌다 — 선택이 정말 풀렸다는 증거.
+    expect(screen.getByTestId("skill-row-toggle")).toHaveAttribute("data-active", "false");
+  });
 });

--- a/src/views/agent-skills/ui/AgentSkillsPage.tsx
+++ b/src/views/agent-skills/ui/AgentSkillsPage.tsx
@@ -256,6 +256,7 @@ export function AgentSkillsPage() {
                     inventory={inventory}
                     onSelect={selectSkill}
                     onBack={isCompact ? returnToList : undefined}
+                    onOverview={isCompact ? undefined : () => setSelected(null)}
                     headingRef={detailHeadingRef}
                     openStepIds={new Set(openStepsBySkill[current.origin.relativePath] ?? [])}
                     onToggleStep={toggleStep}

--- a/src/views/agent-skills/ui/SkillDetail.tsx
+++ b/src/views/agent-skills/ui/SkillDetail.tsx
@@ -24,6 +24,7 @@ export function SkillDetail({
   inventory,
   onSelect,
   onBack,
+  onOverview,
   headingRef,
   openStepIds,
   onToggleStep,
@@ -32,6 +33,12 @@ export function SkillDetail({
   inventory: SkillInventory;
   onSelect: (relativePath: string) => void;
   onBack?: () => void;
+  /**
+   * 넓은 화면(split)의 되돌아갈 문 — 선택을 풀어 진단 개요(FindingsPanel)로.
+   * 이 문이 없던 동안 개요로 돌아가는 유일한 길이 새로고침이었다(2026-08-13
+   * 걷기 실측 — 같은 행 재클릭도 Escape 도 무효).
+   */
+  onOverview?: () => void;
   headingRef?: React.RefObject<HTMLHeadingElement | null>;
   openStepIds: ReadonlySet<string>;
   onToggleStep: (stepId: string) => void;
@@ -64,6 +71,16 @@ export function SkillDetail({
           className={controlClass({ shape: "link", size: "lg", tone: "muted", className: "self-start lg:hidden" })}
         >
           {t("detail.back")}
+        </button>
+      ) : null}
+      {onOverview ? (
+        <button
+          type="button"
+          data-testid="skills-detail-overview"
+          onClick={onOverview}
+          className={controlClass({ shape: "link", size: "lg", tone: "muted", className: "hidden self-start lg:inline-flex" })}
+        >
+          {t("detail.backOverview")}
         </button>
       ) : null}
       <header className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">


### PR DESCRIPTION
## Summary
- 서브에이전트 걷기(스킬 충돌 flow)에서 발견, 본 세션 계기로 재현 확인: 넓은 화면에서 스킬을 하나 고르면 진단 개요(「서로 경쟁하는 것」)로 **돌아갈 길이 0개** — 같은 행 재클릭·Escape 모두 무효(실측), 유일한 복귀는 새로고침.
- 상세 머리에 「전체 진단으로」(en: All findings) 문을 단다. 좁은 화면의 「스킬 목록」 문(onBack)과 대칭인 `onOverview`; 좁은 화면에는 개요 패널이 없으므로 안 그린다.

## Test plan
- TDD: 페이지 테스트 「split view: detail offers a door back to the findings overview」 먼저 넣어 빨강 확인 → 구현 → 9/9 초록(선택 해제 시 목록 활성 표시 걷힘까지)
- `pnpm test:i18n:messages` 16 pass · tsc 통과
- 라이브 실측(dev :3423, 예시 스킬): changelog 선택 → 「전체 진단으로」 보임·클릭 → 개요 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD