### PR TITLE
fix: 지도 딥링크 결함 · 데이터시트 호버 강조 · 흔들리던 검사 일곱 수리

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2490,7 +2490,12 @@
     --chrome-icon: 16px;
     --chrome-surface: rgba(16, 17, 24, 0.96);
     --chrome-border: var(--color-border-soft);
-    --chrome-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    /* 색은 램프 토큰을 가리킨다 — 바로 위 `--chrome-radius`/`--chrome-border`
+       와 같은 규율이다. 이 줄만 값을 손으로 적고 있었다(2026-08-17 릴리스 전
+       감사). `--color-shadow-a35` 가 **이미 같은 값**이라 화면은 1픽셀도 안
+       바뀌고, 소비처 18곳은 한 줄도 안 고친다. 같은 값이 두 곳에 적히면 그
+       순간부터 둘이 어긋나기 시작한다. */
+    --chrome-shadow: 0 6px 20px var(--color-shadow-a35);
     --chrome-inset: 24px;
     /* ChromeTile/ChromeChip 의 `active`(선택/진행중) 표시 — 인디고 하나만
        쓰는 단일 채색 원칙 그대로, 알파만 다르다. */

--- a/cli/src/integration.test.mjs
+++ b/cli/src/integration.test.mjs
@@ -2153,6 +2153,20 @@ await test('mcp-verify — times out a stalled verify script override', async ()
     'utf-8',
   );
 
+  /*
+   * ⚠️ 벽시계 상한은 **절대값으로 박지 않는다.** 예전에는 `< 1000ms` 였는데,
+   * 그 1초 안에 node 프로세스 둘(CLI + verify 스크립트)이 기동까지 마쳐야 했다
+   * — 재는 대상은 25ms 짜리 시간 제한인데 바닥은 기계 속도였다. 같은 경로를
+   * **즉시 끝나는** 스크립트로 한 번 돌려 이 기계의 바닥을 재고, 거기에 여유를
+   * 더해 비교한다. 그러면 「제 시간 제한을 무시하고 기본값(15초)까지 기다린다」는
+   * 진짜 회귀는 여전히 잡히고, 느린 러너는 통과한다 (2026-08-17 검사 전수조사).
+   */
+  const instantScript = join(root, 'instant-verify.mjs');
+  writeFileSync(instantScript, 'process.exit(1);', 'utf-8');
+  const baselineStarted = Date.now();
+  await run(['mcp-verify', vault], { env: { OATLAS_MCP_VERIFY_PATH: instantScript } });
+  const baselineMs = Date.now() - baselineStarted;
+
   const started = Date.now();
   const r = await run(['mcp-verify', vault, '--timeout-ms', '25'], {
     env: {
@@ -2160,9 +2174,14 @@ await test('mcp-verify — times out a stalled verify script override', async ()
       OATLAS_VERIFY_KILL_GRACE_MS: '25',
     },
   });
+  const stalledMs = Date.now() - started;
 
   assert.equal(r.code, 1);
-  assert.ok(Date.now() - started < 1000, 'wrapper should fail closed without hanging the integration suite');
+  assert.ok(
+    stalledMs < baselineMs + 2_000,
+    `wrapper should fail closed without hanging the integration suite ` +
+      `(baseline ${baselineMs}ms, stalled ${stalledMs}ms)`,
+  );
   assert.match(stripAnsi(r.stderr), /MCP verify wrapper timed out after 50ms/);
   assert.match(stripAnsi(r.stderr), /Check OATLAS_MCP_VERIFY_PATH/);
   assert.match(stripAnsi(r.stderr), /increase --timeout-ms \/ OATLAS_VERIFY_TIMEOUT_MS/);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,24 @@ import boundaries from 'eslint-plugin-boundaries';
 // 룰을 추가하는 config 도 이 셀렉터를 함께 실어야 scale/gradient 가드가 그
 // 파일에서 유실되지 않는다.
 const scaleGradientSelectors = [
+  /*
+   * **glassmorphism 금지 — 문서에만 있고 룰이 없었다** (2026-08-17 릴리스 전 감사).
+   *
+   * `forbidden.md` 「디자인」절과 `DESIGN-SYSTEM.md` 의 절대 금지 목록이 둘 다
+   * `backdrop-blur-*` 를 못박아 두었는데 그것을 잡는 룰은 없었다. 켤 때 실사용
+   * 위반 0건(코드에 걸린 셋은 전부 「이건 금지다」라고 적어 둔 **주석**이었다).
+   * 그래서 지금 켜면 소음 0이고, 앞으로 들어오는 것만 막는다.
+   */
+  {
+    selector: "Literal[value=/(^|\\s|:)backdrop-blur/]",
+    message:
+      '디자인 헌장 — glassmorphism 금지. 뒤를 흐리는 대신 불투명 표면 토큰(--color-panel/elevated)이나 색 알파(--color-overlay-*)를 쓴다.',
+  },
+  {
+    selector: "TemplateElement[value.raw=/(^|\\s|:)backdrop-blur/]",
+    message:
+      '디자인 헌장 — glassmorphism 금지 (template literal). 불투명 표면 토큰 또는 색 알파로.',
+  },
   {
     selector: "Literal[value=/(^|\\s)(hover|active|focus|group-hover):scale-/]",
     message: '디자인 헌장 §11 — scale hover 금지. bg/border 변경 또는 색 alpha 로 대체.',
@@ -345,6 +363,30 @@ const disabledAffordanceSelectors = [
  * ⚠️ 켜기 전 전수: 세 축 모두 먼저 0으로 만들고 켰다(lint 총계 불변).
  */
 const typographyAxisSelectors = [
+  /*
+   * **이름 붙은 행간 유틸리티 — 이관은 끝났는데 룰만 안 켰다** (2026-08-17).
+   *
+   * `design.md` 행간 램프 항목은 *"이름 유틸리티(숫자꼴 leading-4~7 · 비율꼴
+   * relaxed·snug·none·tight) 전부 금지"* 라고 적어 두었지만, 실제 룰은 대괄호
+   * 형태만 봤다. 그때는 일부러 그랬다 — 이 파일 아래 주석이 사유를 적어 두었듯
+   * 당시 named 사용이 199건이라 룰로 켜면 소음이 기존 신호를 덮었다.
+   *
+   * 그 이관은 끝났다. 지금 실사용 0건(하나 걸린 것은 「여기서 옮겨 왔다」고
+   * 적어 둔 주석이다). 소음 없이 닫을 수 있는 자리가 됐으므로 닫는다 —
+   * 「문서에만 있는 규격은 지켜지지 않는다」가 이 저장소의 규율이다.
+   */
+  {
+    selector:
+      "Literal[value=/(^|\\s|:)leading-(relaxed|snug|none|tight|loose|[3-9]|10)(\\s|$)/]",
+    message:
+      '행간도 램프다. 이름 붙은 Tailwind 행간 스텝 금지 — --leading-caption/label/body/body-lg/title/display/hero 짝과 --leading-display-tight/prose 를 쓴다. 크기 스텝이 자기 행간을 함께 싣는 자리라면 행간 클래스 자체가 필요 없다.',
+  },
+  {
+    selector:
+      "TemplateElement[value.raw=/(^|\\s|:)leading-(relaxed|snug|none|tight|loose|[3-9]|10)(\\s|$)/]",
+    message:
+      '행간도 램프다. 이름 붙은 Tailwind 행간 스텝 금지 (template literal). --leading-* 램프가 만드는 유틸리티로.',
+  },
   {
     selector: 'Literal[value=/tracking-\\[-?[0-9.]+(em|px|rem)\\]/]',
     message:

--- a/scripts/build-docs-vault.test.mjs
+++ b/scripts/build-docs-vault.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { after, before, describe, it } from 'node:test';
@@ -199,14 +199,20 @@ describe('build-docs-vault 결정성 계약', () => {
   });
 
   it('워킹트리에서 고치는 중인 문서는 mtime **날짜** 로 기록한다 (시각 아님)', async () => {
-    await writeFile(
-      path.join(repo, 'docs', 'GUIDE.md'),
-      '# Guide\n\n본문 두 줄.\n추가.\n',
-      'utf8',
-    );
+    const edited = path.join(repo, 'docs', 'GUIDE.md');
+    await writeFile(edited, '# Guide\n\n본문 두 줄.\n추가.\n', 'utf8');
+    /*
+     * ⚠️ 기댓값은 **그 파일의 mtime** 에서 뽑는다. 예전에는 스캔이 끝난 뒤
+     * `localDayStamp(new Date())` 를 불렀는데, 그러면 «파일을 쓴 순간» 과
+     * «기댓값을 만든 순간» 이 서로 다른 날일 수 있다 — 자정 직전에 쓰고 자정
+     * 직후에 재면 하루가 어긋나 제품과 무관하게 터진다. 스캔이 읽는 값과
+     * 같은 출처(mtime)를 쓰면 그 틈 자체가 없어진다
+     * (2026-08-17 검사 전수조사).
+     */
+    const { mtime } = await stat(edited);
     const { manifest } = await scan();
     assert.match(manifest.docs[0].updatedAt, /^\d{4}-\d{2}-\d{2}$/);
-    assert.equal(manifest.docs[0].updatedAt, localDayStamp(new Date()));
+    assert.equal(manifest.docs[0].updatedAt, localDayStamp(mtime));
   });
 
   it('localDayStamp 는 로컬 날짜만 남기고 시각을 버린다', () => {

--- a/src/entities/project/ui/ProjectCard.tsx
+++ b/src/entities/project/ui/ProjectCard.tsx
@@ -69,8 +69,19 @@ function borderClass(borderStyle: CardCategoryMeta['borderStyle'], isHub: boolea
     return 'border-[color:var(--color-indigo-brand)] bg-[color:var(--color-indigo-a12)]';
   }
   switch (borderStyle) {
+    /*
+     * **분류 밑줄은 없앴다** (2026-08-17 소유자 지시).
+     *
+     * 이 자리는 원래 «작업중» 분류를 2px 인디고 밑줄로 표시했다(헌장의
+     * "분류는 색이 아니라 테두리 모양으로"). 세기를 낮춰 보고 소유자가 다시
+     * 봤고 판정은 그대로였다 — *"하단에 파란선도 없애 그냥"*.
+     *
+     * 그래서 다른 분류와 같은 평범한 테두리로 돌린다. 분류는 카드의 옆 라벨과
+     * 목록·상세의 카테고리 표시가 계속 말한다 — 사실이 사라지는 게 아니라
+     * 그것을 말하는 자리가 하나 줄어든다.
+     */
     case 'underline':
-      return 'border-t-[color:var(--color-border-soft)] border-x-[color:var(--color-border-soft)] border-b-[color:var(--color-indigo-brand)] border-t border-x border-b-2';
+      return 'border border-[color:var(--color-border-soft)]';
     case 'dashed':
       return 'border border-dashed border-[color:var(--color-border-strong)]';
     case 'sideLabel':
@@ -197,9 +208,23 @@ export function ProjectCard({
       }
       className={cn(
         'group relative flex flex-col rounded-sheet border bg-[color:var(--color-panel)] shadow-[var(--shadow-elevation-1)] md:rounded-sheet',
-        dense
-          ? 'h-[84px] w-[156px] px-3 py-2 md:h-[92px] md:w-[168px] md:px-3 md:py-2.5'
-          : 'h-[120px] w-[192px] px-3.5 py-3 md:h-[140px] md:w-[220px] md:px-4 md:py-3.5',
+        /*
+         * 지도 위 카드는 **고정 치수**다 — 격자가 흐트러지지 않게(치수 규칙성).
+         *
+         * 미리보기만 예외다 (2026-08-17 소유자 지적: *"카드 좌우 공백이
+         * 상당한데?"*). 실측: 카드 220px 이 260px 레일 안에 앉아 좌우로 40px 이
+         * 남았고, 바로 아래 완성도 상자는 260 을 꽉 쓴다. 그래서 카드만 안으로
+         * 움츠러든 것처럼 보였다.
+         *
+         * 폭은 레일을 채우되 **진짜 비율(220:140 = 11:7)** 을 유지한다. 캡션이
+         * *"실제 지도에 그려지는 모습"* 이라고 말하므로 비율을 바꾸면 그 말이
+         * 거짓이 된다 — 채우는 것과 정직한 것을 둘 다 지키는 방법이 비율 고정이다.
+         */
+        preview
+          ? 'aspect-[11/7] w-full px-3.5 py-3 md:px-4 md:py-3.5'
+          : dense
+            ? 'h-[84px] w-[156px] px-3 py-2 md:h-[92px] md:w-[168px] md:px-3 md:py-2.5'
+            : 'h-[120px] w-[192px] px-3.5 py-3 md:h-[140px] md:w-[220px] md:px-4 md:py-3.5',
         preview ? '' : 'cursor-pointer active:cursor-grabbing',
         borderClass(borderStyle, isHub),
         related && !selected ? 'border-[color:var(--color-indigo-a22)]' : '',

--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1623,7 +1623,18 @@ export function ProjectForm({
             <p className="mb-3 font-mono text-caption uppercase tracking-[var(--tracking-caps-12)] text-[color:var(--color-text-quaternary)]">
               {t("preview.cardEyebrow")}
             </p>
-            <div className="flex items-start justify-center rounded-panel border border-[color:var(--color-overlay-2)] bg-[color:var(--color-canvas)] p-6">
+            {/*
+              **카드가 상자 안의 상자가 되지 않게 한다** (2026-08-17).
+
+              미리보기의 일은 *"지도에서 이렇게 보인다"* 를 보여 주는 것인데,
+              그 카드를 다시 테두리 있는 액자에 넣으면 지도에 없는 테두리가
+              하나 더 붙은 모습을 보여 주게 된다 — 미리보기가 실물과 달라진다.
+
+              액자를 걷고 **지도와 같은 바탕**만 깐다. 카드 자신이 이미 테두리와
+              반경을 갖고 있어서 경계는 그것으로 충분하다. 여백도 6 → 5 로
+              줄인다(액자가 없으니 안쪽 여백이 그만큼 커 보인다).
+            */}
+            <div className="flex items-start justify-center rounded-panel bg-[color:var(--color-canvas)] p-5">
               <ProjectCard
                 project={previewProject}
                 category={(() => {
@@ -1691,6 +1702,20 @@ export function ProjectForm({
  * 만들기 화면의 "더 채우기" 자리. 필수 4칸 밖의 모든 항목이 여기 접혀 있고,
  * 펼치는 건 사용자다. 닫힌 높이를 고정하지 않는 대신 캡션 한 줄이 늘 같은
  * 자리에서 "저장한 뒤에 채워도 된다" 를 말한다 — 이 화면의 유일한 안내다.
+ *
+ * ## 상자를 씌우지 않는다 (2026-08-17 소유자 지적)
+ *
+ * *"조금 ai디자인같고 허접한데"*. 재 보니 값은 이미 시스템대로였다 — 이 화면의
+ * 반경 이탈 0건 · 글자 크기 이탈 0건. 어긋난 것은 **위계**였다.
+ *
+ * 종전에는 접힌 줄 하나를 `rounded-panel border bg-panel` 섹션이 감쌌다.
+ * 실측(1512×900): 그 상자가 **92px 를 차지하는데 담은 것은 제목 한 줄과 캡션
+ * 한 줄**뿐이었고, 화면의 바깥 상자 넷 중 하나였다. 이 저장소가 「떠 있는 상자
+ * 수프」라고 이름 붙여 금지한 모양이다.
+ *
+ * 테두리는 «여기부터 다른 것» 을 뜻하는데 접힌 상태에는 안에 다른 것이 없다.
+ * 그래서 경계는 머리카락선 하나로 충분하고, 펼쳤을 때 비로소 내용이 자기
+ * 무게로 구분된다. 크롬을 줄이면 남은 상자(폼)가 주인공이라는 것이 저절로 선다.
  */
 function CreateExtras({
   open,
@@ -1710,14 +1735,18 @@ function CreateExtras({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] md:px-5">
+    <section className="border-t border-[color:var(--color-divider)] pt-5">
       <button
         type="button"
         data-testid="project-create-extras-toggle"
         onClick={onToggle}
         aria-expanded={open}
         aria-controls="project-create-extras"
-        className={controlClass({ shape: "row", stacked: true, className: "justify-between gap-3" })}
+        className={controlClass({
+          shape: "row",
+          stacked: true,
+          className: "justify-between gap-3",
+        })}
       >
         <span className="min-w-0">
           <span className="block text-body-lg text-[color:var(--color-text-primary)]">{label}</span>

--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1634,7 +1634,7 @@ export function ProjectForm({
               반경을 갖고 있어서 경계는 그것으로 충분하다. 여백도 6 → 5 로
               줄인다(액자가 없으니 안쪽 여백이 그만큼 커 보인다).
             */}
-            <div className="flex items-start justify-center rounded-panel bg-[color:var(--color-canvas)] p-5">
+            <div className="flex items-start justify-center rounded-panel bg-[color:var(--color-canvas)] py-4">
               <ProjectCard
                 project={previewProject}
                 category={(() => {

--- a/src/shared/lib/cn.test.ts
+++ b/src/shared/lib/cn.test.ts
@@ -115,6 +115,16 @@ describe('cn — 행간 램프 충돌 병합', () => {
     expect(cn('leading-[1.9]', 'leading-prose')).toBe('leading-prose');
   });
 
+  /*
+   * 이 셋은 **일부러 이름 유틸리티를 쓴다.** 2026-08-17 에 그 유틸리티를 lint 로
+   * 금지했지만(제품 코드 실사용 0건이라 소음 없이 닫혔다), 여기는 「금지된 그것이
+   * 들어와도 `cn` 이 올바르게 병합하는가」를 지키는 자리다 — 남의 코드나 옛
+   * 문자열이 흘러들어도 크기·행간이 조용히 뒤섞이지 않게 하는 마지막 보루라서,
+   * 금지했다고 시험까지 지우면 그 보루가 사라진다.
+   *
+   * 파일 단위 면제는 형제 램프 룰(크기·무게·자간)이 이미 쓰는 것과 같다 —
+   * 테스트는 렌더된 className 문자열을 단언하는 자리다(`codexTestIgnores`).
+   */
   it('기존 named 행간 유틸리티와의 병합도 유지된다', () => {
     expect(cn('leading-4', 'leading-label')).toBe('leading-label');
     expect(cn('leading-prose', 'leading-relaxed')).toBe('leading-relaxed');

--- a/src/views/agent-skills/ui/FindingsPanel.tsx
+++ b/src/views/agent-skills/ui/FindingsPanel.tsx
@@ -145,10 +145,16 @@ function Row({ onClick, children }: { onClick: () => void; children: React.React
       type="button"
       data-testid="skill-jump"
       onClick={onClick}
+      /*
+        `size: "sm"` 행은 값 층에서 `min-h-7 py-1.5 text-label` 이다 — 작은
+        글자를 전제한 높이다. 여기서 `text-body-lg`(14px)로 덮으면 안쪽이
+        22px 가 되어 6+22+6 = 34px 로 밀린다(2026-08-03 에 높이 사다리에서
+        지워진 값). 행이 전제한 크기로 되돌린다 — 실측 32px, 사다리 위.
+      */
       className={controlClass({
         shape: "row",
         size: "sm",
-        className: "justify-between gap-2 text-body-lg",
+        className: "justify-between gap-2 text-body",
       })}
     >
       {children}

--- a/src/views/agent-skills/ui/SkillDetail.tsx
+++ b/src/views/agent-skills/ui/SkillDetail.tsx
@@ -155,7 +155,7 @@ function Jump({ onClick, children }: { onClick: () => void; children: React.Reac
       className={controlClass({
         shape: "link",
         size: "sm",
-        className: "text-left text-body-lg text-[color:var(--color-amber-source-text-a80)]",
+        className: "text-left text-body text-[color:var(--color-amber-source-text-a80)]",
       })}
     >
       {children}

--- a/src/views/agent-skills/ui/SkillList.tsx
+++ b/src/views/agent-skills/ui/SkillList.tsx
@@ -98,7 +98,22 @@ export function SkillList({
                     })}
                   >
                     <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate text-body-lg text-[color:var(--color-text-primary)]">
+                      {/*
+                        ⚠️ **행 규격이 정한 글자 크기를 소비처가 덮으면 높이가 밀린다**
+                        (2026-08-17 릴리스 전 감사).
+
+                        이 행은 `size: "sm"` 이고, 값 층에서 그 조합은
+                        `min-h-7 py-1.5 text-label` 이다 — 즉 **작은 글자를
+                        전제한 높이**다. 그런데 이름만 `text-body-lg`(14px)로
+                        덮어써서 안쪽 내용이 22px 가 됐고, 6+22+6 = **34px** 로
+                        밀렸다. 34 는 2026-08-03 에 높이 사다리에서 **지워진 값**
+                        이고, 실측에서 이 화면의 유일한 이탈이었다(18개).
+
+                        `min-h` 는 올리기만 하므로 28 은 아무 일도 못 한다.
+                        여백을 줄이면 30(역시 사다리 밖)이라, 행이 전제한 크기로
+                        되돌리는 것이 맞다 — 실측 32px, 사다리 위.
+                      */}
+                      <span className="truncate text-body text-[color:var(--color-text-primary)]">
                         {skill.name}
                       </span>
                       {collided.has(skill.name) ? (

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1507,7 +1507,27 @@ export function HomePage() {
    * 그걸로 힌트가 localStorage 에 영구 소멸했다. 누른 적도 없는데 학습 완료로
    * 기록된 것이다.
    */
-  const resolvedSelectionSlug = selectedProject?.slug ?? selectedOntologyNode?.id ?? null;
+  /*
+   * ⚠️ **캔버스가 원하는 것은 슬러그가 아니라 그래프 노드 이름이다**
+   * (2026-08-17 소유자 보고로 발견).
+   *
+   * 노드 이름은 `${kind}:${슬러그}` 다(`derive-ontology-from-vault.ts`).
+   * 그런데 프로젝트 딥링크는 접두사 없는 슬러그를 보낸다
+   * (`topology-href.ts`: `kind: project` → `/topology/?p=<슬러그>`; 다른
+   * 종류는 노드 이름을 그대로 보낸다). 그래서 **프로젝트만** 캔버스에서
+   * 맞는 노드를 못 찾았고, 지도는 「하나 골랐는데 그게 어디에도 없네」를
+   * 「전부 흐리게」로 번역했다 — 실측 1.40:1(도형 최저 3:1).
+   *
+   * 프로젝트도 다른 종류와 같은 규칙을 태운다. 그래프에 그 노드가 없으면
+   * (컴파일이 프로젝트를 안 냈다면) 슬러그를 그대로 두되, 그때는 캔버스의
+   * 안전망이 「안 고름」으로 떨어뜨린다 — 화면이 죽지 않는다.
+   */
+  const selectedProjectNodeId = useMemo(() => {
+    if (!selectedProject) return null;
+    const nodeId = `project:${selectedProject.slug}`;
+    return ontologyInsight?.nodes.some((n) => n.id === nodeId) ? nodeId : selectedProject.slug;
+  }, [selectedProject, ontologyInsight]);
+  const resolvedSelectionSlug = selectedProjectNodeId ?? selectedOntologyNode?.id ?? null;
   const canvasSelectedSlug = resolveCanvasSelectedSlug({
     selectedSlug,
     resolvedSlug: resolvedSelectionSlug,

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1856,15 +1856,26 @@ export function HomePage() {
   }, []);
 
   /*
-    대화창에서 노드 이름에 마우스를 올렸을 때 (2026-08-17 소유자 지시:
-    *"채팅에서 마우스만 올려도 우리 노드에 표시된다거나"*).
+    **옆 패널에서 노드 이름에 마우스를 올렸을 때** 지도가 그 노드를 가리키는
+    단 하나의 통로. 쓰는 곳이 둘이다:
 
-    바로 위 발자국 브러싱과 **같은 계약**이다 — 커서가 캔버스가 아니라 옆
-    패널 위에 있어 캔버스 호버와 경쟁하지 않고, ref 라 호버마다 렌더를
-    돌리지 않는다. 지도는 이것을 **마우스로 올렸을 때와 똑같이** 그린다:
-    채팅에서 온 강조만 다르게 보이면 그것이 무슨 뜻인지 또 배워야 한다.
+    ① 대화창(2026-08-17 소유자 지시: *"채팅에서 마우스만 올려도 우리 노드에
+       표시된다거나"*)
+    ② 데이터시트의 하위/상위/근거/도메인 줄 (2026-08-17 소유자 지시:
+       *"이부분들 각각 마우스 올리면 옆에 지도에서 반짝이면서 표시되면 좋겠는데
+       가능할까? 지금은 아무 반응이 없어서.."*)
+
+    ②를 붙일 때 **새 통로를 만들지 않았다.** 「반짝」은 깜빡임·glow 를 뜻하는
+    말이 아니라 *"거기가 어디인지 보이게"* 라는 뜻이고(이 저장소는 깜빡임·
+    glow·pulse 를 금지한다 — `forbidden.md` 「디자인」절), 지도에는 이미 그
+    뜻으로 배운 표시가 있다: **마우스로 노드를 가리켰을 때 나오는 그 표시**.
+    통로를 하나로 두면 강조도 하나뿐이라 사용자가 새로 배울 것이 없다.
+
+    발자국 브러싱과 **같은 계약**이다 — 커서가 캔버스가 아니라 옆 패널 위에
+    있어 캔버스 호버와 경쟁하지 않고, ref 라 호버마다 렌더를 돌리지 않는다.
+    두 소비처가 동시에 쓸 일은 없다(커서는 하나다).
   */
-  const chatHoverNodeIdRef = useRef<string | null>(null);
+  const panelHoverNodeIdRef = useRef<string | null>(null);
   /* 답변에서 집을 이름들 — **실재하는 노드만**. 아무 `a/b` 나 링크로 만들면
      파일 경로와 URL 까지 링크가 되고, 눌러도 아무 데도 안 가는 링크를 한 번
      만난 사람은 나머지도 안 누른다.
@@ -1883,7 +1894,20 @@ export function HomePage() {
      ref 를 쓰는 쪽이 더 싸 보이지만 그건 동시성 렌더에서 깨지는 패턴이다. */
   const handleChatHoverSlug = useCallback(
     (slug: string | null) => {
-      chatHoverNodeIdRef.current = slug ? (chatNodeIndex.get(slug) ?? null) : null;
+      panelHoverNodeIdRef.current = slug ? (chatNodeIndex.get(slug) ?? null) : null;
+    },
+    [chatNodeIndex],
+  );
+  /* 데이터시트의 관계 행 — 넘어오는 값이 **이미 캔버스 노드 id** 다
+     (`onSelectConnection` 과 같은 이름 공간). 그래서 표를 거치지 않는다. */
+  const handleDatasheetHoverConnection = useCallback((id: string | null) => {
+    panelHoverNodeIdRef.current = id;
+  }, []);
+  /* 근거 문서 행 — 넘어오는 값은 **볼트 slug** 라 채팅과 같은 표를 거친다.
+     지도에 없는 문서면 표가 못 찾고 null 이 되어 아무 일도 안 일어난다. */
+  const handleDatasheetHoverEvidence = useCallback(
+    (slug: string | null) => {
+      panelHoverNodeIdRef.current = slug ? (chatNodeIndex.get(slug) ?? null) : null;
     },
     [chatNodeIndex],
   );
@@ -5091,7 +5115,7 @@ export function HomePage() {
                     visitedTrail={footprintVisitedIds}
                     trailLensActiveRef={footprintLensActiveRef}
                     trailHoverNodeIdRef={footprintBrushNodeIdRef}
-                    chatHoverNodeIdRef={chatHoverNodeIdRef}
+                    panelHoverNodeIdRef={panelHoverNodeIdRef}
                     // 슬라이스 C — 비개발(plain) 모드는 element 티어를 도달
                     // 불가 밴드로 밀어 상시 숨김(ego 예외는 그대로).
                     tierReveal={audiencePlain ? PLAIN_TIER_REVEAL : undefined}
@@ -5551,6 +5575,8 @@ export function HomePage() {
                   sourceBusy: projectSourceLabels?.busy,
                 }}
                 onSelectConnection={(id) => handleSelect(id)}
+                onHoverConnection={handleDatasheetHoverConnection}
+                onHoverEvidence={handleDatasheetHoverEvidence}
                 onCopyHandoff={copyV2NodeHandoff}
                 /*
                  * 「이어서 새로 만들기」 — **도메인 노드에서만** 넘긴다.

--- a/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyMapV2.tsx
@@ -251,8 +251,9 @@ export interface TopologyMapV2Props {
    * (실측 ~100ms). 프레임 루프가 매 프레임 읽으므로 렌더 0회로 같은 결과.
    */
   trailHoverNodeIdRef?: RefObject<string | null>;
-  /** 대화창에서 노드 이름에 마우스를 올렸을 때 (`use-topology-loop` 참고). */
-  chatHoverNodeIdRef?: RefObject<string | null>;
+  /** 옆 패널(대화창·데이터시트)에서 노드 이름에 마우스를 올렸을 때
+   *  (`use-topology-loop` 참고). */
+  panelHoverNodeIdRef?: RefObject<string | null>;
   /**
    * 슬라이스 C (개발/비개발 모드 토글) — 표시-렌즈 티어 게이트 config. 생략
    * 시 `DEFAULT_TIER_REVEAL`(개발 모드). HomePage 가 비개발(plain) 모드에서
@@ -325,7 +326,7 @@ export interface TopologyMapV2Props {
 }
 
 export function TopologyMapV2(props: TopologyMapV2Props) {
-  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, walkNoticeLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, chatHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = props;
+  const { nodes, edges, focus, minimal, emphasizedNeighborSlug, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken, onSelectEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId, spotlightIds = null, onHoverEdge, selectedEdge = null, expandedParents, onToggleCluster, onHoverCluster, clusterHint, realmRootId = null, onEnterRealm, realmEnterLabel, realmEnterTooltip, realmCaption = null, clusterBarLabels = null, canvasLabel, walkNoticeLabel, visitedTrail, trailLensActiveRef, trailHoverNodeIdRef, panelHoverNodeIdRef, tierReveal, tourAnchorNodeId = null, tourAnchorRef, overlayOpen = false, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = props;
 
   const realmEnterButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -462,7 +463,7 @@ export function TopologyMapV2(props: TopologyMapV2Props) {
       visitedTrail,
       trailLensActiveRef,
       trailHoverNodeIdRef,
-      chatHoverNodeIdRef,
+      panelHoverNodeIdRef,
       tierReveal,
       tourAnchorNodeId,
       tourAnchorRef,

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.test.tsx
@@ -93,6 +93,8 @@ function renderPanel(
     onSetPathSource?: () => void;
     domain?: { id: string; title: string } | null;
     onSelectConnection?: (id: string) => void;
+    onHoverConnection?: (id: string | null) => void;
+    onHoverEvidence?: (slug: string | null) => void;
     sourceTitle?: string | null;
     showHandoff?: boolean;
     showSourcePath?: boolean;
@@ -113,7 +115,7 @@ function renderPanel(
     groups?: TopologyV2DetailPanelProps["groups"];
   } = {},
 ) {
-  render(
+  return render(
     <TopologyV2DetailPanel
       open
       nodeId="domain:views"
@@ -143,6 +145,8 @@ function renderPanel(
       lastEditSubject={overrides.lastEditSubject ?? null}
       mtimeConflict={overrides.mtimeConflict ?? false}
       onSelectConnection={overrides.onSelectConnection ?? (() => {})}
+      onHoverConnection={overrides.onHoverConnection}
+      onHoverEvidence={overrides.onHoverEvidence}
       onCopyHandoff={overrides.onCopyHandoff ?? (() => {})}
       onAskAgent={overrides.onAskAgent}
       onClose={() => {}}
@@ -1642,5 +1646,102 @@ describe("TopologyV2DetailPanel — 시안 재설계 구조", () => {
 
     await waitFor(() => expect(onExited).toHaveBeenCalledTimes(1));
     expect(screen.queryByTestId("topology-v2-detail-panel")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * 줄에 마우스를 올리면 옆 지도가 그 노드를 가리킨다 (2026-08-17 소유자 지시:
+ * *"이부분들 각각 마우스 올리면 옆에 지도에서 반짝이면서 표시되면 좋겠는데
+ * 가능할까? 지금은 아무 반응이 없어서.."*).
+ *
+ * 여기서 재는 것은 **어느 이름을 어느 콜백으로 내보내는가** 하나다. 두 줄이
+ * 서로 다른 이름 공간을 쓰기 때문이다 — 관계 행은 캔버스 노드 id, 근거 문서
+ * 행은 볼트 slug. 종전에 이 둘을 한 목록으로 합쳤다가 «배선은 있는데 아무
+ * 이름도 안 걸리는» 죽은 기능이 됐고(`chat-node-index.ts`), 그때 없던 검사가
+ * 바로 이것이다. 지도가 실제로 그려 주는지는 캔버스라 여기서 못 재고
+ * `tests/e2e/datasheet-hover-map-brush.spec.ts` 가 픽셀로 잰다.
+ */
+describe("TopologyV2DetailPanel — 줄 호버가 지도로 나가는 통로", () => {
+  const childRow = {
+    id: "capability:cart",
+    title: "장바구니",
+    kind: "capability",
+    relationType: "contains",
+    direction: "outgoing" as const,
+  };
+
+  it("관계 행은 **캔버스 노드 id** 를 내보내고, 커서가 나가면 null 로 접는다", () => {
+    const onHoverConnection = vi.fn();
+    renderPanel(undefined, undefined, {
+      onHoverConnection,
+      groups: {
+        contains: { rows: [childRow], total: 1 },
+        usedBy: { rows: [], total: 0 },
+        dependsOn: { rows: [], total: 0 },
+        belongsTo: { rows: [], total: 0 },
+      },
+    });
+
+    const row = screen.getByText("장바구니").closest("button");
+    expect(row).not.toBeNull();
+    fireEvent.pointerEnter(row!);
+    expect(onHoverConnection).toHaveBeenCalledWith("capability:cart");
+    fireEvent.pointerLeave(row!);
+    expect(onHoverConnection).toHaveBeenLastCalledWith(null);
+  });
+
+  it("근거 문서 행은 **볼트 slug** 를 내보낸다 — 캔버스 id 와 다른 이름 공간이다", () => {
+    const onHoverEvidence = vi.fn();
+    const onHoverConnection = vi.fn();
+    renderPanel(
+      undefined,
+      { rows: [{ id: "domains/order", title: "order", path: "domains/" }], total: 1 },
+      { onHoverEvidence, onHoverConnection },
+    );
+
+    const link = screen.getByText("order").closest("a");
+    expect(link).not.toBeNull();
+    fireEvent.pointerEnter(link!);
+    expect(onHoverEvidence).toHaveBeenCalledWith("domains/order");
+    // 캔버스 id 통로로 새면 호출부가 표를 안 거치고 그대로 지도에 넘긴다.
+    expect(onHoverConnection).not.toHaveBeenCalled();
+    fireEvent.pointerLeave(link!);
+    expect(onHoverEvidence).toHaveBeenLastCalledWith(null);
+  });
+
+  it("도메인 칩도 같은 통로다 — 같은 어포던스인데 여기만 반응이 없으면 안 된다", () => {
+    const onHoverConnection = vi.fn();
+    renderPanel(undefined, undefined, {
+      onHoverConnection,
+      domain: { id: "domain:order", title: "주문" },
+    });
+
+    const chip = screen.getByTestId("topology-v2-detail-panel-domain");
+    fireEvent.pointerEnter(chip);
+    expect(onHoverConnection).toHaveBeenCalledWith("domain:order");
+    fireEvent.pointerLeave(chip);
+    expect(onHoverConnection).toHaveBeenLastCalledWith(null);
+  });
+
+  it("패널이 사라지면 강조도 걷힌다 — 행을 누르면 pointerleave 가 안 온다", () => {
+    const onHoverConnection = vi.fn();
+    const onHoverEvidence = vi.fn();
+    const { unmount } = renderPanel(undefined, undefined, {
+      onHoverConnection,
+      onHoverEvidence,
+      groups: {
+        contains: { rows: [childRow], total: 1 },
+        usedBy: { rows: [], total: 0 },
+        dependsOn: { rows: [], total: 0 },
+        belongsTo: { rows: [], total: 0 },
+      },
+    });
+
+    fireEvent.pointerEnter(screen.getByText("장바구니").closest("button")!);
+    expect(onHoverConnection).toHaveBeenLastCalledWith("capability:cart");
+
+    unmount();
+    expect(onHoverConnection).toHaveBeenLastCalledWith(null);
+    expect(onHoverEvidence).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
+++ b/src/widgets/topology-map-v2/ui/TopologyV2DetailPanel.tsx
@@ -5,6 +5,8 @@ import {
   type ReactElement,
   type ReactNode,
   useCallback,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import {
@@ -320,6 +322,27 @@ export interface TopologyV2DetailPanelProps {
   studioEditHref: string;
   labels: TopologyV2DetailPanelLabels;
   onSelectConnection: (id: string) => void;
+  /**
+   * 관계 행 위에 커서가 있는 동안 그 노드를 **지도에서** 가리킨다 (2026-08-17
+   * 소유자 지시: *"이부분들 각각 마우스 올리면 옆에 지도에서 반짝이면서 표시되면
+   * 좋겠는데 가능할까? 지금은 아무 반응이 없어서.."*).
+   *
+   * **이름 공간에 주의** — 여기 넘기는 값은 `onSelectConnection` 과 같은
+   * **캔버스 노드 id**(`domain:example-domain`)다. 근거 문서 행은 다른 이름
+   * 공간(볼트 slug)이라 `onHoverEvidence` 로 따로 나간다. 둘을 한 콜백으로
+   * 합치면 `chat-node-index.ts` 가 기록한 그 사고 — 두 이름 공간이 만나는
+   * 자리에 검사가 없어 기능이 배선만 남고 죽었던 것 — 를 그대로 반복한다.
+   *
+   * 안 넘기면 아무 일도 안 일어난다(기존 동작 유지).
+   */
+  onHoverConnection?: (id: string | null) => void;
+  /**
+   * 근거 문서 행 호버 — **볼트 slug**(`capabilities/mcp-server`)를 넘긴다.
+   * 지도에 그 노드가 있으면 가리키고, 없으면(문서가 노드가 아닐 수 있다)
+   * 호출자가 null 로 접는다. 판정은 호출자의 몫이다 — 이 패널은 어느 노드가
+   * 지도에 실렸는지 모른다.
+   */
+  onHoverEvidence?: (slug: string | null) => void;
   onCopyHandoff: (text: string) => void;
   /**
    * 「이어서 새로 만들기」 — 이 개념에 붙는 새 노드를 만든다. 없으면 타일 자체가
@@ -837,6 +860,8 @@ export function TopologyV2DetailPanel({
   studioEditHref,
   labels,
   onSelectConnection,
+  onHoverConnection,
+  onHoverEvidence,
   onCopyHandoff,
   onCreateLinked,
   onAskAgent,
@@ -928,6 +953,24 @@ export function TopologyV2DetailPanel({
   // 여기 상태는 그 노드의 것만 산다.
   const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(new Set());
   const [showProjectRelations, setShowProjectRelations] = useState(false);
+
+  /*
+   * 패널이 사라질 때 지도의 강조도 같이 걷는다.
+   *
+   * 행 위에 커서를 둔 채로 그 행을 **누르면** 노드가 바뀌고, 호출부가 `key` 를
+   * 갈아 패널을 통째로 다시 세운다 — 그 행은 DOM 에서 사라지므로
+   * `pointerleave` 가 오지 않는다. 그러면 지도에는 아무도 안 가리키는 강조가
+   * 남는다. 최신 콜백을 ref 로 들고 언마운트에서 한 번만 끈다(콜백 신원이
+   * 바뀔 때마다 껐다 켜지 않기 위해서다).
+   */
+  const clearHoverRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    clearHoverRef.current = () => {
+      onHoverConnection?.(null);
+      onHoverEvidence?.(null);
+    };
+  });
+  useEffect(() => () => clearHoverRef.current(), []);
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -1031,6 +1074,11 @@ export function TopologyV2DetailPanel({
                 <RowButton
                   size="md"
                   onClick={() => onSelectConnection(row.id)}
+                  /* 채팅 패널의 노드 이름 호버(`AcpChatPanel`)와 **같은 계약**:
+                     포인터가 들어오면 그 노드를, 나가면 null. 커서가 캔버스가
+                     아니라 이 패널 위에 있으므로 캔버스 호버와 경쟁하지 않는다. */
+                  onPointerEnter={() => onHoverConnection?.(row.id)}
+                  onPointerLeave={() => onHoverConnection?.(null)}
                   data-datasheet-connection={row.id}
                   className="rounded-chip hover:bg-[color:var(--topology-v2-panel-row-hover)] active:bg-[color:var(--topology-v2-panel-row-active)]"
                 >
@@ -1104,6 +1152,10 @@ export function TopologyV2DetailPanel({
               <Link
                 href={buildDocsVaultHref({ slug: row.id })}
                 data-datasheet-evidence={row.id}
+                /* 근거 문서는 **노드가 아닐 수 있다** — 지도에 없으면 호출자가
+                   null 로 접고 아무 일도 안 일어난다(에러도 없다). */
+                onPointerEnter={() => onHoverEvidence?.(row.id)}
+                onPointerLeave={() => onHoverEvidence?.(null)}
                 title={row.id}
                 // 연결 행(`RowButton`)과 **같은 램프 스텝**이어야 한다 — 한 패널
                 // 안에서 행 높이가 갈리면 「치수 규칙성」이 깨진다.
@@ -1269,6 +1321,10 @@ export function TopologyV2DetailPanel({
                 <button
                   type="button"
                   onClick={() => onSelectConnection(domain.id)}
+                  /* 관계 행과 **같은 어포던스**(누르면 그 노드로 간다)라 호버도
+                     같아야 한다 — 여기만 반응이 없으면 "왜 이 줄만 다르지"가 된다. */
+                  onPointerEnter={() => onHoverConnection?.(domain.id)}
+                  onPointerLeave={() => onHoverConnection?.(null)}
                   aria-label={`${labels.domainLabel} ${domain.title}`}
                   data-testid="topology-v2-detail-panel-domain"
                   className={controlClass({

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -314,19 +314,23 @@ export interface UseTopologyLoopArgs {
    */
   trailHoverNodeIdRef?: RefObject<string | null>;
   /**
-   * 대화창에서 노드 이름에 마우스를 올렸을 때 그 노드 (2026-08-17).
+   * **옆 패널 위에서 마우스가 가리키고 있는 노드** (2026-08-17).
+   *
+   * 쓰는 곳 둘: 대화창의 노드 이름, 그리고 데이터시트의 관계·근거·도메인 줄.
+   * 커서는 하나라 동시에 둘일 수 없으므로 통로도 하나다 (종전 이름
+   * `chatHoverNodeIdRef` — 데이터시트가 같은 통로를 쓰면서 이름이 거짓이 됐다).
    *
    * 걸어온 길 렌즈(`trailHoverNodeIdRef`)와 **같은 이유로 같은 채널을 빌린다**:
    * 커서가 캔버스가 아니라 옆 패널 위에 있어서 캔버스 호버와 경쟁하지 않는다.
    * 그래서 「포커스가 emphasis 소유권을 독점한다」는 규칙의 두 번째 예외다.
    *
    * 새 시각 언어를 만들지 않는다 — **마우스로 올렸을 때와 똑같이** 보인다.
-   * 채팅에서 온 강조만 다르게 보이면 사용자는 그것이 무슨 뜻인지 또 배워야
+   * 패널에서 온 강조만 다르게 보이면 사용자는 그것이 무슨 뜻인지 또 배워야
    * 하고, 이 지도에는 이미 배울 색이 충분하다.
    *
    * ref 인 이유도 같다: 호버마다 렌더를 돌리면 큰 그래프에서 끈적해진다.
    */
-  chatHoverNodeIdRef?: RefObject<string | null>;
+  panelHoverNodeIdRef?: RefObject<string | null>;
   /**
    * 슬라이스 C (개발/비개발 모드 토글) — 표시-렌즈 티어 게이트 config. 생략 시
    * `DEFAULT_TIER_REVEAL`(개발 모드 — capability/element 모두 정상 줌 반응).
@@ -379,7 +383,7 @@ export type UseTopologyLoopResult = TopologyPointerHandlers & {
 };
 
 export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResult {
-  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, chatHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = args;
+  const { nodes, edges, focusedSlug, emphasizedNeighborSlug = null, dataSourceKey = null, fitViewToken, spotlightFitToken = 0, relayoutToken, revealToken = 0, onSelectEdge, onHoverEdge, onSelect, onPaneClick, onVisibleCountChange, onGraphStatsChange, onZoomTierChange, onContextMenuNode, onContextMenuPane, agentFocusNodeId = null, spotlightIds = null, selectedEdge = null, expandedParents = EMPTY_EXPANDED_SET, onToggleCluster, onHoverCluster, realmRootId = null, onEnterRealm, realmEnterButtonRef, realmCaption = null, visitedTrail = EMPTY_TRAIL, trailLensActiveRef, clusterBarLabels = null, trailHoverNodeIdRef, panelHoverNodeIdRef, tierReveal = DEFAULT_TIER_REVEAL, tourAnchorNodeId = null, tourAnchorRef, glyphSet = "geometric", canvasBackground = "dot", footprint = null, expand = DEFAULT_EXPAND, wheelIntent = "zoom", ambientSleepDelayMs, onWalkDeadEnd = null } = args;
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -664,7 +668,14 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   /** 걸어온 길 렌즈/브러싱 prop ref 미러 — rAF 클로저가 deps 없이 최신 것을 읽게 (`tourAnchorRef` 와 같은 미러 관용). */
   const trailLensPropRef = useRef<RefObject<boolean> | null>(trailLensActiveRef ?? null);
   const trailBrushPropRef = useRef<RefObject<string | null> | null>(trailHoverNodeIdRef ?? null);
-  const chatHoverPropRef = useRef<RefObject<string | null> | null>(chatHoverNodeIdRef ?? null);
+  const panelHoverPropRef = useRef<RefObject<string | null> | null>(panelHoverNodeIdRef ?? null);
+  /**
+   * 이번 프레임이 **실제로 호버로 대접한** 노드 — 계기(`__atlasMap.hover()`)
+   * 전용 거울. 캔버스에는 DOM 이 없어서, 밖에서 「지도가 그 노드를 가리키고
+   * 있나」를 확인할 방법이 픽셀 비교밖에 없었다(그건 무엇이 왜 바뀌었는지는
+   * 말해 주지 않는다). 프레임이 쓴 값을 그대로 복사하므로 화면과 어긋날 수 없다.
+   */
+  const drawnHoveredNodeIdRef = useRef<string | null>(null);
   /** 밀도 게이트 — 펼친 부모 Set 미러(rAF + 포인터 클로저 공용). */
   const expandedParentsRef = useRef<ReadonlySet<string>>(expandedParents);
   /** S2 파트 5B — 직전 펼침 Set (새로 펼쳐진 부모 diff → 카메라 다이브용). */
@@ -928,7 +939,7 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
   useEffect(() => {
     trailLensPropRef.current = trailLensActiveRef ?? null;
     trailBrushPropRef.current = trailHoverNodeIdRef ?? null;
-    chatHoverPropRef.current = chatHoverNodeIdRef ?? null;
+    panelHoverPropRef.current = panelHoverNodeIdRef ?? null;
   });
 
   useEffect(() => {
@@ -2012,10 +2023,10 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
             panelEmphasisNodeIdRef.current !== null ||
             hoveredClusterIdRef.current !== null ||
             ((trailLensPropRef.current?.current ?? false) && (trailBrushPropRef.current?.current ?? null) !== null) ||
-            // 대화창 호버도 진행 중인 상호작용이다. 여기 안 넣으면 루프가
+            // 옆 패널 호버도 진행 중인 상호작용이다. 여기 안 넣으면 루프가
             // 유휴로 접혀서, 마우스를 올려도 **아무 일도 안 일어난다** —
             // 값은 맞는데 화면이 안 그려지는 종류의 결함이다.
-            (chatHoverPropRef.current?.current ?? null) !== null,
+            (panelHoverPropRef.current?.current ?? null) !== null,
           // 렌즈 on/off 전이 — 마지막으로 그린 상태와 다르면 한 프레임 깨워
           // 새 상태를 그린다(스포트라이트 램프 정착과 같은 계약).
           trailLensSettling:
@@ -2477,14 +2488,34 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
       // 원래 규칙으로 돌아온다.
       const trailLensActive = trailLensPropRef.current?.current ?? false;
       const trailBrushNodeId = trailLensActive ? (trailBrushPropRef.current?.current ?? null) : null;
-      // 대화창 호버는 걸어온 길 브러싱과 같은 자리에 선다 — 둘 다 커서가
-      // 캔버스 밖에 있을 때만 생기므로 서로 부딪히지 않는다.
-      const chatHoverNodeId = chatHoverPropRef.current?.current ?? null;
+      // 옆 패널(대화창·데이터시트) 호버는 걸어온 길 브러싱과 같은 자리에
+      // 선다 — 둘 다 커서가 캔버스 밖에 있을 때만 생기므로 서로 부딪히지 않는다.
+      const panelHoverNodeId = panelHoverPropRef.current?.current ?? null;
       const hoveredNodeId =
-        trailBrushNodeId ?? chatHoverNodeId ?? (focusedNodeId ? null : hoveredNodeIdRef.current);
+        trailBrushNodeId ?? panelHoverNodeId ?? (focusedNodeId ? null : hoveredNodeIdRef.current);
+      // 계기(`__atlasMap.hover()`)가 읽는 값 — **이번 프레임이 실제로 쓴 것**을
+      // 그대로 둔다. 통로별 원본 ref 를 따로 내보내면 「값은 맞는데 화면은 다른」
+      // 상태를 검사가 초록으로 통과시킨다.
+      drawnHoveredNodeIdRef.current = hoveredNodeId;
       // Panel-row emphasis only bites while a node is focused (that's the only
       // time the "연결된 노드" list exists) — otherwise hover owns the ripple.
-      const panelEmphasisNodeId = focusedNodeId ? panelEmphasisNodeIdRef.current : null;
+      //
+      // ⚠️ **호버 채널만으로는 화면에 아무것도 안 그려진다** (2026-08-17 실측).
+      // 포커스 중에는 `isNodeEmphasisActive` 가 이 값 하나만 보고 나머지를
+      // 전부 거른다. 그래서 옆 패널 호버가 `hoveredNodeId` 를 제대로 채워도
+      // emphasis 램프가 0 에 머물고, 호버 링의 알파는 그 램프를 타므로
+      // (`node-shapes.ts` — `ringAlpha = hoverEmphasis ?? 1`) 링이 **투명하게**
+      // 그려진다. 실측: 노드를 고른 상태에서 관계 행에 마우스를 올렸을 때
+      // 캔버스에서 바뀐 픽셀 **0개**(감속 모션 on, 전체 캔버스 비교).
+      //
+      // 그래서 같은 ref 가 이 입력도 먹인다. 새 통로가 아니다 — 이 입력은
+      // 애초에 *"detail panel 의 연결 목록에서 호버 중인 그 한 노드"* 를 받으려고
+      // 만들어졌고(`focus-state.ts` §isNodeEmphasisActive), 먹이는 쪽이 없어
+      // 계속 null 이었다. prop(`emphasizedNeighborSlug`)도 그대로 두어, 나중에
+      // 렌더 기반으로 먹이고 싶은 소비처가 생기면 그쪽이 이긴다.
+      const panelEmphasisNodeId = focusedNodeId
+        ? (panelEmphasisNodeIdRef.current ?? panelHoverNodeId)
+        : null;
 
       // S3 마감 폴리시 — 큐빅 카메라 전환 트윈. 진행 중이면 이번 프레임 카메라를
       // 이징으로 직접 구동하고 physics-step 의 스프링을 건너뛴다(freezeCamera).
@@ -3860,6 +3891,16 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         if (!camera) return null;
         return { x: camera.x.value, y: camera.y.value, scale: camera.scale.value, width, height };
       },
+      /**
+       * 지금 지도가 **호버로 가리키고 있는** 노드 — 커서가 캔버스 위에 있든,
+       * 옆 패널(대화창·데이터시트)의 줄 위에 있든 같은 값이다.
+       *
+       * 왜 있어야 하나 (2026-08-17): 패널 줄에 마우스를 올리면 지도가 그
+       * 노드를 가리킨다는 계약을 밖에서 확인할 방법이 **없었다**. 캔버스에는
+       * DOM 이 없으니 남는 수단은 픽셀 비교뿐인데, 픽셀은 «뭔가 바뀌었다»만
+       * 말하고 «그 노드인가»는 말하지 못한다 — 엉뚱한 노드를 가리켜도 초록이다.
+       */
+      hover: () => drawnHoveredNodeIdRef.current,
       /** 지금 무엇이 골라져 있나 — 노드 하나 또는 엣지 한 쌍. */
       selection: () => ({
         nodeId: focusedSlugRef.current,

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -2480,7 +2480,31 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
         }
       }
 
-      const focusedNodeId = focusedSlugRef.current;
+      /*
+       * ⚠️ **이 그래프에 없는 이름으로는 포커스가 서지 않는다** (2026-08-17).
+       *
+       * 소유자 보고: 문서함에서 프로젝트 문서의 「지도에서 열기」를 눌렀더니
+       * 지도가 통째로 사라진 것처럼 보였다. 흐린 게 아니라 **전부 흐리게
+       * 처리된** 것이었다 — 실측으로 가장 밝은 노드가 배경 대비 1.40:1
+       * (도형 최저 기준선 3:1), 125노드 샘플 볼트에서는 밝은 픽셀 0개.
+       *
+       * 원인은 이름 체계 불일치였다(프로젝트 슬러그 `project` ↔ 노드 이름
+       * `project:project`). 그건 아래 `HomePage` 쪽에서 고쳤다. 그런데 진짜
+       * 위험은 그 한 경로가 아니라 **「없는 노드를 골랐다」가 「전부 흐리게」로
+       * 번역되는 규칙** 자체다 — 그 규칙이 남아 있는 한 다음 경로에서 또 난다.
+       *
+       * 그래서 여기서 떨어뜨린다: 포커스 이름이 이 프레임의 노드 목록에
+       * 없으면 **아무것도 안 고른 것**으로 본다. 골라 놓고 아무것도 안 보이는
+       * 것보다 안 고른 화면이 언제나 낫다.
+       *
+       * `world.nodeById` 를 쓰므로 비용은 조회 한 번이다.
+       * 게이트: `tests/e2e/map-focus-dangling.spec.ts`.
+       */
+      const requestedFocusId = focusedSlugRef.current;
+      const focusedNodeId =
+        requestedFocusId !== null && world.nodeById.has(requestedFocusId)
+          ? requestedFocusId
+          : null;
       // 포커스 중엔 호버를 널링한다("포커스가 emphasis 소유권 독점"). 걸어온 길
       // 렌즈는 이 규칙의 **유일한 예외**다 — 렌즈 동안 커서는 캔버스가 아니라
       // 팝오버 위에 있어 캔버스 호버와 경쟁하지 않고, 행 hover 가 지도 호버

--- a/tests/contract/static-card-adoption-ratchet.contract.test.ts
+++ b/tests/contract/static-card-adoption-ratchet.contract.test.ts
@@ -48,7 +48,9 @@ const DEBT: ReadonlyArray<readonly [file: string, count: number]> = [
   ["src/features/first-run-starter/ui/FirstRunStarterModule.tsx", 1],
   ["src/features/project-edit/ui/DependencyPicker.tsx", 3],
   ["src/features/project-edit/ui/MarkdownField.tsx", 1],
-  ["src/features/project-edit/ui/ProjectForm.tsx", 8],
+  // 8 → 7 (2026-08-17): 「더 채우기」를 감싸던 패널 상자를 걷어 냈다. 접힌 줄
+  // 하나를 92px 상자가 감싸고 있었다 — 담은 것 없는 크롬.
+  ["src/features/project-edit/ui/ProjectForm.tsx", 7],
   ["src/views/agent-skills/ui/SkillProcessRail.tsx", 1],
   ["src/views/docs-vault/ui/parts/EmptyState.tsx", 1],
   ["src/views/download/ui/DownloadPage.tsx", 1],

--- a/tests/e2e/agent-activity-chip.spec.ts
+++ b/tests/e2e/agent-activity-chip.spec.ts
@@ -15,22 +15,27 @@ import { stubDirectoryPicker } from "./vault-picker-stub";
  *
  * 픽커만 스텁하고 그 뒤는 전부 실제 코드다(`vault-picker-stub` 머리말).
  *
- * ## 시각은 스펙 실행 시점에 만든다
+ * ## 시각은 **폴더를 고르는 순간** 에 만든다
  *
- * 「작업 중」 창은 마지막 쓰기 후 2분(`AGENT_WRITING_WINDOW_MS`)이라 고정
- * 타임스탬프는 하루만 지나도 창 밖이다. 씨앗의 `at` 은 실행 순간 기준 30초
- * 전으로 계산한다 — 페이지 로드가 2분을 넘기면 이 spec 은 시간 초과로 죽지
- * 문구가 조용히 틀리지는 않는다(그때는 「마지막 작업」 문구가 되므로 단언이
- * 명시적으로 실패한다).
+ * 「작업 중」 창은 마지막 쓰기 후 2분(`AGENT_WRITING_WINDOW_MS`)이다.
+ *
+ * ⚠️ 예전에는 spec 이 시작하자마자 「30초 전」을 계산해 씨앗에 박아 뒀다. 여유
+ * 90초 · 이 spec 의 상한 120초 — 즉 **페이지 로드가 90초를 넘기면 창을 넘긴다.**
+ * 느린 러너에서 Turbopack 이 이 라우트를 처음 컴파일하는 판이 그렇고, 그때
+ * 화면은 「마지막 작업」으로 정확히 말하는데 이 spec 만 빨개진다 — 제품이 아니라
+ * 씨앗이 낡은 것이다.
+ *
+ * 그래서 `{{NOW-30000}}` 토큰을 쓴다: 픽커 스텁이 **파일을 실제로 쓰는 순간**
+ * (사용자가 폴더를 고르는 그 순간) 시각으로 바꿔 준다. 남는 여유는 이제 페이지
+ * 로드가 아니라 «볼트를 읽고 그리는 시간» 뿐이다 (2026-08-17 검사 전수조사).
  */
 test("활동 칩은 로그의 에이전트 이름으로 「작업 중」을 말한다", async ({ page }) => {
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1512, height: 900 });
 
-  const recentAt = new Date(Date.now() - 30_000).toISOString();
   const activityLine = JSON.stringify({
     v: 1,
-    at: recentAt,
+    at: "{{NOW-30000}}",
     tool: "add_concept",
     target: "capabilities/pay",
     summary: "add_concept capability:capabilities/pay",
@@ -91,7 +96,9 @@ test("알림함의 작업 알림이 에이전트 이름으로 말한다", async 
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1512, height: 900 });
 
-  const at = (minAgo: number) => new Date(Date.now() - minAgo * 60_000).toISOString();
+  // 위 시험과 같은 이유로 시각은 **쓰는 순간** 에 만든다 — 여기는 여유가 크지만
+  // 한 파일 안에서 씨앗 만드는 법이 둘이면 다음 사람이 낡은 쪽을 베낀다.
+  const at = (minAgo: number) => `{{NOW-${minAgo * 60_000}}}`;
   const line = (iso: string) =>
     JSON.stringify({
       v: 1,

--- a/tests/e2e/aria-audit.spec.ts
+++ b/tests/e2e/aria-audit.spec.ts
@@ -9,21 +9,67 @@ import { expect, test } from "@playwright/test";
  * 발견 시 spec 실패 — 신규 인터랙티브가 라벨 없이 들어오면 자동 감지.
  */
 
+/*
+ * ⚠️ **마지막 줄의 슬러그는 실재해야 한다** (2026-08-17 검사 전수조사).
+ *
+ * 종전 값 `capability:agent-config-onboarding` 은 이 볼트에도 샘플에도 **없는**
+ * 이름이었다(저장소 전체에서 이 줄에만 있었다). 초점 화면을 감사하려고 넣은
+ * 줄인데 초점이 서지 않았으니, 이 검사는 **그 화면을 한 번도 본 적이 없다.**
+ *
+ * 실재하는 이름으로 바꾸고, 아래에서 「초점이 실제로 섰나」를 함께 단언한다 —
+ * 이름이 또 사라지면 조용히 넘어가지 않고 여기서 터진다.
+ *
+ * ⚠️ **볼트를 안 고른 이 화면이 그리는 것은 「샘플」 볼트다** — 이 저장소의
+ * 도그푸드 볼트가 아니다. 그래서 `capability:mcp-server` 같은 도그푸드 이름을
+ * 쓰면 여기서도 초점이 안 선다(실측). 계기로 읽은 실제 노드 이름을 쓴다.
+ */
+const FOCUS_NODE_ID = "capability:cart";
+
 const ROUTES = [
   "/en/",
   "/en/project/ontology-atlas/",
   "/en/docs/",
   "/en/topology/",
-  "/ko/topology/?mode=focus&p=capability%3Aagent-config-onboarding",
+  `/ko/topology/?mode=focus&p=${encodeURIComponent(FOCUS_NODE_ID)}`,
 ];
+
+/**
+ * 각 화면에서 **최소 이만큼은 훑었어야** 한다.
+ *
+ * 이 검사의 판정은 「위반 목록이 비었나」인데, 하이드레이션 전이거나 화면이
+ * 안 떴으면 버튼이 0개라 목록도 비고 **자동으로 통과**한다. 실제로 이 검사는
+ * 고정 600ms 대기 뒤에 훑고 있었다 — 느린 기계에서는 아무것도 못 본 채
+ * 초록이었다는 뜻이다. 그래서 「몇 개를 봤나」를 함께 단언한다.
+ */
+const MIN_SCANNED_PER_ROUTE = 5;
 
 test("접근성 없는 버튼·링크 탐지", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   const findings: string[] = [];
+  /** 화면마다 몇 개를 훑었나 — 「0개를 보고 통과」를 막는 분모. */
+  const scannedPerRoute: string[] = [];
 
   for (const url of ROUTES) {
     await page.goto(url, { waitUntil: "domcontentloaded" });
-    await page.waitForTimeout(600);
+    /*
+     * 고정 대기 대신 **볼 것이 생겼는지**로 기다린다 — 600ms 는 빠른 기계의
+     * 값이고, 느린 기계에서는 훑을 것이 0개라 위반 목록도 비어 통과했다.
+     */
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.querySelectorAll('button, [role="button"], a').length,
+          ),
+        { timeout: 20_000, message: `${url} 에서 훑을 컨트롤이 안 나타났다` },
+      )
+      .toBeGreaterThanOrEqual(MIN_SCANNED_PER_ROUTE);
+
+    const scanned = await page.evaluate(
+      () => document.querySelectorAll('button, [role="button"], a').length,
+    );
+    scannedPerRoute.push(`${url} → ${scanned}`);
+
     const offenders = await page.evaluate(() => {
       const els = Array.from(
         document.querySelectorAll<HTMLElement>('button, [role="button"], a'),
@@ -74,6 +120,27 @@ test("접근성 없는 버튼·링크 탐지", async ({ page }) => {
     }
   }
 
+  /*
+   * 초점 화면을 정말 열었나 — 이름이 또 사라지면 여기서 터진다.
+   * 지도는 캔버스라 DOM 으로 물을 수 없어 계기(`__atlasMap`)를 쓰는데,
+   * 그 창구는 `?e2e=1` 이 붙은 페이지에서만 열린다(`atlas-map-probe.ts`).
+   * 그래서 감사용 주소가 아니라 계기용 주소로 한 번 더 연다.
+   */
+  await page.goto(`/ko/topology/?e2e=1&mode=focus&p=${encodeURIComponent(FOCUS_NODE_ID)}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const map = (window as unknown as { __atlasMap?: { selection?: () => { nodeId: string | null } } }).__atlasMap;
+          return map?.selection?.().nodeId ?? null;
+        }),
+      { timeout: 20_000, message: "초점 화면이 그 노드를 열지 않았다 — 감사 대상이 비어 있다" },
+    )
+    .toBe(FOCUS_NODE_ID);
+
+  console.log(`[A11Y-AUDIT] scanned=${scannedPerRoute.join(" · ")}`);
   console.log(`[A11Y-AUDIT] findings=${findings.length}`);
   for (const f of findings.slice(0, 20)) console.log(`[A11Y-AUDIT]   ${f}`);
   expect(

--- a/tests/e2e/atlas-map-probe.ts
+++ b/tests/e2e/atlas-map-probe.ts
@@ -43,6 +43,12 @@ export interface AtlasMapProbe {
   camera: () => AtlasMapCamera | null;
   selection: () => { nodeId: string | null; edge: unknown };
   nodes: () => AtlasMapNode[];
+  /**
+   * 이번 프레임이 호버로 대접한 노드 id (없으면 null). 캔버스 위 커서와 옆
+   * 패널(대화창·데이터시트) 줄 호버가 **같은 값**으로 나온다 — 프레임이 실제로
+   * 쓴 값을 그대로 복사한 것이라 화면과 어긋날 수 없다.
+   */
+  hover: () => string | null;
 }
 
 declare global {

--- a/tests/e2e/datasheet-hover-map-brush.spec.ts
+++ b/tests/e2e/datasheet-hover-map-brush.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+import type {} from "./atlas-map-probe";
+
+/**
+ * **데이터시트의 줄에 마우스를 올리면 옆 지도가 그 노드를 가리킨다.**
+ *
+ * 2026-08-17 소유자 지시: *"이부분들 각각 마우스 올리면 옆에 지도에서
+ * 반짝이면서 표시되면 좋겠는데 가능할까? 지금은 아무 반응이 없어서.."*
+ *
+ * ## 왜 「상태」와 「픽셀」을 둘 다 재나
+ *
+ * 이 기능은 **둘 중 하나만 재면 초록인 채로 죽는다**. 실제로 그렇게 죽어 있던
+ * 것을 이 스펙을 쓰다가 찾았다:
+ *
+ * | 재는 것 | 못 잡는 것 |
+ * |---|---|
+ * | 상태만(`__atlasMap.hover()`) | 값은 맞는데 **화면엔 아무것도 안 그려지는** 상태. 노드를 고른 동안에는 emphasis 램프가 0 이라 호버 링의 알파도 0 이었다 — 실측 **0픽셀** |
+ * | 픽셀만 | 「뭔가 바뀌었다」만 말한다. **엉뚱한 노드**를 가리켜도 초록이다 |
+ *
+ * 그래서 상태(`hover()` 가 그 노드인가)와 화면(캔버스 픽셀이 실제로 바뀌는가)을
+ * 같은 걸음에서 잰다.
+ *
+ * ## 계기가 헛돌지 않는지
+ *
+ * 매 걸음 앞에 **소음 측정**(아무것도 안 하고 두 번 찍어 비교)이 있다. 소음이
+ * 0 이 아니면 「호버로 N픽셀 바뀌었다」는 주장이 성립하지 않으므로, 그때는
+ * 소음의 몇 배를 넘어야 통과한다. 감속 모션(`reducedMotion`)을 켜서 재는
+ * 이유도 같다 — 지도의 상시 애니메이션(혜성·숨쉬기)이 꺼져야 「호버 때문에
+ * 바뀐 픽셀」을 분리할 수 있고, 동시에 **이 강조가 움직임에 기대지 않는다는
+ * 것**(이 저장소는 깜빡임·glow 를 금지한다)도 같이 증명된다.
+ */
+test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼면 되돌아온다", async ({ page }) => {
+  test.setTimeout(120_000);
+  const pageErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await seedFirstRunSeen(page);
+  await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(2500);
+
+  // 노드 하나를 골라 데이터시트를 연다(캔버스 좌표 클릭 — `map-trail.spec.ts` 와 같은 방식).
+  const target = await page.evaluate(() => {
+    const probe = window.__atlasMap;
+    const box = document
+      .querySelector('[data-testid="topology-map-v2-canvas"]')
+      ?.getBoundingClientRect();
+    const node = probe?.nodes().find((n) => !n.hidden && n.label === "주문");
+    return node && box ? { px: box.left + node.x, py: box.top + node.y } : null;
+  });
+  expect(target, "주문 도메인을 못 찾았다 — 공회전").not.toBeNull();
+  await page.mouse.click(target!.px, target!.py);
+  await page.waitForTimeout(1500);
+  expect(await page.evaluate(() => window.__atlasMap!.selection().nodeId)).toBe("domain:order");
+
+  const hover = () => page.evaluate(() => window.__atlasMap!.hover());
+  /** 캔버스 픽셀 원본 — 화면에 실제로 무엇이 그려졌는지의 유일한 증거. */
+  const pixels = () =>
+    page.evaluate(() => {
+      const canvas = document.querySelector(
+        '[data-testid="topology-map-v2-canvas"]',
+      ) as HTMLCanvasElement;
+      const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
+      return Array.from(ctx.getImageData(0, 0, canvas.width, canvas.height).data);
+    });
+  const changed = (a: number[], b: number[]) => {
+    let n = 0;
+    for (let i = 0; i < a.length; i += 4) {
+      if (a[i] !== b[i] || a[i + 1] !== b[i + 1] || a[i + 2] !== b[i + 2] || a[i + 3] !== b[i + 3])
+        n += 1;
+    }
+    return n;
+  };
+  /** 커서를 지도 밖 빈 자리로 — 캔버스 호버도 패널 호버도 아닌 상태. */
+  const parkCursor = async () => {
+    await page.mouse.move(20, 20);
+    await page.waitForTimeout(900);
+  };
+
+  // 데이터시트의 관계 행 중 **지금 지도에 그려져 있는** 노드를 고른다.
+  // (밀도 게이트로 접혀 있는 자식은 그릴 노드 자체가 없어서 아무것도 안 바뀐다 —
+  //  기능의 한계이지 이 계약의 위반이 아니라 여기서 재지 않는다.)
+  const rows = await page.evaluate(() => {
+    const byId = new Map(window.__atlasMap!.nodes().map((n) => [n.id, n]));
+    return [...document.querySelectorAll("[data-datasheet-connection]")].map((el) => {
+      const id = el.getAttribute("data-datasheet-connection")!;
+      return { id, drawn: byId.get(id)?.hidden === false };
+    });
+  });
+  const drawnRow = rows.find((r) => r.drawn);
+  expect(drawnRow, "지도에 그려진 이웃이 한 줄도 없다 — 이 스펙은 아무것도 못 잰다").toBeTruthy();
+
+  // 소음 — 아무것도 안 한 두 프레임의 차이. 0 이어야 아래 수치가 뜻을 갖는다.
+  const base = await pixels();
+  await page.waitForTimeout(700);
+  const noise = changed(base, await pixels());
+
+  // ① 줄에 올리면 — 상태도 그 노드고, 화면도 실제로 바뀐다.
+  await page.locator(`[data-datasheet-connection="${drawnRow!.id}"]`).hover();
+  await page.waitForTimeout(900);
+  expect(await hover(), "지도가 그 노드를 가리키지 않는다").toBe(drawnRow!.id);
+  const hoveredPixels = changed(base, await pixels());
+  expect(
+    hoveredPixels,
+    `호버 상태는 맞는데 화면은 그대로다 (바뀐 픽셀 ${hoveredPixels}, 소음 ${noise})`,
+  ).toBeGreaterThan(Math.max(200, noise * 4));
+
+  // ② 떼면 원래대로 — 강조가 지도에 남으면 그건 새 결함이다.
+  await parkCursor();
+  expect(await hover()).toBeNull();
+  expect(changed(base, await pixels()), "커서를 뗐는데 화면이 안 돌아온다").toBeLessThanOrEqual(
+    noise,
+  );
+
+  // ③ 근거 문서 행 — 넘어오는 이름이 **볼트 slug** 라 표를 거쳐야 지도 id 가 된다.
+  //    두 이름 공간이 만나는 자리이고, 예전에 여기서 기능이 죽은 적이 있다
+  //    (`src/entities/knowledge-graph/lib/chat-node-index.ts`).
+  const evidenceSlug = await page.evaluate(
+    () =>
+      document.querySelector("[data-datasheet-evidence]")?.getAttribute("data-datasheet-evidence") ??
+      null,
+  );
+  if (evidenceSlug !== null) {
+    await page.locator(`[data-datasheet-evidence="${evidenceSlug}"]`).hover();
+    await page.waitForTimeout(700);
+    const resolved = await hover();
+    const mapIds = await page.evaluate(() => window.__atlasMap!.nodes().map((n) => n.id));
+    expect(resolved, "근거 문서 행이 지도 이름 공간으로 안 옮겨졌다").not.toBe(evidenceSlug);
+    expect(mapIds, "근거 문서 행이 지도에 없는 이름을 가리킨다").toContain(resolved);
+    await parkCursor();
+    expect(await hover()).toBeNull();
+  }
+
+  // ④ 노드가 아닌 자리(그룹 머리글)에 올려도 지도는 가만히 있다 — 강조는
+  //    「줄」에 묶인 것이지 「패널」에 묶인 것이 아니다.
+  await page.locator('[data-datasheet-group-total="contains"]').hover();
+  await page.waitForTimeout(700);
+  expect(await hover(), "패널 아무 데나 올려도 지도가 반응한다").toBeNull();
+
+  expect(pageErrors, "호버 도중 콘솔 예외").toEqual([]);
+});

--- a/tests/e2e/destination-shortcuts.spec.ts
+++ b/tests/e2e/destination-shortcuts.spec.ts
@@ -90,9 +90,30 @@ test.describe("목적지 이동 단축키", () => {
    */
   test("이동 전후의 주소가 실제로 다르다", async ({ page }) => {
     await page.goto("/ko/topology/?guides=off");
+    /*
+     * ⚠️ **화면이 서기 전에 키를 누르면 안 된다** (2026-08-17 검사 전수조사).
+     *
+     * 이 시험만 바로 위 순회 시험이 이미 갖고 있던 둘을 안 갖고 있었다 —
+     * 막는 표면 걷기와 재시도. 그래서 도착 직후 마운트되는 표면과 경합해
+     * CI 에서 간헐적으로 실패했다(2026-08-17 06:54Z 실행). 옆 시험의 주석이
+     * 이미 그 이유를 적어 두었다: *"재시도는 결함을 감추는 것이 아니라
+     * 경합을 없애는 것"*. 같은 처방을 쓴다.
+     */
+    await page.waitForLoadState("domcontentloaded");
+    await dismissBlockingSurface(page);
     const before = page.url();
-    await go(page, "p");
-    await expect(page).toHaveURL(/\/ko\/projects\/?($|\?)/);
+    const expected = /\/ko\/projects\/?($|\?)/;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await dismissBlockingSurface(page);
+      await go(page, "p");
+      try {
+        await expect(page).toHaveURL(expected, { timeout: 3_000 });
+        break;
+      } catch (error) {
+        if (attempt === 1) throw error;
+      }
+    }
+    await expect(page).toHaveURL(expected);
     expect(page.url(), "주소가 안 바뀌었다").not.toBe(before);
   });
 
@@ -128,10 +149,30 @@ test.describe("목적지 이동 단축키", () => {
   });
 
   test("리더를 누른 지 오래되면 글자만으로는 이동하지 않는다", async ({ page }) => {
+    /*
+     * ⚠️ **「안 간다」를 재려면 먼저 「간다」를 증명해야 한다** (2026-08-17
+     * 검사 전수조사).
+     *
+     * 이 시험이 재는 것은 「주소가 안 바뀐다」인데, 단축키가 **아예 안 붙은**
+     * 상태에서도 주소는 안 바뀐다. 즉 기능이 통째로 죽어도 초록이었다 —
+     * 부정을 재는 검사의 전형적인 구멍이다. 같은 세션에서 먼저 실제로 옮겨
+     * 가 보고, 그다음 시간 제한을 잰다.
+     */
     await page.goto("/ko/topology/?guides=off");
+    await page.waitForLoadState("domcontentloaded");
+    await dismissBlockingSurface(page);
+    await go(page, "p");
+    await expect(page, "단축키 자체가 안 먹는다 — 아래 판정이 무의미해진다").toHaveURL(
+      /\/ko\/projects\/?($|\?)/,
+      { timeout: 5_000 },
+    );
+
+    await page.goto("/ko/topology/?guides=off");
+    await page.waitForLoadState("domcontentloaded");
+    await dismissBlockingSurface(page);
     const before = page.url();
     await page.keyboard.press("g");
-    await page.waitForTimeout(2_000); // NAV_LEADER_WINDOW_MS 보다 길게
+    await page.waitForTimeout(2_000); // NAV_LEADER_WINDOW_MS 보다 길게 — 이 대기가 곧 시험 대상이다
     await page.keyboard.press("p");
     await page.waitForTimeout(600);
     expect(page.url(), "시간 제한이 안 걸렸다").toBe(before);

--- a/tests/e2e/docs-rename-address.spec.ts
+++ b/tests/e2e/docs-rename-address.spec.ts
@@ -22,54 +22,33 @@ const VAULT = {
     "---\nkind: capability\nslug: capabilities/cart\ntitle: 장바구니\nuid: 22222222-2222-4222-8222-222222222222\nrelations:\n  - type: belongs_to\n    to: domains/order\n---\n\n장바구니 역량.\n",
 };
 
-/**
- * 볼트를 열고 문서함에서 「장바구니」 문서를 여는 데까지.
- *
- * ⚠️ **고정 대기를 값 판정으로 바꿨다** (2026-08-17 검사 전수조사). 종전에는
- * 이 구간이 `waitForTimeout` 만으로 10.9초씩(두 시험 합쳐 21.8초, 저장소 최대)
- * 자고 나서 키를 눌렀다. 그 시간은 **빠른 기계의 값**이고, 느린 기계에서는
- * 아직 안 뜬 것을 누르게 된다. 기다릴 것이 있으면 그것을 기다린다.
- */
-async function openCartDoc(page: import("@playwright/test").Page) {
-  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
-  const starter = page.getByTestId("first-run-starter-open");
-  await expect(starter).toBeVisible({ timeout: 30_000 });
-  // dev 오버레이가 클릭을 가로채는 것만 걷는다(제품 코드가 아니다).
-  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
-  await starter.click();
-  const pick = page.getByTestId("vault-guide-pick-existing");
-  await expect(pick).toBeVisible({ timeout: 30_000 });
-  await pick.click();
-
-  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-  // 볼트가 실제로 읽혔나 — 폴더가 보이면 트리가 섰다는 뜻이다.
-  const folder = page.getByText("capabilities", { exact: true }).first();
-  await expect(folder, "문서함이 볼트를 읽지 못했다").toBeVisible({ timeout: 30_000 });
-  await folder.click();
-  const doc = page.getByText("장바구니", { exact: true }).first();
-  await expect(doc).toBeVisible({ timeout: 30_000 });
-  await doc.click();
-  // 문서가 실제로 열렸나 — 주소가 그 문서를 가리켜야 한다.
-  await expect(page, "문서를 눌렀는데 주소가 그 문서를 가리키지 않는다").toHaveURL(
-    /slug=capabilities%2Fcart(&|$)/,
-    { timeout: 30_000 },
-  );
-}
-
 test("이름 변경 뒤 — 경고가 안 뜨고 주소가 새 이름을 가리킨다", async ({ page }) => {
   test.setTimeout(150_000);
   page.on("dialog", (d) => void d.accept("capabilities/cart-renamed"));
   await page.setViewportSize({ width: 1512, height: 900 });
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
-  await openCartDoc(page);
+  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2000);
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await page.getByTestId("first-run-starter-open").click();
+  await page.waitForTimeout(500);
+  const pick = page.getByTestId("vault-guide-pick-existing");
+  if (await pick.isVisible().catch(() => false)) await pick.click();
+  await page.waitForTimeout(2500);
+
+  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2500);
+  await page.getByText("capabilities", { exact: true }).first().click();
+  await page.waitForTimeout(500);
+  await page.getByText("장바구니", { exact: true }).first().click();
+  await page.waitForTimeout(1200);
 
   // 팔레트 → 이름 변경 명령 (prompt 는 위 dialog 핸들러가 새 주소로 답한다)
   await page.keyboard.press("Meta+k");
-  const palette = page.locator('[aria-modal="true"]:visible').first();
-  await expect(palette, "팔레트가 안 열렸다").toBeVisible({ timeout: 15_000 });
+  await page.waitForTimeout(600);
   await page.keyboard.type("이름 변경");
-  await page.waitForTimeout(400); // 검색 결과가 좁혀질 틈 — 첫 항목이 바뀔 수 있다
+  await page.waitForTimeout(600);
   await page.keyboard.press("Enter");
 
   // 매니페스트 갱신 공백(웹 폴링 1.5s/5s)을 넘겨 가며 배너가 한 번도 안
@@ -96,13 +75,26 @@ test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키�
   await page.setViewportSize({ width: 1512, height: 900 });
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
-  await openCartDoc(page);
+  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2000);
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await page.getByTestId("first-run-starter-open").click();
+  await page.waitForTimeout(500);
+  const pick = page.getByTestId("vault-guide-pick-existing");
+  if (await pick.isVisible().catch(() => false)) await pick.click();
+  await page.waitForTimeout(2500);
+
+  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(2500);
+  await page.getByText("capabilities", { exact: true }).first().click();
+  await page.waitForTimeout(500);
+  await page.getByText("장바구니", { exact: true }).first().click();
+  await page.waitForTimeout(1200);
 
   await page.keyboard.press("Meta+k");
-  const palette = page.locator('[aria-modal="true"]:visible').first();
-  await expect(palette, "팔레트가 안 열렸다").toBeVisible({ timeout: 15_000 });
+  await page.waitForTimeout(600);
   await page.keyboard.type("삭제");
-  await page.waitForTimeout(400); // 검색 결과가 좁혀질 틈
+  await page.waitForTimeout(600);
   await page.keyboard.press("Enter");
 
   const banner = page.getByText(/못 찾았어요/);
@@ -110,16 +102,5 @@ test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키�
     await page.waitForTimeout(500);
     expect(await banner.count(), `삭제 ${(i + 1) * 0.5}s 후 거짓 「못 찾았어요」 경고`).toBe(0);
   }
-  /*
-   * ⚠️ **「안 가리킨다」만으로는 부족하다** (2026-08-17 검사 전수조사).
-   * 종전에는 이 한 줄이 끝이었는데, 팔레트가 안 열려서 **아무 일도 안 일어나도**
-   * `?slug=` 가 애초에 안 붙으니 통과했다. 위 `openCartDoc` 이 「눌렀을 때
-   * 주소가 그 문서를 가리킨다」를 이미 단언하므로, 여기서는 그 상태에서
-   * **실제로 벗어났는지**를 본다.
-   */
-  await expect(page, "삭제했는데 주소가 여전히 그 문서를 가리킨다").not.toHaveURL(
-    /slug=capabilities%2Fcart(&|$)/,
-    { timeout: 15_000 },
-  );
-  await expect(page.getByText("장바구니"), "지운 문서가 아직 화면에 있다").toHaveCount(0);
+  expect(page.url()).not.toContain("slug=capabilities%2Fcart");
 });

--- a/tests/e2e/docs-rename-address.spec.ts
+++ b/tests/e2e/docs-rename-address.spec.ts
@@ -22,33 +22,54 @@ const VAULT = {
     "---\nkind: capability\nslug: capabilities/cart\ntitle: 장바구니\nuid: 22222222-2222-4222-8222-222222222222\nrelations:\n  - type: belongs_to\n    to: domains/order\n---\n\n장바구니 역량.\n",
 };
 
+/**
+ * 볼트를 열고 문서함에서 「장바구니」 문서를 여는 데까지.
+ *
+ * ⚠️ **고정 대기를 값 판정으로 바꿨다** (2026-08-17 검사 전수조사). 종전에는
+ * 이 구간이 `waitForTimeout` 만으로 10.9초씩(두 시험 합쳐 21.8초, 저장소 최대)
+ * 자고 나서 키를 눌렀다. 그 시간은 **빠른 기계의 값**이고, 느린 기계에서는
+ * 아직 안 뜬 것을 누르게 된다. 기다릴 것이 있으면 그것을 기다린다.
+ */
+async function openCartDoc(page: import("@playwright/test").Page) {
+  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
+  const starter = page.getByTestId("first-run-starter-open");
+  await expect(starter).toBeVisible({ timeout: 30_000 });
+  // dev 오버레이가 클릭을 가로채는 것만 걷는다(제품 코드가 아니다).
+  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
+  await starter.click();
+  const pick = page.getByTestId("vault-guide-pick-existing");
+  await expect(pick).toBeVisible({ timeout: 30_000 });
+  await pick.click();
+
+  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
+  // 볼트가 실제로 읽혔나 — 폴더가 보이면 트리가 섰다는 뜻이다.
+  const folder = page.getByText("capabilities", { exact: true }).first();
+  await expect(folder, "문서함이 볼트를 읽지 못했다").toBeVisible({ timeout: 30_000 });
+  await folder.click();
+  const doc = page.getByText("장바구니", { exact: true }).first();
+  await expect(doc).toBeVisible({ timeout: 30_000 });
+  await doc.click();
+  // 문서가 실제로 열렸나 — 주소가 그 문서를 가리켜야 한다.
+  await expect(page, "문서를 눌렀는데 주소가 그 문서를 가리키지 않는다").toHaveURL(
+    /slug=capabilities%2Fcart(&|$)/,
+    { timeout: 30_000 },
+  );
+}
+
 test("이름 변경 뒤 — 경고가 안 뜨고 주소가 새 이름을 가리킨다", async ({ page }) => {
   test.setTimeout(150_000);
   page.on("dialog", (d) => void d.accept("capabilities/cart-renamed"));
   await page.setViewportSize({ width: 1512, height: 900 });
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
-  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2000);
-  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
-  await page.getByTestId("first-run-starter-open").click();
-  await page.waitForTimeout(500);
-  const pick = page.getByTestId("vault-guide-pick-existing");
-  if (await pick.isVisible().catch(() => false)) await pick.click();
-  await page.waitForTimeout(2500);
-
-  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
-  await page.getByText("capabilities", { exact: true }).first().click();
-  await page.waitForTimeout(500);
-  await page.getByText("장바구니", { exact: true }).first().click();
-  await page.waitForTimeout(1200);
+  await openCartDoc(page);
 
   // 팔레트 → 이름 변경 명령 (prompt 는 위 dialog 핸들러가 새 주소로 답한다)
   await page.keyboard.press("Meta+k");
-  await page.waitForTimeout(600);
+  const palette = page.locator('[aria-modal="true"]:visible').first();
+  await expect(palette, "팔레트가 안 열렸다").toBeVisible({ timeout: 15_000 });
   await page.keyboard.type("이름 변경");
-  await page.waitForTimeout(600);
+  await page.waitForTimeout(400); // 검색 결과가 좁혀질 틈 — 첫 항목이 바뀔 수 있다
   await page.keyboard.press("Enter");
 
   // 매니페스트 갱신 공백(웹 폴링 1.5s/5s)을 넘겨 가며 배너가 한 번도 안
@@ -75,26 +96,13 @@ test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키�
   await page.setViewportSize({ width: 1512, height: 900 });
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
-  await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2000);
-  await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
-  await page.getByTestId("first-run-starter-open").click();
-  await page.waitForTimeout(500);
-  const pick = page.getByTestId("vault-guide-pick-existing");
-  if (await pick.isVisible().catch(() => false)) await pick.click();
-  await page.waitForTimeout(2500);
-
-  await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
-  await page.getByText("capabilities", { exact: true }).first().click();
-  await page.waitForTimeout(500);
-  await page.getByText("장바구니", { exact: true }).first().click();
-  await page.waitForTimeout(1200);
+  await openCartDoc(page);
 
   await page.keyboard.press("Meta+k");
-  await page.waitForTimeout(600);
+  const palette = page.locator('[aria-modal="true"]:visible').first();
+  await expect(palette, "팔레트가 안 열렸다").toBeVisible({ timeout: 15_000 });
   await page.keyboard.type("삭제");
-  await page.waitForTimeout(600);
+  await page.waitForTimeout(400); // 검색 결과가 좁혀질 틈
   await page.keyboard.press("Enter");
 
   const banner = page.getByText(/못 찾았어요/);
@@ -102,5 +110,16 @@ test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키�
     await page.waitForTimeout(500);
     expect(await banner.count(), `삭제 ${(i + 1) * 0.5}s 후 거짓 「못 찾았어요」 경고`).toBe(0);
   }
-  expect(page.url()).not.toContain("slug=capabilities%2Fcart");
+  /*
+   * ⚠️ **「안 가리킨다」만으로는 부족하다** (2026-08-17 검사 전수조사).
+   * 종전에는 이 한 줄이 끝이었는데, 팔레트가 안 열려서 **아무 일도 안 일어나도**
+   * `?slug=` 가 애초에 안 붙으니 통과했다. 위 `openCartDoc` 이 「눌렀을 때
+   * 주소가 그 문서를 가리킨다」를 이미 단언하므로, 여기서는 그 상태에서
+   * **실제로 벗어났는지**를 본다.
+   */
+  await expect(page, "삭제했는데 주소가 여전히 그 문서를 가리킨다").not.toHaveURL(
+    /slug=capabilities%2Fcart(&|$)/,
+    { timeout: 15_000 },
+  );
+  await expect(page.getByText("장바구니"), "지운 문서가 아직 화면에 있다").toHaveCount(0);
 });

--- a/tests/e2e/keyboard-path.spec.ts
+++ b/tests/e2e/keyboard-path.spec.ts
@@ -132,9 +132,26 @@ test.describe("포커스 반환", () => {
 
     const opener = page.getByTestId("topology-shortcuts-help-button");
     await expect(opener).toBeVisible({ timeout: 30_000 });
-    await opener.focus();
-    await page.keyboard.press("Enter");
-    await expect(page.getByTestId("shortcut-sheet-close")).toBeVisible();
+    /*
+     * ⚠️ **보인다 ≠ 키가 붙었다** (2026-08-17, CI 에서 흔들리던 자리).
+     *
+     * 버튼이 보이자마자 Enter 를 눌렀는데, 느린 러너에서는 하이드레이션이
+     * 아직이라 그 Enter 가 아무 데도 안 닿았다 — 시트가 안 열려 15초를 꽉
+     * 기다리다 죽었다(실측 16.0초). 열릴 때까지 다시 누른다.
+     */
+    const sheetClose = page.getByTestId("shortcut-sheet-close");
+    await expect
+      .poll(
+        async () => {
+          if (await sheetClose.isVisible().catch(() => false)) return true;
+          await opener.focus();
+          await page.keyboard.press("Enter");
+          await page.waitForTimeout(250);
+          return sheetClose.isVisible().catch(() => false);
+        },
+        { timeout: 25_000, message: "단축키 시트가 안 열렸다 — Enter 가 아직 안 붙었나" },
+      )
+      .toBe(true);
     await page.keyboard.press("Escape");
 
     await expect

--- a/tests/e2e/map-expand-all.spec.ts
+++ b/tests/e2e/map-expand-all.spec.ts
@@ -56,10 +56,17 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
 
   const selected = await nodePos();
   await page.mouse.click(selected!.px, selected!.py - (selected!.r + 32));
-  await page.waitForTimeout(1600);
-
-  const after = await visibleCount();
-  expect(after - before, "펼침이 주장한 수만큼 드러내지 않았다").toBe(chipBefore!.claimedCount);
+  /*
+   * ⚠️ 고정 1.6초 뒤 **재시도 없는** 수 비교였다 — 펼침이 아직 안 끝난
+   * 기계에서는 수가 안 맞아 그냥 터진다. 값이 도달할 때까지 기다린다
+   * (2026-08-17 검사 전수조사).
+   */
+  await expect
+    .poll(async () => (await visibleCount()) - before, {
+      timeout: 20_000,
+      message: "펼침이 주장한 수만큼 드러내지 않았다",
+    })
+    .toBe(chipBefore!.claimedCount);
   const chipAfter = await orderChip();
   expect(chipAfter!.expanded).toBe(true);
   expect(chipAfter!.shownChildren, "chips 가 화면과 다른 말을 한다").toBe(chipBefore!.claimedCount);
@@ -83,6 +90,7 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
   // 같은 바가 이제 「접기」다 — 눌러서 원상 복귀까지 잰다.
   const expanded = await nodePos();
   await page.mouse.click(expanded!.px, expanded!.py - (expanded!.r + 32));
-  await page.waitForTimeout(1600);
-  expect(await visibleCount(), "접기가 원상 복귀하지 않았다").toBe(before);
+  await expect
+    .poll(visibleCount, { timeout: 20_000, message: "접기가 원상 복귀하지 않았다" })
+    .toBe(before);
 });

--- a/tests/e2e/map-expand-all.spec.ts
+++ b/tests/e2e/map-expand-all.spec.ts
@@ -18,6 +18,37 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * 아니라 **화면 반지름 + 32** 로 셈한다. 바가 이사가면 이 스펙이 큰 소리로
  * 죽고, 그때 오프셋 식을 함께 고친다.
  */
+/**
+ * 배치가 멈출 때까지 — **좌표가 프레임 사이에 안 변할 때**.
+ *
+ * ⚠️ 왜 필요한가 (2026-08-17, 내가 만든 회귀를 고치며 배운 것). 고정 1.6초
+ * 대기를 「수가 맞을 때까지」 폴로 바꿨더니 CI 에서 접기가 실패했다(기대 36,
+ * 실제 50). 수는 맞는 순간 바로 통과하는데 **카메라와 노드는 아직 움직이는
+ * 중**이라, 그 틈에 잰 클릭 좌표가 클릭이 도착할 때는 이미 낡아 빈 곳을
+ * 눌렀다. 고정 대기가 우연히 해 주던 일이 이것이었다.
+ *
+ * 그래서 「수」와 「자리」를 따로 기다린다 — 수는 무엇이 드러났나이고, 자리는
+ * 다음 클릭이 어디로 갈 것인가다.
+ */
+async function settleLayout(page: import("@playwright/test").Page) {
+  const snapshot = () =>
+    page.evaluate(() => {
+      const m = (window as unknown as { __atlasMap?: { nodes: () => Array<{ id: string; x: number; y: number }> } })
+        .__atlasMap;
+      return m ? m.nodes().map((n) => `${n.id}:${Math.round(n.x)},${Math.round(n.y)}`).join("|") : "";
+    });
+  await expect
+    .poll(
+      async () => {
+        const before = await snapshot();
+        await page.waitForTimeout(250);
+        return before !== "" && before === (await snapshot());
+      },
+      { timeout: 30_000, message: "배치가 멈추지 않아 클릭 좌표를 믿을 수 없다" },
+    )
+    .toBe(true);
+}
+
 test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다", async ({ page }) => {
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1512, height: 900 });
@@ -54,6 +85,7 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
   expect(chipBefore!.expanded).toBe(false);
   expect(chipBefore!.claimedCount).toBeGreaterThan(0);
 
+  await settleLayout(page);
   const selected = await nodePos();
   await page.mouse.click(selected!.px, selected!.py - (selected!.r + 32));
   /*
@@ -88,6 +120,8 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
   expect(overlapPairs, "펼쳐진 노드가 서로 겹쳤다").toBe(0);
 
   // 같은 바가 이제 「접기」다 — 눌러서 원상 복귀까지 잰다.
+  // 좌표를 재기 전에 배치가 멈춰야 한다(위 `settleLayout` 머리말).
+  await settleLayout(page);
   const expanded = await nodePos();
   await page.mouse.click(expanded!.px, expanded!.py - (expanded!.r + 32));
   await expect

--- a/tests/e2e/map-focus-dangling.spec.ts
+++ b/tests/e2e/map-focus-dangling.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test";
+import { seedFirstRunSeen } from "./first-run-seed";
+import { stubDirectoryPicker } from "./vault-picker-stub";
+
+/**
+ * **지도는 어떤 딥링크로 들어와도 읽을 수 있어야 한다** (2026-08-17 소유자 보고).
+ *
+ * ## 무엇이 있었나
+ *
+ * 문서함에서 프로젝트 문서의 「지도에서 열기」를 누르면 지도의 **모든 노드가
+ * 사라진 것처럼** 보였다. 소유자: *"이건 또 뭐지?"* · *"로딩속도도 느리고"*.
+ *
+ * 흐린 것이 아니라 **전부 흐리게 처리된 것**이었다. 그 버튼이 만드는 주소는
+ * `?p=<프로젝트 슬러그>`(예: `project`)인데 지도의 노드 이름은 `종류:슬러그`
+ * (`project:project`)다 — 프로젝트 슬러그는 접두사가 없고 노드 이름은 있어서
+ * 둘은 **구조적으로 절대 안 맞는다**. 지도는 「하나를 골랐다」고 판단하면 고른
+ * 것과 그 이웃만 남기고 나머지를 가라앉히는데, 맞는 노드가 하나도 없으니
+ * **전부가 「나머지」** 가 됐다.
+ *
+ * 실측(문서 7개 볼트, 배경 `#0a0a0d`): 화면에서 가장 밝은 노드가 배경 대비
+ * **1.40:1**. UI 도형의 최저 기준선은 3:1 이다. 125개짜리 샘플 볼트에서는
+ * 휘도 60을 넘는 픽셀이 **0개**였다.
+ *
+ * ## 이 검사가 왜 픽셀을 세나
+ *
+ * 이 결함은 **lint 도 타입도 계약 검사도 못 본다** — 쓰인 값은 전부 정당한
+ * 토큰(`--topology-v2-node-stroke-dim`)이고, 틀린 것은 「누구에게 그 토큰을
+ * 발랐는가」다. 게다가 지도는 캔버스라 DOM 이 없어서 셀렉터로 물을 것이 없다.
+ * 그래서 남는 수단은 **그려진 픽셀을 직접 세는 것**뿐이다.
+ *
+ * 판정은 「밝은 픽셀이 몇 개」가 아니라 **「읽을 수 있는 픽셀이 하나라도 있나」**
+ * 다 — 노드 수·배치·줌은 볼트마다 다르지만, *무엇을 그리든 사람이 볼 수 있어야
+ * 한다*는 것은 어느 볼트에서나 참이다.
+ */
+
+const VAULT = {
+  "project.md": `---\nuid: 11111111-1111-4111-8111-111111111111\nslug: project\nkind: project\ntitle: My project\ncontains:\n  - domains/example-domain\n---\n\n# My project\n`,
+  "domains/example-domain.md": `---\nuid: 22222222-2222-4222-8222-222222222222\nslug: domains/example-domain\nkind: domain\ntitle: Example domain\ncapabilities:\n  - capabilities/example-capability\n---\n\n# Example domain\n`,
+  "capabilities/example-capability.md": `---\nuid: 33333333-3333-4333-8333-333333333333\nslug: capabilities/example-capability\nkind: capability\ntitle: Example capability\ndomain: domains/example-domain\n---\n\n# Example capability\n`,
+};
+
+/** 배경보다 확실히 밝은 픽셀 수 — 노드 윤곽·라벨이 여기에 잡힌다. */
+async function readablePixelCount(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    /*
+     * ⚠️ 캔버스가 **둘일 수 있다** — 표면이 바뀌는 동안 나가는 것과 들어오는
+     * 것이 함께 있다(`use-presence`). 첫 번째를 집으면 나가는 쪽(이미 비어
+     * 가는 화면)을 재게 되므로, **가장 밝은 쪽**을 고른다.
+     */
+    const canvases = [
+      ...document.querySelectorAll<HTMLCanvasElement>('[data-testid="topology-map-v2-canvas"]'),
+    ].filter((c) => c.width > 0 && c.height > 0);
+    if (canvases.length === 0) return -1;
+    const canvas = canvases[canvases.length - 1];
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return -1;
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    let readable = 0;
+    // 4픽셀마다 표본 — 전수는 느리고, 노드 윤곽은 몇 픽셀 두께라 충분히 잡힌다.
+    for (let i = 0; i < data.length; i += 4 * 4) {
+      const luminance = 0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2];
+      // 배경은 #0a0a0d(휘도 ≈ 10). 60이면 배경 대비 3:1 을 확실히 넘는다.
+      if (luminance > 60) readable += 1;
+    }
+    return readable;
+  });
+}
+
+async function openVault(page: import("@playwright/test").Page, query: string) {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await seedFirstRunSeen(page);
+  await stubDirectoryPicker(page, VAULT);
+  await page.goto(`/ko/topology/?e2e=1&guides=off`, { waitUntil: "domcontentloaded" });
+  await page.getByTestId("first-run-starter-open").click();
+  await page.getByTestId("vault-guide-pick-existing").click();
+  await expect(page.getByTestId("topology-map-v2-canvas").first()).toBeVisible({ timeout: 30_000 });
+  if (query) {
+    await page.goto(`/ko/topology/?e2e=1&guides=off&${query}`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("topology-map-v2-canvas").first()).toBeVisible({ timeout: 30_000 });
+  }
+  // 배치가 그려질 때까지 — 값으로 판정한다(고정 대기는 기계 속도를 탄다).
+  await expect
+    .poll(() => readablePixelCount(page), { timeout: 30_000, message: "지도가 아무것도 안 그렸다" })
+    .toBeGreaterThan(-1);
+}
+
+test("문서함이 보내는 프로젝트 딥링크로 들어와도 지도가 읽힌다", async ({ page }) => {
+  test.setTimeout(120_000);
+
+  // 기준선 — 파라미터 없이 열었을 때 얼마나 밝은가.
+  await openVault(page, "");
+  const plain = await expect
+    .poll(() => readablePixelCount(page), { timeout: 30_000 })
+    .toBeGreaterThan(0)
+    .then(() => readablePixelCount(page));
+
+  // 문제의 경로 — 프로젝트 문서의 「지도에서 열기」가 실제로 만드는 주소다
+  // (`topology-href.ts`: kind: project → `/topology/?p=<슬러그>`).
+  await page.goto("/ko/topology/?e2e=1&guides=off&p=project", { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("topology-map-v2-canvas").first()).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => readablePixelCount(page), {
+      timeout: 30_000,
+      message:
+        "프로젝트 딥링크로 들어오니 지도에 읽을 수 있는 픽셀이 없다 — " +
+        "맞는 노드가 없는 선택이 「전부 흐리게」로 번역된 것이다",
+    })
+    .toBeGreaterThan(0);
+
+  const viaProjectLink = await readablePixelCount(page);
+  // 기준선의 절반은 나와야 한다 — 「한 픽셀이라도 있으면 통과」로 두면
+  // 라벨 하나만 남고 노드가 전부 가라앉은 상태도 초록이 된다.
+  expect(
+    viaProjectLink,
+    `프로젝트 딥링크(${viaProjectLink})가 파라미터 없는 화면(${plain})보다 크게 어둡다`,
+  ).toBeGreaterThan(plain / 2);
+});
+
+test("지도에 없는 노드를 가리키는 딥링크는 아무것도 안 고른 것으로 떨어진다", async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await openVault(page, "");
+  const plain = await readablePixelCount(page);
+
+  /*
+   * 안전망 그 자체를 잰다. 위 시험은 **원인 하나**(프로젝트 슬러그↔노드 이름
+   * 불일치)를 막지만, 「없는 노드를 골랐다」가 「전부 흐리게」로 번역되는 규칙이
+   * 남아 있는 한 다른 경로에서 같은 사고가 난다. 그래서 아예 존재할 수 없는
+   * 이름으로도 지도가 읽히는지 본다.
+   */
+  await page.goto("/ko/topology/?e2e=1&guides=off&p=element:this-node-does-not-exist", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("topology-map-v2-canvas").first()).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => readablePixelCount(page), {
+      timeout: 30_000,
+      message: "없는 노드를 가리키는 딥링크가 지도를 통째로 가라앉혔다",
+    })
+    .toBeGreaterThan(plain / 2);
+});

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -31,6 +31,70 @@ const selectedId = (page: import("@playwright/test").Page) =>
   page.evaluate(() => window.__atlasMap?.selection().nodeId ?? null);
 
 /**
+ * **한 번 누르고, 옮겨 갈 때까지 기다린다.**
+ *
+ * ⚠️ 예전에는 누른 뒤 고정 250ms 를 세고 한 번만 확인했다. 250ms 는 어느 기계의
+ * 값이라 느린 쪽에서는 아직 안 옮겨 간 상태를 「이 방향엔 이웃이 없다」로 읽고,
+ * 빠른 쪽에서는 남는 시간을 그냥 버린다. 옮겨 가면 **즉시** 돌려주고, 안 옮겨
+ * 가면 `patienceMs` 까지 기다린 뒤에야 「없다」고 답한다
+ * (2026-08-17 검사 전수조사).
+ */
+async function pressAndSettle(
+  page: import("@playwright/test").Page,
+  key: string,
+  from: string | null,
+  patienceMs = 3_000,
+): Promise<string | null> {
+  await page.keyboard.press(key);
+  const deadline = Date.now() + patienceMs;
+  let now = await selectedId(page);
+  while (Date.now() < deadline) {
+    now = await selectedId(page);
+    if (now && now !== from) return now;
+    await page.waitForTimeout(50);
+  }
+  return now;
+}
+
+/**
+ * **좌표를 읽기 전에 좌표가 멈췄는지 기다린다.** 선택 노드의 화면 좌표가 두 번
+ * 연속 같아질 때까지 — 카메라 전이가 흐르는 중에 재면 「화면 밖」이 우연히
+ * 참이 된다.
+ */
+async function settleSelectedPosition(page: import("@playwright/test").Page) {
+  const snapshot = () =>
+    page.evaluate(() => {
+      const probe = window.__atlasMap;
+      const id = probe?.selection().nodeId;
+      if (!probe || !id) return "";
+      const node = probe.nodes().find((n) => n.id === id);
+      return node ? `${id}:${Math.round(node.x)},${Math.round(node.y)}` : "";
+    });
+  await expect
+    .poll(
+      async () => {
+        const before = await snapshot();
+        await page.waitForTimeout(150);
+        return before !== "" && before === (await snapshot());
+      },
+      { timeout: 20_000, message: "카메라가 멈추지 않아 좌표를 믿을 수 없다" },
+    )
+    .toBe(true);
+}
+
+/** 네 방향을 차례로 눌러 **한 번이라도** 옮겨 가는 곳을 찾는다. */
+async function walkOneStep(
+  page: import("@playwright/test").Page,
+  from: string | null,
+): Promise<string | null> {
+  for (const key of DIRECTIONS) {
+    const now = await pressAndSettle(page, key, from);
+    if (now && now !== from) return now;
+  }
+  return null;
+}
+
+/**
  * **막다른 길이 나올 때까지 한 방향으로 걷는다.**
  *
  * ⚠️ 예전에는 「여덟 번 누르고 나서 확인」이었다. 안내가 스스로 사라지게 되자 그
@@ -148,16 +212,7 @@ test.describe("지도 키보드 걷기", () => {
      * 데이터에 따라 달라진다. 이 spec 이 잠그는 성질은 「방향키로 이동한다」이지
      * 「오른쪽에 무엇이 있다」가 아니다.
      */
-    let moved: string | null = null;
-    for (const key of DIRECTIONS) {
-      await page.keyboard.press(key);
-      await page.waitForTimeout(250);
-      const now = await selectedId(page);
-      if (now && now !== first) {
-        moved = now;
-        break;
-      }
-    }
+    const moved = await walkOneStep(page, first);
     expect(moved, `네 방향 어디로도 못 걸었다 (시작: ${first})`).not.toBeNull();
   });
 
@@ -167,17 +222,15 @@ test.describe("지도 키보드 걷기", () => {
     await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
     const from = await selectedId(page);
 
-    let to: string | null = null;
-    for (const key of DIRECTIONS) {
-      await page.keyboard.press(key);
-      await page.waitForTimeout(250);
-      const now = await selectedId(page);
-      if (now && now !== from) {
-        to = now;
-        break;
-      }
-    }
-    test.skip(to === null, "이 볼트에서는 첫 노드에 걸어갈 이웃이 없다");
+    const to = await walkOneStep(page, from);
+    /*
+     * ⚠️ 여기는 `test.skip(to === null, …)` 이었다 — **조용히 건너뛰었다.**
+     * 바로 위 시험(「방향키가 실제로 다른 노드로 옮겨 간다」)이 같은 준비로
+     * 「걸어간다」를 이미 못박고 있으므로, 여기서 못 걷는 것은 볼트 사정이
+     * 아니라 회귀다. 건너뛴 시험은 초록으로 보이고 아무도 안 본다
+     * (2026-08-17 검사 전수조사).
+     */
+    expect(to, `첫 노드(${from})에서 네 방향 어디로도 못 걸었다`).not.toBeNull();
 
     // 둘이 정말 엣지로 이어져 있나 — 화면이 아니라 그래프에 물어본다.
     const connected = await page.evaluate(
@@ -201,9 +254,15 @@ test.describe("지도 키보드 걷기", () => {
     await page.keyboard.press("ArrowRight");
     await expect.poll(() => selectedId(page), { timeout: 5_000 }).not.toBeNull();
 
+    /*
+     * ⚠️ 예전에는 누를 때마다 고정 500ms 였다("카메라 전이가 끝나도록"). 이 시험은
+     * **좌표를 읽어** 판정하므로 기다릴 것은 시간이 아니라 «좌표가 멈췄나» 다 —
+     * 느린 기계에서는 아직 흐르는 중에 재고, 빠른 기계에서는 남는 시간을 버린다
+     * (2026-08-17 검사 전수조사, `map-expand-all` 의 `settleLayout` 과 같은 처방).
+     */
     for (const key of DIRECTIONS) {
       await page.keyboard.press(key);
-      await page.waitForTimeout(500); // 카메라 전이가 끝나도록
+      await settleSelectedPosition(page);
     }
 
     const onScreen = await page.evaluate(() => {

--- a/tests/e2e/map-trail.spec.ts
+++ b/tests/e2e/map-trail.spec.ts
@@ -33,16 +33,19 @@ test("걸어온 길 — 쌓이고, 목록이 맞고, 뒤로 점프하고, 지워
   });
   expect(t, "주문 도메인을 못 찾았다 — 공회전").not.toBeNull();
   await page.mouse.click(t!.px, t!.py);
-  await page.waitForTimeout(900);
-  expect(await selection()).toBe("domain:order");
+  await expect
+    .poll(selection, { timeout: 15_000, message: "domain:order 로 안 걸어갔다" })
+    .toBe("domain:order");
 
   // 2·3걸음 — 팝오버 행으로 이동
   await page.getByText("장바구니", { exact: true }).first().click();
-  await page.waitForTimeout(900);
-  expect(await selection()).toBe("capability:cart");
+  await expect
+    .poll(selection, { timeout: 15_000, message: "capability:cart 로 안 걸어갔다" })
+    .toBe("capability:cart");
   await page.getByText("주문서 작성", { exact: true }).first().click();
-  await page.waitForTimeout(900);
-  expect(await selection()).toBe("capability:checkout");
+  await expect
+    .poll(selection, { timeout: 15_000, message: "capability:checkout 로 안 걸어갔다" })
+    .toBe("capability:checkout");
 
   // 칩이 세 걸음을 센다
   const chip = page.getByText(/걸어온 길 · 3/);

--- a/tests/e2e/offscreen-node-census.spec.ts
+++ b/tests/e2e/offscreen-node-census.spec.ts
@@ -38,8 +38,32 @@ test("첫 화면이 노드를 거의 다 보여 준다", async ({ page }) => {
   await page.getByTestId("vault-guide-pick-existing").click();
   await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 30_000 });
   await expect(page.getByTestId("topology-map-v2-canvas")).toBeVisible({ timeout: 30_000 });
-  // 배치가 정착할 때까지 — 움직이는 중에 세면 숫자가 매번 다르다.
-  await page.waitForTimeout(8_000);
+  /*
+   * 배치가 정착할 때까지 — 움직이는 중에 세면 숫자가 매번 다르다.
+   *
+   * ⚠️ 종전에는 `waitForTimeout(8_000)` 이었다. 8초는 **어느 기계의 값**이고,
+   * 느린 기계에서는 아직 움직이는 중에 세고 빠른 기계에서는 7초를 그냥 버린다.
+   * 정착은 시간이 아니라 **값**으로 판정한다 — 노드 좌표가 프레임 사이에
+   * 거의 안 움직이면 정착이다(2026-08-17 검사 전수조사).
+   */
+  await expect
+    .poll(
+      async () => {
+        const sample = () =>
+          page.evaluate(() => {
+            const map = (
+              window as unknown as { __atlasMap?: { nodes: () => Array<{ id: string; x: number; y: number }> } }
+            ).__atlasMap;
+            return map ? map.nodes().map((n) => `${n.id}:${Math.round(n.x)},${Math.round(n.y)}`).join("|") : "";
+          });
+        const before = await sample();
+        await page.waitForTimeout(400);
+        const after = await sample();
+        return before !== "" && before === after;
+      },
+      { timeout: 60_000, message: "배치가 정착하지 않았다" },
+    )
+    .toBe(true);
 
   const census = await page.evaluate(() => {
     const map = (

--- a/tests/e2e/open-vault-cta.spec.ts
+++ b/tests/e2e/open-vault-cta.spec.ts
@@ -172,7 +172,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
     for (const site of SITES) {
       await page.goto(`${site.route}?guides=off`, { waitUntil: "domcontentloaded" });
       await page.evaluate(() => document.fonts.ready);
-      await page.waitForTimeout(900);
+      // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
       const cta = page.getByTestId(site.testId);
       await expect(cta, `${site.route}: 폴더 여는 길이 안 보인다`).toBeVisible();
@@ -207,7 +207,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
     for (const route of ["/ko/project/new/", "/ko/project/storefront/edit/"]) {
       await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
       await page.evaluate(() => document.fonts.ready);
-      await page.waitForTimeout(900);
+      // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
       await expect(
         page.getByTestId("project-write-disabled-banner").first(),
@@ -242,7 +242,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
     });
     await page.goto("/ko/ontology/insights/?guides=off", { waitUntil: "domcontentloaded" });
     await page.evaluate(() => document.fonts.ready);
-    await page.waitForTimeout(1200);
+    // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
     const cta = page.getByTestId("do-next-open-vault");
     await expect(cta).toBeVisible();
@@ -366,7 +366,7 @@ test.describe("관문은 폴더를 여는 화면이 아니다 — 대신 그 화
       // ② 눌러서 도착한다.
       await page.locator(`[data-reach-hop="${inFold[0].index}"]`).click();
       await page.waitForURL(/\/topology/, { timeout: 15_000 });
-      await page.waitForTimeout(2200);
+      // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
       // ③ 착지점의 주 행동이 그 일이다 — 시트를 거쳐 선택기를 **실제로** 부른다.
       const starter = page.getByTestId("first-run-starter-open");

--- a/tests/e2e/open-vault-cta.spec.ts
+++ b/tests/e2e/open-vault-cta.spec.ts
@@ -67,6 +67,75 @@ const EXEMPT: ReadonlyArray<{ route: string; why: string }> = [
 ];
 const EXEMPT_ROUTES = new Set(EXEMPT.map((e) => e.route));
 
+/**
+ * **DOM 이 조용해질 때까지 기다린다** — 스캔 직전의 유일하게 정직한 기다림.
+ *
+ * ## 왜 여기만 값 판정이 어려웠나 (2026-08-17 검사 전수조사)
+ *
+ * 이 파일의 고정 대기 대부분은 다음 줄이 `page.evaluate` 로 **DOM 을 통째로
+ * 훑는** 자리였다. Playwright 의 자동 대기는 로케이터에만 붙으므로 여기엔 아무
+ * 것도 기다려 주는 것이 없고, 「무엇을 기다릴지」도 라우트마다 다르다 — 어떤
+ * 라우트는 폴더 문장이 0개인 것이 정상이라 「나타날 때까지」로도 못 쓴다.
+ *
+ * 그래서 기다릴 대상을 **「더 나타날 것이 있나」** 로 바꾼다: MutationObserver 가
+ * `quietMs` 동안 아무 변화도 못 보면 그 화면은 다 그려진 것이다.
+ *
+ * ⚠️ **`attributes` 는 보지 않는다.** 실측: 켜 두면 `/ko/topology/` 가 8초 상한을
+ * 그대로 다 쓴다(지도가 매 프레임 속성을 고친다). 끄면 746ms 에 멎고, 감사 대상
+ * 16개 라우트 전부가 280~750ms 다(고정 900ms 보다 대개 빠르고, 느린 기계에서는
+ * 900ms 보다 참을성 있다). 이 스캐너가 읽는 것은 글자와 요소이지 속성이 아니라
+ * 잃는 것도 없다.
+ */
+async function settleDom(page: import("@playwright/test").Page, quietMs = 250, capMs = 5_000) {
+  await page.evaluate(
+    ([quiet, cap]) =>
+      new Promise<void>((resolve) => {
+        let quietTimer = 0;
+        const finish = () => {
+          observer.disconnect();
+          window.clearTimeout(quietTimer);
+          window.clearTimeout(capTimer);
+          resolve();
+        };
+        const observer = new MutationObserver(() => {
+          window.clearTimeout(quietTimer);
+          quietTimer = window.setTimeout(finish, quiet);
+        });
+        const capTimer = window.setTimeout(finish, cap);
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+          attributes: false,
+        });
+        quietTimer = window.setTimeout(finish, quiet);
+      }),
+    [quietMs, capMs] as [number, number],
+  );
+}
+
+/** 스텁 픽커가 실제로 불렸나 — 재시도 없이 한 번 읽으면 늦은 판을 놓친다. */
+const pickerCalls = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => (window as unknown as { __picked?: number }).__picked ?? 0);
+
+/**
+ * **그려진 것만 고른다** — dev 하이드레이션 중의 0×0 유령 사본을 걸러 낸다.
+ *
+ * ⚠️ 실측(2026-08-17): `/ko/project/storefront/` 를 열면 **+100~250ms 사이에만**
+ * 같은 `data-testid` 가 둘이다 — 하나는 정상(93×32), 하나는 **0×0**. +300ms 에는
+ * 다시 하나다. `playwright.config.ts` 가 적어 둔 dev(Turbopack) 이중 마운트
+ * 아티팩트이고 정적 export 에는 없다. 그런데 그냥 `getByTestId` 는 그 창에
+ * 걸리면 strict mode 위반으로 **즉시** 죽는다(자동 대기가 구제해 주지 않는다).
+ *
+ * 앞선 판이 이 창을 우연히 비껴가고 있었을 뿐이라, 위쪽 고정 대기를 하나 줄이자
+ * 바로 드러났다 — 고정 대기가 우연히 해 주던 일이 또 이것이었다.
+ *
+ * **게이트는 그대로다**: 진짜로 «그려진» 사본이 둘이 되면 여전히 strict mode 로
+ * 터진다. 걸러 내는 것은 그리지 않는 유령뿐이다.
+ */
+const paintedTestId = (page: import("@playwright/test").Page, testId: string) =>
+  page.getByTestId(testId).filter({ visible: true });
+
 test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () => {
   test.use({ viewport: { width: 1512, height: 900 } });
 
@@ -81,7 +150,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
       if (route.includes("this-route-does-not-exist")) continue;
       await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
       await page.evaluate(() => document.fonts.ready);
-      await page.waitForTimeout(900);
+      await settleDom(page);
 
       const found = await page.evaluate(
         ({ promise, path }) => {
@@ -174,7 +243,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
       await page.evaluate(() => document.fonts.ready);
       // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
-      const cta = page.getByTestId(site.testId);
+      const cta = paintedTestId(page, site.testId);
       await expect(cta, `${site.route}: 폴더 여는 길이 안 보인다`).toBeVisible();
       await expect(
         cta,
@@ -182,11 +251,15 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
       ).toHaveAttribute("data-open-vault-cta", "picker");
 
       await cta.click();
-      await page.waitForTimeout(400);
-      const picked = await page.evaluate(
-        () => (window as unknown as { __picked?: number }).__picked ?? 0,
-      );
-      expect(picked, `${site.route}: 눌러도 폴더 선택기가 안 열렸다`).toBeGreaterThan(0);
+      // 고정 400ms 뒤 **재시도 없이** 읽었다 — 느린 기계에서는 아직 안 열린
+      // 것을 「안 열린다」로 읽는다. 값이 도달할 때까지 기다린다
+      // (2026-08-17 검사 전수조사).
+      await expect
+        .poll(() => pickerCalls(page), {
+          timeout: 10_000,
+          message: `${site.route}: 눌러도 폴더 선택기가 안 열렸다`,
+        })
+        .toBeGreaterThan(0);
     }
   });
 
@@ -244,7 +317,7 @@ test.describe("막다른 CTA 금지 — 폴더를 열라고 말한 자리", () =
     await page.evaluate(() => document.fonts.ready);
     // 바로 아래 단언이 스스로 기다린다 — 고정 대기는 낭비였다(2026-08-17 전수조사).
 
-    const cta = page.getByTestId("do-next-open-vault");
+    const cta = paintedTestId(page, "do-next-open-vault");
     await expect(cta).toBeVisible();
     await expect(cta).toHaveAttribute("data-open-vault-cta", "download");
     // 갈 곳이 실제로 열려야 한다 — 눌러도 아무 데도 안 가는 버튼 0개.
@@ -306,13 +379,77 @@ test.describe("관문은 폴더를 여는 화면이 아니다 — 대신 그 화
       await page.setViewportSize({ width: viewport.width, height: viewport.height });
       await page.goto("/ko/?guides=off", { waitUntil: "domcontentloaded" });
       await page.evaluate(() => document.fonts.ready);
-      await page.waitForTimeout(1200);
+
+      // ① 그 폭의 접힘 안에 지도로 가는 홉이 **그려져** 있다.
+      const readHops = () =>
+        page.evaluate(() => {
+          const painted = (el: Element) => {
+            const c = getComputedStyle(el);
+            const b = el.getBoundingClientRect();
+            return (
+              b.width > 2 &&
+              b.height > 2 &&
+              c.visibility !== "hidden" &&
+              c.display !== "none" &&
+              Number(c.opacity) >= 0.05
+            );
+          };
+          return [...document.querySelectorAll("a[href]")]
+            .filter(painted)
+            .filter((a) =>
+              /\/topology\/?$/.test(new URL((a as HTMLAnchorElement).href, location.href).pathname),
+            )
+            .map((a, i) => {
+              const b = a.getBoundingClientRect();
+              a.setAttribute("data-reach-hop", String(i));
+              return {
+                index: i,
+                label: (a.textContent ?? "").trim().slice(0, 24),
+                top: Math.round(b.top),
+                bottom: Math.round(b.bottom),
+                // 하단 고정 탭바는 바닥이 뷰포트와 정확히 같으므로 1px 여유를 준다.
+                inFold: b.top >= 0 && b.bottom <= innerHeight + 1,
+              };
+            });
+        });
+
+      /*
+       * ⚠️ **여기서 순서를 바꿨다** (2026-08-17 검사 전수조사).
+       *
+       * 예전에는 고정 1200ms 뒤에 ①을 한 번만 읽었다. 그걸 「DOM 이 조용해질
+       * 때까지」로 바꿨더니 **6배 스로틀에서 터졌다** — 느린 기계의 하이드레이션은
+       * 250ms 넘게 쉬었다가 이어지기도 해서, 조용한 구간을 「다 그려졌다」로
+       * 잘못 읽는다. 조용함은 «무엇이 나타날지 모를 때» 의 차선책이지, 나타날
+       * 것을 아는 자리에서 쓸 판정이 아니다.
+       *
+       * 이 자리는 기다릴 것을 안다: **접힘 안의 홉**. 그것이 나타날 때까지
+       * 기다리고, «없다» 를 세는 아래 단언은 그 뒤에 둔다 — 관문이 다 그려졌다는
+       * 가장 강한 증거가 곧 ①이기 때문이다.
+       */
+      let hops = await readHops();
+      await expect
+        .poll(
+          async () => {
+            hops = await readHops();
+            return hops.filter((h) => h.inFold).length;
+          },
+          {
+            timeout: 25_000,
+            message: `${viewport.width}: 관문 접힘 안에 지도로 가는 길이 없다 — 폴더를 열 수 있는 화면에 닿지 못한다`,
+          },
+        )
+        .toBeGreaterThan(0);
+      const inFold = hops.filter((h) => h.inFold);
 
       /**
        * **결정 자신을 검사가 진다.** 관문에 폴더 컨트롤이 생기면 여기서 빨개지고,
        * 그때 사람은 원장으로 돌아온다 — 조용히 두 번째 첫 실행 표면이 자라는 것을
        * 막는 유일한 자리다.
+       *
+       * 「없다」는 기다릴 수 없으므로, 위에서 관문이 다 그려진 것을 확인한 뒤
+       * DOM 이 조용해지기까지 한 번 더 기다리고 센다.
        */
+      await settleDom(page);
       const folderControls = await page.evaluate(
         () =>
           [...document.querySelectorAll("[data-open-vault-cta]")].filter((el) => {
@@ -325,44 +462,6 @@ test.describe("관문은 폴더를 여는 화면이 아니다 — 대신 그 화
         "관문에 폴더 여는 컨트롤이 생겼다 — 첫 실행 표면이 둘이 된다. 되돌리려면 원장부터",
       ).toBe(0);
 
-      // ① 그 폭의 접힘 안에 지도로 가는 홉이 **그려져** 있다.
-      const hops = await page.evaluate(() => {
-        const painted = (el: Element) => {
-          const c = getComputedStyle(el);
-          const b = el.getBoundingClientRect();
-          return (
-            b.width > 2 &&
-            b.height > 2 &&
-            c.visibility !== "hidden" &&
-            c.display !== "none" &&
-            Number(c.opacity) >= 0.05
-          );
-        };
-        return [...document.querySelectorAll("a[href]")]
-          .filter(painted)
-          .filter((a) =>
-            /\/topology\/?$/.test(new URL((a as HTMLAnchorElement).href, location.href).pathname),
-          )
-          .map((a, i) => {
-            const b = a.getBoundingClientRect();
-            a.setAttribute("data-reach-hop", String(i));
-            return {
-              index: i,
-              label: (a.textContent ?? "").trim().slice(0, 24),
-              top: Math.round(b.top),
-              bottom: Math.round(b.bottom),
-              // 하단 고정 탭바는 바닥이 뷰포트와 정확히 같으므로 1px 여유를 준다.
-              inFold: b.top >= 0 && b.bottom <= innerHeight + 1,
-            };
-          });
-      });
-
-      const inFold = hops.filter((h) => h.inFold);
-      expect(
-        inFold.map((h) => h.label),
-        `${viewport.width}: 관문 접힘 안에 지도로 가는 길이 없다 — 폴더를 열 수 있는 화면에 닿지 못한다 (전체 홉: ${JSON.stringify(hops)})`,
-      ).not.toEqual([]);
-
       // ② 눌러서 도착한다.
       await page.locator(`[data-reach-hop="${inFold[0].index}"]`).click();
       await page.waitForURL(/\/topology/, { timeout: 15_000 });
@@ -374,23 +473,34 @@ test.describe("관문은 폴더를 여는 화면이 아니다 — 대신 그 화
         starter,
         `${viewport.width}: 착지점에 폴더 여는 주 행동이 안 보인다`,
       ).toBeVisible();
-      await starter.click();
-      await page.waitForTimeout(500);
+      /*
+       * **보인다 ≠ 눌린다.** 방금 이동해 온 화면이라 하이드레이션이 아직일 수
+       * 있고, 그때 이 클릭은 아무 데도 안 닿는다. 고정 500ms 로 갈음하던 것을
+       * 열릴 때까지 다시 누르는 것으로 바꾼다 (2026-08-17 검사 전수조사).
+       */
+      const sheet = page.getByTestId("vault-guide-sheet");
+      await expect
+        .poll(
+          async () => {
+            if (await sheet.isVisible().catch(() => false)) return true;
+            await starter.click({ timeout: 5_000 }).catch(() => {});
+            await page.waitForTimeout(250);
+            return sheet.isVisible().catch(() => false);
+          },
+          {
+            timeout: 25_000,
+            message: `${viewport.width}: 안내 시트가 안 열렸다 — 착지점의 경로가 바뀌었다`,
+          },
+        )
+        .toBe(true);
 
-      await expect(
-        page.getByTestId("vault-guide-sheet"),
-        `${viewport.width}: 안내 시트가 안 열렸다 — 착지점의 경로가 바뀌었다`,
-      ).toBeVisible();
       await page.getByTestId("vault-guide-pick-existing").click();
-      await page.waitForTimeout(500);
-
-      const picked = await page.evaluate(
-        () => (window as unknown as { __picked?: number }).__picked ?? 0,
-      );
-      expect(
-        picked,
-        `${viewport.width}: 착지점까지 갔는데 폴더 선택기가 안 열렸다 — 한 홉 뒤 막다른 길`,
-      ).toBeGreaterThan(0);
+      await expect
+        .poll(() => pickerCalls(page), {
+          timeout: 10_000,
+          message: `${viewport.width}: 착지점까지 갔는데 폴더 선택기가 안 열렸다 — 한 홉 뒤 막다른 길`,
+        })
+        .toBeGreaterThan(0);
     });
   }
 });

--- a/tests/e2e/studio-stage-motion.spec.ts
+++ b/tests/e2e/studio-stage-motion.spec.ts
@@ -40,32 +40,72 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * 억제를 잠그는 게이트는 그 반대편도 같이 잠가야 한다.
  */
 
+/**
+ * **하이드레이션을 값으로 기다린다 — 「보인다」와 「눌린다」는 다른 순간이다.**
+ *
+ * ⚠️ 예전에는 고정 1.5초를 세고 한 번 눌렀다. 1.5초는 어느 기계의 값이라 느린
+ * 러너에서는 DOM 클릭이 나갔는데도 React 가 아직 핸들러를 안 붙여 무대가 안
+ * 열렸고, 빠른 기계에서는 1.5초를 그냥 버렸다. **열릴 때까지 다시 누른다**
+ * (2026-08-17 검사 전수조사 — `keyboard-path` 가 같은 처방으로 살아났다).
+ */
+async function clickUntilOpen(
+  page: import("@playwright/test").Page,
+  trigger: import("@playwright/test").Locator,
+  opened: import("@playwright/test").Locator,
+  message: string,
+) {
+  await expect(trigger).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(
+      async () => {
+        if (await opened.isVisible().catch(() => false)) return true;
+        await trigger.click({ timeout: 5_000 }).catch(() => {});
+        await page.waitForTimeout(250);
+        return opened.isVisible().catch(() => false);
+      },
+      { timeout: 40_000, message },
+    )
+    .toBe(true);
+}
+
+/**
+ * **무대가 「나 들어왔다」고 말할 때까지 기다린다 — 사용자도 그 뒤에 누른다.**
+ *
+ * ⚠️ 예전에는 «입장 창이 520ms 니까» 고정 700ms 였다. 잠글 성질은 밀리초가
+ * 아니라 **제품이 세우는 표시**다 — 무대는 입장을 마치면 스스로
+ * `data-studio-entered="true"` 를 세우고 그때부터 재입장을 끈다
+ * (`OntologyStudioPage` · `globals.css`). 그 표시를 기다리면 그 창의 길이가
+ * 바뀌어도 이 spec 은 따라온다 (2026-08-17 검사 전수조사).
+ *
+ * ⚠️ 애니메이션이 끝났는지로 갈음하면 **안 된다** — 실측: CSS 입장은 180ms 에
+ * 끝나는데 억제 표시는 520ms 에 선다. 그 틈에 채우면 재입장이 정당하게 일어나
+ * 아래 ① 이 거짓 빨강이 된다(이 처방의 첫 판이 그랬다).
+ */
+async function waitForStageEntered(page: import("@playwright/test").Page) {
+  await expect(
+    page.locator('[data-studio-entered="true"]'),
+    "무대가 입장을 마쳤다고 말하지 않는다",
+  ).toBeVisible({ timeout: 20_000 });
+}
+
 test("공방 · 방위를 채우면 도착한 것만 움직인다", async ({ page }) => {
   test.setTimeout(240_000);
   await page.setViewportSize({ width: 1512, height: 900 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/ontology/studio/?guides=off", { waitUntil: "domcontentloaded" });
 
-  const entry = page.getByTestId("studio-entry-create");
-  await expect(entry).toBeVisible({ timeout: 30_000 });
-  /*
-   * ⚠️ **하이드레이션을 기다린다.** 카드가 보이는 것과 그 카드가 눌리는 것은 다른
-   * 순간이다 — 기다리지 않고 누른 판은 DOM 클릭이 나갔는데도 무대가 열리지 않았다
-   * (React 가 아직 핸들러를 붙이지 않았다). 「보인다」로 「누를 수 있다」를 갈음하지 않는다.
-   */
-  await page.waitForTimeout(1_500);
-  await entry.click();
   const name = page.getByTestId("studio-create-name");
-  await expect(name, "무대에 이름 입력 자리가 없다").toBeVisible({ timeout: 30_000 });
+  await clickUntilOpen(
+    page,
+    page.getByTestId("studio-entry-create"),
+    name,
+    "무대에 이름 입력 자리가 없다 — 진입 카드가 아직 안 눌린다",
+  );
   await name.fill("결제 승인");
   await page.getByTestId("studio-socket-down").click();
   await expect(page.getByTestId("studio-picker")).toBeVisible({ timeout: 10_000 });
 
-  /*
-   * 입장 창(520ms)이 지난 뒤에 채운다 — 사용자도 무대가 들어온 뒤에 누른다.
-   * 그 전에 누르면 입장이 아직 정당하게 돌고 있어 이 판정이 뜻을 잃는다.
-   */
-  await page.waitForTimeout(700);
+  await waitForStageEntered(page);
 
   const running = await page.evaluate(async () => {
     const row = document.querySelector('[data-testid^="studio-picker-row-"]') as HTMLElement | null;
@@ -122,43 +162,116 @@ test("공방 · 무대가 처음 열릴 때는 입장이 재생된다", async ({
    */
   await page.waitForTimeout(2_500);
 
-  const frames = await page.evaluate(async () => {
-    const button = document.querySelector('[data-testid="studio-entry-create"]') as HTMLElement | null;
-    if (!button) return null;
-    button.click();
-    const out: { name: string; opacity: number }[] = [];
-    for (let i = 0; i < 6; i += 1) {
-      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
-      const card = document.querySelector('[data-testid="studio-center-card"]') as HTMLElement | null;
-      if (!card) continue;
-      const style = getComputedStyle(card);
-      out.push({ name: style.animationName, opacity: Number(style.opacity) });
-    }
-    return out;
-  });
+  /*
+   * **카드가 붙은 프레임만 센다.** 예전에는 rAF 를 딱 6번 돌고 그중 카드가 없는
+   * 프레임은 버렸다 — 느린 기계에서 React 가 3프레임 뒤에 커밋하면 표본이 3개만
+   * 남았고, 더 늦으면 0개라 「무대가 열리지 않았다」는 거짓 빨강이 됐다. 표본
+   * 개수를 목표로 삼고 프레임 예산을 넉넉히 준다. 그리고 클릭이 안 닿은 판
+   * (하이드레이션 전)은 표본 0으로 구별되므로 다시 누른다.
+   */
+  const sampleEntrance = () =>
+    page.evaluate(async () => {
+      const button = document.querySelector(
+        '[data-testid="studio-entry-create"]',
+      ) as HTMLElement | null;
+      if (button) button.click();
+      const out: { name: string; opacity: number }[] = [];
+      let durationMs: number | null = null;
+      for (let i = 0; i < 40 && out.length < 8; i += 1) {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+        const card = document.querySelector(
+          '[data-testid="studio-center-card"]',
+        ) as HTMLElement | null;
+        if (!card) continue;
+        const style = getComputedStyle(card);
+        out.push({ name: style.animationName, opacity: Number(style.opacity) });
+        if (durationMs === null) {
+          // 입장이 «얼마나 오래» 도는지는 브라우저에게 직접 묻는다 — 프레임을
+          // 세어 추정하면 그 값이 곧 기계 속도다.
+          const animation = card
+            .getAnimations()
+            .find(
+              (candidate) =>
+                (candidate as unknown as { animationName?: string }).animationName ===
+                "studioStageIn",
+            );
+          const timing = animation?.effect?.getComputedTiming();
+          if (timing) durationMs = Number(timing.duration) || 0;
+        }
+      }
+      return { clicked: Boolean(button), frames: out, durationMs };
+    });
 
-  expect(frames, "생성 카드를 못 찾았다 — 이 시험이 공회전한다").not.toBeNull();
-  const samples = frames!;
+  let samples: { name: string; opacity: number }[] = [];
+  let durationMs: number | null = null;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const round = await sampleEntrance();
+    if (round.frames.length > 0) {
+      samples = round.frames;
+      durationMs = round.durationMs;
+      break;
+    }
+    // 진입 카드 자체가 없으면 다시 눌러 봐야 소용없다.
+    if (!round.clicked) break;
+    await page.waitForTimeout(300);
+  }
+
   expect(samples.length, "무대가 열리지 않았다 — 중앙 카드가 없다").toBeGreaterThan(2);
   console.log(
-    `[studio-entrance] ${samples.map((s) => `${s.name}/${s.opacity.toFixed(2)}`).join(" · ")}`,
+    `[studio-entrance] ${durationMs}ms · ` +
+      `${samples.map((s) => `${s.name}/${s.opacity.toFixed(2)}`).join(" · ")}`,
   );
 
-  // ③ 입장이 실제로 재생된다.
+  // ③ 입장이 실제로 재생된다 — 카드가 붙은 **첫 프레임**이 입장 중이다.
   expect(
-    samples.every((s) => s.name === "studioStageIn"),
+    samples[0].name,
     `무대가 열리는데 입장 애니메이션이 없다 — 하드컷이다: ${samples.map((s) => s.name).join(", ")}`,
-  ).toBe(true);
+  ).toBe("studioStageIn");
+  expect(
+    samples.filter((s) => s.name === "studioStageIn").length,
+    `입장이 한 프레임 만에 끝났다: ${samples.map((s) => s.name).join(", ")}`,
+  ).toBeGreaterThan(1);
 
   /*
    * 그리고 **첫 프레임에 끝나 있지 않다.** 이름만 보면 「0.01ms 짜리 입장」도 통과한다.
-   * 잠글 성질은 기계와 무관한 쪽이다 — 첫 프레임이 아직 투명한가.
-   * (밀리초나 프레임 수를 못박지 않는다: 기계마다 다르다.)
+   *
+   * ⚠️ 예전에는 `samples[0].opacity < 0.5` 였다 — **첫 프레임이 언제 오는지가 곧
+   * 기계 속도**라, 느린 러너에서 첫 표본이 입장 중반에 잡히면 제품과 무관하게
+   * 터진다.
+   *
+   * ⚠️ 그런데 「프레임 사이에 올라가는가」로만 바꾸면 **부족하다** — 실측(프로브):
+   * 입장을 `animation-duration: 0.01ms` 로 줄여 놓고 재니 프레임이
+   * `0.00 · 0.00 · 1.00 · 1.00 …` 이라 **올라가긴 한다.** (`both` 라서 시작 전
+   * 두 프레임이 `from` 값에 머문다.) 옛 단언(`[0] < 0.5`)도 같은 이유로 이걸
+   * 통과시켰다 — 주석이 잡는다고 쓴 것을 실제로는 한 번도 안 잡고 있었다.
+   *
+   * 그래서 둘로 나눈다:
+   *
+   * - **얼마나 오래 도나** — 브라우저에게 직접 묻는다(`getComputedTiming`).
+   *   기계 속도와 무관한 값이라 여기에 바닥을 건다. 「0.01ms 짜리 입장」이
+   *   여기서 죽는다. 토큰을 손보는 여지를 남기려고 바닥은 낮게(50ms) 잡는다 —
+   *   잡으려는 것은 «있는 척하는 0» 이지 «180 이 아닌 값» 이 아니다.
+   * - **불투명도가 실제로 오르나** — 프레임에서 본다. 절대값이 아니라 처음보다
+   *   끝이 진한가만 본다(6배 스로틀에서 셋째 프레임이 0.81 이었다 — 절대값을
+   *   못박으면 그 기계에서 죽는다).
+   *
+   * (2026-08-17 검사 전수조사)
    */
   expect(
-    samples[0].opacity,
-    `입장이 첫 프레임에 이미 끝나 있다(opacity ${samples[0].opacity}) — 이름만 있고 움직임이 없다`,
-  ).toBeLessThan(0.5);
+    durationMs,
+    "입장 애니메이션의 길이를 읽지 못했다 — 이 판정이 공회전한다",
+  ).not.toBeNull();
+  expect(
+    durationMs!,
+    `입장이 이름만 있고 길이가 없다(${durationMs}ms) — 한 프레임 만에 끝난다`,
+  ).toBeGreaterThan(50);
+
+  const opacities = samples.map((s) => s.opacity);
+  const rendered = opacities.map((o) => o.toFixed(2)).join("→");
+  expect(
+    opacities[opacities.length - 1],
+    `입장이 배어 들어오지 않았다(${rendered}) — 끝이 처음보다 진해야 한다`,
+  ).toBeGreaterThan(opacities[0]);
 });
 
 /**
@@ -194,10 +307,18 @@ test("공방 · 앵커된 임시 표면 셋이 같은 문법으로 나간다", a
   // 강화 모드 — 이미 채워진 방위가 있어야 접힘 목록·편집 카드가 존재한다.
   const enhance = page.getByTestId("studio-entry-enhance");
   await expect(page.getByTestId("studio-entry-create")).toBeVisible({ timeout: 30_000 });
-  await page.waitForTimeout(1_500);
-  if (await enhance.count()) await enhance.click();
-  else await page.getByTestId("studio-entry-create").click();
-  await page.waitForTimeout(2_000);
+  const trigger = (await enhance.count())
+    ? enhance
+    : page.getByTestId("studio-entry-create");
+  // 고정 1.5초(하이드레이션) + 2초(무대가 서기를)였다 — 둘 다 값으로 바꾼다:
+  // 방위가 하나라도 그려지면 무대가 선 것이고, 입장은 스스로 끝났다고 말한다.
+  await clickUntilOpen(
+    page,
+    trigger,
+    page.locator('[data-testid^="studio-socket-"]').first(),
+    "무대가 열리지 않았다 — 방위를 하나도 못 찾았다",
+  );
+  await waitForStageEntered(page);
 
   /** 열었다 Esc 로 닫으며 그 표면의 프레임을 잡는다. */
   const trace = async (selector: string, open: () => Promise<void>) => {
@@ -307,14 +428,15 @@ test("공방 · 피커는 나가는 길을 갖는다", async ({ page }) => {
   await seedFirstRunSeen(page);
   await page.goto("/ko/ontology/studio/?guides=off", { waitUntil: "domcontentloaded" });
 
-  const entry = page.getByTestId("studio-entry-create");
-  await expect(entry).toBeVisible({ timeout: 30_000 });
-  await page.waitForTimeout(1_500);
-  await entry.click();
-  await expect(page.getByTestId("studio-create-name")).toBeVisible({ timeout: 30_000 });
+  await clickUntilOpen(
+    page,
+    page.getByTestId("studio-entry-create"),
+    page.getByTestId("studio-create-name"),
+    "무대에 이름 입력 자리가 없다 — 진입 카드가 아직 안 눌린다",
+  );
   await page.getByTestId("studio-socket-down").click();
   await expect(page.getByTestId("studio-picker")).toBeVisible({ timeout: 10_000 });
-  await page.waitForTimeout(700);
+  await waitForStageEntered(page);
 
   /*
    * **닫는 순간부터 프레임을 잡는다.** 그 전까지 피커는 나가는 길이 없었다 —

--- a/tests/e2e/user-journey-a.spec.ts
+++ b/tests/e2e/user-journey-a.spec.ts
@@ -23,7 +23,17 @@ test("A1·A2·A5 공개 여정 한 플로우", async ({ page }) => {
   await useDogfoodSample(page);
   const consoleErrors: string[] = [];
   const pageErrors: string[] = [];
+  /** 시간 예산 — 기계 속도를 타므로 **보고만** 한다. */
   const findings: string[] = [];
+  /*
+   * **결정론적 사실 — 이쪽은 실패시킨다** (2026-08-17 검사 전수조사).
+   *
+   * 이 spec 은 이름이 「여정」인데 여정 단언이 전부 `console.log` 였다.
+   * *"A2 root map INDEX panel missing — landing detour regression?"* 같은
+   * 문장은 기계 속도와 무관한 사실인데도 찍고 통과했다. 기계 속도를 타는
+   * 것(TTFB 예산)만 보고로 남기고, 있고 없음이 갈리는 것은 실패로 올린다.
+   */
+  const defects: string[] = [];
 
   page.on("pageerror", (err) => pageErrors.push(err.message));
   page.on("console", (msg) => {
@@ -42,7 +52,7 @@ test("A1·A2·A5 공개 여정 한 플로우", async ({ page }) => {
   const detailTtfb = Date.now() - detailStart;
   const detailTitle = await page.title();
   if (!detailTitle || !DETAIL_NAME_RE.test(detailTitle)) {
-    findings.push(`A1 title 에 프로젝트 이름 "${EXPECTED_DETAIL_NAME}" 누락: "${detailTitle}"`);
+    defects.push(`A1 title 에 프로젝트 이름 "${EXPECTED_DETAIL_NAME}" 누락: "${detailTitle}"`);
   }
   if (detailTtfb > 5_000) {
     findings.push(`A1 상세 첫 heading까지 ${detailTtfb}ms (5s 초과)`);
@@ -57,7 +67,7 @@ test("A1·A2·A5 공개 여정 한 플로우", async ({ page }) => {
     .then(() => true)
     .catch(() => false);
   if (!nameInBody) {
-    findings.push(
+    defects.push(
       `A1 hydration 후에도 body 에 "${EXPECTED_DETAIL_NAME}" 텍스트가 나타나지 않음 — client-side render 실패 가능`,
     );
   }
@@ -76,17 +86,21 @@ test("A1·A2·A5 공개 여정 한 플로우", async ({ page }) => {
   if (landingTtfb > 5_000) {
     findings.push(`A2 root map product mark까지 ${landingTtfb}ms (5s 초과)`);
   }
-  // 마케팅 랜딩 경유 없이 지도 chrome(브랜드 pill + INDEX)이 곧바로 뜨는지 —
-  // "0-클릭 aha" 계약의 e2e 증거.
-  const indexPanel = page.getByTestId("topology-index-panel");
-  const indexVisible = await indexPanel
-    .first()
-    .waitFor({ state: "visible", timeout: 5_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!indexVisible) {
-    findings.push("A2 root map INDEX panel missing — landing detour regression?");
-  }
+  /*
+   * **여기서 INDEX 를 요구하던 검사를 지웠다** (2026-08-17 검사 전수조사).
+   *
+   * 종전에는 `/` 에 지도 INDEX 가 없으면 *"landing detour regression?"* 을
+   * 찍었다. 그런데 그 기대는 **뒤집힌 계약**이다 — 2026-07-30 결정으로 볼트를
+   * 아직 안 고른 웹 방문자의 `/` 는 관문(`/download` 와 같은 얼굴)이고
+   * INDEX 는 없는 것이 맞다(`.claude/rules/architecture.md` 「URL 계약」).
+   * 지금 그 계약을 지키는 검사는 따로 있다 —
+   * `ontology-ui.spec.ts` 의 "root renders the gateway face": `download-gnb`
+   * 가 보이고 `topology-index-panel` 은 0개.
+   *
+   * 이 줄이 **로그로만 찍혀서** 계약이 뒤집힌 뒤로도 계속 「결함」이라고
+   * 말하고 있었고 아무도 못 봤다. 실패로 올리자마자 그 사실이 드러났다.
+   * 남의 계약을 여기서 다시 재지 않는다.
+   */
 
   // ── A5. 상세 Cmd+K → 같은 페이지에서 검색 팔레트 ───────────────────────
   // T-11 이후, 상세에서 Cmd+K는 `/`로 튕기지 않고 상세 페이지 안에 SearchPalette를
@@ -124,6 +138,13 @@ test("A1·A2·A5 공개 여정 한 플로우", async ({ page }) => {
   for (const e of pageErrors.slice(0, FINDING_LIMIT)) console.log(`[JOURNEY-A]   ! pageerror: ${e}`);
   for (const e of consoleErrors.slice(0, FINDING_LIMIT)) console.log(`[JOURNEY-A]   ! console.error: ${e}`);
 
-  // audit-only: pageerror가 여정 중에 터지는 것만 즉시 실패. findings·console은 리포트용.
+  console.log(`[JOURNEY-A] defects=${defects.length}`);
+  for (const d of defects) console.log(`[JOURNEY-A]   ✗ ${d}`);
+
+  // pageerror 와 **결정론적 사실**은 실패. 시간 예산(findings)과 console.error 는 보고용.
   expect(pageErrors, `공개 여정 중 pageerror ${pageErrors.length}건:\n${pageErrors.slice(0, 5).join("\n")}`).toHaveLength(0);
+  expect(
+    defects,
+    `공개 여정이 약속한 것이 화면에 없다 ${defects.length}건:\n${defects.join("\n")}`,
+  ).toEqual([]);
 });

--- a/tests/e2e/vault-picker-stub.ts
+++ b/tests/e2e/vault-picker-stub.ts
@@ -15,10 +15,28 @@ import type { Page } from "@playwright/test";
  * (교차 도메인 엣지 등)을 그리는 화면은 어떤 게이트도 본 적이 없다 —
  * 두 번째 소비처가 생긴 지금이 승격 시점이다.
  *
+ * ## 시각이 든 씨앗은 **고를 때** 만든다 — `{{NOW-<ms>}}`
+ *
+ * 씨앗 문자열 안의 `{{NOW-30000}}` 은 파일을 실제로 쓰는 순간(= 사용자가 폴더를
+ * 고르는 순간)에 `new Date(Date.now() - 30000).toISOString()` 으로 바뀐다.
+ *
+ * ⚠️ **왜 spec 쪽에서 계산하면 안 되나** (2026-08-17 검사 전수조사): 활동 칩의
+ * 「작업 중」 창은 마지막 쓰기 후 **2분**이다. spec 이 파일 맨 위에서 「30초 전」을
+ * 계산해 두면, 그 값이 화면에 닿기까지 **페이지 로드 전부**가 그 2분을 갉아먹는다
+ * — 여유는 90초인데 spec 자신의 상한이 120초라, 느린 러너에서는 창을 넘겨
+ * 「마지막 작업」이 되고 제품과 무관하게 터진다. 쓰는 순간에 계산하면 남는 것은
+ * 볼트를 읽고 그리는 시간뿐이다.
+ *
  * @param seed 폴더 안에 미리 넣어 둘 마크다운 (경로 → 내용)
  */
 export async function stubDirectoryPicker(page: Page, seed: Record<string, string>) {
   await page.addInitScript((files: Record<string, string>) => {
+    /** `{{NOW-<ms>}}` → 지금으로부터 그만큼 전의 ISO 시각. */
+    const resolveNowTokens = (body: string) =>
+      body.replace(/\{\{NOW-(\d+)\}\}/g, (_match, ms: string) =>
+        new Date(Date.now() - Number(ms)).toISOString(),
+      );
+
     const grant = async () => "granted" as const;
     // 픽커가 돌려주는 핸들과 그 하위 핸들 전부가 권한 질의에 답해야 한다 —
     // 앱은 IndexedDB 복원 경로에서 `queryPermission` 을 부른다.
@@ -48,7 +66,7 @@ export async function stubDirectoryPicker(page: Page, seed: Record<string, strin
         }
         const file = await cursor.getFileHandle(name, { create: true });
         const writable = await file.createWritable();
-        await writable.write(body);
+        await writable.write(resolveNowTokens(body));
         await writable.close();
       }
       return patch(dir);


### PR DESCRIPTION
## Summary

세 덩어리. 셋 다 **고치기 전에 빨간 것을 실측**하고, **일부러 깨뜨려 게이트가 서는 것**을 확인했다.

### ① 프로젝트 딥링크로 들어오면 지도가 통째로 흐려졌다 (`c69794472`)

소유자 보고: 문서함에서 프로젝트 문서의 「지도에서 열기」를 누르니 지도가 사라진 것처럼 보였다.

흐린 게 아니라 **전부 흐리게 처리된** 것이었다. 노드 이름은 `${kind}:${슬러그}` 인데 프로젝트 딥링크만 접두사 없는 슬러그를 보낸다(`topology-href.ts`). 그래서 프로젝트만 맞는 노드를 못 찾았고, 지도는 「하나 골랐는데 어디에도 없네」를 「나머지는 전부 흐리게」로 번역했다.

실측(문서 7개 볼트, 배경 `#0a0a0d`): 가장 밝은 노드 **1.40:1**(도형 최저 3:1), 라벨 0개. 125노드 샘플 볼트에서는 휘도 60 초과 픽셀 **0개**.

고친 것 둘. **안전망이 더 중요하다** — 포커스 이름이 노드 목록에 없으면 「안 고름」으로 떨어뜨린다. 그 규칙이 남아 있으면 다음 경로에서 또 난다.

「느리다」는 별개가 아니었다. 배포 빌드에서 클릭→첫 잉크 **0.07~0.12초**. 다 그렸는데 결과가 회색이라 「아직 로딩 중」으로 읽힌 것이다.

### ② 데이터시트 줄에 마우스를 올리면 지도가 그 노드를 가리킨다 (`fa25b0585`)

표시를 새로 만들지 않았다 — 지도의 그 노드에 직접 올렸을 때와 **똑같은 모양**이다. 「반짝이면서」를 깜빡임으로 만들지 않은 이유는 이 저장소가 그것을 금지하고 소유자도 *"깜빡이거나 그런거 없이 매우 부드럽게"* 라고 했기 때문이다. 움직임이 없어도 보이며, 검사를 감속 모션에서 돌려 증명한다.

**배선하다 발견**: 노드를 고른 상태에서는 `isNodeEmphasisActive` 가 패널 강조 입력 하나만 보는데 그 입력을 먹이는 쪽이 없었다. 즉 **채팅 호버도 노드를 고른 상태에서는 원래 안 보이고 있었다.** 새 통로가 아니라 비어 있던 자리를 채웠다.

### ③ 흔들리거나 아무것도 안 잡던 검사 일곱 (`0c42c88d5`, `996b2488f`)

전수조사(e2e 79 · 계약 177 · 스크립트 약 200, 11만 줄) 결과 20자리 중 값이 큰 일곱.

| 검사 | 무엇이 |
|---|---|
| `destination-shortcuts` | 화면 서기 전 키 입력(간헐 실패) + **기능이 통째로 죽어도 통과**하던 부정 단언 |
| `aria-audit` | 초점 주소가 **어느 볼트에도 없는 이름** → 그 화면을 한 번도 검사한 적 없음. 위반 0개면 통과(분모 없음) |
| `docs-rename-address` | 고정 대기 21.8초(저장소 최대)인데 삭제 단언이 **아무 일 없어도 통과** |
| `user-journey-a` | 여정 단언이 전부 `console.log` |
| `map-trail` · `map-expand-all` · `offscreen-node-census` | 고정 대기 뒤 재시도 없는 단언 |

**승격하자마자 진짜가 하나 나왔다**: `user-journey-a` 가 *"root map INDEX panel missing"* 을 계속 찍고 있었는데, 그 기대는 2026-07-30 에 **뒤집힌 계약**이었다(볼트 없는 방문자의 `/` 는 관문이고 INDEX 는 없는 것이 맞다 — `ontology-ui.spec.ts` 가 그 계약을 지킨다). 로그로만 찍혀서 계약이 뒤집힌 뒤로도 계속 틀린 말을 하고 있었다.

고정 대기 총량: **116곳 122.8초 → 104곳 104.6초.**

## Test plan

게이트가 실제로 서는지 전부 확인했다(초록 → 깨뜨림 → 빨강 → 되돌림 → 초록).

- `map-focus-dangling` — 고치기 전 프로젝트 딥링크 **614** 대 기준선 **2636**, 없는 노드 **663** 대 **1319**. 고친 뒤 둘 다 통과
- `datasheet-hover-map-brush` — 강조 배선을 끊으니 「호버 상태는 맞는데 화면은 그대로다 (바뀐 픽셀 0)」로 실패
- `destination-shortcuts` — 키를 삼켜 단축키를 죽이니 다섯 전부 빨강, 고친 시험이 "단축키 자체가 안 먹는다"로 잡음
- `aria-audit` — 슬러그를 없는 것으로 바꾸니 "초점 화면이 그 노드를 열지 않았다"로 실패
- `user-journey-a` — 기대 문자열을 없는 것으로 바꾸니 승격된 단언이 실패

기준선: `tsc --noEmit` 깨끗 · `pnpm lint` 0 error / 57 warning(래칫 상한 그대로) · `test:contracts` 1924 통과 · 단위 1353 통과 · 관련 e2e 22개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)