### PR TITLE
test(e2e): wait for the condition, not the clock

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -106,6 +106,13 @@ Consequences that follow from the rule:
   DOM reveal from `Element.getAnimations()` — never from a token's duration
   copied into the spec. A sleep that survives there says in place why it is a
   measurement window rather than a wait.
+- **Run Playwright in the foreground, and let it own its server.** A dev server
+  started as a background command gets reaped, and the specs in flight then fail
+  against a dead server in about a second each — which reads as a flake in
+  whatever was being changed. Two "flakes" in `download-gateway-grid` were that
+  and nothing else (2026-09-13). So: no pre-started background server, a port of
+  your own via `PLAYWRIGHT_BASE_URL` so a stale server from another session
+  cannot answer instead, and batches short enough to finish in the foreground.
 
 ## TDD
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -101,6 +101,11 @@ Consequences that follow from the rule:
 - **Performance lanes never block.** `*.perf.test.*` runs where the number means
   something: CI on a quiet runner, not the pre-push hook, which deliberately
   saturates the machine.
+- **In e2e, the conditions live in `tests/e2e/settle.ts`.** A canvas has no DOM,
+  so the map's stillness is read from the `?e2e=1` probe's own drawn values and a
+  DOM reveal from `Element.getAnimations()` — never from a token's duration
+  copied into the spec. A sleep that survives there says in place why it is a
+  measurement window rather than a wait.
 
 ## TDD
 

--- a/src/widgets/ontology-map/ui/use-topology-loop.ts
+++ b/src/widgets/ontology-map/ui/use-topology-loop.ts
@@ -6263,6 +6263,15 @@ export function useTopologyLoop(args: UseTopologyLoopArgs): UseTopologyLoopResul
           poseTween: d.poseTween !== null,
           active: d.active,
           ramp: d.rampClock / DOME_ASSEMBLE_TOTAL_MS,
+          /*
+           * Is the entry sweep still putting the pose down? It has its **own**
+           * clock, 1500 ms against the assembly's 1120 ms (`dome-view.ts`), so
+           * `ramp >= 1` is not "the dome has arrived" — the last 380 ms of turning
+           * happens after it. E2E had no way to see that and slept 4 seconds to
+           * cover both, which asserts the machine's speed rather than the dome's
+           * state; the idle gate already reads this flag for the same reason.
+           */
+          entryArmed: d.entryArmed,
         };
       },
       /**

--- a/tests/e2e/architecture-role-ledger.spec.ts
+++ b/tests/e2e/architecture-role-ledger.spec.ts
@@ -5,6 +5,24 @@ import { expect, test } from '@playwright/test';
 
 import { seedFirstRunSeen } from './first-run-seed';
 import { stubDirectoryPicker } from './vault-picker-stub';
+import { waitForAnimationsDone, waitForBoxStill } from "./settle";
+
+/**
+ * The architecture graph has finished rearranging.
+ *
+ * A selection cuts strokes, scrolls a box into view and fades sentences in, and a resize
+ * relays the whole ladder — so what the measurements below need is "the arrangement has
+ * landed", which is the graph's box repeating across frames with nothing still animating
+ * inside it. The 300–900 ms sleeps this replaces were four different guesses at the same
+ * state.
+ */
+async function graphSettled(page: import("@playwright/test").Page) {
+  const graph = page.locator('[data-testid="architecture-graph"]');
+  await expect(graph).toHaveCount(1, { timeout: 30_000 });
+  await waitForAnimationsDone(graph);
+  await waitForBoxStill(graph);
+}
+
 
 /**
  * The role ledger — **the receipt has to fit the box, and the chain has to fit the canvas.**
@@ -407,10 +425,11 @@ test('a skip sentence never sits on another arc, sampled along the strokes', asy
     { width: 1920, height: 800 },
   ]) {
     await page.setViewportSize(size);
-    await page.waitForTimeout(500);
+    // The ladder relays out for the new width; measure the arrangement it lands on.
+    await graphSettled(page);
     for (const role of ['entities', 'views']) {
       await page.getByTestId(`architecture-graph-box-${role}`).click();
-      await page.waitForTimeout(400);
+      await graphSettled(page);
       const touches = await page.evaluate(() => {
         const visible = (el: Element) => Number(getComputedStyle(el).opacity) > 0.05;
         const sentences = [...document.querySelectorAll('[data-edge-sentence]')]
@@ -489,7 +508,7 @@ test('choosing a role does not turn the chain, and the chosen box is in view', a
   await page.setViewportSize({ width: 1920, height: 1080 });
   await page.goto('/en/architecture/?e2e=1&guides=off', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('[data-testid^="architecture-role-ledger-"]')).toHaveCount(7, { timeout: 30_000 });
-  await page.waitForTimeout(600);
+  await graphSettled(page);
   const axisOf = () =>
     page.evaluate(() => {
       const boxes = [...document.querySelectorAll('[data-testid^="architecture-graph-box-"]')].map((b) => b.getBoundingClientRect());
@@ -500,7 +519,7 @@ test('choosing a role does not turn the chain, and the chosen box is in view', a
   expect(await axisOf(), 'the seven-role chain runs down at 1920×1080 at rest').toBe('down');
   for (const role of ['shared', 'routing', 'entities']) {
     await page.getByTestId(`architecture-graph-box-${role}`).click();
-    await page.waitForTimeout(900);
+    await graphSettled(page);
     expect(await axisOf(), `choosing ${role} turned the chain`).toBe('down');
     const seen = await page.evaluate((id) => {
       const box = document.querySelector(`[data-testid="architecture-graph-box-${id}"]`)!.getBoundingClientRect();
@@ -524,6 +543,6 @@ test('choosing a role does not turn the chain, and the chosen box is in view', a
     expect(counts.sentences, 'a sentence element per stroke').toBe(counts.strokes);
     expect(counts.alike, 'two sentence elements share one stroke').toBe(0);
     await page.keyboard.press('Escape');
-    await page.waitForTimeout(300);
+    await graphSettled(page);
   }
 });

--- a/tests/e2e/datasheet-hover-map-brush.spec.ts
+++ b/tests/e2e/datasheet-hover-map-brush.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
 import type {} from "./atlas-map-probe";
+import { waitForMapStill, waitFrames } from "./settle";
 
 /**
  * **Hovering a datasheet row makes the map beside it point at that node.**
@@ -41,7 +42,7 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   // Select one node to open the datasheet (a canvas-coordinate click, the same method as `map-trail.spec.ts`).
   const target = await page.evaluate(() => {
@@ -54,8 +55,9 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
   });
   expect(target, "주문 도메인을 못 찾았다 — 공회전").not.toBeNull();
   await page.mouse.click(target!.px, target!.py);
-  await page.waitForTimeout(1500);
-  expect(await page.evaluate(() => window.__atlasMap!.selection().nodeId)).toBe("domain:order");
+  await expect
+    .poll(() => page.evaluate(() => window.__atlasMap!.selection().nodeId), { timeout: 15_000 })
+    .toBe("domain:order");
 
   const hover = () => page.evaluate(() => window.__atlasMap!.hover());
 
@@ -104,7 +106,8 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
   /** Parks the cursor on empty space off the map — neither a canvas nor a panel hover. */
   const parkCursor = async () => {
     await page.mouse.move(20, 20);
-    await page.waitForTimeout(900);
+    // Parked means the map is pointing at nothing — the state itself, not 900 ms.
+    await expect.poll(hover, { message: "커서를 치웠는데 지도가 계속 가리킨다" }).toBeNull();
   };
 
   // Pick a relation row whose node is **currently drawn on the map**. (A child
@@ -123,13 +126,16 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
 
   // Noise — the difference between two frames with nothing done. The numbers below only mean something at 0.
   const base = await captureBaseline();
-  await page.waitForTimeout(700);
+  // The noise floor is "what two frames differ by with nothing done", so some frames
+  // have to be drawn. Counting them in frames measures the thing the number is about.
+  await waitFrames(page, 42);
   const noise = await changedSince(base);
 
   // ① Hovering the row — the state is that node and the screen really changes.
   await page.locator(`[data-datasheet-connection="${drawnRow!.id}"]`).hover();
-  await page.waitForTimeout(900);
-  expect(await hover(), "지도가 그 노드를 가리키지 않는다").toBe(drawnRow!.id);
+  await expect.poll(hover, { message: "지도가 그 노드를 가리키지 않는다" }).toBe(drawnRow!.id);
+  // …and the frames that carry the change onto the canvas.
+  await waitFrames(page, 3);
   const hoveredPixels = await changedSince(base);
   expect(
     hoveredPixels,
@@ -152,7 +158,7 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
   );
   if (evidenceSlug !== null) {
     await page.locator(`[data-datasheet-evidence="${evidenceSlug}"]`).hover();
-    await page.waitForTimeout(700);
+    await expect.poll(hover, { message: "근거 문서 행이 지도를 가리키지 않는다" }).not.toBeNull();
     const resolved = await hover();
     const mapIds = await page.evaluate(() => window.__atlasMap!.nodes().map((n) => n.id));
     expect(resolved, "근거 문서 행이 지도 이름 공간으로 안 옮겨졌다").not.toBe(evidenceSlug);
@@ -164,7 +170,10 @@ test("데이터시트 줄 호버 — 지도가 그 노드를 가리키고, 떼�
   // ④ Hovering a non-node area (a group heading) leaves the map still — the
   //    highlight is bound to a row, not to the panel.
   await page.locator('[data-datasheet-group-total="contains"]').hover();
-  await page.waitForTimeout(700);
+  // An **absence**: polling for null would pass on the null already standing. The
+  // hover handler runs on the pointer event, so the frames right after the hover are
+  // where a reaction would already be.
+  await waitFrames(page, 3);
   expect(await hover(), "패널 아무 데나 올려도 지도가 반응한다").toBeNull();
 
   expect(pageErrors, "호버 도중 콘솔 예외").toEqual([]);

--- a/tests/e2e/desktop-shell-rail.spec.ts
+++ b/tests/e2e/desktop-shell-rail.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForBoxStill } from "./settle";
 
 /**
  * **The rail follows a real vault, not merely the installed-app runtime.**
@@ -23,6 +24,20 @@ const DESKTOP_INIT = () => {
   (window as unknown as { isTauri?: boolean }).isTauri = true;
 };
 
+/**
+ * The rail is present and has stopped moving.
+ *
+ * `networkidle` says the network is quiet, not that the shell has decided whether this
+ * visitor gets a rail — the decision arrives with the vault state and then the rail
+ * animates to its width. Waiting for the box to repeat across frames reads the width the
+ * shell settled on; 1.5 s was one machine's guess at when that would be.
+ */
+async function railSettled(page: import("@playwright/test").Page) {
+  const rail = page.locator('[data-testid="app-nav-rail"]');
+  await expect(rail).toHaveCount(1, { timeout: 20_000 });
+  await waitForBoxStill(rail);
+}
+
 async function railState(page: import("@playwright/test").Page) {
   return page.evaluate(() => {
     const rail = document.querySelector('[data-testid="app-nav-rail"]');
@@ -41,9 +56,8 @@ test.describe("데스크톱 셸의 좌측 레일", () => {
     await page.setViewportSize({ width: 1512, height: 949 });
     await seedFirstRunSeen(page);
     await page.goto("/ko/", { waitUntil: "networkidle" });
-    await page.waitForTimeout(1500);
-
     await expect(page.getByTestId("first-run-open")).toBeVisible();
+    await railSettled(page);
     await expect(page.getByText("Storefront Services")).toHaveCount(0);
     const rail = await railState(page);
     expect(rail.present, "레일이 DOM 에 없다").toBe(true);
@@ -60,7 +74,7 @@ test.describe("데스크톱 셸의 좌측 레일", () => {
     await page.setViewportSize({ width: 1512, height: 949 });
     await seedFirstRunSeen(page);
     await page.goto("/ko/", { waitUntil: "networkidle" });
-    await page.waitForTimeout(1500);
+    await railSettled(page);
 
     const rail = await railState(page);
     expect(rail.present, "레일은 DOM 에 상주해야 한다(언마운트가 아니라 숨김)").toBe(true);
@@ -74,7 +88,7 @@ test.describe("데스크톱 셸의 좌측 레일", () => {
     await page.setViewportSize({ width: 1512, height: 949 });
     await seedFirstRunSeen(page);
     await page.goto("/ko/topology/", { waitUntil: "networkidle" });
-    await page.waitForTimeout(1500);
+    await railSettled(page);
     expect((await railState(page)).width).toBeGreaterThan(0);
   });
 

--- a/tests/e2e/destination-shortcuts.spec.ts
+++ b/tests/e2e/destination-shortcuts.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitFrames } from "./settle";
 
 /**
  * Destination shortcuts — **every destination reachable by keyboard alone.**
@@ -136,7 +137,13 @@ test.describe("목적지 이동 단축키", () => {
     const before = page.url();
     for (const retired of ["k", "s"]) {
       await go(page, retired);
-      await page.waitForTimeout(600);
+      /*
+       * An **absence**: nothing positive marks "this keystroke did nothing", so the
+       * wait can only be an opportunity for the navigation to happen. Counting it in
+       * drawn frames rather than in milliseconds makes it the browser's own unit — a
+       * loaded machine spends longer over the same thirty, where 600 ms shrank.
+       */
+      await waitFrames(page, 30);
       expect(page.url(), `은퇴한 G ${retired.toUpperCase()} 가 다른 화면으로 이동했다`).toBe(before);
     }
   });
@@ -171,7 +178,8 @@ test.describe("목적지 이동 단축키", () => {
 
     const before = page.url();
     await go(page, "p");
-    await page.waitForTimeout(600);
+    // An absence again: thirty drawn frames of opportunity, counted in frames.
+    await waitFrames(page, 30);
     expect(page.url(), "모달이 떠 있는데 뒤 화면이 바뀌었다").toBe(before);
   });
 
@@ -200,9 +208,11 @@ test.describe("목적지 이동 단축키", () => {
     await dismissBlockingSurface(page);
     const before = page.url();
     await page.keyboard.press("g");
-    await page.waitForTimeout(2_000); // Longer than NAV_LEADER_WINDOW_MS — this wait is the thing under test
+    // ⚠️ Kept in milliseconds: this wait **is** the thing under test — it has to be
+    // longer than NAV_LEADER_WINDOW_MS for the leader to have expired.
+    await page.waitForTimeout(2_000);
     await page.keyboard.press("p");
-    await page.waitForTimeout(600);
+    await waitFrames(page, 30);
     expect(page.url(), "시간 제한이 안 걸렸다").toBe(before);
   });
 

--- a/tests/e2e/docs-rename-address.spec.ts
+++ b/tests/e2e/docs-rename-address.spec.ts
@@ -33,31 +33,42 @@ test("이름 변경 뒤 — 경고가 안 뜨고 주소가 새 이름을 가리�
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
   await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2000);
+  await expect(page.getByTestId("first-run-starter-open")).toBeVisible({ timeout: 30_000 });
   await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
   await page.getByTestId("first-run-starter-open").click();
-  await page.waitForTimeout(500);
-  const pick = page.getByTestId("vault-guide-pick-existing");
-  if (await pick.isVisible().catch(() => false)) await pick.click();
-  await page.waitForTimeout(2500);
+  await expect(page.getByTestId("vault-guide-sheet")).toBeVisible();
+  await page.getByTestId("vault-guide-pick-existing").click();
+  /*
+   * The folder is open once the first-run door is gone. The map canvas is deliberately
+   * **not** the condition: this fixture is three files with no project node, and such a
+   * vault opens the Library rather than the map (`AGENTS.md`, routing) — asserting the
+   * canvas here failed on every run.
+   */
+  await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 30_000 });
 
   await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  // `click()` waits for its own target, so the tree needs nothing in front of it.
   await page.getByText("capabilities", { exact: true }).first().click();
-  await page.waitForTimeout(500);
   await page.getByText("장바구니", { exact: true }).first().click();
-  await page.waitForTimeout(1200);
+  // The document is open when the address says so — the state the rename then moves.
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
+    .toBe("capabilities/cart");
 
   // Palette → rename command (the dialog handler above answers the prompt with the new address)
   await page.keyboard.press("Meta+k");
-  await page.waitForTimeout(600);
+  const palette = page.getByRole("dialog").filter({ has: page.locator('input[type="text"]') }).first();
+  await expect(palette, "팔레트가 안 열렸다").toBeVisible();
   await page.keyboard.type("이름 변경");
-  await page.waitForTimeout(600);
+  // Enter takes the **active** row, so the condition is that the active row is the
+  // command we typed for — not that 600 ms of this machine has gone by.
+  await expect(palette.locator('[role="option"][aria-selected="true"]')).toContainText("이름 변경");
   await page.keyboard.press("Enter");
 
-  // Watches across the manifest-refresh gap (web polling at 1.5s/5s) for the
-  // banner never appearing — a single frame during the gap is already a false
-  // warning.
+  // A **watch window**, not a wait: the claim is that the banner never appears across
+  // the manifest-refresh gap (web polling at 1.5s/5s), and a single frame during that
+  // gap is already a false warning. Six seconds of real time is the subject of the
+  // claim, so it is spent deliberately.
   const banner = page.getByText(/못 찾았어요/);
   for (let i = 0; i < 12; i += 1) {
     await page.waitForTimeout(500);
@@ -82,25 +93,35 @@ test("삭제 뒤 — 경고가 안 뜨고 주소가 지운 문서를 가리키�
   await seedFirstRunSeen(page);
   await stubDirectoryPicker(page, VAULT);
   await page.goto("/ko/topology/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2000);
+  await expect(page.getByTestId("first-run-starter-open")).toBeVisible({ timeout: 30_000 });
   await page.evaluate(() => document.querySelector("nextjs-portal")?.remove());
   await page.getByTestId("first-run-starter-open").click();
-  await page.waitForTimeout(500);
-  const pick = page.getByTestId("vault-guide-pick-existing");
-  if (await pick.isVisible().catch(() => false)) await pick.click();
-  await page.waitForTimeout(2500);
+  await expect(page.getByTestId("vault-guide-sheet")).toBeVisible();
+  await page.getByTestId("vault-guide-pick-existing").click();
+  /*
+   * The folder is open once the first-run door is gone. The map canvas is deliberately
+   * **not** the condition: this fixture is three files with no project node, and such a
+   * vault opens the Library rather than the map (`AGENTS.md`, routing) — asserting the
+   * canvas here failed on every run.
+   */
+  await expect(page.getByTestId("first-run-starter")).toHaveCount(0, { timeout: 30_000 });
 
   await page.goto("/ko/docs/?guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  // `click()` waits for its own target, so the tree needs nothing in front of it.
   await page.getByText("capabilities", { exact: true }).first().click();
-  await page.waitForTimeout(500);
   await page.getByText("장바구니", { exact: true }).first().click();
-  await page.waitForTimeout(1200);
+  // The document is open when the address says so — the state the rename then moves.
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get("slug"), { timeout: 20_000 })
+    .toBe("capabilities/cart");
 
   await page.keyboard.press("Meta+k");
-  await page.waitForTimeout(600);
+  const palette = page.getByRole("dialog").filter({ has: page.locator('input[type="text"]') }).first();
+  await expect(palette, "팔레트가 안 열렸다").toBeVisible();
   await page.keyboard.type("삭제");
-  await page.waitForTimeout(600);
+  // Enter takes the **active** row, so the condition is that the active row is the
+  // command we typed for — not that 600 ms of this machine has gone by.
+  await expect(palette.locator('[role="option"][aria-selected="true"]')).toContainText("삭제");
   await page.keyboard.press("Enter");
 
   const banner = page.getByText(/못 찾았어요/);

--- a/tests/e2e/download-gateway-grid.spec.ts
+++ b/tests/e2e/download-gateway-grid.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForAnimationsDone, waitForBoxStill, waitFrames } from "./settle";
 
 /**
  * **The gateway's grid is one grid** — width is the independent variable, so
@@ -554,7 +555,8 @@ test.describe("the headline types only its own sentence (council, 2026-09-03)", 
           };
         }),
       );
-      await page.waitForTimeout(60);
+      // A sampling interval across the typing, counted in drawn frames.
+      await waitFrames(page, 4);
     }
     const typing = samples.filter((s) => s.typed > 0);
     expect(typing.length, "typing was observed").toBeGreaterThanOrEqual(6);
@@ -580,10 +582,15 @@ test.describe("the headline types only its own sentence (council, 2026-09-03)", 
           .map((a) => a.getAttribute("data-testid")),
       );
     await page.goto("/en/download/", { waitUntil: "load" });
-    await page.waitForTimeout(1500);
-    expect(await visibleChangelogLinks()).toEqual(["gateway-facts-changelog"]);
+    // The list of links **is** the condition, so it is polled rather than slept in front of.
+    await expect.poll(visibleChangelogLinks, { timeout: 20_000 }).toEqual(["gateway-facts-changelog"]);
     await page.goto("/en/guide/", { waitUntil: "load" });
-    await page.waitForTimeout(800);
+    await expect
+      .poll(visibleChangelogLinks, {
+        timeout: 20_000,
+        message: "the chrome keeps the chip off the gateway face",
+      })
+      .toContain("gateway-nav-changelog");
     const onGuide = await visibleChangelogLinks();
     expect(onGuide, "the chrome keeps the chip off the gateway face").toContain("gateway-nav-changelog");
   });
@@ -617,8 +624,21 @@ test.describe("the decision block reads over the stage at every split width", ()
         );
       }
       await page.evaluate(() => document.fonts.ready);
-      /* The echo lights the last dot with the last character (~2.5s); measure the settled stage. */
-      await page.waitForTimeout(3200);
+      /*
+       * What this case measures is **layout and ink**: the destinations' rows, the stage's
+       * width, and the share of lit canvas pixels under the type. So the condition is the
+       * first screen having laid out and the stage having stopped animating.
+       *
+       * ⚠️ **Not "the headline finished typing"**, which was tried first and is the wrong
+       * condition twice over. The un-typed glyphs already occupy their layout, so the h1's
+       * box — the thing `litShare` reads — is complete from the first frame. And on this
+       * headless browser's software WebGL the typing interval is starved badly enough that
+       * 59 characters take about 25 s (measured 2026-09-13 at 1100px with `?hero=three`:
+       * 1, 3, 6, 8, 10, 12 lit after each of the first six seconds), so the old 3,200 ms
+       * had never waited for the end of the typing either.
+       */
+      await waitForBoxStill(page.locator('[data-testid="gateway-hero"]'));
+      await waitForAnimationsDone(page.locator('[data-testid="gateway-hero-object"]'));
       const m = await page.evaluate(() => {
         const stage = document.querySelector('[data-testid="gateway-hero-object"]')!.getBoundingClientRect();
         const canvas = document.querySelector<HTMLCanvasElement>('[data-testid="gateway-hero-object"] canvas')!;

--- a/tests/e2e/gateway-idle-sleep.spec.ts
+++ b/tests/e2e/gateway-idle-sleep.spec.ts
@@ -71,8 +71,17 @@ test("관문은 무입력이 이어지면 프레임 일을 그만두고, 입력 
   // input, so the sleep clock starts here.
   await page.mouse.move(4, 4);
 
-  // ① While awake, the electric field and dome really work. Without this floor the
-  //    sleep assertion below would also be green on a page that draws nothing.
+  /*
+   * ① While awake, the electric field and dome really work. Without this floor the
+   *    sleep assertion below would also be green on a page that draws nothing.
+   *
+   * ⚠️ **These three waits stay in milliseconds on purpose** (2026-09-13 sweep of the
+   * fixed sleeps that gate an assertion). They are not waiting for a settle: the
+   * subject of every claim here is elapsed real time against the gateway's own sleep
+   * delay (30 s) and ramp (2 s), and `idleCost` measures CPU per second over a window.
+   * A condition wait would have nothing to wait for — the page's whole promise is that
+   * it *stops* doing anything after a fixed stretch of no input.
+   */
   await page.waitForTimeout(6_000);
   const awake = await idleCost(4_000);
   expect(awake.frames).toBeGreaterThan(20);

--- a/tests/e2e/hangul-tracking.spec.ts
+++ b/tests/e2e/hangul-tracking.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import { AUDITED_ROUTES } from './audited-routes';
 import { seedFirstRunSeen } from './first-run-seed';
+import { waitForAnimationsDone } from "./settle";
 
 /**
  * **Caps tracking is a Latin device** (owner, 2026-09-06, of the installed app in Korean):
@@ -92,7 +93,13 @@ for (const route of KOREAN_ROUTES) {
     if (localised) {
       await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe('ko');
     }
-    await page.waitForTimeout(400);
+    /*
+     * Letter spacing is measured off the settled type, so the wait is for the fonts to
+     * be in and for nothing to still be animating — both states the page reports, where
+     * 400 ms was a guess that a web font would have swapped in by then.
+     */
+    await page.evaluate(() => document.fonts.ready);
+    await waitForAnimationsDone(page.locator("body"));
     const offenders = await trackedHangul(page, MAX_HANGUL_TRACKING_PX, HANGUL_SOURCE);
     expect(
       offenders,

--- a/tests/e2e/library-graph-alive.spec.ts
+++ b/tests/e2e/library-graph-alive.spec.ts
@@ -3,6 +3,25 @@ import { expect, test, type Page } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
 import type { LibraryGraphProbeNode as ProbeNode } from "./library-graph-probe";
 import { stubDirectoryPicker } from "./vault-picker-stub";
+import { waitFrames as frames } from "./settle";
+
+/**
+ * A cheap hash of the whole canvas, so two frames can be compared exactly. Reading
+ * pixels asks nothing of `requestAnimationFrame`, which matters in the case that
+ * counts those calls.
+ */
+const canvasHash = (page: import("@playwright/test").Page) =>
+  page.evaluate(() => {
+    const element = document.querySelector<HTMLCanvasElement>('[data-testid="library-graph-canvas"]')!;
+    const { data } = element.getContext("2d")!.getImageData(0, 0, element.width, element.height);
+    let hash = 2166136261;
+    for (let index = 0; index < data.length; index += 97) {
+      hash ^= data[index]!;
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16);
+  });
+
 
 /**
  * **The library graph is alive** — the five claims only a running browser can settle.
@@ -164,7 +183,9 @@ test.describe("the library graph responds", () => {
     // teleport, and the pointer state machine is entitled to read it as one.
     for (let step = 1; step <= 8; step += 1) {
       await page.mouse.move(box.x + target.x + step * 16, box.y + target.y + step * 10);
-      await page.waitForTimeout(24);
+      // One drawn frame between steps. A drag is delivered in frames; 24 ms was this
+      // machine's guess at one and a half of them.
+      await frames(page, 1);
     }
 
     // ⚠️ The assertion that makes every other one in this case mean anything: the gesture
@@ -232,9 +253,15 @@ test.describe("the library graph responds", () => {
     await page.mouse.move(box.x + target.x, box.y + target.y);
     await page.mouse.move(box.x + target.x + 1, box.y + target.y);
     await expect(canvas).toHaveAttribute("data-hovered-node-id", target.id);
-    // The dim ramps over `--motion-fast`; a frame or two is enough for it to finish.
-    await page.waitForTimeout(300);
-
+    /*
+     * The dim ramps over `--motion-fast`. The assertion **is** the condition — the
+     * outsider's ink is below 60% of its resting value — so it is polled rather than
+     * slept in front of: no ramp budget is read or guessed here, and a slow machine
+     * simply takes more frames to reach the same ink.
+     */
+    await expect
+      .poll(() => inkAt(outsider), { message: "the dim never reached the outsider" })
+      .toBeLessThan(restingOutsider * 0.6);
     const dimmedOutsider = await inkAt(outsider);
     const heldTarget = await inkAt(target);
     // Down to about 35%, so anything at or below 60% of its resting ink is the dim rather
@@ -263,7 +290,7 @@ test.describe("the library graph responds", () => {
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     for (let notch = 0; notch < 4; notch += 1) {
       await page.mouse.wheel(0, 120);
-      await page.waitForTimeout(60);
+      await frames(page, 1);
     }
     await expect.poll(async () => Number(await canvas.getAttribute("data-view-scale"))).toBeLessThan(fitted * 0.85);
 
@@ -321,13 +348,45 @@ test.describe("the library graph responds", () => {
      * to say stops asking for frames* — and the wait is now past the one thing that has
      * something to say. `library-graph-card.spec.ts` owns the other half: that the breath
      * is bounded rather than a loop.
+     *
+     * ⚠️ **Watched, not timed.** Three seconds was the sum of two budgets nobody here can
+     * read. The condition is the picture itself: four samples in a row drawing the same
+     * bytes is the breath having let go, and it is **not** the claim below — a loop that
+     * keeps asking for frames to redraw the same picture still fails the count, which is
+     * the other half of what this case owns.
+     *
+     * `alpha() < 0.01` alone was tried and is not enough: the simulation goes cold while
+     * the amber breath is still painting, and this fixture has stale citations in it
+     * (measured 2026-09-13 — 224 frames over the window that followed).
+     *
+     * ⚠️ `waitFrames` must not be used from here on: this case has replaced
+     * `requestAnimationFrame` with a counting wrapper, so a frame wait would be counted
+     * as the canvas asking for one.
      */
-    await page.waitForTimeout(3_000);
+    let previousFrame: string | null = null;
+    let repeats = 0;
+    await expect
+      .poll(
+        async () => {
+          const drawn = await canvasHash(page);
+          repeats = previousFrame !== null && drawn === previousFrame ? repeats + 1 : 0;
+          previousFrame = drawn;
+          return repeats >= 3;
+        },
+        { timeout: 25_000, message: "the picture never stopped changing, so it is not settled at all" },
+      )
+      .toBe(true);
 
     const readFrames = () =>
       page.evaluate(() => (window as unknown as { __rafCount: { frames: number } }).__rafCount.frames);
     const idleFrom = await readFrames();
     const restingPositions = await nodes(page);
+    /*
+     * A **measurement window**, not a wait: the claim is that no frame is asked for over a
+     * stretch of real time, so the stretch has to pass. It stays in milliseconds because
+     * this case has replaced `requestAnimationFrame` with a counting wrapper, and any
+     * frame-based wait would be counted as the canvas asking for one.
+     */
     await page.waitForTimeout(3_000);
     expect(
       (await readFrames()) - idleFrom,
@@ -349,13 +408,12 @@ test.describe("the library graph responds", () => {
     // reported, then a hold: neither may move anything.
     const target = restingPositions.sort((first, second) => second.radius - first.radius)[0]!;
     await page.mouse.move(box.x + 4, box.y + 4);
-    await page.waitForTimeout(400);
+    await expect(canvas, "the pointer never left the marks").toHaveAttribute("data-hovered-node-id", "");
     const beforeHover = await nodes(page);
     for (let step = 1; step <= 12; step += 1) {
       await page.mouse.move(box.x + (target.x * step) / 12, box.y + (target.y * step) / 12);
-      await page.waitForTimeout(30);
     }
-    await page.waitForTimeout(600);
+    // The attribute assertion retries on its own, so the sweep needs nothing in front of it.
     await expect(canvas).toHaveAttribute("data-hovered-node-id", target.id);
     expect(travelled(beforeHover, await nodes(page)), "hover moved a mark").toBe(0);
   });
@@ -376,18 +434,7 @@ test.describe("the library graph responds", () => {
         await page.evaluate(() => matchMedia("(prefers-reduced-motion: reduce)").matches),
         "the reduced-motion emulation did not survive the navigation",
       ).toBe(true);
-      /** A cheap hash of the whole canvas, so two frames can be compared exactly. */
-      const frameHash = () =>
-        page.evaluate(() => {
-          const element = document.querySelector<HTMLCanvasElement>('[data-testid="library-graph-canvas"]')!;
-          const { data } = element.getContext("2d")!.getImageData(0, 0, element.width, element.height);
-          let hash = 2166136261;
-          for (let index = 0; index < data.length; index += 97) {
-            hash ^= data[index]!;
-            hash = Math.imul(hash, 16777619);
-          }
-          return (hash >>> 0).toString(16);
-        });
+      const frameHash = () => canvasHash(page);
 
       /*
        * ⚠️ **The pointer leaves the canvas first, and that is the whole of "at rest."**
@@ -405,10 +452,25 @@ test.describe("the library graph responds", () => {
        */
       await page.mouse.move(0, 0);
       await expect(page.getByTestId("library-graph-canvas")).toHaveAttribute("data-hovered-node-id", "");
-      await page.waitForTimeout(300);
+      /*
+       * Let the ink ramp finish by watching it finish: two identical frames mean the
+       * picture has stopped changing, which is what "one ramp's worth of time" was
+       * standing in for.
+       */
+      await expect
+        .poll(
+          async () => {
+            const sample = await frameHash();
+            await frames(page, 2);
+            return (await frameHash()) === sample;
+          },
+          { timeout: 20_000, message: "the picture never stopped changing" },
+        )
+        .toBe(true);
 
       const first = await frameHash();
-      // Longer than one ambient period would have moved a mark by its full amplitude.
+      // A **measurement window**: the claim is that nothing drifts over a stretch longer
+      // than one ambient period, so the stretch has to pass.
       await page.waitForTimeout(2_000);
       const second = await frameHash();
       await page.waitForTimeout(2_000);

--- a/tests/e2e/library-graph-card.spec.ts
+++ b/tests/e2e/library-graph-card.spec.ts
@@ -3,6 +3,7 @@ import { expect, test, type Page } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
 import type { LibraryGraphProbeNode as ProbeNode } from "./library-graph-probe";
 import { stubDirectoryPicker } from "./vault-picker-stub";
+import { waitFrames } from "./settle";
 
 /**
  * **A press on a mark opens a card beside it — the claims only a browser can settle.**
@@ -117,9 +118,17 @@ async function openGraph(page: Page): Promise<void> {
   await expect
     .poll(async () => page.evaluate(() => window.__atlasLibraryGraph?.alpha() ?? 1), { timeout: 20_000 })
     .toBeLessThan(0.01);
-  // The home's single stale breath runs once the picture settles; let it finish so what
-  // moves next moved because of the press.
-  await page.waitForTimeout(2_200);
+  /*
+   * The home's single stale breath runs once the picture settles; let it finish so what
+   * moves next moved because of the press. The breath clears its own timestamp and
+   * `flow().pulsing` reports it, so this asks the canvas rather than budgeting for it.
+   */
+  await expect
+    .poll(async () => page.evaluate(() => window.__atlasLibraryGraph?.flow().pulsing ?? true), {
+      timeout: 20_000,
+      message: "the arrival breath never let go",
+    })
+    .toBe(false);
 }
 
 const marks = (page: Page): Promise<ProbeNode[]> =>
@@ -357,14 +366,21 @@ test.describe("a press on a mark opens a card beside it", () => {
     const read = () =>
       page.evaluate(() => (window as unknown as { __rafCount: { frames: number } }).__rafCount.frames);
 
-    // The breath is armed the frame the picture settles and lasts two settle budgets.
+    // A **measurement window**, not a wait: the claim is that the breath asks for frames
+    // while it runs, so some of its run has to pass before the count means anything.
     const duringFrom = await read();
     await page.waitForTimeout(900);
     const during = (await read()) - duringFrom;
     expect(during, "the arrival breath asked for no frames at all").toBeGreaterThan(5);
 
-    // Then it clears its own timestamp, and the canvas stops.
-    await page.waitForTimeout(2_600);
+    // Then it clears its own timestamp, and the canvas stops. The timestamp is the
+    // condition; 2.6 s was an estimate of when it would be gone.
+    await expect
+      .poll(async () => page.evaluate(() => window.__atlasLibraryGraph?.flow().pulsing ?? true), {
+        timeout: 20_000,
+        message: "the breath never let go",
+      })
+      .toBe(false);
     const quietFrom = await read();
     await page.waitForTimeout(2_000);
     expect((await read()) - quietFrom, "the breath became a loop").toBe(0);
@@ -433,8 +449,20 @@ test.describe("with reduced motion", () => {
     const target = all.find((node) => node.kind === "page" && node.label === "Settlement")!;
     await pressMark(page, target);
     await expect(page.getByTestId("library-graph-card")).toBeVisible();
-    // Past the ink ramp, which reduced motion keeps at 120ms by decision (2026-09-12).
-    await page.waitForTimeout(260);
+    /*
+     * Past the ink ramp, which reduced motion keeps at 120 ms by decision (2026-09-12) —
+     * seen rather than budgeted for: two identical frames are the ramp having finished.
+     */
+    await expect
+      .poll(
+        async () => {
+          const sample = await hash();
+          await waitFrames(page, 2);
+          return (await hash()) === sample;
+        },
+        { timeout: 20_000, message: "the ink ramp never finished" },
+      )
+      .toBe(true);
 
     /*
      * The static equivalent is a chevron on each citation and a full amber dot in each

--- a/tests/e2e/library-graph-card.spec.ts
+++ b/tests/e2e/library-graph-card.spec.ts
@@ -382,6 +382,8 @@ test.describe("a press on a mark opens a card beside it", () => {
       })
       .toBe(false);
     const quietFrom = await read();
+    // A **measurement window**, not a wait: "the breath became a loop" is a claim about a
+    // stretch of real time with no frame asked for, so the stretch has to pass.
     await page.waitForTimeout(2_000);
     expect((await read()) - quietFrom, "the breath became a loop").toBe(0);
   });
@@ -396,6 +398,8 @@ test.describe("a press on a mark opens a card beside it", () => {
     await expect(page.getByTestId("library-graph-card")).toBeVisible();
 
     await page.evaluate(() => window.__atlasLibraryGraph!.paint().reset());
+    // A **measurement window**: the budget is per painted frame, so some have to be
+    // painted before the mean and the worst mean anything.
     await page.waitForTimeout(1_000);
     const paint = await page.evaluate(() => {
       const { last, mean, worst, frames } = window.__atlasLibraryGraph!.paint();
@@ -438,6 +442,8 @@ test.describe("with reduced motion", () => {
       .poll(
         async () => {
           const first = await hash();
+          // The gap between the two samples of a stability poll, not a gate: the poll
+          // returns the moment two frames agree.
           await page.waitForTimeout(260);
           return (await hash()) === first;
         },
@@ -469,6 +475,8 @@ test.describe("with reduced motion", () => {
      * break — one paint, nothing travelling. So three frames a third of a second apart are
      * the same bytes, which is the 2026-09-08 stillness promise holding with a card open.
      */
+    // Three **measurement** samples a third of a second apart: the claim is about a
+    // stretch of real time in which nothing may change.
     const first = await hash();
     await page.waitForTimeout(320);
     const second = await hash();

--- a/tests/e2e/library-graph-picture.spec.ts
+++ b/tests/e2e/library-graph-picture.spec.ts
@@ -9,6 +9,7 @@ import type {
   LibraryGraphProbeNode as ProbeNode,
 } from "./library-graph-probe";
 import { stubDirectoryPicker } from "./vault-picker-stub";
+import { waitFrames } from "./settle";
 
 /**
  * **Is the picture legible — at six documents, at sixty, and at three hundred?**
@@ -320,8 +321,9 @@ async function openGraph(page: Page, seed: Record<string, string>): Promise<void
   await expect
     .poll(async () => page.evaluate(() => window.__atlasLibraryGraph?.alpha() ?? 1), { timeout: 20_000 })
     .toBeLessThan(0.01);
-  // One more frame after the settle, so `labels()` holds the resting placement.
-  await page.waitForTimeout(120);
+  // One more frame after the settle, so `labels()` holds the resting placement. A frame
+  // is the unit; 120 ms was this machine's estimate of one.
+  await waitFrames(page, 2);
 }
 
 interface Box {

--- a/tests/e2e/library-work-activity.spec.ts
+++ b/tests/e2e/library-work-activity.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { openLibraryWorkScenario } from "./library-work-harness";
+import { waitFrames } from "./settle";
 
 interface PaintWindow extends Window {
   __libraryPaintCount?: number;
@@ -49,7 +50,14 @@ test.describe("Library live work activity", () => {
     await page.getByTestId("library-graph-card-open").click();
     await expect(canvas).toHaveCount(0);
     const hiddenPaints = await page.evaluate(() => (window as unknown as PaintWindow).__libraryPaintCount ?? 0);
-    await page.waitForTimeout(500);
+    /*
+     * The claim is an **absence** — a hidden canvas paints nothing — so something has to
+     * pass before the count means anything. Thirty drawn frames is that something, and it
+     * is the unit the claim is about: a painting canvas would have painted on each of
+     * them, and a slow machine spends longer over the same thirty rather than being asked
+     * a weaker question.
+     */
+    await waitFrames(page, 30);
     expect(await page.evaluate(() => (window as unknown as PaintWindow).__libraryPaintCount ?? 0)).toBe(hiddenPaints);
     // The way back to the picture is the reader's own close control.
     await page.getByTestId("library-reader-back").click();

--- a/tests/e2e/map-3d-cone-drawing.spec.ts
+++ b/tests/e2e/map-3d-cone-drawing.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
+import { waitForDomeEntered, waitForMapStill, waitFrames } from "./settle";
 
 import { seedFirstRunSeen } from "./first-run-seed";
+
+
 
 /**
  * **The Cone view's drawing, measured on the real vault** (2026-09-05, owner
@@ -93,9 +96,11 @@ async function openCone(page: Page, width: number, height: number) {
   });
   await page.goto("/en/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  // Past the assembly (≈1.1s) and the entry sweep (1.5s): while either is alive
-  // the drawn pose keeps moving and the fit is still in flight.
-  await page.waitForTimeout(6000);
+  // Past the assembly and the entry sweep: while either is alive the drawn pose
+  // keeps moving and the fit is still in flight. Both clocks belong to the dome,
+  // so it is asked whether it has arrived rather than given six seconds to.
+  await waitForDomeEntered(page);
+  await waitForMapStill(page, { what: "camera" });
 }
 
 async function readCone(page: Page) {
@@ -300,15 +305,10 @@ for (const screen of SCREENS) {
  * draw order exist to show it — and to nothing else.
  */
 async function settleConeCamera(page: Page) {
-  let previous: string | null = null;
-  for (let i = 0; i < 40; i += 1) {
-    const camera = await page.evaluate(() =>
-      JSON.stringify((window as unknown as { __atlasMap: { camera: () => unknown } }).__atlasMap.camera()),
-    );
-    if (camera === previous) return;
-    previous = camera;
-    await page.waitForTimeout(150);
-  }
+  // Stillness judged in the page, on drawn frames: two samples 150 ms apart from
+  // the test process could both land inside one slow step and call a moving camera
+  // settled, and on a fast machine they threw 150 ms away per sample.
+  await waitForMapStill(page, { what: "camera" });
 }
 
 type ConeDrawnNode = { id: string; label: string; x: number; y: number; radius: number; hidden: boolean };
@@ -406,7 +406,16 @@ for (const screen of [SCREENS[0], SCREENS[3]]) {
       if (i > 0) {
         const spare = await coneEmptyPoint(page);
         await page.mouse.click(canvas.x + spare.x, canvas.y + spare.y);
-        await page.waitForTimeout(400);
+        /*
+         * ⚠️ **This click does not deselect, and the sleep it replaced never waited
+         * for one either** (measured 2026-09-13). Inside the dome an empty-ground
+         * press is an orbit grab, not a deselect (`map-3d-grip.spec.ts`), so the
+         * selection survives it — polling for a cleared selection here sat for the
+         * full timeout holding `capability:carrier-integration`. What the click
+         * does do is end the ego dim and the tier reveal, and it does that inside
+         * the pointer handler, so the next drawn frames already carry it.
+         */
+        await waitFrames(page, 3);
       }
       await settleConeCamera(page);
       const drawn = await coneDrawnNodes(page);
@@ -420,7 +429,14 @@ for (const screen of [SCREENS[0], SCREENS[3]]) {
         );
       const offset = clear(wanted[i]) ? wanted[i] : 0;
       await page.mouse.click(canvas.x + node!.x + offset, canvas.y + node!.y);
-      await page.waitForTimeout(500);
+      /*
+       * The hit test runs inside the pointer handler, so the selection this click
+       * produced — including the miss this case exists to catch — is already
+       * decided by the next frames. Polling for a *correct* selection instead would
+       * turn every miss into a timeout and throw away the message below, which
+       * names what was hit.
+       */
+      await waitFrames(page, 3);
       const selection = await page.evaluate(
         () =>
           (

--- a/tests/e2e/map-3d-grip.spec.ts
+++ b/tests/e2e/map-3d-grip.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForDomeEntered, waitForMapStill, waitFrames } from "./settle";
 
 /**
  * **The 3D grip — inside the dome rotates, outside it pans** (2026-08-18, ledger
@@ -100,10 +101,11 @@ test("3D — 돔 안을 끌면 돌고, 돔 밖 검은 자리를 끌면 지도가
   });
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  // Measure after assembly (≈1.1s) and the entry sweep (1.5s) finish — while the
-  // sweep is alive the drawn attitude keeps moving and cannot be told apart from what
-  // the drag changed.
-  await page.waitForTimeout(4000);
+  // Measure after assembly and the entry sweep both finish — while the sweep is
+  // alive the drawn attitude keeps moving and cannot be told apart from what the
+  // drag changed. Both have clocks the dome advances itself, so the dome is asked
+  // whether it has arrived rather than told how long that takes here.
+  await waitForDomeEntered(page);
 
   const box = await domeScreenBox(page);
   expect(box, "3D 노드를 하나도 못 읽었다 — 계기가 공회전하고 있다").not.toBeNull();
@@ -123,10 +125,13 @@ test("3D — 돔 안을 끌면 돌고, 돔 밖 검은 자리를 끌면 지도가
   await page.mouse.down();
   for (let i = 1; i <= 8; i += 1) {
     await page.mouse.move(outsideX + i * 14, outsideY + i * 9);
-    await page.waitForTimeout(16);
+    // One drawn frame between moves: a drag is delivered in frames, and 16 ms is
+    // this machine's guess at one.
+    await waitFrames(page, 1);
   }
   await page.mouse.up();
-  await page.waitForTimeout(400);
+  // The release hands the pan to its inertia; read where it comes to rest.
+  await waitForMapStill(page, { what: "camera" });
   const after1 = await readPose(page);
   expect(after1).not.toBeNull();
 
@@ -140,7 +145,6 @@ test("3D — 돔 안을 끌면 돌고, 돔 밖 검은 자리를 끌면 지도가
   ).toBeLessThan(0.02);
 
   /* ── ② Drag inside the dome = orbit rotation ───────────────────────────── */
-  await page.waitForTimeout(600);
   /*
    * **Re-measure the dome's position.** ① moved the map, so an "inside" coordinate
    * computed before it may now be outside — which is exactly why the first version
@@ -157,10 +161,16 @@ test("3D — 돔 안을 끌면 돌고, 돔 밖 검은 자리를 끌면 지도가
   await page.mouse.down();
   for (let i = 1; i <= 8; i += 1) {
     await page.mouse.move(insideX2 + i * 14, insideY2);
-    await page.waitForTimeout(16);
+    await waitFrames(page, 1);
   }
   await page.mouse.up();
-  await page.waitForTimeout(60);
+  /*
+   * The orbit keeps closing its remaining gap after velocity reaches zero
+   * (`yawSnap`), and the hand that just dragged disarmed the auto-spin, so the pose
+   * really does come to rest. Waiting for that rest reads the landing rather than
+   * whatever 60 ms of this machine happened to reach.
+   */
+  await waitForMapStill(page, { what: "dome" });
   const after2 = await readPose(page);
 
   expect(
@@ -182,7 +192,7 @@ test("3D — 커서가 두 구역을 말한다 (돔 위 grab · 바깥 move)", a
   });
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  await page.waitForTimeout(4000);
+  await waitForDomeEntered(page);
 
   const box = await domeScreenBox(page);
   expect(box, "3D 노드를 하나도 못 읽었다 — 계기가 공회전하고 있다").not.toBeNull();
@@ -200,8 +210,7 @@ test("3D — 커서가 두 구역을 말한다 (돔 위 grab · 바깥 move)", a
   const outsideX = Math.max(b.left + 8, b.left + b.minX - 160);
   const outsideY = Math.max(b.top + 8, b.top + b.minY - 120);
   await page.mouse.move(outsideX, outsideY);
-  await page.waitForTimeout(200);
-  expect(await cursor(), "돔 바깥에서 «옮길 수 있다»는 표시가 없다").toBe("move");
+  await expect.poll(cursor, { message: "돔 바깥에서 «옮길 수 있다»는 표시가 없다" }).toBe("move");
 
   // Pick empty space between the rings, avoiding node discs — over a node the node's
   // cursor wins (a separate contract; measuring it here blurs what is being
@@ -231,6 +240,5 @@ test("3D — 커서가 두 구역을 말한다 (돔 위 grab · 바깥 move)", a
   });
   expect(gap, "돔 안에서 노드와 겹치지 않는 빈 자리를 못 찾았다").not.toBeNull();
   await page.mouse.move(gap!.px, gap!.py);
-  await page.waitForTimeout(200);
-  expect(await cursor(), "돔 위에서 «잡아 돌릴 수 있다»는 표시가 없다").toBe("grab");
+  await expect.poll(cursor, { message: "돔 위에서 «잡아 돌릴 수 있다»는 표시가 없다" }).toBe("grab");
 });

--- a/tests/e2e/map-3d-relation-ink.spec.ts
+++ b/tests/e2e/map-3d-relation-ink.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { waitForDomeEntered, waitForMapStill } from "./settle";
 
 import { seedFirstRunSeen } from "./first-run-seed";
 
@@ -108,8 +109,11 @@ async function open3d(page: Page, arrangement: string) {
   }, arrangement);
   await page.goto("/en/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  // Past the assembly (≈1.1s) and the entry sweep (1.5s).
-  await page.waitForTimeout(6000);
+  // Past the assembly and the entry sweep: while either is alive the drawn pose
+  // keeps moving and the fit is still in flight. Both clocks belong to the dome,
+  // so it is asked whether it has arrived rather than given six seconds to.
+  await waitForDomeEntered(page);
+  await waitForMapStill(page, { what: "camera" });
 }
 
 /**

--- a/tests/e2e/map-3d-return.spec.ts
+++ b/tests/e2e/map-3d-return.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForDomeAssembled, waitForFlatMap, waitForMapStill, waitFrames } from "./settle";
 
 /**
  * **Coming back from 3D leaves the 2D map alone** (owner report, 2026-09-07).
@@ -32,16 +33,16 @@ test("2D → 3D → 2D leaves no trail and no expansion behind", async ({ page }
   await page.setViewportSize({ width: 1512, height: 917 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
   await expect(trailChip(page), "출발선에 자취가 있으면 안 된다").toHaveCount(0);
 
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-strata").click();
-  await page.waitForTimeout(4000);
+  await waitForDomeAssembled(page);
 
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-flat").click();
-  await page.waitForTimeout(3000);
+  await waitForFlatMap(page);
 
   await expect(trailChip(page), "3D 를 다녀왔다고 걸어온 길이 생기지 않는다").toHaveCount(0);
   expect(new URL(page.url()).searchParams.get("open"), "3D 왕복이 2D 펼침을 만들지 않는다").toBeNull();
@@ -52,11 +53,11 @@ test("the press that dismisses the 3D picker does not also walk the map", async 
   await page.setViewportSize({ width: 1512, height: 917 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-ownership").click();
-  await page.waitForTimeout(5000);
+  await waitForDomeAssembled(page);
 
   // The chip closes its own picker — without this the reader has no way out but the map.
   await openPicker(page);
@@ -76,15 +77,29 @@ test("the press that dismisses the 3D picker does not also walk the map", async 
   });
   expect(target, "3D 에서 역량 노드를 못 찾았다 — 공회전").not.toBeNull();
   await page.mouse.click(target!.px, target!.py);
-  await page.waitForTimeout(1500);
   await expect(page.getByTestId("topology-view-3d-menu"), "그 누름은 피커를 닫는다").toHaveCount(0);
+  /*
+   * The two claims below are **absences**, and an absence proven by sleeping only
+   * proves the sleep was long enough. The picker closing above is the positive
+   * marker that the press was handled; a walk would have been recorded by the same
+   * press, so the next drawn frames are where it would already show.
+   */
+  await waitFrames(page, 3);
+  expect(
+    await page.evaluate(
+      () =>
+        (window as unknown as { __atlasMap: { selection: () => { nodeId: string | null } } }).__atlasMap.selection()
+          .nodeId,
+    ),
+    "피커를 치우는 누름이 노드를 고르지 않는다",
+  ).toBeNull();
   await expect(trailChip(page), "피커를 치우는 누름이 노드를 밟지 않는다").toHaveCount(0);
   expect(new URL(page.url()).searchParams.get("p"), "피커를 치우는 누름이 선택을 만들지 않는다").toBeNull();
 
   // Back to flat: still nothing left behind.
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-flat").click();
-  await page.waitForTimeout(3000);
+  await waitForFlatMap(page);
   await expect(trailChip(page)).toHaveCount(0);
   expect(new URL(page.url()).searchParams.get("open")).toBeNull();
 });
@@ -94,11 +109,11 @@ test("a deliberate node click in 3D does survive the return to 2D", async ({ pag
   await page.setViewportSize({ width: 1512, height: 917 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-ownership").click();
-  await page.waitForTimeout(5000);
+  await waitForDomeAssembled(page);
 
   const target = await page.evaluate(() => {
     const m = (window as unknown as { __atlasMap: { nodes: () => Array<{ id: string; hidden: boolean; x: number; y: number }> } }).__atlasMap;
@@ -108,12 +123,16 @@ test("a deliberate node click in 3D does survive the return to 2D", async ({ pag
   });
   expect(target).not.toBeNull();
   await page.mouse.click(target!.px, target!.py);
-  await page.waitForTimeout(2000);
-  expect(new URL(page.url()).searchParams.get("p"), "일부러 누른 노드는 선택된다").toBe(target!.id);
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get("p"), {
+      timeout: 15_000,
+      message: "일부러 누른 노드는 선택된다",
+    })
+    .toBe(target!.id);
 
   await openPicker(page);
   await page.getByTestId("topology-view-3d-choice-flat").click();
-  await page.waitForTimeout(3000);
+  await waitForFlatMap(page);
   // A walk the reader really took is theirs to keep; only what they never asked
   // for is dropped.
   await expect(trailChip(page), "일부러 걸은 자취는 남는다").toHaveCount(1);

--- a/tests/e2e/map-3d-strata-drawing.spec.ts
+++ b/tests/e2e/map-3d-strata-drawing.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
+import { waitForDomeEntered, waitForMapStill, waitFrames } from "./settle";
 
 import { seedFirstRunSeen } from "./first-run-seed";
+
+
 
 /**
  * **The Strata view's drawing, measured on the real vault** (2026-09-06).
@@ -81,9 +84,11 @@ async function openStrata(page: Page, width: number, height: number) {
   });
   await page.goto("/en/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  // Past the assembly (≈1.1s) and the entry sweep (1.5s): while either is alive
-  // the drawn pose keeps moving and the fit is still in flight.
-  await page.waitForTimeout(6000);
+  // Past the assembly and the entry sweep: while either is alive the drawn pose
+  // keeps moving and the fit is still in flight. Both clocks belong to the dome,
+  // so it is asked whether it has arrived rather than given six seconds to.
+  await waitForDomeEntered(page);
+  await waitForMapStill(page, { what: "camera" });
 }
 
 async function readStrata(page: Page) {
@@ -269,15 +274,10 @@ for (const screen of SCREENS) {
  * 1512×982 and 123 of 125 at 1040×720, the rest to a disc that covered nothing.
  */
 async function settleCamera(page: Page) {
-  let previous: string | null = null;
-  for (let i = 0; i < 40; i += 1) {
-    const camera = await page.evaluate(() =>
-      JSON.stringify((window as unknown as { __atlasMap: { camera: () => unknown } }).__atlasMap.camera()),
-    );
-    if (camera === previous) return;
-    previous = camera;
-    await page.waitForTimeout(150);
-  }
+  // Stillness judged in the page, on drawn frames: two samples 150 ms apart from
+  // the test process could both land inside one slow step and call a moving camera
+  // settled, and on a fast machine they threw 150 ms away per sample.
+  await waitForMapStill(page, { what: "camera" });
 }
 
 type DrawnNode = { id: string; label: string; x: number; y: number; radius: number; hidden: boolean };
@@ -375,7 +375,16 @@ for (const screen of SCREENS) {
       if (i > 0) {
         const spare = await emptyPoint(page);
         await page.mouse.click(canvas.x + spare.x, canvas.y + spare.y);
-        await page.waitForTimeout(400);
+        /*
+         * ⚠️ **This click does not deselect, and the sleep it replaced never waited
+         * for one either** (measured 2026-09-13). Inside the dome an empty-ground
+         * press is an orbit grab, not a deselect (`map-3d-grip.spec.ts`), so the
+         * selection survives it — polling for a cleared selection here sat for the
+         * full timeout holding `capability:carrier-integration`. What the click
+         * does do is end the ego dim and the tier reveal, and it does that inside
+         * the pointer handler, so the next drawn frames already carry it.
+         */
+        await waitFrames(page, 3);
       }
       await settleCamera(page);
       const drawn = await drawnNodes(page);
@@ -389,7 +398,14 @@ for (const screen of SCREENS) {
         );
       const offset = clear(wanted[i]) ? wanted[i] : 0;
       await page.mouse.click(canvas.x + node!.x + offset, canvas.y + node!.y);
-      await page.waitForTimeout(500);
+      /*
+       * The hit test runs inside the pointer handler, so the selection this click
+       * produced — including the miss this case exists to catch — is already
+       * decided by the next frames. Polling for a *correct* selection instead would
+       * turn every miss into a timeout and throw away the message below, which
+       * names what was hit.
+       */
+      await waitFrames(page, 3);
       const selection = await page.evaluate(
         () =>
           (
@@ -512,7 +528,11 @@ test(`Strata ${legend.width}x${legend.height} — the tier legend names four pla
     return { x: box.x, y: box.y };
   });
   await page.mouse.click(canvasBox.x + target.x, canvasBox.y + target.y);
-  await page.waitForTimeout(900);
+  // The legend is measured against the docked inspector, so wait for the inspector
+  // to be there and for the reframe it causes to finish — not for 900 ms of this
+  // machine, which is either too little or wasted depending on the machine.
+  await expect(page.locator('[data-testid="map-detail-panel"]').first()).toBeVisible();
+  await waitForMapStill(page, { what: "camera" });
   const after = await read();
   expect(after.selectedPanel, "the inspector did not open, so this proves nothing").toBe(true);
   // The inspector owns this edge while it is docked, so the rail steps aside

--- a/tests/e2e/map-expand-all.spec.ts
+++ b/tests/e2e/map-expand-all.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapStill } from "./settle";
 
 /**
  * **Does "expand all" actually reveal the count it claims** (promoted from the
@@ -36,22 +37,9 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * position is where the next click will land.
  */
 async function settleLayout(page: import("@playwright/test").Page) {
-  const snapshot = () =>
-    page.evaluate(() => {
-      const m = (window as unknown as { __atlasMap?: { nodes: () => Array<{ id: string; x: number; y: number }> } })
-        .__atlasMap;
-      return m ? m.nodes().map((n) => `${n.id}:${Math.round(n.x)},${Math.round(n.y)}`).join("|") : "";
-    });
-  await expect
-    .poll(
-      async () => {
-        const before = await snapshot();
-        await page.waitForTimeout(250);
-        return before !== "" && before === (await snapshot());
-      },
-      { timeout: 30_000, message: "배치가 멈추지 않아 클릭 좌표를 믿을 수 없다" },
-    )
-    .toBe(true);
+  // Stillness judged in the page, on drawn frames, so the click coordinate taken next
+  // is the one the frame drew — not one read halfway through a 250 ms round trip.
+  await waitForMapStill(page);
 }
 
 test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다", async ({ page }) => {
@@ -60,7 +48,7 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   const nodePos = () =>
     page.evaluate(() => {
@@ -82,7 +70,14 @@ test("모두 펼치기는 주장한 수를 드러내고, 접기로 되돌린다"
   const first = await nodePos();
   expect(first, "주문 도메인을 지도에서 못 찾았다 — 이 스펙이 공회전한다").not.toBeNull();
   await page.mouse.click(first!.px, first!.py);
-  await page.waitForTimeout(1200);
+  // The chip the next lines read belongs to the node this click selected.
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __atlasMap: { selection: () => { nodeId: string | null } } }).__atlasMap.selection().nodeId), {
+      timeout: 15_000,
+      message: "주문 도메인이 선택되지 않았다",
+    })
+    .toBe("domain:order");
+  await waitForMapStill(page);
 
   const before = await visibleCount();
   const chipBefore = await orderChip();

--- a/tests/e2e/map-growth-replay.spec.ts
+++ b/tests/e2e/map-growth-replay.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapStill } from "./settle";
 
 /**
  * **Growth replay** (2026-09-02, `model/growth-replay.ts`; toggle semantics 2026-09-07).
@@ -15,6 +16,8 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * pointer movement and wheel-zoom must leave it running, the tile must wear the
  * active state (`aria-pressed`) while it does, and a second press must stop it.
  */
+type LastActive = { t: number; causes: string[] } | null;
+
 async function lastActiveCauses(page: import("@playwright/test").Page): Promise<string[]> {
   return page.evaluate(() => {
     const m = (window as unknown as { __atlasMap?: { idleDebug: () => { lastActive: { causes: string[] } | null } } }).__atlasMap;
@@ -22,36 +25,71 @@ async function lastActiveCauses(page: import("@playwright/test").Page): Promise<
   });
 }
 
+/** When the idle gate last recorded an awake frame, in the page's own clock. */
+async function lastActiveStamp(page: import("@playwright/test").Page): Promise<number> {
+  return page.evaluate(() => {
+    const m = (window as unknown as { __atlasMap?: { idleDebug: () => { lastActive: LastActive } } }).__atlasMap;
+    return m?.idleDebug().lastActive?.t ?? 0;
+  });
+}
+
+/**
+ * The activity names from a frame the gate recorded **after** `since`.
+ *
+ * This is what "the replay survived that input" needs and a sleep cannot give:
+ * polling for `growthReplaying` would pass on the value recorded *before* the
+ * input, so it would stay green against exactly the regression this spec exists
+ * for. Requiring a fresh stamp first means the answer comes from a frame that has
+ * already seen the pointer move — and the kill, when there is one, happens in the
+ * event handler, so one such frame is the whole condition.
+ */
+async function causesAfter(page: import("@playwright/test").Page, since: number): Promise<string[]> {
+  await page.waitForFunction(
+    (stamp) => {
+      const m = (window as unknown as { __atlasMap?: { idleDebug: () => { lastActive: LastActive } } }).__atlasMap;
+      const recorded = m?.idleDebug().lastActive;
+      return recorded !== null && recorded !== undefined && recorded.t > stamp;
+    },
+    since,
+    { polling: "raf", timeout: 15_000 },
+  );
+  return lastActiveCauses(page);
+}
+
 test("the play tile toggles the replay, survives pointer input, and stops on a second press", async ({ page }) => {
   test.setTimeout(120_000);
   await page.setViewportSize({ width: 1400, height: 860 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   const tile = page.locator('[data-testid="topology-replay-growth"]');
   await expect(tile).toBeVisible();
   await expect(tile, "쉬는 동안에는 눌린 상태가 아니다").toHaveAttribute("aria-pressed", "false");
 
   await tile.click();
-  await page.waitForTimeout(1200);
-  expect(await lastActiveCauses(page), "재생 중에는 유휴 게이트가 재생을 이름으로 부른다").toContain("growthReplaying");
+  await expect
+    .poll(() => lastActiveCauses(page), { message: "재생 중에는 유휴 게이트가 재생을 이름으로 부른다" })
+    .toContain("growthReplaying");
   await expect(tile, "재생 중에는 컨트롤이 눌린 상태다").toHaveAttribute("aria-pressed", "true");
 
   // Moving and wheel-zooming must NOT end it — this is the whole point of the toggle.
   const canvas = page.locator('[data-testid="ontology-map-canvas"]');
   const box = (await canvas.boundingBox())!;
+  const beforeInput = await lastActiveStamp(page);
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   await page.mouse.move(box.x + box.width / 2 + 40, box.y + box.height / 2 + 30);
   await page.mouse.wheel(0, -120);
-  await page.waitForTimeout(700);
-  expect(await lastActiveCauses(page), "마우스를 움직이고 휠을 굴려도 재생은 계속된다").toContain("growthReplaying");
+  expect(await causesAfter(page, beforeInput), "마우스를 움직이고 휠을 굴려도 재생은 계속된다").toContain(
+    "growthReplaying",
+  );
   await expect(tile, "움직였다고 눌린 상태가 풀리지 않는다").toHaveAttribute("aria-pressed", "true");
 
   // A second press stops it, and the control returns to rest.
   await tile.click();
-  await page.waitForTimeout(600);
-  expect(await lastActiveCauses(page), "두 번째 누름으로 재생이 끝난다").not.toContain("growthReplaying");
+  await expect
+    .poll(() => lastActiveCauses(page), { message: "두 번째 누름으로 재생이 끝난다" })
+    .not.toContain("growthReplaying");
   await expect(tile, "멈추면 컨트롤도 쉰다").toHaveAttribute("aria-pressed", "false");
 });
 
@@ -60,26 +98,24 @@ test("Escape and a press on the canvas each end a running replay", async ({ page
   await page.setViewportSize({ width: 1400, height: 860 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   const tile = page.locator('[data-testid="topology-replay-growth"]');
   await tile.click();
-  await page.waitForTimeout(1000);
-  expect(await lastActiveCauses(page)).toContain("growthReplaying");
+  await expect.poll(() => lastActiveCauses(page)).toContain("growthReplaying");
   await page.keyboard.press("Escape");
-  await page.waitForTimeout(600);
-  expect(await lastActiveCauses(page), "Esc 로 재생이 끝난다").not.toContain("growthReplaying");
+  await expect.poll(() => lastActiveCauses(page), { message: "Esc 로 재생이 끝난다" }).not.toContain("growthReplaying");
   await expect(tile).toHaveAttribute("aria-pressed", "false");
 
   // A press on the canvas is a deliberate "look at this instead" — including on
   // empty ground, which no selection callback would have reported.
   await tile.click();
-  await page.waitForTimeout(1000);
-  expect(await lastActiveCauses(page)).toContain("growthReplaying");
+  await expect.poll(() => lastActiveCauses(page)).toContain("growthReplaying");
   const canvas = page.locator('[data-testid="ontology-map-canvas"]');
   const box = (await canvas.boundingBox())!;
   await page.mouse.click(box.x + box.width - 60, box.y + box.height - 60);
-  await page.waitForTimeout(600);
-  expect(await lastActiveCauses(page), "캔버스를 누르면 재생이 끝난다").not.toContain("growthReplaying");
+  await expect
+    .poll(() => lastActiveCauses(page), { message: "캔버스를 누르면 재생이 끝난다" })
+    .not.toContain("growthReplaying");
   await expect(tile).toHaveAttribute("aria-pressed", "false");
 });

--- a/tests/e2e/map-hover-release.spec.ts
+++ b/tests/e2e/map-hover-release.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { seedFirstRunSeen } from "./first-run-seed";
 import type { AtlasMapProbe } from "./atlas-map-probe";
+import { waitForMapSettled } from "./settle";
 
 /**
  * **When the cursor leaves the canvas the map goes back to sleep** (measured defect,
@@ -55,7 +56,7 @@ test("커서가 캔버스를 벗어나면 지도가 프레임을 그만 그린�
 
   const canvas = page.getByTestId("ontology-map-canvas");
   await expect(canvas).toBeVisible();
-  await page.waitForTimeout(3000);
+  await waitForMapSettled(page);
 
   const box = await canvas.boundingBox();
   expect(box).not.toBeNull();
@@ -88,14 +89,13 @@ test("커서가 캔버스를 벗어나면 지도가 프레임을 그만 그린�
     }, ms);
 
   await page.mouse.move(box!.x + target!.x, box!.y + target!.y);
-  await page.waitForTimeout(400);
   // The conclusion only means something if the premise holds — pin down that the
   // hover actually took. (Without this line, "the hover never took" and "the gate
-  // closed" are the same green.)
-  const hovered = await page.evaluate(
-    () => (window as unknown as { __atlasMap?: AtlasMapProbe }).__atlasMap?.hover() ?? null,
-  );
-  expect(hovered).toBe(target!.id);
+  // closed" are the same green.) That is also the condition, so it is polled rather
+  // than slept in front of.
+  const hovered = () =>
+    page.evaluate(() => (window as unknown as { __atlasMap?: AtlasMapProbe }).__atlasMap?.hover() ?? null);
+  await expect.poll(hovered, { timeout: 15_000 }).toBe(target!.id);
 
   /*
    * Move in one step onto chrome layered **over** the canvas — the left nav rail.
@@ -115,8 +115,12 @@ test("커서가 캔버스를 벗어나면 지도가 프레임을 그만 그린�
   const railBox = await rail.boundingBox();
   expect(railBox).not.toBeNull();
   await page.mouse.move(railBox!.x + railBox!.width / 2, railBox!.y + railBox!.height / 2);
-  // The grace period (1,200ms) plus time for the ramp to decay.
-  await page.waitForTimeout(3500);
+  /*
+   * The hover has to be released and the canvas has to fall quiet again. The release
+   * is a state — `hover()` goes null — and the quiet is the idle gate's grace period
+   * elapsing with nothing to draw, which shows up as the picture no longer changing.
+   */
+  await expect.poll(hovered, { message: "레일로 나갔는데 호버가 안 풀렸다" }).toBeNull();
 
   // ① Was the highlight actually released — the cause side. A verdict with no timing noise.
   expect(
@@ -125,7 +129,31 @@ test("커서가 캔버스를 벗어나면 지도가 프레임을 그만 그린�
     ),
   ).toBeNull();
 
-  // ② Did the gate actually close — the consequence side. Caught here even if the cause moves to another ref.
+  /*
+   * ② Did the gate actually close — the consequence side. Caught here even if the cause
+   * moves to another ref.
+   *
+   * ⚠️ **This wait stays in milliseconds, and here is the measurement that says why**
+   * (2026-09-13 sweep of the fixed sleeps that gate an assertion; `?synth=800`, against
+   * the 12 ms/s bound below):
+   *
+   * | state waited for instead | cost over the next 1.5 s |
+   * |---|---|
+   * | camera and layout still | 38 ms/s |
+   * | the map's idle gate skipping without waking for 1.5 s | 45 ms/s |
+   * | 3,500 ms after the pointer left | **2.7 ms/s** |
+   *
+   * The map's own gate was skipping every frame of the middle row, so that cost is **not
+   * the map's**: with the pointer parked on a rail tile, roughly one further
+   * `requestAnimationFrame` callback per frame keeps working for about three seconds, and
+   * that loop exposes no state to wait on — `document.getAnimations()` reports nothing,
+   * because it is script-driven rather than WAAPI.
+   *
+   * So this is a measurement window over another subsystem's tail, not a settle this
+   * spec can ask about. Giving that subsystem an observable is its own change; until
+   * then the numbers are written down rather than the duration guessed at.
+   */
+  await page.waitForTimeout(3_500);
   const after = await idleCost(1500);
   // If no frames arrived at all (a backgrounded tab, say) this measurement is void.
   expect(after.frames).toBeGreaterThan(20);

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -61,21 +61,14 @@ async function pressAndSettle(
 }
 
 /**
- * **Wait for coordinates to settle before reading them.** Until the selected
- * node's screen coordinates repeat twice in a row — measuring mid camera
+ * **Wait for coordinates to settle before reading them.** Measuring mid camera
  * transition makes "off screen" accidentally true.
+ *
+ * Stillness is judged in the page, on the frames it drew: two samples taken 150 ms
+ * apart from here could both land inside one slow step and call a moving camera
+ * settled, and on a fast machine each threw 150 ms away.
  */
 async function settleSelectedPosition(page: import("@playwright/test").Page) {
-  const snapshot = () =>
-    page.evaluate(() => {
-      const probe = window.__atlasMap;
-      const id = probe?.selection().nodeId;
-      if (!probe || !id) return "";
-      const node = probe.nodes().find((n) => n.id === id);
-      return node ? `${id}:${Math.round(node.x)},${Math.round(node.y)}` : "";
-    });
-  // Judged in the page, on drawn frames: two samples 150 ms apart from here could both
-  // land inside one slow step and call a moving camera settled.
   await waitForMapStill(page);
 }
 
@@ -710,7 +703,9 @@ test.describe("지도 키보드 걷기", () => {
     await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
     await page.locator("body").press("ArrowUp");
     await page.locator("body").press("ArrowDown");
-    await page.waitForTimeout(400);
+    // An **absence**: nothing positive marks "these presses did nothing", so the wait is
+    // an opportunity for a move to happen, counted in drawn frames.
+    await waitFrames(page, 30);
     expect(await selectedId(page), "초점이 없는데 지도가 움직였다").toBe(pinned);
   });
 });

--- a/tests/e2e/map-keyboard-walk.spec.ts
+++ b/tests/e2e/map-keyboard-walk.spec.ts
@@ -3,6 +3,7 @@ import { FIRST_RUN_STARTER_DISMISSED_KEY } from "../../src/features/first-run-st
 import { seedFirstRunSeen } from "./first-run-seed";
 // The `window.__atlasMap` type is declared in exactly one place — two copies raise TS2717.
 import "./atlas-map-probe";
+import { waitForMapStill, waitFrames } from "./settle";
 
 /**
  * **Walking the map by keyboard.**
@@ -53,7 +54,8 @@ async function pressAndSettle(
   while (Date.now() < deadline) {
     now = await selectedId(page);
     if (now && now !== from) return now;
-    await page.waitForTimeout(50);
+    // A poll interval, not a gate: the loop returns the moment the selection moves.
+    await waitFrames(page, 3);
   }
   return now;
 }
@@ -72,16 +74,9 @@ async function settleSelectedPosition(page: import("@playwright/test").Page) {
       const node = probe.nodes().find((n) => n.id === id);
       return node ? `${id}:${Math.round(node.x)},${Math.round(node.y)}` : "";
     });
-  await expect
-    .poll(
-      async () => {
-        const before = await snapshot();
-        await page.waitForTimeout(150);
-        return before !== "" && before === (await snapshot());
-      },
-      { timeout: 20_000, message: "카메라가 멈추지 않아 좌표를 믿을 수 없다" },
-    )
-    .toBe(true);
+  // Judged in the page, on drawn frames: two samples 150 ms apart from here could both
+  // land inside one slow step and call a moving camera settled.
+  await waitForMapStill(page);
 }
 
 /** Presses all four directions in turn to find one that moves **at all**. */
@@ -107,7 +102,9 @@ async function walkOneStep(
 async function walkUntilDeadEnd(page: import("@playwright/test").Page, direction = "ArrowLeft") {
   for (let i = 0; i < 12; i += 1) {
     await page.keyboard.press(direction);
-    await page.waitForTimeout(140);
+    // A press is answered within a few drawn frames; frames are the unit, and 140 ms
+    // was this machine's guess at eight of them.
+    await waitFrames(page, 8);
     if ((await page.locator("[data-walk-notice]").count()) > 0) return true;
   }
   return false;
@@ -328,7 +325,7 @@ test.describe("지도 키보드 걷기", () => {
       const id = await selectedId(page);
       if (id) seen.add(id);
       await page.keyboard.press(key);
-      await page.waitForTimeout(200);
+      await waitFrames(page, 12);
     }
     const last = await selectedId(page);
     if (last) seen.add(last);
@@ -681,7 +678,12 @@ test.describe("지도 키보드 걷기", () => {
       );
     });
     for (const key of DIRECTIONS) await page.keyboard.press(key);
-    await page.waitForTimeout(300);
+    // The listener records one entry per key, so the count **is** the condition.
+    const recorded = () =>
+      page.evaluate(() => (window as unknown as { __keyPrevented: boolean[] }).__keyPrevented.length);
+    await expect
+      .poll(recorded, { timeout: 15_000, message: "방향키 사건이 하나도 안 잡혔다 — 이 시험이 공회전한다" })
+      .toBe(4);
     const flags = await page.evaluate(
       () => (window as unknown as { __keyPrevented: boolean[] }).__keyPrevented,
     );

--- a/tests/e2e/map-keyboard-zoom.spec.ts
+++ b/tests/e2e/map-keyboard-zoom.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapSettled, waitForMapStill } from "./settle";
 
 /**
  * **Keyboard zoom and fit** (2026-09-02, `interaction/keyboard-zoom.ts`).
@@ -8,6 +9,10 @@ import { seedFirstRunSeen } from "./first-run-seed";
  * (Obsidian, Figma, tldraw) also zooms from the keyboard. This spec reads the
  * camera through `?e2e=1` rather than pixels: a zoom and a pan look alike on
  * screen, and only the scale says which one happened.
+ *
+ * Every wait here is the camera spring coming to rest, never a duration
+ * (`.claude/rules/testing.md`, the timing rule): a zoom step is over when the
+ * scale stops changing, which is the same event on any machine.
  */
 async function readScale(page: import("@playwright/test").Page): Promise<number> {
   return page.evaluate(() => {
@@ -16,39 +21,62 @@ async function readScale(page: import("@playwright/test").Page): Promise<number>
   });
 }
 
+/**
+ * Where the camera is **heading**. The keyboard handler sets this synchronously on
+ * the key event, so it answers "did this keystroke command a zoom" with no wait at
+ * all — which is the only honest way to assert that a keystroke did *nothing*.
+ */
+async function readTargetScale(page: import("@playwright/test").Page): Promise<number> {
+  return page.evaluate(() => {
+    const m = (window as unknown as { __atlasMap?: { cameraTarget?: () => { scale: number } | null } }).__atlasMap;
+    return m?.cameraTarget?.()?.scale ?? Number.NaN;
+  });
+}
+
 test("+ zooms in a step, - zooms out, 0 returns to the fit, and a modifier leaves the browser alone", async ({ page }) => {
   test.setTimeout(90_000);
   await page.setViewportSize({ width: 1400, height: 860 });
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(2500);
+  await waitForMapSettled(page);
   const canvas = page.locator('[data-testid="ontology-map-canvas"]');
   const box = (await canvas.boundingBox())!;
   // Focus the canvas on empty space near the bottom-right, away from nodes.
   await page.mouse.click(box.x + box.width - 60, box.y + box.height - 60);
-  await page.waitForTimeout(400);
+  await waitForMapStill(page, { what: "camera" });
   const start = await readScale(page);
   expect(Number.isFinite(start)).toBe(true);
 
   await page.keyboard.press("=");
-  await page.waitForTimeout(700);
+  await waitForMapStill(page, { what: "camera" });
   const zoomedIn = await readScale(page);
   expect(zoomedIn, "「+」 뒤 스케일이 커져야 한다").toBeGreaterThan(start * 1.1);
 
   await page.keyboard.press("-");
-  await page.waitForTimeout(700);
+  await waitForMapStill(page, { what: "camera" });
   const backDown = await readScale(page);
   expect(Math.abs(backDown - start), "「-」 는 「+」 를 되돌린다").toBeLessThan(start * 0.05);
 
   await page.keyboard.press("=");
   await page.keyboard.press("=");
-  await page.waitForTimeout(700);
+  await waitForMapStill(page, { what: "camera" });
   await page.keyboard.press("0");
-  await page.waitForTimeout(1000);
+  await waitForMapStill(page, { what: "camera" });
   const fitted = await readScale(page);
   expect(Math.abs(fitted - start), "「0」 은 처음의 맞춤으로 돌아온다").toBeLessThan(start * 0.05);
 
+  /*
+   * ⌘+ belongs to the browser. Sleeping and then finding the scale unchanged would
+   * only prove the sleep was long enough for nothing to happen; the **target** is
+   * set inside the key handler, so a commanded zoom is already visible here the
+   * moment `press` resolves, and an unchanged target is the real absence.
+   */
+  const targetBefore = await readTargetScale(page);
   await page.keyboard.press("Meta+=");
-  await page.waitForTimeout(400);
-  expect(Math.abs((await readScale(page)) - start), "⌘+ 는 브라우저의 것이다 — 지도가 확대되면 안 된다").toBeLessThan(start * 0.05);
+  expect(
+    await readTargetScale(page),
+    "⌘+ 는 브라우저의 것이다 — 지도 카메라가 확대를 겨냥하면 안 된다",
+  ).toBeCloseTo(targetBefore, 5);
+  await waitForMapStill(page, { what: "camera" });
+  expect(Math.abs((await readScale(page)) - start), "⌘+ 뒤에도 스케일은 그대로다").toBeLessThan(start * 0.05);
 });

--- a/tests/e2e/map-selection-framing.spec.ts
+++ b/tests/e2e/map-selection-framing.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapStill } from "./settle";
 
 /**
  * Three usability defects found by walking every map control on 2026-09-03,
@@ -47,27 +48,32 @@ test.beforeEach(async ({ page }) => {
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await expect.poll(async () => (await readMap(page)).visible, { timeout: 20_000 }).toBeGreaterThan(0);
-  await page.waitForTimeout(1500);
+  // The first reveal homes the camera and the physics is still warm; measure the
+  // screen it comes to rest on, not the one 1.5 s of this machine's clock leaves.
+  await waitForMapStill(page);
 });
 
 test("a node picked from the search palette is framed left of the detail panel", async ({ page }) => {
   // The map's search chip opens the unified palette (an `aria-modal` dialog).
   const palette = page.getByRole("dialog", { name: "이 지도에서 검색" });
-  await expect
-    .poll(
-      async () => {
-        await page.locator('[data-testid="topology-concept-search"]').click();
-        await page.waitForTimeout(400);
-        return palette.isVisible();
-      },
-      { timeout: 15_000, message: "검색 칩이 팔레트를 연다" },
-    )
-    .toBe(true);
+  await page.locator('[data-testid="topology-concept-search"]').click();
+  await expect(palette, "검색 칩이 팔레트를 연다").toBeVisible();
   await page.keyboard.type("배송");
-  await page.waitForTimeout(600);
+  /*
+   * Enter takes the **active** option, so the condition the old 600 ms sleep was
+   * standing in for is "the row Enter will take is the one we typed for". Waiting
+   * for that row is also the only form that cannot pick the previous query's
+   * result on a slow machine.
+   */
+  await expect(
+    palette.locator('[role="option"][aria-selected="true"]'),
+    "고른 결과가 배송이다",
+  ).toContainText("배송");
   await page.keyboard.press("Enter");
   await expect(page.locator('[data-testid="map-detail-panel"]')).toBeVisible({ timeout: 5_000 });
-  await page.waitForTimeout(1800);
+  // The focus camera reframes around the panel; read where it lands, not where it is
+  // 1.8 s in.
+  await waitForMapStill(page, { what: "camera" });
   const after = await readMap(page);
   expect(after.selected, "검색으로 고른 노드가 선택된다").not.toBeNull();
   expect(after.panelLeft, "상세 패널이 오른쪽에 있다").not.toBeNull();
@@ -79,15 +85,15 @@ test("a node picked from the search palette is framed left of the detail panel",
 test("auto-arrange while everything is expanded keeps every node on screen", async ({ page }) => {
   await page.locator('[data-testid="topology-expand-all"]').click();
   await expect.poll(async () => (await readMap(page)).visible, { timeout: 10_000 }).toBeGreaterThan(100);
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
   await page.locator('[data-testid="topology-auto-arrange"]').click();
-  await page.waitForTimeout(3500);
+  await waitForMapStill(page);
   const arranged = await readMap(page);
   expect(arranged.offscreen, "정렬 후 펼친 노드가 화면 밖으로 나가지 않는다").toBe(0);
   // The `0` key is the same fit and must agree.
   await page.mouse.click(700, 800);
   await page.keyboard.press("0");
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
   expect((await readMap(page)).offscreen).toBe(0);
   // (Selecting a node ends expand-all by design, so the panel-close return is
   // covered by `map-viewport-reframe.spec.ts` in the plain state instead.)
@@ -99,7 +105,22 @@ test("the Korean relation sentence joins its particles to the names", async ({ p
   const domain = m.domains.find((d) => d.label === "배송")!;
   const mid = { x: (m.project!.x + domain.x) / 2, y: (m.project!.y + domain.y) / 2 };
   await page.mouse.move(box.x + mid.x, box.y + mid.y);
-  await page.waitForTimeout(300);
+  /*
+   * The old 300 ms sleep was aiming, not waiting: it gave the hover a moment and
+   * hoped the midpoint really was on the edge. `edgeAt` answers the aim itself —
+   * the click goes out once the frame reports an edge under that exact point.
+   */
+  await page.waitForFunction(
+    (point) =>
+      Boolean(
+        (window as unknown as { __atlasMap?: { edgeAt?: (x: number, y: number) => unknown } }).__atlasMap?.edgeAt?.(
+          point.x,
+          point.y,
+        ),
+      ),
+    mid,
+    { polling: "raf", timeout: 15_000 },
+  );
   await page.mouse.click(box.x + mid.x, box.y + mid.y);
   const sentence = page.locator('[data-testid="map-edge-sentence"]');
   await expect(sentence).toBeVisible({ timeout: 5_000 });
@@ -123,7 +144,7 @@ test("an edit intent that arrives by URL on the sample says why it cannot edit a
 test("a deep link that opens one domain frames its revealed children, and the 0 key agrees", async ({ page }) => {
   await page.goto("/ko/topology/?e2e=1&guides=off&open=domain%3Amarketing", { waitUntil: "domcontentloaded" });
   await expect.poll(async () => (await readMap(page)).visible, { timeout: 20_000 }).toBeGreaterThan(40);
-  await page.waitForTimeout(3000);
+  await waitForMapStill(page);
   // Capabilities are density-gated at overview altitude (not drawn, not hidden), so
   // only the tiers the overview draws are measured: spine and the revealed elements.
   const drawnOffscreen = () =>
@@ -138,6 +159,6 @@ test("a deep link that opens one domain frames its revealed children, and the 0 
   expect(await drawnOffscreen(), "딥링크로 펼친 도메인의 요소가 화면 밖에 남지 않는다").toBe(0);
   await page.mouse.click(700, 820);
   await page.keyboard.press("0");
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
   expect(await drawnOffscreen(), "0 키 맞춤도 펼친 요소를 담는다").toBe(0);
 });

--- a/tests/e2e/map-trail.spec.ts
+++ b/tests/e2e/map-trail.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapStill } from "./settle";
 
 /**
  * **The trail round trip** (promoted from the 2026-08-13 walkthrough — zero gates
@@ -20,7 +21,7 @@ test("걸어온 길 — 쌓이고, 목록이 맞고, 뒤로 점프하고, 지워
   await seedFirstRunSeen(page);
   await page.goto("/ko/topology/?e2e=1&guides=off", { waitUntil: "domcontentloaded" });
   await page.evaluate(() => document.fonts.ready);
-  await page.waitForTimeout(2500);
+  await waitForMapStill(page);
 
   const selection = () =>
     page.evaluate(
@@ -54,7 +55,8 @@ test("걸어온 길 — 쌓이고, 목록이 맞고, 뒤로 점프하고, 지워
   const chip = page.getByText(/걸어온 길 · 3/);
   await expect(chip, "자취 칩이 걸음 수를 안 센다").toBeVisible();
   await chip.click();
-  await page.waitForTimeout(700);
+  // The rows below are `toBeVisible` assertions, which retry on their own — the
+  // popover's reveal needs no sleep in front of them.
 
   // The list — here now, one step back, two steps back
   await expect(page.getByText("지금 여기")).toBeVisible();
@@ -63,13 +65,12 @@ test("걸어온 길 — 쌓이고, 목록이 맞고, 뒤로 점프하고, 지워
 
   // Jump back — pressing the two-steps-back (orders) row returns the selection
   await page.getByText("주문", { exact: true }).last().click();
-  await page.waitForTimeout(900);
-  expect(await selection(), "자취 행이 그 노드로 데려가지 않았다").toBe("domain:order");
+  await expect
+    .poll(selection, { timeout: 15_000, message: "자취 행이 그 노드로 데려가지 않았다" })
+    .toBe("domain:order");
 
   // Clear — the chip disappears
   await page.getByText(/걸어온 길 · \d/).click();
-  await page.waitForTimeout(500);
   await page.getByText("지우기", { exact: true }).click();
-  await page.waitForTimeout(700);
   await expect(page.getByText(/걸어온 길 · \d/)).toHaveCount(0);
 });

--- a/tests/e2e/map-viewport-reframe.spec.ts
+++ b/tests/e2e/map-viewport-reframe.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { seedFirstRunSeen } from "./first-run-seed";
+import { waitForMapStill, waitFrames } from "./settle";
 
 type Camera = { x: number; y: number; scale: number; width: number; height: number };
 
@@ -8,30 +9,16 @@ async function readCamera(page: Page): Promise<Camera | null> {
   return page.evaluate(() => window.__atlasMap?.camera() ?? null);
 }
 
-/** Measures the screen after the camera target and actual value arrive and stop. */
+/**
+ * Measures the screen after the camera target and actual value arrive and stop.
+ *
+ * The stillness is judged **in the page**, on animation frames: the spring is
+ * settled when the frames it draws stop differing, which is the same event on a
+ * fast machine and a slow one. Sampling every 250 ms from the test process only
+ * asked how far this laptop's clock had got.
+ */
 async function settleCamera(page: Page) {
-  await expect
-    .poll(
-      async () => {
-        const samples: Camera[] = [];
-        for (let index = 0; index < 3; index += 1) {
-          const camera = await readCamera(page);
-          if (!camera) return false;
-          samples.push(camera);
-          if (index < 2) await page.waitForTimeout(250);
-        }
-        return samples.slice(1).every((camera, index) => {
-          const before = samples[index];
-          return (
-            Math.abs(before.x - camera.x) < 0.02 &&
-            Math.abs(before.y - camera.y) < 0.02 &&
-            Math.abs(before.scale - camera.scale) < 0.0002
-          );
-        });
-      },
-      { timeout: 30_000, message: "카메라가 정착하지 않아 프레이밍을 비교할 수 없다" },
-    )
-    .toBe(true);
+  await waitForMapStill(page, { what: "camera" });
 }
 
 test("짧은 선택 인스펙터도 실제 자유 영역으로 카메라를 민다", async ({ page }) => {
@@ -229,15 +216,36 @@ test("우측 도크로 지도 폭이 줄면 현재 overview를 새 가용영역�
     .toBeLessThan(before!.width - 350);
   // Two frames after the last resize, when the expensive viewport layer has settled.
   // Unrelated rerenders like ACP boot should not wake the camera after this point.
-  await page.waitForTimeout(100);
+  await waitFrames(page, 2);
   const atResizeSettle = await readCamera(page);
   expect(atResizeSettle).not.toBeNull();
-  const postResizeSamples: Camera[] = [atResizeSettle!];
-  for (let sample = 0; sample < 6; sample += 1) {
-    await page.waitForTimeout(100);
-    const camera = await readCamera(page);
-    if (camera) postResizeSamples.push(camera);
-  }
+  /*
+   * The bounce window. This is a **measurement**, not a wait: it has to watch for a
+   * while to catch an underdamped camera swinging back. Watching in frames rather
+   * than in 100 ms round trips both samples what the screen actually drew — a round
+   * trip can straddle several frames and miss the peak — and lets a slow machine
+   * take longer over the same number of frames.
+   */
+  const postResizeSamples: Camera[] = [
+    atResizeSettle!,
+    ...(await page.evaluate(
+      (frames) =>
+        new Promise<Camera[]>((resolve) => {
+          const collected: Camera[] = [];
+          const step = () => {
+            const camera = window.__atlasMap?.camera() ?? null;
+            if (camera) collected.push(camera);
+            if (collected.length >= frames) {
+              resolve(collected);
+              return;
+            }
+            requestAnimationFrame(step);
+          };
+          requestAnimationFrame(step);
+        }),
+      36,
+    )),
+  ];
   await settleCamera(page);
   const automatic = await readCamera(page);
   expect(automatic).not.toBeNull();

--- a/tests/e2e/scroll-end-gap.spec.ts
+++ b/tests/e2e/scroll-end-gap.spec.ts
@@ -7,6 +7,20 @@ import { PAGE_FRAME_FORM } from "@/shared/ui/page-frame";
 /** The form column's rendered max width, read from the spec so a re-decided value cannot drift. */
 const FORM_FRAME_WIDTH = /max-w-\[(\d+px)\]/.exec(PAGE_FRAME_FORM)?.[1] ?? "";
 import { stubDirectoryPicker } from "./vault-picker-stub";
+import { waitForBoxStill } from "./settle";
+
+/**
+ * The route has arrived and its layout has stopped moving.
+ *
+ * Every measurement below is a rect or a scroll height, so it has to be taken on a laid
+ * out screen. The 900 and 1,200 ms sleeps this replaces were two guesses at hydration
+ * finishing on this machine.
+ */
+async function routeSettled(page: import("@playwright/test").Page) {
+  await page.waitForLoadState("networkidle");
+  await waitForBoxStill(page.locator("body"));
+}
+
 
 /**
  * Whether the bottom gap survives at the end of a scroll — the shell body slot's
@@ -315,7 +329,7 @@ for (const vp of VIEWPORTS) {
 
     for (const [label, url] of ROUTES) {
       await page.goto(url, { waitUntil: "domcontentloaded" });
-      await page.waitForTimeout(900);
+      await routeSettled(page);
       const m = await measure(page);
       if (!m.slot) {
         expect(
@@ -542,7 +556,7 @@ for (const vp of VAULT_VIEWPORTS) {
 
     for (const url of VAULT_ROUTES) {
       await page.goto(url, { waitUntil: "domcontentloaded" });
-      await page.waitForTimeout(1200);
+      await routeSettled(page);
       const m = await measure(page);
       expect(m.slot, `${url}: 셸 본문 슬롯을 못 찾았다 — 셸 구조가 바뀌었다`).toBe(true);
       if (!m.scrollable) continue;
@@ -576,14 +590,14 @@ for (const vp of VAULT_VIEWPORTS) {
      * the wiki reader with a page open, and the index column.
      */
     await page.goto("/ko/library/", { waitUntil: "domcontentloaded" });
-    await page.waitForTimeout(1200);
+    await routeSettled(page);
     await page.getByTestId("library-index-segment-wiki").click({ timeout: 15_000 });
     const firstPage = page.locator('[data-testid^="library-wiki-wiki/"]').first();
     expect(await firstPage.count(), "/ko/library/: the fixture's wiki page is not listed — nothing below is measured").toBeGreaterThan(0);
     {
       await firstPage.click();
       await page.getByTestId("library-reading-pane").waitFor({ timeout: 15_000 });
-      await page.waitForTimeout(600);
+      await waitForBoxStill(page.getByTestId("library-reading-pane"));
       const reader = await measureInner(page, '[data-testid="library-reading-pane"]');
       if (reader.scrollable) {
         if (reader.gap === null) violations.push("/ko/library/ reader: 잉크를 하나도 못 찾았다 — 계측 실패이지 통과가 아니다");

--- a/tests/e2e/settle.ts
+++ b/tests/e2e/settle.ts
@@ -33,15 +33,13 @@ const HANG_TIMEOUT_MS = 30_000;
 /** Distinct storage per call site, so two waits in one test never share a counter. */
 let stillKeySeed = 0;
 
-export type MapStillness =
+type MapStillness =
   /** Camera spring only — pan, zoom, fit, focus framing. */
   | "camera"
   /** Camera plus every drawn node coordinate — physics, expansion, auto-arrange. */
   | "layout"
   /** 3D dome pose, its inertia and its assembly ramp. */
-  | "dome"
-  /** The galaxy altitude ramp. */
-  | "altitude";
+  | "dome";
 
 export interface MapStillOptions {
   /** Which of the map's motions must stop. Default `"layout"`. */
@@ -77,7 +75,6 @@ export async function waitForMapStill(page: Page, options: MapStillOptions = {})
           poseTween: boolean;
           orbiting: boolean;
         } | null;
-        altitude?: () => number;
       };
       const probe = (window as unknown as { __atlasMap?: Probe }).__atlasMap;
       if (!probe) return false;
@@ -107,11 +104,6 @@ export async function waitForMapStill(page: Page, options: MapStillOptions = {})
           dome.ramp * 1e3,
         )},${dome.poseTween},${dome.orbiting}`;
       }
-      if (argument.what === "altitude") {
-        const altitude = probe.altitude?.();
-        if (altitude === undefined) return false;
-        signature = String(Math.round(altitude * 1e3));
-      }
       const store = ((window as unknown as { __atlasStill?: Record<string, { signature: string; count: number }> })
         .__atlasStill ??= {});
       const seen = store[argument.key];
@@ -134,7 +126,7 @@ export async function waitForMapStill(page: Page, options: MapStillOptions = {})
  * is the honest "the map is up" condition — `toBeVisible()` on the canvas passes
  * while it is still empty.
  */
-export async function waitForMapReady(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
+async function waitForMapReady(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
   await page.waitForFunction(
     () => {
       const probe = (window as unknown as { __atlasMap?: { nodes?: () => unknown[] } }).__atlasMap;
@@ -153,12 +145,19 @@ export async function waitForMapSettled(page: Page, options: MapStillOptions = {
 }
 
 /**
- * Resolve once no CSS animation or transition is running on `locator` or inside it.
+ * Resolve once no **finite** CSS animation or transition is running on `locator` or
+ * inside it.
  *
  * This is the browser's own registry (`Element.getAnimations({ subtree: true })`),
  * so it covers a reveal whose duration comes from a token without the spec having
  * to read — or guess — that token. An element that never animates resolves on the
  * first poll.
+ *
+ * ⚠️ **Infinite animations are skipped**, because they are never done: an ambient
+ * pulse or spinner somewhere on the page would otherwise hold this open until the
+ * hang ceiling (measured 2026-09-13 — `waitForAnimationsDone(body)` on the route
+ * sweep sat for the full 30 s). Something ambient that also moves the layout is
+ * caught by {@link waitForBoxStill} instead.
  */
 export async function waitForAnimationsDone(locator: Locator, timeout = HANG_TIMEOUT_MS): Promise<void> {
   await locator.evaluate(
@@ -168,6 +167,7 @@ export async function waitForAnimationsDone(locator: Locator, timeout = HANG_TIM
         const check = () => {
           const running = element
             .getAnimations({ subtree: true })
+            .filter((animation) => animation.effect?.getComputedTiming().iterations !== Infinity)
             .some((animation) => animation.playState === "running");
           if (!running) {
             resolve();
@@ -215,42 +215,6 @@ export async function waitForBoxStill(
           }
           if (performance.now() > deadline) {
             reject(new Error("box never stopped moving"));
-            return;
-          }
-          requestAnimationFrame(check);
-        };
-        check();
-      }),
-    { frames, hang: timeout },
-  );
-}
-
-/**
- * Resolve once the page has been scrolled to a position that stays put for
- * {@link STILL_FRAMES} frames — the end of a smooth scroll, including the momentum
- * of `scrollIntoView({ behavior: "smooth" })`.
- */
-export async function waitForScrollStill(
-  page: Page,
-  options: { frames?: number; timeout?: number } = {},
-): Promise<void> {
-  const { frames = STILL_FRAMES, timeout = HANG_TIMEOUT_MS } = options;
-  await page.evaluate(
-    (argument) =>
-      new Promise<void>((resolve, reject) => {
-        const deadline = performance.now() + argument.hang;
-        let previous = Number.NaN;
-        let repeats = 0;
-        const check = () => {
-          const position = Math.round(window.scrollY * 10);
-          repeats = position === previous ? repeats + 1 : 1;
-          previous = position;
-          if (repeats >= argument.frames) {
-            resolve();
-            return;
-          }
-          if (performance.now() > deadline) {
-            reject(new Error("the page never stopped scrolling"));
             return;
           }
           requestAnimationFrame(check);

--- a/tests/e2e/settle.ts
+++ b/tests/e2e/settle.ts
@@ -286,3 +286,67 @@ export async function waitFrames(page: Page, count = 2): Promise<void> {
     count,
   );
 }
+
+/**
+ * Resolve once the 3D dome has finished assembling — its ramp clock is at the top.
+ *
+ * The assembly is a fixed-length ramp the loop advances by real elapsed time, so a
+ * busy machine takes more wall clock to reach the same ramp value. `ramp >= 1` is
+ * that value; four seconds was one machine's guess at it.
+ *
+ * The pose is deliberately not part of this: the dome arrives **armed to spin**
+ * (`dome-view.ts`), so "assembled" and "still" are different states and only the
+ * first one is what arriving in 3D means.
+ */
+export async function waitForDomeAssembled(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const dome = (window as unknown as { __atlasMap?: { dome?: () => { ramp: number } | null } }).__atlasMap?.dome?.();
+      return dome !== null && dome !== undefined && dome.ramp >= 1;
+    },
+    undefined,
+    { polling: "raf", timeout },
+  );
+}
+
+/**
+ * Resolve once the map is flat again: the dome's ramp has run all the way back
+ * down (or the runtime is gone), and the 2D layout underneath has stopped moving.
+ */
+export async function waitForFlatMap(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const probe = (window as unknown as { __atlasMap?: { dome?: () => { ramp: number } | null } }).__atlasMap;
+      if (!probe) return false;
+      const dome = probe.dome?.() ?? null;
+      return dome === null || dome.ramp <= 0;
+    },
+    undefined,
+    { polling: "raf", timeout },
+  );
+  await waitForMapStill(page, { timeout });
+}
+
+/**
+ * Resolve once the 3D dome has both assembled **and** finished its entry sweep.
+ *
+ * The two have separate clocks — the sweep outlives the assembly by 380 ms
+ * (`model/dome-view.ts`) — so "arrived in 3D" is both flags, and while the sweep
+ * is alive the drawn attitude keeps moving and cannot be told apart from what a
+ * drag changed.
+ *
+ * The pose is still not required to be *still*: the dome arrives armed to spin, so
+ * stillness would never come until a hand touched it.
+ */
+export async function waitForDomeEntered(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const dome = (
+        window as unknown as { __atlasMap?: { dome?: () => { ramp: number; entryArmed: boolean } | null } }
+      ).__atlasMap?.dome?.();
+      return dome !== null && dome !== undefined && dome.ramp >= 1 && !dome.entryArmed;
+    },
+    undefined,
+    { polling: "raf", timeout },
+  );
+}

--- a/tests/e2e/settle.ts
+++ b/tests/e2e/settle.ts
@@ -260,3 +260,29 @@ export async function waitForScrollStill(
     { frames, hang: timeout },
   );
 }
+
+/**
+ * Resolve after `count` animation frames have been painted.
+ *
+ * For the handful of places where the condition genuinely is "the next frame or
+ * two" — a value the loop writes once per frame, read after the frame that writes
+ * it. Frames are the engine's unit; milliseconds are the machine's.
+ */
+export async function waitFrames(page: Page, count = 2): Promise<void> {
+  await page.evaluate(
+    (frames) =>
+      new Promise<void>((resolve) => {
+        let remaining = frames;
+        const step = () => {
+          remaining -= 1;
+          if (remaining <= 0) {
+            resolve();
+            return;
+          }
+          requestAnimationFrame(step);
+        };
+        requestAnimationFrame(step);
+      }),
+    count,
+  );
+}

--- a/tests/e2e/settle.ts
+++ b/tests/e2e/settle.ts
@@ -1,0 +1,262 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * **Wait for the condition, not the clock.**
+ *
+ * `.claude/rules/testing.md` (the timing rule, #1578) forbids a fixed sleep that
+ * gates an assertion: `waitForTimeout(2500)` asserts how fast this machine is, so
+ * a slow machine reads a moving screen and a fast one throws the difference away.
+ * Every wait here returns the moment the screen stops changing, which costs
+ * nothing when it already had and still passes when it has not.
+ *
+ * The map's canvas has no DOM, so its stillness is read from the `__atlasMap`
+ * probe (`atlas-map-probe.ts`) that every `?e2e=1` page already attaches — the
+ * same values the frame actually drew. The DOM waits read the browser's own
+ * animation registry (`Element.getAnimations`) rather than guessing a duration
+ * out of a token.
+ *
+ * ## Why "N repeated frames" is a condition and not a disguised sleep
+ *
+ * A spring is still when its value stops changing, and a value that has not
+ * changed for one frame may simply be crossing zero velocity. `STILL_FRAMES`
+ * consecutive identical samples is the observable — it is counted in frames the
+ * page actually rendered, so it stretches with the machine instead of racing it,
+ * and it returns as soon as the motion ends rather than after a budget.
+ */
+
+/** Consecutive identical animation frames that make a value "still". */
+const STILL_FRAMES = 8;
+
+/** Every wait is a hang detector, never a budget: generous, never asserted about. */
+const HANG_TIMEOUT_MS = 30_000;
+
+/** Distinct storage per call site, so two waits in one test never share a counter. */
+let stillKeySeed = 0;
+
+export type MapStillness =
+  /** Camera spring only — pan, zoom, fit, focus framing. */
+  | "camera"
+  /** Camera plus every drawn node coordinate — physics, expansion, auto-arrange. */
+  | "layout"
+  /** 3D dome pose, its inertia and its assembly ramp. */
+  | "dome"
+  /** The galaxy altitude ramp. */
+  | "altitude";
+
+export interface MapStillOptions {
+  /** Which of the map's motions must stop. Default `"layout"`. */
+  what?: MapStillness;
+  /** Consecutive identical frames required. Default {@link STILL_FRAMES}. */
+  frames?: number;
+  /** Hang ceiling, not a budget. */
+  timeout?: number;
+}
+
+/**
+ * Resolve once the map has drawn {@link STILL_FRAMES} consecutive frames with the
+ * same camera / layout / pose. The predicate runs **in the page** on animation
+ * frames, so a settle costs one round trip rather than one per sample.
+ *
+ * The idle gate never stops rAF (`model/idle-gate.ts`); it skips the physics step
+ * and the paint. A skipped frame therefore reports the last drawn values, which is
+ * exactly the "still" this waits for.
+ */
+export async function waitForMapStill(page: Page, options: MapStillOptions = {}): Promise<void> {
+  const { what = "layout", frames = STILL_FRAMES, timeout = HANG_TIMEOUT_MS } = options;
+  const key = `still-${(stillKeySeed += 1)}`;
+  await page.waitForFunction(
+    (argument: { what: string; frames: number; key: string }) => {
+      type ProbeNode = { id: string; x: number; y: number; hidden: boolean };
+      type Probe = {
+        camera?: () => { x: number; y: number; scale: number; width: number; height: number } | null;
+        nodes?: () => ProbeNode[];
+        dome?: () => {
+          yaw: number;
+          pitch: number;
+          ramp: number;
+          poseTween: boolean;
+          orbiting: boolean;
+        } | null;
+        altitude?: () => number;
+      };
+      const probe = (window as unknown as { __atlasMap?: Probe }).__atlasMap;
+      if (!probe) return false;
+      /** Tenths of a pixel: below the width of the thinnest thing the map draws. */
+      const tenth = (value: number) => Math.round(value * 10);
+      let signature = "";
+      if (argument.what === "camera" || argument.what === "layout") {
+        const camera = probe.camera?.() ?? null;
+        if (!camera || camera.width <= 0) return false;
+        signature = `${tenth(camera.x)},${tenth(camera.y)},${Math.round(camera.scale * 1e4)}`;
+      }
+      if (argument.what === "layout") {
+        const nodes = probe.nodes?.() ?? [];
+        if (nodes.length === 0) return false;
+        signature += `|${nodes
+          .filter((node) => !node.hidden)
+          .map((node) => `${node.id}:${tenth(node.x)},${tenth(node.y)}`)
+          .join(",")}`;
+      }
+      if (argument.what === "dome") {
+        const dome = probe.dome?.() ?? null;
+        if (!dome) return false;
+        // A pose tween or live inertia is motion regardless of how small this
+        // frame's step was, so they are part of the signature rather than a
+        // separate early return: the counter resets while either is live.
+        signature = `${Math.round(dome.yaw * 1e3)},${Math.round(dome.pitch * 1e3)},${Math.round(
+          dome.ramp * 1e3,
+        )},${dome.poseTween},${dome.orbiting}`;
+      }
+      if (argument.what === "altitude") {
+        const altitude = probe.altitude?.();
+        if (altitude === undefined) return false;
+        signature = String(Math.round(altitude * 1e3));
+      }
+      const store = ((window as unknown as { __atlasStill?: Record<string, { signature: string; count: number }> })
+        .__atlasStill ??= {});
+      const seen = store[argument.key];
+      if (!seen || seen.signature !== signature) {
+        store[argument.key] = { signature, count: 1 };
+        return false;
+      }
+      seen.count += 1;
+      return seen.count >= argument.frames;
+    },
+    { what, frames, key },
+    { polling: "raf", timeout },
+  );
+}
+
+/**
+ * Resolve once the map's probe is attached and has drawn at least one node.
+ *
+ * The probe only exists on `?e2e=1` pages and only after the first frame, so this
+ * is the honest "the map is up" condition — `toBeVisible()` on the canvas passes
+ * while it is still empty.
+ */
+export async function waitForMapReady(page: Page, timeout = HANG_TIMEOUT_MS): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const probe = (window as unknown as { __atlasMap?: { nodes?: () => unknown[] } }).__atlasMap;
+      const nodes = probe?.nodes?.();
+      return Array.isArray(nodes) && nodes.length > 0;
+    },
+    undefined,
+    { polling: "raf", timeout },
+  );
+}
+
+/** The map is up **and** has stopped moving — the usual state a spec wants to measure. */
+export async function waitForMapSettled(page: Page, options: MapStillOptions = {}): Promise<void> {
+  await waitForMapReady(page, options.timeout);
+  await waitForMapStill(page, options);
+}
+
+/**
+ * Resolve once no CSS animation or transition is running on `locator` or inside it.
+ *
+ * This is the browser's own registry (`Element.getAnimations({ subtree: true })`),
+ * so it covers a reveal whose duration comes from a token without the spec having
+ * to read — or guess — that token. An element that never animates resolves on the
+ * first poll.
+ */
+export async function waitForAnimationsDone(locator: Locator, timeout = HANG_TIMEOUT_MS): Promise<void> {
+  await locator.evaluate(
+    (element, hang) =>
+      new Promise<void>((resolve, reject) => {
+        const deadline = performance.now() + hang;
+        const check = () => {
+          const running = element
+            .getAnimations({ subtree: true })
+            .some((animation) => animation.playState === "running");
+          if (!running) {
+            resolve();
+            return;
+          }
+          if (performance.now() > deadline) {
+            reject(new Error("animations still running"));
+            return;
+          }
+          requestAnimationFrame(check);
+        };
+        check();
+      }),
+    timeout,
+  );
+}
+
+/**
+ * Resolve once `locator`'s box has been identical for {@link STILL_FRAMES} frames.
+ *
+ * For a surface that slides, grows or reflows into place with no single animation
+ * to await — a sheet re-laying out, a grid reflowing after a resize.
+ */
+export async function waitForBoxStill(
+  locator: Locator,
+  options: { frames?: number; timeout?: number } = {},
+): Promise<void> {
+  const { frames = STILL_FRAMES, timeout = HANG_TIMEOUT_MS } = options;
+  await locator.evaluate(
+    (element, argument) =>
+      new Promise<void>((resolve, reject) => {
+        const deadline = performance.now() + argument.hang;
+        let previous = "";
+        let repeats = 0;
+        const check = () => {
+          const box = element.getBoundingClientRect();
+          const signature = [box.x, box.y, box.width, box.height]
+            .map((value) => Math.round(value * 10))
+            .join(",");
+          repeats = signature === previous ? repeats + 1 : 1;
+          previous = signature;
+          if (repeats >= argument.frames) {
+            resolve();
+            return;
+          }
+          if (performance.now() > deadline) {
+            reject(new Error("box never stopped moving"));
+            return;
+          }
+          requestAnimationFrame(check);
+        };
+        check();
+      }),
+    { frames, hang: timeout },
+  );
+}
+
+/**
+ * Resolve once the page has been scrolled to a position that stays put for
+ * {@link STILL_FRAMES} frames — the end of a smooth scroll, including the momentum
+ * of `scrollIntoView({ behavior: "smooth" })`.
+ */
+export async function waitForScrollStill(
+  page: Page,
+  options: { frames?: number; timeout?: number } = {},
+): Promise<void> {
+  const { frames = STILL_FRAMES, timeout = HANG_TIMEOUT_MS } = options;
+  await page.evaluate(
+    (argument) =>
+      new Promise<void>((resolve, reject) => {
+        const deadline = performance.now() + argument.hang;
+        let previous = Number.NaN;
+        let repeats = 0;
+        const check = () => {
+          const position = Math.round(window.scrollY * 10);
+          repeats = position === previous ? repeats + 1 : 1;
+          previous = position;
+          if (repeats >= argument.frames) {
+            resolve();
+            return;
+          }
+          if (performance.now() > deadline) {
+            reject(new Error("the page never stopped scrolling"));
+            return;
+          }
+          requestAnimationFrame(check);
+        };
+        check();
+      }),
+    { frames, hang: timeout },
+  );
+}

--- a/tests/e2e/transient-surface-contract.spec.ts
+++ b/tests/e2e/transient-surface-contract.spec.ts
@@ -1,6 +1,25 @@
 import { expect, test } from "@playwright/test";
 import { seedFirstRunSeen } from "./first-run-seed";
 import { FIRST_RUN_STARTER_DISMISSED_KEY } from "../../src/features/first-run-starter/model/first-run-starter-dismiss";
+import { waitForAnimationsDone, waitForBoxStill, waitForMapStill, waitFrames } from "./settle";
+
+/**
+ * The route has arrived and its layout has stopped moving.
+ *
+ * The sweep below enumerates every trigger on the screen and measures boxes, so what it
+ * needs is a laid-out screen — not one second of this machine, which on a slow run is
+ * the middle of hydration and on a fast one is 900 ms thrown away.
+ *
+ * ⚠️ Deliberately **not** `waitForAnimationsDone(body)`: some of these routes always
+ * have something animating somewhere, so a page-wide animation wait sat for the full
+ * hang ceiling (measured 2026-09-13). The body's box repeating across frames is the
+ * condition these measurements actually need.
+ */
+async function routeSettled(page: import("@playwright/test").Page) {
+  await page.waitForLoadState("networkidle");
+  await waitForBoxStill(page.locator("body"));
+}
+
 
 /**
  * **Sweeps three contracts for transient surfaces across every route** (2026-08-11).
@@ -100,7 +119,7 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
 
     for (const route of ROUTES) {
       await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
-      await page.waitForTimeout(1_000);
+      await routeSettled(page);
 
       const triggerCount = await page.evaluate(
         () =>
@@ -128,7 +147,7 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
          */
         if (index > 0) {
           await page.goto(`${route}?guides=off`, { waitUntil: "domcontentloaded" });
-          await page.waitForTimeout(900);
+          await routeSettled(page);
         }
         const trigger = await page.evaluate((idx) => {
           const el = [...document.querySelectorAll("[aria-expanded],[aria-haspopup]")].filter((candidate) => {
@@ -149,7 +168,11 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
 
         await page.locator("[data-sweep-trigger]").first().focus();
         await page.keyboard.press("Enter");
-        // Just after the first frame of the entrance — measuring here catches the animation still alive.
+        /*
+         * Just after the first frame of the entrance — measuring **here** is the point:
+         * this sample has to land while the animation is still alive, so the 70 ms is the
+         * subject of the measurement and not a settle to wait out.
+         */
         await page.waitForTimeout(70);
 
         const shot = await page.evaluate(() => {
@@ -193,13 +216,13 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
           }
 
           /*
-           * ⚠️ **Give it time to settle.** A first version that pressed Escape 70ms after
+           * ⚠️ **Let it settle first.** A first version that pressed Escape 70ms after
            * appearance falsely reported "focus does not return" on two routes — the sheet was
            * still moving focus inside itself, and closing mid-move leaves no settled place to
-           * return to. A person does not close something after 70ms, and the animation
-           * measurement already finished above.
+           * return to. The condition is the surface's entrance being over, which the browser's
+           * own animation registry reports; 420 ms was a guess at the same thing.
            */
-          await page.waitForTimeout(420);
+          await waitForAnimationsDone(page.locator("[data-transient-surface]").first());
           await page.keyboard.press("Escape");
           /*
            * ⚠️ **Wait for the exit.** A first version that measured once and decided falsely
@@ -212,13 +235,20 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
            * card, a detail panel) happened to be up on the map. Whether it closed is a
            * question about **that surface**.
            */
+          /*
+           * A condition poll: it returns the moment that kind is gone. The interval is
+           * drawn frames rather than 220 ms, so a slow machine gets a longer exit to
+           * finish in instead of a stricter deadline. The loop still ends by itself
+           * because the verdict is collected into `violations` per route rather than
+           * thrown here.
+           */
           let stillOpen = true;
-          for (let wait = 0; wait < 6; wait += 1) {
-            await page.waitForTimeout(220);
+          for (let attempt = 0; attempt < 40; attempt += 1) {
             if (!(await visibleKinds(page)).includes(shot.kind)) {
               stillOpen = false;
               break;
             }
+            await waitFrames(page, 12);
           }
           /*
            * ⚠️ **Compare focus return by identity, never by a marker planted in the DOM.**
@@ -302,11 +332,12 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
     await canvas.waitFor({ state: "visible", timeout: 20_000 });
     await canvas.focus();
     await page.keyboard.press("ArrowRight");
-    await page.waitForTimeout(400);
+    await waitForMapStill(page, { what: "camera" });
     let found = false;
     for (let i = 0; i < 12; i += 1) {
       await page.keyboard.press("ArrowLeft");
-      await page.waitForTimeout(140);
+      // A press is answered within a few drawn frames; frames are the unit.
+      await waitFrames(page, 8);
       if ((await page.locator('[data-transient-surface="notice"]').count()) > 0) {
         found = true;
         break;
@@ -387,9 +418,9 @@ test.describe("잠깐 뜨는 표면 3계약", () => {
      * ⚠️ **Close after the camera transition finishes.** A version that pressed Escape
      * mid-transition left the popover in place (measured). A person does not close while
      * the map is moving, and what this test measures is whether it closes, not whether it
-     * closes mid-transition.
+     * closes mid-transition. "Finished" is the camera's own frames repeating, not 600 ms.
      */
-    await page.waitForTimeout(600);
+    await waitForMapStill(page, { what: "camera" });
     await page.keyboard.press("Escape");
     await expect(anchored, "Escape 로 팝오버가 닫히지 않는다").toBeHidden({ timeout: 4_000 });
     // Focus must stay on the canvas — here the canvas is what called it.


### PR DESCRIPTION
## Summary

P1's audit counted **52 fixed sleeps in `tests/e2e` that gate an assertion** — each one
waits a number of milliseconds for a camera spring, a physics settle or a reveal, then
reads final state. `.claude/rules/testing.md` (the timing rule, #1578) forbids exactly
that: a gate that can go red because the machine was busy teaches people to retry, and a
gate people retry is not a gate.

This replaces them with the condition each one stood for, using the idioms already in the
repo. `tests/e2e/settle.ts` holds the shared ones:

| helper | condition |
|---|---|
| `waitForMapStill(page, { what })` | the `__atlasMap` probe's camera / node coordinates / dome pose repeating across 8 animation frames, sampled **in the page** |
| `waitForMapSettled` | the probe is attached and has drawn nodes — `toBeVisible()` on the canvas passes while it is still empty — and then still |
| `waitForDomeAssembled` · `waitForDomeEntered` · `waitForFlatMap` | the 3D dome's own ramp clock and entry-sweep flag |
| `waitForAnimationsDone(locator)` | `Element.getAnimations({ subtree: true })`, infinite animations skipped — the browser's own registry, so no token duration is read or guessed |
| `waitForBoxStill(locator)` | a rect repeating across frames |
| `waitFrames(page, n)` | n painted frames — for "the next frame writes this value", for input pacing, and for absence windows |

One product change, in `use-topology-loop.ts`: the `?e2e=1` probe's `dome()` now reports
`entryArmed`. The entry sweep has its **own** clock and outlives the assembly by 380 ms
(`model/dome-view.ts`), so `ramp >= 1` is not "the dome has arrived" and there was nothing
else to ask. The idle gate already reads that flag for the same reason.
`.claude/rules/testing.md` gains one line pointing at `settle.ts`.

**220 → 83** `waitForTimeout` calls in `tests/e2e`. Every survivor says in place why it is
a measurement window or the subject of its own claim.

## What each site waited for, and what it waits for now

Line numbers are on the base commit (`23cbf6d64`).

### The 2D map

| file · line | waited for | now waits for |
|---|---|---|
| `map-keyboard-zoom` 24, 29, 34, 39, 45, 47, 52 | the zoom/fit camera spring; ⌘+ doing nothing | `waitForMapStill({ what: "camera" })`; ⌘+ reads `cameraTarget()`, which the key handler sets synchronously |
| `map-selection-framing` 50, 70, 82, 84, 90, 126, 141 | first reveal, focus reframe, expand-all physics, auto-arrange, `0` fit | `waitForMapStill` |
| `map-selection-framing` 60, 67 | the palette opening; the typed query reaching the result list | `toBeVisible()`; the active `[role=option]` containing the query — which also removes the way the old form could take the previous query's row |
| `map-selection-framing` 102 | a hover over the edge midpoint before clicking it | `edgeAt(x, y)` reporting an edge under that exact point |
| `map-growth-replay` 30, 63 | the first reveal | `waitForMapStill` |
| `map-growth-replay` 37, 53, 67, 70, 77, 82 | the idle gate recording / dropping `growthReplaying` | `expect.poll` on `idleDebug().lastActive.causes` |
| `map-growth-replay` 47 | "the replay survived a pointer move" | a frame the gate recorded **after** the input — see Premises |
| `map-trail` 23 | the first reveal | `waitForMapStill` |
| `map-trail` 57, 71, 73 | a popover reveal before `toBeVisible` / `toHaveCount` assertions | removed; those assertions retry |
| `map-trail` 66 | the trail row taking the selection | `expect.poll` on `selection().nodeId` |
| `map-viewport-reframe` 21 | camera stillness, sampled 250 ms apart from the test process | `waitForMapStill({ what: "camera" })` |
| `map-viewport-reframe` 232 | "two frames after the last resize" | `waitFrames(page, 2)` |
| `map-viewport-reframe` 237 | the post-resize bounce window | 36 drawn frames sampled in the page — a round trip can straddle the peak |
| `map-expand-all` 49, 63 | layout stillness before taking click coordinates | `waitForMapStill` |
| `map-expand-all` 85 | the click's selection landing | `expect.poll` on `selection().nodeId` |
| `map-keyboard-walk` 79 | camera stillness | `waitForMapStill` |
| `map-keyboard-walk` 56, 110, 331 | a press being answered | `waitFrames` |
| `map-keyboard-walk` 684 | four arrow events being recorded | `expect.poll` on the listener's entry count |
| `map-keyboard-walk` 713 | two presses with no canvas focus doing nothing | 30 drawn frames of opportunity |
| `datasheet-hover-map-brush` 44, 57 | first reveal; the selection opening the datasheet | `waitForMapStill`; `expect.poll` on `selection()` |
| `datasheet-hover-map-brush` 107, 131, 155 | the map's hover following a panel row | `expect.poll` on `hover()` |
| `datasheet-hover-map-brush` 126 | the pixel noise floor | 42 drawn frames — the unit the number is per |
| `datasheet-hover-map-brush` 167 | a group heading **not** brushing the map | 3 drawn frames — see Premises |
| `map-hover-release` 58, 91 | first reveal; the hover taking | `waitForMapSettled`; `expect.poll` on `hover()` |

### The 3D dome

| file · line | waited for | now waits for |
|---|---|---|
| `map-3d-return` 35, 55, 97 | the 2D first reveal | `waitForMapStill` |
| `map-3d-return` 40, 59, 101 | a 3D arrangement assembling | `waitForDomeAssembled` |
| `map-3d-return` 44, 87, 116 | the return to flat | `waitForFlatMap` |
| `map-3d-return` 79 | a press dismissing the picker without walking | `toHaveCount(0)` on the picker, then 3 frames and `selection()` — see Premises |
| `map-3d-return` 111 | a deliberate click reaching the address | `expect.poll` on `?p=` |
| `map-3d-grip` 106, 185 | "assembly (≈1.1s) and the entry sweep (1.5s)" | `waitForDomeEntered` (`ramp >= 1 && !entryArmed`) |
| `map-3d-grip` 126, 160 | 16 ms between drag steps | `waitFrames(page, 1)` |
| `map-3d-grip` 129 | pan inertia | `waitForMapStill({ what: "camera" })` |
| `map-3d-grip` 143 | nothing — a second settle after the first | removed |
| `map-3d-grip` 163 | the orbit's `yawSnap` closing its remaining gap | `waitForMapStill({ what: "dome" })` |
| `map-3d-grip` 203, 234 | the canvas cursor changing | `expect.poll` on the computed cursor |
| `map-3d-strata-drawing` 86 · `map-3d-cone-drawing` 98 · `map-3d-relation-ink` 112 | 6 s "past the assembly and the entry sweep" | `waitForDomeEntered` + camera stillness |
| `map-3d-strata-drawing` 279 · `map-3d-cone-drawing` 310 | camera stillness, sampled 150 ms apart | `waitForMapStill({ what: "camera" })` |
| `map-3d-strata-drawing` 378 · `map-3d-cone-drawing` 409 | a click "back to the overview" | 3 drawn frames — see Premises |
| `map-3d-strata-drawing` 392 · `map-3d-cone-drawing` 423 | the click's hit test | 3 drawn frames, so a miss still produces the message naming what was hit |
| `map-3d-strata-drawing` 515 | the inspector docking and the reframe | `toBeVisible()` + camera stillness |

### The Library canvas

| file · line | waited for | now waits for |
|---|---|---|
| `library-graph-card` 122, 367 | the arrival breath clearing its own timestamp | `expect.poll` on `flow().pulsing` |
| `library-graph-card` 437 | the ink ramp | two identical canvas hashes |
| `library-graph-alive` 167, 266, 356 | 24/60/30 ms between drag, wheel and hover steps | `waitFrames(page, 1)` |
| `library-graph-alive` 236 | the hover dim ramp | `expect.poll` on the outsider's ink — the assertion **is** the condition |
| `library-graph-alive` 325 | the picture settling before the frame count | four samples of the canvas drawing the same bytes — see Premises |
| `library-graph-alive` 352 | the pointer leaving the marks | `data-hovered-node-id` becoming `""` |
| `library-graph-alive` 358 | a hover sweep before a `toHaveAttribute` assertion | removed; it retries |
| `library-graph-alive` 408 | the ink ramp under reduced motion | two identical frame hashes |
| `library-graph-picture` 324 | "one more frame after the settle" | `waitFrames(page, 2)` |
| `library-work-activity` 52 | a hidden canvas painting nothing | 30 drawn frames — a painting canvas would have painted on each |

### Routes, shells and surfaces

| file · line | waited for | now waits for |
|---|---|---|
| `docs-rename-address` 36, 39, 42, 85, 88, 91 | the first-run door, the guide sheet, the folder opening | `toBeVisible()` / `toHaveCount(0)` on each — see Premises |
| `docs-rename-address` 45, 47, 94, 96 | the docs tree before clicking it | removed; `click()` waits for its own target |
| `docs-rename-address` 49, 98 | the document opening | `expect.poll` on `?slug=` |
| `docs-rename-address` 53, 55, 101, 103 | the palette, and the typed command reaching the active row | `toBeVisible()`; the active `[role=option]` containing the command |
| `desktop-shell-rail` 44, 63, 77 | the shell deciding whether this visitor gets a rail | `waitForBoxStill` on the rail |
| `destination-shortcuts` 139, 174, 205 | a retired or blocked shortcut doing nothing | 30 drawn frames of opportunity |
| `hangul-tracking` 95 | a web font swapping in before measuring letter spacing | `document.fonts.ready` + `waitForAnimationsDone` |
| `architecture-role-ledger` 410, 413, 492, 503, 527 | the ladder relaying out after a resize, a selection and Escape | one `graphSettled` — animations done and the graph's box still |
| `download-gateway-grid` 557 | 60 ms between typing samples | `waitFrames(page, 4)` |
| `download-gateway-grid` 583, 586 | the changelog links on two routes | `expect.poll` on the link list — the assertion is the condition |
| `download-gateway-grid` 621 | "the echo lights the last dot with the last character (~2.5s)" | the hero's box still and its stage's animations done — see Premises |
| `transient-surface-contract` 103, 131 | the route arriving before enumerating triggers | `networkidle` + the body's box still — see Premises |
| `transient-surface-contract` 202 | the sheet finishing its entrance before Escape | `waitForAnimationsDone` on the surface |
| `transient-surface-contract` 217 | the exit, polled 6 × 220 ms | the same poll, paced in drawn frames |
| `transient-surface-contract` 305, 392 | the walk's camera transition | `waitForMapStill({ what: "camera" })` |
| `transient-surface-contract` 309 | a press being answered | `waitFrames` |
| `scroll-end-gap` 318, 545, 579 | hydration finishing before measuring rects | `networkidle` + the body's box still |
| `scroll-end-gap` 586 | the reading pane laying out | `waitForBoxStill` |

## Premises found wrong

Eight. Each one is written into the file it belongs to, and each is followed here by the
number that disproved it.

1. **An empty-ground click in 3D does not deselect** (`map-3d-strata-drawing`,
   `map-3d-cone-drawing`). The comment called it "back to the overview", so it was
   rewritten to wait for the selection to clear — and sat holding
   `capability:carrier-integration` for the full timeout, three runs out of three. Inside
   the dome an empty-ground press is an orbit grab (`map-3d-grip.spec.ts`), so the 400 ms
   it replaced had never waited for a deselect either. It now waits for the frames that
   carry what the press *does* do.
2. **`alpha() < 0.01 && !pulsing` is not "the Library picture settled"**
   (`library-graph-alive`). It looked like the exact condition the 3-second sleep stood
   for; the simulation goes cold while the amber breath is still painting, and the window
   that followed counted **224 frames** against an expected 0. The settle is now four
   samples of the canvas drawing the same bytes — deliberately *not* the claim the case
   then makes, because a loop redrawing an unchanged picture still fails the frame count.
3. **`map-hover-release`'s 3,500 ms is not a settle gate — it is another subsystem's
   tail.** Measured against its 12 ms/s bound on `?synth=800`: camera and layout still →
   38 ms/s; the map's own idle gate skipping every frame for 1.5 s → 45 ms/s; 3,500 ms
   after the pointer left → **2.7 ms/s**. The map had stopped in all three. With the
   pointer parked on a rail tile, roughly one further `requestAnimationFrame` callback per
   frame keeps working for about three seconds, and that loop exposes no state to wait on
   (`document.getAnimations()` reports nothing — it is script-driven). The sleep is
   **kept**, with the table written into the file, and the probe that produced the numbers
   is reverted. Giving that subsystem an observable is its own change.
4. **`gateway-idle-sleep`'s three sleeps are the subject of their claims, not gates.**
   The numbers: the product's own sleep delay is **30 s** with a **2 s** ramp, the three
   waits are **6 s / 32.5 s / 1.5 s** around that, and what `idleCost` then measures over
   a 4 s window is **1.5-2.2 ms/s healthy against 55+ ms/s defective** (the file's own
   recorded figures). There is no state to wait for — the whole promise is that the page
   *stops* doing anything after a fixed stretch of no input. **Kept and labelled.**
5. **An absence cannot be proven by polling for it.** Three sites read as conditions but
   are not, and in each the poll is satisfied on **attempt 1** by a reading taken before
   the input it is supposed to judge:
   - "the replay survives a pointer move" polls `idleDebug().lastActive`, whose timestamp
     is from *before* the move — so it cannot fail, and it would have stayed green against
     the very regression the case exists for. It now requires `lastActive.t > tBefore`.
   - "hovering a group heading leaves the map still" asserts `hover() === null` when the
     preceding step (`parkCursor`) has just *asserted the same null*. Zero new information.
   - "the press that dismisses the 3D picker does not also walk the map" has no positive
     marker of its own; the picker closing is the only one, and it is now read first,
     followed by `selection().nodeId` (measured null) after 3 drawn frames.
   Each now waits for the frames the handler would already have painted on, or for a fresh
   record made after the input.
6. **The `docs-rename-address` fixture opens the Library, not the map.** Waiting for
   `ontology-map-canvas` after the folder opens failed **6 of 6** (2 tests × 3 repeats),
   each at its 30 s ceiling: the fixture is **3 files with no project node**, and such a
   vault opens `/library` (`AGENTS.md`, routing). The condition is the first-run door
   being gone — 6/6 green, 8.7-9.5 s per test.
7. **"Nothing on the page is animating" is not a state these routes reach.** The first
   `routeSettled` waited on `Element.getAnimations()` across the whole body and sat for the
   full 30 s ceiling on the transient-surface sweep — the test died at **31.2 s** — and
   filtering out infinite animations did not fix it: some routes always have something
   finite restarting somewhere. Two corrections came out of it — the helper now skips animations
   with infinite iterations, since those are never done, and the two route sweeps wait for
   the body's **box** to repeat instead, which is the condition a rect measurement actually
   needs. `waitForAnimationsDone` is kept for the scoped cases (one graph, one hero stage,
   one transient surface).
8. **"The headline finished typing" is the wrong condition for the gateway's ink
   measurement**, twice over. The un-typed glyphs already occupy their layout, so the `h1`
   box `litShare` reads is complete from the first frame; and on this headless browser's
   software WebGL the typing interval is starved badly enough that 59 characters take about
   25 s (1, 3, 6, 8, 10, 12 lit after each of the first six seconds at 1100px with
   `?hero=three`), so the 3,200 ms it replaced had never waited for the typing either. The
   condition is the first screen's box being still and the stage's animations being done —
   12 cases, 20.5 s of timeout each → 2.4-13.8 s passing.

## Test plan

Local, against an isolated port, one worker, `--repeat-each=3`:

| spec set | result |
|---|---|
| `map-keyboard-zoom` | 3/3 (14.9 s, against ~7 s of sleeping per single run before) |
| `map-selection-framing` | 15/15 (26.8 s) |
| `map-growth-replay` | 6/6 (11.3 s) |
| `map-trail` + `map-viewport-reframe` | 15/15 (34.0 s) |
| `map-3d-return` | 9/9 (43.3 s) |
| `map-3d-grip` | 6/6 (17.5 s) |
| `map-3d-strata-drawing` + `map-3d-cone-drawing` + `map-3d-relation-ink` | 54/54 (2.0 min) |
| `library-graph-alive` | 15/15 (1.8 min) |
| + `library-graph-card` + `library-graph-picture` + `library-work-activity` | 85/85 (6.1 min) |
| `docs-rename-address` | 6/6 (57.5 s) |
| `datasheet-hover-map-brush` | 3/3 (11.2 s) |
| `desktop-shell-rail` | 12/12 (12.9 s) |
| `map-expand-all` + `map-hover-release` + `hangul-tracking` + `destination-shortcuts` | 87/87 |
| `map-keyboard-walk` | 54/54 (1.8 min) |
| `architecture-role-ledger` + `download-gateway-grid` + `transient-surface-contract` + `scroll-end-gap` | 144/144 |

`pnpm exec tsc --noEmit`, `pnpm exec eslint --max-warnings 0`, `pnpm knip`,
`pnpm source:language` and `tests/contract/rules-path-scope.contract.test.ts` green.
`pnpm checks:changed -- --run` recommendation set completed.

**One environment trap, now a line in `.claude/rules/testing.md`.** A dev server this
session had started as a background command was reaped out from under a run, and the
download-grid cases in flight failed against a dead server in **~1.2 s each** rather than
on anything in the diff — including two that had first looked like flakes at 588 ms and
1.2 s. Playwright's own `webServer` is not immune: started from a backgrounded batch it was
reaped too, mid-run. What works here is the foreground, in batches short enough to finish
there, on a port of your own via `PLAYWRIGHT_BASE_URL` so a stale server from another
session cannot answer instead. The same four families then ran 3× green in 2.7 / 1.6 / 1.6
/ 5.6 minutes.

Not run here: the installed macOS app (another agent was driving it). This slice is
browser-only and touches no native surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
