### PR TITLE
fix: let the app verifier say the display was locked instead of blaming the map

### DIFF
--- a/scripts/lib/verify-macos/payload-contract.mjs
+++ b/scripts/lib/verify-macos/payload-contract.mjs
@@ -67,6 +67,13 @@ export function validateWebviewVerifyPayload(payload, {
   if (payload.readyState !== "complete") {
     return `WebView document was not complete (readyState=${payload.readyState ?? "unknown"})`;
   }
+  if (payload.visibilityState === "hidden") {
+    return (
+      "WebView document is hidden: the display is locked or the window is occluded, so WebKit " +
+      "stops animation frames and the map never mounts. Unlock the display and run again; " +
+      "this run proves nothing about the app."
+    );
+  }
   if (typeof payload.bodyText !== "string" || payload.bodyText.trim().length === 0) {
     return "WebView body text was empty";
   }

--- a/scripts/verify-macos-app-launch.payload-contract.test.mjs
+++ b/scripts/verify-macos-app-launch.payload-contract.test.mjs
@@ -132,6 +132,17 @@ test("payload contract · 모양이 틀린 페이로드를 이유와 함께 막�
     validateWebviewVerifyPayload(validPayload({ readyState: "loading" })),
     /readyState=loading/,
   );
+  // 2026-09-06: a deploy check ran against a locked display; the map mounts after one
+  // animation frame, WebKit fires none for a hidden document, and the run failed on
+  // "marker missing" for a screen nobody saw. The hidden state is named before any marker.
+  assert.match(
+    validateWebviewVerifyPayload(validPayload({ visibilityState: "hidden" })),
+    /document is hidden.*display is locked/,
+  );
+  assert.equal(
+    validateWebviewVerifyPayload(validPayload({ visibilityState: "visible" })),
+    validateWebviewVerifyPayload(validPayload()),
+  );
   assert.match(validateWebviewVerifyPayload(validPayload({ bodyText: "   " })), /body text was empty/);
   assert.match(
     validateWebviewVerifyPayload(validPayload({ bodyText: "lorem ipsum dolor" })),

--- a/src-tauri/src/webview_verify/dom_marker_probe.js
+++ b/src-tauri/src/webview_verify/dom_marker_probe.js
@@ -928,6 +928,10 @@
                                 bodyText: bodyText.slice(0, 240),
                                 bodyChildren: document.body ? document.body.children.length : null,
                                 readyState: document.readyState,
+                                // A locked display or an occluded window makes WebKit stop
+                                // animation frames, and the map mounts after one; without this
+                                // the verifier reports "marker missing" for a screen nobody saw.
+                                visibilityState: document.visibilityState,
                                 bg: getComputedStyle(document.body).backgroundColor,
                                 color: getComputedStyle(document.body).color,
                                 width: innerWidth,
@@ -967,7 +971,7 @@
                                   ),
                                   topologyRelief:
                                     location.pathname.includes("/topology") &&
-                                    /Relief|Ontology relief map|concept cards|온톨로지 지형도|대표 카드|카드 골격|후보 \d+\/\d+개 표시|개념 \d+개 · 관계 \d+개|CONCEPTS/.test(bodyText),
+                                    /Relief|Ontology relief map|concept cards|온톨로지 지형도|대표 카드|카드 골격|후보 \d+\/\d+개 표시|개념 \d+개 · 관계 \d+개|\d+ 개념 · \d+ 관계|\d+ concepts · \d+ relations|CONCEPTS/.test(bodyText),
                                   topologyAttentionWinner,
                                   topologySigmaViewportVisible: Boolean(
                                     sigmaViewportRect &&
@@ -2013,6 +2017,7 @@
                                   bodyText: "",
                                   bodyChildren: document.body ? document.body.children.length : null,
                                   readyState: document.readyState,
+                                  visibilityState: document.visibilityState,
                                   bg: "",
                                   color: "",
                                   width: innerWidth,


### PR DESCRIPTION
## Summary

Tonight's post-deploy verification failed with "WebView did not report the Relief topology marker" while the Mac sat on its lock screen. Cause: `HomePage.tsx` mounts the map after one `requestAnimationFrame`, and WebKit fires none for a hidden document, so `[data-map-engine]` never appeared across all 24 polls. The app was fine; the harness blamed it.

- `dom_marker_probe.js` reports `visibilityState` in both payload shapes.
- `payload-contract.mjs` names a hidden document before any marker check, with the reason and the remedy in one sentence.
- The Relief marker regex also accepts the current Korean census shape (number before the word) and its English twin; the old shape stays for the Rust pin.

## Test plan

- [x] `node --test` on the three harness suites: 32 pass, 0 fail (new hidden/visible cases)
- [x] `cargo test --lib webview_verify_payload` (probe-source pin) ok
- [x] `pnpm checks:changed -- --run` over the three files: 5 passed
- [x] pre-push lanes green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
