### PR TITLE
fix: Windows RC 릴리스 환경 변수 전달 수정

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -349,13 +349,13 @@ jobs:
         run: pnpm test:desktop:bridge
 
       - name: Verify release source commit
-        run: pnpm desktop:release-source -- --mode=pin --tag="${RELEASE_TAG}" --sha="${RELEASE_SHA}"
+        run: pnpm desktop:release-source -- --mode=pin --tag="$env:RELEASE_TAG" --sha="$env:RELEASE_SHA"
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.admit-release.outputs.release_sha }}
 
       - name: Verify release tag version
-        run: pnpm desktop:release-tag -- --tag="${RELEASE_TAG}"
+        run: pnpm desktop:release-tag -- --tag="$env:RELEASE_TAG"
 
       - name: Require updater signing credentials
         run: pnpm desktop:release-secrets -- --updater-only

--- a/scripts/check-desktop-readiness.mjs
+++ b/scripts/check-desktop-readiness.mjs
@@ -1209,13 +1209,16 @@ if (
 if (
   pkg.scripts?.["desktop:release-source"] === "node scripts/check-macos-release-source.mjs" &&
   releaseWorkflow.includes('pnpm desktop:release-source -- --mode=pin --tag="${RELEASE_TAG}" --sha="${RELEASE_SHA}"') &&
+  buildWindowsJob.includes('pnpm desktop:release-source -- --mode=pin --tag="$env:RELEASE_TAG" --sha="$env:RELEASE_SHA"') &&
+  !buildWindowsJob.includes('--tag="${RELEASE_TAG}"') &&
+  !buildWindowsJob.includes('--sha="${RELEASE_SHA}"') &&
   releaseSourceScript.includes("default-branch head") &&
   /RELEASE_SHA:\s*\$\{\{\s*needs\.admit-release\.outputs\.release_sha\s*\}\}/.test(releaseWorkflow)
 ) {
-  pass("desktop release source gate blocks tags from unmerged or stale commits before signing");
+  pass("desktop release source gate blocks tags from unmerged or stale commits before signing on Bash and PowerShell runners");
 } else {
   fail(
-    "package.json and .github/workflows/release-macos.yml must run scripts/check-macos-release-source.mjs before signing so signed DMGs only publish from the default-branch head",
+    "package.json and .github/workflows/release-macos.yml must run scripts/check-macos-release-source.mjs with shell-native environment expansion before signing so release artifacts only publish from the default-branch head",
   );
 }
 
@@ -1253,12 +1256,14 @@ if (
 if (
   pkg.scripts?.["desktop:release-tag"] === "node scripts/check-macos-release-tag.mjs" &&
   releaseWorkflow.includes('pnpm desktop:release-tag -- --tag="${RELEASE_TAG}"') &&
+  buildWindowsJob.includes('pnpm desktop:release-tag -- --tag="$env:RELEASE_TAG"') &&
+  !buildWindowsJob.includes('pnpm desktop:release-tag -- --tag="${RELEASE_TAG}"') &&
   releaseTagScript.includes("does not match macOS app versions")
 ) {
-  pass("desktop release tag gate receives the dispatched release tag before signing");
+  pass("desktop release tag gate receives the dispatched release tag before signing on Bash and PowerShell runners");
 } else {
   fail(
-    "package.json and .github/workflows/release-macos.yml must pass RELEASE_TAG from workflow_dispatch to scripts/check-macos-release-tag.mjs before signing",
+    "package.json and .github/workflows/release-macos.yml must pass RELEASE_TAG from workflow_dispatch with shell-native environment expansion before signing",
   );
 }
 

--- a/tests/contract/windows-desktop-release.contract.test.ts
+++ b/tests/contract/windows-desktop-release.contract.test.ts
@@ -3,6 +3,18 @@ import { describe, expect, it } from 'vitest';
 
 const read = (path: string) => readFileSync(path, 'utf8');
 
+function workflowJob(source: string, name: string): string {
+  const heading = new RegExp(`^  ${name}:\\s*$`, 'm').exec(source);
+  expect(heading, `${name} job`).not.toBeNull();
+
+  const afterHeading = source.slice(heading!.index + heading![0].length);
+  const nextJob = /^  [A-Za-z0-9_-]+:\s*$/m.exec(afterHeading);
+  return source.slice(
+    heading!.index,
+    nextJob ? heading!.index + heading![0].length + nextJob.index : source.length,
+  );
+}
+
 describe('Windows desktop beta release contract', () => {
   it('builds, audits, scans, installs, launches, and stages on a native Windows runner', () => {
     const releaseWorkflow = read('.github/workflows/release-macos.yml');
@@ -42,6 +54,18 @@ describe('Windows desktop beta release contract', () => {
     expect(cargo).toContain("[target.'cfg(target_os = \"windows\")'.dependencies]");
     expect(cargo).toContain('features = ["windows-native"]');
     expect(rustBridge).toContain('"ontology-atlas-mcp.exe"');
+  });
+
+  it('passes admitted release values with PowerShell environment syntax on Windows', () => {
+    const releaseWorkflow = read('.github/workflows/release-macos.yml');
+    const windowsJob = workflowJob(releaseWorkflow, 'build-windows');
+
+    expect(windowsJob).toContain(
+      'pnpm desktop:release-source -- --mode=pin --tag="$env:RELEASE_TAG" --sha="$env:RELEASE_SHA"',
+    );
+    expect(windowsJob).toContain('pnpm desktop:release-tag -- --tag="$env:RELEASE_TAG"');
+    expect(windowsJob).not.toContain('--tag="${RELEASE_TAG}"');
+    expect(windowsJob).not.toContain('--sha="${RELEASE_SHA}"');
   });
 
   it('publishes Windows facts only from the real release asset and checksum pair', () => {


### PR DESCRIPTION
## Summary

- Windows 릴리스 잡에서 Bash식 변수 확장을 PowerShell 환경 변수 문법으로 교체합니다.
- readiness 검사가 Bash와 PowerShell 양쪽의 릴리스 소스·태그 전달을 검증하게 합니다.
- 결함을 되살리면 실패하는 Windows 릴리스 계약 테스트를 추가합니다.

Root cause: PowerShell이 \u0060\u0024\u007bRELEASE_TAG\u007d와 \u0060\u0024\u007bRELEASE_SHA\u007d를 빈 PowerShell 변수로 해석해 RC7 소스 고정 검사가 빈 인자를 받았습니다.

## Test plan

- pnpm exec node --test scripts/check-desktop-readiness.test.mjs
- pnpm test:mcp:docs
- pnpm test:desktop:check
- pnpm desktop:check
- pnpm test:contracts
- pnpm test:mcp:package
- pnpm package:check
- pnpm exec tsc --noEmit
- pnpm lint (0 errors, 기존 기준 57 warnings)
- pnpm test:run
- gate probe: 결함 복원 시 계약 테스트와 desktop:check 실패, 수정 복구 시 둘 다 통과