### PR TITLE
fix(ci): never let the merge step touch a local checkout

### DIFF
--- a/scripts/pr-land.mjs
+++ b/scripts/pr-land.mjs
@@ -86,8 +86,10 @@ export const CONFLICT_INSTRUCTION =
   'conflicts with main, and only its author can resolve that:\n'
   + '    git fetch origin && git merge origin/main\n'
   + '    # resolve the conflict, commit, then push the branch\n'
-  + '  Then run `pnpm pr:land <number>` again. The landing lock was released, so '
-  + 'another pull request can land meanwhile.';
+  + '  If only generated docs-vault JSON, the changelog or the ledger conflict, do not\n'
+  + '  resolve those by hand: `pnpm docs-vault:resolve-conflicts -- --dry-run`, then the\n'
+  + '  write command. Then run `pnpm pr:land <number>` again. The landing lock was\n'
+  + '  released, so another pull request can land meanwhile.';
 
 /** A pull request this script refuses to touch, with the reason a person can act on. */
 export function refuseLanding(pr) {
@@ -826,7 +828,17 @@ export function runPrLand(argv, io = console) {
 
     if (step.action === 'merge') {
       log(`every required context is green on ${pr.headRefOid.slice(0, 9)}; squash merging`);
-      gh(['pr', 'merge', String(number), '--squash', '--delete-branch']);
+      /*
+       * No `--delete-branch`. Measured on the first real landing (#1576, which
+       * merged and then crashed here): that flag makes `gh` do local Git work,
+       * switching the checkout to `main` and deleting the local branch, and in
+       * a worktree setup `main` belongs to another checkout — `fatal: 'main' is
+       * already used by worktree at ...`. The pull request was already merged
+       * by then, so the landing "failed" after succeeding, which is the worst
+       * shape an error can have. The remote branch is deleted below, through
+       * the API, by the repository's own `delete_branch_on_merge` or by us.
+       */
+      gh(['pr', 'merge', String(number), '--squash']);
       const merged = readPr(number);
       if (merged.state !== 'MERGED') {
         release();
@@ -834,6 +846,11 @@ export function runPrLand(argv, io = console) {
         return 1;
       }
       log(`PR #${number} merged: ${merged.url}`);
+      const remote = gh(['api', `repos/${slug}/git/ref/heads/${pr.headRefName}`], { allowFailure: true });
+      if (typeof remote === 'string') {
+        gh(['api', '-X', 'DELETE', `repos/${slug}/git/refs/heads/${pr.headRefName}`], { allowFailure: true });
+        log(`deleted the remote branch ${pr.headRefName}`);
+      }
       git(['fetch', '--prune', 'origin'], { allowFailure: true });
       release();
       if (args.cleanup) cleanupWorktree(args.cleanup);

--- a/scripts/pr-land.test.mjs
+++ b/scripts/pr-land.test.mjs
@@ -165,7 +165,11 @@ describe('pr:land refusals', () => {
     assert.equal(dirty, CONFLICT_INSTRUCTION);
     assert.match(dirty, /git fetch origin && git merge origin\/main/);
     assert.match(dirty, /pnpm pr:land <number>/);
-    assert.match(dirty, /landing lock was released/);
+    assert.match(dirty, /landing lock was\n  released/);
+    // Generated docs-vault JSON, the changelog and the ledger are the recurring
+    // conflict in this repository, and hand-resolving them is forbidden
+    // (`.claude/rules/git.md`, "Do not"), so the refusal names the tool.
+    assert.match(dirty, /pnpm docs-vault:resolve-conflicts/);
     // `mergeable` and `mergeStateStatus` disagree while GitHub is still
     // computing the merge; either saying conflict is a refusal.
     assert.equal(refuseLanding({ ...RECORDED_PR, mergeable: 'CONFLICTING' }), CONFLICT_INSTRUCTION);


### PR DESCRIPTION
## Summary

Found by landing #1576 with `pnpm pr:land`: the pull request **merged**, and the
lander then crashed.

```
[pr-land] every required context is green on bb5ef6374; squash merging
[pr-land] landing lock released
Error: gh pr merge 1576 failed: failed to run git:
  fatal: 'main' is already used by worktree at '/Users/jinan/side-project/ontology-atlas'
```

`gh pr merge --delete-branch` does local Git work after the API merge: it
switches the checkout to the base branch and deletes the local branch. Every
agent here works in a `git worktree`, where `main` belongs to a different
checkout, so that step can only fail. A landing that succeeds and then reports
failure is the worst shape an error can have, because the next agent cannot
tell whether to retry.

The remote branch is deleted through the refs API instead, after checking it is
still there, so the repository's own `delete_branch_on_merge` getting there
first is not an error either.

Also in this change: the conflict hand-back names
`pnpm docs-vault:resolve-conflicts`. Both pull requests that conflicted with
#1576 conflicted on generated docs-vault JSON and the ledger, and
`.claude/rules/git.md` forbids resolving those by hand, so sending the author to
`git merge` alone pointed at the one resolution the rules refuse.

## Test plan

- `pnpm test:pr:land` — 38 cases, including the conflict hand-back naming both
  the merge instruction and the generated-JSON tool.
- `pnpm checks:changed -- --run scripts/pr-land.mjs scripts/pr-land.test.mjs` —
  3/3 passed (`source:language`, `test:pr:land`, `knip`).
- Landed through `pnpm pr:land`, which is also the regression test: the merge
  step must not raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
