### PR TITLE
fix: block the release on the adapters we run, not on all 39 listed agents

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -80,6 +80,14 @@ jobs:
       # noise rather than a rule (same discipline this repository has already set for lint rules).
       # Releases are manual work, so asking here exactly blocks "shipping outdated things."
       #
+      # **It blocks on the runtimes this app runs, and only those** (narrowed 2026-08-26). It used
+      # to fail on any of 39 listed agents moving, and it fired on all four releases of 2026-08-25/26
+      # without the mover ever being one we launch. Each cost a refresh, a PR, a CI round and a
+      # retag to ship a version number for a tool nobody here uses; on rc.14 it was green at tag
+      # time and stale twenty seconds later, which is a rule nobody can satisfy. The blocking set is
+      # read from Rust's `ISOLATION` table so it cannot drift from what the app actually knows;
+      # everything else is reported and does not stop the release.
+      #
       # **When blocked**: Run `pnpm acp:registry`, commit the diff, and push again.
       - name: Verify bundled ACP registry is current
         run: pnpm acp:registry:check

--- a/scripts/build-acp-registry.mjs
+++ b/scripts/build-acp-registry.mjs
@@ -242,6 +242,71 @@ async function fetchIcon(agent) {
   }
 }
 
+/**
+ * The runtimes this application **actually runs**, read from Rust rather than transcribed.
+ *
+ * ⚠️ **Why the gate is narrow now** (measured across rc.11 through rc.14, 2026-08-25/26). The
+ * release check blocked on any of 39 listed agents moving, and it fired on all four releases that
+ * day. Not once was the mover a runtime this app runs: cline, codebuddy-code, dimcode, droid,
+ * glm-acp-agent, grok, gemini-cli, qwen-code. Each cost a full round trip — refresh, PR, CI, retag —
+ * to ship a version number for a tool nobody here launches. On rc.14 the check was green when the
+ * tag was cut and stale twenty seconds later when the workflow ran, which is the shape of a rule
+ * that cannot be satisfied rather than one that is being broken.
+ *
+ * The danger it was written for is real and stays blocking: on 2026-08-20 the snapshot had fallen
+ * behind on `claude-agent-acp` and `codex-acp` themselves, so the app shipped launching adapter
+ * versions whose permission behaviour nobody had measured. That is a safety claim, not freshness.
+ *
+ * So: a stale entry for a runtime in Rust's `ISOLATION` table fails; every other entry is reported
+ * and does not block. `ISOLATION` is the honest source — it is exactly the set this app claims
+ * specific knowledge about, and `runtime-gate.test.ts` already reads it the same way.
+ */
+export function isolatedRuntimeIds() {
+  const rust = readFileSync(join(ROOT, 'src-tauri', 'src', 'acp.rs'), 'utf8');
+  const start = rust.indexOf('ISOLATION: &[IsolationSpec]');
+  if (start < 0) {
+    console.error('[acp-registry] could not find the ISOLATION table in src-tauri/src/acp.rs');
+    process.exit(1);
+  }
+  const block = rust.slice(start, rust.indexOf('];', start));
+  const ids = [...block.matchAll(/id:\s*"([^"]+)"/g)].map((m) => m[1]);
+  if (ids.length === 0) {
+    // ⚠️ An empty list would silently turn this into a gate that never blocks — the exact failure
+    // ("a gate that exists but does not run") the release workflow's own comment records.
+    console.error('[acp-registry] the ISOLATION table parsed to zero runtimes; refusing to pass');
+    process.exit(1);
+  }
+  return ids;
+}
+
+/** Which agents changed, and how — so the message names versions instead of saying "something". */
+export function driftedAgents(committed, current) {
+  const before = new Map(committed.map((a) => [a.id, a]));
+  const drifted = [];
+  for (const agent of current) {
+    const previous = before.get(agent.id);
+    const a = JSON.stringify(previous?.launch ?? null);
+    const b = JSON.stringify(agent.launch ?? null);
+    if (!previous) {
+      drifted.push({ id: agent.id, before: '(new)', after: launchLabel(agent) });
+    } else if (a !== b) {
+      drifted.push({ id: agent.id, before: launchLabel(previous), after: launchLabel(agent) });
+    }
+  }
+  for (const agent of committed) {
+    if (!current.some((a) => a.id === agent.id)) {
+      drifted.push({ id: agent.id, before: launchLabel(agent), after: '(removed)' });
+    }
+  }
+  return drifted;
+}
+
+export function launchLabel(agent) {
+  const launch = agent?.launch;
+  if (!launch) return '(none)';
+  return launch.package ?? launch.command ?? launch.kind ?? '(unknown)';
+}
+
 async function main() {
   const check = process.argv.includes('--check');
   const response = await fetch(SOURCE, { headers: { accept: 'application/json' } });
@@ -265,9 +330,27 @@ async function main() {
     }
     const serialized = `${JSON.stringify(normalized, null, 2)}\n`;
     if (readFileSync(OUT, 'utf8') !== serialized) {
-      console.error('[acp-registry] 커밋된 스냅샷이 최신과 다릅니다.');
-      console.error('  node scripts/build-acp-registry.mjs 를 돌리고 diff 를 확인하세요.');
-      process.exit(1);
+      const drifted = driftedAgents(committed.agents, normalized.agents);
+      const isolated = isolatedRuntimeIds();
+      const blocking = drifted.filter((entry) => isolated.includes(entry.id));
+      const rest = drifted.filter((entry) => !isolated.includes(entry.id));
+
+      const describe = (entry) => `    ${entry.id}: ${entry.before} → ${entry.after}`;
+      if (rest.length > 0) {
+        console.warn(`[acp-registry] ${rest.length} listed agent(s) moved upstream:`);
+        for (const entry of rest) console.warn(describe(entry));
+        console.warn('  Refresh when convenient: node scripts/build-acp-registry.mjs');
+      }
+      if (blocking.length > 0) {
+        console.error('[acp-registry] a runtime this app actually runs has gone stale:');
+        for (const entry of blocking) console.error(describe(entry));
+        console.error('  Run node scripts/build-acp-registry.mjs, review the diff, and commit.');
+        process.exit(1);
+      }
+      console.log(
+        `[acp-registry] snapshot differs, but no runtime this app isolates moved (${isolated.join(', ')}) · ${committed.agents.length} agents`,
+      );
+      return;
     }
     console.log(`[acp-registry] current · ${normalized.agents.length} agents`);
     return;
@@ -301,4 +384,11 @@ async function main() {
   );
 }
 
-await main();
+/*
+ * ⚠️ Only when run as a command. Without this guard, importing this module to test its pure
+ * helpers would fetch the upstream registry — a test that needs the network to check a string
+ * comparison is a test that fails on a plane.
+ */
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/scripts/build-acp-registry.test.mjs
+++ b/scripts/build-acp-registry.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { driftedAgents, isolatedRuntimeIds, launchLabel } from "./build-acp-registry.mjs";
+
+/**
+ * ⚠️ **Why this gate is narrow, and what must stay wide.**
+ *
+ * The release check used to block on any of 39 listed agents moving. Measured across rc.11 through
+ * rc.14 on 2026-08-25/26, it fired on all four releases of that day, and **not once was the mover a
+ * runtime this app runs**: cline, codebuddy-code, dimcode, droid, glm-acp-agent, grok, gemini-cli,
+ * qwen-code. Each cost a full round trip -- refresh, pull request, CI, retag -- to ship a version
+ * number for a tool nobody here launches. On rc.14 the check was green when the tag was cut and
+ * stale twenty seconds later when the workflow ran, which is a rule that cannot be satisfied rather
+ * than one being broken.
+ *
+ * The danger it was written for is real and stays blocking. On 2026-08-20 the snapshot had fallen
+ * behind on `claude-agent-acp` and `codex-acp` themselves, so the app shipped launching adapter
+ * versions whose permission behaviour nobody had measured. That is a safety claim, not freshness.
+ */
+test("the blocking set is read from Rust, not transcribed", () => {
+  const ids = isolatedRuntimeIds();
+  /*
+   * ⚠️ A second hand-kept list would drift from Rust exactly the way the version constant drifted
+   * from `package.json`. `runtime-gate.test.ts` already reads this same table the same way.
+   */
+  assert.ok(ids.length > 0, "the ISOLATION table must not parse to zero runtimes");
+  assert.ok(ids.includes("claude-acp"), "claude-acp is isolated and must be in the blocking set");
+  assert.ok(ids.includes("codex-acp"), "codex-acp is isolated and must be in the blocking set");
+  // The registry lists 39 agents; the app claims specific knowledge about a handful.
+  assert.ok(ids.length < 10, `the blocking set should stay small, got ${ids.length}`);
+});
+
+test("drift names the agent and both versions, so a message is actionable", () => {
+  const before = [{ id: "factory-droid", launch: { kind: "npx", package: "droid@0.203.0" } }];
+  const after = [{ id: "factory-droid", launch: { kind: "npx", package: "droid@0.204.0" } }];
+
+  assert.deepEqual(driftedAgents(before, after), [
+    { id: "factory-droid", before: "droid@0.203.0", after: "droid@0.204.0" },
+  ]);
+});
+
+test("an unchanged agent is not reported as drift", () => {
+  const same = [{ id: "claude-acp", launch: { kind: "npx", package: "x@1.0.0" } }];
+  assert.deepEqual(driftedAgents(same, structuredClone(same)), []);
+});
+
+/*
+ * ⚠️ Added and removed agents are drift too. Reporting only version bumps would let the snapshot
+ * silently lose an entry -- and a runtime disappearing from the list is a bigger change than one
+ * moving a patch version.
+ */
+test("an added or removed agent counts as drift", () => {
+  const added = driftedAgents([], [{ id: "new-agent", launch: { package: "n@1" } }]);
+  assert.deepEqual(added, [{ id: "new-agent", before: "(new)", after: "n@1" }]);
+
+  const removed = driftedAgents([{ id: "gone", launch: { package: "g@1" } }], []);
+  assert.deepEqual(removed, [{ id: "gone", before: "g@1", after: "(removed)" }]);
+});
+
+test("a launch without a package still gets a label instead of undefined", () => {
+  assert.equal(launchLabel({ launch: { kind: "uvx", command: "thing" } }), "thing");
+  assert.equal(launchLabel({ launch: { kind: "custom" } }), "custom");
+  assert.equal(launchLabel({}), "(none)");
+});


### PR DESCRIPTION
## The question

*"Is being caught by this every release right? Did we set something up wrong?"*

**We did.** The check failed on **any of 39 listed agents** moving upstream, and it
fired on **all four releases** of 2026-08-25/26:

| release | what moved | do we run it? |
|---|---|---|
| rc.11 | cline, codebuddy-code, dimcode, droid, glm-acp-agent, grok | no |
| rc.12 | dimcode | no |
| rc.13 | codebuddy-code, gemini-cli, qwen-code | no |
| rc.14 | droid | no |

**Not once was the mover a runtime this app runs.** Each cost a refresh, a pull
request, a CI round and a retag — to ship a version number for a tool nobody here
launches.

rc.14 showed the shape of it: the check was **green when the tag was cut and
stale twenty seconds later** when the workflow ran. That is a rule nobody can
satisfy, not a rule being broken.

## What stays blocking

The danger it was written for is real. On 2026-08-20 the snapshot had fallen
behind on **`claude-agent-acp` and `codex-acp` themselves**, so the app shipped
launching adapter versions whose permission behaviour nobody had measured. That
is a safety claim, not freshness — it still fails the release.

## How the set is decided

Read from Rust's `ISOLATION` table, not transcribed — the same reason the
download page stopped copying `package.json` earlier today, and the same way
`runtime-gate.test.ts` already reads it. A table that parses to **zero** exits
non-zero rather than passing: a gate that never blocks is the failure this
workflow's own comment records.

## Verified both directions

```
droid stale only    → reported, exit 0
  factory-droid: droid@0.203.0 → droid@0.204.0
  snapshot differs, but no runtime this app isolates moved (claude-acp, codex-acp)

claude-acp stale    → exit 1
  a runtime this app actually runs has gone stale:
    claude-acp: …@0.1.0 → …@0.70.0
```

**Under this rule, today's four round trips would have been zero.**

## Tests

This script had **none**. Five now — the blocking set comes from Rust and stays
small, drift names both versions, an added or removed agent counts as drift, and
a launch without a package still gets a label. Probed: emptying the ISOLATION
parse or dropping removal-detection each turns three of them red.

`await main()` is now guarded by an entrypoint check, so importing the module to
test string comparison no longer fetches the upstream registry.

## Test plan

- `pnpm checks:changed -- --run` — 5/5 passed
- `pnpm test:desktop:check` — **382 passed, 0 failed**
- `node --test scripts/build-acp-registry.test.mjs` — 5 passed
- `pnpm acp:registry:check` against the live registry, both directions above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8