### PR TITLE
fix: retry removing the exact-case fixture instead of failing the MCP binary check

### DIFF
--- a/scripts/verify-mcp-binary.mjs
+++ b/scripts/verify-mcp-binary.mjs
@@ -191,7 +191,19 @@ export async function verifyMcpExactCase({ binaryPath, timeoutMs = 25_000 }) {
       }, timeoutMs);
     });
   } finally {
-    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    removeFixtureRoot(fixtureRoot);
+  }
+}
+
+// The probe passed and then the release run failed on this line (Windows, 2026-09-05): EPERM
+// while removing the fixture, because the just-exited child or Defender still held a handle.
+// Node retries EBUSY/EPERM-style removals only when asked; and a scratch folder that stays
+// behind is not a verification failure, so the last resort is a warning, not an exit code.
+function removeFixtureRoot(fixtureRoot) {
+  try {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+  } catch (error) {
+    console.warn(`[verify-mcp-binary] left the exact-case fixture behind: ${fixtureRoot} (${error.code ?? error.message})`);
   }
 }
 


### PR DESCRIPTION
## Summary

- The v1.0.5 Windows release job passed the spawn, parity, and exact-case probes and then failed on `fs.rmSync(fixtureRoot)`: `EPERM, Permission denied: …\Temp\ontology-atlas-mcp-exact-case-evD87C`, the usual Windows handle race right after a child exits.
- The removal now uses `maxRetries: 10, retryDelay: 200` and, as a last resort, warns instead of turning a leftover scratch folder into a verification failure.

## Test plan

- `node --test scripts/verify-mcp-binary.test.mjs` green; `pnpm checks:changed -- --run` green.
- This path triggers the Windows beta workflow, which runs the same script on a Windows runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161ukZCrRs5QZJkhfYkJGNn