### PR TITLE
chore: refresh the ACP registry for rc.14

### DIFF
--- a/src-tauri/src/acp-registry.json
+++ b/src-tauri/src/acp-registry.json
@@ -291,7 +291,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "droid@0.203.0",
+        "package": "droid@0.204.0",
         "args": [
           "exec",
           "--output-format",


### PR DESCRIPTION
## Summary

Fourth refresh today. This one is the sharpest example of why the gate lives at
release time: `pnpm acp:registry:check` was **green when the tag was cut** and
stale by the time the release workflow ran, twenty seconds later.

| agent | before | after |
|---|---|---|
| `droid` | 0.203.0 | 0.204.0 |

`claude-agent-acp` and `codex-acp` are unchanged, so no measured behaviour moves.

Generated by `pnpm acp:registry`, not hand-edited.

## Test plan

- `pnpm acp:registry:check` — current, 39 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8