### PR TITLE
fix: say when a turn has stopped answering, instead of claiming progress

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -3446,6 +3446,8 @@
     "composerLabel": "Write what you want done",
     "send": "Send",
     "stop": "Stop",
+    "turnSilent": "The agent has said nothing for {minutes} minutes",
+    "turnSilentHint": "It may still be working, or it may have finished without telling us. Press Stop to type again.",
     "status": {
       "idle": "Off",
       "starting": "Connecting",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3446,6 +3446,8 @@
     "composerLabel": "무엇을 시킬지 적어요",
     "send": "보내기",
     "stop": "그만",
+    "turnSilent": "에이전트가 {minutes}분째 아무 소식이 없어요",
+    "turnSilentHint": "아직 일하는 중일 수도 있지만, 대답이 끝났는데 알려 주지 않은 것일 수도 있어요. 「그만」을 누르면 다시 입력할 수 있어요.",
     "status": {
       "idle": "꺼짐",
       "starting": "연결 중",

--- a/src/features/acp-session/model/turn-liveness.test.ts
+++ b/src/features/acp-session/model/turn-liveness.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { TURN_SILENCE_LIMIT_MS, turnLiveness } from './turn-liveness';
+
+/**
+ * ⚠️ These hold the difference between "still working" and "stopped answering" — the distinction a
+ * person could not make in the installed rc.11 build, where a finished turn looked exactly like a
+ * running one and locked the composer for thirteen minutes.
+ */
+describe('turn-liveness — 아직 일하는 중인지, 대답을 멈춘 것인지', () => {
+  it('턴이 열려 있지 않으면 판정하지 않는다', () => {
+    for (const status of ['ready', 'idle', 'starting', 'error', 'exited']) {
+      expect(turnLiveness(status, 0, Number.MAX_SAFE_INTEGER)).toBe('idle');
+    }
+  });
+
+  /*
+   * ⚠️ The turn opens before any update exists. Treating a missing timestamp as "silent since the
+   * epoch" would flag every turn on its first frame, which is the opposite failure: the screen would
+   * cry stall while the agent is starting normally.
+   */
+  it('막 시작해 아직 소식이 없는 턴은 멈춘 것이 아니다', () => {
+    expect(turnLiveness('thinking', null, 1_000_000)).toBe('working');
+  });
+
+  it('갱신이 계속 오는 동안은 아무리 길어도 살아 있다', () => {
+    const start = 1_000_000;
+    // A sweep that has run twenty minutes but spoke one second ago is working, not stalled. The
+    // no-timeout rule for `prompt` exists for exactly this turn.
+    expect(turnLiveness('thinking', start + 20 * 60_000, start + 20 * 60_000 + 1_000)).toBe(
+      'working',
+    );
+  });
+
+  it('한계만큼 조용하면 멈춘 것으로 본다', () => {
+    const t = 1_000_000;
+    expect(turnLiveness('thinking', t, t + TURN_SILENCE_LIMIT_MS - 1)).toBe('working');
+    expect(turnLiveness('thinking', t, t + TURN_SILENCE_LIMIT_MS)).toBe('silent');
+    expect(turnLiveness('thinking', t, t + 13 * 60_000)).toBe('silent');
+  });
+
+  it('한계는 호출자가 정할 수 있다 — 시험이 실시간을 기다리지 않도록', () => {
+    expect(turnLiveness('thinking', 0, 50, 100)).toBe('working');
+    expect(turnLiveness('thinking', 0, 100, 100)).toBe('silent');
+  });
+
+  /*
+   * ⚠️ The limit guards a person's patience, not a machine's. Set it below the real gap between
+   * steps and the screen calls a healthy sweep stalled, which teaches people to ignore the warning.
+   */
+  it('한계는 실제 단계 간격보다 충분히 크다', () => {
+    expect(TURN_SILENCE_LIMIT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+});

--- a/src/features/acp-session/model/turn-liveness.ts
+++ b/src/features/acp-session/model/turn-liveness.ts
@@ -1,0 +1,51 @@
+/**
+ * Is a turn that has not answered yet still **alive**?
+ *
+ * ⚠️ **Why this exists** (measured in the installed v1.0.0-rc.11 build, 2026-08-25). A turn ended on
+ * the agent's side without the app ever learning: all nine of its steps completed, the adapter
+ * process stayed up but burned 0.35s of CPU over thirteen minutes, and no `session/prompt` result
+ * arrived. `send()` returns to `ready` only when that promise resolves, and `prompt` is deliberately
+ * given **no timeout** — a turn sweeping a codebase can legitimately take minutes.
+ *
+ * So the screen kept claiming progress forever, the composer refused to send, and pressing Return
+ * did nothing. The stop control (`acpChat.stop`) did recover it, but nothing on screen said so, and
+ * a person has no way to tell "still working" from "stopped answering" when both look identical.
+ *
+ * The repair is not a timeout on the turn; that would cut off the long sweeps the no-limit rule was
+ * written to protect. It is a **liveness check**: a working turn emits `session/update` constantly
+ * — tool rows, thoughts, plan entries — so silence for far longer than any gap between steps means
+ * the turn has stopped talking, whatever it is doing.
+ *
+ * This module is pure. The caller supplies the clock, so the decision is testable without waiting.
+ */
+
+/**
+ * ⚠️ Not a guess at how long a turn takes — a turn may run for many minutes and stay live the whole
+ * way, because it keeps emitting updates. This is how long a turn may stay **silent**.
+ *
+ * The longest observed gap between updates in a real sweep was a single `analyze_repo_structure`
+ * call over 1,419 files, which is seconds. Ninety seconds is well above any real gap and well below
+ * the thirteen minutes a person sat locked out.
+ */
+export const TURN_SILENCE_LIMIT_MS = 90_000;
+
+export type TurnLiveness = 'idle' | 'working' | 'silent';
+
+/**
+ * @param status the session status; only `thinking` can be judged
+ * @param lastUpdateAt epoch ms of the most recent `session/update`, or of the send that opened the
+ *   turn when none has arrived yet. `null` means no turn is open.
+ * @param now epoch ms
+ */
+export function turnLiveness(
+  status: string,
+  lastUpdateAt: number | null,
+  now: number,
+  limitMs: number = TURN_SILENCE_LIMIT_MS,
+): TurnLiveness {
+  if (status !== 'thinking') return 'idle';
+  // ⚠️ No timestamp means the turn just opened, not that it has been silent forever. Reading a
+  // missing clock as "silent" would flag every turn the instant it started.
+  if (lastUpdateAt === null) return 'working';
+  return now - lastUpdateAt >= limitMs ? 'silent' : 'working';
+}

--- a/src/features/acp-session/model/use-acp-session.ts
+++ b/src/features/acp-session/model/use-acp-session.ts
@@ -233,6 +233,13 @@ export function useAcpSession({
 }: UseAcpSessionOptions) {
   const [status, setStatus] = useState<AcpSessionStatus>('idle');
   /*
+   * ⚠️ When the open turn last spoke, so the screen can tell "still working" from "stopped
+   * answering". `prompt` is deliberately given no timeout, so a turn that ends without a result
+   * would otherwise hold the composer shut forever with nothing on screen saying why
+   * (`turn-liveness.ts`, measured in the installed rc.11 build).
+   */
+  const [lastTurnUpdateAt, setLastTurnUpdateAt] = useState<number | null>(null);
+  /*
    * Status is held in a ref as well: the moment the adapter dies (`onExit`) is outside render, so a
    * closure sees a stale value. What is needed there is the status **at that moment** — was a turn
    * in progress (died mid-answer) or had it simply finished?
@@ -373,6 +380,8 @@ export function useAcpSession({
 
   const applyUpdate = useCallback(
     (update: Record<string, unknown>) => {
+      // Any update at all counts as the turn speaking; what it says does not matter here.
+      setLastTurnUpdateAt(Date.now());
       const kind = typeof update.sessionUpdate === 'string' ? update.sessionUpdate : '';
       const content = update.content as { text?: unknown } | undefined;
       const text = typeof content?.text === 'string' ? content.text : '';
@@ -864,15 +873,18 @@ export function useAcpSession({
       if (!client || !sessionId || !text.trim()) return;
       latestUserRequestRef.current = text.trim();
       push({ kind: 'user', id: nextEventId(), text });
+      setLastTurnUpdateAt(Date.now());
       setStatusTracked('thinking');
       try {
         await client.prompt(sessionId, [{ type: 'text', text }]);
         if (!disposedRef.current) {
           setApprovedOntologyWriteTracked(null);
+          setLastTurnUpdateAt(null);
           setStatusTracked('ready');
         }
       } catch (err) {
         setApprovedOntologyWriteTracked(null);
+        setLastTurnUpdateAt(null);
         setError(err instanceof Error ? err.message : String(err));
         setStatusTracked('error');
       }
@@ -949,6 +961,7 @@ export function useAcpSession({
 
   return {
     status,
+    lastTurnUpdateAt,
     events,
     error,
     slashCommands,

--- a/src/widgets/acp-chat-panel/ui/AcpChatPanel.test.tsx
+++ b/src/widgets/acp-chat-panel/ui/AcpChatPanel.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { TURN_SILENCE_LIMIT_MS } from '@/features/acp-session/model/turn-liveness';
+
 /**
  * A fake bridge — it imitates the protocol round trip with no real process.
  *
@@ -836,6 +838,69 @@ describe('대화 패널 — 못 하는 일은 정직하게', () => {
     );
     expect(screen.getByTestId('acp-chat-error')).toHaveTextContent('adapter died');
     expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  /*
+   * ⚠️ Measured in the installed v1.0.0-rc.11 build: a turn ended on the agent's side without a
+   * `session/prompt` result. All nine steps finished, the adapter went idle at 0.35s of CPU over
+   * thirteen minutes, and because `prompt` is deliberately given **no timeout**, the panel kept
+   * claiming progress and refused every keystroke. `cancel` recovered it; nothing on screen said so.
+   *
+   * The point of these two is that a long turn and a dead one must *not* look the same.
+   */
+  it('턴이 오래 조용하면 사실대로 말하고 나가는 길을 가리킨다', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await bootSession();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '지도 만들어줘' } });
+      fireEvent.click(screen.getByTestId('acp-chat-send'));
+      // The agent never answers, and never says anything either.
+      expect(screen.queryByTestId('acp-chat-turn-silent')).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(TURN_SILENCE_LIMIT_MS + 6_000);
+      await waitFor(() =>
+        expect(screen.getByTestId('acp-chat-turn-silent')).toBeInTheDocument(),
+      );
+      // The way out has to be on screen next to the words that name the problem.
+      expect(screen.getByTestId('acp-chat-stop')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('말을 계속하는 턴은 아무리 길어도 멈췄다고 하지 않는다', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await bootSession();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '지도 만들어줘' } });
+      fireEvent.click(screen.getByTestId('acp-chat-send'));
+
+      // Three quiet stretches, each just under the limit, with one word between them: a real sweep.
+      for (let round = 0; round < 3; round += 1) {
+        await vi.advanceTimersByTimeAsync(TURN_SILENCE_LIMIT_MS - 10_000);
+        emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId: 'sess-1',
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: `still going ${round}` },
+            },
+          },
+        });
+        // ⚠️ Chunks of one answer concatenate into a single node, so the text is matched inside the
+        // panel rather than as its own element.
+        await waitFor(() =>
+          expect(screen.getByTestId('acp-chat-panel').textContent).toContain(
+            `still going ${round}`,
+          ),
+        );
+      }
+      expect(screen.queryByTestId('acp-chat-turn-silent')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('빈 말은 보내지 않는다', async () => {

--- a/src/widgets/acp-chat-panel/ui/AcpChatPanel.tsx
+++ b/src/widgets/acp-chat-panel/ui/AcpChatPanel.tsx
@@ -48,6 +48,7 @@ import {
 } from '@/entities/knowledge-graph';
 import { useRowDisclosure } from '@/shared/lib/use-row-disclosure';
 import { useAcpSession, type AcpEvent } from '@/features/acp-session/model/use-acp-session';
+import { turnLiveness } from '@/features/acp-session/model/turn-liveness';
 import { readAcpTrouble } from '@/features/acp-session/model/acp-trouble';
 import { isAgentDoctorAvailable } from '@/features/acp-doctor/model/acp-doctor';
 import { useAgentDoctor } from '@/features/acp-doctor/ui/AgentDoctor';
@@ -280,6 +281,7 @@ export function AcpChatPanel({
   const reducedMotion = usePrefersReducedMotion();
   const {
     status,
+    lastTurnUpdateAt,
     events,
     slashCommands,
     error,
@@ -716,6 +718,39 @@ export function AcpChatPanel({
 
   const busy = status === 'thinking';
   const canType = status === 'ready' || status === 'thinking';
+  /*
+   * ⚠️ A turn that stopped answering looks exactly like one still working, because `prompt` is given
+   * no timeout on purpose (`turn-liveness.ts`). Measured in the installed rc.11 build: nine steps
+   * finished, the adapter went idle, and the composer stayed shut for thirteen minutes with the
+   * screen still claiming progress. `cancel` already recovers it; nothing said so.
+   */
+  /*
+   * ⚠️ The measurement carries **the timestamp it was taken against**, and render trusts it only
+   * while that basis is still current. Without that, a turn that went silent would leave its
+   * thirteen minutes on screen for one tick of the next turn.
+   *
+   * The clock is read in the interval, never during render: a component that asks the time while
+   * rendering is impure, and `react-hooks/purity` rejects it. Nothing is set from the effect body
+   * either, so no render cascades out of it.
+   */
+  const [silence, setSilence] = useState<{ basis: number; minutes: number } | null>(null);
+  useEffect(() => {
+    if (!busy || lastTurnUpdateAt === null) return;
+    const id = window.setInterval(() => {
+      const now = Date.now();
+      setSilence(
+        turnLiveness(status, lastTurnUpdateAt, now) === 'silent'
+          ? {
+              basis: lastTurnUpdateAt,
+              minutes: Math.max(1, Math.floor((now - lastTurnUpdateAt) / 60_000)),
+            }
+          : null,
+      );
+    }, 5_000);
+    return () => window.clearInterval(id);
+  }, [busy, lastTurnUpdateAt, status]);
+  const turnSilent = busy && silence !== null && silence.basis === lastTurnUpdateAt;
+  const silentMinutes = silence?.minutes ?? 0;
   // When the dock's first frame loads and immediately after session replacement,
   // the process effect has not yet started,
   // so the actual state is idle. While this panel is open, the user sees 「Waiting for Connection」 — we project only the screen state as starting without touching the protocol state. As long as sessionEnabled=true, 「Off」 does not flash during render cycles.
@@ -1326,6 +1361,24 @@ export function AcpChatPanel({
             className="pointer-events-none invisible absolute inset-x-0 top-0 h-0 overflow-hidden"
           />
         </div>
+        {/*
+          ⚠️ Named, not guessed at. The panel does not claim the agent is broken -- it cannot know --
+          it says how long the silence has been and points at the control that already recovers it.
+          Saying nothing was the rc.11 defect: the screen kept claiming progress while the person sat
+          locked out with no way to tell that pressing Stop was the way back.
+        */}
+        {turnSilent ? (
+          <p
+            data-testid="acp-chat-turn-silent"
+            role="status"
+            className="mt-2 text-label leading-prose text-[color:var(--color-text-tertiary)]"
+          >
+            <span className="text-[color:var(--color-text-secondary)]">
+              {t('turnSilent', { minutes: silentMinutes })}
+            </span>{' '}
+            {t('turnSilentHint')}
+          </p>
+        ) : null}
         <div className="mt-2 flex items-center justify-between gap-2">
           <span className="flex min-w-0 flex-1 items-center gap-2">{choicesRow}</span>
           <span className="flex shrink-0 items-center gap-1.5">


### PR DESCRIPTION
## What was measured

Pressing the **installed v1.0.0-rc.11 build**, a turn ended on the agent's side
without the app ever learning:

- all **nine** of its steps finished (survey, `analyze_repo_structure`, `infer_imports`, four file reads)
- the adapter process stayed up but burned **0.35s of CPU over thirteen minutes**
- no `session/prompt` result ever arrived

`send()` returns to `ready` only when that promise resolves, and `prompt` is
**deliberately given no timeout** — the comment in `acp-client.ts` explains why: a
turn sweeping a codebase can take minutes, and the screen keeps saying what is
happening.

So the panel kept claiming progress, `submit()` returned silently on every
keystroke, and nothing said that Stop was the way back. Pressing Stop *did*
recover it — the person just had no way to know.

## Why not a timeout

Putting a deadline on the turn would cut off exactly the long sweeps the no-limit
rule was written to protect.

A **working** turn emits `session/update` constantly — tool rows, thoughts, plan
entries. So silence far longer than any gap between steps means the turn has
stopped talking, whatever it is doing. `turn-liveness.ts` is a pure function over
(status, last-update time, now); the caller supplies the clock, so it is testable
without waiting.

The limit is 90s: well above the longest real gap measured (a single
`analyze_repo_structure` over 1,419 files, seconds) and well below the thirteen
minutes a person sat locked out.

## What the screen says

It does **not** claim the agent is broken — it cannot know that. It states the
silence and points at the control that already works:

> 에이전트가 13분째 아무 소식이 없어요
> 아직 일하는 중일 수도 있지만, 대답이 끝났는데 알려 주지 않은 것일 수도 있어요. 「그만」을 누르면 다시 입력할 수 있어요.

## Gates

Six pure-logic cases plus two panel cases. The panel pair is the load-bearing
one: **a long turn and a dead one must not look the same.** One drives 90s of
silence and expects the notice; the other emits a word just under the limit three
times over and expects no notice at all.

**Probed**: forcing `turnSilent` to `false` turns the suite red — 1 failed.

## Notes on shape

- The clock is read inside the interval, never during render — `react-hooks/purity` rejects the latter, correctly.
- The measurement carries the timestamp it was taken against, and render trusts it only while that basis is current. Without that, a silent turn would leave its thirteen minutes on screen for one tick of the next turn.
- Nothing is set from the effect body, so no render cascades out of it. `pnpm exec eslint` on the panel is clean; `main` had zero problems there and still does.

## Test plan

- `pnpm checks:changed -- --run` — **9/9 passed**
- `pnpm exec vitest run` on both suites — **81 passed**
- `pnpm exec tsc --noEmit`, `pnpm source:language` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8