### PR TITLE
fix: post-v1.0.2 review sweep — nine confirmed defects across CI planning, SEO, and the web vault

### DIFF
--- a/app/[locale]/project/[slug]/page.tsx
+++ b/app/[locale]/project/[slug]/page.tsx
@@ -57,6 +57,9 @@ export async function generateMetadata({
     path: `project/${slug}`,
     title,
     description,
+    // opengraph-image.tsx beside this file generates the per-slug card; the
+    // builder must not put an `images` key anywhere the spreads below carry.
+    hasFileConventionImage: true,
   });
 
   // Tags, stack, and category are folded into keywords to strengthen the SEO signal. Deduplicated.

--- a/scripts/classify-change.mjs
+++ b/scripts/classify-change.mjs
@@ -13,6 +13,7 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
 import {
+  CI_PLANNER_SURFACE_PATTERNS,
   normalizeChangedPath,
   suggestFocusedChecks,
 } from './lib/focused-check-suggestions.mjs';
@@ -76,13 +77,9 @@ const GENERATED = [
   /^src\/entities\/docs-vault\/data\//,
 ];
 
-const PLANNER_SURFACE = [
-  /^scripts\/classify-change(?:\.test)?\.mjs$/,
-  /^scripts\/run-ci-lane(?:\.test)?\.mjs$/,
-  /^scripts\/lib\/focused-check-suggestions(?:\.test)?\.mjs$/,
-  /^scripts\/suggest-focused-checks(?:\.test)?\.mjs$/,
-  /^\.github\/workflows\/(?:checks|e2e)\.yml$/,
-];
+// One source of truth with the advisor's own planner rule — a hand-copied pair
+// disagreed about setup-playwright/action.yml until the 2026-09-01 review.
+const PLANNER_SURFACE = CI_PLANNER_SURFACE_PATTERNS;
 
 const ROOT_ALL_LANE_INPUTS = [
   /^package\.json$/,
@@ -126,6 +123,14 @@ const ROOT_VITEST_INPUTS = [
 const BROWSER_INPUTS = [
   /^app\//,
   /^src\/.*\.(?:tsx|css)$/,
+  /*
+   * Plain .ts inside a `ui/` segment is rendering code by FSD convention —
+   * pointer handlers, canvas renderers, layout math — and the "pure TypeScript
+   * relies on affected units" rule below it does not hold there (2026-09-01
+   * review: a rewrite of the map's pan/zoom handlers planned zero browser
+   * evidence). Model/lib .ts stays with affected Vitest, as designed.
+   */
+  /^src\/.*\/ui\/.*\.ts$/,
   /^messages\//,
   /^public\//,
   /^assets\//,
@@ -333,8 +338,12 @@ function gatesPlan({ suggestions, full }) {
       .filter((row) => commandLane(row.command) === 'gates')
       .map((row) => row.command),
   );
+  // smoke:onboarding and smoke:memory-loop spawn the source MCP server
+  // (2026-09-01 review: without them here, a PR touching those scripts got a
+  // gates lane that died on missing mcp/node_modules — a false red no rerun
+  // fixes, because checks.yml gates `pnpm --dir mcp install` on this flag).
   const needsMcp = commands.some((command) =>
-    /^pnpm (?:test:(?:architecture|claude:hooks)|dogfood:(?:agent|brief|graph-db|health|maintenance|status|verify|walk))\b/.test(
+    /^pnpm (?:test:(?:architecture|claude:hooks)|dogfood:(?:agent|brief|graph-db|health|maintenance|status|verify|walk)|smoke:(?:onboarding|memory-loop))\b/.test(
       command,
     ),
   );

--- a/scripts/classify-change.test.mjs
+++ b/scripts/classify-change.test.mjs
@@ -205,3 +205,49 @@ test('every currently tracked path belongs to a known impact namespace', () => {
   assert.ok(files.length > 1_000, 'tracked-path inventory is unexpectedly empty');
   assert.deepEqual(buildImpactPlan({ files }).unknownPaths, []);
 });
+
+// 2026-09-01 review regressions: four formerly-unconditional gates ran on no
+// pull request, rendering .ts in ui/ segments planned zero browser evidence,
+// two MCP-spawning smokes missed the needsMcp flag, and PLANNER_SURFACE was a
+// hand-copy that disagreed with the advisor's own planner rule.
+test('token, toc, and package gates reach the PRs that touch their inputs', () => {
+  const tokens = buildImpactPlan({ files: ['app/globals.css'] });
+  assert.ok(tokens.lanes.gates.commands.includes('pnpm check:tokens'));
+
+  const toc = buildImpactPlan({ files: ['docs/DESIGN-SYSTEM.md'] });
+  assert.ok(toc.lanes.gates.commands.includes('pnpm design:toc:check'));
+
+  const cli = buildImpactPlan({ files: ['cli/src/commands/relate.mjs'] });
+  assert.ok(cli.lanes.gates.commands.includes('pnpm test:cli:commands'));
+});
+
+test('per-file lint carries the warning ratchet', () => {
+  const plan = buildImpactPlan({ files: ['src/shared/lib/cn.ts'] });
+  const lint = plan.lanes.gates.commands.find((command) => command.includes('exec eslint'));
+  assert.ok(lint, 'changed source must plan a lint command');
+  assert.match(lint, /--max-warnings 0/);
+});
+
+test('rendering .ts in a ui/ segment fails closed to smoke; lib .ts stays with units', () => {
+  const ui = buildImpactPlan({
+    files: ['src/widgets/topology-map-v2/ui/topology-pointer-handlers.ts'],
+  });
+  assert.equal(ui.lanes.e2e.mode, 'smoke');
+
+  const lib = buildImpactPlan({ files: ['src/shared/lib/cn.ts'] });
+  assert.equal(lib.lanes.e2e.mode, 'skip');
+});
+
+test('MCP-spawning smokes raise the needsMcp flag', () => {
+  const plan = buildImpactPlan({ files: ['scripts/smoke-clean-onboarding.mjs'] });
+  if (plan.lanes.gates.commands.includes('pnpm smoke:onboarding')) {
+    assert.equal(plan.lanes.gates.needsMcp, true);
+  } else {
+    assert.fail('smoke:onboarding must stay planned for its own script');
+  }
+});
+
+test('the Playwright setup action is planner surface and forces the full plan', () => {
+  const plan = buildImpactPlan({ files: ['.github/actions/setup-playwright/action.yml'] });
+  assert.equal(plan.full, true);
+});

--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -2,18 +2,53 @@ import { existsSync } from 'node:fs';
 
 import { isSupportedSourcePath } from '../quality/source-language/source-paths.mjs';
 
+/**
+ * The one list of files that ARE the CI planner. `classify-change.mjs` imports
+ * it as its full-plan trigger (PLANNER_SURFACE), so the "planner changes run
+ * exhaustive lanes" promise and this advisor rule can never drift apart — the
+ * 2026-09-01 review caught the hand-copied pair disagreeing about
+ * setup-playwright/action.yml, which then rode a focused plan built on the
+ * assumption the CI infrastructure had not changed.
+ */
+export const CI_PLANNER_SURFACE_PATTERNS = Object.freeze([
+  /^scripts\/classify-change(?:\.test)?\.mjs$/,
+  /^scripts\/run-ci-lane(?:\.test)?\.mjs$/,
+  /^scripts\/lib\/focused-check-suggestions(?:\.test)?\.mjs$/,
+  /^scripts\/suggest-focused-checks(?:\.test)?\.mjs$/,
+  /^\.github\/workflows\/(?:checks|e2e)\.yml$/,
+  /^\.github\/actions\/setup-playwright\/action\.yml$/,
+]);
+
 const RULES = [
   {
     command: 'pnpm test:ci:impact',
     reason: 'CI impact planner, executor, or workflow wiring changed',
-    matches: [
-      /^scripts\/classify-change(?:\.test)?\.mjs$/,
-      /^scripts\/run-ci-lane(?:\.test)?\.mjs$/,
-      /^scripts\/lib\/focused-check-suggestions(?:\.test)?\.mjs$/,
-      /^scripts\/suggest-focused-checks(?:\.test)?\.mjs$/,
-      /^\.github\/workflows\/(?:checks|e2e)\.yml$/,
-      /^\.github\/actions\/setup-playwright\/action\.yml$/,
-    ],
+    matches: [...CI_PLANNER_SURFACE_PATTERNS],
+  },
+  {
+    // 2026-09-01 review: check:tokens and design:toc:check were unconditional
+    // CI steps before the impact-aware rework and existed afterwards only in
+    // the push-to-main full lane — a raw color slipping into globals.css or a
+    // stale DESIGN-SYSTEM.md table of contents merged green and turned main
+    // red after the fact.
+    command: 'pnpm check:tokens',
+    reason: 'styles or ramp registries changed — the raw-color and token gates apply',
+    matches: [/^app\/globals\.css$/, /^src\/.+\.css$/, /^src\/shared\/lib\/cn\.ts$/],
+  },
+  {
+    command: 'pnpm design:toc:check',
+    reason: 'the design system document changed and its table of contents is generated',
+    matches: [/^docs\/DESIGN-SYSTEM\.md$/],
+  },
+  {
+    // cli/src/lib has had this aggregate for a while (test:cli:lib below);
+    // cli/src/commands never got its twin, so a command suite whose file name
+    // is not the sibling `<command>.test.mjs` — relate.snapshot-write,
+    // validate.exit-codes — ran only inside `pnpm package:check` on the
+    // push-to-main lane and on no pull request at all (2026-09-01 review).
+    command: 'pnpm test:cli:commands',
+    reason: 'a CLI command implementation changed',
+    matches: [/^cli\/src\/commands\//],
   },
   {
     command: 'pnpm test:mcp:registration',
@@ -1211,7 +1246,10 @@ function directLintSuggestions(paths) {
   if (lintable.length === 0) return [];
   return [
     {
-      command: `pnpm exec eslint ${lintable.join(' ')}`,
+      // --max-warnings 0 matches the full `pnpm lint` lane (2026-09-01 review):
+      // the warning ratchet lives at zero, and a bare eslint run exits 0 on a
+      // new warning, so the breach only surfaced as a red main after merge.
+      command: `pnpm exec eslint --max-warnings 0 ${lintable.join(' ')}`,
       reason: 'design-system ramps and FSD boundaries are lint-enforced on changed source',
       paths: lintable,
     },

--- a/scripts/lib/focused-check-suggestions.test.mjs
+++ b/scripts/lib/focused-check-suggestions.test.mjs
@@ -216,7 +216,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint src/shared/lib/validate-vault-document.ts',
+      'pnpm exec eslint --max-warnings 0 src/shared/lib/validate-vault-document.ts',
       'pnpm exec vitest run src/shared/lib/validate-vault-document.test.ts',
       'pnpm test:contracts',
       'pnpm test:mcp:unit',
@@ -400,8 +400,9 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint src/views/architecture/ui/ArchitectureWorkbench.tsx',
+      'pnpm exec eslint --max-warnings 0 src/views/architecture/ui/ArchitectureWorkbench.tsx',
       'pnpm exec vitest run src/views/architecture/ui/ArchitectureWorkbench.test.tsx',
+      'pnpm test:cli:commands',
       'pnpm test:architecture',
       'pnpm exec playwright test tests/e2e/architecture-workbench.spec.ts',
       'pnpm test:contracts',
@@ -556,6 +557,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm test:cli:lib',
       'pnpm integration:cli:setup',
       'pnpm vault:validate',
@@ -708,7 +710,7 @@ describe('focused check suggestions', () => {
       'pnpm exec node --test scripts/desktop-smoke.test.mjs',
       'pnpm exec node --test scripts/lib/macos-dmg-layout.test.mjs',
       'pnpm exec node --test scripts/lib/redact-command.test.mjs',
-      'pnpm exec eslint src/shared/lib/tauri-vault-fs.ts src/shared/lib/tauri-vault-fs.test.ts ' +
+      'pnpm exec eslint --max-warnings 0 src/shared/lib/tauri-vault-fs.ts src/shared/lib/tauri-vault-fs.test.ts ' +
         'src/views/root-entry/ui/RootEntryPage.tsx src/views/root-entry/ui/RootEntryPage.test.tsx ' +
         'src/views/docs-vault/lib/persistence.ts src/views/docs-vault/ui/DocsVaultPage.tsx ' +
         'src/widgets/app-settings-menu/ui/AppSettingsMenu.tsx',
@@ -790,7 +792,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint app/layout.tsx app/page.tsx app/sitemap.ts app/[locale]/docs/page.tsx',
+      'pnpm exec eslint --max-warnings 0 app/layout.tsx app/page.tsx app/sitemap.ts app/[locale]/docs/page.tsx',
       'pnpm exec vitest run app/sitemap.test.ts',
       'pnpm test:contracts',
       'pnpm exec tsc --noEmit',
@@ -811,7 +813,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint src/views/brand-new-surface/ui/BrandNewPage.tsx app/[locale]/brand-new/page.tsx',
+      'pnpm exec eslint --max-warnings 0 src/views/brand-new-surface/ui/BrandNewPage.tsx app/[locale]/brand-new/page.tsx',
       'pnpm test:contracts',
       'pnpm exec tsc --noEmit',
       'pnpm exec playwright test tests/e2e/a11y-ratchet.spec.ts tests/e2e/contrast-ratchet.spec.ts',
@@ -831,7 +833,7 @@ describe('focused check suggestions', () => {
 
     assert.deepEqual(domainCommands(result), [
       'pnpm exec node --test scripts/validate-messages.test.mjs',
-      'pnpm exec eslint src/i18n/routing.ts src/i18n/request.ts src/i18n/navigation.ts',
+      'pnpm exec eslint --max-warnings 0 src/i18n/routing.ts src/i18n/request.ts src/i18n/navigation.ts',
       'pnpm exec tsc --noEmit',
       // Added 2026-08-08 — a message catalogue is not only the consistency check's
       // input. It is also the input of the gates that read "what does this screen claim
@@ -920,10 +922,11 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint src/shared/lib/cn.ts src/shared/lib/cn.test.ts ' +
+      'pnpm exec eslint --max-warnings 0 src/shared/lib/cn.ts src/shared/lib/cn.test.ts ' +
         'src/widgets/docs-vault/ui/DocsVaultEditor.tsx',
       'pnpm exec vitest run src/shared/lib/cn.test.ts',
       'pnpm exec vitest run src/widgets/docs-vault/ui/DocsVaultEditor.test.tsx',
+      'pnpm check:tokens',
       'pnpm test:contracts',
       // Touching the docs widget also suggests the e2e that drives that screen (mapping
       // added 2026-08-08 — #987 moved a header control, this suggestion was missing, and
@@ -945,7 +948,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
-      'pnpm exec eslint src/shared/config/site.ts src/shared/lib/theme.ts',
+      'pnpm exec eslint --max-warnings 0 src/shared/config/site.ts src/shared/lib/theme.ts',
       'pnpm exec tsc --noEmit',
     ]);
   });
@@ -1076,6 +1079,7 @@ describe('focused check suggestions', () => {
     const result = suggestFocusedChecks(['postcss.config.mjs', 'app/globals.css']);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm check:tokens',
       'pnpm exec playwright test tests/e2e/overflow-sweep.spec.ts',
     ]);
   });
@@ -1140,6 +1144,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm test:dogfood:script-refs',
       'pnpm test:mcp:verify:first-contact',
       'pnpm test:mcp:verify:timeout',
@@ -1205,6 +1210,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm integration:cli:diagnosis',
       'pnpm vault:validate',
     ]);
@@ -1221,6 +1227,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm integration:cli:graph-read',
       'pnpm vault:validate',
     ]);
@@ -1245,6 +1252,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm integration:cli:graph-write',
       'pnpm vault:validate',
     ]);
@@ -1258,6 +1266,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm integration:cli:repo-analysis',
       'pnpm vault:validate',
     ]);
@@ -1273,6 +1282,7 @@ describe('focused check suggestions', () => {
     ]);
 
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:cli:commands',
       'pnpm test:contracts',
       'pnpm integration:cli:local-vault',
       'pnpm vault:validate',

--- a/scripts/lib/po-pilot.mjs
+++ b/scripts/lib/po-pilot.mjs
@@ -6,6 +6,7 @@ import {
   PO_RISK_ROUTES,
   routePoDecision,
 } from './po-risk-router.mjs';
+import { parseFrontmatter as parseSharedFrontmatter } from './parse-frontmatter.mjs';
 
 const PO_PILOT_RUN_COLUMNS = Object.freeze([
   '#',
@@ -70,24 +71,38 @@ const integer = (value, label, minimum = 0) => {
 };
 
 const parseFrontmatter = (source) => {
+  /*
+   * Delegates to the shared frontmatter parser (2026-09-01 review). The private
+   * line-split copy this replaces threw on valid YAML the six sibling scripts
+   * already accept — a comment line, a block scalar, a block list — so an
+   * innocuous owner edit to the register turned the required gates lane red on
+   * every PR. The shared parser also carries the __proto__ and block-scalar
+   * hardening this file's copy never received. What stays local is the register
+   * strictness the shared parser deliberately does not impose: required keys,
+   * date shapes, the outcome enum, and duplicate top-level keys.
+   */
   if (!source.startsWith('---\n')) fail('frontmatter is required');
   const close = source.indexOf('\n---\n', 4);
   if (close < 0) fail('frontmatter is not closed');
-  const entries = source
-    .slice(4, close)
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => {
-      const separator = line.indexOf(':');
-      if (separator < 1) fail(`invalid frontmatter line: ${line}`);
-      return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
-    });
   const seen = new Set();
-  for (const [key] of entries) {
+  for (const line of source.slice(4, close).split('\n')) {
+    const key = /^([A-Za-z0-9_-]+)\s*:/.exec(line)?.[1];
+    if (!key) continue;
     if (seen.has(key)) fail(`duplicate frontmatter key ${key}`);
     seen.add(key);
   }
-  const raw = Object.fromEntries(entries);
+  const parsed = parseSharedFrontmatter(source);
+  if (Array.isArray(parsed.diagnostics) && parsed.diagnostics.length > 0) {
+    fail(`invalid frontmatter: ${parsed.diagnostics[0].message}`);
+  }
+  const raw = {};
+  for (const [key, value] of Object.entries(parsed.frontmatter)) {
+    // The validators below judge the written text, so scalars flow as strings
+    // regardless of the shared parser's typing.
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      raw[key] = String(value);
+    }
+  }
 
   const required = [
     'started',

--- a/scripts/po-pilot.mjs
+++ b/scripts/po-pilot.mjs
@@ -54,11 +54,29 @@ export function runPoPilot(argv, io = console) {
     const result = evaluatePoPilot(pilot, args.asOf);
     const failures = pilotCheckFailures(result);
     io.log(args.json ? JSON.stringify(result, null, 2) : formatPoPilot(result));
+    /*
+     * --check is the CI mode and gates on what a pull request can answer for:
+     * the register's validity, an unsupported keep, and a live safety stop.
+     * The calendar is not on that list (2026-09-01 review): `decision-required`
+     * arrives purely from a date, and the old code returned 1 for it before the
+     * check branch was ever consulted — 21 days after the pilot started, every
+     * PR in the repository would have failed its required gate with no relation
+     * to its content. A due decision is the owner's reminder, printed here as
+     * DUE, never a per-PR failure.
+     */
+    if (args.check) {
+      const gating = ['invalid-keep', 'premature-keep', 'safety-stop'].includes(result.phase);
+      if (gating && failures.length > 0) {
+        for (const failure of failures) io.error(`[po-pilot] FAIL: ${failure}`);
+        return 1;
+      }
+      for (const failure of failures) io.error(`[po-pilot] DUE: ${failure}`);
+      return 0;
+    }
     if (failures.length > 0) {
       for (const failure of failures) io.error(`[po-pilot] FAIL: ${failure}`);
       return 1;
     }
-    if (args.check && result.phase === 'invalid-keep') return 1;
     return 0;
   } catch (error) {
     io.error(error.message.startsWith('[po-pilot]') ? error.message : `[po-pilot] ${error.message}`);

--- a/src/entities/docs-vault/lib/build-vault-markdown.test.ts
+++ b/src/entities/docs-vault/lib/build-vault-markdown.test.ts
@@ -89,3 +89,15 @@ describe("buildNewNodeDoc", () => {
     expect(() => buildNewNodeDoc({ title: "   ", kind: "capability" })).toThrow();
   });
 });
+
+describe("quoteYamlScalar — 타입 재해석 방어 (2026-09-01 리뷰)", () => {
+  it("boolean/number 모양의 title 은 quote 되어 문자열로 남는다", () => {
+    // The other three frontmatter writers gained this guard when top-level
+    // scalars became typed; without it here a web-created '2026' read back as
+    // a number and dropped out of every typeof === 'string' consumer.
+    const md2026 = buildVaultMarkdown({ kind: "domain", title: "2026", slug: "domains/y2026" });
+    expect(md2026).toContain('title: "2026"');
+    const mdTrue = buildVaultMarkdown({ kind: "domain", title: "true", slug: "domains/t" });
+    expect(mdTrue).toContain('title: "true"');
+  });
+});

--- a/src/entities/docs-vault/lib/build-vault-markdown.ts
+++ b/src/entities/docs-vault/lib/build-vault-markdown.ts
@@ -32,6 +32,15 @@ export function generateNodeUid(uid?: string): string {
  * `\n` and the reader unfolds them.
  */
 function quoteYamlScalar(v: string): string {
+  // Boolean- and number-shaped strings must be quoted or the reader re-types
+  // them (2026-09-01 review): the other three writers gained this guard when
+  // top-level scalars became typed, and this fourth one — the very function
+  // whose comment says four places must agree — did not, so a concept titled
+  // '2026' created from the web read back as the number 2026 and dropped out
+  // of every `typeof title === 'string'` consumer.
+  if (v === 'true' || v === 'false' || (v !== '' && !Number.isNaN(Number(v)))) {
+    return `"${v}"`;
+  }
   if (!/[:,#[\]{}"'&|*!%@`\n\t]|^\s|\s$/.test(v)) return v;
   const escaped = v
     .replace(/\\/g, '\\\\')

--- a/src/entities/docs-vault/lib/rename-ref-rewrites.test.ts
+++ b/src/entities/docs-vault/lib/rename-ref-rewrites.test.ts
@@ -113,3 +113,42 @@ describe('rewriteRenamedDocRefs — body links', () => {
     expect(rewriteRenamedDocRefs(raw, args)).toBe(raw);
   });
 });
+
+describe('rewriteRenamedDocRefs — 2026-09-01 review regressions', () => {
+  it('rewrites broader and depends_on refs like the rest of the key family', () => {
+    const raw =
+      '---\nkind: capability\nbroader: [capabilities/auth]\ndepends_on: [capabilities/auth]\n---\n';
+    const next = rewriteRenamedDocRefs(raw, {
+      oldSlug: 'capabilities/auth',
+      newSlug: 'capabilities/authn',
+      referrerSlug: 'capabilities/leaf',
+      canRewriteTail: true,
+    });
+    expect(next).toContain('broader: [capabilities/authn]');
+    expect(next).toContain('depends_on: [capabilities/authn]');
+  });
+
+  it('resolves nested-vault wikilinks before rewriting, both directions', () => {
+    // Inside the nested ontology/ vault, [[capabilities/y]] means
+    // ontology/capabilities/y — the raw form must be rewritten when the NESTED
+    // doc is renamed, and left alone when a root-level doc of the same written
+    // name is renamed.
+    const nestedBody = '---\nkind: document\n---\n\nsee [[capabilities/y]] and [[capabilities/y|the y]].\n';
+    const nestedRename = rewriteRenamedDocRefs(nestedBody, {
+      oldSlug: 'ontology/capabilities/y',
+      newSlug: 'ontology/capabilities/z',
+      referrerSlug: 'ontology/elements/a',
+      canRewriteTail: false,
+    });
+    expect(nestedRename).toContain('[[capabilities/z]]');
+    expect(nestedRename).toContain('[[capabilities/z|the y]]');
+
+    const rootRename = rewriteRenamedDocRefs(nestedBody, {
+      oldSlug: 'capabilities/y',
+      newSlug: 'capabilities/z',
+      referrerSlug: 'ontology/elements/a',
+      canRewriteTail: false,
+    });
+    expect(rootRename, 'a nested link to a different node must not be redirected').toBe(nestedBody);
+  });
+});

--- a/src/entities/docs-vault/lib/rename-ref-rewrites.ts
+++ b/src/entities/docs-vault/lib/rename-ref-rewrites.ts
@@ -30,6 +30,12 @@ const REF_ARRAY_KEYS = [
   'capabilities',
   'elements',
   'dependencies',
+  // `depends_on` is the schema's authoring alias for `dependencies`, and
+  // `broader` (is-a) is written by this web UI itself — omitting them here
+  // orphaned exactly the edges the map renders (2026-09-01 review): the MCP
+  // rewrite iterates every frontmatter key and never had the gap.
+  'depends_on',
+  'broader',
   'relates',
   'contains',
   'describes',
@@ -183,20 +189,31 @@ export function rewriteRenamedDocRefs(
   let next = Object.keys(updates).length > 0 ? applyFrontmatterUpdates(raw, updates) : raw;
 
   // ── body links, on the (possibly frontmatter-updated) text ──────────
-  // Wikilinks are vault-root-relative: exact slug always, bare tail only while
-  // it uniquely resolves.
-  const escapedOldSlug = oldSlug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  /*
+   * Wikilinks resolve the way `extractOutLinksWithContext` resolves them, not
+   * by raw substring (2026-09-01 review): inside the nested ontology/ vault a
+   * `[[capabilities/y]]` means `ontology/capabilities/y`, so matching the raw
+   * written form both missed the nested link that pointed at the renamed doc
+   * AND rewrote a nested link that pointed at a different root-level doc of
+   * the same name. Each target is resolved from the referrer, compared against
+   * the renamed slug, and written back in the referrer's own vault-relative
+   * form. The bare-tail shorthand keeps its unique-resolution guard.
+   */
   next = next.replace(
-    new RegExp(`(\\[\\[)(${escapedOldSlug})(\\||#|\\]\\])`, 'g'),
-    `$1${newSlug}$3`,
+    /(\[\[)([^\]|#]+)((?:[|#][^\]]*)?\]\])/g,
+    (whole, open: string, target: string, rest: string) => {
+      const written = target.trim();
+      if (canRewriteTail && oldTail !== oldSlug && written === oldTail) {
+        return `${open}${newTail}${rest}`;
+      }
+      const nested = referrerSlug.startsWith('ontology/') && !written.startsWith('ontology/');
+      const resolved = nested ? `ontology/${written}` : written;
+      if (resolved !== oldSlug) return whole;
+      const writtenNext =
+        nested && newSlug.startsWith('ontology/') ? newSlug.slice('ontology/'.length) : newSlug;
+      return `${open}${writtenNext}${rest}`;
+    },
   );
-  if (canRewriteTail && oldTail !== oldSlug) {
-    const escapedTail = oldTail.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    next = next.replace(
-      new RegExp(`(\\[\\[)(${escapedTail})(\\||#|\\]\\])`, 'g'),
-      `$1${newTail}$3`,
-    );
-  }
   // Markdown links: re-resolve each target against the referrer's directory and
   // replace the ones that resolve to the renamed document.
   next = next.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (whole, text: string, target: string) => {

--- a/src/shared/lib/page-metadata.test.ts
+++ b/src/shared/lib/page-metadata.test.ts
@@ -49,3 +49,27 @@ describe('buildPageMetadata', () => {
     expect(Object.keys(alternates.languages).sort()).toEqual(['en', 'ko', 'x-default']);
   });
 });
+
+describe('buildPageMetadata — file-convention images', () => {
+  it('omits the images key entirely so a directory opengraph-image can win', () => {
+    /*
+     * 2026-09-01 review: Next treats an OWN `images` property on the leaf
+     * metadata as authoritative over the file-convention image, and the value
+     * arrives through `{...base.openGraph}` spreads even when the page omits
+     * it deliberately. So the flag must remove the key, not blank it — every
+     * project share was carrying the generic site card instead of its
+     * generated per-slug 1200×630.
+     */
+    const meta = buildPageMetadata({
+      locale: 'en',
+      path: 'project/reactor',
+      title: 'Reactor',
+      description: 'A project page with its own generated card.',
+      hasFileConventionImage: true,
+    });
+    expect(Object.hasOwn(meta.openGraph as object, 'images')).toBe(false);
+    expect(Object.hasOwn(meta.twitter as object, 'images')).toBe(false);
+    // The spreads on the project page must not resurrect the key either.
+    expect(Object.hasOwn({ ...(meta.openGraph as object) }, 'images')).toBe(false);
+  });
+});

--- a/src/shared/lib/page-metadata.ts
+++ b/src/shared/lib/page-metadata.ts
@@ -29,6 +29,16 @@ export interface PageMetadataInput {
   description: string;
   /** Only when the page has its own OG image; otherwise the site OG image is used. */
   ogImage?: string;
+  /**
+   * Set when the page's directory carries an `opengraph-image.tsx` file
+   * convention. Next injects that generated image itself, and a leaf `images`
+   * value — including one arriving through an object spread — OVERRIDES it
+   * (`resolve-metadata` treats an own `images` property as authoritative). So
+   * the builder must omit the key entirely, not set it to anything
+   * (2026-09-01 review: every project share carried the generic site card
+   * while the page's own comment claimed the per-slug card would win).
+   */
+  hasFileConventionImage?: boolean;
 }
 
 /**
@@ -55,6 +65,7 @@ export function buildPageMetadata({
   title,
   description,
   ogImage,
+  hasFileConventionImage,
 }: PageMetadataInput): Metadata {
   const canonical = absolute(locale, path);
 
@@ -77,13 +88,13 @@ export function buildPageMetadata({
       title,
       description,
       locale: OG_LOCALE[locale] ?? locale,
-      images: [ogImage ? { url: ogImage } : SITE_OG_IMAGE],
+      ...(hasFileConventionImage ? {} : { images: [ogImage ? { url: ogImage } : SITE_OG_IMAGE] }),
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: [ogImage ?? SITE_OG_IMAGE.url],
+      ...(hasFileConventionImage ? {} : { images: [ogImage ?? SITE_OG_IMAGE.url] }),
     },
   };
 }

--- a/tests/contract/po-council.contract.test.ts
+++ b/tests/contract/po-council.contract.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -410,6 +410,53 @@ describe('Atlas PO pilot can decide its sunset', () => {
       phase: 'collecting',
       metrics: { eligibleDecisions: expect.any(Number) },
     });
+  });
+
+  it('--check never fails a pull request from the calendar alone', () => {
+    /*
+     * 2026-09-01 review: the gates lane runs `po:pilot -- --check` on every PR,
+     * and `decision-required` arrives purely from a date. The old code returned
+     * 1 for it before the check branch was consulted, so 21 days after the
+     * pilot started every PR would have gone red with no relation to its
+     * content. CI mode gates on register validity, an unsupported keep, and a
+     * safety stop; a due decision prints as DUE and stays the owner's reminder.
+     */
+    const farPastDeadline = '2027-01-01';
+    const check = spawnSync(
+      process.execPath,
+      [PILOT_CLI, '--check', `--as-of=${farPastDeadline}`],
+      { cwd: ROOT, encoding: 'utf8' },
+    );
+    expect(check.status, check.stderr).toBe(0);
+    expect(check.stderr).toMatch(/DUE:/);
+    expect(check.stderr).not.toMatch(/FAIL:/);
+
+    // The owner-facing full mode keeps failing loudly at the same date.
+    const full = spawnSync(process.execPath, [PILOT_CLI, `--as-of=${farPastDeadline}`], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    expect(full.status).toBe(1);
+    expect(full.stderr).toMatch(/FAIL:/);
+  });
+
+  it('accepts the YAML forms the shared frontmatter parser accepts', () => {
+    /*
+     * 2026-09-01 review: the private line-split parser threw on a comment line,
+     * a block scalar, or a block list — so an innocuous owner edit to the
+     * register bricked the required gates lane on every PR. Parsing now goes
+     * through scripts/lib/parse-frontmatter.mjs; register strictness (required
+     * keys, dates, enum, duplicate keys) stays local.
+     */
+    const source = read(PILOT);
+    const close = source.indexOf('\n---\n', 4);
+    const withBenignForms = `${source.slice(0, close)}\n# owner note comment\nnote: |-\n  two lines the owner\n  wrote for context\nowners:\n  - stark\n${source.slice(close)}`;
+    const parsed = parsePoPilot(withBenignForms);
+    expect(parsed.metadata.outcome).toBeDefined();
+
+    // The local strictness survives the delegation.
+    const withDuplicate = `${source.slice(0, close)}\noutcome: keep\n${source.slice(close)}`;
+    expect(() => parsePoPilot(withDuplicate)).toThrow(/duplicate frontmatter key/);
   });
 });
 


### PR DESCRIPTION
## Summary

A full-codebase review of main at post-v1.0.2 confirmed ten defects, mostly in the impact-aware CI rework and the SEO/social-card work; this PR fixes nine. The prior v1.0.1 sweep's nine fixes were re-verified intact.

- **The pilot calendar no longer fails every PR** — `po:pilot --check` (the required gates lane) now gates on register validity, an unsupported keep, and a safety stop; `decision-required`, which arrives purely from a date (2026-09-22), prints as DUE and stays the owner's reminder. The owner-facing full mode still fails loudly. The register's private frontmatter parser is replaced with the shared one so a comment line, block scalar, or block list cannot brick CI; register strictness stays local.
- **Four gates reach PRs again** — `check:tokens` and `design:toc:check` get direct path rules; per-file lint carries `--max-warnings 0` like the full lane; and `cli/src/commands/**` gets the `test:cli:commands` aggregate its `lib/` sibling always had.
- **Rendering `.ts` fails closed** — plain `.ts` inside FSD `ui/` segments joins BROWSER_INPUTS so a pointer-handler rewrite plans browser smoke; model/lib `.ts` stays with affected Vitest as originally designed.
- **needsMcp knows the two MCP-spawning smokes**, ending the false-red missing-node_modules lane.
- **PLANNER_SURFACE has one source of truth** shared with the advisor's own planner rule.
- **Per-project social cards win again** — pages with a directory `opengraph-image.tsx` tell `buildPageMetadata` to omit the `images` key entirely, since Next treats an own `images` property (spreads included) as authoritative over the file convention.
- **Web renames are whole again** — the rewriter covers `broader` and `depends_on`, and wikilinks are resolved with the nested-ontology-vault rule before rewriting (both stale-link and wrong-redirect directions fixed).
- **The fourth frontmatter writer quotes typed-looking scalars**, so a web-created concept titled '2026' stays a string.

## Test plan

- `pnpm checks:changed -- --run <branch files>`: 16/16 (po-council contracts, planner suites, page-metadata, rename/build-vault units, a11y + contrast ratchets on a fresh server)
- `pnpm test:ci:impact` 24/24 · advisor suite 93 · classify-change 22 (5 new regression tests)
- New regression tests: pilot calendar/--check (2), shared-parser forms (1), planner coverage (5), file-convention images (1), broader/depends_on + nested wikilinks (2), typed-scalar quoting (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4