### PR TITLE
docs: say plainly that other products' names are their owners' marks

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,6 +17,25 @@ its own `LICENSE` inside the artifact beside Atlas's, and carry no native binari
 A new distributed artifact belongs in this sentence: a notice that under-lists is a
 compliance failure.
 
+## Trademarks
+
+Product names that appear in Atlas — Claude Code, Codex, Cursor, Antigravity,
+Copilot, GitHub and others — are trademarks of their respective owners. Atlas is
+not affiliated with, sponsored by, or endorsed by any of them. It names them only
+to say what it interoperates with, which is the accurate way to describe an
+integration and the only reason they appear.
+
+Names are one thing and marks are another. A service's own glyph appears only
+where that service's published brand guideline was read and permits monochrome
+use to show an integration; every other row falls back to a generic connector
+glyph. `docs/FEATURES.md` owns that rule and names which services have been
+checked. The ACP runtime icons under `public/acp-icons/` are the 16x16 monochrome
+SVGs the ACP registry itself publishes for this purpose, fetched at build time by
+`pnpm acp:registry`, so no brand colour enters the application.
+
+CC0 on an icon set waives copyright, not trademark. Do not read a permissive
+icon licence as permission to wear a mark.
+
 The two inventories at the end are read from the **build graphs** that produce those
 artifacts, so they are supersets of what is actually shipped: a proc-macro crate such
 as `syn`, or a build-only tool such as `typescript`, is listed without being

--- a/docs/records/changes/2026-09-13-trademark-line-on-the-download-page-5e4d93e4-0633-4aed-af93-338307b75020.md
+++ b/docs/records/changes/2026-09-13-trademark-line-on-the-download-page-5e4d93e4-0633-4aed-af93-338307b75020.md
@@ -1,0 +1,6 @@
+---
+id: 5e4d93e4-0633-4aed-af93-338307b75020
+date: 2026-09-13
+category: Added
+---
+The download page and the third-party notices now state that Claude Code, Codex, Cursor and the other product names Atlas mentions are trademarks of their owners and that Atlas is not affiliated with or endorsed by any of them, so a reader can tell a statement of what Atlas connects to from a claim of partnership

--- a/messages/en.json
+++ b/messages/en.json
@@ -517,7 +517,8 @@
   "footer": {
     "license": "MIT licensed",
     "github": "GitHub",
-    "stack": "Local-first · Next.js · TypeScript · Canvas 2D · MCP"
+    "stack": "Local-first · Next.js · TypeScript · Canvas 2D · MCP",
+    "trademarks": "Claude Code, Codex, Cursor and the other product names here are trademarks of their respective owners. Ontology Atlas is not affiliated with or endorsed by any of them; the names say what it connects to."
   },
   "firstRun": {
     "eyebrow": "Local-first workbench",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -517,7 +517,8 @@
   "footer": {
     "license": "MIT licensed",
     "github": "GitHub",
-    "stack": "Local-first · Next.js · TypeScript · Canvas 2D · MCP"
+    "stack": "Local-first · Next.js · TypeScript · Canvas 2D · MCP",
+    "trademarks": "Claude Code, Codex, Cursor를 비롯해 여기 나오는 제품 이름은 각 소유자의 상표입니다. Ontology Atlas는 어느 쪽과도 제휴하거나 승인받은 관계가 아니며, 이름은 무엇과 연결되는지 말하기 위해서만 씁니다."
   },
   "firstRun": {
     "eyebrow": "Local-first workbench",

--- a/src/views/download/ui/DownloadPage.tsx
+++ b/src/views/download/ui/DownloadPage.tsx
@@ -245,6 +245,13 @@ export function DownloadPage() {
                 <span aria-hidden>·</span>
                 <span className="font-mono">{tFooter('stack')}</span>
               </div>
+              {/* Nominative use: the names say what Atlas connects to, and the line
+                  states that no affiliation is claimed. Marks themselves follow the
+                  stricter rule in docs/FEATURES.md — a service's own glyph only where
+                  its published brand guideline was read and permits it. */}
+              <p className="mt-3 max-w-[var(--measure-doc-column)] text-[color:var(--color-text-quaternary)]">
+                {tFooter('trademarks')}
+              </p>
             </footer>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The download page names Claude Code, Codex and Cursor to say what Atlas connects to. Nowhere did it say that this is not a partnership, and `NOTICE.md` inventories every dependency while saying nothing about trademarks.

- **Download page footer** gains one line, in both locales, stating that those names are their owners' marks and that Atlas is not affiliated with or endorsed by any of them.
- **`NOTICE.md`** gains a Trademarks section recording the rule this repository already follows: a name may be used to identify a product; a mark may only be worn where that service's published brand guideline was read and permits it. It also records why the ACP runtime icons are fine — they are the 16×16 monochrome SVGs the ACP registry itself publishes, fetched at build time, so no brand colour enters the app.
- One sentence worth keeping: **CC0 on an icon set waives copyright, not trademark.** That distinction is already the reason every connector but GitHub falls back to a generic glyph.

## Test plan

`pnpm checks:changed -- --run`, all 15 recommendations, 15 passed.

One note on method: the gateway e2e suite failed 2 of 33 on the first attempt. I ran the same spec on untouched `origin/main` in a separate worktree, which passed 33/33, then re-ran mine on an isolated `PLAYWRIGHT_BASE_URL` port and got 33/33 as well. The first failure was a reused stale server, not this change. The baseline run is why I can say that rather than assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP6KnWMjyFgF4ry83pNsxK