### PR TITLE
fix: 눌러서 받은 답이 사라지던 것과, 재지도 않고 괜찮다고 말하던 것

### DIFF
--- a/src/features/acp-doctor/ui/AgentDoctor.test.tsx
+++ b/src/features/acp-doctor/ui/AgentDoctor.test.tsx
@@ -626,3 +626,40 @@ describe('언마운트를 건너뛰는 완료 표시', () => {
     );
   });
 });
+
+/**
+ * **모르는 것을 초록으로 그리지 않는다.**
+ *
+ * #1175 가 「닫아 둔 사이의 완료」를 살리려고 마운트 시 진행 상태를 받아 오게
+ * 했는데, 그러면서 결과 블록이 **검사 없이도** 그려지게 됐다. 그때
+ * `blocked.length === 0` 은 「다 괜찮다」가 아니라 **「아직 아무것도 안 쟀다」**
+ * 인데, 화면은 그것을 「지금은 문제 없어요」라고 말한다 — 재지도 않고 초록을
+ * 그리는 것이라 이 화면이 지키기로 한 두 규율 중 첫째를 정면으로 어긴다.
+ */
+describe('재지 않은 것을 괜찮다고 말하지 않는다', () => {
+  it('진행 상태만 있고 점검을 안 했으면 「문제 없어요」를 안 그린다', async () => {
+    lastInstallProgress.mockResolvedValue({
+      runtimeId: 'claude-acp',
+      job: 'node',
+      stage: 'done',
+      received: null,
+      total: null,
+      note: null,
+      at: Date.now(),
+    });
+    renderHarness();
+
+    // 완료는 보여 준다 — 그게 이 배선의 존재 이유다.
+    await screen.findByTestId('agent-doctor-progress');
+    // 그런데 검사는 한 번도 안 돌았다. 그것을 「괜찮다」로 바꾸면 안 된다.
+    expect(screen.queryByTestId('agent-doctor-all-clear')).toBeNull();
+    expect(screen.queryByTestId('agent-doctor-checks')).toBeNull();
+  });
+
+  it('점검을 돌린 뒤에는 평소대로 말한다', async () => {
+    diagnoseAgent.mockResolvedValue([ok('cli'), ok('launcher')]);
+    renderHarness();
+    fireEvent.click(screen.getByTestId('agent-doctor-scan'));
+    await screen.findByTestId('agent-doctor-all-clear');
+  });
+});

--- a/src/features/acp-doctor/ui/AgentDoctor.tsx
+++ b/src/features/acp-doctor/ui/AgentDoctor.tsx
@@ -386,6 +386,19 @@ export function useAgentDoctor(
         className="mt-1.5 min-w-0 border-t border-[color:var(--color-divider)] pt-2"
       >
         {progressRow}
+        {/*
+          ⚠️ **`checks` 가 없다는 것은 「괜찮다」가 아니라 「안 쟀다」다.**
+
+          #1175 로 진행 상태만 있어도 이 블록이 그려지게 되면서, 점검을 한 번도
+          안 돌린 화면이 `blocked.length === 0` 을 타고 「지금은 문제 없어요」를
+          말하게 됐다 — 재지도 않고 초록을 그리는 것이고, 이 화면이 지키기로 한
+          두 규율 중 첫째("모르는 것을 초록으로 그리지 않는다")를 정면으로 어긴다.
+          (2026-08-20 설치 앱 스크린샷에서 「설치 필요」 배지 바로 아래
+          「지금은 문제 없어요」가 같이 서 있는 것으로 드러났다.)
+
+          그래서 판정 문장은 **잰 것이 있을 때만** 낸다. 진행 줄은 위에 그대로
+          남으므로 완료 표시는 잃지 않는다.
+        */}
         {failed ? (
           <p
             data-testid="agent-doctor-failure"
@@ -393,7 +406,7 @@ export function useAgentDoctor(
           >
             {t('failed')}
           </p>
-        ) : blocked.length === 0 ? (
+        ) : !checks ? null : blocked.length === 0 ? (
           /*
            * **다 괜찮으면 한 줄이다.** 같은 문장 일곱 개는 정보가 아니라 사본이고,
            * 이 화면은 그 실패를 이미 한 번 겪었다.

--- a/src/features/app-update/model/use-app-update.test.ts
+++ b/src/features/app-update/model/use-app-update.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAppUpdate } from './use-app-update';
+
+/**
+ * **사용자가 직접 물어본 답을, 앱이 뒤에서 지우면 안 된다.**
+ *
+ * 2026-08-20 정식 공개 전 검수에서 실측으로 잡혔다: 설치된 앱에서
+ * 「업데이트 확인」을 눌렀더니 마커에는 결과(`failed`)가 잡히는데 **화면에는
+ * 그 문장이 없었다.** 원인은 마운트 4초 뒤에 도는 **자동 확인**이다 —
+ * 자동 경로는 실패를 조용히 넘기려고 `idle` 로 되돌리는데, 그때 사용자가
+ * 방금 받은 답까지 같이 지워진다.
+ *
+ * 사용자 입장에서는 「눌렀더니 뭔가 떴다가 아무 말 없이 사라졌다」가 된다.
+ * 이 저장소가 강등 카드에 대해 정해 둔 정직 규율의 반대편이다.
+ */
+
+const check = vi.fn();
+let desktop = true;
+
+vi.mock('@/shared/lib/desktop-shell', () => ({
+  isDesktopShell: () => desktop,
+}));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: (...args: unknown[]) => check(...args),
+}));
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  check.mockReset();
+  desktop = true;
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('직접 누른 확인의 결과', () => {
+  it('뒤에서 도는 자동 확인이 그 답을 지우지 않는다', async () => {
+    // 엔드포인트가 404 인 상황 — 오늘 이 저장소의 실제 상태다(정식 릴리스 0).
+    check.mockRejectedValue(new Error('404'));
+    const { result } = renderHook(() => useAppUpdate());
+
+    await act(async () => {
+      await result.current.check(true);
+    });
+    expect(result.current.phase.kind, '직접 누른 확인이 실패를 보고해야 한다').toBe('failed');
+
+    // 마운트 4초 뒤의 예약된 자동 확인이 이제 발화한다.
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.phase.kind,
+        '자동 확인이 사용자가 받은 답을 지웠다 — 눌렀는데 아무 말 없이 사라진다',
+      ).toBe('failed');
+    });
+  });
+
+  it('최신이라는 답도 마찬가지로 남는다', async () => {
+    check.mockResolvedValue(null);
+    const { result } = renderHook(() => useAppUpdate());
+
+    await act(async () => {
+      await result.current.check(true);
+    });
+    expect(result.current.phase.kind).toBe('current');
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase.kind, '「최신이에요」가 사라졌다').toBe('current');
+    });
+  });
+
+  it('웹에서는 자동 확인 자체가 없다', async () => {
+    desktop = false;
+    renderHook(() => useAppUpdate());
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(check).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/app-update/model/use-app-update.ts
+++ b/src/features/app-update/model/use-app-update.ts
@@ -54,28 +54,44 @@ export function useAppUpdate() {
       return;
     }
 
-    setPhase({ kind: 'checking' });
+    /*
+     * ⚠️ **자동 확인은 「새 버전이 있다」일 때만 말한다** (2026-08-20 실측으로
+     * 정정). 그 밖의 경우에는 상태를 **아예 건드리지 않는다.**
+     *
+     * 종전에는 자동 경로도 `checking` 과 `idle` 을 썼다. 그래서 사용자가
+     * 「업데이트 확인」을 누른 직후 예약된 자동 확인이 발화하면, 방금 받은 답을
+     * **조용히 지웠다** — 눌렀더니 뭔가 떴다가 아무 말 없이 사라지는 화면이 된다.
+     *
+     * 하필 **실패일 때만** 그랬다: 성공하면 `LAST_CHECK_KEY` 가 쓰여 자동 확인이
+     * 간격에 걸려 건너뛰는데, 실패는 그 값을 안 쓰므로 자동 확인이 그대로 돈다.
+     * 그리고 오늘 이 저장소의 엔드포인트는 정식 릴리스가 없어 **항상 실패**다 —
+     * 즉 이 결함은 예외가 아니라 기본 경로였다.
+     *
+     * 이건 원래 의도이기도 하다. 토스트가 자기 문서에 적어 둔 그대로:
+     * *"`checking` 단계는 그리지 않는다 … 결과가 「새 버전 있음」일 때 처음
+     * 말을 건다."* 코드가 그 약속을 안 지키고 있었다.
+     */
+    if (manual) setPhase({ kind: 'checking' });
     try {
       const { check: checkForUpdate } = await import('@tauri-apps/plugin-updater');
       const update = await checkForUpdate();
       write(LAST_CHECK_KEY, String(Date.now()));
 
       if (!update) {
-        setPhase(manual ? { kind: 'current' } : { kind: 'idle' });
+        if (manual) setPhase({ kind: 'current' });
         return;
       }
       if (!manual && !shouldSurfaceVersion(update.version, read(DISMISSED_VERSION_KEY))) {
-        setPhase({ kind: 'idle' });
+        // 이미 거절한 버전이다. 조용히 넘어가되 **화면은 그대로 둔다.**
         return;
       }
       setPhase({ kind: 'available', version: update.version, notes: update.body ?? null });
     } catch (error) {
       // 자동 확인의 실패는 조용히 넘긴다 — 네트워크가 없다는 이유로 사용자에게
       // 말을 걸 이유가 없다. 사용자가 직접 눌렀을 때만 실패를 보고한다.
+      // **「조용히」는 「지운다」가 아니다** — 위 주석의 결함이 그 혼동이었다.
       if (manual) {
         setPhase({ kind: 'failed', message: error instanceof Error ? error.message : String(error) });
-      } else {
-        setPhase({ kind: 'idle' });
       }
     }
   }, []);


### PR DESCRIPTION
## Summary

소유자가 *"한번 열어서 보여주라! 뭐한건지"* 라고 해서 **설치된 앱을 실제로 열어 찍었더니**, 그 스크린샷에서 결함 둘이 드러났다. **둘 다 이번 라운드에 내가 만든 것이다.**

이 PR 의 요점은 고친 내용보다 그 사실이다 — 계약 2,001개와 단위 7,636개가 전부 초록인 채로 둘 다 살아 있었다. **화면을 열어 보는 것을 대체할 검사는 없었다.**

### ① 눌러서 받은 답을 자동 확인이 지웠다

「업데이트 확인」을 눌러 결과가 떴는데 **화면 캡처에는 그 문장이 없었다** — 마커에는 `resultPhase: failed` 가 잡혔는데도.

원인은 마운트 4초 뒤에 도는 **자동 확인**이다. 자동 경로가 실패를 조용히 넘기려고 `idle` 로 되돌리면서, 사용자가 방금 받은 답까지 같이 지웠다. 사용자에게는 **「눌렀더니 뭔가 떴다가 아무 말 없이 사라졌다」** 가 된다.

하필 **실패일 때만** 그랬다: 성공하면 `LAST_CHECK_KEY` 가 쓰여 자동 확인이 간격에 걸려 건너뛰는데, 실패는 그 값을 안 쓴다. 그리고 지금 이 저장소의 엔드포인트는 정식 릴리스가 없어 **항상 실패**다 — 예외가 아니라 **기본 경로**였다.

**고침**: 자동 확인은 **「새 버전이 있다」일 때만** 말한다. 그 밖에는 상태를 아예 안 건드린다. 이건 원래 의도이기도 했다 — 토스트가 자기 문서에 *"`checking` 단계는 그리지 않는다 … 결과가 「새 버전 있음」일 때 처음 말을 건다"* 고 적어 두고 **코드가 그 약속을 안 지키고 있었다.**

### ② 재지도 않고 「지금은 문제 없어요」라고 말했다

#1175 로 진행 상태만 있어도 결과 블록이 그려지게 되면서, 점검을 **한 번도 안 돌린** 화면이 `blocked.length === 0` 을 타고 초록 문장을 냈다. 그때 그 값의 뜻은 「다 괜찮다」가 아니라 **「아직 아무것도 안 쟀다」** 다.

이 화면이 자기 문서에 첫 번째로 적어 둔 규율이 *"모르는 것을 초록으로 그리지 않는다"* 인데 그것을 정면으로 어긴다. 설치 앱 캡처에서 **「설치 필요」 배지 바로 아래** 「지금은 문제 없어요」가 같이 서 있는 것으로 드러났다.

**고침**: 판정 문장은 **잰 것이 있을 때만** 낸다. 진행 줄은 위에 그대로 남으므로 완료 표시는 잃지 않는다.

## Test plan

- `pnpm test:contracts` 통과 · `pnpm exec tsc --noEmit` 통과 · `pnpm lint` **0 errors / 57 warnings**(래칫 유지)
- acp-doctor **38 passed** · app-update **16 passed**

`use-app-update` 훅에는 **시험이 아예 없었다.** ①은 재현 시험부터 썼다 — 가짜 타이머로 마운트 4초 뒤 자동 확인을 발화시키고, 수동 결과가 살아남는지 본다.

### 게이트 프로브

| 되돌린 결함 | 결과 |
|---|---|
| 자동 경로가 다시 `checking`/`idle` 을 쓰게 | `expected 'idle' to be 'failed'` 로 **1 failed** |
| `!checks` 가드 제거 | 「재지 않은 것을 괜찮다고」 **1 failed** |

### 설치된 앱에서 눈으로 확인

①은 고친 뒤 **다시 빌드·설치해서 찍었고**, 결과 문장이 화면에 남는 것을 확인했다:

```
지금 쓰는 판
1.0.0-rc.9                                  [⟳ 업데이트 확인]
확인하지 못했어요. 인터넷 연결이 없거나, 아직 받을 수 있는 정식 판이 올라오지 않았을 수 있어요.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD