### PR TITLE
chore(ci): give the Intel macOS release build 45 minutes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -134,7 +134,10 @@ jobs:
     needs: admit-release
     environment: release-signing
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    # The Intel runner needs 25-30 minutes for the cold release build plus
+    # notarization (v1.0.5 x64: 28m50s; v1.0.6 first attempt cancelled at 30m
+    # with rustc still running). The arm64 runner finishes in about 15 minutes.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- `build-macos` had `timeout-minutes: 30`. The x64 (Intel) runner needs 25–30 minutes for the cold release build plus notarization: v1.0.5's x64 job finished in 28m50s and the first v1.0.6 attempt was cancelled at the limit with `rustc` still running. arm64 finishes in ~15 minutes. Raised to 45.

## Test plan

- Workflow parses (`js-yaml`); `pnpm checks:changed -- --run` green (Windows release contract test reads this file).
- Proof is the next x64 release build completing under the new limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)