### PR TITLE
fix: distinguish corpus diagnostics from meaning construction quality

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -35,8 +35,8 @@ need their own scoped PO/design/evidence proof before implementation.
 
 | ID | Status | Concrete deliverable | Prerequisite / evidence |
 |---|---|---|---|
-| V1.0 | ready | Typed and readable measurement scope; discovery/oracle pass remains distinct from unmeasured construction | First slice; preserve existing thresholds and per-fixture/empty failure behavior |
-| V1.1 | blocked(V1.0) | Frozen unfamiliar backend task, six owner-approved questions, source reference, license/scope manifest | Preserve the original question approval; independently verify task-specific reference |
+| V1.0 | done(ffcdce35a) | Typed and readable measurement scope; discovery/oracle pass remains distinct from unmeasured construction | First slice; preserve existing thresholds and per-fixture/empty failure behavior |
+| V1.1 | ready | Frozen unfamiliar backend task, six owner-approved questions, source reference, license/scope manifest | Preserve the original question approval; independently verify task-specific reference |
 | V1.2 | blocked(V1.1) | Bounded predicate/state/effect evidence reads for a measured missing read | Existing-tool versus new-tool decision from observed gap |
 | V1.3 | blocked(V1.1) | Scoped document/config evidence retaining current/planned/negated/conflicting context | Activate only witnessed gaps; follow applicable V1.2 decisions |
 | V1.4 | blocked(V1.2) | Source-first business hypotheses with definitions, counter-boundaries, qualifiers and evidence | V1.2 and V1.3 where the task needs them |
@@ -63,6 +63,18 @@ benefit/failure rules. This establishes plan coverage, not implemented UX or
 proven product benefit. Planning/review remain Astra; code implementation is Sol
 low. The prior research-only saved sample and its complete-answer result of 0/6
 remain unchanged.
+
+**V1.0 evidence (2026-09-13):** implementation `ffcdce35a`, following plan
+registration `4aaa70b92`; Sol low implementation and Astra review. Node 24 sibling
+regressions pass 4/4, including all-green discovery with unmeasured construction,
+separate candidate/oracle fixture failures, empty corpus and actual JSON/text
+output. All nine implementation recommendations from `checks:changed -- --run`
+passed. Before/after JSON comparison preserves the complete existing summary and
+every fixture diagnostic. Primary outputs and logs remain outside the repository
+at `/Users/jinan/scratch/atlas-delivery-2026-09-13/` (`v1-0-before.json`,
+`v1-0-after.json`, `v1-0-after.txt`, `v1-0-checks.log`). This closes the reporting
+contract only; independent construction quality, actual human comprehension,
+V3 UX and repeated-use benefit remain unproven. V1.1 is the next ready slice.
 
 V1 and the reuse value in V2/V4 are separate risks: a manually reviewed starting
 vault can test reuse, but its creation method and cost must remain visible and

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,12 +20,49 @@ the current value and sequence. Retain completed evidence below; historical
 scores, green contracts, and node counts do not prove general construction
 quality, correct human judgment, or repeat use.
 
-| Order | ID | Status | Recovery to prove |
+| Order | ID | Work items | Recovery to prove |
 |---:|---|---|---|
-| 1 | V1 | ready | On an unfamiliar work repository, recover source-backed rules, state/effects, responsibilities, and counter-boundaries even when documents and names are weak; keep unsupported meaning explicit. |
-| 2 | V2 | ready | Use task-aware `agent_brief` in a real change, preserving reviewed conditions, currentness, relevant code, and unknown impact; compare against the same source tools without Atlas. |
-| 3 | V3 | ready | Connect one task's baseline, actual code change, proposed meaning, and verification scope so a person can catch an incorrect interpretation or defer it; existing write review is the starting point, not a claim of complete Meaning Diff. |
-| 4 | V4 | ready | A fresh agent in a later related task uses the previous accepted meaning without the prior conversation; measure boundary fidelity, owner re-explanation, false warnings, and review/maintenance burden. |
+| 1 | V1 | V1.0–V1.5 | On an unfamiliar work repository, recover source-backed rules, state/effects, responsibilities, and counter-boundaries even when documents and names are weak; keep unsupported meaning explicit. |
+| 2 | V2 | V2.1–V2.4 | Use task-aware `agent_brief` in a real change, preserving reviewed conditions, currentness, relevant code, and unknown impact; compare against the same source tools without Atlas. |
+| 3 | V3 | V3.1–V3.6 | Connect one task's baseline, actual code change, proposed meaning, and verification scope so a person can catch an incorrect interpretation or defer it; existing write review is the starting point, not a claim of complete Meaning Diff. |
+| 4 | V4 | V4.1–V4.3 | A fresh agent in a later related task uses the previous accepted meaning without the prior conversation; measure boundary fidelity, owner re-explanation, false warnings, and review/maintenance burden. |
+
+The [detailed execution specification](MEANING-WORKFLOW-PLAN.md) defines each
+item's inputs, deliverable, acceptance, negative cases, dependencies and owner
+seams. This table alone owns live status. Numeric IDs group requirements;
+dependencies decide implementation order (V3.3 precedes V3.2). Future items
+need their own scoped PO/design/evidence proof before implementation.
+
+| ID | Status | Concrete deliverable | Prerequisite / evidence |
+|---|---|---|---|
+| V1.0 | ready | Typed and readable measurement scope; discovery/oracle pass remains distinct from unmeasured construction | First slice; preserve existing thresholds and per-fixture/empty failure behavior |
+| V1.1 | blocked(V1.0) | Frozen unfamiliar backend task, six owner-approved questions, source reference, license/scope manifest | Preserve the original question approval; independently verify task-specific reference |
+| V1.2 | blocked(V1.1) | Bounded predicate/state/effect evidence reads for a measured missing read | Existing-tool versus new-tool decision from observed gap |
+| V1.3 | blocked(V1.1) | Scoped document/config evidence retaining current/planned/negated/conflicting context | Activate only witnessed gaps; follow applicable V1.2 decisions |
+| V1.4 | blocked(V1.2) | Source-first business hypotheses with definitions, counter-boundaries, qualifiers and evidence | V1.2 and V1.3 where the task needs them |
+| V1.5 | blocked(V1.4) | Independent candidate and persisted handoff, full-answer source audit, matched prompt/access comparisons | Exact meaning/gap/write approval; frozen run and holdout |
+| V2.1 | blocked(V1.1) | Task/non-goal resolution with supported selection, alternatives or abstention | A reviewed starting vault may isolate reuse; disclose construction cost |
+| V2.2 | blocked(V2.1) | Compact action context preserving conditions, exceptions, currentness and unknowns | Same claims survive budgets and full-body follow-ups |
+| V2.3 | blocked(V2.2) | Actual host-to-MCP task entry and honest unavailable-context fallback | Optional UI links wait for V3.1; initial MCP proof does not |
+| V2.4 | blocked(V2.3) | Atlas-on/off real coding outcomes with equivalent source tools and independent review | V1.5 additionally required for construction claims |
+| V3.1 | blocked(V2.2) | Current-task decision entry with exact baseline, relevant diff and coverage | V2.1/V2.2 plus sufficient evidence or a disclosed reviewed fixture |
+| V3.2 | blocked(V3.3) | Summary, small comparison and detailed review preserving qualifiers, selection and scope | V3.1/V3.3; acceptance actions also use V3.4 |
+| V3.3 | blocked(V3.1) | Meaning Diff retaining conditions, exceptions, units, unknown and uncomparable states | V1.4 evidence/meaning and V3.1 comparison basis |
+| V3.4 | blocked(V3.3) | Distinct meaning acceptance, code verification, merge and deployment states/actions | V3.1/V3.3 and exact proposal/write concurrency guards |
+| V3.5 | blocked(V3.2) | Measured first-review orientation and checked-scope understanding, including a11y/EN/KO | V3.2–V3.4; five seconds is an orientation target, never an approval deadline |
+| V3.6 | blocked(V3.5) | Real reviewer error discovery, correction and deferral against fixed wrong/incomplete cases | V3.1–V3.5; freeze decision rules before collecting results |
+| V4.1 | blocked(V3.4) | Traceable accepted code/meaning transition in ordinary Git with distinct authorities | V3.3/V3.4; no forced meaning update for every task |
+| V4.2 | blocked(V4.1) | A → B → C reuse by a fresh agent without prior conversation or future-answer leakage | V2.4/V4.1 plus unrelated-task and meaning-preserving-refactor controls |
+| V4.3 | blocked(V4.2) | Voluntary repeated use and decision outcomes including acquisition/review/maintenance cost | Consented actual work; MCP calls and app opens alone do not prove value |
+
+**Registration evidence:** the owner requested these six UI/UX commitments
+separately; Astra independently reviewed all 19 plan items against the current
+product thesis and existing corpus implementation. The review corrected
+prompt/access attribution, optional UI-link dependencies and predeclared
+benefit/failure rules. This establishes plan coverage, not implemented UX or
+proven product benefit. Planning/review remain Astra; code implementation is Sol
+low. The prior research-only saved sample and its complete-answer result of 0/6
+remain unchanged.
 
 V1 and the reuse value in V2/V4 are separate risks: a manually reviewed starting
 vault can test reuse, but its creation method and cost must remain visible and

--- a/docs/MEANING-WORKFLOW-PLAN.md
+++ b/docs/MEANING-WORKFLOW-PLAN.md
@@ -1,0 +1,495 @@
+# Meaning workflow implementation plan — V1 to V4
+
+This is the current detailed execution specification for the
+[Atlas product thesis](PRODUCT-DIRECTION.md#the-atlas-product-thesis).
+[BACKLOG.md](BACKLOG.md#current-priority--useful-meaning-across-real-tasks-2026-09-13)
+is the single status ledger. This plan defines scope, dependencies, artifacts,
+and acceptance; it does not duplicate live status or mark hypotheses as shipped.
+
+## Outcome and working agreement
+
+An owner can understand the relevant business rules and boundaries, distinguish
+verified facts from unknowns, and correct or defer an agent's proposed meaning.
+An agent can reuse accepted context in a later task. Confidence must remain
+proportionate to evidence; convenience reduces the cost of that outcome.
+
+Astra owns planning, evidence interpretation, code review, and acceptance of
+verification results. Sol at low reasoning effort implements each bounded code
+slice from an Astra-authored brief. The human remains the meaning acceptor.
+A model or automated reviewer cannot fabricate that decision. Use the existing
+solo/two-seat PO router, not a standing expanded council.
+
+Work one registered slice at a time. Each implementation brief names file
+ownership, exact checkout and Node runtime, read-only boundaries, scratch path,
+port or no-server policy, baseline, positive and negative cases, and primary
+sources. No shared stash, broad staging, or unrelated worktree cleanup. Draft
+PRs land through `pnpm pr:land` after the required checks and Astra review.
+
+The program does not promise support for every enterprise language, complete
+runtime impact, automatic meaning acceptance, or a backend-only product.
+Transactional backend code is the first evaluation target; frontend-owned
+rules, database procedures, and external systems remain relevant when they own
+behavior. No production data, private repository, or remote system is accessed
+without the user's authorization. Preserve source licenses and notices.
+
+## Completion evidence common to every slice
+
+- State the user task and expected ability before implementation. Record what
+  becomes possible, rather than only a new field, screen, or passing command.
+- Keep observed code facts, proposed meaning, and accepted meaning distinct.
+  Track source revision, evidence scope and omissions. No file path or graph
+  health result proves semantic correctness.
+- Record before/after and a deliberately failing case where the claim could
+  become misleading. Do not add prose-pinning tests or weaken a gate to pass.
+- Run every recommendation from `checks:changed`; UI proof follows
+  `design:route`, and changed gates follow `gate-probe`. Changes to construction
+  rules or content-affecting MCP reads/writes use the ontology field-trial
+  protocol. Pure evaluation reporting is not a completed construction trial.
+- Before each comparative run or user study, freeze its critical questions/errors,
+  comparison, intended generalization, and decision rule for supported benefit,
+  insufficient evidence, or failed claim in the existing run manifest. A completed
+  experiment can have an unfavorable result; completion does not prove recovery.
+- Archive primary results, rejected drafts, corrections, source-hidden answers,
+  and source-aware audits. External repository artifacts stay outside Atlas;
+  in-repo regression fixtures use original, generalized examples with clear
+  licensing. Do not replace the first run with a corrected score.
+- A slice is complete only for its stated contract. Keep unknowns and later
+  dependencies visible. V1–V4 do not become complete because their enabling
+  components or this plan exist.
+
+## V1 — Recover defensible meaning from unfamiliar work code
+
+### V1.0 — Make evaluation scope impossible to confuse with construction quality
+
+**User situation:** a contributor sees candidate precision/recall and oracle
+PASS and may mistake them for useful ontology construction.
+**Inputs:** the current meaning corpus runner and candidate projection, which
+omit definitions/competency answers and relax their thresholds.
+**Deliverable:** an explicit typed measurement-scope result and corresponding
+readable report distinguishing candidate discovery, golden-oracle consistency,
+and unmeasured independent construction quality. Preserve existing diagnostic
+counts and discovery pass/fail behavior; document the distinction at its owner.
+**Acceptance:** a passing fixed corpus can still explicitly report construction
+as not measured. Consumers can identify which dimensions were deliberately not
+evaluated without interpreting a percentage or reading the runner source.
+**Negative cases:** all discovery/oracle results green with zero projected
+competency answers; one failed fixture hidden by good aggregate counts; empty
+corpus. None may imply qualified construction or silently disappear.
+**Dependencies/owners:** no later slice; `scripts/evaluate-meaning-corpus.mjs`,
+its tests and `docs/ONTOLOGY-QUALITY.md`. This is the first implementation slice,
+not an improvement claim about the analyzer's business interpretation.
+
+### V1.1 — Register a source-first backend task and fixed answer contract
+
+**User situation:** `common`, `impl`, `util`, stale docs, and indirect calls hide
+business responsibilities that a task requires.
+**Inputs:** a newly selected authorized/permissive repository, exact revision,
+allowed source files, data/schema/ERD availability, language support, and a
+human-reviewed question set. Choose a real policy/state/effect workflow.
+**Deliverable:** a frozen task/evidence manifest, responsibility and predicate
+questions, source-aware reference with explicit inference, and comparable
+conditions with documents present/hidden. Name obfuscation is only a secondary
+behavior-preserving control, not a substitute for real legacy complexity.
+**Acceptance:** questions test actors, objects, rules, states, effects, rejection,
+conditional dependencies and unknowns without revealing the desired domain names
+to the builder. The source-aware reference is independently checked, not a
+model-authored oracle treated as truth. Record model, Node, source and Atlas SHA.
+**Negative cases:** stale document contradicts a current branch; absent backend
+logic resides in a stored procedure/external system; unsupported language; a
+fixture whose names reveal the answer. These become scoped limits or invalid
+setup, not a successful semantic baseline.
+**Dependencies/owners:** V1.0; field-trial/meaning qualification protocols.
+Primary artifacts live in an isolated run directory with original license and
+hashes, not in the dogfood vault or identifiers.
+
+Retain the six owner-approved competency questions from the 13 September trial
+(the following are English translations; the original approval and exact Korean
+wording remain in that trial's `control/question-approval.json`):
+
+1. Whose problem does this system solve, and what is that problem?
+2. What are its core responsibility areas, and where are their boundaries?
+3. What are a representative capability's inputs, outcomes, and preconditions?
+4. Where should a change to that capability start in the implementation, and
+   what are its main external dependencies?
+5. If a core processing or validation rule changes, which capabilities and
+   implementation parts are affected, and where does our knowledge stop?
+6. What is explicitly out of scope, and what merely lacks evidence?
+
+The semantic owner is the conversation user. Bind task-specific probes to these
+questions before seeing results; record any question revision separately. The
+prior approval covers the questions, not a new repository's proposed meaning,
+gaps, or write plan. Keep `answered`, `partial`, and unknown/visible-gap outcomes
+and evaluate the complete answer, not just a selected claim ledger.
+
+### V1.2 — Supply bounded implementation evidence needed by that task
+
+**User situation:** the agent receives entrypoint/import names but cannot read
+the condition or effect that distinguishes competing business interpretations.
+**Inputs:** V1.1's missing reads, actual available source/language tools, and
+existing repository-root/source-currentness protections.
+**Deliverable:** the smallest read path that exposes exact relevant source
+ranges/symbols, supported caller/callee or data relationships, source identity,
+coverage, and next read coordinates. Decide the existing-tool versus new-tool
+seam from a measured missing read before changing a public MCP contract.
+**Acceptance:** the agent can inspect the selected predicate, state write,
+transaction/external effect, and a counterexample without a whole-repo dump.
+Returned text is data; currentness and truncation are explicit. A disconnected
+or unsupported edge remains unknown. File scope and byte/range budgets are
+measured independently of semantic quality.
+**Negative cases:** escaping/symlinked paths, forbidden source scope, source
+changing during a read, oversized/truncated source, dynamic dispatch, and
+instructions embedded in code/docs. No silent widening, fake completeness or
+ontology write is permitted.
+**Dependencies/owners:** V1.1; source analysis/read seams and MCP/CLI contract
+owners identified in that slice. Rooted-reader and client compatibility must
+be included if a new read operation is introduced.
+
+### V1.3 — Preserve document/configuration context without making it the ontology
+
+**User situation:** a tutorial or static package contract contains useful facts,
+but a selected excerpt loses scope or merges current and planned behavior.
+**Inputs:** independently witnessed gaps such as internal RST tutorials,
+`setup.cfg` metadata/options, source contracts and conflicting README sections.
+**Deliverable:** focused evidence discovery/read support and item-level source
+context for current/planned/negated/conflicting statements. Read static manifests
+without executing project setup code. Distinguish build/runtime declarations
+from indispensability and actual deployment.
+**Acceptance:** each returned claim keeps its heading/range/currentness and
+nearby counterevidence. The caller can reach the missing internal text within
+scope. A plan statement does not taint unrelated current evidence or become
+current behavior. Document expansion alone does not count as source-first
+business understanding.
+**Negative cases:** mixed supported/planned list; stale roadmap with implemented
+branch; dynamic metadata; recursive include; out-of-root document link; private
+or differently licensed asset. Preserve partial evidence rather than invent it.
+**Dependencies/owners:** V1.1 and scoped V1.2 decisions;
+`mcp/src/analyze/semantic-evidence.mjs`, `package-contracts.mjs`, discovery/guards.
+Split parser and public-contract changes into separately reviewable increments.
+
+### V1.4 — Build and falsify business-meaning hypotheses
+
+**User situation:** knowing files and tables still does not identify Refund,
+Settlement, Eligibility, or their responsibility boundaries.
+**Inputs:** current behavior/data/contract evidence from the selected workflow,
+alternative interpretations, and source-aware negative examples.
+**Deliverable:** a source-first investigation prompt/workflow tracing trigger →
+predicate → state/effect → failure/retry → verification; intensional capability
+and domain proposals with conditions, units, exclusions, citations and unknowns.
+Preserve useful unassigned evidence without inventing a domain to unlock a schema.
+**Acceptance:** nearby responsibilities are distinguishable by actual behavior
+and counter-boundary. A table, name or import cannot alone establish a domain,
+causality, or historical intent. Code's implemented policy and the owner's
+intended policy remain distinguishable. The exact reviewed proposal is available
+before writes under the unchanged human acceptance boundary.
+**Negative cases:** same name/different context; authorization versus capture;
+conditional versus universal dependency; UI affordance versus server rule;
+original intent absent from code; plausible but unsupported exclusion.
+**Dependencies/owners:** V1.2/V1.3 as needed for the chosen task; construction
+rules, bootstrap guidance, proposal validation and evidence representation.
+Astra owns hypothesis/contract design; Sol implements agreed source changes.
+
+### V1.5 — Prove candidate and persisted meaning independently
+
+**User situation:** a valid plan or successful finalizer may still leave a
+successor unable to explain the system.
+**Inputs:** exact proposal, fixed human-approved questions, current sources,
+separate builder/evaluator/auditor contexts, and approved gaps.
+**Deliverable:** candidate-only evaluation, exact acceptance/release and writer
+receipts, full-body byte readback, source-hidden persisted handoff, full-answer
+source audit, and a comparison to the frozen baseline. Use four matched conditions to
+isolate cause: current prompt/current evidence, new prompt/current evidence,
+current prompt/expanded source evidence, and new prompt/expanded source evidence.
+Keep model, task, source revision, budgets and independent-run setup fixed.
+Archive every applicable condition rather than selecting the best-looking run.
+If access has no measured gap, record it as unchanged and omit duplicate arms;
+do not introduce an evidence tool just to populate an experimental condition.
+**Acceptance:** known responsibilities/rules/boundaries and bounded change
+navigation survive with their qualifiers. Score missing critical meanings and
+unsupported assertions separately; node totals or correct refusals alone do not
+prove sufficient understanding. Source-hidden access is tested, not declared
+by the builder. A holdout repository tests transfer after the known case.
+**Negative cases:** claim/ref/digest mutation, same actor, leaked source, stale
+source, unsupported acceptance, omitted material assertion, and missing scope
+qualifier. Preserve first-pass failures and all setup cost.
+**Dependencies/owners:** V1.4; existing field-trial and qualification helpers.
+Human plan acceptance remains required at the exact write boundary.
+
+## V2 — Make reviewed meaning useful before a real code change
+
+### V2.1 — Resolve task scope without lexical false certainty
+
+**Inputs:** current accepted vault, task/non-goals, aliases/language, matching
+and conflicting definitions, several plausible capabilities.
+**Deliverable:** supported task selection and bounded alternatives/abstention;
+update the existing compact brief rather than creating a duplicate context API.
+**Acceptance:** an unfamiliar agent can identify the relevant responsibility and
+why it was selected. Ambiguous or cross-capability tasks are explicit; child
+path/title matches do not override a conflicting parent boundary.
+**Negative cases:** same name/different context, excluded behavior mentioned in
+prose, Korean/English expressions, no accepted match, multi-domain task.
+**Dependencies/owners:** V1.1 fixed tasks; a sufficiently reviewed starting vault
+may isolate this reuse test from V1 construction. `agent-brief-compact.mjs` and
+its actual task navigation/meaning owners.
+
+### V2.2 — Preserve the facts needed for action in the compact brief
+
+**Inputs:** selected meaning, source/graph revision, conditional rules,
+implementation roles, tests and known/unknown dependency evidence.
+**Deliverable:** concise task context with exact full-body/source follow-ups;
+conditions, exceptions, source currentness and verification scope survive size
+limits. Preserve request-local task behavior unless separately authorized.
+**Acceptance:** an agent can state what to inspect/change, which condition not to
+break, which check can verify it, and what remains unproven. Full detail is
+reachable; an empty relation set is not independence or a safe blast radius.
+**Negative cases:** budget truncates a qualifier, coordinates drift mid-read,
+source exists but meaning is stale, static dependency promoted to runtime impact.
+**Dependencies/owners:** V2.1; compact brief, task-navigation and source receipts.
+
+### V2.3 — Enter the real agent workflow with explicit host boundaries
+
+**Inputs:** one declared supported host and its MCP capabilities/permissions,
+user-enabled integration, normal and unrelated tasks, unavailable/stale vault.
+**Deliverable:** reliable task-context invocation and return-to-source behavior,
+with a precise optional link to relevant human review. No global mandatory hook
+or new telemetry by default.
+**Acceptance:** meaningful tasks use the appropriate brief with no repeated
+manual context paste. Small unrelated work is not charged unnecessary calls.
+Unavailable context is visible, never silently trusted or globally blocking
+without a repository policy. Test actual model-to-tool delivery, not config
+file existence or server instructions alone.
+**Negative cases:** wrong vault, host ignores instructions, disconnected server,
+repeated same-task calls, stale context, unsupported inline visualization.
+**Dependencies/owners:** V2.2; current connector/runtime integration. Establish
+the task identity from V2.1/V2.2 before optional UI links. Human-review links
+wait for V3.1 and do not block the initial MCP-only entry proof; the design
+router owns their rendered proof.
+
+### V2.4 — Compare real coding outcomes with equivalent source access
+
+**Inputs:** fixed work task, same model/source tools/budgets, Atlas-on/off
+conditions, current tests and independent source-aware review.
+**Deliverable:** code and test outcomes, important condition/boundary fidelity,
+unsupported claims, context use and owner effort, followed by costs.
+**Acceptance:** a claimed benefit changes a supported decision or result, not
+only the vocabulary used or number of MCP calls. A manually prepared vault is
+reported with its acquisition cost, never counted as automatic construction.
+**Negative cases:** Atlas-only words in the control's answer key, hidden source
+answers in the off arm, green tests with wrong business policy, unreviewed
+concepts presented as approved context.
+**Dependencies/owners:** V2.3 for the measured host; V1.5 for construction claims.
+
+## V3 — Let a person understand and judge this task's change
+
+The following six items are separate implementation/verification commitments.
+They are not satisfied by a generic dashboard or a single graph screenshot.
+
+### V3.1 — Start from the current task and decision
+
+**User situation:** an agent changed many files; the owner cannot identify the
+business change or the one decision needing attention.
+**Required data:** task identity and requested outcome/non-goals; exact starting
+source/meaning revision; observed task-owned diff; proposed meaning; comparison
+coverage. Concurrent unrelated changes must remain separate.
+**Deliverable:** a task-bound review state and entry that names the decision,
+change and relevant evidence before showing the larger map. Reuse existing
+change-review/analysis/workbench seams where their contracts fit.
+**Acceptance:** a reviewer can identify the task, comparison basis, relevant
+capability/rule and next decision without exploring the whole graph. A link from
+an agent lands at that task/claim, not a generic home screen. Scope can expand
+without losing selection or hiding uninspected boundaries.
+**Negative cases:** stale/missing baseline, wrong task, unrelated concurrent
+file, expected-scope change that violates policy, legitimate out-of-scope refactor.
+No diff comparison silently becomes a safety verdict.
+**Dependencies/owners:** task identity/context from V2.1/V2.2 and sufficient V1
+evidence (or a disclosed reviewed fixture); do not wait for V2.3 UI links. Existing
+`ontology-change-review`, analysis records and workbench integration. Design
+routing decides attention/information-architecture proof before UI code.
+
+### V3.2 — Summary → small comparison → detailed review
+
+**User situation:** raw facts overwhelm the reviewer, but hiding them prevents
+inspection of what the agent is asking them to accept.
+**Required data:** the same typed claims/conditions/unknowns at each depth,
+selected claim identity, total/omitted coverage, precise source/document links.
+**Deliverable:** a short summary, an optional local before/after comparison or
+mini graph, and a full evidence/change review. Plain text is the fallback for
+hosts without inline UI; not every task must open the app or display a graph.
+**Acceptance:** each depth preserves selection, qualifiers and the approval
+scope; the reviewer can drill down and return without losing the task. Every
+batch item is inspectable. Unseen rows are not represented by the first item.
+**Negative cases:** summary drops a condition, hidden rows affect an entire-batch
+approval, narrow map implies complete coverage, unsupported host renders blank,
+keyboard/focus navigation loses the selected claim.
+**Dependencies/owners:** V3.1 and V3.3 typed content. Existing review components
+and map detail surfaces; full responsive/accessibility proof follows routing.
+
+### V3.3 — Meaning Diff preserves conditions, exceptions and unknowns
+
+**User situation:** the edge set looks unchanged although a business threshold,
+state condition, unit or exception changed; a new edge loses its condition.
+**Required data:** verified old meaning where available, observed code diff,
+new proposed meaning, exact rule predicates/units/time/actor/scope, source refs,
+counterevidence, unknowns and stable concept identity.
+**Deliverable:** explicit added/removed/changed/unchanged or uncomparable meaning
+items, separating code observation, interpretation and accepted meaning. Show
+missing before as missing, not empty. Use a table/sentence when clearer than a
+map; use stable local graph alignment for relational changes.
+**Acceptance:** the reviewer sees authorization→capture, threshold/unit/exception
+changes even if nodes/edges are identical. A high-value-only dependency remains
+conditional in summary, graph, full body and agent output. Cosmetic wording and
+path renames alone do not become business changes.
+**Negative cases:** missing/stale before; amount without currency; negation or
+exception lost; conditional edge made universal; source limit promoted to
+product exclusion; incomplete scan reported as no meaning change.
+**Dependencies/owners:** V1.4 meaning/evidence and V3.1 comparison basis;
+`ontology-change-set`, `ontology-change-review` and source/analysis records.
+No public schema extension until an existing representation's concrete loss is
+shown and reviewed.
+
+### V3.4 — Separate meaning acceptance, code verification, merge and deployment
+
+**User situation:** an ambiguous Approve or green mark appears to certify more
+than the person actually reviewed or the system actually checked.
+**Required data:** exact proposal/version/digest, requested action, code state,
+individual verification artifacts and scope, merge/deployment facts only when
+known, and concurrency guards.
+**Deliverable:** distinct visible statuses and scoped actions; meaning acceptance
+applies to the exact meaning delta only. Existing host/write authority remains
+explicit. Rejection/defer does not imply rollback of code already written.
+**Acceptance:** the reviewer can tell what each action changes, which checks ran,
+and which decisions remain. A stale/mutated proposal cannot reuse an earlier
+acceptance. A planned-scope checkmark never means a business rule passed.
+**Negative cases:** missing test result painted green, accepted meaning silently
+merges code, stale digest, partial batch, changed source during review, rejection
+reported as code rollback, nonexistent deployment outcome.
+**Dependencies/owners:** V3.1/V3.3 plus current exact-write/mtime/digest contracts;
+existing review and permission surfaces. This is an authority-sensitive slice
+and must follow the derived PO review.
+
+### V3.5 — Test rapid orientation, not five-second approval
+
+**User situation:** the reviewer needs to know what to check first and what is
+known before spending effort on detail.
+**Required data:** priority grounded in the task and evidence, actual verification
+scope, unknown/omitted coverage and available intervention actions.
+**Deliverable:** clear first-view hierarchy and a measured orientation task:
+identify the principal change, first review item, verified boundary and next
+possible action. Five seconds is an experimental orientation target, not a
+safety SLA or an approval timer.
+**Acceptance:** measure answer correctness and wrong reassurance with time.
+Do not say 'the only thing to check' without adequate scope evidence. Accessible
+text/markers carry the same facts as color and graph; relevant mobile/tablet/
+desktop and EN/KO states remain readable and reachable.
+**Negative cases:** many low-value facts bury the risk, alarming color on a normal
+change, unknown hidden below the fold, ambiguous legend, cropped qualifier,
+keyboard-only user cannot reach evidence, quick approval despite a planted error.
+**Dependencies/owners:** V3.2–V3.4; design/a11y/responsive instruments. Use real
+reviewer measurements and condition waits, not arbitrary timing assertions.
+
+### V3.6 — Prove reviewers detect, correct or defer a wrong proposal
+
+**User situation:** a persuasive agent account creates confidence without an
+independent basis for trusting the change.
+**Required data:** fixed correct/incorrect/incomplete cases, same facts across
+text/diff and visual conditions, independent task judgments, reviewer expertise
+and the actual edit/reject/defer actions.
+**Deliverable:** a decision-quality study and executable UI contracts covering
+error discovery, evidence inspection, correction/defer, false warnings and
+review burden. Preserve first responses, order/learning effects and source scope. Before collecting reviewer results,
+freeze the critical cases, expected accept/correct/defer decisions, benefit
+measure and false-warning tolerance. A critical unsupported approval cannot be
+hidden by faster average decisions or preference. Report a mixed or inconclusive
+result when the predeclared benefit is absent or a protected outcome regresses.
+**Acceptance:** identify dangerous mistaken acceptance, missed critical condition,
+correct deferral and successful correction separately. Higher satisfaction or
+faster approval cannot offset worse decisions. FDE/PM/customer claims require
+actual appropriate participants/tasks; an agent-only study cannot establish them.
+**Negative cases:** polished false explanation, rule changed inside expected
+files, justified unexpected file, conditional dependency omission, stale base,
+no test run, unseen impact boundary, answer sentence omitted from claim ledger.
+**Dependencies/owners:** V3.1–V3.5 and independent evaluation. Keep the producing
+agent's summary separate from verification; no new generic trust score.
+
+## V4 — Preserve accepted meaning and demonstrate repeated value
+
+### V4.1 — Record the code/meaning transition without confusing authorities
+
+**Inputs:** exact code diff, accepted meaning delta/gaps, source/graph versions,
+review decision, and ordinary Git state.
+**Deliverable:** a traceable transition a future reviewer can open from the task
+or history. Coordinate code and accepted Markdown in Git where applicable;
+vault-scoped Git tools do not gain arbitrary source/merge/deploy authority.
+**Acceptance:** identify what changed, why that interpretation was accepted,
+which evidence applied, and which questions remained. No semantic delta is
+created for every task by default. Unrelated dirty work remains untouched.
+**Negative cases:** meaning accepted against another revision, partially written
+batch, rejected proposal recorded as accepted, noisy no-op updates, hidden owner
+notes lost, duplicated semantic state outside the canonical vault.
+**Dependencies/owners:** V3.3/V3.4; existing vault writes, receipts and Git history.
+
+### V4.2 — Complete A → B → C with a fresh successor
+
+**Inputs:** fixed A bug task, B policy/exception change, C later related task;
+source controls and reviewed starting meaning with acquisition cost disclosed.
+**Deliverable:** B's accepted update is returned and correctly applied by a fresh
+C agent without earlier conversation or owner coaching. Include an unrelated
+task and a meaning-preserving refactor as no-update controls.
+**Acceptance:** verify the changed condition, its exceptions and unknowns survive
+retrieval and code inspection. Measure owner re-explanation, repeated discovery,
+missed boundaries, unnecessary proposals and final task outcomes. Distinguish
+source-hidden understanding proof from source-aware coding verification.
+**Negative cases:** C receives old context, B's qualification is lost, future C
+answer leaked into A's initial vault, forced tool calls counted as usefulness,
+all controls use the same generic context despite conflicting task scope.
+**Dependencies/owners:** V2.4/V4.1; benchmark lifecycle and independent evaluators.
+
+### V4.3 — Observe repeat adoption and maintenance cost in actual work
+
+**Inputs:** willing users and permitted work scope, relevant subsequent tasks,
+local/consented measurement and an explicit ability to disable the integration.
+**Deliverable:** repeat-use and decision outcomes with the costs of setup,
+meaning acquisition, review, correction and maintaining current evidence.
+**Acceptance:** measure useful reuse in eligible later tasks and whether the
+integration is retained voluntarily. Record no-match/unknown/fallback cases and
+false warnings; do not hide them in the denominator. App opens, MCP counts,
+preference or confidence alone are not retention/benefit evidence.
+**Negative cases:** repeated use caused by compulsory hooks, private task text
+collected without consent, unused meaning grows, review debt overwhelms benefit,
+quiet UI hides unverified work.
+**Dependencies/owners:** V4.2; owner-approved real-use protocol, no backend/account
+or default telemetry introduced merely for measurement.
+
+## Registration and evidence locations
+
+All live item states and evidence references are maintained in BACKLOG only.
+A plan item can reference an existing contract or workbench; it does not require
+a new route or tool. Link each completed slice's commit/PR and concise proof,
+plus exact external artifact locations when their source license/scope keeps
+them outside this repository. Frozen history and earlier failed trials remain
+available. The owner can reprioritize, but dependency and proof gaps must stay
+visible when the order changes.
+
+## Conversation coverage map
+
+| Owner requirement | Execution or maintained authority |
+|---|---|
+| Know what ontology means; use public sources lawfully | Existing meta-model/Foundations; common evidence agreement; V1.1/V1.5 |
+| Recover work meaning from code, not README/folder names alone | V1.1–V1.4 |
+| Investigate predicates, data/ERD, state, effects and exceptions | V1.1/V1.2/V1.4 |
+| Build strong system/tool instructions and test their actual effect | V1.2/V1.4; separate prompt/access conditions in V1.5 |
+| Backend-oriented first test without excluding frontend-owned rules | Working agreement and V1.1 |
+| Task-aware Agent Brief as the repeated entry | V2.1–V2.4 |
+| Current task/decision before full-system exploration | V3.1 |
+| Summary, small comparison, detailed review | V3.2 |
+| Meaning Diff retains conditions, exceptions and unknowns | V3.3 |
+| Meaning acceptance, code verification, merge, deployment stay distinct | V3.4 |
+| Rapidly identify what to inspect and the checked scope | V3.5 |
+| Find, correct or defer an incorrect agent proposal | V3.6 |
+| Code and accepted meaning share reviewable history | V4.1 |
+| Next independent task reuses accepted meaning | V4.2 |
+| User value and voluntary repeated use, not feature/app-open counts | V4.3 and common outcome |
+| Atlas-specialist PO, consistent current public/internal language, mirrored skills | Product Direction/PO operating system and existing mirrored skills; retain solo/two-seat routing |
+| Sol low implementation; Astra planning and review | Working agreement and every implementation brief |
+
+This map is a coverage index, not another status board. Keep gaps visible when
+an item is blocked or only its enabling infrastructure has been implemented.

--- a/docs/ONTOLOGY-QUALITY.md
+++ b/docs/ONTOLOGY-QUALITY.md
@@ -14,6 +14,18 @@ The owners are `scripts/evaluate-meaning-corpus.mjs` and
 `mcp/src/meaning-evaluation.mjs`; the oracle checks the evaluator contract, not
 an independent agent's construction ability.
 
+The JSON result's `measurementScope` distinguishes `candidateDiscovery` and
+`goldenOracleConsistency` (measured) from `independentConstruction`
+(`not_measured`). Measured identifies a diagnostic's scope; its existing row
+result still decides whether that diagnostic passed. The readable command output
+reports the same separation. Effective thresholds come from the actual evaluator
+results: `relaxedMinimumCoverage` identifies zero minimum coverage requirements,
+while `maximumForbiddenLeakage: 0` remains a strict upper bound. Raw coverage
+metrics can still be calculated even when their minimum requirement is relaxed.
+None of these fields evaluates the correctness of an independent construction.
+This is the reporting contract in [V1.0](MEANING-WORKFLOW-PLAN.md#v10--make-evaluation-scope-impossible-to-confuse-with-construction-quality),
+not completion of the source-first construction program.
+
 Whole-vault validation establishes scanned shape, reference, and path facts.
 `health` also reports meaning currentness; neither a resolvable path nor a fresh
 receipt proves that a definition is correct. Meaning and handoff claims require

--- a/docs/PRODUCT-DIRECTION.md
+++ b/docs/PRODUCT-DIRECTION.md
@@ -67,7 +67,9 @@ Meaning acquisition, later-task usefulness, review burden, and retention are
 separate measurements. Public copy states current mechanisms and their limits;
 development priorities do not become shipped guarantees.
 
-Execution priority belongs in [BACKLOG.md](BACKLOG.md). The
+Execution priority and status belong in [BACKLOG.md](BACKLOG.md); the
+[detailed V1–V4 plan](MEANING-WORKFLOW-PLAN.md) specifies each implementation
+and verification commitment. The
 [PO operating system](PRODUCT-OWNER-OPERATING-SYSTEM.md) turns this product model
 into a bounded recovery proof using the existing five outcomes. The historical
 direction below supplies the retained category and context; v12 governs the

--- a/docs/records/changes/2026-09-13-meaning-corpus-measurement-scope-4ee9abee-508d-4098-84a8-5811bc951ab4.md
+++ b/docs/records/changes/2026-09-13-meaning-corpus-measurement-scope-4ee9abee-508d-4098-84a8-5811bc951ab4.md
@@ -1,0 +1,6 @@
+---
+id: 4ee9abee-508d-4098-84a8-5811bc951ab4
+date: 2026-09-13
+category: Changed
+---
+The meaning-corpus report exposes candidate discovery, golden-oracle consistency, and unmeasured independent construction in JSON and readable output, deriving effective thresholds without changing existing pass/fail behavior. The V1–V4 execution plan registers 19 concrete items, including six separate human-review UX commitments; BACKLOG owns their live status.

--- a/docs/records/po-runs/0b6a7e7d-0da8-465d-b555-3af93ca8c42c.json
+++ b/docs/records/po-runs/0b6a7e7d-0da8-465d-b555-3af93ca8c42c.json
@@ -1,0 +1,31 @@
+{
+  "date": "2026-09-13",
+  "decision": "Register the V1-V4 execution specification and expose the fixed corpus measurement scope (V1.0)",
+  "door": "two-way",
+  "route": "solo",
+  "outcome": "judge",
+  "changes": [
+    "rollback-cheap"
+  ],
+  "boundaries": {
+    "truth": "unchanged",
+    "transfer": "unchanged",
+    "agent-write": "unchanged",
+    "human-correction": "unchanged"
+  },
+  "risk": "none",
+  "firstTurns": 0,
+  "rebuttalTurns": 0,
+  "delta": "unchanged",
+  "uniqueContributors": [],
+  "initialUpdate": {
+    "date": "2026-09-13",
+    "proof": "pending",
+    "ownerClear": "pending",
+    "boundaryMiss": "pending",
+    "laterResult": "pending"
+  },
+  "schema": "po-pilot-run/v1",
+  "id": "0b6a7e7d-0da8-465d-b555-3af93ca8c42c",
+  "recordedAt": "2026-09-13T07:49:25.957Z"
+}

--- a/scripts/evaluate-meaning-corpus.mjs
+++ b/scripts/evaluate-meaning-corpus.mjs
@@ -9,6 +9,11 @@ import {
 } from '../mcp/src/meaning-evaluation.mjs';
 
 const corpusRoot = join(process.cwd(), 'tests/fixtures/meaning-corpus');
+const RELAXED_MINIMUM_COVERAGE = Object.freeze([
+  'definitionCoverage',
+  'citationRecall',
+  'competencyCoverage',
+]);
 
 export function evaluateMeaningCorpus(rootPath = corpusRoot) {
   const rows = readdirSync(rootPath, { withFileTypes: true })
@@ -59,7 +64,29 @@ export function evaluateMeaningCorpus(rootPath = corpusRoot) {
     oracleContractsPassed: rows.filter((row) => row.oracleContract.passed).length,
     totals,
   };
-  return { summary, rows };
+  const candidateThresholds = sharedThresholds(rows, 'candidateCoverage');
+  const oracleThresholds = sharedThresholds(rows, 'oracleContract');
+  const measurementScope = {
+    candidateDiscovery: {
+      status: 'measured',
+      effectiveThresholds: candidateThresholds,
+      relaxedMinimumCoverage: RELAXED_MINIMUM_COVERAGE.filter(
+        (dimension) => candidateThresholds[dimension] === 0,
+      ),
+      strictMaximums: {
+        maximumForbiddenLeakage: candidateThresholds.maximumForbiddenLeakage,
+      },
+    },
+    goldenOracleConsistency: {
+      status: 'measured',
+      effectiveThresholds: oracleThresholds,
+    },
+    independentConstruction: {
+      status: 'not_measured',
+      unmeasuredDimensions: [...RELAXED_MINIMUM_COVERAGE],
+    },
+  };
+  return { summary, measurementScope, rows };
 }
 
 export function passesMeaningCorpus(result) {
@@ -92,6 +119,7 @@ function run() {
     console.log(
       `  aggregate — precision ${format(summary.candidatePrecision)}, recall ${format(summary.candidateRecall)}, oracle ${summary.oracleContractsPassed}/${summary.corpusSize}`,
     );
+    printMeasurementScope(result.measurementScope);
   }
 
   if (!passesMeaningCorpus(result)) {
@@ -105,6 +133,39 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
 
 function ratio(numerator, denominator) {
   return denominator === 0 ? 1 : Number((numerator / denominator).toFixed(4));
+}
+
+function sharedThresholds(rows, resultKey) {
+  const first = rows[0][resultKey].thresholds;
+  if (rows.some((row) => JSON.stringify(row[resultKey].thresholds) !== JSON.stringify(first))) {
+    throw new Error(`${resultKey} thresholds differ across the meaning corpus`);
+  }
+  return { ...first };
+}
+
+function printMeasurementScope(scope) {
+  console.log('  measurement scope');
+  console.log(`    candidate discovery — ${scope.candidateDiscovery.status}`);
+  console.log(`      effective gates — ${formatThresholds(scope.candidateDiscovery.effectiveThresholds)}`);
+  console.log('      relaxed minimum coverage');
+  for (const dimension of scope.candidateDiscovery.relaxedMinimumCoverage) {
+    console.log(`        ${dimension} >= ${scope.candidateDiscovery.effectiveThresholds[dimension]}`);
+  }
+  for (const [dimension, threshold] of Object.entries(scope.candidateDiscovery.strictMaximums)) {
+    console.log(`      strict maximum — ${dimension} <= ${threshold}`);
+  }
+  console.log(`    golden oracle consistency — ${scope.goldenOracleConsistency.status}`);
+  console.log(`      effective gates — ${formatThresholds(scope.goldenOracleConsistency.effectiveThresholds)}`);
+  console.log(`    independent construction — ${scope.independentConstruction.status.replace('_', ' ')}`);
+  console.log(`      unmeasured dimensions — ${scope.independentConstruction.unmeasuredDimensions.join(', ')}`);
+}
+
+function formatThresholds(thresholds) {
+  return Object.entries(thresholds)
+    .map(([dimension, threshold]) =>
+      `${dimension} ${dimension.startsWith('maximum') ? '<=' : '>='} ${threshold}`,
+    )
+    .join('; ');
 }
 
 function format(value) {

--- a/scripts/evaluate-meaning-corpus.test.mjs
+++ b/scripts/evaluate-meaning-corpus.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import test from 'node:test';
 import { tmpdir } from 'node:os';
@@ -19,9 +20,32 @@ test('meaning corpus passes each fixture with no implementation-shaped business 
   assert.equal(result.summary.candidatePrecision, 1);
   assert.equal(result.summary.candidateRecall, 1);
   assert.equal(result.summary.oracleContractsPassed, 3);
+  assert.deepEqual(result.measurementScope.candidateDiscovery, {
+    status: 'measured',
+    effectiveThresholds: result.rows[0].candidateCoverage.thresholds,
+    relaxedMinimumCoverage: [
+      'definitionCoverage',
+      'citationRecall',
+      'competencyCoverage',
+    ],
+    strictMaximums: {
+      maximumForbiddenLeakage: 0,
+    },
+  });
+  assert.equal(result.measurementScope.goldenOracleConsistency.status, 'measured');
+  assert.deepEqual(result.measurementScope.independentConstruction, {
+    status: 'not_measured',
+    unmeasuredDimensions: [
+      'definitionCoverage',
+      'citationRecall',
+      'competencyCoverage',
+    ],
+  });
 
   for (const row of rows.values()) {
     assert.equal(row.candidateCoverage.passed, true, row.id);
+    assert.equal(row.candidateCoverage.metrics.definitionCoverage, 0, row.id);
+    assert.equal(row.candidateCoverage.metrics.competencyCoverage, 0, row.id);
     assert.deepEqual(row.candidateCoverage.findings.falsePositiveSlugs, [], row.id);
     assert.deepEqual(row.candidateCoverage.findings.forbiddenLeakage, [], row.id);
   }
@@ -40,6 +64,43 @@ test('a fixture failure is not masked by passing aggregate thresholds', () => {
   result.rows[0].candidateCoverage.passed = false;
   assert.equal(result.rows.some((row) => !row.candidateCoverage.passed), true);
   assert.equal(passesMeaningCorpus(result), false);
+
+  result.rows[0].candidateCoverage.passed = true;
+  result.rows[0].oracleContract.passed = false;
+  assert.equal(result.rows.some((row) => !row.oracleContract.passed), true);
+  assert.equal(passesMeaningCorpus(result), false);
+});
+
+test('CLI exposes measurement scope in JSON and readable text', () => {
+  const script = join(process.cwd(), 'scripts/evaluate-meaning-corpus.mjs');
+  const jsonRun = spawnSync(process.execPath, [script, '--json'], { encoding: 'utf8' });
+  assert.equal(jsonRun.status, 0, jsonRun.stderr);
+  const result = JSON.parse(jsonRun.stdout);
+  assert.equal(result.measurementScope.independentConstruction.status, 'not_measured');
+
+  const textRun = spawnSync(process.execPath, [script], { encoding: 'utf8' });
+  assert.equal(textRun.status, 0, textRun.stderr);
+  assert.match(
+    textRun.stdout,
+    new RegExp(result.measurementScope.candidateDiscovery.status),
+  );
+  assert.match(
+    textRun.stdout,
+    new RegExp(result.measurementScope.goldenOracleConsistency.status),
+  );
+  assert.match(
+    textRun.stdout,
+    new RegExp(result.measurementScope.independentConstruction.status.replace('_', ' ')),
+  );
+  for (const dimension of result.measurementScope.candidateDiscovery.relaxedMinimumCoverage) {
+    const threshold = result.measurementScope.candidateDiscovery.effectiveThresholds[dimension];
+    assert.match(textRun.stdout, new RegExp(`${dimension}\\s+>=\\s+${threshold}`));
+  }
+  for (const [dimension, threshold] of Object.entries(
+    result.measurementScope.candidateDiscovery.strictMaximums,
+  )) {
+    assert.match(textRun.stdout, new RegExp(`${dimension}\\s+<=\\s+${threshold}`));
+  }
 });
 
 test('an empty corpus cannot pass', () => {


### PR DESCRIPTION
## Summary

The fixed corpus could report candidate/oracle PASS without stating that it had never evaluated independent ontology construction. The JSON and readable report now explicitly separate those measurement scopes, derive effective thresholds from evaluator results, and preserve the existing diagnostic and pass/fail behavior. Independent construction remains `not_measured`.

Register the detailed V1–V4 plan and 19 live BACKLOG items. V3 has six separate UI/UX implementation and verification commitments: task-first decisions, progressive detail, qualified Meaning Diff, distinct acceptance/code/merge/deploy states, orientation rather than fast approval, and detecting/correcting/deferring wrong proposals. Only V1.0 is completed; V1.1 is next. Sol low implemented the runner/tests; Astra planned and reviewed.

This is a reversible internal reporting change with unchanged truth, transfer, agent-write and human-correction boundaries. Recovery contract: readers can identify what the fixed corpus measures and what remains unmeasured without reading its source. No analyzer, ontology, MCP, UI or acceptance gate changes; no semantic-quality or human-comprehension benefit claim.

## Test plan

- Node 24 sibling tests: 4/4 pass, including zero candidate definitions/answers with explicit unmeasured construction, candidate/oracle failure probes, empty corpus and CLI JSON/text.
- Before/after JSON: existing summary and every fixture diagnostic unchanged.
- `pnpm checks:changed -- --run`: all 9 implementation recommendations pass; plan registration checks passed 7/7.
- Astra reviewed the implementation and all 19 plan items, including the six separate UX commitments and their failure cases/dependencies.
