### PR TITLE
fix: 설정을 닫아 둔 사이에 끝난 설치를 놓치지 않게 한다

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use notify_debouncer_full::notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, FileIdMap};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -437,6 +438,8 @@ const ACP_INSTALL_VERIFY_SCRIPT: &str = r#"(() => {
     progressStages: [],
     progressBarWidths: [],
     lastPercentText: "",
+    reopened: "",
+    stagesBeforeReopen: [],
     attempts: 0
   };
   window.__ontologyAtlasAcpInstallVerify = result;
@@ -534,6 +537,42 @@ const ACP_INSTALL_VERIFY_SCRIPT: &str = r#"(() => {
       result.installClicked = node ? "node" : "cli";
       target.click();
       again(500);
+      return;
+    }
+
+    /*
+     * **닫았다 다시 연다** — 이 결함은 그 동작으로만 재현된다 (2026-08-20).
+     * 시트가 언마운트되면 진행 상태가 사라지고, 완료(`done`)는 단발이라
+     * 그 사이에 지나가면 영영 못 본다. Rust 가 마지막 상태를 들고 있다가
+     * 마운트 때 돌려주는지를 여기서 실제로 잰다.
+     */
+    if (!result.reopened && result.progressStages.length > 0) {
+      const sheet = find("app-settings-popover");
+      if (sheet) {
+        result.step = "close-sheet";
+        result.reopened = "closing";
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        again(1200);
+        return;
+      }
+    }
+    if (result.reopened === "closing") {
+      result.step = "reopen-sheet";
+      result.reopened = "reopening";
+      result.stagesBeforeReopen = result.progressStages.slice();
+      // 다시 열기 전에 화면에 남은 것을 지운다 — 그래야 「되살아났다」가
+      // 진짜 복구인지 잔상인지 갈린다.
+      result.progressStages = [];
+      const trigger = find("app-settings-trigger");
+      if (trigger) trigger.click();
+      again(900);
+      return;
+    }
+    if (result.reopened === "reopening") {
+      const nav = find("app-settings-nav-runtimes");
+      if (nav) nav.click();
+      result.reopened = "reopened";
+      again(900);
       return;
     }
 
@@ -1610,6 +1649,12 @@ struct AcpInstallProgress {
     total: Option<u64>,
     /// 그 도구가 실제로 뱉은 줄. 우리가 지어낸 문장이 아니다.
     note: Option<String>,
+    /// 이 상태가 생긴 시각(epoch ms).
+    ///
+    /// **없으면 어제 끝난 설치가 오늘 「설치했어요」로 뜬다.** 화면은 이 값으로
+    /// 낡은 것을 안 그린다 — 마지막 상태를 들고 있는 것과 그것을 언제까지
+    /// 보여 줄지는 다른 질문이다.
+    at: u64,
 }
 
 /// 화면이 듣는 이름. `acp://exit` 와 같은 결로 짓는다.
@@ -1620,6 +1665,37 @@ struct AcpInstallProgress {
 /// 그래서 아래 테스트가 직렬화 결과의 키를 그대로 못박는다.
 const ACP_INSTALL_PROGRESS_EVENT: &str = "acp-install://progress";
 
+/// **마지막 진행 상태를 도구별로 들고 있는 곳.**
+///
+/// ## 왜 필요한가 (2026-08-20, 카운슬 압박으로 발견)
+///
+/// 설정 시트는 닫히면 **통째로 언마운트된다**
+/// (`AppSettingsMenu.tsx` 의 `(open || settingsMounted) && …` 조건부 포털).
+/// 그래서 화면 쪽 `useAgentDoctor` 의 상태가 전부 사라지고 이벤트 구독도 끊긴다.
+///
+/// 갈래가 셋인데 **마지막 하나가 진짜 결함**이다:
+///
+/// | 시트를 닫아 둔 사이 | 다시 열면 |
+/// |---|---|
+/// | Node 내려받는 중 | 250ms 주기라 **0.25초 안에 자가복구**된다 |
+/// | npm 설치 중 | npm 이 조용하면 다음 줄이 나올 때까지 아무것도 안 보인다 |
+/// | **`done` 이 지나감** | `done` 은 **단발**이다 → **영영 완료를 못 본다** |
+///
+/// 소유자가 이 라운드에 명시적으로 요구한 것이 그 완료 표시였다
+/// (*"완료된것도 체크해주고 하나?"*). 이벤트만으로는 그 요구를 못 지킨다.
+///
+/// ## 왜 화면이 아니라 여기인가
+///
+/// 상태를 셸(React)로 올려도 **라우트를 떠나거나 새로고침하면 같이 죽는다** —
+/// 목적지로 옮겨도 마찬가지다. 설치를 실제로 소유한 것은 이쪽 프로세스이므로,
+/// 마지막 상태도 여기 두는 것이 진실원이 하나가 되는 자리다.
+#[derive(Default)]
+struct AcpInstallProgressState {
+    /// `runtime_id` → 그 도구의 마지막 진행. 도구마다 따로 둔다 — 한 칸이면
+    /// Codex 설치가 Claude 의 완료 표시를 덮어쓴다.
+    last: Mutex<HashMap<String, AcpInstallProgress>>,
+}
+
 fn emit_install_progress(
     app: &tauri::AppHandle,
     runtime_id: &str,
@@ -1629,17 +1705,53 @@ fn emit_install_progress(
     total: Option<u64>,
     note: Option<String>,
 ) {
-    let _ = app.emit(
-        ACP_INSTALL_PROGRESS_EVENT,
-        AcpInstallProgress {
-            runtime_id: runtime_id.to_string(),
-            job,
-            stage,
-            received,
-            total,
-            note,
-        },
-    );
+    let payload = AcpInstallProgress {
+        runtime_id: runtime_id.to_string(),
+        job,
+        stage,
+        received,
+        total,
+        note,
+        at: std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+    };
+    // **먼저 적어 두고 그다음에 보낸다.** 순서가 반대면, 이벤트를 받은 화면이
+    // 곧바로 물어봤을 때 아직 안 적힌 값을 읽을 수 있다.
+    if let Some(state) = app.try_state::<AcpInstallProgressState>() {
+        if let Ok(mut last) = state.last.lock() {
+            last.insert(runtime_id.to_string(), payload.clone());
+        }
+    }
+    let _ = app.emit(ACP_INSTALL_PROGRESS_EVENT, payload);
+}
+
+/// 이 도구의 **마지막 진행 상태**. 없으면 `None`.
+///
+/// 화면이 다시 마운트될 때 한 번 물어본다 — 그래야 닫아 둔 사이에 지나간
+/// 완료를 놓치지 않는다.
+#[tauri::command]
+fn acp_install_progress(
+    app: tauri::AppHandle,
+    runtime_id: String,
+) -> Option<AcpInstallProgress> {
+    let state = app.try_state::<AcpInstallProgressState>()?;
+    let last = state.last.lock().ok()?;
+    last.get(&runtime_id).cloned()
+}
+
+/// 다시 점검을 시작하면 **지난 설치 결과는 잊는다.**
+///
+/// 안 지우면, 재점검한 뒤 시트를 닫았다 열었을 때 「설치했어요」가 되살아나
+/// 방금 한 일이 아닌 것을 방금 한 것처럼 말하게 된다. 화면 쪽도 같은 순간에
+/// 자기 상태를 지우므로, 두 곳이 같은 규칙을 따른다.
+fn forget_install_progress(app: &tauri::AppHandle, runtime_id: &str) {
+    if let Some(state) = app.try_state::<AcpInstallProgressState>() {
+        if let Ok(mut last) = state.last.lock() {
+            last.remove(runtime_id);
+        }
+    }
 }
 
 /// **Node 를 앱이 받아 줄 수 있나 — 그렇다면 어디서 무엇을.**
@@ -1881,6 +1993,9 @@ pub(crate) fn is_openable_url(url: &str) -> bool {
 /// 사실만 돌려주고 문장은 화면이 만든다.
 #[tauri::command]
 fn acp_diagnose(app: tauri::AppHandle, runtime_id: String) -> Result<Vec<acp_doctor::AcpCheck>, String> {
+    // 다시 재기 시작하면 지난 설치 결과는 잊는다 — 화면도 같은 순간에 자기
+    // 상태를 지우므로 두 곳이 같은 규칙을 따른다.
+    forget_install_progress(&app, &runtime_id);
     let ctx = doctor_context(&app, &runtime_id)?;
     Ok(acp_doctor::diagnose(&ctx.borrow()))
 }
@@ -3008,6 +3123,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .manage(VaultWatcherState::default())
+        .manage(AcpInstallProgressState::default())
         .manage(AcpSessions::default())
         .setup(|app| {
             #[cfg(target_os = "macos")]
@@ -5663,6 +5779,7 @@ pub fn run() {
             acp_install_node,
             acp_install_plan,
             acp_install_cli,
+            acp_install_progress,
             acp_start,
             acp_send,
             acp_stop,
@@ -6830,6 +6947,7 @@ mod acp_install_progress_tests {
             received: Some(26_043_779),
             total: Some(52_087_559),
             note: None,
+            at: 1_787_000_000_000,
         })
         .expect("progress payload should serialize");
 
@@ -6838,7 +6956,7 @@ mod acp_install_progress_tests {
         keys.sort_unstable();
         assert_eq!(
             keys,
-            vec!["job", "note", "received", "runtimeId", "stage", "total"],
+            vec!["at", "job", "note", "received", "runtimeId", "stage", "total"],
             "화면이 읽는 키와 다르다 — 이러면 진행률이 조용히 사라진다"
         );
         assert_eq!(object["runtimeId"], "claude-acp");

--- a/src/features/acp-doctor/model/acp-doctor.ts
+++ b/src/features/acp-doctor/model/acp-doctor.ts
@@ -148,6 +148,30 @@ export interface AcpInstallProgress {
   total: number | null;
   /** 그 도구가 실제로 뱉은 줄. 우리가 지어낸 문장이 아니다. */
   note: string | null;
+  /** 이 상태가 생긴 시각(epoch ms). 낡은 것을 안 그리기 위한 값. */
+  at: number;
+}
+
+/**
+ * **들고 있던 상태를 언제까지 보여 주나.**
+ *
+ * 마지막 상태를 보관하는 것과 그것을 계속 보여 주는 것은 다른 질문이다.
+ * 이 창이 없으면 어제 끝난 설치가 오늘 설정을 열 때 「설치했어요」로 뜬다 —
+ * 방금 한 일이 아닌 것을 방금 한 것처럼 말하는 셈이다.
+ *
+ * 5분인 이유: 시트를 닫고 딴 일 하다 돌아오는 시간은 덮되(그게 이 값이 존재하는
+ * 이유다), 다음 세션까지 넘어가지는 않는 길이다.
+ */
+export const INSTALL_PROGRESS_FRESH_MS = 5 * 60 * 1000;
+
+/** 지금 그려도 되는 상태인가. `now` 를 받는 이유는 시험이 시계를 고정하려고. */
+export function isInstallProgressFresh(
+  progress: Pick<AcpInstallProgress, 'at'>,
+  now: number = Date.now(),
+): boolean {
+  // 시계가 뒤로 간 경우(시간대 변경·수동 조정)를 낡음으로 오해하지 않는다.
+  const elapsed = now - progress.at;
+  return elapsed < 0 || elapsed <= INSTALL_PROGRESS_FRESH_MS;
 }
 
 /**
@@ -183,4 +207,31 @@ export function formatBytes(bytes: number): string {
   const mb = bytes / (1024 * 1024);
   if (mb < 1) return `${(bytes / 1024).toFixed(0)}KB`;
   return `${mb.toFixed(1)}MB`;
+}
+
+/**
+ * 이 도구의 **마지막 진행 상태**를 Rust 에 물어본다. 없으면 `null`.
+ *
+ * ## 왜 필요한가 (2026-08-20)
+ *
+ * 설정 시트는 닫히면 **통째로 언마운트된다** — 그래서 이 훅의 상태가 사라지고
+ * 이벤트 구독도 끊긴다. Node 내려받기는 250ms 주기라 다시 열면 곧 되살아나지만,
+ * **완료(`done`)는 단발 이벤트**라 닫아 둔 사이에 지나가면 **영영 못 본다.**
+ *
+ * 이벤트만으로는 「끝났다」를 못 지킨다. 그래서 마운트할 때 한 번 물어본다.
+ */
+export async function lastInstallProgress(
+  runtimeId: string,
+): Promise<AcpInstallProgress | null> {
+  const invoke = getInvoke();
+  if (!invoke) return null;
+  try {
+    const last =
+      (await invoke<AcpInstallProgress | null>('acp_install_progress', { runtimeId })) ?? null;
+    // 낡은 것은 아예 안 돌려준다 — 화면마다 판정을 다시 하게 두면 어긋난다.
+    return last && isInstallProgressFresh(last) ? last : null;
+  } catch {
+    // 못 물어봤다고 화면을 세우지 않는다 — 고치기 전과 같은 상태가 될 뿐이다.
+    return null;
+  }
 }

--- a/src/features/acp-doctor/model/install-progress-freshness.test.ts
+++ b/src/features/acp-doctor/model/install-progress-freshness.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  INSTALL_PROGRESS_FRESH_MS,
+  isInstallProgressFresh,
+} from './acp-doctor';
+
+/**
+ * **마지막 상태를 들고 있는 것과, 그것을 언제까지 보여 주는 것은 다른 질문이다.**
+ *
+ * Rust 가 실행기별 마지막 설치 결과를 보관하는 이유는 「닫아 둔 사이에 지나간
+ * 완료」를 놓치지 않기 위해서다. 그런데 창을 안 두면 **어제 끝난 설치가 오늘
+ * 설정을 열 때 「설치했어요」로 뜬다** — 방금 한 일이 아닌 것을 방금 한 것처럼
+ * 말하는 셈이고, 이 저장소가 로딩·진행 표면 전반에서 금지해 온 모양이다.
+ */
+describe('들고 있던 설치 상태의 신선도', () => {
+  const now = 1_787_000_000_000;
+
+  it('방금 것은 그린다', () => {
+    expect(isInstallProgressFresh({ at: now }, now)).toBe(true);
+    expect(isInstallProgressFresh({ at: now - 1_000 }, now)).toBe(true);
+  });
+
+  it('창 경계는 포함한다 — 1ms 차이로 사라지지 않는다', () => {
+    expect(isInstallProgressFresh({ at: now - INSTALL_PROGRESS_FRESH_MS }, now)).toBe(true);
+    expect(isInstallProgressFresh({ at: now - INSTALL_PROGRESS_FRESH_MS - 1 }, now)).toBe(false);
+  });
+
+  it('어제 것은 안 그린다 — 이 검사가 존재하는 이유다', () => {
+    expect(isInstallProgressFresh({ at: now - 24 * 60 * 60 * 1000 }, now)).toBe(false);
+  });
+
+  it('시계가 뒤로 가도 낡음으로 오해하지 않는다', () => {
+    // 시간대 변경·수동 조정으로 경과가 음수가 될 수 있다. 그때 「낡았다」로
+    // 판정하면 방금 끝난 설치가 사라진다.
+    expect(isInstallProgressFresh({ at: now + 60_000 }, now)).toBe(true);
+  });
+
+  it('창이 실제로 유한하다 — 상수가 0 이나 무한이면 이 계약은 아무것도 안 지킨다', () => {
+    expect(INSTALL_PROGRESS_FRESH_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(INSTALL_PROGRESS_FRESH_MS)).toBe(true);
+  });
+});

--- a/src/features/acp-doctor/ui/AgentDoctor.test.tsx
+++ b/src/features/acp-doctor/ui/AgentDoctor.test.tsx
@@ -23,6 +23,8 @@ const nodeInstallPlan = vi.fn<() => Promise<string | null>>();
 const installManagedNode = vi.fn<(runtimeId: string) => Promise<AcpCheck[]>>();
 /** Rust 가 낼 진행 이벤트를 시험이 직접 쏜다. */
 let emitProgress: ((progress: unknown) => void) | null = null;
+/** Rust 가 들고 있는 「마지막 진행」. 시험이 직접 심는다. */
+const lastInstallProgress = vi.fn<(runtimeId: string) => Promise<unknown>>();
 
 vi.mock('../model/acp-doctor', async () => {
   const actual = await vi.importActual<typeof import('../model/acp-doctor')>('../model/acp-doctor');
@@ -35,6 +37,7 @@ vi.mock('../model/acp-doctor', async () => {
     installAgentCli: (runtimeId: string) => installAgentCli(runtimeId),
     nodeInstallPlan: () => nodeInstallPlan(),
     installManagedNode: (runtimeId: string) => installManagedNode(runtimeId),
+    lastInstallProgress: (runtimeId: string) => lastInstallProgress(runtimeId),
     listenInstallProgress: async (
       _runtimeId: string,
       onProgress: (progress: unknown) => void,
@@ -84,6 +87,8 @@ beforeEach(() => {
   nodeInstallPlan.mockResolvedValue(null);
   installManagedNode.mockReset();
   emitProgress = null;
+  lastInstallProgress.mockReset();
+  lastInstallProgress.mockResolvedValue(null);
 });
 
 describe('연동 점검 화면', () => {
@@ -399,6 +404,7 @@ describe('설치 진행', () => {
       received: 26_043_779,
       total: 52_087_559,
       note: null,
+      at: Date.now(),
     });
 
     const row = await screen.findByTestId('agent-doctor-progress');
@@ -423,6 +429,7 @@ describe('설치 진행', () => {
       received: null,
       total: null,
       note: 'added 121 packages in 8s',
+      at: Date.now(),
     });
 
     await screen.findByTestId('agent-doctor-progress');
@@ -447,6 +454,7 @@ describe('설치 진행', () => {
       received: null,
       total: null,
       note: null,
+      at: Date.now(),
     });
 
     const row = await screen.findByTestId('agent-doctor-progress');
@@ -466,6 +474,7 @@ describe('설치 진행', () => {
       received: null,
       total: null,
       note: null,
+      at: Date.now(),
     });
     await screen.findByTestId('agent-doctor-progress');
 
@@ -537,5 +546,83 @@ describe('명령 원문', () => {
     expect(code?.className).not.toContain('overflow-x-auto');
     // 경로에 공백이 있으므로(`Application Support`) 단어 경계로만 접으면 여전히 넘친다.
     expect(code?.className).toContain('break-all');
+  });
+});
+
+/**
+ * **닫아 둔 사이에 끝난 설치를 놓치지 않는가.**
+ *
+ * 설정 시트는 닫히면 통째로 언마운트되고(`AppSettingsMenu.tsx` 의 조건부 포털)
+ * 이 훅의 상태와 이벤트 구독이 함께 사라진다. Node 내려받기는 250ms 주기라
+ * 다시 열면 곧 되살아나지만, **완료(`done`)는 단발 이벤트**라 그 사이에
+ * 지나가면 영영 못 본다 — 소유자가 요구한 「완료된것도 체크」가 바로 그것이다.
+ */
+describe('언마운트를 건너뛰는 완료 표시', () => {
+  const done = {
+    runtimeId: 'claude-acp',
+    job: 'cli' as const,
+    stage: 'done' as const,
+    received: null,
+    total: null,
+    note: null,
+    at: Date.now(),
+  };
+
+  it('마운트할 때 Rust 에 마지막 진행을 물어본다', async () => {
+    diagnoseAgent.mockResolvedValue([ok('cli')]);
+    renderHarness();
+    await waitFor(() => expect(lastInstallProgress).toHaveBeenCalledWith('claude-acp'));
+  });
+
+  it('닫아 둔 사이에 끝났으면 다시 열었을 때 완료가 보인다', async () => {
+    diagnoseAgent.mockResolvedValue([ok('cli')]);
+    lastInstallProgress.mockResolvedValue(done);
+    renderHarness();
+
+    const row = await screen.findByTestId('agent-doctor-progress');
+    expect(row).toHaveAttribute('data-stage', 'done');
+    expect(row.textContent).toContain(ko.acpChat.doctor.progress.cli.done);
+  });
+
+  it('들고 있는 것이 없으면 아무것도 안 그린다 — 없는 일을 지어내지 않는다', async () => {
+    diagnoseAgent.mockResolvedValue([ok('cli')]);
+    lastInstallProgress.mockResolvedValue(null);
+    renderHarness();
+    await waitFor(() => expect(lastInstallProgress).toHaveBeenCalled());
+    expect(screen.queryByTestId('agent-doctor-progress')).toBeNull();
+  });
+
+  it('구독이 먼저 답했으면 그쪽이 이긴다 — 옛 값으로 덮지 않는다', async () => {
+    diagnoseAgent.mockResolvedValue([ok('cli')]);
+    // Rust 는 옛 완료를 들고 있는데, 지금 새 설치가 도는 중이다.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- 해소 시점을 시험이 쥔다
+    let release!: (value: any) => void;
+    lastInstallProgress.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    renderHarness();
+    await waitFor(() => expect(emitProgress).not.toBeNull());
+
+    emitProgress?.({
+      runtimeId: 'claude-acp',
+      job: 'cli',
+      stage: 'installing',
+      received: null,
+      total: null,
+      note: 'reify',
+      at: Date.now(),
+    });
+    await screen.findByTestId('agent-doctor-progress');
+
+    // 뒤늦게 도착한 「마지막 상태」가 지금 도는 것을 덮으면 안 된다.
+    release(done);
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-doctor-progress')).toHaveAttribute(
+        'data-stage',
+        'installing',
+      ),
+    );
   });
 });

--- a/src/features/acp-doctor/ui/AgentDoctor.tsx
+++ b/src/features/acp-doctor/ui/AgentDoctor.tsx
@@ -17,6 +17,7 @@ import {
   formatBytes,
   installAgentCli,
   installManagedNode,
+  lastInstallProgress,
   listenInstallProgress,
   nodeInstallPlan,
   repairAgentCheck,
@@ -105,6 +106,20 @@ export function useAgentDoctor(
     }).then((unlisten) => {
       if (alive) stop = unlisten;
       else unlisten();
+    });
+    /*
+     * **닫아 둔 사이에 지나간 것을 받아 온다.**
+     *
+     * 이 시트는 닫히면 통째로 언마운트되므로(`AppSettingsMenu.tsx` 의 조건부
+     * 포털) 여기 상태가 전부 사라진다. Node 내려받기는 250ms 주기라 곧 다음
+     * 이벤트가 와서 스스로 되살아나지만, **완료는 단발**이라 그 사이에 지나가면
+     * 영영 못 본다 — 소유자가 이 라운드에 요구한 바로 그 표시가 그것이다.
+     *
+     * 이미 온 것이 있으면 덮지 않는다: 구독이 먼저 답할 수도 있고, 그때는 그쪽이
+     * 더 새 값이다.
+     */
+    void lastInstallProgress(runtimeId).then((last) => {
+      if (alive && last) setProgress((current) => current ?? last);
     });
     return () => {
       alive = false;


### PR DESCRIPTION
## Summary

#1173 이 남긴 빈틈이다. **카운슬 압박으로 드러났다** — PO 자리 넷이 "모달이라 진행이 소실된다"를 이동의 근거로 쓰고 있었는데, 실제로 재 보니 그 문장이 절반만 사실이었고 **진짜 결함은 다른 것**이었다.

설정 시트는 닫히면 **통째로 언마운트된다**(`AppSettingsMenu.tsx:596` 의 `(open || settingsMounted) && …` 조건부 포털). `useAgentDoctor` 의 상태가 사라지고 이벤트 구독도 끊긴다. 다시 열면 셋으로 갈린다:

| 닫아 둔 사이 | 다시 열면 |
|---|---|
| Node 내려받는 중 | 250ms 주기(`managed_node.rs`)라 **0.25초 안에 자가복구** |
| npm 설치 중 | npm 이 조용하면 다음 줄까지 공백 |
| **`done` 이 지나감** | `lib.rs` 에서 **단발 방출**이라 **영영 완료를 못 본다** |

소유자가 이번 라운드에 명시적으로 요구한 것이 그 완료 표시다 — *"버튼들만 누르면 알아서 설치되는 과정도 보여주고 **완료된것도 체크해주고** 하나?"*. **이벤트만으로는 그 요구를 못 지킨다.**

## 왜 화면이 아니라 Rust 인가

상태를 셸(React)로 올려도 **라우트를 떠나거나 새로고침하면 같이 죽는다** — 목적지로 옮겨도 마찬가지다. 설치를 실제로 소유한 것이 이쪽 프로세스이므로, 마지막 상태도 여기 두는 것이 진실원이 하나가 되는 자리다. 화면은 마운트할 때 한 번 **물어보고**(pull), 이벤트는 그 위의 실시간 갱신이다. 그러면 이벤트 유실이 원리적으로 무해해진다.

**들고 있는 것과 보여 주는 것은 다른 질문이라** 신선도 창(5분)을 뒀다. 없으면 어제 끝난 설치가 오늘 「설치했어요」로 뜬다 — 방금 한 일이 아닌 것을 방금 한 것처럼 말하는 셈이다. 시계가 뒤로 간 경우(시간대 변경·수동 조정)를 낡음으로 오해하지 않는다. 재점검을 시작하면 Rust 와 화면이 **같은 순간에** 기록을 지운다.

## Test plan

- `cargo test` **218 passed** · `pnpm test:contracts` **1,994 passed** · `pnpm exec tsc --noEmit` 통과
- `pnpm lint` **0 errors / 57 warnings**(래칫 그대로) · acp-doctor 단위 **36 passed**

### 설치된 앱 실측 — 도구가 하나도 없는 깨끗한 환경

이 결함은 **닫았다 여는** 동작으로만 재현되므로 브라우저로는 증명이 안 된다. 검증 드라이버에 그 단계를 넣고 잰 값:

```
닫기 전    stagesBeforeReopen = ["downloading"]
Esc → 재열기 (화면에 남은 목록을 비운 뒤)
다시 연 뒤  progressStages    = ["done"]     ← 종전이면 영영 못 봤을 값
```

### 게이트 프로브

마운트 시 질의를 빼면 **3개가 빨개진다**(물어보나 · 완료가 보이나 · 없을 때 안 그리나) → 되돌리면 31 통과. 신선도 계약은 상수가 0/무한이면 아무것도 안 지키므로 그것까지 단언한다.

늦게 도착한 「마지막 상태」가 **지금 도는 것을 덮지 않는지**도 시험한다 — 구독이 먼저 답했으면 그쪽이 더 새 값이다.

## 카운슬 기록

이 수리는 PO 카운슬 평결의 처방 ⑶ 과 같다(팀장 권고: *"Rust 최종 상태 질의(pull)를 진실원으로"*). 평결이 명시한 이유도 같다 — 셸 구독을 진실원으로 삼는 안은 **같은 결함을 한 층 위로 옮길 뿐**이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD