### PR TITLE
chore: refresh the ACP registry for rc.11

### DIFF
--- a/src-tauri/src/acp-registry.json
+++ b/src-tauri/src/acp-registry.json
@@ -114,7 +114,7 @@
       "cli": "cline",
       "launch": {
         "kind": "npx",
-        "package": "cline@3.0.57",
+        "package": "cline@3.0.58",
         "args": [
           "--acp"
         ]
@@ -132,7 +132,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@tencent-ai/codebuddy-code@2.137.1",
+        "package": "@tencent-ai/codebuddy-code@2.138.0",
         "args": [
           "--acp"
         ]
@@ -255,7 +255,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dimcode@0.3.18",
+        "package": "dimcode@0.3.19",
         "args": [
           "acp"
         ]
@@ -291,7 +291,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "droid@0.202.0",
+        "package": "droid@0.203.0",
         "args": [
           "exec",
           "--output-format",
@@ -365,7 +365,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "glm-acp-agent@1.6.0",
+        "package": "glm-acp-agent@1.6.1",
         "args": []
       }
     },
@@ -415,7 +415,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@xai-official/grok@1.0.8",
+        "package": "@xai-official/grok@1.0.10",
         "args": [
           "agent",
           "stdio"


### PR DESCRIPTION
## Summary

The release run for `v1.0.0-rc.11` stopped at its **first gate** — *"Verify bundled
ACP registry is current"* — because six upstream agents had published new versions
since rc.10.

That gate is deliberately **not** a PR check. It turns red when somebody else
deploys, so as a PR gate it would randomly block unrelated work and become noise
rather than a rule. Asking at release time is exactly what stops a stale snapshot
shipping inside the app.

| agent | before | after |
|---|---|---|
| `cline` | 3.0.57 | 3.0.58 |
| `@tencent-ai/codebuddy-code` | 2.137.1 | 2.138.0 |
| `dimcode` | 0.3.18 | 0.3.19 |
| `droid` | 0.202.0 | 0.203.0 |
| `glm-acp-agent` | 1.6.0 | 1.6.1 |
| `@xai-official/grok` | 1.0.8 | 1.0.10 |

**`claude-agent-acp` and `codex-acp` are unchanged.** Those are the two verified
adapters this product's permission and isolation gates are measured against, so no
measured behaviour moves with this refresh.

Generated by `pnpm acp:registry`, which is the command the workflow's own comment
names for this case. Not hand-edited.

## Test plan

- `pnpm acp:registry:check` — current, 39 agents
- `pnpm checks:changed -- --run` — 2/2 passed (11 tests)

After merge, the `v1.0.0-rc.11` tag is recreated at the new head and the release
workflow is dispatched again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8