### PR TITLE
fix: C 저장소의 의미 분석 근거 누락을 보강

### DIFF
--- a/.agents/skills/ontology-bootstrap/SKILL.md
+++ b/.agents/skills/ontology-bootstrap/SKILL.md
@@ -131,6 +131,12 @@ confidence: number 0.0-1.0
 uncertainty:
 ```
 
+Do not copy a domain-shaped row into `proposal.domains` when its only witness
+is a README heading. Keep it out of the write candidate, answer the domain
+competency question as `partial` or `visible-gap`, and name the missing
+responsibility/ownership evidence. This includes operational headings such as
+Documentation, Installation, Community, and Support, including `&` variants.
+
 (`kind` is not a proposal-row field — the kind is expressed by which bucket
 (project/domains/capabilities/elements) the row sits in. `analyze_repo_structure`
 proposal rows are `additionalProperties: false`, so unknown keys like `status`
@@ -147,7 +153,8 @@ Rules:
   specification's project→domain→capability→element reading order.
 - Treat a concrete package, module, service, schema, UI surface, or file as
   structural evidence until its distinct element role is stated and cited.
-- Do not stop at package buckets when the read-only import packet exposes an
+- Do not stop at package buckets when the analyzer packet (including
+  `elements`, semantic evidence, and the read-only import packet) exposes an
   exact file endpoint that materially improves change navigation. The model
   may select at most four such endpoints beyond the analyzer's bounded element
   candidates. Prefer meaning-dense roles: an execution entrypoint, an external
@@ -163,6 +170,18 @@ Rules:
 - A selected endpoint remains structural evidence, not automatic business
   meaning. Cite its exact repo-relative path, state what the import proves, and
   keep behavioral ownership partial when no semantic source establishes it.
+- If `infer_imports` returns zero files or module edges because the repository
+  language is unsupported, that is a coverage gap, not evidence that source
+  files or runtime/build endpoints are absent. Use exact paths exposed by the
+  analyzer packet when they exist, and keep impact `not_measured` when no
+  dependency witness is available.
+- When the analyzer exposes runtime entrypoints, build manifests, documentation
+  generators, or dependency manifests, inspect them as structural evidence.
+  A README build recipe remains documentation evidence, not an implementation
+  element.
+- Never combine generic README sections such as Documentation, Community, or
+  Support into a compound business domain. Without a durable responsibility or
+  ownership witness, keep the domain competency answer partial or visible-gap.
 - Never mirror an entire directory or service family into elements. If more
   than four exact endpoints look useful, choose the few that answer distinct
   competency or impact questions and record the rest as a visible exploration

--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -131,6 +131,12 @@ confidence: number 0.0-1.0
 uncertainty:
 ```
 
+Do not copy a domain-shaped row into `proposal.domains` when its only witness
+is a README heading. Keep it out of the write candidate, answer the domain
+competency question as `partial` or `visible-gap`, and name the missing
+responsibility/ownership evidence. This includes operational headings such as
+Documentation, Installation, Community, and Support, including `&` variants.
+
 (`kind` is not a proposal-row field — the kind is expressed by which bucket
 (project/domains/capabilities/elements) the row sits in. `analyze_repo_structure`
 proposal rows are `additionalProperties: false`, so unknown keys like `status`
@@ -147,7 +153,8 @@ Rules:
   specification's project→domain→capability→element reading order.
 - Treat a concrete package, module, service, schema, UI surface, or file as
   structural evidence until its distinct element role is stated and cited.
-- Do not stop at package buckets when the read-only import packet exposes an
+- Do not stop at package buckets when the analyzer packet (including
+  `elements`, semantic evidence, and the read-only import packet) exposes an
   exact file endpoint that materially improves change navigation. The model
   may select at most four such endpoints beyond the analyzer's bounded element
   candidates. Prefer meaning-dense roles: an execution entrypoint, an external
@@ -163,6 +170,18 @@ Rules:
 - A selected endpoint remains structural evidence, not automatic business
   meaning. Cite its exact repo-relative path, state what the import proves, and
   keep behavioral ownership partial when no semantic source establishes it.
+- If `infer_imports` returns zero files or module edges because the repository
+  language is unsupported, that is a coverage gap, not evidence that source
+  files or runtime/build endpoints are absent. Use exact paths exposed by the
+  analyzer packet when they exist, and keep impact `not_measured` when no
+  dependency witness is available.
+- When the analyzer exposes runtime entrypoints, build manifests, documentation
+  generators, or dependency manifests, inspect them as structural evidence.
+  A README build recipe remains documentation evidence, not an implementation
+  element.
+- Never combine generic README sections such as Documentation, Community, or
+  Support into a compound business domain. Without a durable responsibility or
+  ownership witness, keep the domain competency answer partial or visible-gap.
 - Never mirror an entire directory or service family into elements. If more
   than four exact endpoints look useful, choose the few that answer distinct
   competency or impact questions and record the rest as a visible exploration

--- a/mcp/src/analyze.mjs
+++ b/mcp/src/analyze.mjs
@@ -96,6 +96,7 @@ const SOURCE_LAYOUT_COORDINATION_ELEMENT_LIMIT = 10;
 const SOURCE_LAYOUT_COORDINATION_ROLE =
   /(?:^|[-_.])(app|main|index|manager|loader|registry|storage|client|server|router|controller)(?:[-_.]|$)/i;
 const SOURCE_LAYOUT_CODE_FILE = /\.(?:[cm]?[jt]sx?|py)$/i;
+const NATIVE_SOURCE_FILE = /\.(?:c|h)$/i;
 const PYTHON_NON_PRODUCT_PACKAGES = new Set(['test', 'tests']);
 const PYTHON_IMPORT_ELEMENT_LIMIT = 12;
 const PYTHON_IMPORT_RISK_ELEMENT_LIMIT = 2;
@@ -132,6 +133,13 @@ const NODE_PACKAGE_DEPENDENCY_LIMIT = 48;
 const RUST_IMPLEMENTATION_ELEMENT_LIMIT = 24;
 const RUST_MODULES_PER_TARGET_LIMIT = 12;
 const RUST_SOURCE_MAX_BYTES = 256 * 1024;
+const NATIVE_SOURCE_ELEMENT_LIMIT = 36;
+const NATIVE_DOC_BUILD_ELEMENT_LIMIT = 12;
+const AUTOTOOLS_IMPLEMENTATION_MANIFESTS = new Map([
+  ['configure.ac', { slug: 'elements/autotools-configure', title: 'Autotools Configure' }],
+  ['configure.in', { slug: 'elements/autotools-configure', title: 'Autotools Configure' }],
+  ['Makefile.am', { slug: 'elements/autotools-build', title: 'Autotools Build' }],
+]);
 const LIBRARY_SOURCE_ELEMENT_LIMIT = 24;
 const IMPLEMENTATION_SOURCE_ELEMENT_LIMIT = 48;
 const CARGO_MANIFEST_MAX_FEATURES = 48;
@@ -383,6 +391,10 @@ export function analyzeRepoStructure(rootPath, options = {}) {
   });
   const sourcePythonPackagePathSet = new Set(sourcePythonPackagePaths);
   const rustImplementationEvidence = discoverRustImplementationEvidence(rootPath, skipped);
+  const nativeImplementationEvidence = discoverAutotoolsImplementationEvidence(rootPath, {
+    ignore,
+    skipped,
+  });
 
   // framework heuristic — *features/* 만 있어도 fsd 로 (ontology-atlas 자체
   // 같이 lean FSD).
@@ -497,7 +509,7 @@ export function analyzeRepoStructure(rootPath, options = {}) {
           evidence: { source: relative(rootPath, subPath) },
         });
       }
-    } else {
+    } else if (!nativeImplementationEvidence.isNativeProject) {
       // generic — src/ 의 깊이 1 폴더 만
       let directLibraryElementCount = 0;
       let directLibraryLimitRecorded = false;
@@ -613,6 +625,12 @@ export function analyzeRepoStructure(rootPath, options = {}) {
       }
     }
   }
+
+  // Native C projects expose source files and build manifests directly rather
+  // than through the JS/Python folder conventions above. Keep those paths as
+  // implementation evidence; the meaning gate still prevents them from
+  // becoming business capabilities without semantic witnesses.
+  elements.push(...nativeImplementationEvidence.elements);
 
   // Repositories may have both a conventional lib/ or src/ root and a
   // separately owned internal/ implementation tree. Keep the primary-root
@@ -2982,7 +3000,10 @@ function detectDomainsFromReadme(rootPath) {
           ) ||
           // operational / aggregate sections that describe the README, not a
           // product ownership boundary
-          /\bin numbers$|^install\b|^core capabilities$|^providers? and (?:local|offline) (?:path|setup|mode)$|^verification$|^community(?: and support)?$/i.test(
+          /\bin numbers$|^install\b|^core capabilities$|^providers? and (?:local|offline) (?:path|setup|mode)$|^verification$|^community(?:\s+(?:and|&)\s+support)?$/i.test(
+            normalizedTitle,
+          ) ||
+          /^(?:documentation\s+(?:and|&)\s+community(?:\s+support|\s+(?:and|&)\s+support)|documentation\s+(?:and|&)\s+support)$/i.test(
             normalizedTitle,
           ) ||
           // narrative / question-style headers
@@ -3128,6 +3149,208 @@ function materializeImplementationOnlySourceElements(
     admitted += 1;
   }
   return out;
+}
+
+function discoverAutotoolsImplementationEvidence(rootPath, { ignore, skipped }) {
+  const hasAutotoolsManifest = [...AUTOTOOLS_IMPLEMENTATION_MANIFESTS.keys()].some(
+    (manifest) => {
+      const path = join(rootPath, manifest);
+      try {
+        return existsSync(path) && statSync(path).isFile() && pathResolvesInsideRoot(rootPath, path);
+      } catch {
+        return false;
+      }
+    },
+  );
+  if (!hasAutotoolsManifest) {
+    return { isNativeProject: false, elements: [] };
+  }
+
+  const sourceCandidates = new Map();
+  const visitedDirectories = new Set();
+  let entriesSeen = 0;
+
+  const addSourceCandidate = (path) => {
+    const source = relative(rootPath, path);
+    if (!source || sourceCandidates.has(source)) return;
+    try {
+      if (
+        !statSync(path).isFile() ||
+        !NATIVE_SOURCE_FILE.test(path) ||
+        !pathResolvesInsideRoot(rootPath, path)
+      ) {
+        return;
+      }
+      sourceCandidates.set(source, path);
+    } catch {
+      // A broken or concurrently removed path is not evidence.
+    }
+  };
+
+  const visitSourceRoot = (dir, depth, descend = true) => {
+    if (depth > 3 || entriesSeen >= 2000) return;
+    let realDirectory;
+    try {
+      realDirectory = realpathSync(dir);
+      if (visitedDirectories.has(realDirectory)) return;
+      visitedDirectories.add(realDirectory);
+    } catch {
+      return;
+    }
+    let entries;
+    try {
+      entries = readdirSync(dir).sort();
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entriesSeen >= 2000) break;
+      entriesSeen += 1;
+      if (ignore.has(entry) || entry.startsWith('.')) continue;
+      const path = join(dir, entry);
+      let pathStat;
+      try {
+        if (!pathResolvesInsideRoot(rootPath, path)) continue;
+        pathStat = statSync(path);
+      } catch {
+        continue;
+      }
+      if (pathStat.isDirectory() && descend) {
+        visitSourceRoot(path, depth + 1);
+      } else if (pathStat.isFile()) {
+        addSourceCandidate(path);
+      }
+    }
+  };
+
+  // Root-level C files are common in small native tools. Conventional source
+  // roots are walked separately so a large repository does not turn every
+  // documentation/vendor file into an implementation candidate.
+  visitSourceRoot(rootPath, 0, false);
+  for (const sourceFolder of SOURCE_FOLDERS) {
+    const sourceRoot = join(rootPath, sourceFolder);
+    try {
+      if (existsSync(sourceRoot) && statSync(sourceRoot).isDirectory()) {
+        visitSourceRoot(sourceRoot, 0);
+      }
+    } catch {
+      // Continue with the remaining conventional source roots.
+    }
+  }
+
+  if (sourceCandidates.size === 0) {
+    return { isNativeProject: false, elements: [] };
+  }
+
+  const elements = [];
+  const claimedSlugs = new Set();
+  const addElement = (row) => {
+    if (claimedSlugs.has(row.slug)) return;
+    claimedSlugs.add(row.slug);
+    elements.push(row);
+  };
+
+  for (const [manifest, descriptor] of AUTOTOOLS_IMPLEMENTATION_MANIFESTS) {
+    const path = join(rootPath, manifest);
+    try {
+      if (!existsSync(path) || !statSync(path).isFile() || !pathResolvesInsideRoot(rootPath, path)) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    const source = relative(rootPath, path);
+    addElement({
+      slug: descriptor.slug,
+      title: descriptor.title,
+      path: source,
+      evidence: { source },
+    });
+  }
+
+  const docsDependencyPath = join(rootPath, 'docs', 'Pipfile');
+  try {
+    if (
+      existsSync(docsDependencyPath) &&
+      statSync(docsDependencyPath).isFile() &&
+      pathResolvesInsideRoot(rootPath, docsDependencyPath)
+    ) {
+      const source = relative(rootPath, docsDependencyPath);
+      addElement({
+        slug: 'elements/docs-dependencies',
+        title: 'Documentation Dependencies',
+        path: source,
+        evidence: { source },
+      });
+    }
+  } catch {
+    // An unreadable dependency manifest is not evidence.
+  }
+
+  const docsRoot = join(rootPath, 'docs');
+  let docsBuildScripts = [];
+  try {
+    if (existsSync(docsRoot) && statSync(docsRoot).isDirectory()) {
+      docsBuildScripts = readdirSync(docsRoot)
+        .filter((entry) => /^build_[A-Za-z0-9_-]+\.py$/i.test(entry))
+        .filter((entry) => {
+          const path = join(docsRoot, entry);
+          try {
+            return statSync(path).isFile() && pathResolvesInsideRoot(rootPath, path);
+          } catch {
+            return false;
+          }
+        })
+        .sort()
+        .slice(0, NATIVE_DOC_BUILD_ELEMENT_LIMIT);
+    }
+  } catch {
+    docsBuildScripts = [];
+  }
+  for (const entry of docsBuildScripts) {
+    const source = `docs/${entry}`;
+    const suffix = slugify(entry.slice('build_'.length, -'.py'.length));
+    if (!suffix) continue;
+    addElement({
+      slug: `elements/docs-build-${suffix}`,
+      title: `Documentation Build ${humanize(suffix)}`,
+      path: source,
+      evidence: { source },
+    });
+  }
+
+  const sortedSources = [...sourceCandidates.keys()].sort((left, right) => {
+    const leftBase = left.split('/').at(-1).toLowerCase();
+    const rightBase = right.split('/').at(-1).toLowerCase();
+    const priority = (base) => (base === 'main.c' || base === 'main.h' ? 0 : base.endsWith('.c') ? 1 : 2);
+    return priority(leftBase) - priority(rightBase) || left.localeCompare(right);
+  });
+  const selectedSources = sortedSources.slice(0, NATIVE_SOURCE_ELEMENT_LIMIT);
+  if (sortedSources.length > selectedSources.length) {
+    pushSkippedOnce(skipped, {
+      path: rootPath,
+      reason: `native-source-element-limit: omitted ${sortedSources.length - selectedSources.length} C/C header paths after ${NATIVE_SOURCE_ELEMENT_LIMIT}`,
+    });
+  }
+  const sourceSlugCounts = new Map();
+  for (const source of selectedSources) {
+    const fileName = source.split('/').at(-1);
+    const stem = slugify(fileName.replace(NATIVE_SOURCE_FILE, ''));
+    if (!stem) continue;
+    const count = sourceSlugCounts.get(stem) ?? 0;
+    sourceSlugCounts.set(stem, count + 1);
+    const slug = count === 0
+      ? `elements/${stem}`
+      : `elements/${stem}-${slugify(source.split('/').slice(-2, -1)[0]) || 'native'}`;
+    addElement({
+      slug,
+      title: humanize(stem),
+      path: source,
+      evidence: { source },
+    });
+  }
+
+  return { isNativeProject: true, elements };
 }
 
 function discoverRustImplementationEvidence(rootPath, skipped) {

--- a/mcp/src/analyze.test.mjs
+++ b/mcp/src/analyze.test.mjs
@@ -1700,6 +1700,114 @@ test('Generic README sections (Usage / Installation / Tests) skipped from domain
   }
 });
 
+test('README ampersand community support sections stay out of domains', () => {
+  const root = withRepo((r) => {
+    writeFileSync(
+      join(r, 'README.md'),
+      '# Native Tool\n\n## Documentation\n\n## Community & Support\n\n## Documentation & Community Support\n\n## Runtime\n',
+    );
+  });
+  try {
+    const result = analyzeRepoStructure(root);
+    assert.deepEqual(result.domains.map((domain) => domain.slug), ['domains/runtime']);
+    assert.deepEqual(
+      result.meaningGate.proposedBusinessOntology.domains.map((domain) => domain.slug),
+      ['domains/runtime'],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('native C repositories expose bounded build, documentation, and source evidence', () => {
+  let outside = null;
+  const root = withRepo((r) => {
+    writeFileSync(
+      join(r, 'README.md'),
+      '# Native Tool\n\nA portable command-line processor.\n\n## Documentation\n\n## Community & Support\n',
+    );
+    writeFileSync(join(r, 'configure.ac'), 'AC_INIT([native-tool])\n');
+    writeFileSync(join(r, 'Makefile.am'), 'bin_PROGRAMS = native-tool\n');
+    mkdirSync(join(r, 'src'), { recursive: true });
+    writeFileSync(join(r, 'src', 'main.c'), 'int main(void) { return 0; }\n');
+    writeFileSync(join(r, 'src', 'parse.c'), 'int parse(void) { return 0; }\n');
+    writeFileSync(join(r, 'src', 'parse.h'), 'int parse(void);\n');
+    outside = mkdtempSync(join(tmpdir(), 'ontology-atlas-native-outside-'));
+    writeFileSync(join(outside, 'escaped.c'), 'int escaped(void) { return 0; }\n');
+    writeFileSync(join(outside, 'build_escape.py'), 'print("escaped")\n');
+    symlinkSync(join(outside, 'escaped.c'), join(r, 'src', 'escaped.c'));
+    mkdirSync(join(r, 'tests'), { recursive: true });
+    writeFileSync(join(r, 'tests', 'native_test.c'), 'int test(void) { return 0; }\n');
+    mkdirSync(join(r, 'vendor'), { recursive: true });
+    writeFileSync(join(r, 'vendor', 'third_party.c'), 'int vendor(void) { return 0; }\n');
+    mkdirSync(join(r, 'docs'), { recursive: true });
+    writeFileSync(join(r, 'docs', 'build_website.py'), 'print("site")\n');
+    writeFileSync(join(r, 'docs', 'Pipfile'), '[packages]\nmarkdown = "*"\n');
+    symlinkSync(join(outside, 'build_escape.py'), join(r, 'docs', 'build_escape.py'));
+  });
+  try {
+    const result = analyzeRepoStructure(root);
+    const paths = result.elements.map((element) => element.path);
+    assert.deepEqual(result.domains, []);
+    assert.deepEqual(result.capabilities, []);
+    assert.ok(paths.includes('configure.ac'));
+    assert.ok(paths.includes('Makefile.am'));
+    assert.ok(paths.includes('docs/build_website.py'));
+    assert.ok(paths.includes('docs/Pipfile'));
+    assert.ok(paths.includes('src/main.c'));
+    assert.ok(paths.includes('src/parse.c'));
+    assert.ok(paths.includes('src/parse.h'));
+    assert.equal(paths.includes('tests/native_test.c'), false);
+    assert.equal(paths.includes('vendor/third_party.c'), false);
+    assert.equal(paths.includes('src/escaped.c'), false);
+    assert.equal(paths.includes('docs/build_escape.py'), false);
+    assert.equal(new Set(result.elements.map((element) => element.slug)).size, result.elements.length);
+    assert.equal(result.suggestedRelations.some((relation) => relation.type === 'depends_on'), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    if (outside) rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test('native evidence scanner stays scoped to Autotools-shaped repositories', () => {
+  const root = withRepo((r) => {
+    writeFileSync(join(r, 'README.md'), '# CMake Tool\n');
+    writeFileSync(join(r, 'CMakeLists.txt'), 'add_executable(tool src/main.c)\n');
+    mkdirSync(join(r, 'src'), { recursive: true });
+    writeFileSync(join(r, 'src', 'main.c'), 'int main(void) { return 0; }\n');
+  });
+  try {
+    const result = analyzeRepoStructure(root);
+    assert.deepEqual(result.elements, []);
+    assert.deepEqual(result.capabilities, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('native documentation generator evidence is sorted and bounded', () => {
+  const root = withRepo((r) => {
+    writeFileSync(join(r, 'README.md'), '# Native Tool\n');
+    writeFileSync(join(r, 'configure.ac'), 'AC_INIT([native-tool])\n');
+    mkdirSync(join(r, 'src'), { recursive: true });
+    writeFileSync(join(r, 'src', 'main.c'), 'int main(void) { return 0; }\n');
+    mkdirSync(join(r, 'docs'), { recursive: true });
+    for (let index = 0; index < 13; index += 1) {
+      writeFileSync(join(r, 'docs', `build_${String(index).padStart(2, '0')}.py`), '');
+    }
+  });
+  try {
+    const result = analyzeRepoStructure(root);
+    const generatorPaths = result.elements
+      .map((element) => element.path)
+      .filter((path) => path.startsWith('docs/build_'));
+    assert.equal(generatorPaths.length, 12);
+    assert.deepEqual(generatorPaths, [...generatorPaths].sort());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('Narrative / language-guide / sentence README H2s skipped from domains', () => {
   const root = withRepo((r) => {
     writeFileSync(


### PR DESCRIPTION
## 변경 내용

- Autotools-shaped C 저장소에서 configure.ac, Makefile.am, docs/Pipfile, docs/build_*.py와 제한된 C/H 구현 경로를 요소 근거로 보존합니다.
- tests/vendor 및 저장소 밖으로 빠지는 symlink는 제외하고, 소스·문서 생성기 후보 수를 bounded scan으로 제한합니다.
- Documentation / Community & Support 같은 README 운영 헤딩이 business domain으로 과잉 승격되지 않도록 보정했습니다.
- ontology-bootstrap 양쪽 skill 문서에 analyzer evidence packet, unsupported-language coverage gap, generic-domain guardrail을 반영했습니다.

## 영향

대규모 native 프로젝트에서도 business ontology와 implementation evidence를 분리해 유지하면서, 분석기가 실제 구현 경로를 놓치지 않습니다. 이번 범위에서는 CMake 일반화, C include graph, Makefile dependency inference, qualification/write behavior 변경은 하지 않았습니다.

## 검증

- `pnpm test:run` — 692 files, 6855 passed, 3 todo
- `pnpm exec node --test mcp/src/analyze.test.mjs` — 95 passed
- `pnpm test:mcp:unit` — 705 passed
- `pnpm integration:mcp:repo-analysis` — 12 passed, 113 skipped
- `pnpm dogfood:verify` — passed
- `pnpm docs:links` — 411 markdown files, no broken references
- `pnpm lint` — 0 errors, 57 pre-existing warnings

`pnpm dogfood:status`는 기존 dogfood vault의 `meaning_assessment: invalid (assessment_input_invalid)` 때문에 exit 1이며, 이번 변경은 vault에 semantic write를 수행하지 않았습니다.