### PR TITLE
fix: follow the insights screen's current title in the desktop smoke contract

### DIFF
--- a/scripts/desktop-smoke.mjs
+++ b/scripts/desktop-smoke.mjs
@@ -43,8 +43,8 @@ export const DESKTOP_SMOKE_ROUTE_TITLES = {
   "ko:/ontology": "온톨로지 · Ontology Atlas",
   "en:/topology": "Map · Ontology Atlas",
   "ko:/topology": "지도 · Ontology Atlas",
-  "en:/ontology/insights": "My folder analysis · Ontology Atlas",
-  "ko:/ontology/insights": "내 폴더 분석 · Ontology Atlas",
+  "en:/ontology/insights": "Insights · Ontology Atlas",
+  "ko:/ontology/insights": "분석 · Ontology Atlas",
 };
 
 /**

--- a/scripts/desktop-smoke.test.mjs
+++ b/scripts/desktop-smoke.test.mjs
@@ -98,8 +98,8 @@ test("desktop smoke titles follow current metadata and do not revive retired sur
     "ko:/ontology": "온톨로지 · Ontology Atlas",
     "en:/topology": "Map · Ontology Atlas",
     "ko:/topology": "지도 · Ontology Atlas",
-    "en:/ontology/insights": "My folder analysis · Ontology Atlas",
-    "ko:/ontology/insights": "내 폴더 분석 · Ontology Atlas",
+    "en:/ontology/insights": "Insights · Ontology Atlas",
+    "ko:/ontology/insights": "분석 · Ontology Atlas",
   });
   assert.equal(
     Object.values(DESKTOP_SMOKE_ROUTE_TITLES).some((title) =>
@@ -311,7 +311,7 @@ test("desktop smoke detects stale route metadata without prescribing another bui
   write(
     outDir,
     routePath,
-    html.replace("My folder analysis · Ontology Atlas", "Verify Graph · Ontology Atlas"),
+    html.replace("Insights · Ontology Atlas", "Verify Graph · Ontology Atlas"),
   );
 
   const report = evaluateDesktopSmoke({


### PR DESCRIPTION
## Summary

- The v1.0.5 rehearsal stopped at "Build signed and notarized release artifact": the packaged static route smoke (`pnpm desktop:smoke`) still expected `My folder analysis · Ontology Atlas` / `내 폴더 분석 · Ontology Atlas` for `/ontology/insights` after #1418 renamed the page to `Insights` / `분석`. No CI lane runs the packaged smoke, so it surfaced only in the rehearsal.
- Updates the contract and its drift fixture to the baked titles.

## Test plan

- `node --test scripts/desktop-smoke.test.mjs` green; `pnpm desktop:smoke` against the current export: ready.
- `pnpm checks:changed -- --run` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161ukZCrRs5QZJkhfYkJGNn