### PR TITLE
fix: read a Korean check report's counts, and say the wiki log line in the screen's language

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -4471,7 +4471,18 @@
       "viewOriginalOne": "View original: {name}",
       "originalMissing": "Cites {name}, which is not in this folder.",
       "compileCreateFile": "Create {path}",
-      "compileModifyFile": "Replace {path}"
+      "compileModifyFile": "Replace {path}",
+      "logCount": {
+        "disagreement": "disagreement {count}",
+        "superseded": "superseded {count}",
+        "missingLink": "missing link {count}",
+        "nameWithoutPage": "names without a page {count}"
+      },
+      "logNoCounts": "ran, counts not stated",
+      "logNew": "new",
+      "logRevised": "revised",
+      "logNothingNew": "nothing new",
+      "emptyNoTemplate": "No wiki pages yet, and no template in this folder. Start a wiki from Settings › Workspace: it writes wiki/_template.md, the shape every page follows."
     },
     "graph": {
       "title": "Graph",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -4471,7 +4471,18 @@
       "viewOriginalOne": "원본 보기: {name}",
       "originalMissing": "{name} 을(를) 인용하지만 이 폴더에는 없습니다.",
       "compileCreateFile": "{path} 만들기",
-      "compileModifyFile": "{path} 바꾸기"
+      "compileModifyFile": "{path} 바꾸기",
+      "logCount": {
+        "disagreement": "어긋남 {count}",
+        "superseded": "대체된 주장 {count}",
+        "missingLink": "빠진 연결 {count}",
+        "nameWithoutPage": "문서 없는 이름 {count}"
+      },
+      "logNoCounts": "실행됨 · 개수 없음",
+      "logNew": "새로 씀",
+      "logRevised": "고침",
+      "logNothingNew": "새 내용 없음",
+      "emptyNoTemplate": "아직 위키 문서가 없고 서식도 없습니다. 설정 › 작업 공간에서 위키를 시작하면 wiki/_template.md 가 생기고, 문서는 그 서식을 따릅니다."
     },
     "graph": {
       "title": "그래프",

--- a/src/entities/docs-vault/data/manifest.json
+++ b/src/entities/docs-vault/data/manifest.json
@@ -23,7 +23,7 @@
       "headings": [],
       "excerpt": "Current as of 2026-08-02. This is the user-facing guide for running ontology-atlas as a local meaning graph: CLI-only, MCP-connected, and web workbench flows over the same markdown vault. ontology-atlas is not a hosted graph database. It is a local-first graph workbench where markdown frontmatter is the graph, git is t",
       "wordCount": 3142,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": []
     },
     {
@@ -96,7 +96,7 @@
       "headings": [],
       "excerpt": "2026-07-27 update — the current architecture is a local-first, git-backed meaning layer: a folder of markdown files that records what each part of the product is, who owns it, what it depends on, and what proves it. People and AI coding agents read and write that same folder. Round 10 permanently removed every login an",
       "wordCount": 4905,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "ANALYSIS-RECORDS",
         "../AGENTS",
@@ -475,7 +475,7 @@
       "headings": [],
       "excerpt": "Question: the LLM Wiki pattern (Karpathy, 2026-04-04) claims its value is accumulation: each new source revises existing pages and flags what it contradicts. The Library's Compile brief embeds the page template and six rules but never names existing pages. Does a wiki built one source at a time, the way the Library run",
       "wordCount": 3055,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "wiki/<slug>",
         "src:…"
@@ -502,7 +502,7 @@
       "headings": [],
       "excerpt": "The single biggest unverified premise of this project: \"AI agents work better when they can read and write the codebase ontology vault.\" Until we have data, this is a belief, not a claim. This folder is the first attempt to put it on a measurement scale. We built CLI · MCP · graph tooling · a macOS local workbench all ",
       "wordCount": 3275,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "benchmark/FINDINGS-2026-08-25",
         "benchmark/tasks",
@@ -863,7 +863,7 @@
       "headings": [],
       "excerpt": "This file keeps the decisions and the arguments that lost when they were made. docs/CHANGELOG.md answers what changed and when; this file answers why it was decided that way, and what was staked on it. Newest first. Records are appended, never edited. When a judgment changes, write a new record whose Prior names the ol",
       "wordCount": 109911,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "wiki/…",
         "wiki/<slug>",
@@ -1256,7 +1256,7 @@
       "headings": [],
       "excerpt": "Status: RFC (Request for Comments). This is a v2.0 release candidate, not a ratified standard — see §0 RFC status and feedback for the review window and how to comment. This document promotes an already-shipped, already-enforced de-facto schema into a formal specification. v2 makes immutable node uid mandatory; this is",
       "wordCount": 7472,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "src:sources/<path>",
         "wikilink",
@@ -4081,7 +4081,7 @@
       "headings": [],
       "excerpt": "This temporary register measures the 2026-09-01 Atlas product-decision system. It is not a second decision archive. Significant rationale stays in DECISIONS.md; this file keeps only the typed facts needed to decide whether the gate earns, narrows, or loses its place. Run pnpm po:pilot for the current report and pnpm po",
       "wordCount": 2682,
-      "updatedAt": "2026-09-06",
+      "updatedAt": "2026-09-07",
       "linksOut": [
         "DECISIONS"
       ]

--- a/src/features/library/lib/wiki-log.test.ts
+++ b/src/features/library/lib/wiki-log.test.ts
@@ -40,6 +40,11 @@ describe("the lint line carries the report's counts when the report states them"
     expect(describeLintTurn(text)).toBe("disagreement 0 · superseded 1 · missing-link 2 · name-without-page 6");
   });
 
+  it("reads a Korean report's count line, as the localized brief asks for it", () => {
+    const text = "…\n**범주별 개수** — 어긋남 0, 대체된 주장 2, 빠진 연결 1, 문서 없는 이름 5.\n```json\n{}\n```";
+    expect(describeLintTurn(text)).toBe("disagreement 0 · superseded 2 · missing-link 1 · name-without-page 5");
+  });
+
   it("does not invent counts the report did not state", () => {
     expect(describeLintTurn("I read the pages and found nothing to report.")).toBe("ran; counts not stated");
     expect(describeLintTurn(null)).toBe("ran; counts not stated");

--- a/src/features/library/lib/wiki-log.ts
+++ b/src/features/library/lib/wiki-log.ts
@@ -96,11 +96,15 @@ export function describeLintTurn(finalText: string | null): string {
     const match = label.exec(text);
     return match ? Number(match[1]) : null;
   };
+  // The report is written in the screen's language (the brief is localized), so each
+  // count is read under its English or Korean label; the summary keeps the English keys,
+  // which the Library translates back when it draws the line (installed app, 2026-09-07:
+  // a Korean report ended with the localized count line and the log said "counts not stated").
   const counts = [
-    ["disagreement", pick(/Disagreement[^\d\n]*?(\d+)/i)],
-    ["superseded", pick(/Superseded[^\d\n]*?(\d+)/i)],
-    ["missing-link", pick(/Missing (?:cross-reference|link)[^\d\n]*?(\d+)/i)],
-    ["name-without-page", pick(/(?:Concept|Name) without a page[^\d\n]*?(\d+)/i)],
+    ["disagreement", pick(/(?:Disagreement|어긋남)[^\d\n]*?(\d+)/i)],
+    ["superseded", pick(/(?:Superseded|대체된 주장)[^\d\n]*?(\d+)/i)],
+    ["missing-link", pick(/(?:Missing (?:cross-reference|link)|빠진 연결)[^\d\n]*?(\d+)/i)],
+    ["name-without-page", pick(/(?:(?:Concept|Name) without a page|문서 없는 이름)[^\d\n]*?(\d+)/i)],
   ] as const;
   const known = counts.filter(([, n]) => n !== null);
   if (known.length === 0) return "ran; counts not stated";

--- a/src/views/library/lib/wiki-log-summary.test.ts
+++ b/src/views/library/lib/wiki-log-summary.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { localizeWikiLogSummary } from "./wiki-log-summary";
+
+const ko = (key: string, values?: Record<string, string | number>) =>
+  ({
+    "wiki.logCount.disagreement": `어긋남 ${values?.count}`,
+    "wiki.logCount.superseded": `대체된 주장 ${values?.count}`,
+    "wiki.logCount.missingLink": `빠진 연결 ${values?.count}`,
+    "wiki.logCount.nameWithoutPage": `문서 없는 이름 ${values?.count}`,
+    "wiki.logNoCounts": "실행됨 · 개수 없음",
+    "wiki.logNew": "새로 씀",
+    "wiki.logRevised": "고침",
+    "wiki.logNothingNew": "새 내용 없음",
+  })[key] ?? key;
+
+describe("localizeWikiLogSummary", () => {
+  it("translates a check's counts while the file keeps the English keys", () => {
+    expect(localizeWikiLogSummary("disagreement 0 · superseded 2 · missing-link 1 · name-without-page 5", ko)).toBe(
+      "어긋남 0 · 대체된 주장 2 · 빠진 연결 1 · 문서 없는 이름 5",
+    );
+    expect(localizeWikiLogSummary("ran; counts not stated", ko)).toBe("실행됨 · 개수 없음");
+  });
+
+  it("translates a compile's verbs and leaves the slugs alone", () => {
+    expect(localizeWikiLogSummary("sources/a.pdf → a (new), b (revised)", ko)).toBe("sources/a.pdf → a (새로 씀), b (고침)");
+  });
+});

--- a/src/views/library/lib/wiki-log-summary.ts
+++ b/src/views/library/lib/wiki-log-summary.ts
@@ -1,0 +1,33 @@
+/**
+ * The wiki log keeps its summaries in one machine form — `disagreement 0 · superseded 2`,
+ * `a, b (new)`, `ran; counts not stated` — so `grep` reads the same words in every vault.
+ * The Library header is where a person reads them, in the screen's language (installed
+ * app, 2026-09-07: a Korean header said "ran; counts not stated").
+ */
+export type LogSummaryTranslator = (key: string, values?: Record<string, string | number>) => string;
+
+const COUNT_KEYS: Record<string, string> = {
+  disagreement: "wiki.logCount.disagreement",
+  superseded: "wiki.logCount.superseded",
+  "missing-link": "wiki.logCount.missingLink",
+  "name-without-page": "wiki.logCount.nameWithoutPage",
+};
+
+export function localizeWikiLogSummary(summary: string, t: LogSummaryTranslator): string {
+  const trimmed = summary.trim();
+  if (trimmed === "ran; counts not stated") return t("wiki.logNoCounts");
+  const parts = trimmed.split(" · ");
+  if (parts.every((part) => /^[a-z-]+ \d+$/.test(part))) {
+    return parts
+      .map((part) => {
+        const [key, count] = part.split(" ");
+        const messageKey = COUNT_KEYS[key];
+        return messageKey ? t(messageKey, { count: Number(count) }) : part;
+      })
+      .join(" · ");
+  }
+  return trimmed
+    .replace(/\(new\)/g, `(${t("wiki.logNew")})`)
+    .replace(/\(revised\)/g, `(${t("wiki.logRevised")})`)
+    .replace(/\bnothing new\b/g, t("wiki.logNothingNew"));
+}

--- a/src/views/library/ui/LibraryPage.tsx
+++ b/src/views/library/ui/LibraryPage.tsx
@@ -799,6 +799,7 @@ export function LibraryPage() {
             onCompile={agent.route === "agent" || agent.route === "local" ? handleCompile : null}
             onLint={agent.route === "agent" ? handleLint : null}
             candidates={openCandidates}
+            hasWikiTemplate={docs.some((doc) => doc.slug === "wiki/_template")}
             onPropose={agent.route === "agent" && hasOntology ? handlePropose : null}
             /*
              * The same picker as step two, reading and writing the same stored answer, so

--- a/src/views/library/ui/parts/LibrarySection.tsx
+++ b/src/views/library/ui/parts/LibrarySection.tsx
@@ -10,6 +10,7 @@ import { isMapKind, type LintNodeCandidate } from "@/features/library";
 import { cn } from "@/shared/lib/cn";
 import { badgeClass } from "@/shared/ui/badge-class";
 import { writerLabel } from "../../lib/writer-label";
+import { localizeWikiLogSummary } from "../../lib/wiki-log-summary";
 import { controlClass } from "@/shared/ui/control-class";
 import { Chip, RowButton, Tooltip } from "@/shared/ui";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
@@ -76,6 +77,8 @@ export interface LibrarySectionProps {
   candidates: readonly LintNodeCandidate[];
   /** Starts one agent turn that proposes the candidate through the ontology-write card; null like the others. */
   onPropose: ((candidate: LintNodeCandidate) => void) | null;
+  /** Whether `wiki/_template.md` exists: without it the empty state says how to get one. */
+  hasWikiTemplate?: boolean;
   /**
    * The brain picker, when this computer offers two and Compile can therefore be pointed
    * at either. Null draws nothing: with one brain there is no choice to make, and the
@@ -183,6 +186,7 @@ export function LibrarySection({
   onLint,
   candidates,
   onPropose,
+  hasWikiTemplate = true,
   brainControl,
   transferNote,
   vaultLabel,
@@ -430,11 +434,11 @@ export function LibrarySection({
             className="flex-none px-3 pb-1 text-caption text-[color:var(--color-text-quaternary)] [word-break:keep-all] [overflow-wrap:anywhere]"
           >
             {model.log.lastCompile
-              ? t("wiki.logCompile", { when: logWhen(model.log.lastCompile.at), summary: model.log.lastCompile.summary })
+              ? t("wiki.logCompile", { when: logWhen(model.log.lastCompile.at), summary: localizeWikiLogSummary(model.log.lastCompile.summary, t) })
               : null}
             {model.log.lastCompile && model.log.lastLint ? " · " : null}
             {model.log.lastLint
-              ? t("wiki.logLint", { when: logWhen(model.log.lastLint.at), summary: model.log.lastLint.summary })
+              ? t("wiki.logLint", { when: logWhen(model.log.lastLint.at), summary: localizeWikiLogSummary(model.log.lastLint.summary, t) })
               : null}
           </p>
         ) : null}
@@ -501,7 +505,7 @@ export function LibrarySection({
             data-testid="library-wiki-empty"
             className="flex-none px-3 pb-1 text-caption text-[color:var(--color-text-tertiary)] [word-break:keep-all]"
           >
-            {t("wiki.empty")}
+            {hasWikiTemplate ? t("wiki.empty") : t("wiki.emptyNoTemplate")}
           </p>
         )}
         {candidates.length > 0 ? (


### PR DESCRIPTION
## Summary

Post-merge inspection of the installed build (main 7ac676131) on a Korean screen found one defect in #1486's wiki log: the localized Check-the-wiki brief asks for a Korean count line, `describeLintTurn` knew only the English labels, so `wiki/_log.md` recorded `ran; counts not stated` and the Library header showed that English sentence.

- The parser reads the counts under their English or Korean labels; the log keeps its machine form (`disagreement 0 · superseded 2 · …`) so `grep` reads the same words in every vault.
- The Library header translates that form back (`localizeWikiLogSummary`), including a compile's `(new)` / `(revised)`.
- The empty-wiki copy named `wiki/_template.md` in a folder that has none (the dogfood vault); it now says the template comes from Settings › Workspace › Start a wiki.

## Test plan

- `pnpm checks:changed -- --run` — 11 checks pass (lint, unit, contracts, source language, i18n messages, docs-vault).
- Installed app on the wiki-only and map-plus-wiki fixture vaults: Check the wiki ran end to end on both; candidates, Propose chip gating, session survival and the map all verified on merged main. The count line defect reproduced on both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)