### PR TITLE
fix: 스킬 화면의 「packet 복사」·「3단 로드 체인」을 사용자 말로

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3520,8 +3520,8 @@
     "detail": {
       "back": "Skill list",
       "backOverview": "All findings",
-      "showLoadChain": "Show the three-stage load chain",
-      "hideLoadChain": "Hide the three-stage load chain",
+      "showLoadChain": "Show how it loads (3 stages)",
+      "hideLoadChain": "Hide how it loads",
       "competing": "Competes with this skill",
       "sameName": "The same name also lives in {source}: which one fires is undefined",
       "sharedTrigger": "Shares a trigger with {name}: {words}"
@@ -3547,7 +3547,7 @@
       "diagnosticResourceUnchecked": "A referenced resource could not be checked.",
       "diagnosticResourcePathUnsupported": "A referenced resource path is outside the supported boundary.",
       "diagnosticSemanticAmbiguous": "Semantic syntax is ambiguous; no label was derived.",
-      "packetCopy": "Copy packet",
+      "packetCopy": "Copy process packet",
       "packetAvailable": "Packet available",
       "packetUnavailable": "Process unavailable; copying is blocked",
       "packetTampered": "Integrity check failed; copying is blocked",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3520,8 +3520,8 @@
     "detail": {
       "back": "스킬 목록",
       "backOverview": "전체 진단으로",
-      "showLoadChain": "3단 로드 체인 보기",
-      "hideLoadChain": "3단 로드 체인 닫기",
+      "showLoadChain": "어떻게 실리는지 보기 (3단계)",
+      "hideLoadChain": "어떻게 실리는지 닫기",
       "competing": "이 스킬과 경쟁하는 것",
       "sameName": "같은 이름이 {source} 에도 있어요. 어느 쪽이 뜰지 정해져 있지 않아요",
       "sharedTrigger": "{name} 와 뜨는 조건이 겹쳐요. {words}"
@@ -3547,12 +3547,12 @@
       "diagnosticResourceUnchecked": "가리킨 자료가 있는지 확인하지 못했습니다.",
       "diagnosticResourcePathUnsupported": "가리킨 자료 경로가 지원 범위 밖입니다.",
       "diagnosticSemanticAmbiguous": "뜻이 여러 갈래라 라벨을 만들지 않았습니다.",
-      "packetCopy": "packet 복사",
-      "packetAvailable": "packet 준비됨",
+      "packetCopy": "절차 묶음 복사",
+      "packetAvailable": "절차 묶음 준비됨",
       "packetUnavailable": "프로세스를 읽을 수 없어 복사를 막았습니다",
       "packetTampered": "무결성 확인에 실패해 복사를 막았습니다",
       "packetCopying": "복사 중…",
-      "packetCopied": "packet 복사됨",
+      "packetCopied": "절차 묶음 복사됨",
       "packetCopyFailed": "복사 실패"
     },
     "findings": {


### PR DESCRIPTION
## Summary
- 스킬 화면 걷기(서브에이전트)에서 확인된 용어 누출 2건: 한국어 화면에 **「packet 복사」**(준비됨/복사됨 동반)와 **「3단 로드 체인 보기」**.
- 실물 기준으로 지음: packet = 원문 절차를 정본 JSON + digest 로 봉인해 에이전트에게 넘기는 묶음 → **「절차 묶음 복사」**. 로드 체인 = 스킬이 실리는 3단(항상 실려요/뜨면 실려요/필요하면 열려요) → **「어떻게 실리는지 보기 (3단계)」**.
- en 은 packet 이 자연스러워 유지, 버튼만 "Copy process packet" 으로 한정(상태 문구는 기존 테스트 고정과 일치 유지).

## Test plan
- `pnpm test:i18n:messages` 16 · `pnpm test:desktop:check` 279 · `pnpm test:run src/views/agent-skills` 9 pass
- 실렌더 확인(dev :3423, 예시 스킬): 「절차 묶음 복사」 버튼·토글 양 상태 스크린샷 확보

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD