### PR TITLE
feat: run the vault census before Codex compaction too

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -119,6 +119,16 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/inject-ontology-summary.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/hooks/inject-ontology-summary.sh
+++ b/.codex/hooks/inject-ontology-summary.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
-# SessionStart hook — Runs once when Codex/agent runtime opens a new session,
-# injecting the ontology vault summary of the current directory into the agent context.
+# SessionStart + PreCompact hook — injects the ontology vault summary of the
+# current directory into the agent context.
+#
+# Wired to PreCompact as well since 2026-09-01, for the same reason as the
+# Claude side: compaction is where an injected census is dropped, and the
+# symptom is a long session that quietly stops knowing which vault it is in.
+#
+# **What was measured, and what was not.** codex-cli 0.151.0 carries the event
+# in its own hook enum (`PreToolUse PermissionRequest PostToolUse PreCompact
+# PostCompact SessionStart SessionEnd SubagentStart SubagentStop Interrupt`)
+# with a matching JSON schema constant, which is why this is wired rather than
+# left out as unverifiable. What was NOT observed is an end-to-end firing: a
+# compaction only happens once a real context window fills, and the interactive
+# probe that would force it costs a full session. If someone ever watches this
+# hook fire during a genuine compaction, record it here and drop this caveat.
 #
 # User intent (R14 rounds): "Read ontology during work to get help, then
 # automatically record via MCP upon completion." This ensures the agent

--- a/scripts/claude-hooks.test.mjs
+++ b/scripts/claude-hooks.test.mjs
@@ -57,6 +57,9 @@ const HOOK_CONFIGS = [
       // The sensor lane, mirrored 2026-09-01 after measuring codex-cli 0.151.0
       // firing PostToolUse for edit tools and honouring a Stop-time block.
       'bash .codex/hooks/fast-sensor.sh',
+      // Twice, like the Claude side: SessionStart and PreCompact. codex-cli
+      // 0.151.0 declares PreCompact in its own hook enum and JSON schema.
+      'bash .codex/hooks/inject-ontology-summary.sh',
       'bash .codex/hooks/inject-ontology-summary.sh',
       'bash .codex/hooks/remind-verify-on-stop.sh',
       'bash .codex/hooks/stamp-verification.sh',


### PR DESCRIPTION
## Summary

The remaining gap from the Codex parity work. `#1374` mirrored the sensor lane after measuring which events actually fire, but left PreCompact out as unverifiable.

It is verifiable, just not the way I first tried. Forcing a real compaction through an interactive session ran into the directory-trust prompt and a usage limit; reading the runtime instead was decisive and free. codex-cli 0.151.0 carries its whole hook event enum in the binary —

```
PreToolUse · PermissionRequest · PostToolUse · PreCompact · PostCompact
SessionStart · SessionEnd · SubagentStart · SubagentStop · Interrupt
```

— with a matching `"const": "PreCompact"` JSON schema entry. So the census hook is wired there exactly as it already is on the Claude side: same script, same silent-when-no-vault behaviour.

**The header states the boundary rather than overclaiming:** the event is declared by the runtime, but no end-to-end firing was observed, because a compaction only happens once a real context window fills. If someone watches it fire during a genuine compaction, the note says to record that and drop the caveat.

Also surfaced by the same reading, and deliberately left for later: Codex exposes `PermissionRequest`, `SessionEnd`, `SubagentStart/Stop`, and `PostCompact`, none of which this repository uses yet.

## Test plan

- `pnpm checks:changed -- --run <branch files>`: 4/4
- `pnpm test:claude:hooks`: 35 (mirror inventory now expects the census twice on both trees)
- `pnpm agents:check`: 118 files, 0 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4