### PR TITLE
fix: keep the edit-time sensor out of files that live outside the repository

### DIFF
--- a/.claude/hooks/fast-sensor.sh
+++ b/.claude/hooks/fast-sensor.sh
@@ -102,7 +102,11 @@ const sessionId = typeof payload?.session_id === "string" ? payload.session_id.r
 
 for (const p of paths) {
   const r = rel(p);
-  if (r.includes("node_modules/") || r.startsWith(".tmp/")) continue;
+  // A path that stays absolute after rel() lies outside the repository (a
+  // scratch file, a file in another checkout). That edit does not belong to
+  // this repository, and judging it ran the repo-wide Markdown gate for a note
+  // written in a temp directory (observed 2026-09-02).
+  if (r.startsWith("/") || r.includes("node_modules/") || r.startsWith(".tmp/")) continue;
 
   if (CODE_EXT.test(r) && CODE_ROOTS.some((c) => r.startsWith(c))) {
     // Session ledger for the Stop-time reminder — source code only.

--- a/.codex/hooks/fast-sensor.sh
+++ b/.codex/hooks/fast-sensor.sh
@@ -117,7 +117,11 @@ const sessionId = typeof payload?.session_id === "string" ? payload.session_id.r
 
 for (const p of paths) {
   const r = rel(p);
-  if (r.includes("node_modules/") || r.startsWith(".tmp/")) continue;
+  // A path that stays absolute after rel() lies outside the repository (a
+  // scratch file, a file in another checkout). That edit does not belong to
+  // this repository, and judging it ran the repo-wide Markdown gate for a note
+  // written in a temp directory (observed 2026-09-02).
+  if (r.startsWith("/") || r.includes("node_modules/") || r.startsWith(".tmp/")) continue;
 
   if (CODE_EXT.test(r) && CODE_ROOTS.some((c) => r.startsWith(c))) {
     // Session ledger for the Stop-time reminder — source code only.

--- a/scripts/claude-hooks.test.mjs
+++ b/scripts/claude-hooks.test.mjs
@@ -704,6 +704,22 @@ describe('fast-sensor lane and stop-time verification reminder', () => {
     }
   });
 
+  it('leaves a file outside the repository alone, ledger and gates included', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sensor-outside-'));
+    const elsewhere = await mkdtemp(join(tmpdir(), 'sensor-elsewhere-'));
+    try {
+      const doc = join(elsewhere, 'note.md');
+      await writeFile(doc, 'A lead — the dash, in a file that is not ours.\n');
+      const result = fireHook(SENSOR, editPayload(doc, 'sess-outside'), dir);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '', 'a scratch file outside the root must not be judged');
+      await assert.rejects(access(join(dir, '.tmp', 'harness', 'session-sess-outside.edits')));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+      await rm(elsewhere, { recursive: true, force: true });
+    }
+  });
+
   it('the stamp ignores non-verification commands and sessions without edits stop freely', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'stop-free-'));
     try {


### PR DESCRIPTION
## Summary

Editing a note in a temp directory made the fast sensor run the repository-wide Markdown gate and report on that unrelated file. `rel()` returns an absolute path for a file outside the root; every later rule treated it as ours. Now an absolute path after `rel()` ends the sensor's interest, on both trees, with a test that edits a file in another temp directory and expects silence and no ledger line.

## Test plan

- [x] `pnpm test:claude:hooks` (37, one new)
- [x] `pnpm checks:changed -- --run` (5 passed), `pnpm agents:check` (48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4