### PR TITLE
chore: refresh the ACP registry again for rc.12

### DIFF
--- a/src-tauri/src/acp-registry.json
+++ b/src-tauri/src/acp-registry.json
@@ -255,7 +255,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dimcode@0.3.19",
+        "package": "dimcode@0.3.20",
         "args": [
           "acp"
         ]


### PR DESCRIPTION
## Summary

The rc.12 release stopped at its first gate again: upstream published once more
in the four hours since `#1257`.

| agent | before | after |
|---|---|---|
| `dimcode` | 0.3.19 | 0.3.20 |

`claude-agent-acp` and `codex-acp` — the two verified adapters this product's
permission and isolation gates are measured against — are unchanged, so no
measured behaviour moves.

**That this fired twice in one afternoon is the gate working as designed.** It is
deliberately not a PR check, because it turns red whenever somebody else deploys;
as a PR gate that would block unrelated work at random. Asking at release time is
what keeps a stale snapshot out of the shipped app.

Generated by `pnpm acp:registry`, not hand-edited.

## Test plan

- `pnpm acp:registry:check` — current, 39 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8