### PR TITLE
fix: let the connection card own the right rail like the node inspector

### DIFF
--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -2936,9 +2936,18 @@ function HomePageImpl() {
     selectedOntologyNode?.id ?? null,
   );
   const selectedNodeOwnsRightRail = selectedNodeFocusActive && !meaningWorkbenchOpen && !acpDockFrameOpen;
+  /*
+   * The connection card stands where the node inspector stands (same right inset, same
+   * top), so it owns the right rail on the same terms: the help, agent and recent tiles
+   * and the activity chip step aside while it is up. Owner's screen, 2026-09-06: with a
+   * relation card open the tiles and the "Claude Agent, last worked" chip sat under
+   * its header, half covered.
+   */
+  const selectedEdgeOwnsRightRail = edgePanelOpen && !meaningWorkbenchOpen && !acpDockFrameOpen;
+  const inspectorOwnsRightRail = selectedNodeOwnsRightRail || selectedEdgeOwnsRightRail;
   const topologyUtilityChromeState = selectedRelationActive
     ? "collapsed-active-relation"
-    : selectedNodeOwnsRightRail
+    : inspectorOwnsRightRail
       ? "selected-node-inspector"
       : selectedSlug
         ? "compact-focus"
@@ -2981,7 +2990,7 @@ function HomePageImpl() {
   const [activityInboxOpen, setActivityInboxOpen] = useState(false);
   const topologyUtilityLaneSuppressionContract = selectedRelationActive
     ? "selected-relation-inspector-owns-right-rail"
-    : selectedNodeOwnsRightRail
+    : inspectorOwnsRightRail
       ? "selected-node-inspector-owns-right-rail"
       : undefined;
 
@@ -4585,7 +4594,7 @@ function HomePageImpl() {
                       ) : undefined
                     }
                   />
-                  {selectedNodeOwnsRightRail ? null : (
+                  {inspectorOwnsRightRail ? null : (
                     <>
                     {/* Mobile-only settings escape hatch: the utility lane is
                         hidden while the expanded INDEX owns the <md surface. */}
@@ -4921,7 +4930,7 @@ function HomePageImpl() {
                         last square tile of this row. The same component owns both feeds and
                         outside click/Escape to avoid duplicating polling/read state. */}
                     <AgentActivityChip
-                      suppressed={Boolean(v2DatasheetModel)}
+                      suppressed={Boolean(v2DatasheetModel) || selectedEdgeOwnsRightRail}
                       liveWork={acpLiveWork}
                       onOpenChange={setActivityInboxOpen}
                       onOpenNode={handleSelect}


### PR DESCRIPTION
## Summary
- Clicking a relation on the map opened the connection card at the top right, where it covered the help, agent and recent tiles and the "Claude Agent · last worked" chip (owner's screen, 2026-09-06). The node inspector already takes that rail (the tiles and chip step aside); the card now takes it on the same terms, since it stands at the same right inset and top.

## Test plan
- `pnpm checks:changed -- --run …` 6 passed (tsc, lint, unit siblings).
- Static export at 1512×982: clicking the project→catalog edge opens the card; `elementsFromPoint` at the card's header corners finds no button beneath it and the activity chip is hidden (`.claude/shots-2026-09-06/edge-card-rail-1512.png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)