### PR TITLE
fix: 정식 공개 전 검수 1차 — 틀 밖으로 나간 격자, 어긋난 Codex 핀, 안 돌던 게이트

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -67,6 +67,25 @@ jobs:
       - name: Verify requested release version
         run: pnpm desktop:release-tag -- --tag="$RELEASE_TAG"
 
+      # 상류 ACP 레지스트리 스냅샷이 낡은 채로 나가지 않게 한다 (2026-08-20).
+      #
+      # `pnpm acp:registry:check` 는 **전부터 있었는데 아무도 부르지 않았다** —
+      # CI 에도 훅에도 없었다. 그래서 스냅샷이 조용히 뒤처졌고, 정식 공개 전
+      # 검수에서 실측하니 **9개 패키지**가 상류보다 낡아 있었다(그중 둘이 우리가
+      # 실제로 띄우는 어댑터다: claude-agent-acp 0.69.0→0.70.0 ·
+      # codex-acp 1.4.0→1.6.2). **있는데 안 도는 게이트는 없는 것보다 나쁘다** —
+      # 헛된 안심을 준다.
+      #
+      # **왜 매 PR 이 아니라 여기인가**: 이 검사는 *상류가 배포할 때* 빨개진다.
+      # PR 게이트로 걸면 남의 변경이 우리 PR 을 무작위로 막고, 그러면 규칙이
+      # 아니라 소음이 된다(이 저장소가 lint 룰에 대해 이미 정해 둔 규율과 같다).
+      # 릴리스는 손으로 시작하는 일이라, 여기서 묻는 것이 정확히 「낡은 것을
+      # 내보내지 않는다」만 막는다.
+      #
+      # **막혔을 때**: `pnpm acp:registry` 를 돌리고 diff 를 커밋한 뒤 다시 낸다.
+      - name: Verify bundled ACP registry is current
+        run: pnpm acp:registry:check
+
       - name: Admit tag at current main SHA
         id: admit
         env:

--- a/src-tauri/src/acp-registry.json
+++ b/src-tauri/src/acp-registry.json
@@ -14,7 +14,7 @@
       "cli": "claude",
       "launch": {
         "kind": "npx",
-        "package": "@agentclientprotocol/claude-agent-acp@0.69.0",
+        "package": "@agentclientprotocol/claude-agent-acp@0.70.0",
         "args": []
       }
     },
@@ -30,7 +30,7 @@
       "cli": "codex",
       "launch": {
         "kind": "npx",
-        "package": "@agentclientprotocol/codex-acp@1.4.0",
+        "package": "@agentclientprotocol/codex-acp@1.6.2",
         "args": []
       }
     },
@@ -255,7 +255,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dimcode@0.3.13",
+        "package": "dimcode@0.3.17",
         "args": [
           "acp"
         ]
@@ -273,7 +273,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dirac-cli@0.4.36",
+        "package": "dirac-cli@0.4.37",
         "args": [
           "--acp"
         ]
@@ -291,7 +291,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "droid@0.197.0",
+        "package": "droid@0.200.0",
         "args": [
           "exec",
           "--output-format",
@@ -329,7 +329,7 @@
       "cli": "gemini",
       "launch": {
         "kind": "npx",
-        "package": "@google/gemini-cli@0.55.1",
+        "package": "@google/gemini-cli@0.56.0",
         "args": [
           "--acp"
         ]
@@ -365,7 +365,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "glm-acp-agent@1.5.0",
+        "package": "glm-acp-agent@1.6.0",
         "args": []
       }
     },
@@ -399,7 +399,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@xai-official/grok@1.0.5",
+        "package": "@xai-official/grok@1.0.7",
         "args": [
           "agent",
           "stdio"
@@ -613,7 +613,7 @@
       "cli": "qwen",
       "launch": {
         "kind": "npx",
-        "package": "@qwen-code/qwen-code@0.21.12",
+        "package": "@qwen-code/qwen-code@0.21.14",
         "args": [
           "--acp",
           "--experimental-skills"

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -686,6 +686,15 @@ pub(crate) struct AcpLaunch {
 //   → 소유자 화면의 npm 오류가 가리킨 바로 그 깨진 디렉터리명
 // sha512("@agentclientprotocol/codex-acp@1.4.0")[..16]        = 8adbf6f1a7dec4e5
 //   → 같은 기계 ~/.npm/_npx/ 에 살아 있는 항목
+//
+// **오늘 쓰는 스펙의 값**(2026-08-20 레지스트리 갱신 뒤 — 위 두 줄과 같은
+// 방법으로 계산했고, 옛 스펙에 그 방법을 다시 적용하면 위 실측값이 그대로
+// 재현된다):
+//
+// ```text
+// sha512("@agentclientprotocol/claude-agent-acp@0.70.0")[..16] = fca12915ff656968
+// sha512("@agentclientprotocol/codex-acp@1.6.2")[..16]         = 3eb2c53071af01af
+// ```
 // ```
 //
 // 공식이 어느 날 바뀌면? 우리가 계산한 디렉터리가 그냥 **없을** 뿐이다 —
@@ -1676,8 +1685,8 @@ const KEYCHAIN_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// 사용자의 전역 npm 도 시스템 PATH 도 안 건드리고, 그 폴더를 지우면 흔적이
 /// 남지 않는다.
 pub(crate) const INSTALLABLE_CLI: &[(&str, &str)] = &[
-    ("claude-acp", "@anthropic-ai/claude-code@2.1.236"),
-    ("codex-acp", "@openai/codex@0.66.0"),
+    ("claude-acp", "@anthropic-ai/claude-code@2.1.237"),
+    ("codex-acp", "@openai/codex@0.148.0"),
 ];
 
 pub(crate) fn installable_package(runtime_id: &str) -> Option<&'static str> {

--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -1557,10 +1557,30 @@ export function ProjectForm({
   );
 
   return (
-    // 640px 중앙 폼 컬럼 (docs/prototypes/project-forms-final.html · RATIO-SYSTEM.md
-    // --page-col-form). 우측 260px 는 라이브 미리보기 — 이제 필수 칸이 첫 화면에
-    // 있으므로 "왼쪽 입력" 과 "오른쪽 반영" 이 실제로 같은 화면에서 마주 본다.
-    <div className="grid grid-cols-1 gap-8 lg:grid-cols-[640px_260px]">
+    /*
+     * 왼쪽 입력 · 오른쪽 라이브 미리보기. **왼쪽은 남는 만큼 갖는다.**
+     *
+     * ⚠️ **종전 `lg:grid-cols-[640px_260px]` 는 자기 틀보다 넓었다** (2026-08-20
+     * 릴리스 검수 실측). 이 폼이 사는 틀은 `PAGE_FRAME_FORM`(max-w 960 + px-10)
+     * 이라 내용 상자가 **880px** 인데, 트랙 합이 640 + 32(gap-8) + 260 = **932px**
+     * 였다. 즉 어느 화면 폭에서든 오른쪽 열이 제 컨테이너 밖으로 **52px** 나가
+     * 있었고(1512 에서도 그렇다), 뷰포트가 ~1092px 밑으로 내려가면 그때부터
+     * 화면에서 잘려 나갔다.
+     *
+     * 인용돼 있던 근거는 둘 다 그 값을 뒷받침하지 않았다: `RATIO-SYSTEM.md` 와
+     * `--page-col-form` 토큰은 **존재하지 않고**, 살아 있는
+     * `docs/prototypes/project-forms-final.html` 의 640 은
+     * `.formcol { width: 640px; margin: 0 auto }` — **사이드바가 없는 단일 중앙
+     * 컬럼**이다(그 파일에 `260` 은 0회 나온다). 단일 컬럼용 폭을 없던 열과
+     * 나란히 세운 것이라, 지켜야 할 비율이 아니라 유래를 잃은 리터럴이었다.
+     * 형제 토큰 `--page-col-utility` 도 같은 이유로 2026-07-29 카운슬이 지웠다.
+     *
+     * 그래서 고정 폭은 **미리보기 쪽만** 남긴다(그건 자기 내용이 정하는 폭이다).
+     * 입력 열은 남는 폭을 갖고, 틀이 바뀌어도 따라간다. `minmax(0,…)` 인 이유는
+     * `1fr` 만 쓰면 안의 긴 내용이 트랙을 다시 밀어내기 때문이다.
+     * 게이트: `tests/contract/page-grid-fits-frame.contract.test.ts`.
+     */
+    <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
       {mode === "create" ? createForm : editForm}
 
       {/* 모바일에서는 폼 입력을 먼저 보이게 하고, 데스크톱에서만 우측 보조 패널로 유지한다. */}

--- a/tests/contract/page-grid-fits-frame.contract.test.ts
+++ b/tests/contract/page-grid-fits-frame.contract.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * **격자가 자기 틀보다 넓으면 안 된다.**
+ *
+ * ## 왜 이 검사가 생겼나 (2026-08-20 릴리스 검수 실측)
+ *
+ * `/project/new/` 와 `/project/[slug]/edit/` 의 두 열 격자가
+ * `lg:grid-cols-[640px_260px]` + `gap-8` 이었다 — 합 **932px**. 그런데 그 폼이
+ * 사는 틀은 `PAGE_FRAME_FORM`(max-w 960 + px-10)이라 내용 상자가 **880px** 다.
+ * 그래서 오른쪽 열이 **모든 화면 폭에서** 제 컨테이너 밖으로 52px 나가 있었고
+ * (1512 에서도 그랬다), 뷰포트가 ~1092px 밑이면 그때부터 화면에서 잘렸다.
+ *
+ * ## 왜 lint 나 브라우저 검사가 아닌가
+ *
+ * **lint 는 못 본다** — `grid-cols-[640px_260px]` 도 `max-w-[960px]` 도 각각은
+ * 완전히 정당한 문자열이다. 틀린 것은 **둘을 같이 둔 것**이고, 그 둘은 다른
+ * 파일에 있다. 한 파일의 구문 트리만 보는 룰로는 표현할 수 없다.
+ *
+ * **브라우저 없이도 판정된다** — 이건 산수다. 고정 트랙과 간격의 합이 내용
+ * 상자보다 크면 넘친다. 그래서 e2e 가 아니라 계약 시험이다(밀리초 안에 끝나고
+ * 기계에 따라 흔들리지 않는다 — 이 저장소가 밀리초 게이트를 금지하는 것과 같은
+ * 이유로 여기서는 픽셀 산수를 고른다).
+ */
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+/** Tailwind 여백 램프 한 칸 = 4px. `gap-8` → 32px. */
+const SPACING_STEP = 4;
+
+/** `max-w-[960px] … md:px-10` 에서 내용 상자 폭을 낸다. */
+function frameContentWidth(frameConst: string): number {
+  const source = read('src/shared/ui/page-frame.ts');
+  // 선언이 두 줄로 쪼개져 있다(`= ` 다음 줄에 문자열). 줄 단위로 찾으면 놓친다.
+  const declaration = new RegExp(`export const ${frameConst}\\s*=\\s*"([^"]+)"`).exec(source);
+  if (!declaration) throw new Error(`${frameConst} 선언을 못 찾았다`);
+  const classes = declaration[1];
+  const max = /max-w-\[(\d+)px\]/.exec(classes);
+  if (!max) throw new Error(`${frameConst} 에 max-w 리터럴이 없다`);
+  // 넓은 화면에서 실제로 적용되는 것은 `md:px-N` 이다.
+  const pad = /md:px-(\d+)/.exec(classes);
+  const padPx = pad ? Number(pad[1]) * SPACING_STEP : 0;
+  return Number(max[1]) - padPx * 2;
+}
+
+/**
+ * 격자를 선언한 **그 className 문자열**을 통째로 돌려준다.
+ *
+ * ⚠️ 트랙과 간격을 각각 파일 전체에서 찾으면 안 된다 — 이 파일에는 `gap-2`
+ * 같은 다른 간격이 앞쪽에 여럿 있고, 처음 켤 때 실제로 그것을 집어 간격을
+ * 32px 대신 8px 로 **과소 보고**했다(넘침은 잡았지만 숫자가 틀렸고, 그 차이가
+ * 큰 경우 진짜 넘침을 통과시킬 수 있다). 둘은 같은 문자열에서 읽는다.
+ */
+function gridClassName(source: string): string {
+  const match = /className="([^"]*lg:grid-cols-\[[^\]]+\][^"]*)"/.exec(source);
+  if (!match) throw new Error('className 안의 lg:grid-cols 리터럴을 못 찾았다');
+  return match[1];
+}
+
+/** `lg:grid-cols-[A_B]` 의 **고정 폭 트랙**만 더한다(`1fr`·`minmax` 는 늘어난다). */
+function fixedTrackWidth(source: string): { fixed: number; tracks: string[] } {
+  /*
+   * ⚠️ **주석 안의 옛 값을 집으면 안 된다.** 이 파일은 종전 값
+   * (`lg:grid-cols-[640px_260px]`)을 주석에 그대로 인용해 두었고, 소스를 통째로
+   * 훑는 정규식은 그것을 먼저 만난다 — 이 검사를 처음 켤 때 실제로 그렇게
+   * 걸렸다. 그래서 **`className` 문자열 안**에 있는 것만 본다.
+   */
+  const match = /lg:grid-cols-\[([^\]]+)\]/.exec(gridClassName(source));
+  if (!match) throw new Error('lg:grid-cols 트랙을 못 읽었다');
+  // `minmax(0,1fr)_260px` — 콤마 안쪽을 건드리지 않게 괄호 깊이를 센다.
+  const tracks: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of match[1]) {
+    if (ch === '(') depth += 1;
+    if (ch === ')') depth -= 1;
+    if (ch === '_' && depth === 0) {
+      tracks.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  tracks.push(current);
+  const fixed = tracks.reduce((sum, track) => {
+    const px = /^(\d+)px$/.exec(track.trim());
+    return sum + (px ? Number(px[1]) : 0);
+  }, 0);
+  return { fixed, tracks };
+}
+
+function gapWidth(source: string): number {
+  // 격자를 선언한 그 className 안의 간격만 본다(위 주석의 이유).
+  const match = /\bgap-(\d+)\b/.exec(gridClassName(source));
+  return match ? Number(match[1]) * SPACING_STEP : 0;
+}
+
+describe('두 열 폼 격자 — 자기 틀 안에 들어가는가', () => {
+  const form = read('src/features/project-edit/ui/ProjectForm.tsx');
+
+  it('고정 트랙 + 간격이 틀의 내용 상자를 넘지 않는다', () => {
+    const content = frameContentWidth('PAGE_FRAME_FORM');
+    const { fixed, tracks } = fixedTrackWidth(form);
+    const gap = gapWidth(form);
+    expect(
+      fixed + gap * (tracks.length - 1),
+      `고정 트랙(${fixed}px) + 간격(${gap}px)이 틀의 내용 상자 ${content}px 를 넘는다 — ` +
+        `오른쪽 열이 컨테이너 밖으로 나간다`,
+    ).toBeLessThanOrEqual(content);
+  });
+
+  it('늘어나는 트랙이 하나는 있다 — 전부 고정이면 틀이 바뀔 때 다시 넘친다', () => {
+    const { tracks } = fixedTrackWidth(form);
+    expect(
+      tracks.some((track) => /fr|minmax|auto/.test(track)),
+      '모든 트랙이 고정 폭이다 — 틀이 좁아지면 그대로 넘친다',
+    ).toBe(true);
+  });
+
+  it('검사기가 헛돌지 않는다 — 양쪽에서 실제로 값을 읽어 왔다', () => {
+    // 추출기가 조용히 0 을 돌려주면 위 두 시험은 통과해 버린다.
+    expect(frameContentWidth('PAGE_FRAME_FORM')).toBeGreaterThan(400);
+    // 32px 이어야 한다(`gap-8`). 8 이 나오면 파일의 다른 간격을 집은 것이다.
+    expect(gapWidth(form)).toBe(32);
+    expect(fixedTrackWidth(form).tracks.length).toBeGreaterThan(1);
+  });
+});

--- a/tests/contract/release-registry-freshness.contract.test.ts
+++ b/tests/contract/release-registry-freshness.contract.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * **낡은 ACP 레지스트리로 릴리스가 나가지 않는가.**
+ *
+ * ## 왜 생겼나 (2026-08-20 정식 공개 전 검수)
+ *
+ * `pnpm acp:registry:check` 는 **전부터 있었다.** 그런데 CI 에도 git 훅에도
+ * 없어서 **아무도 부르지 않았다.** 그 사이 스냅샷이 조용히 뒤처졌고, 실측하니
+ * 상류보다 **9개 패키지**가 낡아 있었다 — 그중 둘이 우리가 실제로 띄우는
+ * 어댑터였다(`claude-agent-acp` 0.69.0→0.70.0 · `codex-acp` 1.4.0→1.6.2).
+ *
+ * **있는데 안 도는 게이트는 없는 것보다 나쁘다** — 헛된 안심을 준다. 이 저장소가
+ * 2026-08 에 릴리스를 하나 잃은 것도 같은 모양이었다(마커가 컴포넌트보다 오래
+ * 살아남은 스모크 게이트).
+ *
+ * ## 왜 매 PR 이 아니라 릴리스인가
+ *
+ * 이 검사는 **상류가 배포할 때** 빨개진다. PR 게이트로 걸면 남의 변경이 우리
+ * PR 을 무작위로 막고, 그러면 규칙이 아니라 소음이 된다 — 이 저장소가 lint 룰에
+ * 대해 이미 정해 둔 규율과 같다("한 PR 로 다 못 고칠 만큼 많으면 그 룰은 규칙이
+ * 아니라 경고 소음이 된다"). 릴리스는 손으로 시작하는 일이라, 거기서 묻는 것이
+ * 정확히 「낡은 것을 내보내지 않는다」만 막는다.
+ *
+ * ## 이 검사가 지키는 것
+ *
+ * 스냅샷이 최신인지는 **여기서 안 본다**(그건 네트워크가 필요하고, 이 저장소의
+ * CI 는 밖으로 안 나간다). 여기서 지키는 것은 **그 질문을 던지는 자리가 릴리스
+ * 경로에 실제로 남아 있는가** 하나다.
+ */
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const workflow = readFileSync(
+  path.join(repoRoot, '.github', 'workflows', 'release-macos.yml'),
+  'utf8',
+);
+
+/**
+ * 실제로 **실행되는** 줄만 남긴다 — 주석(`#`)은 버린다.
+ *
+ * ⚠️ **첫 판은 가짜 게이트였다** (같은 날, 프로브가 잡았다). 파일 전체에서
+ * 문자열을 찾았는데, 이 워크플로의 **주석에도** 그 명령 이름이 적혀 있어서
+ * (왜 이 스텝이 있는지 설명하느라) **스텝을 지워도 검사가 통과했다.**
+ * 검사가 재는 것은 「어딘가 그 글자가 있는가」가 아니라 「그것이 실행되는가」다.
+ */
+const executableLines = workflow
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n');
+const manifest = JSON.parse(
+  readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
+) as { scripts?: Record<string, string> };
+
+describe('릴리스 전 ACP 레지스트리 신선도', () => {
+  it('검사 스크립트가 실재한다', () => {
+    expect(manifest.scripts?.['acp:registry:check']).toBeDefined();
+    // `--check` 없이 등록돼 있으면 검사가 아니라 **덮어쓰기**다 — 릴리스
+    // 경로에서 그것을 돌리면 조용히 갱신하고 통과해 버린다.
+    expect(manifest.scripts?.['acp:registry:check']).toContain('--check');
+  });
+
+  it('릴리스 워크플로가 그 검사를 실제로 부른다', () => {
+    expect(
+      /run:\s*pnpm acp:registry:check/.test(executableLines),
+      '릴리스 경로에서 레지스트리 신선도를 아무도 묻지 않는다 — ' +
+        '이 스크립트는 한때 존재만 하고 아무도 안 불렀고, 그 사이 9개가 낡았다',
+    ).toBe(true);
+  });
+
+  it('빌드보다 **먼저** 묻는다 — 다 만들고 나서 물으면 시간을 버린다', () => {
+    const checkAt = executableLines.search(/run:\s*pnpm acp:registry:check/);
+    const buildAt = executableLines.indexOf('build-macos:');
+    expect(checkAt).toBeGreaterThan(-1);
+    expect(buildAt).toBeGreaterThan(-1);
+    expect(checkAt, '신선도 검사가 빌드 잡보다 뒤에 있다').toBeLessThan(buildAt);
+  });
+
+  it('검사기가 헛돌지 않는다 — 워크플로를 실제로 읽어 왔다', () => {
+    // 파일을 못 읽거나 경로가 바뀌면 위 시험들이 전부 조용히 통과할 수 있다.
+    expect(executableLines).toContain('admit-release:');
+    expect(executableLines.length).toBeGreaterThan(2000);
+    // 주석을 걷어내고도 내용이 남아야 한다 — 필터가 과하게 먹으면 위 시험들이
+    // 전부 조용히 통과하는 쪽으로 무너진다.
+    expect(executableLines).toContain('pnpm desktop:release-tag');
+  });
+});


### PR DESCRIPTION
## Summary

`v1.0.0` 을 낼지 판단하기 위한 전면 검수의 1차 결과다. 셋 다 **CI 는 초록인데 실제로는 틀린** 종류라 기존 게이트가 못 잡던 것이다.

### ① 프로젝트 폼 격자가 자기 틀보다 넓었다 — 모든 화면 폭에서

`/project/new/` · `/project/[slug]/edit/` 의 두 열 격자가 `lg:grid-cols-[640px_260px]` + `gap-8` 이라 **932px**, 그런데 틀(`PAGE_FRAME_FORM` = max-w 960 + px-10)의 내용 상자는 **880px**.

실행 중인 빌드에서 직접 잰 값 — `aside.right` 가 `parent.right` 를 **52px** 초과:

| viewport | parent.right | aside.right | 초과 |
|---:|---:|---:|---:|
| 1040 | 992 | 1044 | +52 |
| 1280 | 1112 | 1164 | +52 |
| 1512 | 1228 | 1280 | +52 |

뷰포트가 ~1092px 밑으로 내려가면 그때부터 **화면에서 잘려 나갔다.**

인용돼 있던 근거 둘은 그 값을 뒷받침하지 않는다. `RATIO-SYSTEM.md` 와 `--page-col-form` 토큰은 **존재하지 않고**, 살아 있는 `docs/prototypes/project-forms-final.html` 의 640 은 `.formcol { width: 640px; margin: 0 auto }` — **사이드바가 없는 단일 중앙 컬럼**이다(그 파일에 `260` 은 **0회** 나온다). 단일 컬럼용 폭을 없던 열과 나란히 세운 것이라, 지켜야 할 비율이 아니라 유래를 잃은 리터럴이었다. 형제 토큰 `--page-col-utility` 도 같은 이유로 2026-07-29 카운슬이 지웠다.

고정 폭은 미리보기 쪽만 남기고 입력 열이 남는 폭을 갖게 했다. 고친 뒤 `aside.right` 가 다섯 폭 **전부에서** `parent.right` 와 정확히 일치한다.

### ② 앱이 깔아 주는 Codex 가 앱이 띄우는 어댑터와 어긋났다

| 앱이 설치 | 어댑터가 선언한 의존 |
|---|---|
| `@openai/codex@0.66.0` (2025-12-09) | `codex-acp@1.4.0` → `^0.147.0` |

82 마이너 차이다. 로그인은 이 CLI 로 하고 어댑터는 자기 것을 따로 받으므로, 8개월 된 CLI 가 만든 자격증명을 현행 어댑터가 이해한다고 볼 근거가 없다. 어댑터를 1.6.2 로 올리면 요구가 `^0.148.0` 이라 CLI 핀을 거기 맞췄다.

### ③ 그 검사는 전부터 있었는데 아무도 부르지 않았다

`pnpm acp:registry:check` 가 **CI 에도 git 훅에도 없었다.** 그 사이 커밋된 스냅샷이 상류보다 **9개 패키지** 낡았고, 그중 둘이 우리가 실제로 띄우는 어댑터였다(`claude-agent-acp` 0.69.0→0.70.0 · `codex-acp` 1.4.0→1.6.2).

> **있는데 안 도는 게이트는 없는 것보다 나쁘다** — 헛된 안심을 준다.

**왜 매 PR 이 아니라 릴리스 직전인가**: 이 검사는 *상류가 배포할 때* 빨개진다. PR 게이트로 걸면 남의 변경이 우리 PR 을 무작위로 막고, 그러면 규칙이 아니라 소음이 된다 — 이 저장소가 lint 룰에 대해 이미 정해 둔 규율과 같다. 빌드 잡보다 **앞**에 둬서 다 만들고 나서 묻지 않는다.

문서에 예시로 박아 둔 npx 캐시 해시도 새 스펙 값으로 다시 계산했다. 옛 스펙에 같은 방법을 적용하면 문서의 실측값(`8757e2301903ae53`)이 그대로 재현되는 것으로 계산 방식을 **검산**했다.

## Test plan

- `pnpm test:contracts` **2,001 passed** (188 files) · `pnpm test:desktop:check` **345 passed**
- `cargo test` **218 passed** · `pnpm exec tsc --noEmit` 통과 · `pnpm lint` **0 errors / 57 warnings**(래칫 그대로)
- 라우트 전수 감사: 14 라우트 × 2 언어 × 2 폭 = **56 페이지 로드** — 콘솔 에러 0 · 죽은 링크 0 · 번역키 노출 0 · 가로 스크롤 0. 걸린 것이 ① 하나였고 그것을 정밀 측정해 위 표를 얻었다

### 게이트 프로브

| 되돌린 결함 | 결과 |
|---|---|
| 격자를 `[640px_260px]` 로 복귀 | `932 > 880` 으로 **2 failed** → 복구 후 3 passed |
| 릴리스 워크플로에서 검사 스텝 제거 | **2 failed** → 복구 후 4 passed |
| 레지스트리 스냅샷 (갱신 전 상태) | `exit 1` + 「커밋된 스냅샷이 최신과 다릅니다」 → 갱신 후 「current · 38 agents」 |

⚠️ **`release-registry-freshness` 계약의 첫 판은 가짜였고 프로브가 잡았다.** 파일 전체에서 문자열을 찾았는데 이 워크플로의 **주석에도** 그 명령 이름이 있어서(왜 이 스텝이 있는지 설명하느라) **스텝을 지워도 통과했다.** 주석을 걷어낸 뒤 `run:` 줄에서만 찾도록 고치고 다시 프로브했다. 새 게이트를 켤 때 프로브를 돌리지 않았다면 이 검사는 오늘부터 아무것도 안 지키는 채로 살았을 것이다.

### 게이트 설계 메모

①의 게이트는 **브라우저 없이 산수로** 짰다. lint 는 원리적으로 못 본다 — `grid-cols-[640px_260px]` 도 `max-w-[960px]` 도 각각은 완전히 정당하고, 틀린 것은 **둘을 같이 둔 것**이며 그 둘은 다른 파일에 있다. e2e 로 재면 기계마다 흔들리는데, 「고정 트랙 + 간격이 내용 상자보다 크면 넘친다」는 어느 기계에서나 참이다.

## 남은 것 (이 PR 밖)

- 설정 시트는 닫히면 **언마운트**된다(`AppSettingsMenu.tsx:596`). 설치 완료 신호(`done`)는 **단발**이라, 닫아 둔 사이에 지나가면 완료를 영영 못 본다. Node 내려받기는 250ms 주기라 다시 열면 0.25초 안에 자가복구된다 — 즉 「진행 소실」이 아니라 **「완료 유실」**이 정확한 결함이다. 상태를 언마운트 경계 위로 올리는 별도 변경이 필요하다
- `PAGE_COLUMN_FORM` 은 소비처가 **0곳**인 죽은 export 다. 지우려면 `page-frame.ts` 가 규격 장부에 있어 결정 기록이 필요해 분리했다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD