### PR TITLE
feat: count which skills and agent seats sessions actually use

### DIFF
--- a/.claude/hooks/record-usage.sh
+++ b/.claude/hooks/record-usage.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# PostToolUse hook — record which skills and agent seats a session actually used.
+#
+# Why this exists (2026-09-02 harness assessment). The repository carries 18
+# skills, 15 agent seats, and the councils that convene them, and nothing counts
+# which of them a session ever invokes. Without that number, "this seat earns
+# its place" and "this skill is dead weight" are both opinions. The same day the
+# decision ledger and the changelog were cut to what a reader needs, on
+# measurement; the process layer needs its own measurement before the same cut
+# can be argued. This hook writes one line per use; `pnpm harness:report`
+# lists every inventoried skill and seat that went unused in the window.
+#
+# What counts as a use (Claude Code):
+#   - the Skill tool           → tool_input.skill
+#   - the Task/Agent tool      → tool_input.subagent_type
+#   - a Read of `<tree>/skills/<name>/...` or `<tree>/agents/<name>.md`, which
+#     is how a session reads a skill without the tool (both agent trees)
+#
+# Cheap by construction: the shell looks for the three markers before any node
+# process starts, so an ordinary Read costs one grep. The ledger is local and
+# gitignored under .tmp/harness/, like every other harness measurement.
+#
+# Mirrored at `.codex/hooks/record-usage.sh`: Codex has no Skill tool, so the
+# mirror reads SubagentStart (agent_type) and shell commands that open a skill
+# or seat file.
+
+set -u
+
+INPUT="$(cat)"
+case "$INPUT" in
+  *'"Skill"'*|*'"Task"'*|*'"Agent"'*|*skills/*|*agents/*) ;;
+  *) exit 0 ;;
+esac
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+REPO_ROOT="$REPO_ROOT" node --input-type=module -e '
+import { readFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  process.exit(0);
+}
+const tool = String(payload?.tool_name ?? "");
+const input = payload?.tool_input ?? {};
+const uses = [];
+if (tool === "Skill" && typeof input.skill === "string") uses.push({ kind: "skill", name: input.skill.replace(/^\//, "") });
+if ((tool === "Task" || tool === "Agent") && typeof input.subagent_type === "string") uses.push({ kind: "agent", name: input.subagent_type });
+const path = typeof input.file_path === "string" ? input.file_path : "";
+const skillRead = /(?:^|\/)\.(?:claude|agents)\/skills\/([^/]+)\//.exec(path);
+if (skillRead) uses.push({ kind: "skill", name: skillRead[1] });
+const agentRead = /(?:^|\/)\.(?:claude|agents)\/agents\/([^/]+)\.md$/.exec(path);
+if (agentRead) uses.push({ kind: "agent", name: agentRead[1] });
+if (uses.length === 0) process.exit(0);
+
+const sessionId = typeof payload?.session_id === "string" ? payload.session_id.replace(/[^\w-]/g, "") : null;
+try {
+  const dir = join(process.env.REPO_ROOT, ".tmp", "harness");
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(
+    join(dir, "usage.jsonl"),
+    uses.map((use) => JSON.stringify({ at: new Date().toISOString(), session: sessionId, ...use, via: tool })).join("\n") + "\n",
+  );
+} catch { /* a missed line costs one count, never the session */ }
+' <<<"$INPUT" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,15 @@
             "command": "\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stamp-verification.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Skill|Task|Agent|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/record-usage.sh\""
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -88,6 +88,10 @@
           {
             "type": "command",
             "command": "bash .codex/hooks/stamp-verification.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/record-usage.sh"
           }
         ]
       },
@@ -97,6 +101,10 @@
           {
             "type": "command",
             "command": "bash .codex/hooks/stamp-verification.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/record-usage.sh"
           }
         ]
       },
@@ -106,6 +114,10 @@
           {
             "type": "command",
             "command": "bash .codex/hooks/stamp-verification.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/record-usage.sh"
           }
         ]
       }
@@ -116,6 +128,16 @@
           {
             "type": "command",
             "command": "bash .codex/hooks/remind-verify-on-stop.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/record-usage.sh"
           }
         ]
       }

--- a/.codex/hooks/record-usage.sh
+++ b/.codex/hooks/record-usage.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# PostToolUse + SubagentStart hook — record which skills and agent seats a
+# session actually used. The Codex mirror of `.claude/hooks/record-usage.sh`;
+# that header carries the reason (2026-09-02: 18 skills and 15 seats with no
+# count of use, so no argument for keeping or cutting any of them).
+#
+# Adapted rather than copied, because Codex has no Skill tool:
+#   - SubagentStart carries `agent_type`, which is the seat or agent invoked
+#     (declared in the codex-cli 0.151.0 hook enum and payload fields).
+#   - A skill is used by reading its file, which on Codex is a shell command
+#     (`cat .agents/skills/<name>/SKILL.md`, `sed -n ... .claude/agents/x.md`),
+#     so `tool_input.command` is scanned for skill and seat paths.
+#
+# The shell checks for the markers before any node process starts, so an
+# ordinary command costs one pattern match. Local and gitignored ledger.
+
+set -u
+
+INPUT="$(cat)"
+case "$INPUT" in
+  *agent_type*|*skills/*|*agents/*) ;;
+  *) exit 0 ;;
+esac
+# Codex sets no project-directory variable; commands run in the session cwd.
+REPO_ROOT="${ATLAS_HOOK_ROOT:-$(pwd)}"
+
+REPO_ROOT="$REPO_ROOT" node --input-type=module -e '
+import { readFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  process.exit(0);
+}
+const uses = [];
+const event = String(payload?.hook_event_name ?? "");
+if (event === "SubagentStart" && typeof payload?.agent_type === "string") uses.push({ kind: "agent", name: payload.agent_type, via: "SubagentStart" });
+const command = typeof payload?.tool_input?.command === "string" ? payload.tool_input.command : "";
+// NOTE: this block sits inside a single-quoted bash argument, so no apostrophe
+// may appear here, in regexes included; the name class stops at whitespace,
+// slash, and double quote, which covers how a path is written in a command.
+for (const m of command.matchAll(/(?:^|[\s"\/])\.(?:claude|agents)\/skills\/([^/\s"]+)\//g)) uses.push({ kind: "skill", name: m[1], via: "shell" });
+for (const m of command.matchAll(/(?:^|[\s"\/])\.(?:claude|agents)\/agents\/([^/\s"]+)\.md/g)) uses.push({ kind: "agent", name: m[1], via: "shell" });
+if (uses.length === 0) process.exit(0);
+
+const sessionId = typeof payload?.session_id === "string" ? payload.session_id.replace(/[^\w-]/g, "") : null;
+try {
+  const dir = join(process.env.REPO_ROOT, ".tmp", "harness");
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(
+    join(dir, "usage.jsonl"),
+    uses.map((use) => JSON.stringify({ at: new Date().toISOString(), session: sessionId, ...use })).join("\n") + "\n",
+  );
+} catch { /* a missed line costs one count, never the session */ }
+' <<<"$INPUT" 2>/dev/null || true
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ available to both agent trees; `AGENTS.md` owns invocation triggers and
 `docs/DECISIONS.md` owns decisions and dissent.
 
 `.claude/settings.json` owns Claude permissions and hooks, and both are
-inventoried agent files. Seven mirror `.codex/hooks/`: the three blocks, the
-vault census, and the sensor lane. A Codex edit is
+inventoried agent files. Eight mirror `.codex/hooks/`: the three blocks, the
+vault census, the sensor lane, and usage. A Codex edit is
 `apply_patch` carrying a patch envelope, so mirrors are adapted, not copied.
 `report-agent-file-drift.sh` is Claude-only, `block-secret-read.sh` Codex-only.
 Headers say why. `pnpm test:claude:hooks` guards wiring, `pnpm harness:report`

--- a/README.md
+++ b/README.md
@@ -827,7 +827,11 @@ edit-time sensor caught, over a `--days=` window (14 by default, `--json` for
 a machine). It reads only local gitignored session state under `.tmp/harness/`
 and reports a `sensor-caught-nothing` verdict when the lane stopped earning its
 place, which is the falsifier those hooks were added under. It also shows when
-`pnpm harness:smoke` last passed per runtime. That smoke drives one short
+`pnpm harness:smoke` last passed per runtime, and which inventoried skills and
+agent seats no session used in 90 days (the `record-usage` hook counts Skill
+and Task calls and skill-file reads on Claude Code, SubagentStart and shell
+reads of skill files on Codex), which is the number a "bring it down" argument
+needs. That smoke drives one short
 Claude Code and Codex session each (a shell command, then the vault node count
 from the census), counts which hook events completed against the project
 wiring, and fails on any hook the runtime marked failed, any count below the

--- a/scripts/claude-hooks.test.mjs
+++ b/scripts/claude-hooks.test.mjs
@@ -32,6 +32,8 @@ const HOOK_CONFIGS = [
       // and PreCompact stdout never reaches the model (its one-day wiring was
       // removed 2026-09-02; the census header records the observation).
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/inject-ontology-summary.sh"',
+      // The usage sensor: which skills and seats a session invokes (2026-09-02).
+      '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/record-usage.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/remind-verify-on-stop.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/report-agent-file-drift.sh"',
       '"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stamp-verification.sh"',
@@ -59,6 +61,11 @@ const HOOK_CONFIGS = [
       // Once: Codex PreCompact/PostCompact output carries no model context
       // (hooks reference), so the 2026-09-01 PreCompact wiring was removed.
       'bash .codex/hooks/inject-ontology-summary.sh',
+      // Usage sensor: SubagentStart plus the three shell PostToolUse groups.
+      'bash .codex/hooks/record-usage.sh',
+      'bash .codex/hooks/record-usage.sh',
+      'bash .codex/hooks/record-usage.sh',
+      'bash .codex/hooks/record-usage.sh',
       'bash .codex/hooks/remind-verify-on-stop.sh',
       'bash .codex/hooks/stamp-verification.sh',
       'bash .codex/hooks/stamp-verification.sh',
@@ -833,3 +840,63 @@ describe('Codex apply_patch payload parity', () => {
     }
   });
 });
+
+// The usage ledger is what the 90-day "unused skill or seat" line in
+// `pnpm harness:report` reads. A sensor that records the wrong name, or fires
+// on every Read, would either hide a dead seat or tax every file open.
+describe('usage sensor', () => {
+  const CLAUDE = '.claude/hooks/record-usage.sh';
+  const CODEX = '.codex/hooks/record-usage.sh';
+  const fire = (hook, payload, dir) =>
+    spawnSync('bash', [hook], {
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir, ATLAS_HOOK_ROOT: dir },
+    });
+  const ledgerOf = async (dir) => {
+    try {
+      return (await readFile(join(dir, '.tmp', 'harness', 'usage.jsonl'), 'utf8')).trim().split('\n').map((l) => JSON.parse(l));
+    } catch {
+      return [];
+    }
+  };
+
+  it('Claude: records a Skill call, a Task seat, and a skill-file Read, and stays silent otherwise', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'usage-claude-'));
+    try {
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Skill', tool_input: { skill: 'po-pass' } }, dir);
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Task', tool_input: { subagent_type: 'po-evidence', prompt: 'x' } }, dir);
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Read', tool_input: { file_path: `${dir}/.claude/skills/design-audit/SKILL.md` } }, dir);
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Read', tool_input: { file_path: `${dir}/.agents/agents/chief.md` } }, dir);
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Read', tool_input: { file_path: `${dir}/src/app/page.tsx` } }, dir);
+      fire(CLAUDE, { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } }, dir);
+      const rows = await ledgerOf(dir);
+      assert.deepEqual(rows.map((r) => [r.kind, r.name]), [
+        ['skill', 'po-pass'],
+        ['agent', 'po-evidence'],
+        ['skill', 'design-audit'],
+        ['agent', 'chief'],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('Codex: records SubagentStart agent_type and shell reads of skill or seat files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'usage-codex-'));
+    try {
+      fire(CODEX, { session_id: 'c1', hook_event_name: 'SubagentStart', agent_id: 'a', agent_type: 'po-steward' }, dir);
+      fire(CODEX, { session_id: 'c1', hook_event_name: 'PostToolUse', tool_name: 'exec_command', tool_input: { command: 'sed -n 1,40p .agents/skills/ontology-sync/SKILL.md && cat .claude/agents/design-lead.md' } }, dir);
+      fire(CODEX, { session_id: 'c1', hook_event_name: 'PostToolUse', tool_name: 'exec_command', tool_input: { command: 'pnpm lint' } }, dir);
+      const rows = await ledgerOf(dir);
+      assert.deepEqual(rows.map((r) => [r.kind, r.name]), [
+        ['agent', 'po-steward'],
+        ['skill', 'ontology-sync'],
+        ['agent', 'design-lead'],
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/scripts/harness-report.mjs
+++ b/scripts/harness-report.mjs
@@ -23,7 +23,7 @@
  * would be the same false confidence the hooks exist to remove.
  */
 
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { readPrepush } from './harness-outcomes.mjs';
@@ -133,6 +133,59 @@ function readSmoke() {
   return latest;
 }
 
+/**
+ * Skills and agent seats: what the repository carries versus what sessions
+ * used. The window is longer than the sensor window because a seat that is
+ * right once a quarter is still a seat; 90 days is the falsifier the process
+ * layer was given on 2026-09-02 ("unused for a quarter: bring it down").
+ */
+export const USAGE_DAYS = 90;
+
+function inventory() {
+  const names = (dir, strip) => {
+    const path = join(process.cwd(), dir);
+    if (!existsSync(path)) return [];
+    return readdirSync(path)
+      .filter((name) => !name.startsWith('.'))
+      .map((name) => (strip ? name.replace(/\.md$/, '') : name))
+      .filter((name) => strip || statSync(join(path, name)).isDirectory())
+      .sort();
+  };
+  return { skills: names('.claude/skills', false), agents: names('.claude/agents', true) };
+}
+
+function readUsage(now, days = USAGE_DAYS) {
+  const sinceMs = now - days * 24 * 60 * 60 * 1000;
+  const path = join(harnessDir(), 'usage.jsonl');
+  const used = { skill: new Map(), agent: new Map() };
+  let recorded = false;
+  if (existsSync(path)) {
+    recorded = true;
+    try {
+      for (const line of readFileSync(path, 'utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const row = JSON.parse(line);
+          const at = Date.parse(row?.at ?? '');
+          if (!Number.isFinite(at) || at < sinceMs || !used[row.kind] || typeof row.name !== 'string') continue;
+          used[row.kind].set(row.name, (used[row.kind].get(row.name) ?? 0) + 1);
+        } catch {
+          continue;
+        }
+      }
+    } catch {
+      /* unreadable ledger reads as no use */
+    }
+  }
+  const { skills, agents } = inventory();
+  return {
+    days,
+    recorded,
+    skills: { total: skills.length, used: skills.filter((s) => used.skill.has(s)).length, unused: skills.filter((s) => !used.skill.has(s)), counts: Object.fromEntries(used.skill) },
+    agents: { total: agents.length, used: agents.filter((a) => used.agent.has(a)).length, unused: agents.filter((a) => !used.agent.has(a)), counts: Object.fromEntries(used.agent) },
+  };
+}
+
 export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
   const sinceMs = now - days * 24 * 60 * 60 * 1000;
   const sessions = readSessions(sinceMs);
@@ -141,6 +194,7 @@ export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
     Object.entries(readSmoke()).map(([runtime, row]) => [runtime, { ...row, stale: row.atMs < sinceMs }]),
   );
   const prepush = readPrepush(process.cwd(), sinceMs);
+  const usage = readUsage(now);
 
   const withEdits = sessions.filter((session) => session.files.size > 0);
   const unverified = withEdits.filter((session) => session.lastVerified < session.lastEdit);
@@ -162,6 +216,7 @@ export function buildHarnessReport({ days = 14, now = Date.now() } = {}) {
     sensor: { findings: findings.length, byKind },
     smoke,
     prepush,
+    usage,
     /**
      * The sensor earns its place by catching things. Zero findings across a
      * window with real edits is the falsifier its own header names.
@@ -195,6 +250,15 @@ function format(report) {
       .map(([lane, n]) => `${lane} ${n}`)
       .join(' · ');
     lines.push(`[harness] pre-push: pushes=${report.prepush.pushes} · refused locally=${report.prepush.blocked}${lanes ? ` (${lanes})` : ''}`);
+  }
+  if (report.usage) {
+    const { skills, agents, days: usageDays, recorded } = report.usage;
+    const list = (names) => (names.length === 0 ? 'none' : names.join(', '));
+    lines.push(
+      `[harness] usage (${usageDays}d): skills ${skills.used}/${skills.total} used, unused: ${list(skills.unused)}`,
+      `[harness] usage (${usageDays}d): agents ${agents.used}/${agents.total} used, unused: ${list(agents.unused)}`,
+    );
+    if (!recorded) lines.push('[harness] no usage ledger yet; the record-usage hook writes one from the first Skill, Task, or skill-file Read.');
   }
   const runtimes = Object.entries(report.smoke ?? {});
   if (runtimes.length === 0) {

--- a/scripts/harness-report.test.mjs
+++ b/scripts/harness-report.test.mjs
@@ -86,6 +86,32 @@ describe('harness report', () => {
     assert.deepEqual(report.prepush, { pushes: 2, blocked: 1, byLane: { lint: 1 } });
   });
 
+  it('lists the inventoried skills and seats no session used in the 90-day window', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'harness-usage-'));
+    const previous = process.cwd();
+    try {
+      for (const skill of ['po-pass', 'gate-probe']) mkdirSync(join(dir, '.claude', 'skills', skill), { recursive: true });
+      mkdirSync(join(dir, '.claude', 'agents'), { recursive: true });
+      for (const seat of ['chief', 'po-wedge']) writeFileSync(join(dir, '.claude', 'agents', `${seat}.md`), '# seat');
+      mkdirSync(join(dir, '.tmp', 'harness'), { recursive: true });
+      writeFileSync(
+        join(dir, '.tmp', 'harness', 'usage.jsonl'),
+        `${JSON.stringify({ at: new Date(recent).toISOString(), kind: 'skill', name: 'po-pass' })}\n` +
+          `${JSON.stringify({ at: new Date(old).toISOString(), kind: 'agent', name: 'chief' })}\n` +
+          `${JSON.stringify({ at: new Date(NOW - 100 * 24 * 60 * 60 * 1000).toISOString(), kind: 'skill', name: 'gate-probe' })}\n`,
+      );
+      process.chdir(dir);
+      const report = buildHarnessReport({ now: NOW });
+      assert.deepEqual(report.usage.skills, { total: 2, used: 1, unused: ['gate-probe'], counts: { 'po-pass': 1 } });
+      // 40 days old is inside the 90-day usage window even though it is outside the 14-day sensor window.
+      assert.deepEqual(report.usage.agents.unused, ['po-wedge']);
+      assert.equal(report.usage.recorded, true);
+    } finally {
+      process.chdir(previous);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('says so when the smoke has never run, instead of staying silent', () => {
     const lines = [];
     withHarnessState({}, () => runHarnessReport([], { log: (line) => lines.push(line), error: () => {} }));


### PR DESCRIPTION
## Summary

The assessment called half the process layer excess (18 skills, 15 seats, councils) and nothing counted use. This adds the measurement the "bring it down" argument needs.

- **`record-usage` hook (both trees).** Claude Code: `Skill` tool, `Task` `subagent_type`, and a `Read` of a skill/seat file in either tree. Codex (no Skill tool): `SubagentStart` `agent_type` and shell commands opening skill/seat files. A shell pattern match runs before any node process, so ordinary Reads stay cheap.
- **`pnpm harness:report`** lists, over 90 days, every inventoried skill and seat with no recorded use.
- Proved on both runtimes (`claude -p` reading a skill file; `codex exec` opening one via `sed`), with the new Codex entries re-trusted in `/hooks`.

## Test plan

- [x] `pnpm test:claude:hooks` (39, two new), `pnpm test:harness:report` (9), `pnpm test:harness:smoke` (13)
- [x] `pnpm checks:changed -- --run` (11 passed), `pnpm agents:check` (48), resident-byte ratchet
- [x] real-runtime proof on Claude Code and Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPLZxoZPcaP2pst4dSL3L4