### PR TITLE
fix: 릴리스 리허설의 도구 확인에 상한을 두고, 모르는 것을 없다고 말하지 않는다

### DIFF
--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -426,12 +426,28 @@ const RULES = [
   {
     command: 'pnpm exec tsc --noEmit',
     reason: 'TypeScript or Next.js static export config changed',
+    /*
+     * ⚠️ **테스트 파일을 빼면 안 된다** (2026-08-21 정정).
+     *
+     * 종전에는 `src/**` 의 `.test.`/`.spec.` 를 부정 전방탐색으로 빼고
+     * `tests/**` 는 아예 안 봤다. 「테스트는 제품 타입에 영향이 없다」는 전제였을
+     * 텐데, **`tsconfig.json` 의 `include` 는 `**\/*.ts` 전부**라 CI 의
+     * `tsc --noEmit` 은 그것들을 검사한다. 그리고 **vitest 는 타입을 안 본다** —
+     * 즉 테스트만 고친 사람은 로컬에서 타입 오류를 만날 방법이 아예 없었고,
+     * `Types · Lint · Docs` 잡에서야 처음 빨개졌다.
+     *
+     * 실제로 그렇게 터졌다(2026-08-21 `#1180`): 계약 시험에 가짜 `spawn` 스텁을
+     * 넣었는데 `SpawnSyncReturns` 와 안 맞았다. 단위 시험 25개는 전부 초록이었다.
+     *
+     * 이 저장소가 게이트에 대해 정해 둔 것 그대로다: **검사가 보는 범위와
+     * 추천기가 보는 범위가 다르면, 그 차이만큼이 CI 에서야 터진다.**
+     */
     matches: [
       /^app\/.*\.(?:ts|tsx)$/,
       /^next\.config\.ts$/,
       /^next-env\.d\.ts$/,
-      /^src\/(?!.*\.(?:test|spec)\.).*\.(?:ts|tsx)$/,
-      /^src\/i18n\/.*\.ts$/,
+      /^src\/.*\.(?:ts|tsx)$/,
+      /^tests\/.*\.(?:ts|tsx)$/,
       /^tsconfig\.json$/,
     ],
   },

--- a/scripts/lib/focused-check-suggestions.test.mjs
+++ b/scripts/lib/focused-check-suggestions.test.mjs
@@ -769,9 +769,18 @@ describe('focused check suggestions', () => {
       'tests/e2e/local-vault-picker.spec.ts',
     ]);
 
+    /*
+     * ⚠️ `tsc` 가 뒤에 붙는다 (2026-08-21 추가). e2e 스펙도 TypeScript 이고
+     * `tsconfig.json` 의 `include` 는 `**\/*.ts` 전부라, CI 의 `tsc --noEmit`
+     * 이 이 파일들을 실제로 검사한다. 종전에는 추천기만 그것을 몰라서, 스펙을
+     * 고친 사람은 타입 오류를 CI 에서야 만났다(`#1180`).
+     *
+     * 순서는 그대로다 — 직접 스펙이 먼저다.
+     */
     assert.deepEqual(result.commands.map((row) => row.command), [
       'pnpm exec playwright test tests/e2e/ontology-ui.spec.ts',
       'pnpm exec playwright test tests/e2e/local-vault-picker.spec.ts',
+      'pnpm exec tsc --noEmit',
     ]);
   });
 
@@ -1068,5 +1077,41 @@ describe('focused check suggestions', () => {
       ),
       '문구와 무관한 화면에도 데스크톱 게이트를 권한다 — 규칙이 너무 넓다',
     );
+  });
+
+  /**
+   * **타입 검사의 사정거리는 `tsconfig` 가 정한다 — 추천기가 아니라.**
+   *
+   * 2026-08-21 `#1180` 에서 터졌다: 계약 시험 파일만 고쳤는데 CI 의
+   * `Types · Lint · Docs` 가 타입 오류로 빨개졌다. 로컬에서는 만날 방법이
+   * 없었다 — 추천기가 테스트 파일에 `tsc` 를 안 권했고, **vitest 는 타입을 안
+   * 본다.** 그런데 `tsconfig.json` 의 `include` 는 `**\/*.ts` 전부다.
+   *
+   * 검사가 보는 범위와 추천기가 보는 범위가 다르면, **그 차이만큼이 CI 에서야
+   * 터진다.**
+   */
+  it('타입 검사를 tsconfig 가 보는 곳 전부에 권한다 — 테스트 파일도 포함', () => {
+    const typecheck = (path) =>
+      suggestFocusedChecks([path]).commands.some(
+        (s) => s.command === 'pnpm exec tsc --noEmit',
+      );
+
+    // 종전에 빠져 있던 둘 — 이것이 이 시험의 존재 이유다.
+    assert.ok(typecheck('tests/contract/release-preflight.contract.test.ts'), 'tests/**');
+    assert.ok(typecheck('src/shared/lib/cn.test.ts'), 'src 의 테스트 파일');
+
+    // 종전에도 되던 것이 그대로 되는지 — 좁히면서 넓힌 게 아님을 확인한다.
+    assert.ok(typecheck('src/shared/lib/cn.ts'), 'src 의 제품 코드');
+    assert.ok(typecheck('app/[locale]/agents/page.tsx'), 'app/**');
+    assert.ok(typecheck('tsconfig.json'), 'tsconfig 자신');
+  });
+
+  it('타입이 없는 파일에는 타입 검사를 권하지 않는다 — 넓히기만 한 게 아니다', () => {
+    const typecheck = (path) =>
+      suggestFocusedChecks([path]).commands.some(
+        (s) => s.command === 'pnpm exec tsc --noEmit',
+      );
+    assert.ok(!typecheck('docs/DECISIONS.md'));
+    assert.ok(!typecheck('scripts/build-docs-vault.mjs'));
   });
 });

--- a/scripts/release-rehearsal.mjs
+++ b/scripts/release-rehearsal.mjs
@@ -108,6 +108,44 @@ export const REHEARSAL_SLOW_STEPS = new Set([
  * (`- name:` 다음 `run:`), 의존 하나를 더 지는 것보다 이 파일이 스스로
  * 설명되는 편이 낫다. 뽑히는 단계 수는 계약 테스트가 지킨다.
  */
+/**
+ * 도구 확인에 두는 상한(ms).
+ *
+ * ## 왜 상한이 필요했나 (2026-08-21)
+ *
+ * `--list` 는 「무엇이 돌 것이고, 이 기계에서 무엇이 안 되나」를 보여 준다
+ * (`docs/DEPLOYMENT.md`). 그래서 도구 넷을 실제로 불러 본다 — 그 자체는 옳다.
+ * 문제는 **상한이 없었다**는 것이다.
+ *
+ * 실측: 이 기계 **0.18초**, CI 러너 **9.75초**. 러너에서 `cargo`/`rustc` 는
+ * rustup 심을 거쳐 뜨느라 첫 호출이 느리다. 그리고 그 9.75초가
+ * vitest 의 기본 시험 상한(5초)을 넘겨, **계약 하나가 무작위로 빨개졌다**
+ * (2026-08-21 `#1178` 에서 관측 → 재실행하니 통과).
+ *
+ * 이 저장소의 규율 그대로다: **기계 속도에 매인 게이트는 게이트가 아니다**
+ * (`.claude/rules/architecture.md`). 도구가 느린 것은 이 검사가 답할 질문이
+ * 아니므로, 못 기다린 것은 **못 기다렸다고** 말하고 넘어간다.
+ *
+ * 시험이 이 값을 낮춰 세 번째 상태를 실제로 만들 수 있어야 해서 env 로 연다 —
+ * 만들 수 없는 상태는 검사할 수 없고, 검사 못 하는 분기는 조용히 썩는다.
+ */
+export const PROBE_TIMEOUT_MS = Number(process.env.RELEASE_REHEARSAL_PROBE_TIMEOUT_MS) || 5_000;
+
+/**
+ * 도구 하나를 불러 본다. **셋 중 하나**를 돌려준다 — `ok` · `missing` ·
+ * `unknown`(상한에 걸림). 「모른다」를 「없다」로 접지 않는 것이 이 함수의 요점이다.
+ */
+export function probeTool(tool, args, { spawn = spawnSync, timeout = PROBE_TIMEOUT_MS } = {}) {
+  const probe = spawn(tool, args, { encoding: "utf8", timeout });
+  if (probe.status === 0) {
+    return { state: "ok", version: String(probe.stdout ?? "").trim().split("\n")[0] };
+  }
+  // Node 는 상한에 걸리면 자식을 신호로 죽인다(`SIGTERM`). 실행 파일이 아예
+  // 없을 때는 `error.code === 'ENOENT'` 다 — 둘은 다른 사실이다.
+  const timedOut = probe.signal != null || probe.error?.code === "ETIMEDOUT";
+  return { state: timedOut ? "unknown" : "missing" };
+}
+
 export function parseReleaseJobSteps(workflow, jobName) {
   const jobStart = workflow.indexOf(`\n  ${jobName}:`);
   if (jobStart < 0) throw new Error(`release-macos.yml 에 ${jobName} 잡이 없다.`);
@@ -416,11 +454,21 @@ function main() {
   console.log(color(1, "[rehearsal] release-macos.yml · admit-release + build-macos — 이 기계에서 순서대로"));
   console.log("");
   for (const [tool, args] of tools) {
-    const probe = spawnSync(tool, args, { encoding: "utf8" });
-    const ok = probe.status === 0;
-    console.log(
-      `${ok ? color(32, "  tool ok  ") : color(31, "  tool MISSING")} ${tool}${ok ? ` — ${probe.stdout.trim().split("\n")[0]}` : " — 러너에는 설치 단계가 있다. 이 기계에 없으면 아래 단계가 여기서 멈춘다."}`,
-    );
+    const probe = probeTool(tool, args);
+    if (probe.state === "ok") {
+      console.log(`${color(32, "  tool ok  ")} ${tool} — ${probe.version}`);
+    } else if (probe.state === "unknown") {
+      // **모르는 것을 없다고 말하지 않는다.** 상한에 걸린 것은 「이 기계에 없다」가
+      // 아니라 「제때 답을 못 받았다」다. 둘을 같은 말로 쓰면 다음 사람이 멀쩡한
+      // 도구를 설치하러 간다.
+      console.log(
+        `${color(33, "  tool ?    ")} ${tool} — ${PROBE_TIMEOUT_MS}ms 안에 답이 없어 확인 못 했다(없다는 뜻이 아니다).`,
+      );
+    } else {
+      console.log(
+        `${color(31, "  tool MISSING")} ${tool} — 러너에는 설치 단계가 있다. 이 기계에 없으면 아래 단계가 여기서 멈춘다.`,
+      );
+    }
   }
   console.log("");
 

--- a/scripts/release-rehearsal.mjs
+++ b/scripts/release-rehearsal.mjs
@@ -134,6 +134,23 @@ export const PROBE_TIMEOUT_MS = Number(process.env.RELEASE_REHEARSAL_PROBE_TIMEO
 /**
  * 도구 하나를 불러 본다. **셋 중 하나**를 돌려준다 — `ok` · `missing` ·
  * `unknown`(상한에 걸림). 「모른다」를 「없다」로 접지 않는 것이 이 함수의 요점이다.
+ *
+ * ⚠️ `spawn` 의 타입을 **이 함수가 실제로 읽는 네 자리로만** 좁혀 둔다.
+ * `typeof spawnSync` 로 두면 시험이 스텁을 넣을 때 `pid`·`output`·`stderr`
+ * 처럼 **여기서 안 보는 필드까지** 채워야 하고, 그러면 스텁이 사실이 아닌 값을
+ * 지어내게 된다. 이음매는 그것을 쓰는 쪽의 실제 요구만큼만 넓은 것이 맞다.
+ *
+ * @param {string} tool
+ * @param {string[]} args
+ * @param {{
+ *   spawn?: (tool: string, args: string[], options: Record<string, unknown>) => {
+ *     status?: number | null,
+ *     signal?: NodeJS.Signals | string | null,
+ *     stdout?: string | null,
+ *     error?: { code?: string } | null,
+ *   },
+ *   timeout?: number,
+ * }} [options]
  */
 export function probeTool(tool, args, { spawn = spawnSync, timeout = PROBE_TIMEOUT_MS } = {}) {
   const probe = spawn(tool, args, { encoding: "utf8", timeout });

--- a/tests/contract/release-preflight.contract.test.ts
+++ b/tests/contract/release-preflight.contract.test.ts
@@ -21,6 +21,8 @@ import {
   localCommandFor,
   parseAdmitReleaseSteps,
   parseBuildMacosSteps,
+  PROBE_TIMEOUT_MS,
+  probeTool,
 } from "../../scripts/release-rehearsal.mjs";
 import { RELEASE_ARTIFACT_STEPS } from "../../scripts/build-macos-release-artifact.mjs";
 
@@ -187,7 +189,19 @@ describe("리허설이 릴리스 잡을 빠짐없이 덮는다", () => {
     ]);
   });
 
-  it("태그 없이 목록을 보면 admission이 검증됐다고 가장하지 않고 명시적으로 SKIP 한다", () => {
+  /*
+   * ⚠️ **이 시험은 한때 무작위로 빨갰다** (2026-08-21, `#1178` 에서 관측).
+   *
+   * `--list` 는 도구 넷을 실제로 불러 본다(그게 「이 기계에서 무엇이 안 되나」의
+   * 답이다). 그런데 상한이 없어서, 러너에서 rustup 심을 거치는 `cargo`/`rustc`
+   * 첫 호출이 느릴 때 **9.75초**가 걸렸다 — vitest 기본 상한 5초를 넘겨 계약이
+   * 터졌다(이 기계에서는 0.18초라 로컬에서는 절대 안 보인다).
+   *
+   * 고친 곳은 둘이다: 스크립트가 도구마다 상한을 두고(`PROBE_TIMEOUT_MS`),
+   * 여기서는 **재는 것이 「빠른가」가 아니라 「무엇을 출력하나」임을 명시**한다.
+   * 기본 상한에 기대면 이 계약은 다시 기계 속도에 매인 게이트가 된다.
+   */
+  it("태그 없이 목록을 보면 admission이 검증됐다고 가장하지 않고 명시적으로 SKIP 한다", { timeout: 60_000 }, () => {
     const rehearsal = spawnSync(process.execPath, ["scripts/release-rehearsal.mjs", "--list"], {
       cwd: root,
       encoding: "utf8",
@@ -199,7 +213,7 @@ describe("리허설이 릴리스 잡을 빠짐없이 덮는다", () => {
     expect(rehearsal.stdout).toContain("ADMISSION SKIP");
   });
 
-  it("태그 목록은 현재 HEAD SHA로 workflow의 admission 두 검사를 나란히 보인다", () => {
+  it("태그 목록은 현재 HEAD SHA로 workflow의 admission 두 검사를 나란히 보인다", { timeout: 60_000 }, () => {
     const sha = currentHeadSha(root);
     const rehearsal = spawnSync(
       process.execPath,
@@ -331,5 +345,55 @@ describe("다운로드 스모크 문구는 살아 있는 카탈로그에서 온�
         retired,
       );
     }
+  });
+});
+
+/**
+ * **도구 확인은 셋을 말한다 — `ok` · 없음 · 「확인 못 함」.**
+ *
+ * 「모른다」를 「없다」로 접으면 다음 사람이 멀쩡한 도구를 설치하러 간다. 그리고
+ * 상한이 없으면 이 확인이 시험 전체를 기계 속도에 묶는다(위 주석의 사고).
+ */
+describe("릴리스 리허설의 도구 확인", () => {
+  it("답한 도구는 버전을 그대로 돌려준다", () => {
+    const result = probeTool("x", ["--version"], {
+      spawn: () => ({ status: 0, stdout: "1.2.3\n다음 줄" }),
+    });
+    expect(result).toEqual({ state: "ok", version: "1.2.3" });
+  });
+
+  it("실행 파일이 없으면 `missing` 이다", () => {
+    const result = probeTool("x", ["--version"], {
+      spawn: () => ({ status: null, error: { code: "ENOENT" } }),
+    });
+    expect(result.state).toBe("missing");
+  });
+
+  it("상한에 걸리면 `unknown` 이다 — 없다고 말하지 않는다", () => {
+    // Node 는 상한에 걸린 자식을 신호로 죽인다. 그것을 「없음」으로 접는 것이
+    // 이 저장소가 로딩·진행 표면 전반에서 금지해 온 「모르는 것을 아는 척」이다.
+    expect(probeTool("x", [], { spawn: () => ({ status: null, signal: "SIGTERM" }) }).state).toBe(
+      "unknown",
+    );
+    expect(
+      probeTool("x", [], { spawn: () => ({ status: null, error: { code: "ETIMEDOUT" } }) }).state,
+    ).toBe("unknown");
+  });
+
+  it("상한을 실제로 넘겨 준다 — 안 넘기면 스크립트가 영영 기다릴 수 있다", () => {
+    let seen: Record<string, unknown> | undefined;
+    probeTool("x", [], {
+      timeout: 1234,
+      spawn: (_tool: string, _args: string[], options: Record<string, unknown>) => {
+        seen = options;
+        return { status: 0, stdout: "" };
+      },
+    });
+    expect(seen?.timeout).toBe(1234);
+  });
+
+  it("기본 상한이 유한하고 0 이 아니다 — 그래야 상한이 상한이다", () => {
+    expect(PROBE_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(PROBE_TIMEOUT_MS)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`release-preflight` 계약이 무작위로 빨개지던 것을 고친다. #1178 에서 관측됐고, 재실행하니 통과했다 — 그때는 「기존 흔들림」으로만 적고 넘어갔는데, 원인이 실제로 있었다.

### 무엇이 흔들렸나

| | |
|---|---|
| 이 기계 | `node scripts/release-rehearsal.mjs --list` **0.18초** |
| CI 러너 | **9.75초** → vitest 기본 상한 **5초**를 넘겨 계약이 터짐 |

`--list` 는 도구 넷(`pnpm`·`bun`·`cargo`·`rustc`)을 **실제로 불러 본다.** 그건 옳다 — `docs/DEPLOYMENT.md` 가 이 모드를 *"what would run, **and what cannot run here**"* 로 정의한다. 러너에서 `cargo`/`rustc` 는 rustup 심을 거쳐 뜨느라 첫 호출이 느리고, 그 시간이 그대로 시험 시간이 됐다.

**문제는 도구 확인이 아니라 상한이 없었던 것이다.** 이 저장소가 이미 못박아 둔 규율 그대로다:

> **밀리초로 게이트를 만들지 않는다 — 기계마다 달라 들쭉날쭉 실패한다.** (`.claude/rules/architecture.md`)

로컬에서는 0.18초라 **영원히 안 보이는** 부류이기도 하다.

### 고친 것 둘

**① 도구마다 상한**(`PROBE_TIMEOUT_MS`, 기본 5초). 도구가 느린 것은 이 검사가 답할 질문이 아니다.

**② 「확인 못 함」을 새 상태로 뒀다.** 상한에 걸린 것을 `MISSING` 으로 접지 않는다:

```
  tool ok    cargo — cargo 1.95.0 (f2d3ce0bd 2026-03-21)
  tool ?     cargo — 5000ms 안에 답이 없어 확인 못 했다(없다는 뜻이 아니다).
  tool MISSING bun — 러너에는 설치 단계가 있다. …
```

**「모른다」를 「없다」로 접으면 다음 사람이 멀쩡한 도구를 설치하러 간다.** Node 는 상한에 걸린 자식을 신호로 죽이고(`signal`), 실행 파일이 아예 없으면 `ENOENT` 다 — **둘은 다른 사실**이라 다르게 말한다.

그리고 계약 두 개에 **명시적 상한**(60초)을 줬다. 기본값에 기대면 이 계약은 다시 기계 속도에 매인 게이트가 된다 — 재는 것은 「빠른가」가 아니라 「무엇을 출력하나」다.

## Test plan

`pnpm exec vitest run tests/contract/release-preflight.contract.test.ts` **25 passed**(20 → 25).

새 시험 5종: 버전을 그대로 돌려주나 · `ENOENT` 는 `missing` 인가 · **상한은 `unknown` 인가**(`signal`·`ETIMEDOUT` 둘 다) · 상한을 실제로 spawn 에 넘기나 · 기본 상한이 유한하고 0이 아닌가.

### 게이트 프로브

| 되돌린 것 | 결과 |
|---|---|
| `timeout` 을 spawn 에서 뺌 | 「상한을 실제로 넘겨 준다」 **빨강** |
| `timedOut` 판정을 `false` 로 고정 | 「상한에 걸리면 `unknown`」 **빨강** |

→ 되돌리니 25 passed.

### 세 번째 상태가 실제로 만들어지는지

상한을 1ms 로 낮춰 확인했다(그래서 env 로 열어 뒀다 — **만들 수 없는 상태는 검사할 수 없고, 검사 못 하는 분기는 조용히 썩는다**):

```
$ RELEASE_REHEARSAL_PROBE_TIMEOUT_MS=1 node scripts/release-rehearsal.mjs --list
  tool ?     pnpm — 1ms 안에 답이 없어 확인 못 했다(없다는 뜻이 아니다).
```

### pre-push 훅으로 검증

방금 머지된 훅(#1179)이 이 브랜치에서 실제로 돌았다 — `pnpm test:contracts` 하나를 정확히 골라 **38초**에 초록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD