### PR TITLE
fix: 다운로드 페이지의 사실 정합성 · 스크롤 모션

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4155,12 +4155,47 @@ body[data-no-tabbar] [data-tabbar="primary"] {
  * 700ms 아이브로우·리드 → 800ms CTA → 950ms 신뢰줄·계기 스트립. 그 뒤 전경은
  * 영구 정지. 지연 리터럴은 이 안무의 악보 값이라 램프 토큰이 아니다.
  */
+/*
+ * ⚠️ **쉬는 상태는 「보임」이다 — 안무는 그 위에 얹힌다** (2026-08-22 정정).
+ *
+ * 여기 있던 `opacity: 0` 은 안무의 시작 프레임이었는데, 그것이 **기본값**이라
+ * 실질적으로 「JS 가 `.is-in` 을 달아 줄 때까지 이 페이지는 백지」였다. 실측:
+ * 정적 export 인 `/ko/download/` 를 열고 곧바로 찍은 첫 스크린샷에 GNB 만
+ * 있었고 히어로 전체가 비어 있었다. 그 뒤에 서 있는 것이 **JS 32파일 ·
+ * 디코드 2,572KB** 다. 다운로드 페이지의 첫 문장이 번들 파싱 뒤에 있을 이유가
+ * 없다 — 마크업에는 이미 다 들어 있었다.
+ *
+ * 그래서 시작 프레임을 `@starting-style` 로 옮겼다. 값도 시간축도 종전과
+ * 똑같고(`gateway-t***` 지연은 그대로 악보다), 바뀐 것은 **누가 방아쇠를
+ * 당기나** 하나다: 하이드레이션 뒤의 rAF 가 아니라 **첫 스타일 계산**이다.
+ * 그래서 안무는 더 일찍, 더 고르게 시작한다.
+ *
+ * 세 갈래 전부 안전하다.
+ * - `@starting-style` 지원(Chrome/Edge/Safari): 종전과 같은 안무.
+ * - 미지원(구 Firefox): at-rule 을 통째로 무시하므로 **처음부터 다 보인다** —
+ *   잃는 것은 등장 순서(장식)뿐이고 정보는 전부 남는다. 감속 사용자에게 주는
+ *   것과 정확히 같은 대체물이다(아래 base 레이어 carve-out).
+ * - JS 실패: 종전에는 영구 백지, 이제는 전문(全文).
+ *
+ * `.is-in` 은 남겨 둔다 — 쉬는 상태와 같은 값이라 아무 일도 하지 않지만,
+ * `useInViewOnce` 를 쓰는 아래 절들이 여전히 그 클래스를 달고 있고, 스크롤
+ * 타임라인을 못 쓰는 브라우저에서 그쪽의 등장을 지는 것이 이 선언이다.
+ */
 .gateway-rise {
-  opacity: 0;
-  transform: translateY(14px);
+  opacity: 1;
+  transform: none;
   transition:
     opacity var(--motion-fast) var(--motion-ease),
     transform var(--motion-settle) var(--motion-ease);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @starting-style {
+    .gateway-rise {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+  }
 }
 
 .gateway-rise.is-in {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4223,6 +4223,97 @@ body[data-no-tabbar] [data-tabbar="primary"] {
   transition-delay: 950ms;
 }
 
+/*
+ * ── 스크롤이 데려오는 등장 — `animation-timeline: view()` (2026-08-22) ──────
+ *
+ * ## 왜 타이머가 아니라 스크롤인가
+ *
+ * 히어로 아래 세 절(시연·증거·에이전트)의 등장은 지금까지
+ * `useInViewOnce` 가 임계값 0.18 을 넘는 **순간** `.is-in` 을 달고, 거기서부터
+ * 120/240ms 짜리 transition 이 **자기 시계로** 도는 구조였다. 그래서 스크롤을
+ * 멈추든 계속하든 되감든 안무는 똑같이 흘렀다 — 손가락과 화면이 이어져 있지
+ * 않았다.
+ *
+ * 스크롤 타임라인은 그 이음매를 만든다: 진행도의 유일한 입력이 **그 원소가
+ * 스크롤포트 안으로 얼마나 들어왔는가**다. 천천히 굴리면 천천히 도착하고,
+ * 멈추면 멈추고, 되감으면 되감긴다. 그래서 이징이 `linear` 인 것이 옳다 —
+ * 가속·감속은 이미 사람의 손이 준다. 여기에 램프 duration 을 얹으면 두 시계가
+ * 겹쳐 오히려 끈적해진다.
+ *
+ * 메인 스레드도 안 쓴다. rAF 도 스크롤 리스너도 없이 컴포지터가 굴리므로,
+ * 이 페이지가 이미 지고 있는 단일 rAF 루프(`gateway-frame-loop.ts` — 전류장 +
+ * 히어로 오브젝트, 무입력 30초 뒤 휴면)에 **한 프레임도 더하지 않는다.**
+ *
+ * ## 세 갈래 전부 안전하다
+ *
+ * - 지원(Chrome/Edge 115+ · Safari 26+): 스크롤이 안무를 진다.
+ * - 미지원(오늘의 Firefox): `@supports` 가 통째로 꺼지고 `.gateway-rise` 의
+ *   쉬는 상태(= 보임)와 `.is-in` transition 이 그대로 남는다. **잃는 것은
+ *   스크롤 연동뿐이고 등장도 내용도 남는다.**
+ * - 감속: 선언 자체가 `no-preference` 안이라 **존재하지 않는다.** 절은 처음부터
+ *   전부 보인다 — 관문의 다른 안무가 감속에 주는 것과 같은 대체물이다.
+ *   그래서 이 클래스들은 `reduced-motion-equivalent` 계약의
+ *   `INTENTIONALLY_STILL` 에 등재돼 있다(사유도 거기 적혀 있다).
+ *
+ * ## 범위 — 왜 히어로에는 안 거나
+ *
+ * 히어로는 첫 화면이라 스크롤 진행도가 언제나 0 근처다. 거기에 걸면 「처음부터
+ * 다 들어와 있는 것」에 안무를 주는 셈이라 아무 일도 안 일어난다. 첫 화면의
+ * 안무는 위의 `@starting-style` 이 지고, 이 아래는 스크롤이 진다 — **한 원소가
+ * 둘 다 받지 않는다.**
+ */
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    /* 절 머리의 세 줄 — 아이브로우 → 제목 → 부제. 시차는 `-d2`/`-d3` 가
+       이미 쓰는 이름을 그대로 재사용한다(등장 순서는 한 벌이어야 한다).
+       원인(제목)이 먼저 움직이므로 design.md 의 스태거 조건을 만족한다. */
+    .gateway-scroll-rise {
+      animation: gatewayScrollRise linear both;
+      animation-timeline: view();
+      animation-range: entry 10% entry 62%;
+    }
+
+    .gateway-scroll-rise.gateway-rise-d2 {
+      animation-range: entry 16% entry 68%;
+    }
+
+    .gateway-scroll-rise.gateway-rise-d3 {
+      animation-range: entry 22% entry 74%;
+    }
+
+    /* 절의 무대(시연 영상 · 증거 지도 · ACP 장면) — 글보다 무거우므로 더 긴
+       구간에서 더 멀리 온다. 질량이 다르면 도착도 달라야 한다. `scale` 은
+       쓰지 않는다 — 이 저장소에서 확대는 지도 카메라의 뜻이다. */
+    .gateway-scroll-stage {
+      animation: gatewayScrollStage linear both;
+      animation-timeline: view();
+      animation-range: entry 4% entry 78%;
+    }
+  }
+}
+
+@keyframes gatewayScrollRise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes gatewayScrollStage {
+  from {
+    opacity: 0;
+    transform: translateY(34px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* 헤드라인 두 줄 — 자기 줄 상자 안에서 올라온다(마스크 리프트). */
 .gateway-hero-line {
   display: block;

--- a/src/views/download/lib/release-facts.ts
+++ b/src/views/download/lib/release-facts.ts
@@ -68,3 +68,21 @@ export const RELEASE_SIGNING = {
 export function buildDmgName(arch: ReleaseArch): string {
   return `ontology-atlas_${RELEASE_VERSION}_${arch}.dmg`;
 }
+
+/**
+ * Windows 설치 파일의 최소 OS.
+ *
+ * `tauri.conf.json` 에는 이 값을 적는 자리가 없다 — macOS 만
+ * `bundle.macOS.minimumSystemVersion` 을 갖는다. 그래서 진실원은 **런타임의
+ * 바닥**이다: Tauri v2 의 Windows 백엔드는 WebView2 를 쓰고, WebView2 런타임이
+ * 지원하는 가장 낮은 데스크톱 OS 가 Windows 10 이다. 릴리스 검증도 그 계열에서
+ * 돈다(`.github/workflows/windows-beta-check.yml` · `release-macos.yml` 의
+ * `windows-2022` 잡 — 의존성 감사 · Defender 검사 · 무인 설치 · 실행 · 번들
+ * MCP 스모크).
+ *
+ * ⚠️ **이 값은 「우리가 검증한 것」이 아니라 「실행에 필요한 것」이다.** 원장
+ * (2026-08-20)이 명시했듯 Windows 11 실기기의 SmartScreen 화면은 검증되지
+ * 않았고, 그 사실은 히어로의 신뢰줄(`trustLineWindows`)이 따로 진다. 이 줄이
+ * 그 경고를 대신하지 않는다.
+ */
+export const RELEASE_MIN_WINDOWS = "Windows 10";

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -12,7 +12,7 @@ import { PAGE_COLUMN, PAGE_GUTTER } from '@/shared/lib/gateway-frame';
 import { GatewayNav, GatewayReadingLinks } from '@/widgets/gateway-chrome';
 import { DemoStage } from './DemoStage';
 import { buttonVariants } from '@/shared/ui';
-import { RELEASE_MIN_MACOS, RELEASE_VERSION } from '../lib/release-facts';
+import { RELEASE_MIN_MACOS, RELEASE_MIN_WINDOWS, RELEASE_VERSION } from '../lib/release-facts';
 import {
   MACOS_RELEASE,
   formatAssetSize,
@@ -496,7 +496,13 @@ function HeroSection({
         </div>
       </div>
 
-      <FactsStrip published={published} primaryAsset={primaryAsset} heroIn={heroIn} />
+      <FactsStrip
+        published={published}
+        primaryAsset={primaryAsset}
+        windowsAsset={windowsInstaller}
+        windowsPrimary={heroWindowsPrimary}
+        heroIn={heroIn}
+      />
     </section>
   );
 }
@@ -524,20 +530,42 @@ function HeroIntelLink() {
 }
 
 /**
- * 음각 계기 스트립 — **등장(950ms) 후 영구 정지.** 사실은 절대 움직이지 않는다:
- * 버전·날짜·최소 OS·크기·SHA-256 전부 릴리스 생성 모듈에서 온 값이고, 미게시
- * 상태에서는 정직하게 줄어든다(없는 파일의 크기·체크섬 행은 존재하지 않는다).
+ * 음각 계기 스트립 — **사실은 절대 움직이지 않는다.** 버전·날짜·최소 OS·크기·
+ * SHA-256 전부 릴리스 생성 모듈에서 온 값이고, 미게시 상태에서는 정직하게
+ * 줄어든다(없는 파일의 크기·체크섬 행은 존재하지 않는다).
  *
  * census 는 여기 없다 — 그 숫자의 캡션은 **자기가 세는 지도와 같은 절**(③)에
  * 산다(소유자 확정). 한 페이지에 같은 정의가 두 번 적히면 둘 다 각주가 된다.
+ *
+ * ## 이 레일은 **주 CTA 가 가리키는 파일**을 말한다 (2026-08-22)
+ *
+ * 그러지 않던 동안 이 페이지는 자기가 파는 것을 어겼다. Windows UA 로 열면
+ * 승자 버튼은 「Windows x64 베타 받기 · 47.8 MB」인데 바로 아래 레일이
+ * `Requires macOS 12 이상 · DMG 53.5 MB · SHA-256 c420d0b4…` 였다 — **내려받지도
+ * 않을 파일의 체크섬**이다. 체크섬은 「받은 것이 우리가 올린 것과 같은가」를
+ * 대조하라고 내미는 값이라, 다른 파일의 것을 보여 주면 값이 0 이 아니라
+ * **음수**다: 대조한 사람은 반드시 불일치를 보고, 그 순간 의심하는 대상은
+ * 자기가 받은 파일이 된다.
+ *
+ * 히어로의 CTA(`heroWindowsPrimary`)와 신뢰줄(`trustLineWindows`)은 이미 감지된
+ * 플랫폼을 따르고 있었다 — 이 레일만 `macosAssetFor` 에 묶여 빠져 있었다.
+ * 그래서 새 판정을 만들지 않고 **같은 불리언을 내려받는다**: 한 화면이 어느
+ * 파일 얘기를 하는지는 한 곳에서만 정해져야 한다.
+ *
+ * mac 분기의 값과 순서는 **1바이트도 바뀌지 않았다** — 서버 스냅숏이 언제나
+ * mac 이므로(`visitor-platform.ts`) 첫 그림도 종전과 같다.
  */
 function FactsStrip({
   published,
   primaryAsset,
+  windowsAsset: windowsInstaller,
+  windowsPrimary,
   heroIn,
 }: {
   published: boolean;
   primaryAsset: ReturnType<typeof macosAssetFor>;
+  windowsAsset: ReturnType<typeof windowsAsset>;
+  windowsPrimary: boolean;
   heroIn: boolean;
 }) {
   const t = useTranslations('download');
@@ -564,15 +592,26 @@ function FactsStrip({
         releaseVersion: RELEASE_VERSION,
       })} · ${t('factUnpublished')}`;
 
+  /** 승자 파일 — 히어로 CTA 가 가리키는 바로 그것. */
+  const subject = windowsPrimary && windowsInstaller ? windowsInstaller : primaryAsset;
+  const subjectIsWindows = subject !== null && subject === windowsInstaller;
+
   const facts: { label: string; value: string }[] = [
     { label: 'Version', value: version },
-    { label: 'Requires', value: `${RELEASE_MIN_MACOS}${t('factMinOsSuffix')}` },
+    {
+      label: 'Requires',
+      value: `${subjectIsWindows ? RELEASE_MIN_WINDOWS : RELEASE_MIN_MACOS}${t('factMinOsSuffix')}`,
+    },
   ];
-  if (published && primaryAsset) {
-    facts.push({ label: 'DMG', value: formatAssetSize(primaryAsset.sizeBytes) });
+  if (published && subject) {
+    facts.push({
+      // 파일 형식이 곧 라벨이다 — 「무엇을 받는가」를 크기 옆에서 한 번 더 말한다.
+      label: subjectIsWindows ? 'EXE' : 'DMG',
+      value: formatAssetSize(subject.sizeBytes),
+    });
     facts.push({
       label: 'SHA-256',
-      value: `${primaryAsset.sha256.slice(0, 8)}…${primaryAsset.sha256.slice(-8)}`,
+      value: `${subject.sha256.slice(0, 8)}…${subject.sha256.slice(-8)}`,
     });
   }
 

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -93,9 +93,36 @@ const SECTION_GAP = 'mt-[var(--gateway-section-gap)]';
  * (`docs/DECISIONS.md` 2026-08-19). 릴리스 정책 두 문장만 콜로폰에 남는다.
  *
  * 모션의 규율은 「정보 모션만」이다 (소유자: *"다운로드 페이지는 모션이
- * 중요함.. 보여지는게 최선인 만큼"*) — 첫 3초 안무(150/220 헤드라인 → 700
- * 리드 → 800 CTA → 950 사실층), 이후 전경 영구 정지. 효과층(전류장·그레인·
- * 커서 링)은 `--gateway-fx-*` 봉인 예외다(`GatewayFx` 독블록).
+ * 중요함.. 보여지는게 최선인 만큼"*). 효과층(전류장·그레인·커서 링)은
+ * `--gateway-fx-*` 봉인 예외다(`GatewayFx` 독블록).
+ *
+ * ## 시계가 둘이다 — 첫 화면은 시간, 그 아래는 스크롤 (2026-08-22)
+ *
+ * ① **히어로는 시간이 진다.** 첫 3초 안무(150/220 헤드라인 → 700 리드 →
+ *    800 CTA → 950 사실층)는 그대로다. 바뀐 것은 방아쇠 하나 — 시작 프레임이
+ *    `@starting-style` 로 옮겨가면서 **첫 스타일 계산**이 안무를 시작한다
+ *    (종전에는 하이드레이션 뒤의 rAF). 그래서 JS 가 늦거나 실패해도 히어로가
+ *    백지가 되지 않는다. 종전에는 됐다 — 실측으로 첫 스크린샷에 GNB 만
+ *    있었고, 그 뒤에 서 있던 것이 JS 32파일·디코드 2,572KB 다.
+ *    자세한 사연은 `app/globals.css` 의 `.gateway-rise` 독블록.
+ *
+ * ② **아래 세 절은 스크롤이 진다.** 소유자: *"부드러운 모션같은거 우리도
+ *    하고싶거든? 스크롤하면서 멋지게"*. `animation-timeline: view()` 라
+ *    진행도의 유일한 입력이 「이 원소가 스크롤포트에 얼마나 들어왔는가」다 —
+ *    천천히 굴리면 천천히 도착하고, 멈추면 멈춘다. rAF 도 스크롤 리스너도
+ *    쓰지 않으므로 이 페이지의 단일 프레임 루프에 한 프레임도 더하지 않는다.
+ *    `useInViewOnce` 는 **떼지 않았다** — `view()` 를 못 쓰는 브라우저에서
+ *    같은 등장을 지는 것이 그쪽이다(한 안무의 두 경로).
+ *
+ * 그러니 「등장 후 전경 영구 정지」는 여전히 참이다. 다시 흐려지거나 되감기는
+ * 원소는 없고, 한 번 도착한 것은 그 자리에 선다 — 무엇이 도착을 **부르는지**만
+ * 절마다 다르다. 실측(1512·834·390 세 폭 × 21 스크롤 지점): 화면 안에 완전히
+ * 들어왔는데 흐린 채로 멈춘 원소 **0건**.
+ *
+ * 감속(`prefers-reduced-motion: reduce`)에서는 스크롤 안무 선언이 **존재하지
+ * 않는다** — 절이 처음부터 전부 보인다(실측: 해당 원소의 애니메이션 0개).
+ * 계약: `tests/contract/reduced-motion-equivalent.contract.test.ts` 가 그
+ * 선언이 `no-preference` 밖으로 새면 빨개진다.
  */
 /**
  * 히어로의 다운로드 CTA 는 **320px 에서 접힌다**.
@@ -211,8 +238,17 @@ function SectionIntro({
   inView?: boolean;
   still?: boolean;
 }) {
+  /**
+   * 절 머리의 등장은 **스크롤이 진다** (2026-08-22).
+   *
+   * `gateway-scroll-rise` 가 붙는 브라우저에서는 `view()` 타임라인이 진행도를
+   * 소유하므로 `is-in` 은 아무 일도 하지 않는다(애니메이션이 평범한 선언을
+   * 이긴다). 안 붙는 브라우저에서는 `is-in` 이 종전 그대로 등장을 진다 —
+   * **그래서 `useInViewOnce` 를 떼지 않았다.** 둘은 같은 안무의 두 경로이지
+   * 두 벌의 안무가 아니다.
+   */
   const rise = (step?: string) =>
-    still ? undefined : cn('gateway-rise', step, inView && 'is-in');
+    still ? undefined : cn('gateway-rise', 'gateway-scroll-rise', step, inView && 'is-in');
 
   return (
     <>
@@ -657,7 +693,13 @@ function DemoSection() {
     >
       <div className={cn(PAGE_COLUMN, 'min-w-0')}>
         <SectionIntro eyebrow="Demo" title={t('demoTitle')} sub={t('demoSub')} inView={inView} />
-        <div className={cn('gateway-rise gateway-rise-d3', inView && 'is-in', 'mt-9')}>
+        <div
+          className={cn(
+            'gateway-rise gateway-scroll-stage gateway-rise-d3',
+            inView && 'is-in',
+            'mt-9',
+          )}
+        >
           <DemoStage />
         </div>
       </div>
@@ -714,7 +756,10 @@ function EvidenceSection({ graph }: { graph: StageGraph }) {
          */}
         <div
           ref={ref}
-          className="mt-9 grid min-w-0 gap-8 lg:grid-cols-[minmax(0,11fr)_minmax(0,9fr)] lg:gap-12"
+          className={cn(
+            'gateway-scroll-stage',
+            'mt-9 grid min-w-0 gap-8 lg:grid-cols-[minmax(0,11fr)_minmax(0,9fr)] lg:gap-12',
+          )}
         >
           <div
             data-testid="download-stage-map-frame"
@@ -885,7 +930,7 @@ function AgentSection() {
         <div
           data-testid="gateway-agent-scene"
           className={cn(
-            'gateway-rise gateway-rise-d3',
+            'gateway-rise gateway-scroll-stage gateway-rise-d3',
             inView && 'is-in',
             'mt-9 max-w-[var(--gateway-stage-max)]',
           )}

--- a/tests/contract/reduced-motion-equivalent.contract.test.ts
+++ b/tests/contract/reduced-motion-equivalent.contract.test.ts
@@ -47,7 +47,36 @@ const INTENTIONALLY_STILL: Readonly<Record<string, string>> = {
   // 동등물을 준다 — gateway-fx-exception.contract.test.ts 가 그 존재를 잠근다.
   "gateway-term-caret":
     "끝없는 캐럿 blink — 감속의 뜻이 이걸 멈추는 것이다. 줄 내용은 감속에서 전부 즉시 보인다.",
+  // ── 스크롤 타임라인 둘 (2026-08-22) ─────────────────────────────────────
+  //
+  // 이 스캐너의 모형은 「시간이 굴리는 애니메이션은 감속에서도 시간을 가져야
+  // 한다(하드컷 금지)」다. 이 둘은 그 모형 밖이다 — **시간이 굴리지 않는다.**
+  // 진행도의 유일한 입력이 `animation-timeline: view()`, 즉 스크롤 위치이고,
+  // duration 은 아예 존재하지 않는다(`auto`). 그래서 여기에 「감속용 짧은
+  // 시간」을 줄 대상 자체가 없다.
+  //
+  // 감속에서 무슨 일이 일어나는지가 이 등재의 근거다: **선언이 존재하지
+  // 않는다.** 둘 다 `@media (prefers-reduced-motion: no-preference)` 안에만
+  // 있으므로 감속 사용자에게는 규칙이 파싱되지 않고, 남는 것은
+  // `.gateway-rise` 의 쉬는 상태 — **처음부터 전부 보임**이다. 그것이 관문의
+  // 다른 안무가 감속에 주는 것과 정확히 같은 대체물이고(base 레이어
+  // carve-out), 잃는 것은 등장 순서뿐 정보는 하나도 없다.
+  //
+  // ⚠️ 이 면제의 조건은 **`no-preference` 안에 있다는 것 하나**다. 누군가 이
+  // 선언을 그 미디어 쿼리 밖으로 옮기면 이 사유는 그 순간 거짓이 된다 —
+  // 바로 아래 시험이 그 조건을 실제로 재므로 옮기면 빨개진다.
+  "gateway-scroll-rise":
+    "스크롤이 굴린다(view() 타임라인) — duration 이 없어 감속용 시간을 줄 대상이 없다. 감속에서는 선언 자체가 존재하지 않고 절은 처음부터 전부 보인다.",
+  "gateway-scroll-stage":
+    "같은 이유 — 무대(영상·지도·ACP 장면)의 스크롤 연동. 감속에서는 선언이 없고 무대는 처음부터 전부 보인다.",
 };
+
+/**
+ * 위 두 등재의 사유는 「`no-preference` 안에만 있다」에 통째로 걸려 있다.
+ * 사유를 글로만 적어 두면 다음 사람이 선언을 밖으로 옮겨도 아무도 모르므로,
+ * 그 조건을 여기서 **잰다**.
+ */
+const SCROLL_TIMELINE_CLASSES = ["gateway-scroll-rise", "gateway-scroll-stage"] as const;
 
 /**
  * 동등물이 실제로 붙어 있어야 하는 표면 — **CSS 에서 뽑아낸다.**
@@ -147,6 +176,56 @@ describe('reduced-motion 동등물 계약', () => {
       `감속 동등물도 없고 이유도 없다 — 감속 사용자에게 통째로 하드컷이다:\n${naked.join('\n')}\n` +
         `덮거나, INTENTIONALLY_STILL 에 이유를 적어라.`,
     ).toEqual([]);
+  });
+
+  /**
+   * 스크롤 타임라인 둘의 면제는 **한 조건 위에 서 있다** — 선언이
+   * `@media (prefers-reduced-motion: no-preference)` 안에만 있다는 것. 그래야
+   * 감속 사용자에게 규칙이 아예 파싱되지 않고 「처음부터 전부 보임」이 된다.
+   * 조건을 글로만 적어 두면 다음 사람이 밖으로 옮겨도 아무 신호가 없으므로
+   * 여기서 잰다.
+   */
+  it('스크롤 타임라인 안무는 no-preference 안에만 산다', () => {
+    const marker = '@media (prefers-reduced-motion: no-preference)';
+    const noPreferenceBlocks: string[] = [];
+    for (let from = 0; ; ) {
+      const at = CSS.indexOf(marker, from);
+      if (at === -1) break;
+      const open = CSS.indexOf('{', at);
+      let depth = 0;
+      let i = open;
+      for (; i < CSS.length; i += 1) {
+        if (CSS[i] === '{') depth += 1;
+        else if (CSS[i] === '}') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+      }
+      noPreferenceBlocks.push(CSS.slice(open + 1, i));
+      from = i + 1;
+    }
+    expect(
+      noPreferenceBlocks.length,
+      'no-preference 블록이 하나도 없다 — 이 시험이 빈손으로 통과하고 있다',
+    ).toBeGreaterThan(0);
+
+    for (const cls of SCROLL_TIMELINE_CLASSES) {
+      const selector = new RegExp(`\\.${cls}(?![\\w-])`);
+      // 선언이 나오는 자리는 전부 no-preference 안이어야 한다: 파일 전체에서
+      // 센 등장 횟수와, no-preference 블록 안에서 센 등장 횟수가 같아야 한다.
+      const total = [...CSS_CODE.matchAll(new RegExp(`\\.${cls}(?![\\w-])`, 'g'))].length;
+      const inside = noPreferenceBlocks
+        .map((block) => [...block.matchAll(new RegExp(`\\.${cls}(?![\\w-])`, 'g'))].length)
+        .reduce((a, b) => a + b, 0);
+      expect(total, `.${cls} 가 CSS 에 없다 — 죽은 면제다`).toBeGreaterThan(0);
+      expect(
+        inside,
+        `.${cls} 의 선언 ${total}건 중 ${inside}건만 no-preference 안이다 — ` +
+          `밖으로 샌 선언은 감속 사용자에게 그대로 적용된다. ` +
+          `INTENTIONALLY_STILL 의 사유가 거짓이 됐으므로 되돌리거나 사유를 다시 써라.`,
+      ).toBe(total);
+      expect(selector.test(CSS_CODE), 'selector 정규식이 헛돌고 있다').toBe(true);
+    }
   });
 
   for (const cls of requiresEquivalent) {


### PR DESCRIPTION
## Summary

게시된 `/ko/download/` 를 실물로 열어 재면서 나온 결함 둘을 고치고, 소유자 요청("부드러운 모션같은거 우리도 하고싶거든? 스크롤하면서 멋지게")대로 히어로 아래 세 절의 등장을 스크롤에 물렸다. 커밋 셋은 각각 되돌릴 수 있게 갈라 두었다.

### ① fix — 사실 레일이 주 CTA 와 다른 파일을 말하고 있었다

Windows UA 로 열면 승자 버튼은 「Windows x64 베타 받기 · 47.8 MB」인데 바로 아래 계기 스트립이 `Requires macOS 12 이상 · DMG 53.5 MB · SHA-256 c420d0b4…` 였다 — **내려받지도 않을 파일의 체크섬**이다.

체크섬은 「받은 것이 우리가 올린 것과 같은가」를 대조하라고 내미는 값이라, 다른 파일의 것을 보여 주면 값이 0 이 아니라 **음수**다: 대조한 사람은 반드시 불일치를 보고, 그 순간 의심하는 대상은 자기가 받은 파일이 된다.

히어로의 CTA 와 신뢰줄은 이미 감지된 플랫폼을 따르고 있었고 이 레일만 `macosAssetFor` 에 묶여 빠져 있었다. 새 판정을 만들지 않고 같은 불리언(`heroWindowsPrimary`)을 내려받는다.

`RELEASE_MIN_WINDOWS` 는 `tauri.conf.json` 에 적을 자리가 없어(macOS 만 `minimumSystemVersion` 을 갖는다) 진실원을 런타임 바닥으로 잡았다 — Tauri v2 의 Windows 백엔드 → WebView2 → Windows 10. 「검증한 것」이 아니라 「실행에 필요한 것」이며, 미검증인 SmartScreen 화면은 신뢰줄이 계속 따로 진다.

### ② fix — 히어로가 JS 를 기다리며 백지로 서 있었다

`.gateway-rise` 의 `opacity: 0` 이 **기본값**이라 실질적으로 「JS 가 `.is-in` 을 달아 줄 때까지 백지」였다. 실측: 게시된 페이지를 열고 곧바로 찍은 첫 스크린샷에 GNB 만 있었고, 그 뒤에 서 있는 것이 **JS 32파일 · 디코드 2,572KB** 다.

시작 프레임을 `@starting-style` 로 옮겼다. 값도 시간축도 종전과 같고 방아쇠만 「하이드레이션 뒤 rAF」 → 「첫 스타일 계산」으로 바뀐다.

### ③ feat — 아래 세 절의 등장을 스크롤이 진다

`animation-timeline: view()`. 진행도의 유일한 입력이 「그 원소가 스크롤포트에 얼마나 들어왔는가」다 — 천천히 굴리면 천천히 도착하고 멈추면 멈춘다. 이징이 `linear` 인 것이 그래서 옳다(가속·감속은 사람의 손이 준다).

rAF 도 스크롤 리스너도 쓰지 않으므로 이 페이지의 단일 프레임 루프(`gateway-frame-loop.ts`)에 **한 프레임도 더하지 않는다.**

두 겹 — 절 머리 세 줄(18px, 기존 `-d2`/`-d3` 시차 재사용)과 절의 무대(34px, 더 긴 구간). `scale` 은 쓰지 않았다: 이 저장소에서 확대는 지도 카메라의 뜻이다. 히어로에는 걸지 않았다(첫 화면은 스크롤 진행도가 언제나 0 근처 — 거기는 `@starting-style` 이 진다).

`useInViewOnce` 는 **떼지 않았다** — `view()` 를 못 쓰는 브라우저에서 같은 등장을 지는 것이 그쪽이다. 한 안무의 두 경로이지 두 벌의 안무가 아니다.

## 게이트

새 클래스는 `reduced-motion-equivalent` 계약에 자동으로 걸려 빨개졌다(그 스캐너의 모형은 「시간이 굴리는 애니메이션」인데 이 둘은 duration 이 아예 없어 감속용 시간을 줄 대상이 없다). 사유와 함께 `INTENTIONALLY_STILL` 에 등재하되, **그 사유가 서 있는 조건 — 선언이 `no-preference` 안에만 있을 것 — 을 재는 시험을 같이 넣었다.** 사유를 글로만 적어 두면 다음 사람이 밖으로 옮겨도 아무 신호가 없다.

프로브: 선언 하나를 블록 밖에 두니 「4건 중 3건만 no-preference 안이다」로 빨개졌고, 되돌리니 39건 통과.

## Test plan

`pnpm checks:changed -- --run` — **7/7 통과** (eslint · release-facts 7 · DownloadPage 27 · 계약 2,018 · overflow-sweep 10 · tsc · gateway-grid 19). pre-push 훅에서 한 번 더 통과.

추가로 `pnpm lint`(0 error, 경고 56건은 전부 `topology-map-v2` 선재) · `pnpm build`(정적 export 성공) · `pnpm decisions:check`(카운슬 트리거 없음).

Playwright 실측:

| 무엇 | 결과 |
|---|---|
| 사실 레일 · mac UA | CTA 53.5 MB · `macOS 12 이상` · `DMG 53.5 MB` · `c420d0b4…` (종전과 동일) |
| 사실 레일 · windows UA | CTA 47.8 MB · `Windows 10 이상` · `EXE 47.8 MB` · `2bd41bdc…` (생성 모듈의 실제 Windows 에셋과 일치) |
| JS 끔 | `h1` opacity **1** · 박스 1112×115 · 본문 전문 (종전이면 opacity 0) |
| 스크롤 연동 | scrollTop 0 → `0.00`/34px · 1800 → `0.15`/28.8px · 2200 → `1.00`/0px. `ViewTimeline` 부착 확인 |
| 감속 | 해당 원소 애니메이션 **0개** · opacity 1 |
| 1512 · 834 · 390 × 21 스크롤 지점 | 화면 안에 완전히 들어왔는데 흐린 채 멈춘 원소 **0건** |

## 남은 것 (이 PR 밖)

- **데모 autoplay loop** — 지금 클립이 199초 원테이크라 루프로 못 돌린다. 8~12초 클립이 새로 필요하고 그건 촬영이지 코드가 아니다. `DemoStage` 의 IO 자동재생 계약은 이미 있으므로 자산 교체 + `loop` 한 줄이면 끝난다.
- **증거 절 지도** — 스크롤 도착 직후 ~3초간 무대 한가운데 뭉쳐 있다가 펴지고, 펴진 뒤에도 라벨이 겹친다. 좌표 pre-solve 가 처방.
- **ACP 장면** — 첫 ~2초 빈 상자. 첫 프레임에 프롬프트 한 줄이 이미 놓여 있어야 하고, 리플레이 어포던스가 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)