### PR TITLE
chore: v1.0.0-rc.9 릴리스 버전을 맞춘다

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2558,7 +2558,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/views/download/lib/release-facts.ts
+++ b/src/views/download/lib/release-facts.ts
@@ -37,7 +37,7 @@
  */
 export const MCP_TOOL_COUNT = 35;
 
-export const RELEASE_VERSION = "1.0.0-rc.8";
+export const RELEASE_VERSION = "1.0.0-rc.9";
 export const RELEASE_MIN_MACOS = "macOS 12";
 export const RELEASE_ARCHES = ["aarch64", "x64"] as const;
 export type ReleaseArch = (typeof RELEASE_ARCHES)[number];


### PR DESCRIPTION
## Summary

`v1.0.0-rc.9` 태그를 만들기 전에 세 버전 원본을 맞춥니다. `package.json` · `src-tauri/tauri.conf.json` · `src-tauri/Cargo.toml` (+ `Cargo.lock` 자기 항목) 을 `1.0.0-rc.8` 에서 `1.0.0-rc.9` 로 올립니다.

이 셋이 어긋나면 `release-macos.yml` 의 `Verify release tag version` 단계에서 멈춥니다.

rc.9 에 담기는 것: 유휴 성능 3경로 · 라우트 데이터 분할 (#1160) · 넓은 화면 관문 + 3D 먼 쪽 저비용 렌더 (#1161) · 앱 안 에이전트 npx 캐시 자가 복구 + Agents/MCP 연결 라벨 (#1162).

## Test plan

- `node scripts/release-rehearsal.mjs --check-versions` — 세 파일 모두 `1.0.0-rc.9` 로 일치 확인
- `Cargo.lock` diff 는 자기 패키지 버전 한 줄뿐 (의존성 변동 없음)
- 병합 뒤 태그 생성 전에 `pnpm desktop:release-rehearsal` 무태그 리허설, 태그 생성 뒤 `--tag=v1.0.0-rc.9` 리허설 실행 예정