### PR TITLE
fix: harden current-main MCP dogfood and bundle parity

### DIFF
--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -6160,6 +6160,71 @@ export function inferImportsFailure(parsed) {
   if (!Number.isInteger(parsed.filesScanned) || parsed.filesScanned < 0) {
     return 'infer_imports response missing filesScanned count';
   }
+
+  // Large scans are deliberately delivered as a bounded review packet. The
+  // automatic 128 KiB response limit is part of the public contract, so a
+  // dogfood/client call must not treat the compact branch as a malformed full
+  // scan merely because its raw edge arrays are absent. Keep the packet
+  // structural checks strict; only the large arrays are omitted.
+  if (parsed.contract === 'inferImportsReview:v1') {
+    const summary = parsed.scanSummary;
+    if (!summary || typeof summary !== 'object' || Array.isArray(summary)) {
+      return 'infer_imports review response missing scanSummary';
+    }
+    for (const propertyName of ['fileEdges', 'externalImports', 'unresolvedImports', 'moduleEdges']) {
+      if (!Number.isInteger(summary[propertyName]) || summary[propertyName] < 0) {
+        return `infer_imports review response missing scanSummary.${propertyName}`;
+      }
+    }
+    const reconciliation = parsed.reconciliationSummary;
+    if (!reconciliation || typeof reconciliation !== 'object' || Array.isArray(reconciliation)) {
+      return 'infer_imports review response missing reconciliationSummary';
+    }
+    for (const propertyName of [
+      'inBoth',
+      'inCodeMissingFromVault',
+      'inCodeMissingEndpointAbsent',
+      'inVaultNotInCode',
+      'unresolvedImports',
+    ]) {
+      if (!Number.isInteger(reconciliation[propertyName]) || reconciliation[propertyName] < 0) {
+        return `infer_imports review response missing reconciliationSummary.${propertyName}`;
+      }
+    }
+    if (typeof reconciliation.hint !== 'string' || reconciliation.hint.length === 0) {
+      return 'infer_imports review response missing reconciliationSummary.hint';
+    }
+    const queue = parsed.reviewQueue;
+    if (!queue || typeof queue !== 'object' || Array.isArray(queue)) {
+      return 'infer_imports review response missing reviewQueue';
+    }
+    if (
+      !Number.isInteger(queue.total) || queue.total < 0 ||
+      !Number.isInteger(queue.returned) || queue.returned < 0 ||
+      typeof queue.exhausted !== 'boolean' ||
+      (queue.afterReviewId !== null && typeof queue.afterReviewId !== 'string')
+    ) {
+      return 'infer_imports review response malformed reviewQueue';
+    }
+    if (queue.returned > queue.total) {
+      return 'infer_imports review response reviewQueue returned exceeds total';
+    }
+    if (parsed.nextReview !== null && (
+      !parsed.nextReview || typeof parsed.nextReview !== 'object' || Array.isArray(parsed.nextReview) ||
+      parsed.nextReview.contract !== 'nextRelationReview:v1'
+    )) {
+      return 'infer_imports review response malformed nextReview';
+    }
+    return null;
+  }
+
+  if (parsed.contract === 'inferImportsFocus:v1') {
+    if (!parsed.focusReview || typeof parsed.focusReview !== 'object' || Array.isArray(parsed.focusReview)) {
+      return 'infer_imports focus response missing focusReview';
+    }
+    return null;
+  }
+
   for (const propertyName of ['edges', 'externalImports', 'unresolved', 'moduleEdges']) {
     if (!Array.isArray(parsed[propertyName])) {
       return `infer_imports response missing ${propertyName} array`;

--- a/scripts/lib/dogfood-walk/gate-evaluator.mjs
+++ b/scripts/lib/dogfood-walk/gate-evaluator.mjs
@@ -92,6 +92,35 @@ import {
   workspaceBriefShapeFailure,
 } from "./shape-validators-workspace.mjs";
 
+// Semantic qualification is intentionally fail-closed in the product
+// response: an unqualified project reports `needs_attention` and a
+// `meaning_assessment` warning. The dogfood walk verifies the transport and
+// structural contracts; it must not turn that honest semantic advisory into a
+// release failure (nor hide any structural/validation failure). Keep this
+// allow-list tiny and explicit so new warning kinds remain blocking until the
+// gate receives a deliberate contract update.
+const NON_BLOCKING_ADVISORY_CHECKS = new Set(["meaning_assessment"]);
+const NON_BLOCKING_ADVISORY_ACTIONS = new Set(["meaning_assessment"]);
+
+function isAdvisoryOnlyChecks(checks) {
+  return Array.isArray(checks) && checks.length > 0 && checks.every((check) => (
+    check?.status === "pass" ||
+    check?.status === "info" ||
+    (check?.status === "warn" && NON_BLOCKING_ADVISORY_CHECKS.has(check?.id))
+  ));
+}
+
+function isAdvisoryOnlyStatus(result, checks) {
+  return result?.status !== "healthy" && isAdvisoryOnlyChecks(checks);
+}
+
+function nonAdvisoryNextActions(actions) {
+  return blockingNextActions(actions).filter((label) => {
+    const id = String(label).split(":", 1)[0];
+    return !NON_BLOCKING_ADVISORY_ACTIONS.has(id);
+  });
+}
+
 export function recordResult(failures, label, result) {
   if (!result) {
     failures.push(`${label}: missing response`);
@@ -691,36 +720,38 @@ export function evaluateDogfoodGate({
   }
   const consistencyFailures = crossToolConsistencyFailures({ kinds, list, validation, compiled, overview });
   failures.push(...consistencyFailures);
-  if (brief && !briefShapeFailure && brief.status !== "healthy") {
+  const briefChecks = brief?.health?.checks;
+  if (brief && !briefShapeFailure && brief.status !== "healthy" && !isAdvisoryOnlyStatus(brief, briefChecks)) {
     failures.push(`workspace_brief: status ${brief.status} (${workspaceBriefSummary(brief)})`);
   }
   const briefFailedChecks = failedHealthChecks(brief?.health?.checks);
   if (briefFailedChecks.length > 0) {
     failures.push(`workspace_brief: failing health checks ${briefFailedChecks.join(", ")}`);
   }
-  const blockingActions = blockingNextActions(brief?.nextActions);
+  const blockingActions = nonAdvisoryNextActions(brief?.nextActions);
   if (blockingActions.length > 0) {
     failures.push(`workspace_brief: actionable nextActions ${blockingActions.join(", ")}`);
   }
-  if (tunedBrief && !tunedBriefShapeFailure && tunedBrief.status !== "healthy") {
+  const tunedBriefChecks = tunedBrief?.health?.checks;
+  if (tunedBrief && !tunedBriefShapeFailure && tunedBrief.status !== "healthy" && !isAdvisoryOnlyStatus(tunedBrief, tunedBriefChecks)) {
     failures.push(`workspace_brief_tuned: status ${tunedBrief.status} (${workspaceBriefSummary(tunedBrief)})`);
   }
   const tunedBriefFailedChecks = failedHealthChecks(tunedBrief?.health?.checks);
   if (tunedBriefFailedChecks.length > 0) {
     failures.push(`workspace_brief_tuned: failing health checks ${tunedBriefFailedChecks.join(", ")}`);
   }
-  const tunedBlockingActions = blockingNextActions(tunedBrief?.nextActions);
+  const tunedBlockingActions = nonAdvisoryNextActions(tunedBrief?.nextActions);
   if (tunedBlockingActions.length > 0) {
     failures.push(`workspace_brief_tuned: actionable nextActions ${tunedBlockingActions.join(", ")}`);
   }
-  if (health && !healthShapeFailure && health.status !== "healthy") {
+  if (health && !healthShapeFailure && health.status !== "healthy" && !isAdvisoryOnlyStatus(health, health.checks)) {
     failures.push(`health: status ${health.status} (${healthStatusSummary(health)})`);
   }
   const healthFailedChecks = failedHealthChecks(health?.checks);
   if (healthFailedChecks.length > 0) {
     failures.push(`health: failing health checks ${healthFailedChecks.join(", ")}`);
   }
-  if (tunedHealth && !tunedHealthShapeFailure && tunedHealth.status !== "healthy") {
+  if (tunedHealth && !tunedHealthShapeFailure && tunedHealth.status !== "healthy" && !isAdvisoryOnlyStatus(tunedHealth, tunedHealth.checks)) {
     failures.push(`health_tuned: status ${tunedHealth.status} (${healthStatusSummary(tunedHealth)})`);
   }
   const tunedHealthFailedChecks = failedHealthChecks(tunedHealth?.checks);

--- a/scripts/lib/dogfood-walk/gate-evaluator.test.mjs
+++ b/scripts/lib/dogfood-walk/gate-evaluator.test.mjs
@@ -581,7 +581,7 @@ describe("evaluateDogfoodGate", () => {
           },
         },
       }),
-      ["strict_args: strict arguments structured error code mismatch — expected unknown_argument, got invalid_arguments"],
+      ["strict_args: strict arguments structured error code mismatch: expected unknown_argument, got invalid_arguments"],
     );
     assert.deepEqual(
       evaluateDogfoodGate({ ...okShape, strictArgs: structuredError('Unknown argument "lmit" for list_concepts.') }),
@@ -683,7 +683,7 @@ describe("evaluateDogfoodGate", () => {
           },
         },
       }),
-      ["strict_unknown_tool: strict unknown-tool structured error code mismatch — expected unknown_tool, got unknown_argument"],
+      ["strict_unknown_tool: strict unknown-tool structured error code mismatch: expected unknown_tool, got unknown_argument"],
     );
     assert.deepEqual(
       evaluateDogfoodGate({
@@ -1300,7 +1300,7 @@ describe("evaluateDogfoodGate", () => {
       ...okShape,
       kinds: { total: 2, byKind: { project: 1 } },
     });
-    assert.deepEqual(failures, ["list_kinds response total mismatch — total 2, byKind 1"]);
+    assert.deepEqual(failures, ["list_kinds response total mismatch: total 2, byKind 1"]);
   });
 
   it("fails on malformed list_concepts payloads", () => {
@@ -1315,14 +1315,27 @@ describe("evaluateDogfoodGate", () => {
     assert.deepEqual(
       evaluateDogfoodGate({
         ...okShape,
-        projectProbe: { total: 0, vaultRoot: "/tmp/vault", nodes: [] },
+        projectProbe: {
+          total: 0,
+          returned: 0,
+          limited: false,
+          pagination: { offset: 0, limit: 100, total: 0, returned: 0, hasMore: false, nextOffset: null },
+          vaultRoot: "/tmp/vault",
+          nodes: [],
+        },
       }),
       ["project_probe response missing project node"],
     );
     assert.deepEqual(
       evaluateDogfoodGate({
         ...okShape,
-        projectProbe: { total: 1, nodes: [{ slug: "project", kind: "project", title: "Project", mtime: 1 }] },
+        projectProbe: {
+          total: 1,
+          returned: 1,
+          limited: false,
+          pagination: { offset: 0, limit: 100, total: 1, returned: 1, hasMore: false, nextOffset: null },
+          nodes: [{ uid: "11111111-1111-4111-8111-111111111111", slug: "project", kind: "project", title: "Project", mtime: 1 }],
+        },
       }),
       ["project_probe: list_concepts response missing vaultRoot"],
     );
@@ -1331,8 +1344,11 @@ describe("evaluateDogfoodGate", () => {
         ...okShape,
         projectProbe: {
           total: 1,
+          returned: 1,
+          limited: false,
+          pagination: { offset: 0, limit: 100, total: 1, returned: 1, hasMore: false, nextOffset: null },
           vaultRoot: "/tmp/vault",
-          nodes: [{ slug: "capabilities/not-project", kind: "capability", title: "Wrong", mtime: 1 }],
+          nodes: [{ uid: "11111111-1111-4111-8111-111111111111", slug: "capabilities/not-project", kind: "capability", title: "Wrong", mtime: 1 }],
         },
       }),
       ["project_probe returned non-project node: capabilities/not-project"],
@@ -1342,8 +1358,11 @@ describe("evaluateDogfoodGate", () => {
         ...okShape,
         projectProbe: {
           total: 2,
+          returned: 1,
+          limited: true,
+          pagination: { offset: 0, limit: 100, total: 2, returned: 1, hasMore: true, nextOffset: 1 },
           vaultRoot: "/tmp/vault",
-          nodes: [{ slug: "project", kind: "project", title: "Project", mtime: 1 }],
+          nodes: [{ uid: "11111111-1111-4111-8111-111111111111", slug: "project", kind: "project", title: "Project", mtime: 1 }],
         },
       }),
       ["project_probe count mismatch — list_kinds project 1, probe 2"],
@@ -1390,7 +1409,7 @@ describe("evaluateDogfoodGate", () => {
     assert.deepEqual(
       evaluateDogfoodGate({ ...okShape, batchStructured: { concepts: [okShape.batch.concepts[0]] } }),
       [
-        'get_concepts structuredContent mismatch — $.concepts[1]: parsed {"ok":true,"slug":"capabilities/mcp-server","frontmatter":{"kind":"capability","title":"MCP S..., structuredContent undefined',
+        'get_concepts structuredContent mismatch — $.concepts[1]: parsed {"ok":true,"uid":"11111111-1111-4111-8111-111111111111","slug":"capabilities/mcp-server","fro..., structuredContent undefined',
       ],
     );
   });
@@ -1960,7 +1979,7 @@ describe("evaluateDogfoodGate", () => {
     );
     assert.deepEqual(
       evaluateDogfoodGate({ ...okShape, overview: { ...okShape.overview, graph: { ...okShape.overview.graph, edges: 3 } } }),
-      ["overview response edge count mismatch — edges 3, resolved+external+unresolved 2"],
+      ["overview response edge count mismatch: edges 3, resolved+external+unresolved 2"],
     );
     assert.deepEqual(
       evaluateDogfoodGate({ ...okShape, overview: { ...okShape.overview, hubs: null } }),
@@ -3941,7 +3960,10 @@ describe("evaluateDogfoodGate", () => {
 
   it("fails when dogfood read surfaces disagree on counts", () => {
     assert.deepEqual(
-      evaluateDogfoodGate({ ...okShape, list: { ...okShape.list, total: 2 } }),
+      evaluateDogfoodGate({
+        ...okShape,
+        list: { ...okShape.list, total: 2, limited: true, pagination: { ...okShape.list.pagination, total: 2, hasMore: true, nextOffset: 1 }, },
+      }),
       [
         "list_concepts structuredContent mismatch — $.total: parsed 2, structuredContent 1",
         "dogfood count mismatch — list_kinds.total 1, list_concepts.total 2",
@@ -4167,13 +4189,97 @@ describe("evaluateDogfoodGate", () => {
   it("fails on unhealthy first-contact diagnosis", () => {
     const failures = evaluateDogfoodGate({
       ...okShape,
-      brief: { ...okShape.brief, status: "needs_attention" },
-      health: { ...okShape.health, status: "needs_attention" },
+      brief: { ...okShape.brief, status: "needs_attention", health: { checks: [{ id: "compile_issues", status: "fail", count: 1 }] } },
+      briefStructured: { ...okShape.briefStructured, status: "needs_attention", health: { checks: [{ id: "compile_issues", status: "fail", count: 1 }] } },
+      health: { ...okShape.health, status: "needs_attention", checks: [{ id: "compile_issues", status: "fail", count: 1 }] },
+      healthStructured: { ...okShape.healthStructured, status: "needs_attention", checks: [{ id: "compile_issues", status: "fail", count: 1 }] },
     });
     assert.deepEqual(failures, [
       "workspace_brief: status needs_attention (1 node, 0 next actions, 1 health check, growth actions:0 external:0 ignoredExternal:0)",
+      "workspace_brief: failing health checks compile_issues:fail:1",
       "health: status needs_attention (issues:0, unresolved:0, cycles:0, 1 check)",
+      "health: failing health checks compile_issues:fail:1",
     ]);
+  });
+
+  it("keeps an honest semantic advisory non-blocking while preserving structural health gates", () => {
+    const semanticAdvisory = {
+      operation: "workspace_brief",
+      status: "needs_attention",
+      summary: { nodes: 1, edges: 0, issues: 0 },
+      nextActions: [{ id: "meaning_assessment", kind: "meaning_assessment", severity: "warn", count: 1 }],
+      health: {
+        checks: [
+          { id: "compile_issues", status: "pass", count: 0 },
+          { id: "meaning_assessment", status: "warn", count: 1 },
+        ],
+      },
+    };
+    const semanticHealth = {
+      operation: "health",
+      status: "needs_attention",
+      summary: { issues: 0, unresolvedEdges: 0, dependencyCycles: 0 },
+      checks: [
+        { id: "compile_issues", status: "pass", count: 0 },
+        { id: "meaning_assessment", status: "warn", count: 1 },
+      ],
+    };
+    assert.deepEqual(
+      evaluateDogfoodGate({
+        ...okShape,
+        brief: semanticAdvisory,
+        briefStructured: semanticAdvisory,
+        tunedBrief: semanticAdvisory,
+        tunedBriefStructured: semanticAdvisory,
+        health: semanticHealth,
+        healthStructured: semanticHealth,
+        tunedHealth: semanticHealth,
+        tunedHealthStructured: semanticHealth,
+      }),
+      [],
+    );
+    assert.deepEqual(
+      evaluateDogfoodGate({
+        ...okShape,
+        brief: {
+          ...semanticAdvisory,
+          health: { checks: [...semanticAdvisory.health.checks, { id: "vault_validation", status: "warn", count: 1 }] },
+        },
+        briefStructured: {
+          ...semanticAdvisory,
+          health: { checks: [...semanticAdvisory.health.checks, { id: "vault_validation", status: "warn", count: 1 }] },
+        },
+      }),
+      ["workspace_brief: status needs_attention (1 node, 1 next action, 3 health checks)"],
+    );
+  });
+
+  it("accepts the bounded infer_imports review branch used for large scans", () => {
+    const packet = {
+      contract: "inferImportsReview:v1",
+      rootPath: "/tmp/repo",
+      filesScanned: 5000,
+      coverage: { contract: "importScanCoverage:v1" },
+      scanSummary: { fileEdges: 100, externalImports: 3, unresolvedImports: 2, moduleEdges: 20 },
+      reconciliationSummary: {
+        inBoth: 1,
+        inCodeMissingFromVault: 2,
+        inCodeMissingEndpointAbsent: 3,
+        inVaultNotInCode: 4,
+        unresolvedImports: 2,
+        hint: "Review observed import candidates before writing semantic relations.",
+      },
+      reviewQueue: { total: 5, returned: 1, exhausted: false, afterReviewId: null },
+      nextReview: { contract: "nextRelationReview:v1" },
+    };
+    assert.deepEqual(
+      evaluateDogfoodGate({
+        ...okShape,
+        inferredImports: packet,
+        inferredImportsStructured: packet,
+      }),
+      [],
+    );
   });
 
   it("fails on failing health checks even when top-level status is healthy", () => {


### PR DESCRIPTION
## 변경
- source/bundled MCP `tools/list` 전체 스키마 parity를 빌드/검증 게이트로 고정
- 대형 `infer_imports` compact review 응답을 strict하게 검증
- semantic `meaning_assessment` advisory와 구조/검증 오류를 dogfood 게이트에서 분리

## 검증
- Node24 `gate-evaluator`: 86/86
- MCP first-contact verify: 127/127
- source/bundled MCP: 35 tools, parity pass
- main 기준으로 생성한 별도 clean worktree에서 검증

`dogfood:status`의 의미 평가 advisory는 숨기지 않고 non-blocking으로 표시합니다.
