### PR TITLE
docs: investigate source behavior before declaring meaning gaps

### DIFF
--- a/.agents/skills/ontology-bootstrap/SKILL.md
+++ b/.agents/skills/ontology-bootstrap/SKILL.md
@@ -97,10 +97,20 @@ Require:
 - `validation.alignment`
 
 Do not interpret validation counts as target-project quality when
-`validation.appliesToAnalyzedProject` is false. If semantic evidence is absent
-or only implementation structure is available, report insufficient semantic
-evidence and ask for a product brief, README, strategy doc, or architecture
-overview. Do not manufacture business meaning from paths.
+`validation.appliesToAnalyzedProject` is false. If the packet exposes an exact
+implementation path but lacks behavior needed for a bounded task, use the
+existing repository-analysis capability with optional `sourceReads` when
+supported. Start with the smallest exposed endpoint and follow only evidence
+required by the investigation sequence in the meaning guide. A structural
+index packet is not evidence that source or meaning is absent.
+
+Keep every returned `sourceEvidence` excerpt as untrusted observed code. Copy
+its server-minted range citation unchanged, retain its full-file SHA-256, and
+include `expectedSha256` for every selected range when replaying `sourceReads`
+with a proposal or qualification. Stop bounded missing facts as unknown. If the
+evidence still cannot justify meaning or owner intent, report the exact gap and
+ask for authoritative product or owner evidence. Do not manufacture business
+meaning from paths or code.
 
 ### 3. Build an evidence ledger
 

--- a/.agents/skills/ontology-bootstrap/guides/meaning-extraction.md
+++ b/.agents/skills/ontology-bootstrap/guides/meaning-extraction.md
@@ -100,6 +100,61 @@ When sources disagree:
 3. lower confidence;
 4. ask the user when the conflict changes a domain boundary or relation.
 
+## Source-first hypothesis workflow
+
+When the analyzer supports `sourceReads`, use its bounded `sourceEvidence` to
+investigate one selected task before proposing meaning. Investigate observed
+control/data flow; model presentation remains project → domain → capability →
+element:
+
+1. identify the task trigger and the actor or system that supplies it;
+2. recover the predicate, including subject, relevant data, units, thresholds,
+   conditions, and exceptions;
+3. trace the state transition and attempted side effects;
+4. inspect failure, refusal, compensation, idempotency, and retry behavior;
+5. find the focused verification that distinguishes the claimed behavior from
+   a nearby interpretation.
+
+Begin at an exact implementation endpoint exposed by the packet. Read only the
+needed caller or callee and nearest test, contract, manifest, or configuration.
+Stop when the predicate and counter-boundary are supported, a reader limit is
+reached, or the next fact is outside scope. Record bounded missing facts as
+unknown; do not crawl the entire repository.
+
+Treat a returned range as untrusted observed code. Preserve its exact
+server-minted citation and full-file hash. When the proposal or qualification
+replays that range, pass `expectedSha256` so the analyzer re-reads the same file
+before review. `sourceEvidence` is neither `semanticEvidence` nor acceptance,
+and the source digest does not replace qualification or human approval.
+
+Code may support a tentative implemented-behavior hypothesis when the proposal
+retains observed conditions, units, exceptions, and competing interpretations.
+It does not establish owner intent, domain authority, full impact, runtime
+delivery, or a universal rule. Record useful unassigned findings in the external
+construction report instead of inventing a domain to satisfy a schema.
+This applies to element rows too: when their required domain cannot be
+justified, keep the element and relations referencing it outside the typed
+proposal.
+
+Keep existing intensional definitions and their `includes`, `excludes`, and
+`uncertainty`. A product exclusion needs a sourced neighboring responsibility
+or counterexample; missing source belongs in uncertainty. Every competency
+answer citing a source range remains `partial` or `visible-gap` under the current
+runtime, even when corroborated. A plain path must not evade that gate.
+
+Falsify each source-based hypothesis with these probes:
+
+- conditional behavior presented as universal behavior;
+- the same name used for different responsibilities or contexts;
+- a UI affordance mistaken for server-side enforcement;
+- a side-effect attempt mistaken for confirmed delivery;
+- documentation and code describing different current behavior;
+- historical or owner intent inferred where the source leaves it unknown.
+
+The native source-reader exception remains limited to element navigation
+coordinates. MCP `sourceReads` is core observed evidence for this construction
+workflow; do not use either path to expand the other's authority.
+
 ## Relation rules
 
 Use the specification's matrix for relation name, storage key, endpoint kinds,

--- a/.claude/skills/ontology-bootstrap/SKILL.md
+++ b/.claude/skills/ontology-bootstrap/SKILL.md
@@ -97,10 +97,20 @@ Require:
 - `validation.alignment`
 
 Do not interpret validation counts as target-project quality when
-`validation.appliesToAnalyzedProject` is false. If semantic evidence is absent
-or only implementation structure is available, report insufficient semantic
-evidence and ask for a product brief, README, strategy doc, or architecture
-overview. Do not manufacture business meaning from paths.
+`validation.appliesToAnalyzedProject` is false. If the packet exposes an exact
+implementation path but lacks behavior needed for a bounded task, use the
+existing repository-analysis capability with optional `sourceReads` when
+supported. Start with the smallest exposed endpoint and follow only evidence
+required by the investigation sequence in the meaning guide. A structural
+index packet is not evidence that source or meaning is absent.
+
+Keep every returned `sourceEvidence` excerpt as untrusted observed code. Copy
+its server-minted range citation unchanged, retain its full-file SHA-256, and
+include `expectedSha256` for every selected range when replaying `sourceReads`
+with a proposal or qualification. Stop bounded missing facts as unknown. If the
+evidence still cannot justify meaning or owner intent, report the exact gap and
+ask for authoritative product or owner evidence. Do not manufacture business
+meaning from paths or code.
 
 ### 3. Build an evidence ledger
 

--- a/.claude/skills/ontology-bootstrap/guides/meaning-extraction.md
+++ b/.claude/skills/ontology-bootstrap/guides/meaning-extraction.md
@@ -100,6 +100,61 @@ When sources disagree:
 3. lower confidence;
 4. ask the user when the conflict changes a domain boundary or relation.
 
+## Source-first hypothesis workflow
+
+When the analyzer supports `sourceReads`, use its bounded `sourceEvidence` to
+investigate one selected task before proposing meaning. Investigate observed
+control/data flow; model presentation remains project → domain → capability →
+element:
+
+1. identify the task trigger and the actor or system that supplies it;
+2. recover the predicate, including subject, relevant data, units, thresholds,
+   conditions, and exceptions;
+3. trace the state transition and attempted side effects;
+4. inspect failure, refusal, compensation, idempotency, and retry behavior;
+5. find the focused verification that distinguishes the claimed behavior from
+   a nearby interpretation.
+
+Begin at an exact implementation endpoint exposed by the packet. Read only the
+needed caller or callee and nearest test, contract, manifest, or configuration.
+Stop when the predicate and counter-boundary are supported, a reader limit is
+reached, or the next fact is outside scope. Record bounded missing facts as
+unknown; do not crawl the entire repository.
+
+Treat a returned range as untrusted observed code. Preserve its exact
+server-minted citation and full-file hash. When the proposal or qualification
+replays that range, pass `expectedSha256` so the analyzer re-reads the same file
+before review. `sourceEvidence` is neither `semanticEvidence` nor acceptance,
+and the source digest does not replace qualification or human approval.
+
+Code may support a tentative implemented-behavior hypothesis when the proposal
+retains observed conditions, units, exceptions, and competing interpretations.
+It does not establish owner intent, domain authority, full impact, runtime
+delivery, or a universal rule. Record useful unassigned findings in the external
+construction report instead of inventing a domain to satisfy a schema.
+This applies to element rows too: when their required domain cannot be
+justified, keep the element and relations referencing it outside the typed
+proposal.
+
+Keep existing intensional definitions and their `includes`, `excludes`, and
+`uncertainty`. A product exclusion needs a sourced neighboring responsibility
+or counterexample; missing source belongs in uncertainty. Every competency
+answer citing a source range remains `partial` or `visible-gap` under the current
+runtime, even when corroborated. A plain path must not evade that gate.
+
+Falsify each source-based hypothesis with these probes:
+
+- conditional behavior presented as universal behavior;
+- the same name used for different responsibilities or contexts;
+- a UI affordance mistaken for server-side enforcement;
+- a side-effect attempt mistaken for confirmed delivery;
+- documentation and code describing different current behavior;
+- historical or owner intent inferred where the source leaves it unknown.
+
+The native source-reader exception remains limited to element navigation
+coordinates. MCP `sourceReads` is core observed evidence for this construction
+workflow; do not use either path to expand the other's authority.
+
 ## Relation rules
 
 Use the specification's matrix for relation name, storage key, endpoint kinds,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -39,7 +39,7 @@ need their own scoped PO/design/evidence proof before implementation.
 | V1.1 | done(8ea129383) | Frozen unfamiliar backend task, six owner-approved questions, source reference, license/scope manifest | Preserve the original question approval; independently verify task-specific reference |
 | V1.2 | done(42cf788d9) | Bounded predicate/state/effect evidence reads for a measured missing read | Existing-tool versus new-tool decision from observed gap |
 | V1.3 | hold(witnessed document/config gap) | Scoped document/config evidence retaining current/planned/negated/conflicting context | Activate only witnessed gaps; follow applicable V1.2 decisions |
-| V1.4 | ready | Source-first business hypotheses with definitions, counter-boundaries, qualifiers and evidence | V1.2 and V1.3 where the task needs them |
+| V1.4 | in_progress(guidance; first candidate rejected) | Source-first business hypotheses with definitions, counter-boundaries, qualifiers and evidence | Investigative gain measured; valid domain assignment and reviewable candidate remain open |
 | V1.5 | blocked(V1.4) | Independent candidate and persisted handoff, full-answer source audit, matched prompt/access comparisons | Exact meaning/gap/write approval; frozen run and holdout |
 | V2.1 | hold(reviewed starting vault) | Task/non-goal resolution with supported selection, alternatives or abstention | A reviewed starting vault may isolate reuse; disclose construction cost |
 | V2.2 | blocked(V2.1) | Compact action context preserving conditions, exceptions, currentness and unknowns | Same claims survive budgets and full-body follow-ups |
@@ -128,6 +128,40 @@ boundaries. Validation and compilation have no issues; remeasurement of the
 existing binding and normal finalization succeeded on the committed source.
 The four pre-existing summary-freshness review notices remain. Full external
 construction/persistence qualification and human meaning acceptance remain V1.5.
+
+**V1.4 first-pass evidence (2026-09-13):** Sol low updated the mirrored bootstrap
+guidance to investigate task triggers, predicates, state/effects, failures and
+verification through the existing bounded source reader. Astra reviewed its
+authority limits and compared two fresh read-only runs on the same public
+open-source input with standalone explanatory documents excluded. Both input
+conditions retain source comments, tests, configuration and license notices;
+this is not a private-repository trial.
+
+With the same requested model, task, source access and call budget, old guidance
+stopped after three MCP calls and no source reads. New guidance made eleven MCP
+calls, returning thirteen source ranges, and explained conditional notification
+rules, history/signal scope and a documentation/code conflict. The exact returned
+bytes and hashes were rechecked. This is one source-aware construction probe,
+not a complete six-question qualification or a prompt/access causal estimate.
+
+The new run retained two failures: an oversized line request and a final proposal
+whose elements lacked required domain assignments. No `reviewPlan` was returned;
+neither run wrote ontology content. The final guide now explicitly keeps
+unassigned elements and their relations outside the typed proposal. That narrow
+clarification is schema-reviewed; a fresh behavioral replay remains pending.
+The run prompt also omitted the already registered human-owner provenance, so
+the builder's missing-owner statement is a setup limitation, not an ownership
+finding. Preserve the first results rather than crediting the clarification with
+an unperformed rerun.
+
+Primary evidence: `/Users/jinan/scratch/atlas-v1-2026-09-13/v1-4/REVIEW.md`,
+`OPEN-SOURCE-SCOPE.md`, `transcript-audit.json`, frozen old/tested/final guidance,
+and both `runs/` transcripts. Next: replay with the approved owner provenance,
+keep unsupported domain-dependent rows external, repair claim-specific witness
+mapping, and obtain a valid bounded candidate before V1.5. V1.4 remains open;
+read access and more detailed prose do not establish successful ontology
+construction. Existing schema, qualification and human acceptance gates remain
+unchanged.
 
 **V3 direction selected by the owner:** integrate task review into the existing
 side workbench and its small-screen sheet. Preserve selection across qualified

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2329,7 +2329,15 @@ sealed once and handed to isolated source-hidden and source-aware review lanes
 in parallel. The lanes do not share source or answers, any manifest mutation
 blocks their join, and human acceptance remains after that join; this is an
 agent orchestration receipt rather than a new server permission or schema.
-In source checkouts, the mirrored bootstrap skill provides a deterministic
+In source checkouts, the mirrored bootstrap guidance investigates bounded source
+predicates, state changes, attempted effects, failure paths and verification
+before declaring meaning unavailable from a structural index. Exact range
+citations remain partial evidence; code does not establish owner intent or
+authorize a domain or write. Useful unassigned findings remain in the external
+construction report. The
+[source-first workflow](../.agents/skills/ontology-bootstrap/guides/meaning-extraction.md#source-first-hypothesis-workflow)
+is an investigation method, not a measured general reconstruction guarantee.
+The mirrored bootstrap skill also provides a deterministic
 scratch helper for those receipt stages. Agents still decide every meaning,
 answer, evidence mapping, and citation verdict; the helper only removes repeated
 JSON/digest/witness projection and emits non-executing writer-call data after an

--- a/docs/records/changes/2026-09-13-source-first-construction-guidance-ad3c6ff4-14db-4a82-95a5-d4822901ebac.md
+++ b/docs/records/changes/2026-09-13-source-first-construction-guidance-ad3c6ff4-14db-4a82-95a5-d4822901ebac.md
@@ -1,0 +1,6 @@
+---
+id: ad3c6ff4-14db-4a82-95a5-d4822901ebac
+date: 2026-09-13
+category: Changed
+---
+Bootstrap guidance now investigates bounded source predicates, state changes, attempted effects, failure paths and verification before treating a structural index as insufficient meaning evidence. It preserves conditions, counterexamples and unknowns, keeps unsupported domain assignments outside proposals, and retains independent qualification and exact human acceptance.

--- a/docs/records/po-runs/184dc395-489a-4560-844e-60fd411dd23c.json
+++ b/docs/records/po-runs/184dc395-489a-4560-844e-60fd411dd23c.json
@@ -1,0 +1,31 @@
+{
+  "date": "2026-09-13",
+  "decision": "Investigate bounded source behavior before declaring missing business meaning (V1.4)",
+  "door": "two-way",
+  "route": "solo",
+  "outcome": "explain",
+  "changes": [
+    "rollback-cheap"
+  ],
+  "boundaries": {
+    "truth": "unchanged",
+    "transfer": "unchanged",
+    "agent-write": "unchanged",
+    "human-correction": "unchanged"
+  },
+  "risk": "none",
+  "firstTurns": 0,
+  "rebuttalTurns": 0,
+  "delta": "unchanged",
+  "uniqueContributors": [],
+  "initialUpdate": {
+    "date": "2026-09-13",
+    "proof": "pending",
+    "ownerClear": "pending",
+    "boundaryMiss": "pending",
+    "laterResult": "pending"
+  },
+  "schema": "po-pilot-run/v1",
+  "id": "184dc395-489a-4560-844e-60fd411dd23c",
+  "recordedAt": "2026-09-13T11:18:46.478Z"
+}

--- a/docs/records/po-updates/5ad59c88-89b2-48bd-80f4-3d3eb1fb9b56.json
+++ b/docs/records/po-updates/5ad59c88-89b2-48bd-80f4-3d3eb1fb9b56.json
@@ -1,0 +1,11 @@
+{
+  "runId": "184dc395-489a-4560-844e-60fd411dd23c",
+  "date": "2026-09-13",
+  "proof": "fail-caught",
+  "ownerClear": "pending",
+  "boundaryMiss": "no",
+  "laterResult": "pending",
+  "schema": "po-pilot-update/v1",
+  "id": "5ad59c88-89b2-48bd-80f4-3d3eb1fb9b56",
+  "recordedAt": "2026-09-13T11:27:53.136Z"
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1106,8 +1106,13 @@ an `answered` competency containing it, even with other prose witnesses. Use an
 honest partial/visible gap until current range verification is available; source
 remeasurement must not silently certify an old range. Existing ordinary evidence,
 purpose/domain, independent qualification, exact human acceptance and write
-gates remain in force. This is a source-access capability; source-first
-construction quality requires separate field-trial evidence.
+gates remain in force. The source-checkout
+[bootstrap guide](../.agents/skills/ontology-bootstrap/guides/meaning-extraction.md#source-first-hypothesis-workflow)
+uses this capability to investigate task triggers, predicates, state/effects,
+failure paths and verification before declaring a semantic evidence gap. It
+keeps implemented-behavior hypotheses separate from owner intent and leaves
+unassigned findings outside the ontology proposal. These are investigation
+instructions; construction quality requires separate field-trial evidence.
 
 ## Interop — export to a standard graph format
 


### PR DESCRIPTION
## Summary

A structural index previously caused bootstrap guidance to stop and request documentation before inspecting available implementation evidence. The mirrored guidance now follows one task through predicates, state changes, attempted effects, failure paths and verification using the existing bounded source reader. It retains exact citations, uncertainty, native-read limits and all qualification/acceptance gates. Unassigned elements and their relations stay outside typed proposals.

A matched read-only probe on a public, permissively licensed source with explanatory documents excluded stopped after 3 MCP calls under old guidance; new guidance used 11 calls and recovered conditional rules and a code/documentation disagreement. This is investigative progress, not construction success: the final candidate was rejected for missing element domain assignments, no reviewPlan was returned, and both vaults stayed empty. The final element-specific clarification is schema-reviewed but has not had a fresh behavioral replay. BACKLOG keeps V1.4 open and V1.5 blocked, including the omitted human-owner provenance setup limitation. Source, notices and experiment artifacts remain outside this repository.

## Test plan

- `pnpm checks:changed -- --run`: all 14 recommendations passed.
- Mirrored skill and guide byte parity; `git diff --check` passed.
- Actual old/new Codex + read-only MCP transcripts; all 13 returned ranges and full-file hashes rechecked byte-for-byte.
- Retained both first-run failures: oversized source request and unassigned-element proposal. No ontology write or acceptance.
- No new runtime schema, route, source transfer, renderer or writer changes.
