### PR TITLE
chore(test): avoid browser setup for source contracts

### DIFF
--- a/docs/DEVELOPMENT-CHECKS.md
+++ b/docs/DEVELOPMENT-CHECKS.md
@@ -52,6 +52,12 @@ again. Full architecture verification reuses Vitest, MCP and CLI library lanes,
 with `pnpm integration:cli:architecture` retaining the unique CLI transport case.
 Focused-only Node suites remain discoverable through the actual impact plan.
 
+Vitest source/parser contracts run in the `contract-node` project without browser
+setup. The two contracts that render React components stay in `jsdom` alongside
+app/src tests. A new contract defaults to Node; add a DOM exception in
+`vitest.config.ts` only when it actually renders. `pnpm test:contracts` and exact
+file, changed-file and shard invocations keep the same test inventory.
+
 Browser timing/allocator changes promote browser evidence, not unrelated MCP,
 type or full unit suites. Focused unit work starts only the shard with commands;
 missing distribution metadata conservatively starts all shards.

--- a/tests/contract/node-contract-environment.contract.test.ts
+++ b/tests/contract/node-contract-environment.contract.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from 'vitest';
+
+it('source contracts run without constructing a browser environment', () => {
+  expect(typeof window).toBe('undefined');
+  expect(typeof document).toBe('undefined');
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,10 +4,15 @@ import path from 'path';
 
 import packageJson from './package.json' with { type: 'json' };
 
+// Only these contract files render components; source/parser guards need no DOM.
+const domContracts = [
+  'tests/contract/brand-asset-parity.contract.test.ts',
+  'tests/contract/node-kind-shape-parity.contract.test.ts',
+];
+
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
     globals: true,
     /*
      * **A hang detector, not a budget** (2026-09-12).
@@ -36,15 +41,34 @@ export default defineConfig({
      * deliberate `unknown` fallback and fail on a repair that is working correctly.
      */
     env: { NEXT_PUBLIC_RELEASE_VERSION: packageJson.version },
-    setupFiles: ['./vitest.setup.ts'],
-    include: [
-      'app/**/*.test.{ts,tsx}',
-      'app/**/*.spec.{ts,tsx}',
-      'src/**/*.test.{ts,tsx}',
-      'src/**/*.spec.{ts,tsx}',
-      'tests/contract/**/*.test.ts',
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'contract-node',
+          environment: 'node',
+          setupFiles: [],
+          include: ['tests/contract/**/*.test.ts'],
+          exclude: domContracts,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'jsdom',
+          environment: 'jsdom',
+          setupFiles: ['./vitest.setup.ts'],
+          include: [
+            'app/**/*.test.{ts,tsx}',
+            'app/**/*.spec.{ts,tsx}',
+            'src/**/*.test.{ts,tsx}',
+            'src/**/*.spec.{ts,tsx}',
+            ...domContracts,
+          ],
+          exclude: ['tests/e2e/**'],
+        },
+      },
     ],
-    exclude: ['tests/e2e/**'],
     // Externalizing next-intl to Node ESM causes the `next/navigation` subpath
     // to fail resolving relative to the pnpm virtual store realpath, breaking
     // test file loading itself (manifested as 15 files failing simultaneously during 2026-07 refactoring). Vite


### PR DESCRIPTION
## Summary

Source and parser contract tests constructed jsdom and loaded browser stubs even though only two contract files render components. Split Vitest into a Node contract project and the existing jsdom app/component project. Keep plugins, aliases, timeout, globals and release-version environment inherited, with setup and discovery owned by each project.

All 1,034 existing test files remain selected exactly once. The two rendering contracts retain jsdom. One regression guard fails if source contracts regain a browser environment; it was RED before the split and GREEN afterward.

## Test plan

- Controlled current-tree contract comparison: identical 266 files / 2,687 assertions; existing config 51.03s wall, scratch split 15.31s wall on the same host. This is local evidence, not a CI percentage claim.
- Actual implementation: 267 contract files / 2,688 assertions pass, including the new environment guard.
- Exact inventory: 1,035 unique files; zero missing or duplicate existing files; 265 Node contracts and 770 jsdom files.
- Exact path, changed-file and three-shard collection checks preserve selection. Both rendering contracts pass in jsdom.
- All 12 changed-path recommendations pass, including types, contract suite, package/doc references and focused mixed-project execution. CI runs the full sharded unit suite before landing.
