### PR TITLE
chore: refresh the bundled ACP registry snapshot

### DIFF
--- a/src-tauri/src/acp-registry.json
+++ b/src-tauri/src/acp-registry.json
@@ -30,7 +30,7 @@
       "cli": "codex",
       "launch": {
         "kind": "npx",
-        "package": "@agentclientprotocol/codex-acp@1.6.2",
+        "package": "@agentclientprotocol/codex-acp@1.7.0",
         "args": []
       }
     },
@@ -114,7 +114,7 @@
       "cli": "cline",
       "launch": {
         "kind": "npx",
-        "package": "cline@3.0.58",
+        "package": "cline@3.0.60",
         "args": [
           "--acp"
         ]
@@ -132,7 +132,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@tencent-ai/codebuddy-code@2.139.0",
+        "package": "@tencent-ai/codebuddy-code@2.141.0",
         "args": [
           "--acp"
         ]
@@ -255,7 +255,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dimcode@0.3.20",
+        "package": "dimcode@0.3.22",
         "args": [
           "acp"
         ]
@@ -273,7 +273,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "dirac-cli@0.4.37",
+        "package": "dirac-cli@0.5.1",
         "args": [
           "--acp"
         ]
@@ -291,7 +291,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "droid@0.204.0",
+        "package": "droid@0.208.0",
         "args": [
           "exec",
           "--output-format",
@@ -347,7 +347,7 @@
       "cli": "copilot",
       "launch": {
         "kind": "npx",
-        "package": "@github/copilot@1.0.80",
+        "package": "@github/copilot@1.0.81",
         "args": [
           "--acp"
         ]
@@ -365,7 +365,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "glm-acp-agent@1.6.1",
+        "package": "glm-acp-agent@1.7.0",
         "args": []
       }
     },
@@ -415,7 +415,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@xai-official/grok@1.0.10",
+        "package": "@xai-official/grok@1.0.13",
         "args": [
           "agent",
           "stdio"
@@ -471,7 +471,7 @@
       "cli": null,
       "launch": {
         "kind": "npx",
-        "package": "@kilocode/cli@7.4.23",
+        "package": "@kilocode/cli@7.5.6",
         "args": [
           "acp"
         ]
@@ -629,7 +629,7 @@
       "cli": "qwen",
       "launch": {
         "kind": "npx",
-        "package": "@qwen-code/qwen-code@0.22.1",
+        "package": "@qwen-code/qwen-code@0.22.3",
         "args": [
           "--acp",
           "--experimental-skills"


### PR DESCRIPTION
## Summary

The v1.0.0-rc.17 release run stopped at its admit job, which is the job's purpose: `@agentclientprotocol/codex-acp` moved 1.6.2 → 1.7.0, and Codex is one of the two runtimes this app actually launches, so shipping the committed pin would have started a version nobody here has run.

Nine other listed agents moved with it and are refreshed in the same snapshot. None of them blocks a release, because the app does not launch them; they are reported so the list stays current rather than drifting until someone needs one.

The new download-page gate in the same admit job passed (`✓ Verify the download page names the newest published release`), which is its first live run.

## Test plan

- `pnpm acp:registry:check` — red before (`a runtime this app actually runs has gone stale`), green after
- `pnpm checks:changed -- --run` — `desktop:check` and the web-surface Playwright smoke pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)