### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/docs/records/changes/2026-09-13-check-report-speaks-in-sentences-bc85113b-e372-4bc4-8971-905fabf84747.md
+++ b/docs/records/changes/2026-09-13-check-report-speaks-in-sentences-bc85113b-e372-4bc4-8971-905fabf84747.md
@@ -1,0 +1,6 @@
+---
+id: bc85113b-e372-4bc4-8971-905fabf84747
+date: 2026-09-13
+category: Fixed
+---
+the folder check report reads as sentences, states each rule once instead of repeating it for every finding, and its table of contents lands on the section it names

--- a/docs/records/changes/2026-09-13-failure-speaks-the-persons-language-c2e4e47e-826a-4a98-ae6a-dfed76f0bc5f.md
+++ b/docs/records/changes/2026-09-13-failure-speaks-the-persons-language-c2e4e47e-826a-4a98-ae6a-dfed76f0bc5f.md
@@ -1,0 +1,6 @@
+---
+id: c2e4e47e-826a-4a98-ae6a-dfed76f0bc5f
+date: 2026-09-13
+category: Fixed
+---
+a failure a person can see is now a sentence in their own language rather than a bare code or an English message, and an action the page already knows cannot succeed is offered disabled, with the reason and the next step readable before the press

--- a/docs/records/changes/2026-09-13-library-picture-fills-its-canvas-daf988f4-9c67-4419-a1bc-c4ad76f2040b.md
+++ b/docs/records/changes/2026-09-13-library-picture-fills-its-canvas-daf988f4-9c67-4419-a1bc-c4ad76f2040b.md
@@ -1,0 +1,6 @@
+---
+id: daf988f4-9c67-4419-a1bc-c4ad76f2040b
+date: 2026-09-13
+category: Fixed
+---
+the Library picture fills more of its canvas, the fit control moves when pressed and rests once the picture is framed, a mark never loses its name, and an unverified citation's amber mark is visible on a small folder and calm on a large one

--- a/docs/records/changes/2026-09-13-page-format-check-answers-in-one-line-b009cc47-892f-40f8-9bf6-fe3330abc826.md
+++ b/docs/records/changes/2026-09-13-page-format-check-answers-in-one-line-b009cc47-892f-40f8-9bf6-fe3330abc826.md
@@ -1,0 +1,6 @@
+---
+id: b009cc47-892f-40f8-9bf6-fe3330abc826
+date: 2026-09-13
+category: Changed
+---
+Check page format answers with one sentence and one action per problem, naming pages and originals by their titles and the place in words, and keeping the codes, line anchors and tool notes whole one press away behind a fold

--- a/docs/records/changes/2026-09-13-verification-runs-only-what-can-break-fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4.md
+++ b/docs/records/changes/2026-09-13-verification-runs-only-what-can-break-fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4.md
@@ -1,0 +1,6 @@
+---
+id: fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4
+date: 2026-09-13
+category: Changed
+---
+verification is faster and narrower: pre-push runs what a push can break, CI shards its slowest job, and tests wait for the condition rather than the clock.

--- a/docs/records/releases/v1.2.2.md
+++ b/docs/records/releases/v1.2.2.md
@@ -1,0 +1,11 @@
+---
+version: v1.2.2
+date: 2026-09-13
+title: switching destinations no longer reloads the app, and every failure a person meets is a sentence
+---
+- eafa766a-975d-44f3-9745-23bc8e59f0f7
+- c2e4e47e-826a-4a98-ae6a-dfed76f0bc5f
+- bc85113b-e372-4bc4-8971-905fabf84747
+- b009cc47-892f-40f8-9bf6-fe3330abc826
+- daf988f4-9c67-4419-a1bc-c4ad76f2040b
+- fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontology-atlas",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "MIT",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2644,7 +2644,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ontology-atlas"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ontology-atlas"
-version = "1.2.1"
+version = "1.2.2"
 description = "Local-first codebase ontology workbench"
 authors = ["ontology-atlas contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ontology Atlas",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "dev.jinan.ontology-atlas",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Cuts **v1.2.2**. `package.json` is the version authority; `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` and the `ontology-atlas` line of `src-tauri/Cargo.lock` follow it, which `pnpm desktop:check` enforces. `mcp/package.json` stays at `0.13.0`; no MCP surface changed, so the registry listing job correctly has nothing to publish.

The release gate cleared: the third verification pass on the installed app returned 「release v1.2.2」. Round two's three blockers (the blank on arrival, the forbidden pre-vault screen, the bare failure code) are closed, two of them on the instrument that found them with a positive control proving that instrument still detects the old defect, and no regression was found.

## The changelog is now records, not a file

Since the records migration the three ledgers are frozen. Five user-visible facts had no record yet and are written here; the sixth already existed. `docs/records/releases/v1.2.2.md` names the six change UUIDs this tag includes:

| UUID | category |
|---|---|
| `eafa766a-975d-44f3-9745-23bc8e59f0f7` | Fixed — a rail press is a route change, not a reload (pre-existing record) |
| `c2e4e47e-826a-4a98-ae6a-dfed76f0bc5f` | Fixed — a failure is a sentence, an impossible action is disabled with its reason |
| `bc85113b-e372-4bc4-8971-905fabf84747` | Fixed — the folder check report reads as sentences and its contents land |
| `daf988f4-9c67-4419-a1bc-c4ad76f2040b` | Fixed — the Library picture fills its canvas and a stale citation stays calm at scale |
| `b009cc47-892f-40f8-9bf6-fe3330abc826` | Changed — Check page format answers in one line, the detail one press away |
| `fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4` | Changed — faster, narrower verification |

Two user-visible facts in this tree still have **no** record and therefore stay Unreleased rather than being included silently: the bell separating what needs me from what was done, and a press opening a Library card beside its mark with citations flowing toward the page. They are reported to the owner instead of being written with copy nobody approved.

Record bodies are English with no em dash on purpose: the composed changelog is scanned by the `current`-scope Markdown language gate (0 Hangul code points) and by the em-dash ratchet, which reads `readLedgerSource('docs/CHANGELOG.md')` rather than the frozen file.

## Test plan

- `pnpm docs-vault:build`
- `pnpm changelog:check` — 421 frozen entries + 6 change facts + 1 release marker fit their templates
- `pnpm download:release-facts:check` — still matches the published v1.2.1, as it must before this tag exists
- `pnpm checks:changed -- --run` — **17 recommended checks, all passing**, including `desktop:check`, `test:records`, `test:desktop:bridge`, `docs:language`, `docs:links`, `knip`, `test:mcp:package` and the web-surface smoke
- pre-push lanes: docs, source_language, comment_refs, decisions — all green

Branched from `origin/main` at `0bec69fd8`, which is two verification-infra commits ahead of the commit the app was verified from (`51d16964e`); neither changes shipping behavior. This lands last so the tag equals the default-branch head at dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK
