### PR TITLE
fix(records): read a frozen ledger the same way on every line ending

### DIFF
--- a/scripts/lib/record-ledgers.mjs
+++ b/scripts/lib/record-ledgers.mjs
@@ -45,8 +45,16 @@ function policyAt(root) {
   }
 }
 
+/**
+ * The freeze is a claim about a ledger's **content**, not about the line endings this
+ * filesystem happened to check out. A Windows checkout with `core.autocrlf` hands the
+ * same three ledgers back as CRLF, so hashing raw bytes reported every one of them as
+ * tampered with and refused to compose the changelog at all. Normalizing first keeps
+ * `legacy.json`'s existing checksums valid, so nothing is re-frozen and no history moves,
+ * and it returns one canonical text so a composed document does not vary by platform.
+ */
 export function readFrozenDocument(relativePath, { root = process.cwd() } = {}) {
-  const raw = readFileSync(path.join(root, relativePath), 'utf8');
+  const raw = readFileSync(path.join(root, relativePath), 'utf8').replace(/\r\n/g, '\n');
   const policy = policyAt(root);
   if (!policy) return raw;
   const expected = policy.policy.documents[relativePath];

--- a/scripts/lib/record-ledgers.test.mjs
+++ b/scripts/lib/record-ledgers.test.mjs
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import os from 'node:os';
 import path from 'node:path';
 import { describe, it } from 'node:test';
-import { readLedgerSource } from './record-ledgers.mjs';
+import { readFrozenDocument, readLedgerSource } from './record-ledgers.mjs';
 
 const hash = (s) => createHash('sha256').update(s).digest('hex');
 function repo() {
@@ -67,6 +67,45 @@ describe('record ledgers', () => {
     writeFileSync(path.join(root, `docs/records/changes/2026-04-02-a-${id}.md`), `---\nid: ${id}\ndate: 2026-04-02\ncategory: Added\n---\nA\n`);
     writeFileSync(path.join(root, 'docs/records/releases/v1.2.0.md'), `---\nversion: v1.2.0\ndate: 2026-04-02\ntitle: duplicate\n---\n- ${id}\n`);
     assert.throws(() => readLedgerSource('docs/CHANGELOG.md', { root }), /already exists in the frozen changelog/);
+  });
+  /**
+   * **Why this was invisible until a release.** The only Windows runner in this
+   * repository is `release-macos.yml`; `checks:changed`, pre-push and CI are all
+   * LF. A Windows checkout with `core.autocrlf` hands back every frozen ledger as
+   * CRLF, the raw-byte hash missed, and `prepare` refused to compose the changelog
+   * at all, so `Install dependencies` failed before any release step ran. Measured
+   * on v1.2.2: `docs/CHANGELOG.md` hashed `d6f09b6d…` as CRLF against a frozen
+   * `9bf78389…`, the exact pair the runner reported.
+   *
+   * All three ledgers the policy names are checked here, so the next one added to
+   * `legacy.json` cannot rot quietly, and the negative control keeps this from
+   * becoming a test that passes because the check was switched off.
+   */
+  it('reads a frozen ledger the same way on either line ending, and still refuses a real edit', () => {
+    const root = repo();
+    const pilot = '# PO PILOT\n\nPreamble.\n\n## 2026-01-01 — run\n\n**Outcome**: legacy.\n';
+    writeFileSync(path.join(root, 'docs/PO-PILOT.md'), pilot);
+    const frozen = {
+      'docs/DECISIONS.md': readFile(root, 'docs/DECISIONS.md'),
+      'docs/CHANGELOG.md': readFile(root, 'docs/CHANGELOG.md'),
+      'docs/PO-PILOT.md': pilot,
+    };
+    writeFileSync(path.join(root, 'docs/records/legacy.json'), JSON.stringify({
+      version: 1,
+      documents: Object.fromEntries(Object.entries(frozen).map(([file, text]) => [file, { sha256: hash(text) }])),
+    }));
+
+    for (const [file, text] of Object.entries(frozen)) {
+      writeFileSync(path.join(root, file), text.replace(/\n/g, '\r\n'));
+    }
+    for (const [file, text] of Object.entries(frozen)) {
+      assert.equal(readFrozenDocument(file, { root }), text, `${file} must read back as its frozen content`);
+    }
+    // One canonical text, so a composed document does not vary by platform either.
+    assert.equal(readLedgerSource('docs/CHANGELOG.md', { root }).content, frozen['docs/CHANGELOG.md']);
+
+    writeFileSync(path.join(root, 'docs/PO-PILOT.md'), pilot.replace('legacy', 'edited').replace(/\n/g, '\r\n'));
+    assert.throws(() => readFrozenDocument('docs/PO-PILOT.md', { root }), /changed after it was frozen/);
   });
   it('rejects impossible calendar dates without trusting their shape', () => {
     const root = repo(); const id = randomUUID();


### PR DESCRIPTION
## Summary

v1.2.2's release run reached the Windows job and failed at `Install dependencies`, inside `prepare`, with a tampering report for a file nobody had touched:

```
[record-ledgers] docs/CHANGELOG.md changed after it was frozen
(expected 9bf78389…50, received d6f09b6d…7b; recover from Git blob aaa5e0d86…)
```

`readFrozenDocument` hashed the file's **raw bytes**. A Windows checkout with `core.autocrlf` hands all three frozen ledgers back as CRLF, so the hash missed and the docs-vault build refused to compose the changelog at all. Staging needs the Windows build and publication needs staging, so this blocked the release outright — and re-running was pointless, because the failure is deterministic, not a flake.

Confirmed by identity rather than inference:

| bytes | sha256 |
|---|---|
| `docs/CHANGELOG.md` as committed (LF) | `9bf78389…50` — matches `legacy.json` |
| the same content re-encoded CRLF | `d6f09b6d14e16f0211a1e9f621927f083ccc7b4c551f2ae0298e18214c5b5a7b` |

That second value is **byte-identical to what the runner printed**, and the failure reproduces locally off CI by checking out CRLF copies of the ledgers.

## The invariant this restores

**The freeze is a claim about a ledger's *content*, not about the line endings the checking filesystem happened to use.** The read now normalizes CRLF to LF before hashing. That keeps every existing `legacy.json` checksum valid — nothing is re-frozen, no historical blob moves, no checksum is refreshed to make a check pass — and it returns one canonical text, so a composed document does not vary by platform either.

The change sits at the single chokepoint all three ledgers pass through, `docs/PO-PILOT.md` included by way of `scripts/lib/po-pilot-records.mjs`. It is one line; the rest is the comment saying why and the test.

## The gap that made it invisible

**The only Windows runner in this repository is `release-macos.yml`.** `checks:changed`, the pre-push lanes and CI all run on LF. So a platform-specific break of this shape is discovered by a release and by nothing earlier: this one arrived with the records migration and sat unseen because no release had run since. It is not a changelog defect and not specific to v1.2.2 — every Windows release build was broken from the moment the ledgers were frozen.

The regression test here closes the specific hole at zero cost: it checks out CRLF copies of **all three** ledgers, so the next document added to `legacy.json` cannot rot quietly, and it keeps a negative control so it cannot pass merely because the check was switched off. Probed both ways — reverting the one-line read turns exactly this test red with the same error class the runner reported, and 8/8 pass with it.

What it does **not** close: it simulates a Windows checkout rather than observing one, so a different platform-specific cause (path separators, directory ordering, a BOM) would still wait for a release. Three ways to close that, costed, **none built here**:

1. **Post-merge Windows `pnpm install` smoke on `main`** — reproduces the exact command that failed, needs no path filter to be correct, and does not slow any PR. Cost: one extra Windows job per push to `main`, roughly 3-5 minutes of Windows runner time (billed at the Windows multiplier). **My recommendation** if you want one.
2. **Per-PR Windows job filtered to the ledger paths** — cheapest to run, about a minute, because these tests need no `pnpm install` at all (`node --test` over node builtins only). But the filter is itself the blind spot: the real break was triggered by *any* change, since the freeze check runs on every install, so a path filter would have missed it.
3. **Nothing further** — accept that the simulated-CRLF test covers the known failure mode and that a release is the Windows canary. Defensible; it is the status quo plus this test.

## Test plan

- `pnpm checks:changed -- --run` — 4 recommended checks, all passing (`source:language`, `test:records`, `test:docs-vault`, `knip`)
- `node --test scripts/lib/record-ledgers.test.mjs` — 8/8
- Gate probe: one-line read reverted → 1 fail, exactly the new test, `RecordLedgerError: … changed after it was frozen`; restored → 8/8
- Local repro of the CI failure and of the fix, against both an LF tree and a simulated-CRLF tree: composed output byte-identical (194,840 chars, `v1.2.2` entry present) in both

Branched from `a80ed4116`. `v1.2.2` was tagged at that commit and its run published nothing, so after this lands the tag is deleted and re-created at the new `main` head, which is what `desktop:release-source --mode=admit` requires ("admit also requires that SHA to be the current default-branch head").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK


---

## ⚠️ Correction (2026-09-13, added after this PR merged)

**This PR's claim that "the only Windows runner in this repository is `release-macos.yml`" is false.**

`.github/workflows/windows-beta-check.yml` runs `pnpm install --frozen-lockfile` on `windows-2022`, on pull requests **and** on pushes to `main`. The claim came from reading the release workflow's job graph instead of listing `.github/workflows/`.

The consequence matters more than the error: that lane **had already reported this exact failure** — red on `main` from `a80708ce9` onward, and red on the v1.2.2 release PR (`34720027112`) eight minutes before it landed. It produces no required status context, so `pnpm pr:land` merged on "every required context is green" and the verdict was never surfaced.

Both halves are fixed in **#1598**: `pr:land` now refuses on any failing check, required or not, with `--allow-failing <context>` as the named escape; and a non-required Windows install canary runs after every push to `main` with no path filter. See `docs/DEVELOPMENT-CHECKS.md`, "The Windows install canary, and why a path filter cannot be one".
