### PR TITLE
fix(records): read every authored ledger the same way on both line endings

### DIFF
--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -25,6 +25,16 @@ export function runChangelogCheck(argv, io = console, { cwd = process.cwd() } = 
   const hasFragments = source.inputs.some((path) => path.startsWith('docs/records/changes/') || path.startsWith('docs/records/releases/'));
   const entries = parseChangelog(hasFragments ? readFileSync(`${cwd}/${FILE}`, 'utf8') : source.content);
   const { entries: broken, shape } = checkChangelogTemplate(entries);
+  /*
+   * A gate that measures nothing must not pass. On a CRLF checkout every heading stopped
+   * matching, so this reported "0 frozen entries ✓" and exited 0 while judging nothing at
+   * all. The frozen ledger always holds released history, so zero entries means the parse
+   * lost the file, not that the file is clean.
+   */
+  if (entries.length === 0) {
+    io.error(`[changelog] parsed 0 entries from ${FILE}; the frozen ledger is never empty, so the parse lost the file rather than finding it clean`);
+    return 2;
+  }
   if (broken.length === 0 && shape.length === 0) {
     const changeFacts = source.inputs.filter((path) => path.startsWith('docs/records/changes/')).length;
     const releaseMarkers = source.inputs.filter((path) => path.startsWith('docs/records/releases/')).length;

--- a/scripts/decisions-find.mjs
+++ b/scripts/decisions-find.mjs
@@ -65,7 +65,10 @@ function firstSentence(text, max = 180) {
 
 /** Split the ledger into records; the preamble before the first dated heading is dropped. */
 export function parseLedger(text) {
-  const lines = text.split('\n');
+  // As in `parseChangelog`: `\r` is a regex line terminator, so `HEADING`'s `(.+)$` cannot
+  // reach end-of-input on a CRLF checkout and every record heading stops matching. This
+  // one is caught by its own test's "hundreds of records" floor rather than passing empty.
+  const lines = text.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').split('\n');
   const records = [];
   let current = null;
   for (let i = 0; i < lines.length; i += 1) {

--- a/scripts/decisions-find.test.mjs
+++ b/scripts/decisions-find.test.mjs
@@ -62,6 +62,19 @@ describe('decision ledger retrieval', () => {
     );
   });
 
+  /**
+   * A CRLF checkout made `HEADING`'s `(.+)$` unmatchable (`\r` is a regex line
+   * terminator), so the whole ledger parsed as zero records. Found on v1.2.2's Windows
+   * job; this file's own "hundreds of records" floor is what caught it rather than a
+   * silent pass, which is why that floor stays.
+   */
+  it('splits the same ledger on a CRLF checkout', () => {
+    const crlf = parseLedger(LEDGER.replace(/\n/g, '\r\n'));
+    assert.equal(crlf.length, records.length);
+    assert.deepEqual(crlf.map((r) => [r.date, r.number, r.title]), records.map((r) => [r.date, r.number, r.title]));
+    assert.deepEqual(crlf.map((r) => r.fields), records.map((r) => r.fields));
+  });
+
   it('reads decision and falsifier fields under English and Korean labels alike', () => {
     assert.match(records[0].fields.decision, /^a tool call whose path/);
     assert.match(records[0].fields.falsifier, /^an unasked write/);

--- a/scripts/lib/changelog-entry-template.mjs
+++ b/scripts/lib/changelog-entry-template.mjs
@@ -36,7 +36,14 @@ const LABEL = /^\*\*([^*]+)\*\*[:：]?\s*(.*)$/;
 
 /** Split the changelog into entries; the preamble before the first entry is dropped. */
 export function parseChangelog(text) {
-  const lines = text.split('\n');
+  /*
+   * `\r` is a line terminator in a JavaScript regex, so `.` does not match it: on a CRLF
+   * checkout `HEADING`'s `(.+)$` can never reach end-of-input and **every** heading stops
+   * matching. The gate then measured zero entries and passed, which is worse than failing.
+   * Normalize here, where every caller reads, rather than at the one call site that reads
+   * the frozen file raw.
+   */
+  const lines = text.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n').split('\n');
   const entries = [];
   let current = null;
   for (let i = 0; i < lines.length; i += 1) {

--- a/scripts/lib/changelog-entry-template.test.mjs
+++ b/scripts/lib/changelog-entry-template.test.mjs
@@ -63,6 +63,35 @@ describe('changelog entry template', () => {
     assert.match(checkChangelogShape(parseChangelog(unreleased('2026-09-04') + unreleased('2026-09-03')))[0], /2 Unreleased entries/);
   });
 
+  /**
+   * **A CRLF checkout made this gate measure nothing and pass** (v1.2.2's Windows job).
+   * `\r` is a line terminator in a JavaScript regex, so `.` never matches it and
+   * `HEADING`'s `(.+)$` cannot reach end-of-input: every heading stopped matching, the
+   * gate reported "0 frozen entries ✓" and exited 0 while judging no entry at all. So
+   * this asserts both halves — CRLF parses, and an empty parse is refused.
+   */
+  it('parses a CRLF checkout, and refuses to pass when it measures nothing', () => {
+    const crlf = `# CHANGELOG\n\n${GOOD}`.replace(/\n/g, '\r\n');
+    assert.equal(parseChangelog(crlf).length, 1, 'a CRLF changelog must still yield its entry');
+    assert.equal(parseChangelog(crlf)[0].title, parseChangelog(`# CHANGELOG\n\n${GOOD}`)[0].title);
+    assert.deepEqual(checkEntryTemplate(parseChangelog(crlf)[0]), []);
+
+    const dir = mkdtempSync(join(tmpdir(), 'changelog-crlf-'));
+    const io = { logs: [], errors: [], log(l) { this.logs.push(l); }, error(l) { this.errors.push(l); } };
+    try {
+      mkdirSync(join(dir, 'docs'));
+      writeFileSync(join(dir, 'docs', 'CHANGELOG.md'), crlf);
+      assert.equal(runChangelogCheck([], io, { cwd: dir }), 0);
+      assert.match(io.logs.join('\n'), /1 frozen entries/);
+      // A ledger the parse lost looks exactly like a clean one without this floor.
+      writeFileSync(join(dir, 'docs', 'CHANGELOG.md'), '# CHANGELOG\n\nno dated entry here\n');
+      assert.equal(runChangelogCheck([], io, { cwd: dir }), 2);
+      assert.match(io.errors.join('\n'), /parsed 0 entries/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('the gate passes a conforming file and names the broken entry in a failing one', () => {
     const dir = mkdtempSync(join(tmpdir(), 'changelog-check-'));
     const io = { logs: [], errors: [], log(l) { this.logs.push(l); }, error(l) { this.errors.push(l); } };

--- a/scripts/lib/po-pilot-records.test.mjs
+++ b/scripts/lib/po-pilot-records.test.mjs
@@ -84,3 +84,14 @@ test('an additive keep policy still passes through the unsupported-keep gate', (
     assert.ok(pilotCheckFailures(result).length > 0);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+/**
+ * A CRLF checkout broke `parsePoPilot`'s duplicate-key pre-scan (`startsWith('---\n')`)
+ * and its table reader, both of which test `\n` directly even though the shared
+ * frontmatter parser normalizes for itself. Found sweeping v1.2.2's Windows failure.
+ */
+test('parses the register identically on a CRLF checkout', () => {
+  const lf = parsePoPilot(LEGACY);
+  const crlf = parsePoPilot(LEGACY.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n'));
+  assert.deepEqual(crlf, lf);
+});

--- a/scripts/lib/po-pilot.mjs
+++ b/scripts/lib/po-pilot.mjs
@@ -292,7 +292,11 @@ const parseUpdate = (row, runsById) => {
   };
 };
 
-export function parsePoPilot(source) {
+export function parsePoPilot(input) {
+  // A Windows checkout hands this `\r\n`. The shared frontmatter parser normalizes for
+  // itself, but the duplicate-key pre-scan above and `tableAfter` below both test `\n`
+  // directly, so normalize once at the entry and let every reader below see one shape.
+  const source = input.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
   const metadata = parseFrontmatter(source);
   const runs = tableAfter(source, '## Structured runs', PO_PILOT_RUN_COLUMNS).map(parseRun);
 

--- a/scripts/lib/record-ledgers.mjs
+++ b/scripts/lib/record-ledgers.mjs
@@ -66,7 +66,12 @@ export function readFrozenDocument(relativePath, { root = process.cwd() } = {}) 
   return raw;
 }
 
-function parseFrontmatter(raw, file) {
+function parseFrontmatter(input, file) {
+  // Same normalization `scripts/lib/parse-frontmatter.mjs` already performs, and for the
+  // same reason: a Windows checkout hands this `---\r\n`, so every `\n` test below reads a
+  // record as having no frontmatter at all. Normalizing here rather than at the two call
+  // sites keeps a third reader from reintroducing it.
+  const raw = input.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
   if (!raw.startsWith('---\n')) throw new RecordLedgerError(`${file}: frontmatter is required`);
   const end = raw.indexOf('\n---\n', 4);
   if (end < 0) throw new RecordLedgerError(`${file}: frontmatter is not closed`);

--- a/scripts/lib/record-ledgers.test.mjs
+++ b/scripts/lib/record-ledgers.test.mjs
@@ -107,6 +107,39 @@ describe('record ledgers', () => {
     writeFileSync(path.join(root, 'docs/PO-PILOT.md'), pilot.replace('legacy', 'edited').replace(/\n/g, '\r\n'));
     assert.throws(() => readFrozenDocument('docs/PO-PILOT.md', { root }), /changed after it was frozen/);
   });
+
+  /**
+   * **The second CRLF defect, and the one that actually blocked v1.2.2.** Normalizing the
+   * frozen ledgers was not enough: the record *fragments* are read by a private
+   * `parseFrontmatter` whose `raw.startsWith('---\n')` is false for `---\r\n`, so every
+   * record reported "frontmatter is required" and the docs-vault build refused to compose.
+   * Frozen documents and fragments are separate readers; this covers the fragment side.
+   */
+  it('composes CRLF record fragments, frozen ledger and release marker together', () => {
+    const root = repo();
+    const change = randomUUID();
+    const decision = randomUUID();
+    const files = {
+      [`docs/records/changes/2026-02-01-crlf-${change}.md`]:
+        `---\nid: ${change}\ndate: 2026-02-01\ncategory: Added\n---\na fact written on a Windows checkout\n`,
+      [`docs/records/decisions/2026-02-01-crlf-${decision}.md`]:
+        `---\nid: ${decision}\ndate: 2026-02-01\n---\n## 2026-02-01 — a decision on a Windows checkout\n\n**Why**: why.\n**Prior**: none.\n**Decision**: yes.\n**Dissent**: none.\n**Falsifier**: no.\n**Owner**: owner.\n`,
+      'docs/records/releases/v1.1.0.md':
+        `---\nversion: v1.1.0\ndate: 2026-02-02\ntitle: a release cut on a Windows checkout\n---\n- ${change}\n`,
+    };
+    for (const [file, text] of Object.entries(files)) {
+      writeFileSync(path.join(root, file), text.replace(/\n/g, '\r\n'));
+    }
+
+    const changelog = readLedgerSource('docs/CHANGELOG.md', { root }).content;
+    assert.match(changelog, /v1\.1\.0: a release cut on a Windows checkout/);
+    assert.match(changelog, /\*\*Added\*\*: a fact written on a Windows checkout/);
+    assert.ok(!changelog.includes('\r'), 'the composed changelog must carry one canonical line ending');
+
+    const decisions = readLedgerSource('docs/DECISIONS.md', { root }).content;
+    assert.match(decisions, /a decision on a Windows checkout/);
+    assert.ok(!decisions.includes('\r'), 'the composed decisions must carry one canonical line ending');
+  });
   it('rejects impossible calendar dates without trusting their shape', () => {
     const root = repo(); const id = randomUUID();
     writeFileSync(path.join(root, `docs/records/changes/2026-02-30-a-${id}.md`), `---\nid: ${id}\ndate: 2026-02-30\ncategory: Added\n---\nA\n`);


### PR DESCRIPTION
## Summary

#1596 normalized the three frozen ledgers and **was not enough**. v1.2.2's Windows job failed again, one layer deeper:

```
[record-ledgers] docs/records/changes/2026-09-13-arrival-paints-…-eafa766a….md:
frontmatter is required
```

Frozen documents and record *fragments* are separate readers. The fragments go through a private `parseFrontmatter` whose `raw.startsWith('---\n')` is false for `---\r\n`, so every record looked like it had no frontmatter and the docs-vault build refused to compose the changelog.

## I stopped guessing and built a local oracle

One bug per release run is not a method. So I reproduced a Windows checkout locally — **all 367 tracked Markdown files under `docs/` and `samples/` converted to CRLF** — and ran the real build plus every ledger gate against them. The first run reproduced the CI failure **byte for byte**: same file, same message.

That found **four** defects, not one, with a single root cause: **`\r` is a line terminator in a JavaScript regex**, so `.` does not match it and any trailing-`$` pattern can never reach end-of-input on a CRLF line.

| reader | what CRLF did | how it showed up |
|---|---|---|
| `record-ledgers` fragments + release markers | "frontmatter is required" on every record | **blocked the release** |
| `changelog-entry-template` | matched no heading at all | `changelog:check` printed **"0 frozen entries" and exited 0** |
| `decisions-find` | parsed the ledger as **0 records** | caught by its own test's "hundreds of records" floor |
| `po-pilot` | duplicate-key pre-scan and table reader | register unreadable |

**The changelog one is the most dangerous and is not a failure — it is a vacuous pass.** The gate did not go red; it stopped having subjects and reported success. So `check-changelog` now has a floor: **zero parsed entries is an error**, because the frozen ledger always holds released history, so zero means the parse lost the file rather than finding it clean. `decisions-find` already had that floor, which is exactly why its failure was loud — that contrast is the argument for adding it.

## The real defect shape

`scripts/lib/parse-frontmatter.mjs` **already does this normalization and already explains why in its own comment**, BOM included. The bug is not a missing `.replace` — it is that three modules reimplemented frontmatter and section parsing privately and none inherited the lesson. Each now normalizes at its **entry**, where every caller passes rather than at one call site, and the comments name that parser as the precedent so a fourth copy does not repeat it.

I did not consolidate them onto the shared parser: each keeps strictness the shared one deliberately does not impose (required keys, the outcome enum, duplicate top-level keys), and `po-pilot.mjs`'s own comment records that a previous consolidation attempt broke valid YAML. That is a refactor to argue separately, not inside a release unblock.

## Test plan

- **CRLF tree**: `docs-vault:build`, `changelog:check`, `decisions:check`, `po:pilot --check`, `test:records`, `test:changelog`, `test:decisions`, `docs:links`, `docs:language` — **9/9 pass** (they were 2 failures + 1 vacuous pass before)
- **LF tree**: same 9 pass, and `changelog:check` measures **421 frozen entries** again rather than 0
- `pnpm checks:changed -- --run` — **8/8**
- **Gate probe, each fix in isolation**: reverting one normalization turns its own lane red and only that lane, then green when restored — `records: fragment frontmatter` → `test:records` RED · `po-pilot: register pre-scan` → `test:records` RED · `changelog: heading parse` → `test:changelog` RED · `decisions: record parse` → `test:decisions` RED · `changelog: vacuous-pass floor` → `test:changelog` RED
- An earlier probe attempt reported four spurious GREENs because shell quoting mangled a literal BOM in the anchor strings, so nothing was actually reverted. Rebuilt the anchors and re-probed; those first results are void.

## Follow-up, deliberately not here

`scripts/new-record.mjs` validates a `--input` body with `body.trim().includes('\n')`, so authoring a record from a CRLF temp file on Windows would be rejected as "must fit one 900-byte line". That is the authoring path, not the build path, and it blocks nothing today. Naming it rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK


---

## ⚠️ Correction (2026-09-13, added after this PR merged)

**This PR's claim that "the only Windows runner in this repository is `release-macos.yml`" is false.**

`.github/workflows/windows-beta-check.yml` runs `pnpm install --frozen-lockfile` on `windows-2022`, on pull requests **and** on pushes to `main`. The claim came from reading the release workflow's job graph instead of listing `.github/workflows/`.

The consequence matters more than the error: that lane **had already reported this exact failure** — red on `main` from `a80708ce9` onward, and red on the v1.2.2 release PR (`34720027112`) eight minutes before it landed. It produces no required status context, so `pnpm pr:land` merged on "every required context is green" and the verdict was never surfaced.

Both halves are fixed in **#1598**: `pr:land` now refuses on any failing check, required or not, with `--allow-failing <context>` as the named escape; and a non-required Windows install canary runs after every push to `main` with no path filter. See `docs/DEVELOPMENT-CHECKS.md`, "The Windows install canary, and why a path filter cannot be one".
