### PR TITLE
fix: the architecture drawing shares its slack instead of hugging the left edge

### DIFF
--- a/src/views/architecture/ui/ArchitectureSketch.tsx
+++ b/src/views/architecture/ui/ArchitectureSketch.tsx
@@ -466,7 +466,20 @@ export function ArchitectureSketch({
          */
         className={cn(
           covered.left || covered.right ? 'cursor-grab active:cursor-grabbing' : undefined,
-          axis === 'down' ? 'justify-center overflow-y-auto' : 'items-center overflow-x-auto',
+          /*
+           * ⚠️ **`safe center`, not `center`.** The drawing keeps one width whatever the window
+           * does — the boxes are a fixed size because scaling an SVG scales the text inside it off
+           * the type ramp, which this file already refused once. So on a wide screen the slack is
+           * real, and it was all landing on the right: measured 2026-08-29 on the built export, the
+           * drawing sat at left gap 0 with 544px spare at 1512, 952px at 1920 and 1586px at 2560,
+           * because a row flex container defaults to `flex-start`. Plain `center` would fix that and
+           * break the other end — a chain wider than its scroller would have its left edge pushed
+           * out of reach, which is the overflow trap `safe` exists for: centre while it fits, start
+           * as soon as it does not. Where the keyword is unsupported the declaration is dropped and
+           * the layout falls back to today's left edge, so the failure mode is the old behaviour.
+           */
+          '[justify-content:safe_center]',
+          axis === 'down' ? 'overflow-y-auto' : 'items-center overflow-x-auto',
           'flex min-h-0 flex-1 [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[color:var(--color-divider)]',
         )}
         style={coveredMask ? { maskImage: coveredMask, WebkitMaskImage: coveredMask } : undefined}

--- a/tests/e2e/architecture-workbench.spec.ts
+++ b/tests/e2e/architecture-workbench.spec.ts
@@ -298,5 +298,30 @@ test('a chain is never cut — it turns, or the page scrolls', async ({ page }) 
       ),
       `the page scrolls sideways at ${width}x${height}`,
     ).toBe(0);
+
+    /*
+     * ⚠️ **The slack is shared, not dumped on one side.** The drawing keeps one width whatever the
+     * window does, so a wide screen has real slack — and all of it was landing on the right, the
+     * default of a row flex container. Measured on the built export 2026-08-29: left gap 0 with
+     * 544px spare at 1512, 952px at 1920, 1586px at 2560. A drawing pinned to one edge of an
+     * otherwise empty stage reads as a screen that has not finished loading.
+     *
+     * The tolerance is 2px for the odd-pixel split, and the assertion is skipped where there is no
+     * slack to share — the check above already proves nothing is cut there.
+     */
+    const gaps = await page
+      .locator('[data-testid="architecture-graph"]')
+      .evaluate((svg) => {
+        const scroller = svg.parentElement as HTMLElement;
+        const s = scroller.getBoundingClientRect();
+        const v = svg.getBoundingClientRect();
+        return { left: v.left - s.left, right: s.right - v.right };
+      });
+    if (gaps.left + gaps.right > 4) {
+      expect(
+        Math.abs(gaps.left - gaps.right),
+        `the drawing hugs one edge at ${width}x${height} (left ${Math.round(gaps.left)}, right ${Math.round(gaps.right)})`,
+      ).toBeLessThanOrEqual(2);
+    }
   }
 });


### PR DESCRIPTION
## Summary

Found while sweeping three window sizes over the built export after reinstalling rc.17. The architecture drawing sits at **left gap 0** with all the spare width on the right:

| viewport | stage | drawing | left gap | right gap |
|---|---:|---:|---:|---:|
| 1512 | 1348 | 804 | **0** | 544 |
| 1920 | 1756 | 804 | **0** | 952 |
| 2560 | 2390 | 804 | **0** | 1586 |

The role chain keeps one width whatever the window does — the boxes are a fixed size because scaling the SVG scales the text inside it off the type ramp, which this file already refused once — so on a wide screen the slack is real. A row flex container defaults to `flex-start`, and nothing had ever said otherwise. At 2560 the chain uses 34% of the stage and the rest is dot grid, which reads as a screen that has not finished loading.

After: 272/272, 476/476, 793/793.

**`safe center`, not `center`.** A chain wider than its scroller would have its left edge pushed outside the scroll range by plain centring. Verified by forcing that case: scroller 400 against an 804 drawing keeps the left edge reachable and the full 804 scrollable, with `justify-content` computing to `safe center`. Where the keyword is unsupported the declaration is dropped and the layout falls back to today's left edge, so the failure mode is the old behaviour rather than a cut.

**The drawing's size is untouched.** Spreading the boxes with available width would change what the drawing says about spacing; that is a design decision, not this repair.

## Test plan

- Gate added to the existing nine-viewport sweep in `architecture-workbench.spec.ts`: where there is slack to share, the two gaps are within 2px. Probed by planting `justify-start` — red at 1920x1200, printing both gaps — and green on restore.
- `pnpm exec playwright test tests/e2e/architecture-workbench.spec.ts` — 6 pass
- `pnpm checks:changed -- --run` — 8 focused checks pass, including `test:architecture`, `test:contracts`, `knip`, `tsc --noEmit`
- Measurements above taken from the built static export at each viewport, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)