### PR TITLE
fix: install MCP dependencies even after an earlier lane fails

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -188,7 +188,13 @@ jobs:
       # into the same "dependencies missing" message — which is what happened on
       # the first run after these suites were wired into CI. `Unit · Contract`
       # and `MCP` already install it for the same reason.
+      # `if: always()` matches the step below rather than the job's default. Without
+      # it, a red `Vault path drift` skips this install, the always-run suites below
+      # still execute, and all nineteen collapse into the same ERR_MODULE_NOT_FOUND
+      # the comment above describes. The log then shows a wall of "dependencies
+      # missing" with the one real failure buried above it.
       - name: Install MCP dependencies
+        if: always()
         run: pnpm --dir mcp install --frozen-lockfile
 
       - name: Node test suites outside vitest
@@ -316,7 +322,11 @@ jobs:
       # Contract tests in this job launch the real source MCP server. The root
       # install intentionally skips mcp/node_modules, so without this lockfile
       # install those probes exit at startup with ERR_MODULE_NOT_FOUND.
+      # Same reason as the `Node test suites` job: the step that needs this install
+      # runs on `always()`, so the install has to as well, or its failure is
+      # reported as a missing module instead.
       - name: Install MCP dependencies
+        if: always()
         run: pnpm --dir mcp install --frozen-lockfile
 
       # This analyzer loads scope adapters for the root, scripts, CLI, and MCP.

--- a/tests/contract/mcp-source-ci-deps.contract.test.ts
+++ b/tests/contract/mcp-source-ci-deps.contract.test.ts
@@ -25,6 +25,44 @@ describe("Unit CI can launch the source MCP used by contract tests", () => {
     expect(probes.length, "MCP dependency gate is idling without a source-server consumer").toBeGreaterThan(2);
   });
 
+  /**
+   * **An install that is skipped makes the next step lie about why it failed.**
+   *
+   * A step with no `if:` inherits `success()`, so the first red step in a job skips
+   * it. Steps marked `if: always()` keep running regardless. Put those two next to
+   * each other and a single real failure, say `Vault path drift`, silently skips the
+   * MCP install and then nineteen always-run suites all die on
+   * `ERR_MODULE_NOT_FOUND`. The log shows a wall of "dependencies missing" and the
+   * one failure worth reading scrolls off the top.
+   *
+   * So the rule is not "always install". It is that an install must run under at
+   * least the conditions of the step that needs it. A third install site is
+   * deliberately left bare: nothing after it runs on `always()`, so an ordinary
+   * short circuit there is correct and honest.
+   */
+  it("an install whose dependent step runs on always() runs on always() too", () => {
+    const workflow = read(".github/workflows/checks.yml");
+    const steps = workflow.split(/\n(?=      - name: )/).slice(1);
+
+    const installIndexes = steps
+      .map((step, index) => (step.includes("pnpm --dir mcp install --frozen-lockfile") ? index : -1))
+      .filter((index) => index >= 0);
+
+    expect(installIndexes.length, "the MCP install steps this gate protects are gone").toBeGreaterThan(1);
+
+    for (const index of installIndexes) {
+      const next = steps[index + 1] ?? "";
+      if (!/\n\s+if: always\(\)/.test(next)) continue;
+
+      const stepName = /- name: (.+)/.exec(steps[index])?.[1] ?? "?";
+      const nextName = /- name: (.+)/.exec(next)?.[1] ?? "?";
+      expect(
+        /\n\s+if: always\(\)/.test(steps[index]),
+        `"${stepName}" is skipped when an earlier step fails, but "${nextName}" runs on always() and needs it. That combination reports a missing module instead of the real failure.`,
+      ).toBe(true);
+    }
+  });
+
   it("installs the MCP lockfile before the full Unit + Contract suite", () => {
     const unit = jobBlock(read(".github/workflows/checks.yml"), "unit");
     const installAt = unit.indexOf("pnpm --dir mcp install --frozen-lockfile");


### PR DESCRIPTION
## Summary

A step with no `if:` inherits `success()`, so the first red step in a job skips it. Steps marked `if: always()` keep running regardless. Two jobs in `checks.yml` place those next to each other:

```
Vault path drift            if: always()   ← one real failure here
Install MCP dependencies    (default)      ← silently skipped
Node test suites x19        if: always()   ← all die on ERR_MODULE_NOT_FOUND
```

The log then shows a wall of "dependencies missing" and the one line worth reading scrolls off the top. This is the exact failure the comment above that install step was written to prevent, reintroduced by the condition on its neighbour.

## What changed

`if: always()` on the two install steps whose dependent step runs on `always()`.

The rule is **not** "always install", which would be a worse default. It is that an install must run under at least the conditions of the step that needs it. The third install site keeps no condition on purpose: nothing after it runs on `always()`, so an ordinary short circuit there is correct and honest, and the gate leaves it alone.

## Test plan

- `pnpm checks:changed -- --run` — 7 passed
- New assertion in `tests/contract/mcp-source-ci-deps.contract.test.ts` reads the workflow, pairs each install with the step that follows it, and fails only on that combination
- Probed red by removing one condition. The failure message names the real problem rather than the mismatch:

```
"Install MCP dependencies" is skipped when an earlier step fails, but
"Node test suites outside vitest" runs on always() and needs it. That
combination reports a missing module instead of the real failure.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGDyqY1Hi1mA9QsouY7kv4