### PR TITLE
fix(seo): align public sitemap and canonicals

### DIFF
--- a/app/[locale]/guide/[segment]/page.tsx
+++ b/app/[locale]/guide/[segment]/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { GatewayDocPage, GUIDE_PAGES, GUIDE_ENTRY_PAGE, resolveGuidePage } from '@/views/gateway-doc';
+import {
+  GatewayDocPage,
+  GUIDE_PAGES,
+  GUIDE_ENTRY_PAGE,
+  guideCanonicalPath,
+  resolveGuidePage,
+} from '@/views/gateway-doc';
 import { buildPageMetadata } from '@/shared/lib/page-metadata';
 import { routing } from '@/i18n/routing';
 
@@ -25,7 +31,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: 'metadata' });
   return buildPageMetadata({
     locale,
-    path: `guide/${page.segment}`,
+    path: guideCanonicalPath(page),
     title: `${tNav(`guidePages.${page.titleKey}`)} · ${t('pages.guide')}`,
     description: t('descriptions.guide'),
   });

--- a/app/[locale]/ontology/edit/page.tsx
+++ b/app/[locale]/ontology/edit/page.tsx
@@ -1,6 +1,23 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { OntologyEditRedirectPage } from "@/views/ontology-edit-redirect";
 import { RouteLoadingFallback } from "@/shared/ui";
+import { absoluteUrl } from "@/shared/config";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "metadata" });
+  return {
+    title: t("pages.topology"),
+    description: t("descriptions.topology"),
+    alternates: { canonical: absoluteUrl(`/${locale}/topology/`) },
+  };
+}
 
 /**
  * `/ontology/edit` — the retired ERD builder, now a thin redirect to `/topology`, whose contextual

--- a/app/[locale]/ontology/studio/page.tsx
+++ b/app/[locale]/ontology/studio/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { OntologyEditRedirectPage } from "@/views/ontology-edit-redirect";
 import { RouteLoadingFallback } from "@/shared/ui";
-import { buildPageMetadata } from "@/shared/lib/page-metadata";
+import { absoluteUrl } from "@/shared/config";
 
 export async function generateMetadata({
   params,
@@ -12,12 +12,11 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "metadata" });
-  return buildPageMetadata({
-    locale,
-    path: 'ontology/studio',
+  return {
     title: t("pages.topology"),
     description: t('descriptions.topology'),
-  });
+    alternates: { canonical: absoluteUrl(`/${locale}/topology/`) },
+  };
 }
 
 /**

--- a/app/[locale]/project/[slug]/edit/page.tsx
+++ b/app/[locale]/project/[slug]/edit/page.tsx
@@ -22,6 +22,7 @@ export async function generateMetadata({
   const project = projects.find((p) => p.slug === slug);
   return {
     title: `${project?.name ?? slug} 편집`,
+    robots: { index: false, follow: false },
   };
 }
 

--- a/app/[locale]/project/fallback/page.tsx
+++ b/app/[locale]/project/fallback/page.tsx
@@ -24,6 +24,7 @@ export async function generateMetadata({
   // English by intent), so a separate `topBarProjectsLabel` is used, localized properly for each locale.
   return {
     title: t("topBarProjectsLabel"),
+    robots: { index: false, follow: false },
   };
 }
 

--- a/app/[locale]/project/new/page.tsx
+++ b/app/[locale]/project/new/page.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'metadata' });
-  return { title: t('pages.projectNew') };
+  return { title: t('pages.projectNew'), robots: { index: false, follow: false } };
 }
 
 export default function Page() {

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBundledProjects } from '@/entities/docs-vault';
+import { routing } from '@/i18n/routing';
+import { SITE_URL } from '@/shared/config';
+import { GUIDE_ENTRY_PAGE, GUIDE_PAGES } from '@/views/gateway-doc';
+
+import sitemap from './sitemap';
+
+const PUBLIC_STATIC_PATHS = [
+  '',
+  'projects',
+  'download',
+  'topology',
+  'docs',
+  'ontology/insights',
+  'guide',
+  'changelog',
+  ...GUIDE_PAGES.filter((page) => page.segment !== GUIDE_ENTRY_PAGE.segment).map(
+    (page) => `guide/${page.segment}`,
+  ),
+] as const;
+
+describe('public sitemap', () => {
+  it('lists every canonical public page and no compatibility or duplicate guide address', async () => {
+    const entries = await sitemap();
+    const actual = entries.map((entry) => entry.url).sort();
+    const expected = routing.locales
+      .flatMap((locale) => [
+        ...PUBLIC_STATIC_PATHS.map(
+          (path) => `${SITE_URL}/${locale}/${path ? `${path}/` : ''}`,
+        ),
+        ...deriveBundledProjects().map(
+          (project) => `${SITE_URL}/${locale}/project/${project.slug}/`,
+        ),
+      ])
+      .sort();
+
+    expect(actual).toEqual(expected);
+    for (const locale of routing.locales) {
+      expect(actual).not.toContain(
+        `${SITE_URL}/${locale}/guide/${GUIDE_ENTRY_PAGE.segment}/`,
+      );
+      expect(actual).not.toContain(`${SITE_URL}/${locale}/ontology/studio/`);
+      expect(actual).not.toContain(`${SITE_URL}/${locale}/ontology/edit/`);
+    }
+  });
+
+  it('does not claim every static page changed at build time', async () => {
+    const entries = await sitemap();
+    const staticEntries = entries.filter((entry) => !entry.url.includes('/project/'));
+
+    expect(staticEntries.length).toBeGreaterThan(0);
+    for (const entry of staticEntries) expect(entry.lastModified).toBeUndefined();
+  });
+
+  it('keeps each canonical paired with its English, Korean, and x-default URLs', async () => {
+    const entries = await sitemap();
+
+    for (const entry of entries) {
+      const languages = entry.alternates?.languages;
+      expect(languages?.en).toMatch(/^https:\/\/ontologyatlas\.com\/en\//);
+      expect(languages?.ko).toMatch(/^https:\/\/ontologyatlas\.com\/ko\//);
+      expect(languages?.['x-default']).toBe(languages?.[routing.defaultLocale]);
+    }
+  });
+});

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from 'next';
 import { deriveBundledProjects } from '@/entities/docs-vault';
 import { SITE_URL } from '@/shared/config';
 import { routing } from '@/i18n/routing';
+import { GUIDE_PAGES, guideCanonicalPath } from '@/views/gateway-doc';
 
 // Static export — must resolve at build time.
 export const dynamic = 'force-static';
@@ -14,6 +15,9 @@ const STATIC_ROUTES = [
   'download',
   'topology',
   'docs',
+  'guide',
+  'changelog',
+  ...GUIDE_PAGES.slice(1).map(guideCanonicalPath),
   // 'ontology' is excluded — it redirects to `/topology`, so it is not its own canonical
   // (`app/[locale]/ontology/page.tsx`). Putting an address whose canonical points elsewhere into
   // the sitemap makes two signals say different things.
@@ -34,8 +38,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
    * A value derived in two places lets a half-fix pass. They are merged into one.
    */
   const projects = deriveBundledProjects();
-  const now = new Date();
-
   const entries: MetadataRoute.Sitemap = [];
 
   // Per-locale entries for the static set + per-locale per-project entries.
@@ -46,7 +48,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const path = route ? `/${locale}/${route}/` : `/${locale}/`;
       entries.push({
         url: `${SITE_URL}${path}`,
-        lastModified: now,
         changeFrequency: 'weekly',
         priority: route === '' ? 1 : 0.8,
         alternates: {
@@ -67,7 +68,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     for (const project of projects) {
       entries.push({
         url: `${SITE_URL}/${locale}/project/${project.slug}/`,
-        lastModified: project.updatedAt ?? now,
+        ...(project.updatedAt ? { lastModified: project.updatedAt } : {}),
         changeFrequency: 'weekly',
         priority: 0.7,
         alternates: {

--- a/scripts/lib/focused-check-suggestions.test.mjs
+++ b/scripts/lib/focused-check-suggestions.test.mjs
@@ -788,6 +788,7 @@ describe('focused check suggestions', () => {
 
     assert.deepEqual(domainCommands(result), [
       'pnpm exec eslint app/layout.tsx app/page.tsx app/sitemap.ts app/[locale]/docs/page.tsx',
+      'pnpm exec vitest run app/sitemap.test.ts',
       'pnpm test:contracts',
       'pnpm exec tsc --noEmit',
       'pnpm exec playwright test tests/e2e/a11y-ratchet.spec.ts tests/e2e/contrast-ratchet.spec.ts',

--- a/src/views/download/lib/structured-data.test.ts
+++ b/src/views/download/lib/structured-data.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { SITE_URL } from '@/shared/config';
+
+import { MACOS_RELEASE, windowsAsset } from './release-state';
+import { RELEASE_MIN_MACOS, RELEASE_MIN_WINDOWS } from './release-facts';
+import { downloadStructuredData } from './structured-data';
+
+describe('downloadStructuredData', () => {
+  it('uses the same trailing-slash URL as the page canonical', () => {
+    const data = downloadStructuredData('ko', '설명');
+    expect(data.url).toBe(`${SITE_URL}/ko/download/`);
+  });
+
+  it('describes every published installer instead of only Apple Silicon', () => {
+    const data = downloadStructuredData('en', 'Description');
+    const windows = windowsAsset();
+    const expectedUrls = [
+      ...(MACOS_RELEASE.published ? MACOS_RELEASE.assets.map((asset) => asset.downloadUrl) : []),
+      ...(windows ? [windows.downloadUrl] : []),
+    ];
+
+    expect(data.downloadUrl).toEqual(expectedUrls);
+    expect(data.operatingSystem).toEqual(
+      windows ? [RELEASE_MIN_MACOS, RELEASE_MIN_WINDOWS] : RELEASE_MIN_MACOS,
+    );
+  });
+});

--- a/src/views/download/lib/structured-data.ts
+++ b/src/views/download/lib/structured-data.ts
@@ -1,6 +1,6 @@
 import { SITE_URL } from '@/shared/config';
-import { RELEASE_MIN_MACOS } from './release-facts';
-import { MACOS_RELEASE } from './release-state';
+import { RELEASE_MIN_MACOS, RELEASE_MIN_WINDOWS } from './release-facts';
+import { MACOS_RELEASE, windowsAsset } from './release-state';
 
 /**
  * `SoftwareApplication` structured data — the only schema that can earn this app download page a
@@ -22,15 +22,20 @@ export function downloadStructuredData(locale: string, description: string) {
   const published = MACOS_RELEASE.published && MACOS_RELEASE.assets.length > 0;
   const primary =
     MACOS_RELEASE.assets.find((asset) => asset.arch === 'aarch64') ?? MACOS_RELEASE.assets[0];
+  const windows = windowsAsset();
+  const downloadUrls = [
+    ...(MACOS_RELEASE.published ? MACOS_RELEASE.assets.map((asset) => asset.downloadUrl) : []),
+    ...(windows ? [windows.downloadUrl] : []),
+  ];
 
   return {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
     name: 'Ontology Atlas',
     applicationCategory: 'DeveloperApplication',
-    operatingSystem: RELEASE_MIN_MACOS,
+    operatingSystem: windows ? [RELEASE_MIN_MACOS, RELEASE_MIN_WINDOWS] : RELEASE_MIN_MACOS,
     description,
-    url: `${SITE_URL}/${locale}/download`,
+    url: `${SITE_URL}/${locale}/download/`,
     inLanguage: locale,
     license: 'https://opensource.org/licenses/MIT',
     isAccessibleForFree: true,
@@ -42,7 +47,7 @@ export function downloadStructuredData(locale: string, description: string) {
     ...(published && primary
       ? {
           softwareVersion: MACOS_RELEASE.tag.replace(/^v/, ''),
-          downloadUrl: primary.downloadUrl,
+          downloadUrl: downloadUrls,
           ...(MACOS_RELEASE.publishedAt ? { datePublished: MACOS_RELEASE.publishedAt } : {}),
         }
       : {}),

--- a/src/views/gateway-doc/index.ts
+++ b/src/views/gateway-doc/index.ts
@@ -3,5 +3,6 @@ export { readVaultDoc } from './lib/vault-doc';
 export {
   GUIDE_PAGES,
   GUIDE_ENTRY_PAGE,
+  guideCanonicalPath,
   resolveGuidePage,
 } from './model/guide-pages';

--- a/src/views/gateway-doc/model/guide-pages.test.ts
+++ b/src/views/gateway-doc/model/guide-pages.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { GUIDE_ENTRY_PAGE, GUIDE_PAGES, resolveGuidePage } from './guide-pages';
+import {
+  GUIDE_ENTRY_PAGE,
+  GUIDE_PAGES,
+  guideCanonicalPath,
+  resolveGuidePage,
+} from './guide-pages';
 
 /**
  * The **honesty** contract of the unknown-segment fallback.
@@ -28,5 +33,17 @@ describe('resolveGuidePage — 폴백은 대체 사실을 말한다', () => {
     const result = resolveGuidePage('ONTOLOGY-ATLAS-SPEC.md');
     expect(result.page).toEqual(GUIDE_ENTRY_PAGE);
     expect(result.matched, '모르는 세그먼트가 특정 장을 사칭하면 안 된다').toBe(false);
+  });
+});
+
+describe('guideCanonicalPath', () => {
+  it('첫 장의 중복 세그먼트를 공유 /guide 주소로 통합한다', () => {
+    expect(guideCanonicalPath(GUIDE_ENTRY_PAGE)).toBe('guide');
+  });
+
+  it('나머지 장은 자기 세그먼트를 canonical 로 유지한다', () => {
+    for (const page of GUIDE_PAGES.slice(1)) {
+      expect(guideCanonicalPath(page)).toBe(`guide/${page.segment}`);
+    }
   });
 });

--- a/src/views/gateway-doc/model/guide-pages.ts
+++ b/src/views/gateway-doc/model/guide-pages.ts
@@ -50,6 +50,15 @@ export const GUIDE_PAGES: readonly GuidePage[] = [
 export const GUIDE_ENTRY_PAGE = GUIDE_PAGES[0]!;
 
 /**
+ * The first chapter is rendered at both `/guide/` and its generated segment route. Search engines
+ * must receive one canonical address for that body, so the shared entry route owns chapter one and
+ * every later chapter keeps its segment.
+ */
+export function guideCanonicalPath(page: GuidePage): string {
+  return page.segment === GUIDE_ENTRY_PAGE.segment ? 'guide' : `guide/${page.segment}`;
+}
+
+/**
  * The result of resolving a segment — it states **which chapter to draw** and **whether that chapter is
  * the one requested**.
  *


### PR DESCRIPTION
## Summary
- expand the canonical sitemap from 16 to 44 URLs by adding the public guide and changelog surfaces
- consolidate the duplicate first guide chapter onto `/guide/`, canonicalize retired ontology redirects to `/topology/`, and noindex local edit/fallback pages
- remove build-time `lastmod` claims from static routes and align SoftwareApplication JSON-LD with all three published installers

## Evidence
- RED: `app/sitemap.test.ts` observed 16 URLs instead of 44 and build-time `lastModified` on every static entry
- GREEN: `pnpm checks:changed -- --run` (10 recommended checks, including 2,157 contracts and 26 Playwright checks)
- `pnpm build` (77 static pages)
- `PLAYWRIGHT_STATIC=1 pnpm exec playwright test tests/e2e/web-surface-smoke.spec.ts` (11 passed)
- export inspection: 44 sitemap URLs, 4 project-only `lastmod`, duplicate guide canonical collapsed, local edit routes `noindex, nofollow`, SoftwareApplication lists macOS 12 + Windows 10 and all 3 installers
- ontology-sync: 92 nodes, 0 orphans, no semantic node delta