### PR TITLE
docs: field-trial 실측이 지목한 결함 둘을 스킬에 봉합

### DIFF
--- a/.agents/skills/ontology-bootstrap/SKILL.md
+++ b/.agents/skills/ontology-bootstrap/SKILL.md
@@ -167,6 +167,15 @@ Rules:
   than four exact endpoints look useful, choose the few that answer distinct
   competency or impact questions and record the rest as a visible exploration
   gap.
+- **Mine the declared external dependencies before closing the model**
+  (2026-08-14 field trial: "what is the most important external dependency?"
+  was the one onboarding question the vault could not answer at all, while the
+  repository's dependency manifest sat unread). Read the manifest the ecosystem
+  uses (package.json, pyproject/requirements, Cargo.toml, go.mod) and the
+  `externalImports` bucket of the import packet, then record the two or three
+  externals the project cannot work without: either as `external` elements
+  with a one-line "why it matters", or as a named list in the project body.
+  Recording none is allowed only with an explicit visible gap stating why.
 - Prefer the repository's language, but normalize vague slogans and technical
   nouns into precise definitions.
 - Merge synonyms. Split overloaded concepts. Keep genuinely uncertain concepts

--- a/.agents/skills/ontology-field-trial/SKILL.md
+++ b/.agents/skills/ontology-field-trial/SKILL.md
@@ -97,6 +97,15 @@ Record, separately:
   output of the whole trial. Both defects found on 2026-08-01 came from this
   list, not from anything the build phase showed.
 
+### Scope-promotion rule
+
+A capability's `Excludes` section bounds **that capability only**. The fresh
+agent must not promote it to project scope: "the store-output capability
+excludes plotting" does not mean "the project has no plotting". Project-level
+scope claims may cite only the project node's own excludes. (2026-08-14 trial:
+the single failed claim of the run was exactly this promotion — the vault was
+right, the handoff answer widened it.)
+
 ### Full-body handoff gate
 
 The list/summary response is a census, not evidence. Before the fresh agent

--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -167,6 +167,15 @@ Rules:
   than four exact endpoints look useful, choose the few that answer distinct
   competency or impact questions and record the rest as a visible exploration
   gap.
+- **Mine the declared external dependencies before closing the model**
+  (2026-08-14 field trial: "what is the most important external dependency?"
+  was the one onboarding question the vault could not answer at all, while the
+  repository's dependency manifest sat unread). Read the manifest the ecosystem
+  uses (package.json, pyproject/requirements, Cargo.toml, go.mod) and the
+  `externalImports` bucket of the import packet, then record the two or three
+  externals the project cannot work without: either as `external` elements
+  with a one-line "why it matters", or as a named list in the project body.
+  Recording none is allowed only with an explicit visible gap stating why.
 - Prefer the repository's language, but normalize vague slogans and technical
   nouns into precise definitions.
 - Merge synonyms. Split overloaded concepts. Keep genuinely uncertain concepts

--- a/.claude/skills/ontology-field-trial/SKILL.md
+++ b/.claude/skills/ontology-field-trial/SKILL.md
@@ -97,6 +97,15 @@ Record, separately:
   output of the whole trial. Both defects found on 2026-08-01 came from this
   list, not from anything the build phase showed.
 
+### Scope-promotion rule
+
+A capability's `Excludes` section bounds **that capability only**. The fresh
+agent must not promote it to project scope: "the store-output capability
+excludes plotting" does not mean "the project has no plotting". Project-level
+scope claims may cite only the project node's own excludes. (2026-08-14 trial:
+the single failed claim of the run was exactly this promotion — the vault was
+right, the handoff answer widened it.)
+
 ### Full-body handoff gate
 
 The list/summary response is a census, not evidence. Before the fresh agent


### PR DESCRIPTION
## Summary
2026-08-14 field-trial(이 세션이 모르는 과학 시뮬레이션 저장소, 4단계 전부 수행 — 구축 5:10/노드10 · 인용 2/2 · 인수 완전3/부분2/불가1 · 주장 11/12)에서 나온 결함 후보 2건을 스킬에 봉합:

1. **ontology-bootstrap**: 「모델을 닫기 전에 선언된 외부 의존을 캔다」 — 6문 중 유일한 완전 불가가 외부 의존 질문이었고, 저장소의 의존 매니페스트는 읽힌 적이 없다. 매니페스트+`externalImports`에서 핵심 2~3개를 external 요소나 프로젝트 본문에 기록, 안 하면 가시 공백 필수.
2. **ontology-field-trial**: 승격 금지 규칙 — 이번 런의 유일한 실패 주장이 「역량의 Excludes 를 프로젝트 범위로 확대」였다(볼트는 옳았음). 인수 에이전트는 프로젝트 범위 주장에 프로젝트 노드의 excludes 만 인용할 수 있다.

기준선(BASELINE.md)은 규율대로 미갱신 — 이번 런이 이긴 측정이 없다.

## Test plan
- `agents:check` skill-copy 20/20 동일 · codex-size-cap 여유 유지 (격리 워크트리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtckonaDFNynMRZK5zgaSD