### PR TITLE
feat: prove the hooks on the runtimes that run them with pnpm harness:smoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ sources; nothing else points at them.
 | `.agents/skills/**`, `.agents/agents/**` | does not read | reads |
 | `.codex/**` | does not read | reads config and hooks |
 
-The Codex column stands for every tool reading the open format: Cursor,
+The Codex column covers every open-format reader: Cursor,
 Antigravity CLI and Copilot resolve `AGENTS.md` and its nested files the same
 way. That file owns the mirror contract, the nested-pointer rule, and what
 `pnpm agents:check` enforces.
@@ -44,8 +44,8 @@ inventoried agent files. Seven mirror `.codex/hooks/`: the three blocks, the
 vault census, and the sensor lane. A Codex edit is
 `apply_patch` carrying a patch envelope, so mirrors are adapted, not copied.
 `report-agent-file-drift.sh` is Claude-only, `block-secret-read.sh` Codex-only.
-Headers say why. Change wiring with `pnpm test:claude:hooks`; judge sensors
-with `pnpm harness:report`.
+Headers say why. `pnpm test:claude:hooks` guards wiring, `pnpm harness:report`
+judges sensors, `pnpm harness:smoke` proves the runtimes.
 
 ## Synchronization
 

--- a/README.md
+++ b/README.md
@@ -825,7 +825,13 @@ sessions edited source, how many ended before verifying, and what the
 edit-time sensor caught, over a `--days=` window (14 by default, `--json` for
 a machine). It reads only local gitignored session state under `.tmp/harness/`
 and reports a `sensor-caught-nothing` verdict when the lane stopped earning its
-place, which is the falsifier those hooks were added under.
+place, which is the falsifier those hooks were added under. It also shows when
+`pnpm harness:smoke` last passed per runtime. That smoke drives one short
+Claude Code and Codex session each (a shell command, then the vault node count
+from the census), counts which hook events completed against the project
+wiring, and fails on any hook the runtime marked failed, any count below the
+wiring, or a census that never reached the model. It needs both CLIs signed in,
+so it is a local check, not CI.
 
 Agent-workflow changes run `pnpm agents:check`; its `pnpm test:agent-skills`
 step proves that scratch readers stop on a wrong vault/repository binding before

--- a/package.json
+++ b/package.json
@@ -157,6 +157,8 @@
     "test:claude:hooks": "node --test scripts/claude-hooks.test.mjs",
     "harness:report": "node scripts/harness-report.mjs",
     "test:harness:report": "node --test scripts/harness-report.test.mjs",
+    "harness:smoke": "node scripts/harness-smoke.mjs",
+    "test:harness:smoke": "node --test scripts/harness-smoke.test.mjs",
     "test:dogfood:compile-fix": "node --test scripts/dogfood-compile-fix.test.mjs",
     "dogfood:health": "node scripts/lib/check-mcp-source-dependencies.mjs && node cli/src/index.mjs health docs/ontology --json",
     "dogfood:agent": "node cli/src/index.mjs agent-brief docs/ontology --json",

--- a/scripts/classify-change.mjs
+++ b/scripts/classify-change.mjs
@@ -34,6 +34,7 @@ export const FULL_LANE_COMMANDS = Object.freeze({
     'pnpm vault:audit',
     'pnpm test:claude:hooks',
     'pnpm test:harness:report',
+    'pnpm test:harness:smoke',
     'pnpm test:checks:changed',
     'pnpm test:ci:impact',
     'pnpm test:source:language',

--- a/scripts/harness-report.mjs
+++ b/scripts/harness-report.mjs
@@ -102,10 +102,42 @@ function readFindings(sinceMs) {
   return rows;
 }
 
+/**
+ * Last `pnpm harness:smoke` verdict per runtime. The parity tests prove the
+ * scripts; only the smoke proves the runtimes run them, so a report that did
+ * not say when that last happened would be reporting on hooks nobody watched.
+ */
+function readSmoke() {
+  const path = join(harnessDir(), 'smoke.jsonl');
+  const latest = {};
+  if (!existsSync(path)) return latest;
+  try {
+    for (const line of readFileSync(path, 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line);
+        const at = Date.parse(row?.at ?? '');
+        if (!Number.isFinite(at) || typeof row.runtime !== 'string') continue;
+        if (!latest[row.runtime] || latest[row.runtime].atMs < at) {
+          latest[row.runtime] = { atMs: at, at: row.at, ok: row.ok === true, problems: Array.isArray(row.problems) ? row.problems : [] };
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return latest;
+  }
+  return latest;
+}
+
 export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
   const sinceMs = now - days * 24 * 60 * 60 * 1000;
   const sessions = readSessions(sinceMs);
   const findings = readFindings(sinceMs);
+  const smoke = Object.fromEntries(
+    Object.entries(readSmoke()).map(([runtime, row]) => [runtime, { ...row, stale: row.atMs < sinceMs }]),
+  );
 
   const withEdits = sessions.filter((session) => session.files.size > 0);
   const unverified = withEdits.filter((session) => session.lastVerified < session.lastEdit);
@@ -125,6 +157,7 @@ export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
       filesTouched: new Set(withEdits.flatMap((session) => [...session.files])).size,
     },
     sensor: { findings: findings.length, byKind },
+    smoke,
     /**
      * The sensor earns its place by catching things. Zero findings across a
      * window with real edits is the falsifier its own header names.
@@ -152,6 +185,16 @@ function format(report) {
         : ''
     }`,
   ];
+  const runtimes = Object.entries(report.smoke ?? {});
+  if (runtimes.length === 0) {
+    lines.push('[harness] runtime smoke: never run here; `pnpm harness:smoke` is the only proof the runtimes fire these hooks.');
+  } else {
+    lines.push(
+      `[harness] runtime smoke: ${runtimes
+        .map(([runtime, row]) => `${runtime} ${row.ok ? 'ok' : 'FAILED'} ${row.at.slice(0, 10)}${row.stale ? ' (stale)' : ''}`)
+        .join(' · ')}`,
+    );
+  }
   if (report.verdict === 'no-data') {
     lines.push('[harness] no source-editing session recorded yet; the lane has nothing to answer for.');
   } else if (report.verdict === 'sensor-caught-nothing') {

--- a/scripts/harness-report.test.mjs
+++ b/scripts/harness-report.test.mjs
@@ -56,6 +56,29 @@ describe('harness report', () => {
     assert.equal(report.verdict, 'sensor-earning-its-place');
   });
 
+  it('reports the last smoke verdict per runtime and flags one older than the window', () => {
+    const report = withHarnessState(
+      {
+        'smoke.jsonl':
+          `${JSON.stringify({ at: new Date(old).toISOString(), runtime: 'claude', ok: true, problems: [] })}\n` +
+          `${JSON.stringify({ at: new Date(recent).toISOString(), runtime: 'codex', ok: false, problems: ['Stop: 0 completed'] })}\n` +
+          `${JSON.stringify({ at: new Date(recent - 5000).toISOString(), runtime: 'codex', ok: true, problems: [] })}\n`,
+      },
+      () => buildHarnessReport({ now: NOW }),
+    );
+    assert.equal(report.smoke.claude.ok, true);
+    assert.equal(report.smoke.claude.stale, true, 'a pass from 40 days ago proves nothing about today');
+    // The newest codex row wins, not the last one written.
+    assert.equal(report.smoke.codex.ok, false);
+    assert.deepEqual(report.smoke.codex.problems, ['Stop: 0 completed']);
+  });
+
+  it('says so when the smoke has never run, instead of staying silent', () => {
+    const lines = [];
+    withHarnessState({}, () => runHarnessReport([], { log: (line) => lines.push(line), error: () => {} }));
+    assert.match(lines.join('\n'), /runtime smoke: never run here/);
+  });
+
   it('names the sensor falsifier when real edits caught nothing', () => {
     const report = withHarnessState(
       { 'session-a.edits': `${recent}\tsrc/a.ts\n` },

--- a/scripts/harness-smoke.mjs
+++ b/scripts/harness-smoke.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * `pnpm harness:smoke` — prove the hooks on the runtimes that run them.
+ *
+ * **Why this exists.** On 2026-09-02 three hooks that every parity test called
+ * green turned out to be silent on a real runtime: the Codex generated-file
+ * guard could not read the payload Codex sends, the PreCompact census on both
+ * trees reached no model, and the Codex census hook had been marked
+ * "SessionStart Failed" on every session because its first line began with a
+ * bracket. `scripts/claude-hooks.test.mjs` feeds each script a hand-written
+ * payload; it cannot see what the runtime does with the script. Only the
+ * runtime can, so this drives one short session per runtime and reads back
+ * what fired, what failed, and whether the vault census actually reached the
+ * model.
+ *
+ * **What one run does, per runtime.** One prompt: run `pnpm lint --version`,
+ * then answer with the node count from the census. That exercises every wired
+ * event in one turn: SessionStart (census), PreToolUse (the three blocks),
+ * PostToolUse (the stamp), Stop (the reminder). The answer is compared with
+ * the vault's real node count, which is the only proof that context arrived.
+ *
+ * **What it costs and where it runs.** One small model call per runtime, and
+ * it needs the runtime installed and signed in, so it is a local check, never
+ * CI. `pnpm harness:report` shows when it last passed, and calls an absent or
+ * stale smoke out, because a hook nobody has watched fire is the dead gate
+ * this repository keeps finding.
+ *
+ * Runtime notes, measured on codex-cli 0.151.0 and the Claude Code CLI:
+ *   - Both are driven with stdin closed. `codex exec` blocks on an open
+ *     non-TTY stdin ("Reading additional input from stdin...").
+ *   - Codex runs a project hook only after `/hooks` trust; an untrusted hook
+ *     shows up here as a count below the expected one, not as a failure.
+ *   - Claude reports each hook as a `hook_response` event with `exit_code`
+ *     and `outcome` on `--output-format stream-json --include-hook-events`;
+ *     Codex prints `hook: <Event>` / `hook: <Event> Completed|Failed` lines.
+ *   - Counts are lower bounds: user-level hooks (`~/.claude`, `~/.codex`) fire
+ *     alongside the project's and cannot be told apart in either output.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const SMOKE_PROMPT =
+  'Run the shell command `pnpm lint --version`. Then answer with exactly one line ' +
+  'containing only the node count from the ontology vault census you were given as ' +
+  'context, or NONE if no such context was given.';
+
+const EVENTS = ['SessionStart', 'PreToolUse', 'PostToolUse', 'Stop'];
+
+/** Number of project hooks the prompt above must fire, per event. */
+function expectedFromHooks(hooks, shellTool) {
+  const groupsFor = (event) => (Array.isArray(hooks?.[event]) ? hooks[event] : []);
+  const size = (group) => (Array.isArray(group?.hooks) ? group.hooks.length : 0);
+  const matches = (group) =>
+    typeof group?.matcher !== 'string' ||
+    group.matcher.split('|').map((part) => part.trim()).includes(shellTool);
+  const expected = {};
+  for (const event of EVENTS) {
+    const groups = groupsFor(event).filter(matches);
+    // Several matcher groups can name the same shell tool; the runtime picks
+    // one, so the lower bound is the smallest of them.
+    expected[event] = groups.length === 0 ? 0 : Math.min(...groups.map(size));
+  }
+  return expected;
+}
+
+export const expectedFromClaudeSettings = (settings) => expectedFromHooks(settings?.hooks, 'Bash');
+export const expectedFromCodexHooks = (config) => expectedFromHooks(config?.hooks, 'exec_command');
+
+const ANSWER = /^(\d+|NONE)$/;
+
+/** Claude Code `--output-format stream-json --include-hook-events` output. */
+export function parseClaudeStream(text) {
+  const events = Object.fromEntries(EVENTS.map((event) => [event, { count: 0, failed: [] }]));
+  let answer = null;
+  let sessionId = null;
+  let censusSeen = false;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('{')) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof row.session_id === 'string' && !sessionId) sessionId = row.session_id;
+    if (row.type === 'system' && row.subtype === 'hook_response') {
+      const bucket = events[row.hook_event];
+      if (!bucket) continue;
+      bucket.count += 1;
+      if (row.exit_code !== 0 || row.outcome !== 'success') {
+        bucket.failed.push(`${row.hook_name} exit=${row.exit_code} ${String(row.stderr ?? '').trim()}`.trim());
+      }
+      if (row.hook_event === 'SessionStart' && /Ontology vault: \d+ nodes/.test(String(row.stdout ?? ''))) {
+        censusSeen = true;
+      }
+    }
+    if (row.type === 'result' && typeof row.result === 'string') {
+      const last = row.result.trim().split('\n').pop().trim();
+      answer = ANSWER.test(last) ? last : row.result.trim();
+    }
+  }
+  return { events, answer, sessionId, censusSeen };
+}
+
+/** `codex exec` human output: `hook: Event`, `hook: Event Completed|Failed`. */
+export function parseCodexOutput(text) {
+  const clean = text.replace(/\x1b\[[0-9;]*m/g, '');
+  const events = Object.fromEntries(EVENTS.map((event) => [event, { count: 0, failed: [] }]));
+  let answer = null;
+  let sessionId = null;
+  for (const raw of clean.split('\n')) {
+    const line = raw.trim();
+    const session = /^session id:\s*(\S+)/.exec(line);
+    if (session) sessionId = session[1];
+    const hook = /^hook:\s+(\w+)(?:\s+(Completed|Failed))?$/.exec(line);
+    if (hook) {
+      const bucket = events[hook[1]];
+      if (!bucket) continue;
+      if (hook[2] === 'Completed') bucket.count += 1;
+      else if (hook[2] === 'Failed') bucket.failed.push(`${hook[1]} Failed`);
+      continue;
+    }
+    if (ANSWER.test(line)) answer = line;
+  }
+  return { events, answer, sessionId, censusSeen: null };
+}
+
+/** Real node count of the dogfood vault, the number the census hands out. */
+export function readVaultNodeCount(cwd = process.cwd()) {
+  const result = spawnSync(process.execPath, ['cli/src/index.mjs', 'overview', 'docs/ontology', '--json'], {
+    cwd,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return null;
+  try {
+    const overview = JSON.parse(result.stdout);
+    const byKind = overview.byKind ?? {};
+    return overview.graph?.nodes ?? Object.values(byKind).reduce((sum, n) => sum + n, 0);
+  } catch {
+    return null;
+  }
+}
+
+/** One verdict per runtime, with every reason spelled out. */
+export function judge({ runtime, observed, expected, nodeCount }) {
+  const problems = [];
+  for (const event of EVENTS) {
+    const seen = observed.events[event];
+    if (seen.failed.length > 0) problems.push(`${event}: ${seen.failed.join('; ')}`);
+    if (seen.count < expected[event]) {
+      problems.push(
+        `${event}: ${seen.count} completed, project wiring expects at least ${expected[event]}` +
+          (runtime === 'codex' ? ' (untrusted in /hooks?)' : ''),
+      );
+    }
+  }
+  if (observed.censusSeen === false) problems.push('SessionStart: no hook printed the vault census');
+  if (nodeCount === null) problems.push('vault: could not read the node count to compare the answer');
+  else if (observed.answer === null) problems.push('answer: the model gave no parsable node count');
+  else if (String(observed.answer) !== String(nodeCount)) {
+    problems.push(`answer: model said ${observed.answer}, the vault has ${nodeCount} nodes; the census did not reach it`);
+  }
+  return { runtime, ok: problems.length === 0, problems, events: observed.events, answer: observed.answer };
+}
+
+const RUNTIMES = {
+  claude: {
+    expected: (cwd) => expectedFromClaudeSettings(JSON.parse(readFileSync(join(cwd, '.claude/settings.json'), 'utf8'))),
+    command: [
+      'claude',
+      ['-p', SMOKE_PROMPT, '--output-format', 'stream-json', '--verbose', '--include-hook-events', '--model', 'haiku', '--allowedTools', 'Bash(pnpm lint:*)'],
+    ],
+    parse: parseClaudeStream,
+  },
+  codex: {
+    expected: (cwd) => expectedFromCodexHooks(JSON.parse(readFileSync(join(cwd, '.codex/hooks.json'), 'utf8'))),
+    command: ['codex', ['exec', '--sandbox', 'read-only', '-c', 'model_reasoning_effort="low"', SMOKE_PROMPT]],
+    parse: parseCodexOutput,
+  },
+};
+
+function installed(bin) {
+  return spawnSync('which', [bin], { encoding: 'utf8' }).status === 0;
+}
+
+/** The smoke session leaves ledger files under its own id; they are not data. */
+function forgetSession(cwd, sessionId) {
+  if (!sessionId) return;
+  const safe = sessionId.replace(/[^\w-]/g, '');
+  for (const suffix of ['edits', 'verified']) {
+    rmSync(join(cwd, '.tmp', 'harness', `session-${safe}.${suffix}`), { force: true });
+  }
+}
+
+function record(cwd, verdict, now) {
+  try {
+    const dir = join(cwd, '.tmp', 'harness');
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(
+      join(dir, 'smoke.jsonl'),
+      JSON.stringify({ at: new Date(now).toISOString(), runtime: verdict.runtime, ok: verdict.ok, problems: verdict.problems }) + '\n',
+    );
+  } catch {
+    /* a missed record costs one report line, never the verdict */
+  }
+}
+
+export function runSmokeFor(runtime, { cwd = process.cwd(), now = Date.now(), spawn = spawnSync } = {}) {
+  const spec = RUNTIMES[runtime];
+  const [bin, args] = spec.command;
+  if (!installed(bin)) return { runtime, ok: null, problems: [`${bin} is not installed here`], events: null, answer: null };
+  const expected = spec.expected(cwd);
+  const result = spawn(bin, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 240_000, maxBuffer: 64 * 1024 * 1024 });
+  const text = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  const observed = spec.parse(text);
+  forgetSession(cwd, observed.sessionId);
+  const verdict = judge({ runtime, observed, expected, nodeCount: readVaultNodeCount(cwd) });
+  if (result.status !== 0) verdict.problems.unshift(`${bin} exited ${result.status ?? result.signal}`);
+  verdict.ok = verdict.problems.length === 0;
+  record(cwd, verdict, now);
+  return verdict;
+}
+
+function parseArgs(argv) {
+  const args = { json: false, runtimes: Object.keys(RUNTIMES) };
+  for (const arg of argv) {
+    if (arg === '--json') args.json = true;
+    else if (arg.startsWith('--runtime=')) {
+      const name = arg.slice('--runtime='.length);
+      if (!RUNTIMES[name]) throw new Error(`unknown runtime ${name}; expected ${Object.keys(RUNTIMES).join(' or ')}`);
+      args.runtimes = [name];
+    } else if (arg !== '--') throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function format(verdicts) {
+  const lines = [];
+  for (const v of verdicts) {
+    if (v.ok === null) {
+      lines.push(`[smoke] ${v.runtime}: skipped (${v.problems[0]})`);
+      continue;
+    }
+    const counts = EVENTS.map((event) => `${event} ${v.events[event].count}`).join(' · ');
+    lines.push(`[smoke] ${v.runtime}: ${v.ok ? 'ok' : 'FAILED'} · ${counts} · census answer ${v.answer ?? 'none'}`);
+    for (const problem of v.problems) lines.push(`[smoke]   - ${problem}`);
+  }
+  return lines.join('\n');
+}
+
+export function runHarnessSmoke(argv, io = console) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    io.error(`[smoke] ${error.message}`);
+    return 2;
+  }
+  if (!existsSync(join(process.cwd(), '.claude', 'settings.json'))) {
+    io.error('[smoke] run from the repository root');
+    return 2;
+  }
+  const verdicts = args.runtimes.map((runtime) => runSmokeFor(runtime));
+  io.log(args.json ? JSON.stringify(verdicts, null, 2) : format(verdicts));
+  return verdicts.some((v) => v.ok === false) ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = runHarnessSmoke(process.argv.slice(2));
+}

--- a/scripts/harness-smoke.test.mjs
+++ b/scripts/harness-smoke.test.mjs
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  expectedFromClaudeSettings,
+  expectedFromCodexHooks,
+  judge,
+  parseClaudeStream,
+  parseCodexOutput,
+} from './harness-smoke.mjs';
+
+/**
+ * The fixtures are trimmed from real runs on 2026-09-02 (Claude Code CLI with
+ * `--include-hook-events`, codex-cli 0.151.0), because the whole point of the
+ * smoke is the shape the runtime actually emits. A parser that passes on an
+ * invented shape is the failure mode this file exists to prevent.
+ */
+
+const claudeRow = (subtype, extra) =>
+  JSON.stringify({ type: 'system', subtype, session_id: 'sess-claude', ...extra });
+
+const CLAUDE_OK = [
+  claudeRow('hook_started', { hook_name: 'SessionStart:startup', hook_event: 'SessionStart' }),
+  claudeRow('hook_response', {
+    hook_name: 'SessionStart:startup',
+    hook_event: 'SessionStart',
+    stdout: 'ontology vault @ /repo/docs/ontology\nOntology vault: 97 nodes (element:58). Load details only when needed.\n',
+    stderr: '',
+    exit_code: 0,
+    outcome: 'success',
+  }),
+  claudeRow('hook_response', { hook_name: 'PreToolUse:Bash', hook_event: 'PreToolUse', stdout: '', stderr: '', exit_code: 0, outcome: 'success' }),
+  claudeRow('hook_response', { hook_name: 'PreToolUse:Bash', hook_event: 'PreToolUse', stdout: '', stderr: '', exit_code: 0, outcome: 'success' }),
+  claudeRow('hook_response', { hook_name: 'PostToolUse:Bash', hook_event: 'PostToolUse', stdout: '', stderr: '', exit_code: 0, outcome: 'success' }),
+  claudeRow('hook_response', { hook_name: 'Stop', hook_event: 'Stop', stdout: '', stderr: '', exit_code: 0, outcome: 'success' }),
+  JSON.stringify({ type: 'result', subtype: 'success', result: '97', session_id: 'sess-claude' }),
+].join('\n');
+
+const CODEX_OK = `OpenAI Codex v0.151.0
+--------
+workdir: /repo
+session id: 01a05f75-14cc-7742-97bc-6db95d700a57
+--------
+user
+${'Run the shell command'}
+hook: SessionStart
+hook: SessionStart Completed
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+hook: PreToolUse Completed
+exec
+/bin/zsh -lc 'pnpm lint --version' in /repo
+ succeeded in 51ms:
+v9.39.4
+
+hook: PostToolUse
+hook: PostToolUse Completed
+codex
+97
+hook: Stop
+hook: Stop Completed
+tokens used
+9,693
+97
+`;
+
+const CLAUDE_SETTINGS = {
+  hooks: {
+    PreToolUse: [
+      { matcher: 'Bash', hooks: [{ type: 'command', command: 'a' }, { type: 'command', command: 'b' }] },
+      { matcher: 'Edit|Write', hooks: [{ type: 'command', command: 'c' }] },
+    ],
+    PostToolUse: [
+      { matcher: 'Edit|Write', hooks: [{ type: 'command', command: 'd' }, { type: 'command', command: 'e' }] },
+      { matcher: 'Bash', hooks: [{ type: 'command', command: 'f' }] },
+    ],
+    Stop: [{ hooks: [{ type: 'command', command: 'g' }] }],
+    SessionStart: [{ hooks: [{ type: 'command', command: 'h' }] }],
+  },
+};
+
+const CODEX_HOOKS = {
+  hooks: {
+    PreToolUse: [
+      { matcher: 'Bash', hooks: [{ command: 'a' }, { command: 'b' }, { command: 'c' }] },
+      { matcher: 'exec_command', hooks: [{ command: 'a' }, { command: 'b' }, { command: 'c' }] },
+      { matcher: 'Edit|apply_patch', hooks: [{ command: 'd' }] },
+    ],
+    PostToolUse: [
+      { matcher: 'Edit|apply_patch', hooks: [{ command: 'e' }] },
+      { matcher: 'exec_command', hooks: [{ command: 'f' }] },
+    ],
+    Stop: [{ hooks: [{ command: 'g' }] }],
+    SessionStart: [{ hooks: [{ command: 'h' }] }],
+  },
+};
+
+describe('harness smoke: expected counts come from the wiring, not from memory', () => {
+  it('reads the Claude shell-tool groups and the matcher-less events', () => {
+    assert.deepEqual(expectedFromClaudeSettings(CLAUDE_SETTINGS), {
+      SessionStart: 1,
+      PreToolUse: 2,
+      PostToolUse: 1,
+      Stop: 1,
+    });
+  });
+
+  it('reads the Codex exec_command groups', () => {
+    assert.deepEqual(expectedFromCodexHooks(CODEX_HOOKS), {
+      SessionStart: 1,
+      PreToolUse: 3,
+      PostToolUse: 1,
+      Stop: 1,
+    });
+  });
+
+  it('expects nothing from an event that is not wired', () => {
+    assert.equal(expectedFromClaudeSettings({ hooks: {} }).Stop, 0);
+  });
+});
+
+describe('harness smoke: parsers read the shapes the runtimes emit', () => {
+  it('Claude: counts hook_response rows, sees the census, and reads the answer', () => {
+    const observed = parseClaudeStream(CLAUDE_OK);
+    assert.equal(observed.events.SessionStart.count, 1);
+    assert.equal(observed.events.PreToolUse.count, 2);
+    assert.equal(observed.events.PostToolUse.count, 1);
+    assert.equal(observed.events.Stop.count, 1);
+    assert.equal(observed.censusSeen, true);
+    assert.equal(observed.answer, '97');
+    assert.equal(observed.sessionId, 'sess-claude');
+  });
+
+  it('Claude: a non-zero exit or a non-success outcome is a failure with its name', () => {
+    const text =
+      CLAUDE_OK +
+      '\n' +
+      claudeRow('hook_response', { hook_name: 'Stop', hook_event: 'Stop', stdout: '', stderr: 'boom', exit_code: 1, outcome: 'success' });
+    const observed = parseClaudeStream(text);
+    assert.deepEqual(observed.events.Stop.failed, ['Stop exit=1 boom']);
+  });
+
+  it('Codex: counts Completed lines, ignores the bare announcement, reads the session id and answer', () => {
+    const observed = parseCodexOutput(CODEX_OK);
+    assert.equal(observed.events.SessionStart.count, 1);
+    assert.equal(observed.events.PreToolUse.count, 3);
+    assert.equal(observed.events.PostToolUse.count, 1);
+    assert.equal(observed.events.Stop.count, 1);
+    assert.equal(observed.answer, '97');
+    assert.equal(observed.sessionId, '01a05f75-14cc-7742-97bc-6db95d700a57');
+    assert.equal(observed.censusSeen, null, 'Codex prints no per-hook stdout; the answer is the proof');
+  });
+
+  it('Codex: a Failed line is a failure and not a completion', () => {
+    const observed = parseCodexOutput(CODEX_OK.replace('hook: SessionStart Completed', 'hook: SessionStart Failed'));
+    assert.equal(observed.events.SessionStart.count, 0);
+    assert.deepEqual(observed.events.SessionStart.failed, ['SessionStart Failed']);
+  });
+
+  it('Codex: ANSI colour does not hide a hook line', () => {
+    const observed = parseCodexOutput(CODEX_OK.replace('hook: Stop Completed', '\x1b[2mhook: Stop Completed\x1b[0m'));
+    assert.equal(observed.events.Stop.count, 1);
+  });
+});
+
+describe('harness smoke: the verdict names every way a hook can be dead', () => {
+  const expected = { SessionStart: 1, PreToolUse: 2, PostToolUse: 1, Stop: 1 };
+
+  it('passes a run where every event completed and the census reached the model', () => {
+    const verdict = judge({ runtime: 'claude', observed: parseClaudeStream(CLAUDE_OK), expected, nodeCount: 97 });
+    assert.equal(verdict.ok, true, verdict.problems.join('\n'));
+  });
+
+  it('fails when a wired event fired fewer times than the wiring promises', () => {
+    const observed = parseCodexOutput(CODEX_OK.replace('hook: PostToolUse Completed\n', ''));
+    const verdict = judge({ runtime: 'codex', observed, expected: { ...expected, PreToolUse: 3 }, nodeCount: 97 });
+    assert.equal(verdict.ok, false);
+    assert.match(verdict.problems.join('\n'), /PostToolUse: 0 completed, project wiring expects at least 1 \(untrusted in \/hooks\?\)/);
+  });
+
+  it('fails when the model answers a different count than the vault holds', () => {
+    const verdict = judge({ runtime: 'claude', observed: parseClaudeStream(CLAUDE_OK), expected, nodeCount: 98 });
+    assert.equal(verdict.ok, false);
+    assert.match(verdict.problems[0], /model said 97, the vault has 98/);
+  });
+
+  it('fails on NONE: a hook that ran but whose context never arrived', () => {
+    const observed = parseClaudeStream(CLAUDE_OK.replace('"result":"97"', '"result":"NONE"'));
+    const verdict = judge({ runtime: 'claude', observed, expected, nodeCount: 97 });
+    assert.equal(verdict.ok, false);
+    assert.match(verdict.problems[0], /model said NONE/);
+  });
+
+  it('fails when the vault count itself cannot be read, instead of passing by default', () => {
+    const verdict = judge({ runtime: 'claude', observed: parseClaudeStream(CLAUDE_OK), expected, nodeCount: null });
+    assert.equal(verdict.ok, false);
+    assert.match(verdict.problems[0], /could not read the node count/);
+  });
+});

--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -397,6 +397,13 @@ const RULES = [
     ],
   },
   {
+    // The smoke reads its expected counts from both hook wirings, so a change
+    // to either settings file re-proves the parsers against them.
+    command: 'pnpm test:harness:smoke',
+    reason: 'the runtime smoke, or the hook wiring it derives its expectations from, changed',
+    matches: [/^scripts\/harness-smoke(?:\.test)?\.mjs$/, /^\.claude\/settings\.json$/, /^\.codex\/hooks\.json$/],
+  },
+  {
     command: 'pnpm test:claude:hooks',
     reason: 'agent hook wiring, a guard, or the commit-message gate changed',
     /*

--- a/scripts/lib/focused-check-suggestions.test.mjs
+++ b/scripts/lib/focused-check-suggestions.test.mjs
@@ -650,8 +650,10 @@ describe('focused check suggestions', () => {
 
     // Every path here is also inventoried by `agent-files`, and `.claude/settings.json`
     // carries the `permissions.deny` rules the secret-read guard derives from
-    // `.gitignore`, so all three gates apply.
+    // `.gitignore`, so all three gates apply. The runtime smoke derives its
+    // expected hook counts from both wiring files, so it re-proves its parsers.
     assert.deepEqual(domainCommands(result), [
+      'pnpm test:harness:smoke',
       'pnpm test:claude:hooks',
       'pnpm agents:check',
       'pnpm exec vitest run tests/contract/agent-files.contract.test.ts tests/contract/nested-agents-pointers.contract.test.ts tests/contract/skill-routing.contract.test.ts tests/contract/rules-path-scope.contract.test.ts tests/contract/secret-read-guard.contract.test.ts tests/contract/node-test-reachability.contract.test.ts tests/contract/agent-file-citations.contract.test.ts',


### PR DESCRIPTION
## Summary

Three hooks that every parity test called green were silent on a real runtime today (Codex generated-file guard, PreCompact census on both trees, Codex census marked `SessionStart Failed`). The hook tests feed scripts hand-written payloads; only the runtime can show what it does with them.

`pnpm harness:smoke` drives one short session per runtime (a shell command, then the vault node count from the census) and reads back what fired:

- **Claude Code**: `hook_response` events with `exit_code`/`outcome` via `--output-format stream-json --include-hook-events`.
- **Codex**: `hook: <Event> Completed|Failed` lines from `codex exec`, stdin closed.
- Expected counts are derived from `.claude/settings.json` and `.codex/hooks.json`, so an untrusted Codex hook shows as a count below the wiring, a runtime-marked failure shows by name, and a census that never arrived shows as `NONE` or a wrong number.
- Cleans up its own sessions' ledger files, records verdicts under `.tmp/harness/smoke.jsonl`; `pnpm harness:report` now shows the last pass per runtime or says it never ran.

Local only (needs both CLIs signed in). Wired into the planner: editing either wiring file or the smoke re-runs its unit tests.

Today's real run:
```
[smoke] claude: ok · SessionStart 3 · PreToolUse 3 · PostToolUse 2 · Stop 3 · census answer 97
[smoke] codex: ok · SessionStart 2 · PreToolUse 4 · PostToolUse 2 · Stop 2 · census answer 97
```

## Test plan

- [x] `pnpm test:harness:smoke` (13), `pnpm test:harness:report` (7)
- [x] `pnpm checks:changed -- --run` (19 passed)
- [x] `pnpm agents:check` (48), `pnpm docs:language`, eslint on the new scripts
- [x] `pnpm harness:smoke` against both real runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4