### PR TITLE
fix(ci): make the registry listing follow publication instead of an event that never fires

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,15 +1,22 @@
 name: Publish to MCP Registry
-run-name: Publish ${{ inputs.tag || github.event.release.tag_name }} to the MCP Registry
+run-name: Publish ${{ inputs.tag }} to the MCP Registry
 
 # Listing Atlas in the official MCP Registry needs no package registry: the entry
 # points at the `.mcpb` asset on a GitHub Release, and the registry fetches that
 # asset itself to verify the URL and SHA-256. Two consequences shape this workflow:
 #
 #   1. It must run **after** the release leaves draft. A draft asset 404s to the
-#      anonymous fetch the registry makes, so `release: [published]` is the trigger
-#      rather than a tag push.
+#      anonymous fetch the registry makes, so the release workflow calls this one
+#      as its last step rather than a tag push starting it.
 #   2. It publishes **metadata we derive**, never a digest anyone typed:
 #      `pnpm mcp:registry` hashes the asset downloaded from the release itself.
+#
+# **Why `workflow_call` and not `release: [published]`** (measured 2026-09-11): the
+# release is published by `gh release edit` with `GITHUB_TOKEN`, and GitHub does not
+# start a workflow from an event that token raised — the recursion guard. v1.2.0 went
+# out and this workflow had zero runs; the entry had to be dispatched by hand. Being
+# a job of the release run instead makes the listing follow publication for the same
+# reason the publication itself is trusted, rather than depending on who pressed it.
 #
 # Authentication is OIDC — `mcp-publisher login github-oidc` proves this repository
 # owns the `io.github.wlsdks/*` namespace with the workflow's own identity, so no
@@ -21,8 +28,12 @@ run-name: Publish ${{ inputs.tag || github.event.release.tag_name }} to the MCP 
 # says so and stops instead of failing.
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: The published release tag whose .mcpb asset should be listed
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -42,7 +53,7 @@ jobs:
       - name: Resolve the release tag
         id: release
         run: |
-          tag="${{ inputs.tag || github.event.release.tag_name }}"
+          tag="${{ inputs.tag }}"
           if [[ -z "${tag}" ]]; then
             echo "::error::no release tag to publish"
             exit 1

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -758,3 +758,27 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+  # The listing follows publication inside the same run, on purpose.
+  #
+  # This was a separate workflow on `release: [published]` until 2026-09-11, when
+  # v1.2.0 shipped and it had **zero runs**: `publish-macos` takes the release out of
+  # draft with `GITHUB_TOKEN`, and GitHub will not start a workflow from an event that
+  # token raised. The trigger could never fire for our own releases, and the entry had
+  # to be dispatched by hand — an "it is wired" claim that was not true.
+  #
+  # `needs: publish-macos` is the honest ordering: the registry fetches the asset with
+  # no credentials, so it must already be public. The called workflow keeps its own
+  # `workflow_dispatch` for re-listing a release that is already out.
+  list-mcp-registry:
+    name: List the MCP server entry
+    needs: [admit-release, publish-macos]
+    permissions:
+      # Not repository write. `id-token: write` mints the short-lived OIDC assertion
+      # `mcp-publisher login github-oidc` exchanges to prove this repository owns the
+      # `io.github.wlsdks/*` namespace; it grants nothing over this repository's contents.
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-mcp-registry.yml
+    with:
+      tag: ${{ needs.admit-release.outputs.release_tag }}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -101,12 +101,16 @@ ownership label), and hosts no files itself. `pnpm mcp:build-bundle` builds and
 boots the bundle, and `pnpm mcp:registry` derives the registry entry from the
 built artifact.
 
-Publishing the registry entry is wired, not manual: `.github/workflows/publish-mcp-registry.yml`
-runs when a release is **published** (a draft asset 404s to the anonymous fetch the
-registry makes), hashes the asset the release actually carries, proves that URL
-returns 200, authenticates with this repository's own OIDC identity, and stops
-without failing when the server version is already listed, since the registry
-treats a version as immutable.
+Publishing the registry entry is wired, not manual: the release workflow's last job
+calls `.github/workflows/publish-mcp-registry.yml` once the release leaves draft (a
+draft asset 404s to the anonymous fetch the registry makes). It hashes the asset the
+release actually carries, proves that URL returns 200, authenticates with this
+repository's own OIDC identity, and stops without failing when the server version is
+already listed, since the registry treats a version as immutable. It was a separate
+`release: [published]` workflow until v1.2.0 shipped and it had zero runs: the release
+is published with `GITHUB_TOKEN`, and GitHub starts no workflow from an event that
+token raised. `workflow_dispatch` remains, for re-listing a release that is already
+out.
 
 Third-party directories list it from the same two facts. [Glama](https://glama.ai/mcp/servers/wlsdks/ontology-atlas)
 builds the server from `mcp/Dockerfile` and introspects the running process for

--- a/tests/contract/workflow-security.contract.test.ts
+++ b/tests/contract/workflow-security.contract.test.ts
@@ -43,11 +43,21 @@ function jobBlock(source: string, jobName: string): string {
   return source.slice(start, next ? start + match[0].length + next.index : source.length);
 }
 
+/**
+ * The part of a job that declares **who it runs as**, stopping before what it runs.
+ *
+ * Two body shapes end that header. A normal job's is `steps:`; a job that calls a
+ * reusable workflow has no steps at all and opens with a job-level `uses:` (four
+ * spaces — a step's `uses:` is six and lives inside `steps:`). Recognising only the
+ * first was fail-closed rather than silently wrong: `list-mcp-registry` threw here
+ * instead of passing unexamined. It still has to be recognised, because a permission
+ * this helper cannot see is a permission `writePermissionsByJob` cannot audit.
+ */
 function jobHeader(source: string, jobName: string): string {
   const block = jobBlock(source, jobName);
-  const steps = block.indexOf("\n    steps:");
-  if (steps < 0) throw new Error(`workflow steps not found: ${jobName}`);
-  return block.slice(0, steps);
+  const body = /\n    (?:steps|uses):/.exec(block);
+  if (!body) throw new Error(`workflow job body not found: ${jobName}`);
+  return block.slice(0, body.index);
 }
 
 function stepNamesUsingSecret(source: string, secretName: string): string[] {
@@ -245,10 +255,15 @@ describe("워크플로 보안 계약", () => {
     expect(jobBlock(release, "publish-macos")).toMatch(
       /^    permissions:\n(?:      .+\n)*?      contents: write\s*$/m,
     );
+    // `list-mcp-registry` is the one write that is not a write over this repository:
+    // `id-token: write` mints the short-lived OIDC assertion the registry exchanges for
+    // proof of namespace ownership. It is listed rather than exempted, so a job that
+    // quietly gained `contents: write` beside it would still show up here.
     expect(writePermissionsByJob(release)).toEqual({
       "build-windows": ["checks"],
       "stage-macos": ["contents"],
       "publish-macos": ["contents"],
+      "list-mcp-registry": ["id-token"],
     });
 
     // Pokes the helper itself so that a new job cannot slip past a check that only
@@ -258,6 +273,15 @@ describe("워크플로 보안 계약", () => {
       "  unexpected-writer:\n    permissions:\n      contents: write\n    steps:\n      - run: true\n\n  build-macos:\n",
     );
     expect(writePermissionsByJob(synthetic)["unexpected-writer"]).toEqual(["contents"]);
+
+    // The same poke in the reusable-workflow shape, which has no `steps:` to find.
+    // Without this the helper could regress to steps-only and go green again, because
+    // every job it then failed to read would simply be absent from the mapping.
+    const syntheticCall = release.replace(
+      "  build-macos:\n",
+      "  unexpected-caller:\n    permissions:\n      contents: write\n    uses: ./.github/workflows/publish-mcp-registry.yml\n    with:\n      tag: v0.0.0\n\n  build-macos:\n",
+    );
+    expect(writePermissionsByJob(syntheticCall)["unexpected-caller"]).toEqual(["contents"]);
   });
 
   it("서명 secret 은 필요한 release step 에서만 보인다", () => {


### PR DESCRIPTION
## Summary

v1.2.0 shipped and `publish-mcp-registry.yml` had **zero runs**.

The trigger was `release: [published]`. `publish-macos` takes the release out of
draft with `GITHUB_TOKEN`, and GitHub starts no workflow from an event that token
raised — the documented recursion guard. The trigger therefore could never fire for
our own releases. The v1.2.0 entry had to be dispatched by hand, while both the
workflow's comment and `mcp/README.md` said publishing was wired.

| | Before | After |
|---|---|---|
| Trigger | `release: [published]` — never fires for our releases | `workflow_call` from the release run's last job |
| Tag | `github.event.release.tag_name` or a typed input | `needs.admit-release.outputs.release_tag` |
| Ordering | implicit | `needs: publish-macos` — the registry fetches the asset anonymously, so it must be public first |
| Manual path | `workflow_dispatch` | unchanged, and it is how v1.2.0 was listed |

Nothing about what gets published changed: `pnpm mcp:registry` still hashes the asset
downloaded from the release, still proves the URL returns 200, and still stops
without failing when the server version is already listed.

## The security contract needed the same lesson

`jobHeader` looked only for `steps:`, so the new reusable-workflow job **threw**
rather than passing unexamined. Fail closed, which is right — but a permission the
helper cannot read is a permission `writePermissionsByJob` cannot audit. It now ends
the header at a job-level `uses:` too (four spaces; a step's `uses:` is six).

The existing synthetic poke gained a reusable-workflow twin, so the helper cannot
regress to steps-only and go green again by silently skipping every job it fails to
read. `id-token: write` is **listed** for the new job rather than exempted — it mints
the short-lived OIDC assertion proving `io.github.wlsdks/*` ownership and grants
nothing over this repository, and listing it means a `contents: write` appearing
beside it would still show up.

## Test plan

- `pnpm checks:changed -- --run` → 12/12
- `tests/contract/workflow-security.contract.test.ts` → 14 passed, including both pokes
- Verified live: the v1.2.0 entry is in the registry — `io.github.wlsdks/ontology-atlas`
  0.13.0, `mcpb` pointing at the release asset with its SHA-256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
