### PR TITLE
feat: draw the architecture policy as a layer ladder and a matrix

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -315,7 +315,12 @@
       "hexagonal": "Hexagonal",
       "mvp": "MVP",
       "custom": "Custom"
-    }
+    },
+    "reachAria": "{role} may depend on {targets}",
+    "reachNone": "depends on no other role",
+    "reachLegendAllowed": "may depend on",
+    "reachLegendSelf": "itself",
+    "reachLegendOrder": "cells follow the row order above"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -318,9 +318,8 @@
     },
     "reachAria": "{role} may depend on {targets}",
     "reachNone": "depends on no other role",
-    "reachLegendAllowed": "may depend on",
-    "reachLegendSelf": "itself",
-    "reachLegendOrder": "cells follow the row order above"
+    "nestDirection": "outer layers depend on inner layers",
+    "nestException": "{from} may not depend on {to}"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -318,8 +318,10 @@
     },
     "reachAria": "{role} may depend on {targets}",
     "reachNone": "depends on no other role",
-    "nestDirection": "outer layers depend on inner layers",
-    "nestException": "{from} may not depend on {to}"
+    "ladderDirection": "the arrow is source-code dependency",
+    "legendAllowed": "may depend on",
+    "legendSelf": "itself",
+    "legendColumns": "column numbers match the layer numbers"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -318,9 +318,8 @@
     },
     "reachAria": "{role}는 {targets}에 의존할 수 있습니다",
     "reachNone": "아무 역할에도 의존하지 않습니다",
-    "reachLegendAllowed": "의존 가능",
-    "reachLegendSelf": "자기 자신",
-    "reachLegendOrder": "칸 순서는 위 행 순서와 같습니다"
+    "nestDirection": "바깥 계층이 안쪽 계층에 의존합니다",
+    "nestException": "{from}는 {to}에 의존할 수 없습니다"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -318,8 +318,10 @@
     },
     "reachAria": "{role}는 {targets}에 의존할 수 있습니다",
     "reachNone": "아무 역할에도 의존하지 않습니다",
-    "nestDirection": "바깥 계층이 안쪽 계층에 의존합니다",
-    "nestException": "{from}는 {to}에 의존할 수 없습니다"
+    "ladderDirection": "화살표는 소스 코드 의존 방향입니다",
+    "legendAllowed": "의존 가능",
+    "legendSelf": "자기 자신",
+    "legendColumns": "열 번호는 계층 번호와 같습니다"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -315,7 +315,12 @@
       "hexagonal": "헥사고날",
       "mvp": "MVP",
       "custom": "사용자 정의"
-    }
+    },
+    "reachAria": "{role}는 {targets}에 의존할 수 있습니다",
+    "reachNone": "아무 역할에도 의존하지 않습니다",
+    "reachLegendAllowed": "의존 가능",
+    "reachLegendSelf": "자기 자신",
+    "reachLegendOrder": "칸 순서는 위 행 순서와 같습니다"
   },
   "ontologyRelations": {
     "relationShort": {

--- a/src/entities/architecture-profile/index.ts
+++ b/src/entities/architecture-profile/index.ts
@@ -5,3 +5,6 @@ export {
   type ArchitectureHandoffContext,
   type ArchitectureProfile,
 } from './model/architecture-profile';
+export {
+  buildArchitectureLayout,
+} from './model/architecture-layout';

--- a/src/entities/architecture-profile/model/architecture-layout.test.ts
+++ b/src/entities/architecture-profile/model/architecture-layout.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FSD_PROFILE_FRONTMATTER,
+  HEXAGONAL_PROFILE_FRONTMATTER,
+} from '../../../../tests/fixtures/architecture-profile-cases.mjs';
+import { parseArchitectureProfile } from './architecture-profile';
+import { buildArchitectureLayout } from './architecture-layout';
+
+const hexagonal = () => buildArchitectureLayout(parseArchitectureProfile(HEXAGONAL_PROFILE_FRONTMATTER));
+const fsd = () => buildArchitectureLayout(parseArchitectureProfile(FSD_PROFILE_FRONTMATTER));
+
+/**
+ * ⚠️ These exist because the old drawing **contradicted its own data** (owner, on the installed
+ * build). It stacked roles in declaration order with a down-arrow between every consecutive pair,
+ * so on the hexagonal profile `domain` — which allows nothing — had an arrow leaving it, and
+ * `port → domain` was drawn with domain above port, pointing the wrong way.
+ */
+describe('architecture layout — 그림이 규칙과 어긋나지 않는다', () => {
+  it('아무것도 의존하지 않는 역할이 맨 아래에 있고, 나가는 화살표가 없다', () => {
+    const layout = hexagonal();
+    const domain = layout.nodes.find((node) => node.id === 'domain');
+    expect(domain?.isSink, 'domain allows nothing').toBe(true);
+    expect(domain?.depth, 'the sink is the last row').toBe(layout.rows.length - 1);
+    expect(layout.edges.filter((edge) => edge.from === 'domain')).toEqual([]);
+  });
+
+  /*
+   * ⚠️ The precise defect. `port → domain` exists in the rules; in declaration order port comes
+   * last, so a stack drew the arrow upward. Every arrow must now go strictly downward.
+   */
+  it('모든 화살표가 아래로만 간다 — 옆으로도 위로도 가지 않는다', () => {
+    const layout = hexagonal();
+    const rowOf = new Map(layout.nodes.map((node) => [node.id, node.depth]));
+    expect(layout.edges.length).toBeGreaterThan(0);
+    for (const edge of layout.edges) {
+      const from = rowOf.get(edge.from)!;
+      const to = rowOf.get(edge.to)!;
+      expect(to, `${edge.from} → ${edge.to} must point down`).toBeGreaterThan(from);
+    }
+  });
+
+  it('헥사고날은 바깥에서 안쪽으로 읽힌다', () => {
+    const layout = hexagonal();
+    const row = (id: string) => layout.nodes.find((node) => node.id === id)!.depth;
+    expect(row('adapter')).toBeLessThan(row('application'));
+    expect(row('application')).toBeLessThan(row('port'));
+    expect(row('port')).toBeLessThan(row('domain'));
+  });
+
+  /*
+   * ⚠️ Depth is the LONGEST path to a sink. With the shortest one, `adapter` — which reaches
+   * `domain` directly as well as through `application` — would land one row above domain, beside
+   * the roles it depends on, and its arrows would run sideways.
+   */
+  it('건너뛰는 의존이 있어도 층이 무너지지 않는다', () => {
+    const layout = hexagonal();
+    expect(layout.rows.length, 'adapter · application · port · domain').toBe(4);
+    const skipping = layout.edges.filter((edge) => edge.skips);
+    expect(skipping.length, 'adapter reaches past application').toBeGreaterThan(0);
+  });
+
+  /*
+   * ⚠️ `lower-only` is one sentence, not a graph: every role may reach every role beneath it.
+   * Seven roles would draw 21 arrows, which is noise rather than information — the renderer says
+   * the rule once instead. The layout still reports the policy so it can make that choice.
+   */
+  it('lower-only 는 선언 순서가 곧 층이고, 정책을 그대로 알려 준다', () => {
+    const layout = fsd();
+    expect(layout.policy).toBe('lower-only');
+    expect(layout.rows.map((row) => row[0])).toEqual([
+      'routing',
+      'app',
+      'views',
+      'widgets',
+      'features',
+      'entities',
+      'shared',
+    ]);
+    expect(layout.nodes.find((node) => node.id === 'shared')?.isSink).toBe(true);
+  });
+
+  /*
+   * ⚠️ `explicit` lets somebody write a cycle. A screen that hangs on bad input is worse than one
+   * that draws it, so this only asks that the function returns and keeps every role.
+   */
+  it('순환이 있어도 멈추지 않고 모든 역할을 돌려준다', () => {
+    const cyclic = parseArchitectureProfile({
+      ...HEXAGONAL_PROFILE_FRONTMATTER,
+      allow_domain: ['adapter'],
+    });
+    const layout = buildArchitectureLayout(cyclic);
+    expect(layout.nodes.map((node) => node.id).sort()).toEqual(
+      ['adapter', 'application', 'domain', 'port'].sort(),
+    );
+  });
+});

--- a/src/entities/architecture-profile/model/architecture-layout.ts
+++ b/src/entities/architecture-profile/model/architecture-layout.ts
@@ -1,0 +1,135 @@
+import type { ArchitectureProfile } from './architecture-profile';
+
+/**
+ * Where each role sits, and which arrows are real.
+ *
+ * ⚠️ **The old drawing was wrong, not merely plain** (owner, on the installed build: *"this is
+ * poor — 'roles and dependency direction' is neither good-looking nor a flow you can read at a
+ * glance"*). It stacked the roles in declaration order and put a down-arrow between every
+ * consecutive pair, whatever the rules said. On the storefront profile that produced a picture
+ * contradicting its own data: `domain` allows nothing yet had an arrow leaving it, and
+ * `port → domain` was drawn as domain-above-port, pointing the wrong way.
+ *
+ * So the layout is derived from the rules instead of from array order.
+ *
+ * **The two policies are genuinely different pictures, and flattening them into one is what broke.**
+ * Under `lower-only` the rule is a single sentence — every role may reach every role beneath it —
+ * so drawing all 21 edges of a seven-role profile is noise, and an ordered spine says it exactly.
+ * Under `explicit` the rule *is* a graph, and only the declared edges exist.
+ */
+
+interface ArchitectureLayoutNode {
+  id: string;
+  /** Row index. 0 is the deepest layer — the one nothing may depend upon. */
+  depth: number;
+  /** Position within the row, left to right, stable across renders. */
+  column: number;
+  /** Nothing is allowed to leave this role. */
+  isSink: boolean;
+}
+
+interface ArchitectureLayoutEdge {
+  from: string;
+  to: string;
+  /** True when the arrow skips at least one layer — drawn lighter so the spine stays legible. */
+  skips: boolean;
+}
+
+export interface ArchitectureLayout {
+  policy: 'explicit' | 'lower-only';
+  nodes: ArchitectureLayoutNode[];
+  edges: ArchitectureLayoutEdge[];
+  /** Rows, deepest last, so a renderer can lay out top-to-bottom without recomputing. */
+  rows: string[][];
+}
+
+function allowedFor(profile: ArchitectureProfile, roleId: string, index: number): string[] {
+  if (profile.dependencyPolicy === 'lower-only') {
+    return profile.roles.slice(index + 1).map((role) => role.id);
+  }
+  return profile.allows[roleId] ?? [];
+}
+
+/**
+ * Depth is the **longest** path to a sink, not the shortest.
+ *
+ * ⚠️ With shortest-path depth, a role that both reaches its neighbour and skips past it would land
+ * on the same row as the thing it depends on, and the arrow between them would run sideways. The
+ * longest path guarantees every arrow points down at least one row, which is the property that
+ * makes the picture readable at all.
+ */
+function computeDepths(
+  profile: ArchitectureProfile,
+  allows: Map<string, string[]>,
+): Map<string, number> {
+  const depth = new Map<string, number>();
+  const visiting = new Set<string>();
+
+  const walk = (id: string): number => {
+    const cached = depth.get(id);
+    if (cached !== undefined) return cached;
+    /*
+     * ⚠️ A cycle is a broken profile, not an impossible one: `explicit` lets somebody write
+     * `allow_a: [b]` and `allow_b: [a]`. Returning 0 keeps the screen drawable instead of hanging,
+     * and the cycle stays visible as two roles on the same row with arrows both ways.
+     */
+    if (visiting.has(id)) return 0;
+    visiting.add(id);
+    let deepest = 0;
+    for (const target of allows.get(id) ?? []) {
+      if (!allows.has(target)) continue;
+      deepest = Math.max(deepest, walk(target) + 1);
+    }
+    visiting.delete(id);
+    depth.set(id, deepest);
+    return deepest;
+  };
+
+  for (const role of profile.roles) walk(role.id);
+  return depth;
+}
+
+export function buildArchitectureLayout(profile: ArchitectureProfile): ArchitectureLayout {
+  const allows = new Map<string, string[]>();
+  profile.roles.forEach((role, index) => {
+    allows.set(role.id, allowedFor(profile, role.id, index));
+  });
+
+  const depth = computeDepths(profile, allows);
+  const maxDepth = Math.max(0, ...[...depth.values()]);
+
+  /*
+   * Rows read top-to-bottom as "reaches the most" → "reaches nothing", so the deepest role is drawn
+   * last. Inside a row, declaration order is preserved: the profile's author chose it, and a
+   * renderer reshuffling equals every render would make the picture move for no reason.
+   */
+  const rows: string[][] = Array.from({ length: maxDepth + 1 }, () => []);
+  for (const role of profile.roles) {
+    rows[maxDepth - (depth.get(role.id) ?? 0)]!.push(role.id);
+  }
+
+  const nodes: ArchitectureLayoutNode[] = [];
+  rows.forEach((row, rowIndex) => {
+    row.forEach((id, column) => {
+      nodes.push({
+        id,
+        depth: rowIndex,
+        column,
+        isSink: (allows.get(id) ?? []).length === 0,
+      });
+    });
+  });
+
+  const rowOf = new Map(nodes.map((node) => [node.id, node.depth]));
+  const edges: ArchitectureLayoutEdge[] = [];
+  for (const role of profile.roles) {
+    for (const target of allows.get(role.id) ?? []) {
+      if (!allows.has(target)) continue;
+      const from = rowOf.get(role.id) ?? 0;
+      const to = rowOf.get(target) ?? 0;
+      edges.push({ from: role.id, to: target, skips: to - from > 1 });
+    }
+  }
+
+  return { policy: profile.dependencyPolicy, nodes, edges, rows };
+}

--- a/src/views/architecture/ui/ArchitectureFlow.tsx
+++ b/src/views/architecture/ui/ArchitectureFlow.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import {
+  buildArchitectureLayout,
+  type ArchitectureProfile,
+} from '@/entities/architecture-profile';
+
+/**
+ * The dependency rules, drawn as the flow they are.
+ *
+ * ⚠️ **Why this is hand-drawn and not a graph library.** `AGENTS.md` names the canvas-2D
+ * `topology-map-v2` engine as *the* graph renderer and says another one needs a decision record;
+ * that rule is about the map's thousands of force-laid nodes. This is a handful of roles in a
+ * settled layered order, so a library would add a dependency, a bundle, and a second visual
+ * language to answer a layout that is a few lines of arithmetic.
+ *
+ * **Three defects the owner reported on the installed build, in order.**
+ *
+ * 1. *The picture disagreed with its data.* A stack of cards put a down-arrow between every
+ *    consecutive pair whatever the rules said, so `domain` — which allows nothing — had an arrow
+ *    leaving it and `port → domain` pointed the wrong way. `architecture-layout.ts` now derives the
+ *    rows and edges from the rules.
+ * 2. *The screen said everything twice.* A diagram of the roles sat above a list of the same roles,
+ *    so neither half could use the width and the result was both repetitive and empty. One band per
+ *    role now carries the name, the glob and the reach together.
+ * 3. *A single spine threw the information away.* For a `lower-only` profile the drawing collapsed
+ *    to seven rows and one hairline — *"this is poor too"*. Refusing to draw 21 implied edges was
+ *    right; drawing **nothing** in their place was not.
+ *
+ * **What replaced the spine: the reach grid.** Every band carries one cell per role, in layer
+ * order, filled where a dependency is allowed. Because the columns line up between bands, a
+ * strictly layered project draws a triangle — and that shape *is* the answer to "did the agent
+ * respect the architecture", because a dependency pointing back up appears on the wrong side of the
+ * diagonal where nothing else sits. This is the dependency-structure matrix, folded into the rows
+ * so a reader who does not know what a DSM is still sees a staircase.
+ *
+ * **The two policies stay two pictures.** `explicit` genuinely *is* a graph, so its declared edges
+ * are drawn as arcs in a gutter. `lower-only` is a single sentence, so it has no gutter and the
+ * grid carries it alone. Flattening them into one drawing is what produced defect 1.
+ */
+
+/** One band's height. Fixed so the arc overlay's arithmetic matches the DOM without measuring it. */
+const BAND_H = 64;
+/** The lane the arcs run in, left of the bands. Only `explicit` profiles draw one. */
+const GUTTER = 88;
+/*
+ * ⚠️ **Every arc starts and ends on a marked point.** A first pass ran the curves into the bare
+ * edge of the bands and they crowded into a smear that read as decoration rather than as four
+ * declared rules. One station dot per role is the device a transit map uses, and it is what makes
+ * the dependencies countable rather than merely felt.
+ */
+const STATION_X = GUTTER - 12;
+const DOT_R = 3.5;
+/** How far out each successive lane sits, so a skip cannot lie on top of a neighbouring edge. */
+const LANE_STEP = 24;
+const LANE_INSET = 18;
+
+function laneX(span: number) {
+  // A one-row hop hugs the bands; the further an edge skips, the further out it bows.
+  return Math.max(4, STATION_X - LANE_INSET - (span - 1) * LANE_STEP);
+}
+
+/** An arc between two station dots: leaves horizontally, arrives horizontally at the dot's edge. */
+function edgePath(y1: number, y2: number, span: number) {
+  const x = laneX(span);
+  return `M ${STATION_X} ${y1} C ${x} ${y1}, ${x} ${y2}, ${STATION_X - DOT_R - 1} ${y2}`;
+}
+
+export function ArchitectureFlow({
+  profile,
+  roleLabel,
+  reachLabel,
+  sinkLabel,
+  legend,
+}: {
+  profile: ArchitectureProfile;
+  roleLabel: (id: string) => string;
+  /** Reads the reach grid aloud, because a grid of cells is not a sentence. */
+  reachLabel: (role: string, targets: string) => string;
+  /** What "depends on nothing" is called. */
+  sinkLabel: string;
+  /** Teaches the grid: what a filled cell, an open cell and the column order mean. */
+  legend: { allowed: string; self: string; order: string };
+}) {
+  const layout = useMemo(() => buildArchitectureLayout(profile), [profile]);
+  const pathsOf = useMemo(
+    () => new Map(profile.roles.map((role) => [role.id, role.paths])),
+    [profile],
+  );
+
+  /*
+   * The grid's columns are the rows of the drawing, in the same order, so a cell's position alone
+   * says which layer it means and an upward dependency lands on the wrong side of the diagonal.
+   */
+  const columns = layout.rows.flat();
+  const depthOf = new Map(layout.nodes.map((node) => [node.id, node.depth]));
+  const allowedOf = (id: string) =>
+    layout.edges.filter((edge) => edge.from === id).map((edge) => edge.to);
+
+  const centreOf = (depth: number) => depth * BAND_H + BAND_H / 2;
+  const height = layout.rows.length * BAND_H;
+  const drawsArcs = layout.policy === 'explicit';
+
+  return (
+    <div className="flex w-full max-w-2xl flex-col gap-3" data-testid="architecture-flow">
+      <div className="relative overflow-hidden rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)]">
+        {drawsArcs ? (
+          <svg
+            className="pointer-events-none absolute left-0 top-0"
+            width={GUTTER}
+            height={height}
+            viewBox={`0 0 ${GUTTER} ${height}`}
+            aria-hidden
+          >
+            <defs>
+              <marker
+                id="architecture-flow-arrow"
+                viewBox="0 0 8 8"
+                refX="7"
+                refY="4"
+                markerWidth="5"
+                markerHeight="5"
+                orient="auto"
+              >
+                <path d="M0,0 L8,4 L0,8 z" fill="var(--color-indigo-a60)" />
+              </marker>
+            </defs>
+
+            {layout.edges.map((edge) => {
+              const from = depthOf.get(edge.from) ?? 0;
+              const to = depthOf.get(edge.to) ?? 0;
+              return (
+                <path
+                  key={`${edge.from}->${edge.to}`}
+                  d={edgePath(centreOf(from), centreOf(to), Math.abs(to - from))}
+                  fill="none"
+                  stroke={edge.skips ? 'var(--color-indigo-a30)' : 'var(--color-indigo-a60)'}
+                  strokeWidth={edge.skips ? 1 : 1.5}
+                  markerEnd="url(#architecture-flow-arrow)"
+                  data-testid={`architecture-flow-edge-${edge.from}-${edge.to}`}
+                />
+              );
+            })}
+
+            {/* Dots last, so an arrowhead cannot sit on top of one. */}
+            {layout.rows.map((row, depth) => (
+              <circle
+                key={row.join('+')}
+                cx={STATION_X}
+                cy={centreOf(depth)}
+                r={DOT_R}
+                fill="var(--color-panel)"
+                stroke={
+                  depth === layout.rows.length - 1
+                    ? 'var(--color-indigo-a60)'
+                    : 'var(--color-indigo-a30)'
+                }
+                strokeWidth="1.5"
+              />
+            ))}
+          </svg>
+        ) : null}
+
+        <ol className={drawsArcs ? 'm-0 list-none p-0 pl-22' : 'm-0 list-none p-0'}>
+          {layout.rows.map((row, depth) => (
+            <li
+              key={row.join('+')}
+              /*
+               * `h-16` with border-box keeps the row exactly BAND_H tall despite the divider, which
+               * is what lets the overlay compute centres instead of measuring them.
+               */
+              className="flex h-16 items-center gap-4 border-t border-[color:var(--color-divider)] pl-4 pr-4 first:border-t-0"
+              data-testid={`architecture-flow-band-${depth}`}
+            >
+              {row.map((id) => {
+                const allowed = allowedOf(id);
+                const isSink = allowed.length === 0;
+                return (
+                  <div
+                    key={id}
+                    className="flex min-w-0 flex-1 items-center gap-4"
+                    data-testid={`architecture-role-${id}`}
+                  >
+                    <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
+                      <h3
+                        className={
+                          isSink
+                            ? 'min-w-0 truncate text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-indigo-text-soft)]'
+                            : 'min-w-0 truncate text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]'
+                        }
+                      >
+                        {roleLabel(id)}
+                      </h3>
+                      <p className="min-w-0 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
+                        {(pathsOf.get(id) ?? []).join('  ·  ')}
+                      </p>
+                    </div>
+
+                    {/*
+                      ⚠️ The grid is the picture, so it must not also be the accessible text: a
+                      screen reader gets the sentence, and the cells are hidden from it.
+                    */}
+                    <p className="sr-only">
+                      {isSink
+                        ? sinkLabel
+                        : reachLabel(roleLabel(id), allowed.map(roleLabel).join(', '))}
+                    </p>
+                    <div
+                      className="flex shrink-0 gap-1"
+                      aria-hidden
+                      data-testid={`architecture-reach-${id}`}
+                    >
+                      {columns.map((column) => {
+                        const state =
+                          column === id ? 'self' : allowed.includes(column) ? 'on' : 'off';
+                        return (
+                          <span
+                            key={column}
+                            data-reach={state}
+                            className={
+                              state === 'on'
+                                ? 'size-2 rounded-full bg-[color:var(--color-indigo-a60)]'
+                                : state === 'self'
+                                  ? 'size-2 rounded-full border border-[color:var(--color-text-quaternary)]'
+                                  : 'size-2 rounded-full bg-[color:var(--color-overlay-2)]'
+                            }
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </li>
+          ))}
+        </ol>
+      </div>
+      {/*
+        ⚠️ A grid of cells is not self-explanatory: nothing on screen says the columns are the rows
+        above in the same order, and that mapping is the whole reason an upward dependency would be
+        visible. The diagonal of open cells hints at it; this states it. Real cells rather than
+        typed glyphs, so the legend cannot drift from what is drawn.
+      */}
+      <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-caption text-[color:var(--color-text-quaternary)]">
+        <span className="flex items-center gap-1.5">
+          <span className="size-2 rounded-full bg-[color:var(--color-indigo-a60)]" aria-hidden />
+          {legend.allowed}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            className="size-2 rounded-full border border-[color:var(--color-text-quaternary)]"
+            aria-hidden
+          />
+          {legend.self}
+        </span>
+        <span>{legend.order}</span>
+      </p>
+    </div>
+  );
+}

--- a/src/views/architecture/ui/ArchitectureFlow.tsx
+++ b/src/views/architecture/ui/ArchitectureFlow.tsx
@@ -1,41 +1,59 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   buildArchitectureLayout,
   type ArchitectureProfile,
 } from '@/entities/architecture-profile';
+import { RowButton } from '@/shared/ui';
 
 /**
- * The dependency rules, drawn as nested layers.
+ * The dependency policy: a ladder of layers, and the matrix that states the whole rule.
  *
- * ⚠️ **Four rounds of owner rejection got here, and each one was the same mistake.** The screen
- * kept being a *list of roles with decoration attached* — first a stack of cards with an arrow
- * between every consecutive pair, then a column of boxes, then bands with arcs in a gutter, then
- * bands with a grid of dots in the corner. Every round asked the reader to assemble the shape from
- * rows. The verdict never changed: *"can you see a flow in this? a flow.."*
+ * ⚠️ **Five rounds got here, and the research says why four of them failed.**
  *
- * A flow is not a list. So the drawing is now the one every layered architecture is taught with:
- * **layers nested inside each other, with dependency running inward.** The outermost ring may
- * depend on everything it contains; the core depends on nothing. Containment *is* the rule, so the
- * picture cannot disagree with the data the way the first version did — there are no arrows to
- * point the wrong way, and the sink is at the centre because nothing is inside it.
+ * Rounds 1–4 were a *list of roles with decoration attached* — cards with an arrow between every
+ * consecutive pair, boxes in a column, bands with arcs in a gutter, bands with dots in the corner.
+ * Round 5 was nested rings. The owner rejected each one, latterly with *"can you see a flow in
+ * this? a flow.."*, and the last rejection is the one with a measured cause behind it: the
+ * nested-rectangle literature is blunt that **beyond 2–3 levels of nesting the form stops being
+ * readable**, because deep nesting leaves no room for labels. Feature-Sliced Design has seven
+ * layers. The onion was not a near miss; it was the wrong instrument for this depth.
  *
- * ⚠️ **Containment is only honest when the profile is fully nested.** It claims every outer layer
- * may reach every inner one. `lower-only` says exactly that, and a well-formed hexagonal profile
- * does too. A profile with a hole — an outer layer forbidden from some inner layer — would be
- * over-stated by the rings, so the holes are computed and named beneath the drawing rather than
- * silently drawn as permission.
+ * **What the evidence actually supports for 4–8 layers.**
+ *
+ * - **One nesting level, not seven.** Full-width bands in dependency order, constant height, label
+ *   in a leading strip. A long name truncates horizontally instead of deforming the geometry.
+ * - **A policy matrix beside them.** Ghoniem, Fekete and Castagliola measured the crossover: past
+ *   about twenty vertices a matrix beats node-link at everything except path-finding, and below it
+ *   the graph wins. At four to eight, the matrix is sixteen to sixty-four cells — small enough to
+ *   read at a glance, and the only form in which *"there are no exceptions"* is a visible claim
+ *   rather than an absence. A legal layering draws a filled triangle; a hole is an empty cell where
+ *   the triangle should be solid, and needs no separate mark because its **position** is the
+ *   exception. Concentric rings could not say this at all, which is why they needed a paragraph of
+ *   disclaimer underneath.
+ * - **One arrow, not n².** A single stroke down the gutter carrying one stated semantic. Arrow
+ *   direction is genuinely ambiguous here — source-code dependency and data flow run in *opposite*
+ *   directions across a boundary — so the legend names which one this is, once.
+ * - **Motion that answers a question.** Hovering or focusing a layer raises it and everything it
+ *   may reach and dims the rest, and lights its row and column in the matrix. That is Shneiderman's
+ *   focus-plus-context and Heer and Shneiderman's linked highlighting, and it is the same ego-focus
+ *   behaviour the map already uses. This is what makes the reach legible: a static picture of seven
+ *   rows cannot show it, and no amount of restyling the rows was ever going to.
+ *
+ * ⚠️ **No layout library.** Every candidate — ELK, dagre, Cytoscape, Reaflow — solves *layout
+ * search*, and there is nothing to search: the order is the data. ELK alone is 455 KB gzipped to
+ * place eight boxes, and it is the one non-permissive licence among them. The geometry here is a
+ * loop over an array.
  */
 
-/** The drawing's own coordinate space; the SVG scales to its container. */
-const W = 640;
-/** How far each layer sits inside the one that may depend on it. */
-const INSET_X = 36;
-const INSET_Y = 26;
-/** The core is a destination, not a hairline, so it keeps a real height of its own. */
-const CORE_H = 72;
+/** Row and header heights, as Tailwind steps so the three columns stay in register. */
+const ROW_CLASS = 'h-14';
+const ROW_H = 56;
+const HEADER_H = 24;
+/** One matrix column. Cell pitch, not cell size — the dot inside is smaller. */
+const CELL_CLASS = 'w-4';
 
 export function ArchitectureFlow({
   profile,
@@ -43,152 +61,219 @@ export function ArchitectureFlow({
   reachLabel,
   sinkLabel,
   directionLabel,
-  exceptionLabel,
+  legend,
 }: {
   profile: ArchitectureProfile;
   roleLabel: (id: string) => string;
-  /** Reads one layer's reach aloud, because a drawing is not a sentence. */
+  /** Reads one layer's reach aloud, because a matrix is not a sentence. */
   reachLabel: (role: string, targets: string) => string;
   /** What "depends on nothing" is called. */
   sinkLabel: string;
-  /** States which way the rings are read. */
+  /** Names the one arrow's semantic. Ambiguity here is the most common misread. */
   directionLabel: string;
-  /** Names a pair the rings would otherwise claim is allowed. */
-  exceptionLabel: (from: string, to: string) => string;
+  legend: { allowed: string; self: string; columns: string };
 }) {
   const layout = useMemo(() => buildArchitectureLayout(profile), [profile]);
+  const [focus, setFocus] = useState<string | null>(null);
+
   const pathsOf = useMemo(
     () => new Map(profile.roles.map((role) => [role.id, role.paths])),
     [profile],
   );
-
-  /*
-   * Outer to inner. A row can hold more than one role at the same depth; they share a ring, which
-   * is the truthful reading — same depth means neither may depend on the other.
-   */
-  const rings = layout.rows;
-  const allowedOf = (id: string) =>
-    layout.edges.filter((edge) => edge.from === id).map((edge) => edge.to);
-
-  /*
-   * ⚠️ The holes. Containment says "outer reaches every inner"; these are the pairs where it does
-   * not, and printing them is what keeps the picture from granting permission the profile withheld.
-   */
-  const exceptions = useMemo(() => {
-    const found: Array<{ from: string; to: string }> = [];
-    rings.forEach((ring, outer) => {
-      for (const from of ring) {
-        const allowed = new Set(allowedOf(from));
-        for (const inner of rings.slice(outer + 1)) {
-          for (const to of inner) {
-            if (!allowed.has(to)) found.push({ from, to });
-          }
-        }
-      }
-    });
-    return found;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- rings and edges both come from layout
+  /** Outer to inner. Roles sharing a depth share a rung: neither may depend on the other. */
+  const rungs = layout.rows;
+  const order = rungs.flat();
+  const allows = useMemo(() => {
+    const map = new Map<string, Set<string>>(order.map((id) => [id, new Set<string>()]));
+    for (const edge of layout.edges) map.get(edge.from)?.add(edge.to);
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- order is derived from layout
   }, [layout]);
 
-  const depth = rings.length;
-  const height = CORE_H + 2 * (depth - 1) * INSET_Y;
-  const coreX = (depth - 1) * INSET_X;
+  const reaches = (id: string) => allows.get(id) ?? new Set<string>();
+  /** Focus keeps the focused layer and everything it may reach; everything else recedes. */
+  const inFocus = (id: string) => focus === null || focus === id || reaches(focus).has(id);
+
+  const gutterHeight = rungs.length * ROW_H;
 
   return (
-    <div className="flex w-full max-w-2xl flex-col gap-3" data-testid="architecture-flow">
-      <svg
-        viewBox={`0 0 ${W} ${height}`}
-        className="w-full"
-        aria-hidden
-        data-testid="architecture-flow-svg"
-      >
-        <defs>
-          <marker
-            id="architecture-flow-inward-head"
-            viewBox="0 0 8 8"
-            refX="7"
-            refY="4"
-            markerWidth="5"
-            markerHeight="5"
-            orient="auto"
-          >
-            <path d="M0,0 L8,4 L0,8 z" fill="var(--color-indigo-a60)" />
-          </marker>
-        </defs>
-
-        {rings.map((ring, index) => {
-          const isCore = index === depth - 1;
-          const x = index * INSET_X;
-          const y = index * INSET_Y;
-          const w = W - 2 * x;
-          const h = height - 2 * y;
-          return (
-            <g key={ring.join('+')} data-testid={`architecture-layer-${index}`}>
-              <rect
-                x={x}
-                y={y}
-                width={w}
-                height={h}
-                rx="12"
-                fill={isCore ? 'var(--color-indigo-a08)' : 'var(--color-panel)'}
-                stroke={isCore ? 'var(--color-indigo-a46)' : 'var(--color-border-soft)'}
-                strokeWidth="1"
-              />
-              {ring.map((id, position) => (
-                <text
-                  key={id}
-                  /*
-                   * A ring's label lives in the strip it owns — the band above its child. The core
-                   * has no child, so its label sits in the middle of the space it encloses.
-                   */
-                  x={isCore ? W / 2 : x + 14 + position * 180}
-                  y={isCore ? y + h / 2 : y + INSET_Y / 2}
-                  textAnchor={isCore ? 'middle' : 'start'}
-                  dominantBaseline="middle"
-                  data-testid={`architecture-role-${id}`}
-                >
-                  <tspan
-                    className={
-                      isCore
-                        ? 'fill-[var(--color-indigo-text-soft)] text-body font-[var(--font-weight-emphasis)]'
-                        : 'fill-[var(--color-text-primary)] text-body font-[var(--font-weight-emphasis)]'
-                    }
-                  >
-                    {roleLabel(id)}
-                  </tspan>
-                  <tspan
-                    dx="10"
-                    className="fill-[var(--color-text-quaternary)] font-mono text-caption"
-                  >
-                    {(pathsOf.get(id) ?? []).join('  ·  ')}
-                  </tspan>
-                </text>
-              ))}
-            </g>
-          );
-        })}
-
+    <div
+      className="flex w-full max-w-2xl flex-col gap-3"
+      data-testid="architecture-flow"
+      onMouseLeave={() => setFocus(null)}
+    >
+      {/*
+        ⚠️ **One table, not a diagram beside a table.** A first cut floated the ladder and the matrix
+        as separate columns; with no surface under the rows the ladder read as sparse text again and
+        a wide gap opened between a label and its own cells. Bands of constant height inside one
+        panel put a row and its policy on the same line, which is also what lets a focused row
+        recede as a unit.
+      */}
+      <div className="relative overflow-hidden rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)]">
         {/*
-          ⚠️ The arrow is the reason this reads as a flow rather than as a set of boxes. It runs
-          from outside the outermost ring to the edge of the core, piercing every boundary on the
-          way, so the direction of dependency is a single stroke the eye follows in one movement.
+          One arrow with one meaning, drawn over the gutter column. An arrow per permitted pair
+          would be 21 strokes on a seven-layer profile and would say nothing the order does not:
+          the matrix carries which, this carries which way.
         */}
-        <line
-          x1={10}
-          y1={height / 2}
-          x2={coreX - 8}
-          y2={height / 2}
-          stroke="var(--color-indigo-a60)"
-          strokeWidth="1.5"
-          markerEnd="url(#architecture-flow-inward-head)"
-          data-testid="architecture-flow-inward"
-        />
-      </svg>
+        <svg
+          className="pointer-events-none absolute left-0"
+          style={{ top: `${HEADER_H}px` }}
+          width={40}
+          height={gutterHeight}
+          viewBox={`0 0 40 ${gutterHeight}`}
+          aria-hidden
+        >
+          <defs>
+            <marker
+              id="architecture-ladder-head"
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="5"
+              markerHeight="5"
+              orient="auto"
+            >
+              <path d="M0,0 L8,4 L0,8 z" fill="var(--color-indigo-a60)" />
+            </marker>
+          </defs>
+          <line
+            x1={22}
+            y1={18}
+            x2={22}
+            y2={gutterHeight - 18}
+            stroke="var(--color-indigo-a60)"
+            strokeWidth="1.5"
+            markerEnd="url(#architecture-ladder-head)"
+            data-testid="architecture-flow-inward"
+          />
+        </svg>
+
+        <div
+          className="flex items-center pr-4"
+          style={{ height: `${HEADER_H}px` }}
+          aria-hidden
+          data-testid="architecture-matrix-header"
+        >
+          <span className="w-10 shrink-0" />
+          <span className="min-w-0 flex-1" />
+          {order.map((id, column) => (
+            <span
+              key={id}
+              className={`${CELL_CLASS} shrink-0 text-center font-mono text-caption tabular-nums text-[color:var(--color-text-quaternary)] transition-opacity duration-[var(--motion-fast)] ${
+                focus !== null && focus !== id && !reaches(focus).has(id) ? 'opacity-40' : ''
+              }`}
+            >
+              {column + 1}
+            </span>
+          ))}
+        </div>
+
+        <ol className="m-0 list-none p-0" data-testid="architecture-matrix">
+          {rungs.map((rung, depth) => (
+            <li
+              key={rung.join('+')}
+              className={`flex ${ROW_CLASS} items-center border-t border-[color:var(--color-divider)] pr-4 transition-opacity duration-[var(--motion-fast)] ${
+                rung.every((id) => !inFocus(id)) ? 'opacity-40' : 'opacity-100'
+              }`}
+              onMouseEnter={() => setFocus(rung[0] ?? null)}
+            >
+              <span className="w-10 shrink-0" />
+              {rung.map((id) => (
+                <div key={id} className="flex min-w-0 flex-1 items-center" data-testid={`architecture-rung-${id}`}>
+                  <RowButton
+                    active={focus === id}
+                    hoverInk="strong"
+                    hoverSurface="lift"
+                    /*
+                     * Hover and keyboard focus set the same state, so the reach is reachable
+                     * without a pointer. `RowButton` is the registered primitive; a hand-written
+                     * control would raise a ratchet that has stood at zero.
+                     */
+                    onMouseEnter={() => setFocus(id)}
+                    onFocus={() => setFocus(id)}
+                    onBlur={() => setFocus(null)}
+                    onClick={() => setFocus((current) => (current === id ? null : id))}
+                    data-testid={`architecture-role-${id}`}
+                    data-focus-state={
+                      focus === null
+                        ? 'rest'
+                        : focus === id
+                          ? 'focused'
+                          : inFocus(id)
+                            ? 'reached'
+                            : 'dimmed'
+                    }
+                    className="min-w-0 flex-1 justify-start px-3 py-2 text-left"
+                  >
+                    <span className="flex min-w-0 items-baseline gap-2">
+                      {/*
+                        The index is how a reader decodes a matrix column: seven Korean layer names
+                        cannot be written above 112px of cells, and numbering rows and columns alike
+                        is what every dependency-structure matrix does instead.
+                      */}
+                      <span className="shrink-0 font-mono text-caption tabular-nums text-[color:var(--color-text-quaternary)]">
+                        {depth + 1}
+                      </span>
+                      <span
+                        className={
+                          reaches(id).size === 0
+                            ? 'shrink-0 text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-indigo-text-soft)]'
+                            : 'shrink-0 text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]'
+                        }
+                      >
+                        {roleLabel(id)}
+                      </span>
+                      <span className="min-w-0 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
+                        {(pathsOf.get(id) ?? []).join('  ·  ')}
+                      </span>
+                    </span>
+                  </RowButton>
+                </div>
+              ))}
+
+              {/*
+                Rows are the consumer, columns the provider, so a filled cell reads "this row may
+                depend on that column". A legal layering is a filled triangle and a hole is a gap in
+                it -- the exception needs no mark because its position is the exception.
+              */}
+              <div
+                className="flex shrink-0"
+                aria-hidden
+                data-testid={`architecture-matrix-row-${rung[0]}`}
+              >
+                {order.map((columnId) => {
+                  const rowId = rung[0]!;
+                  const state =
+                    columnId === rowId ? 'self' : reaches(rowId).has(columnId) ? 'on' : 'off';
+                  /*
+                   * Linked highlighting: the focused layer's own row and its column both light, so
+                   * focusing a band answers "what may it reach" and "who may reach it" at once.
+                   */
+                  const lit = focus !== null && (focus === rowId || focus === columnId);
+                  return (
+                    <span key={columnId} data-reach={state} className={`${CELL_CLASS} flex justify-center`}>
+                      <span
+                        className={
+                          state === 'on'
+                            ? `size-2 rounded-full transition-colors duration-[var(--motion-fast)] ${lit ? 'bg-[color:var(--color-indigo-brand)]' : 'bg-[color:var(--color-indigo-a60)]'}`
+                            : state === 'self'
+                              ? 'size-2 rounded-full border border-[color:var(--color-text-quaternary)]'
+                              : 'size-2 rounded-full bg-[color:var(--color-overlay-2)]'
+                        }
+                      />
+                    </span>
+                  );
+                })}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
 
       {/* The drawing is hidden from assistive technology, so the same facts are stated here. */}
       <ol className="sr-only">
-        {rings.flat().map((id) => {
-          const allowed = allowedOf(id);
+        {order.map((id) => {
+          const allowed = [...reaches(id)];
           return (
             <li key={id}>
               {allowed.length === 0
@@ -199,18 +284,26 @@ export function ArchitectureFlow({
         })}
       </ol>
 
-      <p className="text-caption text-[color:var(--color-text-quaternary)]">{directionLabel}</p>
-
-      {exceptions.length > 0 ? (
-        <ul
-          className="flex flex-col gap-1 text-caption text-[color:var(--color-amber-source-a90)]"
-          data-testid="architecture-nest-exceptions"
-        >
-          {exceptions.map(({ from, to }) => (
-            <li key={`${from}->${to}`}>{exceptionLabel(roleLabel(from), roleLabel(to))}</li>
-          ))}
-        </ul>
-      ) : null}
+      {/*
+        ⚠️ A legend is not optional here. With an achromatic palette and one accent, shape and
+        position carry everything, and C4's own test is that the diagram must still make sense with
+        colour removed — which only holds if the reader is told what the marks mean.
+      */}
+      <p className="flex flex-wrap items-center gap-x-4 gap-y-1 text-caption text-[color:var(--color-text-quaternary)]">
+        <span className="flex items-center gap-1.5">
+          <span className="size-2 rounded-full bg-[color:var(--color-indigo-a60)]" aria-hidden />
+          {legend.allowed}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span
+            className="size-2 rounded-full border border-[color:var(--color-text-quaternary)]"
+            aria-hidden
+          />
+          {legend.self}
+        </span>
+        <span>{legend.columns}</span>
+        <span>{directionLabel}</span>
+      </p>
     </div>
   );
 }

--- a/src/views/architecture/ui/ArchitectureFlow.tsx
+++ b/src/views/architecture/ui/ArchitectureFlow.tsx
@@ -8,81 +8,53 @@ import {
 } from '@/entities/architecture-profile';
 
 /**
- * The dependency rules, drawn as the flow they are.
+ * The dependency rules, drawn as nested layers.
  *
- * ⚠️ **Why this is hand-drawn and not a graph library.** `AGENTS.md` names the canvas-2D
- * `topology-map-v2` engine as *the* graph renderer and says another one needs a decision record;
- * that rule is about the map's thousands of force-laid nodes. This is a handful of roles in a
- * settled layered order, so a library would add a dependency, a bundle, and a second visual
- * language to answer a layout that is a few lines of arithmetic.
+ * ⚠️ **Four rounds of owner rejection got here, and each one was the same mistake.** The screen
+ * kept being a *list of roles with decoration attached* — first a stack of cards with an arrow
+ * between every consecutive pair, then a column of boxes, then bands with arcs in a gutter, then
+ * bands with a grid of dots in the corner. Every round asked the reader to assemble the shape from
+ * rows. The verdict never changed: *"can you see a flow in this? a flow.."*
  *
- * **Three defects the owner reported on the installed build, in order.**
+ * A flow is not a list. So the drawing is now the one every layered architecture is taught with:
+ * **layers nested inside each other, with dependency running inward.** The outermost ring may
+ * depend on everything it contains; the core depends on nothing. Containment *is* the rule, so the
+ * picture cannot disagree with the data the way the first version did — there are no arrows to
+ * point the wrong way, and the sink is at the centre because nothing is inside it.
  *
- * 1. *The picture disagreed with its data.* A stack of cards put a down-arrow between every
- *    consecutive pair whatever the rules said, so `domain` — which allows nothing — had an arrow
- *    leaving it and `port → domain` pointed the wrong way. `architecture-layout.ts` now derives the
- *    rows and edges from the rules.
- * 2. *The screen said everything twice.* A diagram of the roles sat above a list of the same roles,
- *    so neither half could use the width and the result was both repetitive and empty. One band per
- *    role now carries the name, the glob and the reach together.
- * 3. *A single spine threw the information away.* For a `lower-only` profile the drawing collapsed
- *    to seven rows and one hairline — *"this is poor too"*. Refusing to draw 21 implied edges was
- *    right; drawing **nothing** in their place was not.
- *
- * **What replaced the spine: the reach grid.** Every band carries one cell per role, in layer
- * order, filled where a dependency is allowed. Because the columns line up between bands, a
- * strictly layered project draws a triangle — and that shape *is* the answer to "did the agent
- * respect the architecture", because a dependency pointing back up appears on the wrong side of the
- * diagonal where nothing else sits. This is the dependency-structure matrix, folded into the rows
- * so a reader who does not know what a DSM is still sees a staircase.
- *
- * **The two policies stay two pictures.** `explicit` genuinely *is* a graph, so its declared edges
- * are drawn as arcs in a gutter. `lower-only` is a single sentence, so it has no gutter and the
- * grid carries it alone. Flattening them into one drawing is what produced defect 1.
+ * ⚠️ **Containment is only honest when the profile is fully nested.** It claims every outer layer
+ * may reach every inner one. `lower-only` says exactly that, and a well-formed hexagonal profile
+ * does too. A profile with a hole — an outer layer forbidden from some inner layer — would be
+ * over-stated by the rings, so the holes are computed and named beneath the drawing rather than
+ * silently drawn as permission.
  */
 
-/** One band's height. Fixed so the arc overlay's arithmetic matches the DOM without measuring it. */
-const BAND_H = 64;
-/** The lane the arcs run in, left of the bands. Only `explicit` profiles draw one. */
-const GUTTER = 88;
-/*
- * ⚠️ **Every arc starts and ends on a marked point.** A first pass ran the curves into the bare
- * edge of the bands and they crowded into a smear that read as decoration rather than as four
- * declared rules. One station dot per role is the device a transit map uses, and it is what makes
- * the dependencies countable rather than merely felt.
- */
-const STATION_X = GUTTER - 12;
-const DOT_R = 3.5;
-/** How far out each successive lane sits, so a skip cannot lie on top of a neighbouring edge. */
-const LANE_STEP = 24;
-const LANE_INSET = 18;
-
-function laneX(span: number) {
-  // A one-row hop hugs the bands; the further an edge skips, the further out it bows.
-  return Math.max(4, STATION_X - LANE_INSET - (span - 1) * LANE_STEP);
-}
-
-/** An arc between two station dots: leaves horizontally, arrives horizontally at the dot's edge. */
-function edgePath(y1: number, y2: number, span: number) {
-  const x = laneX(span);
-  return `M ${STATION_X} ${y1} C ${x} ${y1}, ${x} ${y2}, ${STATION_X - DOT_R - 1} ${y2}`;
-}
+/** The drawing's own coordinate space; the SVG scales to its container. */
+const W = 640;
+/** How far each layer sits inside the one that may depend on it. */
+const INSET_X = 36;
+const INSET_Y = 26;
+/** The core is a destination, not a hairline, so it keeps a real height of its own. */
+const CORE_H = 72;
 
 export function ArchitectureFlow({
   profile,
   roleLabel,
   reachLabel,
   sinkLabel,
-  legend,
+  directionLabel,
+  exceptionLabel,
 }: {
   profile: ArchitectureProfile;
   roleLabel: (id: string) => string;
-  /** Reads the reach grid aloud, because a grid of cells is not a sentence. */
+  /** Reads one layer's reach aloud, because a drawing is not a sentence. */
   reachLabel: (role: string, targets: string) => string;
   /** What "depends on nothing" is called. */
   sinkLabel: string;
-  /** Teaches the grid: what a filled cell, an open cell and the column order mean. */
-  legend: { allowed: string; self: string; order: string };
+  /** States which way the rings are read. */
+  directionLabel: string;
+  /** Names a pair the rings would otherwise claim is allowed. */
+  exceptionLabel: (from: string, to: string) => string;
 }) {
   const layout = useMemo(() => buildArchitectureLayout(profile), [profile]);
   const pathsOf = useMemo(
@@ -91,172 +63,154 @@ export function ArchitectureFlow({
   );
 
   /*
-   * The grid's columns are the rows of the drawing, in the same order, so a cell's position alone
-   * says which layer it means and an upward dependency lands on the wrong side of the diagonal.
+   * Outer to inner. A row can hold more than one role at the same depth; they share a ring, which
+   * is the truthful reading — same depth means neither may depend on the other.
    */
-  const columns = layout.rows.flat();
-  const depthOf = new Map(layout.nodes.map((node) => [node.id, node.depth]));
+  const rings = layout.rows;
   const allowedOf = (id: string) =>
     layout.edges.filter((edge) => edge.from === id).map((edge) => edge.to);
 
-  const centreOf = (depth: number) => depth * BAND_H + BAND_H / 2;
-  const height = layout.rows.length * BAND_H;
-  const drawsArcs = layout.policy === 'explicit';
+  /*
+   * ⚠️ The holes. Containment says "outer reaches every inner"; these are the pairs where it does
+   * not, and printing them is what keeps the picture from granting permission the profile withheld.
+   */
+  const exceptions = useMemo(() => {
+    const found: Array<{ from: string; to: string }> = [];
+    rings.forEach((ring, outer) => {
+      for (const from of ring) {
+        const allowed = new Set(allowedOf(from));
+        for (const inner of rings.slice(outer + 1)) {
+          for (const to of inner) {
+            if (!allowed.has(to)) found.push({ from, to });
+          }
+        }
+      }
+    });
+    return found;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rings and edges both come from layout
+  }, [layout]);
+
+  const depth = rings.length;
+  const height = CORE_H + 2 * (depth - 1) * INSET_Y;
+  const coreX = (depth - 1) * INSET_X;
 
   return (
     <div className="flex w-full max-w-2xl flex-col gap-3" data-testid="architecture-flow">
-      <div className="relative overflow-hidden rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)]">
-        {drawsArcs ? (
-          <svg
-            className="pointer-events-none absolute left-0 top-0"
-            width={GUTTER}
-            height={height}
-            viewBox={`0 0 ${GUTTER} ${height}`}
-            aria-hidden
+      <svg
+        viewBox={`0 0 ${W} ${height}`}
+        className="w-full"
+        aria-hidden
+        data-testid="architecture-flow-svg"
+      >
+        <defs>
+          <marker
+            id="architecture-flow-inward-head"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto"
           >
-            <defs>
-              <marker
-                id="architecture-flow-arrow"
-                viewBox="0 0 8 8"
-                refX="7"
-                refY="4"
-                markerWidth="5"
-                markerHeight="5"
-                orient="auto"
-              >
-                <path d="M0,0 L8,4 L0,8 z" fill="var(--color-indigo-a60)" />
-              </marker>
-            </defs>
+            <path d="M0,0 L8,4 L0,8 z" fill="var(--color-indigo-a60)" />
+          </marker>
+        </defs>
 
-            {layout.edges.map((edge) => {
-              const from = depthOf.get(edge.from) ?? 0;
-              const to = depthOf.get(edge.to) ?? 0;
-              return (
-                <path
-                  key={`${edge.from}->${edge.to}`}
-                  d={edgePath(centreOf(from), centreOf(to), Math.abs(to - from))}
-                  fill="none"
-                  stroke={edge.skips ? 'var(--color-indigo-a30)' : 'var(--color-indigo-a60)'}
-                  strokeWidth={edge.skips ? 1 : 1.5}
-                  markerEnd="url(#architecture-flow-arrow)"
-                  data-testid={`architecture-flow-edge-${edge.from}-${edge.to}`}
-                />
-              );
-            })}
-
-            {/* Dots last, so an arrowhead cannot sit on top of one. */}
-            {layout.rows.map((row, depth) => (
-              <circle
-                key={row.join('+')}
-                cx={STATION_X}
-                cy={centreOf(depth)}
-                r={DOT_R}
-                fill="var(--color-panel)"
-                stroke={
-                  depth === layout.rows.length - 1
-                    ? 'var(--color-indigo-a60)'
-                    : 'var(--color-indigo-a30)'
-                }
-                strokeWidth="1.5"
+        {rings.map((ring, index) => {
+          const isCore = index === depth - 1;
+          const x = index * INSET_X;
+          const y = index * INSET_Y;
+          const w = W - 2 * x;
+          const h = height - 2 * y;
+          return (
+            <g key={ring.join('+')} data-testid={`architecture-layer-${index}`}>
+              <rect
+                x={x}
+                y={y}
+                width={w}
+                height={h}
+                rx="12"
+                fill={isCore ? 'var(--color-indigo-a08)' : 'var(--color-panel)'}
+                stroke={isCore ? 'var(--color-indigo-a46)' : 'var(--color-border-soft)'}
+                strokeWidth="1"
               />
-            ))}
-          </svg>
-        ) : null}
-
-        <ol className={drawsArcs ? 'm-0 list-none p-0 pl-22' : 'm-0 list-none p-0'}>
-          {layout.rows.map((row, depth) => (
-            <li
-              key={row.join('+')}
-              /*
-               * `h-16` with border-box keeps the row exactly BAND_H tall despite the divider, which
-               * is what lets the overlay compute centres instead of measuring them.
-               */
-              className="flex h-16 items-center gap-4 border-t border-[color:var(--color-divider)] pl-4 pr-4 first:border-t-0"
-              data-testid={`architecture-flow-band-${depth}`}
-            >
-              {row.map((id) => {
-                const allowed = allowedOf(id);
-                const isSink = allowed.length === 0;
-                return (
-                  <div
-                    key={id}
-                    className="flex min-w-0 flex-1 items-center gap-4"
-                    data-testid={`architecture-role-${id}`}
+              {ring.map((id, position) => (
+                <text
+                  key={id}
+                  /*
+                   * A ring's label lives in the strip it owns — the band above its child. The core
+                   * has no child, so its label sits in the middle of the space it encloses.
+                   */
+                  x={isCore ? W / 2 : x + 14 + position * 180}
+                  y={isCore ? y + h / 2 : y + INSET_Y / 2}
+                  textAnchor={isCore ? 'middle' : 'start'}
+                  dominantBaseline="middle"
+                  data-testid={`architecture-role-${id}`}
+                >
+                  <tspan
+                    className={
+                      isCore
+                        ? 'fill-[var(--color-indigo-text-soft)] text-body font-[var(--font-weight-emphasis)]'
+                        : 'fill-[var(--color-text-primary)] text-body font-[var(--font-weight-emphasis)]'
+                    }
                   >
-                    <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
-                      <h3
-                        className={
-                          isSink
-                            ? 'min-w-0 truncate text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-indigo-text-soft)]'
-                            : 'min-w-0 truncate text-body font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]'
-                        }
-                      >
-                        {roleLabel(id)}
-                      </h3>
-                      <p className="min-w-0 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
-                        {(pathsOf.get(id) ?? []).join('  ·  ')}
-                      </p>
-                    </div>
+                    {roleLabel(id)}
+                  </tspan>
+                  <tspan
+                    dx="10"
+                    className="fill-[var(--color-text-quaternary)] font-mono text-caption"
+                  >
+                    {(pathsOf.get(id) ?? []).join('  ·  ')}
+                  </tspan>
+                </text>
+              ))}
+            </g>
+          );
+        })}
 
-                    {/*
-                      ⚠️ The grid is the picture, so it must not also be the accessible text: a
-                      screen reader gets the sentence, and the cells are hidden from it.
-                    */}
-                    <p className="sr-only">
-                      {isSink
-                        ? sinkLabel
-                        : reachLabel(roleLabel(id), allowed.map(roleLabel).join(', '))}
-                    </p>
-                    <div
-                      className="flex shrink-0 gap-1"
-                      aria-hidden
-                      data-testid={`architecture-reach-${id}`}
-                    >
-                      {columns.map((column) => {
-                        const state =
-                          column === id ? 'self' : allowed.includes(column) ? 'on' : 'off';
-                        return (
-                          <span
-                            key={column}
-                            data-reach={state}
-                            className={
-                              state === 'on'
-                                ? 'size-2 rounded-full bg-[color:var(--color-indigo-a60)]'
-                                : state === 'self'
-                                  ? 'size-2 rounded-full border border-[color:var(--color-text-quaternary)]'
-                                  : 'size-2 rounded-full bg-[color:var(--color-overlay-2)]'
-                            }
-                          />
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })}
+        {/*
+          ⚠️ The arrow is the reason this reads as a flow rather than as a set of boxes. It runs
+          from outside the outermost ring to the edge of the core, piercing every boundary on the
+          way, so the direction of dependency is a single stroke the eye follows in one movement.
+        */}
+        <line
+          x1={10}
+          y1={height / 2}
+          x2={coreX - 8}
+          y2={height / 2}
+          stroke="var(--color-indigo-a60)"
+          strokeWidth="1.5"
+          markerEnd="url(#architecture-flow-inward-head)"
+          data-testid="architecture-flow-inward"
+        />
+      </svg>
+
+      {/* The drawing is hidden from assistive technology, so the same facts are stated here. */}
+      <ol className="sr-only">
+        {rings.flat().map((id) => {
+          const allowed = allowedOf(id);
+          return (
+            <li key={id}>
+              {allowed.length === 0
+                ? `${roleLabel(id)}: ${sinkLabel}`
+                : reachLabel(roleLabel(id), allowed.map(roleLabel).join(', '))}
             </li>
+          );
+        })}
+      </ol>
+
+      <p className="text-caption text-[color:var(--color-text-quaternary)]">{directionLabel}</p>
+
+      {exceptions.length > 0 ? (
+        <ul
+          className="flex flex-col gap-1 text-caption text-[color:var(--color-amber-source-a90)]"
+          data-testid="architecture-nest-exceptions"
+        >
+          {exceptions.map(({ from, to }) => (
+            <li key={`${from}->${to}`}>{exceptionLabel(roleLabel(from), roleLabel(to))}</li>
           ))}
-        </ol>
-      </div>
-      {/*
-        ⚠️ A grid of cells is not self-explanatory: nothing on screen says the columns are the rows
-        above in the same order, and that mapping is the whole reason an upward dependency would be
-        visible. The diagonal of open cells hints at it; this states it. Real cells rather than
-        typed glyphs, so the legend cannot drift from what is drawn.
-      */}
-      <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-caption text-[color:var(--color-text-quaternary)]">
-        <span className="flex items-center gap-1.5">
-          <span className="size-2 rounded-full bg-[color:var(--color-indigo-a60)]" aria-hidden />
-          {legend.allowed}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span
-            className="size-2 rounded-full border border-[color:var(--color-text-quaternary)]"
-            aria-hidden
-          />
-          {legend.self}
-        </span>
-        <span>{legend.order}</span>
-      </p>
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
@@ -58,46 +58,59 @@ describe('ArchitectureWorkbench', () => {
   });
 
   /*
-   * ⚠️ **A `lower-only` profile must still draw its rules.** The drawing used to collapse this
-   * policy to one hairline spine, on the argument that 21 implied edges are noise. Refusing to draw
-   * them was right; drawing *nothing* in their place left seven rows and a decorative line, and the
-   * owner's verdict on the installed build was "this is poor too".
+   * ⚠️ **The drawing must be a shape, not a list with decoration.** Four rounds died on the same
+   * mistake: cards with arrows between them, boxes in a column, bands with arcs, bands with a grid
+   * of dots. Each asked the reader to assemble the structure from rows, and the owner's verdict
+   * never changed -- "can you see a flow in this?".
    *
-   * The reach grid carries them instead: one cell per role, in row order, filled where a dependency
-   * is allowed. Because the columns line up between rows, a strictly layered project draws a
-   * triangle -- and a dependency pointing back up would land on the empty side of the diagonal,
-   * which is what makes "did the agent respect the architecture" answerable by looking.
+   * Nested layers are the shape every layered architecture is taught with, and containment *is* the
+   * rule: an outer ring may depend on everything it encloses, the core depends on nothing. There
+   * are no arrows left to point the wrong way, which is what broke the very first version.
    */
-  it('draws every allowed dependency as a triangle, not one decorative line', () => {
+  it('nests the layers outer to inner, with the sink at the core', () => {
     renderWorkbench();
     const order = ['routing', 'app', 'views', 'widgets', 'features', 'entities', 'shared'];
-    const cellsOf = (id: string) =>
-      [...screen.getByTestId(`architecture-reach-${id}`).children].map((cell) =>
-        cell.getAttribute('data-reach'),
-      );
+    const rings = [...screen.getByTestId('architecture-flow-svg').querySelectorAll('g[data-testid^="architecture-layer-"]')];
 
-    // The top layer may reach every layer beneath it, and none above -- there are none.
-    expect(cellsOf('routing')).toEqual(['self', 'on', 'on', 'on', 'on', 'on', 'on']);
-    // The sink reaches nothing, so its row is empty apart from itself.
-    expect(cellsOf('shared')).toEqual(['off', 'off', 'off', 'off', 'off', 'off', 'self']);
+    expect(rings, 'one ring per layer').toHaveLength(order.length);
+    expect(
+      rings.map((ring) => ring.querySelector('text')?.getAttribute('data-testid')),
+      'rings run outer to inner in dependency order',
+    ).toEqual(order.map((id) => `architecture-role-${id}`));
 
     /*
-     * The shape itself: every filled cell sits to the right of that row's own column. This is the
-     * assertion that fails the moment a rule points upward, whatever the row count.
+     * Geometry, not just order: each ring must sit strictly inside the one that may depend on it.
+     * A regression that drew them stacked or overlapping would keep the order and lose the meaning.
      */
-    order.forEach((id, row) => {
-      const cells = cellsOf(id);
-      expect(cells, `${id} must have one cell per role`).toHaveLength(order.length);
-      expect(cells[row], `${id} must mark itself at column ${row}`).toBe('self');
-      expect(
-        cells.slice(0, row),
-        `${id} must not be allowed to depend on a layer above it`,
-      ).not.toContain('on');
-      expect(
-        cells.slice(row + 1).every((cell) => cell === 'on'),
-        `${id} must reach every layer beneath it`,
-      ).toBe(true);
+    const boxes = rings.map((ring) => {
+      const rect = ring.querySelector('rect')!;
+      return {
+        x: Number(rect.getAttribute('x')),
+        y: Number(rect.getAttribute('y')),
+        w: Number(rect.getAttribute('width')),
+        h: Number(rect.getAttribute('height')),
+      };
     });
+    boxes.slice(1).forEach((inner, index) => {
+      const outer = boxes[index]!;
+      expect(inner.x, `ring ${index + 1} starts inside ring ${index}`).toBeGreaterThan(outer.x);
+      expect(inner.y, `ring ${index + 1} starts inside ring ${index}`).toBeGreaterThan(outer.y);
+      expect(inner.x + inner.w, 'and ends inside it').toBeLessThan(outer.x + outer.w);
+      expect(inner.y + inner.h, 'and ends inside it').toBeLessThan(outer.y + outer.h);
+    });
+
+    // One stroke the eye follows: dependency runs inward, from outside the shell to the core.
+    expect(screen.getByTestId('architecture-flow-inward')).toBeInTheDocument();
+  });
+
+  /*
+   * ⚠️ Containment claims every outer layer reaches every inner one. A `lower-only` profile says
+   * exactly that, so there is nothing to disclaim -- and if this list ever appeared for FSD, the
+   * rings would be granting permission the profile withheld.
+   */
+  it('claims no permission the profile withheld', () => {
+    renderWorkbench();
+    expect(screen.queryByTestId('architecture-nest-exceptions')).toBeNull();
   });
 
   it('keeps the same blueprint while switching from understand to plan and verify', () => {

--- a/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
@@ -37,6 +37,69 @@ describe('ArchitectureWorkbench', () => {
     );
   });
 
+  /*
+   * ⚠️ **The screen used to say everything twice.** A diagram of the roles sat above a list of the
+   * same roles, so `adapter` and its globs appeared in two places at once. The owner's reaction to
+   * the installed build was that it neither looked good nor read as a flow -- and the redundancy is
+   * why: with the information split across two blocks neither half could use the width, leaving a
+   * screen that was simultaneously repetitive and empty. One band per role now carries the name,
+   * the globs and the allowances together.
+   */
+  it('draws each role exactly once', () => {
+    renderWorkbench();
+    for (const id of ['routing', 'app', 'views', 'widgets', 'features', 'entities', 'shared']) {
+      expect(
+        screen.getAllByTestId(`architecture-role-${id}`),
+        `${id} must be drawn once, not once per block`,
+      ).toHaveLength(1);
+    }
+    // The glob is the part that was literally duplicated, so it is what the guard reads.
+    expect(screen.getAllByText('src/shared/**')).toHaveLength(1);
+  });
+
+  /*
+   * ⚠️ **A `lower-only` profile must still draw its rules.** The drawing used to collapse this
+   * policy to one hairline spine, on the argument that 21 implied edges are noise. Refusing to draw
+   * them was right; drawing *nothing* in their place left seven rows and a decorative line, and the
+   * owner's verdict on the installed build was "this is poor too".
+   *
+   * The reach grid carries them instead: one cell per role, in row order, filled where a dependency
+   * is allowed. Because the columns line up between rows, a strictly layered project draws a
+   * triangle -- and a dependency pointing back up would land on the empty side of the diagonal,
+   * which is what makes "did the agent respect the architecture" answerable by looking.
+   */
+  it('draws every allowed dependency as a triangle, not one decorative line', () => {
+    renderWorkbench();
+    const order = ['routing', 'app', 'views', 'widgets', 'features', 'entities', 'shared'];
+    const cellsOf = (id: string) =>
+      [...screen.getByTestId(`architecture-reach-${id}`).children].map((cell) =>
+        cell.getAttribute('data-reach'),
+      );
+
+    // The top layer may reach every layer beneath it, and none above -- there are none.
+    expect(cellsOf('routing')).toEqual(['self', 'on', 'on', 'on', 'on', 'on', 'on']);
+    // The sink reaches nothing, so its row is empty apart from itself.
+    expect(cellsOf('shared')).toEqual(['off', 'off', 'off', 'off', 'off', 'off', 'self']);
+
+    /*
+     * The shape itself: every filled cell sits to the right of that row's own column. This is the
+     * assertion that fails the moment a rule points upward, whatever the row count.
+     */
+    order.forEach((id, row) => {
+      const cells = cellsOf(id);
+      expect(cells, `${id} must have one cell per role`).toHaveLength(order.length);
+      expect(cells[row], `${id} must mark itself at column ${row}`).toBe('self');
+      expect(
+        cells.slice(0, row),
+        `${id} must not be allowed to depend on a layer above it`,
+      ).not.toContain('on');
+      expect(
+        cells.slice(row + 1).every((cell) => cell === 'on'),
+        `${id} must reach every layer beneath it`,
+      ).toBe(true);
+    });
+  });
+
   it('keeps the same blueprint while switching from understand to plan and verify', () => {
     renderWorkbench();
     const role = screen.getByTestId('architecture-role-features');

--- a/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
@@ -22,6 +22,8 @@ function renderWorkbench(handoffContext?: ArchitectureHandoffContext) {
   );
 }
 
+const order_all = ['routing', 'app', 'views', 'widgets', 'features', 'entities', 'shared'];
+
 describe('ArchitectureWorkbench', () => {
   it('opens with a scoped living blueprint instead of an ontology graph', () => {
     renderWorkbench();
@@ -58,59 +60,66 @@ describe('ArchitectureWorkbench', () => {
   });
 
   /*
-   * ⚠️ **The drawing must be a shape, not a list with decoration.** Four rounds died on the same
-   * mistake: cards with arrows between them, boxes in a column, bands with arcs, bands with a grid
-   * of dots. Each asked the reader to assemble the structure from rows, and the owner's verdict
-   * never changed -- "can you see a flow in this?".
+   * ⚠️ **The matrix is where the policy is checkable.** Five rounds of this screen were a list of
+   * roles with decoration attached, and the last one -- concentric rings -- failed for a measured
+   * reason: the nested-rectangle literature puts the legibility limit at 2-3 levels and
+   * Feature-Sliced Design has seven. Rings also cannot state an exception, only imply permission.
    *
-   * Nested layers are the shape every layered architecture is taught with, and containment *is* the
-   * rule: an outer ring may depend on everything it encloses, the core depends on nothing. There
-   * are no arrows left to point the wrong way, which is what broke the very first version.
+   * Rows are the consumer and columns the provider, so a legal layering draws a filled triangle and
+   * a hole is a gap in it. That shape is the assertion: it fails the moment a rule points upward,
+   * whatever the layer count, and it needs no separate mark for an exception because the position
+   * of an empty cell *is* the exception.
    */
-  it('nests the layers outer to inner, with the sink at the core', () => {
+  it('states the whole policy as a triangle', () => {
     renderWorkbench();
     const order = ['routing', 'app', 'views', 'widgets', 'features', 'entities', 'shared'];
-    const rings = [...screen.getByTestId('architecture-flow-svg').querySelectorAll('g[data-testid^="architecture-layer-"]')];
+    const cellsOf = (id: string) =>
+      [...screen.getByTestId(`architecture-matrix-row-${id}`).children].map((cell) =>
+        cell.getAttribute('data-reach'),
+      );
 
-    expect(rings, 'one ring per layer').toHaveLength(order.length);
-    expect(
-      rings.map((ring) => ring.querySelector('text')?.getAttribute('data-testid')),
-      'rings run outer to inner in dependency order',
-    ).toEqual(order.map((id) => `architecture-role-${id}`));
-
-    /*
-     * Geometry, not just order: each ring must sit strictly inside the one that may depend on it.
-     * A regression that drew them stacked or overlapping would keep the order and lose the meaning.
-     */
-    const boxes = rings.map((ring) => {
-      const rect = ring.querySelector('rect')!;
-      return {
-        x: Number(rect.getAttribute('x')),
-        y: Number(rect.getAttribute('y')),
-        w: Number(rect.getAttribute('width')),
-        h: Number(rect.getAttribute('height')),
-      };
-    });
-    boxes.slice(1).forEach((inner, index) => {
-      const outer = boxes[index]!;
-      expect(inner.x, `ring ${index + 1} starts inside ring ${index}`).toBeGreaterThan(outer.x);
-      expect(inner.y, `ring ${index + 1} starts inside ring ${index}`).toBeGreaterThan(outer.y);
-      expect(inner.x + inner.w, 'and ends inside it').toBeLessThan(outer.x + outer.w);
-      expect(inner.y + inner.h, 'and ends inside it').toBeLessThan(outer.y + outer.h);
+    order.forEach((id, row) => {
+      const cells = cellsOf(id);
+      expect(cells, `${id} needs one cell per layer`).toHaveLength(order.length);
+      expect(cells[row], `${id} marks itself at column ${row + 1}`).toBe('self');
+      expect(
+        cells.slice(0, row),
+        `${id} must not be allowed to depend on a layer above it`,
+      ).not.toContain('on');
+      expect(
+        cells.slice(row + 1).every((cell) => cell === 'on'),
+        `${id} must reach every layer beneath it`,
+      ).toBe(true);
     });
 
-    // One stroke the eye follows: dependency runs inward, from outside the shell to the core.
+    // One stroke with one stated meaning, rather than an arrow per permitted pair.
     expect(screen.getByTestId('architecture-flow-inward')).toBeInTheDocument();
   });
 
   /*
-   * ⚠️ Containment claims every outer layer reaches every inner one. A `lower-only` profile says
-   * exactly that, so there is nothing to disclaim -- and if this list ever appeared for FSD, the
-   * rings would be granting permission the profile withheld.
+   * ⚠️ **The interaction is the part a static picture cannot do.** "Can you see a flow in this?"
+   * was asked of a drawing with no way to ask it a question. Focusing a layer raises it and
+   * everything it may reach and recedes the rest -- Shneiderman's focus-plus-context, and the same
+   * ego-focus the map already uses. Keyboard focus drives it too, so the reach is not pointer-only.
    */
-  it('claims no permission the profile withheld', () => {
+  it('raises a focused layer and its reach, and recedes the rest', () => {
     renderWorkbench();
-    expect(screen.queryByTestId('architecture-nest-exceptions')).toBeNull();
+    const stateOf = (id: string) =>
+      screen.getByTestId(`architecture-role-${id}`).getAttribute('data-focus-state');
+
+    expect(order_all.map(stateOf).every((state) => state === 'rest')).toBe(true);
+
+    fireEvent.focus(screen.getByTestId('architecture-role-features'));
+    expect(stateOf('features')).toBe('focused');
+    // Everything beneath it is reachable...
+    expect(stateOf('entities')).toBe('reached');
+    expect(stateOf('shared')).toBe('reached');
+    // ...and everything above it is not.
+    expect(stateOf('widgets')).toBe('dimmed');
+    expect(stateOf('routing')).toBe('dimmed');
+
+    fireEvent.blur(screen.getByTestId('architecture-role-features'));
+    expect(stateOf('features')).toBe('rest');
   });
 
   it('keeps the same blueprint while switching from understand to plan and verify', () => {

--- a/src/views/architecture/ui/ArchitectureWorkbench.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.tsx
@@ -262,11 +262,8 @@ export function ArchitectureWorkbench({
                 roleLabel={roleLabel}
                 reachLabel={(role, targets) => t('reachAria', { role, targets })}
                 sinkLabel={t('reachNone')}
-                legend={{
-                  allowed: t('reachLegendAllowed'),
-                  self: t('reachLegendSelf'),
-                  order: t('reachLegendOrder'),
-                }}
+                directionLabel={t('nestDirection')}
+                exceptionLabel={(from, to) => t('nestException', { from, to })}
               />
             </div>
           </div>

--- a/src/views/architecture/ui/ArchitectureWorkbench.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { ArrowDown, Bot, Boxes, CircleHelp, FileCode2, ShieldCheck } from 'lucide-react';
+import { Bot, Boxes, CircleHelp, FileCode2, ShieldCheck } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { Link } from '@/i18n/navigation';
@@ -15,17 +15,10 @@ import { ICON_SIZE } from '@/shared/ui/icon-size';
 import { badgeClass } from '@/shared/ui/badge-class';
 import { Button, EmptyState, RowButton, Surface, buttonVariants } from '@/shared/ui';
 import { SegmentedControl } from '@/shared/ui/segmented-control';
+import { ArchitectureFlow } from './ArchitectureFlow';
 
 type Mode = 'understand' | 'plan' | 'verify';
 type CopyState = 'idle' | 'pending' | 'copied' | 'error';
-
-function allowedRoles(profile: ArchitectureProfile, roleIndex: number): string[] | null {
-  const role = profile.roles[roleIndex]!;
-  if (profile.dependencyPolicy === 'lower-only') {
-    return profile.roles.slice(roleIndex + 1).map((candidate) => candidate.id);
-  }
-  return profile.allows[role.id] ?? null;
-}
 
 export function ArchitectureWorkbench({
   profiles,
@@ -251,44 +244,30 @@ export function ArchitectureWorkbench({
               ))}
             </div>
 
-            <div className="mt-6 flex flex-col items-center" data-architecture-mode={mode}>
-              {selected.roles.map((role, index) => {
-                const allowed = allowedRoles(selected, index);
-                return (
-                  <div key={role.id} className="contents">
-                    <article
-                      data-testid={`architecture-role-${role.id}`}
-                      className="w-full max-w-2xl rounded-panel border border-[color:var(--color-border-soft)] bg-[color:var(--color-panel)] p-[var(--card-pad)] shadow-[var(--shadow-elevation-1)]"
-                    >
-                      <div className="flex flex-wrap items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <h3 className="text-body-lg font-[var(--font-weight-emphasis)] text-[color:var(--color-text-primary)]">
-                            {roleLabel(role.id)}
-                          </h3>
-                          <p className="mt-1 truncate font-mono text-caption text-[color:var(--color-text-quaternary)]">
-                            {role.paths.join(' · ')}
-                          </p>
-                        </div>
-                        <span className="text-caption text-[color:var(--color-text-quaternary)]">
-                          {t('rolePaths', { count: role.paths.length })}
-                        </span>
-                      </div>
-                      {allowed ? (
-                        <p className="mt-3 text-caption text-[color:var(--color-text-tertiary)]">
-                          {allowed.length > 0
-                            ? `→ ${allowed.map(roleLabel).join(' · ')}`
-                            : '→ ∅'}
-                        </p>
-                      ) : null}
-                    </article>
-                    {index < selected.roles.length - 1 ? (
-                      <span className="my-2 inline-flex size-7 items-center justify-center rounded-chip border border-[color:var(--color-divider)] bg-[color:var(--color-overlay-1)] text-[color:var(--color-text-quaternary)]">
-                        <ArrowDown size={ICON_SIZE.sm} aria-hidden />
-                      </span>
-                    ) : null}
-                  </div>
-                );
-              })}
+            {/*
+              ⚠️ **One artifact, not a picture and then a list of the same thing.** This was two
+              blocks -- a diagram of four boxes, then four cards repeating the same roles -- and the
+              owner's reaction to the installed build was that it neither looked good nor read as a
+              flow. Saying everything twice is why: neither half could use the width, so the screen
+              was simultaneously redundant and empty. One band per role carries the name, the globs
+              and the allowances, and the arrows run down the gutter beside them.
+
+              `data-architecture-mode` stays here because the scroll-reanchor test uses it to tell
+              which stage is mounted; it moved with the block it was attached to.
+            */}
+            <div className="mt-6" data-testid="architecture-flow-panel" data-architecture-mode={mode}>
+              {/* The policy sentence is the section description above; do not print it twice. */}
+              <ArchitectureFlow
+                profile={selected}
+                roleLabel={roleLabel}
+                reachLabel={(role, targets) => t('reachAria', { role, targets })}
+                sinkLabel={t('reachNone')}
+                legend={{
+                  allowed: t('reachLegendAllowed'),
+                  self: t('reachLegendSelf'),
+                  order: t('reachLegendOrder'),
+                }}
+              />
             </div>
           </div>
         </section>

--- a/src/views/architecture/ui/ArchitectureWorkbench.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.tsx
@@ -262,8 +262,12 @@ export function ArchitectureWorkbench({
                 roleLabel={roleLabel}
                 reachLabel={(role, targets) => t('reachAria', { role, targets })}
                 sinkLabel={t('reachNone')}
-                directionLabel={t('nestDirection')}
-                exceptionLabel={(from, to) => t('nestException', { from, to })}
+                directionLabel={t('ladderDirection')}
+                legend={{
+                  allowed: t('legendAllowed'),
+                  self: t('legendSelf'),
+                  columns: t('legendColumns'),
+                }}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

The architecture tab stacked the roles in declaration order and put a down-arrow between every consecutive pair regardless of the rules, so on the storefront profile `domain` — which allows nothing — had an arrow leaving it and `port → domain` pointed upward. Fixing that took six rounds, and five of them failed the same way.

**The recurring mistake.** Rounds 1–4 were a *list of roles with decoration attached*: cards with arrows, boxes in a column, bands with arcs in a gutter, bands with a grid of dots in the corner. Round 5 was nested rings. Each asked the reader to assemble the structure from rows, and the owner's verdict never changed — *"can you see a flow in this? a flow.."*

**What research settled it.** Nested rectangles stop being readable past two or three levels because deep nesting leaves no room for labels; Feature-Sliced Design has seven. Rings also encode a total order and nothing else — they cannot state an exception, only imply permission, which is why round 5 needed a disclaimer paragraph underneath. And hexagonal is not a total order, so one ring component could not render both samples honestly.

**What shipped.**

- **One nesting level.** Bands of constant height in dependency order, numbered, label in a leading strip so a long name truncates instead of deforming the geometry.
- **A policy matrix beside them.** Rows are the consumer, columns the provider. Ghoniem/Fekete/Castagliola measured the crossover at ~20 vertices — below it node-link wins on path-finding, above it the matrix wins on everything else — and at 4–8 layers the matrix is 16–64 cells. A legal layering draws a filled triangle; a hole is a gap in it and needs no separate mark, because its **position** is the exception. This is the only form in which *"there are no exceptions"* is a visible claim rather than an absence.
- **One arrow, not n².** Arrow direction is genuinely ambiguous here — source-code dependency and data flow run in *opposite* directions across a boundary — so the legend names which one this is, once.
- **The interaction, which is the part a static picture cannot do.** Hovering or focusing a layer raises it and everything it may reach, recedes the rest, and lights its row and column in the matrix. Focus-plus-context plus linked highlighting — the same ego-focus the map already uses. Keyboard drives it too, through the registered `RowButton` primitive rather than a hand-written control (that ratchet stands at zero).

**Underneath:** `architecture-layout.ts` derives rows and edges from the rules, placing each role by the **longest** path to a sink — shortest-path depth would put a role on the same row as something it depends on. Cycles return instead of hanging.

**No layout library.** Every candidate solves *layout search* and there is nothing to search: the order is the data. ELK alone is 455 KB gzipped to place eight boxes, and the only non-permissive licence among them.

## Test plan

Gates probed in **both** directions per `design-gates.md`:

| Probe | Result |
|---|---|
| matrix renders nothing | test fails |
| a rule points back up | test fails |
| real code | passes |

- `architecture-layout.test.ts` — 6 cases: sink last with no outgoing edge, every arrow strictly down, hexagonal reads outside→inside, skips do not collapse layers, `lower-only` keeps declaration order, cycles terminate.
- `ArchitectureWorkbench.test.tsx` — each role drawn exactly once; the triangle assertion; and focus raises a layer's reach while receding the rest, driven by `fireEvent.focus` so the keyboard path is what is measured.
- `pnpm checks:changed -- --run` — 10 passed.
- `PLAYWRIGHT_STATIC=1`: a11y ratchet, a11y open surfaces, architecture workbench, scroll-end gap at 5 viewports, **hover contrast** and **cursor affordance** across 42 cases — all passed. The old card list was removed, so the `<main>` element floor was re-measured deliberately.
- `pnpm test:run` — 7629 passed.
- Screenshots in dark mode on both samples, plus a measured focus state (`features` → `entities`/`shared` reached, layers 1–4 dimmed).

Two unused type exports were dropped rather than added to the dead-code ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8