### PR TITLE
chore: v1.0.0-rc.7 릴리스 버전을 맞춘다

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2558,7 +2558,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/views/download/lib/release-facts.ts
+++ b/src/views/download/lib/release-facts.ts
@@ -37,7 +37,7 @@
  */
 export const MCP_TOOL_COUNT = 35;
 
-export const RELEASE_VERSION = "1.0.0-rc.6";
+export const RELEASE_VERSION = "1.0.0-rc.7";
 export const RELEASE_MIN_MACOS = "macOS 12";
 export const RELEASE_ARCHES = ["aarch64", "x64"] as const;
 export type ReleaseArch = (typeof RELEASE_ARCHES)[number];


### PR DESCRIPTION
기존 v1.0.0-rc.6 태그와 공개 prerelease가 이미 존재하므로 새 API-key 전환 릴리스를 rc.7로 준비합니다.

- package, Tauri, Cargo, download release version 정렬
- 기존 공개 rc.6 release facts generated file은 publish workflow가 rc.7 게시 뒤 갱신

검증: desktop release tag gate, package check, desktop check, native bridge, TypeScript, package contracts, web smoke, gateway grid