### PR TITLE
fix(app): every failure a person can see is a sentence, and the gate can tell

### DIFF
--- a/src/features/docs-vault-local/ui/OntologyStarterCta.tsx
+++ b/src/features/docs-vault-local/ui/OntologyStarterCta.tsx
@@ -5,6 +5,8 @@ import { CheckCircle2, ClipboardCopy, Sparkles } from 'lucide-react';
 import { ICON_SIZE } from '@/shared/ui/icon-size';
 import { useTranslations } from 'next-intl';
 import { copyText } from '@/shared/lib/copy-text';
+import { useFailureSentence } from '@/shared/lib/use-failure-sentence';
+import type { FailureCopy } from '@/shared/lib/use-failure-sentence';
 import { ATLAS_CLI } from '@/shared/config/cli-invocation';
 import { controlClass } from '@/shared/ui/control-class';
 
@@ -115,8 +117,15 @@ export function buildOntologyStarterAgentVerifyPrompt(
  */
 export function OntologyStarterCta({ onScaffold, docCount, vaultPath = null }: Props) {
   const t = useTranslations('featuresMisc.starterCta');
+  const failureSentence = useFailureSentence();
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  /*
+   * The failure is kept as a sentence **plus** its English detail, never as the thrown message.
+   * Scaffolding writes into a folder the person chose, so the two failures that actually happen
+   * here are `permission-denied` and `already-exists`, and the `failures` catalogue has a sentence
+   * with a next step for both. The thrown English goes to `data-failure-detail`.
+   */
+  const [error, setError] = useState<FailureCopy | null>(null);
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const [cliCopyState, setCliCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const [jsonGateCopyState, setJsonGateCopyState] = useState<
@@ -140,7 +149,7 @@ export function OntologyStarterCta({ onScaffold, docCount, vaultPath = null }: P
     try {
       await onScaffold();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t('errorFallback'));
+      setError(failureSentence(err, t('errorFallback')));
     } finally {
       setBusy(false);
     }
@@ -312,9 +321,10 @@ export function OntologyStarterCta({ onScaffold, docCount, vaultPath = null }: P
         {error ? (
           <p
             role="alert"
+            data-failure-detail={error.detail ?? undefined}
             className="mt-3 break-keep text-label text-[color:var(--color-status-danger)]"
           >
-            {error}
+            {error.sentence}
           </p>
         ) : null}
       </section>

--- a/src/features/first-run-starter/model/use-first-run-starter.test.ts
+++ b/src/features/first-run-starter/model/use-first-run-starter.test.ts
@@ -250,11 +250,34 @@ describe('첫 실행 카드 — 말할 수 있는 실패는 말한다', () => {
     ).toBe('errorPermissionDenied');
   });
 
-  it('그 밖의 실패는 원문을 쓰되, 비어 있어도 카드가 뜬다', () => {
+  it('그 밖의 실패는 원문 대신 문장을 쓰고, 원문은 detail 로 내려간다', () => {
     mocks.vault.errorCode = 'access-failed';
     const { result } = renderHook(() => useFirstRunStarter());
-    // An empty string drops the screen to `errorFallback` — null would show no card at all.
-    expect(result.current.errorText).toBe('');
+    // `access-failed` is the one code that carries a cause string. With nothing to recognise it
+    // falls back to the card's own sentence rather than showing a blank line.
+    expect(result.current.errorText).toBe('errorFallback');
+    expect(result.current.errorDetail).toBeNull();
+  });
+
+  /*
+   * Re-inspection before v1.2.2, S20: this branch handed `vault.errorMessage` to the card, which
+   * printed it as a "quiet clue" beneath the Korean sentence — the cause string in English on a
+   * Korean screen, while `no-raw-error-copy` stayed green.
+   */
+  it('access-failed 의 원문 영어는 화면 문장에 절대 오지 않는다', () => {
+    mocks.vault.errorCode = 'access-failed';
+    mocks.vault.errorMessage = 'Tauri command failed: EPIPE writing manifest';
+    const { result } = renderHook(() => useFirstRunStarter());
+    expect(result.current.errorText).toBe('errorFallback');
+    expect(result.current.errorDetail).toBe('Tauri command failed: EPIPE writing manifest');
+  });
+
+  it('OS 가 막은 폴더도 errno 는 detail 로만 남는다', () => {
+    mocks.vault.errorCode = 'permission-denied';
+    mocks.vault.errorMessage = 'Operation not permitted (os error 1)';
+    const { result } = renderHook(() => useFirstRunStarter());
+    expect(result.current.errorText).toBe('errorPermissionDenied');
+    expect(result.current.errorDetail).toBe('Operation not permitted (os error 1)');
   });
 
 });

--- a/src/features/first-run-starter/model/use-first-run-starter.ts
+++ b/src/features/first-run-starter/model/use-first-run-starter.ts
@@ -10,6 +10,7 @@ import {
 import { isDesktopShell } from '@/shared/lib/desktop-shell';
 import { requestAgentChat } from '@/shared/lib/agent-chat-intent';
 import { useFailureSentence } from '@/shared/lib/use-failure-sentence';
+import type { FailureCopy } from '@/shared/lib/use-failure-sentence';
 import { deniedFolderName } from '@/entities/vault-session';
 import { getTauriVaultRootPath } from '@/shared/lib/tauri-vault-fs';
 import { buildFromCodePrompt } from './build-from-code-prompt';
@@ -106,10 +107,10 @@ export function useFirstRunStarter() {
   /**
    * **Say whatever can be said about what went wrong.**
    *
-   * ⚠️ This used to read `vault.errorMessage` alone. But "not a valid root",
-   * "folder is gone", and "no permission" **deliberately leave that value
-   * `null`** so the raw string is not leaked to the screen. So all three became
-   * states where this card **said nothing at all** (review 2026-08-16). Silence
+   * ⚠️ This used to read `vault.errorMessage` alone. But "not a valid root" and
+   * "folder is gone" leave that value `null` so no raw string reaches the
+   * screen, and "no permission" leaves an errno. So all three became states
+   * where this card **said nothing useful at all** (review 2026-08-16). Silence
    * on screen while the code knows the meaning is worse than leaking the raw string.
    *
    * The neighbouring screen (`FirstRunPage`) already handled these branches — two
@@ -121,24 +122,37 @@ export function useFirstRunStarter() {
    * ⚠️ `actionError` is a **failure code**, not a sentence — see `use-vault-create-flow.ts`. It
    * used to be the thrown English, which this card then showed to a Korean reader (B2).
    */
-  const errorText =
+  const failure: FailureCopy | null =
     actionError !== null
-      ? failureSentence(actionError, t('errorFallback')).sentence
+      ? failureSentence(actionError, t('errorFallback'))
       : vault.status === 'error'
-        ? (vault.errorCode === 'root-rejected'
-            ? t('errorRootRejected')
-            : vault.errorCode === 'path-missing'
-              ? t('errorPathMissing')
-              : vault.errorCode === 'permission-denied'
-                // The OS refused; a retry gives the same refusal, so name the folder and the setting.
-                ? t('errorPermissionDenied', {
+        ? vault.errorCode === 'root-rejected'
+          ? { sentence: t('errorRootRejected'), detail: null }
+          : vault.errorCode === 'path-missing'
+            ? { sentence: t('errorPathMissing'), detail: null }
+            : vault.errorCode === 'permission-denied'
+              // The OS refused; a retry gives the same refusal, so name the folder and the setting.
+              ? {
+                  sentence: t('errorPermissionDenied', {
                     folder:
                       deniedFolderName(
                         vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null,
                       ) ?? t('errorPermissionDeniedThisFolder'),
-                  })
-                : vault.errorMessage) ?? ''
+                  }),
+                  detail: vault.errorMessage,
+                }
+              /*
+               * ⚠️ `access-failed` is the one code that **does** carry a cause string, and this
+               * branch used to hand it straight to the card, which printed it beneath the
+               * Korean line as a "quiet clue" — raw English on the first-run screen
+               * (re-inspection before v1.2.2, S20). The same lookup the coded branches use
+               * recognises the OS signatures in that string; anything else falls back to this
+               * card's own sentence and keeps the English on `detail`.
+               */
+              : failureSentence(vault.errorMessage, t('errorFallback'))
         : null;
+  const errorText = failure?.sentence ?? null;
+  const errorDetail = failure?.detail ?? null;
 
   useEffect(() => {
     if (!visible) return;
@@ -178,7 +192,10 @@ export function useFirstRunStarter() {
     createVault: handleCreate,
     busy,
     scaffolding,
+    /** The sentence the card renders. Always the reader's language, never a thrown message. */
     errorText,
+    /** The machine half of the same failure. Only ever for `data-failure-detail` or the console. */
+    errorDetail,
     /**
      * Detects a browser without File System Access (Safari, Firefox). Both open-folder
      * and create-vault use FSA, so when unsupported the primary CTA is degraded

--- a/src/features/first-run-starter/ui/BuildFromCodeConfirmDialog.tsx
+++ b/src/features/first-run-starter/ui/BuildFromCodeConfirmDialog.tsx
@@ -38,6 +38,10 @@ export function BuildFromCodeConfirmDialog({
   const failureSentence = useFailureSentence();
   const location = build.location;
   const creating = build.stage === 'creating';
+  // The sentence is the reader's; the code stays on `data-failure-detail` so a developer can still
+  // tell `permission-denied` from `already-exists` without it being on screen.
+  const failure =
+    build.errorText !== null ? failureSentence(build.errorText, t('buildFromCodeFailed')) : null;
 
   return (
     <Dialog
@@ -94,12 +98,13 @@ export function BuildFromCodeConfirmDialog({
         ))}
       </code>
 
-      {build.errorText !== null ? (
+      {failure !== null ? (
         <p
           data-testid="build-from-code-error"
+          data-failure-detail={failure.detail ?? undefined}
           className="mt-2 text-label leading-label text-[color:var(--color-danger-text)]"
         >
-          {failureSentence(build.errorText, t('buildFromCodeFailed')).sentence}
+          {failure.sentence}
         </p>
       ) : null}
 

--- a/src/features/first-run-starter/ui/BuildFromCodeDoor.test.tsx
+++ b/src/features/first-run-starter/ui/BuildFromCodeDoor.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import koMessages from '../../../../messages/ko.json';
+import enMessages from '../../../../messages/en.json';
+
+import { BuildFromCodeDoor } from './BuildFromCodeDoor';
+
+import type { useBuildFromCode } from '../model/use-build-from-code';
+
+/**
+ * **R3 of the re-inspection before v1.2.2 — a bare failure code painted as Korean copy.**
+ *
+ * `use-build-from-code.ts` returns `failureCodeOf(err) ?? ''`, so `build.errorText` is a
+ * kebab-case **code**. This door rendered `{build.errorText || t('buildFromCodeFailed')}`,
+ * which put the literal token `permission-denied` onto a Korean first-run screen. Its sibling
+ * `BuildFromCodeConfirmDialog` had been converted in the same change; this one had not, and
+ * neither rule in `no-raw-error-copy.contract.test.ts` could see it — no `.message`, no catch
+ * binding, and the `a || t(…)` spelling was outside the matcher.
+ *
+ * The inspection could not force the native folder picker into a permission failure, so the
+ * defect was source-confirmed and runtime-unconfirmed. This file is the cheap reproduction: the
+ * producer's own code, handed to the door as state, rendered in both locales.
+ */
+
+/** The three codes `failureCodeOf` mints from a folder-pick refusal. */
+const CODES = ['permission-denied', 'target-missing', 'already-exists'] as const;
+
+function buildWith(errorText: string | null): ReturnType<typeof useBuildFromCode> {
+  return {
+    stage: 'idle',
+    location: null,
+    reusesExisting: false,
+    pickedMapFolder: false,
+    errorText,
+    chooseProject: vi.fn(async () => undefined),
+    confirm: vi.fn(async () => undefined),
+    reset: vi.fn(),
+  };
+}
+
+function renderDoor(errorText: string | null, locale: 'ko' | 'en') {
+  return render(
+    <NextIntlClientProvider locale={locale} messages={locale === 'ko' ? koMessages : enMessages}>
+      <BuildFromCodeDoor build={buildWith(errorText)} variant="card" />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('내 코드로 지도 만들기 — 실패는 코드가 아니라 문장으로 보인다', () => {
+  it.each(CODES)('%s 는 화면에 토큰으로 남지 않는다 (ko)', (code) => {
+    renderDoor(code, 'ko');
+    const line = screen.getByTestId('first-run-build-error');
+    expect(line.textContent, 'the producer\'s code is being painted as copy').not.toContain(code);
+    // The catalogue's own sentence for the code, not the door's generic fallback.
+    expect(line.textContent).toBe(koMessages.failures[code]);
+    // The machine half is kept where a developer reads it and a reader does not.
+    expect(line.getAttribute('data-failure-detail')).toBe(code);
+  });
+
+  it.each(CODES)('%s reaches an English reader as a sentence too', (code) => {
+    renderDoor(code, 'en');
+    const line = screen.getByTestId('first-run-build-error');
+    expect(line.textContent).toBe(enMessages.failures[code]);
+    expect(line.getAttribute('data-failure-detail')).toBe(code);
+  });
+
+  it('알아보지 못한 실패는 이 문의 자기 문장으로 떨어진다', () => {
+    // `messageOf` returns `''` for "it failed and nothing recognised it".
+    renderDoor('', 'ko');
+    const line = screen.getByTestId('first-run-build-error');
+    expect(line.textContent).toBe(koMessages.firstRunStarter.buildFromCodeFailed);
+    expect(line.getAttribute('data-failure-detail')).toBeNull();
+  });
+
+  it('실패가 없으면 오류 줄 대신 안내가 선다', () => {
+    renderDoor(null, 'ko');
+    expect(screen.queryByTestId('first-run-build-error')).toBeNull();
+    expect(screen.getByText(koMessages.firstRunStarter.buildFromCodeHint)).toBeTruthy();
+  });
+
+  /*
+   * The probe for this file's own instrument: the pre-repair expression, evaluated here, really
+   * does produce the token. Without this the assertions above could pass against a screen that
+   * never had the defect.
+   */
+  it('probe: the pre-repair expression yields the bare token', () => {
+    const errorText: string | null = 'permission-denied';
+    const preRepair = errorText || koMessages.firstRunStarter.buildFromCodeFailed;
+    expect(preRepair).toBe('permission-denied');
+  });
+});

--- a/src/features/first-run-starter/ui/BuildFromCodeDoor.tsx
+++ b/src/features/first-run-starter/ui/BuildFromCodeDoor.tsx
@@ -5,6 +5,7 @@ import { Fragment } from 'react';
 import { Bot } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
+import { useFailureSentence } from '@/shared/lib/use-failure-sentence';
 import { controlClass } from '@/shared/ui/control-class';
 
 import { BuildFromCodeConfirmDialog } from './BuildFromCodeConfirmDialog';
@@ -40,7 +41,18 @@ export interface BuildFromCodeDoorProps {
 
 export function BuildFromCodeDoor({ build, variant, disabled = false }: BuildFromCodeDoorProps) {
   const t = useTranslations('firstRunStarter');
+  const failureSentence = useFailureSentence();
   const busy = build.stage === 'choosing' || build.stage === 'creating';
+  /*
+   * ⚠️ `build.errorText` is a **failure code**, not a sentence — `use-build-from-code.ts` returns
+   * `failureCodeOf(err) ?? ''`. Until this line was converted it rendered that token raw, so a
+   * folder-pick refused by macOS printed the literal `permission-denied` onto a Korean screen
+   * (re-inspection before v1.2.2, R3). Its sibling `BuildFromCodeConfirmDialog` was converted with
+   * the other eight consumers in the same change and this one was not, which is why the gate that
+   * change shipped now also watches the `a || t(…)` spelling and not only `err.message ? …`.
+   */
+  const failure =
+    build.errorText !== null ? failureSentence(build.errorText, t('buildFromCodeFailed')) : null;
 
   return (
     <>
@@ -91,17 +103,21 @@ export function BuildFromCodeDoor({ build, variant, disabled = false }: BuildFro
       */}
       <BuildFromCodeConfirmDialog build={build} />
 
-      {build.location === null && build.errorText !== null ? (
+      {build.location === null && failure !== null ? (
         /*
          * A failure before a project is chosen has no dialog to live in — the dialog opens on a
          * location, and there is none. Without this the button simply did nothing and the person
          * pressed it again.
+         *
+         * `data-failure-detail` is where the machine half goes: a developer reads the attribute,
+         * a reader reads the sentence.
          */
         <p
           data-testid={variant === 'card' ? 'first-run-build-error' : 'index-build-error'}
+          data-failure-detail={failure.detail ?? undefined}
           className="mt-1 break-keep text-caption leading-caption text-[color:var(--color-danger-text)]"
         >
-          {build.errorText || t('buildFromCodeFailed')}
+          {failure.sentence}
         </p>
       ) : variant === 'card' ? (
         /* What will actually happen, before it happens — including that it asks before writing. */

--- a/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
+++ b/src/features/first-run-starter/ui/FirstRunStarterModule.tsx
@@ -178,6 +178,7 @@ export function FirstRunStarterModule({
     busy,
     scaffolding,
     errorText,
+    errorDetail,
     fsaUnsupported,
   } = useFirstRunStarter();
   const { state: cliCopyState, copy: copyCliCommand } = useCopyFeedback();
@@ -706,27 +707,26 @@ export function FirstRunStarterModule({
         </p>
       )}
 
-      {/* The raw browser string (`errorText`) used to occupy the whole
-          user-facing slot. `window.showDirectoryPicker is not a function` is not
-          a sentence a person can read and choose a next action from. Now one
-          human sentence comes first and the cause string stays beneath it as a
-          quiet clue — the cause is kept while the reading order is inverted.
+      {/* The raw browser string used to occupy the whole user-facing slot.
+          `window.showDirectoryPicker is not a function` is not a sentence a person can
+          read and choose a next action from.
           2026-08-02 — when the reference block moved to the bottom, this warning
           was pushed to the end of the card, far from the button it explains. It
-          stays inside the action layer. */}
+          stays inside the action layer.
+          ⚠️ v1.2.2 — the "quiet clue beneath the sentence" that this block used to render was
+          `vault.errorMessage`, i.e. the cause string in English on a Korean card
+          (re-inspection, S20). The hook now hands over a sentence for the slot and the English on
+          `errorDetail`, which goes to `data-failure-detail` — read by a developer, not a reader.
+          The visible line is also no longer the generic fallback for every failure: when the code
+          is recognised it is the sentence written for that exact failure. */}
       {errorText !== null ? (
-        <div role="alert" className="mt-2">
-          <p className="text-label text-[color:var(--color-status-danger)]">
-            {t("errorFallback")}
-          </p>
-          {errorText ? (
-            <p
-              data-testid="first-run-starter-error-detail"
-              className="mt-0.5 break-words text-label leading-label text-[color:var(--map-panel-text-quaternary)]"
-            >
-              {errorText}
-            </p>
-          ) : null}
+        <div
+          role="alert"
+          className="mt-2"
+          data-testid="first-run-starter-error"
+          data-failure-detail={errorDetail ?? undefined}
+        >
+          <p className="text-label text-[color:var(--color-status-danger)]">{errorText}</p>
         </div>
       ) : null}
 

--- a/src/features/project-edit/ui/ProjectForm.errorFocus.test.tsx
+++ b/src/features/project-edit/ui/ProjectForm.errorFocus.test.tsx
@@ -91,7 +91,16 @@ describe("ProjectForm — 저장 거절은 눌린 사람에게 도착한다", ()
     expect(onSubmit, "저장이 호출되지 않았다 — 이 시험이 헛돈다").toHaveBeenCalledTimes(1);
 
     const banner = await screen.findByTestId("project-error-banner");
-    expect(banner).toHaveTextContent("데모 모드에서는 저장할 수 없습니다");
+    /*
+     * ⚠️ The banner shows **the copy written for a failed save**, not the thrown message
+     * (v1.2.2: `no-raw-error-copy` R1). This fixture throws Korean; the real rejections throw
+     * English from the vault layer, and a screen cannot translate either of them. The thrown
+     * text is kept where a developer reads it and a reader does not.
+     */
+    expect(banner).toHaveTextContent(koMessages.settings.projectForm.validation.saveFailed);
+    expect(banner.getAttribute("data-failure-detail")).toContain(
+      "데모 모드에서는 저장할 수 없습니다",
+    );
     expect(
       document.activeElement,
       "저장이 거절됐는데 초점이 그대로다 — 긴 폼·짧은 화면에서는 이유가 화면 밖에 뜬다",

--- a/src/features/project-edit/ui/ProjectForm.tsx
+++ b/src/features/project-edit/ui/ProjectForm.tsx
@@ -14,6 +14,9 @@ import {
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
+
+import { useFailureSentence } from "@/shared/lib/use-failure-sentence";
+import type { FailureCopy } from "@/shared/lib/use-failure-sentence";
 import { usePrefersReducedMotion } from '@/shared/lib/use-prefers-reduced-motion';
 import { ChevronDown } from "lucide-react";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
@@ -209,6 +212,7 @@ export function ProjectForm({
   openVaultAction,
 }: Props) {
   const t = useTranslations("settings.projectForm");
+  const failureSentence = useFailureSentence();
   const reducedMotion = usePrefersReducedMotion();
   // The freshness model returns a grade only; the screen chooses the words.
   const tFreshness = useTranslations("projectFreshness");
@@ -341,7 +345,12 @@ export function ProjectForm({
   const [submitting, setSubmitting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [mobilePreviewOpen, setMobilePreviewOpen] = useState(false);
-  const [globalError, setGlobalError] = useState<string | null>(null);
+  /*
+   * A failed save keeps **both halves**: the sentence the banner shows and the English cause a
+   * developer reads off `data-failure-detail`. It used to hold `err.message`, which put the
+   * vault layer's English into this banner on a Korean screen.
+   */
+  const [globalError, setGlobalError] = useState<FailureCopy | null>(null);
   const [saveNotice, setSaveNotice] = useState<string | null>(null);
   const submitBehaviorRef = useRef<"stay" | "return">("stay");
   const [sectionOpen, setSectionOpen] = useState<Record<string, boolean>>(() =>
@@ -697,7 +706,7 @@ export function ProjectForm({
         );
       }
     } catch (err) {
-      setGlobalError(err instanceof Error ? err.message : t("validation.saveFailed"));
+      setGlobalError(failureSentence(err, t("validation.saveFailed")));
     } finally {
       setSubmitting(false);
     }
@@ -710,7 +719,7 @@ export function ProjectForm({
     try {
       await onDelete();
     } catch (err) {
-      setGlobalError(err instanceof Error ? err.message : t("validation.deleteFailed"));
+      setGlobalError(failureSentence(err, t("validation.deleteFailed")));
     } finally {
       setDeleting(false);
     }
@@ -1187,10 +1196,11 @@ export function ProjectForm({
         role="alert"
         tabIndex={-1}
         data-testid="project-error-banner"
+        data-failure-detail={globalError?.detail ?? undefined}
         className="rounded-card border border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-3 py-3 text-body-lg text-[color:var(--color-status-danger)]"
       >
         <p className="font-[var(--font-weight-signature)]">
-          {globalError ?? t("validation.globalErrorBanner")}
+          {globalError?.sentence ?? t("validation.globalErrorBanner")}
         </p>
         {Object.keys(errors).length > 0 ? (
           <>

--- a/src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx
+++ b/src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
+
+import { useFailureSentence } from "@/shared/lib/use-failure-sentence";
+import type { FailureCopy } from "@/shared/lib/use-failure-sentence";
 import { PencilLine, X } from "lucide-react";
 import { ICON_SIZE } from "@/shared/ui/icon-size";
 import { type Project } from "@/entities/project";
@@ -142,6 +145,7 @@ export function ProjectQuickEditPanel({
   settingsHref,
 }: Props) {
   const t = useTranslations("settings.quickEdit");
+  const failureSentence = useFailureSentence();
   const [open, setOpen] = useState(false);
   const [values, setValues] = useState<QuickEditValues>(() =>
     toQuickEditValues(project),
@@ -150,7 +154,11 @@ export function ProjectQuickEditPanel({
     toQuickEditValues(project),
   );
   const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  /*
+   * Both halves of the failure. The empty-name refusal is copy this panel wrote, so its `detail`
+   * is null; a rejected patch carries the vault layer's English on `detail` and shows a sentence.
+   */
+  const [error, setError] = useState<FailureCopy | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const { patchProject } = useProjectMutations();
 
@@ -217,7 +225,7 @@ export function ProjectQuickEditPanel({
     // Only the name is required — the description is optional (the counterpart of not
     // making anyone delete the starter default).
     if (!nextPatch.name?.trim()) {
-      setError(t("errorEmpty"));
+      setError({ sentence: t("errorEmpty"), detail: null });
       return;
     }
 
@@ -241,11 +249,7 @@ export function ProjectQuickEditPanel({
           : t("noticeAppliedNoLabels"),
       );
     } catch (submitError) {
-      setError(
-        submitError instanceof Error
-          ? submitError.message
-          : t("errorGeneric"),
-      );
+      setError(failureSentence(submitError, t("errorGeneric")));
     } finally {
       setPending(false);
     }
@@ -374,7 +378,12 @@ export function ProjectQuickEditPanel({
             </div>
 
             {error ? (
-              <p className="text-body text-[color:var(--color-status-danger)]">{error}</p>
+              <p
+                data-failure-detail={error.detail ?? undefined}
+                className="text-body text-[color:var(--color-status-danger)]"
+              >
+                {error.sentence}
+              </p>
             ) : null}
 
             {notice ? (

--- a/src/views/first-run/ui/FirstRunPage.tsx
+++ b/src/views/first-run/ui/FirstRunPage.tsx
@@ -8,6 +8,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useLocalVault } from "@/entities/vault-session";
 import { useJustStartVault, useVaultCreateFlow } from "@/features/docs-vault-local";
 import { useFailureSentence } from '@/shared/lib/use-failure-sentence';
+import type { FailureCopy } from '@/shared/lib/use-failure-sentence';
 import { deniedFolderName } from "@/entities/vault-session";
 import { getTauriVaultRootPath } from "@/shared/lib/tauri-vault-fs";
 import { isTauriVaultRuntime } from "@/shared/lib/tauri-vault-fs";
@@ -104,25 +105,28 @@ export function FirstRunPage() {
    * over `err.message`, and this line printed the developer's English onto a Korean screen
    * (installed-app inspection, B2). An unrecognised code falls through to this screen's own
    * fallback, which is the sentence somebody wrote for exactly this press.
+   *
+   * Every branch resolves to a `FailureCopy`, so the sentence and the machine half never share a
+   * slot: `sentence` is rendered, `detail` only ever reaches `data-failure-detail`.
    */
-  const errorText =
+  const failure: FailureCopy | null =
     justStartError !== null
-      ? failureSentence(justStartError, t("errorFallback")).sentence
+      ? failureSentence(justStartError, t("errorFallback"))
       : actionError !== null
-        ? failureSentence(actionError, t("errorFallback")).sentence
+        ? failureSentence(actionError, t("errorFallback"))
         : vault.status === "error"
           ? // A "cannot be a vault root" case is a rejection, not a failure. Showing "please try again"
             // here would make the screen lie, since every retry gives the same result.
             vault.errorCode === "root-rejected"
-            ? t("errorRootRejected")
+            ? { sentence: t("errorRootRejected"), detail: null }
             : /*
                * ⚠️ "the folder is gone" is **also not something a retry fixes** (review
-               * 2026-08-16). This branch used to fall through to `errorMessage`, but that
-               * value is deliberately blank so the raw cause is not leaked — so what
-               * actually showed was "please try again", with the same result every press.
+               * 2026-08-16). `use-local-vault.ts` leaves `errorMessage` null on this code
+               * alone, so falling through to it showed "please try again", with the same
+               * result every press.
                */
               vault.errorCode === "path-missing"
-              ? t("errorPathMissing")
+              ? { sentence: t("errorPathMissing"), detail: null }
               : /*
                  * ⚠️ The operating system refused, and a retry gives the same refusal. The raw
                  * `Operation not permitted (os error 1)` names an errno, not a folder, and never
@@ -130,13 +134,27 @@ export function FirstRunPage() {
                  * sentence that names the folder and where to allow it.
                  */
                 vault.errorCode === "permission-denied"
-                ? t("errorPermissionDenied", {
-                    folder:
-                      deniedFolderName(
-                        vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null,
-                      ) ?? t("errorPermissionDeniedThisFolder"),
-                  })
-                : vault.errorMessage ?? t("errorFallback")
+                ? {
+                    sentence: t("errorPermissionDenied", {
+                      folder:
+                        deniedFolderName(
+                          vault.handle ? getTauriVaultRootPath(vault.handle) ?? null : null,
+                        ) ?? t("errorPermissionDeniedThisFolder"),
+                    }),
+                    detail: vault.errorMessage,
+                  }
+                : /*
+                   * ⚠️ `access-failed` is the branch that **does** carry a cause string
+                   * (`use-local-vault.ts:241` documents it: "errorMessage carries the cause
+                   * string, including a Tauri command's Err(String)"). A comment here once
+                   * claimed the opposite — that the value is "deliberately blank so the raw
+                   * cause is not leaked" — and on the strength of that claim this line rendered
+                   * it directly, which put raw English on the first-run screen while the gate
+                   * that change shipped stayed green (re-inspection before v1.2.2, S20). The
+                   * same lookup the coded branches use recognises the OS signatures in that
+                   * string and otherwise falls back to this screen's own sentence.
+                   */
+                  failureSentence(vault.errorMessage, t("errorFallback"))
           : null;
 
   const cardBase = controlClass({
@@ -309,12 +327,13 @@ export function FirstRunPage() {
         </div>
         )}
 
-        {errorText ? (
+        {failure ? (
           <p
             role="alert"
+            data-failure-detail={failure.detail ?? undefined}
             className="break-keep text-center text-label text-[color:var(--color-status-danger)]"
           >
-            {errorText}
+            {failure.sentence}
           </p>
         ) : null}
 

--- a/src/views/project-detail/ui/ProjectDetailPage.tsx
+++ b/src/views/project-detail/ui/ProjectDetailPage.tsx
@@ -38,6 +38,7 @@ import { VaultConflictError } from "@/entities/vault-session";
 import { useOntologyInsight } from "@/features/vault-ontology";
 import { CopyProjectLinkButton } from "@/features/project-share";
 import { useDocumentTitle } from "@/shared/lib/use-document-title";
+import { useFailureSentence } from "@/shared/lib/use-failure-sentence";
 import { useTaxonomy } from "@/features/taxonomy";
 import { ProjectQuickEditPanel } from "@/features/project-quick-edit";
 import { useConstructionReviewSession } from "@/features/construction-review-local";
@@ -233,6 +234,7 @@ export function ProjectDetailPage({
   initialRelated = [],
 }: Props) {
   const t = useTranslations("projectPages.detail");
+  const failureSentence = useFailureSentence();
   const router = useRouter();
   const constructionReview = useConstructionReviewSession(slug);
   // The tab lives in the URL — it has to be shareable and reproducible by an agent. Left as hidden
@@ -396,12 +398,18 @@ export function ProjectDetailPage({
   const handoffSnippet = buildAgentHandoffSnippet(project.slug);
 
   const canManageProject = projectMutations.canEdit;
-  const projectSaveErrorMessage = (err: unknown) =>
-    err instanceof VaultConflictError
-      ? t("saveErrorConflict")
-      : err instanceof Error
-        ? err.message
-        : t("saveErrorGeneric");
+  /*
+   * ⚠️ The toast prefix wraps this in a Korean sentence (`saveErrorPrefix`), so what goes inside it
+   * must be a sentence in the same language. It used to be `err.message` — the vault layer's
+   * English, spliced into Korean prose. A toast has no `data-*` attribute to hide the machine half
+   * in, so the English goes to the console, which is the other place the gate permits.
+   */
+  const projectSaveErrorMessage = (err: unknown) => {
+    if (err instanceof VaultConflictError) return t("saveErrorConflict");
+    const failure = failureSentence(err, t("saveErrorGeneric"));
+    if (failure.detail) console.error("project save failed", failure.detail);
+    return failure.sentence;
+  };
   const saveProjectField = async (
     field: "name" | "description",
     next: string,

--- a/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
+++ b/src/widgets/docs-vault/ui/DocsVaultEditor.tsx
@@ -2,6 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
+
+import { useFailureSentence } from '@/shared/lib/use-failure-sentence';
+import type { FailureCopy } from '@/shared/lib/use-failure-sentence';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -151,6 +154,7 @@ export function DocsVaultEditor({
   vaultScope,
 }: Props) {
   const t = useTranslations('vaultWidgets.editor');
+  const failureSentence = useFailureSentence();
   const locale = useLocale();
   // The relation vocabulary is read from the same namespace by the map editor and the document editor.
   const tRelations = useTranslations('ontologyRelations');
@@ -159,7 +163,13 @@ export function DocsVaultEditor({
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
   const [loadedSlug, setLoadedSlug] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  /*
+   * ⚠️ The editor's failure carries **two halves** (v1.2.2 repair). It used to hold a plain string
+   * that was `err.message` on both the load and the save path, so a rejected write printed the
+   * vault layer's English into this pane. `sentence` is what the pane renders; `detail` is the
+   * machine half and only ever reaches `data-failure-detail`.
+   */
+  const [error, setError] = useState<FailureCopy | null>(null);
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
   const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null);
@@ -419,7 +429,7 @@ export function DocsVaultEditor({
   const doSave = useCallback(async () => {
     if (saving || content === null || !dirty) return;
     if (legacyDraftConflict) {
-      setError(t('saveConflict'));
+      setError({ sentence: t('saveConflict'), detail: null });
       return;
     }
     setSaving(true);
@@ -446,19 +456,17 @@ export function DocsVaultEditor({
       const name = err instanceof Error ? err.name : '';
       setError(
         name === 'VaultConflictError'
-          ? t('saveConflict')
+          ? { sentence: t('saveConflict'), detail: null }
           : name === 'VaultIdentityUidError'
-            ? t('saveIdentityUid')
+            ? { sentence: t('saveIdentityUid'), detail: null }
             : name === 'VaultIdentityHistoryError'
-              ? t('saveIdentityHistory')
-              : err instanceof Error
-                ? err.message
-                : t('saveFailed'),
+              ? { sentence: t('saveIdentityHistory'), detail: null }
+              : failureSentence(err, t('saveFailed')),
       );
     } finally {
       setSaving(false);
     }
-  }, [content, dirty, doc.slug, legacyDraftConflict, onSave, saving, t, vaultScope]);
+  }, [content, dirty, doc.slug, failureSentence, legacyDraftConflict, onSave, saving, t, vaultScope]);
 
   const requestClose = useCallback(() => {
     if (saving) return;
@@ -506,7 +514,7 @@ export function DocsVaultEditor({
         const cannotVerifyLegacyDraft =
           diskChangedSinceDraft && typeof draft.diskMtime !== 'number';
         setLegacyDraftConflict(cannotVerifyLegacyDraft);
-        setError(diskChangedSinceDraft ? t('saveConflict') : null);
+        setError(diskChangedSinceDraft ? { sentence: t('saveConflict'), detail: null } : null);
         setSavedFlash(false);
         setDraftSavedAt(shouldRestoreDraft ? draft.updatedAt : null);
         setAutocomplete(null);
@@ -518,12 +526,12 @@ export function DocsVaultEditor({
         setLoadedSlug(doc.slug);
         setDraftSavedAt(null);
         setLegacyDraftConflict(false);
-        setError(err instanceof Error ? err.message : String(err));
+        setError(failureSentence(err, t('loadFailed')));
       });
     return () => {
       cancelled = true;
     };
-  }, [doc.mtime, doc.slug, getDocContent, t, vaultScope]);
+  }, [doc.mtime, doc.slug, failureSentence, getDocContent, t, vaultScope]);
 
   // After a clean save, once the parent manifest refreshes with the new mtime, the
   // baseline for the next edit advances too. External mtime changes while dirty are
@@ -624,12 +632,14 @@ export function DocsVaultEditor({
 
   if (!loading && error && content === null) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
+      <div
+        className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center"
+        data-failure-detail={error.detail ?? undefined}
+      >
+        {/* The sentence is the reader's. The English cause stays on `data-failure-detail`: it used
+            to sit here in mono, which is raw `Error.message` on a Korean screen. */}
         <div className="text-body text-[color:var(--color-text-tertiary)]">
-          {t('loadFailed')}
-        </div>
-        <div className="font-mono text-label text-[color:var(--color-text-quaternary)]">
-          {error}
+          {error.sentence}
         </div>
         <Chip
           onClick={requestClose}
@@ -821,8 +831,9 @@ export function DocsVaultEditor({
         <div
           className="break-keep border-b border-[color:var(--color-danger-a32)] bg-[color:var(--color-danger-a08)] px-4 py-1.5 text-label leading-label text-[color:var(--color-danger-text-strong)]"
           aria-live="polite"
+          data-failure-detail={error.detail ?? undefined}
         >
-          {error}
+          {error.sentence}
         </div>
       ) : null}
       {/* Formatting toolbar */}

--- a/tests/contract/no-raw-error-copy.contract.test.ts
+++ b/tests/contract/no-raw-error-copy.contract.test.ts
@@ -4,62 +4,89 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
- * **A thrown `Error`'s message is never the sentence a person reads.**
+ * **A failure a person can see is a sentence in their language, never a machine's token.**
  *
  * ## The measured defect
  *
- * Installed-app inspection before v1.2.2, finding B2. On a Korean screen, pressing
- * the answer page's redraft button (`library.answers.refresh`) printed
+ * Installed-app inspection before v1.2.2, finding B2. On a Korean screen, pressing the answer
+ * page's redraft button (`library.answers.refresh`) printed
  *
  * > The retained question or its history cannot be read.
  *
- * into the page body, in brighter ink than the Korean around it. The sentence is the
- * argument of a `throw new Error(...)` in `answer-revision-store.ts` — written for
- * whoever reads a stack trace, in a module that cannot know which language the reader
- * chose.
+ * into the page body, in brighter ink than the Korean around it. The sentence is the argument of a
+ * `throw new Error(...)` in `answer-revision-store.ts` — written for whoever reads a stack trace,
+ * in a module that cannot know which language the reader chose.
  *
- * It was not one string. The inspection found **eight sites across six files**, every one
- * of them the same shape:
+ * It was not one string. The inspection found **eight sites across six files**, every one of them
+ * the same shape:
  *
  * ```ts
  * err instanceof Error && err.message ? err.message : t('wiki.newPageFailed')
  * ```
  *
- * Read it aloud: *prefer the developer's English; fall back to the sentence we wrote for
- * this press.* That is backwards, and it is backwards in a way no type checker and no
- * existing lint rule can see — both arms are `string`.
+ * Read it aloud: *prefer the developer's English; fall back to the sentence we wrote for this
+ * press.* That is backwards, and it is backwards in a way no type checker and no existing lint
+ * rule can see — both arms are `string`.
  *
- * ## The two rules, and why two
+ * ## What the re-inspection then found about this gate itself
+ *
+ * The first version of this file shipped green while **the first-run screen still leaked**, which
+ * is the more important defect: a gate that cannot see the thing it was written for teaches the
+ * next person that the thing is fixed. Three separate holes (re-inspection before v1.2.2, R3, S20
+ * and S21):
+ *
+ * 1. **One spelling.** R1 required `.message` inside the *condition*. The tree's actual spelling
+ *    is `err instanceof Error ? err.message : t('…')` — the condition never says `.message`.
+ *    Dropping that single clause surfaced **eight live sites** repo-wide.
+ * 2. **One operator.** A code preferred over copy is written `build.errorText || t('…')` and
+ *    `vault.errorMessage ?? t('…')`, not as a `?:`. `BuildFromCodeDoor` painted the literal token
+ *    `permission-denied` on a Korean first-run card through the first of those, and `FirstRunPage`
+ *    put the vault layer's English on the same screen through the second — both while this file
+ *    was green, and one of them from *inside* the list of files R3 claims to have repaired.
+ * 3. **One property name.** The leaked value is not always spelled `.message`. `errorMessage` and
+ *    `errorText` are this repository's own names for the same raw text, and a rule that knows only
+ *    `.message` is blind to the producer that hands over a bare code.
+ *
+ * A source comment in `FirstRunPage.tsx` also asserted that `vault.errorMessage` "is deliberately
+ * blank so the raw cause is not leaked". That was false — `use-local-vault.ts` documents the
+ * opposite for `access-failed` ("`errorMessage` carries the cause string, including a Tauri
+ * command's `Err(String)`") — and the false comment is what made the leak beneath it look
+ * deliberate. It has been corrected at the source.
+ *
+ * ## The three rules, and why three
  *
  * | Rule | Range | What it catches |
  * |---|---|---|
- * | **R1** | every non-test file under `src/` | the eight-site shape: a raw message *preferred over* copy |
- * | **R2** | the files this repair owns | any *other* shape that would leak one, in the exact modules that leaked |
+ * | **R1** | every non-test file under `src/`, four justified sites aside | a raw failure value *preferred over* copy, in any of the three spellings a fallback is written in |
+ * | **R2** | every non-test file under `src/`, no allowlist | a raw failure value spliced into hand-written prose or into a translated sentence's own text |
+ * | **R3** | the files this repair owns | any *other* shape that would leak one, in the exact modules that leaked |
  *
- * R1 is the one that generalises and it carries **no allowlist**: there is no honest
- * reason to rank a thrown English string above a translated sentence. R2 exists because
- * R1 only knows one shape — a regression written as `toast.show(err.message)` would pass
- * it. Making R2 repository-wide would need an allowlist of roughly twenty pre-existing
- * `setError(err.message)` sites in surfaces this repair does not own, and an allowlist
- * that long is a gate that says nothing. Scoped to the repaired files it is a ratchet:
- * these modules are clean now and may not slide back.
+ * R1 and R2 generalise. R3 exists because neither knows every shape — a regression written as
+ * `toast.show(err.message)` passes both — and it is a ratchet: these modules are clean now and
+ * may not slide back. Making R3 repository-wide would need an allowlist of roughly thirty
+ * pre-existing `setError(err.message)` sites in surfaces this repair does not own, and an
+ * allowlist that long is a gate that says nothing.
  *
- * ## What R2 still permits, and why each is not the defect
+ * ## What is permitted, and why each is not the defect
  *
- * - **An argument to `t(...)`** — `t('wiki.compileFailed', { reason })` renders a Korean
- *   sentence with a machine fact inside it. That is the shape `native-error.ts` already
- *   settled on for Tauri rejections (sentence, then detail in parentheses); the reader
- *   gets a sentence in their language either way.
- * - **The receiver of a string test** — `err.message.includes('already exists')` reads
- *   the message to decide something. Nothing is rendered.
- * - **Inside `console.*`** — the developer's console is where the developer's English
- *   belongs.
- * - **A `data-*` or `aria-hidden` attribute** — likewise a place a person reads only
- *   when they are debugging. `RetainedAnswerContext` puts the English on
- *   `data-failure-detail` for exactly this reason.
+ * These four positions are where a **developer** reads, and a reader does not. They are the whole
+ * allowlist of *positions*; `PERMITTED_SITES` below is the whole allowlist of *places*, and every
+ * row there names why a person never sees that one.
  *
- * Anything else in those files is a leak, and the fix is the one this repair applied:
- * mint a code at the throw site (`codedFailure`) and let the screen own the sentence
+ * - **An argument to `t(...)`** — `t('wiki.compileFailed', { reason })` renders a Korean sentence
+ *   with a machine fact inside it. That is the shape `native-error.ts` already settled on for
+ *   Tauri rejections (sentence, then detail in parentheses); the reader gets a sentence in their
+ *   language either way. R2 still refuses the inverse — a raw value carrying the *sentence* while
+ *   the copy is reduced to a prefix.
+ * - **The receiver of a string test** — `err.message.includes('already exists')` reads the message
+ *   to decide something. Nothing is rendered.
+ * - **Inside `console.*`** — the developer's console is where the developer's English belongs.
+ * - **A `data-*` or `aria-hidden` attribute** — likewise a place a person reads only when they are
+ *   debugging. `useFailureSentence` returns `detail` for exactly this, and every screen repaired
+ *   here puts it on `data-failure-detail`.
+ *
+ * Anything else in front of a reader is a leak, and the fix is the one this repair applied: mint a
+ * code at the throw site (`codedFailure`) and let the screen own the sentence
  * (`useFailureSentence`).
  */
 
@@ -85,33 +112,159 @@ function parse(path: string, text: string): ts.SourceFile {
   );
 }
 
-/** Is this `<something>.message`? */
-function isMessageAccess(node: ts.Node): node is ts.PropertyAccessExpression {
-  return ts.isPropertyAccessExpression(node) && node.name.text === 'message';
+/**
+ * The property names this repository gives raw failure text.
+ *
+ * `message` is a thrown `Error`'s. `errorMessage` is `use-local-vault`'s cause string and
+ * `agent-activity-status`'s parse complaint. `errorText` is what `use-build-from-code` hands over —
+ * since v1.2.2 a bare kebab-case *code*, which is worse on screen than a sentence, not better.
+ * `errorDetail` is the machine half a repaired screen carries beside its sentence.
+ */
+const RAW_FAILURE_FIELD = /^(message|errorMessage|errorText|errorDetail)$/;
+
+/** Is this `<something>.message` / `.errorMessage` / `.errorText` / `.errorDetail`? */
+function isRawFailureAccess(node: ts.Node): node is ts.PropertyAccessExpression {
+  return ts.isPropertyAccessExpression(node) && RAW_FAILURE_FIELD.test(node.name.text);
 }
 
-function containsMessageAccess(node: ts.Node): boolean {
-  if (isMessageAccess(node)) return true;
+function containsRawFailure(node: ts.Node): boolean {
+  if (isRawFailureAccess(node)) return true;
   let found = false;
   ts.forEachChild(node, (child) => {
-    if (!found && containsMessageAccess(child)) found = true;
+    if (!found && containsRawFailure(child)) found = true;
   });
   return found;
 }
 
-/** A `t(...)` / `tSomething(...)` call — this repository's translator shape. */
-function isTranslatorCall(node: ts.Node, file: ts.SourceFile): boolean {
+/**
+ * The translators **this file** binds, read from its own `useTranslations` / `getTranslations`
+ * declarations, plus a bare `t`.
+ *
+ * The first version matched the name pattern `/(^|\.)t[A-Z0-9_]?[A-Za-z0-9_]*$/`, which also
+ * accepts `toast`, `title`, `text` and `tooltip` — so `toast(err.message)` counted as "passed to a
+ * translator" and was permitted (re-inspection, S21). Reading the file's own bindings cannot make
+ * that mistake, and it still recognises every one of the thirty-odd `tSomething` names in the
+ * tree without listing them.
+ */
+function translatorNames(file: ts.SourceFile): Set<string> {
+  const names = new Set<string>(['t']);
+  const visit = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const initializer = ts.isAwaitExpression(node.initializer)
+        ? node.initializer.expression
+        : node.initializer;
+      if (
+        ts.isCallExpression(initializer)
+        && /(^|\.)(useTranslations|getTranslations)$/.test(initializer.expression.getText(file))
+      ) {
+        names.add(node.name.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return names;
+}
+
+/** A `t(...)` / `tSomething(...)` / `t.rich(...)` call — this file's own translator shape. */
+function isTranslatorCall(node: ts.Node, file: ts.SourceFile, names: Set<string>): boolean {
   if (!ts.isCallExpression(node)) return false;
   const callee = node.expression.getText(file);
-  return /(^|\.)t[A-Z0-9_]?[A-Za-z0-9_]*$/.test(callee);
+  return names.has(callee) || names.has(callee.split('.')[0] ?? '');
 }
 
 /** Copy: a translated sentence, or a literal string standing in for one. */
-function isCopy(node: ts.Node, file: ts.SourceFile): boolean {
+function isCopy(node: ts.Node, file: ts.SourceFile, names: Set<string>): boolean {
   return (
-    isTranslatorCall(node, file)
+    isTranslatorCall(node, file, names)
     || ts.isStringLiteral(node)
     || ts.isNoSubstitutionTemplateLiteral(node)
+  );
+}
+
+/** The four positions only a developer reads. See the header table. */
+function inDeveloperPosition(node: ts.Node, file: ts.SourceFile, names: Set<string>): boolean {
+  let cursor: ts.Node | undefined = node.parent;
+  while (cursor) {
+    if (ts.isCallExpression(cursor)) {
+      const callee = cursor.expression.getText(file);
+      // The receiver of a string test reads the value; it renders nothing.
+      if (
+        /\.(message|errorMessage|errorText|errorDetail)\.(includes|startsWith|endsWith|trim|toLowerCase|match|split|slice)$/
+          .test(callee)
+      ) return true;
+      if (/^console\./.test(callee)) return true;
+      if (isTranslatorCall(cursor, file, names)) return true;
+    }
+    if (ts.isJsxAttribute(cursor) && /^(data-|aria-hidden$)/.test(cursor.name.getText(file))) {
+      return true;
+    }
+    cursor = cursor.parent;
+  }
+  return false;
+}
+
+/**
+ * A reference read only to **decide** something — the condition of a `?:`, an `if`, or the operand
+ * of `!`. It is the same permission `err.message.includes('x')` already has: the value is
+ * inspected, and nothing is rendered. Deliberately narrow, and deliberately not part of
+ * `inDeveloperPosition`: the left operand of `a || copy` is also "a truth test", and permitting
+ * that would blind R1 to the code-rendered-as-copy shape it exists for.
+ */
+function isReadToDecide(reference: ts.Node): boolean {
+  const parent = reference.parent;
+  if (!parent) return false;
+  if (ts.isConditionalExpression(parent) && parent.condition === reference) return true;
+  if (ts.isIfStatement(parent) && parent.expression === reference) return true;
+  if (
+    ts.isPrefixUnaryExpression(parent)
+    && parent.operator === ts.SyntaxKind.ExclamationToken
+  ) return true;
+  return false;
+}
+
+/**
+ * One step of flow, and only one: an expression that names a `const` whose **every** later
+ * reference sits in a developer position is itself in a developer position.
+ *
+ * `VaultAgentSetupPanel` needs exactly this — `const detail = err instanceof Error ? err.message
+ * .trim() : ''` followed by `t('agentSetup.writeFailed', { files, detail })`. That is the
+ * sentence-plus-detail shape `native-error.ts` settled on, and reading it as a leak would be a
+ * false positive that teaches people to widen the allowlist. One step is deliberate: further
+ * tracking would make this gate a type checker, and the point of a contract test is that a person
+ * can read why it fired.
+ */
+function flowsOnlyToDeveloperPositions(
+  node: ts.Node,
+  file: ts.SourceFile,
+  names: Set<string>,
+): boolean {
+  let cursor: ts.Node | undefined = node.parent;
+  while (cursor && !ts.isVariableDeclaration(cursor)) {
+    if (ts.isBlock(cursor) || ts.isSourceFile(cursor)) return false;
+    cursor = cursor.parent;
+  }
+  if (!cursor || !ts.isVariableDeclaration(cursor) || !ts.isIdentifier(cursor.name)) return false;
+  const name = cursor.name.text;
+  const declared = cursor.name;
+  const references: ts.Identifier[] = [];
+  const collect = (child: ts.Node) => {
+    if (ts.isIdentifier(child) && child.text === name && child !== declared) {
+      // A property name (`{ detail: x }`'s key) is not a read of the value.
+      const parent = child.parent;
+      const isKey =
+        (ts.isPropertyAssignment(parent) || ts.isPropertySignature(parent)) && parent.name === child;
+      const isMember = ts.isPropertyAccessExpression(parent) && parent.name === child;
+      if (!isKey && !isMember) references.push(child);
+    }
+    ts.forEachChild(child, collect);
+  };
+  collect(file);
+  return (
+    references.length > 0
+    && references.every(
+      (reference) => isReadToDecide(reference) || inDeveloperPosition(reference, file, names),
+    )
   );
 }
 
@@ -121,22 +274,49 @@ export interface Leak {
   text: string;
 }
 
-/** R1 — a raw message ranked above copy. */
-export function rawMessagePreferredOverCopy(path: string, text: string): Leak[] {
+function record(path: string, file: ts.SourceFile, node: ts.Node): Leak {
+  return {
+    path,
+    line: file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1,
+    text: node.getText(file).replace(/\s+/g, ' ').slice(0, 160),
+  };
+}
+
+/**
+ * R1 — a raw failure value ranked above the copy written for that press.
+ *
+ * All three spellings of "prefer the raw, fall back to copy": `?:`, `||` and `??`. The preferred
+ * arm must itself not be copy, so `localVault.errorMessage ? t('banner', { message: … }) : t('…')`
+ * — a translated sentence with a machine fact inside it — is not a leak.
+ */
+export function rawFailurePreferredOverCopy(path: string, text: string): Leak[] {
   const file = parse(path, text);
+  const names = translatorNames(file);
   const out: Leak[] = [];
   const visit = (node: ts.Node) => {
-    if (
-      ts.isConditionalExpression(node)
-      && containsMessageAccess(node.condition)
-      && containsMessageAccess(node.whenTrue)
-      && isCopy(node.whenFalse, file)
+    let preferred: ts.Expression | null = null;
+    let fallback: ts.Expression | null = null;
+    if (ts.isConditionalExpression(node)) {
+      preferred = node.whenTrue;
+      fallback = node.whenFalse;
+    } else if (
+      ts.isBinaryExpression(node)
+      && (node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+        || node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken)
     ) {
-      out.push({
-        path,
-        line: file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1,
-        text: node.getText(file).replace(/\s+/g, ' ').slice(0, 160),
-      });
+      preferred = node.left;
+      fallback = node.right;
+    }
+    if (
+      preferred
+      && fallback
+      && containsRawFailure(preferred)
+      && !isCopy(preferred, file, names)
+      && isCopy(fallback, file, names)
+      && !inDeveloperPosition(node, file, names)
+      && !flowsOnlyToDeveloperPositions(node, file, names)
+    ) {
+      out.push(record(path, file, node));
     }
     ts.forEachChild(node, visit);
   };
@@ -145,10 +325,55 @@ export function rawMessagePreferredOverCopy(path: string, text: string): Leak[] 
 }
 
 /**
- * Every identifier in this file that is bound to a thrown value — a `catch (x)` binding or
- * the parameter of a `.catch(x => …)` callback. `.message` on one of these is an `Error`'s
- * message; `.message` on a typed validation problem is not, and this is how the two are
- * told apart without a type checker.
+ * R2 — a raw failure value spliced into hand-written prose.
+ *
+ * `` setError(`<a sentence in Hangul>: ${err.message}`) `` and
+ * `` setError(`${t('saveFailed')}: ${err.message}`) `` both put the reader's language and the
+ * developer's English in one string, with the English carrying the part that says what happened.
+ * The permitted inverse is `t('saveFailed', { detail })`, where the catalogue owns the sentence and
+ * the fact sits inside it — there the translator, not the template, decides the shape.
+ *
+ * Non-ASCII literal text is the tell for the first form: prose in a locale, written into source.
+ * A translator call inside the same template is the tell for the second.
+ */
+export function rawFailureSplicedIntoProse(path: string, text: string): Leak[] {
+  const file = parse(path, text);
+  const names = translatorNames(file);
+  const out: Leak[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isTemplateExpression(node)) {
+      const literals = [node.head.text, ...node.templateSpans.map((span) => span.literal.text)];
+      /*
+       * Prose in a locale, hand-written into source — Hangul, kana or Han, the same scripts
+       * `.githooks/commit-msg` and the `source:language` gate look for. Deliberately not "any
+       * non-ASCII": `wikiProblemMachineLine` joins a validator code and its message with an em
+       * dash, and that dash is punctuation, not a sentence somebody wrote for a reader.
+       */
+      const hasLocalisedProse = literals.some((literal) =>
+        /[\u1100-\u11FF\u3040-\u30FF\u3130-\u318F\u4E00-\u9FFF\uAC00-\uD7A3]/.test(literal),
+      );
+      const hasCopy = node.templateSpans.some((span) => isTranslatorCall(span.expression, file, names));
+      const carriesRaw = node.templateSpans.some((span) => containsRawFailure(span.expression));
+      if (
+        carriesRaw
+        && (hasLocalisedProse || hasCopy)
+        && !inDeveloperPosition(node, file, names)
+        && !flowsOnlyToDeveloperPositions(node, file, names)
+      ) {
+        out.push(record(path, file, node));
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return out;
+}
+
+/**
+ * Every identifier in this file that is bound to a thrown value — a `catch (x)` binding or the
+ * parameter of a `.catch(x => …)` callback. `.message` on one of these is an `Error`'s message;
+ * `.message` on a typed validation problem is not, and this is how the two are told apart without
+ * a type checker.
  */
 function thrownBindings(file: ts.SourceFile): Set<string> {
   const names = new Set<string>();
@@ -181,35 +406,23 @@ function thrownBindings(file: ts.SourceFile): Set<string> {
   return names;
 }
 
-/** R2 — a thrown message used anywhere but the four places a developer reads. */
+/** R3 — a thrown message used anywhere but the four places a developer reads. */
 export function thrownMessageOutsideDeveloperReach(path: string, text: string): Leak[] {
   const file = parse(path, text);
+  const names = translatorNames(file);
   const bound = thrownBindings(file);
   const out: Leak[] = [];
   if (bound.size === 0) return out;
 
   const visit = (node: ts.Node) => {
-    if (isMessageAccess(node) && ts.isIdentifier(node.expression) && bound.has(node.expression.text)) {
-      let cursor: ts.Node | undefined = node.parent;
-      let permitted = false;
-      while (cursor) {
-        if (ts.isCallExpression(cursor)) {
-          const callee = cursor.expression.getText(file);
-          // The receiver of a string test reads the message; it renders nothing.
-          if (new RegExp(`\\.message\\.(includes|startsWith|endsWith|trim|toLowerCase|match|split|slice)$`).test(callee)) permitted = true;
-          if (/^console\./.test(callee)) permitted = true;
-          if (isTranslatorCall(cursor, file)) permitted = true;
-        }
-        if (ts.isJsxAttribute(cursor) && /^(data-|aria-hidden$)/.test(cursor.name.getText(file))) permitted = true;
-        cursor = cursor.parent;
-      }
-      if (!permitted) {
-        out.push({
-          path,
-          line: file.getLineAndCharacterOfPosition(node.getStart(file)).line + 1,
-          text: (node.parent ?? node).getText(file).replace(/\s+/g, ' ').slice(0, 160),
-        });
-      }
+    if (
+      ts.isPropertyAccessExpression(node)
+      && node.name.text === 'message'
+      && ts.isIdentifier(node.expression)
+      && bound.has(node.expression.text)
+      && !inDeveloperPosition(node, file, names)
+    ) {
+      out.push(record(path, file, node.parent ?? node));
     }
     ts.forEachChild(node, visit);
   };
@@ -218,8 +431,9 @@ export function thrownMessageOutsideDeveloperReach(path: string, text: string): 
 }
 
 /**
- * The modules the v1.2.2 B2 repair rewrote: the eight leak sites, the store and hook that
- * minted and carried the thrown English, and the three components that rendered it.
+ * The modules the v1.2.2 B2 repair rewrote, plus the modules the re-inspection's R3/S20/S21 repair
+ * rewrote: the leak sites, the store and hook that minted and carried the thrown English, and the
+ * components that rendered it.
  *
  * Removing a row weakens the ratchet. Adding one is how a newly repaired surface joins.
  */
@@ -230,15 +444,73 @@ const REPAIRED = [
   'src/views/library/ui/parts/AnswerRevisionComparison.tsx',
   'src/views/home/ui/HomePage.tsx',
   'src/views/first-run/ui/FirstRunPage.tsx',
+  'src/views/project-detail/ui/ProjectDetailPage.tsx',
   'src/widgets/app-settings-menu/ui/VaultShapeSettings.tsx',
+  'src/widgets/docs-vault/ui/DocsVaultEditor.tsx',
   'src/features/docs-vault-local/model/use-just-start-vault.ts',
   'src/features/docs-vault-local/model/use-vault-create-flow.ts',
+  'src/features/docs-vault-local/ui/OntologyStarterCta.tsx',
   'src/features/first-run-starter/model/use-build-from-code.ts',
   'src/features/first-run-starter/model/use-first-run-starter.ts',
   'src/features/first-run-starter/ui/BuildFromCodeConfirmDialog.tsx',
+  'src/features/first-run-starter/ui/BuildFromCodeDoor.tsx',
+  'src/features/first-run-starter/ui/FirstRunStarterModule.tsx',
   'src/features/library/lib/answer-revision-store.ts',
   'src/features/library/lib/answer-revision.ts',
+  'src/features/project-edit/ui/ProjectForm.tsx',
+  'src/features/project-quick-edit/ui/ProjectQuickEditPanel.tsx',
 ] as const;
+
+/**
+ * **The whole allowlist of places, and why a person never sees each one.**
+ *
+ * The first version of this gate had no such list and no need of one, because its predicate was
+ * too narrow to fire anywhere. Run against the pre-repair tree (`git checkout origin/main -- src`,
+ * then this file) the widened R1 matches **thirteen** sites: nine were leaks a person could see
+ * and are now sentences, and these four are not. R3's new rows add two more converted sites the
+ * ranking rules cannot see. Each row below is here because its reason is a *fact about the
+ * destination* that no predicate can read off the expression:
+ */
+const PERMITTED_SITES: readonly { path: string; count: number; reason: string }[] = [
+  {
+    path: 'src/entities/vault-session/model/agent-activity-status.ts',
+    count: 1,
+    // A field on the parse result for a malformed `agent-activity.json`. Nothing in `src/` reads
+    // it — verified by search: the only reader is this module's own unit test. The screens read
+    // `valid`, `stale` and `heartbeat` and write their own sentences from those.
+    reason: 'errorMessage on the heartbeat parse result; no surface reads it, only its unit test',
+  },
+  {
+    path: 'src/shared/lib/local-endpoint.ts',
+    count: 1,
+    // `LocalVerifyVerdict.detail` is declared, in its own doc comment, as "the fact the screen
+    // appends" — the machine half of the sentence-plus-detail shape. The verdict's `reason` is
+    // what picks the sentence; `detail` never stands alone.
+    reason: 'the detail half of a verdict whose reason picks the sentence',
+  },
+  {
+    path: 'src/shared/ui/webview-error-reporter.tsx',
+    count: 1,
+    // The component renders no markup at all, by design ("a reporter that could itself fail to
+    // paint would be reporting from inside the problem"). The value goes to the app log through
+    // `sendWebviewErrorReport`, which is the installed app's stand-in for a console nobody has
+    // open.
+    reason: 'window error text forwarded to the app log by a component that renders nothing',
+  },
+  {
+    path: 'src/views/project-detail/ui/construction-review/ConstructionReviewPanel.tsx',
+    count: 1,
+    // The diagnostics an external ACP agent returned with its qualification, listed in the
+    // review's technical evidence section beside the plan and source digests. This repository did
+    // not mint these strings and has no code to translate them by; a translated synonym here is a
+    // word the reader has to map back to the agent transcript they are comparing against — the
+    // same reason `wikiProblemMachineLine` is deliberately not localised.
+    reason: "an external agent's diagnostic payload in the review's technical evidence section",
+  },
+];
+
+const permittedCount = (path: string): number =>
+  PERMITTED_SITES.find((site) => site.path === path)?.count ?? 0;
 
 describe('no raw error copy — a failure speaks the reader\'s language', () => {
   it('scans a real tree, so a pass is not an empty sweep', () => {
@@ -246,18 +518,32 @@ describe('no raw error copy — a failure speaks the reader\'s language', () => 
     expect(SOURCES.some((path) => path.endsWith('.tsx')), 'read no components').toBe(true);
   });
 
-  it('R1 — no site ranks a thrown message above the copy written for that press', () => {
-    const leaks = SOURCES.flatMap((path) => rawMessagePreferredOverCopy(path, readFileSync(path, 'utf8')));
+  it('R1 — no site ranks a raw failure value above the copy written for that press', () => {
+    const leaks = SOURCES.flatMap((path) => {
+      const found = rawFailurePreferredOverCopy(path, readFileSync(path, 'utf8'));
+      return found.length <= permittedCount(path) ? [] : found;
+    });
     expect(
       leaks.map((leak) => `${leak.path}:${leak.line}  ${leak.text}`),
-      'A thrown Error message is the developer\'s English and cannot be translated. Mint a code '
-      + 'at the throw site with `codedFailure(...)` and let the screen look it up with '
-      + '`useFailureSentence(err, t(...))`, which returns the reader\'s sentence and keeps the '
-      + 'English on `detail` for a data-* attribute or the console.',
+      'A thrown message is the developer\'s English and a failure code is the machine\'s token; '
+      + 'neither can be translated by the screen that shows it. Mint a code at the throw site with '
+      + '`codedFailure(...)` and let the screen look it up with `useFailureSentence(err, t(...))`, '
+      + 'which returns the reader\'s sentence and keeps the English on `detail` for a data-* '
+      + 'attribute or the console.',
     ).toEqual([]);
   });
 
-  it.each(REPAIRED)('R2 — %s keeps a thrown message out of everything a reader sees', (path) => {
+  it('R2 — no raw failure value is spliced into prose the reader was meant to get whole', () => {
+    const leaks = SOURCES.flatMap((path) => rawFailureSplicedIntoProse(path, readFileSync(path, 'utf8')));
+    expect(
+      leaks.map((leak) => `${leak.path}:${leak.line}  ${leak.text}`),
+      'Half a sentence in the reader\'s language and half in the developer\'s is not a sentence. '
+      + 'Put the fact inside the translated sentence — `t(\'key\', { detail })` — so the catalogue '
+      + 'decides the shape, or keep it on `data-failure-detail`.',
+    ).toEqual([]);
+  });
+
+  it.each(REPAIRED)('R3 — %s keeps a thrown message out of everything a reader sees', (path) => {
     const leaks = thrownMessageOutsideDeveloperReach(path, readFileSync(path, 'utf8'));
     expect(
       leaks.map((leak) => `${leak.path}:${leak.line}  ${leak.text}`),
@@ -273,38 +559,112 @@ describe('no raw error copy — a failure speaks the reader\'s language', () => 
     }
   });
 
-  it('probe: the planted B2 shape comes back red, and the repaired shape does not', () => {
-    // The exact line the inspection found, verbatim.
+  /**
+   * An allowlist entry that is no longer needed is a blanket exemption nobody notices. Each row
+   * must still match the site it was written for, exactly — one fewer and the row goes, one more
+   * and the new one needs its own reason.
+   */
+  it.each(PERMITTED_SITES)('the allowlist row for $path is still earned', ({ path, count, reason }) => {
+    expect(SOURCES.includes(path), `${path} is gone; drop the allowlist row`).toBe(true);
+    expect(reason.length, 'a row without a reason is not an allowlist row').toBeGreaterThan(20);
+    expect(
+      rawFailurePreferredOverCopy(path, readFileSync(path, 'utf8')).length,
+      `${path} no longer has exactly ${count} permitted site(s); update or drop the row`,
+    ).toBe(count);
+  });
+
+  it('probe: every shape the rules claim to catch comes back red, and the repairs do not', () => {
+    // ── R1, spelling one: the exact line the B2 inspection found, verbatim.
     const planted = 'const a = () => { try { f(); } catch (err) { '
       + 'toast.show(err instanceof Error && err.message ? err.message : t("wiki.newPageFailed")); } };';
-    expect(rawMessagePreferredOverCopy('planted.ts', planted)).toHaveLength(1);
-    // Two, because R2 counts accesses rather than expressions and the shape reads `.message`
+    expect(rawFailurePreferredOverCopy('planted.ts', planted)).toHaveLength(1);
+    // Two, because R3 counts accesses rather than expressions and the shape reads `.message`
     // twice: once to test it, once to render it. Both halves are the defect.
     expect(thrownMessageOutsideDeveloperReach('planted.ts', planted)).toHaveLength(2);
+
+    // ── R1, spelling two: the eight live sites' actual shape — the condition never says
+    // `.message`, which is the clause whose removal surfaced them (re-inspection, S21).
+    const plantedInstanceOf = 'const a = () => { try { f(); } catch (err) { '
+      + 'setError(err instanceof Error ? err.message : t("validation.saveFailed")); } };';
+    expect(rawFailurePreferredOverCopy('planted.ts', plantedInstanceOf)).toHaveLength(1);
+
+    // ── R1, spelling three: a producer's failure **code** rendered as copy. This is
+    // `BuildFromCodeDoor.tsx:104` before the repair, which painted the literal token
+    // `permission-denied` onto a Korean first-run card (re-inspection, R3).
+    const plantedCode = 'const C = ({ build, t }) => <p>{build.errorText || t("buildFromCodeFailed")}</p>;';
+    expect(rawFailurePreferredOverCopy('planted.tsx', plantedCode)).toHaveLength(1);
+
+    // ── R1, spelling four: `??` over the vault layer's cause string — `FirstRunPage.tsx:139`
+    // before the repair (re-inspection, S20).
+    const plantedNullish = 'const C = ({ vault, t }) => <p>{vault.errorMessage ?? t("errorFallback")}</p>;';
+    expect(rawFailurePreferredOverCopy('planted.tsx', plantedNullish)).toHaveLength(1);
 
     // The `: ''` variant the three creation hooks used, which leaks the same way.
     const plantedEmpty = 'const a = () => { try { f(); } catch (err) { '
       + "setActionError(err instanceof Error && err.message ? err.message : ''); } };";
-    expect(rawMessagePreferredOverCopy('planted.ts', plantedEmpty)).toHaveLength(1);
+    expect(rawFailurePreferredOverCopy('planted.ts', plantedEmpty)).toHaveLength(1);
 
-    // A shape R1 cannot see but R2 can, which is why both exist.
+    // ── R2: a catch-bound message interpolated into a sentence in the reader's language.
+    const plantedProse = 'const a = () => { try { f(); } catch (err) { '
+      // The Hangul is escaped so the sentence exists in the parsed source but not in this file:
+      // `source:language` counts CJK code points in source, and a gate that has to be excused is
+      // not a gate. `\uC800\uC7A5...` reads "could not be saved".
+      + 'setError(`\uC800\uC7A5\uD558\uC9C0 \uBABB\uD588\uC5B4\uC694: ${err.message}`); } };';
+    expect(rawFailureSplicedIntoProse('planted.ts', plantedProse)).toHaveLength(1);
+
+    // ── R2: the same splice with the copy reduced to a prefix. The catalogue must own the whole
+    // sentence, not the first four characters of it.
+    const plantedPrefixed = 'const a = () => { try { f(); } catch (err) { '
+      + 'setError(`${t("saveFailed")}: ${err.message}`); } };';
+    expect(rawFailureSplicedIntoProse('planted.ts', plantedPrefixed)).toHaveLength(1);
+
+    // ── R3: a shape R1 and R2 cannot see, which is why the ratchet exists.
     const plantedBare = 'const a = () => { try { f(); } catch (err) { setError(err.message); } };';
-    expect(rawMessagePreferredOverCopy('planted.ts', plantedBare)).toHaveLength(0);
+    expect(rawFailurePreferredOverCopy('planted.ts', plantedBare)).toHaveLength(0);
+    expect(rawFailureSplicedIntoProse('planted.ts', plantedBare)).toHaveLength(0);
     expect(thrownMessageOutsideDeveloperReach('planted.ts', plantedBare)).toHaveLength(1);
 
-    // The repair passes both.
+    // ── The hole the re-inspection named: `toast`, `title`, `text` and `tooltip` all matched the
+    // old translator *name pattern*, so a raw message handed to any of them was read as "passed
+    // to a translator" and permitted. Reading the file's own bindings, they are not translators.
+    for (const sink of ['toast', 'title', 'text', 'tooltip']) {
+      const plantedSink = `const a = () => { try { f(); } catch (err) { ${sink}(err.message); } };`;
+      expect(
+        thrownMessageOutsideDeveloperReach('planted.ts', plantedSink),
+        `${sink}(err.message) must not pass as a translator call`,
+      ).toHaveLength(1);
+    }
+
+    // ── The repairs pass all three.
     const repaired = 'const a = () => { try { f(); } catch (err) { '
       + 'toast.show(failureSentence(err, t("wiki.newPageFailed")).sentence); } };';
-    expect(rawMessagePreferredOverCopy('planted.ts', repaired)).toEqual([]);
+    expect(rawFailurePreferredOverCopy('planted.ts', repaired)).toEqual([]);
+    expect(rawFailureSplicedIntoProse('planted.ts', repaired)).toEqual([]);
     expect(thrownMessageOutsideDeveloperReach('planted.ts', repaired)).toEqual([]);
 
-    // The three permitted developer-facing positions really are permitted.
+    // ── The four permitted positions really are permitted.
     const permitted = 'const a = () => { try { f(); } catch (err) {'
       + ' if (err.message.includes("x")) console.error(err.message);'
       + ' toast.show(t("wiki.compileFailed", { reason: err.message })); } };';
     expect(thrownMessageOutsideDeveloperReach('permitted.ts', permitted)).toEqual([]);
+    const permittedAttribute =
+      'const C = ({ failure }) => <p data-failure-detail={failure.detail}>{failure.sentence}</p>;';
+    expect(rawFailurePreferredOverCopy('permitted.tsx', permittedAttribute)).toEqual([]);
 
-    // A typed problem object is not an Error, and must not be mistaken for one.
+    // ── A translated sentence carrying a machine fact is not the inverse of itself: the
+    // preferred arm is copy, so R1 must stay quiet (`DocsVaultPage`'s vault-status banner).
+    const permittedBanner = 'const C = ({ v, t }) => <p>{v.errorMessage '
+      + '? t("errorBanner", { message: v.errorMessage }) : t("unknownError")}</p>;';
+    expect(rawFailurePreferredOverCopy('permitted.tsx', permittedBanner)).toEqual([]);
+
+    // ── One step of flow: the detail half goes to `t(...)` through a const
+    // (`VaultAgentSetupPanel`), which is the sentence-plus-detail shape, not a leak.
+    const permittedFlow = 'const f = (t) => { try { g(); } catch (err) {'
+      + " const detail = err instanceof Error ? err.message.trim() : '';"
+      + ' setError(detail ? t("writeFailed", { detail }) : t("writeFailedNoDetail")); } };';
+    expect(rawFailurePreferredOverCopy('permitted.ts', permittedFlow)).toEqual([]);
+
+    // ── A typed problem object is not an Error, and must not be mistaken for one.
     const notAnError = 'const a = (problem: P) => <span>{problem.message}</span>;';
     expect(thrownMessageOutsideDeveloperReach('p.tsx', notAnError)).toEqual([]);
   });


### PR DESCRIPTION
## Summary

A folder-pick refused by macOS painted the literal token `permission-denied` onto a Korean
first-run card. `use-build-from-code.ts` has returned `failureCodeOf(err) ?? ''` since the B2
repair (#1582), and `BuildFromCodeDoor.tsx:104` still rendered `{build.errorText || t('…')}` —
the one consumer of the nine that was not converted. Its own sibling,
`BuildFromCodeConfirmDialog.tsx`, was converted in that change.

**The gate was green through all of it, which matters more than the one site.**
`tests/contract/no-raw-error-copy.contract.test.ts` recognised one spelling — `.message` inside
the *condition* of a `?:` — and therefore missed:

- the tree's actual spelling, `err instanceof Error ? err.message : t('…')`. Dropping that single
  clause surfaces **8 live sites** (the re-inspection's S21);
- both fallback operators. `build.errorText || t('…')` is how a code reaches a screen and
  `vault.errorMessage ?? t('…')` is how a cause string does — the two first-run leaks (R3, S20);
- the property names this repository gives raw failure text: `errorMessage`, `errorText`.

Two of the leaks were on the first-run screen, from *inside* the file list the gate declares
repaired, and a comment at `FirstRunPage.tsx:119-123` asserted that the leaked value "is
deliberately blank so the raw cause is not leaked". That is the opposite of what
`use-local-vault.ts:241` documents for `access-failed` ("`errorMessage` carries the cause string,
including a Tauri command's `Err(String)`"). The false comment is why the leak beneath it read as
deliberate; it is corrected at the source, and so is its twin in `use-first-run-starter.ts`.

Widened, R1 matches **13 sites** on the pre-repair tree. Nine are leaks a person could see and are
now sentences; R3's new rows catch two more the ranking rules cannot see; four are not leaks and
are allowlisted by place, each with the fact about its destination that no predicate can read.

## The sites

Every converted site now calls `useFailureSentence(err, t('…'))`: a recognised code gets the
`failures` catalogue's sentence, anything else gets the screen's own copy, and the English or the
token goes to `data-failure-detail`.

### The 8 the dropped clause surfaces

| # | site | showed | shows now (ko / en) |
|---|---|---|---|
| 1 | `first-run-starter/ui/BuildFromCodeDoor.tsx:104` **(blocker)** | `permission-denied` / `target-missing` / `already-exists` — the producer's bare code | `이 폴더에 쓸 권한이 없어서 아무것도 바뀌지 않았어요. 시스템 설정의 개인정보 보호 및 보안에서…` / `This folder refused the write, so nothing changed. Allow Ontology Atlas to reach this folder in System Settings…`; code on `data-failure-detail`. Unrecognised → `폴더를 만들지 못했어요…` / `The folder could not be created…` |
| 2 | `docs-vault-local/ui/OntologyStarterCta.tsx:143` | `err.message` from scaffolding, e.g. `NotFoundError: A requested file or directory could not be found…` | the catalogue sentence for `target-missing` / `already-exists` / `permission-denied`, else `시작 시드 만들기 실패` / `Failed to create starter` |
| 3 | `project-edit/ui/ProjectForm.tsx:700` | `err.message` from a rejected save | `저장 실패` / `Save failed`, or the catalogue sentence; cause on `data-failure-detail` |
| 4 | `project-edit/ui/ProjectForm.tsx:713` | `err.message` from a rejected delete | `삭제 실패` / `Delete failed`, or the catalogue sentence |
| 5 | `project-quick-edit/ui/ProjectQuickEditPanel.tsx:245` | `submitError.message` | `변경 내용을 반영하지 못했습니다.` / `Could not apply the changes.`, or the catalogue sentence |
| 6 | `views/project-detail/ui/ProjectDetailPage.tsx:402` | `err.message` spliced into the Korean toast `저장 실패: {message}` | `저장 실패: 저장 실패` → `저장 실패: <sentence>` / `Save failed: <sentence>`; a toast has no attribute, so the English goes to `console.error` |
| 7 | `widgets/docs-vault/ui/DocsVaultEditor.tsx:454` | `err.message` from a rejected write, in the editor's danger strip | `저장 실패` / `Save failed`, or the catalogue sentence; cause on `data-failure-detail` |
| 8 | `entities/vault-session/model/agent-activity-status.ts:203` | `error.message` on the heartbeat parse result | **unchanged — allowlisted.** No surface reads the field; the only reader is its own unit test |

### The three the widened operators and property names add

| # | site | showed | shows now (ko / en) |
|---|---|---|---|
| 9 | `views/first-run/ui/FirstRunPage.tsx:139` (S20) | `vault.errorMessage` — the vault layer's cause string, raw, on the first-run screen | the catalogue sentence, else `폴더를 열지 못했습니다. 다시 시도해 주세요.` / `Could not open the folder. Try again.`; cause on `data-failure-detail`. The `permission-denied` branch now also parks its errno there |
| 10 | `first-run-starter/model/use-first-run-starter.ts:140` + `ui/FirstRunStarterModule.tsx:717` (S20) | the same cause string, rendered as a "quiet clue" line beneath a generic Korean sentence | the hook returns `errorText` (sentence) and `errorDetail` (machine half); the card shows the sentence for *that* failure instead of the generic fallback, and carries the English on `data-failure-detail` |
| 11 | `widgets/docs-vault/ui/DocsVaultEditor.tsx:521` (R3-only) | `err.message : String(err)` in mono under `파일을 불러오지 못했어요` | the catalogue sentence, else `파일을 불러오지 못했어요` / `Failed to load file`; the mono English line is gone and the cause is on `data-failure-detail` |

`BuildFromCodeConfirmDialog.tsx` also gained `data-failure-detail`: it already showed the
sentence but discarded the code, so a developer could not tell `permission-denied` from
`already-exists`.

## What the widened gate now catches that it did not

| shape | example | before | now |
|---|---|---|---|
| a code rendered as copy | `build.errorText \|\| t('buildFromCodeFailed')` | green | **R1 red** |
| a cause string preferred with `??` | `vault.errorMessage ?? t('errorFallback')` | green | **R1 red** |
| `err.message` ranked above copy, condition not mentioning it | `err instanceof Error ? err.message : t('saveFailed')` | green (8 live sites) | **R1 red** |
| a catch-bound message spliced into a sentence in the reader's language | `` setError(`<Hangul>: ${err.message}`) `` | green | **R2 red** |
| copy reduced to a prefix on a raw sentence | `` setError(`${t('saveFailed')}: ${err.message}`) `` | green | **R2 red** |
| a raw message handed to a sink whose name starts with `t` | `toast(err.message)`, `title(…)`, `text(…)`, `tooltip(…)` | green — the old `/(^\|\.)t[A-Z0-9_]?[A-Za-z0-9_]*$/` read them as translators | **R3 red** — translators are read from the file's own `useTranslations` / `getTranslations` bindings |

Two shapes are newly **green on purpose**, because reading them as leaks would teach people to
widen the allowlist: a translated sentence carrying a machine fact (`t('errorBanner', { message })`
preferred over `t('unknownError')`, `DocsVaultPage`'s vault-status banner), and the detail half
reaching `t(…)` through one `const` (`VaultAgentSetupPanel`). R1 now checks that the preferred arm
is not itself copy, and follows exactly one step of flow.

## The surviving allowlist

`PERMITTED_SITES` is the whole allowlist of places. A row that stops matching its site fails the
test, so an exemption cannot outlive its reason.

| site | why a person never sees it |
|---|---|
| `entities/vault-session/model/agent-activity-status.ts` | `errorMessage` on the malformed-heartbeat parse result. Nothing in `src/` reads it — verified by search; the only reader is this module's unit test. Screens read `valid`, `stale`, `heartbeat` and write their own sentences |
| `shared/lib/local-endpoint.ts` | `LocalVerifyVerdict.detail` is declared in its own doc comment as "the fact the screen appends". `reason` picks the sentence; `detail` never stands alone |
| `shared/ui/webview-error-reporter.tsx` | renders no markup at all by design; the text goes to the app log through `sendWebviewErrorReport`, the installed app's stand-in for a console nobody has open |
| `views/project-detail/ui/construction-review/ConstructionReviewPanel.tsx` | an external ACP agent's diagnostic payload, in the review's technical evidence section beside the plan and source digests. This repository never minted the string and has no code to translate it by — the same reason `wikiProblemMachineLine` is deliberately not localised |

The four permitted *positions* are unchanged and documented in the file header: an argument to
`t(…)`, the receiver of a string test, `console.*`, and a `data-*` / `aria-hidden` attribute.

## Test plan

The blocker was graded **source-confirmed, runtime-unconfirmed** — the inspection could not force
the native open panel into a permission failure. Reproduced the cheap way instead, and probed the
gate on real source rather than only in memory. **No installed app was driven; two other agents
are measuring it.** Browser and unit proof only.

- `src/features/first-run-starter/ui/BuildFromCodeDoor.test.tsx` (new) renders the producer's own
  three codes in `ko` and `en`: the token is absent from the text, the catalogue sentence is
  present, and the code is on `data-failure-detail`. Restoring the pre-repair expression turns
  **6 of its 9 assertions red**; the repair turns them green again.
- Gate probe on real source, planted in `BuildFromCodeDoor.tsx` one shape at a time
  (`/Users/jinan/scratch/atlas-library-fixture-20260911/opus-g2-codes/gate-probe.log`):
  `build.errorText || t('…')` → **R1 red**; `build.errorText.message` ranked above copy → **R1
  red**; a Hangul sentence interpolating `build.errorText` → **R2 red**. Restored → **30 passed**.
- Baseline probe: `git checkout origin/main -- src` with this gate reports **9 R1 leaks and 5
  failing R3 files**, naming every site in the tables above
  (`.../opus-g2-codes/baseline-origin-main.log`). Restored → 30 passed.
- `ProjectForm.errorFocus.test.tsx` updated: its fixture throws a Korean sentence and it asserted
  the banner echoed it. It now asserts the banner shows the copy written for a failed save and
  that the thrown text is on `data-failure-detail`. Its subject — focus and scroll behaviour — is
  untouched and still passes.
- `pnpm checks:changed -- --run $(git diff --name-only origin/main...HEAD)` — **14/14 pass**,
  including `pnpm test:contracts`, `pnpm source:language`, `pnpm knip`, `pnpm exec tsc --noEmit`
  and the four recommended Playwright specs.
- `pnpm exec vitest run` — **1034 files, 10268 passed**.

The gate's own Hangul probe string is written with `\uXXXX` escapes: `source:language` counts CJK
code points in source, and a gate that has to be excused is not a gate.

## Not covered

- The runtime path to `BuildFromCodeDoor`'s failure branch still needs a native picker that
  refuses, which no instrument here can force. The proof is the producer's code handed to the
  rendered component, not a real macOS refusal.
- R3 stays scoped to the files this repair owns. Repository-wide it would need ~30 pre-existing
  `setError(err.message)` sites allowlisted, and an allowlist that long is a gate that says
  nothing. R1 and R2 are the repository-wide rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
