### PR TITLE
fix: do not call it silence while the person is the one being waited on

### DIFF
--- a/src/features/acp-session/model/turn-liveness.test.ts
+++ b/src/features/acp-session/model/turn-liveness.test.ts
@@ -39,9 +39,22 @@ describe('turn-liveness — 아직 일하는 중인지, 대답을 멈춘 것인�
     expect(turnLiveness('thinking', t, t + 13 * 60_000)).toBe('silent');
   });
 
+  /*
+   * ⚠️ Caught in the installed rc.12 build, by the fix's own first outing: a permission card sat on
+   * screen while the notice below it said the agent had gone quiet for three minutes. Updates do
+   * stop while an answer is awaited — but the person *is* the thing that has stopped, and the card
+   * already explains the wait.
+   */
+  it('사람의 승인을 기다리는 중이면 침묵이라고 하지 않는다', () => {
+    const t = 1_000_000;
+    expect(turnLiveness('thinking', t, t + 13 * 60_000, true)).toBe('awaiting-answer');
+    // Same clock, no card on screen: still a stall.
+    expect(turnLiveness('thinking', t, t + 13 * 60_000, false)).toBe('silent');
+  });
+
   it('한계는 호출자가 정할 수 있다 — 시험이 실시간을 기다리지 않도록', () => {
-    expect(turnLiveness('thinking', 0, 50, 100)).toBe('working');
-    expect(turnLiveness('thinking', 0, 100, 100)).toBe('silent');
+    expect(turnLiveness('thinking', 0, 50, false, 100)).toBe('working');
+    expect(turnLiveness('thinking', 0, 100, false, 100)).toBe('silent');
   });
 
   /*

--- a/src/features/acp-session/model/turn-liveness.ts
+++ b/src/features/acp-session/model/turn-liveness.ts
@@ -29,21 +29,32 @@
  */
 export const TURN_SILENCE_LIMIT_MS = 90_000;
 
-export type TurnLiveness = 'idle' | 'working' | 'silent';
+export type TurnLiveness = 'idle' | 'working' | 'awaiting-answer' | 'silent';
 
 /**
  * @param status the session status; only `thinking` can be judged
  * @param lastUpdateAt epoch ms of the most recent `session/update`, or of the send that opened the
  *   turn when none has arrived yet. `null` means no turn is open.
  * @param now epoch ms
+ * @param awaitingAnswer a permission request is on screen, waiting for the person
  */
 export function turnLiveness(
   status: string,
   lastUpdateAt: number | null,
   now: number,
+  awaitingAnswer = false,
   limitMs: number = TURN_SILENCE_LIMIT_MS,
 ): TurnLiveness {
   if (status !== 'thinking') return 'idle';
+  /*
+   * ⚠️ **The ball is in the person's court, so silence is theirs, not the agent's.** Caught in the
+   * installed rc.12 build: a permission card sat on screen while the notice underneath said the
+   * agent had gone quiet for three minutes. Updates genuinely stop while an answer is awaited, so
+   * the check below sees a stall — but the wait is already explained by the card, and telling
+   * somebody that nothing is happening while they are the thing that is not happening is worse than
+   * saying nothing.
+   */
+  if (awaitingAnswer) return 'awaiting-answer';
   // ⚠️ No timestamp means the turn just opened, not that it has been silent forever. Reading a
   // missing clock as "silent" would flag every turn the instant it started.
   if (lastUpdateAt === null) return 'working';

--- a/src/widgets/acp-chat-panel/ui/AcpChatPanel.test.tsx
+++ b/src/widgets/acp-chat-panel/ui/AcpChatPanel.test.tsx
@@ -903,6 +903,31 @@ describe('대화 패널 — 못 하는 일은 정직하게', () => {
     }
   });
 
+  /*
+   * ⚠️ Caught by this very fix's first outing in the installed rc.12 build: a permission card sat on
+   * screen while the notice under it said the agent had gone quiet for three minutes. Updates do
+   * stop while an answer is awaited -- but the person is the thing that has stopped, the card
+   * already explains the wait, and telling somebody nothing is happening while they are the thing
+   * not happening is worse than saying nothing.
+   */
+  it('승인 카드가 떠 있는 동안은 조용해도 멈췄다고 하지 않는다', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await bootSession();
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '지도 만들어줘' } });
+      fireEvent.click(screen.getByTestId('acp-chat-send'));
+      emit(permissionRequest('/tmp/vault/a.md', 91));
+      await waitFor(() =>
+        expect(screen.getByTestId("acp-permission-card")).toBeInTheDocument(),
+      );
+
+      await vi.advanceTimersByTimeAsync(TURN_SILENCE_LIMIT_MS + 6_000);
+      expect(screen.queryByTestId('acp-chat-turn-silent')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('빈 말은 보내지 않는다', async () => {
     await bootSession();
     expect(screen.getByTestId('acp-chat-send')).toBeDisabled();

--- a/src/widgets/acp-chat-panel/ui/AcpChatPanel.tsx
+++ b/src/widgets/acp-chat-panel/ui/AcpChatPanel.tsx
@@ -739,7 +739,7 @@ export function AcpChatPanel({
     const id = window.setInterval(() => {
       const now = Date.now();
       setSilence(
-        turnLiveness(status, lastTurnUpdateAt, now) === 'silent'
+        turnLiveness(status, lastTurnUpdateAt, now, pending !== null) === 'silent'
           ? {
               basis: lastTurnUpdateAt,
               minutes: Math.max(1, Math.floor((now - lastTurnUpdateAt) / 60_000)),
@@ -748,7 +748,7 @@ export function AcpChatPanel({
       );
     }, 5_000);
     return () => window.clearInterval(id);
-  }, [busy, lastTurnUpdateAt, status]);
+  }, [busy, lastTurnUpdateAt, pending, status]);
   const turnSilent = busy && silence !== null && silence.basis === lastTurnUpdateAt;
   const silentMinutes = silence?.minutes ?? 0;
   // When the dock's first frame loads and immediately after session replacement,


### PR DESCRIPTION
## What happened

Caught by **the previous fix's own first outing** in the installed rc.12 build: a
permission card sat on screen while the notice underneath it said the agent had
gone quiet for three minutes.

The liveness check was right about the facts — `session/update` genuinely stops
while an answer is awaited. It was wrong about **whose** silence it was. The card
already explains the wait, and telling somebody that nothing is happening while
they are the thing that is not happening is worse than saying nothing.

## The change

`turnLiveness` gains an `awaiting-answer` verdict, returned before the silence
comparison. The panel passes `pending !== null`.

Same clock with **no** card on screen still reads as a stall — that assertion is
in the test beside the new one, so the repair cannot quietly disable the original
defect's gate.

## Gates

Seven pure-logic cases, three panel cases. **Probed**: neutering the pending-check
turns all three panel cases red.

## Test plan

- `pnpm checks:changed -- --run` — **7/7 passed**
- `turn-liveness.test.ts` — 7 passed · `AcpChatPanel.test.tsx` — 76 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8