### PR TITLE
chore(ci): let the Windows beta job reuse a main-scoped Rust cache

### DIFF
--- a/.github/workflows/windows-beta-check.yml
+++ b/.github/workflows/windows-beta-check.yml
@@ -15,8 +15,30 @@ name: Windows x64 Beta Check
 # this workflow itself.
 #
 # ⚠️ This job does not build the `.exe` users receive. That is built by the `build-windows` job in `release-macos.yml` from tags. The artifacts uploaded here are early-warning copies — so narrowing the trigger does not weaken release verification.
+#
+# Why this also runs on a push to `main` (2026-09-04). The Rust cache below never produced a
+# hit: `gh cache list` showed one 813 MB entry per `refs/pull/<n>/merge` and none for
+# `refs/heads/main`, because GitHub lets a run restore only caches saved on its own ref or on
+# the default branch, and this workflow ran on pull requests alone. Every PR therefore rebuilt
+# every dependency crate: 644–675 s for the release bundle and 161–178 s for `cargo test`
+# across the last three green runs (17–20 min per job). A `main` run after each merge that
+# touches these paths saves the cache where every later PR can read it. The `paths` list is
+# duplicated on purpose: workflow triggers cannot share a YAML anchor.
 on:
   pull_request:
+    paths:
+      - ".github/workflows/release-macos.yml"
+      - ".github/workflows/windows-beta-check.yml"
+      - "mcp/**"
+      - "scripts/build-mcp-binary.mjs"
+      - "scripts/verify-mcp-binary.mjs"
+      - "scripts/stage-windows-release-assets.mjs"
+      - "scripts/lib/mcp-binary.mjs"
+      - "src-tauri/**"
+      - "tests/contract/windows-desktop-release.contract.test.ts"
+  push:
+    branches:
+      - main
     paths:
       - ".github/workflows/release-macos.yml"
       - ".github/workflows/windows-beta-check.yml"
@@ -52,6 +74,48 @@ env:
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
+  # The JavaScript production audit needs the lockfile and the npm registry, not Windows.
+  # It lived inside the Windows job until 2026-09-04, where a registry.npmjs.org socket
+  # timeout (observed four times that day, 113–192 s of retries even when it passed) failed
+  # or delayed a job whose other 17 minutes had nothing to do with the registry. As its own
+  # Linux job it finishes in under a minute, fails on its own, and reruns for cents.
+  audit-js:
+    name: Audit JavaScript production dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.0 --activate
+          pnpm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install bundled MCP server dependencies
+        run: pnpm --dir mcp install --frozen-lockfile
+
+      # A bounded outer retry around pnpm audit's own two retries keeps the same scope and
+      # level and still fails on a real advisory: the final attempt's exit code is honoured.
+      - name: Audit JavaScript production dependencies
+        run: |
+          for attempt in 1 2 3 4; do
+            if pnpm audit --prod --audit-level=high; then exit 0; else status=$?; fi
+            if [ "$attempt" -eq 4 ]; then exit "$status"; fi
+            delay=$((attempt * 30))
+            echo "pnpm audit failed (exit $status); retrying in ${delay} s (attempt $attempt of 4)..."
+            sleep "$delay"
+          done
+
   verify-windows:
     name: Verify unsigned Windows x64 beta
     runs-on: windows-2022
@@ -101,21 +165,8 @@ jobs:
       - name: Install bundled MCP server dependencies
         run: pnpm --dir mcp install --frozen-lockfile
 
-      # Observed three times (2026-09-04): a registry.npmjs.org socket timeout fails this
-      # step after pnpm audit's own two retries, killing the whole ~20-minute job for a
-      # transient network blip. A bounded outer retry keeps the same scope/level and still
-      # fails the step on a real advisory (the final attempt's exit code is honoured).
-      - name: Audit JavaScript production dependencies
-        shell: pwsh
-        run: |
-          for ($attempt = 1; $attempt -le 4; $attempt++) {
-            pnpm audit --prod --audit-level=high
-            if ($LASTEXITCODE -eq 0) { break }
-            if ($attempt -eq 4) { exit $LASTEXITCODE }
-            $delaySeconds = $attempt * 30
-            Write-Host "pnpm audit failed (exit $LASTEXITCODE); retrying in $delaySeconds s (attempt $attempt of 4)..."
-            Start-Sleep -Seconds $delaySeconds
-          }
+      # The JavaScript production audit runs in the `audit-js` job above; this lane keeps
+      # only the checks that need a Windows runner.
 
       - name: Audit Rust dependencies
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0


### PR DESCRIPTION
## Summary

- The Windows beta job took 17–20 min per PR although it has cached the Rust build since 2026-08-02. `gh cache list` shows one 813 MB entry per `refs/pull/<n>/merge` and none for `refs/heads/main`: a run can restore only caches from its own ref or the default branch, and this workflow never ran on `main`, so every PR rebuilt every dependency crate (644–675 s release bundle + 161–178 s `cargo test` over the last three green runs, 80 % of the job).
- Adds a `push: main` trigger with the same `paths` so a merge that touches native inputs saves the cache where later PRs can read it. The first `main` run is a cold build; the next PR measures the gain.
- Moves `pnpm audit --prod` to its own Linux job (`audit-js`) with the same bounded retry. It needs the lockfile and the npm registry, not Windows; a registry timeout failed or delayed the Windows lane four times today.

Expected steady state: Windows job under 10 min; audit job under 1 min and rerunnable on its own.

## Test plan

- `tests/contract/windows-desktop-release.contract.test.ts` (82 tests) green via `pnpm checks:changed -- --run`.
- Workflow parses (`js-yaml`): triggers `pull_request, push, workflow_dispatch`; jobs `audit-js, verify-windows`; the Windows job keeps only the Rust audits.
- `pnpm po:route -- --mechanical` → skip.
- Post-merge: watch the `main` run save `v0-rust-verify-windows-…` under `refs/heads/main`, then measure the next PR's step times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161ukZCrRs5QZJkhfYkJGNn