### PR TITLE
chore: cut v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.0.0-rc.19",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2603,7 +2603,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.0.0-rc.19"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.0.0-rc.19"
+version = "1.0.0"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.0.0-rc.19",
+  "version": "1.0.0",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Version bump only, same shape as every rc cut (#1329, #1306): `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` to `1.0.0`, `Cargo.lock` resynced by `cargo check`. The hardening batch (#1351) landed first; README's status section and the changelog banner already describe release state by tag, so no prose changes ride along.

After merge: `pnpm desktop:release-preflight` on main, tag `v1.0.0` at the merged head, dispatch `release-macos.yml`, human approval on the `release` environment, then the generated download-facts PR.

## Test plan

- `pnpm desktop:check` green locally (asserts the three manifests stay equal)
- PR CI (Checks / E2E smoke / Windows beta / Vault freshness)