### PR TITLE
docs(records): let the v1.2.2 marker name everything the tag ships

### DIFF
--- a/docs/records/changes/2026-09-13-bell-separates-what-waits-on-me-aa412b15-d7a7-45ab-8fca-7505907bd43d.md
+++ b/docs/records/changes/2026-09-13-bell-separates-what-waits-on-me-aa412b15-d7a7-45ab-8fca-7505907bd43d.md
@@ -1,0 +1,6 @@
+---
+id: aa412b15-d7a7-45ab-8fca-7505907bd43d
+date: 2026-09-13
+category: Changed
+---
+The notification panel now answers three questions in one place with the counts engraved in its tabs, what waits on you, what got done and what happened when, instead of one undifferentiated event log, and opening it no longer marks every unread result read

--- a/docs/records/changes/2026-09-13-library-press-opens-a-card-beside-the-mark-c329c399-66d8-46c0-88a6-3ee0cea811f5.md
+++ b/docs/records/changes/2026-09-13-library-press-opens-a-card-beside-the-mark-c329c399-66d8-46c0-88a6-3ee0cea811f5.md
@@ -1,0 +1,6 @@
+---
+id: c329c399-66d8-46c0-88a6-3ee0cea811f5
+date: 2026-09-13
+category: Changed
+---
+A press on the Library picture opens a card anchored beside the mark rather than leaving the picture for the page, carrying the mark's identity, one sentence, a facts line that goes amber with the stale citation count, the marks at the other end of its relations with each one's state, and doors to open the page or ask for a redraft

--- a/docs/records/releases/v1.2.2.md
+++ b/docs/records/releases/v1.2.2.md
@@ -9,3 +9,6 @@ title: switching destinations no longer reloads the app, and every failure a per
 - b009cc47-892f-40f8-9bf6-fe3330abc826
 - daf988f4-9c67-4419-a1bc-c4ad76f2040b
 - fbb5edc8-1ab9-40e2-843c-d02ae08f4ae4
+- c97bf0dc-0ce0-40e6-aa27-229bf4eb91ce
+- aa412b15-d7a7-45ab-8fca-7505907bd43d
+- c329c399-66d8-46c0-88a6-3ee0cea811f5


### PR DESCRIPTION
## Summary

The `v1.2.2` release marker selected six change facts. The tree the tag points at carries nine.

- **Two user-visible changes had no record at all.** The notification panel that separates what waits on you from what was done (#1570), and the Library press that opens a card beside the mark instead of leaving for the page (#1574). Both sentences are derived from the commits' own bodies, not invented.
- **One record existed but was Unreleased.** The audit-log lock fix (#1599) wrote its `Fixed` fragment and deliberately did not touch the marker.

Records are immutable. A marker that under-describes its own tag would stay wrong permanently, and anyone checking out `v1.2.2` would see three facts sitting in Unreleased that in truth shipped. The tag has not been published yet, so this is the last moment the correction is free.

## Test plan

`pnpm checks:changed -- --run`, all six recommendations, 6 passed:

- `docs-vault:build`
- `test:records` — 23 tests
- `bundled-vault-budget.contract.test.ts`
- `docs:language` — ratchets current
- `docs:links` — 504 files, no broken references
- `changelog:check` — 421 frozen entries + **9** change facts + 1 release marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK