### PR TITLE
perf: give the release build a profile, and freeze the webview prototype

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,3 +66,19 @@ keyring = { version = "3", features = ["apple-native"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+
+# Cargo's release defaults leave 16 codegen units, no cross-crate inlining, and full debug symbols.
+# Measured on this app: these three take the Rust half of the binary from 13.4 MB to 8.3 MB, with no
+# change to what the code means.
+#
+# Tauri's size guidance names two more that are deliberately absent.
+# `opt-level = "s"` saves a further 1.5 MB by optimising for size over speed; the Rust half of this
+# app hashes and walks vault files, and 1.5 MB of an 89 MB bundle does not justify trading throughput
+# nobody has measured.
+# `panic = "abort"` saves 1.7 MB and changes what a bug costs: today a panic inside one command fails
+# that command and leaves the window standing, and with abort it takes the whole app down. For a
+# workbench holding an owner's unsaved judgement that is the wrong trade at any size.
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,8 @@
         "script-src": "'self'",
         "worker-src": "'self' blob:",
         "style-src": "'unsafe-inline' 'self'"
-      }
+      },
+      "freezePrototype": true
     }
   },
   "bundle": {
@@ -53,7 +54,7 @@
     "category": "DeveloperTool",
     "shortDescription": "Local-first codebase ontology workbench for Ontology Atlas",
     "longDescription": "Ontology Atlas is a local-first desktop app for opening a markdown ontology vault, editing codebase meaning, and handing the same graph to AI agents without a backend or login. The repository, CLI, and release assets remain under the ontology-atlas project name.",
-    "copyright": "Copyright © 2026 ontology-atlas contributors",
+    "copyright": "Copyright \u00a9 2026 ontology-atlas contributors",
     "macOS": {
       "minimumSystemVersion": "12.0"
     },


### PR DESCRIPTION
## Summary

Two settings the official Tauri documentation names and this app had never applied.

**`[profile.release]` did not exist.** Every release build shipped with 16 codegen units, no cross-crate inlining, and full debug symbols. [Tauri's app-size guidance](https://v2.tauri.app/concept/size/) names the settings; nobody had put them in.

**`freezePrototype` was unset.** The [security configuration reference](https://v2.tauri.app/reference/config/) documents it as the guard against prototype pollution through the custom protocol. The frontend is a first-party static export with `script-src 'self'`, so the exposure was small — but the setting is free, and "small" is not the same as "argued".

## Measured, not assumed

Both numbers come from `tauri build` on this machine, so the comparison is like for like:

| | Rust code | Bundled binary | App bundle |
|---|---|---|---|
| Before | 13.4 MB | 27.5 MB | 89 MB |
| After | **8.3 MB** | **22.4 MB** | **84 MB** |

The remaining 14.1 MB of that binary is the brotli-compressed static export, which no compiler flag touches. Worth knowing for anyone chasing size later: the raw `out/` is 72 MB, of which `en` 26 MB + `ko` 29 MB is two full locale trees, and the 61 MB MCP sidecar still dominates the bundle at 68%.

## Two recommended settings deliberately left out

Both are documented in `Cargo.toml` so nobody has to rediscover the reasoning.

- **`panic = "abort"`** saves a further 1.7 MB and changes what a bug costs. Today a panic inside one command fails that command and leaves the window standing; with abort it takes the whole app down. That is the wrong trade for a workbench holding an owner's unsaved judgement, at any size.
- **`opt-level = "s"`** saves 1.5 MB by preferring size to speed in code that walks and hashes vault files. 1.5 MB of an 89 MB bundle does not justify trading throughput nobody has measured. Worth revisiting *after* someone measures a vault scan.

Also checked and **not** enabled: `build.removeUnusedCommands`. `src-tauri/gen/schemas/acl-manifests.json` has no `__app__` entry, so the 48 application-defined commands are not ACL-registered; enabling it now risks stripping all of them. It would need app-command permissions in the capability first.

## Test plan

`pnpm checks:changed -- --run` — 4/4 passed.

The packaged app was rebuilt and exercised after the change, because a compiler flag that silently breaks a release build is exactly the failure a unit suite cannot see:

- window opens at `1512x900`, `fit source=default ... recentered=false`
- vault watcher starts and logs
- ProMotion frame-rate cap release still succeeds — the objc path survives LTO
- WebView loads a real vault and reports `1512x868` of rendered content **with the prototype frozen**

No screenshots: no visual surface changed.