### PR TITLE
fix: ACP 재연 장면의 빈 첫 프레임

### DIFF
--- a/src/views/download/ui/AcpChatScene.tsx
+++ b/src/views/download/ui/AcpChatScene.tsx
@@ -54,13 +54,41 @@ function toolCallLine(why: string): string {
   return `add_relation | "${why}"`;
 }
 
-/** 도착 시각(ms) — 말풍선 → 도구 호출 → 결과. 인과가 리듬이다. */
-const STEP_AT = [250, 1050, 1750];
+/**
+ * 도착 시각(ms) — **에이전트의 두 걸음**(도구 호출 → 결과)만 도착한다.
+ *
+ * ## 사람의 문장은 등장하지 않는다 — 전제라서다 (2026-08-22)
+ *
+ * 종전 악보는 `[250, 1050, 1750]` 이고 첫 값이 말풍선의 것이었다. 그래서 절이
+ * 뷰포트에 들어온 뒤 최소 250ms, 그리고 세 줄이 다 찰 때까지 1,750ms 동안
+ * **17rem 짜리 빈 상자**가 서 있었다. 실측(1512, 스크롤 도착 직후 스크린샷):
+ * 머리글 한 줄 아래로 250px 가 통째로 비어 있었고, 5초 뒤에야 세 줄이 찼다.
+ * 테두리만 있는 빈 상자는 「연출 대기」가 아니라 **「고장났거나 로딩 중」**
+ * 으로 읽힌다.
+ *
+ * 고칠 방향은 둘이었다. ① 전체를 빠르게 — 빈 상자 시간이 줄 뿐 없어지지
+ * 않는다. ② **첫 줄을 안무에서 빼기** — 이쪽을 골랐다. 이 장면의 논증은
+ * 「사람이 말하면 에이전트가 볼트를 고친다」이고, 거기서 **움직여야 하는 것은
+ * 에이전트의 응답**이다. 사람의 문장은 그 응답이 답하는 **전제**이지 결과가
+ * 아니다 — 이미 보내진 메시지가 화면에 있고 거기에 에이전트가 반응하는 것이,
+ * 대화라는 것이 실제로 일어나는 모양이기도 하다.
+ *
+ * 그래서 상자는 **첫 프레임부터 비어 있지 않다**. 잃은 것은 말풍선이 떠오르는
+ * 장식 하나이고, 얻은 것은 「이 절이 무엇을 보여 주는지」가 도착 즉시 읽히는
+ * 것이다. design.md 의 「정보 모션만」이 정확히 이 교환을 요구한다.
+ *
+ * 남은 두 걸음의 간격(650ms)은 종전 말풍선→호출 간격(800ms)보다 짧다 — 앞의
+ * 한 걸음이 사라졌으므로 전체 길이를 그만큼 되돌려 리듬을 유지한다.
+ */
+const STEP_AT = [400, 1050];
+
+/** 첫 줄(사람의 문장)은 언제나 켜져 있다 — 안무의 시작점이 1 인 이유. */
+const PREMISE_SHOWN = 1;
 
 export function AcpChatScene() {
   const t = useTranslations('download');
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const [shown, setShown] = useState(0);
+  const [shown, setShown] = useState(PREMISE_SHOWN);
 
   useEffect(() => {
     const el = rootRef.current;
@@ -70,19 +98,20 @@ export function AcpChatScene() {
       matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     let timers: number[] = [];
+    /** 되감아도 **전제까지만** 되감는다 — 빈 상자로 돌아가지 않는다. */
     const clear = (): void => {
       for (const id of timers) window.clearTimeout(id);
       timers = [];
-      setShown(0);
+      setShown(PREMISE_SHOWN);
     };
     const play = (): void => {
       clear();
       if (reduced) {
-        setShown(STEP_AT.length);
+        setShown(PREMISE_SHOWN + STEP_AT.length);
         return;
       }
       STEP_AT.forEach((at, i) => {
-        timers.push(window.setTimeout(() => setShown(i + 1), at));
+        timers.push(window.setTimeout(() => setShown(PREMISE_SHOWN + i + 1), at));
       });
     };
 

--- a/src/views/download/ui/DownloadPage.test.tsx
+++ b/src/views/download/ui/DownloadPage.test.tsx
@@ -595,6 +595,35 @@ describe('DownloadPage', () => {
   });
 
   /**
+   * **첫 프레임에 빈 상자가 없다** (회귀 2026-08-22).
+   *
+   * 종전 악무는 세 줄을 전부 타이머에 걸어서(250/1050/1750ms), 절이 뷰포트에
+   * 들어온 뒤 17rem 짜리 테두리 상자가 **아무것도 없이** 서 있었다. 실측:
+   * 스크롤 도착 직후 스크린샷에 머리글 아래 250px 가 통째로 비어 있었다.
+   * 테두리만 있는 빈 상자는 「연출 대기」가 아니라 「고장났거나 로딩 중」으로
+   * 읽힌다.
+   *
+   * 사람의 문장은 에이전트의 응답이 답하는 **전제**이지 연출의 결과가 아니다.
+   * 그래서 첫 줄은 안무에서 빠지고 처음부터 켜져 있다.
+   *
+   * 이 시험이 잠그는 것은 「몇 ms 냐」가 아니라 **「첫 그림에 글자가 있느냐」**
+   * 다 — 타이밍을 값으로 박으면 리듬을 조정할 때마다 빨개지는데, 그건 규격이
+   * 아니라 소음이다. 잠글 것은 상자가 비지 않는다는 성질 하나다.
+   */
+  it('never paints the ACP scene as an empty box — the human line is the premise', () => {
+    renderDownloadPage();
+
+    const chat = screen.getByTestId('gateway-agent-chat');
+    const lines = chat.querySelectorAll('.gateway-term-line');
+    expect(lines.length, '재연 세 줄이 있어야 이 시험이 뜻을 갖는다').toBe(3);
+
+    // 첫 줄 = 사람의 문장. 타이머가 한 번도 안 돌았어도 켜져 있다.
+    expect(lines[0].className).toContain('is-on');
+    // 그리고 그 줄에 실제로 글자가 있다 — 클래스만 켜고 비어 있으면 같은 결함이다.
+    expect((lines[0].textContent ?? '').trim().length).toBeGreaterThan(0);
+  });
+
+  /**
    * 헤드라인은 **소유자의 문장 그대로**다 — 리메이크의 고정점이라 문장으로
    * 잠근다(다듬어 고치는 순간 이 화면의 전제가 바뀐 것이고, 그건 원장을 거쳐야
    * 한다). 두 줄 + 리드까지가 한 벌이다.


### PR DESCRIPTION
> **스택 PR** — base 가 `main` 이 아니라 #1190 이다. #1190 을 먼저 머지하면 base 가 자동으로 `main` 으로 내려간다.

## Summary

ACP 재연 장면이 절 도착 직후 **17rem 짜리 빈 상자**로 서 있었다. 세 줄을 전부 타이머에 걸어(250/1050/1750ms) 첫 값이 사람의 말풍선이었기 때문이다. 실측(1512, 스크롤 도착 직후): 머리글 아래 250px 가 통째로 비었고 5초 뒤에야 세 줄이 찼다.

테두리만 있는 빈 상자는 「연출 대기」가 아니라 **「고장났거나 로딩 중」**으로 읽힌다.

고칠 방향은 둘이었다.

1. 전체를 빠르게 — 빈 상자 시간이 줄 뿐 **없어지지 않는다**
2. **첫 줄을 안무에서 빼기** — 이쪽

이 장면의 논증은 「사람이 말하면 에이전트가 볼트를 고친다」이고, 거기서 움직여야 하는 것은 **에이전트의 응답**이다. 사람의 문장은 그 응답이 답하는 **전제**이지 연출의 결과가 아니다 — 이미 보내진 메시지가 화면에 있고 거기에 에이전트가 반응하는 것이, 대화라는 것이 실제로 일어나는 모양이기도 하다.

잃은 것은 말풍선이 떠오르는 장식 하나. 얻은 것은 이 절이 무엇을 보여 주는지가 **도착 즉시** 읽히는 것 — `design.md` 의 「정보 모션만」이 정확히 이 교환을 요구한다. 되감을 때도 전제까지만 되감는다.

남은 두 걸음의 간격(650ms)은 종전 말풍선→호출 간격(800ms)보다 짧다. 앞의 한 걸음이 사라졌으므로 전체 길이를 그만큼 되돌려 리듬을 유지한다.

## Test plan

`pnpm checks:changed -- --run` 4/4 통과 (eslint · 계약 2,018 · tsc · gateway-grid 19) + `DownloadPage.test.tsx` 28건.

실측 (1512, 200ms 간격 14회):

| t | 보이는 줄 |
|---|---|
| 51ms | **1** (빈 상자 구간 **0**) |
| 543ms | 2 |
| 1284ms | 3 (종전 1750ms+) |

회귀 시험은 타이밍이 아니라 **성질**을 잠근다 — 「첫 그림에 글자가 있느냐」 하나다. ms 를 값으로 박으면 리듬을 조정할 때마다 빨개지고 그건 규격이 아니라 소음이다.

프로브: `PREMISE_SHOWN` 을 0 으로 되돌리니 그 시험만 빨개졌고(`expected … to contain 'is-on'`), 되돌리니 28건 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)