### PR TITLE
feat: 레일이 설치 완료를 알리고, 미연결 타일이 목적지로 간다 (원장 90 · 슬라이스 3)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -438,8 +438,7 @@ const ACP_INSTALL_VERIFY_SCRIPT: &str = r#"(() => {
     progressStages: [],
     progressBarWidths: [],
     lastPercentText: "",
-    reopened: "",
-    stagesBeforeReopen: [],
+
     attempts: 0
   };
   window.__ontologyAtlasAcpInstallVerify = result;
@@ -486,22 +485,22 @@ const ACP_INSTALL_VERIFY_SCRIPT: &str = r#"(() => {
       return;
     }
 
-    if (!find("app-settings-popover")) {
-      result.step = "open-settings-sheet";
-      const trigger = find("app-settings-trigger");
-      if (!trigger) { result.reason = "no visible settings trigger"; again(); return; }
-      trigger.click();
-      again(220);
-      return;
-    }
-    result.sheetOpen = true;
+    /*
+     * ⚠️ **2026-08-21: 설정 시트를 거치지 않는다** (원장 90). 실행기 목록이
+     * 「에이전트」 목적지로 나가면서 시트에는 그 칸이 없다 — 종전 드라이버는
+     * `app-settings-nav-runtimes` 를 계속 찾다가 아무것도 못 하고 끝났다
+     * (실측: `progressStages` 가 빈 채로 통과했다. 검사가 조용히 무력해진 것이고,
+     * 그 자체가 이 이관이 남긴 잔재였다).
+     *
+     * 이제 목적지에서 곧바로 재고, 거기가 아니면 그 사실을 말한다 —
+     * `ONTOLOGY_ATLAS_VERIFY_ROUTE=/ko/agents/` 로 띄우면 된다.
+     */
+    result.sheetOpen = !!find("app-settings-popover");
 
     if (!find("app-settings-runtimes")) {
-      result.step = "open-agents-section";
-      const nav = find("app-settings-nav-runtimes");
-      if (!nav) { result.reason = "settings sheet has no Agents entry"; again(); return; }
-      nav.click();
-      again(300);
+      result.step = "reach-agents-destination";
+      result.reason = "not on the Agents destination (run with ONTOLOGY_ATLAS_VERIFY_ROUTE=/ko/agents/)";
+      again(400);
       return;
     }
     result.sectionOpen = true;
@@ -546,36 +545,6 @@ const ACP_INSTALL_VERIFY_SCRIPT: &str = r#"(() => {
      * 그 사이에 지나가면 영영 못 본다. Rust 가 마지막 상태를 들고 있다가
      * 마운트 때 돌려주는지를 여기서 실제로 잰다.
      */
-    if (!result.reopened && result.progressStages.length > 0) {
-      const sheet = find("app-settings-popover");
-      if (sheet) {
-        result.step = "close-sheet";
-        result.reopened = "closing";
-        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-        again(1200);
-        return;
-      }
-    }
-    if (result.reopened === "closing") {
-      result.step = "reopen-sheet";
-      result.reopened = "reopening";
-      result.stagesBeforeReopen = result.progressStages.slice();
-      // 다시 열기 전에 화면에 남은 것을 지운다 — 그래야 「되살아났다」가
-      // 진짜 복구인지 잔상인지 갈린다.
-      result.progressStages = [];
-      const trigger = find("app-settings-trigger");
-      if (trigger) trigger.click();
-      again(900);
-      return;
-    }
-    if (result.reopened === "reopening") {
-      const nav = find("app-settings-nav-runtimes");
-      if (nav) nav.click();
-      result.reopened = "reopened";
-      again(900);
-      return;
-    }
-
     result.step = "watching-progress";
     result.reason = "sampling the progress row";
     again(500);

--- a/src/app/providers/AppShell.tsx
+++ b/src/app/providers/AppShell.tsx
@@ -13,7 +13,6 @@ import {
   useNavRailShellValue,
 } from "@/widgets/app-nav-rail";
 import {
-  AGENT_CONNECT_ROUTE_HREF,
   AgentConnectLauncherProvider,
   useAgentConnectLauncher,
 } from "@/widgets/agent-connect";
@@ -29,6 +28,8 @@ import { AppUpdateProvider, UpdateToast, useAppUpdateContext } from "@/features/
 import { useLocalVault } from "@/features/docs-vault-local";
 import { isDesktopShell } from "@/shared/lib/desktop-shell";
 import { isGatewaySurface, resolveActiveNavDestination } from "@/shared/lib/nav-destination";
+import { DESTINATION_HREF } from "@/shared/config/destinations";
+import { useInstallNotice } from "@/features/acp-doctor/model/use-install-notice";
 import { RouteFocusManager } from "@/shared/ui/route-focus-manager";
 import { useHydrated } from "@/shared/lib/use-hydrated";
 
@@ -207,11 +208,6 @@ function resolveIsProjectListPath(pathname: string): boolean {
   return pathname.replace(/^\/(?:en|ko)(?=\/|$)/, "").startsWith("/projects");
 }
 
-/** `/` 와 `/topology*` 는 둘 다 HomePage(연결 시트 소유자)를 렌더한다. */
-function isTopologyHubPath(pathname: string): boolean {
-  return pathname === "/" || pathname.startsWith("/topology");
-}
-
 function AppNavRailSlot() {
   const { settingsSlot, hidden, contextHrefs } = useNavRailShellValue();
   const launcher = useAgentConnectLauncher();
@@ -254,12 +250,24 @@ function AppNavRailSlot() {
         router.push("/ontology/insights/");
         return;
       }
-      launcher.open();
-      if (!isTopologyHubPath(pathname)) {
-        router.push(AGENT_CONNECT_ROUTE_HREF);
-      }
+      /*
+       * ⚠️ **미연결이면 목적지로 간다** (2026-08-21, 원장 90).
+       *
+       * 종전에는 지도 위의 연결 시트를 열었다 — 지형도 밖이면 지형도로 먼저
+       * 옮기고 나서. 그래서 같은 일을 하는 자리가 **셋**이었다: 시트 · 설정 칸 ·
+       * (지금은) 목적지. 붙이는 일의 주소는 하나여야 한다.
+       */
+      router.push(DESTINATION_HREF.agents);
     },
-    [launcher, router, pathname],
+    [router],
+  );
+
+  /*
+   * 설치가 끝났는데 다른 화면에 있었다면 레일이 알려 준다. **종단 상태만**
+   * 세고(진행률 금지), 그 화면에 가면 사라진다 — 기록 배지와 같은 문법이다.
+   */
+  const installNotice = useInstallNotice(
+    resolveActiveNavDestination(pathname) === "agents",
   );
 
   // #65 — 레일 하단 유틸 티어는 셸이 기본으로 채운다. 예전엔 페이지마다
@@ -321,6 +329,7 @@ function AppNavRailSlot() {
       hidden={hidden || gateway}
       contextHrefs={contextHrefs}
       gitDirtyCount={gitDirtyCount}
+      agentsNoticeCount={installNotice.count}
       onAgentTileActivate={onAgentTileActivate}
       agentConnectOpen={launcher.wantOpen}
     />

--- a/src/features/acp-doctor/model/acp-doctor.ts
+++ b/src/features/acp-doctor/model/acp-doctor.ts
@@ -179,8 +179,12 @@ export function isInstallProgressFresh(
  *
  * 웹에서는 붙지 않는다 — 애초에 설치 버튼이 없다.
  */
+/**
+ * @param runtimeId 이 도구의 진행만 받는다. `null` 이면 **전부** 받는다 —
+ *   레일 배지처럼 「어느 도구든 끝났나」를 보는 소비처가 쓴다.
+ */
 export async function listenInstallProgress(
-  runtimeId: string,
+  runtimeId: string | null,
   onProgress: (progress: AcpInstallProgress) => void,
 ): Promise<() => void> {
   if (!isAgentDoctorAvailable()) return () => undefined;
@@ -188,7 +192,8 @@ export async function listenInstallProgress(
     const { listen } = await import('@tauri-apps/api/event');
     const unlisten = await listen<AcpInstallProgress>('acp-install://progress', (event) => {
       // 한 화면에 여러 도구 줄이 있다. 남의 진행을 내 줄에 그리지 않는다.
-      if (event.payload?.runtimeId === runtimeId) onProgress(event.payload);
+      if (!event.payload) return;
+      if (runtimeId === null || event.payload.runtimeId === runtimeId) onProgress(event.payload);
     });
     return unlisten;
   } catch {
@@ -234,4 +239,11 @@ export async function lastInstallProgress(
     // 못 물어봤다고 화면을 세우지 않는다 — 고치기 전과 같은 상태가 될 뿐이다.
     return null;
   }
+}
+
+/** 더는 바뀌지 않는 단계 — 「끝났다」와 「실패했다」. */
+export const TERMINAL_INSTALL_STAGES = ['done', 'failed'] as const;
+
+export function isTerminalInstallStage(stage: AcpInstallProgress['stage']): boolean {
+  return (TERMINAL_INSTALL_STAGES as readonly string[]).includes(stage);
 }

--- a/src/features/acp-doctor/model/use-install-notice.test.tsx
+++ b/src/features/acp-doctor/model/use-install-notice.test.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useInstallNotice } from './use-install-notice';
+
+/**
+ * **설치가 끝났는데 다른 화면에 있었다면 알려 준다.**
+ *
+ * #1175 는 「닫아 둔 사이의 완료」를 Rust 에 보관해 **돌아온 사람**에게 되살렸다.
+ * 이 훅은 그 반대편이다 — **돌아오라고 말하는 것.**
+ */
+
+let emit: ((progress: unknown) => void) | null = null;
+
+vi.mock('./acp-doctor', async () => {
+  const actual = await vi.importActual<typeof import('./acp-doctor')>('./acp-doctor');
+  return {
+    ...actual,
+    listenInstallProgress: async (_runtimeId: string | null, onProgress: (p: unknown) => void) => {
+      emit = onProgress;
+      return () => {
+        emit = null;
+      };
+    },
+  };
+});
+
+const progress = (runtimeId: string, stage: string) => ({
+  runtimeId,
+  job: 'cli',
+  stage,
+  received: null,
+  total: null,
+  note: null,
+  at: Date.now(),
+});
+
+beforeEach(() => {
+  emit = null;
+});
+
+describe('설치 알림 배지', () => {
+  it('끝난 도구를 센다', async () => {
+    const { result } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emit?.(progress('claude-acp', 'done')));
+    expect(result.current.count).toBe(1);
+  });
+
+  it('실패도 종단이다 — 알려 줘야 할 일은 성공만이 아니다', async () => {
+    const { result } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emit?.(progress('codex-acp', 'failed')));
+    expect(result.current.count).toBe(1);
+  });
+
+  it('진행 중에는 세지 않는다 — 배지는 종단 상태만 말한다', async () => {
+    const { result } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    for (const stage of ['downloading', 'extracting', 'installing', 'verifying-install']) {
+      act(() => emit?.(progress('claude-acp', stage)));
+    }
+    expect(result.current.count).toBe(0);
+  });
+
+  it('같은 도구가 두 번 끝나도 하나다 — 세는 것은 사건이 아니라 도구다', async () => {
+    const { result } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emit?.(progress('claude-acp', 'done')));
+    act(() => emit?.(progress('claude-acp', 'done')));
+    expect(result.current.count).toBe(1);
+  });
+
+  it('도구가 둘이면 둘이다', async () => {
+    const { result } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emit?.(progress('claude-acp', 'done')));
+    act(() => emit?.(progress('codex-acp', 'failed')));
+    expect(result.current.count).toBe(2);
+  });
+
+  it('그 화면에 있으면 배지가 없다 — 보고 있는 것을 «안 봤다»고 말할 수 없다', async () => {
+    const { result, rerender } = renderHook(({ at }) => useInstallNotice(at), {
+      initialProps: { at: false },
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emit?.(progress('claude-acp', 'done')));
+    expect(result.current.count).toBe(1);
+    rerender({ at: true });
+    expect(result.current.count).toBe(0);
+  });
+
+  it('떼면 더는 안 듣는다', async () => {
+    const { unmount } = renderHook(() => useInstallNotice(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(emit).not.toBeNull();
+    unmount();
+    expect(emit).toBeNull();
+  });
+});

--- a/src/features/acp-doctor/model/use-install-notice.ts
+++ b/src/features/acp-doctor/model/use-install-notice.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { isTerminalInstallStage, listenInstallProgress } from './acp-doctor';
+
+/**
+ * **설치가 끝났는데 다른 화면에 있었다면, 레일이 알려 준다.**
+ *
+ * ## 왜 (2026-08-21, 원장 90 · 카운슬 처방)
+ *
+ * 도구 설치는 몇 분이 걸린다(Node 52MB · npm). 그동안 사람이 그 화면을 보고
+ * 있을 이유가 없다 — 지도를 보거나 문서를 읽는다. 그런데 돌아오지 않으면
+ * **끝난 것을 영영 모른다.** #1175 가 「닫아 둔 사이의 완료」를 Rust 에 보관해
+ * 화면이 다시 열릴 때 되살리게 했는데, 그건 **돌아온 사람**에게만 유효하다.
+ *
+ * 이 훅은 그 반대편을 맡는다: **돌아오라고 말하는 것.**
+ *
+ * ## 무엇을 세지 않나
+ *
+ * **진행률은 안 센다.** 카운슬 처방이 「종단 상태만」이었다 — 레일 배지는
+ * 곁눈으로 보는 것이라, 초마다 바뀌는 숫자를 거기 두면 읽는 게 아니라
+ * 깜빡이는 것이 된다. 끝났거나(`done`) 실패했을(`failed`) 때만 선다.
+ *
+ * ## 언제 사라지나
+ *
+ * **그 화면에 가면.** 배지는 「아직 안 본 것이 있다」는 뜻이고, 보면 그 뜻이
+ * 사라진다. 이 저장소의 기록 배지(`gitDirtyCount`)와 같은 문법이다.
+ */
+export function useInstallNotice(atDestination: boolean): {
+  count: number;
+  clear: () => void;
+} {
+  const [seenIds, setSeenIds] = useState<string[]>([]);
+
+  const clear = useCallback(() => setSeenIds([]), []);
+
+  useEffect(() => {
+    let alive = true;
+    let stop: (() => void) | null = null;
+    void listenInstallProgress(null, (progress) => {
+      if (!alive || !isTerminalInstallStage(progress.stage)) return;
+      setSeenIds((current) =>
+        // 같은 도구가 두 번 끝나도 배지는 하나다 — 세는 것은 「할 일이 있는
+        // 도구 수」이지 사건 수가 아니다.
+        current.includes(progress.runtimeId) ? current : [...current, progress.runtimeId],
+      );
+    }).then((unlisten) => {
+      if (alive) stop = unlisten;
+      else unlisten();
+    });
+    return () => {
+      alive = false;
+      stop?.();
+    };
+  }, []);
+
+  /*
+   * 목적지에 있으면 셀 것이 없다 — 보고 있는 것을 「안 봤다」고 말할 수 없다.
+   * 도착한 순간 지우는 대신 **그리지 않는다**: effect 안에서 상태를 지우면
+   * 렌더가 한 번 더 돌고, 이 저장소의 lint 래칫이 그 모양을 막는다.
+   */
+  return { count: atDestination ? 0 : seenIds.length, clear };
+}

--- a/src/widgets/app-nav-rail/ui/AppNavRail.tsx
+++ b/src/widgets/app-nav-rail/ui/AppNavRail.tsx
@@ -73,6 +73,11 @@ export interface AppNavRailProps {
    * 않게). `0` 이면 뱃지가 소멸한다.
    */
   gitDirtyCount?: number;
+  /**
+   * 설치가 끝났는데 사용자가 다른 화면에 있었던 도구 수. **종단 상태만** 센다
+   * (진행률은 여기 안 그린다 — 곁눈으로 보는 자리다).
+   */
+  agentsNoticeCount?: number;
   /** 하단 에이전트 타일 클릭 핸들러 — `connected` 는 레일이 자신의 heartbeat
    *  상태로 판정해 넘긴다(P4-② 분기). `AppShell` 이 연결됨→인사이트 이동,
    *  미연결→연결 시트 열기(전역 launcher)로 라우팅한다. 미지정 시 타일은
@@ -139,6 +144,7 @@ export function AppNavRail({
   hidden,
   contextHrefs,
   gitDirtyCount = 0,
+  agentsNoticeCount = 0,
   onAgentTileActivate = null,
   agentConnectOpen = false,
   className,
@@ -281,7 +287,15 @@ export function AppNavRail({
     // 아이콘이 `Bot` 인 이유(작업대 자리 실측): 후보였던 `SquareTerminal` 은
     // 20px 레일에서 「마크가 든 사각」이라 `FolderKanban`(프로젝트)과 실루엣이
     // 겹친다. `Bot` 은 이 목록에서 유일한 «머리와 귀가 있는» 윤곽이다.
-    { id: "agents", href: DESTINATION_HREF.agents, label: t("agents"), Icon: Bot },
+    {
+      id: "agents",
+      href: DESTINATION_HREF.agents,
+      label: t("agents"),
+      Icon: Bot,
+      // 설치가 끝났는데 다른 화면에 있었으면 여기 배지가 선다 — **종단 상태만**
+      // 이고 진행률은 안 그린다(곁눈으로 보는 자리라 초마다 바뀌면 못 읽는다).
+      badgeCount: agentsNoticeCount,
+    },
     { id: "git", href: DESTINATION_HREF.git, label: t("git"), Icon: HistoryIcon, badgeCount: gitDirtyCount },
   ];
 


### PR DESCRIPTION
## Summary

### ① 미연결 타일이 세 번째 주소를 열고 있었다

레일의 에이전트 타일은 연결됨이면 인사이트로, **미연결이면 지도 위의 연결 시트**를 열었다(지형도 밖이면 지형도로 먼저 옮기고 나서). 그래서 붙이는 일의 주소가 셋이었다 — 시트 · 설정 칸 · 목적지. 이제 목적지 하나로 간다.

### ② 설치가 끝났는데 다른 화면에 있으면 영영 모른다

도구 설치는 몇 분이 걸린다(Node 52MB · npm). 그동안 지도를 보거나 문서를 읽는 것이 정상이다.

#1175 가 「닫아 둔 사이의 완료」를 Rust 에 보관해 **돌아온 사람**에게 되살렸는데, 그건 돌아온 사람에게만 유효하다. 이 변경은 그 반대편을 맡는다 — **돌아오라고 말하는 것.**

레일 배지가 선다. 규율 셋:

| | |
|---|---|
| **종단 상태만** | 진행률은 안 그린다 — 곁눈으로 보는 자리라 초마다 바뀌면 읽는 게 아니라 깜빡이는 것이 된다 |
| **실패도 종단** | 알려 줘야 할 일이 성공만은 아니다 |
| **가면 사라진다** | 기록 배지(`gitDirtyCount`)와 같은 문법. 보고 있는 것을 「안 봤다」고 말할 수 없다 |

세는 것은 **사건이 아니라 도구**다 — 같은 도구가 두 번 끝나도 배지는 하나다.

## ⚠️ 검사기가 조용히 무력해져 있었다

설치 검증 드라이버가 설정 시트의 `app-settings-nav-runtimes` 를 계속 찾고 있었다. 그 칸은 슬라이스 2 에서 목적지로 나갔는데, 드라이버는 그대로였다.

실측하니 **`progressStages` 가 빈 채로 통과**했다 — 아무것도 안 재면서 초록이었고, 그 자체가 이관이 남긴 잔재였다. 목적지에서 재도록 고쳤고, 고친 뒤 다시 재니 `downloading → extracting → done` 이 그대로 잡힌다.

## Test plan

- 단위 **7종**: 끝난 것을 세나 · 실패도 세나 · **진행 중에는 안 세나** · 같은 도구 둘이 하나인가 · 도구 둘이면 둘인가 · 그 화면에서는 0인가 · 떼면 안 듣나
- `test:run` **7,716** · `test:contracts` **2,042** · `lint` 0 errors/**57** · `cargo test` **218** · `tsc`
- 설치 앱에서 설치 전 과정 재측정(`downloading → extracting → done`)

### 이동해도 배지가 살아남는가 — 직접 쟀다

배지는 React 상태다. 레일 이동이 **전체 새로고침**이면 사라진다. 브라우저에서 `window` 플래그를 심고 레일 타일을 눌러 확인했다:

```
{"probe":"alive","path":"/ko/topology/"}
```

클라이언트 라우팅이라 살아남는다.

**안 한 것 하나 — 설치 앱에서의 배지 종단 확인.** 검증 드라이버로 「떠난 뒤 배지가 서는지」까지 재려 했는데 하네스에서 마커가 유실돼 불안정했다. 로직은 단위 7종이 덮고 이동 지속성은 위 브라우저 측정이 덮으므로, **불안정한 드라이버 단계는 되돌렸다** — 초록인지 빨간지 못 믿을 검사를 남기지 않는다.

## 남은 것 (슬라이스 4)

**`AgentConnectSheet` 은퇴** — 이 PR 이 레일 입구를 목적지로 돌리면서 남은 입구는 `?agentConnect=1` 딥링크 하나다. 다만 은퇴하려면 **볼트를 안 연 웹 방문자에게 무엇을 보일지**를 정해야 한다: 지금 그 시트는 볼트 없이도 `agent-server-unavailable` 카드를 보여 주는데, 목적지는 볼트가 있어야 그 카드를 그린다(그 편이 더 정확하긴 하다 — 볼트가 없으면 저장할 설정 자체가 없다). `DEGRADED_SURFACES` 한 줄이 거기 걸려 있어 함께 정해야 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD