### PR TITLE
chore: cut v1.0.0-rc.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2603,7 +2603,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.0.0-rc.18"
+version = "1.0.0-rc.19"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.0.0-rc.18"
+version = "1.0.0-rc.19"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Three version files and the lockfile; the download page reads its version from `package.json`, so it follows without a fourth edit.

**No changelog entry this time.** Every user-visible change since rc.18 already wrote its own entry when it landed; the three remaining PRs (#1307, #1310, #1318) changed only the internal qualification helpers with no public MCP, CLI, schema or UI surface.

**Carries, since rc.18:**

- The installed app never paints a sample over a real vault (#1328)
- Task-scoped compact agent briefs, `detail:"compact"` with a request-local `task` (#1327)
- The download hero splits only when the column can hold the decision (#1325)
- Choosing a role no longer turns the architecture chain (#1324); the chain stays whole in the installed app (#1320)
- The count stays on the fade, sentences clear every arc, the headline hydrates clean (#1322)
- Readable ACP controls and guidance (#1319); current ACP next actions (#1315)
- The hero object assembles as the headline is typed (#1317); every stroke says its sentence (#1316)
- `relation_notes` named in the meta-model and read back through `find_path` (#1314)
- Hardened first-ontology qualification handoff (#1312); role boxes finish their sentences (#1309, #1311)

## Release gates, before the tag

```
✓ desktop:release-tag          v1.0.0-rc.19 matches package, Tauri and Cargo; /download derives from package.json
✓ download:release-facts:check macos-release.generated.ts matches the published v1.0.0-rc.18 — 2 DMG, 1 Windows
✓ acp:registry:check           snapshot differs only for runtimes this app does not isolate (claude-acp, codex-acp unmoved) · 39 agents
```

## Test plan

- `pnpm checks:changed -- --run` — 8/8: `source:language`, `knip`, `test:desktop:bridge`, `desktop:check`, `test:dogfood:script-refs`, the agent-file contracts, the web-surface smoke, `test:mcp:package`
- `pnpm docs-vault:build` — no generated drift
- The three release gates above, run before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZr55diwJHSb6VvjZi8Yar
