### PR TITLE
chore: 푸시 전에 CI 가 볼 것을 먼저 보는 pre-push 훅

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -46,6 +46,10 @@
 | 새 capability / domain / element 노드 | `docs/ontology/<kind>s/<slug>.md` (dogfood) |
 | `.claude/rules/` 로드 조건 변경 | `CLAUDE.md` 표 + `tests/contract/rules-path-scope.contract.test.ts` |
 
+> **`checks:changed` 목록에서 골라 돌리지 마라** (2026-08-21). 실패는 목록이
+> 아니라 **고른 것**에서 났다 — 08-20 하루에 CI 두 라운드가 그렇게 탔다.
+> `pnpm checks:changed -- --run` 이 전부 돌리고 첫 실패에서 멈춘다.
+
 ## PR
 
 - 제목은 위의 영문 prefix 로 시작. 본문은 `Summary` 와 `Test plan` 두 섹션.
@@ -55,11 +59,11 @@
 ## 함부로 하지 말 것
 
 - `--no-verify` 로 hook 을 건너뛰지 말 것. **이 저장소의 hook 은 실제로 돌아간다**
-  — `pnpm install` 이 git 의 hook 위치를 `.githooks/` 로 바꿔 두고, 거기 있는
-  `pre-commit` 이 "생성된 파일이 원본과 어긋난 채 커밋되는 것"을 커밋하는 순간
-  막는다. 예전에는 이 어긋남이 CI 에서야 터져서 이틀에 세 번 실패했고, 그걸
-  커밋 시점으로 앞당긴 것이다 (`docs/DEVELOPMENT-CHECKS.md`). 막히면 hook 이
-  시키는 명령을 그대로 돌린다.
+  — `pnpm install` 이 git 의 hook 위치를 `.githooks/` 로 바꿔 두고, `pre-commit`
+  이 "생성된 파일이 원본과 어긋난 채 커밋되는 것"을, `pre-push` 가 "`checks:changed`
+  가 지목한 검사가 빨간 채 푸시되는 것"을 그 자리에서 막는다. 예전에는 둘 다
+  CI 에서야 터졌다 (`docs/DEVELOPMENT-CHECKS.md`). 막히면 hook 이 시키는 명령을
+  그대로 돌린다.
 - `git reset --hard` / `git push --force` 는 사용자가 직접 시켰을 때만.
 - main 에 force push 절대 금지.
 - **자동 생성된 JSON 의 충돌을 손으로 고치지 말 것.** `src/entities/docs-vault/data/*`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,75 @@
+#!/bin/sh
+# 푸시 전에 CI 가 볼 것을 먼저 본다 (2026-08-21)
+#
+# ## 왜 생겼나
+#
+# `pnpm checks:changed` 는 **무엇을 돌릴지 정확히 지목해 왔다.** 문제는 그
+# 목록을 받아 **일부만 골라 돌리는 것**이었다. 2026-08-20 하루에 CI 두 라운드가
+# 그렇게 탔다 — `test:contracts` 만 돌리고 `test:run` 과 e2e 를 건너뛰었고,
+# 건너뛴 자리에서 정확히 터졌다. 그 사이 브랜치는 못 머지하고 대기했다.
+#
+# 옆의 `pre-commit` 이 같은 교훈을 이미 적어 뒀다: **기억에 의존하는 규율은
+# 세 번 이상 반복되면 규율이 아니라 사고 대기열이다.** 그래서 판정을 8분 뒤
+# CI 에서 푸시 자리로 옮긴다. 고르는 여지를 없애는 것이 요점이다.
+#
+# ## 무엇을 재나 — **푸시되는 범위**다, 작업본이 아니라
+#
+# `pre-commit` 이 작업본 대신 인덱스를 재는 것과 같은 이유다: 커밋이 남기는
+# 것은 인덱스이고, **푸시가 남기는 것은 커밋 범위**다. 작업본을 재면 이미
+# 커밋해 둔 변경을 놓치고, 아직 커밋 안 한 변경을 잘못 센다.
+#
+# git 이 stdin 으로 `<local ref> <local sha> <remote ref> <remote sha>` 를 준다.
+#  · remote sha 가 0 이면 원격에 없는 새 브랜치다 → 기준선에서 갈라진 지점부터
+#  · local sha 가 0 이면 브랜치 삭제다 → 잴 것이 없다
+#
+# ## 우회
+#
+# `--no-verify` 인데 `.claude/rules/git.md` 가 금지한다. 급하면 그 규칙을 먼저
+# 고쳐라 — 훅을 조용히 건너뛰는 것이 아니라.
+
+set -e
+
+# 훅이 자기 자신을 검사 대상으로 삼지 않게, 기준선은 원격의 기본 브랜치다.
+BASE_REF="origin/main"
+ZERO="0000000000000000000000000000000000000000"
+
+ranges=""
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -n "$local_sha" ] || continue
+  case "$local_sha" in "$ZERO") continue ;; esac
+  if [ "$remote_sha" = "$ZERO" ]; then
+    # 새 브랜치 — 기준선에서 갈라진 지점부터 잰다. 기준선을 모르면(클론 직후 등)
+    # 판정을 지어내지 않고 그 사실을 말하고 통과시킨다.
+    if base=$(git merge-base "$BASE_REF" "$local_sha" 2>/dev/null); then
+      ranges="$ranges $base..$local_sha"
+    else
+      echo "[pre-push] $BASE_REF 를 못 찾아 범위를 못 정했다 — 검사를 건너뛴다."
+      exit 0
+    fi
+  else
+    ranges="$ranges $remote_sha..$local_sha"
+  fi
+done
+
+# stdin 이 비어 있으면(수동 실행 등) 잴 것이 없다.
+[ -n "$ranges" ] || exit 0
+
+paths=""
+for range in $ranges; do
+  paths="$paths
+$(git diff --name-only "$range" --)"
+done
+
+paths=$(printf '%s\n' "$paths" | sed '/^$/d' | sort -u)
+[ -n "$paths" ] || exit 0
+
+echo "[pre-push] 푸시되는 범위의 변경으로 검사를 고른다 ($(printf '%s\n' "$paths" | wc -l | tr -d ' ') 파일)"
+
+# shellcheck disable=SC2086
+if ! node scripts/suggest-focused-checks.mjs --run $paths; then
+  echo ""
+  echo "[pre-push] CI 가 볼 것을 여기서 먼저 봤고, 빨갛다."
+  echo "[pre-push] 고치고 다시 푸시해라 — CI 를 8분 태우는 것보다 싸다."
+  echo ""
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,8 +279,9 @@ mechanism this budget assumes.)
 - Start structural repo work with CodeGraph, then open only the exact files or symbols still needed.
 - Ask the ontology only focused questions (`get_concept`, `find_path`, `query_ontology` with narrow operations). Avoid full `list_concepts` dumps unless the task genuinely needs the whole vault.
 - Verify focused-first. Start with `pnpm checks:changed` (or `pnpm checks:changed -- <path...>`) and direct sibling/unit/contract checks for touched paths. Escalate to full `pnpm test:run`, `pnpm lint`, `pnpm build`, broad Playwright, or desktop packaging only when shared contracts, routing, config, release surfaces, or user-facing workflows changed, or when focused checks leave a concrete risk uncovered.
-  - **It is also the *last* command before you open a PR** — run what it recommends for
-    every path you touched, not a list you wrote from memory. A hand-written list is
+  - **Do not pick from its list — run all of it.** `pnpm checks:changed -- --run` executes
+    the recommendations and stops at the first failure; a `pre-push` hook runs the same over
+    the pushed range. Every CI round burned here came from picking (`.claude/rules/git.md`). A hand-written list is
     always narrower than the tool, and it only ever errs narrow: 2026-08-01 lost three
     CI rounds to exactly this (docs edited without regenerating the vault, a fourth
     version site missed, a smoke marker outliving its component) and the tool would

--- a/scripts/suggest-focused-checks.mjs
+++ b/scripts/suggest-focused-checks.mjs
@@ -46,6 +46,51 @@ export function untrackedPathsForAdvisor(output) {
   );
 }
 
+/**
+ * 추천을 **그대로 실행**한다 — 첫 실패에서 멈춘다.
+ *
+ * ## 왜 이 모드가 생겼나 (2026-08-21)
+ *
+ * 이 도구는 무엇을 돌릴지 **정확히** 지목해 왔다. 그런데 사람(과 에이전트)이
+ * 그 목록을 받아 **일부만 골라 돌렸다.** 2026-08-20 하루에 CI 두 라운드가
+ * 그렇게 탔다 — `test:contracts` 만 돌리고 `test:run` 과 e2e 를 건너뛰었고,
+ * 건너뛴 자리에서 정확히 터졌다.
+ *
+ * 같은 저장소의 `pre-commit` 훅이 그 교훈을 이미 적어 뒀다: *"기억에 의존하는
+ * 규율은 세 번 이상 반복되면 규율이 아니라 사고 대기열이다."* 고르는 여지를
+ * 없애는 것이 답이고, 그 자리는 **추천기 자신**이다.
+ *
+ * 첫 실패에서 멈추는 이유: 뒤의 검사는 대개 같은 원인으로 무너져서, 다 돌리면
+ * 화면이 길어질 뿐 새 정보가 없다. 고칠 것 하나를 정확히 준다.
+ */
+export function runFocusedChecks({
+  commands = [],
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  spawn = spawnSync,
+} = {}) {
+  if (commands.length === 0) {
+    stdout.write('[focused-checks] 돌릴 것이 없다 — 바뀐 경로에 걸리는 검사가 없다.\n');
+    return 0;
+  }
+  for (const [index, suggestion] of commands.entries()) {
+    stdout.write(`\n[focused-checks] (${index + 1}/${commands.length}) ${suggestion.command}\n`);
+    const result = spawn(suggestion.command, {
+      cwd,
+      shell: true,
+      stdio: 'inherit',
+    });
+    const code = result.status ?? 1;
+    if (code !== 0) {
+      stdout.write(`\n[focused-checks] 실패: ${suggestion.command}\n`);
+      stdout.write('[focused-checks] 고치고 다시 돌려라. 남은 검사는 안 돌렸다.\n');
+      return code;
+    }
+  }
+  stdout.write(`\n[focused-checks] ${commands.length}개 통과\n`);
+  return 0;
+}
+
 export function runSuggestFocusedChecks({
   argv = process.argv.slice(2),
   cwd = process.cwd(),
@@ -58,10 +103,15 @@ export function runSuggestFocusedChecks({
     stdout.write(`${suggestFocusedChecksUsage()}\n`);
     return 0;
   }
+  // `--run` 은 경로가 아니다. 안 걸러내면 그 문자열이 바뀐 파일로 취급된다.
+  const run = args.includes('--run');
+  const pathArgs = args.filter((arg) => arg !== '--run');
   try {
-    const paths = args.length > 0 ? args : changedPathsFromGit({ cwd, spawn });
-    stdout.write(`${formatFocusedCheckSuggestions(suggestFocusedChecks(paths))}\n`);
-    return 0;
+    const paths = pathArgs.length > 0 ? pathArgs : changedPathsFromGit({ cwd, spawn });
+    const suggestions = suggestFocusedChecks(paths);
+    stdout.write(`${formatFocusedCheckSuggestions(suggestions)}\n`);
+    if (!run) return 0;
+    return runFocusedChecks({ commands: suggestions.commands, cwd, stdout, spawn });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     stderr.write(`[focused-checks] ${message}\n`);
@@ -78,6 +128,7 @@ export function suggestFocusedChecksUsage() {
   return `Usage:
   pnpm checks:changed
   pnpm checks:changed -- <path...>
+  pnpm checks:changed -- --run          # 추천을 그대로 실행 (첫 실패에서 멈춘다)
 
 Suggests the first focused checks for changed files so agents avoid full-suite
 verification by default. With no path arguments it

--- a/scripts/suggest-focused-checks.test.mjs
+++ b/scripts/suggest-focused-checks.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import {
   changedPathsFromGit,
+  runFocusedChecks,
   runSuggestFocusedChecks,
   stripLeadingSeparator,
   suggestFocusedChecksUsage,
@@ -116,5 +117,92 @@ describe('focused check suggestion CLI', () => {
         'scripts/new-helper.mjs',
       ],
     );
+  });
+});
+
+/**
+ * `--run` — **추천을 그대로 실행한다.**
+ *
+ * 2026-08-21 에 생겼다. 이 도구는 무엇을 돌릴지 정확히 지목해 왔는데, 사람과
+ * 에이전트가 그 목록을 받아 **일부만 골라 돌렸다.** 08-20 하루에 CI 두 라운드가
+ * 그렇게 탔다. 그래서 고르는 여지를 없앤다.
+ */
+describe('focused checks --run', () => {
+  it('추천을 순서대로 다 돌린다', () => {
+    const ran = [];
+    const code = runFocusedChecks({
+      commands: [{ command: 'a' }, { command: 'b' }],
+      stdout: { write() {} },
+      spawn(command) {
+        ran.push(command);
+        return { status: 0 };
+      },
+    });
+    assert.equal(code, 0);
+    assert.deepEqual(ran, ['a', 'b']);
+  });
+
+  it('첫 실패에서 멈추고 그 종료 코드를 그대로 올린다', () => {
+    const ran = [];
+    const code = runFocusedChecks({
+      commands: [{ command: 'ok' }, { command: 'bad' }, { command: 'never' }],
+      stdout: { write() {} },
+      spawn(command) {
+        ran.push(command);
+        return { status: command === 'bad' ? 3 : 0 };
+      },
+    });
+    // 뒤의 검사는 대개 같은 원인으로 무너진다 — 고칠 것 하나를 정확히 준다.
+    assert.equal(code, 3);
+    assert.deepEqual(ran, ['ok', 'bad']);
+  });
+
+  it('spawn 이 상태를 안 주면 실패로 친다 — 모르는 것을 통과로 바꾸지 않는다', () => {
+    const code = runFocusedChecks({
+      commands: [{ command: 'x' }],
+      stdout: { write() {} },
+      spawn: () => ({}),
+    });
+    assert.equal(code, 1);
+  });
+
+  it('돌릴 것이 없으면 0 이다 — 없는 것을 실패로 만들지 않는다', () => {
+    assert.equal(runFocusedChecks({ commands: [], stdout: { write() {} } }), 0);
+  });
+
+  it('`--run` 은 경로로 새지 않는다', () => {
+    // 안 걸러내면 그 문자열이 「바뀐 파일」로 취급돼 추천이 통째로 달라진다.
+    const ran = [];
+    runSuggestFocusedChecks({
+      argv: ['--', '--run', 'src/shared/lib/cn.ts'],
+      stdout: { write() {} },
+      spawn(command, options) {
+        // git 호출은 여기 오지 않는다(경로를 인자로 줬으므로).
+        ran.push({ command, shell: options?.shell === true });
+        return { status: 0 };
+      },
+    });
+    assert.ok(ran.length > 0, '추천이 하나도 안 돌았다');
+    assert.ok(
+      ran.every((entry) => entry.shell),
+      '검사는 셸로 돌아야 한다(파이프·인용이 든 명령이 있다)',
+    );
+    assert.ok(
+      !ran.some((entry) => String(entry.command).includes('--run')),
+      '`--run` 이 경로로 새어 명령에 들어갔다',
+    );
+  });
+
+  it('`--run` 없이는 아무것도 실행하지 않는다 — 추천만 한다', () => {
+    let spawned = 0;
+    runSuggestFocusedChecks({
+      argv: ['--', 'src/shared/lib/cn.ts'],
+      stdout: { write() {} },
+      spawn() {
+        spawned += 1;
+        return { status: 0 };
+      },
+    });
+    assert.equal(spawned, 0);
   });
 });

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -46,7 +46,7 @@
       "headings": [],
       "excerpt": "2026-07-27 update — the current architecture is a local-first, git-backed meaning layer: a folder of markdown files that records what each part of the product is, who owns it, what it depends on, and what proves it. People and AI coding agents read and write that same folder. Round 10 permanently removed every login an",
       "wordCount": 3894,
-      "updatedAt": "2026-08-20",
+      "updatedAt": "2026-08-21",
       "linksOut": [
         "../AGENTS",
         "PRODUCT-DIRECTION",
@@ -491,7 +491,7 @@
       "headings": [],
       "excerpt": "이 파일은 결정과 그때 진 반대 의견을 남긴다. docs/CHANGELOG.md 는 무엇이 언제 바뀌었나를 답하고, 이 파일은 왜 그렇게 정했고, 무엇을 걸었나를 답한다. 최신이 위. 기록은 덧붙이기만 한다 — 지난 기록을 고치지 않는다. 판단이 바뀌었으면 새 기록을 쓰고 옛 기록을 뒤집힘 으로 표시한다. 틀린 기록도 자산이다. 1. 소집 전에 읽는다. 카운슬을 열기 전(그리고 단독 PO 패스를 쓰기 전) 같은 표면 · 같은 질문에 대한 선행 결정이 있는지 먼저 본다. 있으면 새 패스는 그것을 ① 여전히 유효하다고 인용하거나 ② 명시적으로 뒤집는다. 조용히 다시 결정",
       "wordCount": 156380,
-      "updatedAt": "2026-08-20",
+      "updatedAt": "2026-08-21",
       "linksOut": [
         "slug"
       ]
@@ -597,7 +597,7 @@
       "headings": [],
       "excerpt": "Complete inventory of features users can actually use right now. Last updated: 2026-08-02 (지금 있는 라우트, 설치한 앱이 지키기로 한 약속, 프로젝트가 무엇을 뜻하는지 확정한 기록(project meaning receipt)을 다시 확인했다 — /ontology 는 /topology?index=expanded 로, /ontology/edit 은 /ontology/studio 로 보내는 옛 주소 호환 redirect 이고, Insights 는 할 일 · 구성 · 연결 · 경계 · 신선도 다섯 개 ",
       "wordCount": 20526,
-      "updatedAt": "2026-08-20",
+      "updatedAt": "2026-08-21",
       "linksOut": [
         "slug",
         "project:slug",


### PR DESCRIPTION
## Summary

소유자 지시: *"CI하기전에 로컬에서 다 성공하게 해서 머지하게 하던지"*.

**문제는 도구가 아니라 「고르는 것」이었다.** `pnpm checks:changed` 는 무엇을 돌릴지 **정확히 지목해 왔다.** 2026-08-20 하루에 CI 두 라운드가 탔는데, 두 번 다 그 목록을 받아 **일부만 골라 돌린** 결과였다 — `test:contracts` 만 돌리고 `test:run` 과 e2e 를 건너뛴 뒤, **건너뛴 자리에서 정확히** 터졌다. 그 사이 브랜치는 못 머지하고 대기했다.

옆의 `pre-commit` 훅이 그 교훈을 이미 적어 뒀다:

> **기억에 의존하는 규율은 세 번 이상 반복되면 규율이 아니라 사고 대기열이다.**

그래서 고르는 여지를 없앤다.

### 무엇이 생겼나

1. **`pnpm checks:changed -- --run`** — 추천을 **그대로 실행**하고 **첫 실패에서 멈춘다**. 뒤의 검사는 대개 같은 원인으로 무너져서 다 돌리면 화면만 길어진다. 고칠 것 하나를 정확히 준다.
2. **`.githooks/pre-push`** — 푸시할 때 그것을 돌린다. 이미 `pnpm install` 이 `core.hooksPath` 를 `.githooks/` 로 잡아 두므로 **배선이 따로 필요 없다.**

### 무엇을 재나 — **푸시되는 범위**다, 작업본이 아니라

`pre-commit` 이 작업본 대신 인덱스를 재는 것과 같은 이유다: 커밋이 남기는 것은 인덱스이고, **푸시가 남기는 것은 커밋 범위**다. git 이 stdin 으로 주는 `<local sha> <remote sha>` 로 범위를 만든다.

- 원격에 없는 새 브랜치(`remote sha` 가 0) → `origin/main` 과 갈라진 지점부터
- 브랜치 삭제(`local sha` 가 0) → 잴 것이 없다
- 기준선을 못 찾으면 → **판정을 지어내지 않고** 그 사실을 말하고 통과시킨다

## Test plan

### 게이트 프로브 — 결함을 넣고 실제로 빨개지는지

`<main>` 랜드마크를 깨뜨린 커밋을 만들고 훅을 돌렸다:

```
exit=1  elapsed=2s
  × `<main>` 랜드마크를 소유한다 — 이 저장소는 셸이 아니라 뷰가 소유한다
[focused-checks] 실패: pnpm exec vitest run src/views/agents/ui/AgentsPage.test.tsx
[pre-push] CI 가 볼 것을 여기서 먼저 봤고, 빨갛다.
```

**CI 가 8분 걸려 찾던 것을 2초에 잡고, 고칠 명령을 정확히 지목한다.**

### 실측 시간

| 범위 | 시간 | 결과 |
|---|---|---|
| 2파일(이 PR 초기) | **1초** | 초록 |
| 7검사(이 PR 최종) | **19초** | 초록 |
| 35파일(`/agents` PR 범위) | **72초** | 14/21 에서 빨강 ↓ |

추천기가 잘 좁혀 주므로 작은 변경은 **1초**다. 큰 변경도 72초 — CI 8분보다 훨씬 싸다.

### ⚠️ 훅이 이 PR 의 저자를 잡았다

최악값 측정에서 `14/21` 이 빨갰는데, **이미 머지된 범위**라 이상했다. 원인은 내가 방금 쓴 문서였다:

```
× 상주 총량이 20KB 를 넘지 않는다 — 되돌아가는 길에 저항을 둔다
AssertionError: expected 20781 to be less than 20000
```

상주 규칙(`git.md`)에 20줄을 더해 예산을 781바이트 넘겼다. 매 턴 실리는 파일이라 진짜 비용이고, `CLAUDE.md` 가 *"여기 무엇을 더하면 다른 무엇이 밀려난다"* 고 적어 둔 그대로다. 압축해서 예산 안으로 되돌렸다.

**이건 프로브가 아니라 실전이었다** — 훅이 없었으면 이 PR 도 CI 한 라운드를 태웠을 것이다.

### 단위 시험 6종

`--run` 모드에 붙였다: 순서대로 다 돌리나 · 첫 실패에서 멈추고 그 코드를 올리나 · `spawn` 이 상태를 안 주면 **실패로 치나**(모르는 것을 통과로 바꾸지 않는다) · 돌릴 것이 없으면 0인가 · **`--run` 이 경로로 새지 않나**(안 걸러내면 그 문자열이 「바뀐 파일」로 취급돼 추천이 통째로 달라진다) · `--run` 없이는 아무것도 실행하지 않나.

### 기준선

`node --test scripts/suggest-focused-checks.test.mjs` **12 passed** · `rules-path-scope` 6 passed · `pnpm agents:check` ok(AGENTS.md 32,455/32,768) · 그리고 **이 브랜치를 훅 자신으로 검증**했다(7검사 19초 초록).

## buzz 참고

`block/buzz`(Apache-2.0)가 `lefthook.yml` 의 `pre-push` 로 정확히 같은 일을 한다 — 경로별로 `rust-tests` · `desktop-check` · `desktop-typecheck` · `desktop-test` 등을 푸시 자리에서 돌린다. 그 파일 머리말이 *"아래 glob 은 CI 의 `changes` 잡 필터를 거울처럼 따른다"* 로 시작하고, **의도적으로 다르게 둔 것 다섯**을 하나하나 적어 뒀다.

**구조만 배웠다.** 우리는 경로 필터를 복제하지 않는다 — `checks:changed` 가 이미 그 매핑의 단일 출처이고, 훅은 그것을 부르기만 한다. buzz 가 `file-size-check` 에 대해 *"자기 merge-base diff 가 곧 경로 필터"* 라고 적은 것과 같은 이유다. YAML·문구는 옮기지 않았다.

## 남은 것

이 훅은 **마지막 그물이지 첫 그물이 아니다.** 푸시 자리에서 처음 빨개지면 그때부터 고치는 왕복이 시작된다 — 규칙에도 그렇게 적었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD