### PR TITLE
fix: let the change-review detail align by structure, not by a repeated number

### DIFF
--- a/src/features/ontology-change-review/ui/OntologyChangeReview.tsx
+++ b/src/features/ontology-change-review/ui/OntologyChangeReview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -28,25 +28,41 @@ function ChangeDetails({ item }: { item: OntologyChangeItem }) {
 
   return (
     <>
+      {/*
+        ⚠️ **One grid for the whole list, not one grid per row.** Each row used to be its own
+        `grid grid-cols-[4.5rem_…]`, so the labels lined up only because 4.5rem was written four
+        times — and 4.5rem is 72px holding four 11px labels of two characters each, about 22px of
+        text. The remaining 50px read as a gap between a label and its own value, which is what
+        made this block look crooked (owner, on the installed rc.13 build).
+
+        `auto` sizes the shared column to the widest label instead, so alignment is a property of
+        the structure rather than of a number that has to be kept true by hand, and a longer word
+        or another locale cannot break it.
+
+        The field list below keeps its explicit 6rem: those keys are raw frontmatter names, and
+        `contextual-meaning-editor.spec.ts` measures that column at 96px inside a 352px panel.
+      */}
       {item.relation ? (
-        <dl className="grid gap-1.5 text-label">
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-label">
           {([
             ['from', item.relation.from],
             ['relation', item.relation.type],
             ['to', item.relation.to],
           ] as const).map(([label, value]) => (
-            <div key={label} className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-2">
+            <Fragment key={label}>
               <dt className="text-[color:var(--color-text-quaternary)]">{t(label)}</dt>
               <dd className="break-words font-mono text-[color:var(--color-text-primary)]">{value}</dd>
-            </div>
+            </Fragment>
           ))}
           {item.relation.why ? (
-            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-2">
+            <>
+              {/* The reason is prose and the only new thing here: from/relation/to already appear
+                  in the row's own summary, so this line gets the space to be read. */}
               <dt className="text-[color:var(--color-text-quaternary)]">{t('why')}</dt>
-              <dd className="break-words text-[color:var(--color-text-secondary)]">
+              <dd className="break-words leading-prose text-[color:var(--color-text-secondary)]">
                 {item.relation.why}
               </dd>
-            </div>
+            </>
           ) : null}
         </dl>
       ) : null}
@@ -142,7 +158,12 @@ function ChangeItemRow({
         {mounted ? (
           <div
             ref={contentRef}
-            className="ai-row-disclosure-body grid gap-2 pb-2 pl-7 pr-1"
+            /*
+              ⚠️ `pt` matters here in a way it does not on the other disclosures: this row carries a
+              filled active background, so without it the first label sits flush against that fill and
+              reads as part of the header rather than as the start of the detail.
+            */
+            className="ai-row-disclosure-body grid gap-2 pb-2.5 pl-7 pr-1 pt-1.5"
           >
             <ChangeDetails item={item} />
           </div>

--- a/tests/e2e/contextual-meaning-editor.spec.ts
+++ b/tests/e2e/contextual-meaning-editor.spec.ts
@@ -101,6 +101,56 @@ test('map relation editor previews, reviews, and writes one relation without lea
     ),
   ).toBe(true);
 
+  /*
+   * ⚠️ The relation rows (from · relation · to · why) used to be **one grid each**, aligned only because
+   * `4.5rem` was written four times. 72px held four 11px two-character labels — about 22px of text —
+   * and the 50px left over read as a gap between a label and its own value (owner, on the installed
+   * rc.13 build). They share one grid now, so this measures the property that replaced the number:
+   * every label starts at the same x, every value starts at the same x, and neither column is
+   * mostly empty.
+   */
+  const relationFit = await review.evaluate((element) => {
+    const list = element.querySelector<HTMLElement>('dl');
+    if (!list) return null;
+    const labels = [...list.querySelectorAll<HTMLElement>('dt')];
+    const values = [...list.querySelectorAll<HTMLElement>('dd')];
+    const box = (el: HTMLElement) => el.getBoundingClientRect();
+    return {
+      labelCount: labels.length,
+      labelLefts: labels.map((el) => Math.round(box(el).left)),
+      valueLefts: values.map((el) => Math.round(box(el).left)),
+      /*
+       * ⚠️ **The text, not the cell.** A grid item fills its column, so `dt.getBoundingClientRect()`
+       * returns the column width whatever the label says — comparing the two measures a thing
+       * against itself. A probe caught exactly that: restoring the hardcoded 4.5rem left this
+       * check green. A Range around the text node measures what is actually drawn.
+       */
+      widestLabelText: Math.max(
+        ...labels.map((el) => {
+          const range = document.createRange();
+          range.selectNodeContents(el);
+          return Math.round(range.getBoundingClientRect().width);
+        }),
+      ),
+      columnWidth: labels.length ? Math.round(box(labels[0]).width) : 0,
+    };
+  });
+  /*
+   * ⚠️ Not `if (relationFit)`. A silent skip would let this whole measurement disappear the day the
+   * markup changes, and a gate that can vanish without saying so is not a gate.
+   */
+  expect(relationFit, 'the review must render a relation detail list to measure').not.toBeNull();
+  {
+    expect(relationFit!.labelCount, 'relation detail must render its labels').toBeGreaterThan(1);
+    expect(new Set(relationFit!.labelLefts).size, 'labels share one column').toBe(1);
+    expect(new Set(relationFit!.valueLefts).size, 'values share one column').toBe(1);
+    /*
+     * The column is sized by its widest label, so the slack inside it is the difference between
+     * the labels themselves — never the 50px of dead space a hardcoded 4.5rem left behind.
+     */
+    expect(relationFit!.columnWidth - relationFit!.widestLabelText).toBeLessThanOrEqual(1);
+  }
+
   await page.getByTestId('meaning-editor-apply').click();
   await expect(page.getByTestId('topology-map-v2')).toHaveAttribute(
     'data-preview-phase',


### PR DESCRIPTION
## What was reported

On the installed rc.13 build: the change-review detail **looks crooked**, and
**「시작」 has no space above it**.

Both are real, and they have different causes.

## The missing space

The disclosure body carried `pb-2` and **no top padding at all**. Other
disclosures do the same, but this is the one whose header row renders a *filled*
active background — so the first label sat flush against that fill and read as
part of the header rather than as the start of the detail.

## The crookedness was structural

Each of the four rows (from · relation · to · why) was **its own grid**. The
columns lined up only because `4.5rem` was written four times.

**Measured in the browser: that column is 72px holding an 11px two-character
label, so 53px of it is empty** — a gap between a label and its own value, four
times over.

The list is one grid now with an `auto` column, so **alignment is a property of
the structure** rather than a number that has to be kept true by hand. A longer
label or another locale cannot break it.

The field list keeps its explicit `6rem`. Those keys are raw frontmatter names
like `relation_notes`, and `contextual-meaning-editor.spec.ts` already measures
that column at 96px inside a 352px panel. That number has a reason; the other one
did not.

## The first gate I wrote was vacuous

Worth stating plainly. A grid item fills its column, so comparing
`dt.getBoundingClientRect().width` against the column width **compares a thing to
itself** — restoring the old `4.5rem` left the check green.

It measures a `Range` around the text node now. Probed: with `4.5rem` it fails at
**53px**; with `auto` it passes. The `if (relationFit)` guard also became an
explicit non-null assertion, so the measurement cannot silently disappear if the
markup changes.

## Test plan

- `PLAYWRIGHT_STATIC=1 pnpm exec playwright test tests/e2e/contextual-meaning-editor.spec.ts` — 2 passed (this is what CI runs)
- Probed both directions on a real build, not just a rerun of the same bundle
- `pnpm checks:changed -- --run` — **7/7 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8