### PR TITLE
feat: count what the harness changes downstream with pnpm harness:outcomes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -161,6 +161,12 @@ for name in $lane_names; do
   fi
 done
 
+# One line per push into the local harness ledger, pass or fail. This is the
+# number that says whether the gate earns its minutes: `pnpm harness:outcomes`
+# sets pushes refused here against PR commits that failed in CI. Measurement
+# only; a failed write never changes the push's fate.
+node scripts/harness-prepush-ledger.mjs "$n_changed" "$lane_names" "$failed" 2>/dev/null || true
+
 if [ -n "$failed" ]; then
   for name in $failed; do
     echo ""

--- a/README.md
+++ b/README.md
@@ -833,6 +833,13 @@ wiring, and fails on any hook the runtime marked failed, any count below the
 wiring, or a census that never reached the model. It needs both CLIs signed in,
 so it is a local check, not CI.
 
+`pnpm harness:outcomes` looks downstream of the harness: pushes the pre-push
+gate refused locally (one ledger line per push, written by the hook) against
+merged-PR commits whose CI checks failed, and `fix:` commits landing after
+each release tag. The first pair is the push gate's earned value; the second is
+what a release shipped. Both are proxies and are named as such; `--local` skips
+the GitHub calls.
+
 Agent-workflow changes run `pnpm agents:check`; its `pnpm test:agent-skills`
 step proves that scratch readers stop on a wrong vault/repository binding before
 semantic reads and that qualification keeps explicit unknown/refusal behavior.

--- a/package.json
+++ b/package.json
@@ -159,6 +159,8 @@
     "test:harness:report": "node --test scripts/harness-report.test.mjs",
     "harness:smoke": "node scripts/harness-smoke.mjs",
     "test:harness:smoke": "node --test scripts/harness-smoke.test.mjs",
+    "harness:outcomes": "node scripts/harness-outcomes.mjs",
+    "test:harness:outcomes": "node --test scripts/harness-outcomes.test.mjs",
     "test:dogfood:compile-fix": "node --test scripts/dogfood-compile-fix.test.mjs",
     "dogfood:health": "node scripts/lib/check-mcp-source-dependencies.mjs && node cli/src/index.mjs health docs/ontology --json",
     "dogfood:agent": "node cli/src/index.mjs agent-brief docs/ontology --json",

--- a/scripts/classify-change.mjs
+++ b/scripts/classify-change.mjs
@@ -35,6 +35,7 @@ export const FULL_LANE_COMMANDS = Object.freeze({
     'pnpm test:claude:hooks',
     'pnpm test:harness:report',
     'pnpm test:harness:smoke',
+    'pnpm test:harness:outcomes',
     'pnpm test:checks:changed',
     'pnpm test:ci:impact',
     'pnpm test:source:language',

--- a/scripts/harness-outcomes.mjs
+++ b/scripts/harness-outcomes.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * `pnpm harness:outcomes` — what the harness changed about outcomes, not about
+ * itself.
+ *
+ * **Why this exists.** `pnpm harness:report` says what the hooks did: findings
+ * caught, stops reminded, runtimes proved. None of that says whether the work
+ * got better. The 2026-09-02 assessment scored the loop and observability
+ * layers lowest for exactly that reason: the harness could count its own
+ * activity and nothing downstream of it. Two numbers are downstream and cheap:
+ *
+ *   1. **Round-trips.** A push the local pre-push gate refused is a CI
+ *      round-trip that did not happen; a PR commit whose CI checks failed is
+ *      one that did. The ratio between them is the push gate's earned value.
+ *   2. **Escaped defects.** `fix:` commits landing after a release tag are the
+ *      defects that release shipped. Two full reviews found twenty confirmed
+ *      defects in v1.0.0 (2026-09-01), none of which a shape check could have
+ *      caught; this line keeps that count visible per release instead of once.
+ *
+ * **What it reads.** The local pre-push ledger (`.tmp/harness/prepush.jsonl`),
+ * `git tag` and `git log` for releases, and, unless `--local` is passed, the
+ * GitHub API through `gh` for merged pull requests and their per-commit check
+ * runs. Nothing is written anywhere.
+ *
+ * **What it does not claim.** A commit with a failed check run is a round-trip,
+ * not a defect: a flaky shard counts, and a failure fixed by a force-push of
+ * the same commit is invisible. A `fix:` commit is a subject line, not a
+ * verified escape. Both are lower-effort proxies, named as such.
+ */
+
+import { execFile, spawnSync } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function run(bin, args, { cwd } = {}) {
+  const result = spawnSync(bin, args, { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  return result.status === 0 ? result.stdout : null;
+}
+
+const execFileAsync = promisify(execFile);
+async function runAsync(bin, args, { cwd } = {}) {
+  try {
+    const { stdout } = await execFileAsync(bin, args, { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+/** Run `work(item)` over `items` with at most `limit` in flight; order is kept. */
+async function mapPool(items, limit, work) {
+  const results = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await work(items[index]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+/** Local pre-push ledger: pushes attempted, pushes refused, refusals by lane. */
+export function summarizePrepush(lines, sinceMs) {
+  const summary = { pushes: 0, blocked: 0, byLane: {} };
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const at = Date.parse(row?.at ?? '');
+    if (!Number.isFinite(at) || at < sinceMs) continue;
+    summary.pushes += 1;
+    const failed = Array.isArray(row.failed) ? row.failed : [];
+    if (failed.length > 0) summary.blocked += 1;
+    for (const lane of failed) summary.byLane[lane] = (summary.byLane[lane] ?? 0) + 1;
+  }
+  return summary;
+}
+
+export function readPrepush(cwd, sinceMs) {
+  const path = join(cwd, '.tmp', 'harness', 'prepush.jsonl');
+  if (!existsSync(path)) return null;
+  try {
+    return summarizePrepush(readFileSync(path, 'utf8').split('\n'), sinceMs);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One merged pull request: how many of its commits reached CI with a failing
+ * check, and which checks. `commits` is [{ sha, checkRuns: [{ name, conclusion }] }].
+ */
+export function summarizePullRequest(pr) {
+  const failures = [];
+  for (const commit of pr.commits) {
+    const failed = (commit.checkRuns ?? []).filter((check) => check.conclusion === 'failure');
+    if (failed.length > 0) failures.push({ sha: commit.sha.slice(0, 7), checks: [...new Set(failed.map((c) => c.name))] });
+  }
+  return {
+    number: pr.number,
+    title: pr.title,
+    mergedAt: pr.mergedAt,
+    commits: pr.commits.length,
+    ciFailures: failures.length,
+    failedChecks: failures,
+  };
+}
+
+const parseJson = (text, fallback) => {
+  try {
+    return text ? JSON.parse(text) : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+async function fetchMergedPullRequests(cwd, sinceMs) {
+  // Listing commits inline for many PRs trips GitHub's GraphQL node limit
+  // (measured 2026-09-02 at --limit 100), so the list is cheap and each PR in
+  // the window is asked for its commits on its own. Serial calls measured
+  // 4.5 minutes for a 14-day window here (this repository merges several PRs
+  // a day), so the per-PR and per-commit reads run in a small pool.
+  const out = run('gh', ['pr', 'list', '--state', 'merged', '--limit', '100', '--json', 'number,title,mergedAt'], { cwd });
+  if (out === null) return null;
+  const rows = parseJson(out, null);
+  if (!Array.isArray(rows)) return null;
+  const slug = run('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], { cwd })?.trim();
+  if (!slug) return null;
+  const inWindow = rows.filter((row) => Date.parse(row.mergedAt) >= sinceMs);
+  // 100 merged PRs inside the window means the list, not the window, set the
+  // edge; the report says so rather than passing a partial count as a total.
+  const capped = rows.length >= 100 && inWindow.length === rows.length;
+  const pullRequests = await mapPool(inWindow, 6, async (row) => {
+    const detail = await runAsync('gh', ['pr', 'view', String(row.number), '--json', 'commits'], { cwd });
+    const listed = parseJson(detail, {}).commits ?? [];
+    const commits = await mapPool(listed, 4, async (commit) => {
+      const raw = await runAsync('gh', ['api', `repos/${slug}/commits/${commit.oid}/check-runs?per_page=100`], { cwd });
+      const checkRuns = (parseJson(raw, {}).check_runs ?? []).map((c) => ({ name: c.name, conclusion: c.conclusion }));
+      return { sha: commit.oid, checkRuns };
+    });
+    return summarizePullRequest({ number: row.number, title: row.title, mergedAt: row.mergedAt, commits });
+  });
+  return { pullRequests, capped };
+}
+
+/** Release intervals from an ordered tag list: each tag to the next, then the last to HEAD. */
+export function releaseIntervals(tags, head = 'HEAD') {
+  const releases = tags.filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag));
+  const intervals = [];
+  for (let i = 0; i < releases.length; i += 1) {
+    intervals.push({ from: releases[i], to: releases[i + 1] ?? head });
+  }
+  return intervals;
+}
+
+/** `fix:` subjects among a list of commit subjects. */
+export function countFixes(subjects) {
+  const total = subjects.filter((s) => s.trim()).length;
+  const fixes = subjects.filter((s) => /^fix(?:\(.*\))?:/.test(s.trim())).length;
+  return { total, fixes };
+}
+
+export function readReleases(cwd) {
+  const tags = run('git', ['tag', '--sort=creatordate'], { cwd });
+  if (tags === null) return [];
+  return releaseIntervals(tags.split('\n').filter(Boolean)).map((interval) => {
+    const log = run('git', ['log', '--format=%s', `${interval.from}..${interval.to}`], { cwd }) ?? '';
+    return { ...interval, ...countFixes(log.split('\n')) };
+  });
+}
+
+export async function buildOutcomes({ days = 14, now = Date.now(), cwd = process.cwd(), remote = true } = {}) {
+  const sinceMs = now - days * DAY_MS;
+  const prepush = readPrepush(cwd, sinceMs);
+  const fetched = remote ? await fetchMergedPullRequests(cwd, sinceMs) : null;
+  const pullRequests = fetched?.pullRequests ?? null;
+  const releases = readReleases(cwd).slice(-4);
+  const escaped = pullRequests ? pullRequests.reduce((sum, pr) => sum + pr.ciFailures, 0) : null;
+  return {
+    windowDays: days,
+    generatedAt: new Date(now).toISOString(),
+    prepush,
+    pullRequests,
+    pullRequestsCapped: fetched?.capped ?? false,
+    roundTrips: {
+      blockedLocally: prepush?.blocked ?? null,
+      escapedToCi: escaped,
+    },
+    releases,
+  };
+}
+
+function format(report) {
+  const lines = [`[outcomes] last ${report.windowDays} day(s)`];
+  const { prepush, pullRequests, roundTrips, releases } = report;
+  if (prepush === null) {
+    lines.push('[outcomes] pre-push: no ledger yet; the gate writes one per push from 2026-09-02 on.');
+  } else {
+    const byLane = Object.entries(prepush.byLane)
+      .sort((a, b) => b[1] - a[1])
+      .map(([lane, n]) => `${lane} ${n}`)
+      .join(' · ');
+    lines.push(`[outcomes] pre-push: pushes=${prepush.pushes} · refused locally=${prepush.blocked}${byLane ? ` (${byLane})` : ''}`);
+  }
+  if (pullRequests === null) {
+    lines.push('[outcomes] CI: not read (pass without --local and sign in to gh to count escaped round-trips).');
+  } else {
+    lines.push(
+      `[outcomes] CI: merged PRs=${pullRequests.length}${report.pullRequestsCapped ? ' (list capped at 100; the window is wider)' : ''} · commits that failed CI=${roundTrips.escapedToCi}`,
+    );
+    for (const pr of pullRequests.filter((p) => p.ciFailures > 0)) {
+      lines.push(`[outcomes]   #${pr.number} ${pr.ciFailures}/${pr.commits} commits: ${pr.failedChecks.map((f) => `${f.sha} (${f.checks.join(', ')})`).join('; ')}`);
+    }
+    if (roundTrips.blockedLocally !== null) {
+      const total = roundTrips.blockedLocally + roundTrips.escapedToCi;
+      lines.push(
+        total === 0
+          ? '[outcomes] round-trips: none in either place; nothing to judge yet.'
+          : `[outcomes] round-trips: ${roundTrips.blockedLocally} caught locally, ${roundTrips.escapedToCi} escaped to CI (${Math.round((100 * roundTrips.blockedLocally) / total)}% local).`,
+      );
+    }
+  }
+  if (releases.length > 0) {
+    lines.push(`[outcomes] fixes after release: ${releases.map((r) => `${r.from}→${r.to} ${r.fixes}/${r.total}`).join(' · ')}`);
+  }
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const args = { json: false, days: 14, remote: true };
+  for (const arg of argv) {
+    if (arg === '--json') args.json = true;
+    else if (arg === '--local') args.remote = false;
+    else if (arg.startsWith('--days=')) {
+      const days = Number(arg.slice('--days='.length));
+      if (!Number.isFinite(days) || days <= 0) throw new Error(`--days must be a positive number; received ${arg}`);
+      args.days = days;
+    } else if (arg !== '--') throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+export async function runHarnessOutcomes(argv, io = console) {
+  try {
+    const args = parseArgs(argv);
+    const report = await buildOutcomes({ days: args.days, remote: args.remote });
+    io.log(args.json ? JSON.stringify(report, null, 2) : format(report));
+    return 0;
+  } catch (error) {
+    io.error(`[outcomes] ${error.message}`);
+    return 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await runHarnessOutcomes(process.argv.slice(2));
+}

--- a/scripts/harness-outcomes.test.mjs
+++ b/scripts/harness-outcomes.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { countFixes, releaseIntervals, summarizePrepush, summarizePullRequest } from './harness-outcomes.mjs';
+import { appendPrepushRecord, prepushRecord } from './harness-prepush-ledger.mjs';
+
+/**
+ * The outcome numbers are the first thing downstream of the harness that can
+ * say whether it earns its minutes, so the way they are counted has to be
+ * exact: a refused push counted twice, or a flaky shard counted as a defect,
+ * would argue for the wrong change.
+ */
+
+const NOW = Date.parse('2026-09-02T00:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+const row = (daysAgo, failed) => JSON.stringify({ at: new Date(NOW - daysAgo * DAY).toISOString(), files: 3, lanes: ['lint', 'unit'], failed });
+
+describe('pre-push ledger', () => {
+  it('turns the three strings the hook has into a well-formed record', () => {
+    const record = prepushRecord({ files: '12', lanes: ' typecheck lint unit', failed: ' lint', now: NOW });
+    assert.deepEqual(record, { at: '2026-09-02T00:00:00.000Z', files: 12, lanes: ['typecheck', 'lint', 'unit'], failed: ['lint'] });
+  });
+
+  it('records a clean push with an empty failed list, not a missing one', () => {
+    assert.deepEqual(prepushRecord({ files: '1', lanes: 'docs', failed: '' }).failed, []);
+  });
+
+  it('appends under .tmp/harness of the given root', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prepush-ledger-'));
+    try {
+      appendPrepushRecord({ files: '2', lanes: 'lint', failed: 'lint', now: NOW }, { cwd: dir });
+      appendPrepushRecord({ files: '2', lanes: 'lint', failed: '', now: NOW + 1 }, { cwd: dir });
+      const lines = readFileSync(join(dir, '.tmp', 'harness', 'prepush.jsonl'), 'utf8').trim().split('\n');
+      assert.equal(lines.length, 2);
+      assert.equal(JSON.parse(lines[0]).failed[0], 'lint');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('counts a push once however many lanes refused it, and each lane once per push', () => {
+    const summary = summarizePrepush([row(1, ['lint', 'unit']), row(2, ['lint']), row(3, []), 'not json', row(40, ['docs'])], NOW - 14 * DAY);
+    assert.equal(summary.pushes, 3, 'the 40-day-old push is outside the window');
+    assert.equal(summary.blocked, 2);
+    assert.deepEqual(summary.byLane, { lint: 2, unit: 1 });
+  });
+});
+
+describe('CI round-trips per pull request', () => {
+  const pr = {
+    number: 1370,
+    title: 'feat: fast-sensor lane',
+    mergedAt: '2026-09-01T10:00:00Z',
+    commits: [
+      { sha: '91b52011111', checkRuns: [{ name: 'Unit · Contract', conclusion: 'failure' }, { name: 'Lint', conclusion: 'success' }] },
+      { sha: 'cd94c122222', checkRuns: [{ name: 'Unit · Contract', conclusion: 'failure' }, { name: 'Unit · Contract', conclusion: 'success' }] },
+      { sha: 'dbebc7c3333', checkRuns: [{ name: 'Unit · Contract', conclusion: 'success' }] },
+      { sha: 'aaaaaaa4444', checkRuns: [] },
+    ],
+  };
+
+  it('counts commits with at least one failed check, naming the check once', () => {
+    const summary = summarizePullRequest(pr);
+    assert.equal(summary.commits, 4);
+    assert.equal(summary.ciFailures, 2);
+    assert.deepEqual(summary.failedChecks, [
+      { sha: '91b5201', checks: ['Unit · Contract'] },
+      { sha: 'cd94c12', checks: ['Unit · Contract'] },
+    ]);
+  });
+
+  it('does not count a commit that never reached CI as a pass or a failure', () => {
+    assert.equal(summarizePullRequest({ ...pr, commits: [pr.commits[3]] }).ciFailures, 0);
+  });
+});
+
+describe('escaped defects per release', () => {
+  it('pairs each release tag with the next and the last with HEAD, ignoring prereleases', () => {
+    assert.deepEqual(releaseIntervals(['v1.0.0-rc.19', 'v1.0.0', 'v1.0.1', 'v1.0.2'], 'main'), [
+      { from: 'v1.0.0', to: 'v1.0.1' },
+      { from: 'v1.0.1', to: 'v1.0.2' },
+      { from: 'v1.0.2', to: 'main' },
+    ]);
+  });
+
+  it('counts conventional fix subjects, scoped or not, and nothing else', () => {
+    assert.deepEqual(countFixes(['fix: a', 'fix(mcp): b', 'feat: c', 'chore: fix typo', '', 'refactor: d']), { total: 5, fixes: 2 });
+  });
+});

--- a/scripts/harness-prepush-ledger.mjs
+++ b/scripts/harness-prepush-ledger.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Append one pre-push outcome to the local harness ledger.
+ *
+ * Called by `.githooks/pre-push` after its lanes finish, pass or fail. The hook
+ * is the layer that turns an eight-minute CI round-trip into a local one, and
+ * until 2026-09-02 nothing counted how often it did: the report could say what
+ * the edit-time sensor caught, but not whether the push gate ever refused a
+ * push, which is the number that says whether the gate is worth its minutes.
+ *
+ * Written from Node rather than in the hook's POSIX shell so the JSON is
+ * always well-formed and the shape is unit-tested; the hook only hands over
+ * three strings. Local and gitignored under `.tmp/harness/`, like every other
+ * harness measurement.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const words = (value) => String(value ?? '').split(/\s+/).filter(Boolean);
+
+export function prepushRecord({ files, lanes, failed, now = Date.now() }) {
+  const count = Number(files);
+  return {
+    at: new Date(now).toISOString(),
+    files: Number.isFinite(count) ? count : 0,
+    lanes: words(lanes),
+    failed: words(failed),
+  };
+}
+
+export function appendPrepushRecord(input, { cwd = process.cwd() } = {}) {
+  const record = prepushRecord(input);
+  const dir = join(cwd, '.tmp', 'harness');
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(join(dir, 'prepush.jsonl'), JSON.stringify(record) + '\n');
+  return record;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const [files, lanes, failed] = process.argv.slice(2);
+  try {
+    appendPrepushRecord({ files, lanes, failed });
+  } catch {
+    // The ledger is a measurement; a failed write must never change a push's fate.
+  }
+}

--- a/scripts/harness-report.mjs
+++ b/scripts/harness-report.mjs
@@ -26,6 +26,8 @@
 import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { readPrepush } from './harness-outcomes.mjs';
+
 // Resolved per call, not at import: a module-level constant captures the
 // directory the process started in, which silently reports on the wrong
 // repository from a worktree or a test fixture.
@@ -138,6 +140,7 @@ export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
   const smoke = Object.fromEntries(
     Object.entries(readSmoke()).map(([runtime, row]) => [runtime, { ...row, stale: row.atMs < sinceMs }]),
   );
+  const prepush = readPrepush(process.cwd(), sinceMs);
 
   const withEdits = sessions.filter((session) => session.files.size > 0);
   const unverified = withEdits.filter((session) => session.lastVerified < session.lastEdit);
@@ -158,6 +161,7 @@ export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
     },
     sensor: { findings: findings.length, byKind },
     smoke,
+    prepush,
     /**
      * The sensor earns its place by catching things. Zero findings across a
      * window with real edits is the falsifier its own header names.
@@ -185,6 +189,13 @@ function format(report) {
         : ''
     }`,
   ];
+  if (report.prepush) {
+    const lanes = Object.entries(report.prepush.byLane)
+      .sort((a, b) => b[1] - a[1])
+      .map(([lane, n]) => `${lane} ${n}`)
+      .join(' · ');
+    lines.push(`[harness] pre-push: pushes=${report.prepush.pushes} · refused locally=${report.prepush.blocked}${lanes ? ` (${lanes})` : ''}`);
+  }
   const runtimes = Object.entries(report.smoke ?? {});
   if (runtimes.length === 0) {
     lines.push('[harness] runtime smoke: never run here; `pnpm harness:smoke` is the only proof the runtimes fire these hooks.');

--- a/scripts/harness-report.test.mjs
+++ b/scripts/harness-report.test.mjs
@@ -73,6 +73,19 @@ describe('harness report', () => {
     assert.deepEqual(report.smoke.codex.problems, ['Stop: 0 completed']);
   });
 
+  it('reads the pre-push ledger into the same window as everything else', () => {
+    const report = withHarnessState(
+      {
+        'prepush.jsonl':
+          `${JSON.stringify({ at: new Date(recent).toISOString(), files: 3, lanes: ['lint'], failed: ['lint'] })}\n` +
+          `${JSON.stringify({ at: new Date(recent).toISOString(), files: 1, lanes: ['docs'], failed: [] })}\n` +
+          `${JSON.stringify({ at: new Date(old).toISOString(), files: 1, lanes: ['docs'], failed: ['docs'] })}\n`,
+      },
+      () => buildHarnessReport({ now: NOW }),
+    );
+    assert.deepEqual(report.prepush, { pushes: 2, blocked: 1, byLane: { lint: 1 } });
+  });
+
   it('says so when the smoke has never run, instead of staying silent', () => {
     const lines = [];
     withHarnessState({}, () => runHarnessReport([], { log: (line) => lines.push(line), error: () => {} }));

--- a/scripts/lib/focused-check-suggestions.mjs
+++ b/scripts/lib/focused-check-suggestions.mjs
@@ -404,6 +404,13 @@ const RULES = [
     matches: [/^scripts\/harness-smoke(?:\.test)?\.mjs$/, /^\.claude\/settings\.json$/, /^\.codex\/hooks\.json$/],
   },
   {
+    // The pre-push hook writes the ledger these outcomes are counted from, so
+    // editing the hook re-proves the record shape it hands over.
+    command: 'pnpm test:harness:outcomes',
+    reason: 'the outcome report, the pre-push ledger writer, or the hook that feeds it changed',
+    matches: [/^scripts\/harness-(?:outcomes|prepush-ledger)(?:\.test)?\.mjs$/, /^\.githooks\/pre-push$/],
+  },
+  {
     command: 'pnpm test:claude:hooks',
     reason: 'agent hook wiring, a guard, or the commit-message gate changed',
     /*


### PR DESCRIPTION
## Summary

The harness could count its own activity and nothing after it. This adds the two cheapest downstream numbers:

- **Pre-push ledger.** `.githooks/pre-push` now writes one line per push (lanes run, lanes refused) through a unit-tested Node writer; a failed write never changes the push's fate. This is the first count of how often the local gate actually saves a CI round-trip.
- **`pnpm harness:outcomes`.** Sets those refusals against merged-PR commits whose CI checks failed (escaped round-trips, per commit via `gh`, concurrent pool after the serial version measured 4.5 min) and lists `fix:` commits after each release tag. Both are named as proxies in the header. `--local` skips GitHub.
- `pnpm harness:report` carries the local pre-push line, so one report covers all local harness state.

Today's real numbers (no ledger yet): 100 merged PRs in 14 days, 30 commits failed CI; fixes after release 1/3 · 1/9 · 2/7 · 3/8.

## Test plan

- [x] `pnpm test:harness:outcomes` (8), `pnpm test:harness:report` (8)
- [x] `pnpm checks:changed -- --run` (18 passed)
- [x] `pnpm agents:check` (48), `pnpm docs:language`, pre-push / reachability / dead-code contracts (24)
- [x] the push of this branch wrote the first ledger line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4