### PR TITLE
fix(mcp): let the release gate accept the live witness check on a stale receipt

### DIFF
--- a/mcp/scripts/verify.mjs
+++ b/mcp/scripts/verify.mjs
@@ -8643,13 +8643,44 @@ function agentBriefPrivateSourceCoordinate(value) {
   return false;
 }
 
+const AGENT_BRIEF_LIVE_WITNESS_STATUSES = new Set([
+  'witnesses_supported', 'witnesses_missing', 'no_witnesses', 'inventory_truncated',
+]);
+
+// `projectSource.live` (projectSourceLiveWitnesses:v1) appears only when the
+// receipt is behind the source or the ontology: it says whether the recorded
+// witness paths still resolve in the live checkout. The dogfood vault in CI has
+// no bound source, so a release rehearsal against the real vault is the first
+// place this object is seen; it must be part of the categorical contract there.
+function validAgentBriefLiveWitnesses(live) {
+  return agentBriefExactKeys(live, [
+    'contract', 'status', 'basis', 'sourceRevision', 'sourceFingerprint', 'witnessSummary', 'missingPaths',
+  ])
+    && live.contract === 'projectSourceLiveWitnesses:v1'
+    && AGENT_BRIEF_LIVE_WITNESS_STATUSES.has(live.status)
+    && ['receipt', 'current_graph'].includes(live.basis)
+    && (live.sourceRevision === null || hasNonEmptyString(live.sourceRevision))
+    && hasNonEmptyString(live.sourceFingerprint)
+    && agentBriefPlainObject(live.witnessSummary)
+    && ['total', 'supported', 'missing'].every(
+      (field) => Number.isInteger(live.witnessSummary[field]) && live.witnessSummary[field] >= 0,
+    )
+    && live.witnessSummary.supported + live.witnessSummary.missing === live.witnessSummary.total
+    && Array.isArray(live.missingPaths)
+    && live.missingPaths.length <= 5
+    && live.missingPaths.every((path) => hasNonEmptyString(path));
+}
+
 function validAgentBriefProjectSource(value, projectSlug) {
+  const baseKeys = [
+    'contractVersion', 'projectSlug', 'status', 'currentness', 'measuredAt',
+    'topGap', 'nextAction', 'bindingCardinality', 'receipt',
+  ];
+  const hasLive = agentBriefPlainObject(value) && Object.hasOwn(value, 'live');
   if (
     !hasNonEmptyString(projectSlug)
-    || !agentBriefExactKeys(value, [
-      'contractVersion', 'projectSlug', 'status', 'currentness', 'measuredAt',
-      'topGap', 'nextAction', 'bindingCardinality', 'receipt',
-    ])
+    || !agentBriefExactKeys(value, hasLive ? [...baseKeys, 'live'] : baseKeys)
+    || (hasLive && !validAgentBriefLiveWitnesses(value.live))
     || value.contractVersion !== 1
     || value.projectSlug !== projectSlug
     || !AGENT_BRIEF_SOURCE_STATUSES.has(value.status)

--- a/mcp/src/verify-script.test.mjs
+++ b/mcp/src/verify-script.test.mjs
@@ -11354,6 +11354,37 @@ Continue.`;
       }),
       'agent_brief projectSource exposes private source coordinates',
     );
+    const liveWitnesses = {
+      contract: 'projectSourceLiveWitnesses:v1',
+      status: 'witnesses_supported',
+      basis: 'current_graph',
+      sourceRevision: 'a'.repeat(40),
+      sourceFingerprint: `sha256:${'b'.repeat(64)}`,
+      witnessSummary: { total: 3, supported: 3, missing: 0 },
+      missingPaths: [],
+    };
+    assert.equal(
+      agentBriefFailure({ ...payload, projectSource: { ...payload.projectSource, live: liveWitnesses } }),
+      null,
+      'a live witness check beside the receipt is part of the contract',
+    );
+    assert.equal(
+      agentBriefFailure({
+        ...payload,
+        projectSource: { ...payload.projectSource, live: { ...liveWitnesses, basis: 'guess' } },
+      }),
+      'agent_brief response malformed categorical projectSource',
+    );
+    assert.equal(
+      agentBriefFailure({
+        ...payload,
+        projectSource: {
+          ...payload.projectSource,
+          live: { ...liveWitnesses, witnessSummary: { total: 3, supported: 1, missing: 1 } },
+        },
+      }),
+      'agent_brief response malformed categorical projectSource',
+    );
     assert.equal(
       agentBriefFailure({ ...payload, meaningAssessment: undefined }),
       'agent_brief response missing categorical meaningAssessment',


### PR DESCRIPTION
## Summary

- `pnpm desktop:release-rehearsal` for v1.0.5 stopped at the MCP release gate: `agent_brief response malformed categorical projectSource`. Since #1417 the brief attaches `projectSource.live` (`projectSourceLiveWitnesses:v1`) when the receipt is behind the source or the ontology; the gate's exact-key check predates it. CI never sees the object because the dogfood vault there has no bound source.
- The gate now accepts an optional `live` object and validates its shape (contract, status set, `basis` receipt|current_graph, revision, fingerprint, consistent witness summary, ≤5 missing paths).

## Test plan

- Red-first: `mcp/src/verify-script.test.mjs` gains a passing live object and two malformed ones (bad basis, inconsistent summary); the suite is green.
- `pnpm dogfood:release-gate` against the real dogfood vault with a bound, `ontology_changed` source: 32 passed, 0 failed.
- `pnpm checks:changed -- --run` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161ukZCrRs5QZJkhfYkJGNn