### PR TITLE
fix: Dialog 반응형 스펙이 시드 CTA 를 기다리지 않고 건너뛰던 것을 고친다

### DIFF
--- a/tests/e2e/dialog-responsive.spec.ts
+++ b/tests/e2e/dialog-responsive.spec.ts
@@ -41,12 +41,17 @@ test("center Dialog 는 세 폭에서 스크림·폭 공식·수납을 지킨다
   // 실제 문서가 잡힐 때까지 기다린 뒤 연다.
   await page.goto("/ko/docs/", { waitUntil: "domcontentloaded" });
   const seedCta = page.getByRole("button", { name: "시작 시드 만들기" });
-  if (await seedCta.isVisible().catch(() => false)) {
+  const treeButton = page.getByRole("navigation", { name: "문서 목록" }).getByRole("button").first();
+  // ⚠️ `isVisible()` 은 **기다리지 않는다**. 예전에는 goto 직후 그것으로 CTA 를
+  // 물었는데, 아직 안 그려진 그 순간이면 false 가 나와 **클릭을 건너뛰고** 빈
+  // 폴더인 채로 트리를 30초 기다리다 죽었다(2026-08-21 CI 3회 재시도 전부 실패,
+  // 로컬 정적 빌드에서도 재현). 둘 중 무엇이든 먼저 나타날 때까지 기다린 뒤
+  // 판단한다 — 빈 폴더면 CTA, 이미 문서가 있으면 트리다.
+  await expect(seedCta.or(treeButton).first()).toBeVisible({ timeout: 30_000 });
+  if (await seedCta.isVisible()) {
     await seedCta.click();
   }
-  await expect(page.getByRole("navigation", { name: "문서 목록" }).getByRole("button").first()).toBeVisible({
-    timeout: 30_000,
-  });
+  await expect(treeButton).toBeVisible({ timeout: 30_000 });
   await page.getByTestId("docs-sidebar-new-doc").click();
   const dialog = page.getByRole("dialog");
   await expect(dialog, `pageerrors: ${pageErrors.join(" | ") || "(none)"}`).toBeVisible();


### PR DESCRIPTION
## Summary

**main 이 지금 빨갛다.** `dialog-responsive` 가 CI 재시도 3회를 전부 실패하고, 깨끗한 정적 빌드에서 로컬 재현된다. 제품 결함이 아니라 **스펙 자신의 경쟁 조건**이다.

### 무엇이 일어났나

스펙은 `/topology` 에서 볼트를 시드한 뒤 `/docs` 로 간다. 그 사이에 쓰기 완료 레이스가 있다는 것은 **스펙이 자기 주석에 이미 적어 두었고**, 그래서 `/docs` 자신의 시드 CTA 를 누르는 보조 경로를 두었다.

문제는 그 보조 경로를 **`isVisible()` 로 물었다**는 것이다.

```ts
if (await seedCta.isVisible().catch(() => false)) { await seedCta.click(); }
```

`isVisible()` 은 Playwright 의 자동 대기가 **붙지 않는** 즉시 판정이다. `goto` 직후 아직 안 그려진 그 찰나면 `false` 가 나오고, 그러면 **클릭을 건너뛴 채** 빈 폴더 상태로 트리를 30초 기다리다 죽는다. 보조 경로가 정작 필요한 느린 환경에서만 사라지는 구조였다.

측정한 것:

| | 결과 |
|---|---|
| CI (main · 슬라이스 4 브랜치) | 3회 재시도 전부 실패 |
| 로컬 깨끗한 빌드 (`PLAYWRIGHT_STATIC=1`) | 재현 |
| 프로브 — CTA 를 실제로 누르면 | 문서 목록 nav 버튼 **7개** |

프로브로 확인한 실패 시점의 `/docs`: 「빈 폴더 감지됨」 + 시드 CTA 가 그려져 있고 **페이지 에러 0**. 즉 화면은 멀쩡했고 스펙이 그것을 안 눌렀을 뿐이다.

### 고친 방식

둘 중 무엇이든 **먼저 나타날 때까지 기다린 뒤** 판단한다. 빈 폴더면 CTA, 이미 문서가 있으면 트리다.

```ts
await expect(seedCta.or(treeButton).first()).toBeVisible({ timeout: 30_000 });
if (await seedCta.isVisible()) await seedCta.click();
await expect(treeButton).toBeVisible({ timeout: 30_000 });
```

`waitForTimeout` 을 심지 않았다 — 고정 대기는 이 결함을 **느린 기계에서 다시** 만든다. 기다리는 대상은 시간이 아니라 화면이어야 한다.

## ⚠️ 곁다리로 드러난 것 — 로컬 e2e 는 포트가 3100 고정이다

원인을 좁히는 동안 `PORT=4321` 을 붙여 「main 과 브랜치를 따로 재 봤다」고 판단했는데, `playwright.config.ts` 는 `PLAYWRIGHT_BASE_URL` 만 보고 포트는 **3100 고정**이며 로컬은 `reuseExistingServer: true` 다. 그래서 뒤이은 실행들이 **먼저 뜬 서버를 그대로 재사용**했고, 그 오염된 측정이 「main 은 통과한다」는 잘못된 중간 결론을 만들었다. 서버를 죽이고 다시 재니 main 도 빨갰다.

브랜치를 갈라 가며 e2e 를 비교할 때는 `lsof -ti:3100 | xargs kill` 를 먼저 하거나 `PLAYWRIGHT_BASE_URL` 로 포트를 바꾼다.

## Test plan

`pnpm exec playwright test tests/e2e/dialog-responsive.spec.ts --project=smoke --repeat-each=4` → **4 passed** (고치기 전 같은 빌드에서 1 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AjZLaXd2921SuAk5LaeZD