### PR TITLE
fix: unbracket the census header so Codex stops marking the SessionStart hook failed

### DIFF
--- a/.claude/hooks/inject-ontology-summary.sh
+++ b/.claude/hooks/inject-ontology-summary.sh
@@ -15,6 +15,10 @@
 # User intent (R14 rounds): "Read ontology during work and automatically record via MCP upon completion". This ensures
 # the agent recognizes the vault from the very first moment of work without the user needing to say "use ontology" for every prompt.
 #
+# Sources, read 2026-09-02: https://code.claude.com/docs/en/hooks (exit-0
+# stdout reaches context only for UserPromptSubmit, UserPromptExpansion,
+# SessionStart, PostModelSwitch; SessionStart matchers include `compact`).
+#
 # Output convention (Claude Code hooks):
 #   - exit 0 + empty stdout → silent (blocks noise in repos without vault)
 #   - exit 0 + stdout content → added to agent system context (this is our path)
@@ -91,8 +95,15 @@ if ! JSON=$($CLI_BIN overview "$VAULT" --json 2>"$CLI_STDERR"); then
       ;;
   esac
 
+  # The first output line is deliberately not bracketed. Codex reads a hook's
+  # stdout as JSON when it looks like JSON, and a line starting with `[` looks
+  # like an array: the earlier `[ontology vault @ …]` header made codex-cli
+  # 0.151.0 mark this hook "SessionStart Failed" on every session (measured
+  # 2026-09-02 by tracing the hook to a clean exit 0 and then removing the
+  # bracket, after which the same run reported Completed). Claude Code never
+  # minded, but one census format for both runtimes is cheaper than two.
   cat <<EOF
-[ontology vault @ ${VAULT}]
+ontology vault @ ${VAULT}
 Vault will not compile — no ontology context this session.
 $REASON
 Fix it before trusting any ontology answer: \`$FIX\`.
@@ -135,7 +146,7 @@ if [ -z "$SUMMARY" ]; then
 fi
 
 cat <<EOF
-[ontology vault @ ${VAULT}]
+ontology vault @ ${VAULT}
 $SUMMARY
 
 Token budget: prefer focused ontology reads and the narrowest available source

--- a/.codex/hooks/inject-ontology-summary.sh
+++ b/.codex/hooks/inject-ontology-summary.sh
@@ -17,6 +17,11 @@
 # recognizes the vault from the very first moment of work, without requiring
 # the user to say "use ontology" in every prompt.
 #
+# Sources, read 2026-09-02: https://developers.openai.com/codex/hooks
+# (SessionStart plain stdout is added as developer context; SessionStart with
+# `source: compact` runs after compaction; PreCompact/PostCompact carry no
+# context; project hooks run only after `/hooks` trust).
+#
 # Output convention (agent hooks):
 #   - exit 0 + empty stdout → silent (blocks noise in repos without a vault)
 #   - exit 0 + non-empty stdout → added to agent system context (our path)
@@ -98,8 +103,15 @@ if ! JSON=$($CLI_BIN overview "$VAULT" --json 2>"$CLI_STDERR"); then
       ;;
   esac
 
+  # The first output line is deliberately not bracketed. Codex reads a hook's
+  # stdout as JSON when it looks like JSON, and a line starting with `[` looks
+  # like an array: the earlier `[ontology vault @ …]` header made codex-cli
+  # 0.151.0 mark this hook "SessionStart Failed" on every session (measured
+  # 2026-09-02 by tracing the hook to a clean exit 0 and then removing the
+  # bracket, after which the same run reported Completed). Claude Code never
+  # minded, but one census format for both runtimes is cheaper than two.
   cat <<EOF
-[ontology vault @ ${VAULT}]
+ontology vault @ ${VAULT}
 Vault will not compile — no ontology context this session.
 $REASON
 Fix it before trusting any ontology answer: \`$FIX\`.
@@ -142,7 +154,7 @@ if [ -z "$SUMMARY" ]; then
 fi
 
 cat <<EOF
-[ontology vault @ ${VAULT}]
+ontology vault @ ${VAULT}
 $SUMMARY
 
 Token budget: prefer focused ontology reads and the narrowest available source


### PR DESCRIPTION
## Summary

Every Codex session here showed `hook: SessionStart Failed` for the ontology census. Tracing the hook under a real `codex exec` showed a clean exit 0 in 0.2s; removing the leading `[` from the `[ontology vault @ …]` header turned the same run to `Completed`. Codex parses hook stdout as JSON when it looks like JSON, and a line starting with `[` looks like an array. Both trees now print `ontology vault @ …` so one format serves both runtimes.

Proof after the change, with the persisted `/hooks` trust and no bypass flag: both SessionStart hooks `Completed`, and Codex, asked with no tools how many nodes the census gave it, answered `97`.

The census headers now cite the Claude Code and Codex hook references as read on 2026-09-02.

## Test plan

- [x] `pnpm test:claude:hooks` (36 pass)
- [x] `pnpm checks:changed -- --run` (3 passed)
- [x] `pnpm agents:check` (48 pass), `pnpm docs:language`
- [x] `codex exec` without the trust bypass: SessionStart Completed ×2, census answered from context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4