### PR TITLE
fix: give the phone-only reading links a 44px touch target

### DIFF
--- a/src/widgets/gateway-chrome/ui/GatewayReadingLinks.tsx
+++ b/src/widgets/gateway-chrome/ui/GatewayReadingLinks.tsx
@@ -59,6 +59,15 @@ export function GatewayReadingLinks({ className }: { className?: string }) {
             className={controlClass({
               shape: 'link',
               tone: active ? 'default' : 'secondary',
+              // These two are drawn only below `sm`, which is where the pointer is a finger:
+              // measured 390x844 with a coarse pointer, "Guide" was 29x24 and "Changelog"
+              // 53x24, and a probe 20px above or below either one landed on the footer, not
+              // the link. The row is the only route to /guide and /changelog at that width,
+              // so the smallest target on the page guarded the only door. `touch-hit-expand`
+              // raises the hit box to `--touch-target-min` without moving any ink; the pair's
+              // 16px `gap-x-4` keeps the widened boxes apart (60.5 vs 69 at 390), which is the
+              // overlap the utility was rejected for elsewhere in `globals.css`.
+              className: 'touch-hit-expand',
             })}
           >
             {item.label}

--- a/tests/e2e/touch-target-contract.spec.ts
+++ b/tests/e2e/touch-target-contract.spec.ts
@@ -173,45 +173,62 @@ test.describe("터치 타깃 계약 (pointer: coarse)", () => {
    * signal that coarse promotion is missing from the new-surface checklist, so the
    * registry is widened to here.
    */
-  test("관문(/download)의 모든 컨트롤이 44px 히트 영역을 갖는다", async ({ page }) => {
-    await page.goto("/ko/download/?guides=off");
-    await expect(page.getByTestId("download-gnb")).toBeVisible();
+  /**
+   * Two viewports, because the gateway's control set is width-conditional.
+   *
+   * This case ran only at the file's 768 default until 2026-09-04, and that is
+   * where it went blind: `GatewayReadingLinks` — the guide/changelog pair that is
+   * the *only* route to those two pages once `GatewayNav` collapses them — is
+   * `sm:hidden`, so at 768 it is not drawn, has a zero rect, and the filter below
+   * drops it. The gate therefore scanned /download at the one width where the
+   * component under test does not exist, and stayed green while the pair measured
+   * 29x24 and 53x24 on a real phone.
+   *
+   * 390 is the phone band; 768 keeps the tablet coverage this case already had.
+   * A control that appears on only one side of `sm` is now measured on that side.
+   */
+  for (const width of [390, 768]) {
+    test(`관문(/download) ${width}px 의 모든 컨트롤이 44px 히트 영역을 갖는다`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto("/ko/download/?guides=off");
+      await expect(page.getByTestId("download-gnb")).toBeVisible();
 
-    const short = await page.evaluate((min) => {
-      const hit = (el: Element) => {
-        const r = el.getBoundingClientRect();
-        const a = getComputedStyle(el, "::after");
-        if (a.content && a.content !== "none" && a.position === "absolute") {
-          return {
-            w: Math.max(r.width, parseFloat(a.width) || 0),
-            h: Math.max(r.height, parseFloat(a.height) || 0),
-          };
-        }
-        return { w: r.width, h: r.height };
-      };
-      return Array.from(document.querySelectorAll("button:not([disabled]), a[href]"))
-        .filter((el) => {
+      const short = await page.evaluate((min) => {
+        const hit = (el: Element) => {
           const r = el.getBoundingClientRect();
-          const cs = getComputedStyle(el);
-          return (
-            r.width > 0 &&
-            r.height > 0 &&
-            cs.visibility !== "hidden" &&
-            !el.closest(".sr-only")
-          );
-        })
-        .map((el) => ({
-          id:
-            el.getAttribute("data-testid") ||
-            (el.textContent || "").trim().slice(0, 24) ||
-            el.tagName,
-          ...hit(el),
-        }))
-        .filter((b) => b.w < min || b.h < min);
-    }, MIN);
+          const a = getComputedStyle(el, "::after");
+          if (a.content && a.content !== "none" && a.position === "absolute") {
+            return {
+              w: Math.max(r.width, parseFloat(a.width) || 0),
+              h: Math.max(r.height, parseFloat(a.height) || 0),
+            };
+          }
+          return { w: r.width, h: r.height };
+        };
+        return Array.from(document.querySelectorAll("button:not([disabled]), a[href]"))
+          .filter((el) => {
+            const r = el.getBoundingClientRect();
+            const cs = getComputedStyle(el);
+            return (
+              r.width > 0 &&
+              r.height > 0 &&
+              cs.visibility !== "hidden" &&
+              !el.closest(".sr-only")
+            );
+          })
+          .map((el) => ({
+            id:
+              el.getAttribute("data-testid") ||
+              (el.textContent || "").trim().slice(0, 24) ||
+              el.tagName,
+            ...hit(el),
+          }))
+          .filter((b) => b.w < min || b.h < min);
+      }, MIN);
 
-    expect(short, `44px 미만 히트 영역: ${JSON.stringify(short)}`).toEqual([]);
-  });
+      expect(short, `44px 미만 히트 영역: ${JSON.stringify(short)}`).toEqual([]);
+    });
+  }
 });
 
 interface Audit258Result {


### PR DESCRIPTION
## Summary

Below `sm` the gateway chrome collapses `/guide` and `/changelog` into `GatewayReadingLinks`, which makes that row **the only route to both pages at phone widths** — and it was the smallest target on the page.

Measured at 390×844 with a coarse pointer: `Guide` 29×24, `Changelog` 53×24, and an `elementFromPoint` probe 20px above or below either one landed on the `<footer>`, not the link. `touch-hit-expand` raises the hit box to `--touch-target-min` (44px) without moving any ink. The pair's 16px `gap-x-4` keeps the widened boxes apart (60.5 vs 69 at 390), which is the overlap `globals.css` rejected the utility for elsewhere.

**The gate that claimed to cover this was blind.** `tests/e2e/touch-target-contract.spec.ts` scanned `/download` only at the file's 768 default, and the component under test is `sm:hidden` — at 768 it is not drawn, has a zero rect, and the size filter dropped it. The case now runs at 390 **and** 768, so a control that exists on only one side of `sm` is measured on that side.

Routing: `po:route` → solo · two-way · risk=none · no ledger record. `design:route --change=responsive` → no directions, no council; proof = changed-path checks + responsive/computer-use bands.

## Test plan

- **Gate probe** — reverted the source fix, ran the spec: RED at 390 (`gateway-footer-guide` 28.5×24, `gateway-footer-changelog` 40.8×24), GREEN at 768. Restored the fix: all 11 cases pass.
- **Used it for real** — a `touchscreen.tap` 14px above the ink centre of "Guide" at 390×844 now navigates to `/en/guide/`; the same point previously hit the footer.
- `pnpm checks:changed -- --run` → 6/6 passed (source-language, knip, 229 contract files / 2307 tests, `tsc --noEmit`, lint, unit).
- No before/after screenshots: the footer band is **pixel-identical** before and after (0 changed pixels in the band) — the hit area moves no ink, which is the point of the utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfuNJxiSixsA6yi9HGnF2L