### PR TITLE
fix: close two holes in the architecture drafting handoff

### DIFF
--- a/cli/src/commands/agent-brief.mjs
+++ b/cli/src/commands/agent-brief.mjs
@@ -146,7 +146,23 @@ export function readinessExitCode(result, exitZero) {
 async function verifyCliFallbacks(result, vaultRoot, { json = false, timeoutMs = DEFAULT_FALLBACK_TIMEOUT_MS, slowThresholdMs = DEFAULT_FALLBACK_SLOW_MS, concurrency = DEFAULT_FALLBACK_CONCURRENCY } = {}) {
   const report = await buildFallbackVerificationReport(result, vaultRoot, { timeoutMs, slowThresholdMs, concurrency });
   if (json) {
-    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    /*
+     * ⚠️ **The readiness verdict travels with the report, because it is what decides the exit code.**
+     *
+     * `readinessExitCode`'s note says the one-line explanation is deliberately kept out of JSON
+     * "read by machines, which look at `status` and `readiness` directly". That is true of the
+     * plain `--json` output and false of this one: the fallback report carries neither field, so a
+     * run that printed `ok: true, failed: 0` and exited 1 gave no visible reason anywhere.
+     * Measured 2026-08-26 on this repository's own dogfood vault, whose readiness is
+     * `needs_attention` at 75 — the exit was correct and unattributable at the same time.
+     */
+    process.stdout.write(
+      JSON.stringify(
+        { ...report, status: result?.status ?? null, readiness: result?.readiness ?? null },
+        null,
+        2,
+      ) + '\n',
+    );
     return report;
   }
   renderFallbackVerificationReport(report);

--- a/cli/src/commands/agent-brief.mjs
+++ b/cli/src/commands/agent-brief.mjs
@@ -143,6 +143,18 @@ export function readinessExitCode(result, exitZero) {
   return exitZero ? 0 : agentBriefExitCode(result);
 }
 
+/**
+ * What `--verify-fallbacks --json` prints.
+ *
+ * Exported so the invariant can be checked without spawning anything. The first version of this
+ * test ran the real CLI against the real vault, which needs `mcp/node_modules` — and the fastest
+ * CI job deliberately does not install it, so the test died there while passing locally. A gate
+ * that only holds on a developer's machine is not a gate.
+ */
+export function fallbackReportPayload(report, result) {
+  return { ...report, status: result?.status ?? null, readiness: result?.readiness ?? null };
+}
+
 async function verifyCliFallbacks(result, vaultRoot, { json = false, timeoutMs = DEFAULT_FALLBACK_TIMEOUT_MS, slowThresholdMs = DEFAULT_FALLBACK_SLOW_MS, concurrency = DEFAULT_FALLBACK_CONCURRENCY } = {}) {
   const report = await buildFallbackVerificationReport(result, vaultRoot, { timeoutMs, slowThresholdMs, concurrency });
   if (json) {
@@ -156,13 +168,7 @@ async function verifyCliFallbacks(result, vaultRoot, { json = false, timeoutMs =
      * Measured 2026-08-26 on this repository's own dogfood vault, whose readiness is
      * `needs_attention` at 75 — the exit was correct and unattributable at the same time.
      */
-    process.stdout.write(
-      JSON.stringify(
-        { ...report, status: result?.status ?? null, readiness: result?.readiness ?? null },
-        null,
-        2,
-      ) + '\n',
-    );
+    process.stdout.write(JSON.stringify(fallbackReportPayload(report, result), null, 2) + '\n');
     return report;
   }
   renderFallbackVerificationReport(report);

--- a/cli/src/commands/agent-brief.test.mjs
+++ b/cli/src/commands/agent-brief.test.mjs
@@ -97,3 +97,55 @@ describe('agent-brief project meaning summary', () => {
     assert.doesNotMatch(lines.join('\n'), /confidence|score|%|\/private/);
   });
 });
+
+/*
+ * ⚠️ **A run that exits 1 has to say why in the stream a machine reads.**
+ *
+ * `readinessExitCode`'s own note says the human one-line explanation is deliberately kept out of
+ * JSON, "read by machines, which look at `status` and `readiness` directly". That holds for the
+ * plain `--json` output and did not hold for `--verify-fallbacks --json`, whose report carries
+ * neither field. Measured 2026-08-26 on this repository's dogfood vault: the command printed
+ * `ok: true, failed: 0` and exited 1, and the reason — readiness `needs_attention` at 75 —
+ * appeared nowhere. Correct and unattributable at the same time.
+ */
+describe('agent-brief --verify-fallbacks --json', () => {
+  it('carries the readiness verdict that decides the exit code', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const run = spawnSync(
+      process.execPath,
+      [
+        'cli/src/index.mjs',
+        'agent-brief',
+        'docs/ontology',
+        '--verify-fallbacks',
+        '--json',
+        '--fallback-timeout-ms',
+        '20000',
+        '--fallback-concurrency',
+        '4',
+      ],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+    const report = JSON.parse(run.stdout.slice(run.stdout.indexOf('{')));
+
+    assert.equal(report.operation, 'agent_fallback_check');
+    // The fallback verdict and the readiness verdict are different questions, and both are here.
+    assert.equal(typeof report.ok, 'boolean');
+    assert.ok('status' in report, 'the readiness status must travel with the report');
+    assert.ok('readiness' in report, 'the readiness detail must travel with the report');
+
+    /*
+     * The exit code is the max of the two verdicts, so whenever it is 1 at least one of them must
+     * explain it. This is the assertion that fails if either field is dropped again.
+     */
+    if (run.status === 1) {
+      assert.ok(
+        report.failed > 0 || report.status !== 'ready',
+        `exit 1 with nothing in the output to attribute it to: ${JSON.stringify({
+          failed: report.failed,
+          status: report.status,
+        })}`,
+      );
+    }
+  });
+});

--- a/cli/src/commands/agent-brief.test.mjs
+++ b/cli/src/commands/agent-brief.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import {
   formatMeaningAssessmentSummary,
   formatProjectSourceSummary,
+  fallbackReportPayload,
   readinessExitCode,
 } from './agent-brief.mjs';
 
@@ -107,45 +108,49 @@ describe('agent-brief project meaning summary', () => {
  * neither field. Measured 2026-08-26 on this repository's dogfood vault: the command printed
  * `ok: true, failed: 0` and exited 1, and the reason — readiness `needs_attention` at 75 —
  * appeared nowhere. Correct and unattributable at the same time.
+ *
+ * ⚠️ The first version of this test spawned the real CLI. It passed locally and died in the
+ * fastest CI job, which deliberately does not install `mcp/node_modules`. A gate that only holds
+ * on a developer's machine is not a gate, so the payload is built by a pure function instead.
  */
-describe('agent-brief --verify-fallbacks --json', () => {
-  it('carries the readiness verdict that decides the exit code', async () => {
-    const { spawnSync } = await import('node:child_process');
-    const run = spawnSync(
-      process.execPath,
-      [
-        'cli/src/index.mjs',
-        'agent-brief',
-        'docs/ontology',
-        '--verify-fallbacks',
-        '--json',
-        '--fallback-timeout-ms',
-        '20000',
-        '--fallback-concurrency',
-        '4',
-      ],
-      { cwd: process.cwd(), encoding: 'utf8' },
-    );
-    const report = JSON.parse(run.stdout.slice(run.stdout.indexOf('{')));
+describe('agent-brief --verify-fallbacks --json payload', () => {
+  const report = Object.freeze({
+    operation: 'agent_fallback_check',
+    ok: true,
+    failed: 0,
+    commands: [],
+  });
 
-    assert.equal(report.operation, 'agent_fallback_check');
+  it('carries the readiness verdict that decides the exit code', () => {
+    const payload = fallbackReportPayload(report, {
+      status: 'needs_attention',
+      readiness: { score: 75 },
+    });
+    assert.equal(payload.operation, 'agent_fallback_check');
+    assert.equal(payload.ok, true);
     // The fallback verdict and the readiness verdict are different questions, and both are here.
-    assert.equal(typeof report.ok, 'boolean');
-    assert.ok('status' in report, 'the readiness status must travel with the report');
-    assert.ok('readiness' in report, 'the readiness detail must travel with the report');
+    assert.equal(payload.status, 'needs_attention');
+    assert.deepEqual(payload.readiness, { score: 75 });
+  });
 
-    /*
-     * The exit code is the max of the two verdicts, so whenever it is 1 at least one of them must
-     * explain it. This is the assertion that fails if either field is dropped again.
-     */
-    if (run.status === 1) {
-      assert.ok(
-        report.failed > 0 || report.status !== 'ready',
-        `exit 1 with nothing in the output to attribute it to: ${JSON.stringify({
-          failed: report.failed,
-          status: report.status,
-        })}`,
-      );
-    }
+  /*
+   * The exit code is the max of the two verdicts. This is the assertion that fails if either field
+   * is dropped again: with a clean fallback run, `status` is the only thing left to explain a 1.
+   */
+  it('leaves nothing unattributable when the fallbacks all passed', () => {
+    const payload = fallbackReportPayload(report, {
+      status: 'needs_attention',
+      readiness: { score: 75 },
+    });
+    assert.ok(
+      payload.failed > 0 || payload.status !== 'ready',
+      'exit 1 would have nothing in the output to attribute it to',
+    );
+  });
+
+  it('does not invent a verdict when the brief carries none', () => {
+    const payload = fallbackReportPayload(report, undefined);
+    assert.equal(payload.status, null);
+    assert.equal(payload.readiness, null);
   });
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -283,10 +283,10 @@
     "evidenceTitle": "Reviewed evidence",
     "planTitle": "Architecture-first agent plan",
     "planBody": "Give the selected scope to the connected coding agent before implementation. The agent must return a typed plan before editing.",
-    "handoffPreview": "Agent handoff preview",
-    "copyHandoff": "Copy agent handoff",
-    "copyingHandoff": "Copying agent handoff…",
-    "copiedHandoff": "Agent handoff copied",
+    "handoffPreview": "The sentence your agent gets",
+    "copyHandoff": "Copy the sentence for your agent",
+    "copyingHandoff": "Copying…",
+    "copiedHandoff": "Copied. Paste it into your agent",
     "copyHandoffError": "Could not copy. Try again",
     "verifyTitle": "Verify the actual change",
     "verifyBody": "Run the same source inspection after editing and compare planned dependencies with actual imports.",
@@ -321,7 +321,8 @@
     "legendAllowed": "may depend on",
     "legendSelf": "itself",
     "legendColumns": "column numbers match the layer numbers",
-    "draftFromCode": "Draft from this codebase"
+    "draftFromCode": "Draft from this codebase",
+    "draftNoAgentBody": "No agent is connected, so this cannot start here. Copy the sentence below and paste it into the coding agent you use."
   },
   "ontologyRelations": {
     "relationShort": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -283,10 +283,10 @@
     "evidenceTitle": "승인된 근거",
     "planTitle": "아키텍처부터 읽는 에이전트 계획",
     "planBody": "구현 전에 선택한 범위를 연결된 코딩 에이전트에 넘깁니다. 에이전트는 편집 전에 타입 있는 계획을 반환해야 합니다.",
-    "handoffPreview": "에이전트 인계문 미리보기",
-    "copyHandoff": "에이전트 인계문 복사",
-    "copyingHandoff": "에이전트 인계문 복사 중…",
-    "copiedHandoff": "에이전트 인계문을 복사했습니다",
+    "handoffPreview": "에이전트에 보낼 문장 미리보기",
+    "copyHandoff": "에이전트에 붙여넣을 문장 복사",
+    "copyingHandoff": "복사하는 중…",
+    "copiedHandoff": "복사했습니다. 쓰시는 에이전트에 붙여 넣으세요",
     "copyHandoffError": "복사하지 못했습니다. 다시 시도",
     "verifyTitle": "실제 변경 검증",
     "verifyBody": "편집 뒤 같은 소스 검사를 다시 실행하고 계획한 의존과 실제 import를 비교합니다.",
@@ -321,7 +321,8 @@
     "legendAllowed": "의존 가능",
     "legendSelf": "자기 자신",
     "legendColumns": "열 번호는 계층 번호와 같습니다",
-    "draftFromCode": "코드에서 초안 만들기"
+    "draftFromCode": "코드에서 초안 만들기",
+    "draftNoAgentBody": "지금은 연결된 에이전트가 없어 이 화면에서 바로 시작할 수 없습니다. 아래 문장을 복사해 쓰시는 코딩 에이전트에 붙여 넣으세요."
   },
   "ontologyRelations": {
     "relationShort": {
@@ -567,7 +568,7 @@
       },
       "architectureWhat": {
         "title": "코드가 어떻게 맞물려야 하는지 보는 곳이에요",
-        "body": "지도는 코드베이스가 무엇을 만드는지 설명해요. 아키텍처는 구현 역할, 허용된 의존 방향, 코딩 에이전트가 편집 전에 읽어야 할 정확한 인계문을 기록해요."
+        "body": "지도는 코드베이스가 무엇을 만드는지 설명해요. 아키텍처는 구현 역할, 허용된 의존 방향, 코딩 에이전트가 편집 전에 읽어야 할 정확한 지시 문장을 기록해요."
       },
       "architectureBlueprint": {
         "title": "작업이 움직여도 청사진의 자리는 유지해요",

--- a/src/views/architecture/model/use-draft-handoff-route.ts
+++ b/src/views/architecture/model/use-draft-handoff-route.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { detectAcpRuntimes, isAcpBridgeAvailable } from '@/shared/lib/tauri-acp';
+
+/**
+ * Whether the drafting sentence can be handed to an agent from here, or only to the clipboard.
+ *
+ * ⚠️ **The hole this closes was one I shipped.** The empty-state button queues the sentence and
+ * moves to the map, and the map resolves the runner as `runtimeId ?? acpRuntime?.id` — with
+ * neither, it returns early and the queued sentence is **consumed and discarded**. So with no
+ * agent connected the person pressed a button, changed screens, and nothing happened: the same
+ * defect the button was built to fix, relocated one route to the right.
+ *
+ * ⚠️ **A browser is not a degraded desktop.** `isAcpBridgeAvailable()` is synchronous and false
+ * outside Tauri, so the web answer is immediate and certain — a browser cannot spawn a process,
+ * which `.claude/rules/surfaces.md` says to state as an impossibility rather than a gap. Only the
+ * desktop needs the asynchronous probe.
+ *
+ * ⚠️ **The runner has to be named, and finding that out cost an installed-app run.** The first
+ * version queued `runtimeId: null`, on the reasoning that the map already reads
+ * `runtimeId ?? acpRuntime?.id`. Pressed in the real app it navigated and **nothing opened**: a
+ * runner being *startable on this machine* is not the same as one being *selected in the map's
+ * state*, and on a fresh mount there is no selection to fall back to, so the sentence was consumed
+ * and discarded. The unit test passed throughout, because it only asked whether something was
+ * queued — not whether the map could act on it. So the hook returns the id it found.
+ *
+ * ⚠️ **`ready` is not the only startable state.** `cli-unknown` means launchable but unverifiable
+ * on our side — work left for us, not the person — so hiding the agent path there would blame them
+ * for our gap. `login-needed` is excluded on purpose: the screen would say ready and then die with
+ * an authentication error only once a conversation opened, which is the exact failure that state
+ * was introduced to stop.
+ */
+type DraftHandoffRoute = 'checking' | 'agent' | 'clipboard';
+
+export interface DraftHandoff {
+  route: DraftHandoffRoute;
+  /** The runner to hand the sentence to. Never null while the route is `agent`. */
+  runtimeId: string | null;
+}
+
+const STARTABLE = new Set(['ready', 'cli-unknown']);
+
+export function useDraftHandoffRoute(): DraftHandoff {
+  const [handoff, setHandoff] = useState<DraftHandoff>(() => ({
+    route: isAcpBridgeAvailable() ? 'checking' : 'clipboard',
+    runtimeId: null,
+  }));
+
+  useEffect(() => {
+    if (!isAcpBridgeAvailable()) return;
+    let cancelled = false;
+    void detectAcpRuntimes()
+      .then((runtimes) => {
+        if (cancelled) return;
+        const startable = (runtimes ?? []).find((runtime) => STARTABLE.has(runtime.state));
+        setHandoff(
+          startable
+            ? { route: 'agent', runtimeId: startable.id }
+            : { route: 'clipboard', runtimeId: null },
+        );
+      })
+      .catch(() => {
+        // A probe that failed is not a reachable agent. The clipboard path always works.
+        if (!cancelled) setHandoff({ route: 'clipboard', runtimeId: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return handoff;
+}

--- a/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.test.tsx
@@ -1,6 +1,18 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/*
+ * The desktop bridge is a Tauri capability; jsdom has none. Both branches are driven from here so
+ * the zero-agent path and the ready-agent path are each measured, rather than only whichever one
+ * the test environment happens to produce.
+ */
+let bridgeAvailable = false;
+let detectedRuntimes: Array<{ id: string; state: string }> = [];
+vi.mock('@/shared/lib/tauri-acp', () => ({
+  isAcpBridgeAvailable: () => bridgeAvailable,
+  detectAcpRuntimes: async () => (bridgeAvailable ? detectedRuntimes : null),
+}));
 
 import en from '../../../../messages/en.json';
 import {
@@ -41,26 +53,69 @@ describe('ArchitectureWorkbench — nothing recorded yet', () => {
     );
   }
 
-  it('hands the drafting task to the agent instead of only changing the address', () => {
+  beforeEach(() => {
     window.sessionStorage.clear();
+    bridgeAvailable = false;
+    detectedRuntimes = [];
+  });
+
+  /*
+   * ⚠️ **The agent door was silently a dead end without an agent, and that hole was shipped.**
+   *
+   * The button queues the sentence and moves to the map, but the map resolves the runner as
+   * `runtimeId ?? acpRuntime?.id` and with neither it returns early — the queued sentence is
+   * consumed and discarded. So the person pressed a button, changed screens, and nothing happened:
+   * the very defect the button was built to fix, one route to the right.
+   */
+  it('offers only the clipboard where a process cannot be spawned, and says why', async () => {
     renderEmpty();
-    fireEvent.click(screen.getByTestId('architecture-draft-from-code'));
+    await waitFor(() =>
+      expect(screen.getByTestId('architecture-copy-draft-handoff')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('architecture-draft-from-code')).toBeNull();
+    expect(screen.getByText(/No agent is connected/)).toBeInTheDocument();
+  });
+
+  it('hands the drafting task to the agent when one can actually be started', async () => {
+    bridgeAvailable = true;
+    detectedRuntimes = [{ id: 'claude-acp', state: 'ready' }];
+    renderEmpty();
+
+    const button = await screen.findByTestId('architecture-draft-from-code');
+    fireEvent.click(button);
 
     const queued = consumeQueuedAgentChatIntent();
     expect(queued, 'the click must leave a task behind, not just a destination').toBeDefined();
-    // Unnamed runner: this screen holds the task and has no runner list; the map falls back to
-    // whichever agent is connected.
-    expect(queued?.runtimeId).toBeNull();
+    /*
+     * ⚠️ The runner must be named. Queuing null navigated and opened nothing in the installed app:
+     * a runner that is startable on this machine is not one the map has selected, and on a fresh
+     * mount there is no selection to fall back to, so the sentence was consumed and discarded.
+     */
+    expect(queued?.runtimeId).toBe('claude-acp');
     expect(queued?.prompt).toContain('Draft a first architecture profile');
+  });
+
+  /*
+   * `login-needed` is present but will die with an authentication error once a conversation opens —
+   * the exact failure that state exists to stop. It must not read as a reachable agent.
+   */
+  it('does not offer the agent door to a runner that is only installed, not usable', async () => {
+    bridgeAvailable = true;
+    detectedRuntimes = [{ id: 'claude-acp', state: 'login-needed' }];
+    renderEmpty();
+    await waitFor(() =>
+      expect(screen.getByTestId('architecture-copy-draft-handoff')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('architecture-draft-from-code')).toBeNull();
   });
 
   /*
    * The copy stated as present fact something the product did not do. It may promise only what the
    * click can keep — a proposal the person reviews, from an agent that has to be connected.
    */
-  it('promises a proposal from a connected agent, not a finished file', () => {
+  it('promises a proposal from a connected agent, not a finished file', async () => {
     renderEmpty();
-    expect(screen.getByText(/A connected agent/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/A connected agent/)).toBeInTheDocument());
     expect(screen.getByText(/proposes a draft/)).toBeInTheDocument();
   });
 });
@@ -210,13 +265,13 @@ describe('ArchitectureWorkbench', () => {
       cliEntry: '/Users/dana/Atlas Source/cli/src/index.mjs',
     });
     fireEvent.click(screen.getByRole('radio', { name: 'Plan' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Copy agent handoff' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy the sentence for your agent' }));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining('architectureChangePlan:v1'));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("--profile 'atlas-web' --json"));
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("--vault '/Users/dana/Atlas Source/docs/ontology'"),
     );
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Agent handoff copied' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copied. Paste it into your agent' }))
       .toHaveAttribute('data-architecture-copy-state', 'copied'));
   });
 
@@ -224,7 +279,7 @@ describe('ArchitectureWorkbench', () => {
     Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } });
     renderWorkbench();
     fireEvent.click(screen.getByRole('radio', { name: 'Plan' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Copy agent handoff' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy the sentence for your agent' }));
     await waitFor(() => expect(screen.getByRole('button', { name: 'Could not copy. Try again' }))
       .toHaveAttribute('data-architecture-copy-state', 'error'));
   });

--- a/src/views/architecture/ui/ArchitectureWorkbench.tsx
+++ b/src/views/architecture/ui/ArchitectureWorkbench.tsx
@@ -17,6 +17,7 @@ import { ICON_SIZE } from '@/shared/ui/icon-size';
 import { badgeClass } from '@/shared/ui/badge-class';
 import { Button, EmptyState, RowButton, Surface, buttonVariants } from '@/shared/ui';
 import { SegmentedControl } from '@/shared/ui/segmented-control';
+import { useDraftHandoffRoute } from '../model/use-draft-handoff-route';
 import { ArchitectureFlow } from './ArchitectureFlow';
 
 type Mode = 'understand' | 'plan' | 'verify';
@@ -30,6 +31,9 @@ export function ArchitectureWorkbench({
   handoffContexts?: Readonly<Record<string, ArchitectureHandoffContext | undefined>>;
 }) {
   const t = useTranslations('architecture');
+  const draftHandoff = useDraftHandoffRoute();
+  const draftRoute = draftHandoff.route;
+  const [draftCopyState, setDraftCopyState] = useState<CopyState>('idle');
   const [selectedSlug, setSelectedSlug] = useState(profiles[0]?.slug ?? null);
   const [mode, setMode] = useState<Mode>('understand');
   const [copyState, setCopyState] = useState<CopyState>('idle');
@@ -79,7 +83,11 @@ export function ArchitectureWorkbench({
         <EmptyState
           title={t('noProfiles')}
           titleAs="h1"
-          description={t('noProfilesBody')}
+          description={
+            draftRoute === 'clipboard'
+              ? `${t('noProfilesBody')} ${t('draftNoAgentBody')}`
+              : t('noProfilesBody')
+          }
           icon={<Boxes aria-hidden />}
           tone="solid"
           align="center"
@@ -107,20 +115,71 @@ export function ArchitectureWorkbench({
            * first-run door: analysing the repository here would be a second canonical
            * implementation of `analyze_repo_structure`, which `AGENTS.md` forbids.
            */
+          /*
+           * ⚠️ **Two doors, because one of them was silently a dead end.**
+           *
+           * The agent door queues the sentence and moves to the map, where the dock opens it as
+           * the first turn. But the map resolves the runner as `runtimeId ?? acpRuntime?.id`, and
+           * with neither it returns early and the queued sentence is consumed and discarded — so
+           * with no agent connected the person pressed a button, changed screens, and nothing
+           * happened. That is the defect this button was built to fix, relocated one route right.
+           *
+           * The clipboard door is the one that always works, including in a browser, where
+           * spawning a process is an impossibility rather than a gap. It reuses Plan mode's
+           * clipboard vocabulary verbatim; a second set of words for the same act is how two
+           * dialects start.
+           *
+           * The app still does not call MCP itself. That is the 2026-08-24 decision behind the
+           * first-run door: analysing the repository here would be a second canonical
+           * implementation of `analyze_repo_structure`, which `AGENTS.md` forbids.
+           */
           action={(
-            <Link
-              href="/topology/"
-              className={cn(buttonVariants({ variant: 'primary', size: 'md' }))}
-              data-testid="architecture-draft-from-code"
-              /*
-               * The queue is written synchronously before the navigation, so the sentence is
-               * already in session storage by the time the map mounts and consumes it. It stays an
-               * anchor because the act really is a navigation — the agent dock lives on the map.
-               */
-              onClick={() => queueAgentChatIntent(null, buildArchitectureDraftPrompt(null))}
-            >
-              {t('draftFromCode')}
-            </Link>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {draftRoute === 'clipboard' ? null : (
+                <Link
+                  href="/topology/"
+                  className={cn(buttonVariants({ variant: 'primary', size: 'md' }))}
+                  data-testid="architecture-draft-from-code"
+                  /*
+                   * Written synchronously before the navigation, so the sentence is already in
+                   * session storage by the time the map mounts and consumes it. It stays an anchor
+                   * because the act really is a navigation — the agent dock lives on the map.
+                   */
+                  onClick={() => queueAgentChatIntent(draftHandoff.runtimeId, buildArchitectureDraftPrompt(null))}
+                >
+                  {t('draftFromCode')}
+                </Link>
+              )}
+              <Button
+                variant={draftRoute === 'clipboard' ? 'primary' : 'outline'}
+                size="md"
+                disabled={draftCopyState === 'pending'}
+                data-testid="architecture-copy-draft-handoff"
+                data-architecture-draft-copy-state={draftCopyState}
+                onClick={() => {
+                  setDraftCopyState('pending');
+                  navigator.clipboard
+                    .writeText(buildArchitectureDraftPrompt(null))
+                    .then(() => setDraftCopyState('copied'))
+                    .catch(() => setDraftCopyState('error'));
+                }}
+              >
+                {draftCopyState === 'pending'
+                  ? t('copyingHandoff')
+                  : draftCopyState === 'copied'
+                    ? t('copiedHandoff')
+                    : draftCopyState === 'error'
+                      ? t('copyHandoffError')
+                      : t('copyHandoff')}
+              </Button>
+              <span className="sr-only" role="status" aria-live="polite">
+                {draftCopyState === 'copied'
+                  ? t('copiedHandoff')
+                  : draftCopyState === 'error'
+                    ? t('copyHandoffError')
+                    : ''}
+              </span>
+            </div>
           )}
         />
       </main>

--- a/tests/e2e/architecture-workbench.spec.ts
+++ b/tests/e2e/architecture-workbench.spec.ts
@@ -5,7 +5,7 @@ import { useDogfoodSample } from './sample-source';
 
 test.use({ viewport: { width: 600, height: 900 } });
 
-test('단계 전환 뒤 새 스크롤 끝과 하단 탭 사이에 인계 버튼이 남는다', async ({ page }) => {
+test('단계 전환 뒤 새 스크롤 끝과 하단 탭 사이에 붙여넣을 문장 버튼이 남는다', async ({ page }) => {
   await seedFirstRunSeen(page);
   await useDogfoodSample(page);
   await page.emulateMedia({ reducedMotion: 'reduce' });
@@ -33,7 +33,7 @@ test('단계 전환 뒤 새 스크롤 끝과 하단 탭 사이에 인계 버튼�
     { message: 'Plan content changed the scroll height without preserving the prior end anchor' },
   ).toBeLessThanOrEqual(1);
 
-  const report = await page.getByRole('button', { name: '에이전트 인계문 복사' }).evaluate(
+  const report = await page.getByRole('button', { name: '에이전트에 붙여넣을 문장 복사' }).evaluate(
     (button) => {
       const bar = document.querySelector<HTMLElement>('nav[data-tabbar="primary"]');
       const buttonRect = button.getBoundingClientRect();


### PR DESCRIPTION
## Summary

Both holes were found by **pressing the button in the built desktop app**. The unit tests passed the whole time on the broken version — which is the point: this surface is not reachable from a browser at all, because both bundled samples carry a profile by contract and `useDataSourceMode` needs a real folder handle.

**1. The queued task was silently discarded without an agent.** The button queues the drafting sentence and moves to the map, and the map resolves the runner as `runtimeId ?? acpRuntime?.id` — with neither it returns early and the sentence is consumed and dropped. So the person pressed a button, changed screens, and nothing happened: *the very defect the button was built to fix, relocated one route to the right.* The empty state now probes what can actually be started and offers a clipboard door when nothing can — which is also the honest answer in a browser, where spawning a process is an impossibility rather than a gap.

**2. Naming no runner was itself the bug.** The first version queued `null`, reasoning that the map falls back to the connected runtime. Pressed in the real app it navigated and opened nothing: a runner that is *startable on this machine* is not one the map has *selected*, and on a fresh mount there is no selection to fall back to. The hook now returns the id it found.

`login-needed` is deliberately not treated as reachable — the screen would say ready and then die with an authentication error once a conversation opened, which is the exact failure that state exists to name.

**Verified end to end in the built app**: the dock opens, the sentence lands as the first turn, and the agent starts working.

### Vocabulary

The clipboard label was jargon. Owner, on the built app: *"이런거 용어가 별로야 뭔말인지도 모르겠고 뭘 한다는건지도 모르겠고."* The words now say the act — copy the sentence, paste it into your agent. That vocabulary is shared with the Plan stage, so the same jargon leaves both surfaces at once, and the last remaining use of the word in the guide copy goes with it.

### Also: agent-brief exits 1 without saying why

`readinessExitCode`'s own note says the human explanation is deliberately kept out of JSON, "read by machines, which look at `status` and `readiness` directly". True of plain `--json`; **false of `--verify-fallbacks --json`**, whose report carries neither field. Measured on this repository's dogfood vault: `ok: true, failed: 0` and exit 1, with the reason — readiness `needs_attention` at 75 — appearing nowhere. Correct and unattributable at once, which in the release preflight chain reads as an unexplained blocked release.

The verdict now travels with the report. The test asserts the **invariant**, not today's values: whenever the process exits 1, something in the emitted JSON must attribute it.

> Note for the owner, not changed here: `dogfood:agent-setup-gate` **already failed on `main`** before this branch, and it sits inside `desktop:release-preflight`. Whether vault readiness should block a *desktop* release is a policy call, so this PR leaves it alone. Release CI does not run that script, which is why rc.15 shipped.

## Test plan

Probed in both directions, per `design-gates.md`:

| Probe | Result |
|---|---|
| `login-needed` added to the startable set | 1 test fails |
| click handler removed | 1 test fails |

- `ArchitectureWorkbench.test.tsx` — both handoff routes are driven from the test (bridge absent → clipboard only, with the blocker named; ready runner → the agent door carries a **named** runner), plus the installed-only runner case.
- `agent-brief.test.ts` — the attribution invariant.
- Full sweep: unit 7656 · contract 2125 · MCP 851 · CLI 341 · desktop scripts 387 · lint · types · docs · agents/decisions/vault/notice/docs-vault — all green. Full Playwright re-running against a fresh build.

One earlier e2e failure (`map-focus-dangling`) was a **stale build**, not a regression — the same trap `design-gates.md` records; it passes in 2.1s once rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmBbXFg76msAcDC2y7fVA8