### PR TITLE
fix: harness audit removes the PreCompact wiring that injected nothing and names the Codex trust step

### DIFF
--- a/.claude/hooks/inject-ontology-summary.sh
+++ b/.claude/hooks/inject-ontology-summary.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# SessionStart + PreCompact hook — injects a summary of the ontology vault in
-# the current directory into the agent context.
+# SessionStart hook — injects a summary of the ontology vault in the current
+# directory into the agent context.
 #
-# Wired to PreCompact as well since 2026-09-01: compaction is exactly where an
-# injected census is dropped, and the symptom is a long session that quietly
-# stops knowing which vault it is working in. Re-running the same script at that
-# moment restores the same facts through the same stdout convention, so the
-# protection needs no second output contract to be true. A repository with no
-# vault stays silent at both events, as before.
+# **Compaction is covered by this same wiring, and not by PreCompact.** A
+# SessionStart entry with no matcher fires for every source, including
+# `compact`, and its stdout is one of the few that Claude Code adds to context
+# (documented exceptions: UserPromptSubmit, UserPromptExpansion, SessionStart,
+# PostModelSwitch). A PreCompact hook was wired here for one day (2026-09-01)
+# on the assumption that its stdout followed the same convention; it does not.
+# Its output reached the terminal transcript only, while the census the model
+# actually saw after compaction came from this SessionStart entry (observed
+# 2026-09-02). The duplicate was removed so the wiring says what it does.
 #
 # User intent (R14 rounds): "Read ontology during work and automatically record via MCP upon completion". This ensures
 # the agent recognizes the vault from the very first moment of work without the user needing to say "use ontology" for every prompt.

--- a/.claude/hooks/stamp-verification.sh
+++ b/.claude/hooks/stamp-verification.sh
@@ -3,8 +3,9 @@
 #
 # One half of the Stop-time verification reminder. `fast-sensor.sh` records
 # which source files this session edited; this hook records the last moment a
-# verification family command ran (vitest, eslint, tsc, checks:changed,
-# test:run, playwright, node --test, cargo test). At Stop time the reminder
+# verification family command ran (a bare runner such as vitest, eslint,
+# tsc, playwright, node --test, cargo test, or any pnpm test*/lint/typecheck/
+# checks/build/*:check script). At Stop time the reminder
 # compares the two timestamps: edits newer than the last verification get one
 # nudge to run `pnpm checks:changed -- --run`.
 #
@@ -38,7 +39,12 @@ try {
 const command = payload?.tool_input?.command;
 if (typeof command !== "string") process.exit(0);
 
-const VERIFY = /(vitest|eslint|tsc\s+--noEmit|checks:changed|test:run|playwright\s+test|node\s+--test|cargo\s+test|test:claude:hooks)/;
+// Two shapes: a bare runner, or a pnpm script from the verification families
+// this repository actually uses (test*, lint, typecheck, checks:*, build, and
+// every *:check gate). The first version listed nine runner names and missed
+// 61 of the 65 verification scripts in package.json (measured 2026-09-02), so
+// `pnpm lint` or `pnpm test:contracts` still ended in a false turn-back.
+const VERIFY = /(vitest|eslint|tsc\s+--noEmit|playwright\s+test|node\s+--test|cargo\s+test|pnpm\s+(?:--dir\s+\S+\s+)?(?:run\s+)?(?:test|lint|typecheck|checks|build|[\w:-]*:check)\b)/;
 if (!VERIFY.test(command)) process.exit(0);
 
 const sessionId = typeof payload?.session_id === "string" ? payload.session_id.replace(/[^\w-]/g, "") : "";

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,16 +84,6 @@
           }
         ]
       }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/inject-ontology-summary.sh\""
-          }
-        ]
-      }
     ]
   }
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -21,6 +21,11 @@ args = [
   "--redact-network-headers",
 ]
 
+# Hooks in ./hooks.json run only after you trust them: Codex records a hash per
+# hook definition and skips new or changed entries until `/hooks` approves them
+# (measured 2026-09-02: the PostToolUse and Stop mirrors were silent for that
+# reason alone). Re-open `/hooks` after any change to that file.
+
 # Secrets, and what this file cannot do about them.
 #
 # `.claude/settings.json` carries `permissions.deny` rules that refuse reads of

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -119,16 +119,6 @@
           }
         ]
       }
-    ],
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash .codex/hooks/inject-ontology-summary.sh"
-          }
-        ]
-      }
     ]
   }
 }

--- a/.codex/hooks/fast-sensor.sh
+++ b/.codex/hooks/fast-sensor.sh
@@ -43,7 +43,11 @@
 set -u
 
 INPUT="$(cat)"
-REPO_ROOT="${CODEX_PROJECT_DIR:-$(pwd)}"
+# Codex sets no project-directory variable for hooks (none exists in the
+# 0.151.0 binary or the hooks reference); commands run in the session cwd,
+# which is the repository root because hooks.json paths are relative to it.
+# ATLAS_HOOK_ROOT is a test seam only, so a fixture can point at a temp root.
+REPO_ROOT="${ATLAS_HOOK_ROOT:-$(pwd)}"
 
 RESULT="$(
   REPO_ROOT="$REPO_ROOT" node --input-type=module -e '

--- a/.codex/hooks/inject-ontology-summary.sh
+++ b/.codex/hooks/inject-ontology-summary.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env bash
-# SessionStart + PreCompact hook — injects the ontology vault summary of the
-# current directory into the agent context.
+# SessionStart hook — injects the ontology vault summary of the current
+# directory into the agent context.
 #
-# Wired to PreCompact as well since 2026-09-01, for the same reason as the
-# Claude side: compaction is where an injected census is dropped, and the
-# symptom is a long session that quietly stops knowing which vault it is in.
-#
-# **What was measured, and what was not.** codex-cli 0.151.0 carries the event
-# in its own hook enum (`PreToolUse PermissionRequest PostToolUse PreCompact
-# PostCompact SessionStart SessionEnd SubagentStart SubagentStop Interrupt`)
-# with a matching JSON schema constant, which is why this is wired rather than
-# left out as unverifiable. What was NOT observed is an end-to-end firing: a
-# compaction only happens once a real context window fills, and the interactive
-# probe that would force it costs a full session. If someone ever watches this
-# hook fire during a genuine compaction, record it here and drop this caveat.
+# **Why this is not also wired to PreCompact.** codex-cli 0.151.0 does declare
+# PreCompact and PostCompact, and for one day (2026-09-01) this script was
+# wired there on the strength of that enum alone. The output contract was not
+# checked: the Codex hooks reference gives both events only `continue`,
+# `stopReason`, `systemMessage` (a UI warning) and `suppressOutput`. No stdout
+# and no `additionalContext` reaches the model from either, so the wiring
+# could never restore a census and was removed (2026-09-02). Whether Codex
+# re-fires SessionStart after compaction is not documented; if a later version
+# documents a context-carrying compaction event, wire it then, with the proof.
 #
 # User intent (R14 rounds): "Read ontology during work to get help, then
 # automatically record via MCP upon completion." This ensures the agent

--- a/.codex/hooks/remind-verify-on-stop.sh
+++ b/.codex/hooks/remind-verify-on-stop.sh
@@ -29,7 +29,11 @@
 set -u
 
 INPUT="$(cat)"
-REPO_ROOT="${CODEX_PROJECT_DIR:-$(pwd)}"
+# Codex sets no project-directory variable for hooks (none exists in the
+# 0.151.0 binary or the hooks reference); commands run in the session cwd,
+# which is the repository root because hooks.json paths are relative to it.
+# ATLAS_HOOK_ROOT is a test seam only, so a fixture can point at a temp root.
+REPO_ROOT="${ATLAS_HOOK_ROOT:-$(pwd)}"
 
 REPO_ROOT="$REPO_ROOT" node --input-type=module -e '
 import { readFileSync, statSync, existsSync } from "node:fs";

--- a/.codex/hooks/stamp-verification.sh
+++ b/.codex/hooks/stamp-verification.sh
@@ -3,8 +3,9 @@
 #
 # One half of the Stop-time verification reminder. `fast-sensor.sh` records
 # which source files this session edited; this hook records the last moment a
-# verification family command ran (vitest, eslint, tsc, checks:changed,
-# test:run, playwright, node --test, cargo test). At Stop time the reminder
+# verification family command ran (a bare runner such as vitest, eslint,
+# tsc, playwright, node --test, cargo test, or any pnpm test*/lint/typecheck/
+# checks/build/*:check script). At Stop time the reminder
 # compares the two timestamps: edits newer than the last verification get one
 # nudge to run `pnpm checks:changed -- --run`.
 #
@@ -24,7 +25,11 @@
 set -u
 
 INPUT="$(cat)"
-REPO_ROOT="${CODEX_PROJECT_DIR:-$(pwd)}"
+# Codex sets no project-directory variable for hooks (none exists in the
+# 0.151.0 binary or the hooks reference); commands run in the session cwd,
+# which is the repository root because hooks.json paths are relative to it.
+# ATLAS_HOOK_ROOT is a test seam only, so a fixture can point at a temp root.
+REPO_ROOT="${ATLAS_HOOK_ROOT:-$(pwd)}"
 
 REPO_ROOT="$REPO_ROOT" node --input-type=module -e '
 import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
@@ -40,7 +45,12 @@ try {
 const command = payload?.tool_input?.command;
 if (typeof command !== "string") process.exit(0);
 
-const VERIFY = /(vitest|eslint|tsc\s+--noEmit|checks:changed|test:run|playwright\s+test|node\s+--test|cargo\s+test|test:claude:hooks)/;
+// Two shapes: a bare runner, or a pnpm script from the verification families
+// this repository actually uses (test*, lint, typecheck, checks:*, build, and
+// every *:check gate). The first version listed nine runner names and missed
+// 61 of the 65 verification scripts in package.json (measured 2026-09-02), so
+// `pnpm lint` or `pnpm test:contracts` still ended in a false turn-back.
+const VERIFY = /(vitest|eslint|tsc\s+--noEmit|playwright\s+test|node\s+--test|cargo\s+test|pnpm\s+(?:--dir\s+\S+\s+)?(?:run\s+)?(?:test|lint|typecheck|checks|build|[\w:-]*:check)\b)/;
 if (!VERIFY.test(command)) process.exit(0);
 
 const sessionId = typeof payload?.session_id === "string" ? payload.session_id.replace(/[^\w-]/g, "") : "";

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ search name. Project containment is implicit; do not add `project:`.
 `AGENTS.md` is canonical. `CLAUDE.md` imports it and contains only
 Claude-specific visibility and loading information. Keep this file below the
 32 KiB Codex cap; `pnpm agents:check` verifies the cap, the import bridge,
-references, mirrored skills/agents, and that every agent-read file is English.
+references, mirrored skills/agents, and English in every agent-read file.
 That subject set covers `.claude/hooks/`, `.claude/settings.json` and
 `.codex/`: a guard's refusal text is all a blocked agent gets to read.
 `.claude/skills/<name>/` and `.agents/skills/<name>/`, plus the matching agent
@@ -199,4 +199,5 @@ also carries a nested `AGENTS.md` naming those rules, because Codex merges
 They stay pointers: the cap check measures root plus the largest nested file,
 since Codex truncates the merge in silence. Do not name a tool inside a shared
 skill body; branch on capability. `.claude/settings.json` owns Claude hooks and
-`.codex/hooks.json` owns their Codex mirror.
+`.codex/hooks.json` owns their Codex mirror; Codex skips a new or changed
+entry there until a person trusts it in `/hooks`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,7 @@ sources; nothing else points at them.
 The Codex column stands for every tool reading the open format: Cursor,
 Antigravity CLI and Copilot resolve `AGENTS.md` and its nested files the same
 way. That file owns the mirror contract, the nested-pointer rule, and what
-`pnpm agents:check` enforces. Importing it organizes context; it does not reduce
-bytes.
+`pnpm agents:check` enforces.
 
 ## Claude Code loading
 
@@ -42,7 +41,7 @@ available to both agent trees; `AGENTS.md` owns invocation triggers and
 
 `.claude/settings.json` owns Claude permissions and hooks, and both are
 inventoried agent files. Seven mirror `.codex/hooks/`: the three blocks, the
-vault census (also at PreCompact), and the sensor lane. A Codex edit is
+vault census, and the sensor lane. A Codex edit is
 `apply_patch` carrying a patch envelope, so mirrors are adapted, not copied.
 `report-agent-file-drift.sh` is Claude-only, `block-secret-read.sh` Codex-only.
 Headers say why. Change wiring with `pnpm test:claude:hooks`; judge sensors

--- a/scripts/claude-hooks.test.mjs
+++ b/scripts/claude-hooks.test.mjs
@@ -28,10 +28,9 @@ const HOOK_CONFIGS = [
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/block-npm-publish.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/block-unsafe-git.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/fast-sensor.sh"',
-      // Twice on purpose: the same census script runs at SessionStart and again
-      // at PreCompact, which is where an injected census would otherwise be
-      // dropped from a long session.
-      '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/inject-ontology-summary.sh"',
+      // Once: a matcher-less SessionStart also fires for the `compact` source,
+      // and PreCompact stdout never reaches the model (its one-day wiring was
+      // removed 2026-09-02; the census header records the observation).
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/inject-ontology-summary.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/remind-verify-on-stop.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/report-agent-file-drift.sh"',
@@ -57,9 +56,8 @@ const HOOK_CONFIGS = [
       // The sensor lane, mirrored 2026-09-01 after measuring codex-cli 0.151.0
       // firing PostToolUse for edit tools and honouring a Stop-time block.
       'bash .codex/hooks/fast-sensor.sh',
-      // Twice, like the Claude side: SessionStart and PreCompact. codex-cli
-      // 0.151.0 declares PreCompact in its own hook enum and JSON schema.
-      'bash .codex/hooks/inject-ontology-summary.sh',
+      // Once: Codex PreCompact/PostCompact output carries no model context
+      // (hooks reference), so the 2026-09-01 PreCompact wiring was removed.
       'bash .codex/hooks/inject-ontology-summary.sh',
       'bash .codex/hooks/remind-verify-on-stop.sh',
       'bash .codex/hooks/stamp-verification.sh',
@@ -516,7 +514,7 @@ describe('Codex secret read guard', () => {
       cwd: root,
       input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
       encoding: 'utf8',
-      env: { ...process.env, CODEX_PROJECT_DIR: root },
+      env: { ...process.env, ATLAS_HOOK_ROOT: root },
     });
     return (result.stdout ?? '').trim();
   };
@@ -681,6 +679,31 @@ describe('fast-sensor lane and stop-time verification reminder', () => {
     }
   });
 
+  it('stamps the pnpm verification families this repository actually runs', async () => {
+    // The first regex listed nine runner names and missed 61 of the 65
+    // verification scripts in package.json (2026-09-02), so `pnpm lint` and
+    // `pnpm test:contracts` still ended in a false turn-back.
+    const dir = await mkdtemp(join(tmpdir(), 'stamp-family-'));
+    try {
+      const stampPath = join(dir, '.tmp', 'harness', 'session-sess-family.verified');
+      for (const command of ['pnpm lint', 'pnpm test:contracts', 'pnpm --dir mcp test', 'pnpm docs:check']) {
+        await rm(stampPath, { force: true });
+        const result = fireHook(
+          STAMP,
+          { session_id: 'sess-family', tool_name: 'Bash', tool_input: { command } },
+          dir,
+        );
+        assert.equal(result.status, 0, result.stderr);
+        await access(stampPath);
+      }
+      await rm(stampPath, { force: true });
+      fireHook(STAMP, { session_id: 'sess-family', tool_name: 'Bash', tool_input: { command: 'pnpm dev' } }, dir);
+      await assert.rejects(access(stampPath), 'pnpm dev is not verification');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('the stamp ignores non-verification commands and sessions without edits stop freely', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'stop-free-'));
     try {
@@ -752,7 +775,7 @@ describe('Codex apply_patch payload parity', () => {
     spawnSync('bash', [hook], {
       input: JSON.stringify(payload),
       encoding: 'utf8',
-      env: { ...process.env, CODEX_PROJECT_DIR: projectDir, CLAUDE_PROJECT_DIR: projectDir },
+      env: { ...process.env, ATLAS_HOOK_ROOT: projectDir, CLAUDE_PROJECT_DIR: projectDir },
     });
 
   it('refuses a generated-output file named inside a patch envelope', () => {

--- a/scripts/harness-report.mjs
+++ b/scripts/harness-report.mjs
@@ -13,7 +13,9 @@
  *
  * **What it reads** — local, gitignored session state under `.tmp/harness/`:
  * per-session edit ledgers, verification stamps, and the findings log. Nothing
- * leaves the machine, and nothing here is vault data.
+ * leaves the machine, and nothing here is vault data. Because every file there
+ * counts, a manual probe of a hook must run against a temp root; a probe left
+ * in the real directory was counted as a session on 2026-09-02.
  *
  * **What it deliberately does not claim.** It cannot measure the published
  * "explicit user correction" rate: `.ontology-atlas/activity.jsonl` records MCP


### PR DESCRIPTION
## Summary

A re-audit of the 2026-09-01 harness work against the runtimes themselves, not their event enums. Five findings, all fixed:

- **PreCompact injected nothing on either tree.** Claude Code adds exit-0 stdout to context only for UserPromptSubmit, UserPromptExpansion, SessionStart and PostModelSwitch; the census the model actually saw after a real compaction came from the matcher-less SessionStart entry firing for the `compact` source. Codex gives PreCompact/PostCompact only `continue`, `stopReason`, `systemMessage`, `suppressOutput`. Both entries removed; headers record the observation.
- **Codex skips untrusted project hooks in silence.** The earlier measurement used `--dangerously-bypass-hook-trust`. Without the flag, `codex exec` in this repo fired four PreToolUse hooks but only one PostToolUse and one Stop hook (the user-level ones). AGENTS.md and `.codex/config.toml` now state the `/hooks` trust step.
- **The verification stamp missed 61 of 65 verification scripts** (`pnpm lint`, `pnpm test:contracts`, every `*:check`), so the Stop reminder turned sessions back falsely. Regex widened to the pnpm families this repo runs, with a pinning test.
- **`CODEX_PROJECT_DIR` does not exist** in the Codex binary or reference. Renamed `ATLAS_HOOK_ROOT` and documented as a test seam; runtime relies on the session cwd.
- **Probe residue counted as data** in `pnpm harness:report`; the header now requires probes to use a temp root.

Two filler sentences trimmed from AGENTS.md / CLAUDE.md to stay under the resident-context byte ratchet.

## Test plan

- [x] `pnpm test:claude:hooks` (36 pass, one new stamp-family test)
- [x] `pnpm checks:changed -- --run` (13 passed, includes the resident-byte ratchet)
- [x] `pnpm agents:check` (48 pass)
- [x] `pnpm docs:language`
- [x] `codex exec` without the trust bypass, observing which hooks fire

After merge: open Codex in this repo and approve the new hooks in `/hooks`, or the sensor lane and Stop reminder stay silent there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4