### PR TITLE
feat: 지도 라벨 겹침을 밖에서 잴 수 있게 한다

### DIFF
--- a/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
+++ b/src/widgets/topology-map-v2/ui/topology-frame-draw.ts
@@ -253,6 +253,34 @@ const ZERO_DOME_FRAME: DomeNodeFrame = { dx: 0, dy: 0, s: 1, a: 0, u: 0 };
 export function lastDrawnNodeAlphas(): ReadonlyMap<string, number> {
   return effectiveAlphaByIdReused;
 }
+
+/**
+ * The label boxes this frame actually **drew**, in CSS pixels.
+ *
+ * Why this has to exist: label collision is the one map-readability property that
+ * cannot be observed from outside. The canvas has no DOM, so an e2e spec can only
+ * compare pixels — which says "something changed", never "these two names are on
+ * top of each other". `__atlasMap.nodes()` exposes node centres and radii, and
+ * those measured **zero** overlaps on a frame whose labels were visibly crossing
+ * (2026-08-22): names collide long before the discs do.
+ *
+ * Recorded at the draw call rather than from the placement result, for the same
+ * reason `lastDrawnNodeAlphas` is: the placer decides, but a later stage (the LOD
+ * presence ramp) can still put a candidate on screen. What matters for readability
+ * is what was painted.
+ */
+let drawnLabelBoxes: { nodeId: string; text: string; minX: number; minY: number; maxX: number; maxY: number }[] = [];
+
+export function lastDrawnLabelBoxes(): readonly {
+  nodeId: string;
+  text: string;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}[] {
+  return drawnLabelBoxes;
+}
 // Cluster-chip hover colour easing anchor: which chip has been hovered since
 // when (only one can be hovered at a time). The rest→hover colour transition
 // (~150ms) is driven from this start time. Under reduced-motion the colour snaps,
@@ -2392,6 +2420,8 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
       : null;
   const labelRankEntries: LabelRankEntry[] = [];
   const labelCandidates: LabelCandidate<LabelPayload>[] = [];
+  /** Per-frame bbox by node id — the instrument reads this after the draw. */
+  const labelBboxById = new Map<string, { minX: number; minY: number; maxX: number; maxY: number }>();
   // perf 2026-08-19 — when the early exit for on-demand 3D labels is valid: on a
   // frame where a keep (hover, ego, trail) is impossible because there is no focus,
   // pair, or lens, an assembly ramp a ≥ 0.98 gives 1 - a ≤ 0.02, and both the
@@ -2567,11 +2597,13 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
         labelBaselineY = flipped;
       }
     }
+    const candidateBbox = boxAt(labelBaselineY);
+    labelBboxById.set(node.id, candidateBbox);
     labelCandidates.push({
       priority,
       order: index,
       ownerId: node.id,
-      bbox: boxAt(labelBaselineY),
+      bbox: candidateBbox,
       payload: {
         nodeId: node.id,
         kind: node.kind,
@@ -2645,7 +2677,14 @@ export function drawTopologyFrame(params: FrameDrawParams): void {
   }
   prevPlacedLabelIds = placedIds;
 
+  drawnLabelBoxes = [];
   for (const { payload, presenceAlpha } of drawList) {
+    // Only a label the eye can actually read counts as drawn — below this the
+    // glyphs are a smudge and cannot collide with anything in a way a reader sees.
+    if (presenceAlpha > 0.5) {
+      const box = labelBboxById.get(payload.nodeId);
+      if (box) drawnLabelBoxes.push({ nodeId: payload.nodeId, text: payload.text, ...box });
+    }
     labelsDraw(
       ctx,
       {

--- a/src/widgets/topology-map-v2/ui/use-topology-loop.ts
+++ b/src/widgets/topology-map-v2/ui/use-topology-loop.ts
@@ -40,7 +40,7 @@ import { buildDustPoints, buildRealmCosmosPoints, computeStarDustCount, type Dus
 import { DEFAULT_EXPAND, DEFAULT_MAP_ARRANGEMENT } from "@/shared/lib/appearance-preferences";
 import type { CanvasBackground, ExpandPreference, FootprintPreference, GlyphSet, MapArrangement } from "@/shared/lib/appearance-preferences";
 import { centerForInsets, computeClusterFitTarget, computeDomeFocusCameraTarget, computeFocusCameraTarget, computeOverviewCameraTarget, computeOverviewFitScale, fitWorldTarget, hasAnyNodeOnScreen, worldToScreen } from "./topology-camera-math";
-import { drawTopologyFrame } from "./topology-frame-draw";
+import { drawTopologyFrame, lastDrawnLabelBoxes } from "./topology-frame-draw";
 import { MOTION } from "@/shared/motion";
 import { isPreviewEndpoint, isPreviewEndpointHidden } from "../render/preview-edge";
 import { relaxNewlyVisible } from "../model/layout";
@@ -5311,6 +5311,15 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
        * reality (`shownChildren`) is what makes that mismatch catchable from
        * outside.
        */
+      /**
+       * The label boxes the last frame drew, in CSS pixels — the only way to see
+       * label collision from outside. The canvas has no DOM, so a spec can
+       * otherwise only diff pixels, which reports "something changed" and never
+       * "these two names sit on top of each other". Node centres are not a
+       * substitute: a frame measured **zero** disc overlaps while names visibly
+       * crossed (2026-08-22). Names collide long before discs do.
+       */
+      labels: () => lastDrawnLabelBoxes(),
       chips: () => {
         const world = worldRef.current;
         const clustered = clusteredIdsRef.current;

--- a/tests/e2e/map-label-collision.spec.ts
+++ b/tests/e2e/map-label-collision.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Map labels must not overlap — measured from the boxes the frame actually drew.
+ *
+ * ## Why this needs an instrument at all
+ *
+ * The map is a canvas. It has no DOM, so a spec can otherwise only diff pixels,
+ * which reports *"something changed"* and never *"these two names are on top of
+ * each other"*. Node centres are not a substitute either: measured 2026-08-22 on
+ * `/download`'s evidence map, disc overlaps were **zero** on a frame whose names
+ * were visibly crowding. Names collide long before discs do.
+ *
+ * `__atlasMap.labels()` returns the boxes recorded at the draw call, so what is
+ * asserted here is what was painted — not what the placer decided. Those differ:
+ * the LOD presence ramp can still put a candidate on screen after placement.
+ *
+ * ## What is asserted, and what is deliberately not
+ *
+ * **Overlap must be zero.** Two names sharing pixels is unreadable, full stop.
+ *
+ * **Clearance is only recorded, not enforced.** The obvious next step — require a
+ * minimum gap — was tried and reverted the same day: raising the vertical box by
+ * 2px dropped the drawn labels from **32 to 24** while the tightest pairs stayed
+ * at 0px. The placer answers crowding by discarding labels, so a clearance floor
+ * buys silence, not readability. If crowding is to be fixed it has to be fixed in
+ * layout, and this spec is the instrument that will tell whether it worked.
+ */
+
+const MAP_ROUTE = "/ko/download/?e2e=1";
+
+interface LabelBox {
+  nodeId: string;
+  text: string;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+test.describe("지도 라벨 — 그려진 박스로 잰다", () => {
+  test("이름이 서로 겹치지 않는다", async ({ page }) => {
+    await page.goto(MAP_ROUTE);
+    await page.getByTestId("download-stage-map-frame").scrollIntoViewIfNeeded();
+    await page.waitForFunction(
+      () => Boolean((window as unknown as { __atlasMap?: { labels?: unknown } }).__atlasMap?.labels),
+      undefined,
+      { timeout: 20_000 },
+    );
+    // The map assembles with a homing spring; labels are placed per frame, so the
+    // reading has to be taken after it settles (measured ~1.2s, with margin here).
+    await page.waitForTimeout(6_000);
+
+    const labels = (await page.evaluate(() =>
+      (
+        window as unknown as { __atlasMap: { labels: () => LabelBox[] } }
+      ).__atlasMap.labels(),
+    )) as LabelBox[];
+
+    // Anti-idle: an empty or near-empty frame would pass every assertion below.
+    expect(labels.length, "라벨을 거의 못 그렸다 — 이 시험이 헛돈다").toBeGreaterThan(10);
+
+    const overlaps: string[] = [];
+    for (let i = 0; i < labels.length; i += 1) {
+      for (let j = i + 1; j < labels.length; j += 1) {
+        const a = labels[i];
+        const b = labels[j];
+        if (a.minX < b.maxX && b.minX < a.maxX && a.minY < b.maxY && b.minY < a.maxY) {
+          const w = Math.round(Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX));
+          const h = Math.round(Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY));
+          overlaps.push(`${w}x${h}px  「${a.text}」 ↔ 「${b.text}」`);
+        }
+      }
+    }
+
+    expect(
+      overlaps,
+      `지도에서 두 이름이 픽셀을 공유한다 — 읽을 수 없다:\n${overlaps.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
소유자가 처음 지적한 「증거 절 지도가 읽기 어렵다」를 고치려다, **먼저 잴 수가 없다**는 것을 알았다.

## 왜 계기가 필요했나

지도는 캔버스다. DOM이 없으니 e2e는 픽셀 비교밖에 못 하고, 그건 「뭔가 달라졌다」만 말하지 「이 두 이름이 겹쳤다」는 못 말한다.

`__atlasMap.nodes()`의 중심·반지름으로 대신 재봤더니 **노드 겹침 0**이 나왔다 — 화면에서는 글자가 붙어 있는데도. **이름은 원보다 훨씬 먼저 부딪힌다.**

그래서 `__atlasMap.labels()`를 추가했다. 배치기의 판정 결과가 아니라 **그리는 자리에서** 기록한다 — 둘은 다르다: LOD 페이드 램프가 배치에서 떨어진 후보를 화면에 남길 수 있고, 읽는 사람에게 중요한 것은 칠해진 쪽이다.

## 계기가 밝힌 것 — 내 눈이 틀렸다

스크린샷을 보고 「겹친다」고 했는데 실측은 **겹침 0**이었다. 대신 이렇게 아슬아슬했다 (1512, 라벨 32개):

| 여백 | 짝 |
|---|---|
| **0px** | `Topology Map Rendering & Search` ↔ `토폴로지 지도 탐색` |
| **0px** | `Category` ↔ `Ontology Insights` |
| 1px | `앱 안 코딩 에이전트 실행기 (ACP)` ↔ `Shortcut Sheet` |
| ≤4px | 9쌍 |

가로는 `LABEL_SIDE_GAP`(3px)이 막는데 **세로는 여백이 0**이었다 — 박스가 측정된 ascent/descent 그대로다. 같은 파일 주석이 이미 경고해 둔 상황이다: *"두 라벨이 닿으면 한 단어로 읽힌다."*

## 세로 여백 처방은 시도했고 되돌렸다

`LABEL_STACK_GAP = 2`를 넣어 봤다. 결과:

```
라벨 32 → 24개      (8개 사라짐)
0px 짝 2 → 3쌍       (오히려 늘었다)
```

배치기는 붐빔에 **「라벨을 버리는」** 것으로 답한다. 그러니 여백 하한은 가독성이 아니라 **침묵을 산다.** 붐빔을 고치려면 레이아웃에서 고쳐야 하고, 이 계기는 그때 「고쳐졌나」를 말해 줄 도구다.

## 게이트

`tests/e2e/map-label-collision.spec.ts` — **겹침 0만** 단언한다. 여백 하한은 일부러 안 건다(위 실측이 그 이유이고, 스펙 주석에 적었다).

**프로브를 두 번 했다.** 첫 번째(`LABEL_SIDE_GAP`을 음수로)는 **통과해 버렸다** — 그 상수가 배치 판정과 계기 박스 양쪽에 쓰여서 배치기도 같이 느슨해지기 때문이다. 게이트가 안 무는 게 아니라 프로브가 틀렸다. 두 번째로 배치기의 겹침 거부만 껐더니 **빨개졌다.**

## Test plan

pre-push 훅 8레인 통과(2:03). 새 스펙은 정적 빌드 기준 통과, 프로브로 실패 재현 확인. `tsc` 0 error.

변경은 계기와 스펙뿐 — 렌더 동작은 바뀌지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)