### PR TITLE
fix(ci): pr:land removes a worktree only when asked, and says so

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -135,6 +135,13 @@ Escalate only when the risk requires it:
 The final report names what ran and why that scope was sufficient. Do not run
 the full suite by habit.
 
+Measurements, captures and harness scripts live **outside** the repository —
+`/Users/jinan/scratch/<fixture>/…` — never in a worktree's gitignored `output/`
+or `.qa-scratch/`. A worktree is removed when its work lands, and
+`git status --porcelain` does not count ignored files, so an ignored evidence
+directory reads clean and goes with it. Measured 2026-09-13: a report cited
+ko+en captures at a path that no longer existed by the time it was read.
+
 ## Verify web and app separately (2026-07-27)
 
 Web and app no longer promise identical screens (`.claude/rules/surfaces.md`),

--- a/scripts/pr-land.mjs
+++ b/scripts/pr-land.mjs
@@ -51,6 +51,8 @@
  *   5. **Merge, prune, release.** Wait for the required contexts (read from the
  *      branch protection, never listed here), squash merge, delete the remote
  *      branch, prune locally, and always release the lock, including on Ctrl-C.
+ *      **No worktree is removed** unless `--cleanup <path>` asks for one:
+ *      `--worktree` only says where step 3 runs. See `worktreeToRemove`.
  *
  * One landing, in order: **lock, merge main, local checks, ready, one CI run,
  * merge, clean.**
@@ -574,16 +576,51 @@ function sleep(seconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.round(seconds * 1000));
 }
 
+/**
+ * **Which worktree a landing removes: `--cleanup`'s path, and nothing else.**
+ *
+ * ⚠️ Written as a named function of the parsed flags, and exported, because on
+ * 2026-09-13 an agent whose landing worktree disappeared read `--worktree` as
+ * "the worktree this landing owns" and reported that a successful
+ * `pnpm pr:land <n> --worktree <path>` had removed it, taking gitignored
+ * evidence with it. It had not: removal has always been `--cleanup`'s alone,
+ * and that landing's log carries no `cleanup:` line at all. The two flags
+ * answer different questions — `--worktree` is *where the local lanes run*,
+ * `--cleanup` is *what to remove when the landing is done* — and the inline
+ * `if (args.cleanup)` was true but unprovable. This is the same rule with a
+ * name and a recorded test, so the next agent can read the guarantee instead
+ * of inferring it from a missing directory.
+ *
+ * Whatever removed that worktree was outside this script; the flag separation
+ * is now pinned so this file can be ruled out by reading rather than by trust.
+ */
+export function worktreeToRemove(args) {
+  return args.cleanup ?? null;
+}
+
+/**
+ * What a removal says **before** it happens.
+ *
+ * It announced itself only afterwards, and only on success, so a landing that
+ * removed a worktree and a landing that never touched one read identically
+ * until the directory was gone. The path and the judgement go out first.
+ *
+ * ⚠️ The clean/dirty judgement is `git status --porcelain`, which **does not
+ * count ignored files**. That is the whole of the trap the 2026-09-13 landing
+ * hit: a worktree holding nothing but gitignored captures under `output/` reads
+ * clean, so the announcement says so out loud rather than implying the tree was
+ * empty.
+ */
+export function describeCleanup({ path, status }) {
+  if (status === null) return `${path} is not a Git worktree; left alone`;
+  if (status !== '') return `${path} still has uncommitted work; left alone`;
+  return `removing ${path} — tracked files clean (ignored files are not counted, so anything under an ignored path goes with it)`;
+}
+
 function cleanupWorktree(path) {
   const status = git(['-C', path, 'status', '--porcelain'], { allowFailure: true });
-  if (status === null) {
-    log(`cleanup: ${path} is not a Git worktree; left alone`);
-    return;
-  }
-  if (status !== '') {
-    log(`cleanup: ${path} still has uncommitted work; left alone`);
-    return;
-  }
+  log(`cleanup: ${describeCleanup({ path, status })}`);
+  if (status === null || status !== '') return;
   const branch = git(['-C', path, 'rev-parse', '--abbrev-ref', 'HEAD'], { allowFailure: true });
   git(['worktree', 'remove', path], { allowFailure: true });
   if (branch && branch !== 'main' && branch !== 'HEAD') {
@@ -775,7 +812,8 @@ export function runPrLand(argv, io = console) {
 
   if (pr?.state === 'MERGED') {
     io.log(`[pr-land] PR #${number} is already merged: ${pr.url}`);
-    if (args.cleanup) cleanupWorktree(args.cleanup);
+    const removal = worktreeToRemove(args);
+    if (removal) cleanupWorktree(removal);
     return 0;
   }
   const refusal = refuseLanding(pr);
@@ -968,7 +1006,8 @@ export function runPrLand(argv, io = console) {
       }
       git(['fetch', '--prune', 'origin'], { allowFailure: true });
       release();
-      if (args.cleanup) cleanupWorktree(args.cleanup);
+      const removal = worktreeToRemove(args);
+      if (removal) cleanupWorktree(removal);
       log('done. Next agent: `pnpm pr:land <number>`.');
       return 0;
     }

--- a/scripts/pr-land.test.mjs
+++ b/scripts/pr-land.test.mjs
@@ -16,6 +16,8 @@ import {
   refuseLanding,
   requiredCheckState,
   runInFlight,
+  describeCleanup,
+  worktreeToRemove,
 } from './pr-land.mjs';
 
 /**
@@ -132,6 +134,49 @@ describe('pr:land argument parsing', () => {
     assert.equal(parseArgs(['12', '--cleanup=/tmp/wt']).cleanup, '/tmp/wt');
     assert.equal(parseArgs(['12', '--worktree', '/tmp/wt']).worktree, '/tmp/wt');
     assert.equal(parseArgs(['12', '--worktree=/tmp/wt']).worktree, '/tmp/wt');
+  });
+
+  /**
+   * ⚠️ **`--worktree` removes nothing, in either spelling.**
+   *
+   * On 2026-09-13 an agent landed with `--worktree <path>`, found that path gone
+   * afterwards, and reported that the landing had deleted it along with the
+   * gitignored evidence inside it. The landing's own log carried no `cleanup:`
+   * line, so it had not — but nothing in this suite said so, and the next agent
+   * had only the source to trust. Both flag shapes are pinned here now, for both
+   * flags, so this script can be ruled out by reading.
+   */
+  it('removes a worktree only when --cleanup asks, never for --worktree', () => {
+    assert.equal(worktreeToRemove(parseArgs(['12', '--worktree', '/tmp/wt'])), null);
+    assert.equal(worktreeToRemove(parseArgs(['12', '--worktree=/tmp/wt'])), null);
+    assert.equal(worktreeToRemove(parseArgs(['12', '--cleanup', '/tmp/wt'])), '/tmp/wt');
+    assert.equal(worktreeToRemove(parseArgs(['12', '--cleanup=/tmp/wt'])), '/tmp/wt');
+    // Both together is the deliberate shape: run the lanes here, then remove it.
+    assert.equal(
+      worktreeToRemove(parseArgs(['12', '--worktree=/tmp/wt', '--cleanup=/tmp/wt'])),
+      '/tmp/wt',
+    );
+    // And a bare landing removes nothing at all.
+    assert.equal(worktreeToRemove(parseArgs(['12'])), null);
+  });
+
+  /**
+   * A removal says what it is about to do, and says the one thing that made the
+   * 2026-09-13 loss possible: `git status --porcelain` does not count ignored
+   * files, so a worktree holding only gitignored captures reads clean.
+   */
+  it('announces the path and the judgement before removing anything', () => {
+    const clean = describeCleanup({ path: '/tmp/wt', status: '' });
+    assert.match(clean, /^removing \/tmp\/wt/);
+    assert.match(clean, /ignored files are not counted/);
+    assert.equal(
+      describeCleanup({ path: '/tmp/wt', status: ' M src/a.ts' }),
+      '/tmp/wt still has uncommitted work; left alone',
+    );
+    assert.equal(
+      describeCleanup({ path: '/tmp/nope', status: null }),
+      '/tmp/nope is not a Git worktree; left alone',
+    );
   });
 
   it('defaults the worktree to the caller, which is the branch it wrote', () => {


### PR DESCRIPTION
## Summary

Two changes, from a landing whose worktree disappeared and took its gitignored
captures with it (2026-09-13, PR #1581).

**⚠️ First, a correction to the premise.** I reported that
`pnpm pr:land <n> --worktree <path>` had removed that worktree. **It had not.**
`cleanupWorktree` is called at exactly two sites, both under `if (args.cleanup)`,
and that landing's log carries no `cleanup:` line — it ends
`merged → landing lock released → done`. `--worktree` has never removed
anything. Whatever removed it was outside this script, and the local branch went
with it, so it is worth someone chasing the actual actor (the path is
Orca-managed; `orca automations list` reports none).

So this PR does not change the flag semantics — they were already right. It makes
them **provable**, which is the part that failed: the guarantee existed only as an
inline condition two call sites apart, so the next agent could reach it by reading
the whole script or by trusting a claim, and I trusted the claim.

1. **`worktreeToRemove(args)`** — one named, exported, tested rule. Both flag
   shapes of both flags are pinned: `--worktree` is *where the local lanes run*,
   `--cleanup` is *what to remove afterwards*, both together is the deliberate
   shape, and a bare landing removes nothing. This file can now be ruled out by
   reading.
2. **A removal announces itself before it happens**, with the path and the
   judgement. It used to log only afterwards and only on success, so "removed a
   worktree" and "never touched one" read identically until the directory was
   gone. The announcement also names the trap it hides:

   ```
   cleanup: removing /path/wt — tracked files clean (ignored files are not
   counted, so anything under an ignored path goes with it)
   ```

   `git status --porcelain` does not count ignored files, so a worktree holding
   nothing but gitignored captures under `output/` reads clean. That is the whole
   mechanism of the loss, whoever pulled the trigger.
3. **Where evidence lives**, in `.claude/rules/testing.md`: measurements, captures
   and harness scripts go outside the repository — `/Users/jinan/scratch/<fixture>/…`
   — never a worktree's gitignored `output/` or `.qa-scratch/`.

   It went there rather than into `AGENTS.md`'s rendered-evidence paragraph because
   the resident-context ratchet refused the four lines
   (`rules-path-scope.contract.test.ts`: 27 368 > 27 144 bytes) and was right to —
   this is detail for whoever is generating evidence, not a fact every turn pays
   for before reading its task. `testing.md` is path-loaded and already owns
   verification evidence.

## Test plan

- `pnpm checks:changed -- --run $(git diff --name-only origin/main...HEAD)` —
  **8/8 pass** (eslint, `pr-land.test.mjs`, `source:language`, knip,
  `test:contracts`, `tsc --noEmit`, plus the two MCP/agent-file contract lanes).
- `node --test scripts/pr-land.test.mjs` — 47 pass, including the two new cases:
  - *removes a worktree only when `--cleanup` asks, never for `--worktree`* —
    `--worktree /tmp/wt` and `--worktree=/tmp/wt` both yield `null`; `--cleanup`
    in both spellings yields the path; both flags together yield the path; a bare
    `12` yields `null`.
  - *announces the path and the judgement before removing anything* — the clean
    message starts with the path and says ignored files are not counted; the dirty
    and not-a-worktree messages are unchanged and still leave the tree alone.
- The resident-context ratchet is the reason the rule is where it is, and it is
  green: `rules-path-scope.contract.test.ts` passes with `AGENTS.md` untouched.

No behaviour changed for any existing invocation: `--cleanup` removes exactly what
it removed before, and every other landing removes nothing, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
