### PR TITLE
chore(mcp): claim the Glama listing with a maintainers file

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["wlsdks"]
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -108,6 +108,12 @@ returns 200, authenticates with this repository's own OIDC identity, and stops
 without failing when the server version is already listed, since the registry
 treats a version as immutable.
 
+Third-party directories list it from the same two facts. [Glama](https://glama.ai/mcp/servers/wlsdks/ontology-atlas)
+builds the server from `mcp/Dockerfile` and introspects the running process for
+its tool list, so nothing there is typed by hand either. The root `glama.json`
+names the GitHub accounts allowed to maintain that entry; it is the whole file,
+because `maintainers` is the only field its schema requires.
+
 Two honest limits on those rows. **The image is not published yet** — build it
 yourself with `docker build -f mcp/Dockerfile -t ontology-atlas-mcp .` from the
 repository root, which is the context an outside directory uses when it builds a

--- a/scripts/classify-change.mjs
+++ b/scripts/classify-change.mjs
@@ -127,6 +127,9 @@ const KNOWN_PATHS = [
   /^(?:AGENTS|CLAUDE|CODE_OF_CONDUCT|CONTRIBUTING|NOTICE|README|SECURITY)\.md$/,
   /^LICENSE$/,
   /^(?:eslint\.config\.mjs|next\.config\.ts|package\.json|playwright\.config\.ts|pnpm-lock\.yaml|postcss\.config\.mjs|tsconfig\.json|vitest\.config\.ts|vitest\.setup\.ts)$/,
+  // A third-party directory reads this at the repository root and nothing here builds from it,
+  // so it is known and drives no lane. `glama.json` names who may maintain the Glama listing.
+  /^glama\.json$/,
 ];
 
 const ROOT_VITEST_INPUTS = [


### PR DESCRIPTION
## Summary

The [Glama listing](https://glama.ai/mcp/servers/wlsdks/ontology-atlas) is live
and scoring. One of its score items is whether the repository declares who may
maintain the entry; without the file the directory cannot tell an owner's update
from a stranger's, so the item stays unmet on a listing that is otherwise built
entirely from this repository's own `mcp/Dockerfile`.

- `glama.json` — two fields, because that is the whole schema.
  [`https://glama.ai/mcp/schemas/server.json`](https://glama.ai/mcp/schemas/server.json)
  requires `maintainers` and defines nothing else, so nothing is invented to fill
  it out.
- `mcp/README.md` — the paragraph that was missing beside the MCP Registry one.
  The directory builds from the Dockerfile and introspects the running process
  for its tool list, so that listing is derived the same way the registry entry
  is; `glama.json` is the only hand-written part.

## Test plan

- `pnpm checks:changed -- --run` → 6/6 (includes `docs:links`, the package-contract
  node tests, and `vault:validate` 104 files / 0 issues)
- pre-push lanes → 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
